### PR TITLE
feat: unify on-screen title to 'type-globe - ...' (#71)

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -41,7 +41,7 @@ Quiz is paired with score-attack modes; listening is paired with the RPG. The tw
 
 ```
 ┌─────────────────────────────────────┬──────────┐
-│ Q3/10                                │ Score    │
+│ 3/10                                 │ Score    │
 │ Which keyword moves ownership in     │ 12,340   │
 │ Rust?                                ├──────────┤
 │                                      │ Time     │

--- a/src/io/romaji.rs
+++ b/src/io/romaji.rs
@@ -1,7 +1,7 @@
 /// Convert Japanese kana text into lowercase Hepburn-style ASCII.
 ///
 /// This is intentionally pragmatic rather than linguistically complete:
-/// it targets TypeGlobe's JA input mode (#69), where players need a
+/// it targets type-globe's JA input mode (#69), where players need a
 /// no-IME typing target for quiz/listening answers. The key project
 /// rules are:
 /// - ASCII only

--- a/src/ui/listen.rs
+++ b/src/ui/listen.rs
@@ -207,7 +207,7 @@ impl ListenUI {
     fn render_main_pane(&self, f: &mut Frame, area: Rect) {
         let title_text = match self.phase {
             Phase::Playing => "type-globe - Listening",
-            Phase::Result => "type-globe - Listening - Result",
+            Phase::Result => "type-globe - Listening",
         };
 
         let body_lines = match self.phase {

--- a/src/ui/listen.rs
+++ b/src/ui/listen.rs
@@ -206,8 +206,8 @@ impl ListenUI {
 
     fn render_main_pane(&self, f: &mut Frame, area: Rect) {
         let title_text = match self.phase {
-            Phase::Playing => "TypeGlobe — Listening Practice",
-            Phase::Result => "TypeGlobe — Listening Practice  (result)",
+            Phase::Playing => "type-globe - Listening",
+            Phase::Result => "type-globe - Listening - Result",
         };
 
         let body_lines = match self.phase {

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -221,7 +221,7 @@ impl MenuUI {
     }
 
     fn render_title(&self, f: &mut Frame, area: Rect) {
-        let title = Paragraph::new("type-globe - The answer is never shown")
+        let title = Paragraph::new("type-globe")
             .style(STYLE_TITLE)
             .alignment(Alignment::Center)
             .block(Block::default().borders(Borders::ALL));

--- a/src/ui/quiz.rs
+++ b/src/ui/quiz.rs
@@ -423,8 +423,8 @@ impl QuizUI {
         let (current, total) = self.quiz_game.get_progress();
         let title_text = match self.phase {
             Phase::Playing => format!("type-globe - Quiz {current}/{total}"),
-            Phase::Summary => "type-globe - Quiz - Run complete".to_string(),
-            Phase::NamingForRecord => "type-globe - Quiz - Records entry".to_string(),
+            Phase::Summary => "type-globe - Quiz".to_string(),
+            Phase::NamingForRecord => "type-globe - Quiz".to_string(),
         };
         let title = Paragraph::new(title_text)
             .style(STYLE_TITLE)

--- a/src/ui/quiz.rs
+++ b/src/ui/quiz.rs
@@ -422,9 +422,9 @@ impl QuizUI {
 
         let (current, total) = self.quiz_game.get_progress();
         let title_text = match self.phase {
-            Phase::Playing => format!("TypeGlobe — Quiz  Q{current}/{total}"),
-            Phase::Summary => "TypeGlobe — Quiz  Run complete".to_string(),
-            Phase::NamingForRecord => "TypeGlobe — Quiz  Records entry".to_string(),
+            Phase::Playing => format!("type-globe - Quiz {current}/{total}"),
+            Phase::Summary => "type-globe - Quiz - Run complete".to_string(),
+            Phase::NamingForRecord => "type-globe - Quiz - Records entry".to_string(),
         };
         let title = Paragraph::new(title_text)
             .style(STYLE_TITLE)

--- a/src/ui/records.rs
+++ b/src/ui/records.rs
@@ -126,7 +126,7 @@ impl RecordsUI {
     }
 
     fn render_title(&self, f: &mut Frame, area: Rect) {
-        let title = Paragraph::new("TypeGlobe — Records (local self-bests)")
+        let title = Paragraph::new("type-globe - Records")
             .style(STYLE_TITLE)
             .alignment(Alignment::Center)
             .block(Block::default().borders(Borders::ALL));


### PR DESCRIPTION
closes #71

## 変更
- TypeGlobe → type-globe（全画面）
- em dash → 半角ハイフン
- Q プレフィックス削除
- 副題撤去（menu / records / listen result）
- docs/spec.md の例図も更新

## Test plan
- [x] cargo test 通過 (114)
- [x] cargo clippy 通過