### PR TITLE
fix: 1-cell horizontal margin around block titles (#76 follow-up)

### DIFF
--- a/src/ui/listen.rs
+++ b/src/ui/listen.rs
@@ -219,7 +219,7 @@ impl ListenUI {
             .alignment(Alignment::Center)
             .block(
                 Block::default()
-                    .title(title_text)
+                    .title(format!(" {title_text} "))
                     .title_style(STYLE_TITLE)
                     .borders(Borders::ALL)
                     .padding(Padding::uniform(1)),
@@ -301,7 +301,7 @@ impl ListenUI {
         ];
         let para = Paragraph::new(lines).alignment(Alignment::Left).block(
             Block::default()
-                .title("Status")
+                .title(" Status ")
                 .borders(Borders::ALL)
                 .padding(Padding::uniform(1)),
         );
@@ -352,7 +352,7 @@ impl ListenUI {
         };
         let para = Paragraph::new(lines)
             .alignment(Alignment::Left)
-            .block(Block::default().title("Log").borders(Borders::ALL));
+            .block(Block::default().title(" Log ").borders(Borders::ALL));
         f.render_widget(para, area);
     }
 

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -292,7 +292,7 @@ impl MenuUI {
         let language_list = List::new(items)
             .block(
                 Block::default()
-                    .title("Select Language / 言語を選択してください")
+                    .title(" Select Language / 言語を選択してください ")
                     .borders(Borders::ALL)
                     .padding(Padding::uniform(1)),
             )
@@ -327,7 +327,7 @@ impl MenuUI {
         let mode_list = List::new(items)
             .block(
                 Block::default()
-                    .title("Select Game Mode / ゲームモードを選択してください")
+                    .title(" Select Game Mode / ゲームモードを選択してください ")
                     .borders(Borders::ALL)
                     .padding(Padding::uniform(1)),
             )
@@ -368,7 +368,7 @@ impl MenuUI {
             .wrap(ratatui::widgets::Wrap { trim: true })
             .block(
                 Block::default()
-                    .title("Details / 説明")
+                    .title(" Details / 説明 ")
                     .borders(Borders::ALL)
                     .padding(Padding::uniform(1)),
             );

--- a/src/ui/quiz.rs
+++ b/src/ui/quiz.rs
@@ -564,7 +564,7 @@ impl QuizUI {
                 .alignment(Alignment::Left)
                 .block(
                     Block::default()
-                        .title("Question")
+                        .title(" Question ")
                         .borders(Borders::ALL)
                         .padding(Padding::uniform(1)),
                 )
@@ -603,7 +603,7 @@ impl QuizUI {
 
             let choices_list = List::new(choice_items).block(
                 Block::default()
-                    .title("Choices")
+                    .title(" Choices ")
                     .borders(Borders::ALL)
                     .padding(Padding::uniform(1)),
             );
@@ -648,7 +648,7 @@ impl QuizUI {
 
         let body = Paragraph::new(lines).alignment(Alignment::Left).block(
             Block::default()
-                .title("Summary")
+                .title(" Summary ")
                 .borders(Borders::ALL)
                 .padding(Padding::uniform(1)),
         );
@@ -686,7 +686,7 @@ impl QuizUI {
 
         let body = Paragraph::new(lines).alignment(Alignment::Left).block(
             Block::default()
-                .title("Records entry")
+                .title(" Records entry ")
                 .borders(Borders::ALL)
                 .padding(Padding::uniform(1)),
         );

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -137,7 +137,7 @@ impl StatusPane {
         // breathing room inside the border so the labels and values
         // don't crash into the frame.
         let block = Block::default()
-            .title(Span::styled(self.title.clone(), STYLE_TITLE))
+            .title(Span::styled(format!(" {} ", self.title), STYLE_TITLE))
             .borders(Borders::ALL)
             .padding(Padding::uniform(1));
         let inner = block.inner(area);


### PR DESCRIPTION
follow-up to #76

罫線とタイトル文字が密接していた件を、各 Block の title を ' Title ' 形式に統一して解消。

`┌Select Language─` → `┌ Select Language ─`

## Test plan
- [x] cargo test 通過 (121)