### PR TITLE
feat: 1-cell inner padding for left/right TUI panes (#76)

### DIFF
--- a/src/ui/listen.rs
+++ b/src/ui/listen.rs
@@ -30,7 +30,7 @@ use ratatui::{
     layout::{Alignment, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Paragraph},
+    widgets::{Block, Borders, Padding, Paragraph},
     Frame, Terminal,
 };
 use std::io;
@@ -221,7 +221,8 @@ impl ListenUI {
                 Block::default()
                     .title(title_text)
                     .title_style(STYLE_TITLE)
-                    .borders(Borders::ALL),
+                    .borders(Borders::ALL)
+                    .padding(Padding::uniform(1)),
             );
         f.render_widget(para, area);
     }
@@ -300,7 +301,12 @@ impl ListenUI {
         ];
         let para = Paragraph::new(lines)
             .alignment(Alignment::Left)
-            .block(Block::default().title("Status").borders(Borders::ALL));
+            .block(
+                Block::default()
+                    .title("Status")
+                    .borders(Borders::ALL)
+                    .padding(Padding::uniform(1)),
+            );
         f.render_widget(para, area);
     }
 

--- a/src/ui/listen.rs
+++ b/src/ui/listen.rs
@@ -299,14 +299,12 @@ impl ListenUI {
             Line::from(format!("Plays  : {}", self.plays)),
             Line::from(format!("Time   : {mins}:{secs:02}")),
         ];
-        let para = Paragraph::new(lines)
-            .alignment(Alignment::Left)
-            .block(
-                Block::default()
-                    .title("Status")
-                    .borders(Borders::ALL)
-                    .padding(Padding::uniform(1)),
-            );
+        let para = Paragraph::new(lines).alignment(Alignment::Left).block(
+            Block::default()
+                .title("Status")
+                .borders(Borders::ALL)
+                .padding(Padding::uniform(1)),
+        );
         f.render_widget(para, area);
     }
 

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -11,7 +11,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+    widgets::{Block, Borders, List, ListItem, ListState, Padding, Paragraph},
     Frame, Terminal,
 };
 use std::io;
@@ -293,7 +293,8 @@ impl MenuUI {
             .block(
                 Block::default()
                     .title("Select Language / 言語を選択してください")
-                    .borders(Borders::ALL),
+                    .borders(Borders::ALL)
+                    .padding(Padding::uniform(1)),
             )
             .highlight_style(STYLE_SELECTED);
 
@@ -327,7 +328,8 @@ impl MenuUI {
             .block(
                 Block::default()
                     .title("Select Game Mode / ゲームモードを選択してください")
-                    .borders(Borders::ALL),
+                    .borders(Borders::ALL)
+                    .padding(Padding::uniform(1)),
             )
             .highlight_style(STYLE_SELECTED);
 
@@ -367,7 +369,8 @@ impl MenuUI {
             .block(
                 Block::default()
                     .title("Details / 説明")
-                    .borders(Borders::ALL),
+                    .borders(Borders::ALL)
+                    .padding(Padding::uniform(1)),
             );
         f.render_widget(detail, area);
     }

--- a/src/ui/quiz.rs
+++ b/src/ui/quiz.rs
@@ -15,7 +15,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, List, ListItem, Paragraph},
+    widgets::{Block, Borders, List, ListItem, Padding, Paragraph},
     Frame, Terminal,
 };
 use std::io;
