### PR TITLE
feat: unify bilingual text order to English first (#74)

### DIFF
--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -54,7 +54,7 @@ const LANGUAGE_OPTIONS: [LanguageOption; 2] = [
         label: "English",
         description: [
             "Use English prompts and localized records.",
-            "English questions and records labels are used.",
+            "問題文と記録表示を英語にします。",
         ],
     },
 ];

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -44,7 +44,7 @@ struct ModeOption {
 
 const LANGUAGE_OPTIONS: [LanguageOption; 2] = [
     LanguageOption {
-        label: "日本語 / Japanese",
+        label: "Japanese / 日本語",
         description: [
             "Use Japanese prompts and localized records.",
             "問題文と記録表示を日本語にします。",
@@ -292,7 +292,7 @@ impl MenuUI {
         let language_list = List::new(items)
             .block(
                 Block::default()
-                    .title("言語を選択してください / Select Language")
+                    .title("Select Language / 言語を選択してください")
                     .borders(Borders::ALL),
             )
             .highlight_style(STYLE_SELECTED);
@@ -326,7 +326,7 @@ impl MenuUI {
         let mode_list = List::new(items)
             .block(
                 Block::default()
-                    .title("ゲームモードを選択してください / Select Game Mode")
+                    .title("Select Game Mode / ゲームモードを選択してください")
                     .borders(Borders::ALL),
             )
             .highlight_style(STYLE_SELECTED);
@@ -366,7 +366,7 @@ impl MenuUI {
             .wrap(ratatui::widgets::Wrap { trim: true })
             .block(
                 Block::default()
-                    .title("説明 / Details")
+                    .title("Details / 説明")
                     .borders(Borders::ALL),
             );
         f.render_widget(detail, area);


### PR DESCRIPTION
closes #74

## 変更
言語選択・モード選択・詳細パネル等の二言語並記を全て `English / 日本語` の順に揃える。
モード説明は元から en/ja 順だったので、それを基準に他を反転。

## Test plan
- [x] cargo test 通過 (121)