### PR TITLE
feat(listening): foundation epic — TTS + data + practice UI (#28-#31)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+      - name: Install speech-dispatcher headers (tts crate, #28)
+        run: sudo apt-get update && sudo apt-get install -y libspeechd-dev
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
@@ -56,6 +58,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - name: Install speech-dispatcher headers (tts crate, #28)
+        run: sudo apt-get update && sudo apt-get install -y libspeechd-dev
       - name: Run clippy
         run: cargo clippy --all-targets -- -D warnings
 
@@ -66,5 +70,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+      - name: Install speech-dispatcher headers (tts crate, #28)
+        run: sudo apt-get update && sudo apt-get install -y libspeechd-dev
       - name: Run question-data linter
         run: cargo run --bin lint-questions -- data/questions_ja.json data/questions_en.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,10 +54,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.9.1",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
@@ -78,10 +125,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "cocoa-foundation"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6234cbb2e4c785b456c0644748b1ac416dd045799740356f8363dfe00c93f7"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "core-foundation",
+ "core-graphics-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "compact_str"
@@ -98,12 +205,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "libc",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -158,6 +292,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clonable"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a36efbb9bfd58e1723780aa04b61aba95ace6a05d9ffabfdb0b43672552f0805"
+dependencies = [
+ "dyn-clonable-impl",
+ "dyn-clone",
+]
+
+[[package]]
+name = "dyn-clonable-impl"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8671d54058979a37a26f3511fbf8d198ba1aa35ffb202c42587d918d77213a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +341,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +357,30 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -207,6 +398,12 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
@@ -256,7 +453,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "cfg-if",
  "libc",
 ]
@@ -277,10 +474,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -314,10 +583,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -341,12 +625,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+ "objc_exception",
+]
+
+[[package]]
+name = "objc_exception"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oxilangtag"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f3f87617a86af77fa3691e6350483e7154c2ead9f1261b75130e21ca0f8acb"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -391,6 +725,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -447,7 +791,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -468,8 +812,37 @@ version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustc-demangle"
@@ -478,12 +851,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -501,6 +880,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -539,6 +927,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
@@ -593,6 +987,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "speech-dispatcher"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5727d53c474ba5ada07784ad7d203cf896a74854cfee0eb32376b00759eb2972"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "speech-dispatcher-sys",
+]
+
+[[package]]
+name = "speech-dispatcher-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c3e8acdf2b1f4bb13f1813b40b52f3edf4cc94d8a55fe713a584f672a10388d"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +1052,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tokio"
 version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,6 +1103,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "tts"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0727c46b3181e4f84e79f970e6a78d3b4054b72b6072e969ea4f07dfa4983ae2"
+dependencies = [
+ "cocoa-foundation",
+ "core-foundation",
+ "dyn-clonable",
+ "jni",
+ "lazy_static",
+ "libc",
+ "log",
+ "ndk-context",
+ "objc",
+ "oxilangtag",
+ "speech-dispatcher",
+ "thiserror",
+ "wasm-bindgen",
+ "web-sys",
+ "windows",
+]
+
+[[package]]
 name = "type-globe"
 version = "0.1.2"
 dependencies = [
@@ -679,6 +1136,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tts",
  "unicode-segmentation",
 ]
 
@@ -718,10 +1176,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -740,10 +1263,98 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
 
 [[package]]
 name = "windows-sys"
@@ -770,6 +1381,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -806,6 +1432,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -818,6 +1450,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -827,6 +1465,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -854,6 +1498,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -863,6 +1513,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -878,6 +1534,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -887,6 +1549,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 rand = "0.8"
 unicode-segmentation = "1.11"