@@ -558,7 +558,12 @@ impl QuizUI {
             let question_line = self.question_reveal_line(question);
             let question_paragraph = Paragraph::new(question_line)
                 .alignment(Alignment::Left)
-                .block(Block::default().title("Question").borders(Borders::ALL))
+                .block(
+                    Block::default()
+                        .title("Question")
+                        .borders(Borders::ALL)
+                        .padding(Padding::uniform(1)),
+                )
                 .wrap(ratatui::widgets::Wrap { trim: true });
             f.render_widget(question_paragraph, chunks[0]);
 
@@ -593,7 +598,12 @@ impl QuizUI {
                 .collect();
 
             let choices_list = List::new(choice_items)
-                .block(Block::default().title("Choices").borders(Borders::ALL));
+                .block(
+                    Block::default()
+                        .title("Choices")
+                        .borders(Borders::ALL)
+                        .padding(Padding::uniform(1)),
+                );
 
             f.render_widget(choices_list, chunks[1]);
         } else {
@@ -635,7 +645,12 @@ impl QuizUI {
 
         let body = Paragraph::new(lines)
             .alignment(Alignment::Left)
-            .block(Block::default().title("Summary").borders(Borders::ALL));
+            .block(
+                Block::default()
+                    .title("Summary")
+                    .borders(Borders::ALL)
+                    .padding(Padding::uniform(1)),
+            );
         f.render_widget(body, area);
     }
 
@@ -671,7 +686,8 @@ impl QuizUI {
         let body = Paragraph::new(lines).alignment(Alignment::Left).block(
             Block::default()
                 .title("Records entry")
-                .borders(Borders::ALL),
+                .borders(Borders::ALL)
+                .padding(Padding::uniform(1)),
         );
         f.render_widget(body, area);
     }

--- a/src/ui/quiz.rs
+++ b/src/ui/quiz.rs
@@ -552,7 +552,11 @@ impl QuizUI {
 
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
-                .constraints([Constraint::Length(3), Constraint::Min(4)])
+                // Length(5) keeps 1 visible row of question text after
+                // the 2-row border and Issue #76's 2-row vertical padding
+                // (border + padding eats 4 rows). Choices stays Min so
+                // it absorbs whatever vertical space is left.
+                .constraints([Constraint::Length(5), Constraint::Min(6)])
                 .split(area);
 
             let question_line = self.question_reveal_line(question);

--- a/src/ui/quiz.rs
+++ b/src/ui/quiz.rs
@@ -597,13 +597,12 @@ impl QuizUI {
                 })
                 .collect();
 
-            let choices_list = List::new(choice_items)
-                .block(
-                    Block::default()
-                        .title("Choices")
-                        .borders(Borders::ALL)
-                        .padding(Padding::uniform(1)),
-                );
+            let choices_list = List::new(choice_items).block(
+                Block::default()
+                    .title("Choices")
+                    .borders(Borders::ALL)
+                    .padding(Padding::uniform(1)),
+            );
 
             f.render_widget(choices_list, chunks[1]);
         } else {
@@ -643,14 +642,12 @@ impl QuizUI {
             )),
         ];
 
-        let body = Paragraph::new(lines)
-            .alignment(Alignment::Left)
-            .block(
-                Block::default()
-                    .title("Summary")
-                    .borders(Borders::ALL)
-                    .padding(Padding::uniform(1)),
-            );
+        let body = Paragraph::new(lines).alignment(Alignment::Left).block(
+            Block::default()
+                .title("Summary")
+                .borders(Borders::ALL)
+                .padding(Padding::uniform(1)),
+        );
         f.render_widget(body, area);
     }
 

--- a/src/ui/records.rs
+++ b/src/ui/records.rs
@@ -22,7 +22,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Paragraph},
+    widgets::{Block, Borders, Padding, Paragraph},
     Frame, Terminal,
 };
 use std::io;
@@ -204,7 +204,8 @@ impl RecordsUI {
         let body = Paragraph::new(lines).alignment(Alignment::Left).block(
             Block::default()
                 .title(Span::styled(format!(" {title} "), STYLE_SECTION))
-                .borders(Borders::ALL),
+                .borders(Borders::ALL)
+                .padding(Padding::uniform(1)),
         );
         f.render_widget(body, area);
     }
@@ -246,7 +247,8 @@ impl RecordsUI {
         let body = Paragraph::new(lines).alignment(Alignment::Left).block(
             Block::default()
                 .title(Span::styled(format!(" {title} "), STYLE_SECTION))
-                .borders(Borders::ALL),
+                .borders(Borders::ALL)
+                .padding(Padding::uniform(1)),
         );
         f.render_widget(body, area);
     }

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -13,7 +13,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Gauge, Paragraph},
+    widgets::{Block, Borders, Gauge, Padding, Paragraph},
     Frame,
 };
 use std::time::Duration;
@@ -133,9 +133,13 @@ impl StatusPane {
     }
 
     pub fn render(&self, f: &mut Frame, area: Rect) {
+        // Per Issue #76 the left and right content panes get 1-cell
+        // breathing room inside the border so the labels and values
+        // don't crash into the frame.
         let block = Block::default()
             .title(Span::styled(self.title.clone(), STYLE_TITLE))
-            .borders(Borders::ALL);
+            .borders(Borders::ALL)
+            .padding(Padding::uniform(1));
         let inner = block.inner(area);
         f.render_widget(block, area);
 


### PR DESCRIPTION
closes #76

左右の本文ペインの内側に Padding::uniform(1) を入れ、文字が枠に密接しないように呼吸感を作る。
ヘッダ（type-globe タイトル枠）とフッタ（help_line）はスコープ外で従来どおり。

対象:
- quiz: Question / Choices / Summary / Records entry
- listening: 本文 + Status
- records: 各セクション
- menu: Select Language / Select Game Mode / Details
- status (右ペイン共通): StatusPane

## Test plan
- [x] cargo test 通過 (121)