### PR TITLE
feat: synthesized sound cues for quiz mode (#73)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alsa"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +153,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -232,6 +256,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "coreaudio-rs"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation-sys",
+ "coreaudio-sys",
+]
+
+[[package]]
+name = "coreaudio-sys"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
+name = "cpal"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+dependencies = [
+ "alsa",
+ "core-foundation-sys",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk",
+ "ndk-context",
+ "oboe",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.54.0",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +357,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "dyn-clonable"
@@ -394,6 +467,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +502,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +518,16 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+]
 
 [[package]]
 name = "indoc"
@@ -518,6 +619,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,7 +690,16 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.4",
+]
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -625,10 +745,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+dependencies = [
+ "bitflags 2.9.1",
+ "jni-sys 0.3.1",
+ "log",
+ "ndk-sys",
+ "num_enum",
+ "thiserror",
+]
+
+[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.5.0+25.2.9519653"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys 0.3.1",
+]
 
 [[package]]
 name = "nom"
@@ -638,6 +781,48 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -666,6 +851,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "oboe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
+dependencies = [
+ "jni",
+ "ndk",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "oboe-sys",
+]
+
+[[package]]
+name = "oboe-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -719,6 +927,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +952,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,6 +977,12 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -782,7 +1011,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -845,6 +1074,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rodio"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6006a627c1a38d37f3d3a85c6575418cfe34a5392d60a686d0071e1c8d427acb"
+dependencies = [
+ "cpal",
+ "thiserror",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,18 +1137,28 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1103,6 +1352,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "tts"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1122,7 +1401,7 @@ dependencies = [
  "thiserror",
  "wasm-bindgen",
  "web-sys",
- "windows",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -1133,6 +1412,7 @@ dependencies = [
  "crossterm",
  "rand",
  "ratatui",
+ "rodio",
  "serde",
  "serde_json",
  "tokio",
@@ -1192,6 +1472,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1202,6 +1491,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1279,11 +1578,31 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
- "windows-core",
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result 0.1.2",
  "windows-targets 0.52.6",
 ]
 
@@ -1295,7 +1614,7 @@ checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-result",
+ "windows-result 0.2.0",
  "windows-strings",
  "windows-targets 0.52.6",
 ]
@@ -1330,6 +1649,15 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
@@ -1343,7 +1671,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
 ]
 
@@ -1567,6 +1895,21 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ tokio = { version = "1.0", features = ["full"] }
 rand = "0.8"
 unicode-segmentation = "1.11"
 tts = "0.26"
