### PR TITLE
feat: quiz advances immediately on correct and freezes final time (#70)

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -56,13 +56,13 @@ Quiz is paired with score-attack modes; listening is paired with the RPG. The tw
 ```
 
 - **No arrow-key selection.** Players type the correct choice's text directly; this both selects and answers.
-- **Exact match auto-confirms.** Question data must avoid prefix ambiguity so the match point is deterministic.
-- Input echo shows only the characters that are still on a valid answer prefix; non-prefix typos are rejected immediately.
+- **Exact match auto-confirms and immediately advances** to the next question — there is no "Correct!" interstitial and no Enter-to-continue. The flow is a continuous typing rhythm.
+- **Only the correct choice's typings are accepted as a valid prefix.** Any divergence (including the full text of a wrong choice) is treated as a mistype: the input flashes red and the buffer resets to zero, and the run does not advance. The player can only proceed by typing the correct answer.
 - Matching is **case-insensitive**.
 - A single logical answer may accept **multiple typed spellings**.
 - In JA mode, romanized aliases may be accepted for the same answer (for example `tokyo` and `toukyou`, `osaka` and `oosaka`). Question data may declare these explicitly with `ja_typings`. When a choice has a well-established official Latin spelling (for example a proper name), that spelling may also be accepted. The implementation may also derive additional common ASCII aliases from kana as long as it never reveals the answer string before typing.
 - Score = function(CPM, accuracy, correctness).
-- One run is fixed at **10 questions** (constant `QUIZ_RUN_LENGTH`), sampled from the language's question pool. After the 10th question, the UI shows a Summary (Score / Correct / Accuracy / CPM / WPM / Time), then a Records-entry screen prompts for a name and writes a `ScoreEntry` to `records_<lang>.json` (Top 10 by score; ts as tiebreaker). Esc on either screen returns to the menu without saving.
+- One run is fixed at **10 questions** (constant `QUIZ_RUN_LENGTH`), sampled from the language's question pool. The total Time is **frozen at the last correct keystroke** of the final question (or at the moment the final question is skipped via Tab) — it does not keep ticking on the Summary / Records-entry screens. After the 10th question, the UI shows a Summary (Score / Correct / Accuracy / CPM / WPM / Time), then a Records-entry screen prompts for a name and writes a `ScoreEntry` to `records_<lang>.json` (Top 10 by score; ts as tiebreaker). Esc on either screen returns to the menu without saving.
 
 ### Time Attack 25
 

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -5,4 +5,4 @@ pub use listening::{ListeningSession, SubmissionResult};
 // `is_correct_listening_input` stays reachable via
 // `listening::is_correct_listening_input`; not re-exported until a
 // non-test caller appears.
-pub use quiz::{QuizGame, QuizResult};
+pub use quiz::QuizGame;

--- a/src/game/quiz.rs
+++ b/src/game/quiz.rs
@@ -28,16 +28,20 @@ pub struct QuizGame {
     /// choice — including them would inflate WPM for fast guessers.
     typed_correct_chars: u32,
     start_time: Option<Instant>,
+    /// Elapsed time at the moment the run ended (last question answered or
+    /// skipped). Once set, `get_total_time` returns this fixed value so the
+    /// final result screen shows the time of the last keystroke, not a
+    /// timer that keeps ticking afterwards.
+    frozen_time: Option<Duration>,
     language: Language,
 }
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct QuizResult {
     pub is_correct: bool,
     pub correct_answer_index: usize,
-    #[allow(dead_code)]
     pub selected_answer_index: usize,
-    #[allow(dead_code)]
     pub time_taken: Duration,
 }
 
@@ -54,6 +58,7 @@ impl QuizGame {
             total_answers: 0,
             typed_correct_chars: 0,
             start_time: None,
+            frozen_time: None,
             language,
         }
     }
@@ -79,9 +84,10 @@ impl QuizGame {
     }
 
     /// The question the player most recently submitted an answer for.
-    /// Required by the result screen, which has to render the choices /
-    /// correct_answer_index of *that* question even though
-    /// `current_question_index` has already advanced to the next one.
+    /// Kept for tests and possible future reuse — Issue #70 removed the
+    /// per-question result screen, so the production code no longer needs
+    /// it during the run.
+    #[allow(dead_code)]
     pub fn get_answered_question(&self) -> Option<&Question> {
         self.last_answered_index.and_then(|i| self.questions.get(i))
     }
@@ -98,17 +104,19 @@ impl QuizGame {
             .collect()
     }
 
-    /// All currently acceptable typed strings for the active question.
-    /// Used by the UI for live prefix validation so a mistyped suffix
-    /// is rejected immediately instead of forcing a Backspace recovery.
-    pub fn current_typing_candidates(&self) -> Vec<String> {
+    /// Typed strings that count as the **correct** answer for the active
+    /// question. Per Issue #70 the player can only advance by typing the
+    /// correct choice — wrong choices' typings are not accepted, so the
+    /// candidate list is intentionally narrow.
+    pub fn current_correct_typing_candidates(&self) -> Vec<String> {
         let Some(question) = self.get_current_question() else {
             return Vec::new();
         };
-        let mut candidates: Vec<String> = question
-            .choices
-            .iter()
-            .flat_map(|choice| DataLoader::get_choice_typing_texts(choice, &self.language))
+        let Some(choice) = question.choices.get(question.correct_answer_index) else {
+            return Vec::new();
+        };
+        let mut candidates: Vec<String> = DataLoader::get_choice_typing_texts(choice, &self.language)
+            .into_iter()
             .map(|candidate| candidate.to_lowercase())
             .collect();
         candidates.sort();
@@ -116,14 +124,16 @@ impl QuizGame {
         candidates
     }
 
-    /// Whether `typed` is still a valid prefix of at least one answer
-    /// candidate for the active question. Empty input is always valid.
-    pub fn is_valid_typed_prefix(&self, typed: &str) -> bool {
+    /// Whether `typed` is still a valid prefix of the **correct** answer
+    /// for the active question. Empty input is always valid. Anything that
+    /// diverges from the correct prefix is rejected like a mistype, which
+    /// is the contract Issue #70 asks for.
+    pub fn is_valid_correct_typed_prefix(&self, typed: &str) -> bool {
         if typed.is_empty() {
             return true;
         }
         let typed = typed.to_lowercase();
-        self.current_typing_candidates()
+        self.current_correct_typing_candidates()
             .iter()
             .any(|candidate| candidate.starts_with(&typed))
     }
@@ -187,6 +197,8 @@ impl QuizGame {
             self.last_answered_index = Some(self.current_question_index);
             self.current_question_index += 1;
 
+            self.maybe_freeze_time();
+
             Some(result)
         } else {
             None
@@ -214,7 +226,27 @@ impl QuizGame {
     }
 
     pub fn get_total_time(&self) -> Option<Duration> {
+        if let Some(d) = self.frozen_time {
+            return Some(d);
+        }
         self.start_time.map(|start| start.elapsed())
+    }
+
+    /// Snapshot the current elapsed time once the run is finished, so the
+    /// summary screen reports the time of the final correct keystroke
+    /// rather than a timer that keeps running while the result is on
+    /// screen. Idempotent — only fires the first time it's called after
+    /// `is_game_finished()` returns true.
+    fn maybe_freeze_time(&mut self) {
+        if self.frozen_time.is_some() {
+            return;
+        }
+        if !self.is_game_finished() {
+            return;
+        }
+        if let Some(start) = self.start_time {
+            self.frozen_time = Some(start.elapsed());
+        }
     }
 
     /// Characters per minute over the full run so far. Returns 0 when the
@@ -249,6 +281,7 @@ impl QuizGame {
         if self.current_question_index < self.questions.len() {
             self.current_question_index += 1;
             self.total_answers += 1;
+            self.maybe_freeze_time();
             true
         } else {
             false
@@ -404,17 +437,27 @@ mod tests {
     }
 
     #[test]
-    fn valid_prefix_accepts_partial_match() {
+    fn valid_prefix_accepts_partial_match_of_correct_choice() {
         let question = make_question(&["borrow", "move", "ref", "clone"], 1);
         let game = QuizGame::new(vec![question], Language::English);
-        assert!(game.is_valid_typed_prefix("mo"));
+        assert!(game.is_valid_correct_typed_prefix("mo"));
     }
 
     #[test]
     fn valid_prefix_rejects_wrong_branch() {
         let question = make_question(&["borrow", "move", "ref", "clone"], 1);
         let game = QuizGame::new(vec![question], Language::English);
-        assert!(!game.is_valid_typed_prefix("mx"));
+        assert!(!game.is_valid_correct_typed_prefix("mx"));
+    }
+
+    #[test]
+    fn valid_prefix_rejects_wrong_choice_text() {
+        // Per Issue #70 only the correct choice's typings are valid; typing
+        // a wrong choice's full text must be rejected as a mistype.
+        let question = make_question(&["borrow", "move", "ref", "clone"], 1);
+        let game = QuizGame::new(vec![question], Language::English);
+        assert!(!game.is_valid_correct_typed_prefix("b"));
+        assert!(!game.is_valid_correct_typed_prefix("borrow"));
     }
 
     #[test]
@@ -422,9 +465,37 @@ mod tests {
         let mut question = make_question(&["東京", "大阪", "京都", "名古屋"], 0);
         question.choices[0].ja_typings = vec!["tokyo".into(), "toukyou".into()];
         let game = QuizGame::new(vec![question], Language::Japanese);
-        assert!(game.is_valid_typed_prefix("tok"));
-        assert!(game.is_valid_typed_prefix("tou"));
-        assert!(!game.is_valid_typed_prefix("tax"));
+        assert!(game.is_valid_correct_typed_prefix("tok"));
+        assert!(game.is_valid_correct_typed_prefix("tou"));
+        assert!(!game.is_valid_correct_typed_prefix("tax"));
+    }
+
+    #[test]
+    fn final_time_is_frozen_at_last_correct_answer() {
+        // Two questions; after answering both, get_total_time() must return
+        // a stable value even after additional time elapses.
+        let q1 = make_question(&["right", "a", "b", "c"], 0);
+        let q2 = make_question(&["right", "a", "b", "c"], 0);
+        let mut game = QuizGame::new(vec![q1, q2], Language::English);
+        game.start();
+        game.answer_question_typed("right");
+        game.answer_question_typed("right");
+        let frozen = game.get_total_time().unwrap();
+        std::thread::sleep(Duration::from_millis(20));
+        let after_sleep = game.get_total_time().unwrap();
+        assert_eq!(frozen, after_sleep);
+    }
+
+    #[test]
+    fn final_time_is_frozen_when_last_question_is_skipped() {
+        let q = make_question(&["right", "a", "b", "c"], 0);
+        let mut game = QuizGame::new(vec![q], Language::English);
+        game.start();
+        assert!(game.skip_question());
+        let frozen = game.get_total_time().unwrap();
+        std::thread::sleep(Duration::from_millis(20));
+        let after_sleep = game.get_total_time().unwrap();
+        assert_eq!(frozen, after_sleep);
     }
 
     #[test]

--- a/src/game/quiz.rs
+++ b/src/game/quiz.rs
@@ -115,10 +115,11 @@ impl QuizGame {
         let Some(choice) = question.choices.get(question.correct_answer_index) else {
             return Vec::new();
         };
-        let mut candidates: Vec<String> = DataLoader::get_choice_typing_texts(choice, &self.language)
-            .into_iter()
-            .map(|candidate| candidate.to_lowercase())
-            .collect();
+        let mut candidates: Vec<String> =
+            DataLoader::get_choice_typing_texts(choice, &self.language)
+                .into_iter()
+                .map(|candidate| candidate.to_lowercase())
+                .collect();
         candidates.sort();
         candidates.dedup();
         candidates

--- a/src/game/quiz.rs
+++ b/src/game/quiz.rs
@@ -11,14 +11,6 @@ pub const QUIZ_RUN_LENGTH: usize = 10;
 pub struct QuizGame {
     questions: Vec<Question>,
     current_question_index: usize,
-    /// Index of the most recently answered question, recorded *before*
-    /// `current_question_index` advances. The result screen needs this so
-    /// it can render the choices and `correct_answer_index` of the
-    /// question the player just answered, not the next one — otherwise
-    /// two consecutive questions whose `correct_answer_index` happens to
-    /// match (e.g. both `1`) make the "Wrong. Answer: X" line read off
-    /// the next question entirely.
-    last_answered_index: Option<usize>,
     score: u32,
     correct_answers: u32,
     total_answers: u32,
@@ -36,12 +28,19 @@ pub struct QuizGame {
     language: Language,
 }
 
+/// Per-answer outcome. Issue #70 removed the result interstitial, so
+/// production code only reads `is_correct` (via `Option::is_some` on the
+/// return value, since wrong answers are now blocked at the input layer).
+/// The remaining fields are kept for tests and possible future reuse.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct QuizResult {
+    #[cfg_attr(not(test), allow(dead_code))]
     pub is_correct: bool,
+    #[cfg_attr(not(test), allow(dead_code))]
     pub correct_answer_index: usize,
+    #[cfg_attr(not(test), allow(dead_code))]
     pub selected_answer_index: usize,
+    #[cfg_attr(not(test), allow(dead_code))]
     pub time_taken: Duration,
 }
 
@@ -52,7 +51,6 @@ impl QuizGame {
         Self {
             questions,
             current_question_index: 0,
-            last_answered_index: None,
             score: 0,
             correct_answers: 0,
             total_answers: 0,
@@ -81,15 +79,6 @@ impl QuizGame {
 
     pub fn get_current_question(&self) -> Option<&Question> {
         self.questions.get(self.current_question_index)
-    }
-
-    /// The question the player most recently submitted an answer for.
-    /// Kept for tests and possible future reuse — Issue #70 removed the
-    /// per-question result screen, so the production code no longer needs
-    /// it during the run.
-    #[allow(dead_code)]
-    pub fn get_answered_question(&self) -> Option<&Question> {
-        self.last_answered_index.and_then(|i| self.questions.get(i))
     }
 
     pub fn get_question_text(&self, question: &Question) -> String {
@@ -193,9 +182,6 @@ impl QuizGame {
                 time_taken: question_start_time.elapsed(),
             };
 
-            // Record before advancing so the result screen can render
-            // the question that was just answered, not the next one.
-            self.last_answered_index = Some(self.current_question_index);
             self.current_question_index += 1;
 
             self.maybe_freeze_time();
@@ -573,46 +559,6 @@ mod tests {
         game.start();
         game.answer_question_typed("toukyou");
         assert_eq!(game.typed_correct_chars, 7);
-    }
-
-    #[test]
-    fn get_answered_question_points_at_just_answered_question() {
-        // Regression for the H2O / Tokyo result-screen bug: `answer_question`
-        // advances `current_question_index`, but the result screen needs the
-        // question the player *just* submitted. With two questions whose
-        // `correct_answer_index` happen to coincide (both `1`), looking up
-        // `current_question.choices[result.correct_answer_index]` after the
-        // answer would yield Q2's "Tokyo" while the run was actually on Q1
-        // ("H2O"). `get_answered_question` must keep returning Q1 here.
-        let q1 = make_question(&["CO2", "H2O", "O2", "N2"], 1);
-        let q2 = make_question(&["Osaka", "Tokyo", "Kyoto", "Nagoya"], 1);
-        let mut game = QuizGame::new(vec![q1, q2], Language::English);
-        game.start();
-
-        // Answer Q1 correctly. After this call, current_question_index = 1
-        // but the result screen still wants Q1.
-        let result = game.answer_question_typed("H2O").expect("result");
-        assert!(result.is_correct);
-
-        let answered = game
-            .get_answered_question()
-            .expect("just-answered question is set");
-        assert_eq!(
-            answered.choices[result.correct_answer_index].labels["en"],
-            "H2O"
-        );
-
-        // And `get_current_question` correctly points at Q2 for the
-        // next round — the two getters are not interchangeable.
-        let current = game.get_current_question().expect("next question");
-        assert_eq!(current.choices[1].labels["en"], "Tokyo");
-    }
-
-    #[test]
-    fn get_answered_question_is_none_before_any_answer() {
-        let q = make_question(&["a", "b", "c", "d"], 0);
-        let game = QuizGame::new(vec![q], Language::English);
-        assert!(game.get_answered_question().is_none());
     }
 
     #[test]

--- a/src/ui/quiz.rs
+++ b/src/ui/quiz.rs
@@ -1,4 +1,4 @@
-use crate::game::{QuizGame, QuizResult};
+use crate::game::QuizGame;
 use crate::io::Storage;
 use crate::jiwa_core::{RevealHandle, RevealOpts, Rgb};
 use crate::types::{Language, Question, ScoreEntry};
@@ -50,8 +50,6 @@ pub struct QuizUI {
     /// `docs/spec.md`, this is the only source of truth for which choice is
     /// being picked — there is no arrow / number-key fallback.
     input_buffer: String,
-    current_result: Option<QuizResult>,
-    show_result: bool,
     phase: Phase,
     name_buffer: String,
     records_file_path: String,
@@ -78,8 +76,6 @@ impl QuizUI {
         Self {
             quiz_game,
             input_buffer: String::new(),
-            current_result: None,
-            show_result: false,
             phase: Phase::Playing,
             name_buffer: String::new(),
             records_file_path,
@@ -159,10 +155,6 @@ impl QuizUI {
             Phase::Playing => {}
         }
 
-        if self.show_result {
-            return self.handle_key_result(key);
-        }
-
         match key.code {
             KeyCode::Enter => {}
             // The guard's side effect (skip_question) is intentional — Tab
@@ -190,23 +182,6 @@ impl QuizUI {
                 self.handle_playing_char(c);
             }
             _ => {}
-        }
-        false
-    }
-
-    fn handle_key_result(&mut self, key: KeyEvent) -> bool {
-        if key.code == KeyCode::Enter {
-            if self.quiz_game.is_game_finished() {
-                self.phase = Phase::Summary;
-                self.show_result = false;
-                self.current_result = None;
-                self.input_buffer.clear();
-                return false;
-            }
-            self.show_result = false;
-            self.current_result = None;
-            self.input_buffer.clear();
-            self.clear_reject_flash();
         }
         false
     }
@@ -286,7 +261,7 @@ impl QuizUI {
     }
 
     fn ui(&mut self, f: &mut Frame) {
-        if self.phase == Phase::Playing && !self.show_result {
+        if self.phase == Phase::Playing {
             self.ensure_reveal_for_current_question();
         }
 
@@ -319,9 +294,6 @@ impl QuizUI {
             return;
         }
         let line = match self.phase {
-            // Hide the echo on result / summary — keeps the screen calm
-            // during the "correct/wrong" reveal and final score reveal.
-            Phase::Playing if self.show_result => Line::from(""),
             Phase::Playing => self.render_playing_input_line(),
             Phase::Summary => Line::from(""),
             Phase::NamingForRecord => Line::from(vec![
@@ -365,8 +337,12 @@ impl QuizUI {
     fn handle_playing_char(&mut self, c: char) {
         let mut attempted = self.input_buffer.clone();
         attempted.push(c);
-        if !self.quiz_game.is_valid_typed_prefix(&attempted) {
+        // Per Issue #70 only the correct answer's typings are accepted;
+        // any divergence is treated as a mistype that flashes red and
+        // resets the buffer to zero so the player retries from scratch.
+        if !self.quiz_game.is_valid_correct_typed_prefix(&attempted) {
             self.note_rejected_char(c);
+            self.input_buffer.clear();
             return;
         }
 
@@ -376,7 +352,7 @@ impl QuizUI {
         let typed = self.input_buffer.to_lowercase();
         if self
             .quiz_game
-            .current_typing_candidates()
+            .current_correct_typing_candidates()
             .iter()
             .any(|candidate| candidate == &typed)
         {
@@ -384,12 +360,19 @@ impl QuizUI {
         }
     }
 
+    /// Record the correct answer in the game state and advance immediately.
+    /// Issue #70: there is no "Correct!" interstitial — the player flows
+    /// straight into the next question, or into the summary screen if this
+    /// was the final question (in which case `QuizGame` has already frozen
+    /// the elapsed time).
     fn submit_current_answer(&mut self) {
         let typed = self.input_buffer.clone();
-        if let Some(result) = self.quiz_game.answer_question_typed(&typed) {
-            self.current_result = Some(result);
-            self.show_result = true;
+        if self.quiz_game.answer_question_typed(&typed).is_some() {
+            self.input_buffer.clear();
             self.clear_reject_flash();
+            if self.quiz_game.is_game_finished() {
+                self.phase = Phase::Summary;
+            }
         }
     }
 
@@ -452,7 +435,6 @@ impl QuizUI {
         match self.phase {
             Phase::Summary => self.render_summary(f, chunks[1]),
             Phase::NamingForRecord => self.render_naming(f, chunks[1]),
-            Phase::Playing if self.show_result => self.render_result(f, chunks[1]),
             Phase::Playing => self.render_question(f, chunks[1]),
         }
     }
@@ -523,38 +505,6 @@ impl QuizUI {
                 .block(Block::default().borders(Borders::ALL));
             f.render_widget(no_question, area);
         }
-    }
-
-    fn render_result(&self, f: &mut Frame, area: Rect) {
-        // Use `get_answered_question` (not `get_current_question`) — the
-        // index has already advanced past the one we just answered, and
-        // we need *that* question's choices to look up the correct
-        // answer text. Otherwise two questions whose `correct_answer_index`
-        // happen to match (e.g. both `1`) leak the next question's
-        // choice into the "Wrong. Answer: …" line.
-        let (Some(result), Some(question)) =
-            (&self.current_result, self.quiz_game.get_answered_question())
-        else {
-            return;
-        };
-
-        let choices = self.quiz_game.get_choice_texts(question);
-
-        let (result_text, result_style) = if result.is_correct {
-            ("Correct!".to_string(), STYLE_CORRECT)
-        } else {
-            let correct_text = choices
-                .get(result.correct_answer_index)
-                .cloned()
-                .unwrap_or_else(|| "(unknown)".to_string());
-            (format!("Wrong. Answer: {correct_text}"), STYLE_INCORRECT)
-        };
-
-        let result_paragraph = Paragraph::new(result_text)
-            .style(result_style)
-            .alignment(Alignment::Center)
-            .block(Block::default().title("Result").borders(Borders::ALL));
-        f.render_widget(result_paragraph, area);
     }
 
     fn render_help_line(&self, f: &mut Frame, area: Rect) {
@@ -630,17 +580,6 @@ impl QuizUI {
 
     fn help_line(&self) -> HelpLine {
         match self.phase {
-            Phase::Playing if self.show_result => {
-                let next_label = if self.quiz_game.is_game_finished() {
-                    "Summary"
-                } else {
-                    "Next"
-                };
-                HelpLine::new(vec![
-                    HelpEntry::new("Esc", "Quit"),
-                    HelpEntry::new("Enter", next_label),
-                ])
-            }
             Phase::Playing => HelpLine::new(vec![
                 HelpEntry::new("Esc", "Quit"),
                 HelpEntry::new("Tab", "Skip"),
@@ -661,4 +600,5 @@ impl QuizUI {
             ]),
         }
     }
+
 }

--- a/src/ui/quiz.rs
+++ b/src/ui/quiz.rs
@@ -34,9 +34,9 @@ const STYLE_INPUT_ECHO: Style = Style::new().fg(Color::Yellow).add_modifier(Modi
 const STYLE_CHOICE_LABEL: Style = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD);
 const INPUT_REJECT_FLASH_MS: u64 = 180;
 
-/// High-level state machine for one Quiz session. The per-question
-/// "show_result" flag still lives separately; this enum captures the flow
-/// across the run: playing → summary → records-name-entry → done.
+/// High-level state machine for one Quiz session. Issue #70 removed the
+/// per-question result interstitial, so playing → summary → records-name-
+/// entry → done is the entire flow.
 #[derive(Debug, Clone, PartialEq)]
 enum Phase {
     Playing,
@@ -600,5 +600,4 @@ impl QuizUI {
             ]),
         }
     }
-
 }


### PR DESCRIPTION
## 関連 Issue
closes #70

## 変更内容

### 正解時の即遷移
- `show_result` フェーズと `Correct!` 表示・Enter 待ちを撤去
- 正解の最後の文字を打ち込んだ瞬間に次の問題へ移る

### 不正解は 0 文字目に戻る
- `current_correct_typing_candidates()` / `is_valid_correct_typed_prefix()` を新設、正解選択肢の typing 候補のみを許可
- 候補から外れたらミスタイプ扱い（赤フラッシュ + バッファ全消去）

### 最終タイム凍結
- `QuizGame.frozen_time: Option<Duration>` を追加
- 最終問の正解確定／Tab スキップ時に `maybe_freeze_time()` が経過時間を凍結
- `get_total_time()` は凍結値があればそれを返す → Summary / Records-entry でタイマーが進まない

### docs/spec.md
- 新フローと Time 凍結の仕様を反映

## Test plan
- [x] `cargo test` 通過（116 passed）
- [x] `cargo clippy -- -D warnings` 通過
- 動作確認はターミナル必要のため未実施