### PR TITLE
CI・LICENSE・Cargo.tomlをgitppと同水準に整える

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "+ cargo fmt"
+cargo fmt
+
+echo "+ cargo clippy -- -D warnings"
+cargo clippy -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master, develop ]
+  pull_request:
+    branches: [ main, master, develop ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+      - name: Run tests
+        run: cargo test --verbose
+
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Check formatting
+        run: cargo fmt -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - name: Run clippy
+        run: cargo clippy -- -D warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: write
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            binary: type-globe
+            asset_name: type-globe-linux-x86_64
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            binary: type-globe
+            asset_name: type-globe-linux-x86_64-musl
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            binary: type-globe
+            asset_name: type-globe-macos-x86_64
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            binary: type-globe
+            asset_name: type-globe-macos-aarch64
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            binary: type-globe.exe
+            asset_name: type-globe-windows-x86_64.exe
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Install musl-tools (Linux musl only)
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+      - name: Strip binary (Unix)
+        if: runner.os != 'Windows'
+        run: strip target/${{ matrix.target }}/release/${{ matrix.binary }}
+      - name: Package artifact
+        run: |
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/${{ matrix.binary }} dist/${{ matrix.asset_name }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset_name }}
+          path: dist/${{ matrix.asset_name }}
+          if-no-files-found: error
+
+  release:
+    name: Publish Release
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Publish to GitHub Releases
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-globe"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["kako-jun"]
 description = "A quiz and typing game that combines learning with skill improvement"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ description = "A quiz and typing game that combines learning with skill improvem
 license = "MIT"
 homepage = "https://github.com/kako-jun/type-globe"
 repository = "https://github.com/kako-jun/type-globe"
-documentation = "https://docs.rs/type-globe"
 readme = "README.md"
 keywords = ["game", "tui", "typing", "quiz"]
 categories = ["command-line-utilities", "games"]
@@ -28,3 +27,4 @@ cargo-husky = { version = "1", default-features = false, features = ["user-hooks
 lto = true
 codegen-units = 1
 panic = "abort"
+strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,14 @@ edition = "2021"
 authors = ["kako-jun"]
 description = "A quiz and typing game that combines learning with skill improvement"
 license = "MIT"
+homepage = "https://github.com/kako-jun/type-globe"
+repository = "https://github.com/kako-jun/type-globe"
+documentation = "https://docs.rs/type-globe"
+readme = "README.md"
+keywords = ["game", "tui", "typing", "quiz"]
+categories = ["command-line-utilities", "games"]
+exclude = [".github/", "target/"]
+rust-version = "1.78.0"
 
 [dependencies]
 ratatui = "0.29"
@@ -12,3 +20,8 @@ crossterm = "0.28"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
+
+[profile.release]
+lto = true
+codegen-units = 1
+panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 
+[dev-dependencies]
+cargo-husky = { version = "1", default-features = false, features = ["user-hooks"] }
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 kako-jun
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## 関連 Issue
closes #7

## 変更内容
- MIT LICENSE ファイルを追加
- Cargo.toml にメタデータ追加（homepage, repository, documentation, keywords, categories, rust-version, release profile）
- GitHub Actions CI（test + fmt + clippy）を追加
- GitHub Actions Release（タグプッシュで5ターゲットのクロスビルド + GitHub Releases）を追加
- cargo-husky による pre-commit フック追加（cargo fmt + cargo clippy）