### PR TITLE
feat: shuffle quiz choices, delayed jiwa, soft-green question (#72)

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -55,6 +55,9 @@ Quiz is paired with score-attack modes; listening is paired with the RPG. The tw
 [Esc] Quit  [Tab] Skip  [F5] Restart
 ```
 
+- **The four choices are shuffled per question** so the answer's display position varies. Labels A/B/C/D are positional, not identity-based; the typing match is identity-based and stays correct under any shuffle.
+- **The choices fade in after the question text.** The question reveal starts immediately; the choices block stays invisible for ~0.5 s, then all four fade in together over ~0.3 s. This frames the question first and the options second.
+- **Question text settles to a soft green** (`Rgb(160, 220, 160)`) so it stays distinct from the choices and the input echo.
 - **No arrow-key selection.** Players type the correct choice's text directly; this both selects and answers.
 - **Exact match auto-confirms and immediately advances** to the next question — there is no "Correct!" interstitial and no Enter-to-continue. The flow is a continuous typing rhythm.
 - **Only the correct choice's typings are accepted as a valid prefix.** Any divergence (including the full text of a wrong choice) is treated as a mistype: the input flashes red and the buffer resets to zero, and the run does not advance. The player can only proceed by typing the correct answer.

--- a/src/jiwa_core/mod.rs
+++ b/src/jiwa_core/mod.rs
@@ -20,7 +20,7 @@
 pub mod pulse;
 pub mod reveal;
 
-pub use reveal::{RevealHandle, RevealOpts, Rgb};
+pub use reveal::{lerp_rgb, RevealHandle, RevealOpts, Rgb};
 // `RevealedGrapheme` and `pulse::PulseFrame` are part of the public
 // surface but constructed inside their respective `snapshot` methods;
 // callers receive them by value, so they stay reachable via

--- a/src/jiwa_core/reveal.rs
+++ b/src/jiwa_core/reveal.rs
@@ -70,7 +70,9 @@ impl RevealOpts {
             char_interval: Duration::from_millis(45),
             fade_duration: Duration::from_millis(320),
             fade_from: Rgb(60, 60, 60),
-            fade_to: Rgb(255, 255, 255),
+            // Per Issue #72 the question text settles to a soft green so
+            // it stays distinct from the choices and the input echo.
+            fade_to: Rgb(160, 220, 160),
         }
     }
 }
@@ -104,6 +106,10 @@ impl RevealHandle {
     }
 
     /// Convenience for production callers: anchors at `Instant::now()`.
+    /// Currently unused — quiz/listen pass an explicit `now` so the
+    /// question and choices reveals stay aligned to a single instant —
+    /// kept on the public API for future call sites.
+    #[allow(dead_code)]
     pub fn start(text: &str, opts: RevealOpts) -> Self {
         Self::start_at(text, opts, Instant::now())
     }

--- a/src/jiwa_core/reveal.rs
+++ b/src/jiwa_core/reveal.rs
@@ -187,7 +187,10 @@ fn fade_progress(age: Duration, fade: Duration) -> f32 {
     raw.clamp(0.0, 1.0) as f32
 }
 
-fn lerp_rgb(a: Rgb, b: Rgb, t: f32) -> Rgb {
+/// Linearly interpolate two RGB triples. Public so the UI layer can use
+/// the same lerp for fade-in effects elsewhere (Issue #72: menu detail
+/// panel, quiz choices block) without duplicating the channel math.
+pub fn lerp_rgb(a: Rgb, b: Rgb, t: f32) -> Rgb {
     let t = t.clamp(0.0, 1.0);
     Rgb(
         lerp_u8(a.0, b.0, t),

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -1,3 +1,4 @@
+use crate::jiwa_core::{lerp_rgb, Rgb};
 use crate::types::{GameMode, Language};
 use crate::ui::{HelpEntry, HelpLine};
 use crossterm::{
@@ -28,8 +29,8 @@ const REDRAW_TICK: Duration = Duration::from_millis(30);
 /// final color after a selection change (Issue #72 follow-up: jiwa across
 /// the whole UI).
 const DETAIL_FADE_MS: u64 = 320;
-const DETAIL_FADE_FROM: Color = Color::Rgb(60, 60, 60);
-const DETAIL_FADE_TO: Color = Color::Rgb(220, 220, 220);
+const DETAIL_FADE_FROM: Rgb = Rgb(60, 60, 60);
+const DETAIL_FADE_TO: Rgb = Rgb(220, 220, 220);
 
 struct LanguageOption {
     label: &'static str,
@@ -149,12 +150,22 @@ impl MenuUI {
         &mut self,
         terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     ) -> Result<(Language, GameMode), Box<dyn std::error::Error>> {
+        // Long timeout used once the description panel has finished
+        // fading in — large enough that the menu effectively waits on
+        // input without burning a tick every 30 ms.
+        const IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+
         loop {
             terminal.draw(|f| self.ui(f))?;
 
-            // Poll instead of blocking read so the description panel can
-            // re-render mid-fade without waiting for the next keypress.
-            if event::poll(REDRAW_TICK)? {
+            // Tick fast while the fade is still moving, then fall back
+            // to an input-blocking timeout so the menu is otherwise idle.
+            let timeout = if self.detail_fade_in_progress() {
+                REDRAW_TICK
+            } else {
+                IDLE_TIMEOUT
+            };
+            if event::poll(timeout)? {
                 if let Event::Key(key) = event::read()? {
                     if let Some(result) = self.handle_key(key) {
                         return Ok(result);
@@ -370,32 +381,16 @@ impl MenuUI {
         } else {
             (elapsed_ms as f32 / DETAIL_FADE_MS as f32).clamp(0.0, 1.0)
         };
-        lerp_color(DETAIL_FADE_FROM, DETAIL_FADE_TO, alpha)
+        let Rgb(r, g, b) = lerp_rgb(DETAIL_FADE_FROM, DETAIL_FADE_TO, alpha);
+        Color::Rgb(r, g, b)
     }
-}
 
-fn lerp_color(from: Color, to: Color, t: f32) -> Color {
-    let (fr, fg, fb) = unwrap_rgb(from);
-    let (tr, tg, tb) = unwrap_rgb(to);
-    let r = lerp_u8(fr, tr, t);
-    let g = lerp_u8(fg, tg, t);
-    let b = lerp_u8(fb, tb, t);
-    Color::Rgb(r, g, b)
-}
-
-fn unwrap_rgb(c: Color) -> (u8, u8, u8) {
-    match c {
-        Color::Rgb(r, g, b) => (r, g, b),
-        _ => (255, 255, 255),
+    /// True while the detail panel's fade-in is still progressing, so the
+    /// run loop can poll instead of blocking. Once it returns false the
+    /// menu can use a long-timeout poll and stay idle.
+    fn detail_fade_in_progress(&self) -> bool {
+        self.selection_changed_at.elapsed().as_millis() < (DETAIL_FADE_MS as u128)
     }
-}
-
-fn lerp_u8(a: u8, b: u8, t: f32) -> u8 {
-    let af = a as f32;
-    let bf = b as f32;
-    (af + (bf - af) * t.clamp(0.0, 1.0))
-        .round()
-        .clamp(0.0, 255.0) as u8
 }
 
 fn split_selection_area(area: Rect) -> [Rect; 2] {

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -5,7 +5,6 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use std::time::{Duration, Instant};
 use ratatui::{
     backend::CrosstermBackend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -15,6 +14,7 @@ use ratatui::{
     Frame, Terminal,
 };
 use std::io;
+use std::time::{Duration, Instant};
 
 const STYLE_TITLE: Style = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD);
 const STYLE_SELECTED: Style = Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD);
@@ -324,11 +324,7 @@ impl MenuUI {
         state.select(Some(self.selected_mode));
         f.render_stateful_widget(mode_list, list_area, &mut state);
 
-        self.render_detail_panel(
-            f,
-            detail_area,
-            MODE_OPTIONS[self.selected_mode].description,
-        );
+        self.render_detail_panel(f, detail_area, MODE_OPTIONS[self.selected_mode].description);
     }
 
     fn help_line(&self) -> HelpLine {

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -5,6 +5,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
+use std::time::{Duration, Instant};
 use ratatui::{
     backend::CrosstermBackend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -18,7 +19,17 @@ use std::io;
 const STYLE_TITLE: Style = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD);
 const STYLE_SELECTED: Style = Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD);
 const STYLE_NORMAL: Style = Style::new();
-const STYLE_LABEL: Style = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD);
+
+/// Cadence used by the menu while a description is fading in. Short enough
+/// that the lerp reads as continuous motion; the rest of the time the
+/// blocking event read takes over so the menu is otherwise idle.
+const REDRAW_TICK: Duration = Duration::from_millis(30);
+/// How long the right-pane description spends fading from dim gray to its
+/// final color after a selection change (Issue #72 follow-up: jiwa across
+/// the whole UI).
+const DETAIL_FADE_MS: u64 = 320;
+const DETAIL_FADE_FROM: Color = Color::Rgb(60, 60, 60);
+const DETAIL_FADE_TO: Color = Color::Rgb(220, 220, 220);
 
 struct LanguageOption {
     label: &'static str,
@@ -83,6 +94,12 @@ pub struct MenuUI {
     selected_mode: usize,
     step: MenuStep,
     should_quit: bool,
+    /// Wall-clock instant of the last selection or step change. The
+    /// detail panel fades in from `DETAIL_FADE_FROM` to `DETAIL_FADE_TO`
+    /// over `DETAIL_FADE_MS` starting from this instant, so each new
+    /// selection's description shows up with a soft jiwa rather than
+    /// snapping into place.
+    selection_changed_at: Instant,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -98,6 +115,7 @@ impl MenuUI {
             selected_mode: 0,
             step: MenuStep::LanguageSelection,
             should_quit: false,
+            selection_changed_at: Instant::now(),
         }
     }
 
@@ -124,6 +142,7 @@ impl MenuUI {
         };
         self.step = MenuStep::ModeSelection;
         self.should_quit = false;
+        self.selection_changed_at = Instant::now();
     }
 
     fn run_app(
@@ -133,12 +152,16 @@ impl MenuUI {
         loop {
             terminal.draw(|f| self.ui(f))?;
 
-            if let Event::Key(key) = event::read()? {
-                if let Some(result) = self.handle_key(key) {
-                    return Ok(result);
-                }
-                if self.should_quit {
-                    return Err("User quit".into());
+            // Poll instead of blocking read so the description panel can
+            // re-render mid-fade without waiting for the next keypress.
+            if event::poll(REDRAW_TICK)? {
+                if let Event::Key(key) = event::read()? {
+                    if let Some(result) = self.handle_key(key) {
+                        return Ok(result);
+                    }
+                    if self.should_quit {
+                        return Err("User quit".into());
+                    }
                 }
             }
         }
@@ -146,6 +169,10 @@ impl MenuUI {
 
     fn handle_key(&mut self, key: KeyEvent) -> Option<(Language, GameMode)> {
         const MODE_COUNT: usize = 4;
+
+        let prev_language = self.selected_language;
+        let prev_mode = self.selected_mode;
+        let prev_step = self.step.clone();
 
         match key.code {
             KeyCode::Char('q') => {
@@ -196,6 +223,14 @@ impl MenuUI {
             }
             _ => {}
         }
+
+        if self.selected_language != prev_language
+            || self.selected_mode != prev_mode
+            || self.step != prev_step
+        {
+            self.selection_changed_at = Instant::now();
+        }
+
         None
     }
 
@@ -258,7 +293,6 @@ impl MenuUI {
         self.render_detail_panel(
             f,
             detail_area,
-            "Language",
             LANGUAGE_OPTIONS[self.selected_language].description,
         );
     }
@@ -293,7 +327,6 @@ impl MenuUI {
         self.render_detail_panel(
             f,
             detail_area,
-            "Mode",
             MODE_OPTIONS[self.selected_mode].description,
         );
     }
@@ -314,12 +347,12 @@ impl MenuUI {
         }
     }
 
-    fn render_detail_panel(&self, f: &mut Frame, area: Rect, title: &str, description: [&str; 2]) {
+    fn render_detail_panel(&self, f: &mut Frame, area: Rect, description: [&str; 2]) {
+        let color = self.detail_fade_color();
+        let style = Style::new().fg(color);
         let lines = vec![
-            Line::from(Span::styled(title, STYLE_LABEL)),
-            Line::default(),
-            Line::from(description[0]),
-            Line::from(description[1]),
+            Line::from(Span::styled(description[0].to_string(), style)),
+            Line::from(Span::styled(description[1].to_string(), style)),
         ];
 
         let detail = Paragraph::new(lines)
@@ -331,6 +364,42 @@ impl MenuUI {
             );
         f.render_widget(detail, area);
     }
+
+    /// Linear interpolation from `DETAIL_FADE_FROM` to `DETAIL_FADE_TO`
+    /// based on time elapsed since the last selection / step change.
+    fn detail_fade_color(&self) -> Color {
+        let elapsed_ms = self.selection_changed_at.elapsed().as_millis() as u64;
+        let alpha = if DETAIL_FADE_MS == 0 {
+            1.0
+        } else {
+            (elapsed_ms as f32 / DETAIL_FADE_MS as f32).clamp(0.0, 1.0)
+        };
+        lerp_color(DETAIL_FADE_FROM, DETAIL_FADE_TO, alpha)
+    }
+}
+
+fn lerp_color(from: Color, to: Color, t: f32) -> Color {
+    let (fr, fg, fb) = unwrap_rgb(from);
+    let (tr, tg, tb) = unwrap_rgb(to);
+    let r = lerp_u8(fr, tr, t);
+    let g = lerp_u8(fg, tg, t);
+    let b = lerp_u8(fb, tb, t);
+    Color::Rgb(r, g, b)
+}
+
+fn unwrap_rgb(c: Color) -> (u8, u8, u8) {
+    match c {
+        Color::Rgb(r, g, b) => (r, g, b),
+        _ => (255, 255, 255),
+    }
+}
+
+fn lerp_u8(a: u8, b: u8, t: f32) -> u8 {
+    let af = a as f32;
+    let bf = b as f32;
+    (af + (bf - af) * t.clamp(0.0, 1.0))
+        .round()
+        .clamp(0.0, 255.0) as u8
 }
 
 fn split_selection_area(area: Rect) -> [Rect; 2] {

--- a/src/ui/quiz.rs
+++ b/src/ui/quiz.rs
@@ -1,6 +1,6 @@
 use crate::game::QuizGame;
 use crate::io::Storage;
-use crate::jiwa_core::{RevealHandle, RevealOpts, Rgb};
+use crate::jiwa_core::{lerp_rgb, RevealHandle, RevealOpts, Rgb};
 use crate::types::{Language, Question, ScoreEntry};
 use crate::ui::{HelpEntry, HelpLine, InputChannel, PaneFrame, RecvOutcome, StatusPane};
 use crossterm::{
@@ -669,15 +669,10 @@ impl QuizUI {
     }
 }
 
-/// Interpolate two `Rgb` triples and return a ratatui `Color` so the
-/// quiz renderer can fade the choices block in over `CHOICES_FADE_MS`
-/// (Issue #72) without pulling in a second color helper.
+/// Interpolate two `Rgb` triples and return a ratatui `Color`. Thin
+/// wrapper over `jiwa_core::lerp_rgb` so the choices fade-in (Issue #72)
+/// uses the same channel math as the question text reveal.
 fn lerp_rgb_color(from: Rgb, to: Rgb, t: f32) -> Color {
-    let t = t.clamp(0.0, 1.0);
-    let lerp = |a: u8, b: u8| -> u8 {
-        let af = a as f32;
-        let bf = b as f32;
-        (af + (bf - af) * t).round().clamp(0.0, 255.0) as u8
-    };
-    Color::Rgb(lerp(from.0, to.0), lerp(from.1, to.1), lerp(from.2, to.2))
+    let Rgb(r, g, b) = lerp_rgb(from, to, t);
+    Color::Rgb(r, g, b)
 }

--- a/src/ui/quiz.rs
+++ b/src/ui/quiz.rs
@@ -16,6 +16,7 @@ use ratatui::{
     widgets::{Block, Borders, List, ListItem, Paragraph},
     Frame, Terminal,
 };
+use rand::seq::SliceRandom;
 use std::io;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -31,8 +32,16 @@ const STYLE_DIM: Style = Style::new().fg(Color::DarkGray);
 const STYLE_CORRECT: Style = Style::new().fg(Color::Green).add_modifier(Modifier::BOLD);
 const STYLE_INCORRECT: Style = Style::new().fg(Color::Red).add_modifier(Modifier::BOLD);
 const STYLE_INPUT_ECHO: Style = Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD);
-const STYLE_CHOICE_LABEL: Style = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD);
 const INPUT_REJECT_FLASH_MS: u64 = 180;
+/// How long after the question reveal starts before the choices block begins
+/// fading in (Issue #72). Roughly the time it takes for the eye to land on
+/// the question line, so the choices show up just as the player is ready
+/// to look down.
+const CHOICES_REVEAL_DELAY_MS: u64 = 500;
+/// How long the choices block takes to fade from invisible to its final
+/// color. The four choices appear as a single group (Issue #72), so this
+/// is the only timing knob the choices reveal needs.
+const CHOICES_FADE_MS: u64 = 320;
 
 /// High-level state machine for one Quiz session. Issue #70 removed the
 /// per-question result interstitial, so playing → summary → records-name-
@@ -62,6 +71,15 @@ pub struct QuizUI {
     /// Question index the current `reveal` is anchored to. Used to detect
     /// when we need to reset the animation for the next question.
     reveal_for_question: Option<usize>,
+    /// Permutation of the active question's choices (Issue #72). Indices
+    /// reference the original `question.choices`; `correct_answer_index`
+    /// stays meaningful because the typing match is identity-based, not
+    /// position-based.
+    choice_order: Vec<usize>,
+    /// Wall-clock instant at which the choices block begins fading in
+    /// (Issue #72). Set when a new question's reveal is anchored, so the
+    /// choices appear `CHOICES_REVEAL_DELAY_MS` after the question text.
+    choices_reveal_starts_at: Option<Instant>,
     rejected_char: Option<char>,
     reject_flash_until: Option<Instant>,
 }
@@ -82,6 +100,8 @@ impl QuizUI {
             saved: false,
             reveal: None,
             reveal_for_question: None,
+            choice_order: Vec::new(),
+            choices_reveal_starts_at: None,
             rejected_char: None,
             reject_flash_until: None,
         }
@@ -282,11 +302,43 @@ impl QuizUI {
         if self.reveal_for_question == Some(current_idx) {
             return;
         }
+        let now = Instant::now();
         self.reveal = self.quiz_game.get_current_question().map(|question| {
             let text = self.quiz_game.get_question_text(question);
-            RevealHandle::start(&text, RevealOpts::default_quiz())
+            RevealHandle::start_at(&text, RevealOpts::default_quiz(), now)
         });
+        // Issue #72: shuffle the four choices each question and stagger
+        // their reveal so the player reads the question first, then the
+        // choices fade in together a moment later.
+        if let Some(question) = self.quiz_game.get_current_question() {
+            let mut order: Vec<usize> = (0..question.choices.len()).collect();
+            order.shuffle(&mut rand::thread_rng());
+            self.choice_order = order;
+            self.choices_reveal_starts_at =
+                Some(now + Duration::from_millis(CHOICES_REVEAL_DELAY_MS));
+        } else {
+            self.choice_order.clear();
+            self.choices_reveal_starts_at = None;
+        }
         self.reveal_for_question = Some(current_idx);
+    }
+
+    /// Linear fade-in alpha for the choices block. Returns 0.0 while the
+    /// reveal is still scheduled in the future, ramps to 1.0 over
+    /// `CHOICES_FADE_MS`, and stays pinned at 1.0 afterwards.
+    fn choices_fade_alpha(&self) -> f32 {
+        let Some(starts_at) = self.choices_reveal_starts_at else {
+            return 1.0;
+        };
+        let now = Instant::now();
+        if now < starts_at {
+            return 0.0;
+        }
+        let elapsed_ms = now.saturating_duration_since(starts_at).as_millis() as u64;
+        if CHOICES_FADE_MS == 0 {
+            return 1.0;
+        }
+        (elapsed_ms as f32 / CHOICES_FADE_MS as f32).clamp(0.0, 1.0)
     }
 
     fn render_input_echo(&self, f: &mut Frame, area: Rect) {
@@ -481,16 +533,33 @@ impl QuizUI {
 
             // Plain non-highlighted list — typed selection means there is no
             // "currently focused" choice. Labels A/B/C/D match docs/spec.md.
+            // Issue #72: display order is the shuffled `choice_order`, not
+            // the original index, so the answer's position varies per
+            // question and the four choices fade in together after the
+            // question text is on screen.
             const LABELS: [&str; 4] = ["A", "B", "C", "D"];
-            let choice_items: Vec<ListItem> = choices
+            let alpha = self.choices_fade_alpha();
+            let label_color = lerp_rgb_color(Rgb(20, 60, 80), Rgb(80, 200, 255), alpha);
+            let text_color = lerp_rgb_color(Rgb(20, 20, 20), Rgb(255, 255, 255), alpha);
+            let label_style = Style::new()
+                .fg(label_color)
+                .add_modifier(Modifier::BOLD);
+            let text_style = Style::new().fg(text_color);
+            let order: Vec<usize> = if self.choice_order.len() == choices.len() {
+                self.choice_order.clone()
+            } else {
+                (0..choices.len()).collect()
+            };
+            let choice_items: Vec<ListItem> = order
                 .iter()
                 .enumerate()
-                .map(|(i, choice)| {
-                    let label = LABELS.get(i).copied().unwrap_or("?");
-                    ListItem::new(Line::from(vec![
-                        Span::styled(format!("{label}) "), STYLE_CHOICE_LABEL),
-                        Span::styled(choice.clone(), STYLE_NORMAL),
-                    ]))
+                .filter_map(|(display_idx, &orig_idx)| {
+                    let label = LABELS.get(display_idx).copied().unwrap_or("?");
+                    let choice = choices.get(orig_idx)?.clone();
+                    Some(ListItem::new(Line::from(vec![
+                        Span::styled(format!("{label}) "), label_style),
+                        Span::styled(choice, text_style),
+                    ])))
                 })
                 .collect();
 
@@ -600,4 +669,17 @@ impl QuizUI {
             ]),
         }
     }
+}
+
+/// Interpolate two `Rgb` triples and return a ratatui `Color` so the
+/// quiz renderer can fade the choices block in over `CHOICES_FADE_MS`
+/// (Issue #72) without pulling in a second color helper.
+fn lerp_rgb_color(from: Rgb, to: Rgb, t: f32) -> Color {
+    let t = t.clamp(0.0, 1.0);
+    let lerp = |a: u8, b: u8| -> u8 {
+        let af = a as f32;
+        let bf = b as f32;
+        (af + (bf - af) * t).round().clamp(0.0, 255.0) as u8
+    };
+    Color::Rgb(lerp(from.0, to.0), lerp(from.1, to.1), lerp(from.2, to.2))
 }

--- a/src/ui/quiz.rs
+++ b/src/ui/quiz.rs
@@ -8,6 +8,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
+use rand::seq::SliceRandom;
 use ratatui::{
     backend::CrosstermBackend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -16,7 +17,6 @@ use ratatui::{
     widgets::{Block, Borders, List, ListItem, Paragraph},
     Frame, Terminal,
 };
-use rand::seq::SliceRandom;
 use std::io;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -541,9 +541,7 @@ impl QuizUI {
             let alpha = self.choices_fade_alpha();
             let label_color = lerp_rgb_color(Rgb(20, 60, 80), Rgb(80, 200, 255), alpha);
             let text_color = lerp_rgb_color(Rgb(20, 20, 20), Rgb(255, 255, 255), alpha);
-            let label_style = Style::new()
-                .fg(label_color)
-                .add_modifier(Modifier::BOLD);
+            let label_style = Style::new().fg(label_color).add_modifier(Modifier::BOLD);
             let text_style = Style::new().fg(text_color);
             let order: Vec<usize> = if self.choice_order.len() == choices.len() {
                 self.choice_order.clone()


### PR DESCRIPTION
closes #72

## 変更
- **Quiz**: 4択を毎問シャッフル / 問題文 → 約500ms後に4択が一斉 jiwa フェード / 問題文の終端色を薄い緑 (160,220,160)
- **Menu**: 右ペイン詳細から 'Mode' / 'Language' の青ラベルを削除（不要との指示）
- **Menu**: 各モード説明テキストも選択変更時に jiwa フェードイン（poll-based redraw に変更）
- **docs/spec.md**: シャッフル / 遅延 jiwa / 緑色を仕様に明記

## Test plan
- [x] cargo test 通過 (114)
- [x] cargo clippy 通過