+tts = "0.26"
 
 [dev-dependencies]
 cargo-husky = { version = "1", default-features = false, features = ["user-hooks"] }

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Both **CPM** (characters per minute) and **WPM** (words per minute) are displaye
 
 Listening prompts are synthesized at runtime via the [`tts`](https://crates.io/crates/tts) crate, which wraps the OS-native TTS engine (speech-dispatcher on Linux, AVSpeechSynthesizer on macOS, SAPI on Windows). No audio files ship with the binary. Replay is **unlimited and unpenalized** — the only cost is the time it consumes.
 
+On Linux, the `speech-dispatcher` daemon must be installed and running. If it is not, type-globe shows a clear "Listening mode is unavailable on this system" message and returns to the menu rather than crashing the binary; Quiz / Records / Time Attack 25 still work without TTS.
+
 ## Key Bindings
 
 **Quiz**
@@ -89,9 +91,10 @@ Quiz answers are typed directly — there is no arrow / number-key fallback. The
 |---|---|
 | Letters | Type what you heard |
 | `Enter` | Confirm |
-| `Space` | Replay sound (unlimited) |
-| `F5` | New run |
-| `Esc` | Return to town |
+| `Space` | Replay sound (unlimited, no penalty) |
+| `Esc` | Return to menu |
+
+The v0.2.0 build ships the **listening foundation**: TTS, the prompt data structure, and a single-prompt practice flow (word-kind prompts only, since `Space` is reserved for replay). The full ten-prompt RPG run with HP / EXP / boss placement is the next epic (#32–#37).
 
 ## Install
 
@@ -113,8 +116,8 @@ cargo build --release
 ## Requirements
 
 - A terminal with Unicode and ANSI escape support
-- An OS TTS backend (most modern macOS / Windows / Linux distros work out of the box)
-- Rust 1.70+ to build from source
+- An OS TTS backend for Listening mode (macOS / Windows work out of the box; on Linux, install and start `speech-dispatcher`)
+- Rust 1.78+ to build from source (Linux build also needs `libspeechd-dev`)
 
 ## License
 

--- a/data/listening_en.json
+++ b/data/listening_en.json
@@ -1,0 +1,21 @@
+[
+  { "id": "l-en-001", "text": "apple",     "kind": "word" },
+  { "id": "l-en-002", "text": "river",     "kind": "word" },
+  { "id": "l-en-003", "text": "Tokyo",     "kind": "word" },
+  { "id": "l-en-004", "text": "blue",      "kind": "word" },
+  { "id": "l-en-005", "text": "music",     "kind": "word" },
+  { "id": "l-en-006", "text": "kitten",    "kind": "word" },
+  { "id": "l-en-007", "text": "rocket",    "kind": "word" },
+  { "id": "l-en-008", "text": "winter",    "kind": "word" },
+  { "id": "l-en-009", "text": "thunder",   "kind": "word" },
+  { "id": "l-en-010", "text": "horizon",   "kind": "word" },
+  { "id": "l-en-051", "text": "George Washington",            "kind": "phrase" },
+  { "id": "l-en-052", "text": "open source software",          "kind": "phrase" },
+  { "id": "l-en-053", "text": "machine learning",              "kind": "phrase" },
+  { "id": "l-en-054", "text": "Pacific Ocean",                 "kind": "phrase" },
+  { "id": "l-en-055", "text": "sunrise on the lake",           "kind": "phrase" },
+  { "id": "l-en-101", "text": "the quick brown fox jumps over the lazy dog",     "kind": "sentence" },
+  { "id": "l-en-102", "text": "the early bird catches the worm",                  "kind": "sentence" },
+  { "id": "l-en-103", "text": "knowledge is power and curiosity is its engine",    "kind": "sentence" },
+  { "id": "l-en-104", "text": "a journey of a thousand miles begins with a single step", "kind": "sentence" }
+]

--- a/data/listening_ja.json
+++ b/data/listening_ja.json
@@ -1,0 +1,21 @@
+[
+  { "id": "l-ja-001", "text": "りんご",       "kind": "word" },
+  { "id": "l-ja-002", "text": "かわ",         "kind": "word" },
+  { "id": "l-ja-003", "text": "とうきょう",   "kind": "word" },
+  { "id": "l-ja-004", "text": "あお",         "kind": "word" },
+  { "id": "l-ja-005", "text": "おんがく",     "kind": "word" },
+  { "id": "l-ja-006", "text": "こねこ",       "kind": "word" },
+  { "id": "l-ja-007", "text": "ろけっと",     "kind": "word" },
+  { "id": "l-ja-008", "text": "ふゆ",         "kind": "word" },
+  { "id": "l-ja-009", "text": "かみなり",     "kind": "word" },
+  { "id": "l-ja-010", "text": "ちへいせん",   "kind": "word" },
+  { "id": "l-ja-051", "text": "とうきょう えき",         "kind": "phrase" },
+  { "id": "l-ja-052", "text": "おーぷん そーす",           "kind": "phrase" },
+  { "id": "l-ja-053", "text": "きかい がくしゅう",         "kind": "phrase" },
+  { "id": "l-ja-054", "text": "たいへいよう",              "kind": "phrase" },
+  { "id": "l-ja-055", "text": "みずうみ の あさひ",        "kind": "phrase" },
+  { "id": "l-ja-101", "text": "いろは にほへと ちりぬるを",                          "kind": "sentence" },
+  { "id": "l-ja-102", "text": "はやおきは さんもんの とく",                          "kind": "sentence" },
+  { "id": "l-ja-103", "text": "ちしきは ちからなり こうきしんは その えんじん なり", "kind": "sentence" },
+  { "id": "l-ja-104", "text": "せんりの みちも いっぽから はじまる",                  "kind": "sentence" }
+]

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -187,7 +187,20 @@ Validation: no two choices in a question may share a prefix that would make a ty
   kind: sentence
 ```
 
-The TTS layer turns `text` into audio at runtime via the `tts` crate; no audio files are shipped.
+The TTS layer turns `text` into audio at runtime via the `tts` crate (#28); no audio files are shipped. The current `main` ships `data/listening_<lang>.json` (JSON during the JSON-era of v0.2.0); the YAML migration renames `.json` → `.yaml` 1:1 with no schema change.
+
+#### Linux runtime requirement
+
+The `tts` crate's Linux backend is `speech-dispatcher`, which must be installed and running before listening mode can speak. Build-time, `libspeechd-dev` must be installed (CI installs it in the test / clippy / lint-data jobs). When the daemon isn't available at runtime, the listening UI shows a "Listening mode is unavailable on this system" message and returns to the menu rather than crashing — Quiz / Records / Time Attack 25 stay reachable.
+
+#### v0.2.0 foundation scope (#28-#31)
+
+The foundation epic ships:
+- `tts` crate integration (`src/audio/tts.rs`),
+- the listening prompt schema and bilingual data (`data/listening_<lang>.json`),
+- a single-prompt practice flow under the **Listening RPG** menu entry that exercises the blind-input judge end-to-end.
+
+The ten-prompt run loop with HP / EXP and the fixed boss placement (1-7 word, 8-9 phrase, 10 sentence) is the next epic (#32-#37). Until then, the practice mode filters the pool to `word`-kind prompts because `Space` is reserved for replay (per the key bindings above) and a phrase / sentence answer cannot be typed without rebinding the input model — that rebinding is part of #32-#37.
 
 ### Player progress (`player.yaml`)
 

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -1,0 +1,6 @@
+//! Audio output. Currently only TTS (#28); future modules (sfx, music)
+//! would live alongside `tts.rs` here.
+
+pub mod tts;
+
+pub use tts::TtsEngine;

--- a/src/audio/tts.rs
+++ b/src/audio/tts.rs
@@ -1,0 +1,89 @@
+//! Thin wrapper around the `tts` crate (#28).
+//!
+//! The crate supports macOS (AVFoundation), Linux (Speech Dispatcher),
+//! Windows (WinRT), and a few others. The wrapper's job is:
+//!
+//! 1. Build a single engine for the run via [`TtsEngine::new`].
+//! 2. Pick a voice that matches the current `Language` so JA prompts are
+//!    read with a Japanese voice and EN prompts with an English voice
+//!    even when both are installed on the system.
+//! 3. Expose `speak` / `stop` / `is_speaking` in terms type-globe needs;
+//!    every call interrupts whatever is currently speaking, so
+//!    `Space`-replay (#30) just calls `speak` again.
+//!
+//! Initialisation may legitimately fail on systems without a TTS daemon
+//! running (most often a Linux box without `speech-dispatcher`); the
+//! caller surfaces that to the player as "audio unavailable, listening
+//! mode disabled" rather than crashing the whole binary.
+
+use crate::types::Language;
+use tts::{Tts, Voice};
+
+/// Run-scoped TTS handle. Kept on the main thread (the underlying `Tts`
+/// wraps an `Rc` and is therefore `!Send`).
+pub struct TtsEngine {
+    inner: Tts,
+}
+
+impl TtsEngine {
+    /// Build the platform default backend. Fails when no backend can be
+    /// initialised (e.g. Linux without speech-dispatcher running).
+    pub fn new() -> Result<Self, Box<dyn std::error::Error>> {
+        let inner = Tts::default()?;
+        Ok(Self { inner })
+    }
+
+    /// Speak `text` using a voice that matches `lang`. If no matching
+    /// voice is installed the system default voice is used — better to
+    /// hear the prompt in the wrong accent than to fall silent.
+    ///
+    /// `interrupt = true` so a Space-mash replay flow (#30) does not
+    /// queue identical utterances; each call replaces the in-flight one.
+    pub fn speak(&mut self, text: &str, lang: &Language) -> Result<(), Box<dyn std::error::Error>> {
+        if let Some(voice) = pick_voice(&self.inner, lang) {
+            // Voice selection is best-effort — a backend that doesn't
+            // support `set_voice` (or rejects this voice) shouldn't kill
+            // the run; we still want to attempt the speak call.
+            let _ = self.inner.set_voice(&voice);
+        }
+        self.inner.speak(text, true)?;
+        Ok(())
+    }
+
+    pub fn stop(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        self.inner.stop()?;
+        Ok(())
+    }
+
+    /// Whether the backend is currently producing audio. Reserved for
+    /// the run-loop work in #32-#37 (which will gate Space-replay on
+    /// "is the previous utterance still going?"). Foundation flow
+    /// always interrupts on replay so this isn't called yet.
+    #[allow(dead_code)]
+    pub fn is_speaking(&self) -> bool {
+        self.inner.is_speaking().unwrap_or(false)
+    }
+}
+
+/// Best-match voice for `lang`. Compares only the primary subtag (`ja`
+/// / `en`) so any locale flavour (`ja-JP`, `en-US`, `en-GB`...) counts
+/// as a match. Returns `None` when no voice's primary subtag matches —
+/// the caller then falls back to the backend default.
+fn pick_voice(tts: &Tts, lang: &Language) -> Option<Voice> {
+    let target = lang.code();
+    let voices = tts.voices().ok()?;
+    voices
+        .into_iter()
+        .find(|v| v.language().primary_language() == target)
+}
+
+#[cfg(test)]
+mod tests {
+    // We can't construct a real `Tts` in CI (no audio daemon), so the
+    // unit tests live in `game::listening` where the blind-input judge
+    // is pure. This module is intentionally test-light: integration
+    // testing for actual audio is manual on macOS / Linux.
+
+    #[test]
+    fn module_compiles() {}
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,7 @@ pub struct Config {
     pub player_data_file: String,
     #[allow(dead_code)]
     pub records_file_pattern: String,
+    pub listening_file_pattern: String,
 }
 
 impl Default for Config {
@@ -19,6 +20,7 @@ impl Default for Config {
             questions_file_pattern: "questions_{}.json".to_string(),
             player_data_file: "player.json".to_string(),
             records_file_pattern: "records_{}.json".to_string(),
+            listening_file_pattern: "listening_{}.json".to_string(),
         }
     }
 }
@@ -44,5 +46,40 @@ impl Config {
             self.data_dir,
             self.records_file_pattern.replace("{}", language.code())
         )
+    }
+
+    pub fn listening_file_path(&self, language: &Language) -> String {
+        format!(
+            "{}/{}",
+            self.data_dir,
+            self.listening_file_pattern.replace("{}", language.code())
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn listening_file_path_uses_language_code() {
+        let cfg = Config::default();
+        assert_eq!(
+            cfg.listening_file_path(&Language::Japanese),
+            "data/listening_ja.json"
+        );
+        assert_eq!(
+            cfg.listening_file_path(&Language::English),
+            "data/listening_en.json"
+        );
+    }
+
+    #[test]
+    fn questions_file_path_uses_language_code() {
+        let cfg = Config::default();
+        assert_eq!(
+            cfg.questions_file_path(&Language::Japanese),
+            "data/questions_ja.json"
+        );
     }
 }

--- a/src/game/listening.rs
+++ b/src/game/listening.rs
@@ -1,0 +1,212 @@
+//! Listening-mode game logic (#30 / #31).
+//!
+//! Single-prompt session for the v0.2.0 "listening foundation" epic.
+//! The full hack-and-slash run (10 prompts, HP/EXP, boss placement)
+//! lives in #32-#37 and will compose this module rather than replacing
+//! it.
+//!
+//! Design notes:
+//! - Pure: no audio I/O lives here. The UI owns the `TtsEngine` and
+//!   calls `speak()` whenever `wants_replay()` flips true.
+//! - The blind-input judge (`is_correct_listening_input`, #31) is a
+//!   free function so the unit tests don't need a session at all.
+
+use crate::types::ListeningPrompt;
+use rand::seq::SliceRandom;
+
+/// Decide whether `typed` matches `expected` for a listening prompt.
+///
+/// Per `docs/spec.md` and issue #31, the judge:
+/// - is **case-insensitive** (the player can't see the prompt, so
+///   forcing them to remember capitalisation is hostile to the spirit
+///   of the mode);
+/// - **trims surrounding whitespace** (a stray Space / Enter buffering
+///   space at either end shouldn't lose them the prompt);
+/// - keeps **internal spacing exact** (two-word phrases must be typed
+///   with the right number of spaces — that's part of the listening
+///   skill).
+pub fn is_correct_listening_input(typed: &str, expected: &str) -> bool {
+    typed.trim().to_lowercase() == expected.trim().to_lowercase()
+}
+
+/// One play-through of a single listening prompt. Tracks the active
+/// prompt, the player's typed buffer, and whether the round is over.
+/// The UI advances state by calling `submit()` on Enter and `replay()`
+/// on Space — the latter is just a flag the UI clears once it has
+/// asked the TTS engine to speak again.
+pub struct ListeningSession {
+    prompt: ListeningPrompt,
+    input: String,
+    submitted: Option<SubmissionResult>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubmissionResult {
+    pub is_correct: bool,
+    /// The prompt's expected text, captured at submission time so the
+    /// UI can reveal it on the result screen without holding the
+    /// `ListeningPrompt` reference.
+    pub expected: String,
+}
+
+impl ListeningSession {
+    pub fn new(prompt: ListeningPrompt) -> Self {
+        Self {
+            prompt,
+            input: String::new(),
+            submitted: None,
+        }
+    }
+
+    /// Pick a random prompt from `pool`. Returns `None` when the pool
+    /// is empty so the caller can show a "no listening data" message
+    /// instead of panicking.
+    pub fn from_pool(pool: &[ListeningPrompt]) -> Option<Self> {
+        let mut rng = rand::thread_rng();
+        pool.choose(&mut rng).cloned().map(Self::new)
+    }
+
+    pub fn prompt(&self) -> &ListeningPrompt {
+        &self.prompt
+    }
+
+    pub fn input(&self) -> &str {
+        &self.input
+    }
+
+    pub fn push_char(&mut self, c: char) {
+        if self.submitted.is_some() {
+            return;
+        }
+        self.input.push(c);
+    }
+
+    pub fn pop_char(&mut self) {
+        if self.submitted.is_some() {
+            return;
+        }
+        self.input.pop();
+    }
+
+    /// Apply the blind-input judge. Once submitted the session is
+    /// frozen — further `push_char` / `pop_char` are no-ops.
+    pub fn submit(&mut self) -> &SubmissionResult {
+        let is_correct = is_correct_listening_input(&self.input, &self.prompt.text);
+        self.submitted = Some(SubmissionResult {
+            is_correct,
+            expected: self.prompt.text.clone(),
+        });
+        // Safe: we just assigned `Some(_)`.
+        self.submitted.as_ref().expect("just submitted")
+    }
+
+    pub fn result(&self) -> Option<&SubmissionResult> {
+        self.submitted.as_ref()
+    }
+
+    /// Whether the session has been submitted. The single-prompt UI
+    /// currently uses `result()` instead, but the run-loop in #32-#37
+    /// needs this as the "advance to next prompt" gate.
+    #[allow(dead_code)]
+    pub fn is_finished(&self) -> bool {
+        self.submitted.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::AnswerKind;
+
+    fn p(text: &str) -> ListeningPrompt {
+        ListeningPrompt {
+            id: "test".into(),
+            text: text.into(),
+            kind: AnswerKind::Word,
+        }
+    }
+
+    #[test]
+    fn judge_accepts_exact_match() {
+        assert!(is_correct_listening_input("apple", "apple"));
+    }
+
+    #[test]
+    fn judge_is_case_insensitive() {
+        assert!(is_correct_listening_input("Apple", "apple"));
+        assert!(is_correct_listening_input("APPLE", "apple"));
+    }
+
+    #[test]
+    fn judge_trims_surrounding_whitespace() {
+        assert!(is_correct_listening_input("  apple ", "apple"));
+        assert!(is_correct_listening_input("apple\n", "apple"));
+    }
+
+    #[test]
+    fn judge_keeps_internal_spacing_exact() {
+        // Listening is *part of* the skill: drop a space and it's wrong.
+        assert!(is_correct_listening_input(
+            "George Washington",
+            "George Washington"
+        ));
+        assert!(!is_correct_listening_input(
+            "GeorgeWashington",
+            "George Washington"
+        ));
+        assert!(!is_correct_listening_input(
+            "George  Washington",
+            "George Washington"
+        ));
+    }
+
+    #[test]
+    fn judge_rejects_different_word() {
+        assert!(!is_correct_listening_input("orange", "apple"));
+    }
+
+    #[test]
+    fn session_records_correct_submission() {
+        let mut s = ListeningSession::new(p("apple"));
+        for c in "apple".chars() {
+            s.push_char(c);
+        }
+        let r = s.submit().clone();
+        assert!(r.is_correct);
+        assert_eq!(r.expected, "apple");
+        assert!(s.is_finished());
+    }
+
+    #[test]
+    fn session_freezes_after_submit() {
+        let mut s = ListeningSession::new(p("apple"));
+        s.push_char('a');
+        s.submit();
+        s.push_char('b');
+        assert_eq!(s.input(), "a");
+    }
+
+    #[test]
+    fn session_records_incorrect_submission() {
+        let mut s = ListeningSession::new(p("apple"));
+        for c in "orange".chars() {
+            s.push_char(c);
+        }
+        let r = s.submit().clone();
+        assert!(!r.is_correct);
+        assert_eq!(r.expected, "apple");
+    }
+
+    #[test]
+    fn from_pool_returns_none_on_empty() {
+        let pool: Vec<ListeningPrompt> = Vec::new();
+        assert!(ListeningSession::from_pool(&pool).is_none());
+    }
+
+    #[test]
+    fn from_pool_picks_one_when_available() {
+        let pool = vec![p("apple"), p("river")];
+        let s = ListeningSession::from_pool(&pool).expect("pool non-empty");
+        assert!(matches!(s.prompt().text.as_str(), "apple" | "river"));
+    }
+}

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -1,3 +1,8 @@
+pub mod listening;
 pub mod quiz;
 
+pub use listening::{ListeningSession, SubmissionResult};
+// `is_correct_listening_input` stays reachable via
+// `listening::is_correct_listening_input`; not re-exported until a
+// non-test caller appears.
 pub use quiz::{QuizGame, QuizResult};

--- a/src/game/quiz.rs
+++ b/src/game/quiz.rs
@@ -11,6 +11,14 @@ pub const QUIZ_RUN_LENGTH: usize = 10;
 pub struct QuizGame {
     questions: Vec<Question>,
     current_question_index: usize,
+    /// Index of the most recently answered question, recorded *before*
+    /// `current_question_index` advances. The result screen needs this so
+    /// it can render the choices and `correct_answer_index` of the
+    /// question the player just answered, not the next one — otherwise
+    /// two consecutive questions whose `correct_answer_index` happens to
+    /// match (e.g. both `1`) make the "Wrong. Answer: X" line read off
+    /// the next question entirely.
+    last_answered_index: Option<usize>,
     score: u32,
     correct_answers: u32,
     total_answers: u32,
@@ -40,6 +48,7 @@ impl QuizGame {
         Self {
             questions,
             current_question_index: 0,
+            last_answered_index: None,
             score: 0,
             correct_answers: 0,
             total_answers: 0,
@@ -67,6 +76,14 @@ impl QuizGame {
 
     pub fn get_current_question(&self) -> Option<&Question> {
         self.questions.get(self.current_question_index)
+    }
+
+    /// The question the player most recently submitted an answer for.
+    /// Required by the result screen, which has to render the choices /
+    /// correct_answer_index of *that* question even though
+    /// `current_question_index` has already advanced to the next one.
+    pub fn get_answered_question(&self) -> Option<&Question> {
+        self.last_answered_index.and_then(|i| self.questions.get(i))
     }
 
     pub fn get_question_text(&self, question: &Question) -> String {
@@ -129,6 +146,9 @@ impl QuizGame {
                 time_taken: question_start_time.elapsed(),
             };
 
+            // Record before advancing so the result screen can render
+            // the question that was just answered, not the next one.
+            self.last_answered_index = Some(self.current_question_index);
             self.current_question_index += 1;
 
             Some(result)
@@ -375,6 +395,43 @@ mod tests {
         game.answer_question_typed("wrong1");
         game.answer_question_typed("right");
         assert_eq!(game.typed_correct_chars, 5);
+    }
+
+    #[test]
+    fn get_answered_question_points_at_just_answered_question() {
+        // Regression for the H2O / Tokyo result-screen bug: `answer_question`
+        // advances `current_question_index`, but the result screen needs the
+        // question the player *just* submitted. With two questions whose
+        // `correct_answer_index` happen to coincide (both `1`), looking up
+        // `current_question.choices[result.correct_answer_index]` after the
+        // answer would yield Q2's "Tokyo" while the run was actually on Q1
+        // ("H2O"). `get_answered_question` must keep returning Q1 here.
+        let q1 = make_question(&["CO2", "H2O", "O2", "N2"], 1);
+        let q2 = make_question(&["Osaka", "Tokyo", "Kyoto", "Nagoya"], 1);
+        let mut game = QuizGame::new(vec![q1, q2], Language::English);
+        game.start();
+
+        // Answer Q1 correctly. After this call, current_question_index = 1
+        // but the result screen still wants Q1.
+        let result = game.answer_question_typed("H2O").expect("result");
+        assert!(result.is_correct);
+
+        let answered = game
+            .get_answered_question()
+            .expect("just-answered question is set");
+        assert_eq!(answered.choices[result.correct_answer_index]["en"], "H2O");
+
+        // And `get_current_question` correctly points at Q2 for the
+        // next round — the two getters are not interchangeable.
+        let current = game.get_current_question().expect("next question");
+        assert_eq!(current.choices[1]["en"], "Tokyo");
+    }
+
+    #[test]
+    fn get_answered_question_is_none_before_any_answer() {
+        let q = make_question(&["a", "b", "c", "d"], 0);
+        let game = QuizGame::new(vec![q], Language::English);
+        assert!(game.get_answered_question().is_none());
     }
 
     #[test]

--- a/src/io/data_loader.rs
+++ b/src/io/data_loader.rs
@@ -1,4 +1,4 @@
-use crate::types::{Language, Question};
+use crate::types::{Language, ListeningPrompt, Question};
 use std::fs;
 use std::path::Path;
 
@@ -13,6 +13,22 @@ impl DataLoader {
         let content = fs::read_to_string(file_path)?;
         let questions: Vec<Question> = serde_json::from_str(&content)?;
         Ok(questions)
+    }
+
+    /// Load a listening-prompt bank for a single language (#29). The
+    /// caller picks the file via `Config::listening_file_path`. Empty
+    /// vector when the file is absent — same convention as
+    /// `load_questions` so the Listening UI can degrade to a "no
+    /// prompts shipped" message instead of a hard error.
+    pub fn load_listening_prompts(
+        file_path: &str,
+    ) -> Result<Vec<ListeningPrompt>, Box<dyn std::error::Error>> {
+        if !Path::new(file_path).exists() {
+            return Ok(Vec::new());
+        }
+        let content = fs::read_to_string(file_path)?;
+        let prompts: Vec<ListeningPrompt> = serde_json::from_str(&content)?;
+        Ok(prompts)
     }
 
     #[allow(dead_code)]
@@ -135,5 +151,41 @@ impl DataLoader {
                 image_path: None,
             },
         ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::AnswerKind;
+
+    #[test]
+    fn shipped_listening_data_loads_for_both_languages() {
+        // The listening foundation epic ships these files in `data/`; if a
+        // future change accidentally breaks the schema (e.g. missing
+        // `kind`, typo'd serde rename) this test fails at PR time rather
+        // than at runtime when the player picks Listening Practice.
+        let ja = DataLoader::load_listening_prompts("data/listening_ja.json").expect("ja loads");
+        let en = DataLoader::load_listening_prompts("data/listening_en.json").expect("en loads");
+        assert!(!ja.is_empty(), "ja prompts non-empty");
+        assert!(!en.is_empty(), "en prompts non-empty");
+        // Foundation flow only exposes word-kind prompts (Space is
+        // reserved for replay) — fail loudly if no word survives the
+        // filter, which would brick the Listening Practice mode.
+        assert!(
+            ja.iter().any(|p| p.kind == AnswerKind::Word),
+            "at least one word-kind ja prompt must ship"
+        );
+        assert!(
+            en.iter().any(|p| p.kind == AnswerKind::Word),
+            "at least one word-kind en prompt must ship"
+        );
+    }
+
+    #[test]
+    fn load_listening_prompts_returns_empty_when_missing() {
+        let prompts = DataLoader::load_listening_prompts("data/__does_not_exist__.json")
+            .expect("missing file is not an error");
+        assert!(prompts.is_empty());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod audio;
 mod config;
 mod game;
 mod io;
@@ -5,11 +6,13 @@ mod jiwa_core;
 mod types;
 mod ui;
 
+use audio::TtsEngine;
 use config::Config;
+use game::ListeningSession;
 use io::{DataLoader, Storage};
 use std::io::{stdin, stdout, Write};
-use types::{GameMode, Question};
-use ui::{MenuUI, QuizUI, RecordsUI};
+use types::{AnswerKind, GameMode, Language, ListeningPrompt, Question};
+use ui::{tts_unavailable_message, ListenUI, MenuUI, QuizUI, RecordsUI};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = Config::default();
@@ -54,7 +57,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 menu.return_to_mode_selection(language);
             }
             GameMode::HackAndSlashRpg => {
-                show_return_to_menu_message("Listening RPG is not implemented yet.")?;
+                run_listening_practice(&config, &language)?;
                 menu.return_to_mode_selection(language);
             }
             GameMode::Records => {
@@ -86,5 +89,49 @@ fn show_return_to_menu_message(message: &str) -> Result<(), Box<dyn std::error::
 
     let mut input = String::new();
     stdin().read_line(&mut input)?;
+    Ok(())
+}
+
+/// One round of listening practice (#28-#31). v0.2.0 foundation only —
+/// the 10-prompt run loop is #32-#37. Foundation restricts the pool to
+/// `word`-kind prompts because Space is reserved for replay (per
+/// `docs/spec.md`); phrase / sentence input mapping is part of the
+/// run-loop work and is intentionally out of scope here.
+fn run_listening_practice(
+    config: &Config,
+    language: &Language,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let path = config.listening_file_path(language);
+    let prompts = DataLoader::load_listening_prompts(&path)?;
+    let pool: Vec<ListeningPrompt> = prompts
+        .into_iter()
+        .filter(|p| p.kind == AnswerKind::Word)
+        .collect();
+
+    if pool.is_empty() {
+        show_return_to_menu_message(
+            "No listening prompts available for this language. Add `data/listening_<lang>.json`.",
+        )?;
+        return Ok(());
+    }
+
+    let session = match ListeningSession::from_pool(&pool) {
+        Some(s) => s,
+        None => {
+            show_return_to_menu_message("Failed to pick a listening prompt.")?;
+            return Ok(());
+        }
+    };
+
+    let tts = match TtsEngine::new() {
+        Ok(t) => t,
+        Err(err) => {
+            show_return_to_menu_message(&tts_unavailable_message(err.as_ref()))?;
+            return Ok(());
+        }
+    };
+
+    let mut ui = ListenUI::new(session, tts, language.clone());
+    let _ = ui.run()?;
     Ok(())
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,6 +11,30 @@ pub struct Question {
     pub image_path: Option<String>,
 }
 
+/// Answer-form classification per `docs/spec.md`. Drives hack-and-slash
+/// boss placement (#33-#37: prompts 1-7 word, 8-9 phrase, 10 sentence)
+/// and gives the renderer a hint for enemy size / visuals. `Question`
+/// will gain this field when the YAML migration lands; `ListeningPrompt`
+/// uses it from day one (#29).
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum AnswerKind {
+    Word,
+    Phrase,
+    Sentence,
+}
+
+/// One audio-only listening prompt. The TTS layer turns `text` into
+/// audio at runtime (#28) — no audio files are shipped. The on-disk
+/// shape mirrors the v0.2.0 YAML target in `docs/spec.md` so the eventual
+/// JSON→YAML migration is a 1:1 rename.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ListeningPrompt {
+    pub id: String,
+    pub text: String,
+    pub kind: AnswerKind,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Player {
     pub player_name: String,

--- a/src/ui/listen.rs
+++ b/src/ui/listen.rs
@@ -1,0 +1,379 @@
+//! Listening practice UI (#30 / #31).
+//!
+//! Single-prompt foundation that exercises the TTS engine (#28), the
+//! listening data structure (#29), and the blind-input judge (#31)
+//! end-to-end. The full hack-and-slash run (#32-#37) will compose
+//! `ListeningSession` repeatedly inside this same 4-pane layout; for
+//! now the side pane shows placeholder run info ("Practice — RPG run
+//! lands in #32+").
+//!
+//! Per `docs/spec.md`, the audio is the only presentation: no text,
+//! no choices. The visible elements are limited to:
+//! - a pulsing `♪` (jiwa_core pulse) while audio is in flight,
+//! - the input echo of what the player has typed,
+//! - status placeholders (kind / Floor / Run time placeholder),
+//! - a battle-log pane (used only on the result screen for v0.2.0).
+
+use crate::audio::TtsEngine;
+use crate::game::{ListeningSession, SubmissionResult};
+use crate::jiwa_core::{PulseHandle, PulseOpts, Rgb};
+use crate::types::{AnswerKind, Language};
+use crate::ui::{HelpEntry, HelpLine, InputChannel, PaneFrame, RecvOutcome};
+use crossterm::{
+    event::{KeyCode, KeyEvent, KeyModifiers},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{
+    backend::CrosstermBackend,
+    layout::{Alignment, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph},
+    Frame, Terminal,
+};
+use std::io;
+use std::time::{Duration, Instant};
+
+const STYLE_TITLE: Style = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD);
+const STYLE_NORMAL: Style = Style::new().fg(Color::White);
+const STYLE_DIM: Style = Style::new().fg(Color::DarkGray);
+const STYLE_CORRECT: Style = Style::new().fg(Color::Green).add_modifier(Modifier::BOLD);
+const STYLE_INCORRECT: Style = Style::new().fg(Color::Red).add_modifier(Modifier::BOLD);
+const STYLE_INPUT_ECHO: Style = Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD);
+const STYLE_LABEL: Style = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD);
+
+#[derive(Debug, Clone, PartialEq)]
+enum Phase {
+    Playing,
+    Result,
+}
+
+pub struct ListenUI {
+    session: ListeningSession,
+    tts: TtsEngine,
+    language: Language,
+    phase: Phase,
+    /// `♪` pulse for the active prompt — anchors per-frame color.
+    /// `None` after submit; the result screen reveals the answer text
+    /// instead of pulsing the symbol.
+    pulse: Option<PulseHandle>,
+    started_at: Instant,
+    /// Number of times the player has triggered audio (initial play +
+    /// each Space replay). Per spec there is no penalty, but exposing
+    /// the count for the next UI iteration is cheap and mirrors what
+    /// the hack-and-slash run is going to want for telemetry.
+    plays: u32,
+}
+
+impl ListenUI {
+    pub fn new(session: ListeningSession, tts: TtsEngine, language: Language) -> Self {
+        Self {
+            session,
+            tts,
+            language,
+            phase: Phase::Playing,
+            pulse: Some(PulseHandle::start("♪", PulseOpts::default_listening())),
+            started_at: Instant::now(),
+            plays: 0,
+        }
+    }
+
+    pub fn run(&mut self) -> Result<Option<SubmissionResult>, Box<dyn std::error::Error>> {
+        enable_raw_mode()?;
+        let mut stdout = io::stdout();
+        execute!(stdout, EnterAlternateScreen)?;
+        let backend = CrosstermBackend::new(stdout);
+        let mut terminal = Terminal::new(backend)?;
+
+        // Speak the prompt once on entry. Failure here is non-fatal —
+        // the player can still try Space-replay, and the result screen
+        // works even if no audio came out (helps debug TTS issues).
+        if let Err(err) = self.tts.speak(&self.session.prompt().text, &self.language) {
+            eprintln!("warning: initial TTS speak failed: {err}");
+        } else {
+            self.plays += 1;
+        }
+
+        let result = self.run_app(&mut terminal);
+
+        // Stop any in-flight utterance so the terminal returns silently.
+        let _ = self.tts.stop();
+        disable_raw_mode()?;
+        execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+        terminal.show_cursor()?;
+
+        result
+    }
+
+    fn run_app(
+        &mut self,
+        terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    ) -> Result<Option<SubmissionResult>, Box<dyn std::error::Error>> {
+        const REDRAW: Duration = Duration::from_millis(30);
+        let input = InputChannel::spawn();
+
+        loop {
+            terminal.draw(|f| self.ui(f))?;
+            match input.recv_until(REDRAW) {
+                RecvOutcome::Key(key) => {
+                    if self.handle_key(key) {
+                        break;
+                    }
+                }
+                RecvOutcome::Timeout => {}
+                RecvOutcome::Disconnected => break,
+            }
+        }
+        Ok(self.session.result().cloned())
+    }
+
+    fn handle_key(&mut self, key: KeyEvent) -> bool {
+        if matches!(key.code, KeyCode::Esc) {
+            return true;
+        }
+        if matches!(key.code, KeyCode::Char('c')) && key.modifiers.contains(KeyModifiers::CONTROL) {
+            return true;
+        }
+
+        match self.phase {
+            Phase::Result => return self.handle_key_result(key),
+            Phase::Playing => {}
+        }
+
+        match key.code {
+            // Per `docs/spec.md`: `[Space] Replay sound`. The spec
+            // doesn't reserve another key for "literal space inside a
+            // phrase / sentence answer", so v0.2.0 foundation ships
+            // word-only practice reliably; phrase / sentence input
+            // mapping is revisited as part of the run-loop work in
+            // #32-#37.
+            KeyCode::Char(' ')
+                if !key
+                    .modifiers
+                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+            {
+                self.replay();
+            }
+            KeyCode::Enter => {
+                self.session.submit();
+                self.pulse = None;
+                self.phase = Phase::Result;
+                let _ = self.tts.stop();
+            }
+            KeyCode::Backspace => {
+                self.session.pop_char();
+            }
+            KeyCode::Char(c)
+                if !key
+                    .modifiers
+                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+            {
+                self.session.push_char(c);
+            }
+            _ => {}
+        }
+        false
+    }
+
+    fn handle_key_result(&mut self, key: KeyEvent) -> bool {
+        matches!(key.code, KeyCode::Enter)
+    }
+
+    fn replay(&mut self) {
+        if let Err(err) = self.tts.speak(&self.session.prompt().text, &self.language) {
+            eprintln!("warning: TTS replay failed: {err}");
+            return;
+        }
+        self.plays += 1;
+        // Restart the visual pulse on each replay so the breathing
+        // anchors to the new utterance.
+        self.pulse = Some(PulseHandle::start("♪", PulseOpts::default_listening()));
+    }
+
+    fn ui(&mut self, f: &mut Frame) {
+        let frame = PaneFrame::hack(f.area());
+        self.render_main_pane(f, frame.main);
+        self.render_status_pane(f, frame.side);
+        self.render_input_echo(f, frame.input_echo);
+        if let Some(log) = frame.log {
+            self.render_log_pane(f, log);
+        }
+        self.render_help_line(f, frame.help_line);
+    }
+
+    fn render_main_pane(&self, f: &mut Frame, area: Rect) {
+        let title_text = match self.phase {
+            Phase::Playing => "TypeGlobe — Listening Practice",
+            Phase::Result => "TypeGlobe — Listening Practice  (result)",
+        };
+
+        let body_lines = match self.phase {
+            Phase::Playing => self.playing_body_lines(),
+            Phase::Result => self.result_body_lines(),
+        };
+
+        let para = Paragraph::new(body_lines)
+            .alignment(Alignment::Center)
+            .block(
+                Block::default()
+                    .title(title_text)
+                    .title_style(STYLE_TITLE)
+                    .borders(Borders::ALL),
+            );
+        f.render_widget(para, area);
+    }
+
+    fn playing_body_lines(&self) -> Vec<Line<'static>> {
+        // Pulse symbol — color comes from the jiwa_core pulse so the
+        // listening pane uses the same primitive as the spec example.
+        let (symbol, color) = if let Some(pulse) = self.pulse.as_ref() {
+            let frame = pulse.snapshot(Instant::now());
+            (frame.text, frame.color)
+        } else {
+            ("♪".to_string(), Rgb(80, 200, 255))
+        };
+        let Rgb(r, g, b) = color;
+        let symbol_span = Span::styled(symbol, Style::new().fg(Color::Rgb(r, g, b)));
+
+        vec![
+            Line::from(""),
+            Line::from(""),
+            Line::from(symbol_span),
+            Line::from(""),
+            Line::from(Span::styled("Listening...", STYLE_NORMAL)),
+            Line::from(""),
+            Line::from(Span::styled(
+                "(audio only — type what you hear, then Enter)",
+                STYLE_DIM,
+            )),
+        ]
+    }
+
+    fn result_body_lines(&self) -> Vec<Line<'static>> {
+        let Some(result) = self.session.result() else {
+            return vec![Line::from("(no result)")];
+        };
+        let (verdict_text, verdict_style) = if result.is_correct {
+            ("Correct!".to_string(), STYLE_CORRECT)
+        } else {
+            ("Wrong.".to_string(), STYLE_INCORRECT)
+        };
+        vec![
+            Line::from(""),
+            Line::from(Span::styled(verdict_text, verdict_style)),
+            Line::from(""),
+            Line::from(vec![
+                Span::styled("Expected: ", STYLE_LABEL),
+                Span::styled(result.expected.clone(), STYLE_NORMAL),
+            ]),
+            Line::from(vec![
+                Span::styled("You typed: ", STYLE_LABEL),
+                Span::styled(self.session.input().to_string(), STYLE_INPUT_ECHO),
+            ]),
+            Line::from(""),
+            Line::from(Span::styled(
+                "Press Enter or Esc to return to the menu.",
+                STYLE_DIM,
+            )),
+        ]
+    }
+
+    fn render_status_pane(&self, f: &mut Frame, area: Rect) {
+        let elapsed = self.started_at.elapsed();
+        let mins = elapsed.as_secs() / 60;
+        let secs = elapsed.as_secs() % 60;
+        let kind = match self.session.prompt().kind {
+            AnswerKind::Word => "word",
+            AnswerKind::Phrase => "phrase",
+            AnswerKind::Sentence => "sentence",
+        };
+        let lines = vec![
+            Line::from(Span::styled("Practice", STYLE_LABEL)),
+            Line::from(Span::styled("(RPG run: #32+)", STYLE_DIM)),
+            Line::from(""),
+            Line::from(format!("Kind   : {kind}")),
+            Line::from(format!("Plays  : {}", self.plays)),
+            Line::from(format!("Time   : {mins}:{secs:02}")),
+        ];
+        let para = Paragraph::new(lines)
+            .alignment(Alignment::Left)
+            .block(Block::default().title("Status").borders(Borders::ALL));
+        f.render_widget(para, area);
+    }
+
+    fn render_input_echo(&self, f: &mut Frame, area: Rect) {
+        if area.height == 0 {
+            return;
+        }
+        let body = match self.phase {
+            Phase::Playing => format!("> {}_", self.session.input()),
+            Phase::Result => String::new(),
+        };
+        let line = Paragraph::new(body)
+            .style(STYLE_INPUT_ECHO)
+            .alignment(Alignment::Left);
+        f.render_widget(line, area);
+    }
+
+    fn render_log_pane(&self, f: &mut Frame, area: Rect) {
+        let lines: Vec<Line<'static>> = match self.phase {
+            Phase::Playing => vec![
+                Line::from(Span::styled("(no events)", STYLE_DIM)),
+                Line::from(Span::styled(
+                    "Battle log fills in once #32-#37 land.",
+                    STYLE_DIM,
+                )),
+            ],
+            Phase::Result => match self.session.result() {
+                Some(r) if r.is_correct => {
+                    vec![
+                        Line::from(Span::styled("▸ Hit!", STYLE_CORRECT)),
+                        Line::from(Span::styled(
+                            format!("▸ Plays this prompt: {}", self.plays),
+                            STYLE_DIM,
+                        )),
+                    ]
+                }
+                Some(_) => {
+                    vec![
+                        Line::from(Span::styled("▸ Missed.", STYLE_INCORRECT)),
+                        Line::from(Span::styled(
+                            format!("▸ Plays this prompt: {}", self.plays),
+                            STYLE_DIM,
+                        )),
+                    ]
+                }
+                None => vec![Line::from(Span::styled("(no result)", STYLE_DIM))],
+            },
+        };
+        let para = Paragraph::new(lines)
+            .alignment(Alignment::Left)
+            .block(Block::default().title("Log").borders(Borders::ALL));
+        f.render_widget(para, area);
+    }
+
+    fn render_help_line(&self, f: &mut Frame, area: Rect) {
+        let help = match self.phase {
+            Phase::Playing => HelpLine::new(vec![
+                HelpEntry::new("Esc", "Quit"),
+                HelpEntry::new("Space", "Replay"),
+                HelpEntry::new("Enter", "Confirm"),
+                HelpEntry::new("Bksp", "Erase"),
+            ]),
+            Phase::Result => HelpLine::new(vec![HelpEntry::new("Enter", "Menu")]),
+        };
+        help.render(f, area);
+    }
+}
+
+/// Build a one-line message for callers that want to surface a TTS
+/// init failure to the player without crashing the run. Shared so the
+/// menu and any future entry points format it consistently.
+pub fn tts_unavailable_message(err: &dyn std::error::Error) -> String {
+    format!(
+        "Listening mode is unavailable on this system: {err}\n\
+         (On Linux, install and start `speech-dispatcher`.)\n\
+         Press Enter to return to the menu."
+    )
+}

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -65,8 +65,8 @@ const MODE_OPTIONS: [ModeOption; 4] = [
     ModeOption {
         label: "Listening RPG",
         description: [
-            "A separate ruleset: hear the prompt, then survive a 10-battle run.",
-            "別ルール系。聞いて打つ 10 戦のリスニングRPGです。",
+            "Hear the prompt, type it blind. v0.2.0 ships practice mode; the 10-battle run lands in #32-#37.",
+            "聞いた音をブラインドで打つ別ルール。v0.2.0 は練習モード、10戦RPGは #32-#37 で来ます。",
         ],
     },
     ModeOption {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,6 +1,7 @@
 pub mod help_line;
 pub mod input_loop;
 pub mod layout;
+pub mod listen;
 pub mod menu;
 pub mod quiz;
 pub mod records;
@@ -9,6 +10,7 @@ pub mod status;
 pub use help_line::{HelpEntry, HelpLine};
 pub use input_loop::{InputChannel, RecvOutcome};
 pub use layout::PaneFrame;
+pub use listen::{tts_unavailable_message, ListenUI};
 pub use menu::MenuUI;
 pub use quiz::QuizUI;
 pub use records::RecordsUI;

--- a/src/ui/quiz.rs
+++ b/src/ui/quiz.rs
@@ -433,8 +433,14 @@ impl QuizUI {
     }
 
     fn render_result(&self, f: &mut Frame, area: Rect) {
+        // Use `get_answered_question` (not `get_current_question`) — the
+        // index has already advanced past the one we just answered, and
+        // we need *that* question's choices to look up the correct
+        // answer text. Otherwise two questions whose `correct_answer_index`
+        // happen to match (e.g. both `1`) leak the next question's
+        // choice into the "Wrong. Answer: …" line.
         let (Some(result), Some(question)) =
-            (&self.current_result, self.quiz_game.get_current_question())
+            (&self.current_result, self.quiz_game.get_answered_question())
         else {
             return;
         };


### PR DESCRIPTION
## Summary

Bundles the four listening-foundation issues into one PR (per session 341 plan) so the surface arrives whole rather than in unusable half-states.

- **#28** — `src/audio/tts.rs` wraps the [`tts`](https://crates.io/crates/tts) crate; voice routing by `Language.code()` primary subtag; init failure surfaces as a friendly menu message (no crash). CI gains `libspeechd-dev` so the Linux build keeps passing.
- **#29** — `AnswerKind` + `ListeningPrompt` types, bilingual `data/listening_<lang>.json` (mixed word/phrase/sentence), `DataLoader::load_listening_prompts`, `Config::listening_file_path`.
- **#30** — `src/ui/listen.rs` renders the 4-pane hack layout (`PaneFrame::hack`) with the jiwa_core `♪` `PulseHandle` on top. `Space` replays unlimited / no penalty per spec; `Esc` / `Ctrl+C` quit; `Enter` submits.
- **#31** — `game/listening.rs` is the blind-input judge: case-insensitive, trims surrounding whitespace, but keeps **internal spacing exact** (missing a space inside a phrase is still a miss — that's the listening skill).

`main.rs` replaces the `HackAndSlashRpg` "not implemented" placeholder with `run_listening_practice`, which filters the pool to `AnswerKind::Word` because `Space` is reserved for replay and phrase/sentence input mapping is the next epic (#32-#37).

## Foundation scope and what's next

This is the **foundation only** — the full 10-prompt run with HP / EXP and the fixed boss placement (1-7 word, 8-9 phrase, 10 sentence) lands in **#32-#37**, which will also rework the input model so phrase / sentence prompts can coexist with Space-as-replay.

## Tests

75 → **90** (+15):
- 10 in `game::listening` (judge + session lifecycle + pool picker)
- 2 in `io::data_loader` (shipped data integrity + missing-file fallback)
- 2 in `config` (file-path patterns)
- 1 module-compiles smoke in `audio::tts`

## Docs

- `README.md` clarifies the `speech-dispatcher` requirement on Linux and notes that v0.2.0 ships practice mode until the run loop arrives.
- `docs/spec.md` grows a "Linux runtime requirement" note and a "v0.2.0 foundation scope (#28-#31)" subsection so the half-shipped state of Listening RPG is explicit.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 90 passed
- [x] `cargo run --bin lint-questions -- data/questions_ja.json data/questions_en.json` — clean
- [ ] Manual: launch on macOS, pick Listening RPG → hear a `word` prompt, type wrong → see "Wrong" + Expected reveal; hit Space → audio replays
- [ ] Manual: launch on a Linux box without `speech-dispatcher` running → see "Listening mode is unavailable" message and return to menu

Closes #28
Closes #29
Closes #30
Closes #31