### PR TITLE
feat: show j/k before arrow keys in menu help (#75)

### DIFF
--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -341,12 +341,12 @@ impl MenuUI {
     fn help_line(&self) -> HelpLine {
         match self.step {
             MenuStep::LanguageSelection => HelpLine::new(vec![
-                HelpEntry::new("↑↓", "Select"),
+                HelpEntry::new("j/k, ↑/↓", "Select"),
                 HelpEntry::new("Enter", "Confirm"),
                 HelpEntry::new("q", "Quit"),
             ]),
             MenuStep::ModeSelection => HelpLine::new(vec![
-                HelpEntry::new("↑↓", "Select"),
+                HelpEntry::new("j/k, ↑/↓", "Select"),
                 HelpEntry::new("Enter", "Confirm"),
                 HelpEntry::new("Esc", "Back"),
                 HelpEntry::new("q", "Quit"),


### PR DESCRIPTION
closes #75

メニュー操作ヒントを `j/k, ↑/↓` に変更し、Vim 流の j/k を基本、矢印を補助の順序で見せる。

## Test plan
- [x] cargo test 通過 (121)