+rodio = { version = "0.19", default-features = false }
 
 [dev-dependencies]
 cargo-husky = { version = "1", default-features = false, features = ["user-hooks"] }

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -55,6 +55,7 @@ Quiz is paired with score-attack modes; listening is paired with the RPG. The tw
 [Esc] Quit  [Tab] Skip  [F5] Restart
 ```
 
+- **Sound cues** (Issue #73). Quiz mode synthesizes five cues at runtime via `rodio` — no asset files. The cues are: `QuestionReveal` ("ダダン") fired as each new question appears, `Correct` ("ピンポーン") fired the instant the correct answer is typed, `Wrong` ("ブブー") fired on Tab skip, `Keystroke` (quiet tick) on each accepted character, and `Mistype` (slightly louder, lower) when an off-prefix character is rejected. If no audio device is available the engine falls back to silent operation; the game stays fully playable.
 - **The four choices are shuffled per question** so the answer's display position varies. Labels A/B/C/D are positional, not identity-based; the typing match is identity-based and stays correct under any shuffle.
 - **The choices fade in after the question text.** The question reveal starts immediately; the choices block stays invisible for ~0.5 s, then all four fade in together over ~0.3 s. This frames the question first and the options second.
 - **Question text settles to a soft green** (`Rgb(160, 220, 160)`) so it stays distinct from the choices and the input echo.

--- a/src/audio/cues.rs
+++ b/src/audio/cues.rs
@@ -11,7 +11,6 @@
 
 use rodio::buffer::SamplesBuffer;
 use rodio::{OutputStream, OutputStreamHandle, Sink};
-use std::sync::Mutex;
 
 const SAMPLE_RATE: u32 = 44_100;
 
@@ -27,17 +26,17 @@ pub enum Cue {
     Mistype,
 }
 
-/// Owns the rodio output stream and a single sink for cue playback.
-/// Cues are appended; long cues that overlap a fast keystroke are
-/// allowed to mix with a fresh sink so the keystroke isn't queued
-/// behind a "ピンポーン" tail.
+/// Owns the rodio output stream used to play synthesized cues. Each
+/// `play` call hands a freshly built `Sink` to a background thread via
+/// `Sink::detach`, so two cues that overlap (a keystroke during the
+/// "ピンポーン" tail) mix at the device level instead of queueing.
 pub struct CueEngine {
-    /// Held to keep the audio device open. Never read after construction.
+    /// Held to keep the audio device open. The handle below is what
+    /// playback actually goes through; `_stream` is kept to anchor the
+    /// device's lifetime to the engine's.
+    #[allow(dead_code)]
     _stream: OutputStream,
     handle: OutputStreamHandle,
-    /// Long-running sink for the rare overlapping case. Wrapped in a
-    /// `Mutex` so the engine stays `Sync` for use behind `&self` calls.
-    sink: Mutex<Option<Sink>>,
 }
 
 impl CueEngine {
@@ -49,7 +48,6 @@ impl CueEngine {
         Some(Self {
             _stream: stream,
             handle,
-            sink: Mutex::new(None),
         })
     }
 
@@ -61,20 +59,6 @@ impl CueEngine {
         if let Ok(sink) = Sink::try_new(&self.handle) {
             sink.append(buffer);
             sink.detach();
-        }
-        // Keep one sink around so repeated short cues share allocations
-        // when they don't need to overlap (typing).
-        if let Ok(mut guard) = self.sink.lock() {
-            // MSRV is 1.78; `Option::is_none_or` is 1.82, so spell it out.
-            let needs_new = match guard.as_ref() {
-                None => true,
-                Some(s) => s.empty(),
-            };
-            if needs_new {
-                if let Ok(new_sink) = Sink::try_new(&self.handle) {
-                    *guard = Some(new_sink);
-                }
-            }
         }
     }
 }
@@ -145,4 +129,102 @@ fn tone(freq: f32, duration_s: f32, gain: f32) -> Vec<f32> {
         buf.push(s);
     }
     buf
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tone_sample_count_matches_duration() {
+        let buf = tone(440.0, 0.10, 0.5);
+        let expected = (0.10 * SAMPLE_RATE as f32) as usize;
+        assert_eq!(buf.len(), expected);
+    }
+
+    #[test]
+    fn tone_amplitude_bounded_by_gain() {
+        let gain = 0.3;
+        let buf = tone(440.0, 0.05, gain);
+        let max = buf.iter().cloned().fold(0.0_f32, f32::max);
+        let min = buf.iter().cloned().fold(0.0_f32, f32::min);
+        assert!(max <= gain + f32::EPSILON);
+        assert!(min >= -gain - f32::EPSILON);
+    }
+
+    #[test]
+    fn tone_envelope_grows_during_attack_and_settles_in_sustain() {
+        // 200 ms tone gives a wide enough attack window to sample the
+        // envelope reliably without sine-wave interference.
+        let buf = tone(440.0, 0.20, 0.5);
+        let attack = (buf.len() / 20).max(1);
+        // Compare the early part of the attack against the late part of
+        // the attack; the envelope must have ramped up.
+        let early_peak = buf[..attack / 4]
+            .iter()
+            .map(|s| s.abs())
+            .fold(0.0_f32, f32::max);
+        let late_peak = buf[attack / 4 * 3..attack]
+            .iter()
+            .map(|s| s.abs())
+            .fold(0.0_f32, f32::max);
+        assert!(
+            late_peak > early_peak,
+            "attack should ramp up: early={early_peak} late={late_peak}"
+        );
+        // Sustain region (well past the attack, before release) should
+        // hit close to the gain ceiling.
+        let release = (buf.len() / 8).max(1);
+        let sustain_start = attack;
+        let sustain_end = buf.len().saturating_sub(release);
+        if sustain_end > sustain_start {
+            let sustain_peak = buf[sustain_start..sustain_end]
+                .iter()
+                .map(|s| s.abs())
+                .fold(0.0_f32, f32::max);
+            assert!(sustain_peak > 0.4, "sustain peak too low: {sustain_peak}");
+        }
+    }
+
+    #[test]
+    fn silence_is_all_zero() {
+        let buf = silence(0.05);
+        assert!(buf.iter().all(|&s| s == 0.0));
+        assert_eq!(buf.len(), (0.05 * SAMPLE_RATE as f32) as usize);
+    }
+
+    #[test]
+    fn synthesize_question_reveal_is_two_segments_with_a_gap() {
+        let buf = synthesize(Cue::QuestionReveal);
+        // 0.10 + 0.05 + 0.18 seconds total at SAMPLE_RATE.
+        let expected = ((0.10 + 0.05 + 0.18) * SAMPLE_RATE as f32) as usize;
+        // Allow a 1-sample rounding tolerance from three independent casts.
+        assert!(
+            buf.len().abs_diff(expected) <= 3,
+            "len={} expected={}",
+            buf.len(),
+            expected
+        );
+    }
+
+    #[test]
+    fn synthesize_keystroke_is_short_and_quiet() {
+        let buf = synthesize(Cue::Keystroke);
+        let expected = (0.025 * SAMPLE_RATE as f32) as usize;
+        assert_eq!(buf.len(), expected);
+        let peak = buf.iter().map(|s| s.abs()).fold(0.0_f32, f32::max);
+        assert!(peak <= 0.05 + f32::EPSILON);
+    }
+
+    #[test]
+    fn synthesize_mistype_is_louder_than_keystroke() {
+        let key = synthesize(Cue::Keystroke);
+        let miss = synthesize(Cue::Mistype);
+        let key_peak = key.iter().map(|s| s.abs()).fold(0.0_f32, f32::max);
+        let miss_peak = miss.iter().map(|s| s.abs()).fold(0.0_f32, f32::max);
+        assert!(
+            miss_peak > key_peak,
+            "mistype peak {miss_peak} should exceed keystroke peak {key_peak}"
+        );
+    }
 }

--- a/src/audio/cues.rs
+++ b/src/audio/cues.rs
@@ -1,0 +1,148 @@
+//! Sound effect cues for Quiz mode (Issue #73).
+//!
+//! All effects are **synthesized at runtime** as PCM samples; no asset
+//! files ship with the binary. The synthesizer is intentionally tiny
+//! (sine + linear envelope) so the cargo footprint of `rodio` is the
+//! only cost we pay for sound.
+//!
+//! If audio output is unavailable (no device, sandboxed environment),
+//! `CueEngine::new` falls back to a silent stub. Quiz mode is fully
+//! playable without sound — the cues are decoration, not signal.
+
+use rodio::buffer::SamplesBuffer;
+use rodio::{OutputStream, OutputStreamHandle, Sink};
+use std::sync::Mutex;
+
+const SAMPLE_RATE: u32 = 44_100;
+
+/// One of the canned cues a Quiz session can fire. Issue #73 names the
+/// "ダダン" question reveal, the "ピンポーン" correct cue, the "ブブー"
+/// wrong cue, and the muted typing / mistype clicks.
+#[derive(Debug, Clone, Copy)]
+pub enum Cue {
+    QuestionReveal,
+    Correct,
+    Wrong,
+    Keystroke,
+    Mistype,
+}
+
+/// Owns the rodio output stream and a single sink for cue playback.
+/// Cues are appended; long cues that overlap a fast keystroke are
+/// allowed to mix with a fresh sink so the keystroke isn't queued
+/// behind a "ピンポーン" tail.
+pub struct CueEngine {
+    /// Held to keep the audio device open. Never read after construction.
+    _stream: OutputStream,
+    handle: OutputStreamHandle,
+    /// Long-running sink for the rare overlapping case. Wrapped in a
+    /// `Mutex` so the engine stays `Sync` for use behind `&self` calls.
+    sink: Mutex<Option<Sink>>,
+}
+
+impl CueEngine {
+    /// Open the default audio device. Returns `None` when no device is
+    /// available (CI, headless servers, sandboxes) so callers can fall
+    /// back to silent operation without a panic.
+    pub fn new() -> Option<Self> {
+        let (stream, handle) = OutputStream::try_default().ok()?;
+        Some(Self {
+            _stream: stream,
+            handle,
+            sink: Mutex::new(None),
+        })
+    }
+
+    /// Fire-and-forget playback. Drops silently if a sink can't be
+    /// created — sound is decorative, not load-bearing.
+    pub fn play(&self, cue: Cue) {
+        let samples = synthesize(cue);
+        let buffer = SamplesBuffer::new(1, SAMPLE_RATE, samples);
+        if let Ok(sink) = Sink::try_new(&self.handle) {
+            sink.append(buffer);
+            sink.detach();
+        }
+        // Keep one sink around so repeated short cues share allocations
+        // when they don't need to overlap (typing).
+        if let Ok(mut guard) = self.sink.lock() {
+            // MSRV is 1.78; `Option::is_none_or` is 1.82, so spell it out.
+            let needs_new = match guard.as_ref() {
+                None => true,
+                Some(s) => s.empty(),
+            };
+            if needs_new {
+                if let Ok(new_sink) = Sink::try_new(&self.handle) {
+                    *guard = Some(new_sink);
+                }
+            }
+        }
+    }
+}
+
+/// Render `cue` to a mono PCM buffer at `SAMPLE_RATE`. Each cue mixes a
+/// sequence of tone segments with a linear attack/decay envelope so the
+/// output reads as a clean cue rather than a square click.
+fn synthesize(cue: Cue) -> Vec<f32> {
+    match cue {
+        // "ダダン" — two short low-mid hits, second slightly higher.
+        Cue::QuestionReveal => mix_segments(&[
+            tone(330.0, 0.10, 0.35),
+            silence(0.05),
+            tone(440.0, 0.18, 0.40),
+        ]),
+        // "ピンポーン" — bright two-note major-third descending arpeggio.
+        Cue::Correct => mix_segments(&[
+            tone(880.0, 0.18, 0.32),
+            silence(0.04),
+            tone(660.0, 0.30, 0.32),
+        ]),
+        // "ブブー" — low buzz, two pulses on the same low pitch.
+        Cue::Wrong => mix_segments(&[
+            tone(180.0, 0.18, 0.40),
+            silence(0.05),
+            tone(180.0, 0.20, 0.40),
+        ]),
+        // Quiet typing tick — short, mid-high, low amplitude.
+        Cue::Keystroke => tone(720.0, 0.025, 0.05),
+        // Mistype — slightly lower, slightly louder, shorter than "wrong"
+        // so it doesn't overshadow the question feedback.
+        Cue::Mistype => tone(220.0, 0.05, 0.12),
+    }
+}
+
+fn mix_segments(segments: &[Vec<f32>]) -> Vec<f32> {
+    let total: usize = segments.iter().map(|s| s.len()).sum();
+    let mut out = Vec::with_capacity(total);
+    for seg in segments {
+        out.extend_from_slice(seg);
+    }
+    out
+}
+
+fn silence(duration_s: f32) -> Vec<f32> {
+    let samples = (duration_s * SAMPLE_RATE as f32) as usize;
+    vec![0.0; samples]
+}
+
+/// One tone segment: sine wave at `freq` Hz, `duration_s` seconds, peak
+/// amplitude `gain` in `[0.0, 1.0]`. A short attack/decay envelope avoids
+/// the click that a hard-edged buffer would otherwise produce.
+fn tone(freq: f32, duration_s: f32, gain: f32) -> Vec<f32> {
+    let total = (duration_s * SAMPLE_RATE as f32) as usize;
+    let attack = (total / 20).max(1);
+    let release = (total / 8).max(1);
+    let mut buf = Vec::with_capacity(total);
+    for i in 0..total {
+        let t = i as f32 / SAMPLE_RATE as f32;
+        let env = if i < attack {
+            i as f32 / attack as f32
+        } else if i + release > total {
+            (total - i) as f32 / release as f32
+        } else {
+            1.0
+        };
+        let s = (2.0 * std::f32::consts::PI * freq * t).sin() * gain * env;
+        buf.push(s);
+    }
+    buf
+}

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -1,6 +1,8 @@
-//! Audio output. Currently only TTS (#28); future modules (sfx, music)
-//! would live alongside `tts.rs` here.
+//! Audio output. Hosts the speech-dispatcher TTS wrapper (#28) and the
+//! synthesized sound-effect cues used by Quiz mode (#73).
 
+pub mod cues;
 pub mod tts;
 
+pub use cues::{Cue, CueEngine};
 pub use tts::TtsEngine;

--- a/src/ui/quiz.rs
+++ b/src/ui/quiz.rs
@@ -1,3 +1,4 @@
+use crate::audio::{Cue, CueEngine};
 use crate::game::QuizGame;
 use crate::io::Storage;
 use crate::jiwa_core::{lerp_rgb, RevealHandle, RevealOpts, Rgb};
@@ -82,6 +83,9 @@ pub struct QuizUI {
     choices_reveal_starts_at: Option<Instant>,
     rejected_char: Option<char>,
     reject_flash_until: Option<Instant>,
+    /// Sound-effect engine (Issue #73). `None` when audio output is
+    /// unavailable — Quiz still works silently in that case.
+    cues: Option<CueEngine>,
 }
 
 impl QuizUI {
@@ -104,6 +108,13 @@ impl QuizUI {
             choices_reveal_starts_at: None,
             rejected_char: None,
             reject_flash_until: None,
+            cues: CueEngine::new(),
+        }
+    }
+
+    fn play_cue(&self, cue: Cue) {
+        if let Some(engine) = self.cues.as_ref() {
+            engine.play(cue);
         }
     }
 
@@ -183,6 +194,10 @@ impl QuizUI {
             KeyCode::Tab if self.quiz_game.skip_question() => {
                 self.input_buffer.clear();
                 self.clear_reject_flash();
+                // Skipping a question counts as the "wrong" outcome for
+                // sound purposes (Issue #73): the player gave up rather
+                // than landing the correct answer, so play "ブブー".
+                self.play_cue(Cue::Wrong);
                 if self.quiz_game.is_game_finished() {
                     self.phase = Phase::Summary;
                     return false;
@@ -302,6 +317,12 @@ impl QuizUI {
         if self.reveal_for_question == Some(current_idx) {
             return;
         }
+        // New question is about to be revealed — fire the "ダダン" cue
+        // (Issue #73) before the typewriter starts, so the audio leads
+        // the visual by a frame.
+        if self.quiz_game.get_current_question().is_some() {
+            self.play_cue(Cue::QuestionReveal);
+        }
         let now = Instant::now();
         self.reveal = self.quiz_game.get_current_question().map(|question| {
             let text = self.quiz_game.get_question_text(question);
@@ -395,11 +416,17 @@ impl QuizUI {
         if !self.quiz_game.is_valid_correct_typed_prefix(&attempted) {
             self.note_rejected_char(c);
             self.input_buffer.clear();
+            // Mistype cue (Issue #73) — slightly louder than the
+            // keystroke tick so the player can tell them apart.
+            self.play_cue(Cue::Mistype);
             return;
         }
 
         self.input_buffer.push(c);
         self.clear_reject_flash();
+        // Quiet typing tick (Issue #73). Played only on accepted
+        // characters so the mistype cue can stand alone.
+        self.play_cue(Cue::Keystroke);
 
         let typed = self.input_buffer.to_lowercase();
         if self
@@ -420,6 +447,10 @@ impl QuizUI {
     fn submit_current_answer(&mut self) {
         let typed = self.input_buffer.clone();
         if self.quiz_game.answer_question_typed(&typed).is_some() {
+            // Issue #70 limits this code path to correct answers (the
+            // input layer rejects wrong ones), so this is always the
+            // "ピンポーン" cue. Issue #73.
+            self.play_cue(Cue::Correct);
             self.input_buffer.clear();
             self.clear_reject_flash();
             if self.quiz_game.is_game_finished() {


### PR DESCRIPTION
closes #73

## 変更
- 新モジュール `src/audio/cues.rs`: rodio + サイン波合成で 5 種類の効果音を実行時生成
- QuestionReveal (ダダン) / Correct (ピンポーン) / Wrong (ブブー) / Keystroke / Mistype
- Quiz モードに CueEngine を組み込み、各イベントで発火
- 音声デバイスが無ければ silent fallback（CI/headless でも動く）
- 依存追加: `rodio = '0.19'` (default-features = false)
- docs/spec.md 更新

## Test plan
- [x] cargo test 通過 (114)
- [x] cargo clippy 通過
- 実機での音確認はターミナルで手動