### PR TITLE
fix(data): clean prefix conflicts + add CI linter (#58, #60)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,4 +57,14 @@ jobs:
         with:
           components: clippy
       - name: Run clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
+
+  lint-data:
+    name: Lint question data (#60)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run question-data linter
+        run: cargo run --bin lint-questions -- data/questions_ja.json data/questions_en.json

--- a/data/questions_ja.json
+++ b/data/questions_ja.json
@@ -36,10 +36,6 @@
     },
     "choices": [
       {
-        "ja": "let",
-        "en": "let"
-      },
-      {
         "ja": "let mut",
         "en": "let mut"
       },
@@ -48,11 +44,15 @@
         "en": "var"
       },
       {
+        "ja": "const",
+        "en": "const"
+      },
+      {
         "ja": "mut",
         "en": "mut"
       }
     ],
-    "correct_answer_index": 1,
+    "correct_answer_index": 0,
     "image_path": null
   },
   {
@@ -848,8 +848,8 @@
     },
     "choices": [
       {
-        "ja": "Java",
-        "en": "Java"
+        "ja": "Java SE",
+        "en": "Java SE"
       },
       {
         "ja": "JavaScript",
@@ -1500,8 +1500,8 @@
         "en": "Light"
       },
       {
-        "ja": "エル",
-        "en": "L"
+        "ja": "エル（Lawliet）",
+        "en": "L (Lawliet)"
       },
       {
         "ja": "ミサ",
@@ -2635,25 +2635,25 @@
     "id": "q00095",
     "genre": "science",
     "question_text": {
-      "ja": "さんそのげんそきごうは?",
-      "en": "What is the chemical symbol for oxygen?"
+      "ja": "げんそきごう「O」がしめすげんそは?",
+      "en": "Which element does the chemical symbol 'O' represent?"
     },
     "choices": [
       {
-        "ja": "O",
-        "en": "O"
+        "ja": "酸素",
+        "en": "Oxygen"
       },
       {
-        "ja": "Ox",
-        "en": "Ox"
+        "ja": "オスミウム",
+        "en": "Osmium"
       },
       {
-        "ja": "Og",
-        "en": "Og"
+        "ja": "オガネソン",
+        "en": "Oganesson"
       },
       {
-        "ja": "Om",
-        "en": "Om"
+        "ja": "鉄",
+        "en": "Iron"
       }
     ],
     "correct_answer_index": 0,

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -164,7 +164,7 @@ Quiz-side runs are not bound by this layout — quiz questions may freely mix ki
   kind: sentence
 ```
 
-Validation: no two choices in a question may share a prefix that would make a typed answer ambiguous before `Enter`. (Enforced by a build-time linter.)
+Validation: no two choices in a question may share a prefix that would make a typed answer ambiguous before `Enter`. Enforced by `cargo run --bin lint-questions -- <files>` (CI job `lint-data`) and by the unit tests `shipped_question_data_is_clean_{ja,en}` in `src/io/validator.rs`.
 
 ### Listening prompt (`data/listening_<lang>.yaml`)
 

--- a/src/bin/lint-questions.rs
+++ b/src/bin/lint-questions.rs
@@ -1,0 +1,68 @@
+//! Build-time linter for bundled question data.
+//!
+//! Loads each JSON path passed on the command line, runs the prefix-conflict
+//! validator (`io::validator::find_prefix_conflicts`), prints every conflict
+//! to stderr, and exits with code 1 if any were found. CI runs this on the
+//! shipped `data/questions_*.json` so that a regression in the data fails
+//! the build, not just a runtime warning. (#60, spec.md "build-time linter")
+//!
+//! The library tests already enforce the same invariant
+//! (`shipped_question_data_is_clean_*`); this binary covers ad-hoc data
+//! files that are not part of the test fixture, e.g. a contributor's
+//! work-in-progress JSON.
+
+#[path = "../types.rs"]
+#[allow(dead_code)]
+mod types;
+
+#[path = "../io/validator.rs"]
+mod validator;
+
+use std::process::ExitCode;
+use types::Question;
+use validator::{find_prefix_conflicts, format_conflict};
+
+fn main() -> ExitCode {
+    let paths: Vec<String> = std::env::args().skip(1).collect();
+    if paths.is_empty() {
+        eprintln!("usage: lint-questions <path-to-questions.json> [more.json ...]");
+        return ExitCode::from(2);
+    }
+
+    let mut total_conflicts = 0usize;
+    let mut load_errors = 0usize;
+
+    for path in &paths {
+        match load(path) {
+            Ok(questions) => {
+                let conflicts = find_prefix_conflicts(&questions);
+                for c in &conflicts {
+                    eprintln!("{}: {}", path, format_conflict(c));
+                }
+                total_conflicts += conflicts.len();
+            }
+            Err(e) => {
+                eprintln!("{}: load error: {}", path, e);
+                load_errors += 1;
+            }
+        }
+    }
+
+    if total_conflicts > 0 || load_errors > 0 {
+        eprintln!(
+            "lint-questions: {} conflict(s), {} load error(s) across {} file(s)",
+            total_conflicts,
+            load_errors,
+            paths.len()
+        );
+        ExitCode::from(1)
+    } else {
+        ExitCode::SUCCESS
+    }
+}
+
+fn load(path: &str) -> Result<Vec<Question>, Box<dyn std::error::Error>> {
+    let text = std::fs::read_to_string(path)?;
+    let questions: Vec<Question> = serde_json::from_str(&text)?;
+    Ok(questions)
+}

--- a/src/io/validator.rs
+++ b/src/io/validator.rs
@@ -285,22 +285,22 @@ mod tests {
         assert_eq!(conflicts[0].language, "en");
     }
 
-    // TODO(#27, #58): ignored until #58 cleans up the bundled data — the
-    // validator already reports the real conflicts (let / let mut,
-    // Java / JavaScript, etc.). Run with `cargo test -- --ignored` once
-    // the data is fixed.
-    #[test]
-    #[ignore]
-    fn shipped_question_data_is_clean_ja() {
-        let path = "data/questions_ja.json";
+    // Bundled data must stay free of prefix conflicts; the build-time
+    // linter (#60) re-enforces this in CI on the same data files. Reads
+    // the JSON directly with serde_json so the assertion logic compiles
+    // unchanged when this module is `#[path]`-included into the
+    // `lint-questions` binary, where `crate::io::DataLoader` is absent.
+    fn assert_data_clean(path: &str) {
         if !std::path::Path::new(path).exists() {
             return;
         }
-        let questions = crate::io::DataLoader::load_questions(path).expect("load ja");
+        let text = std::fs::read_to_string(path).expect("read questions json");
+        let questions: Vec<Question> = serde_json::from_str(&text).expect("parse questions json");
         let conflicts = find_prefix_conflicts(&questions);
         assert!(
             conflicts.is_empty(),
-            "shipped ja data has prefix conflicts:\n{}",
+            "shipped data ({}) has prefix conflicts:\n{}",
+            path,
             conflicts
                 .iter()
                 .map(format_conflict)
@@ -310,22 +310,12 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
+    fn shipped_question_data_is_clean_ja() {
+        assert_data_clean("data/questions_ja.json");
+    }
+
+    #[test]
     fn shipped_question_data_is_clean_en() {
-        let path = "data/questions_en.json";
-        if !std::path::Path::new(path).exists() {
-            return;
-        }
-        let questions = crate::io::DataLoader::load_questions(path).expect("load en");
-        let conflicts = find_prefix_conflicts(&questions);
-        assert!(
-            conflicts.is_empty(),
-            "shipped en data has prefix conflicts:\n{}",
-            conflicts
-                .iter()
-                .map(format_conflict)
-                .collect::<Vec<_>>()
-                .join("\n")
-        );
+        assert_data_clean("data/questions_en.json");
     }
 }


### PR DESCRIPTION
## Summary

- **#58**: Fixes the six prefix conflicts the runtime validator (#59) was warning about in the bundled data — `let` / `let mut`, `Java` / `JavaScript`, `L` / `Light`, and `O` / `Ox` / `Og` / `Om`.
- **#60**: Adds `src/bin/lint-questions.rs`, a non-zero-on-conflict CLI; a new CI job `lint-data` runs it on `data/questions_*.json` so a regression in shipped data fails the build (not just stderr noise).

## Notes

- The two `shipped_question_data_is_clean_{ja,en}` tests are promoted from `#[ignore]` to regular tests (36 → 38 passing).
- They no longer go through `crate::io::DataLoader`; they read the JSON via `serde_json` so the same module compiles cleanly when `#[path]`-included into `lint-questions`.
- `clippy` job widens to `--all-targets` to cover the new bin and tests.
- `docs/spec.md` linter sentence updated to point at the actual enforcement paths.

## Data changes

| Question | Before | After |
| --- | --- | --- |
| q00002 (Rust mutable) | choices include `let` and `let mut` | `let mut` (correct), `var`, `const`, `mut` |
| q00031 (J in JSON) | `Java`, `JavaScript`, … | `Java SE`, `JavaScript`, … |
| q00054 (Death Note shinigami) | … `L` / `エル` … | … `L (Lawliet)` / `エル（Lawliet）` … |
| q00095 (oxygen) | "Symbol for oxygen?" → `O / Ox / Og / Om` | "Which element does symbol 'O' represent?" → `Oxygen / Osmium / Oganesson / Iron` |

## Test plan

- [x] `cargo test` (38 / 0 / 0)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo run --bin lint-questions -- data/questions_ja.json data/questions_en.json` → exit 0
- [x] Same binary against an intentionally broken JSON → exit 1, prints conflict
- [x] No-args invocation → exit 2 with usage line
- [ ] CI green (test / fmt / clippy / lint-data)

Closes #58, closes #60.