### PR TITLE
fix(quiz): tick the UI loop so Time advances (#54)

### DIFF
--- a/src/ui/quiz.rs
+++ b/src/ui/quiz.rs
@@ -67,14 +67,22 @@ impl QuizUI {
         &mut self,
         terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     ) -> Result<u32, Box<dyn std::error::Error>> {
+        // Poll cadence: small enough that the side-pane Time advances within
+        // a noticeable fraction of a second (#54), large enough not to spin.
+        const TICK: Duration = Duration::from_millis(250);
+
         loop {
             terminal.draw(|f| self.ui(f))?;
 
-            if let Event::Key(key) = event::read()? {
-                if self.handle_key(key) {
-                    break;
+            if event::poll(TICK)? {
+                if let Event::Key(key) = event::read()? {
+                    if self.handle_key(key) {
+                        break;
+                    }
                 }
             }
+            // No event in this tick — loop redraws so Time / CPM / WPM keep
+            // moving even while the player is thinking.
         }
 
         Ok(self.quiz_game.get_final_score())


### PR DESCRIPTION
## Related Issue
- closes #54

## Summary
- replace the blocking `event::read()` with `event::poll(250ms)` + `event::read()` in `QuizUI::run_app` so the loop redraws even when the player is thinking
- the status pane's Time / CPM / WPM fields now advance sub-second instead of freezing between keystrokes
- 250 ms cadence is small enough to be visually responsive, large enough not to spin the CPU

## Verification
- `cargo build`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` — 25 passed