### PR TITLE
TUIをgitppのratatui実装パターンに刷新

### DIFF
--- a/src/io/typing_texts.rs
+++ b/src/io/typing_texts.rs
@@ -99,7 +99,7 @@ impl TypingTexts {
         let mut hasher = DefaultHasher::new();
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap()
+            .unwrap_or_default()
             .as_nanos()
             .hash(&mut hasher);
         

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Storage::ensure_data_directory(&config.data_dir)?;
 
     let mut menu = MenuUI::new();
-    let (language, mode) = menu.run()?;
+    let (language, mode) = match menu.run() {
+        Ok(result) => result,
+        Err(_) => return Ok(()),
+    };
 
     let questions_file = config.questions_file_path(&language);
     

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -5,7 +5,7 @@ use crossterm::{
 };
 use ratatui::{
     backend::CrosstermBackend,
-    layout::{Alignment, Constraint, Direction, Layout},
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
@@ -14,10 +14,16 @@ use ratatui::{
 use std::io;
 use crate::types::{GameMode, Language};
 
+const STYLE_TITLE: Style = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD);
+const STYLE_SELECTED: Style = Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD);
+const STYLE_NORMAL: Style = Style::new();
+const STYLE_HELP: Style = Style::new().fg(Color::Gray);
+
 pub struct MenuUI {
     selected_language: usize,
     selected_mode: usize,
     step: MenuStep,
+    should_quit: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -32,6 +38,7 @@ impl MenuUI {
             selected_language: 0,
             selected_mode: 0,
             step: MenuStep::LanguageSelection,
+            should_quit: false,
         }
     }
 
@@ -56,32 +63,32 @@ impl MenuUI {
             terminal.draw(|f| self.ui(f))?;
 
             if let Event::Key(key) = event::read()? {
-                match self.handle_input(key) {
-                    Some(result) => return Ok(result),
-                    None => {}
+                if let Some(result) = self.handle_key(key) {
+                    return Ok(result);
+                }
+                if self.should_quit {
+                    return Err("User quit".into());
                 }
             }
         }
     }
 
-    fn handle_input(&mut self, key: KeyEvent) -> Option<(Language, GameMode)> {
+    fn handle_key(&mut self, key: KeyEvent) -> Option<(Language, GameMode)> {
         match key.code {
-            KeyCode::Char('q') => std::process::exit(0),
-            KeyCode::Up => {
+            KeyCode::Char('q') => {
+                self.should_quit = true;
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
                 match self.step {
                     MenuStep::LanguageSelection => {
-                        if self.selected_language > 0 {
-                            self.selected_language -= 1;
-                        }
+                        self.selected_language = self.selected_language.saturating_sub(1);
                     }
                     MenuStep::ModeSelection => {
-                        if self.selected_mode > 0 {
-                            self.selected_mode -= 1;
-                        }
+                        self.selected_mode = self.selected_mode.saturating_sub(1);
                     }
                 }
             }
-            KeyCode::Down => {
+            KeyCode::Down | KeyCode::Char('j') => {
                 match self.step {
                     MenuStep::LanguageSelection => {
                         if self.selected_language < 1 {
@@ -140,77 +147,89 @@ impl MenuUI {
             ])
             .split(f.area());
 
-        let title = Paragraph::new("TypeGlobe - Quiz & Typing Game")
-            .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
-            .alignment(Alignment::Center)
-            .block(Block::default().borders(Borders::ALL));
-        f.render_widget(title, chunks[0]);
+        self.render_title(f, chunks[0]);
 
         match self.step {
-            MenuStep::LanguageSelection => {
-                let languages = vec!["日本語 (Japanese)", "English"];
-                let items: Vec<ListItem> = languages
-                    .iter()
-                    .enumerate()
-                    .map(|(i, &lang)| {
-                        let style = if i == self.selected_language {
-                            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
-                        } else {
-                            Style::default()
-                        };
-                        ListItem::new(Line::from(Span::styled(lang, style)))
-                    })
-                    .collect();
-
-                let language_list = List::new(items)
-                    .block(Block::default().title("言語を選択してください / Select Language").borders(Borders::ALL))
-                    .highlight_style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD));
-
-                let mut state = ListState::default();
-                state.select(Some(self.selected_language));
-                f.render_stateful_widget(language_list, chunks[1], &mut state);
-            }
-            MenuStep::ModeSelection => {
-                let modes = vec![
-                    "クイズモード / Quiz Mode",
-                    "タイピングモード / Typing Mode", 
-                    "クイズ+タイピングモード / Quiz+Typing Mode",
-                    "タイムアタック25 / Time Attack 25",
-                    "RPGモード / RPG Mode",
-                    "ステルスモード / Stealth Mode",
-                ];
-                let items: Vec<ListItem> = modes
-                    .iter()
-                    .enumerate()
-                    .map(|(i, &mode)| {
-                        let style = if i == self.selected_mode {
-                            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
-                        } else {
-                            Style::default()
-                        };
-                        ListItem::new(Line::from(Span::styled(mode, style)))
-                    })
-                    .collect();
-
-                let mode_list = List::new(items)
-                    .block(Block::default().title("ゲームモードを選択してください / Select Game Mode").borders(Borders::ALL))
-                    .highlight_style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD));
-
-                let mut state = ListState::default();
-                state.select(Some(self.selected_mode));
-                f.render_stateful_widget(mode_list, chunks[1], &mut state);
-            }
+            MenuStep::LanguageSelection => self.render_language_selection(f, chunks[1]),
+            MenuStep::ModeSelection => self.render_mode_selection(f, chunks[1]),
         }
 
+        self.render_help(f, chunks[2]);
+    }
+
+    fn render_title(&self, f: &mut Frame, area: Rect) {
+        let title = Paragraph::new("TypeGlobe - Quiz & Typing Game")
+            .style(STYLE_TITLE)
+            .alignment(Alignment::Center)
+            .block(Block::default().borders(Borders::ALL));
+        f.render_widget(title, area);
+    }
+
+    fn render_language_selection(&self, f: &mut Frame, area: Rect) {
+        let languages = vec!["日本語 (Japanese)", "English"];
+        let items: Vec<ListItem> = languages
+            .iter()
+            .enumerate()
+            .map(|(i, &lang)| {
+                let style = if i == self.selected_language {
+                    STYLE_SELECTED
+                } else {
+                    STYLE_NORMAL
+                };
+                ListItem::new(Line::from(Span::styled(lang, style)))
+            })
+            .collect();
+
+        let language_list = List::new(items)
+            .block(Block::default().title("言語を選択してください / Select Language").borders(Borders::ALL))
+            .highlight_style(STYLE_SELECTED);
+
+        let mut state = ListState::default();
+        state.select(Some(self.selected_language));
+        f.render_stateful_widget(language_list, area, &mut state);
+    }
+
+    fn render_mode_selection(&self, f: &mut Frame, area: Rect) {
+        let modes = vec![
+            "クイズモード / Quiz Mode",
+            "タイピングモード / Typing Mode",
+            "クイズ+タイピングモード / Quiz+Typing Mode",
+            "タイムアタック25 / Time Attack 25",
+            "RPGモード / RPG Mode",
+            "ステルスモード / Stealth Mode",
+        ];
+        let items: Vec<ListItem> = modes
+            .iter()
+            .enumerate()
+            .map(|(i, &mode)| {
+                let style = if i == self.selected_mode {
+                    STYLE_SELECTED
+                } else {
+                    STYLE_NORMAL
+                };
+                ListItem::new(Line::from(Span::styled(mode, style)))
+            })
+            .collect();
+
+        let mode_list = List::new(items)
+            .block(Block::default().title("ゲームモードを選択してください / Select Game Mode").borders(Borders::ALL))
+            .highlight_style(STYLE_SELECTED);
+
+        let mut state = ListState::default();
+        state.select(Some(self.selected_mode));
+        f.render_stateful_widget(mode_list, area, &mut state);
+    }
+
+    fn render_help(&self, f: &mut Frame, area: Rect) {
         let help_text = match self.step {
-            MenuStep::LanguageSelection => "↑↓: 選択 / Select | Enter: 決定 / Confirm | q: 終了 / Quit",
-            MenuStep::ModeSelection => "↑↓: 選択 / Select | Enter: 決定 / Confirm | Esc: 戻る / Back | q: 終了 / Quit",
+            MenuStep::LanguageSelection => "↑↓/j/k: 選択 / Select | Enter: 決定 / Confirm | q: 終了 / Quit",
+            MenuStep::ModeSelection => "↑↓/j/k: 選択 / Select | Enter: 決定 / Confirm | Esc: 戻る / Back | q: 終了 / Quit",
         };
 
         let help = Paragraph::new(help_text)
-            .style(Style::default().fg(Color::Gray))
+            .style(STYLE_HELP)
             .alignment(Alignment::Center)
             .block(Block::default().borders(Borders::ALL));
-        f.render_widget(help, chunks[2]);
+        f.render_widget(help, area);
     }
 }

--- a/src/ui/quiz.rs
+++ b/src/ui/quiz.rs
@@ -5,15 +5,24 @@ use crossterm::{
 };
 use ratatui::{
     backend::CrosstermBackend,
-    layout::{Alignment, Constraint, Direction, Layout},
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Gauge},
+    widgets::{Block, Borders, Gauge, List, ListItem, ListState, Paragraph},
     Frame, Terminal,
 };
 use std::io;
 use crate::game::{QuizGame, QuizResult};
 use crate::types::{Question, Language};
+
+const STYLE_TITLE: Style = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD);
+const STYLE_SELECTED: Style = Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD);
+const STYLE_NORMAL: Style = Style::new().fg(Color::White);
+const STYLE_HELP: Style = Style::new().fg(Color::Gray);
+const STYLE_STATS: Style = Style::new().fg(Color::Cyan);
+const STYLE_CORRECT: Style = Style::new().fg(Color::Green).add_modifier(Modifier::BOLD);
+const STYLE_INCORRECT: Style = Style::new().fg(Color::Red).add_modifier(Modifier::BOLD);
+const STYLE_CONTINUE: Style = Style::new().fg(Color::Yellow);
 
 pub struct QuizUI {
     quiz_game: QuizGame,
@@ -26,7 +35,7 @@ impl QuizUI {
     pub fn new(questions: Vec<Question>, language: Language) -> Self {
         let mut quiz_game = QuizGame::new(questions, language);
         quiz_game.start();
-        
+
         Self {
             quiz_game,
             selected_choice: 0,
@@ -56,7 +65,7 @@ impl QuizUI {
             terminal.draw(|f| self.ui(f))?;
 
             if let Event::Key(key) = event::read()? {
-                if self.handle_input(key) {
+                if self.handle_key(key) {
                     break;
                 }
             }
@@ -65,17 +74,17 @@ impl QuizUI {
         Ok(self.quiz_game.get_final_score())
     }
 
-    fn handle_input(&mut self, key: KeyEvent) -> bool {
+    fn handle_key(&mut self, key: KeyEvent) -> bool {
         match key.code {
             KeyCode::Char('q') => return true,
-            
-            KeyCode::Up => {
-                if !self.show_result && self.selected_choice > 0 {
-                    self.selected_choice -= 1;
+
+            KeyCode::Up | KeyCode::Char('k') => {
+                if !self.show_result {
+                    self.selected_choice = self.selected_choice.saturating_sub(1);
                 }
             }
-            
-            KeyCode::Down => {
+
+            KeyCode::Down | KeyCode::Char('j') => {
                 if !self.show_result {
                     if let Some(question) = self.quiz_game.get_current_question() {
                         if self.selected_choice < question.choices.len() - 1 {
@@ -84,59 +93,38 @@ impl QuizUI {
                     }
                 }
             }
-            
-            KeyCode::Char('1') => {
-                if !self.show_result {
-                    self.selected_choice = 0;
-                }
-            }
-            KeyCode::Char('2') => {
-                if !self.show_result {
-                    self.selected_choice = 1;
-                }
-            }
-            KeyCode::Char('3') => {
-                if !self.show_result {
-                    self.selected_choice = 2;
-                }
-            }
-            KeyCode::Char('4') => {
-                if !self.show_result {
-                    self.selected_choice = 3;
-                }
-            }
-            
+
+            KeyCode::Char('1') if !self.show_result => self.selected_choice = 0,
+            KeyCode::Char('2') if !self.show_result => self.selected_choice = 1,
+            KeyCode::Char('3') if !self.show_result => self.selected_choice = 2,
+            KeyCode::Char('4') if !self.show_result => self.selected_choice = 3,
+
             KeyCode::Enter | KeyCode::Char(' ') => {
                 if self.show_result {
                     if self.quiz_game.is_game_finished() {
                         return true;
-                    } else {
-                        self.show_result = false;
-                        self.current_result = None;
-                        self.selected_choice = 0;
                     }
-                } else {
-                    if let Some(result) = self.quiz_game.answer_question(self.selected_choice) {
-                        self.current_result = Some(result);
-                        self.show_result = true;
-                    }
+                    self.show_result = false;
+                    self.current_result = None;
+                    self.selected_choice = 0;
+                } else if let Some(result) = self.quiz_game.answer_question(self.selected_choice) {
+                    self.current_result = Some(result);
+                    self.show_result = true;
                 }
             }
-            
+
             KeyCode::Char('s') => {
-                if !self.show_result {
-                    if self.quiz_game.skip_question() {
-                        if self.quiz_game.is_game_finished() {
-                            return true;
-                        }
-                        self.selected_choice = 0;
+                if !self.show_result && self.quiz_game.skip_question() {
+                    if self.quiz_game.is_game_finished() {
+                        return true;
                     }
+                    self.selected_choice = 0;
                 }
             }
-            
+
             _ => {}
         }
-        
+
         false
     }
 
@@ -154,41 +142,41 @@ impl QuizUI {
 
         self.render_title(f, chunks[0]);
         self.render_progress(f, chunks[1]);
-        
+
         if self.show_result {
             self.render_result(f, chunks[2]);
         } else {
             self.render_question(f, chunks[2]);
         }
-        
+
         self.render_help(f, chunks[3]);
     }
 
-    fn render_title(&self, f: &mut Frame, area: ratatui::layout::Rect) {
+    fn render_title(&self, f: &mut Frame, area: Rect) {
         let title = Paragraph::new("TypeGlobe - クイズモード")
-            .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
+            .style(STYLE_TITLE)
             .alignment(Alignment::Center)
             .block(Block::default().borders(Borders::ALL));
         f.render_widget(title, area);
     }
 
-    fn render_progress(&self, f: &mut Frame, area: ratatui::layout::Rect) {
+    fn render_progress(&self, f: &mut Frame, area: Rect) {
         let (current, total) = self.quiz_game.get_progress();
         let progress_ratio = if total > 0 { current as f64 / total as f64 } else { 0.0 };
-        
+
         let gauge = Gauge::default()
             .block(Block::default().title(format!("進捗: {}/{}", current, total)).borders(Borders::ALL))
             .gauge_style(Style::default().fg(Color::Blue))
             .ratio(progress_ratio);
-        
+
         f.render_widget(gauge, area);
     }
 
-    fn render_question(&self, f: &mut Frame, area: ratatui::layout::Rect) {
+    fn render_question(&self, f: &mut Frame, area: Rect) {
         if let Some(question) = self.quiz_game.get_current_question() {
             let question_text = self.quiz_game.get_question_text(question);
             let choices = self.quiz_game.get_choice_texts(question);
-            
+
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .constraints([
@@ -198,7 +186,7 @@ impl QuizUI {
                 .split(area);
 
             let question_paragraph = Paragraph::new(question_text)
-                .style(Style::default().fg(Color::White))
+                .style(STYLE_NORMAL)
                 .alignment(Alignment::Left)
                 .block(Block::default().title("問題").borders(Borders::ALL))
                 .wrap(ratatui::widgets::Wrap { trim: true });
@@ -210,9 +198,9 @@ impl QuizUI {
                 .map(|(i, choice)| {
                     let text = format!("{}. {}", i + 1, choice);
                     let style = if i == self.selected_choice {
-                        Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+                        STYLE_SELECTED
                     } else {
-                        Style::default().fg(Color::White)
+                        STYLE_NORMAL
                     };
                     ListItem::new(Line::from(Span::styled(text, style)))
                 })
@@ -220,7 +208,7 @@ impl QuizUI {
 
             let choices_list = List::new(choice_items)
                 .block(Block::default().title("選択肢").borders(Borders::ALL))
-                .highlight_style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD));
+                .highlight_style(STYLE_SELECTED);
 
             let mut state = ListState::default();
             state.select(Some(self.selected_choice));
@@ -234,68 +222,72 @@ impl QuizUI {
         }
     }
 
-    fn render_result(&self, f: &mut Frame, area: ratatui::layout::Rect) {
-        if let (Some(result), Some(question)) = (&self.current_result, self.quiz_game.get_current_question()) {
-            let choices = self.quiz_game.get_choice_texts(question);
-            
-            let result_text = if result.is_correct {
-                "正解！".to_string()
-            } else {
-                format!("不正解。正解は: {}", choices.get(result.correct_answer_index).unwrap_or(&"不明".to_string()))
-            };
-            
-            let result_color = if result.is_correct { Color::Green } else { Color::Red };
-            
-            let chunks = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([
-                    Constraint::Length(3),
-                    Constraint::Length(3),
-                    Constraint::Min(2),
-                ])
-                .split(area);
+    fn render_result(&self, f: &mut Frame, area: Rect) {
+        let (Some(result), Some(question)) = (&self.current_result, self.quiz_game.get_current_question()) else {
+            return;
+        };
 
-            let result_paragraph = Paragraph::new(result_text)
-                .style(Style::default().fg(result_color).add_modifier(Modifier::BOLD))
-                .alignment(Alignment::Center)
-                .block(Block::default().title("結果").borders(Borders::ALL));
-            f.render_widget(result_paragraph, chunks[0]);
+        let choices = self.quiz_game.get_choice_texts(question);
 
-            let stats_text = format!(
-                "現在のスコア: {} | 正答率: {:.1}%",
-                self.quiz_game.get_final_score(),
-                self.quiz_game.get_accuracy() * 100.0
-            );
-            
-            let stats_paragraph = Paragraph::new(stats_text)
-                .style(Style::default().fg(Color::Cyan))
-                .alignment(Alignment::Center)
-                .block(Block::default().title("統計").borders(Borders::ALL));
-            f.render_widget(stats_paragraph, chunks[1]);
+        let (result_text, result_style) = if result.is_correct {
+            ("正解！".to_string(), STYLE_CORRECT)
+        } else {
+            let correct_text = choices
+                .get(result.correct_answer_index)
+                .cloned()
+                .unwrap_or_else(|| "不明".to_string());
+            (format!("不正解。正解は: {}", correct_text), STYLE_INCORRECT)
+        };
 
-            let continue_text = if self.quiz_game.is_game_finished() {
-                "Enterキーでゲーム終了"
-            } else {
-                "Enterキーで次の問題へ"
-            };
-            
-            let continue_paragraph = Paragraph::new(continue_text)
-                .style(Style::default().fg(Color::Yellow))
-                .alignment(Alignment::Center)
-                .block(Block::default().borders(Borders::ALL));
-            f.render_widget(continue_paragraph, chunks[2]);
-        }
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(3),
+                Constraint::Length(3),
+                Constraint::Min(2),
+            ])
+            .split(area);
+
+        let result_paragraph = Paragraph::new(result_text)
+            .style(result_style)
+            .alignment(Alignment::Center)
+            .block(Block::default().title("結果").borders(Borders::ALL));
+        f.render_widget(result_paragraph, chunks[0]);
+
+        let stats_text = format!(
+            "現在のスコア: {} | 正答率: {:.1}%",
+            self.quiz_game.get_final_score(),
+            self.quiz_game.get_accuracy() * 100.0
+        );
+
+        let stats_paragraph = Paragraph::new(stats_text)
+            .style(STYLE_STATS)
+            .alignment(Alignment::Center)
+            .block(Block::default().title("統計").borders(Borders::ALL));
+        f.render_widget(stats_paragraph, chunks[1]);
+
+        let continue_text = if self.quiz_game.is_game_finished() {
+            "Enterキーでゲーム終了"
+        } else {
+            "Enterキーで次の問題へ"
+        };
+
+        let continue_paragraph = Paragraph::new(continue_text)
+            .style(STYLE_CONTINUE)
+            .alignment(Alignment::Center)
+            .block(Block::default().borders(Borders::ALL));
+        f.render_widget(continue_paragraph, chunks[2]);
     }
 
-    fn render_help(&self, f: &mut Frame, area: ratatui::layout::Rect) {
+    fn render_help(&self, f: &mut Frame, area: Rect) {
         let help_text = if self.show_result {
             "Enter: 次へ | q: 終了"
         } else {
-            "↑↓: 選択 | 1-4: 直接選択 | Enter/Space: 決定 | s: スキップ | q: 終了"
+            "↑↓/j/k: 選択 | 1-4: 直接選択 | Enter/Space: 決定 | s: スキップ | q: 終了"
         };
 
         let help = Paragraph::new(help_text)
-            .style(Style::default().fg(Color::Gray))
+            .style(STYLE_HELP)
             .alignment(Alignment::Center)
             .block(Block::default().borders(Borders::ALL));
         f.render_widget(help, area);

--- a/src/ui/typing.rs
+++ b/src/ui/typing.rs
@@ -5,14 +5,22 @@ use crossterm::{
 };
 use ratatui::{
     backend::CrosstermBackend,
-    layout::{Alignment, Constraint, Direction, Layout},
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Paragraph, Gauge},
+    widgets::{Block, Borders, Gauge, Paragraph},
     Frame, Terminal,
 };
 use std::io;
 use crate::game::{TypingGame, TypingResult, CharacterStatus};
+
+const STYLE_TITLE: Style = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD);
+const STYLE_HELP: Style = Style::new().fg(Color::Gray);
+const STYLE_STATS: Style = Style::new().fg(Color::Cyan);
+const STYLE_CHAR_CORRECT: Style = Style::new().fg(Color::Green);
+const STYLE_CHAR_INCORRECT: Style = Style::new().fg(Color::Red).add_modifier(Modifier::UNDERLINED);
+const STYLE_CHAR_CURRENT: Style = Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD);
+const STYLE_CHAR_UNTYPED: Style = Style::new().fg(Color::Gray);
 
 pub struct TypingUI {
     typing_game: TypingGame,
@@ -50,7 +58,7 @@ impl TypingUI {
             terminal.draw(|f| self.ui(f))?;
 
             if let Event::Key(key) = event::read()? {
-                if self.handle_input(key) {
+                if self.handle_key(key) {
                     break;
                 }
             }
@@ -66,40 +74,30 @@ impl TypingUI {
         }))
     }
 
-    fn handle_input(&mut self, key: KeyEvent) -> bool {
+    fn handle_key(&mut self, key: KeyEvent) -> bool {
         if self.finished {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Enter | KeyCode::Esc => return true,
-                _ => {}
-            }
-            return false;
+            return matches!(key.code, KeyCode::Char('q') | KeyCode::Enter | KeyCode::Esc);
         }
 
         match key.code {
-            KeyCode::Char('q') => {
-                if key.modifiers.contains(KeyModifiers::CONTROL) {
-                    return true;
-                }
-            }
+            KeyCode::Char('q') if key.modifiers.contains(KeyModifiers::CONTROL) => return true,
             KeyCode::Esc => return true,
-            
+
             KeyCode::Char(ch) => {
                 self.typing_game.type_character(ch);
                 if self.typing_game.is_finished() {
-                    if let Some(result) = self.typing_game.get_result() {
-                        self.final_result = Some(result);
-                        self.finished = true;
-                    }
+                    self.final_result = self.typing_game.get_result();
+                    self.finished = true;
                 }
             }
-            
+
             KeyCode::Backspace => {
                 self.typing_game.backspace();
             }
-            
+
             _ => {}
         }
-        
+
         false
     }
 
@@ -123,77 +121,72 @@ impl TypingUI {
         self.render_help(f, chunks[4]);
     }
 
-    fn render_title(&self, f: &mut Frame, area: ratatui::layout::Rect) {
+    fn render_title(&self, f: &mut Frame, area: Rect) {
         let title = if self.finished {
             "TypeGlobe - タイピング完了！"
         } else {
             "TypeGlobe - タイピングモード"
         };
-        
+
         let title_widget = Paragraph::new(title)
-            .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
+            .style(STYLE_TITLE)
             .alignment(Alignment::Center)
             .block(Block::default().borders(Borders::ALL));
         f.render_widget(title_widget, area);
     }
 
-    fn render_progress(&self, f: &mut Frame, area: ratatui::layout::Rect) {
+    fn render_progress(&self, f: &mut Frame, area: Rect) {
         let progress = self.typing_game.get_progress();
-        
+
         let gauge = Gauge::default()
             .block(Block::default().title("進捗").borders(Borders::ALL))
             .gauge_style(Style::default().fg(Color::Blue))
             .ratio(progress as f64);
-        
+
         f.render_widget(gauge, area);
     }
 
-    fn render_text(&self, f: &mut Frame, area: ratatui::layout::Rect) {
-        let target_text = self.typing_game.get_target_text();
-        let typed_text = self.typing_game.get_typed_text();
+    fn render_text(&self, f: &mut Frame, area: Rect) {
         let character_status = self.typing_game.get_character_status();
-        
-        let mut spans = Vec::new();
-        
-        for (i, (ch, status)) in target_text.chars().zip(character_status.iter()).enumerate() {
-            let style = match status {
-                CharacterStatus::Correct => Style::default().fg(Color::Green),
-                CharacterStatus::Incorrect => Style::default().fg(Color::Red).add_modifier(Modifier::UNDERLINED),
-                CharacterStatus::Current => Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
-                CharacterStatus::Untyped => Style::default().fg(Color::Gray),
-            };
-            
-            spans.push(Span::styled(ch.to_string(), style));
-        }
-        
+        let target_text = self.typing_game.get_target_text();
+
+        let spans: Vec<Span> = target_text
+            .chars()
+            .zip(character_status.iter())
+            .map(|(ch, status)| {
+                let style = match status {
+                    CharacterStatus::Correct => STYLE_CHAR_CORRECT,
+                    CharacterStatus::Incorrect => STYLE_CHAR_INCORRECT,
+                    CharacterStatus::Current => STYLE_CHAR_CURRENT,
+                    CharacterStatus::Untyped => STYLE_CHAR_UNTYPED,
+                };
+                Span::styled(ch.to_string(), style)
+            })
+            .collect();
+
         let text_paragraph = Paragraph::new(Line::from(spans))
-            .style(Style::default())
             .alignment(Alignment::Left)
             .block(Block::default().title("テキスト").borders(Borders::ALL))
             .wrap(ratatui::widgets::Wrap { trim: false });
-        
+
         f.render_widget(text_paragraph, area);
     }
 
-    fn render_stats(&self, f: &mut Frame, area: ratatui::layout::Rect) {
-        let stats_text = if self.finished {
-            if let Some(result) = &self.final_result {
-                format!(
-                    "WPM: {:.1} | 正確性: {:.1}% | 時間: {:.1}s | エラー: {}",
-                    result.wpm,
-                    result.accuracy,
-                    result.total_time.as_secs_f32(),
-                    result.errors
-                )
-            } else {
-                "結果を取得中...".to_string()
-            }
+    fn render_stats(&self, f: &mut Frame, area: Rect) {
+        let stats_text = if let Some(result) = &self.final_result {
+            format!(
+                "WPM: {:.1} | 正確性: {:.1}% | 時間: {:.1}s | エラー: {}",
+                result.wpm,
+                result.accuracy,
+                result.total_time.as_secs_f32(),
+                result.errors
+            )
         } else {
             let current_wpm = self.typing_game.calculate_wpm();
             let current_accuracy = self.typing_game.calculate_accuracy();
             let position = self.typing_game.get_current_position();
             let total = self.typing_game.get_target_text().len();
-            
+
             format!(
                 "WPM: {:.1} | 正確性: {:.1}% | 進捗: {}/{}",
                 current_wpm,
@@ -202,15 +195,15 @@ impl TypingUI {
                 total
             )
         };
-        
+
         let stats_paragraph = Paragraph::new(stats_text)
-            .style(Style::default().fg(Color::Cyan))
+            .style(STYLE_STATS)
             .alignment(Alignment::Center)
             .block(Block::default().title("統計").borders(Borders::ALL));
         f.render_widget(stats_paragraph, area);
     }
 
-    fn render_help(&self, f: &mut Frame, area: ratatui::layout::Rect) {
+    fn render_help(&self, f: &mut Frame, area: Rect) {
         let help_text = if self.finished {
             "Enter/q: 終了"
         } else {
@@ -218,7 +211,7 @@ impl TypingUI {
         };
 
         let help = Paragraph::new(help_text)
-            .style(Style::default().fg(Color::Gray))
+            .style(STYLE_HELP)
             .alignment(Alignment::Center)
             .block(Block::default().borders(Borders::ALL));
         f.render_widget(help, area);


### PR DESCRIPTION
## 関連 Issue
closes #2

## 変更内容
- `handle_input` → `handle_key` にメソッド名統一
- 描画処理を `render_xxx` メソッドに分割（menu.rs: 4メソッド、quiz.rs, typing.rs も同様）
- スタイル定数化（各UIファイルに `const STYLE_*` 定義）
- `std::process::exit(0)` → `should_quit` フラグに置き換え
- `.unwrap()` → `.unwrap_or_default()` 等の安全化
- j/k vim キーバインド追加（gitpp パターン）
- `saturating_sub` パターン統一

機能追加・表示変更なし。リファクタリングのみ。