### PR TITLE
feat: 問題数を100問から884問に拡充

### DIFF
--- a/data/questions_en.json
+++ b/data/questions_en.json
@@ -8,20 +8,24 @@
     },
     "choices": [
       {
+        "en": "CO2",
         "ja": "CO2",
-        "en": "CO2"
+        "ja_typings": []
       },
       {
+        "ja": "H2O",
         "en": "H2O",
-        "ja": "H2O"
+        "ja_typings": []
       },
       {
         "en": "O2",
-        "ja": "O2"
+        "ja": "O2",
+        "ja_typings": []
       },
       {
+        "en": "N2",
         "ja": "N2",
-        "en": "N2"
+        "ja_typings": []
       }
     ],
     "correct_answer_index": 1,
@@ -37,22 +41,28261 @@
     "choices": [
       {
         "en": "Osaka",
-        "ja": "大阪"
+        "ja": "大阪",
+        "ja_typings": [
+          "osaka",
+          "oosaka"
+        ]
       },
       {
+        "en": "Tokyo",
         "ja": "東京",
-        "en": "Tokyo"
+        "ja_typings": [
+          "tokyo",
+          "toukyou"
+        ]
       },
       {
+        "en": "Kyoto",
         "ja": "京都",
-        "en": "Kyoto"
+        "ja_typings": [
+          "kyoto",
+          "kyouto"
+        ]
       },
       {
         "ja": "名古屋",
-        "en": "Nagoya"
+        "en": "Nagoya",
+        "ja_typings": [
+          "nagoya"
+        ]
       }
     ],
     "correct_answer_index": 1,
     "image_path": null
+  },
+  {
+    "choices": [
+      {
+        "en": "<class 'list'>",
+        "ja": "<class 'list'>",
+        "ja_typings": []
+      },
+      {
+        "en": "<class 'array'>",
+        "ja": "<class 'array'>",
+        "ja_typings": []
+      },
+      {
+        "en": "<class 'tuple'>",
+        "ja": "<class 'tuple'>",
+        "ja_typings": []
+      },
+      {
+        "en": "<class 'dict'>",
+        "ja": "<class 'dict'>",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00003",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the output of `print(type([]))`?",
+      "ja": "Pythonで`print(type([]))`の出力は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "def",
+        "ja": "def",
+        "ja_typings": []
+      },
+      {
+        "en": "function",
+        "ja": "function",
+        "ja_typings": []
+      },
+      {
+        "en": "fn",
+        "ja": "fn",
+        "ja_typings": []
+      },
+      {
+        "en": "func",
+        "ja": "func",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00004",
+    "image_path": null,
+    "question_text": {
+      "en": "Which keyword defines a function in Python?",
+      "ja": "Pythonで関数を定義するキーワードは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "3",
+        "ja": "3",
+        "ja_typings": []
+      },
+      {
+        "en": "2",
+        "ja": "2",
+        "ja_typings": []
+      },
+      {
+        "en": "4",
+        "ja": "4",
+        "ja_typings": []
+      },
+      {
+        "en": "0",
+        "ja": "0",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00005",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `len([1,2,3])` return?",
+      "ja": "`len([1,2,3])`の戻り値は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "dict",
+        "ja": "dict",
+        "ja_typings": []
+      },
+      {
+        "en": "list",
+        "ja": "list",
+        "ja_typings": []
+      },
+      {
+        "en": "tuple",
+        "ja": "tuple",
+        "ja_typings": []
+      },
+      {
+        "en": "set",
+        "ja": "set",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00006",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Python data structure uses key-value pairs?",
+      "ja": "Pythonでキーと値のペアを使うデータ構造は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "open()",
+        "ja": "open()",
+        "ja_typings": []
+      },
+      {
+        "en": "file()",
+        "ja": "file()",
+        "ja_typings": []
+      },
+      {
+        "en": "read()",
+        "ja": "read()",
+        "ja_typings": []
+      },
+      {
+        "en": "load()",
+        "ja": "load()",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00007",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the correct way to open a file in Python?",
+      "ja": "Pythonでファイルを開く正しい方法は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "//",
+        "ja": "//",
+        "ja_typings": []
+      },
+      {
+        "en": "/",
+        "ja": "/",
+        "ja_typings": []
+      },
+      {
+        "en": "%",
+        "ja": "%",
+        "ja_typings": []
+      },
+      {
+        "en": "**",
+        "ja": "**",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00008",
+    "image_path": null,
+    "question_text": {
+      "en": "Which operator is used for floor division in Python?",
+      "ja": "Pythonで切り捨て除算に使う演算子は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "0,1,2,3,4",
+        "ja": "0,1,2,3,4",
+        "ja_typings": []
+      },
+      {
+        "en": "1,2,3,4,5",
+        "ja": "1,2,3,4,5",
+        "ja_typings": []
+      },
+      {
+        "en": "0,1,2,3,4,5",
+        "ja": "0,1,2,3,4,5",
+        "ja_typings": []
+      },
+      {
+        "en": "1,2,3,4",
+        "ja": "1,2,3,4",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00009",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `range(5)` produce?",
+      "ja": "`range(5)`が生成するのは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "append()",
+        "ja": "append()",
+        "ja_typings": []
+      },
+      {
+        "en": "add()",
+        "ja": "add()",
+        "ja_typings": []
+      },
+      {
+        "en": "push()",
+        "ja": "push()",
+        "ja_typings": []
+      },
+      {
+        "en": "insert_end()",
+        "ja": "insert_end()",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00010",
+    "image_path": null,
+    "question_text": {
+      "en": "Which method adds an element to a list in Python?",
+      "ja": "Pythonでリストに要素を追加するメソッドは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "anonymous function",
+        "ja": "むめいかんすう",
+        "ja_typings": []
+      },
+      {
+        "en": "a loop",
+        "ja": "ループ",
+        "ja_typings": []
+      },
+      {
+        "en": "a class",
+        "ja": "クラス",
+        "ja_typings": []
+      },
+      {
+        "en": "a module",
+        "ja": "もじゅーる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00011",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a lambda in Python?",
+      "ja": "Pythonのlambdaとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "max()",
+        "ja": "max()",
+        "ja_typings": []
+      },
+      {
+        "en": "top()",
+        "ja": "top()",
+        "ja_typings": []
+      },
+      {
+        "en": "largest()",
+        "ja": "largest()",
+        "ja_typings": []
+      },
+      {
+        "en": "greatest()",
+        "ja": "greatest()",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00012",
+    "image_path": null,
+    "question_text": {
+      "en": "Which built-in function returns the largest value?",
+      "ja": "最大値を返すpython組み込み関数は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "let",
+        "ja": "let",
+        "ja_typings": []
+      },
+      {
+        "en": "var",
+        "ja": "var",
+        "ja_typings": []
+      },
+      {
+        "en": "const",
+        "ja": "const",
+        "ja_typings": []
+      },
+      {
+        "en": "val",
+        "ja": "val",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00013",
+    "image_path": null,
+    "question_text": {
+      "en": "What keyword declares an immutable variable in Rust?",
+      "ja": "Rustで不変変数を宣言するキーワードは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "each value has one owner",
+        "ja": "かくちはひとつのおーなーをもつ",
+        "ja_typings": []
+      },
+      {
+        "en": "values are shared freely",
+        "ja": "ちはじゆうにきょうゆうされる",
+        "ja_typings": []
+      },
+      {
+        "en": "no memory management",
+        "ja": "めもりかんりなし",
+        "ja_typings": []
+      },
+      {
+        "en": "garbage collected",
+        "ja": "がーびっじこれくしょん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00014",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Rust ownership rule?",
+      "ja": "Rustのオーナーシップの基本ルールは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "&",
+        "ja": "&",
+        "ja_typings": []
+      },
+      {
+        "en": "*",
+        "ja": "*",
+        "ja_typings": []
+      },
+      {
+        "en": "@",
+        "ja": "@",
+        "ja_typings": []
+      },
+      {
+        "en": "#",
+        "ja": "#",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00015",
+    "image_path": null,
+    "question_text": {
+      "en": "Which symbol denotes a reference in Rust?",
+      "ja": "Rustで参照を示す記号は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "nullable value",
+        "ja": "null許容の値",
+        "ja_typings": []
+      },
+      {
+        "en": "error handling",
+        "ja": "えらーはんどりんぐ",
+        "ja_typings": []
+      },
+      {
+        "en": "iteration",
+        "ja": "いてれーしょん",
+        "ja_typings": []
+      },
+      {
+        "en": "concurrency",
+        "ja": "へいこうせい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00016",
+    "image_path": null,
+    "question_text": {
+      "en": "What is `Option<T>` used for in Rust?",
+      "ja": "Rustの`Option<T>`の用途は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "compiles the project",
+        "ja": "ぷろじぇくとをこんぱいる",
+        "ja_typings": []
+      },
+      {
+        "en": "runs tests",
+        "ja": "てすとをじっこう",
+        "ja_typings": []
+      },
+      {
+        "en": "publishes crate",
+        "ja": "くれーとをこうかい",
+        "ja_typings": []
+      },
+      {
+        "en": "formats code",
+        "ja": "こーどをふぉーまっと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00017",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `cargo build` do?",
+      "ja": "`cargo build`は何をするコマンドか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Debug",
+        "ja": "Debug",
+        "ja_typings": []
+      },
+      {
+        "en": "Display",
+        "ja": "Display",
+        "ja_typings": []
+      },
+      {
+        "en": "Print",
+        "ja": "Print",
+        "ja_typings": []
+      },
+      {
+        "en": "Format",
+        "ja": "Format",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00018",
+    "image_path": null,
+    "question_text": {
+      "en": "Which trait enables printing with `{:?}` in Rust?",
+      "ja": "Rustで`{:?}`による表示を可能にするとれーとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "growable array",
+        "ja": "かちょうかのうなはいれつ",
+        "ja_typings": []
+      },
+      {
+        "en": "hash map",
+        "ja": "はっしゅまっぷ",
+        "ja_typings": []
+      },
+      {
+        "en": "linked list",
+        "ja": "れんけつりすと",
+        "ja_typings": []
+      },
+      {
+        "en": "fixed array",
+        "ja": "こていはいれつ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00019",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a `Vec<T>` in Rust?",
+      "ja": "Rustの`Vec<T>`とは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Result type",
+        "ja": "Resultがた",
+        "ja_typings": []
+      },
+      {
+        "en": "exceptions",
+        "ja": "れいがい",
+        "ja_typings": []
+      },
+      {
+        "en": "error codes",
+        "ja": "えらーこーど",
+        "ja_typings": []
+      },
+      {
+        "en": "panic always",
+        "ja": "つねにぱにっく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00020",
+    "image_path": null,
+    "question_text": {
+      "en": "How do you handle errors in Rust idiomatically?",
+      "ja": "Rustでエラーを慣用的に扱う方法は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "implements methods for a type",
+        "ja": "かたにめそっどをじっそう",
+        "ja_typings": []
+      },
+      {
+        "en": "imports a module",
+        "ja": "もじゅーるをいんぽーと",
+        "ja_typings": []
+      },
+      {
+        "en": "declares interface",
+        "ja": "いんたーふぇーすをせんげん",
+        "ja_typings": []
+      },
+      {
+        "en": "creates enum",
+        "ja": "えぬむをさくせい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00021",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `impl` keyword do in Rust?",
+      "ja": "Rustの`impl`キーワードの役割は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "fn main()",
+        "ja": "fn main()",
+        "ja_typings": []
+      },
+      {
+        "en": "fn start()",
+        "ja": "fn start()",
+        "ja_typings": []
+      },
+      {
+        "en": "fn run()",
+        "ja": "fn run()",
+        "ja_typings": []
+      },
+      {
+        "en": "fn init()",
+        "ja": "fn init()",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00022",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the entry point of a Rust program?",
+      "ja": "Rustプログラムのエントリーポイントは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "let",
+        "ja": "let",
+        "ja_typings": []
+      },
+      {
+        "en": "var",
+        "ja": "var",
+        "ja_typings": []
+      },
+      {
+        "en": "dim",
+        "ja": "dim",
+        "ja_typings": []
+      },
+      {
+        "en": "define",
+        "ja": "define",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00023",
+    "image_path": null,
+    "question_text": {
+      "en": "Which keyword declares a block-scoped variable in JS?",
+      "ja": "JSでブロックスコープ変数を宣言するキーワードは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "strict equality",
+        "ja": "げんみつなどうち",
+        "ja_typings": []
+      },
+      {
+        "en": "assignment",
+        "ja": "だいにゅう",
+        "ja_typings": []
+      },
+      {
+        "en": "loose equality",
+        "ja": "ゆるやかなどうち",
+        "ja_typings": []
+      },
+      {
+        "en": "comparison",
+        "ja": "ひかく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00024",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `===` check in JavaScript?",
+      "ja": "JavaScriptの`===`は何を確認するか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "() => {}",
+        "ja": "() => {}",
+        "ja_typings": []
+      },
+      {
+        "en": "function() {}",
+        "ja": "function() {}",
+        "ja_typings": []
+      },
+      {
+        "en": "fn() {}",
+        "ja": "fn() {}",
+        "ja_typings": []
+      },
+      {
+        "en": "def() {}",
+        "ja": "def() {}",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00025",
+    "image_path": null,
+    "question_text": {
+      "en": "How do you create an arrow function in JS?",
+      "ja": "JSでアロー関数を作る構文は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Not a Number",
+        "ja": "すうちでない",
+        "ja_typings": []
+      },
+      {
+        "en": "Null and None",
+        "ja": "nullとnone",
+        "ja_typings": []
+      },
+      {
+        "en": "New Array Node",
+        "ja": "あたらしいはいれつのーど",
+        "ja_typings": []
+      },
+      {
+        "en": "Not an Object",
+        "ja": "おぶじぇくとでない",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00026",
+    "image_path": null,
+    "question_text": {
+      "en": "What is `NaN` in JavaScript?",
+      "ja": "JavaScriptの`NaN`とは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JSON.parse()",
+        "ja": "JSON.parse()",
+        "ja_typings": []
+      },
+      {
+        "en": "JSON.stringify()",
+        "ja": "JSON.stringify()",
+        "ja_typings": []
+      },
+      {
+        "en": "JSON.convert()",
+        "ja": "JSON.convert()",
+        "ja_typings": []
+      },
+      {
+        "en": "JSON.decode()",
+        "ja": "JSON.decode()",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00027",
+    "image_path": null,
+    "question_text": {
+      "en": "Which method converts JSON string to object?",
+      "ja": "JSON文字列をオブジェクトに変換するメソッドは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "waits for all promises",
+        "ja": "すべてのぷろみすをまつ",
+        "ja_typings": []
+      },
+      {
+        "en": "cancels all promises",
+        "ja": "すべてのぷろみすをきゃんせる",
+        "ja_typings": []
+      },
+      {
+        "en": "runs promises in series",
+        "ja": "ぷろみすをじゅんじにじっこう",
+        "ja_typings": []
+      },
+      {
+        "en": "rejects all promises",
+        "ja": "すべてのぷろみすをきゃく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00028",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `Promise.all()` do?",
+      "ja": "`Promise.all()`は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "extends",
+        "ja": "extends",
+        "ja_typings": []
+      },
+      {
+        "en": "inherits",
+        "ja": "inherits",
+        "ja_typings": []
+      },
+      {
+        "en": "implements",
+        "ja": "implements",
+        "ja_typings": []
+      },
+      {
+        "en": "derives",
+        "ja": "derives",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00029",
+    "image_path": null,
+    "question_text": {
+      "en": "Which keyword is used for class inheritance in JS?",
+      "ja": "JSでクラスの継承に使うキーワードは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "object",
+        "ja": "object",
+        "ja_typings": []
+      },
+      {
+        "en": "null",
+        "ja": "null",
+        "ja_typings": []
+      },
+      {
+        "en": "undefined",
+        "ja": "undefined",
+        "ja_typings": []
+      },
+      {
+        "en": "boolean",
+        "ja": "boolean",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00030",
+    "image_path": null,
+    "question_text": {
+      "en": "What is `typeof null` in JavaScript?",
+      "ja": "JavaScriptで`typeof null`の結果は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "map()",
+        "ja": "map()",
+        "ja_typings": []
+      },
+      {
+        "en": "filter()",
+        "ja": "filter()",
+        "ja_typings": []
+      },
+      {
+        "en": "reduce()",
+        "ja": "reduce()",
+        "ja_typings": []
+      },
+      {
+        "en": "forEach()",
+        "ja": "forEach()",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00031",
+    "image_path": null,
+    "question_text": {
+      "en": "Which array method creates a new array by transforming each element?",
+      "ja": "各要素を変換して新配列を作るはいれつメソッドは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "true",
+        "ja": "true",
+        "ja_typings": []
+      },
+      {
+        "en": "false",
+        "ja": "false",
+        "ja_typings": []
+      },
+      {
+        "en": "undefined",
+        "ja": "undefined",
+        "ja_typings": []
+      },
+      {
+        "en": "1",
+        "ja": "1",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00032",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `Array.isArray([])` return?",
+      "ja": "`Array.isArray([])`の戻り値は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "O(1)",
+        "ja": "O(1)",
+        "ja_typings": []
+      },
+      {
+        "en": "O(n)",
+        "ja": "O(n)",
+        "ja_typings": []
+      },
+      {
+        "en": "O(log n)",
+        "ja": "O(log n)",
+        "ja_typings": []
+      },
+      {
+        "en": "O(n²)",
+        "ja": "O(n²)",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00033",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the time complexity of accessing an array element by index?",
+      "ja": "はいれつのいんでくすによるアクセスの計算量は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "stack",
+        "ja": "すたっく",
+        "ja_typings": []
+      },
+      {
+        "en": "queue",
+        "ja": "きゅー",
+        "ja_typings": []
+      },
+      {
+        "en": "heap",
+        "ja": "ひーぷ",
+        "ja_typings": []
+      },
+      {
+        "en": "tree",
+        "ja": "つりー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00034",
+    "image_path": null,
+    "question_text": {
+      "en": "Which data structure uses LIFO order?",
+      "ja": "LIFO順を使うでーたこうぞうは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "data and pointer",
+        "ja": "でーたとぽいんたー",
+        "ja_typings": []
+      },
+      {
+        "en": "key and value",
+        "ja": "きーとちー",
+        "ja_typings": []
+      },
+      {
+        "en": "index and value",
+        "ja": "いんでくすとち",
+        "ja_typings": []
+      },
+      {
+        "en": "hash and data",
+        "ja": "はっしゅとでーた",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00035",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a linked list node composed of?",
+      "ja": "れんけつりすとののーどは何で構成されるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "pre-order",
+        "ja": "まえじゅん",
+        "ja_typings": []
+      },
+      {
+        "en": "in-order",
+        "ja": "ちゅうじゅん",
+        "ja_typings": []
+      },
+      {
+        "en": "post-order",
+        "ja": "こうじゅん",
+        "ja_typings": []
+      },
+      {
+        "en": "level-order",
+        "ja": "れべるじゅん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00036",
+    "image_path": null,
+    "question_text": {
+      "en": "Which tree traversal visits root first?",
+      "ja": "ねをさいしょにたどる木の探索順は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "two keys map to same bucket",
+        "ja": "ふたつのきーがどうじはっしゅ",
+        "ja_typings": []
+      },
+      {
+        "en": "hash value is zero",
+        "ja": "はっしゅがぜろになる",
+        "ja_typings": []
+      },
+      {
+        "en": "hash function crashes",
+        "ja": "はっしゅかんすうがくらっしゅ",
+        "ja_typings": []
+      },
+      {
+        "en": "key is not found",
+        "ja": "きーがみつからない",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00037",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a hash collision?",
+      "ja": "はっしゅしょうとつとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "O(n²)",
+        "ja": "O(n²)",
+        "ja_typings": []
+      },
+      {
+        "en": "O(n log n)",
+        "ja": "O(n log n)",
+        "ja_typings": []
+      },
+      {
+        "en": "O(n)",
+        "ja": "O(n)",
+        "ja_typings": []
+      },
+      {
+        "en": "O(log n)",
+        "ja": "O(log n)",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00038",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the worst-case complexity of quicksort?",
+      "ja": "くいっくそーとの最悪計算量は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "queue",
+        "ja": "きゅー",
+        "ja_typings": []
+      },
+      {
+        "en": "stack",
+        "ja": "すたっく",
+        "ja_typings": []
+      },
+      {
+        "en": "array",
+        "ja": "はいれつ",
+        "ja_typings": []
+      },
+      {
+        "en": "tree",
+        "ja": "つりー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00039",
+    "image_path": null,
+    "question_text": {
+      "en": "Which data structure supports BFS traversal naturally?",
+      "ja": "はばゆうせんたんさくを自然にサポートするでーたこうぞうは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "left < root < right",
+        "ja": "ひだり < ね < みぎ",
+        "ja_typings": []
+      },
+      {
+        "en": "left > root > right",
+        "ja": "ひだり > ね > みぎ",
+        "ja_typings": []
+      },
+      {
+        "en": "all nodes equal",
+        "ja": "すべてのーどがひとしい",
+        "ja_typings": []
+      },
+      {
+        "en": "sorted by insertion order",
+        "ja": "そうにゅうじゅんにせいれつ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00040",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a binary search tree property?",
+      "ja": "にぶんたんさくきのせいしつは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "minimum value",
+        "ja": "さいしょうち",
+        "ja_typings": []
+      },
+      {
+        "en": "maximum value",
+        "ja": "さいだいち",
+        "ja_typings": []
+      },
+      {
+        "en": "median value",
+        "ja": "ちゅうかんち",
+        "ja_typings": []
+      },
+      {
+        "en": "random value",
+        "ja": "らんだむち",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00041",
+    "image_path": null,
+    "question_text": {
+      "en": "What does a min-heap guarantee at the root?",
+      "ja": "みにひーぷはねに何を保証するか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "adjacency list",
+        "ja": "となりあいりすと",
+        "ja_typings": []
+      },
+      {
+        "en": "adjacency matrix",
+        "ja": "となりあいぎょうれつ",
+        "ja_typings": []
+      },
+      {
+        "en": "edge list",
+        "ja": "へんりすと",
+        "ja_typings": []
+      },
+      {
+        "en": "incidence matrix",
+        "ja": "そくしぎょうれつ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00042",
+    "image_path": null,
+    "question_text": {
+      "en": "Which graph representation uses adjacency lists?",
+      "ja": "となりあいりすとをつかうグラフひょうげんは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "solving by storing subproblem results",
+        "ja": "ぶぶんもんだいをほぞんしてかいく",
+        "ja_typings": []
+      },
+      {
+        "en": "randomized algorithm",
+        "ja": "らんだまいずどあるごりずむ",
+        "ja_typings": []
+      },
+      {
+        "en": "brute force search",
+        "ja": "ぜんけんさく",
+        "ja_typings": []
+      },
+      {
+        "en": "greedy selection",
+        "ja": "どんよくほう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00043",
+    "image_path": null,
+    "question_text": {
+      "en": "What is dynamic programming?",
+      "ja": "どうてきけいかくほうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "merge sort",
+        "ja": "まーじそーと",
+        "ja_typings": []
+      },
+      {
+        "en": "quick sort",
+        "ja": "くいっくそーと",
+        "ja_typings": []
+      },
+      {
+        "en": "heap sort",
+        "ja": "ひーぷそーと",
+        "ja_typings": []
+      },
+      {
+        "en": "selection sort",
+        "ja": "せんたくそーと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00044",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sorting algorithm is stable and O(n log n)?",
+      "ja": "あんていでO(n log n)のせいれつあるごりずむは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "describing algorithm complexity",
+        "ja": "あるごりずむのけいさんりょうをひょうげん",
+        "ja_typings": []
+      },
+      {
+        "en": "measuring memory size",
+        "ja": "めもりしょうひをそくてい",
+        "ja_typings": []
+      },
+      {
+        "en": "defining variable scope",
+        "ja": "へんすうのすこーぷをていぎ",
+        "ja_typings": []
+      },
+      {
+        "en": "declaring constants",
+        "ja": "ていすうをせんげん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00045",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Big O notation used for?",
+      "ja": "Big O記法は何のために使うか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "shortest path",
+        "ja": "さいたんけいろ",
+        "ja_typings": []
+      },
+      {
+        "en": "minimum spanning tree",
+        "ja": "さいしょうぜんいきき",
+        "ja_typings": []
+      },
+      {
+        "en": "topological order",
+        "ja": "いそがきじゅん",
+        "ja_typings": []
+      },
+      {
+        "en": "strongly connected components",
+        "ja": "きょうれんけつせいぶん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00046",
+    "image_path": null,
+    "question_text": {
+      "en": "What does Dijkstra's algorithm find?",
+      "ja": "ダイクストラのあるごりずむは何を求めるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "caching computed results",
+        "ja": "けいさんけっかをきゃっしゅ",
+        "ja_typings": []
+      },
+      {
+        "en": "memory allocation",
+        "ja": "めもりかくほ",
+        "ja_typings": []
+      },
+      {
+        "en": "garbage collection",
+        "ja": "がーびっじこれくしょん",
+        "ja_typings": []
+      },
+      {
+        "en": "code optimization",
+        "ja": "こーどさいてきか",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00047",
+    "image_path": null,
+    "question_text": {
+      "en": "What is memoization?",
+      "ja": "めもいぜーしょんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "merge sort",
+        "ja": "まーじそーと",
+        "ja_typings": []
+      },
+      {
+        "en": "bubble sort",
+        "ja": "ばぶるそーと",
+        "ja_typings": []
+      },
+      {
+        "en": "insertion sort",
+        "ja": "そうにゅうそーと",
+        "ja_typings": []
+      },
+      {
+        "en": "counting sort",
+        "ja": "かうんとそーと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00048",
+    "image_path": null,
+    "question_text": {
+      "en": "Which algorithm uses divide and conquer?",
+      "ja": "ぶんちしほうを使うあるごりずむは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "a function calling itself",
+        "ja": "じぶんじしんをよびだすかんすう",
+        "ja_typings": []
+      },
+      {
+        "en": "a loop structure",
+        "ja": "るーぷこうぞう",
+        "ja_typings": []
+      },
+      {
+        "en": "a data type",
+        "ja": "でーたがた",
+        "ja_typings": []
+      },
+      {
+        "en": "an error handler",
+        "ja": "えらーはんどらー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00049",
+    "image_path": null,
+    "question_text": {
+      "en": "What is recursion?",
+      "ja": "さいきとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "the condition to stop recursion",
+        "ja": "さいきをとめるじょうけん",
+        "ja_typings": []
+      },
+      {
+        "en": "the first recursive call",
+        "ja": "さいしょのさいきよびだし",
+        "ja_typings": []
+      },
+      {
+        "en": "the input parameter",
+        "ja": "にゅうりょくぱらめーた",
+        "ja_typings": []
+      },
+      {
+        "en": "the return value",
+        "ja": "もどりち",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00050",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the base case in recursion?",
+      "ja": "さいきのきていじょうけんとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "binary search",
+        "ja": "にぶんたんさく",
+        "ja_typings": []
+      },
+      {
+        "en": "linear search",
+        "ja": "せんけいたんさく",
+        "ja_typings": []
+      },
+      {
+        "en": "depth-first search",
+        "ja": "ふかさゆうせんたんさく",
+        "ja_typings": []
+      },
+      {
+        "en": "breadth-first search",
+        "ja": "はばゆうせんたんさく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00051",
+    "image_path": null,
+    "question_text": {
+      "en": "Which search requires a sorted array?",
+      "ja": "せいれつされたはいれつが必要な探索は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "O(n²)",
+        "ja": "O(n²)",
+        "ja_typings": []
+      },
+      {
+        "en": "O(n log n)",
+        "ja": "O(n log n)",
+        "ja_typings": []
+      },
+      {
+        "en": "O(n)",
+        "ja": "O(n)",
+        "ja_typings": []
+      },
+      {
+        "en": "O(1)",
+        "ja": "O(1)",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00052",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the time complexity of bubble sort?",
+      "ja": "ばぶるそーとの計算量は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "hiding internal details",
+        "ja": "ないぶしょうさいをかくす",
+        "ja_typings": []
+      },
+      {
+        "en": "inheriting properties",
+        "ja": "ぷろぱてぃをけいしょう",
+        "ja_typings": []
+      },
+      {
+        "en": "overriding methods",
+        "ja": "めそっどをおーばーらいど",
+        "ja_typings": []
+      },
+      {
+        "en": "creating instances",
+        "ja": "いんすたんすをさくせい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00053",
+    "image_path": null,
+    "question_text": {
+      "en": "What is encapsulation?",
+      "ja": "かぷせるかとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "same interface, different behaviors",
+        "ja": "どうじいんたーふぇーす、ことなるどうさ",
+        "ja_typings": []
+      },
+      {
+        "en": "one class one method",
+        "ja": "いちくらすいちめそっど",
+        "ja_typings": []
+      },
+      {
+        "en": "multiple inheritance",
+        "ja": "たじゅうけいしょう",
+        "ja_typings": []
+      },
+      {
+        "en": "static typing",
+        "ja": "せいてきがたずけ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00054",
+    "image_path": null,
+    "question_text": {
+      "en": "What is polymorphism?",
+      "ja": "たたいせいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "calls parent class",
+        "ja": "おやくらすをよびだす",
+        "ja_typings": []
+      },
+      {
+        "en": "creates subclass",
+        "ja": "さぶくらすをさくせい",
+        "ja_typings": []
+      },
+      {
+        "en": "deletes instance",
+        "ja": "いんすたんすをさくじょ",
+        "ja_typings": []
+      },
+      {
+        "en": "copies object",
+        "ja": "おぶじぇくとをこぴー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00055",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `super()` do in OOP?",
+      "ja": "OOPで`super()`は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "cannot be instantiated directly",
+        "ja": "ちょくせつしてきれつかできない",
+        "ja_typings": []
+      },
+      {
+        "en": "has no methods",
+        "ja": "めそっどがない",
+        "ja_typings": []
+      },
+      {
+        "en": "is always static",
+        "ja": "つねにすたてぃっく",
+        "ja_typings": []
+      },
+      {
+        "en": "inherits from interface",
+        "ja": "いんたーふぇーすからけいしょう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00056",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an abstract class?",
+      "ja": "ちゅうしょうくらすとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "contract of method signatures",
+        "ja": "めそっどしぐにちゃのけいやく",
+        "ja_typings": []
+      },
+      {
+        "en": "a concrete class",
+        "ja": "きゅうしょうてきなくらす",
+        "ja_typings": []
+      },
+      {
+        "en": "a data container",
+        "ja": "でーたこんてな",
+        "ja_typings": []
+      },
+      {
+        "en": "a static method",
+        "ja": "すたてぃっくめそっど",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00057",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an interface in OOP?",
+      "ja": "OOPのいんたーふぇーすとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Singleton",
+        "ja": "Singleton",
+        "ja_typings": []
+      },
+      {
+        "en": "Factory",
+        "ja": "Factory",
+        "ja_typings": []
+      },
+      {
+        "en": "Observer",
+        "ja": "Observer",
+        "ja_typings": []
+      },
+      {
+        "en": "Strategy",
+        "ja": "Strategy",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00058",
+    "image_path": null,
+    "question_text": {
+      "en": "What pattern ensures a class has only one instance?",
+      "ja": "クラスのいんすたんすをひとつにするぱたーんは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Strategy",
+        "ja": "Strategy",
+        "ja_typings": []
+      },
+      {
+        "en": "Singleton",
+        "ja": "Singleton",
+        "ja_typings": []
+      },
+      {
+        "en": "Decorator",
+        "ja": "Decorator",
+        "ja_typings": []
+      },
+      {
+        "en": "Command",
+        "ja": "Command",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00059",
+    "image_path": null,
+    "question_text": {
+      "en": "What pattern defines a family of algorithms?",
+      "ja": "あるごりずむのかぞくをていぎするぱたーんは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "notifies subscribers of changes",
+        "ja": "こうどくしゃにへんかをつうち",
+        "ja_typings": []
+      },
+      {
+        "en": "creates objects",
+        "ja": "おぶじぇくとをさくせい",
+        "ja_typings": []
+      },
+      {
+        "en": "wraps objects",
+        "ja": "おぶじぇくとをらっぷ",
+        "ja_typings": []
+      },
+      {
+        "en": "restricts instances",
+        "ja": "いんすたんすをせいげん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00060",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the Observer pattern do?",
+      "ja": "おぶざーばーぱたーんは何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "creates objects without specifying class",
+        "ja": "くらすをしていせずおぶじぇくとさくせい",
+        "ja_typings": []
+      },
+      {
+        "en": "observes state changes",
+        "ja": "じょうたいへんかをかんさつ",
+        "ja_typings": []
+      },
+      {
+        "en": "adds behavior dynamically",
+        "ja": "どうてきにどうさをついか",
+        "ja_typings": []
+      },
+      {
+        "en": "reduces coupling",
+        "ja": "けつごうをへらす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00061",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Factory pattern?",
+      "ja": "ふぁくとりーぱたーんとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Decorator",
+        "ja": "Decorator",
+        "ja_typings": []
+      },
+      {
+        "en": "Singleton",
+        "ja": "Singleton",
+        "ja_typings": []
+      },
+      {
+        "en": "Facade",
+        "ja": "Facade",
+        "ja_typings": []
+      },
+      {
+        "en": "Template",
+        "ja": "Template",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00062",
+    "image_path": null,
+    "question_text": {
+      "en": "Which pattern adds behavior without modifying class?",
+      "ja": "くらすをへんこうせずにどうさをついかするぱたーんは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "saves work temporarily",
+        "ja": "さぎょうをいじてきほぞん",
+        "ja_typings": []
+      },
+      {
+        "en": "deletes branch",
+        "ja": "ぶらんちをさくじょ",
+        "ja_typings": []
+      },
+      {
+        "en": "merges branches",
+        "ja": "ぶらんちをがったい",
+        "ja_typings": []
+      },
+      {
+        "en": "creates tag",
+        "ja": "たぐをさくせい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00063",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `git stash` do?",
+      "ja": "`git stash`は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "personal copy of a repo",
+        "ja": "りぽのこじんようこぴー",
+        "ja_typings": []
+      },
+      {
+        "en": "a branch name",
+        "ja": "ぶらんちめい",
+        "ja_typings": []
+      },
+      {
+        "en": "a commit hash",
+        "ja": "こみっとはっしゅ",
+        "ja_typings": []
+      },
+      {
+        "en": "a merge strategy",
+        "ja": "がったいせんりゃく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00064",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a git fork?",
+      "ja": "git forkとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "applies a specific commit",
+        "ja": "とくていのこみっとをてきよう",
+        "ja_typings": []
+      },
+      {
+        "en": "removes a commit",
+        "ja": "こみっとをさくじょ",
+        "ja_typings": []
+      },
+      {
+        "en": "lists all commits",
+        "ja": "こみっとをいちらん",
+        "ja_typings": []
+      },
+      {
+        "en": "creates a branch",
+        "ja": "ぶらんちをさくせい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00065",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `git cherry-pick` do?",
+      "ja": "`git cherry-pick`は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "named reference to a commit",
+        "ja": "こみっとへのなまえつきさんしょう",
+        "ja_typings": []
+      },
+      {
+        "en": "a branch alias",
+        "ja": "ぶらんちのべつめい",
+        "ja_typings": []
+      },
+      {
+        "en": "a merge request",
+        "ja": "まーじりくえすと",
+        "ja_typings": []
+      },
+      {
+        "en": "a remote name",
+        "ja": "りもーとめい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00066",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a git tag?",
+      "ja": "git tagとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "reapplies commits on new base",
+        "ja": "こみっとをあたらしいきていにてきよう",
+        "ja_typings": []
+      },
+      {
+        "en": "reverts all changes",
+        "ja": "すべてのへんこうをもとにもどす",
+        "ja_typings": []
+      },
+      {
+        "en": "creates a new branch",
+        "ja": "あたらしいぶらんちをさくせい",
+        "ja_typings": []
+      },
+      {
+        "en": "pushes to remote",
+        "ja": "りもーとにぷっしゅ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00067",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `git rebase` do?",
+      "ja": "`git rebase`は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "testing individual components",
+        "ja": "こぶひんのてすと",
+        "ja_typings": []
+      },
+      {
+        "en": "testing entire system",
+        "ja": "しすてむぜんたいのてすと",
+        "ja_typings": []
+      },
+      {
+        "en": "testing user interface",
+        "ja": "ゆーざーいんたーふぇーすのてすと",
+        "ja_typings": []
+      },
+      {
+        "en": "testing performance",
+        "ja": "ぱふぉーまんすのてすと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00068",
+    "image_path": null,
+    "question_text": {
+      "en": "What is unit testing?",
+      "ja": "ゆにっとてすととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Test Driven Development",
+        "ja": "てすときどうかいはつ",
+        "ja_typings": []
+      },
+      {
+        "en": "Type Definition Document",
+        "ja": "かたていぎどきゅめんと",
+        "ja_typings": []
+      },
+      {
+        "en": "Tool Deployment Design",
+        "ja": "つーるはいひせっけい",
+        "ja_typings": []
+      },
+      {
+        "en": "Total Data Delivery",
+        "ja": "そうでーたはいそう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00069",
+    "image_path": null,
+    "question_text": {
+      "en": "What does TDD stand for?",
+      "ja": "TDDの略語の意味は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "simulated dependency",
+        "ja": "ぎそのいぞんかんけい",
+        "ja_typings": []
+      },
+      {
+        "en": "real database",
+        "ja": "じっさいのでーたべーす",
+        "ja_typings": []
+      },
+      {
+        "en": "test runner",
+        "ja": "てすとじっこうき",
+        "ja_typings": []
+      },
+      {
+        "en": "assertion library",
+        "ja": "あさーしょんらいぶらり",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00070",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a mock in testing?",
+      "ja": "テストのもっくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "testing component interactions",
+        "ja": "こんぽーねんとのれんけいをてすと",
+        "ja_typings": []
+      },
+      {
+        "en": "testing one function",
+        "ja": "ひとつのかんすうをてすと",
+        "ja_typings": []
+      },
+      {
+        "en": "testing UI only",
+        "ja": "UIのみてすと",
+        "ja_typings": []
+      },
+      {
+        "en": "testing code style",
+        "ja": "こーどすたいるをてすと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00071",
+    "image_path": null,
+    "question_text": {
+      "en": "What is integration testing?",
+      "ja": "とうごうてすととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "checks expected condition",
+        "ja": "きたいするじょうけんをかくにん",
+        "ja_typings": []
+      },
+      {
+        "en": "runs the test",
+        "ja": "てすとをじっこう",
+        "ja_typings": []
+      },
+      {
+        "en": "logs a message",
+        "ja": "めっせーじをきろく",
+        "ja_typings": []
+      },
+      {
+        "en": "skips the test",
+        "ja": "てすとをすきっぷ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00072",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `assert` do in testing?",
+      "ja": "テストで`assert`は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "no side effects, same input = same output",
+        "ja": "ふくさよううなし、どうにゅうりょく=どうしゅつりょく",
+        "ja_typings": []
+      },
+      {
+        "en": "modifies global state",
+        "ja": "ぐろーばるじょうたいをへんこう",
+        "ja_typings": []
+      },
+      {
+        "en": "uses external variables",
+        "ja": "がいぶへんすうをしよう",
+        "ja_typings": []
+      },
+      {
+        "en": "called only once",
+        "ja": "いちどしかよびだせない",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00073",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a pure function?",
+      "ja": "じゅんすいかんすうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "takes or returns a function",
+        "ja": "かんすうをうけとるかかえす",
+        "ja_typings": []
+      },
+      {
+        "en": "runs faster than normal",
+        "ja": "ふつうよりはやくじっこう",
+        "ja_typings": []
+      },
+      {
+        "en": "has more parameters",
+        "ja": "よりおおくのぱらめーたをもつ",
+        "ja_typings": []
+      },
+      {
+        "en": "is recursive",
+        "ja": "さいきてき",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00074",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a higher-order function?",
+      "ja": "こうかいかんすうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "combining elements into one value",
+        "ja": "ようそをひとつのちにまとめる",
+        "ja_typings": []
+      },
+      {
+        "en": "filtering elements",
+        "ja": "ようそをふぃるたりんぐ",
+        "ja_typings": []
+      },
+      {
+        "en": "sorting elements",
+        "ja": "ようそをせいれつ",
+        "ja_typings": []
+      },
+      {
+        "en": "mapping elements",
+        "ja": "ようそをまっぴんぐ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00075",
+    "image_path": null,
+    "question_text": {
+      "en": "What is `reduce` used for?",
+      "ja": "`reduce`は何に使うか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "data cannot be changed after creation",
+        "ja": "さくせいごにでーたをかえられない",
+        "ja_typings": []
+      },
+      {
+        "en": "data is always null",
+        "ja": "でーたはつねにnull",
+        "ja_typings": []
+      },
+      {
+        "en": "variables are global",
+        "ja": "へんすうはぐろーばる",
+        "ja_typings": []
+      },
+      {
+        "en": "functions have no return",
+        "ja": "かんすうはもどらない",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00076",
+    "image_path": null,
+    "question_text": {
+      "en": "What is immutability?",
+      "ja": "ふへんせいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "combining functions to build new ones",
+        "ja": "かんすうをくみあわせてあたらしいかんすうをつくる",
+        "ja_typings": []
+      },
+      {
+        "en": "calling all functions at once",
+        "ja": "すべてのかんすうをいちどによびだす",
+        "ja_typings": []
+      },
+      {
+        "en": "defining functions inside loops",
+        "ja": "るーぷないにかんすうをていぎ",
+        "ja_typings": []
+      },
+      {
+        "en": "converting functions to strings",
+        "ja": "かんすうをもじれつにへんかん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00077",
+    "image_path": null,
+    "question_text": {
+      "en": "What is function composition?",
+      "ja": "かんすうごうせいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "types checked at compile time",
+        "ja": "かんぱいるじにがたをかくにん",
+        "ja_typings": []
+      },
+      {
+        "en": "types checked at runtime",
+        "ja": "じっこうじにがたをかくにん",
+        "ja_typings": []
+      },
+      {
+        "en": "no type checking",
+        "ja": "がたかくにんなし",
+        "ja_typings": []
+      },
+      {
+        "en": "types inferred by AI",
+        "ja": "AIがたをすいろん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00078",
+    "image_path": null,
+    "question_text": {
+      "en": "What is static typing?",
+      "ja": "せいてきがたずけとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "compiler deduces type from context",
+        "ja": "こんぱいらがぶんみゃくからがたをすいてい",
+        "ja_typings": []
+      },
+      {
+        "en": "developer declares every type",
+        "ja": "かいはつしゃがすべてのがたをせんげん",
+        "ja_typings": []
+      },
+      {
+        "en": "runtime assigns types",
+        "ja": "じっこうじにがたをわりあて",
+        "ja_typings": []
+      },
+      {
+        "en": "types are always strings",
+        "ja": "がたはつねにもじれつ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00079",
+    "image_path": null,
+    "question_text": {
+      "en": "What is type inference?",
+      "ja": "がたすいろんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "type that works with many types",
+        "ja": "おおくのがたにたいおうするがた",
+        "ja_typings": []
+      },
+      {
+        "en": "always integer type",
+        "ja": "つねにせいすうがた",
+        "ja_typings": []
+      },
+      {
+        "en": "a string template",
+        "ja": "もじれつてんぷれーと",
+        "ja_typings": []
+      },
+      {
+        "en": "a null type",
+        "ja": "nullがた",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00080",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a generic type?",
+      "ja": "じぇねりっくがたとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "two processes wait for each other",
+        "ja": "ふたつのぷろせすがたがいにまちつづける",
+        "ja_typings": []
+      },
+      {
+        "en": "process running too fast",
+        "ja": "ぷろせすがはやすぎるじっこう",
+        "ja_typings": []
+      },
+      {
+        "en": "memory overflow",
+        "ja": "めもりおーばーふろー",
+        "ja_typings": []
+      },
+      {
+        "en": "CPU overload",
+        "ja": "CPUかふか",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00081",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a deadlock?",
+      "ja": "でっどろっくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "mutual exclusion lock",
+        "ja": "そうごはいたじょきょのろっく",
+        "ja_typings": []
+      },
+      {
+        "en": "multiple threads running",
+        "ja": "ふくすうすれっどじっこう",
+        "ja_typings": []
+      },
+      {
+        "en": "memory allocation unit",
+        "ja": "めもりかくほたんい",
+        "ja_typings": []
+      },
+      {
+        "en": "message queue",
+        "ja": "めっせーじきゅー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00082",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a mutex?",
+      "ja": "みゅーてっくすとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "outcome depends on thread timing",
+        "ja": "けっかがすれっどのたいみんぐによる",
+        "ja_typings": []
+      },
+      {
+        "en": "two threads with same speed",
+        "ja": "どうじそくどのふたつのすれっど",
+        "ja_typings": []
+      },
+      {
+        "en": "process priority conflict",
+        "ja": "ぷろせすゆうせんどのこんぐりくと",
+        "ja_typings": []
+      },
+      {
+        "en": "infinite loop",
+        "ja": "むげんるーぷ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00083",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a race condition?",
+      "ja": "れーすじょうけんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "non-blocking asynchronous code",
+        "ja": "ふぶろっきんぐのひどうきこーど",
+        "ja_typings": []
+      },
+      {
+        "en": "parallel computing",
+        "ja": "へいこうけいさん",
+        "ja_typings": []
+      },
+      {
+        "en": "synchronous locking",
+        "ja": "どうきてきろっく",
+        "ja_typings": []
+      },
+      {
+        "en": "error catching",
+        "ja": "えらーきゃっち",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00084",
+    "image_path": null,
+    "question_text": {
+      "en": "What is async/await used for?",
+      "ja": "async/awaitは何のために使うか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "smallest unit of execution",
+        "ja": "さいしょうのじっこうたんい",
+        "ja_typings": []
+      },
+      {
+        "en": "a type of variable",
+        "ja": "へんすうのしゅるい",
+        "ja_typings": []
+      },
+      {
+        "en": "a network connection",
+        "ja": "ねっとわーくせつぞく",
+        "ja_typings": []
+      },
+      {
+        "en": "a file handle",
+        "ja": "ふぁいるはんどる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00085",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a thread?",
+      "ja": "すれっどとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "memory not freed after use",
+        "ja": "しようごにかいほうされないめもり",
+        "ja_typings": []
+      },
+      {
+        "en": "reading wrong memory",
+        "ja": "まちがっためもりをよむ",
+        "ja_typings": []
+      },
+      {
+        "en": "writing beyond array bounds",
+        "ja": "はいれつはんいがいへきおく",
+        "ja_typings": []
+      },
+      {
+        "en": "accessing null pointer",
+        "ja": "nullぽいんたーにあくせす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00086",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a memory leak?",
+      "ja": "めもりりーくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "automatic memory management",
+        "ja": "じどうめもりかんり",
+        "ja_typings": []
+      },
+      {
+        "en": "manual memory freeing",
+        "ja": "てどうめもりかいほう",
+        "ja_typings": []
+      },
+      {
+        "en": "disk cleanup",
+        "ja": "でぃすくせいそう",
+        "ja_typings": []
+      },
+      {
+        "en": "removing dead code",
+        "ja": "でっどこーどさくじょ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00087",
+    "image_path": null,
+    "question_text": {
+      "en": "What is garbage collection?",
+      "ja": "がーびっじこれくしょんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "call stack exceeds its limit",
+        "ja": "こーるすたっくがかぎりをこえる",
+        "ja_typings": []
+      },
+      {
+        "en": "array index out of bounds",
+        "ja": "はいれつのいんでくすがはんいがい",
+        "ja_typings": []
+      },
+      {
+        "en": "heap memory full",
+        "ja": "ひーぷめもりまんぱい",
+        "ja_typings": []
+      },
+      {
+        "en": "too many variables",
+        "ja": "へんすうがおおすぎる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00088",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a stack overflow?",
+      "ja": "すたっくおーばーふろーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "dynamic memory allocation area",
+        "ja": "どうてきめもりかくほりょういき",
+        "ja_typings": []
+      },
+      {
+        "en": "function call memory",
+        "ja": "かんすうよびだしめもり",
+        "ja_typings": []
+      },
+      {
+        "en": "code storage area",
+        "ja": "こーどほぞんりょういき",
+        "ja_typings": []
+      },
+      {
+        "en": "CPU register",
+        "ja": "CPUれじすた",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00089",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the heap in memory?",
+      "ja": "めもりのひーぷとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HyperText Transfer Protocol",
+        "ja": "はいぱーてきすとてんそうぷろとこる",
+        "ja_typings": []
+      },
+      {
+        "en": "High Traffic TCP Protocol",
+        "ja": "こうとらふぃっくTCPぷろとこる",
+        "ja_typings": []
+      },
+      {
+        "en": "Hosted Text Transfer Process",
+        "ja": "ほすてっどてきすとてんそうぷろせす",
+        "ja_typings": []
+      },
+      {
+        "en": "HyperText Transport Process",
+        "ja": "はいぱーてきすとてんそうぷろせす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00090",
+    "image_path": null,
+    "question_text": {
+      "en": "What does HTTP stand for?",
+      "ja": "HTTPの略語の意味は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "unique device identifier on network",
+        "ja": "ねっとわーくじょうのゆにーくなそうちしきべつし",
+        "ja_typings": []
+      },
+      {
+        "en": "website domain name",
+        "ja": "うぇぶさいとどめいんめい",
+        "ja_typings": []
+      },
+      {
+        "en": "MAC address alias",
+        "ja": "MACあどれすのべつめい",
+        "ja_typings": []
+      },
+      {
+        "en": "user login name",
+        "ja": "ゆーざーろぐいんめい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00091",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an IP address?",
+      "ja": "IPあどれすとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "translates domain to IP",
+        "ja": "どめいんをIPにへんかん",
+        "ja_typings": []
+      },
+      {
+        "en": "stores web pages",
+        "ja": "うぇぶぺーじをほぞん",
+        "ja_typings": []
+      },
+      {
+        "en": "encrypts traffic",
+        "ja": "つうしんをあんごうか",
+        "ja_typings": []
+      },
+      {
+        "en": "assigns MAC addresses",
+        "ja": "MACあどれすをわりあて",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00092",
+    "image_path": null,
+    "question_text": {
+      "en": "What does DNS do?",
+      "ja": "DNSは何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "stateless web API standard",
+        "ja": "むじょうたいのうぇぶAPIきじゅん",
+        "ja_typings": []
+      },
+      {
+        "en": "database query language",
+        "ja": "でーたべーすくえりげんご",
+        "ja_typings": []
+      },
+      {
+        "en": "frontend framework",
+        "ja": "ふろんとえんどふれーむわーく",
+        "ja_typings": []
+      },
+      {
+        "en": "server-side rendering",
+        "ja": "さーばーさいどれんだりんぐ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00093",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a REST API?",
+      "ja": "REST APIとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PUT",
+        "ja": "PUT",
+        "ja_typings": []
+      },
+      {
+        "en": "GET",
+        "ja": "GET",
+        "ja_typings": []
+      },
+      {
+        "en": "POST",
+        "ja": "POST",
+        "ja_typings": []
+      },
+      {
+        "en": "DELETE",
+        "ja": "DELETE",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00094",
+    "image_path": null,
+    "question_text": {
+      "en": "What HTTP method is used to update a resource?",
+      "ja": "りそーすをこうしんするHTTPめそっどは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ls",
+        "ja": "ls",
+        "ja_typings": []
+      },
+      {
+        "en": "dir",
+        "ja": "dir",
+        "ja_typings": []
+      },
+      {
+        "en": "list",
+        "ja": "list",
+        "ja_typings": []
+      },
+      {
+        "en": "show",
+        "ja": "show",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00095",
+    "image_path": null,
+    "question_text": {
+      "en": "Which command lists files in Linux?",
+      "ja": "Linuxでふぁいるをいちらんするこまんどは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sets file permissions",
+        "ja": "ふぁいるのけんげんをせってい",
+        "ja_typings": []
+      },
+      {
+        "en": "changes file owner",
+        "ja": "ふぁいるのおーなーをへんこう",
+        "ja_typings": []
+      },
+      {
+        "en": "creates directory",
+        "ja": "でぃれくとりをさくせい",
+        "ja_typings": []
+      },
+      {
+        "en": "deletes file",
+        "ja": "ふぁいるをさくじょ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00096",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `chmod 755` do?",
+      "ja": "`chmod 755`は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "first line specifying interpreter",
+        "ja": "いんたーぷりたをしていするさいしょのぎょう",
+        "ja_typings": []
+      },
+      {
+        "en": "comment in shell script",
+        "ja": "しぇるすくりぷとのこめんと",
+        "ja_typings": []
+      },
+      {
+        "en": "variable declaration",
+        "ja": "へんすうせんげん",
+        "ja_typings": []
+      },
+      {
+        "en": "function definition",
+        "ja": "かんすうていぎ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00097",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a shebang line?",
+      "ja": "しぇばんらいんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "searches text patterns",
+        "ja": "てきすとぱたーんをけんさく",
+        "ja_typings": []
+      },
+      {
+        "en": "copies files",
+        "ja": "ふぁいるをこぴー",
+        "ja_typings": []
+      },
+      {
+        "en": "compresses files",
+        "ja": "ふぁいるをあっしゅく",
+        "ja_typings": []
+      },
+      {
+        "en": "monitors processes",
+        "ja": "ぷろせすをかんし",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00098",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `grep` do?",
+      "ja": "`grep`は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sends output to next command",
+        "ja": "しゅつりょくをつぎのこまんどにおくる",
+        "ja_typings": []
+      },
+      {
+        "en": "runs commands in background",
+        "ja": "こまんどをばっくぐらうんどでじっこう",
+        "ja_typings": []
+      },
+      {
+        "en": "redirects to file",
+        "ja": "ふぁいるにりだいれくと",
+        "ja_typings": []
+      },
+      {
+        "en": "separates arguments",
+        "ja": "ひきすうをくぎる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00099",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `|` (pipe) do in shell?",
+      "ja": "しぇるの`|`（ぱいぷ）は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Structured Query Language",
+        "ja": "こうぞうかくえりげんご",
+        "ja_typings": []
+      },
+      {
+        "en": "Simple Query Logic",
+        "ja": "かんたんくえりろじっく",
+        "ja_typings": []
+      },
+      {
+        "en": "Server Query Layer",
+        "ja": "さーばーくえりそう",
+        "ja_typings": []
+      },
+      {
+        "en": "Stored Query Library",
+        "ja": "ほぞんずみくえりらいぶらり",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00100",
+    "image_path": null,
+    "question_text": {
+      "en": "What does SQL stand for?",
+      "ja": "SQLの略語の意味は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "unique identifier for each row",
+        "ja": "かくぎょうのゆにーくしきべつし",
+        "ja_typings": []
+      },
+      {
+        "en": "first column in table",
+        "ja": "てーぶるのさいしょのれつ",
+        "ja_typings": []
+      },
+      {
+        "en": "encrypted field",
+        "ja": "あんごうかふぃーるど",
+        "ja_typings": []
+      },
+      {
+        "en": "foreign reference",
+        "ja": "がいぶさんしょう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00101",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a primary key?",
+      "ja": "しゅきーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "combines rows from multiple tables",
+        "ja": "ふくすうてーぶるのぎょうをけつごう",
+        "ja_typings": []
+      },
+      {
+        "en": "creates a new table",
+        "ja": "あたらしいてーぶるをさくせい",
+        "ja_typings": []
+      },
+      {
+        "en": "deletes duplicate rows",
+        "ja": "じゅうふくぎょうをさくじょ",
+        "ja_typings": []
+      },
+      {
+        "en": "sorts table data",
+        "ja": "てーぶるでーたをせいれつ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00102",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a JOIN in SQL?",
+      "ja": "SQLのJOINとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "speeds up data retrieval",
+        "ja": "でーたけんさくをこうそくか",
+        "ja_typings": []
+      },
+      {
+        "en": "ensures data integrity",
+        "ja": "でーたのせいごうせいをほしょう",
+        "ja_typings": []
+      },
+      {
+        "en": "compresses table data",
+        "ja": "てーぶるでーたをあっしゅく",
+        "ja_typings": []
+      },
+      {
+        "en": "backs up the database",
+        "ja": "でーたべーすをばっくあっぷ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00103",
+    "image_path": null,
+    "question_text": {
+      "en": "What is indexing in databases?",
+      "ja": "でーたべーすのいんでくすとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "atomic set of operations",
+        "ja": "げんしてきなそうさのあつまり",
+        "ja_typings": []
+      },
+      {
+        "en": "a single SQL query",
+        "ja": "ひとつのSQLくえり",
+        "ja_typings": []
+      },
+      {
+        "en": "database backup process",
+        "ja": "でーたべーすばっくあっぷぷろせす",
+        "ja_typings": []
+      },
+      {
+        "en": "user authentication",
+        "ja": "ゆーざーにんしょう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00104",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a transaction in databases?",
+      "ja": "でーたべーすのとらんざくしょんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Atomicity Consistency Isolation Durability",
+        "ja": "げんしせいいっかんせいどくりつせいもちぞくせい",
+        "ja_typings": []
+      },
+      {
+        "en": "All Conditions In Database",
+        "ja": "でーたべーすのすべてのじょうけん",
+        "ja_typings": []
+      },
+      {
+        "en": "Automatic Cache Index Design",
+        "ja": "じどうきゃっしゅいんでくすせっけい",
+        "ja_typings": []
+      },
+      {
+        "en": "Access Control Identity Domain",
+        "ja": "あくせすせいぎょしきべつどめいん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00105",
+    "image_path": null,
+    "question_text": {
+      "en": "What does ACID stand for?",
+      "ja": "ACIDの略語の意味は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "injecting malicious SQL into queries",
+        "ja": "くえりにあくいのあるSQLをそうにゅう",
+        "ja_typings": []
+      },
+      {
+        "en": "optimizing SQL queries",
+        "ja": "SQLくえりをさいてきか",
+        "ja_typings": []
+      },
+      {
+        "en": "importing SQL data",
+        "ja": "SQLでーたをいんぽーと",
+        "ja_typings": []
+      },
+      {
+        "en": "encrypting SQL data",
+        "ja": "SQLでーたをあんごうか",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00106",
+    "image_path": null,
+    "question_text": {
+      "en": "What is SQL injection?",
+      "ja": "SQLいんじぇくしょんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cross-Site Scripting attack",
+        "ja": "くろすさいとすくりぷてぃんぐこうげき",
+        "ja_typings": []
+      },
+      {
+        "en": "Extra Security System",
+        "ja": "きょうかせきゅりてぃしすてむ",
+        "ja_typings": []
+      },
+      {
+        "en": "XML Style Sheet",
+        "ja": "XMLすたいるしーと",
+        "ja_typings": []
+      },
+      {
+        "en": "External Source Server",
+        "ja": "がいぶそーすさーばー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00107",
+    "image_path": null,
+    "question_text": {
+      "en": "What is XSS?",
+      "ja": "XSSとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HTTP over TLS/SSL",
+        "ja": "TLS/SSLによるあんごうかHTTP",
+        "ja_typings": []
+      },
+      {
+        "en": "HTTP with speed boost",
+        "ja": "そくどこうかHTTP",
+        "ja_typings": []
+      },
+      {
+        "en": "HTTP for servers only",
+        "ja": "さーばーせんようHTTP",
+        "ja_typings": []
+      },
+      {
+        "en": "HTTP with caching",
+        "ja": "きゃっしゅつきHTTP",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00108",
+    "image_path": null,
+    "question_text": {
+      "en": "What is HTTPS?",
+      "ja": "HTTPSとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "forcing user to make unintended request",
+        "ja": "ゆーざーにひとしらずのりくえすとをさせる",
+        "ja_typings": []
+      },
+      {
+        "en": "stealing database credentials",
+        "ja": "でーたべーすのにんしょうじょうほうをぬすむ",
+        "ja_typings": []
+      },
+      {
+        "en": "injecting scripts into pages",
+        "ja": "ぺーじにすくりぷとをそうにゅう",
+        "ja_typings": []
+      },
+      {
+        "en": "overloading server with traffic",
+        "ja": "さーばーにとらふぃっくをかける",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00109",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a CSRF attack?",
+      "ja": "CSRF攻撃とは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "one-way transformation of data",
+        "ja": "でーたのいっぽうこうへんかん",
+        "ja_typings": []
+      },
+      {
+        "en": "two-way encryption",
+        "ja": "そうほうこうあんごうか",
+        "ja_typings": []
+      },
+      {
+        "en": "data compression",
+        "ja": "でーたあっしゅく",
+        "ja_typings": []
+      },
+      {
+        "en": "data storage",
+        "ja": "でーたほぞん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00110",
+    "image_path": null,
+    "question_text": {
+      "en": "What is hashing in security?",
+      "ja": "せきゅりてぃのはっしゅかとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "containerization platform",
+        "ja": "こんてなかぷらっとふぉーむ",
+        "ja_typings": []
+      },
+      {
+        "en": "virtual machine software",
+        "ja": "かそうましんそふとうぇあ",
+        "ja_typings": []
+      },
+      {
+        "en": "cloud storage service",
+        "ja": "くらうどすとれーじさーびす",
+        "ja_typings": []
+      },
+      {
+        "en": "CI/CD pipeline tool",
+        "ja": "CI/CDぱいぷらいんつーる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00111",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Docker?",
+      "ja": "Dockerとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "container orchestration system",
+        "ja": "こんてなおーけすとれーしょんしすてむ",
+        "ja_typings": []
+      },
+      {
+        "en": "database management system",
+        "ja": "でーたべーすかんりしすてむ",
+        "ja_typings": []
+      },
+      {
+        "en": "code review tool",
+        "ja": "こーどれびゅーつーる",
+        "ja_typings": []
+      },
+      {
+        "en": "monitoring platform",
+        "ja": "もにたりんぐぷらっとふぉーむ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00112",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Kubernetes?",
+      "ja": "Kubernetesとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Continuous Integration/Delivery",
+        "ja": "けいぞくてきとうごう/はいそう",
+        "ja_typings": []
+      },
+      {
+        "en": "Code Inspection/Change Deploy",
+        "ja": "こーどけんさ/へんこうはいひ",
+        "ja_typings": []
+      },
+      {
+        "en": "Container Integration/Distribution",
+        "ja": "こんてなとうごう/はいふ",
+        "ja_typings": []
+      },
+      {
+        "en": "Cloud Infrastructure/Design",
+        "ja": "くらうどきばんせっけい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00113",
+    "image_path": null,
+    "question_text": {
+      "en": "What is CI/CD?",
+      "ja": "CI/CDとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "managing infra through code",
+        "ja": "こーどをつうじてきばんをかんり",
+        "ja_typings": []
+      },
+      {
+        "en": "writing code on servers",
+        "ja": "さーばーでこーどをかく",
+        "ja_typings": []
+      },
+      {
+        "en": "converting code to hardware",
+        "ja": "こーどをはーどうぇあにへんかん",
+        "ja_typings": []
+      },
+      {
+        "en": "hosting code in cloud",
+        "ja": "くらうどでこーどをほすと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00114",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Infrastructure as Code?",
+      "ja": "Infrastructure as Codeとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "small independently deployable service",
+        "ja": "しょうきぼのどくりつはいひかのうなさーびす",
+        "ja_typings": []
+      },
+      {
+        "en": "a small VM",
+        "ja": "しょうきぼかそうましん",
+        "ja_typings": []
+      },
+      {
+        "en": "a lightweight database",
+        "ja": "けいりょうでーたべーす",
+        "ja_typings": []
+      },
+      {
+        "en": "a frontend component",
+        "ja": "ふろんとえんどこんぽーねんと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00115",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a microservice?",
+      "ja": "まいくろさーびすとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "interface for software to communicate",
+        "ja": "そふとうぇあがつうしんするためのいんたーふぇーす",
+        "ja_typings": []
+      },
+      {
+        "en": "a programming language",
+        "ja": "ぷろぐらみんぐげんご",
+        "ja_typings": []
+      },
+      {
+        "en": "a database type",
+        "ja": "でーたべーすのしゅるい",
+        "ja_typings": []
+      },
+      {
+        "en": "a design pattern",
+        "ja": "せっけいぱたーん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00116",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an API?",
+      "ja": "APIとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "software with public source code",
+        "ja": "そーすこーどがこうかいされているそふとうぇあ",
+        "ja_typings": []
+      },
+      {
+        "en": "free commercial software",
+        "ja": "むりょうしょうようそふとうぇあ",
+        "ja_typings": []
+      },
+      {
+        "en": "software without license",
+        "ja": "らいせんすなしそふとうぶ",
+        "ja_typings": []
+      },
+      {
+        "en": "browser-based software",
+        "ja": "ぶらうざーべーすそふとうぇあ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00117",
+    "image_path": null,
+    "question_text": {
+      "en": "What is open source software?",
+      "ja": "おーぷんそーすそふとうぇあとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MAJOR.MINOR.PATCH version numbering",
+        "ja": "MAJOR.MINOR.PATCHばんごうつけ",
+        "ja_typings": []
+      },
+      {
+        "en": "random version numbers",
+        "ja": "らんだむなばーじょんばんごう",
+        "ja_typings": []
+      },
+      {
+        "en": "date-based versioning",
+        "ja": "にちつきばーじょにんぐ",
+        "ja_typings": []
+      },
+      {
+        "en": "letter-based versioning",
+        "ja": "もじつきばーじょにんぐ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00118",
+    "image_path": null,
+    "question_text": {
+      "en": "What is semantic versioning?",
+      "ja": "せまんてぃっくばーじょにんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "tool that checks code style",
+        "ja": "こーどすたいるをかくにんするつーる",
+        "ja_typings": []
+      },
+      {
+        "en": "tool that runs tests",
+        "ja": "てすとをじっこうするつーる",
+        "ja_typings": []
+      },
+      {
+        "en": "tool that compiles code",
+        "ja": "こーどをこんぱいるするつーる",
+        "ja_typings": []
+      },
+      {
+        "en": "tool that deploys code",
+        "ja": "こーどをはいひするつーる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00119",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a linter?",
+      "ja": "りんたーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "improving code without changing behavior",
+        "ja": "どうさをかえずにこーどをかいぜん",
+        "ja_typings": []
+      },
+      {
+        "en": "adding new features",
+        "ja": "あたらしいきのうをついか",
+        "ja_typings": []
+      },
+      {
+        "en": "fixing bugs",
+        "ja": "ばぐをしゅうせい",
+        "ja_typings": []
+      },
+      {
+        "en": "rewriting from scratch",
+        "ja": "さいしょからかきなおす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00120",
+    "image_path": null,
+    "question_text": {
+      "en": "What is refactoring?",
+      "ja": "りふぁくたりんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "future cost of shortcuts taken now",
+        "ja": "いまとったちかみちのみらいのこすと",
+        "ja_typings": []
+      },
+      {
+        "en": "money owed for software licenses",
+        "ja": "そふとうぇあらいせんすのさいむ",
+        "ja_typings": []
+      },
+      {
+        "en": "bugs introduced by new features",
+        "ja": "あたらしいきのうによるばぐ",
+        "ja_typings": []
+      },
+      {
+        "en": "outdated documentation",
+        "ja": "ふるいどきゅめんとしょ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00121",
+    "image_path": null,
+    "question_text": {
+      "en": "What is technical debt?",
+      "ja": "ぎじゅつてきふさいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "examining code for quality",
+        "ja": "ひんしつのためにこーどをけんとう",
+        "ja_typings": []
+      },
+      {
+        "en": "running automated tests",
+        "ja": "じどうてすとをじっこう",
+        "ja_typings": []
+      },
+      {
+        "en": "deploying code to production",
+        "ja": "こーどをほんばんにはいひ",
+        "ja_typings": []
+      },
+      {
+        "en": "deleting unused code",
+        "ja": "つかわないこーどをさくじょ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00122",
+    "image_path": null,
+    "question_text": {
+      "en": "What is code review?",
+      "ja": "こーどれびゅーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "automates compilation and packaging",
+        "ja": "こんぱいるとぱっけーじをじどうか",
+        "ja_typings": []
+      },
+      {
+        "en": "stores source code",
+        "ja": "そーすこーどをほぞん",
+        "ja_typings": []
+      },
+      {
+        "en": "monitors application health",
+        "ja": "あぷりのけんこうをかんし",
+        "ja_typings": []
+      },
+      {
+        "en": "manages user accounts",
+        "ja": "ゆーざーあかうんとをかんり",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00123",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a build system?",
+      "ja": "びるどしすてむとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "providing dependencies from outside",
+        "ja": "がいぶからいぞんかんけいをていきょう",
+        "ja_typings": []
+      },
+      {
+        "en": "installing npm packages",
+        "ja": "npmぱっけーじをいんすとーる",
+        "ja_typings": []
+      },
+      {
+        "en": "injecting code at runtime",
+        "ja": "じっこうじにこーどをそうにゅう",
+        "ja_typings": []
+      },
+      {
+        "en": "caching function results",
+        "ja": "かんすうけっかをきゃっしゅ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00124",
+    "image_path": null,
+    "question_text": {
+      "en": "What is dependency injection?",
+      "ja": "いぞんせいのちゅうにゅうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "mechanism for handling async events",
+        "ja": "ひどうきいべんとをしょりするしくみ",
+        "ja_typings": []
+      },
+      {
+        "en": "a type of loop statement",
+        "ja": "るーぷぶんのしゅるい",
+        "ja_typings": []
+      },
+      {
+        "en": "error handling mechanism",
+        "ja": "えらーしょりのしくみ",
+        "ja_typings": []
+      },
+      {
+        "en": "UI rendering cycle",
+        "ja": "UIれんだりんぐのしゅき",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00125",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an event loop?",
+      "ja": "いべんとるーぷとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Document Object Model",
+        "ja": "どきゅめんとおぶじぇくともでる",
+        "ja_typings": []
+      },
+      {
+        "en": "Data Object Management",
+        "ja": "でーたおぶじぇくとかんり",
+        "ja_typings": []
+      },
+      {
+        "en": "Dynamic Output Module",
+        "ja": "どうてきしゅつりょくもじゅーる",
+        "ja_typings": []
+      },
+      {
+        "en": "Distributed Object Method",
+        "ja": "ぶんさんおぶじぇくとめそっど",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00126",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the DOM?",
+      "ja": "DOMとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "event propagates up the DOM tree",
+        "ja": "いべんとがDOMツリーをのぼる",
+        "ja_typings": []
+      },
+      {
+        "en": "events are queued",
+        "ja": "いべんとがきゅーにはいる",
+        "ja_typings": []
+      },
+      {
+        "en": "events are cancelled",
+        "ja": "いべんとがキャンセルされる",
+        "ja_typings": []
+      },
+      {
+        "en": "events repeat in loop",
+        "ja": "いべんとがるーぷでくりかえす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00127",
+    "image_path": null,
+    "question_text": {
+      "en": "What is event bubbling?",
+      "ja": "いべんとばぶりんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "loading resources only when needed",
+        "ja": "ひつようなときだけりそーすをろーど",
+        "ja_typings": []
+      },
+      {
+        "en": "loading all resources at start",
+        "ja": "きどうじにすべてのりそーすをろーど",
+        "ja_typings": []
+      },
+      {
+        "en": "loading in random order",
+        "ja": "らんだむなじゅんでろーど",
+        "ja_typings": []
+      },
+      {
+        "en": "loading from local cache only",
+        "ja": "ろーかるきゃっしゅからのみろーど",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00128",
+    "image_path": null,
+    "question_text": {
+      "en": "What is lazy loading?",
+      "ja": "れいじーろーでぃんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "removing unused code from bundles",
+        "ja": "ばんどるからつかわないこーどをさくじょ",
+        "ja_typings": []
+      },
+      {
+        "en": "optimizing recursive algorithms",
+        "ja": "さいきあるごりずむのさいてきか",
+        "ja_typings": []
+      },
+      {
+        "en": "sorting import statements",
+        "ja": "いんぽーとのせいれつ",
+        "ja_typings": []
+      },
+      {
+        "en": "caching dependency trees",
+        "ja": "いぞんかんけいつりーのきゃっしゅ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00129",
+    "image_path": null,
+    "question_text": {
+      "en": "What is tree shaking?",
+      "ja": "つりーしぇいきんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "indication of deeper problem in code",
+        "ja": "こーどのふかいもんだいのしょうこう",
+        "ja_typings": []
+      },
+      {
+        "en": "runtime error message",
+        "ja": "じっこうじえらーめっせーじ",
+        "ja_typings": []
+      },
+      {
+        "en": "compiler warning",
+        "ja": "こんぱいらけいこく",
+        "ja_typings": []
+      },
+      {
+        "en": "style guide violation",
+        "ja": "すたいるがいどのいはん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00130",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a code smell?",
+      "ja": "こーどすめるとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "two developers working on same code",
+        "ja": "ふたりがどうじにどうじこーどをさぎょう",
+        "ja_typings": []
+      },
+      {
+        "en": "programming in two languages",
+        "ja": "ふたつのげんごでぷろぐらみんぐ",
+        "ja_typings": []
+      },
+      {
+        "en": "using two machines",
+        "ja": "ふたつのましんをしよう",
+        "ja_typings": []
+      },
+      {
+        "en": "writing code twice for safety",
+        "ja": "あんぜんのためこーどをにかいかく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00131",
+    "image_path": null,
+    "question_text": {
+      "en": "What is pair programming?",
+      "ja": "ぺあぷろぐらみんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Integrated Development Environment",
+        "ja": "とうごうかいはつかんきょう",
+        "ja_typings": []
+      },
+      {
+        "en": "Internet Data Exchange",
+        "ja": "いんたーねっとでーたこうかん",
+        "ja_typings": []
+      },
+      {
+        "en": "Internal Deploy Engine",
+        "ja": "ないぶはいひえんじん",
+        "ja_typings": []
+      },
+      {
+        "en": "Interface Design Element",
+        "ja": "いんたーふぇーすせっけいようそ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00132",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an IDE?",
+      "ja": "IDEとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "type determined by interface not class",
+        "ja": "くらすでなくいんたーふぇーすでがたをはんてい",
+        "ja_typings": []
+      },
+      {
+        "en": "converting string to number",
+        "ja": "もじれつをすうちにへんかん",
+        "ja_typings": []
+      },
+      {
+        "en": "strict type checking",
+        "ja": "きびしいがたかくにん",
+        "ja_typings": []
+      },
+      {
+        "en": "defining types at compile time",
+        "ja": "かんぱいるじにがたをていぎ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00133",
+    "image_path": null,
+    "question_text": {
+      "en": "What is duck typing?",
+      "ja": "だっくたいぴんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "function with its captured environment",
+        "ja": "かんきょうをほじしたかんすう",
+        "ja_typings": []
+      },
+      {
+        "en": "a sealed class",
+        "ja": "ふいんされたくらす",
+        "ja_typings": []
+      },
+      {
+        "en": "end of function scope",
+        "ja": "かんすうのすこーぷのおわり",
+        "ja_typings": []
+      },
+      {
+        "en": "an anonymous object",
+        "ja": "むめいおぶじぇくと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00134",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a closure?",
+      "ja": "くろーじゃとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "transforming f(a,b) into f(a)(b)",
+        "ja": "f(a,b)をf(a)(b)にへんかん",
+        "ja_typings": []
+      },
+      {
+        "en": "adding curry to code",
+        "ja": "こーどにかりーをついか",
+        "ja_typings": []
+      },
+      {
+        "en": "memoizing function results",
+        "ja": "かんすうけっかをきおく",
+        "ja_typings": []
+      },
+      {
+        "en": "defining variadic functions",
+        "ja": "かへいすうかんすうをていぎ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00135",
+    "image_path": null,
+    "question_text": {
+      "en": "What is currying?",
+      "ja": "かりーかとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "binary instruction format for browsers",
+        "ja": "ぶらうざーようのばいなりめいれいけいしき",
+        "ja_typings": []
+      },
+      {
+        "en": "a JavaScript framework",
+        "ja": "JavaScriptふれーむわーく",
+        "ja_typings": []
+      },
+      {
+        "en": "a CSS preprocessor",
+        "ja": "CSSぷりぷろせっさ",
+        "ja_typings": []
+      },
+      {
+        "en": "a server runtime",
+        "ja": "さーばーじっこうかんきょう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00136",
+    "image_path": null,
+    "question_text": {
+      "en": "What is WebAssembly (WASM)?",
+      "ja": "WebAssembly (WASM)とは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "object from which others inherit",
+        "ja": "ほかのおぶじぇくとがけいしょうするおぶじぇくと",
+        "ja_typings": []
+      },
+      {
+        "en": "first version of software",
+        "ja": "そふとうぇあのさいしょのばーじょん",
+        "ja_typings": []
+      },
+      {
+        "en": "a constructor function",
+        "ja": "こんすとらくたかんすう",
+        "ja_typings": []
+      },
+      {
+        "en": "a static method",
+        "ja": "すたてぃっくめそっど",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00137",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a prototype in JavaScript?",
+      "ja": "JavaScriptのぷろとたいぷとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "calling multiple methods in sequence",
+        "ja": "めそっどをれんけつしてよびだす",
+        "ja_typings": []
+      },
+      {
+        "en": "inheriting methods from parent",
+        "ja": "おやからめそっどをけいしょう",
+        "ja_typings": []
+      },
+      {
+        "en": "linking two objects",
+        "ja": "ふたつのおぶじぇくとをれんけつ",
+        "ja_typings": []
+      },
+      {
+        "en": "calling same method twice",
+        "ja": "どうじめそっどをにかいよびだす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00138",
+    "image_path": null,
+    "question_text": {
+      "en": "What is method chaining?",
+      "ja": "めそっどちぇーにんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "five OOP design principles",
+        "ja": "ごつのOOPせっけいげんそく",
+        "ja_typings": []
+      },
+      {
+        "en": "a security standard",
+        "ja": "せきゅりてぃきじゅん",
+        "ja_typings": []
+      },
+      {
+        "en": "a testing framework",
+        "ja": "てすとふれーむわーく",
+        "ja_typings": []
+      },
+      {
+        "en": "a data format",
+        "ja": "でーたけいしき",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00139",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the SOLID principle?",
+      "ja": "SOLIDげんそくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Don't Repeat Yourself",
+        "ja": "じぶんじしんをくりかえさない",
+        "ja_typings": []
+      },
+      {
+        "en": "Design Reusable Years",
+        "ja": "さいりようかのうなねんのせっけい",
+        "ja_typings": []
+      },
+      {
+        "en": "Deploy Rapidly Yearly",
+        "ja": "まいとしはやくはいひ",
+        "ja_typings": []
+      },
+      {
+        "en": "Define Register Yield",
+        "ja": "さいじぇいきゅうをていぎ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00140",
+    "image_path": null,
+    "question_text": {
+      "en": "What is DRY principle?",
+      "ja": "DRYげんそくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Keep It Simple Stupid",
+        "ja": "かんたんにしておけ",
+        "ja_typings": []
+      },
+      {
+        "en": "Keys In Secure Storage",
+        "ja": "かぎをあんぜんにほぞん",
+        "ja_typings": []
+      },
+      {
+        "en": "Keep Iterations Short Strong",
+        "ja": "いてれーしょんをみじかくつよく",
+        "ja_typings": []
+      },
+      {
+        "en": "Kill Invalid Session States",
+        "ja": "ふせいせっしょんをさくじょ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00141",
+    "image_path": null,
+    "question_text": {
+      "en": "What is KISS principle?",
+      "ja": "KISSげんそくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HTTP callback when event occurs",
+        "ja": "いべんとはっせいじのHTTPこーるばっく",
+        "ja_typings": []
+      },
+      {
+        "en": "a browser plugin",
+        "ja": "ぶらうざーぷらぐいん",
+        "ja_typings": []
+      },
+      {
+        "en": "a type of API key",
+        "ja": "APIきーのしゅるい",
+        "ja_typings": []
+      },
+      {
+        "en": "a frontend hook",
+        "ja": "ふろんとえんどふっく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00142",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a webhook?",
+      "ja": "うぇぶふっくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "query language for APIs",
+        "ja": "APIのためのくえりげんご",
+        "ja_typings": []
+      },
+      {
+        "en": "graph database query",
+        "ja": "ぐらふでーたべーすくえり",
+        "ja_typings": []
+      },
+      {
+        "en": "frontend rendering library",
+        "ja": "ふろんとえんどれんだりんぐらいぶらり",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS animation library",
+        "ja": "CSSあにめーしょんらいぶらり",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00143",
+    "image_path": null,
+    "question_text": {
+      "en": "What is GraphQL?",
+      "ja": "GraphQLとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "rendering HTML on server",
+        "ja": "さーばーでHTMLをせいせい",
+        "ja_typings": []
+      },
+      {
+        "en": "rendering CSS on server",
+        "ja": "さーばーでCSSをせいせい",
+        "ja_typings": []
+      },
+      {
+        "en": "processing data on client",
+        "ja": "くらいあんとでもにょりをしょり",
+        "ja_typings": []
+      },
+      {
+        "en": "caching on server",
+        "ja": "さーばーできゃっしゅ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00144",
+    "image_path": null,
+    "question_text": {
+      "en": "What is server-side rendering?",
+      "ja": "さーばーさいどれんだりんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "attaching JS to server-rendered HTML",
+        "ja": "さーばーせいせいHTMLにJSをてんぷ",
+        "ja_typings": []
+      },
+      {
+        "en": "loading CSS styles",
+        "ja": "CSSすたいるのろーど",
+        "ja_typings": []
+      },
+      {
+        "en": "compressing images",
+        "ja": "がぞうのあっしゅく",
+        "ja_typings": []
+      },
+      {
+        "en": "managing cookies",
+        "ja": "くっきーのかんり",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00145",
+    "image_path": null,
+    "question_text": {
+      "en": "What is hydration in web development?",
+      "ja": "うぇぶかいはつのはいどれーしょんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "self-contained unit of code",
+        "ja": "どくりつしたこーどのたんい",
+        "ja_typings": []
+      },
+      {
+        "en": "a hardware component",
+        "ja": "はーどうぇあこんぽーねんと",
+        "ja_typings": []
+      },
+      {
+        "en": "a CSS class",
+        "ja": "CSSくらす",
+        "ja_typings": []
+      },
+      {
+        "en": "a database table",
+        "ja": "でーたべーすてーぶる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00146",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a module in programming?",
+      "ja": "ぷろぐらみんぐのもじゅーるとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "installing and managing libraries",
+        "ja": "らいぶらりのいんすとーるとかんり",
+        "ja_typings": []
+      },
+      {
+        "en": "organizing files in folders",
+        "ja": "ふぁいるをふぉるだでせいり",
+        "ja_typings": []
+      },
+      {
+        "en": "managing server packages",
+        "ja": "さーばーぱっけーじのかんり",
+        "ja_typings": []
+      },
+      {
+        "en": "shipping software updates",
+        "ja": "そふとうぇあこうしんのはいそう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00147",
+    "image_path": null,
+    "question_text": {
+      "en": "What is package management?",
+      "ja": "ぱっけーじかんりとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "OS-level configuration value",
+        "ja": "OSれべるのせってちち",
+        "ja_typings": []
+      },
+      {
+        "en": "local variable in function",
+        "ja": "かんすうのろーかるへんすう",
+        "ja_typings": []
+      },
+      {
+        "en": "global JS variable",
+        "ja": "ぐろーばるJS変数",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS variable",
+        "ja": "CSS変数",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00148",
+    "image_path": null,
+    "question_text": {
+      "en": "What is environment variable?",
+      "ja": "かんきょうへんすうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "inconsistency from concurrent access",
+        "ja": "どうじあくせすによるふせいごうせい",
+        "ja_typings": []
+      },
+      {
+        "en": "slow query execution",
+        "ja": "くえりのおそいじっこう",
+        "ja_typings": []
+      },
+      {
+        "en": "index corruption",
+        "ja": "いんでくすのそんしょう",
+        "ja_typings": []
+      },
+      {
+        "en": "data type mismatch",
+        "ja": "でーたがたのふいっち",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00149",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a race condition in databases?",
+      "ja": "でーたべーすのれーすじょうけんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "organizing data to reduce redundancy",
+        "ja": "じょうちょうをへらすでーたのせいり",
+        "ja_typings": []
+      },
+      {
+        "en": "sorting table rows",
+        "ja": "てーぶるぎょうのせいれつ",
+        "ja_typings": []
+      },
+      {
+        "en": "encrypting sensitive data",
+        "ja": "きみつでーたのあんごうか",
+        "ja_typings": []
+      },
+      {
+        "en": "compressing table data",
+        "ja": "てーぶるでーたのあっしゅく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00150",
+    "image_path": null,
+    "question_text": {
+      "en": "What is normalization in databases?",
+      "ja": "でーたべーすのせいきかとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cascading Style Sheets",
+        "ja": "かすけーでぃんぐすたいるしーと",
+        "ja_typings": []
+      },
+      {
+        "en": "Computer Style System",
+        "ja": "こんぴゅーたすたいるしすてむ",
+        "ja_typings": []
+      },
+      {
+        "en": "Content Style Standard",
+        "ja": "こんてんつすたいるきじゅん",
+        "ja_typings": []
+      },
+      {
+        "en": "Creative Style Syntax",
+        "ja": "くりえいてぃぶすたいるこうもん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00151",
+    "image_path": null,
+    "question_text": {
+      "en": "What does CSS stand for?",
+      "ja": "CSSのふりがなの意味は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "<a>",
+        "ja": "<a>",
+        "ja_typings": []
+      },
+      {
+        "en": "<link>",
+        "ja": "<link>",
+        "ja_typings": []
+      },
+      {
+        "en": "<href>",
+        "ja": "<href>",
+        "ja_typings": []
+      },
+      {
+        "en": "<url>",
+        "ja": "<url>",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00152",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML tag creates a hyperlink?",
+      "ja": "ハイパーリンクをつくるHTMLたぐは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "content, padding, border, margin",
+        "ja": "こんてんつぱでぃんぐぼーだーまーじん",
+        "ja_typings": []
+      },
+      {
+        "en": "width, height, color, font",
+        "ja": "はばたかさいろふぉんと",
+        "ja_typings": []
+      },
+      {
+        "en": "display, position, float, clear",
+        "ja": "ひょうじいちふろーとくりあ",
+        "ja_typings": []
+      },
+      {
+        "en": "flex, grid, block, inline",
+        "ja": "ふれっくすぐりっどぶろっくいんらいん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00153",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the CSS box model?",
+      "ja": "CSSのぼっくすもでるとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "flexible layout model",
+        "ja": "ふれきしぶるれいあうともでる",
+        "ja_typings": []
+      },
+      {
+        "en": "fixed grid layout",
+        "ja": "こていぐりっどれいあうと",
+        "ja_typings": []
+      },
+      {
+        "en": "absolute positioning",
+        "ja": "ぜったいいちしてい",
+        "ja_typings": []
+      },
+      {
+        "en": "full-screen mode",
+        "ja": "ふるすくりーんもーど",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00154",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `display: flex` enable?",
+      "ja": "`display: flex`は何を可能にするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "rules applied at specific screen sizes",
+        "ja": "とくていがめんさいずにてきようするるーる",
+        "ja_typings": []
+      },
+      {
+        "en": "querying a database",
+        "ja": "でーたべーすをくえり",
+        "ja_typings": []
+      },
+      {
+        "en": "fetching media files",
+        "ja": "めでぃあふぁいるをとりこむ",
+        "ja_typings": []
+      },
+      {
+        "en": "importing stylesheets",
+        "ja": "すたいるしーとをいんぽーと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00155",
+    "image_path": null,
+    "question_text": {
+      "en": "What is media query in CSS?",
+      "ja": "CSSのめでぃあくえりとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JavaScript UI library",
+        "ja": "JavaScriptのUIらいぶらり",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS framework",
+        "ja": "CSSふれーむわーく",
+        "ja_typings": []
+      },
+      {
+        "en": "database ORM",
+        "ja": "でーたべーすORM",
+        "ja_typings": []
+      },
+      {
+        "en": "backend framework",
+        "ja": "ばっくえんどふれーむわーく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00156",
+    "image_path": null,
+    "question_text": {
+      "en": "What is React?",
+      "ja": "Reactとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "reusable UI building block",
+        "ja": "さいりようかのうなUIのたんい",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS animation",
+        "ja": "CSSあにめーしょん",
+        "ja_typings": []
+      },
+      {
+        "en": "database model",
+        "ja": "でーたべーすもでる",
+        "ja_typings": []
+      },
+      {
+        "en": "server endpoint",
+        "ja": "さーばーえんどぽいんと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00157",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a React component?",
+      "ja": "Reactこんぽーねんととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JavaScript XML syntax extension",
+        "ja": "JavaScript XMLこうもんかくちょう",
+        "ja_typings": []
+      },
+      {
+        "en": "Java Scripting Extension",
+        "ja": "Javaすくりぷとかくちょう",
+        "ja_typings": []
+      },
+      {
+        "en": "JSON Exchange Format",
+        "ja": "JSONこうかんけいしき",
+        "ja_typings": []
+      },
+      {
+        "en": "JavaScript Index",
+        "ja": "JavaScriptいんでくす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00158",
+    "image_path": null,
+    "question_text": {
+      "en": "What is JSX?",
+      "ja": "JSXとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "lightweight copy of real DOM",
+        "ja": "じっさいDOMのかるいこぴー",
+        "ja_typings": []
+      },
+      {
+        "en": "server-side DOM rendering",
+        "ja": "さーばーさいどDOMれんだりんぐ",
+        "ja_typings": []
+      },
+      {
+        "en": "DOM created by CSS",
+        "ja": "CSSがさくせいしたDOM",
+        "ja_typings": []
+      },
+      {
+        "en": "cached DOM snapshot",
+        "ja": "DOMのきゃっしゅすなっぷしょっと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00159",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the virtual DOM in React?",
+      "ja": "Reactのばーちゃるどむとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "manages component local state",
+        "ja": "こんぽーねんとのろーかるじょうたいをかんり",
+        "ja_typings": []
+      },
+      {
+        "en": "fetches API data",
+        "ja": "APIでーたをとりこむ",
+        "ja_typings": []
+      },
+      {
+        "en": "creates new component",
+        "ja": "あたらしいこんぽーねんとをさくせい",
+        "ja_typings": []
+      },
+      {
+        "en": "handles routing",
+        "ja": "るーてぃんぐをしょり",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00160",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `useState` do in React?",
+      "ja": "Reactの`useState`は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "runs side effects after render",
+        "ja": "れんだーごにふくさようをじっこう",
+        "ja_typings": []
+      },
+      {
+        "en": "updates component styles",
+        "ja": "こんぽーねんとのすたいるをこうしん",
+        "ja_typings": []
+      },
+      {
+        "en": "creates global state",
+        "ja": "ぐろーばるじょうたいをさくせい",
+        "ja_typings": []
+      },
+      {
+        "en": "handles form input",
+        "ja": "ふぉーむにゅうりょくをしょり",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00161",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `useEffect` do in React?",
+      "ja": "Reactの`useEffect`は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "progressive JavaScript framework",
+        "ja": "ぷろぐれっしぶJavaScriptふれーむわーく",
+        "ja_typings": []
+      },
+      {
+        "en": "backend Node.js framework",
+        "ja": "ばっくえんどNode.jsふれーむわーく",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS preprocessor",
+        "ja": "CSSぷりぷろせっさ",
+        "ja_typings": []
+      },
+      {
+        "en": "database query builder",
+        "ja": "でーたべーすくえりびるだー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00162",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Vue.js?",
+      "ja": "Vue.jsとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "typed superset of JavaScript",
+        "ja": "がたつきJavaScriptのすーぱーせっと",
+        "ja_typings": []
+      },
+      {
+        "en": "JavaScript backend runtime",
+        "ja": "JavaScriptばっくえんどじっこうかんきょう",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS framework",
+        "ja": "CSSふれーむわーく",
+        "ja_typings": []
+      },
+      {
+        "en": "HTML template engine",
+        "ja": "HTMLてんぷれーとえんじん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00163",
+    "image_path": null,
+    "question_text": {
+      "en": "What is TypeScript?",
+      "ja": "TypeScriptとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Node.js package manager",
+        "ja": "Node.jsぱっけーじまねーじゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "network protocol manager",
+        "ja": "ねっとわーくぷろとこるまねーじゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "new project module",
+        "ja": "あたらしいぷろじぇくとのもじゅーる",
+        "ja_typings": []
+      },
+      {
+        "en": "null pointer method",
+        "ja": "nullぽいんたーめそっど",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00164",
+    "image_path": null,
+    "question_text": {
+      "en": "What is npm?",
+      "ja": "npmとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JavaScript server-side runtime",
+        "ja": "JavaScriptのさーばーがわじっこうかんきょう",
+        "ja_typings": []
+      },
+      {
+        "en": "browser JavaScript engine",
+        "ja": "ぶらうざーJavaScriptえんじん",
+        "ja_typings": []
+      },
+      {
+        "en": "database for JSON",
+        "ja": "JSONのでーたべーす",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS compiler",
+        "ja": "CSSこんぱいら",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00165",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Node.js?",
+      "ja": "Node.jsとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "module bundler for JavaScript",
+        "ja": "JavaScriptのもじゅーるばんどらー",
+        "ja_typings": []
+      },
+      {
+        "en": "web server software",
+        "ja": "うぇぶさーばーそふとうぇあ",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS framework",
+        "ja": "CSSふれーむわーく",
+        "ja_typings": []
+      },
+      {
+        "en": "backend framework",
+        "ja": "ばっくえんどふれーむわーく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00166",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Webpack?",
+      "ja": "Webpackとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Single Page Application",
+        "ja": "しんぐるぺーじあぷりけーしょん",
+        "ja_typings": []
+      },
+      {
+        "en": "Server-side PHP Application",
+        "ja": "さーばーがわPHPあぷり",
+        "ja_typings": []
+      },
+      {
+        "en": "Secure Protocol API",
+        "ja": "あんぜんぷろとこるAPI",
+        "ja_typings": []
+      },
+      {
+        "en": "Static Page Archive",
+        "ja": "せいてきぺーじあーかいぶ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00167",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a SPA?",
+      "ja": "SPAとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Server-Side Rendering",
+        "ja": "さーばーさいどれんだりんぐ",
+        "ja_typings": []
+      },
+      {
+        "en": "Static Style Rules",
+        "ja": "せいてきすたいるるーる",
+        "ja_typings": []
+      },
+      {
+        "en": "Shared Script Resources",
+        "ja": "きょうゆうすくりぷとりそーす",
+        "ja_typings": []
+      },
+      {
+        "en": "Secure Session Registry",
+        "ja": "あんぜんせっしょんとうろく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00168",
+    "image_path": null,
+    "question_text": {
+      "en": "What is SSR in web?",
+      "ja": "うぇぶのSSRとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "small data stored in browser",
+        "ja": "ぶらうざーにほぞんされるしょうさなでーた",
+        "ja_typings": []
+      },
+      {
+        "en": "server-side session",
+        "ja": "さーばーがわせっしょん",
+        "ja_typings": []
+      },
+      {
+        "en": "encrypted token",
+        "ja": "あんごうかされたとーくん",
+        "ja_typings": []
+      },
+      {
+        "en": "database record",
+        "ja": "でーたべーすのれこーど",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00169",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a cookie?",
+      "ja": "くっきーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "browser-based persistent key-value store",
+        "ja": "ぶらうざーのきーちストレージ",
+        "ja_typings": []
+      },
+      {
+        "en": "local database server",
+        "ja": "ろーかるでーたべーすさーばー",
+        "ja_typings": []
+      },
+      {
+        "en": "server-side cache",
+        "ja": "さーばーがわきゃっしゅ",
+        "ja_typings": []
+      },
+      {
+        "en": "file system API",
+        "ja": "ふぁいるしすてむAPI",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00170",
+    "image_path": null,
+    "question_text": {
+      "en": "What is localStorage?",
+      "ja": "localStorageとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "makes HTTP requests",
+        "ja": "HTTPりくえすとをおこなう",
+        "ja_typings": []
+      },
+      {
+        "en": "reads local files",
+        "ja": "ろーかるふぁいるをよむ",
+        "ja_typings": []
+      },
+      {
+        "en": "queries database",
+        "ja": "でーたべーすをくえり",
+        "ja_typings": []
+      },
+      {
+        "en": "renders HTML",
+        "ja": "HTMLをれんだー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00171",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `fetch()` do in JS?",
+      "ja": "JSの`fetch()`は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cross-Origin Resource Sharing",
+        "ja": "くろすおりじんりそーすきょうゆう",
+        "ja_typings": []
+      },
+      {
+        "en": "Content Oriented Rendering System",
+        "ja": "こんてんつしこうれんだりんぐしすてむ",
+        "ja_typings": []
+      },
+      {
+        "en": "Cache Override Request Scheme",
+        "ja": "きゃっしゅおーばーらいどりくえすとけいしき",
+        "ja_typings": []
+      },
+      {
+        "en": "Client Origin Response Standard",
+        "ja": "くらいあんとおりじんおうとうきじゅん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00172",
+    "image_path": null,
+    "question_text": {
+      "en": "What is CORS?",
+      "ja": "CORSとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Content Delivery Network",
+        "ja": "こんてんつはいしんねっとわーく",
+        "ja_typings": []
+      },
+      {
+        "en": "Centralized Data Node",
+        "ja": "ちゅうおうかでーたのーど",
+        "ja_typings": []
+      },
+      {
+        "en": "Cloud Database Network",
+        "ja": "くらうどでーたべーすねっとわーく",
+        "ja_typings": []
+      },
+      {
+        "en": "Client Domain Name",
+        "ja": "くらいあんとどめいんめい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00173",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a CDN?",
+      "ja": "CDNとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HTML that conveys meaning",
+        "ja": "いみをつたえるHTML",
+        "ja_typings": []
+      },
+      {
+        "en": "HTML with inline styles",
+        "ja": "いんらいんすたいるつきHTML",
+        "ja_typings": []
+      },
+      {
+        "en": "HTML without CSS",
+        "ja": "CSSなしHTML",
+        "ja_typings": []
+      },
+      {
+        "en": "compressed HTML",
+        "ja": "あっしゅくされたHTML",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00174",
+    "image_path": null,
+    "question_text": {
+      "en": "What is semantic HTML?",
+      "ja": "せまんてぃっくHTMLとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "declares character encoding",
+        "ja": "もじぶんにょくをせんげん",
+        "ja_typings": []
+      },
+      {
+        "en": "sets page title",
+        "ja": "ぺーじのたいとるをせってい",
+        "ja_typings": []
+      },
+      {
+        "en": "defines CSS styles",
+        "ja": "CSSすたいるをていぎ",
+        "ja_typings": []
+      },
+      {
+        "en": "links JavaScript file",
+        "ja": "JavaScriptふぁいるをりんく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00175",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the purpose of `<meta charset>`?",
+      "ja": "`<meta charset>`の目的は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "loads content only when needed",
+        "ja": "ひつようなときだけこんてんつをろーど",
+        "ja_typings": []
+      },
+      {
+        "en": "caches all content",
+        "ja": "すべてのこんてんつをきゃっしゅ",
+        "ja_typings": []
+      },
+      {
+        "en": "preloads all images",
+        "ja": "すべてのがぞうをじぜんろーど",
+        "ja_typings": []
+      },
+      {
+        "en": "loads on first visit only",
+        "ja": "さいしょのほうもんのみろーど",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00176",
+    "image_path": null,
+    "question_text": {
+      "en": "What is lazy loading in web?",
+      "ja": "うぇぶのれいじーろーでぃんぐとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "build from basic to enhanced",
+        "ja": "きほんからこうきのうへきちく",
+        "ja_typings": []
+      },
+      {
+        "en": "add features progressively over time",
+        "ja": "じかんとともにきのうをついか",
+        "ja_typings": []
+      },
+      {
+        "en": "enhance CSS over HTML",
+        "ja": "HTMLよりCSSをきょうか",
+        "ja_typings": []
+      },
+      {
+        "en": "upgrade to latest browser only",
+        "ja": "さいしんぶらうざーのみたいおう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00177",
+    "image_path": null,
+    "question_text": {
+      "en": "What is progressive enhancement?",
+      "ja": "ぷろぐれっしぶえんはんすめんととは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "extends CSS with variables and nesting",
+        "ja": "へんすうとねすとでCSSをかくちょう",
+        "ja_typings": []
+      },
+      {
+        "en": "compresses CSS files",
+        "ja": "CSSふぁいるをあっしゅく",
+        "ja_typings": []
+      },
+      {
+        "en": "converts CSS to JavaScript",
+        "ja": "CSSをJavaScriptにへんかん",
+        "ja_typings": []
+      },
+      {
+        "en": "generates CSS from images",
+        "ja": "がぞうからCSSをせいせい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00178",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a CSS preprocessor?",
+      "ja": "CSSぷりぷろせっさとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "utility-first CSS framework",
+        "ja": "ゆーてぃりてぃおしのCSSふれーむわーく",
+        "ja_typings": []
+      },
+      {
+        "en": "component-based UI library",
+        "ja": "こんぽーねんとべーすのUIらいぶらり",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS-in-JS solution",
+        "ja": "CSS-in-JSそりゅーしょん",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS animation library",
+        "ja": "CSSあにめーしょんらいぶらり",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00179",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Tailwind CSS?",
+      "ja": "Tailwind CSSとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "removing unused JS from bundle",
+        "ja": "つかわないJSをばんどるからのぞく",
+        "ja_typings": []
+      },
+      {
+        "en": "optimizing CSS selectors",
+        "ja": "CSSせれくたをさいてきか",
+        "ja_typings": []
+      },
+      {
+        "en": "caching static assets",
+        "ja": "せいてきあせっとをきゃっしゅ",
+        "ja_typings": []
+      },
+      {
+        "en": "sorting DOM elements",
+        "ja": "DOMようそをせいれつ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00180",
+    "image_path": null,
+    "question_text": {
+      "en": "What is tree shaking in frontend?",
+      "ja": "ふろんとえんどのつりーしぇいきんぐとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "metadata and resource links",
+        "ja": "めたでーたとりそーすりんく",
+        "ja_typings": []
+      },
+      {
+        "en": "visible page content",
+        "ja": "ひょうじされるぺーじこんてんつ",
+        "ja_typings": []
+      },
+      {
+        "en": "JavaScript functions",
+        "ja": "JavaScriptかんすう",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS styles",
+        "ja": "CSSすたいる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00181",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the purpose of `<head>` in HTML?",
+      "ja": "HTMLの`<head>`の役割は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "positions relative to nearest positioned ancestor",
+        "ja": "もっともちかいいちしていそせんへのそうたいいち",
+        "ja_typings": []
+      },
+      {
+        "en": "positions relative to viewport",
+        "ja": "びゅーぽーとへのそうたいいち",
+        "ja_typings": []
+      },
+      {
+        "en": "stacks with other elements",
+        "ja": "ほかのようそとかさなる",
+        "ja_typings": []
+      },
+      {
+        "en": "removes from document flow",
+        "ja": "ぶんしょうのふろーからとりのぞく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00182",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `position: absolute` do in CSS?",
+      "ja": "CSSの`position: absolute`は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "controls stacking order of elements",
+        "ja": "ようそのかさなりじゅんをせいぎょ",
+        "ja_typings": []
+      },
+      {
+        "en": "sets element zoom level",
+        "ja": "ようそのずーむをせってい",
+        "ja_typings": []
+      },
+      {
+        "en": "defines CSS grid zones",
+        "ja": "CSSぐりっどのぞーんをていぎ",
+        "ja_typings": []
+      },
+      {
+        "en": "sets animation delay",
+        "ja": "あにめーしょんのおくれをせってい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00183",
+    "image_path": null,
+    "question_text": {
+      "en": "What is z-index in CSS?",
+      "ja": "CSSのz-indexとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Block Element Modifier naming convention",
+        "ja": "ぶろっくようそもでぃふぁいやめいめいきやく",
+        "ja_typings": []
+      },
+      {
+        "en": "Browser Event Model",
+        "ja": "ぶらうざーいべんともでる",
+        "ja_typings": []
+      },
+      {
+        "en": "Built-in Extension Method",
+        "ja": "そなわったかくちょうめそっど",
+        "ja_typings": []
+      },
+      {
+        "en": "Background Effect Mode",
+        "ja": "はいけいこうかもーど",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00184",
+    "image_path": null,
+    "question_text": {
+      "en": "What is BEM in CSS?",
+      "ja": "CSSのBEMとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "custom property storing a value",
+        "ja": "ちをほぞんするかすたむぷろぱてぃ",
+        "ja_typings": []
+      },
+      {
+        "en": "JavaScript variable in CSS",
+        "ja": "CSSのJavaScriptへんすう",
+        "ja_typings": []
+      },
+      {
+        "en": "random CSS value",
+        "ja": "らんだむCSSち",
+        "ja_typings": []
+      },
+      {
+        "en": "inherited CSS property",
+        "ja": "けいしょうするCSSぷろぱてぃ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00185",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a CSS variable?",
+      "ja": "CSS変数とは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "making web usable for everyone",
+        "ja": "ウェブをすべての人が使えるよう",
+        "ja_typings": []
+      },
+      {
+        "en": "URL shortening",
+        "ja": "URLたんしゅく",
+        "ja_typings": []
+      },
+      {
+        "en": "caching strategy",
+        "ja": "きゃっしゅせんりゃく",
+        "ja_typings": []
+      },
+      {
+        "en": "server-side security",
+        "ja": "さーばーがわせきゅりてぃ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00186",
+    "image_path": null,
+    "question_text": {
+      "en": "What is accessibility (a11y) in web?",
+      "ja": "うぇぶのアクセシビリティとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Accessible Rich Internet Applications",
+        "ja": "アクセスしやすいりちなインターネットアプリ",
+        "ja_typings": []
+      },
+      {
+        "en": "Automated Rendering Index API",
+        "ja": "じどうれんだりんぐしすう",
+        "ja_typings": []
+      },
+      {
+        "en": "Advanced Resource Integration Architecture",
+        "ja": "こうきゅうりそーすとうごうあーきてくちゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "Application Route Inspection Agent",
+        "ja": "あぷりるーとけんさえーじぇんと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00187",
+    "image_path": null,
+    "question_text": {
+      "en": "What is ARIA in web accessibility?",
+      "ja": "うぇぶのARIAとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Progressive Web App",
+        "ja": "ぷろぐれっしぶうぇぶあぷり",
+        "ja_typings": []
+      },
+      {
+        "en": "Private Web Archive",
+        "ja": "ぷらいべーとうぇぶあーかいぶ",
+        "ja_typings": []
+      },
+      {
+        "en": "Public Webpack Agent",
+        "ja": "こうかいWebpackえーじぇんと",
+        "ja_typings": []
+      },
+      {
+        "en": "Preloaded Web Asset",
+        "ja": "じぜんろーどされたうぇぶあせっと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00188",
+    "image_path": null,
+    "question_text": {
+      "en": "What is PWA?",
+      "ja": "PWAとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "background script for offline support",
+        "ja": "おふらいんたいおうのばっくぐらうんどすくりぷと",
+        "ja_typings": []
+      },
+      {
+        "en": "server-side worker process",
+        "ja": "さーばーがわわーかーぷろせす",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS animation worker",
+        "ja": "CSSあにめーしょんわーかー",
+        "ja_typings": []
+      },
+      {
+        "en": "database connection pool",
+        "ja": "でーたべーすせつぞくぷーる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00189",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a service worker?",
+      "ja": "さーびすわーかーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "React framework with SSR and SSG",
+        "ja": "SSRとSSGのReactふれーむわーく",
+        "ja_typings": []
+      },
+      {
+        "en": "Node.js web server",
+        "ja": "Node.jsうぇぶさーばー",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS framework",
+        "ja": "CSSふれーむわーく",
+        "ja_typings": []
+      },
+      {
+        "en": "JavaScript test runner",
+        "ja": "JavaScriptてすとじっこうき",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00190",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Next.js?",
+      "ja": "Next.jsとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "full-stack Svelte framework",
+        "ja": "ふるすたっくSvelteふれーむわーく",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS animation toolkit",
+        "ja": "CSSあにめーしょんつーるきっと",
+        "ja_typings": []
+      },
+      {
+        "en": "JavaScript bundler",
+        "ja": "JavaScriptばんどらー",
+        "ja_typings": []
+      },
+      {
+        "en": "headless CMS",
+        "ja": "へっどれすCMS",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00191",
+    "image_path": null,
+    "question_text": {
+      "en": "What is SvelteKit?",
+      "ja": "SvelteKitとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "describes image for accessibility",
+        "ja": "アクセシビリティのためにがぞうをせつめい",
+        "ja_typings": []
+      },
+      {
+        "en": "sets image alignment",
+        "ja": "がぞうのいちをせってい",
+        "ja_typings": []
+      },
+      {
+        "en": "defines image source",
+        "ja": "がぞうのそーすをていぎ",
+        "ja_typings": []
+      },
+      {
+        "en": "sets image size",
+        "ja": "がぞうのさいずをせってい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00192",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the purpose of `alt` attribute in `<img>`?",
+      "ja": "`<img>`の`alt`属性の目的は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "multiplexing multiple requests",
+        "ja": "ふくすうりくえすとをたじゅうか",
+        "ja_typings": []
+      },
+      {
+        "en": "removing all headers",
+        "ja": "すべてのへっだーをさくじょ",
+        "ja_typings": []
+      },
+      {
+        "en": "using UDP instead of TCP",
+        "ja": "TCPのかわりにUDPをしよう",
+        "ja_typings": []
+      },
+      {
+        "en": "encrypting by default",
+        "ja": "きほんであんごうか",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00193",
+    "image_path": null,
+    "question_text": {
+      "en": "What is HTTP/2 improvement?",
+      "ja": "HTTP/2の改善点は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "full-duplex communication protocol",
+        "ja": "ぜんにほうこうつうしんぷろとこる",
+        "ja_typings": []
+      },
+      {
+        "en": "unidirectional HTTP streaming",
+        "ja": "いっぽうこうHTTPすとりーみんぐ",
+        "ja_typings": []
+      },
+      {
+        "en": "REST API standard",
+        "ja": "REST APIきじゅん",
+        "ja_typings": []
+      },
+      {
+        "en": "WebAssembly socket",
+        "ja": "WebAssemblyそけっと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00194",
+    "image_path": null,
+    "question_text": {
+      "en": "What is WebSocket?",
+      "ja": "WebSocketとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "encapsulated DOM sub-tree",
+        "ja": "かぷせるかされたDOMのさぶつりー",
+        "ja_typings": []
+      },
+      {
+        "en": "invisible DOM elements",
+        "ja": "みえないDOMようそ",
+        "ja_typings": []
+      },
+      {
+        "en": "server-side DOM",
+        "ja": "さーばーがわDOM",
+        "ja_typings": []
+      },
+      {
+        "en": "cached DOM snapshot",
+        "ja": "きゃっしゅされたDOMすなっぷしょっと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00195",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Shadow DOM?",
+      "ja": "シャドウDOMとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "user-defined HTML tag",
+        "ja": "ゆーざーていぎのHTMLたぐ",
+        "ja_typings": []
+      },
+      {
+        "en": "styled HTML element",
+        "ja": "すたいるつきHTMLようそ",
+        "ja_typings": []
+      },
+      {
+        "en": "hidden HTML element",
+        "ja": "かくされたHTMLようそ",
+        "ja_typings": []
+      },
+      {
+        "en": "dynamic HTML element",
+        "ja": "どうてきHTMLようそ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00196",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a custom HTML element?",
+      "ja": "かすたむHTMLようそとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "loads script after HTML parsing",
+        "ja": "HTMLかいせきごにすくりぷとをろーど",
+        "ja_typings": []
+      },
+      {
+        "en": "disables script execution",
+        "ja": "すくりぷとじっこうをむこうか",
+        "ja_typings": []
+      },
+      {
+        "en": "loads script before HTML",
+        "ja": "HTMLのまえにすくりぷとをろーど",
+        "ja_typings": []
+      },
+      {
+        "en": "compresses script file",
+        "ja": "すくりぷとふぁいるをあっしゅく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00197",
+    "image_path": null,
+    "question_text": {
+      "en": "What is `defer` attribute in `<script>`?",
+      "ja": "`<script>`の`defer`属性は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "em is parent-relative, rem is root-relative",
+        "ja": "emはおや、remはるーとからそうたい",
+        "ja_typings": []
+      },
+      {
+        "en": "em is pixels, rem is percentages",
+        "ja": "emはぴくせる、remはぱーせんと",
+        "ja_typings": []
+      },
+      {
+        "en": "em is for fonts, rem is for margins",
+        "ja": "emはふぉんと、remはまーじん",
+        "ja_typings": []
+      },
+      {
+        "en": "em is absolute, rem is relative",
+        "ja": "emはぜったい、remはそうたい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00198",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the difference between `em` and `rem` in CSS?",
+      "ja": "CSSの`em`と`rem`のちがいは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "two-dimensional layout system",
+        "ja": "にじげんれいあうとしすてむ",
+        "ja_typings": []
+      },
+      {
+        "en": "one-dimensional flex layout",
+        "ja": "いちじげんふれっくすれいあうと",
+        "ja_typings": []
+      },
+      {
+        "en": "table-based layout",
+        "ja": "てーぶるべーすれいあうと",
+        "ja_typings": []
+      },
+      {
+        "en": "fixed-position system",
+        "ja": "こていいちしすてむ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00199",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a CSS grid?",
+      "ja": "CSSぐりっどとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "visible area of browser window",
+        "ja": "ぶらうざーうぃんどうのひょうじりょういき",
+        "ja_typings": []
+      },
+      {
+        "en": "screen resolution setting",
+        "ja": "がめんかいぞうどせってい",
+        "ja_typings": []
+      },
+      {
+        "en": "full page width",
+        "ja": "ぺーじのぜんはば",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS container unit",
+        "ja": "CSSこんてなたんい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00200",
+    "image_path": null,
+    "question_text": {
+      "en": "What is viewport in CSS?",
+      "ja": "CSSのびゅーぽーととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "removing unnecessary characters from code",
+        "ja": "こーどから不要文字をとりのぞく",
+        "ja_typings": []
+      },
+      {
+        "en": "compressing images",
+        "ja": "がぞうをあっしゅく",
+        "ja_typings": []
+      },
+      {
+        "en": "caching static files",
+        "ja": "せいてきふぁいるをきゃっしゅ",
+        "ja_typings": []
+      },
+      {
+        "en": "splitting code into chunks",
+        "ja": "こーどをちゃんくにぶんかつ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00201",
+    "image_path": null,
+    "question_text": {
+      "en": "What is minification in web?",
+      "ja": "うぇぶのみにふぁいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "dividing bundle into smaller chunks",
+        "ja": "ばんどるをしょうさなちゃんくにぶんかつ",
+        "ja_typings": []
+      },
+      {
+        "en": "splitting CSS from JS",
+        "ja": "JSからCSSをわける",
+        "ja_typings": []
+      },
+      {
+        "en": "separating test code",
+        "ja": "てすとこーどをきりはなす",
+        "ja_typings": []
+      },
+      {
+        "en": "dividing HTML sections",
+        "ja": "HTMLせくしょんをぶんかつ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00202",
+    "image_path": null,
+    "question_text": {
+      "en": "What is code splitting?",
+      "ja": "こーどすぷりってぃんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "loads and executes script asynchronously",
+        "ja": "すくりぷとをひどうきにろーどじっこう",
+        "ja_typings": []
+      },
+      {
+        "en": "prevents script execution",
+        "ja": "すくりぷとじっこうをぼうし",
+        "ja_typings": []
+      },
+      {
+        "en": "caches the script",
+        "ja": "すくりぷとをきゃっしゅ",
+        "ja_typings": []
+      },
+      {
+        "en": "loads script synchronously",
+        "ja": "どうきにすくりぷとをろーど",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00203",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `async` attribute do in `<script>`?",
+      "ja": "`<script>`の`async`属性は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "open standard for authorization",
+        "ja": "にんかのおーぷんきじゅん",
+        "ja_typings": []
+      },
+      {
+        "en": "password encryption method",
+        "ja": "ぱすわーどあんごうかほうほう",
+        "ja_typings": []
+      },
+      {
+        "en": "object authentication",
+        "ja": "おぶじぇくとにんしょう",
+        "ja_typings": []
+      },
+      {
+        "en": "online API handler",
+        "ja": "おんらいんAPIはんどらー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00204",
+    "image_path": null,
+    "question_text": {
+      "en": "What is OAuth?",
+      "ja": "OAuthとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JSON Web Token for auth",
+        "ja": "にんしょうようのJSONうぇぶとーくん",
+        "ja_typings": []
+      },
+      {
+        "en": "JavaScript Web Tool",
+        "ja": "JavaScriptうぶえぶつーる",
+        "ja_typings": []
+      },
+      {
+        "en": "JSON Writer Template",
+        "ja": "JSONきじゅつてんぷれーと",
+        "ja_typings": []
+      },
+      {
+        "en": "Java Web Transaction",
+        "ja": "Javaうぇぶとらんざくしょん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00205",
+    "image_path": null,
+    "question_text": {
+      "en": "What is JWT?",
+      "ja": "JWTとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "backend content management without frontend",
+        "ja": "ふろんとえんどなしのCMS",
+        "ja_typings": []
+      },
+      {
+        "en": "CMS without user interface",
+        "ja": "ゆーざーいんたーふぇーすなしCMS",
+        "ja_typings": []
+      },
+      {
+        "en": "CMS stored in cloud",
+        "ja": "くらうどほぞんのCMS",
+        "ja_typings": []
+      },
+      {
+        "en": "CMS for static sites only",
+        "ja": "せいてきさいとのみのCMS",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00206",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a headless CMS?",
+      "ja": "へっどれすCMSとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "XML file listing site pages",
+        "ja": "さいとのぺーじをいちらんするXMLふぁいる",
+        "ja_typings": []
+      },
+      {
+        "en": "visual site design",
+        "ja": "びじゅあるなさいとせっけい",
+        "ja_typings": []
+      },
+      {
+        "en": "HTML navigation menu",
+        "ja": "HTMLなびげーしょんめにゅー",
+        "ja_typings": []
+      },
+      {
+        "en": "Google Analytics report",
+        "ja": "Googleアナリティクスレポート",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00207",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a sitemap?",
+      "ja": "さいとまっぷとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Search Engine Optimization",
+        "ja": "けんさくえんじんさいてきか",
+        "ja_typings": []
+      },
+      {
+        "en": "Secure Encoded Output",
+        "ja": "あんぜんなえんこーどしゅつりょく",
+        "ja_typings": []
+      },
+      {
+        "en": "Server Environment Options",
+        "ja": "さーばーかんきょうせってい",
+        "ja_typings": []
+      },
+      {
+        "en": "Static Element Object",
+        "ja": "せいてきようそおぶじぇくと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00208",
+    "image_path": null,
+    "question_text": {
+      "en": "What is SEO?",
+      "ja": "SEOとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Google's page experience metrics",
+        "ja": "Googleのぺーじたいけんしひょう",
+        "ja_typings": []
+      },
+      {
+        "en": "browser security standards",
+        "ja": "ぶらうざーせきゅりてぃきじゅん",
+        "ja_typings": []
+      },
+      {
+        "en": "web development checklist",
+        "ja": "うぇぶかいはつちぇっくりすと",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS performance metrics",
+        "ja": "CSSぱふぉーまんすしひょう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00209",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Core Web Vitals?",
+      "ja": "コアうぇぶばいたるずとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Largest Contentful Paint",
+        "ja": "さいだいこんてんつのびょうが",
+        "ja_typings": []
+      },
+      {
+        "en": "Lowest CPU Processing",
+        "ja": "さいていCPUしょり",
+        "ja_typings": []
+      },
+      {
+        "en": "Longest Cache Period",
+        "ja": "さいちょうきゃっしゅきかん",
+        "ja_typings": []
+      },
+      {
+        "en": "Last Click Position",
+        "ja": "さいごのくりっくいち",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00210",
+    "image_path": null,
+    "question_text": {
+      "en": "What does LCP stand for in web performance?",
+      "ja": "うぇぶぱふぉーまんすのLCPとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JSON file describing PWA app",
+        "ja": "PWAを説明するJSONふぁいる",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS configuration file",
+        "ja": "CSS設定ふぁいる",
+        "ja_typings": []
+      },
+      {
+        "en": "server routing config",
+        "ja": "さーばーるーてぃんぐせってい",
+        "ja_typings": []
+      },
+      {
+        "en": "list of site dependencies",
+        "ja": "さいとのいぞんかんけいいちらん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00211",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a web manifest file?",
+      "ja": "うぇぶましふぇすとふぁいるとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "same code renders on server and client",
+        "ja": "どうじこーどをさーばーとくらいあんとでれんだー",
+        "ja_typings": []
+      },
+      {
+        "en": "rendering only on client",
+        "ja": "くらいあんとのみれんだー",
+        "ja_typings": []
+      },
+      {
+        "en": "rendering only on server",
+        "ja": "さーばーのみれんだー",
+        "ja_typings": []
+      },
+      {
+        "en": "rendering in parallel",
+        "ja": "へいこうれんだー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00212",
+    "image_path": null,
+    "question_text": {
+      "en": "What is isomorphic rendering?",
+      "ja": "あいそもーふぃっくれんだりんぐとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "fast frontend build tool",
+        "ja": "こうそくふろんとえんどびるどつーる",
+        "ja_typings": []
+      },
+      {
+        "en": "Vue.js only bundler",
+        "ja": "Vue.jsせんようばんどらー",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS preprocessor",
+        "ja": "CSSぷりぷろせっさ",
+        "ja_typings": []
+      },
+      {
+        "en": "backend web server",
+        "ja": "ばっくえんどうぇぶさーばー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00213",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Vite?",
+      "ja": "Viteとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JavaScript linting tool",
+        "ja": "JavaScriptのりんたー",
+        "ja_typings": []
+      },
+      {
+        "en": "ES6 compiler",
+        "ja": "ES6こんぱいら",
+        "ja_typings": []
+      },
+      {
+        "en": "JavaScript bundler",
+        "ja": "JavaScriptばんどらー",
+        "ja_typings": []
+      },
+      {
+        "en": "Express server middleware",
+        "ja": "Expressさーばーみどるうぇあ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00214",
+    "image_path": null,
+    "question_text": {
+      "en": "What is ESLint?",
+      "ja": "ESLintとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "opinionated code formatter",
+        "ja": "独自方針のこーどふぉーまったー",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS preprocessor",
+        "ja": "CSSぷりぷろせっさ",
+        "ja_typings": []
+      },
+      {
+        "en": "JavaScript linter",
+        "ja": "JavaScriptりんたー",
+        "ja_typings": []
+      },
+      {
+        "en": "package manager",
+        "ja": "ぱっけーじまねーじゃ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00215",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Prettier?",
+      "ja": "Prettierとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "metadata sent with request/response",
+        "ja": "りくえすと/おうとうとともにおくるめたでーた",
+        "ja_typings": []
+      },
+      {
+        "en": "page title in HTML",
+        "ja": "HTMLのぺーじたいとる",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS heading style",
+        "ja": "CSSのみだしすたいる",
+        "ja_typings": []
+      },
+      {
+        "en": "database column header",
+        "ja": "でーたべーすれつみだし",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00216",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an HTTP header?",
+      "ja": "HTTPへっだーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "resource not found",
+        "ja": "りそーすがみつからない",
+        "ja_typings": []
+      },
+      {
+        "en": "server internal error",
+        "ja": "さーばーないぶえらー",
+        "ja_typings": []
+      },
+      {
+        "en": "access forbidden",
+        "ja": "アクセスきんし",
+        "ja_typings": []
+      },
+      {
+        "en": "connection timeout",
+        "ja": "せつぞくたいむあうと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00217",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 404 error?",
+      "ja": "404えらーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "internal server error",
+        "ja": "さーばーないぶえらー",
+        "ja_typings": []
+      },
+      {
+        "en": "resource not found",
+        "ja": "りそーすがみつからない",
+        "ja_typings": []
+      },
+      {
+        "en": "access forbidden",
+        "ja": "アクセスきんし",
+        "ja_typings": []
+      },
+      {
+        "en": "redirect response",
+        "ja": "りだいれくとおうとう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00218",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 500 error?",
+      "ja": "500えらーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "response telling client to go to new URL",
+        "ja": "あたらしいURLへいどうするおうとう",
+        "ja_typings": []
+      },
+      {
+        "en": "caching server response",
+        "ja": "さーばーおうとうをきゃっしゅ",
+        "ja_typings": []
+      },
+      {
+        "en": "compressing response body",
+        "ja": "おうとうぼでぃをあっしゅく",
+        "ja_typings": []
+      },
+      {
+        "en": "blocking client request",
+        "ja": "くらいあんとりくえすとをそしょ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00219",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a redirect in HTTP?",
+      "ja": "HTTPのりだいれくととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "escaping user input",
+        "ja": "ゆーざーにゅうりょくをえすけーぷ",
+        "ja_typings": []
+      },
+      {
+        "en": "encrypting all data",
+        "ja": "すべてのでーたをあんごうか",
+        "ja_typings": []
+      },
+      {
+        "en": "using HTTPS",
+        "ja": "HTTPSをつかう",
+        "ja_typings": []
+      },
+      {
+        "en": "disabling JavaScript",
+        "ja": "JavaScriptをむこうか",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00220",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Cross-Site Scripting (XSS) prevented by?",
+      "ja": "XSSを防ぐには何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HTTP header controlling resource loading",
+        "ja": "りそーすろーどをせいぎょするHTTPへっだー",
+        "ja_typings": []
+      },
+      {
+        "en": "cookie security setting",
+        "ja": "くっきーのせきゅりてぃせってい",
+        "ja_typings": []
+      },
+      {
+        "en": "CORS configuration",
+        "ja": "CORSのせってい",
+        "ja_typings": []
+      },
+      {
+        "en": "SSL certificate policy",
+        "ja": "SSLしょうめいしょのぽりしー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00221",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Content Security Policy?",
+      "ja": "コンテンツせきゅりてぃぽりしーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "URL that accepts API requests",
+        "ja": "APIりくえすとをうけつけるURL",
+        "ja_typings": []
+      },
+      {
+        "en": "server hostname",
+        "ja": "さーばーのほすとめい",
+        "ja_typings": []
+      },
+      {
+        "en": "database connection string",
+        "ja": "でーたべーすせつぞくもじれつ",
+        "ja_typings": []
+      },
+      {
+        "en": "frontend route",
+        "ja": "ふろんとえんどるーと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00222",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a REST endpoint?",
+      "ja": "RESTえんどぽいんととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "handling events on parent for children",
+        "ja": "おやがこどもののいべんとをしょり",
+        "ja_typings": []
+      },
+      {
+        "en": "delegating events to server",
+        "ja": "いべんとをさーばーにいにん",
+        "ja_typings": []
+      },
+      {
+        "en": "preventing event bubbling",
+        "ja": "いべんとばぶりんぐをぼうし",
+        "ja_typings": []
+      },
+      {
+        "en": "creating custom events",
+        "ja": "かすたむいべんとをさくせい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00223",
+    "image_path": null,
+    "question_text": {
+      "en": "What is event delegation in JS?",
+      "ja": "JSのいべんとでりげーしょんとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "delaying function until input stops",
+        "ja": "にゅうりょくがとまるまでかんすうをおくらす",
+        "ja_typings": []
+      },
+      {
+        "en": "cancelling previous function call",
+        "ja": "まえのかんすうよびだしをキャンセル",
+        "ja_typings": []
+      },
+      {
+        "en": "batching multiple events",
+        "ja": "ふくすうのいべんとをまとめる",
+        "ja_typings": []
+      },
+      {
+        "en": "filtering duplicate events",
+        "ja": "じゅうふくいべんとをふぃるたー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00224",
+    "image_path": null,
+    "question_text": {
+      "en": "What is debouncing in JS?",
+      "ja": "JSのでばうんすとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "limiting function call frequency",
+        "ja": "かんすうよびだしのひんどをせいげん",
+        "ja_typings": []
+      },
+      {
+        "en": "slowing network speed",
+        "ja": "ねっとわーくそくどをおとす",
+        "ja_typings": []
+      },
+      {
+        "en": "compressing data transfer",
+        "ja": "でーたてんそうをあっしゅく",
+        "ja_typings": []
+      },
+      {
+        "en": "delaying API response",
+        "ja": "APIおうとうをおくらす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00225",
+    "image_path": null,
+    "question_text": {
+      "en": "What is throttling in JS?",
+      "ja": "JSのすろっとりんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "reusable custom HTML element",
+        "ja": "さいりようかのうなかすたむHTMLようそ",
+        "ja_typings": []
+      },
+      {
+        "en": "React component",
+        "ja": "Reactこんぽーねんと",
+        "ja_typings": []
+      },
+      {
+        "en": "server-side component",
+        "ja": "さーばーがわこんぽーねんと",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS design component",
+        "ja": "CSSせっけいこんぽーねんと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00226",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a web component?",
+      "ja": "うぇぶこんぽーねんととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "storing responses to avoid refetching",
+        "ja": "さいとりこみをさけるおうとうのほぞん",
+        "ja_typings": []
+      },
+      {
+        "en": "server-side database cache",
+        "ja": "さーばーがわでーたべーすきゃっしゅ",
+        "ja_typings": []
+      },
+      {
+        "en": "browser memory allocation",
+        "ja": "ぶらうざーめもりかくほ",
+        "ja_typings": []
+      },
+      {
+        "en": "CDN configuration",
+        "ja": "CDNのせってい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00227",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an HTTP cache?",
+      "ja": "HTTPきゃっしゅとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "stateless authentication",
+        "ja": "むじょうたいにんしょう",
+        "ja_typings": []
+      },
+      {
+        "en": "data encryption",
+        "ja": "でーたあんごうか",
+        "ja_typings": []
+      },
+      {
+        "en": "database connection",
+        "ja": "でーたべーすせつぞく",
+        "ja_typings": []
+      },
+      {
+        "en": "HTML template rendering",
+        "ja": "HTMLてんぷれーとれんだー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00228",
+    "image_path": null,
+    "question_text": {
+      "en": "What is JSON Web Token (JWT) used for?",
+      "ja": "JWTは何のために使うか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vue.js full-stack framework",
+        "ja": "Vue.jsふるすたっくふれーむわーく",
+        "ja_typings": []
+      },
+      {
+        "en": "Node.js web server",
+        "ja": "Node.jsうぇぶさーばー",
+        "ja_typings": []
+      },
+      {
+        "en": "React SSR framework",
+        "ja": "ReactSSRふれーむわーく",
+        "ja_typings": []
+      },
+      {
+        "en": "JavaScript bundler",
+        "ja": "JavaScriptばんどらー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00229",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Nuxt.js?",
+      "ja": "Nuxt.jsとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "static site builder with islands",
+        "ja": "あいらんどあーきてくちゃのせいてきさいとびるだー",
+        "ja_typings": []
+      },
+      {
+        "en": "JavaScript runtime",
+        "ja": "JavaScriptじっこうかんきょう",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS framework",
+        "ja": "CSSふれーむわーく",
+        "ja_typings": []
+      },
+      {
+        "en": "database ORM",
+        "ja": "でーたべーすORM",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00230",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Astro?",
+      "ja": "Astroとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "single repo containing multiple projects",
+        "ja": "ふくすうぷろじぇくトをふくむひとつのりぽ",
+        "ja_typings": []
+      },
+      {
+        "en": "read-only repository",
+        "ja": "どくとりのりぽじとり",
+        "ja_typings": []
+      },
+      {
+        "en": "monolithic backend app",
+        "ja": "ものりしっくばっくえんどあぷり",
+        "ja_typings": []
+      },
+      {
+        "en": "private fork repository",
+        "ja": "ぷらいべーとふぉーくりぽ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00231",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a monorepo?",
+      "ja": "ものりぽとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "tool for developing UI components in isolation",
+        "ja": "こんぽーねんたをとくりつかいはつするつーる",
+        "ja_typings": []
+      },
+      {
+        "en": "documentation generator",
+        "ja": "どきゅめんとせいせいき",
+        "ja_typings": []
+      },
+      {
+        "en": "e2e testing framework",
+        "ja": "e2eてすとふれーむわーく",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS component library",
+        "ja": "CSSこんぽーねんとらいぶらり",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00232",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Storybook?",
+      "ja": "Storybookとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "browser automation and e2e testing tool",
+        "ja": "ぶらうざーじどうかとe2eてすとつーる",
+        "ja_typings": []
+      },
+      {
+        "en": "React component library",
+        "ja": "Reactこんぽーねんとらいぶらり",
+        "ja_typings": []
+      },
+      {
+        "en": "JavaScript bundler",
+        "ja": "JavaScriptばんどらー",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS animation framework",
+        "ja": "CSSあにめーしょんふれーむわーく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00233",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Playwright?",
+      "ja": "Playwrightとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "end-to-end type-safe API",
+        "ja": "えんどつーえんどがたあんぜんAPI",
+        "ja_typings": []
+      },
+      {
+        "en": "TypeScript RPC library",
+        "ja": "TypeScriptRPCらいぶらり",
+        "ja_typings": []
+      },
+      {
+        "en": "remote database client",
+        "ja": "りもーとでーたべーすくらいあんと",
+        "ja_typings": []
+      },
+      {
+        "en": "React state manager",
+        "ja": "Reactじょうたいかんり",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00234",
+    "image_path": null,
+    "question_text": {
+      "en": "What is tRPC?",
+      "ja": "tRPCとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "serverless compute at edge",
+        "ja": "えっじのさーばーれすけいさん",
+        "ja_typings": []
+      },
+      {
+        "en": "cloud storage service",
+        "ja": "くらうどすとれーじさーびす",
+        "ja_typings": []
+      },
+      {
+        "en": "DNS management tool",
+        "ja": "DNSかんりつーる",
+        "ja_typings": []
+      },
+      {
+        "en": "CDN only service",
+        "ja": "CDNのみのさーびす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00235",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Cloudflare Workers?",
+      "ja": "Cloudflare Workersとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "frontend cloud deployment platform",
+        "ja": "ふろんとえんどくらうどはいひぷらっとふぉーむ",
+        "ja_typings": []
+      },
+      {
+        "en": "backend server framework",
+        "ja": "ばっくえんどさーばーふれーむわーく",
+        "ja_typings": []
+      },
+      {
+        "en": "containerization service",
+        "ja": "こんてなかさーびす",
+        "ja_typings": []
+      },
+      {
+        "en": "database hosting",
+        "ja": "でーたべーすほすてぃんぐ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00236",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Vercel?",
+      "ja": "Vercelとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "tells crawlers which pages to skip",
+        "ja": "くろーらーにどのぺーじをとばすかつたえる",
+        "ja_typings": []
+      },
+      {
+        "en": "defines site security rules",
+        "ja": "さいとのせきゅりてぃるーるをていぎ",
+        "ja_typings": []
+      },
+      {
+        "en": "configures web server",
+        "ja": "うぇぶさーばーをせってい",
+        "ja_typings": []
+      },
+      {
+        "en": "lists all site pages",
+        "ja": "すべてのさいとぺーじをいちらん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00237",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the purpose of `robots.txt`?",
+      "ja": "`robots.txt`の目的は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "metadata for social sharing previews",
+        "ja": "SNSしぇあのぷれびゅーめたでーた",
+        "ja_typings": []
+      },
+      {
+        "en": "graph database protocol",
+        "ja": "ぐらふでーたべーすぷろとこる",
+        "ja_typings": []
+      },
+      {
+        "en": "open source API standard",
+        "ja": "おーぷんそーすAPIきじゅん",
+        "ja_typings": []
+      },
+      {
+        "en": "network graph routing",
+        "ja": "ねっとわーくぐらふるーてぃんぐ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00238",
+    "image_path": null,
+    "question_text": {
+      "en": "What is open graph protocol?",
+      "ja": "おーぷんぐらふぷろとこるとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "software managing hardware and software",
+        "ja": "はーどとそふとをかんりするそふとうぇあ",
+        "ja_typings": []
+      },
+      {
+        "en": "programming language",
+        "ja": "ぷろぐらみんぐげんご",
+        "ja_typings": []
+      },
+      {
+        "en": "database management system",
+        "ja": "でーたべーすかんりしすてむ",
+        "ja_typings": []
+      },
+      {
+        "en": "network protocol",
+        "ja": "ねっとわーくぷろとこる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00239",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an operating system?",
+      "ja": "おぺれーてぃんぐしすてむとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "running multiple OS on one hardware",
+        "ja": "いちはーどでふくすうOSをじっこう",
+        "ja_typings": []
+      },
+      {
+        "en": "increasing CPU speed",
+        "ja": "CPUそくどをあげる",
+        "ja_typings": []
+      },
+      {
+        "en": "compressing disk data",
+        "ja": "でぃすくでーたをあっしゅく",
+        "ja_typings": []
+      },
+      {
+        "en": "networking two computers",
+        "ja": "にたいのPCをつなぐ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00240",
+    "image_path": null,
+    "question_text": {
+      "en": "What is virtualization?",
+      "ja": "かそうかとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "core of operating system",
+        "ja": "OSのかくしん",
+        "ja_typings": []
+      },
+      {
+        "en": "user application",
+        "ja": "ゆーざーあぷりけーしょん",
+        "ja_typings": []
+      },
+      {
+        "en": "network driver",
+        "ja": "ねっとわーくどらいばー",
+        "ja_typings": []
+      },
+      {
+        "en": "file system type",
+        "ja": "ふぁいるしすてむのしゅるい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00241",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a kernel?",
+      "ja": "かーねるとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "firmware initializing hardware at boot",
+        "ja": "きどうじにはーどをしょきかするふぁーむうぇあ",
+        "ja_typings": []
+      },
+      {
+        "en": "operating system kernel",
+        "ja": "OSかーねる",
+        "ja_typings": []
+      },
+      {
+        "en": "disk partition tool",
+        "ja": "でぃすくぱーてぃしょんつーる",
+        "ja_typings": []
+      },
+      {
+        "en": "network configuration",
+        "ja": "ねっとわーくせってい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00242",
+    "image_path": null,
+    "question_text": {
+      "en": "What is BIOS?",
+      "ja": "BIOSとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Solid State Drive",
+        "ja": "そりっどすてーとどらいぶ",
+        "ja_typings": []
+      },
+      {
+        "en": "Secure Storage Device",
+        "ja": "あんぜんすとれーじでばいす",
+        "ja_typings": []
+      },
+      {
+        "en": "Software Simulation Disk",
+        "ja": "そふとうぇあしみゅれーしょんでぃすく",
+        "ja_typings": []
+      },
+      {
+        "en": "System Status Drive",
+        "ja": "しすてむじょうたいどらいぶ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00243",
+    "image_path": null,
+    "question_text": {
+      "en": "What is SSD?",
+      "ja": "SSDとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Random Access Memory",
+        "ja": "らんだむあくせすめもり",
+        "ja_typings": []
+      },
+      {
+        "en": "Read-only Archive Memory",
+        "ja": "どくとりあーかいぶめもり",
+        "ja_typings": []
+      },
+      {
+        "en": "Rapid Application Module",
+        "ja": "こうそくあぷりけーしょんもじゅーる",
+        "ja_typings": []
+      },
+      {
+        "en": "Remote Access Machine",
+        "ja": "りもーとあくせすましん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00244",
+    "image_path": null,
+    "question_text": {
+      "en": "What is RAM?",
+      "ja": "RAMとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Central Processing Unit",
+        "ja": "ちゅうおうしょりそうち",
+        "ja_typings": []
+      },
+      {
+        "en": "Core Processing Utility",
+        "ja": "かーしょりゆーてぃりてぃ",
+        "ja_typings": []
+      },
+      {
+        "en": "Computer Power Unit",
+        "ja": "こんぴゅーたでんりょくたんい",
+        "ja_typings": []
+      },
+      {
+        "en": "Cache Processing Unit",
+        "ja": "きゃっしゅしょりそうち",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00245",
+    "image_path": null,
+    "question_text": {
+      "en": "What is CPU?",
+      "ja": "CPUとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Graphics Processing Unit",
+        "ja": "ぐらふぃっくすしょりそうち",
+        "ja_typings": []
+      },
+      {
+        "en": "General Program Utility",
+        "ja": "はんようぷろぐらむゆーてぃりてぃ",
+        "ja_typings": []
+      },
+      {
+        "en": "Global Power Unit",
+        "ja": "ぐろーばるでんりょくたんい",
+        "ja_typings": []
+      },
+      {
+        "en": "Grid Processing Unit",
+        "ja": "ぐりっどしょりそうち",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00246",
+    "image_path": null,
+    "question_text": {
+      "en": "What is GPU?",
+      "ja": "GPUとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "internet communication protocol suite",
+        "ja": "いんたーねっとつうしんぷろとこるぐん",
+        "ja_typings": []
+      },
+      {
+        "en": "type of CPU instruction",
+        "ja": "CPUめいれいのしゅるい",
+        "ja_typings": []
+      },
+      {
+        "en": "file transfer standard",
+        "ja": "ふぁいるてんそうきじゅん",
+        "ja_typings": []
+      },
+      {
+        "en": "terminal control protocol",
+        "ja": "たーみなるせいぎょぷろとこる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00247",
+    "image_path": null,
+    "question_text": {
+      "en": "What is TCP/IP?",
+      "ja": "TCP/IPとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "network security barrier",
+        "ja": "ねっとわーくせきゅりてぃのかべ",
+        "ja_typings": []
+      },
+      {
+        "en": "database access control",
+        "ja": "でーたべーすあくせすせいぎょ",
+        "ja_typings": []
+      },
+      {
+        "en": "antivirus software",
+        "ja": "あんちういるすそふとうぇあ",
+        "ja_typings": []
+      },
+      {
+        "en": "CPU heat protection",
+        "ja": "CPUねつほご",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00248",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a firewall?",
+      "ja": "ふぁいあうぉーるとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "automatically assigns IP addresses",
+        "ja": "IPあどれすをじどうわりあて",
+        "ja_typings": []
+      },
+      {
+        "en": "encrypts network traffic",
+        "ja": "ねっとわーくつうしんをあんごうか",
+        "ja_typings": []
+      },
+      {
+        "en": "resolves domain names",
+        "ja": "どめいんめいをかいけつ",
+        "ja_typings": []
+      },
+      {
+        "en": "manages user accounts",
+        "ja": "ゆーざーあかうんとをかんり",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00249",
+    "image_path": null,
+    "question_text": {
+      "en": "What is DHCP?",
+      "ja": "DHCPとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "unique hardware network identifier",
+        "ja": "はーどのゆにーくなねっとわーくしきべつし",
+        "ja_typings": []
+      },
+      {
+        "en": "IP address alias",
+        "ja": "IPあどれすのべつめい",
+        "ja_typings": []
+      },
+      {
+        "en": "domain name record",
+        "ja": "どめいんめいのれこーど",
+        "ja_typings": []
+      },
+      {
+        "en": "router configuration",
+        "ja": "るーたーのせってい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00250",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a MAC address?",
+      "ja": "MACあどれすとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Virtual Private Network",
+        "ja": "かそうぷらいべーとねっとわーく",
+        "ja_typings": []
+      },
+      {
+        "en": "Verified Protocol Node",
+        "ja": "けんしょうずみぷろとこるのーど",
+        "ja_typings": []
+      },
+      {
+        "en": "Variable Port Number",
+        "ja": "かへんぽーとばんごう",
+        "ja_typings": []
+      },
+      {
+        "en": "Visual Page Navigator",
+        "ja": "びじゅあるぺーじなびげーたー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00251",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a VPN?",
+      "ja": "VPNとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "translates private to public IP",
+        "ja": "しにゅうりょくIPをこうかいIPにへんかん",
+        "ja_typings": []
+      },
+      {
+        "en": "assigns domain names",
+        "ja": "どめいんめいをわりあて",
+        "ja_typings": []
+      },
+      {
+        "en": "encrypts network packets",
+        "ja": "ねっとわーくぱけっとをあんごうか",
+        "ja_typings": []
+      },
+      {
+        "en": "monitors network traffic",
+        "ja": "ねっとわーくつうしんをかんし",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00252",
+    "image_path": null,
+    "question_text": {
+      "en": "What is NAT in networking?",
+      "ja": "ねっとわーくのNATとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "logical subdivision of a network",
+        "ja": "ねっとわーくの論理的な細分",
+        "ja_typings": []
+      },
+      {
+        "en": "type of network cable",
+        "ja": "ねっとわーくけーぶるのしゅるい",
+        "ja_typings": []
+      },
+      {
+        "en": "wireless network protocol",
+        "ja": "むせんねっとわーくぷろとこる",
+        "ja_typings": []
+      },
+      {
+        "en": "network security zone",
+        "ja": "ねっとわーくせきゅりてぃぞーん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00253",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a subnet?",
+      "ja": "さぶねっととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "redundant array of independent disks",
+        "ja": "どくりつでぃすくのじょうちょうはいれつ",
+        "ja_typings": []
+      },
+      {
+        "en": "random access index drive",
+        "ja": "らんだむあくせすいんでくすどらいぶ",
+        "ja_typings": []
+      },
+      {
+        "en": "remote access interface device",
+        "ja": "りもーとあくせすいんたーふぇーすでばいす",
+        "ja_typings": []
+      },
+      {
+        "en": "real-time AI data",
+        "ja": "りあるたいむAIでーた",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00254",
+    "image_path": null,
+    "question_text": {
+      "en": "What is RAID in storage?",
+      "ja": "すとれーじのRAIDとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "distributes traffic across servers",
+        "ja": "さーばーにつうしんをぶんさん",
+        "ja_typings": []
+      },
+      {
+        "en": "monitors CPU load",
+        "ja": "CPUふかをかんし",
+        "ja_typings": []
+      },
+      {
+        "en": "balances database queries",
+        "ja": "でーたべーすくえりをちょうせい",
+        "ja_typings": []
+      },
+      {
+        "en": "manages server power",
+        "ja": "さーばーでんりょくをかんり",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00255",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a load balancer?",
+      "ja": "ろーどばらんさーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "intermediary between client and server",
+        "ja": "くらいあんととさーばーのちゅうかい",
+        "ja_typings": []
+      },
+      {
+        "en": "backup server",
+        "ja": "ばっくあっぷさーばー",
+        "ja_typings": []
+      },
+      {
+        "en": "DNS server",
+        "ja": "DNSさーばー",
+        "ja_typings": []
+      },
+      {
+        "en": "mail server",
+        "ja": "めーるさーばー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00256",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a proxy server?",
+      "ja": "ぷろくしさーばーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sits in front of servers",
+        "ja": "さーばーのまえにいちする",
+        "ja_typings": []
+      },
+      {
+        "en": "sits in front of clients",
+        "ja": "くらいあんとのまえにいちする",
+        "ja_typings": []
+      },
+      {
+        "en": "caches client data",
+        "ja": "くらいあんとでーたをきゃっしゅ",
+        "ja_typings": []
+      },
+      {
+        "en": "monitors server logs",
+        "ja": "さーばーろぐをかんし",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00257",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a reverse proxy?",
+      "ja": "りばーすぷろくしとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Secure Shell remote protocol",
+        "ja": "あんぜんなしぇるりもーとぷろとこる",
+        "ja_typings": []
+      },
+      {
+        "en": "Simple Service Handler",
+        "ja": "かんたんなさーびすはんどらー",
+        "ja_typings": []
+      },
+      {
+        "en": "Secure Script Host",
+        "ja": "あんぜんなすくりぷとほすと",
+        "ja_typings": []
+      },
+      {
+        "en": "Shared Server Hub",
+        "ja": "きょうゆうさーばーはぶ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00258",
+    "image_path": null,
+    "question_text": {
+      "en": "What is SSH?",
+      "ja": "SSHとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "software creating and managing VMs",
+        "ja": "VMをさくせいかんりするそふとうぇあ",
+        "ja_typings": []
+      },
+      {
+        "en": "high-speed processor",
+        "ja": "こうそくしょりそうち",
+        "ja_typings": []
+      },
+      {
+        "en": "network monitoring tool",
+        "ja": "ねっとわーくかんしつーる",
+        "ja_typings": []
+      },
+      {
+        "en": "database indexer",
+        "ja": "でーたべーすいんでくさー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00259",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a hypervisor?",
+      "ja": "はいぱーばいざーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "immutable snapshot of container filesystem",
+        "ja": "こんてなふぁいるしすてむのふへんすなっぷ",
+        "ja_typings": []
+      },
+      {
+        "en": "virtual machine backup",
+        "ja": "かそうましんばっくあっぷ",
+        "ja_typings": []
+      },
+      {
+        "en": "disk partition image",
+        "ja": "でぃすくぱーてぃしょんいめーじ",
+        "ja_typings": []
+      },
+      {
+        "en": "OS installation disk",
+        "ja": "OSいんすとーるでぃすく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00260",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a container image?",
+      "ja": "こんてないめーじとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "running code without managing servers",
+        "ja": "さーばーかんりなしでこーどをじっこう",
+        "ja_typings": []
+      },
+      {
+        "en": "computing with no power",
+        "ja": "でんりょくなしのけいさん",
+        "ja_typings": []
+      },
+      {
+        "en": "computing on local machine only",
+        "ja": "ろーかるましんのみけいさん",
+        "ja_typings": []
+      },
+      {
+        "en": "computing without internet",
+        "ja": "いんたーねっとなしけいさん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00261",
+    "image_path": null,
+    "question_text": {
+      "en": "What is serverless computing?",
+      "ja": "さーばーれすけいさんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "processing data near the source",
+        "ja": "でーたそーすのちかくでしょり",
+        "ja_typings": []
+      },
+      {
+        "en": "computing on blockchain",
+        "ja": "ぶろっくちぇーんでけいさん",
+        "ja_typings": []
+      },
+      {
+        "en": "computing on GPU only",
+        "ja": "GPUのみけいさん",
+        "ja_typings": []
+      },
+      {
+        "en": "computing at data center",
+        "ja": "でーたせんたーでけいさん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00262",
+    "image_path": null,
+    "question_text": {
+      "en": "What is edge computing?",
+      "ja": "えっじけいさんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "delivering content with low latency",
+        "ja": "ていれいてんしーでこんてんつはいしん",
+        "ja_typings": []
+      },
+      {
+        "en": "storing large databases",
+        "ja": "だいきぼでーたべーすのほぞん",
+        "ja_typings": []
+      },
+      {
+        "en": "processing complex queries",
+        "ja": "ふくざつくえりのしょり",
+        "ja_typings": []
+      },
+      {
+        "en": "running server-side code",
+        "ja": "さーばーがわこーどのじっこう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00263",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a content delivery network optimized for?",
+      "ja": "CDNは何のために最適化されているか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "storing frequently accessed data for speed",
+        "ja": "こうひんどでーたをほぞんして高速化",
+        "ja_typings": []
+      },
+      {
+        "en": "encrypting stored data",
+        "ja": "ほぞんでーたをあんごうか",
+        "ja_typings": []
+      },
+      {
+        "en": "compressing stored data",
+        "ja": "ほぞんでーたをあっしゅく",
+        "ja_typings": []
+      },
+      {
+        "en": "backing up stored data",
+        "ja": "ほぞんでーたをばっくあっぷ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00264",
+    "image_path": null,
+    "question_text": {
+      "en": "What is caching in computing?",
+      "ja": "けいさんきのきゃっしゅとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "async communication buffer between services",
+        "ja": "さーびす間の非同期通信バッファ",
+        "ja_typings": []
+      },
+      {
+        "en": "user notification queue",
+        "ja": "ゆーざーつうちきゅー",
+        "ja_typings": []
+      },
+      {
+        "en": "database write buffer",
+        "ja": "でーたべーすきおみこみばっふぁ",
+        "ja_typings": []
+      },
+      {
+        "en": "email sending queue",
+        "ja": "めーるそうしんきゅー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00265",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a message queue?",
+      "ja": "めっせーじきゅーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "publishers send to topics, subscribers receive",
+        "ja": "しゅっぱんしゃがそうしん、こうどくしゃがじゅしん",
+        "ja_typings": []
+      },
+      {
+        "en": "point-to-point messaging",
+        "ja": "いちたいいちめっせーじんぐ",
+        "ja_typings": []
+      },
+      {
+        "en": "broadcast to all users",
+        "ja": "ぜんゆーざーにほうそう",
+        "ja_typings": []
+      },
+      {
+        "en": "encrypted direct messaging",
+        "ja": "あんごうかちょくせつめっせーじ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00266",
+    "image_path": null,
+    "question_text": {
+      "en": "What is pub/sub messaging?",
+      "ja": "pub/subめっせーじんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "server located close to users",
+        "ja": "ゆーざーのちかくにあるさーばー",
+        "ja_typings": []
+      },
+      {
+        "en": "cloud data node",
+        "ja": "くらうどでーたのーど",
+        "ja_typings": []
+      },
+      {
+        "en": "database replica",
+        "ja": "でーたべーすのれぷりか",
+        "ja_typings": []
+      },
+      {
+        "en": "network router",
+        "ja": "ねっとわーくるーたー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00267",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a CDN edge node?",
+      "ja": "CDNのえっじのーどとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "adding more servers",
+        "ja": "さーばーをふやす",
+        "ja_typings": []
+      },
+      {
+        "en": "upgrading existing server",
+        "ja": "きそんさーばーをきょうか",
+        "ja_typings": []
+      },
+      {
+        "en": "compressing server data",
+        "ja": "さーばーでーたをあっしゅく",
+        "ja_typings": []
+      },
+      {
+        "en": "adding more CPU cores",
+        "ja": "CPUこあをふやす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00268",
+    "image_path": null,
+    "question_text": {
+      "en": "What is horizontal scaling?",
+      "ja": "すいへいすけーりんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "upgrading existing server resources",
+        "ja": "きそんさーばーのりそーすをきょうか",
+        "ja_typings": []
+      },
+      {
+        "en": "adding more servers",
+        "ja": "さーばーをふやす",
+        "ja_typings": []
+      },
+      {
+        "en": "adding more data centers",
+        "ja": "でーたせんたーをふやす",
+        "ja_typings": []
+      },
+      {
+        "en": "upgrading network speed",
+        "ja": "ねっとわーくそくどをきょうか",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00269",
+    "image_path": null,
+    "question_text": {
+      "en": "What is vertical scaling?",
+      "ja": "すいちょくすけーりんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "facility housing computing infrastructure",
+        "ja": "けいさんきばんをほうじょするしせつ",
+        "ja_typings": []
+      },
+      {
+        "en": "company headquarters",
+        "ja": "かいしゃのほんしゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "cloud storage account",
+        "ja": "くらうどすとれーじあかうんと",
+        "ja_typings": []
+      },
+      {
+        "en": "network operations center",
+        "ja": "ねっとわーくうんようせんたー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00270",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a data center?",
+      "ja": "でーたせんたーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "time system runs without failure",
+        "ja": "しすてむがふぐなくどうさしているじかん",
+        "ja_typings": []
+      },
+      {
+        "en": "time to complete an update",
+        "ja": "こうしんにかかるじかん",
+        "ja_typings": []
+      },
+      {
+        "en": "CPU processing time",
+        "ja": "CPUしょりじかん",
+        "ja_typings": []
+      },
+      {
+        "en": "network connection time",
+        "ja": "ねっとわーくせつぞくじかん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00271",
+    "image_path": null,
+    "question_text": {
+      "en": "What is uptime in computing?",
+      "ja": "けいさんきのあっぷたいむとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Service Level Agreement",
+        "ja": "さーびすすいじゅんのけいやく",
+        "ja_typings": []
+      },
+      {
+        "en": "System Load Average",
+        "ja": "しすてむふかへいきん",
+        "ja_typings": []
+      },
+      {
+        "en": "Secure Login API",
+        "ja": "あんぜんなろぐいんAPI",
+        "ja_typings": []
+      },
+      {
+        "en": "Software License Archive",
+        "ja": "そふとうぇあらいせんすあーかいぶ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00272",
+    "image_path": null,
+    "question_text": {
+      "en": "What is SLA?",
+      "ja": "SLAとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "tracking system health and performance",
+        "ja": "しすてむのけんこうとぱふぉーまんすをついせき",
+        "ja_typings": []
+      },
+      {
+        "en": "monitoring code quality",
+        "ja": "こーどひんしつをかんし",
+        "ja_typings": []
+      },
+      {
+        "en": "watching user behavior",
+        "ja": "ゆーざーこうどうをかんし",
+        "ja_typings": []
+      },
+      {
+        "en": "checking database integrity",
+        "ja": "でーたべーすせいごうせいをかくにん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00273",
+    "image_path": null,
+    "question_text": {
+      "en": "What is monitoring in DevOps?",
+      "ja": "DevOpsのもにたりんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "running two identical environments",
+        "ja": "ふたつのどうじかんきょうをじっこう",
+        "ja_typings": []
+      },
+      {
+        "en": "gradual traffic rollout",
+        "ja": "だんかいてきなつうしんきりかえ",
+        "ja_typings": []
+      },
+      {
+        "en": "color-coded code deployment",
+        "ja": "いろわけのこーどはいひ",
+        "ja_typings": []
+      },
+      {
+        "en": "server room color system",
+        "ja": "さーばールームのいろわけ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00274",
+    "image_path": null,
+    "question_text": {
+      "en": "What is blue-green deployment?",
+      "ja": "ぶるーぐりーんはいひとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "releasing to small user subset first",
+        "ja": "さきにしょうすうのゆーざーにリリース",
+        "ja_typings": []
+      },
+      {
+        "en": "deploying to all users at once",
+        "ja": "いちどにぜんゆーざーにはいひ",
+        "ja_typings": []
+      },
+      {
+        "en": "deploying without testing",
+        "ja": "てすとなしにはいひ",
+        "ja_typings": []
+      },
+      {
+        "en": "automated rollback deployment",
+        "ja": "じどうろーるばっくはいひ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00275",
+    "image_path": null,
+    "question_text": {
+      "en": "What is canary deployment?",
+      "ja": "かなりあはいひとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "storage for container images",
+        "ja": "こんてないめーじのほぞんばしょ",
+        "ja_typings": []
+      },
+      {
+        "en": "database for containers",
+        "ja": "こんてなのでーたべーす",
+        "ja_typings": []
+      },
+      {
+        "en": "OS registry for apps",
+        "ja": "OSのあぷりとうろく",
+        "ja_typings": []
+      },
+      {
+        "en": "network DNS registry",
+        "ja": "ネットワークDNSとうろく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00276",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a container registry?",
+      "ja": "こんてなれじすとりとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "infrastructure as code tool",
+        "ja": "インフラをコードで管理するツール",
+        "ja_typings": []
+      },
+      {
+        "en": "container runtime",
+        "ja": "こんてなじっこうかんきょう",
+        "ja_typings": []
+      },
+      {
+        "en": "CI/CD pipeline tool",
+        "ja": "CI/CDぱいぷらいんつーる",
+        "ja_typings": []
+      },
+      {
+        "en": "monitoring platform",
+        "ja": "もにたりんぐぷらっとふぉーむ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00277",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Terraform?",
+      "ja": "Terraformとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "IT automation and config management tool",
+        "ja": "ITじどうかとせってかんりつーる",
+        "ja_typings": []
+      },
+      {
+        "en": "container orchestration tool",
+        "ja": "こんてなおーけすとれーしょんつーる",
+        "ja_typings": []
+      },
+      {
+        "en": "log analysis platform",
+        "ja": "ろぐぶんせきぷらっとふぉーむ",
+        "ja_typings": []
+      },
+      {
+        "en": "network packet analyzer",
+        "ja": "ねっとわーくぱけっとかいせき",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00278",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Ansible?",
+      "ja": "Ansibleとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "monitoring and alerting toolkit",
+        "ja": "もにたりんぐとあらーとのつーるきっと",
+        "ja_typings": []
+      },
+      {
+        "en": "container platform",
+        "ja": "こんてなぷらっとふぉーむ",
+        "ja_typings": []
+      },
+      {
+        "en": "log management system",
+        "ja": "ろぐかんりしすてむ",
+        "ja_typings": []
+      },
+      {
+        "en": "infrastructure provisioner",
+        "ja": "きばんぷろびじょにんぐ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00279",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Prometheus?",
+      "ja": "Prometheusとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "visualization and dashboard tool",
+        "ja": "びじゅあらいぜーしょんとだっしゅぼーどつーる",
+        "ja_typings": []
+      },
+      {
+        "en": "database backup tool",
+        "ja": "でーたべーすばっくあっぷつーる",
+        "ja_typings": []
+      },
+      {
+        "en": "code quality analyzer",
+        "ja": "こーどひんしつかいせきつーる",
+        "ja_typings": []
+      },
+      {
+        "en": "network configuration tool",
+        "ja": "ねっとわーくせってつーる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00280",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Grafana?",
+      "ja": "Grafanaとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Elasticsearch Logstash Kibana",
+        "ja": "Elasticsearchろぐすたっしゅきばな",
+        "ja_typings": []
+      },
+      {
+        "en": "Edge Load Kubernetes",
+        "ja": "えっじろーどくーばねてぃす",
+        "ja_typings": []
+      },
+      {
+        "en": "Event Log Kernel",
+        "ja": "いべんとろぐかーねる",
+        "ja_typings": []
+      },
+      {
+        "en": "Elastic Linux Kernel",
+        "ja": "えらすてぃっくLinuxかーねる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00281",
+    "image_path": null,
+    "question_text": {
+      "en": "What is ELK stack?",
+      "ja": "ELKすたっくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ability to understand system state from outputs",
+        "ja": "しゅつりょくからじょうたいをりかいできること",
+        "ja_typings": []
+      },
+      {
+        "en": "ability to monitor CPU usage",
+        "ja": "CPU使用率をかんしできること",
+        "ja_typings": []
+      },
+      {
+        "en": "ability to view source code",
+        "ja": "そーすこーどをみられること",
+        "ja_typings": []
+      },
+      {
+        "en": "ability to access logs",
+        "ja": "ろぐにアクセスできること",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00282",
+    "image_path": null,
+    "question_text": {
+      "en": "What is observability in systems?",
+      "ja": "しすてむのかんそくかのうせいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "smallest deployable unit in K8s",
+        "ja": "K8sのさいしょうはいひたんい",
+        "ja_typings": []
+      },
+      {
+        "en": "K8s database unit",
+        "ja": "K8sのでーたべーすたんい",
+        "ja_typings": []
+      },
+      {
+        "en": "K8s network unit",
+        "ja": "K8sのねっとわーくたんい",
+        "ja_typings": []
+      },
+      {
+        "en": "K8s storage unit",
+        "ja": "K8sのすとれーじたんい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00283",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a container pod in Kubernetes?",
+      "ja": "Kubernetesのぽっどとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "script defining container image",
+        "ja": "こんてないめーじをていぎするすくりぷと",
+        "ja_typings": []
+      },
+      {
+        "en": "Docker network config",
+        "ja": "Dockerねっとわーくせってい",
+        "ja_typings": []
+      },
+      {
+        "en": "Docker volume config",
+        "ja": "Dockerぼりゅーむせってい",
+        "ja_typings": []
+      },
+      {
+        "en": "Docker compose file",
+        "ja": "Dockerこんぽーずふぁいる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00284",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a Dockerfile?",
+      "ja": "Dockerfileとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "tool for multi-container applications",
+        "ja": "ふくすうこんてなあぷりのつーる",
+        "ja_typings": []
+      },
+      {
+        "en": "Docker installation script",
+        "ja": "Dockerいんすとーるすくりぷと",
+        "ja_typings": []
+      },
+      {
+        "en": "Docker image builder",
+        "ja": "Dockerいめーじびるだー",
+        "ja_typings": []
+      },
+      {
+        "en": "Docker networking tool",
+        "ja": "Dockerねっとわーくつーる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00285",
+    "image_path": null,
+    "question_text": {
+      "en": "What is `docker-compose`?",
+      "ja": "`docker-compose`とは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "logical isolation within cluster",
+        "ja": "くらすたないのろんりてきかくり",
+        "ja_typings": []
+      },
+      {
+        "en": "global cluster name",
+        "ja": "くらすたのぐろーばるめい",
+        "ja_typings": []
+      },
+      {
+        "en": "network isolation zone",
+        "ja": "ねっとわーくかくりぞーん",
+        "ja_typings": []
+      },
+      {
+        "en": "storage partition",
+        "ja": "すとれーじぱーてぃしょん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00286",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a Kubernetes namespace?",
+      "ja": "Kubernetesのなめすぺーすとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kubernetes application package",
+        "ja": "Kubernetesあぷりぱっけーじ",
+        "ja_typings": []
+      },
+      {
+        "en": "monitoring dashboard",
+        "ja": "もにたりんぐだっしゅぼーど",
+        "ja_typings": []
+      },
+      {
+        "en": "Docker image format",
+        "ja": "Dockerいめーじけいしき",
+        "ja_typings": []
+      },
+      {
+        "en": "CI pipeline config",
+        "ja": "CIぱいぷらいんせってい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00287",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a Helm chart?",
+      "ja": "Helmちゃーととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "using Git as source of truth for infra",
+        "ja": "きばんのせいしんとしてGitをつかう",
+        "ja_typings": []
+      },
+      {
+        "en": "Git-based CI/CD only",
+        "ja": "GitべースのCI/CDのみ",
+        "ja_typings": []
+      },
+      {
+        "en": "GitLab operations",
+        "ja": "GitLabのうんよう",
+        "ja_typings": []
+      },
+      {
+        "en": "Git security operations",
+        "ja": "Gitのせきゅりてぃうんよう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00288",
+    "image_path": null,
+    "question_text": {
+      "en": "What is GitOps?",
+      "ja": "GitOpsとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "intentionally injecting failures to test resilience",
+        "ja": "たいきゅうせいをためすためにいとてきにしょうがいそうにゅう",
+        "ja_typings": []
+      },
+      {
+        "en": "random code changes",
+        "ja": "らんだむなこーどへんこう",
+        "ja_typings": []
+      },
+      {
+        "en": "disorganized development process",
+        "ja": "ふせいりなかいはつぷろせす",
+        "ja_typings": []
+      },
+      {
+        "en": "testing on production only",
+        "ja": "ほんばんのみでてすと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00289",
+    "image_path": null,
+    "question_text": {
+      "en": "What is chaos engineering?",
+      "ja": "かおすえんじにありんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HTTP callback triggered by events",
+        "ja": "いべんとにトリガーされるHTTPこーるばっく",
+        "ja_typings": []
+      },
+      {
+        "en": "frontend JavaScript hook",
+        "ja": "ふろんとえんどJavaScriptふっく",
+        "ja_typings": []
+      },
+      {
+        "en": "backend API endpoint",
+        "ja": "ばっくえんどAPIえんどぽいんと",
+        "ja_typings": []
+      },
+      {
+        "en": "browser event listener",
+        "ja": "ぶらうざーいべんとりすなー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00290",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a webhook?",
+      "ja": "うぇぶふっくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "time delay before transfer begins",
+        "ja": "てんそうが始まるまでの時間遅延",
+        "ja_typings": []
+      },
+      {
+        "en": "network throughput",
+        "ja": "ねっとわーくすいといっぷりょう",
+        "ja_typings": []
+      },
+      {
+        "en": "CPU processing speed",
+        "ja": "CPUしょりそくど",
+        "ja_typings": []
+      },
+      {
+        "en": "disk read speed",
+        "ja": "でぃすくよみとりそくど",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00291",
+    "image_path": null,
+    "question_text": {
+      "en": "What is latency in computing?",
+      "ja": "けいさんきのれいてんしーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "amount of work done per unit time",
+        "ja": "たんいじかんあたりのさぎょうりょう",
+        "ja_typings": []
+      },
+      {
+        "en": "time to process one task",
+        "ja": "いちさぎょうのしょりじかん",
+        "ja_typings": []
+      },
+      {
+        "en": "memory bandwidth",
+        "ja": "めもりたいいき",
+        "ja_typings": []
+      },
+      {
+        "en": "disk capacity",
+        "ja": "でぃすくようりょう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00292",
+    "image_path": null,
+    "question_text": {
+      "en": "What is throughput in computing?",
+      "ja": "けいさんきのすいとうっぷりょうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Application Programming Interface",
+        "ja": "あぷりけーしょんぷろぐらみんぐいんたーふぇーす",
+        "ja_typings": []
+      },
+      {
+        "en": "Advanced Protocol Integration",
+        "ja": "こうきゅうぷろとこるとうごう",
+        "ja_typings": []
+      },
+      {
+        "en": "Automated Process Interface",
+        "ja": "じどうぷろせすいんたーふぇーす",
+        "ja_typings": []
+      },
+      {
+        "en": "Application Protocol Index",
+        "ja": "あぷりけーしょんぷろとこるいんでくす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00293",
+    "image_path": null,
+    "question_text": {
+      "en": "What does API stand for?",
+      "ja": "APIのりゃくごのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Uniform Resource Locator",
+        "ja": "とういつりそーすいちしかし",
+        "ja_typings": []
+      },
+      {
+        "en": "Universal Request Link",
+        "ja": "はんようりくえすとりんく",
+        "ja_typings": []
+      },
+      {
+        "en": "Unified Route Label",
+        "ja": "とういつるーとらべる",
+        "ja_typings": []
+      },
+      {
+        "en": "User Resource Library",
+        "ja": "ゆーざーりそーすらいぶらり",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00294",
+    "image_path": null,
+    "question_text": {
+      "en": "What does URL stand for?",
+      "ja": "URLのりゃくごのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Integrated Development Environment",
+        "ja": "とうごうかいはつかんきょう",
+        "ja_typings": []
+      },
+      {
+        "en": "Internal Debug Engine",
+        "ja": "ないぶでばっぐえんじん",
+        "ja_typings": []
+      },
+      {
+        "en": "Interface Design Element",
+        "ja": "いんたーふぇーすせっけいようそ",
+        "ja_typings": []
+      },
+      {
+        "en": "Iterative Deployment Engine",
+        "ja": "はんぷくはいひえんじん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00295",
+    "image_path": null,
+    "question_text": {
+      "en": "What does IDE stand for?",
+      "ja": "IDEのりゃくごのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Object-Relational Mapping",
+        "ja": "おぶじぇくとかんけいしゃぞう",
+        "ja_typings": []
+      },
+      {
+        "en": "Open Resource Management",
+        "ja": "おーぷんりそーすかんり",
+        "ja_typings": []
+      },
+      {
+        "en": "Optimized Request Module",
+        "ja": "さいてきかりくえすともじゅーる",
+        "ja_typings": []
+      },
+      {
+        "en": "Output Response Model",
+        "ja": "しゅつりょくおうとうもでる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00296",
+    "image_path": null,
+    "question_text": {
+      "en": "What does ORM stand for?",
+      "ja": "ORMのりゃくごのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Model View Controller",
+        "ja": "もでるびゅーこんとろーらー",
+        "ja_typings": []
+      },
+      {
+        "en": "Main Version Code",
+        "ja": "めいんばーじょんこーど",
+        "ja_typings": []
+      },
+      {
+        "en": "Mobile View Component",
+        "ja": "もばいるびゅーこんぽーねんと",
+        "ja_typings": []
+      },
+      {
+        "en": "Multi Value Cache",
+        "ja": "たちかんりきゃっしゅ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00297",
+    "image_path": null,
+    "question_text": {
+      "en": "What does MVC stand for?",
+      "ja": "MVCのりゃくごのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Software as a Service",
+        "ja": "さーびすとしてのそふとうぇあ",
+        "ja_typings": []
+      },
+      {
+        "en": "Security as a System",
+        "ja": "しすてむとしてのせきゅりてぃ",
+        "ja_typings": []
+      },
+      {
+        "en": "Storage and a Server",
+        "ja": "すとれーじとさーばー",
+        "ja_typings": []
+      },
+      {
+        "en": "Scalable API Service",
+        "ja": "すけーらぶるAPIさーびす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00298",
+    "image_path": null,
+    "question_text": {
+      "en": "What does SaaS stand for?",
+      "ja": "SaaSのりゃくごのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Infrastructure as a Service",
+        "ja": "さーびすとしてのきばん",
+        "ja_typings": []
+      },
+      {
+        "en": "Integration and a System",
+        "ja": "とうごうとしすてむ",
+        "ja_typings": []
+      },
+      {
+        "en": "Interface as a Standard",
+        "ja": "きじゅんとしてのいんたーふぇーす",
+        "ja_typings": []
+      },
+      {
+        "en": "Identity and a Server",
+        "ja": "しきべつとさーばー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00299",
+    "image_path": null,
+    "question_text": {
+      "en": "What does IaaS stand for?",
+      "ja": "IaaSのりゃくごのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Platform as a Service",
+        "ja": "さーびすとしてのぷらっとふぉーむ",
+        "ja_typings": []
+      },
+      {
+        "en": "Privacy and a System",
+        "ja": "ぷらいばしーとしすてむ",
+        "ja_typings": []
+      },
+      {
+        "en": "Process as a Service",
+        "ja": "さーびすとしてのぷろせす",
+        "ja_typings": []
+      },
+      {
+        "en": "Package as a Server",
+        "ja": "さーばーとしてのぱっけーじ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00300",
+    "image_path": null,
+    "question_text": {
+      "en": "What does PaaS stand for?",
+      "ja": "PaaSのりゃくごのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Create Read Update Delete",
+        "ja": "さくせいよみこうしんさくじょ",
+        "ja_typings": []
+      },
+      {
+        "en": "Copy Refresh Update Deploy",
+        "ja": "こぴーこうしんはいひ",
+        "ja_typings": []
+      },
+      {
+        "en": "Cache Read Update Delete",
+        "ja": "きゃっしゅよみこうしんさくじょ",
+        "ja_typings": []
+      },
+      {
+        "en": "Create Run Update Dump",
+        "ja": "さくせいじっこうこうしんだんぷ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00301",
+    "image_path": null,
+    "question_text": {
+      "en": "What does CRUD stand for?",
+      "ja": "CRUDのりゃくごのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Object-Oriented Programming",
+        "ja": "おぶじぇくとしこうぷろぐらみんぐ",
+        "ja_typings": []
+      },
+      {
+        "en": "Open Operation Protocol",
+        "ja": "おーぷんそうさぷろとこる",
+        "ja_typings": []
+      },
+      {
+        "en": "Ordered Output Process",
+        "ja": "じゅんじょつきしゅつりょくぷろせす",
+        "ja_typings": []
+      },
+      {
+        "en": "Object Output Port",
+        "ja": "おぶじぇくとしゅつりょくぽーと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00302",
+    "image_path": null,
+    "question_text": {
+      "en": "What does OOP stand for?",
+      "ja": "OOPのりゃくごのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Command Line Interface",
+        "ja": "こまんどらいんいんたーふぇーす",
+        "ja_typings": []
+      },
+      {
+        "en": "Client Logic Integration",
+        "ja": "くらいあんとろじっくとうごう",
+        "ja_typings": []
+      },
+      {
+        "en": "Core Library Index",
+        "ja": "こあらいぶらりいんでくす",
+        "ja_typings": []
+      },
+      {
+        "en": "Compiled Language Input",
+        "ja": "こんぱいるでごにゅうりょく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00303",
+    "image_path": null,
+    "question_text": {
+      "en": "What does CLI stand for?",
+      "ja": "CLIのりゃくごのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Graphical User Interface",
+        "ja": "ぐらふぃかるゆーざーいんたーふぇーす",
+        "ja_typings": []
+      },
+      {
+        "en": "General Utility Index",
+        "ja": "はんようゆーてぃりてぃいんでくす",
+        "ja_typings": []
+      },
+      {
+        "en": "Global Update Interface",
+        "ja": "ぐろーばるこうしんいんたーふぇーす",
+        "ja_typings": []
+      },
+      {
+        "en": "Grid UI Integration",
+        "ja": "ぐりっどUIとうごう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00304",
+    "image_path": null,
+    "question_text": {
+      "en": "What does GUI stand for?",
+      "ja": "GUIのりゃくごのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Software Development Kit",
+        "ja": "そふとうぇあかいはつきっと",
+        "ja_typings": []
+      },
+      {
+        "en": "Secure Data Key",
+        "ja": "あんぜんなでーたきー",
+        "ja_typings": []
+      },
+      {
+        "en": "System Deployment Kit",
+        "ja": "しすてむはいひきっと",
+        "ja_typings": []
+      },
+      {
+        "en": "Service Discovery Key",
+        "ja": "さーびすはっけんきー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00305",
+    "image_path": null,
+    "question_text": {
+      "en": "What does SDK stand for?",
+      "ja": "SDKのりゃくごのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "End of File",
+        "ja": "ふぁいるのおわり",
+        "ja_typings": []
+      },
+      {
+        "en": "Error on Function",
+        "ja": "かんすうのえらー",
+        "ja_typings": []
+      },
+      {
+        "en": "Execute Other Function",
+        "ja": "べつのかんすうをじっこう",
+        "ja_typings": []
+      },
+      {
+        "en": "Event on Failure",
+        "ja": "しっぱいのいべんと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00306",
+    "image_path": null,
+    "question_text": {
+      "en": "What does EOF stand for in programming?",
+      "ja": "ぷろぐらみんぐのEOFのりゃくごのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "true/false data type",
+        "ja": "しんぎゃくのでーたがた",
+        "ja_typings": []
+      },
+      {
+        "en": "integer type",
+        "ja": "せいすうがた",
+        "ja_typings": []
+      },
+      {
+        "en": "string type",
+        "ja": "もじれつがた",
+        "ja_typings": []
+      },
+      {
+        "en": "array type",
+        "ja": "はいれつがた",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00307",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a boolean?",
+      "ja": "ぶーりあんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "absence of a value",
+        "ja": "ちが存在しないこと",
+        "ja_typings": []
+      },
+      {
+        "en": "zero integer",
+        "ja": "ゼロのせいすう",
+        "ja_typings": []
+      },
+      {
+        "en": "empty string",
+        "ja": "くうのもじれつ",
+        "ja_typings": []
+      },
+      {
+        "en": "false boolean",
+        "ja": "falseのぶーりあん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00308",
+    "image_path": null,
+    "question_text": {
+      "en": "What is null?",
+      "ja": "nullとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "variable declared but not assigned",
+        "ja": "せんげんされたがだいにゅうされていないへんすう",
+        "ja_typings": []
+      },
+      {
+        "en": "null value",
+        "ja": "nullのち",
+        "ja_typings": []
+      },
+      {
+        "en": "false value",
+        "ja": "falseのち",
+        "ja_typings": []
+      },
+      {
+        "en": "zero value",
+        "ja": "ぜろのち",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00309",
+    "image_path": null,
+    "question_text": {
+      "en": "What is undefined in JavaScript?",
+      "ja": "JavaScriptのundefinedとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "converting a value to another type",
+        "ja": "ちをべつのかたにへんかん",
+        "ja_typings": []
+      },
+      {
+        "en": "checking if types match",
+        "ja": "かたがいっちするかかくにん",
+        "ja_typings": []
+      },
+      {
+        "en": "declaring a new type",
+        "ja": "あたらしいかたをせんげん",
+        "ja_typings": []
+      },
+      {
+        "en": "deleting a variable type",
+        "ja": "へんすうのかたをさくじょ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00310",
+    "image_path": null,
+    "question_text": {
+      "en": "What is type casting?",
+      "ja": "かたへんかんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "container preventing name conflicts",
+        "ja": "なまえのしょうとつをふせぐこんてな",
+        "ja_typings": []
+      },
+      {
+        "en": "network address space",
+        "ja": "ねっとわーくあどれすくうかん",
+        "ja_typings": []
+      },
+      {
+        "en": "database schema",
+        "ja": "でーたべーすすきーま",
+        "ja_typings": []
+      },
+      {
+        "en": "variable scope",
+        "ja": "へんすうのすこーぷ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00311",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a namespace?",
+      "ja": "なめすぺーすとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "set of named constants",
+        "ja": "なまえつきていすうのあつまり",
+        "ja_typings": []
+      },
+      {
+        "en": "dynamic array",
+        "ja": "どうてきはいれつ",
+        "ja_typings": []
+      },
+      {
+        "en": "error number type",
+        "ja": "えらーばんごうがた",
+        "ja_typings": []
+      },
+      {
+        "en": "network enumeration",
+        "ja": "ねっとわーくれっきょ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00312",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an enum?",
+      "ja": "えぬむとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "custom data type grouping fields",
+        "ja": "ふぃーるどをまとめたかすたむでーたがた",
+        "ja_typings": []
+      },
+      {
+        "en": "built-in array type",
+        "ja": "そなわったはいれつがた",
+        "ja_typings": []
+      },
+      {
+        "en": "function signature",
+        "ja": "かんすうのしぐにちゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "class without methods",
+        "ja": "めそっどなしのくらす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00313",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a struct?",
+      "ja": "すとらくととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "prints formatted output",
+        "ja": "しょしきつきしゅつりょく",
+        "ja_typings": []
+      },
+      {
+        "en": "reads formatted input",
+        "ja": "しょしきつきにゅうりょくよみこみ",
+        "ja_typings": []
+      },
+      {
+        "en": "allocates memory",
+        "ja": "めもりをかくほ",
+        "ja_typings": []
+      },
+      {
+        "en": "defines format string",
+        "ja": "しょしきもじれつをていぎ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00314",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `printf` do in C?",
+      "ja": "Cの`printf`は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "variable storing memory address",
+        "ja": "めもりあどれすをほぞんするへんすう",
+        "ja_typings": []
+      },
+      {
+        "en": "index into an array",
+        "ja": "はいれつのいんでくす",
+        "ja_typings": []
+      },
+      {
+        "en": "reference to a function",
+        "ja": "かんすうのさんしょう",
+        "ja_typings": []
+      },
+      {
+        "en": "null value",
+        "ja": "nullのち",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00315",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a pointer in C?",
+      "ja": "Cのぽいんたーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "includes a header file",
+        "ja": "へっだーふぁいるをとりこむ",
+        "ja_typings": []
+      },
+      {
+        "en": "defines a macro",
+        "ja": "まくろをていぎ",
+        "ja_typings": []
+      },
+      {
+        "en": "starts a comment",
+        "ja": "こめんとをかいし",
+        "ja_typings": []
+      },
+      {
+        "en": "imports a library",
+        "ja": "らいぶらりをいんぽーと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00316",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `#include` do in C?",
+      "ja": "Cの`#include`は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "error before program runs",
+        "ja": "ぷろぐらむじっこうまえのえらー",
+        "ja_typings": []
+      },
+      {
+        "en": "error during execution",
+        "ja": "じっこうちゅうのえらー",
+        "ja_typings": []
+      },
+      {
+        "en": "error in test code",
+        "ja": "てすとこーどのえらー",
+        "ja_typings": []
+      },
+      {
+        "en": "error in database",
+        "ja": "でーたべーすのえらー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00317",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a compile error?",
+      "ja": "かんぱいるえらーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "error during program execution",
+        "ja": "ぷろぐらむじっこうちゅうのえらー",
+        "ja_typings": []
+      },
+      {
+        "en": "error before compilation",
+        "ja": "かんぱいるまえのえらー",
+        "ja_typings": []
+      },
+      {
+        "en": "error in source code format",
+        "ja": "そーすこーどけいしきのえらー",
+        "ja_typings": []
+      },
+      {
+        "en": "error in test output",
+        "ja": "てすとしゅつりょくのえらー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00318",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a runtime error?",
+      "ja": "じっこうじえらーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "program runs but produces wrong results",
+        "ja": "じっこうはするが結果がまちがい",
+        "ja_typings": []
+      },
+      {
+        "en": "program fails to compile",
+        "ja": "かんぱいるに失敗",
+        "ja_typings": []
+      },
+      {
+        "en": "program crashes at runtime",
+        "ja": "じっこうちゅうにくらっしゅ",
+        "ja_typings": []
+      },
+      {
+        "en": "program has syntax error",
+        "ja": "こうもんえらーがある",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00319",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a logic error?",
+      "ja": "ろじっくえらーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "standard input stream",
+        "ja": "ひょうじゅんにゅうりょくすとりーむ",
+        "ja_typings": []
+      },
+      {
+        "en": "static input definition",
+        "ja": "せいてきにゅうりょくていぎ",
+        "ja_typings": []
+      },
+      {
+        "en": "string input module",
+        "ja": "もじれつにゅうりょくもじゅーる",
+        "ja_typings": []
+      },
+      {
+        "en": "system info node",
+        "ja": "しすてむじょうほうのーど",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00320",
+    "image_path": null,
+    "question_text": {
+      "en": "What is `stdin`?",
+      "ja": "`stdin`とは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "standard output stream",
+        "ja": "ひょうじゅんしゅつりょくすとりーむ",
+        "ja_typings": []
+      },
+      {
+        "en": "static output definition",
+        "ja": "せいてきしゅつりょくていぎ",
+        "ja_typings": []
+      },
+      {
+        "en": "string output module",
+        "ja": "もじれつしゅつりょくもじゅーる",
+        "ja_typings": []
+      },
+      {
+        "en": "system traffic output",
+        "ja": "しすてむつうしんしゅつりょく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00321",
+    "image_path": null,
+    "question_text": {
+      "en": "What is `stdout`?",
+      "ja": "`stdout`とは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "standard error stream",
+        "ja": "ひょうじゅんえらーすとりーむ",
+        "ja_typings": []
+      },
+      {
+        "en": "static error report",
+        "ja": "せいてきえらーほうこく",
+        "ja_typings": []
+      },
+      {
+        "en": "string error module",
+        "ja": "もじれつえらーもじゅーる",
+        "ja_typings": []
+      },
+      {
+        "en": "system task error",
+        "ja": "しすてむたすくえらー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00322",
+    "image_path": null,
+    "question_text": {
+      "en": "What is `stderr`?",
+      "ja": "`stderr`とは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "named storage location for data",
+        "ja": "でーたのなまえつきほぞんばしょ",
+        "ja_typings": []
+      },
+      {
+        "en": "fixed constant value",
+        "ja": "こていのていすうち",
+        "ja_typings": []
+      },
+      {
+        "en": "function parameter",
+        "ja": "かんすうぱらめーた",
+        "ja_typings": []
+      },
+      {
+        "en": "loop counter",
+        "ja": "るーぷかうんたー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00323",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a variable?",
+      "ja": "へんすうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "value that cannot change",
+        "ja": "かえられないち",
+        "ja_typings": []
+      },
+      {
+        "en": "variable with fixed type",
+        "ja": "かたこていのへんすう",
+        "ja_typings": []
+      },
+      {
+        "en": "loop limit value",
+        "ja": "るーぷのかぎりち",
+        "ja_typings": []
+      },
+      {
+        "en": "function return value",
+        "ja": "かんすうのもどりち",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00324",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a constant?",
+      "ja": "ていすうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "order in which operators are evaluated",
+        "ja": "えんざんしがひょうかされるじゅん",
+        "ja_typings": []
+      },
+      {
+        "en": "strength of an operator",
+        "ja": "えんざんしのちから",
+        "ja_typings": []
+      },
+      {
+        "en": "number of operands required",
+        "ja": "ひつようなオペランドのかず",
+        "ja_typings": []
+      },
+      {
+        "en": "speed of operator execution",
+        "ja": "えんざんしじっこうのそくど",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00325",
+    "image_path": null,
+    "question_text": {
+      "en": "What is operator precedence?",
+      "ja": "えんざんしのゆうせんじゅんいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "stopping evaluation when result is determined",
+        "ja": "けっかがきまるとひょうかをとめる",
+        "ja_typings": []
+      },
+      {
+        "en": "fast execution optimization",
+        "ja": "こうそくじっこうのさいてきか",
+        "ja_typings": []
+      },
+      {
+        "en": "evaluating only one operand",
+        "ja": "いちオペランドのみひょうか",
+        "ja_typings": []
+      },
+      {
+        "en": "ignoring second operand always",
+        "ja": "つねにだいにオペランドをむし",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00326",
+    "image_path": null,
+    "question_text": {
+      "en": "What is short-circuit evaluation?",
+      "ja": "たんらくひょうかとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "condition ? value_if_true : value_if_false",
+        "ja": "じょうけん?しんのち:ぎのち",
+        "ja_typings": []
+      },
+      {
+        "en": "operator with three operands only",
+        "ja": "さんつのオペランドのみのえんざんし",
+        "ja_typings": []
+      },
+      {
+        "en": "third operator in expression",
+        "ja": "しきのさんばんめのえんざんし",
+        "ja_typings": []
+      },
+      {
+        "en": "triple assignment operator",
+        "ja": "みっつだいにゅうえんざんし",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00327",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a ternary operator?",
+      "ja": "さんこうえんざんしとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Death Note",
+        "ja": "でーすのーと",
+        "ja_typings": []
+      },
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": []
+      },
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": []
+      },
+      {
+        "en": "One Piece",
+        "ja": "わんぴーす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00328",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features a boy who gains power from a Death Note?",
+      "ja": "しのちょうからちからをえる少年のアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Naruto Uzumaki",
+        "ja": "うずまきなると",
+        "ja_typings": []
+      },
+      {
+        "en": "Sasuke Uchiha",
+        "ja": "うちはさすけ",
+        "ja_typings": []
+      },
+      {
+        "en": "Sakura Haruno",
+        "ja": "はるのさくら",
+        "ja_typings": []
+      },
+      {
+        "en": "Kakashi Hatake",
+        "ja": "はたけかかし",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00329",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the name of the protagonist in Naruto?",
+      "ja": "Narutoのしゅじんこうのなまえは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Attack on Titan",
+        "ja": "しんげきのきょじん",
+        "ja_typings": []
+      },
+      {
+        "en": "Fullmetal Alchemist",
+        "ja": "はがねのれんきんじゅつし",
+        "ja_typings": []
+      },
+      {
+        "en": "Dragon Ball Z",
+        "ja": "どらごんぼーるぜっと",
+        "ja_typings": []
+      },
+      {
+        "en": "Sword Art Online",
+        "ja": "そーどあーとおんらいん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00330",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is set in a world where humans live inside walls to avoid Titans?",
+      "ja": "きょじんからのがれるためにかべのなかでくらすせかいのアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Spirited Away",
+        "ja": "せんとちひろのかみかくし",
+        "ja_typings": []
+      },
+      {
+        "en": "My Neighbor Totoro",
+        "ja": "となりのトトロ",
+        "ja_typings": []
+      },
+      {
+        "en": "Princess Mononoke",
+        "ja": "もののけひめ",
+        "ja_typings": []
+      },
+      {
+        "en": "Howl's Moving Castle",
+        "ja": "ハウルのうごくしろ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00331",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Studio Ghibli film features a girl who works in a bathhouse for spirits?",
+      "ja": "せいれいのゆやではたらくしょうじょのスタジオジブリえいがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "one punch defeats any enemy",
+        "ja": "いちげきですべてのてきをたおす",
+        "ja_typings": []
+      },
+      {
+        "en": "super speed",
+        "ja": "ちょうそくど",
+        "ja_typings": []
+      },
+      {
+        "en": "flight",
+        "ja": "ひこう",
+        "ja_typings": []
+      },
+      {
+        "en": "telepathy",
+        "ja": "てれぱしー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00332",
+    "image_path": null,
+    "question_text": {
+      "en": "What power does Saitama from One Punch Man have?",
+      "ja": "わんぱんまんのさいたまのちからは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "One Piece",
+        "ja": "わんぴーす",
+        "ja_typings": []
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "ふぇありーている",
+        "ja_typings": []
+      },
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": []
+      },
+      {
+        "en": "Dragon Ball",
+        "ja": "どらごんぼーる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00333",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features the Straw Hat Pirates?",
+      "ja": "むぎわらかいぞくだんのアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Akira Toriyama",
+        "ja": "とりやまあきら",
+        "ja_typings": []
+      },
+      {
+        "en": "Eiichiro Oda",
+        "ja": "おだえいいちろう",
+        "ja_typings": []
+      },
+      {
+        "en": "Masashi Kishimoto",
+        "ja": "きしもとまさし",
+        "ja_typings": []
+      },
+      {
+        "en": "Tite Kubo",
+        "ja": "くぼたいと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00334",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Dragon Ball?",
+      "ja": "ドラゴンボールのさくしゃは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Demon Slayer",
+        "ja": "きめつのやいば",
+        "ja_typings": []
+      },
+      {
+        "en": "Jujutsu Kaisen",
+        "ja": "じゅじゅつかいせん",
+        "ja_typings": []
+      },
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": []
+      },
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00335",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is about a boy named Tanjiro fighting demons?",
+      "ja": "たんじろうというしょうねんがおにとたたかうアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "virtual reality MMORPG",
+        "ja": "ばーちゃるりありてぃMMORPG",
+        "ja_typings": []
+      },
+      {
+        "en": "feudal Japan",
+        "ja": "えどじだいのにほん",
+        "ja_typings": []
+      },
+      {
+        "en": "outer space",
+        "ja": "うちゅう",
+        "ja_typings": []
+      },
+      {
+        "en": "post-apocalyptic earth",
+        "ja": "ぶんめいほうかいごのちきゅう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00336",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the setting of Sword Art Online?",
+      "ja": "ソードアートオンラインのぶたいは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pokemon",
+        "ja": "ぽけもん",
+        "ja_typings": []
+      },
+      {
+        "en": "Digimon",
+        "ja": "でじもん",
+        "ja_typings": []
+      },
+      {
+        "en": "Beyblade",
+        "ja": "べいぶれーど",
+        "ja_typings": []
+      },
+      {
+        "en": "Yu-Gi-Oh",
+        "ja": "ゆうぎおー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00337",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime follows a boy who wants to be the best Pokemon trainer?",
+      "ja": "さいきょうのぽけもんとれーなーをめざすしょうねんのアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hideaki Anno",
+        "ja": "あんのひであき",
+        "ja_typings": []
+      },
+      {
+        "en": "Hayao Miyazaki",
+        "ja": "みやざきはやお",
+        "ja_typings": []
+      },
+      {
+        "en": "Satoshi Kon",
+        "ja": "こんさとし",
+        "ja_typings": []
+      },
+      {
+        "en": "Osamu Tezuka",
+        "ja": "てづかおさむ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00338",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created the Evangelion series?",
+      "ja": "えんがえりおんしりーずをつくったのは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Attack on Titan",
+        "ja": "しんげきのきょじん",
+        "ja_typings": []
+      },
+      {
+        "en": "Fullmetal Alchemist",
+        "ja": "はがねのれんきんじゅつし",
+        "ja_typings": []
+      },
+      {
+        "en": "My Hero Academia",
+        "ja": "ぼくのひーろーあかでみあ",
+        "ja_typings": []
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ぶらっくくろーばー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00339",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features the Survey Corps?",
+      "ja": "ちょうさへいだんがとうじょうするアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Izuku Midoriya",
+        "ja": "みどりやいずく",
+        "ja_typings": []
+      },
+      {
+        "en": "Katsuki Bakugo",
+        "ja": "ばくごうかつき",
+        "ja_typings": []
+      },
+      {
+        "en": "Shouto Todoroki",
+        "ja": "とどろきしょうと",
+        "ja_typings": []
+      },
+      {
+        "en": "Tenya Iida",
+        "ja": "いいだてんや",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00340",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the full name of the protagonist in My Hero Academia?",
+      "ja": "ぼくのひーろーあかでみあのしゅじんこうのフルネームは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": []
+      },
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": []
+      },
+      {
+        "en": "Dragon Ball",
+        "ja": "どらごんぼーる",
+        "ja_typings": []
+      },
+      {
+        "en": "One Piece",
+        "ja": "わんぴーす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00341",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features ninjas with special chakra abilities?",
+      "ja": "とくべつなちゃくらのうりょくをもつにんじゃのアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gainax",
+        "ja": "がいなっくす",
+        "ja_typings": []
+      },
+      {
+        "en": "Toei Animation",
+        "ja": "とうえいあにめーしょん",
+        "ja_typings": []
+      },
+      {
+        "en": "Madhouse",
+        "ja": "まっどはうす",
+        "ja_typings": []
+      },
+      {
+        "en": "Kyoto Animation",
+        "ja": "きょーとあにめーしょん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00342",
+    "image_path": null,
+    "question_text": {
+      "en": "What studio produced Neon Genesis Evangelion?",
+      "ja": "しんせいきえんがえりおんをせいさくしたすたじおは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dragon Ball",
+        "ja": "どらごんぼーる",
+        "ja_typings": []
+      },
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": []
+      },
+      {
+        "en": "One Piece",
+        "ja": "わんぴーす",
+        "ja_typings": []
+      },
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00343",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime series is known for the 'Kamehameha' attack?",
+      "ja": "かめはめはこうげきでゆうめいなアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "magical girl",
+        "ja": "まほうしょうじょ",
+        "ja_typings": []
+      },
+      {
+        "en": "mecha",
+        "ja": "めか",
+        "ja_typings": []
+      },
+      {
+        "en": "isekai",
+        "ja": "いせかい",
+        "ja_typings": []
+      },
+      {
+        "en": "sports",
+        "ja": "すぽーつ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00344",
+    "image_path": null,
+    "question_text": {
+      "en": "What genre is Sailor Moon?",
+      "ja": "せーらーむーんのジャンルは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ash Ketchum",
+        "ja": "さとし",
+        "ja_typings": []
+      },
+      {
+        "en": "Misty",
+        "ja": "かすみ",
+        "ja_typings": []
+      },
+      {
+        "en": "Brock",
+        "ja": "たけし",
+        "ja_typings": []
+      },
+      {
+        "en": "Gary",
+        "ja": "しげる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00345",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is Pikachu's trainer in Pokemon anime?",
+      "ja": "ポケモンアニメでぴかちゅうのとれーなーは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Haikyuu!!",
+        "ja": "はいきゅー!!",
+        "ja_typings": []
+      },
+      {
+        "en": "Slam Dunk",
+        "ja": "すらむだんく",
+        "ja_typings": []
+      },
+      {
+        "en": "Kuroko's Basketball",
+        "ja": "くろこのバスケ",
+        "ja_typings": []
+      },
+      {
+        "en": "Captain Tsubasa",
+        "ja": "きゃぷてんつばさ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00346",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is set in a sports high school for volleyball?",
+      "ja": "ばれーぼーるのこうこうのアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "genre where character is transported to another world",
+        "ja": "べつのせかいにうつされるジャンル",
+        "ja_typings": []
+      },
+      {
+        "en": "genre about samurai",
+        "ja": "さむらいのジャンル",
+        "ja_typings": []
+      },
+      {
+        "en": "genre about sports",
+        "ja": "すぽーつのジャンル",
+        "ja_typings": []
+      },
+      {
+        "en": "genre about mecha robots",
+        "ja": "めかろぼっとのジャンル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00347",
+    "image_path": null,
+    "question_text": {
+      "en": "What is isekai?",
+      "ja": "いせかいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "One Piece",
+        "ja": "わんぴーす",
+        "ja_typings": []
+      },
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": []
+      },
+      {
+        "en": "Dragon Ball",
+        "ja": "どらごんぼーる",
+        "ja_typings": []
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "ふぇありーている",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00348",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features Monkey D. Luffy?",
+      "ja": "もんきーでぃーるふぃーがとうじょうするアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "U.A. High School",
+        "ja": "ゆーえいこうこう",
+        "ja_typings": []
+      },
+      {
+        "en": "Shiketsu High",
+        "ja": "しけつこうこう",
+        "ja_typings": []
+      },
+      {
+        "en": "Ketsubutsu Academy",
+        "ja": "けつぶつがくえん",
+        "ja_typings": []
+      },
+      {
+        "en": "Seiai Academy",
+        "ja": "せいあいがくえん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00349",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the name of the school in My Hero Academia?",
+      "ja": "ぼくのひーろーあかでみあのがっこうのなまえは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Death Note",
+        "ja": "でーすのーと",
+        "ja_typings": []
+      },
+      {
+        "en": "Monster",
+        "ja": "もんすたー",
+        "ja_typings": []
+      },
+      {
+        "en": "Psycho-Pass",
+        "ja": "さいこぱす",
+        "ja_typings": []
+      },
+      {
+        "en": "Detective Conan",
+        "ja": "めいたんていこなん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00350",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime follows L and Light's cat-and-mouse detective game?",
+      "ja": "Lとライトのかくれんぼのようなすいりのアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": []
+      },
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": []
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "ふぇありーている",
+        "ja_typings": []
+      },
+      {
+        "en": "Attack on Titan",
+        "ja": "しんげきのきょじん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00351",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is set in the fictional Konoha village?",
+      "ja": "かそうのこのははのむらが舞台のアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Naruto, Bleach, One Piece",
+        "ja": "なるとぶりーちわんぴーす",
+        "ja_typings": []
+      },
+      {
+        "en": "Dragon Ball, Naruto, One Piece",
+        "ja": "どらごんぼーるなるとわんぴーす",
+        "ja_typings": []
+      },
+      {
+        "en": "Bleach, Dragon Ball, Fairy Tail",
+        "ja": "ぶりーちどらごんぼーるふぇありーている",
+        "ja_typings": []
+      },
+      {
+        "en": "One Piece, My Hero, Attack on Titan",
+        "ja": "わんぴーすひーろーきょじん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00352",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the 'Big Three' of older Shonen Jump anime?",
+      "ja": "むかしのじゃんぷのさんだいアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "anime featuring giant robots",
+        "ja": "きょだいろぼっとがとうじょうするアニメ",
+        "ja_typings": []
+      },
+      {
+        "en": "anime about magic users",
+        "ja": "まほうつかいのアニメ",
+        "ja_typings": []
+      },
+      {
+        "en": "anime set in feudal Japan",
+        "ja": "えどじだいのアニメ",
+        "ja_typings": []
+      },
+      {
+        "en": "anime about cooking",
+        "ja": "りょうりのアニメ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00353",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a mecha anime?",
+      "ja": "めかアニメとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kiki's Delivery Service",
+        "ja": "まじょのたっきゅうびん",
+        "ja_typings": []
+      },
+      {
+        "en": "Spirited Away",
+        "ja": "せんとちひろのかみかくし",
+        "ja_typings": []
+      },
+      {
+        "en": "Nausicaa",
+        "ja": "なうしか",
+        "ja_typings": []
+      },
+      {
+        "en": "Castle in the Sky",
+        "ja": "てんくうのしろらぴゅた",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00354",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Ghibli film features a young witch who delivers by broomstick?",
+      "ja": "ほうきではいたつするわかいまじょのジブリえいがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": []
+      },
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": []
+      },
+      {
+        "en": "Dragon Ball",
+        "ja": "どらごんぼーる",
+        "ja_typings": []
+      },
+      {
+        "en": "One Piece",
+        "ja": "わんぴーす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00355",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime follows Ichigo Kurosaki, a Soul Reaper?",
+      "ja": "いちごくろさきというしにがみのアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "anime targeted at young male audience",
+        "ja": "わかいだんせいむけアニメ",
+        "ja_typings": []
+      },
+      {
+        "en": "anime targeted at young female audience",
+        "ja": "わかいじょせいむけアニメ",
+        "ja_typings": []
+      },
+      {
+        "en": "anime for adult men",
+        "ja": "おとなのだんせいむけアニメ",
+        "ja_typings": []
+      },
+      {
+        "en": "anime for children",
+        "ja": "こどもむけアニメ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00356",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'shonen' anime?",
+      "ja": "しょうねんアニメとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "anime targeted at young female audience",
+        "ja": "わかいじょせいむけアニメ",
+        "ja_typings": []
+      },
+      {
+        "en": "anime targeted at young male audience",
+        "ja": "わかいだんせいむけアニメ",
+        "ja_typings": []
+      },
+      {
+        "en": "anime about romance only",
+        "ja": "れんあいのみのアニメ",
+        "ja_typings": []
+      },
+      {
+        "en": "anime with female protagonists only",
+        "ja": "じょしゅじんこうのみのアニメ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00357",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'shoujo' anime?",
+      "ja": "しょうじょアニメとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dragon Ball",
+        "ja": "どらごんぼーる",
+        "ja_typings": []
+      },
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": []
+      },
+      {
+        "en": "One Piece",
+        "ja": "わんぴーす",
+        "ja_typings": []
+      },
+      {
+        "en": "Baki",
+        "ja": "ばき",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00358",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is about a boy named Goku who trains in martial arts?",
+      "ja": "ごくうというしょうねんがぶどうをきわめるアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Original Video Animation",
+        "ja": "おりじなるびでおあにめーしょん",
+        "ja_typings": []
+      },
+      {
+        "en": "Official Voice Acting",
+        "ja": "こうしきせいゆうえんぎ",
+        "ja_typings": []
+      },
+      {
+        "en": "Online Visual Archive",
+        "ja": "おんらいんびじゅあるあーかいぶ",
+        "ja_typings": []
+      },
+      {
+        "en": "Overseas Video Animation",
+        "ja": "かいがいびでおあにめーしょん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00359",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'OVA' stand for in anime?",
+      "ja": "アニメのOVAのりゃくごのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "One Piece",
+        "ja": "わんぴーす",
+        "ja_typings": []
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "ふぇありーている",
+        "ja_typings": []
+      },
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": []
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ぶらっくくろーばー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00360",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is famous for the 'Thousand Sunny' ship?",
+      "ja": "さうざんどさにーごうでゆうめいなアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JoJo's Bizarre Adventure",
+        "ja": "じょじょのきみょうなぼうけん",
+        "ja_typings": []
+      },
+      {
+        "en": "Fullmetal Alchemist",
+        "ja": "はがねのれんきんじゅつし",
+        "ja_typings": []
+      },
+      {
+        "en": "Noragami",
+        "ja": "のらがみ",
+        "ja_typings": []
+      },
+      {
+        "en": "Blue Exorcist",
+        "ja": "あおのえくそしすと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00361",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime series has 'Stand' abilities as its main power system?",
+      "ja": "すたんどのうりょくがメインのアニメシリーズは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "a quirk that can be passed to others",
+        "ja": "ひとにわたせるこせい",
+        "ja_typings": []
+      },
+      {
+        "en": "a villain's ultimate power",
+        "ja": "ヴィランのさいきょうのちから",
+        "ja_typings": []
+      },
+      {
+        "en": "a hero association rank",
+        "ja": "ひーろーきょうかいのくらす",
+        "ja_typings": []
+      },
+      {
+        "en": "a special move name",
+        "ja": "とくしゅわざのなまえ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00362",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'One For All' in My Hero Academia?",
+      "ja": "ぼくのひーろーあかでみあのわんふぉーおーるとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Food Wars",
+        "ja": "しょくげきのそうま",
+        "ja_typings": []
+      },
+      {
+        "en": "Silver Spoon",
+        "ja": "ぎんのさじ",
+        "ja_typings": []
+      },
+      {
+        "en": "Sweetness and Lightning",
+        "ja": "あまあまといなずま",
+        "ja_typings": []
+      },
+      {
+        "en": "Cooking Master Boy",
+        "ja": "ちゅうかいちばん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00363",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is set in a cooking high school?",
+      "ja": "りょうりのこうこうのアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Raditz",
+        "ja": "らでぃっつ",
+        "ja_typings": []
+      },
+      {
+        "en": "Frieza",
+        "ja": "ふりーざ",
+        "ja_typings": []
+      },
+      {
+        "en": "Cell",
+        "ja": "せる",
+        "ja_typings": []
+      },
+      {
+        "en": "Beerus",
+        "ja": "びーるす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00364",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the villain in the first arc of Dragon Ball Z?",
+      "ja": "ドラゴンボールZさいしょのあーくのヴィランは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "science of transmuting matter",
+        "ja": "ぶっしつへんかんのかがく",
+        "ja_typings": []
+      },
+      {
+        "en": "magic spells",
+        "ja": "まほうのじゅもん",
+        "ja_typings": []
+      },
+      {
+        "en": "martial arts style",
+        "ja": "ぶどうのりゅうは",
+        "ja_typings": []
+      },
+      {
+        "en": "alchemy potions",
+        "ja": "れんきんやく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00365",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Alchemy' in Fullmetal Alchemist?",
+      "ja": "はがねのれんきんじゅつしのれんきんじゅつとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Attack on Titan",
+        "ja": "しんげきのきょじん",
+        "ja_typings": []
+      },
+      {
+        "en": "Jujutsu Kaisen",
+        "ja": "じゅじゅつかいせん",
+        "ja_typings": []
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ぶらっくくろーばー",
+        "ja_typings": []
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "ふぇありーている",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00366",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features the 'Survey Corps' fighting Titans?",
+      "ja": "ちょうさへいだんがきょじんとたたかうアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "romantic fantasy",
+        "ja": "ろまんてぃっくふぁんたじー",
+        "ja_typings": []
+      },
+      {
+        "en": "action shonen",
+        "ja": "あくしょんしょうねん",
+        "ja_typings": []
+      },
+      {
+        "en": "mecha",
+        "ja": "めか",
+        "ja_typings": []
+      },
+      {
+        "en": "horror",
+        "ja": "ほらー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00367",
+    "image_path": null,
+    "question_text": {
+      "en": "What genre is 'Your Name (Kimi no Na wa)'?",
+      "ja": "きみのなわのジャンルは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hayao Miyazaki",
+        "ja": "みやざきはやお",
+        "ja_typings": []
+      },
+      {
+        "en": "Isao Takahata",
+        "ja": "たかはたいさお",
+        "ja_typings": []
+      },
+      {
+        "en": "Satoshi Kon",
+        "ja": "こんさとし",
+        "ja_typings": []
+      },
+      {
+        "en": "Mamoru Oshii",
+        "ja": "おしいまもる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00368",
+    "image_path": null,
+    "question_text": {
+      "en": "Who directed Spirited Away?",
+      "ja": "もののけひめをかんとくしたのは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Catbus",
+        "ja": "ねこばす",
+        "ja_typings": []
+      },
+      {
+        "en": "Totoro Bus",
+        "ja": "トトロバス",
+        "ja_typings": []
+      },
+      {
+        "en": "Meow Train",
+        "ja": "にゃーれっしゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "Nyanko Express",
+        "ja": "にゃんこえくすぷれす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00369",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the name of the cat bus in My Neighbor Totoro?",
+      "ja": "となりのトトロのねこばすのなまえは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Demon Slayer",
+        "ja": "きめつのやいば",
+        "ja_typings": []
+      },
+      {
+        "en": "My Hero Academia",
+        "ja": "ぼくのひーろーあかでみあ",
+        "ja_typings": []
+      },
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": []
+      },
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00370",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features heroes called 'Hashira'?",
+      "ja": "はしらとよばれるひーろーたちのアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shadow Clone Jutsu",
+        "ja": "かげぶんしんのじゅつ",
+        "ja_typings": []
+      },
+      {
+        "en": "Rasengan",
+        "ja": "らせんがん",
+        "ja_typings": []
+      },
+      {
+        "en": "Chidori",
+        "ja": "ちどり",
+        "ja_typings": []
+      },
+      {
+        "en": "Fire Style",
+        "ja": "かとん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00371",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the name of Naruto's signature technique?",
+      "ja": "なるとのとくいわざのなまえは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sword Art Online",
+        "ja": "そーどあーとおんらいん",
+        "ja_typings": []
+      },
+      {
+        "en": "Log Horizon",
+        "ja": "ろぐほらいずん",
+        "ja_typings": []
+      },
+      {
+        "en": ".hack//Sign",
+        "ja": ".hack//サイン",
+        "ja_typings": []
+      },
+      {
+        "en": "No Game No Life",
+        "ja": "のーげーむのーらいふ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00372",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is about a virtual game where dying in-game means death in real life?",
+      "ja": "げーむないしすると現実でもしぬアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "writing names to kill people",
+        "ja": "なまえをかいてひとをころす",
+        "ja_typings": []
+      },
+      {
+        "en": "seeing the future",
+        "ja": "みらいをみる",
+        "ja_typings": []
+      },
+      {
+        "en": "mind control",
+        "ja": "せんのうする",
+        "ja_typings": []
+      },
+      {
+        "en": "time travel",
+        "ja": "じかんりょこう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00373",
+    "image_path": null,
+    "question_text": {
+      "en": "What power does Light Yagami use in Death Note?",
+      "ja": "デスノートでやがみらいとが使うちからは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": []
+      },
+      {
+        "en": "Boruto",
+        "ja": "ぼると",
+        "ja_typings": []
+      },
+      {
+        "en": "Dragon Ball",
+        "ja": "どらごんぼーる",
+        "ja_typings": []
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "ふぇありーている",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00374",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is set in the Hidden Leaf Village?",
+      "ja": "かくれこのはのさとをぶたいにしたアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "a superpower",
+        "ja": "ちょうのうりょく",
+        "ja_typings": []
+      },
+      {
+        "en": "a school rule",
+        "ja": "がっこうのきまり",
+        "ja_typings": []
+      },
+      {
+        "en": "a villain title",
+        "ja": "ヴィランのしょうごう",
+        "ja_typings": []
+      },
+      {
+        "en": "a fighting technique",
+        "ja": "ぶとうのわざ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00375",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the 'Quirk' in My Hero Academia?",
+      "ja": "ぼくのひーろーあかでみあのこせいとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Death Note",
+        "ja": "でーすのーと",
+        "ja_typings": []
+      },
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": []
+      },
+      {
+        "en": "Noragami",
+        "ja": "のらがみ",
+        "ja_typings": []
+      },
+      {
+        "en": "Soul Eater",
+        "ja": "そうるいーたー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00376",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features Ryuk, a death god?",
+      "ja": "りゅーくというしにがみがとうじょうするアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "giant humanoid creature",
+        "ja": "きょだいなにんげんがたいきもの",
+        "ja_typings": []
+      },
+      {
+        "en": "large robot",
+        "ja": "きょだいなろぼっと",
+        "ja_typings": []
+      },
+      {
+        "en": "supernatural spirit",
+        "ja": "ちょうしぜんのれい",
+        "ja_typings": []
+      },
+      {
+        "en": "ancient warrior",
+        "ja": "こだいのせんし",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00377",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Titan' in Attack on Titan?",
+      "ja": "しんげきのきょじんのきょじんとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yu-Gi-Oh",
+        "ja": "ゆうぎおー",
+        "ja_typings": []
+      },
+      {
+        "en": "Pokemon",
+        "ja": "ぽけもん",
+        "ja_typings": []
+      },
+      {
+        "en": "Beyblade",
+        "ja": "べいぶれーど",
+        "ja_typings": []
+      },
+      {
+        "en": "Digimon",
+        "ja": "でじもん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00378",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is based on a card game?",
+      "ja": "かーどげーむをもとにしたアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Frieza",
+        "ja": "ふりーざ",
+        "ja_typings": []
+      },
+      {
+        "en": "Cell",
+        "ja": "せる",
+        "ja_typings": []
+      },
+      {
+        "en": "Buu",
+        "ja": "ぶう",
+        "ja_typings": []
+      },
+      {
+        "en": "Vegeta",
+        "ja": "べじーた",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00379",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the main antagonist of the Frieza arc in Dragon Ball Z?",
+      "ja": "ドラゴンボールZのふりーざへんのしゅてきは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "world where everything is decided by games",
+        "ja": "ゲームですべてがきめられるせかい",
+        "ja_typings": []
+      },
+      {
+        "en": "virtual MMORPG",
+        "ja": "ばーちゃるMMORPG",
+        "ja_typings": []
+      },
+      {
+        "en": "feudal Japan",
+        "ja": "えどじだいのにほん",
+        "ja_typings": []
+      },
+      {
+        "en": "post-apocalyptic earth",
+        "ja": "ぶんめいほうかいごのちきゅう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00380",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the setting of 'No Game No Life'?",
+      "ja": "のーげーむのーらいふの舞台は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hiromu Arakawa",
+        "ja": "あらかわひろむ",
+        "ja_typings": []
+      },
+      {
+        "en": "Masashi Kishimoto",
+        "ja": "きしもとまさし",
+        "ja_typings": []
+      },
+      {
+        "en": "Tite Kubo",
+        "ja": "くぼたいと",
+        "ja_typings": []
+      },
+      {
+        "en": "Akira Toriyama",
+        "ja": "とりやまあきら",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00381",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote the manga 'Fullmetal Alchemist'?",
+      "ja": "はがねのれんきんじゅつしをかいたのは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "voice actor",
+        "ja": "せいゆう",
+        "ja_typings": []
+      },
+      {
+        "en": "anime director",
+        "ja": "かんとく",
+        "ja_typings": []
+      },
+      {
+        "en": "character designer",
+        "ja": "きゃらくたーでざいなー",
+        "ja_typings": []
+      },
+      {
+        "en": "soundtrack composer",
+        "ja": "おんがくさっきょくか",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00382",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'seiyuu' in anime?",
+      "ja": "アニメのせいゆうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "dubbed has translated voice, subbed has subtitles",
+        "ja": "だぶどはほんやくおんせい、さぶどはじまく",
+        "ja_typings": []
+      },
+      {
+        "en": "dubbed is the original, subbed is translated",
+        "ja": "だぶどはげんさく、さぶどはほんやく",
+        "ja_typings": []
+      },
+      {
+        "en": "dubbed is higher quality",
+        "ja": "だぶどのほうがこうひん",
+        "ja_typings": []
+      },
+      {
+        "en": "subbed has no audio",
+        "ja": "さぶどにはおとがない",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00383",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the difference between dubbed and subbed anime?",
+      "ja": "だぶどとさぶどのアニメのちがいは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Black Butler",
+        "ja": "くろしつじ",
+        "ja_typings": []
+      },
+      {
+        "en": "Overlord",
+        "ja": "おーばーろーど",
+        "ja_typings": []
+      },
+      {
+        "en": "Moriarty the Patriot",
+        "ja": "ゆうこくのもりあーてぃ",
+        "ja_typings": []
+      },
+      {
+        "en": "The Case Study of Vanitas",
+        "ja": "ヴァニタスのカルテ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00384",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime series is set in 19th century England with a demon butler?",
+      "ja": "あくまのしつじがいる19せいきえいこくのアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "popular manga magazine",
+        "ja": "にんきまんがざっし",
+        "ja_typings": []
+      },
+      {
+        "en": "anime streaming service",
+        "ja": "アニメはいしんさーびす",
+        "ja_typings": []
+      },
+      {
+        "en": "anime convention",
+        "ja": "アニメのいべんと",
+        "ja_typings": []
+      },
+      {
+        "en": "anime film studio",
+        "ja": "アニメえいがすたじお",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00385",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Shounen Jump'?",
+      "ja": "しょうねんじゃんぷとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jujutsu Kaisen",
+        "ja": "じゅじゅつかいせん",
+        "ja_typings": []
+      },
+      {
+        "en": "Noragami",
+        "ja": "のらがみ",
+        "ja_typings": []
+      },
+      {
+        "en": "Blue Exorcist",
+        "ja": "あおのえくそしすと",
+        "ja_typings": []
+      },
+      {
+        "en": "Soul Eater",
+        "ja": "そうるいーたー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00386",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime follows a group of exorcists called 'jujutsu sorcerers'?",
+      "ja": "じゅじゅつしのようしゃたちのアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nezuko",
+        "ja": "ねずこ",
+        "ja_typings": []
+      },
+      {
+        "en": "Aoi",
+        "ja": "あおい",
+        "ja_typings": []
+      },
+      {
+        "en": "Shinobu",
+        "ja": "しのぶ",
+        "ja_typings": []
+      },
+      {
+        "en": "Kanao",
+        "ja": "かなお",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00387",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the name of Tanjiro's sister in Demon Slayer?",
+      "ja": "きめつのやいばでたんじろうのいもうとのなまえは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": []
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "ふぇありーている",
+        "ja_typings": []
+      },
+      {
+        "en": "Inuyasha",
+        "ja": "いぬやしゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00388",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features the 'Nine-Tails Fox' sealed inside a character?",
+      "ja": "きゅうびがふういんされたキャラのアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "depicting everyday life",
+        "ja": "にちじょうせいかつをえがく",
+        "ja_typings": []
+      },
+      {
+        "en": "depicting extreme action",
+        "ja": "きょくたんなあくしょんをえがく",
+        "ja_typings": []
+      },
+      {
+        "en": "depicting fantasy worlds",
+        "ja": "ふぁんたじーのせかいをえがく",
+        "ja_typings": []
+      },
+      {
+        "en": "depicting sports tournaments",
+        "ja": "すぽーつたいかいをえがく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00389",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the anime genre 'slice of life'?",
+      "ja": "あにめのすらいすおぶらいふジャンルとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "seasonal broadcast unit (~13 episodes)",
+        "ja": "きせつほうそうのたんい（やく13わ）",
+        "ja_typings": []
+      },
+      {
+        "en": "OVA episode format",
+        "ja": "OVAわけいしき",
+        "ja_typings": []
+      },
+      {
+        "en": "anime film format",
+        "ja": "アニメえいがけいしき",
+        "ja_typings": []
+      },
+      {
+        "en": "streaming season format",
+        "ja": "はいしんきせつけいしき",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00390",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'cour' in anime terminology?",
+      "ja": "アニメようごのくーるとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jujutsu Kaisen",
+        "ja": "じゅじゅつかいせん",
+        "ja_typings": []
+      },
+      {
+        "en": "Demon Slayer",
+        "ja": "きめつのやいば",
+        "ja_typings": []
+      },
+      {
+        "en": "My Hero Academia",
+        "ja": "ぼくのひーろーあかでみあ",
+        "ja_typings": []
+      },
+      {
+        "en": "One Piece",
+        "ja": "わんぴーす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00391",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is produced by MAPPA?",
+      "ja": "MAPPAがせいさくしたアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "high-quality animation and emotional stories",
+        "ja": "こうひんなあにめーしょんとかんどうてきなはなし",
+        "ja_typings": []
+      },
+      {
+        "en": "mecha anime",
+        "ja": "めかアニメ",
+        "ja_typings": []
+      },
+      {
+        "en": "action-heavy shonen",
+        "ja": "あくしょんしょうねん",
+        "ja_typings": []
+      },
+      {
+        "en": "violent horror anime",
+        "ja": "はきょくてきなほらーアニメ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00392",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Kyoto Animation known for?",
+      "ja": "きょーとあにめーしょんはなにでゆうめいか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jujutsu Kaisen",
+        "ja": "じゅじゅつかいせん",
+        "ja_typings": []
+      },
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": []
+      },
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": []
+      },
+      {
+        "en": "My Hero Academia",
+        "ja": "ぼくのひーろーあかでみあ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00393",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features Satoru Gojo?",
+      "ja": "ごじょうさとるがとうじょうするアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Eiichiro Oda",
+        "ja": "おだえいいちろう",
+        "ja_typings": []
+      },
+      {
+        "en": "Masashi Kishimoto",
+        "ja": "きしもとまさし",
+        "ja_typings": []
+      },
+      {
+        "en": "Akira Toriyama",
+        "ja": "とりやまあきら",
+        "ja_typings": []
+      },
+      {
+        "en": "Hiromu Arakawa",
+        "ja": "あらかわひろむ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00394",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the creator of One Piece?",
+      "ja": "ワンピースのさくしゃは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Naruto's signature phrase",
+        "ja": "ナルトのくちぐせ",
+        "ja_typings": []
+      },
+      {
+        "en": "a jutsu name",
+        "ja": "じゅつのなまえ",
+        "ja_typings": []
+      },
+      {
+        "en": "a village name",
+        "ja": "むらのなまえ",
+        "ja_typings": []
+      },
+      {
+        "en": "a character title",
+        "ja": "きゃらのしょうごう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00395",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Dattebayo' associated with in Naruto?",
+      "ja": "ナルトで「だってばよ」はなにと関係するか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Castle in the Sky",
+        "ja": "てんくうのしろらぴゅた",
+        "ja_typings": []
+      },
+      {
+        "en": "Nausicaa",
+        "ja": "かぜのたにのなうしか",
+        "ja_typings": []
+      },
+      {
+        "en": "Princess Mononoke",
+        "ja": "もののけひめ",
+        "ja_typings": []
+      },
+      {
+        "en": "The Wind Rises",
+        "ja": "かぜたちぬ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00396",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Ghibli film features a flying island called Laputa?",
+      "ja": "ラピュタというとぶしまのジブリえいがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Doraemon",
+        "ja": "どらえもん",
+        "ja_typings": []
+      },
+      {
+        "en": "Nobita",
+        "ja": "のびた",
+        "ja_typings": []
+      },
+      {
+        "en": "Shizuka",
+        "ja": "しずか",
+        "ja_typings": []
+      },
+      {
+        "en": "Gian",
+        "ja": "じゃいあん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00397",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the name of the robot in Doraemon?",
+      "ja": "ドラえもんのろぼっとのなまえは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Attack on Titan",
+        "ja": "しんげきのきょじん",
+        "ja_typings": []
+      },
+      {
+        "en": "Code Geass",
+        "ja": "こーどぎあす",
+        "ja_typings": []
+      },
+      {
+        "en": "Gurren Lagann",
+        "ja": "てんげんとっぱぐれんらがん",
+        "ja_typings": []
+      },
+      {
+        "en": "Neon Genesis Evangelion",
+        "ja": "しんせいきえんがえりおん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00398",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is set in a world with 'Titans' and 3D Maneuver Gear?",
+      "ja": "きょじんと立体機動装置のせかいのアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "fantasy isekai world",
+        "ja": "ふぁんたじーのいせかい",
+        "ja_typings": []
+      },
+      {
+        "en": "virtual MMORPG",
+        "ja": "ばーちゃるMMORPG",
+        "ja_typings": []
+      },
+      {
+        "en": "futuristic Japan",
+        "ja": "みらいのにほん",
+        "ja_typings": []
+      },
+      {
+        "en": "post-apocalyptic world",
+        "ja": "ぶんめいほうかいごのせかい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00399",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the setting of 'Re:Zero'?",
+      "ja": "りぜろの舞台は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": []
+      },
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": []
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "ふぇありーている",
+        "ja_typings": []
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ぶらっくくろーばー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00400",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features the 'Akatsuki' organization?",
+      "ja": "あかつきというそしきがとうじょうするアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "exhibits about Studio Ghibli films",
+        "ja": "スタジオジブリさくひんのてんじ",
+        "ja_typings": []
+      },
+      {
+        "en": "live anime performances",
+        "ja": "アニメのらいぶぱふぉーまんす",
+        "ja_typings": []
+      },
+      {
+        "en": "anime figure collection",
+        "ja": "アニメのふぃぎゅあこれくしょん",
+        "ja_typings": []
+      },
+      {
+        "en": "anime film production",
+        "ja": "アニメえいがせいさく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00401",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Ghibli Museum' famous for?",
+      "ja": "ジブリびじゅつかんはなにでゆうめいか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": []
+      },
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": []
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "ふぇありーている",
+        "ja_typings": []
+      },
+      {
+        "en": "One Piece",
+        "ja": "わんぴーす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00402",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime has 'Zanpakuto' as spirit swords?",
+      "ja": "ざんぱくとうというせいれいけんのアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1997",
+        "ja": "1997ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1995",
+        "ja": "1995ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1999",
+        "ja": "1999ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "2001",
+        "ja": "2001ねん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00403",
+    "image_path": null,
+    "question_text": {
+      "en": "What year did the original Pokemon anime first air in Japan?",
+      "ja": "ぽけもんアニメがにほんではじめてほうそうされたのはなんねんか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hunter x Hunter",
+        "ja": "はんたーはんたー",
+        "ja_typings": []
+      },
+      {
+        "en": "Yu Yu Hakusho",
+        "ja": "ゆゆはくしょ",
+        "ja_typings": []
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "ふぇありーている",
+        "ja_typings": []
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ぶらっくくろーばー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00404",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features characters fighting with 'Nen' energy?",
+      "ja": "ねんをつかってたたかうアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Edward's automail limbs",
+        "ja": "えどわーどのぎそくしし",
+        "ja_typings": []
+      },
+      {
+        "en": "a type of alchemy",
+        "ja": "れんきんじゅつのしゅるい",
+        "ja_typings": []
+      },
+      {
+        "en": "a city name",
+        "ja": "まちのなまえ",
+        "ja_typings": []
+      },
+      {
+        "en": "a villain's title",
+        "ja": "ヴィランのしょうごう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00405",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Fullmetal' referring to in Fullmetal Alchemist?",
+      "ja": "はがねのれんきんじゅつしの「はがねの」はなにをさすか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Re:Zero",
+        "ja": "りぜろ",
+        "ja_typings": []
+      },
+      {
+        "en": "Overlord",
+        "ja": "おーばーろーど",
+        "ja_typings": []
+      },
+      {
+        "en": "That Time I Got Reincarnated as a Slime",
+        "ja": "てんせいしたらスライムだったけん",
+        "ja_typings": []
+      },
+      {
+        "en": "KonoSuba",
+        "ja": "このすばー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00406",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features the character Rem?",
+      "ja": "れむがとうじょうするアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "all animation",
+        "ja": "すべてのアニメーション",
+        "ja_typings": []
+      },
+      {
+        "en": "only Japanese animation",
+        "ja": "にほんのアニメのみ",
+        "ja_typings": []
+      },
+      {
+        "en": "cartoon characters",
+        "ja": "まんがのキャラクター",
+        "ja_typings": []
+      },
+      {
+        "en": "motion pictures",
+        "ja": "えいが",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00407",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Anime' literally referring to in Japanese?",
+      "ja": "にほんごで「アニメ」はもともと何をさすか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "My Hero Academia",
+        "ja": "ぼくのひーろーあかでみあ",
+        "ja_typings": []
+      },
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": []
+      },
+      {
+        "en": "Dragon Ball Z",
+        "ja": "どらごんぼーるZ",
+        "ja_typings": []
+      },
+      {
+        "en": "One Piece",
+        "ja": "わんぴーす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00408",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is famous for the phrase 'Plus Ultra'?",
+      "ja": "ぷらすうるとらというフレーズでゆうめいなアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "My Hero Academia",
+        "ja": "ぼくのひーろーあかでみあ",
+        "ja_typings": []
+      },
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": []
+      },
+      {
+        "en": "Dragon Ball",
+        "ja": "どらごんぼーる",
+        "ja_typings": []
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ぶらっくくろーばー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00409",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is about a boy who discovers he can become a hero by training hard?",
+      "ja": "はげんれんしゅうでひーろーになれることをしったしょうねんのアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Attack on Titan",
+        "ja": "あたっくおんたいたん",
+        "ja_typings": []
+      },
+      {
+        "en": "Titan Attack",
+        "ja": "たいたんあたっく",
+        "ja_typings": []
+      },
+      {
+        "en": "Rumbling Titans",
+        "ja": "らんぶりんぐたいたんず",
+        "ja_typings": []
+      },
+      {
+        "en": "Rising Titans",
+        "ja": "らいじんぐたいたんず",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00410",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Shingeki no Kyojin' in English?",
+      "ja": "しんげきのきょじんの英語タイトルは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Infinity",
+        "ja": "むげん",
+        "ja_typings": []
+      },
+      {
+        "en": "Six Eyes",
+        "ja": "ろくがん",
+        "ja_typings": []
+      },
+      {
+        "en": "Reverse Cursed Technique",
+        "ja": "はんてんじゅつしき",
+        "ja_typings": []
+      },
+      {
+        "en": "Domain Expansion",
+        "ja": "りょういきてんかい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00411",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the name of Satoru Gojo's special ability?",
+      "ja": "ごじょうさとるの特殊能力のなまえは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "psychological thriller",
+        "ja": "しんりさすぺんす",
+        "ja_typings": []
+      },
+      {
+        "en": "action shonen",
+        "ja": "あくしょんしょうねん",
+        "ja_typings": []
+      },
+      {
+        "en": "romance",
+        "ja": "れんあい",
+        "ja_typings": []
+      },
+      {
+        "en": "fantasy adventure",
+        "ja": "ふぁんたじーぼうけん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00412",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is a psychological thriller with 'Death Note'?",
+      "ja": "デスノートはどんなジャンルのアニメか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nintendo 64",
+        "ja": "にんてんどうろくじゅうよん",
+        "ja_typings": []
+      },
+      {
+        "en": "Super Famicom",
+        "ja": "すーぱーふぁみこん",
+        "ja_typings": []
+      },
+      {
+        "en": "Sega Saturn",
+        "ja": "せがさたーん",
+        "ja_typings": []
+      },
+      {
+        "en": "Atari 2600",
+        "ja": "あたりにせんろっぴゃく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00413",
+    "image_path": null,
+    "question_text": {
+      "en": "What console launched the modern era of 3D gaming?",
+      "ja": "3Dげーむのしんじだいをひらいたてゆきとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Legend of Zelda",
+        "ja": "ぜるだのでんせつ",
+        "ja_typings": []
+      },
+      {
+        "en": "Metroid",
+        "ja": "めとろいど",
+        "ja_typings": []
+      },
+      {
+        "en": "Kirby",
+        "ja": "かーびぃ",
+        "ja_typings": []
+      },
+      {
+        "en": "Star Fox",
+        "ja": "すたーふぉっくす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00414",
+    "image_path": null,
+    "question_text": {
+      "en": "What game features Link as the protagonist?",
+      "ja": "りんくがしゅじんこうのげーむは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Minecraft",
+        "ja": "まいんくらふと",
+        "ja_typings": []
+      },
+      {
+        "en": "Tetris",
+        "ja": "てとりす",
+        "ja_typings": []
+      },
+      {
+        "en": "GTA V",
+        "ja": "GTA5",
+        "ja_typings": []
+      },
+      {
+        "en": "Wii Sports",
+        "ja": "wiiすぽーつ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00415",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the best-selling video game of all time (as of 2024)?",
+      "ja": "2024ねんじてんでもっともうれたびでおげーむは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sony",
+        "ja": "そにー",
+        "ja_typings": []
+      },
+      {
+        "en": "Microsoft",
+        "ja": "まいくろそふと",
+        "ja_typings": []
+      },
+      {
+        "en": "Nintendo",
+        "ja": "にんてんどう",
+        "ja_typings": []
+      },
+      {
+        "en": "Sega",
+        "ja": "せが",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00416",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company makes the PlayStation?",
+      "ja": "ぷれいすてーしょんをつくっているかいしゃは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Super Mario",
+        "ja": "すーぱーまりお",
+        "ja_typings": []
+      },
+      {
+        "en": "Donkey Kong",
+        "ja": "どんきーこんぐ",
+        "ja_typings": []
+      },
+      {
+        "en": "Sonic",
+        "ja": "そにっく",
+        "ja_typings": []
+      },
+      {
+        "en": "Mega Man",
+        "ja": "ろっくまん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00417",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features Mario and Luigi?",
+      "ja": "まりおとるいーじがとうじょうするげーむは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pac-Man",
+        "ja": "ぱっくまん",
+        "ja_typings": []
+      },
+      {
+        "en": "Kirby",
+        "ja": "かーびぃ",
+        "ja_typings": []
+      },
+      {
+        "en": "Pikachu",
+        "ja": "ぴかちゅう",
+        "ja_typings": []
+      },
+      {
+        "en": "Chocobo",
+        "ja": "ちょこぼ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00418",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the iconic yellow ghost-eating character?",
+      "ja": "おばけをたべるきいろいキャラクターは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Halo",
+        "ja": "へいろー",
+        "ja_typings": []
+      },
+      {
+        "en": "Doom",
+        "ja": "どぅーむ",
+        "ja_typings": []
+      },
+      {
+        "en": "Call of Duty",
+        "ja": "こーるおぶでゅーてぃ",
+        "ja_typings": []
+      },
+      {
+        "en": "Battlefield",
+        "ja": "ばとるふぃーるど",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00419",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game series features Master Chief?",
+      "ja": "ますたーちいふがとうじょうするげーむシリーズは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PUBG",
+        "ja": "ぱぶじー",
+        "ja_typings": []
+      },
+      {
+        "en": "Fortnite",
+        "ja": "ふぉーとないと",
+        "ja_typings": []
+      },
+      {
+        "en": "Warzone",
+        "ja": "うぉーぞーん",
+        "ja_typings": []
+      },
+      {
+        "en": "Apex Legends",
+        "ja": "えいぺっくすれじぇんず",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00420",
+    "image_path": null,
+    "question_text": {
+      "en": "What game popularized the battle royale genre?",
+      "ja": "ばとるろわいやるジャンルをひろめたげーむは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sega",
+        "ja": "せが",
+        "ja_typings": []
+      },
+      {
+        "en": "Nintendo",
+        "ja": "にんてんどう",
+        "ja_typings": []
+      },
+      {
+        "en": "Capcom",
+        "ja": "かぷこむ",
+        "ja_typings": []
+      },
+      {
+        "en": "Konami",
+        "ja": "こなみ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00421",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company made Sonic the Hedgehog?",
+      "ja": "そにっくざへっじほっぐをつくったかいしゃは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Halo",
+        "ja": "へいろー",
+        "ja_typings": []
+      },
+      {
+        "en": "Gears of War",
+        "ja": "ぎあすおぶうぉー",
+        "ja_typings": []
+      },
+      {
+        "en": "Mass Effect",
+        "ja": "ますえふぇくと",
+        "ja_typings": []
+      },
+      {
+        "en": "Destiny",
+        "ja": "ですてぃにー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00422",
+    "image_path": null,
+    "question_text": {
+      "en": "What game series features the Covenant as enemies?",
+      "ja": "こべナントがてきとしてとうじょうするげーむシリーズは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Portal",
+        "ja": "ぽーたる",
+        "ja_typings": []
+      },
+      {
+        "en": "Half-Life",
+        "ja": "はーふらいふ",
+        "ja_typings": []
+      },
+      {
+        "en": "Mirror's Edge",
+        "ja": "みらーずえっじ",
+        "ja_typings": []
+      },
+      {
+        "en": "Bioshock",
+        "ja": "ばいおしょっく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00423",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game is famous for the phrase 'The Cake is a Lie'?",
+      "ja": "「けーきはうそだ」というフレーズでゆうめいなげーむは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "dark fantasy medieval world",
+        "ja": "くらいちゅうせいふぁんたじーのせかい",
+        "ja_typings": []
+      },
+      {
+        "en": "futuristic space",
+        "ja": "みらいのうちゅう",
+        "ja_typings": []
+      },
+      {
+        "en": "modern day city",
+        "ja": "げんだいのとし",
+        "ja_typings": []
+      },
+      {
+        "en": "post-apocalyptic wasteland",
+        "ja": "ぶんめいほうかいごのこうやー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00424",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the setting of the Dark Souls series?",
+      "ja": "ダークソウルシリーズの舞台は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Resident Evil",
+        "ja": "ばいおはざーど",
+        "ja_typings": []
+      },
+      {
+        "en": "Silent Hill",
+        "ja": "さいれんとひる",
+        "ja_typings": []
+      },
+      {
+        "en": "Alone in the Dark",
+        "ja": "あろーんいんざだーく",
+        "ja_typings": []
+      },
+      {
+        "en": "Fatal Frame",
+        "ja": "ぜろ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00425",
+    "image_path": null,
+    "question_text": {
+      "en": "What game created the 'survival horror' genre?",
+      "ja": "さばいばるほらーというジャンルをつくったげーむは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "2011",
+        "ja": "2011ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "2009",
+        "ja": "2009ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "2013",
+        "ja": "2013ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "2015",
+        "ja": "2015ねん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00426",
+    "image_path": null,
+    "question_text": {
+      "en": "What year was the original Minecraft released to the public?",
+      "ja": "おりじなるまいんくらふとがこうかいされたのはなんねんか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "clear lines by filling them",
+        "ja": "れつをうめてきえす",
+        "ja_typings": []
+      },
+      {
+        "en": "defeat enemies",
+        "ja": "てきをたおす",
+        "ja_typings": []
+      },
+      {
+        "en": "collect all pieces",
+        "ja": "すべてのぴーすをあつめる",
+        "ja_typings": []
+      },
+      {
+        "en": "build the tallest tower",
+        "ja": "いちばんたかいとうをたてる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00427",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the objective in Tetris?",
+      "ja": "テトリスのもくてきは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Red Dead Redemption",
+        "ja": "れっどでっどりでんぷしょん",
+        "ja_typings": []
+      },
+      {
+        "en": "GTA",
+        "ja": "グランドせふとおーと",
+        "ja_typings": []
+      },
+      {
+        "en": "Outlaws of the West",
+        "ja": "あうとろーずおぶざうぇすと",
+        "ja_typings": []
+      },
+      {
+        "en": "Wild West Online",
+        "ja": "わいるどうぇすとおんらいん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00428",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game series features Arthur Morgan or John Marston?",
+      "ja": "あーさーもるがんまたはじょんまーすとんがとうじょうするシリーズは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "life simulation",
+        "ja": "せいかつしみゅれーしょん",
+        "ja_typings": []
+      },
+      {
+        "en": "action RPG",
+        "ja": "あくしょんRPG",
+        "ja_typings": []
+      },
+      {
+        "en": "survival horror",
+        "ja": "さばいばるほらー",
+        "ja_typings": []
+      },
+      {
+        "en": "strategy",
+        "ja": "すとらてじー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00429",
+    "image_path": null,
+    "question_text": {
+      "en": "What genre is 'The Sims'?",
+      "ja": "ざしむずのジャンルは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Legend of Zelda",
+        "ja": "ぜるだのでんせつ",
+        "ja_typings": []
+      },
+      {
+        "en": "Fire Emblem",
+        "ja": "ふぁいあーえんぶれむ",
+        "ja_typings": []
+      },
+      {
+        "en": "Xenoblade",
+        "ja": "ぜのぶれーど",
+        "ja_typings": []
+      },
+      {
+        "en": "Metroid",
+        "ja": "めとろいど",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00430",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nintendo franchise features Link and Zelda?",
+      "ja": "りんくとぜるだのにんてんどうフランチャイズは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "social deduction",
+        "ja": "しゃかいてきすいろん",
+        "ja_typings": []
+      },
+      {
+        "en": "battle royale",
+        "ja": "ばとるろわいやる",
+        "ja_typings": []
+      },
+      {
+        "en": "real-time strategy",
+        "ja": "りあるたいむすとらてじー",
+        "ja_typings": []
+      },
+      {
+        "en": "MMORPG",
+        "ja": "MMORPG",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00431",
+    "image_path": null,
+    "question_text": {
+      "en": "What type of game is 'Among Us'?",
+      "ja": "あまんぐあすのゲームジャンルは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Color TV-Game",
+        "ja": "からーTVゲーム",
+        "ja_typings": []
+      },
+      {
+        "en": "Famicom",
+        "ja": "ふぁみこん",
+        "ja_typings": []
+      },
+      {
+        "en": "Game & Watch",
+        "ja": "ゲームあんどうぉっち",
+        "ja_typings": []
+      },
+      {
+        "en": "Game Boy",
+        "ja": "ゲームぼーい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00432",
+    "image_path": null,
+    "question_text": {
+      "en": "What was Nintendo's first game console?",
+      "ja": "にんてんどうのはじめてのゲームきは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mass Effect",
+        "ja": "ますえふぇくと",
+        "ja_typings": []
+      },
+      {
+        "en": "Halo",
+        "ja": "へいろー",
+        "ja_typings": []
+      },
+      {
+        "en": "Destiny",
+        "ja": "ですてぃにー",
+        "ja_typings": []
+      },
+      {
+        "en": "Gears of War",
+        "ja": "ぎあすおぶうぉー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00433",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game series features Commander Shepard?",
+      "ja": "しぇぱーどさがおのシリーズは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Navi",
+        "ja": "なび",
+        "ja_typings": []
+      },
+      {
+        "en": "Tatl",
+        "ja": "たとる",
+        "ja_typings": []
+      },
+      {
+        "en": "Midna",
+        "ja": "みどな",
+        "ja_typings": []
+      },
+      {
+        "en": "Fi",
+        "ja": "ふぁい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00434",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the name of Link's fairy companion in Ocarina of Time?",
+      "ja": "時のオカリナでりんくのようせいのなまえは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Japanese-style role-playing game",
+        "ja": "にほんしきのRPG",
+        "ja_typings": []
+      },
+      {
+        "en": "Java-based RPG engine",
+        "ja": "JavaべーすのRPGえんじん",
+        "ja_typings": []
+      },
+      {
+        "en": "Junior RPG for kids",
+        "ja": "こどもむけのRPG",
+        "ja_typings": []
+      },
+      {
+        "en": "jungle role-playing game",
+        "ja": "じゃんぐるRPG",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00435",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a JRPG?",
+      "ja": "JRPGとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Square Enix",
+        "ja": "すくえあえにっくす",
+        "ja_typings": []
+      },
+      {
+        "en": "Capcom",
+        "ja": "かぷこむ",
+        "ja_typings": []
+      },
+      {
+        "en": "Konami",
+        "ja": "こなみ",
+        "ja_typings": []
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "ばんだいなむこ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00436",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game company made Final Fantasy?",
+      "ja": "ふぁいなるふぁんたじーをつくったかいしゃは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "character dies permanently when killed",
+        "ja": "しぬとキャラがえいきゅうにきえる",
+        "ja_typings": []
+      },
+      {
+        "en": "infinite lives system",
+        "ja": "むげんのいのちのしすてむ",
+        "ja_typings": []
+      },
+      {
+        "en": "auto-save after death",
+        "ja": "しごとじどうほぞん",
+        "ja_typings": []
+      },
+      {
+        "en": "death animation system",
+        "ja": "しのあにめーしょんしすてむ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00437",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'permadeath' in games?",
+      "ja": "ゲームのぱーまですとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "procedural generation with permadeath",
+        "ja": "じどうせいせいとぱーまです",
+        "ja_typings": []
+      },
+      {
+        "en": "game about thieves",
+        "ja": "どろぼうのゲーム",
+        "ja_typings": []
+      },
+      {
+        "en": "classic 8-bit game",
+        "ja": "クラシックはちびっとゲーム",
+        "ja_typings": []
+      },
+      {
+        "en": "linear adventure game",
+        "ja": "いちじゅんのぼうけんゲーム",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00438",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a roguelike game?",
+      "ja": "ろーぐらいくゲームとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "checkmate opponent's king",
+        "ja": "あいてのきんぐをちぇっくめーと",
+        "ja_typings": []
+      },
+      {
+        "en": "capture all pieces",
+        "ja": "ぜんてはつきょうする",
+        "ja_typings": []
+      },
+      {
+        "en": "reach the other side",
+        "ja": "はんたいがわにとうたつ",
+        "ja_typings": []
+      },
+      {
+        "en": "collect most points",
+        "ja": "もっともてんすうをとる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00439",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the objective in chess (video game version)?",
+      "ja": "チェスのもくてきは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1985",
+        "ja": "1985ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1983",
+        "ja": "1983ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1987",
+        "ja": "1987ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1989",
+        "ja": "1989ねん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00440",
+    "image_path": null,
+    "question_text": {
+      "en": "What year was the first Super Mario Bros released?",
+      "ja": "はつのすーぱーまりおぶらざーずはいつはつばいされたか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Halo",
+        "ja": "へいろー",
+        "ja_typings": []
+      },
+      {
+        "en": "Star Wars Battlefront",
+        "ja": "すたーうぉーずばとるふろんと",
+        "ja_typings": []
+      },
+      {
+        "en": "Destiny",
+        "ja": "ですてぃにー",
+        "ja_typings": []
+      },
+      {
+        "en": "Anthem",
+        "ja": "あんせむ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00441",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features the Covenant, Flood, and Forerunners?",
+      "ja": "こべナント、ふらっど、ふぉーらんなーがとうじょうするゲームは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "city building simulation",
+        "ja": "まちづくりしみゅれーしょん",
+        "ja_typings": []
+      },
+      {
+        "en": "action platformer",
+        "ja": "あくしょんぷらっとふぉーまー",
+        "ja_typings": []
+      },
+      {
+        "en": "racing game",
+        "ja": "れーすゲーム",
+        "ja_typings": []
+      },
+      {
+        "en": "horror survival",
+        "ja": "ほらーさばいばる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00442",
+    "image_path": null,
+    "question_text": {
+      "en": "What type of game is 'SimCity'?",
+      "ja": "しむしてぃのゲームジャンルは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bells",
+        "ja": "ベル",
+        "ja_typings": []
+      },
+      {
+        "en": "Gold Coins",
+        "ja": "きんか",
+        "ja_typings": []
+      },
+      {
+        "en": "Nook Miles",
+        "ja": "ぬっきーまいる",
+        "ja_typings": []
+      },
+      {
+        "en": "Rupees",
+        "ja": "るぴー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00443",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the main currency in Animal Crossing?",
+      "ja": "あつまれどうぶつのもりのつうかは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pokemon",
+        "ja": "ぽけもん",
+        "ja_typings": []
+      },
+      {
+        "en": "Monster Hunter",
+        "ja": "もんすたーはんたー",
+        "ja_typings": []
+      },
+      {
+        "en": "Digimon",
+        "ja": "でじもん",
+        "ja_typings": []
+      },
+      {
+        "en": "Dragon Quest Monsters",
+        "ja": "ドラゴンクエストモンスターズ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00444",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game is known for the catchphrase 'Gotta Catch 'Em All'?",
+      "ja": "「ぜんぶつかまえろ」というキャッチフレーズのゲームは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Microsoft",
+        "ja": "まいくろそふと",
+        "ja_typings": []
+      },
+      {
+        "en": "Sony",
+        "ja": "そにー",
+        "ja_typings": []
+      },
+      {
+        "en": "Nintendo",
+        "ja": "にんてんどう",
+        "ja_typings": []
+      },
+      {
+        "en": "Valve",
+        "ja": "ばるぶ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00445",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company makes the Xbox?",
+      "ja": "えっくすぼっくすをつくっているかいしゃは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HP",
+        "ja": "HP",
+        "ja_typings": []
+      },
+      {
+        "en": "MP",
+        "ja": "MP",
+        "ja_typings": []
+      },
+      {
+        "en": "SP",
+        "ja": "SP",
+        "ja_typings": []
+      },
+      {
+        "en": "AP",
+        "ja": "AP",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00446",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'health points' abbreviated as in games?",
+      "ja": "ゲームでヘルスポイントのりゃくごは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MP",
+        "ja": "MP",
+        "ja_typings": []
+      },
+      {
+        "en": "HP",
+        "ja": "HP",
+        "ja_typings": []
+      },
+      {
+        "en": "SP",
+        "ja": "SP",
+        "ja_typings": []
+      },
+      {
+        "en": "FP",
+        "ja": "FP",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00447",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'magic points' abbreviated as in games?",
+      "ja": "ゲームでまほうぽいんとのりゃくごは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Non-Player Character",
+        "ja": "のんぷれいやーキャラクター",
+        "ja_typings": []
+      },
+      {
+        "en": "New Player Content",
+        "ja": "にゅーぷれいやーこんてんつ",
+        "ja_typings": []
+      },
+      {
+        "en": "Next Play Control",
+        "ja": "ねくすとぷれいこんとろーる",
+        "ja_typings": []
+      },
+      {
+        "en": "Network Play Connection",
+        "ja": "ねっとわーくぷれいせつぞく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00448",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'NPC' mean in video games?",
+      "ja": "ビデオゲームのNPCのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Downloadable Content",
+        "ja": "だうんろーどかのうなこんてんつ",
+        "ja_typings": []
+      },
+      {
+        "en": "Dynamic Level Content",
+        "ja": "どうてきれべるこんてんつ",
+        "ja_typings": []
+      },
+      {
+        "en": "Direct Link Connection",
+        "ja": "ちょくせつりんくせつぞく",
+        "ja_typings": []
+      },
+      {
+        "en": "Dual-Layer Cartridge",
+        "ja": "だぶるれいやーかーとりっじ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00449",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'DLC' in gaming?",
+      "ja": "ゲームのDLCのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "repeatedly fighting to gain levels",
+        "ja": "くりかえしたたかってれべるあげ",
+        "ja_typings": []
+      },
+      {
+        "en": "crafting items",
+        "ja": "どうぐをつくる",
+        "ja_typings": []
+      },
+      {
+        "en": "exploring new areas",
+        "ja": "あたらしいりょいきをたんさく",
+        "ja_typings": []
+      },
+      {
+        "en": "completing side quests",
+        "ja": "サブクエストをクリア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00450",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'grinding' in RPGs?",
+      "ja": "RPGの「ぐらいんど」とは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "random in-game reward container",
+        "ja": "らんだむなゲームないほうしゅうコンテナ",
+        "ja_typings": []
+      },
+      {
+        "en": "storage for items",
+        "ja": "アイテムのほぞんぼっくす",
+        "ja_typings": []
+      },
+      {
+        "en": "chest with guaranteed rewards",
+        "ja": "ほしょうりわーどのはこ",
+        "ja_typings": []
+      },
+      {
+        "en": "enemy drop container",
+        "ja": "てきのどろっぷコンテナ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00451",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'loot box'?",
+      "ja": "るーとぼっくすとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "hidden joke or secret by developers",
+        "ja": "かいはつしゃのかくされたじょーくやひみつ",
+        "ja_typings": []
+      },
+      {
+        "en": "seasonal event content",
+        "ja": "きせつイベントコンテンツ",
+        "ja_typings": []
+      },
+      {
+        "en": "bonus stage at the end",
+        "ja": "さいごのぼーなすすてーじ",
+        "ja_typings": []
+      },
+      {
+        "en": "collectible egg item",
+        "ja": "しゅうしゅうひんのたまご",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00452",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an 'Easter egg' in games?",
+      "ja": "ゲームのイースターたまごとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "completing a game as fast as possible",
+        "ja": "できるだけはやくゲームをクリア",
+        "ja_typings": []
+      },
+      {
+        "en": "racing mini-game mode",
+        "ja": "れーすのみにゲームもーど",
+        "ja_typings": []
+      },
+      {
+        "en": "skipping all cutscenes",
+        "ja": "すべてのカットシーンをスキップ",
+        "ja_typings": []
+      },
+      {
+        "en": "playing on highest difficulty",
+        "ja": "さいこうなんどでぷれい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00453",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'speedrunning'?",
+      "ja": "すぴーどらんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "First-Person Shooter",
+        "ja": "いちにんしょうシューター",
+        "ja_typings": []
+      },
+      {
+        "en": "Fast Pacing System",
+        "ja": "こうそくぺーすしすてむ",
+        "ja_typings": []
+      },
+      {
+        "en": "Full Player Score",
+        "ja": "ふるぷれいやーすこあ",
+        "ja_typings": []
+      },
+      {
+        "en": "Frames Per Second gaming",
+        "ja": "ふれーむぱーせかんどゲーム",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00454",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'FPS' as a game genre?",
+      "ja": "ゲームジャンルとしてのFPSとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Multiplayer Online Battle Arena",
+        "ja": "たにんぷれいおんらいんばとるあれな",
+        "ja_typings": []
+      },
+      {
+        "en": "Mobile Online Battle App",
+        "ja": "もばいるおんらいんばとるあぷ",
+        "ja_typings": []
+      },
+      {
+        "en": "Modern Open Battle Action",
+        "ja": "もだんおーぷんばとるあくしょん",
+        "ja_typings": []
+      },
+      {
+        "en": "Multi-Object Battle Assignment",
+        "ja": "ふくすうもくひょうばとるかだい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00455",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'MOBA' as a game genre?",
+      "ja": "ゲームジャンルとしてのMOBAとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Minecraft",
+        "ja": "まいんくらふと",
+        "ja_typings": []
+      },
+      {
+        "en": "Terraria",
+        "ja": "てらりあ",
+        "ja_typings": []
+      },
+      {
+        "en": "Fortnite",
+        "ja": "ふぉーとないと",
+        "ja_typings": []
+      },
+      {
+        "en": "Roblox",
+        "ja": "ろぶろっくす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00456",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game has 'Creepers' as enemies?",
+      "ja": "クリーパーがてきとしてとうじょうするゲームは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "the classic overworld theme",
+        "ja": "クラシックなマップテーマ",
+        "ja_typings": []
+      },
+      {
+        "en": "a pop song",
+        "ja": "ぽっぷそんぐ",
+        "ja_typings": []
+      },
+      {
+        "en": "a battle anthem",
+        "ja": "せんとうのひめい",
+        "ja_typings": []
+      },
+      {
+        "en": "the Zelda lullaby",
+        "ja": "ぜるだのこもりうた",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00457",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the iconic opening music of the original Legend of Zelda?",
+      "ja": "ゼルダのでんせつのアイコニックなオープニング音楽は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "defeat a boss without taking damage",
+        "ja": "ダメージをうけずにボスをたおす",
+        "ja_typings": []
+      },
+      {
+        "en": "defeat a boss in one hit",
+        "ja": "いちげきでボスをたおす",
+        "ja_typings": []
+      },
+      {
+        "en": "fight boss with no weapons",
+        "ja": "ぶきなしでボスとたたかう",
+        "ja_typings": []
+      },
+      {
+        "en": "kill boss before it attacks",
+        "ja": "ボスがこうげきするまえにたおす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00458",
+    "image_path": null,
+    "question_text": {
+      "en": "What does it mean to 'no-hit' a boss?",
+      "ja": "ボスを「のーひっと」するとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "player has failed and must restart",
+        "ja": "プレイヤーがしっぱいしてやりなおし",
+        "ja_typings": []
+      },
+      {
+        "en": "the game is completed",
+        "ja": "ゲームがクリアされた",
+        "ja_typings": []
+      },
+      {
+        "en": "a multiplayer session ends",
+        "ja": "たにんぷれいのせっしょんが終わった",
+        "ja_typings": []
+      },
+      {
+        "en": "a loading screen appears",
+        "ja": "ろーどがめんがひょうじ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00459",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Game Over' traditionally?",
+      "ja": "「ゲームオーバー」はどういいみか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "cooperative multiplayer gameplay",
+        "ja": "きょうりょくたにんぷれい",
+        "ja_typings": []
+      },
+      {
+        "en": "competitive multiplayer",
+        "ja": "きょうそうたにんぷれい",
+        "ja_typings": []
+      },
+      {
+        "en": "single player with AI partner",
+        "ja": "AIぱーとなーとのたんどく",
+        "ja_typings": []
+      },
+      {
+        "en": "online ranking system",
+        "ja": "おんらいんらんきんぐしすてむ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00460",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'co-op' gaming?",
+      "ja": "こおぷゲームとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "open-world with player freedom",
+        "ja": "プレイヤーのじゆうなおーぷんわーるど",
+        "ja_typings": []
+      },
+      {
+        "en": "game played in physical sandbox",
+        "ja": "ぶつりてきなすなばでのゲーム",
+        "ja_typings": []
+      },
+      {
+        "en": "game with no objectives",
+        "ja": "もくてきのないゲーム",
+        "ja_typings": []
+      },
+      {
+        "en": "children's educational game",
+        "ja": "こどものきょういくゲーム",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00461",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'sandbox' game?",
+      "ja": "さんどぼっくすゲームとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Resident Evil",
+        "ja": "ばいおはざーど",
+        "ja_typings": []
+      },
+      {
+        "en": "Devil May Cry",
+        "ja": "でびるめいくらい",
+        "ja_typings": []
+      },
+      {
+        "en": "Street Fighter",
+        "ja": "すとりーとふぁいたー",
+        "ja_typings": []
+      },
+      {
+        "en": "Monster Hunter",
+        "ja": "もんすたーはんたー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00462",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Capcom game series features Leon Kennedy and Chris Redfield?",
+      "ja": "れおんけねでぃとくりすれっどふぃーるどのカプコンシリーズは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "instant hit detection along line of sight",
+        "ja": "しやのびょうしょくにそくじあたりはんてい",
+        "ja_typings": []
+      },
+      {
+        "en": "projectile with travel time",
+        "ja": "ひこうじかんのあるだんがん",
+        "ja_typings": []
+      },
+      {
+        "en": "melee hit detection",
+        "ja": "きんせんこうげきはんてい",
+        "ja_typings": []
+      },
+      {
+        "en": "player detection system",
+        "ja": "プレイヤーはんていしすてむ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00463",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'hit scan' in FPS games?",
+      "ja": "FPSのひっとすきゃんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "high latency causing delay",
+        "ja": "こうれいてんしーによるおくれ",
+        "ja_typings": []
+      },
+      {
+        "en": "slow frame rate",
+        "ja": "ていふれーむれーと",
+        "ja_typings": []
+      },
+      {
+        "en": "server maintenance window",
+        "ja": "さーばーめんてなんすのじかん",
+        "ja_typings": []
+      },
+      {
+        "en": "game crash event",
+        "ja": "ゲームのくらっしゅ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00464",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'lag' in online gaming?",
+      "ja": "おんらいんゲームのらぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "open-world action-adventure",
+        "ja": "おーぷんわーるどアクションぼうけん",
+        "ja_typings": []
+      },
+      {
+        "en": "linear JRPG",
+        "ja": "いちじゅんのJRPG",
+        "ja_typings": []
+      },
+      {
+        "en": "turn-based strategy",
+        "ja": "ターンせいすとらてじー",
+        "ja_typings": []
+      },
+      {
+        "en": "racing game",
+        "ja": "れーすゲーム",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00465",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game is famous for 'The Legend of Zelda: Breath of the Wild'?",
+      "ja": "ゼルダのでんせつ ブレスオブザワイルドはどんなゲームか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nintendo Switch",
+        "ja": "にんてんどうスイッチ",
+        "ja_typings": []
+      },
+      {
+        "en": "Sony Switch",
+        "ja": "そにースイッチ",
+        "ja_typings": []
+      },
+      {
+        "en": "Xbox Switch",
+        "ja": "えっくすぼっくすスイッチ",
+        "ja_typings": []
+      },
+      {
+        "en": "Sega Switch",
+        "ja": "せがスイッチ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00466",
+    "image_path": null,
+    "question_text": {
+      "en": "What console is the Switch?",
+      "ja": "スイッチはどのゲームきか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "capture opponent's king",
+        "ja": "あいてのきんぐをつかまえる",
+        "ja_typings": []
+      },
+      {
+        "en": "collect all opponent pieces",
+        "ja": "あいてのこまをすべてとる",
+        "ja_typings": []
+      },
+      {
+        "en": "reach opponent's back row",
+        "ja": "あいてのうしろのれつにとどく",
+        "ja_typings": []
+      },
+      {
+        "en": "earn the most points",
+        "ja": "もっともてんすうをかくとく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00467",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the objective in chess?",
+      "ja": "チェスのもくてきは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Player versus Player",
+        "ja": "プレイヤー対プレイヤー",
+        "ja_typings": []
+      },
+      {
+        "en": "Platform versus Platform",
+        "ja": "ぷらっとふぉーむたいぷらっとふぉーむ",
+        "ja_typings": []
+      },
+      {
+        "en": "Points versus Progress",
+        "ja": "てんすうたいしんちょく",
+        "ja_typings": []
+      },
+      {
+        "en": "Procedural versus Pre-made",
+        "ja": "じどうたいてづくり",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00468",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'PvP' in games?",
+      "ja": "ゲームのPvPとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Player versus Environment",
+        "ja": "プレイヤー対かんきょう",
+        "ja_typings": []
+      },
+      {
+        "en": "Player versus Enemy",
+        "ja": "プレイヤー対てき",
+        "ja_typings": []
+      },
+      {
+        "en": "Player versus Events",
+        "ja": "プレイヤー対イベント",
+        "ja_typings": []
+      },
+      {
+        "en": "Points versus Experience",
+        "ja": "てんすうたいたいけんち",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00469",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'PvE' in games?",
+      "ja": "ゲームのPvEとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "temporary enhancement to character stats",
+        "ja": "キャラのすたーつのいちじてきこうじょう",
+        "ja_typings": []
+      },
+      {
+        "en": "attack that hits multiple enemies",
+        "ja": "ふくすうのてきにあたるこうげき",
+        "ja_typings": []
+      },
+      {
+        "en": "item that restores health",
+        "ja": "HPをかいふくするアイテム",
+        "ja_typings": []
+      },
+      {
+        "en": "armor ability upgrade",
+        "ja": "よろいののうりょくきょうか",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00470",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'buff' in games?",
+      "ja": "ゲームのばふとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "weakening something overpowered",
+        "ja": "つよすぎるものをよわくする",
+        "ja_typings": []
+      },
+      {
+        "en": "strengthening something weak",
+        "ja": "よわいものをつよくする",
+        "ja_typings": []
+      },
+      {
+        "en": "removing a character",
+        "ja": "キャラをさくじょ",
+        "ja_typings": []
+      },
+      {
+        "en": "adding new content",
+        "ja": "あたらしいこんてんつをついか",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00471",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'nerf' in game balance?",
+      "ja": "ゲームバランスのなーふとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Capcom",
+        "ja": "かぷこむ",
+        "ja_typings": []
+      },
+      {
+        "en": "SNK",
+        "ja": "えすえぬけー",
+        "ja_typings": []
+      },
+      {
+        "en": "Namco",
+        "ja": "なむこ",
+        "ja_typings": []
+      },
+      {
+        "en": "Midway",
+        "ja": "みっどうぇい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00472",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company made Street Fighter?",
+      "ja": "すとりーとふぁいたーをつくったかいしゃは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Breakout",
+        "ja": "ぶれいくあうと",
+        "ja_typings": []
+      },
+      {
+        "en": "Pong",
+        "ja": "ぽんぐ",
+        "ja_typings": []
+      },
+      {
+        "en": "Space Invaders",
+        "ja": "すぺーすいんべーだーず",
+        "ja_typings": []
+      },
+      {
+        "en": "Galaga",
+        "ja": "ぎゃらが",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00473",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the classic arcade game where you break bricks with a ball?",
+      "ja": "ぼーるでれんがをこわすクラシックアーケードゲームは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "League of Legends",
+        "ja": "りーぐおぶれじぇんず",
+        "ja_typings": []
+      },
+      {
+        "en": "Dota 2",
+        "ja": "どーたつー",
+        "ja_typings": []
+      },
+      {
+        "en": "Smite",
+        "ja": "すまいと",
+        "ja_typings": []
+      },
+      {
+        "en": "Heroes of the Storm",
+        "ja": "ひーろーずおぶざすとーむ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00474",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the most popular MOBA game?",
+      "ja": "もっとにんきのあるMOBAゲームは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "dark fantasy medieval world",
+        "ja": "くらいふぁんたじーのちゅうせいせかい",
+        "ja_typings": []
+      },
+      {
+        "en": "futuristic cyberpunk city",
+        "ja": "みらいのさいばーぱんくとし",
+        "ja_typings": []
+      },
+      {
+        "en": "ancient Japan",
+        "ja": "こだいのにほん",
+        "ja_typings": []
+      },
+      {
+        "en": "post-apocalyptic USA",
+        "ja": "ぶんめいほうかいごのアメリカ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00475",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the setting of 'The Witcher' series?",
+      "ja": "ウィッチャーシリーズの舞台は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "reviving after death to continue play",
+        "ja": "しんでもふっかつしてぷれいをつづける",
+        "ja_typings": []
+      },
+      {
+        "en": "loading a save file",
+        "ja": "さらにゅうのろーど",
+        "ja_typings": []
+      },
+      {
+        "en": "starting the game over",
+        "ja": "ゲームをさいしょからやりなおす",
+        "ja_typings": []
+      },
+      {
+        "en": "switching to a new character",
+        "ja": "あたらしいキャラにきりかえる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00476",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'respawning' in games?",
+      "ja": "ゲームのりすぽーんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wood, Stone, Metal",
+        "ja": "もく、いし、きんぞく",
+        "ja_typings": []
+      },
+      {
+        "en": "Gold Coins",
+        "ja": "きんか",
+        "ja_typings": []
+      },
+      {
+        "en": "Bricks",
+        "ja": "れんが",
+        "ja_typings": []
+      },
+      {
+        "en": "Crystal",
+        "ja": "クリスタル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00477",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the main resource in Fortnite for building?",
+      "ja": "フォートナイトでけんちくにつかうまいんりそーすは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "in-game award for completing a challenge",
+        "ja": "ちゃれんじクリアのゲームないほうしょう",
+        "ja_typings": []
+      },
+      {
+        "en": "final game completion screen",
+        "ja": "ゲームのさいしゅうクリアがめん",
+        "ja_typings": []
+      },
+      {
+        "en": "high score record",
+        "ja": "ハイスコアきろく",
+        "ja_typings": []
+      },
+      {
+        "en": "unlocked weapon or item",
+        "ja": "かいじょされたぶきやアイテム",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00478",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an 'achievement' in games?",
+      "ja": "ゲームのあちーぶめんととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "number of frames rendered per second",
+        "ja": "いちびょうあたりのふれーむすう",
+        "ja_typings": []
+      },
+      {
+        "en": "game difficulty level",
+        "ja": "ゲームのなんいどれべる",
+        "ja_typings": []
+      },
+      {
+        "en": "internet connection speed",
+        "ja": "いんたーねっとせつぞくそくど",
+        "ja_typings": []
+      },
+      {
+        "en": "animation smoothness setting",
+        "ja": "あにめーしょんなめらかさのせってい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00479",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'frame rate' in games?",
+      "ja": "ゲームのふれーむれーととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "synchronizing frame rate with display refresh",
+        "ja": "ふれーむれーとをてぃすぷれいのりふれっしゅにどうき",
+        "ja_typings": []
+      },
+      {
+        "en": "vertical screen split mode",
+        "ja": "すいちょくがめんぶんかつもーど",
+        "ja_typings": []
+      },
+      {
+        "en": "voice sync for multiplayer",
+        "ja": "たにんぷれいのおんせいどうき",
+        "ja_typings": []
+      },
+      {
+        "en": "video quality setting",
+        "ja": "どうがひんしつのせってい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00480",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'V-sync' in gaming?",
+      "ja": "ゲームのVsyncとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "one of the first arcade video games",
+        "ja": "さいしょきのアーケードビデオゲーム",
+        "ja_typings": []
+      },
+      {
+        "en": "a pinball machine",
+        "ja": "ぴんぼーるましん",
+        "ja_typings": []
+      },
+      {
+        "en": "a Nintendo handheld game",
+        "ja": "にんてんどうけいたいゲーム",
+        "ja_typings": []
+      },
+      {
+        "en": "an Atari driving game",
+        "ja": "あたりのどらいびんぐゲーム",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00481",
+    "image_path": null,
+    "question_text": {
+      "en": "What was Pong?",
+      "ja": "ぽんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "shooter genre with extremely dense projectiles",
+        "ja": "だんがんびっしりのシューターゲーム",
+        "ja_typings": []
+      },
+      {
+        "en": "shooter with single large bullet",
+        "ja": "おおきなたまひとつのシューター",
+        "ja_typings": []
+      },
+      {
+        "en": "physical shooting game",
+        "ja": "ぶつりてきしゃげきゲーム",
+        "ja_typings": []
+      },
+      {
+        "en": "sword-fighting game",
+        "ja": "けんとうゲーム",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00482",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'bullet hell' in games?",
+      "ja": "ゲームのたんまくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "location where game progress is saved",
+        "ja": "ゲームのしんちょくをほぞんするばしょ",
+        "ja_typings": []
+      },
+      {
+        "en": "checkpoint that restores health",
+        "ja": "HPをかいふくするチェックポイント",
+        "ja_typings": []
+      },
+      {
+        "en": "item for saving inventory",
+        "ja": "インベントリほぞんアイテム",
+        "ja_typings": []
+      },
+      {
+        "en": "the game's final destination",
+        "ja": "ゲームのさいしゅうもくてき",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00483",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'save point'?",
+      "ja": "せーぶぽいんととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "large freely explorable environment",
+        "ja": "おおきくじゆうにたんさくできるかんきょう",
+        "ja_typings": []
+      },
+      {
+        "en": "game with no story",
+        "ja": "ものがたりのないゲーム",
+        "ja_typings": []
+      },
+      {
+        "en": "multiplayer game world",
+        "ja": "たにんぷれいのゲームせかい",
+        "ja_typings": []
+      },
+      {
+        "en": "game with random world generation",
+        "ja": "らんだむせいせいのゲームせかい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00484",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'open world' in games?",
+      "ja": "ゲームのおーぷんわーるどとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "players take turns to act",
+        "ja": "プレイヤーがじゅんばんにこうどう",
+        "ja_typings": []
+      },
+      {
+        "en": "real-time combat",
+        "ja": "りあるたいむせんとう",
+        "ja_typings": []
+      },
+      {
+        "en": "automatic combat system",
+        "ja": "じどうせんとうしすてむ",
+        "ja_typings": []
+      },
+      {
+        "en": "time-limited battle mode",
+        "ja": "じかんせいのバトルもーど",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00485",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'turn-based' combat?",
+      "ja": "ターンせいせんとうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "strategy game with real-time gameplay",
+        "ja": "りあるたいむのすとらてじーゲーム",
+        "ja_typings": []
+      },
+      {
+        "en": "racing strategy game",
+        "ja": "れーすすとらてじーゲーム",
+        "ja_typings": []
+      },
+      {
+        "en": "real-world problem simulation",
+        "ja": "げんじつもんだいのしみゅれーしょん",
+        "ja_typings": []
+      },
+      {
+        "en": "online team strategy game",
+        "ja": "おんらいんちーむすとらてじー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00486",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'real-time strategy' (RTS)?",
+      "ja": "りあるたいむすとらてじーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "update fixing bugs or balancing",
+        "ja": "ばぐのしゅうせいやバランスのこうしん",
+        "ja_typings": []
+      },
+      {
+        "en": "new game level",
+        "ja": "あたらしいゲームれべる",
+        "ja_typings": []
+      },
+      {
+        "en": "skin or appearance pack",
+        "ja": "スキンやがいかんぱっく",
+        "ja_typings": []
+      },
+      {
+        "en": "seasonal game event",
+        "ja": "きせつゲームイベント",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00487",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'patch' in gaming?",
+      "ja": "ゲームのぱっちとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "multiplatform",
+        "ja": "まるちぷらっとふぉーむ",
+        "ja_typings": []
+      },
+      {
+        "en": "cross-play",
+        "ja": "くろすぷれい",
+        "ja_typings": []
+      },
+      {
+        "en": "universal",
+        "ja": "ゆにばーさる",
+        "ja_typings": []
+      },
+      {
+        "en": "platform-agnostic",
+        "ja": "ぷらっとふぉーむぎょうとく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00488",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the term for games released on multiple platforms?",
+      "ja": "ふくすうぷらっとふぉームでリリースされるゲームのようごは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "game where player jumps between platforms",
+        "ja": "プレイヤーがぷらっとふぉーむをとびわたるゲーム",
+        "ja_typings": []
+      },
+      {
+        "en": "game played on game console platform",
+        "ja": "ゲームきぷらっとふぉームで遊ぶゲーム",
+        "ja_typings": []
+      },
+      {
+        "en": "game about building platforms",
+        "ja": "ぷらっとふぉームをけんちくするゲーム",
+        "ja_typings": []
+      },
+      {
+        "en": "game with online platform features",
+        "ja": "おんらいんぷらっとふぁむきのうつきゲーム",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00489",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'platformer' game?",
+      "ja": "ぷらっとふぉーまーゲームとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "exploration game with abilities unlocking new areas",
+        "ja": "のうりょくかいじょで新エリアを探索",
+        "ja_typings": []
+      },
+      {
+        "en": "space exploration game",
+        "ja": "うちゅうたんさくゲーム",
+        "ja_typings": []
+      },
+      {
+        "en": "game combining Metroid and Castlevania mechanics",
+        "ja": "めとろいどとかすとるばにあのゲームシステムを合わせたゲーム",
+        "ja_typings": []
+      },
+      {
+        "en": "horror survival platformer",
+        "ja": "ほらーさばいばるぷらっとふぁーまー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00490",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Metroidvania' genre?",
+      "ja": "めとろいどばにあジャンルとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "9th generation",
+        "ja": "きゅうせだい",
+        "ja_typings": []
+      },
+      {
+        "en": "8th generation",
+        "ja": "はちせだい",
+        "ja_typings": []
+      },
+      {
+        "en": "10th generation",
+        "ja": "じゅっせだい",
+        "ja_typings": []
+      },
+      {
+        "en": "7th generation",
+        "ja": "ななせだい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00491",
+    "image_path": null,
+    "question_text": {
+      "en": "What console generation is the PlayStation 5?",
+      "ja": "プレイステーション5は何世代目のゲームきか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "game made without major publisher",
+        "ja": "大手ぱぶりっしゃーなしのゲーム",
+        "ja_typings": []
+      },
+      {
+        "en": "game for mobile only",
+        "ja": "モバイルのみのゲーム",
+        "ja_typings": []
+      },
+      {
+        "en": "foreign import game",
+        "ja": "がいこくゆにゅうゲーム",
+        "ja_typings": []
+      },
+      {
+        "en": "in-development unreleased game",
+        "ja": "かいはつちゅうのみリリースゲーム",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00492",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an 'indie game'?",
+      "ja": "いんでぃゲームとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PC game distribution platform",
+        "ja": "PCゲームはいしんぷらっとふぁーむ",
+        "ja_typings": []
+      },
+      {
+        "en": "game development engine",
+        "ja": "ゲーム開発エンジン",
+        "ja_typings": []
+      },
+      {
+        "en": "console by Valve",
+        "ja": "Valveのゲームき",
+        "ja_typings": []
+      },
+      {
+        "en": "game streaming service",
+        "ja": "ゲームはいしんさーびす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00493",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Steam?",
+      "ja": "Steamとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Japanese comic book style",
+        "ja": "にほんのまんがスタイル",
+        "ja_typings": []
+      },
+      {
+        "en": "Japanese animation",
+        "ja": "にほんのアニメーション",
+        "ja_typings": []
+      },
+      {
+        "en": "Japanese novel",
+        "ja": "にほんのしょうせつ",
+        "ja_typings": []
+      },
+      {
+        "en": "Japanese film",
+        "ja": "にほんのえいが",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00494",
+    "image_path": null,
+    "question_text": {
+      "en": "What is manga?",
+      "ja": "まんがとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Akira Toriyama",
+        "ja": "とりやまあきら",
+        "ja_typings": []
+      },
+      {
+        "en": "Eiichiro Oda",
+        "ja": "おだえいいちろう",
+        "ja_typings": []
+      },
+      {
+        "en": "Masashi Kishimoto",
+        "ja": "きしもとまさし",
+        "ja_typings": []
+      },
+      {
+        "en": "Tite Kubo",
+        "ja": "くぼたいと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00495",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Dragon Ball manga?",
+      "ja": "ドラゴンボールのまんがをかいたのは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "One Piece",
+        "ja": "わんぴーす",
+        "ja_typings": []
+      },
+      {
+        "en": "Dragon Ball",
+        "ja": "どらごんぼーる",
+        "ja_typings": []
+      },
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": []
+      },
+      {
+        "en": "Demon Slayer",
+        "ja": "きめつのやいば",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00496",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the best-selling manga of all time?",
+      "ja": "もっともうれたまんがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Weekly Shonen Jump",
+        "ja": "しゅうかんしょうねんじゃんぷ",
+        "ja_typings": []
+      },
+      {
+        "en": "Weekly Shonen Magazine",
+        "ja": "しゅうかんしょうねんまがじん",
+        "ja_typings": []
+      },
+      {
+        "en": "Big Comic Spirits",
+        "ja": "びっぐこみっくすぴりっつ",
+        "ja_typings": []
+      },
+      {
+        "en": "Shonen Sunday",
+        "ja": "しょうねんさんでー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00497",
+    "image_path": null,
+    "question_text": {
+      "en": "What magazine did Naruto run in?",
+      "ja": "ナルトが掲載されていたざっしは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "collected manga volume",
+        "ja": "まんがのたんこうぼん",
+        "ja_typings": []
+      },
+      {
+        "en": "chapter running in magazine",
+        "ja": "ざっしけいさいのかい",
+        "ja_typings": []
+      },
+      {
+        "en": "limited edition release",
+        "ja": "かいていばんのはっぴょう",
+        "ja_typings": []
+      },
+      {
+        "en": "manga digital format",
+        "ja": "まんがのでじたるけいしき",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00498",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'tankoubon'?",
+      "ja": "たんこうぼんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "adult men",
+        "ja": "せいじんだんせい",
+        "ja_typings": []
+      },
+      {
+        "en": "young boys",
+        "ja": "しょうねん",
+        "ja_typings": []
+      },
+      {
+        "en": "young girls",
+        "ja": "しょうじょ",
+        "ja_typings": []
+      },
+      {
+        "en": "adult women",
+        "ja": "せいじんじょせい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00499",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'seinen' manga targeted at?",
+      "ja": "せいねんまんがはなにをたいしょうとしているか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "adult women",
+        "ja": "せいじんじょせい",
+        "ja_typings": []
+      },
+      {
+        "en": "young girls",
+        "ja": "しょうじょ",
+        "ja_typings": []
+      },
+      {
+        "en": "adult men",
+        "ja": "せいじんだんせい",
+        "ja_typings": []
+      },
+      {
+        "en": "young boys",
+        "ja": "しょうねん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00500",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'josei' manga targeted at?",
+      "ja": "じょせいまんがはなにをたいしょうとしているか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "manga artist",
+        "ja": "まんがか",
+        "ja_typings": []
+      },
+      {
+        "en": "manga publisher",
+        "ja": "まんがのしゅっぱんしゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "manga reader",
+        "ja": "まんがのどくしゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "manga editor",
+        "ja": "まんがのへんしゅうしゃ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00501",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'manga-ka' mean?",
+      "ja": "まんがかとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "reading guide for kanji",
+        "ja": "かんじのよみがたのてびき",
+        "ja_typings": []
+      },
+      {
+        "en": "sound effect text",
+        "ja": "おんさようのてきすと",
+        "ja_typings": []
+      },
+      {
+        "en": "speech bubble text",
+        "ja": "ふきだしのてきすと",
+        "ja_typings": []
+      },
+      {
+        "en": "character name label",
+        "ja": "キャラのなまえのらべる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00502",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'furigana' in manga?",
+      "ja": "まんがのふりがなとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kentaro Miura",
+        "ja": "みうらけんたろう",
+        "ja_typings": []
+      },
+      {
+        "en": "Hajime Isayama",
+        "ja": "いさやまはじめ",
+        "ja_typings": []
+      },
+      {
+        "en": "Hirohiko Araki",
+        "ja": "あらきひろひこ",
+        "ja_typings": []
+      },
+      {
+        "en": "Rumiko Takahashi",
+        "ja": "たかはしるみこ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00503",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created the manga 'Berserk'?",
+      "ja": "まんが「ベルセルク」をかいたのは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "a hero so powerful he defeats enemies in one punch",
+        "ja": "いちげきでてきをたおすひーろー",
+        "ja_typings": []
+      },
+      {
+        "en": "a boxing champion",
+        "ja": "ぼくしんぐのチャンピオン",
+        "ja_typings": []
+      },
+      {
+        "en": "a cook who fights with food",
+        "ja": "たべもので戦うりょうりにん",
+        "ja_typings": []
+      },
+      {
+        "en": "a school delinquent",
+        "ja": "こうこうのふりょう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00504",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the manga 'One Punch Man' about?",
+      "ja": "まんが「ワンパンマン」はなにについてか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Berserk",
+        "ja": "べるせるく",
+        "ja_typings": []
+      },
+      {
+        "en": "Doraemon",
+        "ja": "どらえもん",
+        "ja_typings": []
+      },
+      {
+        "en": "Crayon Shin-chan",
+        "ja": "くれよんしんちゃん",
+        "ja_typings": []
+      },
+      {
+        "en": "Yotsuba",
+        "ja": "よつばと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00505",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga is known for its intricate artwork style?",
+      "ja": "ふくざつなえのまんがで知られるのは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Astro Boy",
+        "ja": "てつわんあとむ",
+        "ja_typings": []
+      },
+      {
+        "en": "Doraemon",
+        "ja": "どらえもん",
+        "ja_typings": []
+      },
+      {
+        "en": "Sailor Moon",
+        "ja": "せーらーむーん",
+        "ja_typings": []
+      },
+      {
+        "en": "Dragon Ball",
+        "ja": "どらごんぼーる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00506",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the most famous work of Osamu Tezuka?",
+      "ja": "てづかおさむのもっともゆうめいなさくひんは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "action and adventure for young boys",
+        "ja": "しょうねんのアクションとぼうけん",
+        "ja_typings": []
+      },
+      {
+        "en": "romance for young girls",
+        "ja": "しょうじょのれんあい",
+        "ja_typings": []
+      },
+      {
+        "en": "everyday life stories",
+        "ja": "にちじょうせいかつのはなし",
+        "ja_typings": []
+      },
+      {
+        "en": "historical drama",
+        "ja": "れきしのどらま",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00507",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Shonen' manga primarily about?",
+      "ja": "しょうねんまんがのおもなないようは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JoJo's Bizarre Adventure",
+        "ja": "じょじょのきみょうなぼうけん",
+        "ja_typings": []
+      },
+      {
+        "en": "Fist of the North Star",
+        "ja": "ほくとのけん",
+        "ja_typings": []
+      },
+      {
+        "en": "Vinland Saga",
+        "ja": "ゔぃんらんどさが",
+        "ja_typings": []
+      },
+      {
+        "en": "Kingdom",
+        "ja": "きんぐだむ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00508",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga follows the Joestars across multiple generations?",
+      "ja": "じょえすたーけのものがたりのまんがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Korean-style digital vertical scroll comic",
+        "ja": "かんこくしきのたてなが電子まんが",
+        "ja_typings": []
+      },
+      {
+        "en": "animated manga episode",
+        "ja": "アニメかされたまんがのわ",
+        "ja_typings": []
+      },
+      {
+        "en": "Japanese manga on web",
+        "ja": "ウェブのにほんまんが",
+        "ja_typings": []
+      },
+      {
+        "en": "manga with animated panels",
+        "ja": "うごくコマのまんが",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00509",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'webtoon'?",
+      "ja": "うぇぶとぅーんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tite Kubo",
+        "ja": "くぼたいと",
+        "ja_typings": []
+      },
+      {
+        "en": "Masashi Kishimoto",
+        "ja": "きしもとまさし",
+        "ja_typings": []
+      },
+      {
+        "en": "Akira Toriyama",
+        "ja": "とりやまあきら",
+        "ja_typings": []
+      },
+      {
+        "en": "Eiichiro Oda",
+        "ja": "おだえいいちろう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00510",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Bleach?",
+      "ja": "ブリーチをかいたのは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "psychological thriller manga",
+        "ja": "しんりすりらーまんが",
+        "ja_typings": []
+      },
+      {
+        "en": "sports manga",
+        "ja": "すぽーつまんが",
+        "ja_typings": []
+      },
+      {
+        "en": "romantic comedy manga",
+        "ja": "ろまんてぃっくこめでぃまんが",
+        "ja_typings": []
+      },
+      {
+        "en": "sci-fi adventure manga",
+        "ja": "さいえんすふぃくしょんぼうけんまんが",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00511",
+    "image_path": null,
+    "question_text": {
+      "en": "What type of story is 'Monster' by Naoki Urasawa?",
+      "ja": "うらさわなおきのモンスターはどんなものがたりか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "self-published fan comic",
+        "ja": "じがんのファンまんが",
+        "ja_typings": []
+      },
+      {
+        "en": "official manga chapter",
+        "ja": "こうしきのまんがかい",
+        "ja_typings": []
+      },
+      {
+        "en": "licensed manga reprint",
+        "ja": "きょかずみのまんがさいはん",
+        "ja_typings": []
+      },
+      {
+        "en": "manga award winner",
+        "ja": "まんがしょうじゅしょうさく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00512",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'doujinshi'?",
+      "ja": "どうじんしとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Inuyasha",
+        "ja": "いぬやしゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "Rurouni Kenshin",
+        "ja": "るろうにけんしん",
+        "ja_typings": []
+      },
+      {
+        "en": "Vagabond",
+        "ja": "バガボンド",
+        "ja_typings": []
+      },
+      {
+        "en": "Blade of the Immortal",
+        "ja": "むげんのじゅうにん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00513",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga is about a time-traveling story in feudal Japan?",
+      "ja": "せんごくじだいのにほんにタイムトラベルするまんがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "a curious 5-year-old girl's daily life",
+        "ja": "ごさいのしょうじょのにちじょう",
+        "ja_typings": []
+      },
+      {
+        "en": "a fantasy adventure",
+        "ja": "ふぁんたじーぼうけん",
+        "ja_typings": []
+      },
+      {
+        "en": "a high school romance",
+        "ja": "こうこうのれんあい",
+        "ja_typings": []
+      },
+      {
+        "en": "a sports tournament",
+        "ja": "すぽーつたいかい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00514",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the manga 'Yotsubato!' about?",
+      "ja": "まんが「よつばと!」はなにについてか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kingdom",
+        "ja": "きんぐだむ",
+        "ja_typings": []
+      },
+      {
+        "en": "Vagabond",
+        "ja": "バガボンド",
+        "ja_typings": []
+      },
+      {
+        "en": "Lone Wolf and Cub",
+        "ja": "こかみのおおかみ",
+        "ja_typings": []
+      },
+      {
+        "en": "Vinland Saga",
+        "ja": "ゔぃんらんどさが",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00515",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga series is set in ancient China?",
+      "ja": "こだいちゅうごくをぶたいにしたまんがシリーズは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Eiichiro Oda",
+        "ja": "おだえいいちろう",
+        "ja_typings": []
+      },
+      {
+        "en": "Masashi Kishimoto",
+        "ja": "きしもとまさし",
+        "ja_typings": []
+      },
+      {
+        "en": "Akira Toriyama",
+        "ja": "とりやまあきら",
+        "ja_typings": []
+      },
+      {
+        "en": "Rumiko Takahashi",
+        "ja": "たかはしるみこ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00516",
+    "image_path": null,
+    "question_text": {
+      "en": "Who draws One Piece?",
+      "ja": "ワンピースをかいているのは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vikings in medieval Europe",
+        "ja": "ちゅうせいヨーロッパのバイキング",
+        "ja_typings": []
+      },
+      {
+        "en": "Vikings in ancient Japan",
+        "ja": "こだいにほんのバイキング",
+        "ja_typings": []
+      },
+      {
+        "en": "Samurai in medieval Japan",
+        "ja": "ちゅうせいにほんのさむらい",
+        "ja_typings": []
+      },
+      {
+        "en": "Warriors in ancient Greece",
+        "ja": "こだいギリシャのせんし",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00517",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the premise of Vinland Saga?",
+      "ja": "ゔぃんらんどさがのせっていは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "dramatic realist manga for adults",
+        "ja": "おとなのためのしじつてきなまんが",
+        "ja_typings": []
+      },
+      {
+        "en": "funny children's manga",
+        "ja": "こどものためのおもしろまんが",
+        "ja_typings": []
+      },
+      {
+        "en": "newspaper political cartoon",
+        "ja": "しんぶんのせいじまんが",
+        "ja_typings": []
+      },
+      {
+        "en": "animated manga format",
+        "ja": "アニメかけいしき",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00518",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'gekiga'?",
+      "ja": "げきがとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fullmetal Alchemist",
+        "ja": "はがねのれんきんじゅつし",
+        "ja_typings": []
+      },
+      {
+        "en": "Noragami",
+        "ja": "のらがみ",
+        "ja_typings": []
+      },
+      {
+        "en": "Blue Exorcist",
+        "ja": "あおのえくそしすと",
+        "ja_typings": []
+      },
+      {
+        "en": "Soul Eater",
+        "ja": "そうるいーたー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00519",
+    "image_path": null,
+    "question_text": {
+      "en": "What manga features Edward and Alphonse Elric?",
+      "ja": "えどわーどとあるふぉんすえるりっくのまんがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Demon Slayer",
+        "ja": "でーもんすれいやー",
+        "ja_typings": []
+      },
+      {
+        "en": "Blade of Demons",
+        "ja": "ぶれいどおぶでーもんず",
+        "ja_typings": []
+      },
+      {
+        "en": "Demon Sword",
+        "ja": "でーもんそーど",
+        "ja_typings": []
+      },
+      {
+        "en": "Night of Demons",
+        "ja": "ないとおぶでーもんず",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00520",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Kimetsu no Yaiba known as in English?",
+      "ja": "きめつのやいばの英語タイトルは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Attack on Titan",
+        "ja": "しんげきのきょじん",
+        "ja_typings": []
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "ふぇありーている",
+        "ja_typings": []
+      },
+      {
+        "en": "Sword Art Online",
+        "ja": "そーどあーとおんらいん",
+        "ja_typings": []
+      },
+      {
+        "en": "That Time I Got Reincarnated as a Slime",
+        "ja": "てんせいスライム",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00521",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga is drawn by Hajime Isayama?",
+      "ja": "いさやまはじめがかいたまんがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "adult women",
+        "ja": "せいじんじょせい",
+        "ja_typings": []
+      },
+      {
+        "en": "young girls",
+        "ja": "しょうじょ",
+        "ja_typings": []
+      },
+      {
+        "en": "young boys",
+        "ja": "しょうねん",
+        "ja_typings": []
+      },
+      {
+        "en": "adult men",
+        "ja": "せいじんだんせい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00522",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Josei' manga magazine aimed at?",
+      "ja": "じょせいまんがざっしのたいしょうは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "manga adaptation of light novel",
+        "ja": "らいとのべるのまんがか",
+        "ja_typings": []
+      },
+      {
+        "en": "short manga chapter",
+        "ja": "みじかいまんがかい",
+        "ja_typings": []
+      },
+      {
+        "en": "manga with simple art",
+        "ja": "かんたんなえのまんが",
+        "ja_typings": []
+      },
+      {
+        "en": "manga for young children",
+        "ja": "ようじむけまんが",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00523",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the manga equivalent of a light novel?",
+      "ja": "らいとのべるのまんがそうとうは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fullmetal Alchemist",
+        "ja": "はがねのれんきんじゅつし",
+        "ja_typings": []
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ぶらっくくろーばー",
+        "ja_typings": []
+      },
+      {
+        "en": "Magi",
+        "ja": "まぎ",
+        "ja_typings": []
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "ふぇありーている",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00524",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga features the Elric brothers searching for the Philosopher's Stone?",
+      "ja": "けんじゃのいしをさがすえるりっくきょうだいのまんがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fujiko F. Fujio",
+        "ja": "ふじこえふふじお",
+        "ja_typings": []
+      },
+      {
+        "en": "Osamu Tezuka",
+        "ja": "てづかおさむ",
+        "ja_typings": []
+      },
+      {
+        "en": "Shotaro Ishinomori",
+        "ja": "いしのもりしょうたろう",
+        "ja_typings": []
+      },
+      {
+        "en": "Go Nagai",
+        "ja": "ながいごう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00525",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Doraemon?",
+      "ja": "ドラえもんをかいたのは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "historical samurai drama",
+        "ja": "れきしのさむらいどらま",
+        "ja_typings": []
+      },
+      {
+        "en": "sci-fi thriller",
+        "ja": "SF/すりらー",
+        "ja_typings": []
+      },
+      {
+        "en": "supernatural romance",
+        "ja": "ちょうしぜんれんあい",
+        "ja_typings": []
+      },
+      {
+        "en": "sports manga",
+        "ja": "すぽーつまんが",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00526",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the genre of 'Vagabond'?",
+      "ja": "バガボンドのジャンルは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "story derived from main series featuring side characters",
+        "ja": "メインシリーズのサブキャラのはなし",
+        "ja_typings": []
+      },
+      {
+        "en": "sequel to original manga",
+        "ja": "オリジナルまんがのぞくへん",
+        "ja_typings": []
+      },
+      {
+        "en": "remix version of original",
+        "ja": "オリジナルのりみっくすばん",
+        "ja_typings": []
+      },
+      {
+        "en": "overseas licensed version",
+        "ja": "かいがいきょかばん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00527",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'spin-off' manga?",
+      "ja": "スピンオフまんがとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "right to left reading direction",
+        "ja": "みぎからひだりによむ",
+        "ja_typings": []
+      },
+      {
+        "en": "bottom to top reading",
+        "ja": "したからうえによむ",
+        "ja_typings": []
+      },
+      {
+        "en": "left to right reading",
+        "ja": "ひだりからみぎによむ",
+        "ja_typings": []
+      },
+      {
+        "en": "diagonal reading",
+        "ja": "ななめによむ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00528",
+    "image_path": null,
+    "question_text": {
+      "en": "What makes manga read differently from Western comics?",
+      "ja": "まんがが西洋まんがとちがうよみかたは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "One Piece",
+        "ja": "わんぴーす",
+        "ja_typings": []
+      },
+      {
+        "en": "Dragon Ball",
+        "ja": "どらごんぼーる",
+        "ja_typings": []
+      },
+      {
+        "en": "Golgo 13",
+        "ja": "ごるごじゅうさん",
+        "ja_typings": []
+      },
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00529",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga has the longest running story?",
+      "ja": "もっともちょうへんのまんがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "romance and emotional stories",
+        "ja": "れんあいとかんじょうのはなし",
+        "ja_typings": []
+      },
+      {
+        "en": "intense action battles",
+        "ja": "げきれつなアクションバトル",
+        "ja_typings": []
+      },
+      {
+        "en": "historical epics",
+        "ja": "れきしのたいさく",
+        "ja_typings": []
+      },
+      {
+        "en": "sports competitions",
+        "ja": "すぽーつたいかい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00530",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'shojo manga' famous for?",
+      "ja": "しょうじょまんがはなにでゆうめいか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Naoko Takeuchi",
+        "ja": "たけうちなおこ",
+        "ja_typings": []
+      },
+      {
+        "en": "Rumiko Takahashi",
+        "ja": "たかはしるみこ",
+        "ja_typings": []
+      },
+      {
+        "en": "CLAMP",
+        "ja": "くらんぷ",
+        "ja_typings": []
+      },
+      {
+        "en": "Yoshihiro Togashi",
+        "ja": "とがしよしひろ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00531",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the creator of Sailor Moon manga?",
+      "ja": "セーラームーンまんがのさくしゃは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "horror involving spirals",
+        "ja": "らせんをもとにしたほらー",
+        "ja_typings": []
+      },
+      {
+        "en": "comedy about cooking",
+        "ja": "りょうりのこめでぃ",
+        "ja_typings": []
+      },
+      {
+        "en": "romance in high school",
+        "ja": "こうこうのれんあい",
+        "ja_typings": []
+      },
+      {
+        "en": "historical action",
+        "ja": "れきしのアクション",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00532",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the manga 'Uzumaki' known for?",
+      "ja": "まんが「うずまき」はなにでゆうめいか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fist of the North Star",
+        "ja": "ほくとのけん",
+        "ja_typings": []
+      },
+      {
+        "en": "Berserk",
+        "ja": "べるせるく",
+        "ja_typings": []
+      },
+      {
+        "en": "Vinland Saga",
+        "ja": "ゔぃんらんどさが",
+        "ja_typings": []
+      },
+      {
+        "en": "Kingdom",
+        "ja": "きんぐだむ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00533",
+    "image_path": null,
+    "question_text": {
+      "en": "What manga features Kenshiro as the main character?",
+      "ja": "けんしろうがしゅじんこうのまんがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1997",
+        "ja": "1997ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1995",
+        "ja": "1995ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1999",
+        "ja": "1999ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "2001",
+        "ja": "2001ねん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00534",
+    "image_path": null,
+    "question_text": {
+      "en": "What year was the first chapter of One Piece published?",
+      "ja": "ワンピースのさいしょのかいがしゅっぱんされたのはなんねんか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jujutsu Kaisen",
+        "ja": "じゅじゅつかいせん",
+        "ja_typings": []
+      },
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": []
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ぶらっくくろーばー",
+        "ja_typings": []
+      },
+      {
+        "en": "Soul Eater",
+        "ja": "そうるいーたー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00535",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the manga about Yuji Itadori eating a cursed finger?",
+      "ja": "ゆうじいただりがじゅのゆびをたべるまんがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "basketball",
+        "ja": "ばすけっとぼーる",
+        "ja_typings": []
+      },
+      {
+        "en": "baseball",
+        "ja": "やきゅう",
+        "ja_typings": []
+      },
+      {
+        "en": "soccer",
+        "ja": "さっかー",
+        "ja_typings": []
+      },
+      {
+        "en": "volleyball",
+        "ja": "ばれーぼーる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00536",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the main theme of 'Slam Dunk'?",
+      "ja": "スラムダンクのメインテーマは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Erased (Boku dake ga Inai Machi)",
+        "ja": "ぼくだけがいないまち",
+        "ja_typings": []
+      },
+      {
+        "en": "Monster",
+        "ja": "もんすたー",
+        "ja_typings": []
+      },
+      {
+        "en": "Death Note",
+        "ja": "でーすのーと",
+        "ja_typings": []
+      },
+      {
+        "en": "20th Century Boys",
+        "ja": "20せいきしょうねん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00537",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga features time-travel murder mystery?",
+      "ja": "タイムトラベルのさつじんミステリーのまんがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "complex psychological thriller manga",
+        "ja": "ふくざつなしんりすりらーまんが",
+        "ja_typings": []
+      },
+      {
+        "en": "simple action manga",
+        "ja": "かんたんなアクションまんが",
+        "ja_typings": []
+      },
+      {
+        "en": "children's manga",
+        "ja": "こどものまんが",
+        "ja_typings": []
+      },
+      {
+        "en": "romantic comedy manga",
+        "ja": "ろまんてぃっくこめでぃまんが",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00538",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Naoki Urasawa known for?",
+      "ja": "うらさわなおきはなにでゆうめいか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Weekly Shonen Jump",
+        "ja": "しゅうかんしょうねんじゃんぷ",
+        "ja_typings": []
+      },
+      {
+        "en": "Monthly Shonen Jump",
+        "ja": "げっかんしょうねんじゃんぷ",
+        "ja_typings": []
+      },
+      {
+        "en": "Shonen Magazine",
+        "ja": "しょうねんまがじん",
+        "ja_typings": []
+      },
+      {
+        "en": "Young Jump",
+        "ja": "ようじゃんぷ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00539",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the manga that Chainsaw Man is serialized in?",
+      "ja": "チェーンソーマンがけいさいされているまんがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yoshihiro Togashi",
+        "ja": "とがしよしひろ",
+        "ja_typings": []
+      },
+      {
+        "en": "Masashi Kishimoto",
+        "ja": "きしもとまさし",
+        "ja_typings": []
+      },
+      {
+        "en": "Tite Kubo",
+        "ja": "くぼたいと",
+        "ja_typings": []
+      },
+      {
+        "en": "Akira Toriyama",
+        "ja": "とりやまあきら",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00540",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created 'Hunter x Hunter'?",
+      "ja": "ハンターハンターをかいたのは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "a boy who secretly draws shojo manga",
+        "ja": "ひそかにしょうじょまんがをかくしょうねん",
+        "ja_typings": []
+      },
+      {
+        "en": "a monthly manga magazine",
+        "ja": "げっかんのまんがざっし",
+        "ja_typings": []
+      },
+      {
+        "en": "a shonen manga artist's life",
+        "ja": "しょうねんまんがかのせいかつ",
+        "ja_typings": []
+      },
+      {
+        "en": "a manga club in school",
+        "ja": "がっこうのまんがぶ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00541",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Gekkan Shounen Nozaki-kun' about?",
+      "ja": "「げっかんしょうねんのざきくん」はなにについてか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hunter x Hunter",
+        "ja": "はんたーはんたー",
+        "ja_typings": []
+      },
+      {
+        "en": "Yu Yu Hakusho",
+        "ja": "ゆゆはくしょ",
+        "ja_typings": []
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "ふぇありーている",
+        "ja_typings": []
+      },
+      {
+        "en": "Magi",
+        "ja": "まぎ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00542",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga ran from 1999 and features Gon Freecss as protagonist?",
+      "ja": "1999ねんかられんさいのごんふりーくすがしゅじんこうのまんがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "four-panel comic strip",
+        "ja": "よんコマのまんが",
+        "ja_typings": []
+      },
+      {
+        "en": "manga with four main characters",
+        "ja": "しにんのメインキャラのまんが",
+        "ja_typings": []
+      },
+      {
+        "en": "manga spanning four volumes",
+        "ja": "よんかんのまんが",
+        "ja_typings": []
+      },
+      {
+        "en": "manga about four seasons",
+        "ja": "しきのまんが",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00543",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'yonkoma' manga?",
+      "ja": "よんこままんがとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "iyashikei (healing/soothing) manga",
+        "ja": "いやしけい（ほっこり）まんが",
+        "ja_typings": []
+      },
+      {
+        "en": "action shonen",
+        "ja": "あくしょんしょうねん",
+        "ja_typings": []
+      },
+      {
+        "en": "sports manga",
+        "ja": "すぽーつまんが",
+        "ja_typings": []
+      },
+      {
+        "en": "horror manga",
+        "ja": "ほらーまんが",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00544",
+    "image_path": null,
+    "question_text": {
+      "en": "What type of manga is 'Yuru Camp'?",
+      "ja": "ゆるキャンのまんがのしゅるいは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hiro Mashima",
+        "ja": "ましまひろ",
+        "ja_typings": []
+      },
+      {
+        "en": "Eiichiro Oda",
+        "ja": "おだえいいちろう",
+        "ja_typings": []
+      },
+      {
+        "en": "Masashi Kishimoto",
+        "ja": "きしもとまさし",
+        "ja_typings": []
+      },
+      {
+        "en": "Yoshihiro Togashi",
+        "ja": "とがしよしひろ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00545",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the creator of Fairy Tail?",
+      "ja": "フェアリーテイルをかいたのは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cardcaptor Sakura",
+        "ja": "カードキャプターさくら",
+        "ja_typings": []
+      },
+      {
+        "en": "Sailor Moon",
+        "ja": "せーらーむーん",
+        "ja_typings": []
+      },
+      {
+        "en": "Ouran High School Host Club",
+        "ja": "おうらんこうこうホストクラブ",
+        "ja_typings": []
+      },
+      {
+        "en": "Fruits Basket",
+        "ja": "ふるーつばすけっと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00546",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the famous manga by CLAMP?",
+      "ja": "CLAMPのゆうめいなまんがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "mature themes for adult men",
+        "ja": "せいじんだんせいのためのおとなのテーマ",
+        "ja_typings": []
+      },
+      {
+        "en": "school romance stories",
+        "ja": "がっこうのれんあいはなし",
+        "ja_typings": []
+      },
+      {
+        "en": "magical girl themes",
+        "ja": "まほうしょうじょテーマ",
+        "ja_typings": []
+      },
+      {
+        "en": "tournament battle arcs",
+        "ja": "たいかいばとるへん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00547",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Seinen' manga known for?",
+      "ja": "せいねんまんがはなにでゆうめいか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "distinctive flamboyant art style",
+        "ja": "どくとくのはなやかなえのスタイル",
+        "ja_typings": []
+      },
+      {
+        "en": "simple minimalist drawing",
+        "ja": "かんたんなミニマリストのえ",
+        "ja_typings": []
+      },
+      {
+        "en": "realistic photo-like art",
+        "ja": "しゃしんのようなリアルなえ",
+        "ja_typings": []
+      },
+      {
+        "en": "abstract expressionist style",
+        "ja": "ちゅうしょうひょうげんしゅぎのスタイル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00548",
+    "image_path": null,
+    "question_text": {
+      "en": "What makes Hirohiko Araki unique as a manga artist?",
+      "ja": "まんがかとしてのあらきひろひこのとくちょうは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Paris",
+        "ja": "ぱり",
+        "ja_typings": []
+      },
+      {
+        "en": "Lyon",
+        "ja": "りよん",
+        "ja_typings": []
+      },
+      {
+        "en": "Marseille",
+        "ja": "まるせいゆ",
+        "ja_typings": []
+      },
+      {
+        "en": "Nice",
+        "ja": "にーす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00549",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of France?",
+      "ja": "ふらんすのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tokyo",
+        "ja": "とうきょう",
+        "ja_typings": []
+      },
+      {
+        "en": "Osaka",
+        "ja": "おおさか",
+        "ja_typings": []
+      },
+      {
+        "en": "Kyoto",
+        "ja": "きょうと",
+        "ja_typings": []
+      },
+      {
+        "en": "Nagoya",
+        "ja": "なごや",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00550",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Japan?",
+      "ja": "にほんのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Russia",
+        "ja": "ろしあ",
+        "ja_typings": []
+      },
+      {
+        "en": "Canada",
+        "ja": "かなだ",
+        "ja_typings": []
+      },
+      {
+        "en": "China",
+        "ja": "ちゅうごく",
+        "ja_typings": []
+      },
+      {
+        "en": "United States",
+        "ja": "あめりか",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00551",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the largest country by area?",
+      "ja": "めんせきがもっともおおきいくには？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nile",
+        "ja": "ないる",
+        "ja_typings": []
+      },
+      {
+        "en": "Amazon",
+        "ja": "あまぞん",
+        "ja_typings": []
+      },
+      {
+        "en": "Yangtze",
+        "ja": "ようすこう",
+        "ja_typings": []
+      },
+      {
+        "en": "Mississippi",
+        "ja": "みししっぴ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00552",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the longest river in the world?",
+      "ja": "せかいでもっともながいかわは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mount Everest",
+        "ja": "えべれすとさん",
+        "ja_typings": []
+      },
+      {
+        "en": "K2",
+        "ja": "けーつー",
+        "ja_typings": []
+      },
+      {
+        "en": "Kangchenjunga",
+        "ja": "かんちぇんじゅんがさん",
+        "ja_typings": []
+      },
+      {
+        "en": "Mont Blanc",
+        "ja": "もんぶらん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00553",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the highest mountain in the world?",
+      "ja": "せかいでもっともたかいやまは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Africa",
+        "ja": "あふりか",
+        "ja_typings": []
+      },
+      {
+        "en": "Asia",
+        "ja": "あじあ",
+        "ja_typings": []
+      },
+      {
+        "en": "Middle East",
+        "ja": "ちゅうとう",
+        "ja_typings": []
+      },
+      {
+        "en": "Europe",
+        "ja": "えーろっぱ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00554",
+    "image_path": null,
+    "question_text": {
+      "en": "What continent is Egypt in?",
+      "ja": "えじぷとはどのたいりくにあるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Berlin",
+        "ja": "べるりん",
+        "ja_typings": []
+      },
+      {
+        "en": "Munich",
+        "ja": "みゅんへん",
+        "ja_typings": []
+      },
+      {
+        "en": "Hamburg",
+        "ja": "はんぶるく",
+        "ja_typings": []
+      },
+      {
+        "en": "Frankfurt",
+        "ja": "ふらんくふると",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00555",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Germany?",
+      "ja": "どいつのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Atlantic Ocean",
+        "ja": "たいせいよう",
+        "ja_typings": []
+      },
+      {
+        "en": "Pacific Ocean",
+        "ja": "たいへいよう",
+        "ja_typings": []
+      },
+      {
+        "en": "Indian Ocean",
+        "ja": "いんどよう",
+        "ja_typings": []
+      },
+      {
+        "en": "Southern Ocean",
+        "ja": "なんきょくかい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00556",
+    "image_path": null,
+    "question_text": {
+      "en": "What ocean separates Africa from South America?",
+      "ja": "あふりかとみなみあめりかをへだてるうみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Canberra",
+        "ja": "きゃんべら",
+        "ja_typings": []
+      },
+      {
+        "en": "Sydney",
+        "ja": "しどにー",
+        "ja_typings": []
+      },
+      {
+        "en": "Melbourne",
+        "ja": "めるぼるん",
+        "ja_typings": []
+      },
+      {
+        "en": "Brisbane",
+        "ja": "ぶりずべん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00557",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Australia?",
+      "ja": "おーすとらりあのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vatican City",
+        "ja": "ばちかんし",
+        "ja_typings": []
+      },
+      {
+        "en": "Monaco",
+        "ja": "もなこ",
+        "ja_typings": []
+      },
+      {
+        "en": "San Marino",
+        "ja": "さんまりの",
+        "ja_typings": []
+      },
+      {
+        "en": "Liechtenstein",
+        "ja": "りひてんしゅたいん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00558",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the smallest country in the world?",
+      "ja": "せかいでもっともちいさいくには？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Brasilia",
+        "ja": "ぶらじりあ",
+        "ja_typings": []
+      },
+      {
+        "en": "Rio de Janeiro",
+        "ja": "りおでじゃねいろ",
+        "ja_typings": []
+      },
+      {
+        "en": "São Paulo",
+        "ja": "さんぱうろ",
+        "ja_typings": []
+      },
+      {
+        "en": "Salvador",
+        "ja": "さるばどーる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00559",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Brazil?",
+      "ja": "ぶらじるのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Beijing",
+        "ja": "ぺきん",
+        "ja_typings": []
+      },
+      {
+        "en": "Shanghai",
+        "ja": "しゃんはい",
+        "ja_typings": []
+      },
+      {
+        "en": "Hong Kong",
+        "ja": "ほんこん",
+        "ja_typings": []
+      },
+      {
+        "en": "Guangzhou",
+        "ja": "こうしゅう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00560",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of China?",
+      "ja": "ちゅうごくのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sahara",
+        "ja": "さはら",
+        "ja_typings": []
+      },
+      {
+        "en": "Arabian",
+        "ja": "あらびあ",
+        "ja_typings": []
+      },
+      {
+        "en": "Gobi",
+        "ja": "ごび",
+        "ja_typings": []
+      },
+      {
+        "en": "Antarctic",
+        "ja": "なんきょく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00561",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the largest desert in the world?",
+      "ja": "せかいでもっともおおきいさばくは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "7",
+        "ja": "なな",
+        "ja_typings": []
+      },
+      {
+        "en": "5",
+        "ja": "ご",
+        "ja_typings": []
+      },
+      {
+        "en": "6",
+        "ja": "ろく",
+        "ja_typings": []
+      },
+      {
+        "en": "8",
+        "ja": "はち",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00562",
+    "image_path": null,
+    "question_text": {
+      "en": "How many continents are there?",
+      "ja": "たいりくはいくつあるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Washington D.C.",
+        "ja": "わしんとんでぃーしー",
+        "ja_typings": []
+      },
+      {
+        "en": "New York",
+        "ja": "にゅーよーく",
+        "ja_typings": []
+      },
+      {
+        "en": "Los Angeles",
+        "ja": "ろさんぜるす",
+        "ja_typings": []
+      },
+      {
+        "en": "Chicago",
+        "ja": "しかご",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00563",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of the USA?",
+      "ja": "アメリカのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rome",
+        "ja": "ろーま",
+        "ja_typings": []
+      },
+      {
+        "en": "Milan",
+        "ja": "みらの",
+        "ja_typings": []
+      },
+      {
+        "en": "Naples",
+        "ja": "なぽり",
+        "ja_typings": []
+      },
+      {
+        "en": "Florence",
+        "ja": "ふぃれんつぇ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00564",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Italy?",
+      "ja": "いたりあのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Madrid",
+        "ja": "まどりーど",
+        "ja_typings": []
+      },
+      {
+        "en": "Barcelona",
+        "ja": "ばるせろな",
+        "ja_typings": []
+      },
+      {
+        "en": "Seville",
+        "ja": "せびりあ",
+        "ja_typings": []
+      },
+      {
+        "en": "Valencia",
+        "ja": "ばれんしあ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00565",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Spain?",
+      "ja": "すぺいんのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ottawa",
+        "ja": "おたわ",
+        "ja_typings": []
+      },
+      {
+        "en": "Toronto",
+        "ja": "とろんと",
+        "ja_typings": []
+      },
+      {
+        "en": "Vancouver",
+        "ja": "ばんくーばー",
+        "ja_typings": []
+      },
+      {
+        "en": "Montreal",
+        "ja": "もんとりおーる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00566",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Canada?",
+      "ja": "かなだのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Moscow",
+        "ja": "もすくわ",
+        "ja_typings": []
+      },
+      {
+        "en": "Saint Petersburg",
+        "ja": "さんくとぺてるぶるく",
+        "ja_typings": []
+      },
+      {
+        "en": "Novosibirsk",
+        "ja": "のぼしびるすく",
+        "ja_typings": []
+      },
+      {
+        "en": "Vladivostok",
+        "ja": "うらじおすとく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00567",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Russia?",
+      "ja": "ろしあのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Seoul",
+        "ja": "そうる",
+        "ja_typings": []
+      },
+      {
+        "en": "Busan",
+        "ja": "ぷさん",
+        "ja_typings": []
+      },
+      {
+        "en": "Incheon",
+        "ja": "いんちぇおん",
+        "ja_typings": []
+      },
+      {
+        "en": "Daegu",
+        "ja": "てぐ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00568",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of South Korea?",
+      "ja": "かんこくのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "New Delhi",
+        "ja": "にゅーでりー",
+        "ja_typings": []
+      },
+      {
+        "en": "Mumbai",
+        "ja": "むんばい",
+        "ja_typings": []
+      },
+      {
+        "en": "Kolkata",
+        "ja": "こるかた",
+        "ja_typings": []
+      },
+      {
+        "en": "Chennai",
+        "ja": "ちぇんない",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00569",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of India?",
+      "ja": "いんどのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mexico City",
+        "ja": "めきしこしてぃー",
+        "ja_typings": []
+      },
+      {
+        "en": "Guadalajara",
+        "ja": "ぐあだらはら",
+        "ja_typings": []
+      },
+      {
+        "en": "Monterrey",
+        "ja": "もんてれー",
+        "ja_typings": []
+      },
+      {
+        "en": "Tijuana",
+        "ja": "てぃふあな",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00570",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Mexico?",
+      "ja": "めきしこのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "France",
+        "ja": "ふらんす",
+        "ja_typings": []
+      },
+      {
+        "en": "Germany",
+        "ja": "どいつ",
+        "ja_typings": []
+      },
+      {
+        "en": "Italy",
+        "ja": "いたりあ",
+        "ja_typings": []
+      },
+      {
+        "en": "Belgium",
+        "ja": "べるぎー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00571",
+    "image_path": null,
+    "question_text": {
+      "en": "What country has the Eiffel Tower?",
+      "ja": "えっふぇるとうはどのくににあるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Italy",
+        "ja": "いたりあ",
+        "ja_typings": []
+      },
+      {
+        "en": "Greece",
+        "ja": "ぎりしあ",
+        "ja_typings": []
+      },
+      {
+        "en": "Spain",
+        "ja": "すぺいん",
+        "ja_typings": []
+      },
+      {
+        "en": "Turkey",
+        "ja": "とるこ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00572",
+    "image_path": null,
+    "question_text": {
+      "en": "What country has the Colosseum?",
+      "ja": "ころっせおはどのくににあるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Brazil",
+        "ja": "ぶらじる",
+        "ja_typings": []
+      },
+      {
+        "en": "Peru",
+        "ja": "ぺるー",
+        "ja_typings": []
+      },
+      {
+        "en": "Colombia",
+        "ja": "ころんびあ",
+        "ja_typings": []
+      },
+      {
+        "en": "Venezuela",
+        "ja": "べねずえら",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00573",
+    "image_path": null,
+    "question_text": {
+      "en": "What country is the Amazon rainforest mostly in?",
+      "ja": "あまぞんのねったいうりんはおもにどのくににあるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mediterranean Sea",
+        "ja": "ちちゅうかい",
+        "ja_typings": []
+      },
+      {
+        "en": "Red Sea",
+        "ja": "こうかい",
+        "ja_typings": []
+      },
+      {
+        "en": "Black Sea",
+        "ja": "こっかい",
+        "ja_typings": []
+      },
+      {
+        "en": "Caspian Sea",
+        "ja": "かすぴかい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00574",
+    "image_path": null,
+    "question_text": {
+      "en": "What sea is between Europe and Africa?",
+      "ja": "ゆーろっぱとあふりかのあいだのうみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ecuador",
+        "ja": "えくあどる",
+        "ja_typings": []
+      },
+      {
+        "en": "Peru",
+        "ja": "ぺるー",
+        "ja_typings": []
+      },
+      {
+        "en": "Colombia",
+        "ja": "ころんびあ",
+        "ja_typings": []
+      },
+      {
+        "en": "Chile",
+        "ja": "ちり",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00575",
+    "image_path": null,
+    "question_text": {
+      "en": "What country owns the Galapagos Islands?",
+      "ja": "がらぱごすとうはどのくにのりょうどか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Andes",
+        "ja": "あんです",
+        "ja_typings": []
+      },
+      {
+        "en": "Himalayas",
+        "ja": "ひまらや",
+        "ja_typings": []
+      },
+      {
+        "en": "Rockies",
+        "ja": "ろっきー",
+        "ja_typings": []
+      },
+      {
+        "en": "Alps",
+        "ja": "あるぷす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00576",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the longest mountain range?",
+      "ja": "せかいでもっともながいさんみゃくは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lake Baikal",
+        "ja": "ばいかるこ",
+        "ja_typings": []
+      },
+      {
+        "en": "Lake Superior",
+        "ja": "すぺりおるこ",
+        "ja_typings": []
+      },
+      {
+        "en": "Caspian Sea",
+        "ja": "かすぴかい",
+        "ja_typings": []
+      },
+      {
+        "en": "Crater Lake",
+        "ja": "くれーたーれいく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00577",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the deepest lake in the world?",
+      "ja": "せかいでもっともふかいみずうみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "China",
+        "ja": "ちゅうごく",
+        "ja_typings": []
+      },
+      {
+        "en": "Australia",
+        "ja": "おーすとらりあ",
+        "ja_typings": []
+      },
+      {
+        "en": "Brazil",
+        "ja": "ぶらじる",
+        "ja_typings": []
+      },
+      {
+        "en": "Russia",
+        "ja": "ろしあ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00578",
+    "image_path": null,
+    "question_text": {
+      "en": "What country has the most natural UNESCO World Heritage Sites?",
+      "ja": "しぜんのユネスコせかいいさんがもっともおおいくには？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pacific Ocean",
+        "ja": "たいへいよう",
+        "ja_typings": []
+      },
+      {
+        "en": "Atlantic Ocean",
+        "ja": "たいせいよう",
+        "ja_typings": []
+      },
+      {
+        "en": "Indian Ocean",
+        "ja": "いんどよう",
+        "ja_typings": []
+      },
+      {
+        "en": "Arctic Ocean",
+        "ja": "ほっきょくかい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00579",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the largest ocean?",
+      "ja": "もっともおおきいうみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "South America",
+        "ja": "みなみあめりか",
+        "ja_typings": []
+      },
+      {
+        "en": "Central America",
+        "ja": "ちゅうおうあめりか",
+        "ja_typings": []
+      },
+      {
+        "en": "North America",
+        "ja": "きたあめりか",
+        "ja_typings": []
+      },
+      {
+        "en": "Europe",
+        "ja": "えーろっぱ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00580",
+    "image_path": null,
+    "question_text": {
+      "en": "What continent is Argentina in?",
+      "ja": "あるぜんちんはどのたいりくにあるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Japan",
+        "ja": "にほん",
+        "ja_typings": []
+      },
+      {
+        "en": "China",
+        "ja": "ちゅうごく",
+        "ja_typings": []
+      },
+      {
+        "en": "South Korea",
+        "ja": "かんこく",
+        "ja_typings": []
+      },
+      {
+        "en": "Thailand",
+        "ja": "たいらんど",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00581",
+    "image_path": null,
+    "question_text": {
+      "en": "What country is known as the Land of the Rising Sun?",
+      "ja": "ひのでのくにといわれるのはどのくにか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cairo",
+        "ja": "かいろ",
+        "ja_typings": []
+      },
+      {
+        "en": "Alexandria",
+        "ja": "あれくさんどりあ",
+        "ja_typings": []
+      },
+      {
+        "en": "Luxor",
+        "ja": "るくそーる",
+        "ja_typings": []
+      },
+      {
+        "en": "Aswan",
+        "ja": "あすわん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00582",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Egypt?",
+      "ja": "えじぷとのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ural Mountains",
+        "ja": "うらるさんみゃく",
+        "ja_typings": []
+      },
+      {
+        "en": "Himalayas",
+        "ja": "ひまらや",
+        "ja_typings": []
+      },
+      {
+        "en": "Caucasus",
+        "ja": "こーかさすさんみゃく",
+        "ja_typings": []
+      },
+      {
+        "en": "Alps",
+        "ja": "あるぷす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00583",
+    "image_path": null,
+    "question_text": {
+      "en": "What mountain range separates Europe and Asia?",
+      "ja": "ゆーろっぱとあじあをへだてるさんみゃくは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Australia",
+        "ja": "おーすとらりあ",
+        "ja_typings": []
+      },
+      {
+        "en": "Indonesia",
+        "ja": "いんどねしあ",
+        "ja_typings": []
+      },
+      {
+        "en": "Philippines",
+        "ja": "ふぃりぴん",
+        "ja_typings": []
+      },
+      {
+        "en": "Papua New Guinea",
+        "ja": "ぱぷあにゅーぎにあ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00584",
+    "image_path": null,
+    "question_text": {
+      "en": "What country has the Great Barrier Reef?",
+      "ja": "グレートバリアリーフはどのくににあるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ankara",
+        "ja": "あんから",
+        "ja_typings": []
+      },
+      {
+        "en": "Istanbul",
+        "ja": "いすたんぶーる",
+        "ja_typings": []
+      },
+      {
+        "en": "Izmir",
+        "ja": "いずみる",
+        "ja_typings": []
+      },
+      {
+        "en": "Bursa",
+        "ja": "ぶるさ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00585",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Turkey?",
+      "ja": "とるこのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pretoria",
+        "ja": "ぷれとりあ",
+        "ja_typings": []
+      },
+      {
+        "en": "Cape Town",
+        "ja": "けいぷたうん",
+        "ja_typings": []
+      },
+      {
+        "en": "Johannesburg",
+        "ja": "よはねすばーぐ",
+        "ja_typings": []
+      },
+      {
+        "en": "Durban",
+        "ja": "だーばん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00586",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of South Africa?",
+      "ja": "みなみあふりかのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Multiple countries in North Africa",
+        "ja": "きたあふりかのふくすうのくに",
+        "ja_typings": []
+      },
+      {
+        "en": "Egypt only",
+        "ja": "えじぷとのみ",
+        "ja_typings": []
+      },
+      {
+        "en": "Libya only",
+        "ja": "りびあのみ",
+        "ja_typings": []
+      },
+      {
+        "en": "Algeria only",
+        "ja": "あるじぇりあのみ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00587",
+    "image_path": null,
+    "question_text": {
+      "en": "What country is the Sahara Desert mostly in?",
+      "ja": "さはらさばくはおもにどのくににあるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Buenos Aires",
+        "ja": "ぶえのすあいれす",
+        "ja_typings": []
+      },
+      {
+        "en": "Córdoba",
+        "ja": "こるどば",
+        "ja_typings": []
+      },
+      {
+        "en": "Rosario",
+        "ja": "ろさりお",
+        "ja_typings": []
+      },
+      {
+        "en": "Mendoza",
+        "ja": "めんどさ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00588",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Argentina?",
+      "ja": "あるぜんちんのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Stockholm",
+        "ja": "すとっくほるむ",
+        "ja_typings": []
+      },
+      {
+        "en": "Oslo",
+        "ja": "おすろ",
+        "ja_typings": []
+      },
+      {
+        "en": "Copenhagen",
+        "ja": "こぺんはーげん",
+        "ja_typings": []
+      },
+      {
+        "en": "Helsinki",
+        "ja": "へるしんき",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00589",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Sweden?",
+      "ja": "すうぇーでんのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Athens",
+        "ja": "あてね",
+        "ja_typings": []
+      },
+      {
+        "en": "Thessaloniki",
+        "ja": "てっさろにき",
+        "ja_typings": []
+      },
+      {
+        "en": "Crete",
+        "ja": "くれーた",
+        "ja_typings": []
+      },
+      {
+        "en": "Sparta",
+        "ja": "すぱるた",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00590",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Greece?",
+      "ja": "ぎりしあのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Amsterdam",
+        "ja": "あむすてるだむ",
+        "ja_typings": []
+      },
+      {
+        "en": "The Hague",
+        "ja": "でんはーぐ",
+        "ja_typings": []
+      },
+      {
+        "en": "Rotterdam",
+        "ja": "ろってるだむ",
+        "ja_typings": []
+      },
+      {
+        "en": "Utrecht",
+        "ja": "うとれひと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00591",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Netherlands?",
+      "ja": "おらんだのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Warsaw",
+        "ja": "わるしゃわ",
+        "ja_typings": []
+      },
+      {
+        "en": "Krakow",
+        "ja": "くらこふ",
+        "ja_typings": []
+      },
+      {
+        "en": "Gdansk",
+        "ja": "グダニスク",
+        "ja_typings": []
+      },
+      {
+        "en": "Wroclaw",
+        "ja": "ぶろつわふ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00592",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Poland?",
+      "ja": "ぽーらんどのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sweden",
+        "ja": "すうぇーでん",
+        "ja_typings": []
+      },
+      {
+        "en": "Indonesia",
+        "ja": "いんどねしあ",
+        "ja_typings": []
+      },
+      {
+        "en": "Philippines",
+        "ja": "ふぃりぴん",
+        "ja_typings": []
+      },
+      {
+        "en": "Japan",
+        "ja": "にほん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00593",
+    "image_path": null,
+    "question_text": {
+      "en": "What country has the most islands?",
+      "ja": "もっともおおいしまのあるくには？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wellington",
+        "ja": "うぇりんとん",
+        "ja_typings": []
+      },
+      {
+        "en": "Auckland",
+        "ja": "おーくらんど",
+        "ja_typings": []
+      },
+      {
+        "en": "Christchurch",
+        "ja": "くらいすとちゃーち",
+        "ja_typings": []
+      },
+      {
+        "en": "Dunedin",
+        "ja": "だにーでぃん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00594",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of New Zealand?",
+      "ja": "にゅーじーらんどのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Abuja",
+        "ja": "あぶじゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "Lagos",
+        "ja": "らごす",
+        "ja_typings": []
+      },
+      {
+        "en": "Kano",
+        "ja": "かの",
+        "ja_typings": []
+      },
+      {
+        "en": "Ibadan",
+        "ja": "いばだん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00595",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Nigeria?",
+      "ja": "ないじぇりあのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bangkok",
+        "ja": "ばんこく",
+        "ja_typings": []
+      },
+      {
+        "en": "Chiang Mai",
+        "ja": "ちぇんまい",
+        "ja_typings": []
+      },
+      {
+        "en": "Pattaya",
+        "ja": "ぱたや",
+        "ja_typings": []
+      },
+      {
+        "en": "Phuket",
+        "ja": "ぷーけっと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00596",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Thailand?",
+      "ja": "たいらんどのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "India",
+        "ja": "いんど",
+        "ja_typings": []
+      },
+      {
+        "en": "Pakistan",
+        "ja": "ぱきすたん",
+        "ja_typings": []
+      },
+      {
+        "en": "Bangladesh",
+        "ja": "ばんぐらでしゅ",
+        "ja_typings": []
+      },
+      {
+        "en": "Nepal",
+        "ja": "ねぱーる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00597",
+    "image_path": null,
+    "question_text": {
+      "en": "What country is the Taj Mahal in?",
+      "ja": "たじまはるはどのくににあるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Riyadh",
+        "ja": "りやど",
+        "ja_typings": []
+      },
+      {
+        "en": "Mecca",
+        "ja": "めっか",
+        "ja_typings": []
+      },
+      {
+        "en": "Jeddah",
+        "ja": "じぇっだ",
+        "ja_typings": []
+      },
+      {
+        "en": "Medina",
+        "ja": "めでぃな",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00598",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Saudi Arabia?",
+      "ja": "さうじあらびあのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nairobi",
+        "ja": "ないろびー",
+        "ja_typings": []
+      },
+      {
+        "en": "Mombasa",
+        "ja": "もんばさ",
+        "ja_typings": []
+      },
+      {
+        "en": "Kisumu",
+        "ja": "きすむ",
+        "ja_typings": []
+      },
+      {
+        "en": "Nakuru",
+        "ja": "なくる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00599",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Kenya?",
+      "ja": "けにあのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lagos",
+        "ja": "らごす",
+        "ja_typings": []
+      },
+      {
+        "en": "Cairo",
+        "ja": "かいろ",
+        "ja_typings": []
+      },
+      {
+        "en": "Kinshasa",
+        "ja": "きんしゃさ",
+        "ja_typings": []
+      },
+      {
+        "en": "Johannesburg",
+        "ja": "よはねすばーぐ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00600",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the largest city in Africa by population?",
+      "ja": "じんこうがもっともおおいあふりかのとしは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "USA and Canada",
+        "ja": "あめりかとかなだ",
+        "ja_typings": []
+      },
+      {
+        "en": "USA and Mexico",
+        "ja": "あめりかとめきしこ",
+        "ja_typings": []
+      },
+      {
+        "en": "Canada and UK",
+        "ja": "かなだとえいこく",
+        "ja_typings": []
+      },
+      {
+        "en": "USA and UK",
+        "ja": "あめりかとえいこく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00601",
+    "image_path": null,
+    "question_text": {
+      "en": "What two countries share Niagara Falls?",
+      "ja": "ないあがらのたきをきょうゆうするふたつのくには？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lisbon",
+        "ja": "りずぼん",
+        "ja_typings": []
+      },
+      {
+        "en": "Porto",
+        "ja": "ぽると",
+        "ja_typings": []
+      },
+      {
+        "en": "Faro",
+        "ja": "ふぁろ",
+        "ja_typings": []
+      },
+      {
+        "en": "Braga",
+        "ja": "ぶらが",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00602",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Portugal?",
+      "ja": "ぽるとがるのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vienna",
+        "ja": "うぃーん",
+        "ja_typings": []
+      },
+      {
+        "en": "Salzburg",
+        "ja": "ざるつぶるく",
+        "ja_typings": []
+      },
+      {
+        "en": "Graz",
+        "ja": "ぐらーつ",
+        "ja_typings": []
+      },
+      {
+        "en": "Innsbruck",
+        "ja": "いんすぶるっく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00603",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Austria?",
+      "ja": "おーすとりあのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1945",
+        "ja": "1945ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1943",
+        "ja": "1943ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1947",
+        "ja": "1947ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1940",
+        "ja": "1940ねん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00604",
+    "image_path": null,
+    "question_text": {
+      "en": "In what year did World War II end?",
+      "ja": "だいにじせかいたいせんはなんねんにおわったか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "George Washington",
+        "ja": "じょーじわしんとん",
+        "ja_typings": []
+      },
+      {
+        "en": "Abraham Lincoln",
+        "ja": "えいぶらはむりんかーん",
+        "ja_typings": []
+      },
+      {
+        "en": "Thomas Jefferson",
+        "ja": "とーますじぇふぁーそん",
+        "ja_typings": []
+      },
+      {
+        "en": "John Adams",
+        "ja": "じょんあだむず",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00605",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first President of the United States?",
+      "ja": "アメリカのしょだいだいとうりょうは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1789",
+        "ja": "1789ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1776",
+        "ja": "1776ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1804",
+        "ja": "1804ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1815",
+        "ja": "1815ねん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00606",
+    "image_path": null,
+    "question_text": {
+      "en": "What year did the French Revolution begin?",
+      "ja": "ふらんすかくめいはなんねんにはじまったか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Various Chinese emperors",
+        "ja": "れきだいのちゅうごくこうてい",
+        "ja_typings": []
+      },
+      {
+        "en": "Genghis Khan",
+        "ja": "ちんぎすかん",
+        "ja_typings": []
+      },
+      {
+        "en": "Kublai Khan",
+        "ja": "くびらいかん",
+        "ja_typings": []
+      },
+      {
+        "en": "Emperor Qin Shi Huang alone",
+        "ja": "しこうていだけ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00607",
+    "image_path": null,
+    "question_text": {
+      "en": "Who built the Great Wall of China?",
+      "ja": "ちゅうごくのばんりのちょうじょうをきずいたのは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ancient Egyptians",
+        "ja": "こだいえじぷとじん",
+        "ja_typings": []
+      },
+      {
+        "en": "Ancient Romans",
+        "ja": "こだいろーまじん",
+        "ja_typings": []
+      },
+      {
+        "en": "Ancient Greeks",
+        "ja": "こだいぎりしあじん",
+        "ja_typings": []
+      },
+      {
+        "en": "Ancient Mesopotamians",
+        "ja": "こだいめそぽたみあじん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00608",
+    "image_path": null,
+    "question_text": {
+      "en": "What civilization built the pyramids of Giza?",
+      "ja": "ぎざのぴらみっどをきずいたぶんめいは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "476 AD",
+        "ja": "476ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "410 AD",
+        "ja": "410ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "565 AD",
+        "ja": "565ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "395 AD",
+        "ja": "395ねん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00609",
+    "image_path": null,
+    "question_text": {
+      "en": "When did the Roman Empire fall?",
+      "ja": "ろーまていこくはいつほろんだか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "French military leader and emperor",
+        "ja": "ふらんすのぐんじどうしゃとこうてい",
+        "ja_typings": []
+      },
+      {
+        "en": "British admiral",
+        "ja": "えいこくのかいぐんていとく",
+        "ja_typings": []
+      },
+      {
+        "en": "Russian tsar",
+        "ja": "ろしあのツァーリ",
+        "ja_typings": []
+      },
+      {
+        "en": "Prussian king",
+        "ja": "ぷろいせんのおう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00610",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Napoleon Bonaparte?",
+      "ja": "なぽれおんぼなぱるととは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1492",
+        "ja": "1492ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1498",
+        "ja": "1498ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1488",
+        "ja": "1488ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1510",
+        "ja": "1510ねん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00611",
+    "image_path": null,
+    "question_text": {
+      "en": "What year did Columbus reach the Americas?",
+      "ja": "ころんぶすがアメリカにたっしたのはなんねんか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "political tension between USA and USSR",
+        "ja": "アメリカとソ連の政治的緊張",
+        "ja_typings": []
+      },
+      {
+        "en": "war fought in cold climates",
+        "ja": "さむいきこうでのせんそう",
+        "ja_typings": []
+      },
+      {
+        "en": "war between Northern and Southern states",
+        "ja": "ほくぶとなんぶのせんそう",
+        "ja_typings": []
+      },
+      {
+        "en": "war without weapons",
+        "ja": "ぶきなしのせんそう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00612",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the Cold War?",
+      "ja": "れいせんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cleopatra VII",
+        "ja": "くれおぱとら7せい",
+        "ja_typings": []
+      },
+      {
+        "en": "Ramesses II",
+        "ja": "らめせす2せい",
+        "ja_typings": []
+      },
+      {
+        "en": "Tutankhamun",
+        "ja": "つたんかーめん",
+        "ja_typings": []
+      },
+      {
+        "en": "Nefertiti",
+        "ja": "ねふぇるてぃてぃ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00613",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the last Pharaoh of ancient Egypt?",
+      "ja": "こだいえじぷとのさいごのふぁらおは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1868",
+        "ja": "1868ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1853",
+        "ja": "1853ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1889",
+        "ja": "1889ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1912",
+        "ja": "1912ねん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00614",
+    "image_path": null,
+    "question_text": {
+      "en": "In what year did Japan's Meiji Restoration begin?",
+      "ja": "にほんのめいじいしんははじまったのはなんねんか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "English charter limiting royal power",
+        "ja": "おうけんをせいげんするえいこくのけんしょう",
+        "ja_typings": []
+      },
+      {
+        "en": "Roman law code",
+        "ja": "ろーまのほうてん",
+        "ja_typings": []
+      },
+      {
+        "en": "French revolutionary document",
+        "ja": "ふらんすかくめいのぶんしょ",
+        "ja_typings": []
+      },
+      {
+        "en": "Church constitution",
+        "ja": "きょうかいのけんぽう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00615",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the Magna Carta?",
+      "ja": "まぐなかるたとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mahatma Gandhi",
+        "ja": "まはとまがんじー",
+        "ja_typings": []
+      },
+      {
+        "en": "Jawaharlal Nehru",
+        "ja": "じゃわはるらーるねるー",
+        "ja_typings": []
+      },
+      {
+        "en": "Subhas Chandra Bose",
+        "ja": "すばーすちゃんどらぼーす",
+        "ja_typings": []
+      },
+      {
+        "en": "Bhagat Singh",
+        "ja": "ばがとしん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00616",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led the Indian independence movement against Britain?",
+      "ja": "えいこくにたいするいんどどくりつうんどうをひきいたのは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "European cultural revival 14th-17th century",
+        "ja": "14-17せいきのおうしゅうぶんかのふっこう",
+        "ja_typings": []
+      },
+      {
+        "en": "Roman Empire's golden age",
+        "ja": "ろーまていこくのおうごんじだい",
+        "ja_typings": []
+      },
+      {
+        "en": "Medieval crusade period",
+        "ja": "ちゅうせいじゅうじぐんのじだい",
+        "ja_typings": []
+      },
+      {
+        "en": "Age of Exploration",
+        "ja": "だいこうかいじだい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00617",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the Renaissance?",
+      "ja": "るねさんすとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1989",
+        "ja": "1989ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1991",
+        "ja": "1991ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1985",
+        "ja": "1985ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1993",
+        "ja": "1993ねん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00618",
+    "image_path": null,
+    "question_text": {
+      "en": "When did the Berlin Wall fall?",
+      "ja": "べるりんのかべはいつたおれたか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "colonial protest against British taxation",
+        "ja": "えいこくかぜいへのしょくみんちのこうぎ",
+        "ja_typings": []
+      },
+      {
+        "en": "tea festival in Boston",
+        "ja": "ぼすとんのちゃのさいてん",
+        "ja_typings": []
+      },
+      {
+        "en": "British tea trade event",
+        "ja": "えいこくのちゃのぼうえきいべんと",
+        "ja_typings": []
+      },
+      {
+        "en": "American tea company celebration",
+        "ja": "アメリカのちゃかいしゃのさいてん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00619",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the Boston Tea Party?",
+      "ja": "ぼすとんてぃーぱーてぃーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Karl Marx and Friedrich Engels",
+        "ja": "かーるまるくすとふりーどりひえんげるす",
+        "ja_typings": []
+      },
+      {
+        "en": "Vladimir Lenin",
+        "ja": "うらじーみるれーにん",
+        "ja_typings": []
+      },
+      {
+        "en": "Leon Trotsky",
+        "ja": "れおんとろつきー",
+        "ja_typings": []
+      },
+      {
+        "en": "Joseph Stalin",
+        "ja": "じょせふすたーりん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00620",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote the Communist Manifesto?",
+      "ja": "きょうさんとうせんげんをかいたのは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ancient trade routes connecting East and West",
+        "ja": "ひがしとにしをつなぐこだいのぼうえきろ",
+        "ja_typings": []
+      },
+      {
+        "en": "Chinese imperial road",
+        "ja": "ちゅうごくこうていのどうろ",
+        "ja_typings": []
+      },
+      {
+        "en": "road built of silk material",
+        "ja": "きぬでつくられたどうろ",
+        "ja_typings": []
+      },
+      {
+        "en": "Indian spice trade route",
+        "ja": "いんどのこうしんりょうぼうえきろ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00621",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the Silk Road?",
+      "ja": "しるくろーどとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Roman general and dictator",
+        "ja": "ろーまのしょうぐんとどくさいしゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "Greek philosopher",
+        "ja": "ぎりしあのてつがくしゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "Egyptian pharaoh",
+        "ja": "えじぷとのふぁらお",
+        "ja_typings": []
+      },
+      {
+        "en": "Persian king",
+        "ja": "ぺるしあのおう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00622",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Julius Caesar?",
+      "ja": "じゅりあすかいさーとは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1914",
+        "ja": "1914ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1916",
+        "ja": "1916ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1912",
+        "ja": "1912ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1918",
+        "ja": "1918ねん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00623",
+    "image_path": null,
+    "question_text": {
+      "en": "What year did the first World War begin?",
+      "ja": "だいいちじせかいたいせんはなんねんにはじまったか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "founder of Mongol Empire",
+        "ja": "もんごるていこくのきそしゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "Chinese emperor",
+        "ja": "ちゅうごくのこうてい",
+        "ja_typings": []
+      },
+      {
+        "en": "Japanese shogun",
+        "ja": "にほんのしょうぐん",
+        "ja_typings": []
+      },
+      {
+        "en": "Persian conqueror",
+        "ja": "ぺるしあのせいふくしゃ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00624",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Genghis Khan?",
+      "ja": "ちんぎすかんとは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Meiji Restoration",
+        "ja": "めいじいしん",
+        "ja_typings": []
+      },
+      {
+        "en": "Mongol invasion",
+        "ja": "もんごるのしんにゅう",
+        "ja_typings": []
+      },
+      {
+        "en": "Perry's arrival",
+        "ja": "ぺりーのらいこう",
+        "ja_typings": []
+      },
+      {
+        "en": "Edo Period end",
+        "ja": "えどじだいのおわり",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00625",
+    "image_path": null,
+    "question_text": {
+      "en": "What ended the feudal period in Japan?",
+      "ja": "にほんのほうけんじだいをおわらせたのは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "racial segregation in South Africa",
+        "ja": "みなみあふりかのじんしゅぶんり",
+        "ja_typings": []
+      },
+      {
+        "en": "South African independence movement",
+        "ja": "みなみあふりかのどくりつうんどう",
+        "ja_typings": []
+      },
+      {
+        "en": "African traditional religion",
+        "ja": "アフリカのでんとうてきしゅうきょう",
+        "ja_typings": []
+      },
+      {
+        "en": "South African economic policy",
+        "ja": "みなみあふりかのけいざいせいさく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00626",
+    "image_path": null,
+    "question_text": {
+      "en": "What was apartheid?",
+      "ja": "あぱるとへいととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1865",
+        "ja": "1865ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1863",
+        "ja": "1863ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1867",
+        "ja": "1867ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1861",
+        "ja": "1861ねん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00627",
+    "image_path": null,
+    "question_text": {
+      "en": "When did the American Civil War end?",
+      "ja": "アメリカなんぼくせんそうはなんねんにおわったか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Johannes Gutenberg",
+        "ja": "よはねすぐーてんべるく",
+        "ja_typings": []
+      },
+      {
+        "en": "Leonardo da Vinci",
+        "ja": "れおなるどだびんち",
+        "ja_typings": []
+      },
+      {
+        "en": "Isaac Newton",
+        "ja": "あいざっくにゅーとん",
+        "ja_typings": []
+      },
+      {
+        "en": "Nikola Tesla",
+        "ja": "にこらてすら",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00628",
+    "image_path": null,
+    "question_text": {
+      "en": "Who invented the printing press?",
+      "ja": "いんさつきをはつめいしたのは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "14th century pandemic plague",
+        "ja": "14せいきのぺすとのぱんでみっく",
+        "ja_typings": []
+      },
+      {
+        "en": "World War I battle",
+        "ja": "だいいちじたいせんのせんとう",
+        "ja_typings": []
+      },
+      {
+        "en": "Medieval famine",
+        "ja": "ちゅうせいのききん",
+        "ja_typings": []
+      },
+      {
+        "en": "African drought event",
+        "ja": "あふりかのかんばつ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00629",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the Black Death?",
+      "ja": "ぺすととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "American civil rights leader",
+        "ja": "アメリカのこうみんけんうんどうのしどうしゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "British prime minister",
+        "ja": "えいこくのしゅしょう",
+        "ja_typings": []
+      },
+      {
+        "en": "German reformer",
+        "ja": "どいつのかいかくしゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "South African president",
+        "ja": "みなみあふりかのだいとうりょう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00630",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Martin Luther King Jr.?",
+      "ja": "まーてぃんるーさーきんぐじゅにあとは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1991",
+        "ja": "1991ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1989",
+        "ja": "1989ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1993",
+        "ja": "1993ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1985",
+        "ja": "1985ねん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00631",
+    "image_path": null,
+    "question_text": {
+      "en": "What year did the Soviet Union collapse?",
+      "ja": "ソヴィエトれんぽうはなんねんにほうかいしたか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fidel Castro",
+        "ja": "ふぃでるかすとろ",
+        "ja_typings": []
+      },
+      {
+        "en": "Che Guevara",
+        "ja": "ちぇげばら",
+        "ja_typings": []
+      },
+      {
+        "en": "Raul Castro",
+        "ja": "らうるかすとろ",
+        "ja_typings": []
+      },
+      {
+        "en": "Fulgencio Batista",
+        "ja": "ふるへんしおばてぃすた",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00632",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led the Cuban Revolution?",
+      "ja": "きゅーばかくめいをひきいたのは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Allied invasion of Normandy in 1944",
+        "ja": "1944ねんのどーるのだんせんじょうりくさくせん",
+        "ja_typings": []
+      },
+      {
+        "en": "Japanese attack on Pearl Harbor",
+        "ja": "にほんのぱーるはーばーこうげき",
+        "ja_typings": []
+      },
+      {
+        "en": "Germany's invasion of France",
+        "ja": "どいつのふらんすしんこう",
+        "ja_typings": []
+      },
+      {
+        "en": "End of World War II",
+        "ja": "だいにじたいせんのおわり",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00633",
+    "image_path": null,
+    "question_text": {
+      "en": "What was D-Day?",
+      "ja": "でぃーでーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1912",
+        "ja": "1912ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1914",
+        "ja": "1914ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1910",
+        "ja": "1910ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1915",
+        "ja": "1915ねん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00634",
+    "image_path": null,
+    "question_text": {
+      "en": "When did the Titanic sink?",
+      "ja": "たいたにっくはなんねんにしずんだか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "founder of modern nursing",
+        "ja": "きんだいかんごのそしゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "British queen",
+        "ja": "えいこくのじょおう",
+        "ja_typings": []
+      },
+      {
+        "en": "American scientist",
+        "ja": "アメリカのかがくしゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "French artist",
+        "ja": "ふらんすのがか",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00635",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Florence Nightingale?",
+      "ja": "ふろれんすないちんげーるとは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "vast empire from Greece to India",
+        "ja": "ぎりしあからいんどまでのきょだいなていこく",
+        "ja_typings": []
+      },
+      {
+        "en": "Roman Empire",
+        "ja": "ろーまていこく",
+        "ja_typings": []
+      },
+      {
+        "en": "Persian Empire",
+        "ja": "ぺるしあていこく",
+        "ja_typings": []
+      },
+      {
+        "en": "Macedonian city-states only",
+        "ja": "まけどにあのとしこっかのみ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00636",
+    "image_path": null,
+    "question_text": {
+      "en": "What empire did Alexander the Great build?",
+      "ja": "アレクサンドロスだいおうはどのようなていこくをきずいたか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1941",
+        "ja": "1941ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1939",
+        "ja": "1939ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1943",
+        "ja": "1943ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1945",
+        "ja": "1945ねん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00637",
+    "image_path": null,
+    "question_text": {
+      "en": "When did Japan attack Pearl Harbor?",
+      "ja": "にほんはなんねんにぱーるはーばーをこうげきしたか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Neil Armstrong",
+        "ja": "にーるあーむすとろんぐ",
+        "ja_typings": []
+      },
+      {
+        "en": "Buzz Aldrin",
+        "ja": "ばずおるどりん",
+        "ja_typings": []
+      },
+      {
+        "en": "Yuri Gagarin",
+        "ja": "ゆーりががーりん",
+        "ja_typings": []
+      },
+      {
+        "en": "John Glenn",
+        "ja": "じょんぐれん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00638",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first man on the moon?",
+      "ja": "はじめて月にたったのは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Medieval European religious military campaigns",
+        "ja": "ちゅうせいおうしゅうのしゅうきょうてきぐんじえんせい",
+        "ja_typings": []
+      },
+      {
+        "en": "Ancient Greek military alliance",
+        "ja": "こだいぎりしあのぐんじどうめい",
+        "ja_typings": []
+      },
+      {
+        "en": "Roman expansion campaigns",
+        "ja": "ろーまのかくちょうえんせい",
+        "ja_typings": []
+      },
+      {
+        "en": "Viking raids on Europe",
+        "ja": "えいこくへのばいきんぐのしゅうげき",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00639",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the Crusades?",
+      "ja": "じゅうじぐんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "18th century philosophical movement emphasizing reason",
+        "ja": "18せいきのりせいをじゅうしするてつがくうんどう",
+        "ja_typings": []
+      },
+      {
+        "en": "Ancient Greek philosophy era",
+        "ja": "こだいぎりしあてつがくのじだい",
+        "ja_typings": []
+      },
+      {
+        "en": "Medieval church domination",
+        "ja": "ちゅうせいのきょうかいしはい",
+        "ja_typings": []
+      },
+      {
+        "en": "Renaissance art movement",
+        "ja": "るねさんすのびじゅつうんどう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00640",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the Enlightenment?",
+      "ja": "けいもうじだいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "South African anti-apartheid leader and president",
+        "ja": "みなみあふりかのはんあぱるとへいとうどうしゃとだいとうりょう",
+        "ja_typings": []
+      },
+      {
+        "en": "Kenyan independence leader",
+        "ja": "けにあのどくりつうんどうのしどうしゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "Nigerian president",
+        "ja": "ないじぇりあのだいとうりょう",
+        "ja_typings": []
+      },
+      {
+        "en": "Egyptian revolutionary",
+        "ja": "えじぷとのかくめいか",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00641",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Nelson Mandela?",
+      "ja": "ねるそんまんでらとは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1945",
+        "ja": "1945ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1919",
+        "ja": "1919ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1950",
+        "ja": "1950ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1941",
+        "ja": "1941ねん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00642",
+    "image_path": null,
+    "question_text": {
+      "en": "When was the United Nations founded?",
+      "ja": "こくさいれんごうはなんねんにせつりつされたか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "shift from agricultural to industrial economy",
+        "ja": "のうぎょうからこうぎょうけいざいへのてんかん",
+        "ja_typings": []
+      },
+      {
+        "en": "political revolution in France",
+        "ja": "ふらんすのせいじかくめい",
+        "ja_typings": []
+      },
+      {
+        "en": "technology revolution in 20th century",
+        "ja": "20せいきのぎじゅつかくめい",
+        "ja_typings": []
+      },
+      {
+        "en": "industrial nations forming alliance",
+        "ja": "こうぎょうこくのどうめいけっせい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00643",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the Industrial Revolution?",
+      "ja": "さんぎょうかくめいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "founder of People's Republic of China",
+        "ja": "ちゅうかじんみんきょうわこくのきそしゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "Japanese emperor",
+        "ja": "にほんのてんのう",
+        "ja_typings": []
+      },
+      {
+        "en": "Vietnamese communist leader",
+        "ja": "べとなむのきょうさんしゅぎしどうしゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "Korean war hero",
+        "ja": "ちょうせんせんそうのえいゆう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00644",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Mao Zedong?",
+      "ja": "もうたくとうとは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1953",
+        "ja": "1953ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1950",
+        "ja": "1950ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1955",
+        "ja": "1955ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1945",
+        "ja": "1945ねん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00645",
+    "image_path": null,
+    "question_text": {
+      "en": "When did the Korean War end?",
+      "ja": "ちょうせんせんそうはなんねんにおわったか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "last active pharaoh of ancient Egypt",
+        "ja": "こだいえじぷとのさいごのふぁらお",
+        "ja_typings": []
+      },
+      {
+        "en": "Roman empress",
+        "ja": "ろーまのこうごう",
+        "ja_typings": []
+      },
+      {
+        "en": "Greek goddess",
+        "ja": "ぎりしあのめがみ",
+        "ja_typings": []
+      },
+      {
+        "en": "Persian queen",
+        "ja": "ぺるしあのじょおう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00646",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Cleopatra?",
+      "ja": "くれおぱとらとは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "war between Britain and China over trade",
+        "ja": "えいこくとちゅうごくのぼうえきせんそう",
+        "ja_typings": []
+      },
+      {
+        "en": "war over drug prohibition",
+        "ja": "やくぶつきんしのせんそう",
+        "ja_typings": []
+      },
+      {
+        "en": "war between China and Japan",
+        "ja": "ちゅうにちせんそう",
+        "ja_typings": []
+      },
+      {
+        "en": "war in British India",
+        "ja": "えいりょういんどのせんそう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00647",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the Opium War?",
+      "ja": "あへんせんそうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "16th US president who abolished slavery",
+        "ja": "どれいせいをはいしした16だいアメリカだいとうりょう",
+        "ja_typings": []
+      },
+      {
+        "en": "1st US president",
+        "ja": "アメリカしょだいだいとうりょう",
+        "ja_typings": []
+      },
+      {
+        "en": "US president during WWI",
+        "ja": "だいいちじたいせんのアメリカだいとうりょう",
+        "ja_typings": []
+      },
+      {
+        "en": "US president during WWII",
+        "ja": "だいにじたいせんのアメリカだいとうりょう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00648",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Abraham Lincoln?",
+      "ja": "えいぶらはむりんかーんとは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1969",
+        "ja": "1969ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1967",
+        "ja": "1967ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1971",
+        "ja": "1971ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1965",
+        "ja": "1965ねん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00649",
+    "image_path": null,
+    "question_text": {
+      "en": "What year did the Moon landing occur?",
+      "ja": "つきにひとがおりたのはなんねんか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "WWII US program to develop atomic bomb",
+        "ja": "だいにじたいせんのアメリカのげんしばくだんかいはつ",
+        "ja_typings": []
+      },
+      {
+        "en": "construction of Manhattan island",
+        "ja": "まんはったんとうのけんせつ",
+        "ja_typings": []
+      },
+      {
+        "en": "Cold War spy program",
+        "ja": "れいせんのすぱいけいかく",
+        "ja_typings": []
+      },
+      {
+        "en": "space exploration program",
+        "ja": "うちゅうたんさくけいかく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00650",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the Manhattan Project?",
+      "ja": "まんはったんぷろじぇくととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "inventor of AC electrical system",
+        "ja": "こうりゅうでんきのはつめいか",
+        "ja_typings": []
+      },
+      {
+        "en": "inventor of the telephone",
+        "ja": "でんわのはつめいか",
+        "ja_typings": []
+      },
+      {
+        "en": "founder of Tesla Motors",
+        "ja": "てすらもーたーずのそうぎょうしゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "inventor of the light bulb",
+        "ja": "でんきゅうのはつめいか",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00651",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Nikola Tesla?",
+      "ja": "にこらてすらとは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "military government led by a shogun",
+        "ja": "しょうぐんにひきいられたぶがてくせいけん",
+        "ja_typings": []
+      },
+      {
+        "en": "imperial government system",
+        "ja": "こうしつのせいふしすてむ",
+        "ja_typings": []
+      },
+      {
+        "en": "samurai martial arts school",
+        "ja": "さむらいのぶどうがっこう",
+        "ja_typings": []
+      },
+      {
+        "en": "Buddhist temple organization",
+        "ja": "ぶっきょうじのそしき",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00652",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Shogunate in Japanese history?",
+      "ja": "にほんのしょうぐんとはどのようなものか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "series of conflicts between England and France",
+        "ja": "えいふらんかんのいちれんのぶんそう",
+        "ja_typings": []
+      },
+      {
+        "en": "war lasting exactly 100 years",
+        "ja": "ちょうど100ねんつづいたせんそう",
+        "ja_typings": []
+      },
+      {
+        "en": "war between 100 nations",
+        "ja": "100のくにのせんそう",
+        "ja_typings": []
+      },
+      {
+        "en": "Medieval plague lasting 100 years",
+        "ja": "100ねんつづいたちゅうせいのえきびょう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00653",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the Hundred Years' War?",
+      "ja": "ひゃくねんせんそうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "founder of the Edo shogunate",
+        "ja": "えどばくふのきそしゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "first emperor of Japan",
+        "ja": "にほんのしょだいてんのう",
+        "ja_typings": []
+      },
+      {
+        "en": "samurai who unified Japan alone",
+        "ja": "にほんをたんどくでとういつしたさむらい",
+        "ja_typings": []
+      },
+      {
+        "en": "reformer of the Meiji era",
+        "ja": "めいじじだいのかいかくしゃ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00654",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Tokugawa Ieyasu?",
+      "ja": "とくがわいえやすとは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "peace treaty ending World War I",
+        "ja": "だいいちじたいせんをおわらせるわへいじょうやく",
+        "ja_typings": []
+      },
+      {
+        "en": "peace treaty ending World War II",
+        "ja": "だいにじたいせんをおわらせるわへいじょうやく",
+        "ja_typings": []
+      },
+      {
+        "en": "treaty dividing Europe in Cold War",
+        "ja": "れいせんでのおうしゅうのぶんかつじょうやく",
+        "ja_typings": []
+      },
+      {
+        "en": "trade treaty between France and Germany",
+        "ja": "ふらんすとどいつのぼうえきじょうやく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00655",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the Treaty of Versailles?",
+      "ja": "べるさいゆじょうやくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "British PM during World War II",
+        "ja": "だいにじたいせんのえいこくしゅしょう",
+        "ja_typings": []
+      },
+      {
+        "en": "British PM during World War I",
+        "ja": "だいいちじたいせんのえいこくしゅしょう",
+        "ja_typings": []
+      },
+      {
+        "en": "British king during WWII",
+        "ja": "だいにじたいせんのえいこくおう",
+        "ja_typings": []
+      },
+      {
+        "en": "American president during WWII",
+        "ja": "だいにじたいせんのアメリカだいとうりょう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00656",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Winston Churchill?",
+      "ja": "うぃんすとんちゃーちるとは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1918",
+        "ja": "1918ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1916",
+        "ja": "1916ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1920",
+        "ja": "1920ねん",
+        "ja_typings": []
+      },
+      {
+        "en": "1919",
+        "ja": "1919ねん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00657",
+    "image_path": null,
+    "question_text": {
+      "en": "When did World War I end?",
+      "ja": "だいいちじせかいたいせんはなんねんにおわったか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "H₂O",
+        "ja": "H₂O",
+        "ja_typings": []
+      },
+      {
+        "en": "HO₂",
+        "ja": "HO₂",
+        "ja_typings": []
+      },
+      {
+        "en": "H₂O₂",
+        "ja": "H₂O₂",
+        "ja_typings": []
+      },
+      {
+        "en": "OH₂",
+        "ja": "OH₂",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00658",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the chemical symbol for water?",
+      "ja": "みずのかがくしきは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "object at rest stays at rest unless acted upon",
+        "ja": "がいりょくなしにせいしのぶったいはせいしをたもつ",
+        "ja_typings": []
+      },
+      {
+        "en": "F = ma",
+        "ja": "F = ma",
+        "ja_typings": []
+      },
+      {
+        "en": "equal and opposite reactions",
+        "ja": "さようとはんさようがひとしい",
+        "ja_typings": []
+      },
+      {
+        "en": "energy cannot be created or destroyed",
+        "ja": "えねるぎーはそうせいもしょうめつもしない",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00659",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Newton's first law of motion?",
+      "ja": "にゅーとんのうんどうのだいいちほうそくは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mars",
+        "ja": "かせい",
+        "ja_typings": []
+      },
+      {
+        "en": "Jupiter",
+        "ja": "もくせい",
+        "ja_typings": []
+      },
+      {
+        "en": "Saturn",
+        "ja": "どせい",
+        "ja_typings": []
+      },
+      {
+        "en": "Venus",
+        "ja": "きんせい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00660",
+    "image_path": null,
+    "question_text": {
+      "en": "What planet is known as the Red Planet?",
+      "ja": "あかいわくせいとよばれるのは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "plants converting light to energy",
+        "ja": "しょくぶつがひかりをえねるぎーにへんかん",
+        "ja_typings": []
+      },
+      {
+        "en": "animal digestion process",
+        "ja": "どうぶつのしょうかぷろせす",
+        "ja_typings": []
+      },
+      {
+        "en": "water cycle process",
+        "ja": "みずのじゅんかんぷろせす",
+        "ja_typings": []
+      },
+      {
+        "en": "cellular respiration",
+        "ja": "さいぼうこきゅう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00661",
+    "image_path": null,
+    "question_text": {
+      "en": "What is photosynthesis?",
+      "ja": "こうごうせいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "about 300,000 km/s",
+        "ja": "やく30まんkm/s",
+        "ja_typings": []
+      },
+      {
+        "en": "about 30,000 km/s",
+        "ja": "やく3まんkm/s",
+        "ja_typings": []
+      },
+      {
+        "en": "about 3,000 km/s",
+        "ja": "やく3せんkm/s",
+        "ja_typings": []
+      },
+      {
+        "en": "about 3,000,000 km/s",
+        "ja": "やく300まんkm/s",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00662",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the speed of light?",
+      "ja": "ひかりのそくどは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "molecule storing genetic information",
+        "ja": "いでんじょうほうをほぞんするぶんし",
+        "ja_typings": []
+      },
+      {
+        "en": "protein in muscles",
+        "ja": "きんにくのたんぱくしつ",
+        "ja_typings": []
+      },
+      {
+        "en": "type of RNA",
+        "ja": "RNAのしゅるい",
+        "ja_typings": []
+      },
+      {
+        "en": "cell membrane component",
+        "ja": "さいぼうまくのせいぶん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00663",
+    "image_path": null,
+    "question_text": {
+      "en": "What is DNA?",
+      "ja": "DNAとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "table organizing chemical elements",
+        "ja": "かがくげんそをせいりしたひょう",
+        "ja_typings": []
+      },
+      {
+        "en": "table of chemical reactions",
+        "ja": "かがくはんのうのひょう",
+        "ja_typings": []
+      },
+      {
+        "en": "table of atomic weights only",
+        "ja": "げんしりょうのみのひょう",
+        "ja_typings": []
+      },
+      {
+        "en": "table of natural compounds",
+        "ja": "しぜんかごうぶつのひょう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00664",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the periodic table?",
+      "ja": "げんそのしゅうきひょうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "rapid air expansion from lightning heat",
+        "ja": "いなびかりの熱による急速な空気膨張",
+        "ja_typings": []
+      },
+      {
+        "en": "clouds colliding",
+        "ja": "くものしょうとつ",
+        "ja_typings": []
+      },
+      {
+        "en": "electric discharge from clouds",
+        "ja": "くもからのほうでん",
+        "ja_typings": []
+      },
+      {
+        "en": "sonic boom from rain",
+        "ja": "あめのそにっくぶーむ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00665",
+    "image_path": null,
+    "question_text": {
+      "en": "What causes thunder?",
+      "ja": "かみなりがなるりゆうは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "region where gravity is so strong light cannot escape",
+        "ja": "光が脱出できないほど重力が強い領域",
+        "ja_typings": []
+      },
+      {
+        "en": "dark star that produces no light",
+        "ja": "ひかりをだしていないくらいほし",
+        "ja_typings": []
+      },
+      {
+        "en": "empty space in galaxy",
+        "ja": "ぎゃらくしーのそらのくうかん",
+        "ja_typings": []
+      },
+      {
+        "en": "remnant of a supernova",
+        "ja": "ちょうしんせいのなごり",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00666",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a black hole?",
+      "ja": "ぶらっくほーるとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "change in heritable traits over generations",
+        "ja": "せだいをこえてかわるいでんてきとくせい",
+        "ja_typings": []
+      },
+      {
+        "en": "transformation within one organism's lifetime",
+        "ja": "いのちのあいだにそのどうぶつがかわること",
+        "ja_typings": []
+      },
+      {
+        "en": "adaptation to daily environment",
+        "ja": "にちじょうかんきょうへのてきおう",
+        "ja_typings": []
+      },
+      {
+        "en": "growth and development of individual",
+        "ja": "こたいのせいちょうとはったつ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00667",
+    "image_path": null,
+    "question_text": {
+      "en": "What is evolution?",
+      "ja": "しんかとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "6",
+        "ja": "6",
+        "ja_typings": []
+      },
+      {
+        "en": "12",
+        "ja": "12",
+        "ja_typings": []
+      },
+      {
+        "en": "14",
+        "ja": "14",
+        "ja_typings": []
+      },
+      {
+        "en": "8",
+        "ja": "8",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00668",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the atomic number of Carbon?",
+      "ja": "たんそのげんしばんごうは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "attraction between masses",
+        "ja": "しつりょうかんのひきつけあい",
+        "ja_typings": []
+      },
+      {
+        "en": "repulsion between charges",
+        "ja": "でんかのはんぱつりょく",
+        "ja_typings": []
+      },
+      {
+        "en": "electromagnetic force",
+        "ja": "でんじりょく",
+        "ja_typings": []
+      },
+      {
+        "en": "nuclear binding force",
+        "ja": "かくりょく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00669",
+    "image_path": null,
+    "question_text": {
+      "en": "What is gravity?",
+      "ja": "じゅうりょくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Einstein's theory of space, time, and gravity",
+        "ja": "アインシュタインのくうかんじかんじゅうりょくのりろん",
+        "ja_typings": []
+      },
+      {
+        "en": "theory of evolution",
+        "ja": "しんかろん",
+        "ja_typings": []
+      },
+      {
+        "en": "theory of quantum mechanics",
+        "ja": "りょうしりきがく",
+        "ja_typings": []
+      },
+      {
+        "en": "Newton's laws of motion",
+        "ja": "にゅーとんのうんどうほうそく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00670",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the theory of relativity?",
+      "ja": "そうたいせいりろんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nitrogen",
+        "ja": "ちっそ",
+        "ja_typings": []
+      },
+      {
+        "en": "Oxygen",
+        "ja": "さんそ",
+        "ja_typings": []
+      },
+      {
+        "en": "Carbon Dioxide",
+        "ja": "にさんかたんそ",
+        "ja_typings": []
+      },
+      {
+        "en": "Argon",
+        "ja": "あるごん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00671",
+    "image_path": null,
+    "question_text": {
+      "en": "What gas is most abundant in Earth's atmosphere?",
+      "ja": "ちきゅうのたいきにもっともおおいきたいは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "nerve cell",
+        "ja": "しんけいさいぼう",
+        "ja_typings": []
+      },
+      {
+        "en": "muscle cell",
+        "ja": "きんにくさいぼう",
+        "ja_typings": []
+      },
+      {
+        "en": "blood cell",
+        "ja": "けっきゅう",
+        "ja_typings": []
+      },
+      {
+        "en": "skin cell",
+        "ja": "ひふさいぼう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00672",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a neuron?",
+      "ja": "にゅーろんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "universe began from a hot dense state",
+        "ja": "うちゅうはこうおんこうみつじょうたいからはじまった",
+        "ja_typings": []
+      },
+      {
+        "en": "universe has always existed",
+        "ja": "うちゅうはつねにそんざいしていた",
+        "ja_typings": []
+      },
+      {
+        "en": "universe is contracting",
+        "ja": "うちゅうはしゅうしゅくしている",
+        "ja_typings": []
+      },
+      {
+        "en": "stars created the universe",
+        "ja": "ほしがうちゅうをつくった",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00673",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Big Bang theory?",
+      "ja": "びっぐばんりろんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "cell's powerhouse producing ATP",
+        "ja": "さいぼうのATPせいさんそうち",
+        "ja_typings": []
+      },
+      {
+        "en": "protein synthesis organelle",
+        "ja": "たんぱくしつごうせいのきかん",
+        "ja_typings": []
+      },
+      {
+        "en": "cell's genetic material storage",
+        "ja": "さいぼうのいでんじかんり",
+        "ja_typings": []
+      },
+      {
+        "en": "cell membrane pump",
+        "ja": "さいぼうまくのぽんぷ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00674",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the mitochondria?",
+      "ja": "みとこんどりあとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "water moving through semipermeable membrane",
+        "ja": "はんとうまくをこしてみずがいどうする",
+        "ja_typings": []
+      },
+      {
+        "en": "nutrient absorption in cells",
+        "ja": "さいぼうでのえいようきゅうしゅう",
+        "ja_typings": []
+      },
+      {
+        "en": "gas exchange in lungs",
+        "ja": "はいでのがすこうかん",
+        "ja_typings": []
+      },
+      {
+        "en": "salt dissolving in water",
+        "ja": "しおがみずにとけること",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00675",
+    "image_path": null,
+    "question_text": {
+      "en": "What is osmosis?",
+      "ja": "しんとうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "atmosphere trapping heat",
+        "ja": "たいきがねつをとじこめる",
+        "ja_typings": []
+      },
+      {
+        "en": "plants using sunlight",
+        "ja": "しょくぶつがたいようこうをりようする",
+        "ja_typings": []
+      },
+      {
+        "en": "ocean warming by sun",
+        "ja": "たいようにようる海のあたたまり",
+        "ja_typings": []
+      },
+      {
+        "en": "volcanoes releasing CO2",
+        "ja": "かざんがCO₂をほうしゅつする",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00676",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the greenhouse effect?",
+      "ja": "おんしつこうかとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "gravity",
+        "ja": "じゅうりょく",
+        "ja_typings": []
+      },
+      {
+        "en": "magnetic force",
+        "ja": "じりょく",
+        "ja_typings": []
+      },
+      {
+        "en": "nuclear force",
+        "ja": "かくりょく",
+        "ja_typings": []
+      },
+      {
+        "en": "centrifugal force",
+        "ja": "えんしんりょく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00677",
+    "image_path": null,
+    "question_text": {
+      "en": "What force keeps planets in orbit?",
+      "ja": "わくせいをきどうにたもつりょくは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "contains DNA and controls cell activities",
+        "ja": "DNAをもちさいぼうかつどうをせいぎょ",
+        "ja_typings": []
+      },
+      {
+        "en": "produces energy for the cell",
+        "ja": "さいぼうのためにえねるぎーをせいさん",
+        "ja_typings": []
+      },
+      {
+        "en": "creates proteins for the cell",
+        "ja": "さいぼうのためにたんぱくしつをつくる",
+        "ja_typings": []
+      },
+      {
+        "en": "controls cell movement",
+        "ja": "さいぼうのうごきをせいぎょ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00678",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the function of the nucleus in a cell?",
+      "ja": "さいぼうのかくのやくわりは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "smallest unit of an element",
+        "ja": "げんそのさいしょうたんい",
+        "ja_typings": []
+      },
+      {
+        "en": "smallest particle of matter",
+        "ja": "ぶっしつのさいしょうりゅうし",
+        "ja_typings": []
+      },
+      {
+        "en": "subatomic particle",
+        "ja": "そうあとみっくりゅうし",
+        "ja_typings": []
+      },
+      {
+        "en": "molecule of two atoms",
+        "ja": "ふたつのげんしのぶんし",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00679",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an atom?",
+      "ja": "げんしとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "positively charged particle in nucleus",
+        "ja": "かくのなかのせいのでんかりゅうし",
+        "ja_typings": []
+      },
+      {
+        "en": "negatively charged particle",
+        "ja": "ふのでんかりゅうし",
+        "ja_typings": []
+      },
+      {
+        "en": "neutral particle in nucleus",
+        "ja": "かくのなかのちゅうせいりゅうし",
+        "ja_typings": []
+      },
+      {
+        "en": "particle outside nucleus",
+        "ja": "かくのそとのりゅうし",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00680",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a proton?",
+      "ja": "ようしとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "negatively charged particle orbiting nucleus",
+        "ja": "かくをこうかいするふのでんかりゅうし",
+        "ja_typings": []
+      },
+      {
+        "en": "positively charged particle",
+        "ja": "せいのでんかりゅうし",
+        "ja_typings": []
+      },
+      {
+        "en": "particle in nucleus",
+        "ja": "かくのなかのりゅうし",
+        "ja_typings": []
+      },
+      {
+        "en": "neutral particle",
+        "ja": "ちゅうせいりゅうし",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00681",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an electron?",
+      "ja": "でんしとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "neutral particle in the nucleus",
+        "ja": "かくのなかのちゅうせいりゅうし",
+        "ja_typings": []
+      },
+      {
+        "en": "positively charged nuclear particle",
+        "ja": "かくのせいでんかりゅうし",
+        "ja_typings": []
+      },
+      {
+        "en": "negatively charged orbital particle",
+        "ja": "ふのでんかこうかいりゅうし",
+        "ja_typings": []
+      },
+      {
+        "en": "particle outside the atom",
+        "ja": "げんしのそとのりゅうし",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00682",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a neutron?",
+      "ja": "ちゅうせいしとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "galaxy containing our solar system",
+        "ja": "たいようけいをふくむぎゃらくしー",
+        "ja_typings": []
+      },
+      {
+        "en": "visible path of the moon",
+        "ja": "つきのみちすじ",
+        "ja_typings": []
+      },
+      {
+        "en": "meteor shower event",
+        "ja": "りゅうせいうのできごと",
+        "ja_typings": []
+      },
+      {
+        "en": "region of dense stars near Sun",
+        "ja": "たいようきんくのこうみつほしいき",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00683",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Milky Way?",
+      "ja": "あまのがわとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "waves of electric and magnetic fields",
+        "ja": "でんきとじきのは",
+        "ja_typings": []
+      },
+      {
+        "en": "radiation from radioactive materials",
+        "ja": "ほうしゃせいぶっしつからのほうしゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "radiation from the sun only",
+        "ja": "たいようからのみのほうしゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "radiation in Earth's core",
+        "ja": "ちきゅうのかくのほうしゃ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00684",
+    "image_path": null,
+    "question_text": {
+      "en": "What is electromagnetic radiation?",
+      "ja": "でんじほうしゃとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "forces holding atoms together in molecules",
+        "ja": "ぶんしのなかでげんしをつなぐちから",
+        "ja_typings": []
+      },
+      {
+        "en": "chemical reaction rate",
+        "ja": "かがくはんのうのそくど",
+        "ja_typings": []
+      },
+      {
+        "en": "process of dissolving substances",
+        "ja": "ぶっしつのようかいぷろせす",
+        "ja_typings": []
+      },
+      {
+        "en": "separation of compounds",
+        "ja": "かごうぶつのぶんりかい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00685",
+    "image_path": null,
+    "question_text": {
+      "en": "What is chemical bonding?",
+      "ja": "かがくけつごうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "testable proposed explanation",
+        "ja": "けんしょう可能なかていの説明",
+        "ja_typings": []
+      },
+      {
+        "en": "proven scientific fact",
+        "ja": "しょうめいされたかがくてきじじつ",
+        "ja_typings": []
+      },
+      {
+        "en": "experimental result",
+        "ja": "じっけんけっか",
+        "ja_typings": []
+      },
+      {
+        "en": "scientific law",
+        "ja": "かがくてきほうそく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00686",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a hypothesis?",
+      "ja": "かせつとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "systematic approach to testing hypotheses",
+        "ja": "かせつをけんしょうするけいとうてきなほうほう",
+        "ja_typings": []
+      },
+      {
+        "en": "collection of scientific facts",
+        "ja": "かがくてきじじつのしゅうしゅう",
+        "ja_typings": []
+      },
+      {
+        "en": "laboratory equipment usage",
+        "ja": "じっけんきぐのしよう",
+        "ja_typings": []
+      },
+      {
+        "en": "publishing research papers",
+        "ja": "けんきゅうろんぶんのこうかい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00687",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the scientific method?",
+      "ja": "かがくてきほうほうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "unit of heredity on DNA",
+        "ja": "DNAじょうのいでんのたんい",
+        "ja_typings": []
+      },
+      {
+        "en": "type of protein",
+        "ja": "たんぱくしつのしゅるい",
+        "ja_typings": []
+      },
+      {
+        "en": "cell membrane component",
+        "ja": "さいぼうまくのせいぶん",
+        "ja_typings": []
+      },
+      {
+        "en": "RNA molecule",
+        "ja": "RNAぶんし",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00688",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a gene?",
+      "ja": "いでんしとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "feeding relationships in ecosystem",
+        "ja": "せいたいけいのしょくじかんけい",
+        "ja_typings": []
+      },
+      {
+        "en": "path food takes in digestion",
+        "ja": "しょうかのなかのしょくひんのみち",
+        "ja_typings": []
+      },
+      {
+        "en": "supply chain for food industry",
+        "ja": "しょくひんさんぎょうのさぷらいちぇーん",
+        "ja_typings": []
+      },
+      {
+        "en": "chain of supermarkets",
+        "ja": "すーぱーのれんさ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00689",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the food chain?",
+      "ja": "しょくもつれんさとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "100°C",
+        "ja": "100ど",
+        "ja_typings": []
+      },
+      {
+        "en": "90°C",
+        "ja": "90ど",
+        "ja_typings": []
+      },
+      {
+        "en": "110°C",
+        "ja": "110ど",
+        "ja_typings": []
+      },
+      {
+        "en": "80°C",
+        "ja": "80ど",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00690",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the boiling point of water at sea level?",
+      "ja": "かいめんでのみずのふってんは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "substances transform into new substances",
+        "ja": "ぶっしつがあたらしいぶっしつにへんかん",
+        "ja_typings": []
+      },
+      {
+        "en": "physical change in matter",
+        "ja": "ぶっしつのぶつりてきへんか",
+        "ja_typings": []
+      },
+      {
+        "en": "mixing two liquids",
+        "ja": "ふたつのえきたいをまぜる",
+        "ja_typings": []
+      },
+      {
+        "en": "dissolving a solid",
+        "ja": "こたいをようかいする",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00691",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a chemical reaction?",
+      "ja": "かがくはんのうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "time for half of atoms to decay",
+        "ja": "げんしのはんぶんがほうかいするまでのじかん",
+        "ja_typings": []
+      },
+      {
+        "en": "half the element's lifespan",
+        "ja": "げんそのじゅみょうのはんぶん",
+        "ja_typings": []
+      },
+      {
+        "en": "time for element to double",
+        "ja": "げんそが2ばいになるじかん",
+        "ja_typings": []
+      },
+      {
+        "en": "half the atomic weight",
+        "ja": "げんしりょうのはんぶん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00692",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the half-life of a radioactive element?",
+      "ja": "ほうしゃせいげんそのはんぶんきとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "substance that speeds up reaction without being consumed",
+        "ja": "じぶんはへらずにはんのうをはやめるぶっしつ",
+        "ja_typings": []
+      },
+      {
+        "en": "substance consumed in reaction",
+        "ja": "はんのうでしょうひされるぶっしつ",
+        "ja_typings": []
+      },
+      {
+        "en": "substance that stops reaction",
+        "ja": "はんのうをとめるぶっしつ",
+        "ja_typings": []
+      },
+      {
+        "en": "substance produced by reaction",
+        "ja": "はんのうでせいせいされるぶっしつ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00693",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a catalyst?",
+      "ja": "しょくばいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "energy of motion",
+        "ja": "うんどうのえねるぎー",
+        "ja_typings": []
+      },
+      {
+        "en": "stored potential energy",
+        "ja": "たくわえられたいねるぎー",
+        "ja_typings": []
+      },
+      {
+        "en": "thermal energy",
+        "ja": "ねつえねるぎー",
+        "ja_typings": []
+      },
+      {
+        "en": "chemical energy",
+        "ja": "かがくえねるぎー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00694",
+    "image_path": null,
+    "question_text": {
+      "en": "What is kinetic energy?",
+      "ja": "うんどうえねるぎーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "stored energy due to position or state",
+        "ja": "いちやじょうたいによるたくわえられたえねるぎー",
+        "ja_typings": []
+      },
+      {
+        "en": "energy of motion",
+        "ja": "うんどうのえねるぎー",
+        "ja_typings": []
+      },
+      {
+        "en": "electrical energy",
+        "ja": "でんきえねるぎー",
+        "ja_typings": []
+      },
+      {
+        "en": "nuclear energy",
+        "ja": "かくえねるぎー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00695",
+    "image_path": null,
+    "question_text": {
+      "en": "What is potential energy?",
+      "ja": "いねるぎーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "energy cannot be created or destroyed",
+        "ja": "えねるぎーはそうせいもしょうめつもしない",
+        "ja_typings": []
+      },
+      {
+        "en": "energy increases in closed systems",
+        "ja": "へいさいけいでえねるぎーはふえる",
+        "ja_typings": []
+      },
+      {
+        "en": "energy is always converted to heat",
+        "ja": "えねるぎーはつねにねつにへんかん",
+        "ja_typings": []
+      },
+      {
+        "en": "energy is constant only in space",
+        "ja": "えねるぎーはうちゅうでのみいってい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00696",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the law of conservation of energy?",
+      "ja": "えねるぎーほぞんのほうそくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "carry oxygen through the body",
+        "ja": "さんそをからだにはこぶ",
+        "ja_typings": []
+      },
+      {
+        "en": "fight infections",
+        "ja": "かんせんしょうとたたかう",
+        "ja_typings": []
+      },
+      {
+        "en": "form blood clots",
+        "ja": "けっせんをつくる",
+        "ja_typings": []
+      },
+      {
+        "en": "produce hormones",
+        "ja": "ほるもんをせいさん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00697",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the role of red blood cells?",
+      "ja": "せっけっきゅうのやくわりは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "fight infections and foreign bodies",
+        "ja": "かんせんしょうとがいぶしんたいとたたかう",
+        "ja_typings": []
+      },
+      {
+        "en": "carry oxygen",
+        "ja": "さんそをはこぶ",
+        "ja_typings": []
+      },
+      {
+        "en": "clot blood",
+        "ja": "ちをかたまらせる",
+        "ja_typings": []
+      },
+      {
+        "en": "store nutrients",
+        "ja": "えいようをちょくせつほぞん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00698",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the function of white blood cells?",
+      "ja": "はっけっきゅうのやくわりは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "pancreas",
+        "ja": "すいぞう",
+        "ja_typings": []
+      },
+      {
+        "en": "liver",
+        "ja": "かんぞう",
+        "ja_typings": []
+      },
+      {
+        "en": "kidney",
+        "ja": "じんぞう",
+        "ja_typings": []
+      },
+      {
+        "en": "spleen",
+        "ja": "ひぞう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00699",
+    "image_path": null,
+    "question_text": {
+      "en": "What organ produces insulin?",
+      "ja": "いんすりんをせいさんするきかんは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "filter blood and produce urine",
+        "ja": "けつえきをこしてにょうをつくる",
+        "ja_typings": []
+      },
+      {
+        "en": "digest food",
+        "ja": "しょくぶつをしょうか",
+        "ja_typings": []
+      },
+      {
+        "en": "produce oxygen",
+        "ja": "さんそをせいさん",
+        "ja_typings": []
+      },
+      {
+        "en": "control heartbeat",
+        "ja": "しんぱくをせいぎょ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00700",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the function of the kidney?",
+      "ja": "じんぞうのやくわりは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "substance stimulating immune response",
+        "ja": "めんえきはんのうをうながすぶっしつ",
+        "ja_typings": []
+      },
+      {
+        "en": "medicine killing bacteria directly",
+        "ja": "さいきんをちょくせつころすやくざい",
+        "ja_typings": []
+      },
+      {
+        "en": "medicine reducing fever",
+        "ja": "ねつをさげるやくざい",
+        "ja_typings": []
+      },
+      {
+        "en": "medicine for pain relief",
+        "ja": "いたみどめのやくざい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00701",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a vaccine?",
+      "ja": "ワクチンとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "measure of acidity or alkalinity",
+        "ja": "さんせいやアルカリせいのはかりかた",
+        "ja_typings": []
+      },
+      {
+        "en": "measure of chemical purity",
+        "ja": "かがくじゅんすいどのはかりかた",
+        "ja_typings": []
+      },
+      {
+        "en": "measure of temperature",
+        "ja": "おんどのはかりかた",
+        "ja_typings": []
+      },
+      {
+        "en": "measure of pressure",
+        "ja": "あつりょくのはかりかた",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00702",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the pH scale?",
+      "ja": "pHすけーるとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "rain with high acidity from pollution",
+        "ja": "おせんによるさんせいのつよいあめ",
+        "ja_typings": []
+      },
+      {
+        "en": "rain in tropical areas",
+        "ja": "ねったいちほうのあめ",
+        "ja_typings": []
+      },
+      {
+        "en": "rain with heavy metal content",
+        "ja": "じゅうきんぞくをふくむあめ",
+        "ja_typings": []
+      },
+      {
+        "en": "rain during volcanic eruption",
+        "ja": "かざんふんかちゅうのあめ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00703",
+    "image_path": null,
+    "question_text": {
+      "en": "What is acid rain?",
+      "ja": "さんせいうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "splitting an atom releasing energy",
+        "ja": "げんしをわってえねるぎーをかいほう",
+        "ja_typings": []
+      },
+      {
+        "en": "combining atoms to release energy",
+        "ja": "げんしをあわせてえねるぎーをかいほう",
+        "ja_typings": []
+      },
+      {
+        "en": "radioactive decay of atoms",
+        "ja": "げんしのほうしゃせいほうかい",
+        "ja_typings": []
+      },
+      {
+        "en": "chemical breakdown of molecules",
+        "ja": "ぶんしのかがくてきぶんかい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00704",
+    "image_path": null,
+    "question_text": {
+      "en": "What is nuclear fission?",
+      "ja": "かくぶんれつとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "combining nuclei to release energy",
+        "ja": "かくをあわせてえねるぎーをかいほう",
+        "ja_typings": []
+      },
+      {
+        "en": "splitting nucleus to release energy",
+        "ja": "かくをわってえねるぎーをかいほう",
+        "ja_typings": []
+      },
+      {
+        "en": "radioactive emission from nucleus",
+        "ja": "かくからのほうしゃせいはっしゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "nuclear chain reaction",
+        "ja": "かくれんさはんのう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00705",
+    "image_path": null,
+    "question_text": {
+      "en": "What is nuclear fusion?",
+      "ja": "かくゆうごうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "massive sections of Earth's crust",
+        "ja": "ちきゅうのちかくのきょだいなぶぶん",
+        "ja_typings": []
+      },
+      {
+        "en": "layers of the atmosphere",
+        "ja": "たいきのそう",
+        "ja_typings": []
+      },
+      {
+        "en": "ocean floor sections",
+        "ja": "かいていのぶぶん",
+        "ja_typings": []
+      },
+      {
+        "en": "continental shelf regions",
+        "ja": "たいりくだなのりょういき",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00706",
+    "image_path": null,
+    "question_text": {
+      "en": "What is tectonic plates?",
+      "ja": "プレートとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "movement of tectonic plates",
+        "ja": "プレートのうごき",
+        "ja_typings": []
+      },
+      {
+        "en": "underground explosions",
+        "ja": "ちかのばくはつ",
+        "ja_typings": []
+      },
+      {
+        "en": "volcanic activity",
+        "ja": "かざんかつどう",
+        "ja_typings": []
+      },
+      {
+        "en": "ocean tides",
+        "ja": "うみのしおか",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00707",
+    "image_path": null,
+    "question_text": {
+      "en": "What causes an earthquake?",
+      "ja": "じしんのげんいんは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "layer absorbing UV radiation",
+        "ja": "しがいせんをきゅうしゅうするそう",
+        "ja_typings": []
+      },
+      {
+        "en": "layer containing most oxygen",
+        "ja": "さんそをもっともふくむそう",
+        "ja_typings": []
+      },
+      {
+        "en": "layer reflecting radio waves",
+        "ja": "でんぱをはんしゃするそう",
+        "ja_typings": []
+      },
+      {
+        "en": "layer containing greenhouse gases",
+        "ja": "おんしつこうかがすをふくむそう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00708",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the ozone layer?",
+      "ja": "おぞんそうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "energy from naturally replenishing sources",
+        "ja": "しぜんにおぎなわれるみなもとのえねるぎー",
+        "ja_typings": []
+      },
+      {
+        "en": "energy from oil and gas",
+        "ja": "せきゆとがすのえねるぎー",
+        "ja_typings": []
+      },
+      {
+        "en": "energy from nuclear fission",
+        "ja": "かくぶんれつのえねるぎー",
+        "ja_typings": []
+      },
+      {
+        "en": "energy from coal",
+        "ja": "せきたんのえねるぎー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00709",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a renewable energy source?",
+      "ja": "さいせいかのうなえねるぎーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "4",
+        "ja": "よん",
+        "ja_typings": []
+      },
+      {
+        "en": "3",
+        "ja": "さん",
+        "ja_typings": []
+      },
+      {
+        "en": "5",
+        "ja": "ご",
+        "ja_typings": []
+      },
+      {
+        "en": "6",
+        "ja": "ろく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00710",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 2 + 2?",
+      "ja": "2たす2はいくつ？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "12",
+        "ja": "じゅうに",
+        "ja_typings": []
+      },
+      {
+        "en": "11",
+        "ja": "じゅういち",
+        "ja_typings": []
+      },
+      {
+        "en": "13",
+        "ja": "じゅうさん",
+        "ja_typings": []
+      },
+      {
+        "en": "14",
+        "ja": "じゅうし",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00711",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the square root of 144?",
+      "ja": "144のへいほうこんは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "3.14159",
+        "ja": "さんてんいちよんいちごきゅう",
+        "ja_typings": []
+      },
+      {
+        "en": "2.71828",
+        "ja": "にてんなないちはちにはち",
+        "ja_typings": []
+      },
+      {
+        "en": "1.41421",
+        "ja": "いちてんよんいちよんにいち",
+        "ja_typings": []
+      },
+      {
+        "en": "1.73205",
+        "ja": "いちてんななさんにれい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00712",
+    "image_path": null,
+    "question_text": {
+      "en": "What is pi approximately equal to?",
+      "ja": "えんしゅうりつπはおよそいくつ？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "a²+b²=c²",
+        "ja": "えーじじょうたすびーじじょうはしーじじょう",
+        "ja_typings": []
+      },
+      {
+        "en": "a+b=c",
+        "ja": "えーたすびーはしー",
+        "ja_typings": []
+      },
+      {
+        "en": "a×b=c",
+        "ja": "えーかけるびーはしー",
+        "ja_typings": []
+      },
+      {
+        "en": "a²-b²=c",
+        "ja": "えーじじょうひくびーじじょうはしー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00713",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Pythagorean theorem?",
+      "ja": "ぴたごらすのていりとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "a number divisible only by 1 and itself",
+        "ja": "1とじぶんじしんでのみわりきれるかず",
+        "ja_typings": []
+      },
+      {
+        "en": "a number divisible by 2",
+        "ja": "2でわりきれるかず",
+        "ja_typings": []
+      },
+      {
+        "en": "a number greater than 100",
+        "ja": "100よりおおきいかず",
+        "ja_typings": []
+      },
+      {
+        "en": "a negative number",
+        "ja": "ふのかず",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00714",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a prime number?",
+      "ja": "そすうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "3628800",
+        "ja": "さんひゃくろくじゅうにまんはっせん",
+        "ja_typings": []
+      },
+      {
+        "en": "3628000",
+        "ja": "さんびゃくろくじゅうにまんぜろ",
+        "ja_typings": []
+      },
+      {
+        "en": "36288000",
+        "ja": "さんぜんろっぴゃくにじゅうはちまん",
+        "ja_typings": []
+      },
+      {
+        "en": "362880",
+        "ja": "さんじゅうろくまんにせんはっぴゃくはちじゅう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00715",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 10 factorial (10!)?",
+      "ja": "10の かいじょう(10!)はいくつ？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "180 degrees",
+        "ja": "ひゃくはちじゅうど",
+        "ja_typings": []
+      },
+      {
+        "en": "90 degrees",
+        "ja": "きゅうじゅうど",
+        "ja_typings": []
+      },
+      {
+        "en": "270 degrees",
+        "ja": "にひゃくななじゅうど",
+        "ja_typings": []
+      },
+      {
+        "en": "360 degrees",
+        "ja": "さんびゃくろくじゅうど",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00716",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the sum of angles in a triangle?",
+      "ja": "さんかっけいのないかくのわは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "πr²",
+        "ja": "ぱいあーるじじょう",
+        "ja_typings": []
+      },
+      {
+        "en": "2πr",
+        "ja": "にぱいあーる",
+        "ja_typings": []
+      },
+      {
+        "en": "πr",
+        "ja": "ぱいあーる",
+        "ja_typings": []
+      },
+      {
+        "en": "πd",
+        "ja": "ぱいでぃー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00717",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the area of a circle?",
+      "ja": "えんのめんせきは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "2πr",
+        "ja": "にぱいあーる",
+        "ja_typings": []
+      },
+      {
+        "en": "πr²",
+        "ja": "ぱいあーるじじょう",
+        "ja_typings": []
+      },
+      {
+        "en": "πr",
+        "ja": "ぱいあーる",
+        "ja_typings": []
+      },
+      {
+        "en": "4πr",
+        "ja": "よんぱいあーる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00718",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the circumference of a circle?",
+      "ja": "えんのしゅうちょうは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "0, 1, 1, 2, 3, 5",
+        "ja": "れい いち いち に さん ご",
+        "ja_typings": []
+      },
+      {
+        "en": "1, 2, 3, 5, 8",
+        "ja": "いち に さん ご はち",
+        "ja_typings": []
+      },
+      {
+        "en": "0, 1, 2, 3, 5",
+        "ja": "れい いち に さん ご",
+        "ja_typings": []
+      },
+      {
+        "en": "1, 1, 2, 4, 8",
+        "ja": "いち いち に よん はち",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00719",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Fibonacci sequence starting with?",
+      "ja": "ふぃぼなっちすうれつのはじまりは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "average of values",
+        "ja": "あたいのへいきん",
+        "ja_typings": []
+      },
+      {
+        "en": "middle value",
+        "ja": "まんなかのあたい",
+        "ja_typings": []
+      },
+      {
+        "en": "most frequent value",
+        "ja": "もっともひんぱんなあたい",
+        "ja_typings": []
+      },
+      {
+        "en": "range of values",
+        "ja": "あたいのはんい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00720",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'mean' refer to in statistics?",
+      "ja": "とうけいでのへいきんとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "middle value in sorted data",
+        "ja": "せいれつされたでーたのまんなかのあたい",
+        "ja_typings": []
+      },
+      {
+        "en": "average of all values",
+        "ja": "すべてのあたいのへいきん",
+        "ja_typings": []
+      },
+      {
+        "en": "most common value",
+        "ja": "もっともよくでるあたい",
+        "ja_typings": []
+      },
+      {
+        "en": "difference between max and min",
+        "ja": "さいだいとさいしょうのさ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00721",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the median?",
+      "ja": "ちゅうおうちとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "most frequently occurring value",
+        "ja": "もっともひんぱんにでるあたい",
+        "ja_typings": []
+      },
+      {
+        "en": "average value",
+        "ja": "へいきんち",
+        "ja_typings": []
+      },
+      {
+        "en": "middle value",
+        "ja": "なかまのち",
+        "ja_typings": []
+      },
+      {
+        "en": "range of values",
+        "ja": "はんい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00722",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the mode in statistics?",
+      "ja": "とうけいでのさいひんちとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "equation with x²",
+        "ja": "えっくすじじょうをふくむほうていしき",
+        "ja_typings": []
+      },
+      {
+        "en": "equation with x³",
+        "ja": "えっくすさんじょうをふくむほうていしき",
+        "ja_typings": []
+      },
+      {
+        "en": "equation with no variables",
+        "ja": "へんすうのないほうていしき",
+        "ja_typings": []
+      },
+      {
+        "en": "equation with only addition",
+        "ja": "たしざんだけのほうていしき",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00723",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a quadratic equation?",
+      "ja": "にじほうていしきとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "x = (-b ± √(b²-4ac)) / 2a",
+        "ja": "えっくすはまいなすびーぷらすまいなするーとびーじじょうひくよんえーしーわるにえー",
+        "ja_typings": []
+      },
+      {
+        "en": "x = -b/a",
+        "ja": "えっくすはまいなすびーわるえー",
+        "ja_typings": []
+      },
+      {
+        "en": "x = b/2a",
+        "ja": "えっくすはびーわるにえー",
+        "ja_typings": []
+      },
+      {
+        "en": "x = √b/a",
+        "ja": "えっくすはるーとびーわるえー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00724",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the quadratic formula?",
+      "ja": "にじほうていしきのかいのこうしきは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "inverse of exponentiation",
+        "ja": "べきじょうのぎゃくさん",
+        "ja_typings": []
+      },
+      {
+        "en": "square root operation",
+        "ja": "へいほうこんのけいさん",
+        "ja_typings": []
+      },
+      {
+        "en": "sum of a series",
+        "ja": "すうれつのわ",
+        "ja_typings": []
+      },
+      {
+        "en": "ratio of two numbers",
+        "ja": "にすうのひ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00725",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a logarithm?",
+      "ja": "たいすうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "rate of change of a function",
+        "ja": "かんすうのへんかのわりあい",
+        "ja_typings": []
+      },
+      {
+        "en": "area under a curve",
+        "ja": "きょくせんのしたのめんせき",
+        "ja_typings": []
+      },
+      {
+        "en": "sum of a function",
+        "ja": "かんすうのわ",
+        "ja_typings": []
+      },
+      {
+        "en": "inverse of a function",
+        "ja": "かんすうのぎゃく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00726",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the derivative in calculus?",
+      "ja": "びぶんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "area under a curve",
+        "ja": "きょくせんのしたのめんせき",
+        "ja_typings": []
+      },
+      {
+        "en": "rate of change",
+        "ja": "へんかのわりあい",
+        "ja_typings": []
+      },
+      {
+        "en": "slope of a function",
+        "ja": "かんすうのかたむき",
+        "ja_typings": []
+      },
+      {
+        "en": "maximum of a function",
+        "ja": "かんすうのさいだいち",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00727",
+    "image_path": null,
+    "question_text": {
+      "en": "What is integration in calculus?",
+      "ja": "せきぶんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "quantity with magnitude and direction",
+        "ja": "おおきさとむきをもつりょう",
+        "ja_typings": []
+      },
+      {
+        "en": "quantity with magnitude only",
+        "ja": "おおきさだけをもつりょう",
+        "ja_typings": []
+      },
+      {
+        "en": "a type of matrix",
+        "ja": "ぎょうれつのいっしゅ",
+        "ja_typings": []
+      },
+      {
+        "en": "a scalar value",
+        "ja": "すからーのあたい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00728",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a vector?",
+      "ja": "べくとるとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "rectangular array of numbers",
+        "ja": "すうのちょうほうけいのはいれつ",
+        "ja_typings": []
+      },
+      {
+        "en": "single row of numbers",
+        "ja": "すうのいちぎょう",
+        "ja_typings": []
+      },
+      {
+        "en": "a polynomial",
+        "ja": "たこうしき",
+        "ja_typings": []
+      },
+      {
+        "en": "a prime number set",
+        "ja": "そすうのしゅうごう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00729",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a matrix in mathematics?",
+      "ja": "すうがくでのぎょうれつとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "likelihood of an event",
+        "ja": "できごとのおこりやすさ",
+        "ja_typings": []
+      },
+      {
+        "en": "frequency of an event",
+        "ja": "できごとのひんど",
+        "ja_typings": []
+      },
+      {
+        "en": "certainty of an event",
+        "ja": "できごとのかくじつせい",
+        "ja_typings": []
+      },
+      {
+        "en": "range of outcomes",
+        "ja": "けっかのはんい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00730",
+    "image_path": null,
+    "question_text": {
+      "en": "What is probability?",
+      "ja": "かくりつとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1/6",
+        "ja": "ろくぶんのいち",
+        "ja_typings": []
+      },
+      {
+        "en": "1/2",
+        "ja": "にぶんのいち",
+        "ja_typings": []
+      },
+      {
+        "en": "1/3",
+        "ja": "さんぶんのいち",
+        "ja_typings": []
+      },
+      {
+        "en": "1/4",
+        "ja": "よんぶんのいち",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00731",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the probability of rolling a 6 on a die?",
+      "ja": "さいころで6がでるかくりつは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "collection of distinct objects",
+        "ja": "ことなるものの あつまり",
+        "ja_typings": []
+      },
+      {
+        "en": "ordered sequence",
+        "ja": "じゅんじょのあるならび",
+        "ja_typings": []
+      },
+      {
+        "en": "mathematical function",
+        "ja": "すうがくてきかんすう",
+        "ja_typings": []
+      },
+      {
+        "en": "pair of numbers",
+        "ja": "すうのくみ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00732",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a set in mathematics?",
+      "ja": "すうがくでのしゅうごうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "all elements in either set",
+        "ja": "どちらかのしゅうごうにあるすべての要素",
+        "ja_typings": []
+      },
+      {
+        "en": "elements in both sets",
+        "ja": "りょうほうにあるようそ",
+        "ja_typings": []
+      },
+      {
+        "en": "elements in only one set",
+        "ja": "いっぽうにしかないようそ",
+        "ja_typings": []
+      },
+      {
+        "en": "the empty set",
+        "ja": "くうしゅうごう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00733",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the union of two sets?",
+      "ja": "につのしゅうごうのわしゅうごうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "elements common to both sets",
+        "ja": "りょうほうのしゅうごうにふくまれるようそ",
+        "ja_typings": []
+      },
+      {
+        "en": "all elements in either set",
+        "ja": "どちらかにあるすべてのようそ",
+        "ja_typings": []
+      },
+      {
+        "en": "elements in only one set",
+        "ja": "いっぽうにしかないようそ",
+        "ja_typings": []
+      },
+      {
+        "en": "the complement set",
+        "ja": "ほごしゅうごう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00734",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the intersection of two sets?",
+      "ja": "につのしゅうごうのせきしゅうごうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "relation mapping input to output",
+        "ja": "にゅうりょくをしゅつりょくにたいおうさせるかんけい",
+        "ja_typings": []
+      },
+      {
+        "en": "a type of matrix",
+        "ja": "ぎょうれつのいっしゅ",
+        "ja_typings": []
+      },
+      {
+        "en": "a polynomial expression",
+        "ja": "たこうしきひょうげん",
+        "ja_typings": []
+      },
+      {
+        "en": "a geometric shape",
+        "ja": "きかがくてきけいじょう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00735",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a function in math?",
+      "ja": "すうがくでのかんすうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "number with real and imaginary parts",
+        "ja": "じつぶぶんときょぶぶんをもつかず",
+        "ja_typings": []
+      },
+      {
+        "en": "number greater than 1000",
+        "ja": "1000よりおおきいかず",
+        "ja_typings": []
+      },
+      {
+        "en": "negative integer",
+        "ja": "ふのせいすう",
+        "ja_typings": []
+      },
+      {
+        "en": "irrational number",
+        "ja": "むりすう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00736",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a complex number?",
+      "ja": "ふくそすうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "number that cannot be expressed as fraction",
+        "ja": "ぶんすうでひょうせないかず",
+        "ja_typings": []
+      },
+      {
+        "en": "negative number",
+        "ja": "ふのかず",
+        "ja_typings": []
+      },
+      {
+        "en": "very large number",
+        "ja": "とてもおおきいかず",
+        "ja_typings": []
+      },
+      {
+        "en": "number divisible by prime",
+        "ja": "そすうでわれるかず",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00737",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an irrational number?",
+      "ja": "むりすうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "7",
+        "ja": "なな",
+        "ja_typings": []
+      },
+      {
+        "en": "-7",
+        "ja": "まいなすなな",
+        "ja_typings": []
+      },
+      {
+        "en": "0",
+        "ja": "れい",
+        "ja_typings": []
+      },
+      {
+        "en": "49",
+        "ja": "よんじゅうきゅう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00738",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the absolute value of -7?",
+      "ja": "-7のぜったいちは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "0",
+        "ja": "れい",
+        "ja_typings": []
+      },
+      {
+        "en": "1",
+        "ja": "いち",
+        "ja_typings": []
+      },
+      {
+        "en": "-1",
+        "ja": "まいなすいち",
+        "ja_typings": []
+      },
+      {
+        "en": "undefined",
+        "ja": "ていぎされていない",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00739",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the slope of a horizontal line?",
+      "ja": "すいへいせんのかたむきは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "undefined",
+        "ja": "ていぎされていない",
+        "ja_typings": []
+      },
+      {
+        "en": "0",
+        "ja": "れい",
+        "ja_typings": []
+      },
+      {
+        "en": "1",
+        "ja": "いち",
+        "ja_typings": []
+      },
+      {
+        "en": "-1",
+        "ja": "まいなすいち",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00740",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the slope of a vertical line?",
+      "ja": "すいちょくせんのかたむきは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sequence where each term is multiplied by a constant",
+        "ja": "かくこうをていすうでかけるすうれつ",
+        "ja_typings": []
+      },
+      {
+        "en": "sequence where each term adds a constant",
+        "ja": "かくこうにていすうをたすすうれつ",
+        "ja_typings": []
+      },
+      {
+        "en": "sequence of prime numbers",
+        "ja": "そすうのすうれつ",
+        "ja_typings": []
+      },
+      {
+        "en": "sequence of squares",
+        "ja": "じじょうのすうれつ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00741",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a geometric progression?",
+      "ja": "とうひすうれつとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sequence where each term adds a constant",
+        "ja": "かくこうにていすうをたすすうれつ",
+        "ja_typings": []
+      },
+      {
+        "en": "sequence where each term is multiplied",
+        "ja": "かくこうをかけるすうれつ",
+        "ja_typings": []
+      },
+      {
+        "en": "decreasing sequence",
+        "ja": "げんしょうするすうれつ",
+        "ja_typings": []
+      },
+      {
+        "en": "random number sequence",
+        "ja": "らんすうのすうれつ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00742",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an arithmetic progression?",
+      "ja": "とうさすうれつとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "(4/3)πr³",
+        "ja": "よんさんぶんのぱいあーるさんじょう",
+        "ja_typings": []
+      },
+      {
+        "en": "πr²",
+        "ja": "ぱいあーるじじょう",
+        "ja_typings": []
+      },
+      {
+        "en": "(4/3)πr²",
+        "ja": "よんさんぶんのぱいあーるじじょう",
+        "ja_typings": []
+      },
+      {
+        "en": "πr³",
+        "ja": "ぱいあーるさんじょう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00743",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the formula for the volume of a sphere?",
+      "ja": "きゅうのたいせきのこうしきは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "2.71828",
+        "ja": "にてんなないちはちにはち",
+        "ja_typings": []
+      },
+      {
+        "en": "3.14159",
+        "ja": "さんてんいちよんいちごきゅう",
+        "ja_typings": []
+      },
+      {
+        "en": "1.41421",
+        "ja": "いちてんよんいちよんにいち",
+        "ja_typings": []
+      },
+      {
+        "en": "1.61803",
+        "ja": "いちてんろくいちはちれいさん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00744",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Euler's number 'e'?",
+      "ja": "おいらーのすうeはおよそいくつ？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "triangular array of binomial coefficients",
+        "ja": "にこうけいすうのさんかっけいはいれつ",
+        "ja_typings": []
+      },
+      {
+        "en": "triangle with all sides equal",
+        "ja": "すべてのへんがひとしいさんかっけい",
+        "ja_typings": []
+      },
+      {
+        "en": "triangle used in geometry proofs",
+        "ja": "きかがくのしょうめいにつかうさんかっけい",
+        "ja_typings": []
+      },
+      {
+        "en": "a graph type in statistics",
+        "ja": "とうけいのぐらふのいっしゅ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00745",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Pascal's triangle?",
+      "ja": "ぱすかるのさんかっけいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "arrangement of items in order",
+        "ja": "こうもくをじゅんじょよくならべたもの",
+        "ja_typings": []
+      },
+      {
+        "en": "selection without order",
+        "ja": "じゅんじょをきにしないせんたく",
+        "ja_typings": []
+      },
+      {
+        "en": "multiplication of all integers to n",
+        "ja": "nまでのせいすうのせき",
+        "ja_typings": []
+      },
+      {
+        "en": "sum of a series",
+        "ja": "すうれつのわ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00746",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a permutation?",
+      "ja": "じゅんれつとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "selection without regard to order",
+        "ja": "じゅんじょをきにしないせんたく",
+        "ja_typings": []
+      },
+      {
+        "en": "arrangement in specific order",
+        "ja": "とくていのじゅんじょによるならべかた",
+        "ja_typings": []
+      },
+      {
+        "en": "sum of elements",
+        "ja": "ようそのわ",
+        "ja_typings": []
+      },
+      {
+        "en": "product of elements",
+        "ja": "ようそのせき",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00747",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a combination?",
+      "ja": "くみあわせとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mandarin Chinese",
+        "ja": "まんだりんちゃいにーず",
+        "ja_typings": []
+      },
+      {
+        "en": "English",
+        "ja": "えいご",
+        "ja_typings": []
+      },
+      {
+        "en": "Spanish",
+        "ja": "すぺいんご",
+        "ja_typings": []
+      },
+      {
+        "en": "Hindi",
+        "ja": "ひんでぃーご",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00748",
+    "image_path": null,
+    "question_text": {
+      "en": "What language has the most native speakers?",
+      "ja": "もっともおおくのぼごわしゃをもつげんごは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "26",
+        "ja": "にじゅうろく",
+        "ja_typings": []
+      },
+      {
+        "en": "24",
+        "ja": "にじゅうし",
+        "ja_typings": []
+      },
+      {
+        "en": "28",
+        "ja": "にじゅうはち",
+        "ja_typings": []
+      },
+      {
+        "en": "30",
+        "ja": "さんじゅう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00749",
+    "image_path": null,
+    "question_text": {
+      "en": "How many letters are in the English alphabet?",
+      "ja": "えいごのあるふぁべっとはなんもじ？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Portuguese",
+        "ja": "ぽるとがるご",
+        "ja_typings": []
+      },
+      {
+        "en": "Spanish",
+        "ja": "すぺいんご",
+        "ja_typings": []
+      },
+      {
+        "en": "English",
+        "ja": "えいご",
+        "ja_typings": []
+      },
+      {
+        "en": "French",
+        "ja": "ふらんすご",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00750",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the official language of Brazil?",
+      "ja": "ぶらじるのこうようごは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Arabic",
+        "ja": "あらびあご",
+        "ja_typings": []
+      },
+      {
+        "en": "Hebrew",
+        "ja": "へぶらいご",
+        "ja_typings": []
+      },
+      {
+        "en": "Turkish",
+        "ja": "とるこご",
+        "ja_typings": []
+      },
+      {
+        "en": "Persian",
+        "ja": "ぺるしあご",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00751",
+    "image_path": null,
+    "question_text": {
+      "en": "What language is spoken in Egypt?",
+      "ja": "えじぷとでつかわれるげんごは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kanji, Hiragana, Katakana",
+        "ja": "かんじ、ひらがな、かたかな",
+        "ja_typings": []
+      },
+      {
+        "en": "Latin alphabet only",
+        "ja": "らてんもじのみ",
+        "ja_typings": []
+      },
+      {
+        "en": "Arabic script",
+        "ja": "あらびあもじ",
+        "ja_typings": []
+      },
+      {
+        "en": "Cyrillic script",
+        "ja": "きりるもじ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00752",
+    "image_path": null,
+    "question_text": {
+      "en": "What script is used for Japanese?",
+      "ja": "にほんごではどのもじをつかうか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "word with similar meaning",
+        "ja": "にたいみのことば",
+        "ja_typings": []
+      },
+      {
+        "en": "word with opposite meaning",
+        "ja": "はんたいのいみのことば",
+        "ja_typings": []
+      },
+      {
+        "en": "word that sounds the same",
+        "ja": "おなじおとのことば",
+        "ja_typings": []
+      },
+      {
+        "en": "word from another language",
+        "ja": "べつのげんごからのことば",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00753",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a synonym?",
+      "ja": "どうぎごとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "word with opposite meaning",
+        "ja": "はんたいのいみのことば",
+        "ja_typings": []
+      },
+      {
+        "en": "word with similar meaning",
+        "ja": "にたいみのことば",
+        "ja_typings": []
+      },
+      {
+        "en": "word from another language",
+        "ja": "べつのげんごからのことば",
+        "ja_typings": []
+      },
+      {
+        "en": "a foreign word",
+        "ja": "がいこくご",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00754",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an antonym?",
+      "ja": "はんたいごとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Japanese poem with 5-7-5 syllables",
+        "ja": "ごしちごのおんのにほんのし",
+        "ja_typings": []
+      },
+      {
+        "en": "Chinese poem form",
+        "ja": "ちゅうごくのしのけいしき",
+        "ja_typings": []
+      },
+      {
+        "en": "free verse poem",
+        "ja": "じゆうし",
+        "ja_typings": []
+      },
+      {
+        "en": "rhyming couplet",
+        "ja": "ぐいんをそろえたにれんく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00755",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a haiku?",
+      "ja": "はいくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "word borrowed from another language",
+        "ja": "べつのげんごからかりたことば",
+        "ja_typings": []
+      },
+      {
+        "en": "word used in legal documents",
+        "ja": "ほうりつぶんしょにつかうことば",
+        "ja_typings": []
+      },
+      {
+        "en": "made-up word",
+        "ja": "つくりことば",
+        "ja_typings": []
+      },
+      {
+        "en": "archaic word",
+        "ja": "ふるいことば",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00756",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'loanword' mean?",
+      "ja": "がいらいごとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "word that imitates a sound",
+        "ja": "おとをまねることば",
+        "ja_typings": []
+      },
+      {
+        "en": "very long word",
+        "ja": "とてもながいことば",
+        "ja_typings": []
+      },
+      {
+        "en": "a silent letter",
+        "ja": "さいれんとれたー",
+        "ja_typings": []
+      },
+      {
+        "en": "compound word",
+        "ja": "ふくごうご",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00757",
+    "image_path": null,
+    "question_text": {
+      "en": "What is onomatopoeia?",
+      "ja": "おのまとぺとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "aqua",
+        "ja": "あくあ",
+        "ja_typings": []
+      },
+      {
+        "en": "terra",
+        "ja": "てら",
+        "ja_typings": []
+      },
+      {
+        "en": "ignis",
+        "ja": "いぐにす",
+        "ja_typings": []
+      },
+      {
+        "en": "aer",
+        "ja": "あえる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00758",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Latin word for water?",
+      "ja": "みずのらてんごは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Indo-European",
+        "ja": "いんどーよーろっぱごぞく",
+        "ja_typings": []
+      },
+      {
+        "en": "Afro-Asiatic",
+        "ja": "あふろあじあごぞく",
+        "ja_typings": []
+      },
+      {
+        "en": "Sino-Tibetan",
+        "ja": "ちゅうごくちべっとごぞく",
+        "ja_typings": []
+      },
+      {
+        "en": "Austronesian",
+        "ja": "おーすとろねしあごぞく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00759",
+    "image_path": null,
+    "question_text": {
+      "en": "What language family does English belong to?",
+      "ja": "えいごはどのごぞくか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "word that reads same forwards and backwards",
+        "ja": "まえからもうしろからもよめることば",
+        "ja_typings": []
+      },
+      {
+        "en": "word with silent letters",
+        "ja": "さいれんとれたーのあることば",
+        "ja_typings": []
+      },
+      {
+        "en": "compound word",
+        "ja": "ふくごうご",
+        "ja_typings": []
+      },
+      {
+        "en": "a very short word",
+        "ja": "とてもみじかいことば",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00760",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a palindrome?",
+      "ja": "かいぶんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Early Modern English",
+        "ja": "そうききんだいえいご",
+        "ja_typings": []
+      },
+      {
+        "en": "Old English",
+        "ja": "こえいご",
+        "ja_typings": []
+      },
+      {
+        "en": "Middle English",
+        "ja": "ちゅうえいご",
+        "ja_typings": []
+      },
+      {
+        "en": "Latin",
+        "ja": "らてんご",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00761",
+    "image_path": null,
+    "question_text": {
+      "en": "What language did Shakespeare write in?",
+      "ja": "しぇいくすぴあはなにごでかいたか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "English",
+        "ja": "えいご",
+        "ja_typings": []
+      },
+      {
+        "en": "Spanish",
+        "ja": "すぺいんご",
+        "ja_typings": []
+      },
+      {
+        "en": "Mandarin",
+        "ja": "まんだりん",
+        "ja_typings": []
+      },
+      {
+        "en": "French",
+        "ja": "ふらんすご",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00762",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the most studied second language globally?",
+      "ja": "せかいでもっともまなばれているだいにげんごは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "study of word origins",
+        "ja": "ことばのおこりのがくもん",
+        "ja_typings": []
+      },
+      {
+        "en": "study of grammar",
+        "ja": "ぶんぽうのがくもん",
+        "ja_typings": []
+      },
+      {
+        "en": "study of dialects",
+        "ja": "ほうげんのがくもん",
+        "ja_typings": []
+      },
+      {
+        "en": "study of pronunciation",
+        "ja": "はつおんのがくもん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00763",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'etymology' mean?",
+      "ja": "ごげんがくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "rules for structure of language",
+        "ja": "げんごのこうぞうのきそく",
+        "ja_typings": []
+      },
+      {
+        "en": "vocabulary of a language",
+        "ja": "げんごのごい",
+        "ja_typings": []
+      },
+      {
+        "en": "pronunciation system",
+        "ja": "はつおんのしすてむ",
+        "ja_typings": []
+      },
+      {
+        "en": "writing system",
+        "ja": "ひょうきほう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00764",
+    "image_path": null,
+    "question_text": {
+      "en": "What is grammar?",
+      "ja": "ぶんぽうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "rules about sentence structure",
+        "ja": "ぶんのこうぞうにかんするきそく",
+        "ja_typings": []
+      },
+      {
+        "en": "study of word meaning",
+        "ja": "ことばのいみのけんきゅう",
+        "ja_typings": []
+      },
+      {
+        "en": "pronunciation rules",
+        "ja": "はつおんのきそく",
+        "ja_typings": []
+      },
+      {
+        "en": "origin of words",
+        "ja": "ことばのおこり",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00765",
+    "image_path": null,
+    "question_text": {
+      "en": "What is syntax?",
+      "ja": "こうぶんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "study of meaning in language",
+        "ja": "げんごのいみのけんきゅう",
+        "ja_typings": []
+      },
+      {
+        "en": "study of sentence structure",
+        "ja": "ぶんのこうぞうのけんきゅう",
+        "ja_typings": []
+      },
+      {
+        "en": "study of sounds",
+        "ja": "おとのけんきゅう",
+        "ja_typings": []
+      },
+      {
+        "en": "study of dialects",
+        "ja": "ほうげんのけんきゅう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00766",
+    "image_path": null,
+    "question_text": {
+      "en": "What is semantics?",
+      "ja": "いみろんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "regional variation of a language",
+        "ja": "げんごのちいきてきへんたい",
+        "ja_typings": []
+      },
+      {
+        "en": "simplified form of language",
+        "ja": "げんごのかんりゃくけい",
+        "ja_typings": []
+      },
+      {
+        "en": "foreign language",
+        "ja": "がいこくご",
+        "ja_typings": []
+      },
+      {
+        "en": "written form of language",
+        "ja": "ごのきじゅつけい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00767",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a dialect?",
+      "ja": "ほうげんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "constructed international language",
+        "ja": "じんこうてきなこくさいきょうつうご",
+        "ja_typings": []
+      },
+      {
+        "en": "ancient Latin dialect",
+        "ja": "こだいらてんのほうげん",
+        "ja_typings": []
+      },
+      {
+        "en": "Spanish dialect",
+        "ja": "すぺいんごのほうげん",
+        "ja_typings": []
+      },
+      {
+        "en": "mix of French and Italian",
+        "ja": "ふらんすごとイタリアごのまぜ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00768",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Esperanto?",
+      "ja": "えすぺらんととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "smallest unit of sound in language",
+        "ja": "げんごでもっともちいさなおとのたんい",
+        "ja_typings": []
+      },
+      {
+        "en": "written letter",
+        "ja": "きじゅつもじ",
+        "ja_typings": []
+      },
+      {
+        "en": "unit of meaning",
+        "ja": "いみのたんい",
+        "ja_typings": []
+      },
+      {
+        "en": "sentence structure unit",
+        "ja": "ぶんこうぞうのたんい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00769",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a phoneme?",
+      "ja": "おんそとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Russian",
+        "ja": "ろしあご",
+        "ja_typings": []
+      },
+      {
+        "en": "Greek",
+        "ja": "ぎりしあご",
+        "ja_typings": []
+      },
+      {
+        "en": "Arabic",
+        "ja": "あらびあご",
+        "ja_typings": []
+      },
+      {
+        "en": "Hebrew",
+        "ja": "へぶらいご",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00770",
+    "image_path": null,
+    "question_text": {
+      "en": "What language uses the Cyrillic alphabet?",
+      "ja": "きりるもじをつかうげんごは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "word describing an action or state",
+        "ja": "こうどうやじょうたいをあらわすことば",
+        "ja_typings": []
+      },
+      {
+        "en": "word describing a noun",
+        "ja": "めいしをせつめいすることば",
+        "ja_typings": []
+      },
+      {
+        "en": "name of a person or thing",
+        "ja": "ひとやものの なまえ",
+        "ja_typings": []
+      },
+      {
+        "en": "connecting word",
+        "ja": "つなぎことば",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00771",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a verb?",
+      "ja": "どうしとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "word that describes a noun",
+        "ja": "めいしをしゅうしょくすることば",
+        "ja_typings": []
+      },
+      {
+        "en": "word describing an action",
+        "ja": "こうどうをあらわすことば",
+        "ja_typings": []
+      },
+      {
+        "en": "a type of pronoun",
+        "ja": "だいめいしのいっしゅ",
+        "ja_typings": []
+      },
+      {
+        "en": "word connecting clauses",
+        "ja": "せつをつなぐことば",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00772",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an adjective?",
+      "ja": "けいようしとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "word naming a person, place, or thing",
+        "ja": "ひとやばしょやものをなまえづけることば",
+        "ja_typings": []
+      },
+      {
+        "en": "word describing an action",
+        "ja": "こうどうをあらわすことば",
+        "ja_typings": []
+      },
+      {
+        "en": "word modifying verbs",
+        "ja": "どうしをしゅうしょくすることば",
+        "ja_typings": []
+      },
+      {
+        "en": "connecting word",
+        "ja": "つなぐことば",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00773",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a noun?",
+      "ja": "めいしとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "word showing relationship between nouns",
+        "ja": "めいしかんのかんけいをしめすことば",
+        "ja_typings": []
+      },
+      {
+        "en": "word describing action",
+        "ja": "こうどうをあらわすことば",
+        "ja_typings": []
+      },
+      {
+        "en": "plural noun form",
+        "ja": "めいしのふくすうけい",
+        "ja_typings": []
+      },
+      {
+        "en": "type of adjective",
+        "ja": "けいようしのいっしゅ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00774",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a preposition?",
+      "ja": "ぜんちしとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "direct comparison without 'like' or 'as'",
+        "ja": "likeやasをつかわないちょくせつのひかく",
+        "ja_typings": []
+      },
+      {
+        "en": "comparison using 'like' or 'as'",
+        "ja": "likeやasをつかったひかく",
+        "ja_typings": []
+      },
+      {
+        "en": "giving human traits to non-humans",
+        "ja": "にんげんいがいのものにじんかくをもたせること",
+        "ja_typings": []
+      },
+      {
+        "en": "exaggeration for effect",
+        "ja": "こうかのためのこちょう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00775",
+    "image_path": null,
+    "question_text": {
+      "en": "What is metaphor?",
+      "ja": "いんゆとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "comparison using 'like' or 'as'",
+        "ja": "likeやasをつかったひかく",
+        "ja_typings": []
+      },
+      {
+        "en": "direct comparison without 'like' or 'as'",
+        "ja": "likeやasをつかわないひかく",
+        "ja_typings": []
+      },
+      {
+        "en": "repetition of initial sounds",
+        "ja": "しょきおんのくりかえし",
+        "ja_typings": []
+      },
+      {
+        "en": "word imitating sound",
+        "ja": "おとをまねることば",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00776",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a simile?",
+      "ja": "しみりとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "repetition of initial consonant sounds",
+        "ja": "しょきしいんのくりかえし",
+        "ja_typings": []
+      },
+      {
+        "en": "comparison using 'like'",
+        "ja": "likeをつかったひかく",
+        "ja_typings": []
+      },
+      {
+        "en": "word with same spelling, different meaning",
+        "ja": "つづりがおなじでいみがちがうことば",
+        "ja_typings": []
+      },
+      {
+        "en": "giving objects human traits",
+        "ja": "ものにじんかくをもたせること",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00777",
+    "image_path": null,
+    "question_text": {
+      "en": "What is alliteration?",
+      "ja": "どうじしゅんぷうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Japan",
+        "ja": "にほん",
+        "ja_typings": []
+      },
+      {
+        "en": "China",
+        "ja": "ちゅうごく",
+        "ja_typings": []
+      },
+      {
+        "en": "Korea",
+        "ja": "かんこく",
+        "ja_typings": []
+      },
+      {
+        "en": "Thailand",
+        "ja": "たいらんど",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00778",
+    "image_path": null,
+    "question_text": {
+      "en": "What country is sushi originally from?",
+      "ja": "すしのげんちはどこ？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sitar",
+        "ja": "したーる",
+        "ja_typings": []
+      },
+      {
+        "en": "shamisen",
+        "ja": "しゃみせん",
+        "ja_typings": []
+      },
+      {
+        "en": "erhu",
+        "ja": "にこ",
+        "ja_typings": []
+      },
+      {
+        "en": "didgeridoo",
+        "ja": "でぃじゅりどぅー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00779",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the traditional instrument of India?",
+      "ja": "いんどのでんとうがっきは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Spanish dance and music style",
+        "ja": "すぺいんのぶようとおんがくのすたいる",
+        "ja_typings": []
+      },
+      {
+        "en": "Italian opera style",
+        "ja": "いたりあのおぺらすたいる",
+        "ja_typings": []
+      },
+      {
+        "en": "Brazilian dance",
+        "ja": "ぶらじるのぶよう",
+        "ja_typings": []
+      },
+      {
+        "en": "Mexican folk music",
+        "ja": "めきしこのみんぞくおんがく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00780",
+    "image_path": null,
+    "question_text": {
+      "en": "What is flamenco?",
+      "ja": "ふらめんことは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "annual festival with samba parades",
+        "ja": "さんばぱれーどのねんかんまつり",
+        "ja_typings": []
+      },
+      {
+        "en": "Christmas celebration",
+        "ja": "くりすますのいわい",
+        "ja_typings": []
+      },
+      {
+        "en": "harvest festival",
+        "ja": "しゅうかくまつり",
+        "ja_typings": []
+      },
+      {
+        "en": "water festival",
+        "ja": "みずまつり",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00781",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Carnival in Brazil?",
+      "ja": "ぶらじるのかーにばるとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ancient Roman amphitheater",
+        "ja": "こだいろーまのえんけいきょうぎじょう",
+        "ja_typings": []
+      },
+      {
+        "en": "Egyptian pyramid",
+        "ja": "えじぷとのぴらみっど",
+        "ja_typings": []
+      },
+      {
+        "en": "Greek temple",
+        "ja": "ぎりしあのしんでん",
+        "ja_typings": []
+      },
+      {
+        "en": "Medieval castle",
+        "ja": "ちゅうせいのしろ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00782",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Colosseum?",
+      "ja": "ころっせうむとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Japanese art of flower arranging",
+        "ja": "にほんのかどう",
+        "ja_typings": []
+      },
+      {
+        "en": "Japanese sword art",
+        "ja": "にほんのけんじゅつ",
+        "ja_typings": []
+      },
+      {
+        "en": "Korean paper folding",
+        "ja": "かんこくのおりがみ",
+        "ja_typings": []
+      },
+      {
+        "en": "Chinese tea ceremony",
+        "ja": "ちゅうごくのちゃのゆ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00783",
+    "image_path": null,
+    "question_text": {
+      "en": "What is ikebana?",
+      "ja": "いけばなとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Scotland",
+        "ja": "すこっとらんど",
+        "ja_typings": []
+      },
+      {
+        "en": "Ireland",
+        "ja": "あいるらんど",
+        "ja_typings": []
+      },
+      {
+        "en": "Wales",
+        "ja": "うぇーるず",
+        "ja_typings": []
+      },
+      {
+        "en": "England",
+        "ja": "いんぐらんど",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00784",
+    "image_path": null,
+    "question_text": {
+      "en": "What country does the kilt come from?",
+      "ja": "きるとはどこのくにのもの？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "chado",
+        "ja": "ちゃどう",
+        "ja_typings": []
+      },
+      {
+        "en": "kabuki",
+        "ja": "かぶき",
+        "ja_typings": []
+      },
+      {
+        "en": "noh",
+        "ja": "のう",
+        "ja_typings": []
+      },
+      {
+        "en": "sumo",
+        "ja": "すもう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00785",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the traditional Japanese tea ceremony called?",
+      "ja": "にほんのちゃどうのこうしきめいしょうは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Halloween",
+        "ja": "はろうぃん",
+        "ja_typings": []
+      },
+      {
+        "en": "Thanksgiving",
+        "ja": "さんくすぎびんぐ",
+        "ja_typings": []
+      },
+      {
+        "en": "Christmas",
+        "ja": "くりすます",
+        "ja_typings": []
+      },
+      {
+        "en": "Easter",
+        "ja": "いーすたー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00786",
+    "image_path": null,
+    "question_text": {
+      "en": "What festival is celebrated on October 31?",
+      "ja": "10がつ31にちにいわわれるまつりは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hindu festival of lights",
+        "ja": "ひんどうきょうのひかりのまつり",
+        "ja_typings": []
+      },
+      {
+        "en": "Muslim new year",
+        "ja": "いすらむのしんねん",
+        "ja_typings": []
+      },
+      {
+        "en": "Buddhist harvest festival",
+        "ja": "ぶっきょうのしゅうかくまつり",
+        "ja_typings": []
+      },
+      {
+        "en": "Sikh water festival",
+        "ja": "しっきょうのみずまつり",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00787",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Diwali?",
+      "ja": "でぃわりとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mexican holiday honoring deceased",
+        "ja": "しにょにけいいをひょうするめきしこのしゅくじつ",
+        "ja_typings": []
+      },
+      {
+        "en": "Spanish funeral rite",
+        "ja": "すぺいんのそうぎのぎしき",
+        "ja_typings": []
+      },
+      {
+        "en": "Halloween-inspired festival",
+        "ja": "はろうぃんにもとづくまつり",
+        "ja_typings": []
+      },
+      {
+        "en": "South American harvest day",
+        "ja": "なんべいのしゅうかくのひ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00788",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Day of the Dead (Día de los Muertos)?",
+      "ja": "しゃのひ（でぃーあでろすむえるとす）とは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Japanese art of paper folding",
+        "ja": "かみをおるにほんのげいじゅつ",
+        "ja_typings": []
+      },
+      {
+        "en": "Chinese ink painting",
+        "ja": "ちゅうごくのすみえ",
+        "ja_typings": []
+      },
+      {
+        "en": "Korean pottery art",
+        "ja": "かんこくのとうじ",
+        "ja_typings": []
+      },
+      {
+        "en": "Japanese wood carving",
+        "ja": "にほんのもくちょう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00789",
+    "image_path": null,
+    "question_text": {
+      "en": "What is origami?",
+      "ja": "おりがみとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Spring Festival",
+        "ja": "しゅんせつ",
+        "ja_typings": []
+      },
+      {
+        "en": "Moon Festival",
+        "ja": "つきまつり",
+        "ja_typings": []
+      },
+      {
+        "en": "Dragon Festival",
+        "ja": "りゅうまつり",
+        "ja_typings": []
+      },
+      {
+        "en": "Harvest Festival",
+        "ja": "しゅうかくまつり",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00790",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Chinese New Year also called?",
+      "ja": "ちゅうごくのしんねんはなんともいわれるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "soccer (football)",
+        "ja": "さっかーふっとぼーる",
+        "ja_typings": []
+      },
+      {
+        "en": "basketball",
+        "ja": "ばすけっとぼーる",
+        "ja_typings": []
+      },
+      {
+        "en": "cricket",
+        "ja": "くりけっと",
+        "ja_typings": []
+      },
+      {
+        "en": "baseball",
+        "ja": "やきゅう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00791",
+    "image_path": null,
+    "question_text": {
+      "en": "What sport is most popular globally?",
+      "ja": "せかいでもっとものきんのすぽーつは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "kimono",
+        "ja": "きもの",
+        "ja_typings": []
+      },
+      {
+        "en": "hanbok",
+        "ja": "はんぼく",
+        "ja_typings": []
+      },
+      {
+        "en": "cheongsam",
+        "ja": "ちょんさむ",
+        "ja_typings": []
+      },
+      {
+        "en": "sari",
+        "ja": "さりー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00792",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the traditional clothing of Japan?",
+      "ja": "にほんのでんとうてきなぎは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ancient Indian practice of mind and body",
+        "ja": "こだいいんどのこころとからだのしょう",
+        "ja_typings": []
+      },
+      {
+        "en": "Chinese martial art",
+        "ja": "ちゅうごくのぶどう",
+        "ja_typings": []
+      },
+      {
+        "en": "Japanese meditation technique",
+        "ja": "にほんのめでぃてーしょんぎほう",
+        "ja_typings": []
+      },
+      {
+        "en": "Korean breathing exercise",
+        "ja": "かんこくのこきゅうたいそう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00793",
+    "image_path": null,
+    "question_text": {
+      "en": "What is yoga?",
+      "ja": "よがとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Korean fermented vegetable dish",
+        "ja": "かんこくのはっこうやさいりょうり",
+        "ja_typings": []
+      },
+      {
+        "en": "Japanese pickled vegetables",
+        "ja": "にほんのつけもの",
+        "ja_typings": []
+      },
+      {
+        "en": "Chinese noodle dish",
+        "ja": "ちゅうごくのめんりょうり",
+        "ja_typings": []
+      },
+      {
+        "en": "Thai spicy soup",
+        "ja": "たいのからいすーぷ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00794",
+    "image_path": null,
+    "question_text": {
+      "en": "What is kimchi?",
+      "ja": "きむちとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "respectful greeting in Hindu culture",
+        "ja": "ひんどぅーぶんかのそんけいのあいさつ",
+        "ja_typings": []
+      },
+      {
+        "en": "goodbye in Japanese",
+        "ja": "にほんごのさようなら",
+        "ja_typings": []
+      },
+      {
+        "en": "thank you in Arabic",
+        "ja": "あらびあごのありがとう",
+        "ja_typings": []
+      },
+      {
+        "en": "good morning in Swahili",
+        "ja": "すわひりごのおはよう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00795",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the meaning of 'namaste'?",
+      "ja": "なますてのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Italy",
+        "ja": "いたりあ",
+        "ja_typings": []
+      },
+      {
+        "en": "China",
+        "ja": "ちゅうごく",
+        "ja_typings": []
+      },
+      {
+        "en": "France",
+        "ja": "ふらんす",
+        "ja_typings": []
+      },
+      {
+        "en": "Spain",
+        "ja": "すぺいん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00796",
+    "image_path": null,
+    "question_text": {
+      "en": "What country did pasta originally come from?",
+      "ja": "ぱすたのげんちはどこ？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "famous painting by Leonardo da Vinci",
+        "ja": "れおなるど・だ・ゔぃんちのゆうめいなえ",
+        "ja_typings": []
+      },
+      {
+        "en": "ancient Greek sculpture",
+        "ja": "こだいぎりしあのちょうこく",
+        "ja_typings": []
+      },
+      {
+        "en": "Renaissance building",
+        "ja": "るねっさんすけんちく",
+        "ja_typings": []
+      },
+      {
+        "en": "Egyptian artifact",
+        "ja": "えじぷとのこうぶつ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00797",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Mona Lisa?",
+      "ja": "もなりざとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "mausoleum in India",
+        "ja": "いんどのびょうびょう",
+        "ja_typings": []
+      },
+      {
+        "en": "temple in Thailand",
+        "ja": "たいのしんでん",
+        "ja_typings": []
+      },
+      {
+        "en": "palace in China",
+        "ja": "ちゅうごくのきゅうでん",
+        "ja_typings": []
+      },
+      {
+        "en": "fortress in Pakistan",
+        "ja": "ぱきすたんのとりで",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00798",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Taj Mahal?",
+      "ja": "たじまはるとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Russian nesting doll",
+        "ja": "ろしあのだるまにんぎょう",
+        "ja_typings": []
+      },
+      {
+        "en": "Japanese puzzle box",
+        "ja": "にほんのひみつはこ",
+        "ja_typings": []
+      },
+      {
+        "en": "Chinese porcelain figure",
+        "ja": "ちゅうごくのとうじにんぎょう",
+        "ja_typings": []
+      },
+      {
+        "en": "German wooden toy",
+        "ja": "どいつのもくせいおもちゃ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00799",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a matryoshka?",
+      "ja": "まとりょーしかとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "China",
+        "ja": "ちゅうごく",
+        "ja_typings": []
+      },
+      {
+        "en": "India",
+        "ja": "いんど",
+        "ja_typings": []
+      },
+      {
+        "en": "Europe",
+        "ja": "ゆーろっぱ",
+        "ja_typings": []
+      },
+      {
+        "en": "Middle East",
+        "ja": "ちゅうとう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00800",
+    "image_path": null,
+    "question_text": {
+      "en": "What country is known for inventing gunpowder?",
+      "ja": "かやくをはつめいしたとされるくには？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "decorative handwriting or lettering",
+        "ja": "かざりもじのてがき",
+        "ja_typings": []
+      },
+      {
+        "en": "painted silk art",
+        "ja": "ぬのにえをかくげいじゅつ",
+        "ja_typings": []
+      },
+      {
+        "en": "stone carving art",
+        "ja": "いしぼりのげいじゅつ",
+        "ja_typings": []
+      },
+      {
+        "en": "weaving pattern art",
+        "ja": "おりものもようのげいじゅつ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00801",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the art of calligraphy?",
+      "ja": "しょどうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Japanese warrior class",
+        "ja": "にほんのぶし",
+        "ja_typings": []
+      },
+      {
+        "en": "Chinese noble class",
+        "ja": "ちゅうごくのきぞく",
+        "ja_typings": []
+      },
+      {
+        "en": "Korean royal guard",
+        "ja": "かんこくのきんえいたい",
+        "ja_typings": []
+      },
+      {
+        "en": "Mongolian cavalry soldier",
+        "ja": "もうこのきへいへいし",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00802",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a samurai?",
+      "ja": "さむらいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "symbol of Olympic games",
+        "ja": "おりんぴっくのしょうちょう",
+        "ja_typings": []
+      },
+      {
+        "en": "torch used to signal race start",
+        "ja": "れーすのすたーとのしんごうたいまつ",
+        "ja_typings": []
+      },
+      {
+        "en": "fire kept in ancient Rome",
+        "ja": "こだいろーまでともされたひ",
+        "ja_typings": []
+      },
+      {
+        "en": "eternal flame of peace",
+        "ja": "えいきゅうへいわのほのお",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00803",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Olympic flame?",
+      "ja": "おりんぴっくのほのおとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Japanese style comics",
+        "ja": "にほんすたいるのまんが",
+        "ja_typings": []
+      },
+      {
+        "en": "Korean animation",
+        "ja": "かんこくのあにめ",
+        "ja_typings": []
+      },
+      {
+        "en": "Chinese illustrated novel",
+        "ja": "ちゅうごくのさしえしょうせつ",
+        "ja_typings": []
+      },
+      {
+        "en": "Japanese film genre",
+        "ja": "にほんのえいがじゃんる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00804",
+    "image_path": null,
+    "question_text": {
+      "en": "What is manga?",
+      "ja": "まんがとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "urban culture with rap, DJing, breakdancing",
+        "ja": "らっぷ、でぃーじぇい、ぶれいくだんすのあーばんぶんか",
+        "ja_typings": []
+      },
+      {
+        "en": "Japanese street fashion",
+        "ja": "にほんのすとりーとふぁっしょん",
+        "ja_typings": []
+      },
+      {
+        "en": "Latin music movement",
+        "ja": "らてんおんがくのうんどう",
+        "ja_typings": []
+      },
+      {
+        "en": "European folk culture revival",
+        "ja": "ゆーろっぱのみんぞくぶんかのふっかつ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00805",
+    "image_path": null,
+    "question_text": {
+      "en": "What is hip-hop culture?",
+      "ja": "ひっぷほっぷぶんかとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "7",
+        "ja": "なな",
+        "ja_typings": []
+      },
+      {
+        "en": "6",
+        "ja": "ろく",
+        "ja_typings": []
+      },
+      {
+        "en": "5",
+        "ja": "ご",
+        "ja_typings": []
+      },
+      {
+        "en": "8",
+        "ja": "はち",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00806",
+    "image_path": null,
+    "question_text": {
+      "en": "How many continents are there on Earth?",
+      "ja": "ちきゅうにはいくつのたいりくがあるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pacific Ocean",
+        "ja": "たいへいよう",
+        "ja_typings": []
+      },
+      {
+        "en": "Atlantic Ocean",
+        "ja": "たいせいよう",
+        "ja_typings": []
+      },
+      {
+        "en": "Indian Ocean",
+        "ja": "いんどよう",
+        "ja_typings": []
+      },
+      {
+        "en": "Arctic Ocean",
+        "ja": "ほっきょくかい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00807",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the largest ocean?",
+      "ja": "もっともおおきなうみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "366",
+        "ja": "さんびゃくろくじゅうろく",
+        "ja_typings": []
+      },
+      {
+        "en": "365",
+        "ja": "さんびゃくろくじゅうご",
+        "ja_typings": []
+      },
+      {
+        "en": "367",
+        "ja": "さんびゃくろくじゅうなな",
+        "ja_typings": []
+      },
+      {
+        "en": "364",
+        "ja": "さんびゃくろくじゅうし",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00808",
+    "image_path": null,
+    "question_text": {
+      "en": "How many days are in a leap year?",
+      "ja": "うるうどしはなんにち？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Au",
+        "ja": "おーゆー",
+        "ja_typings": []
+      },
+      {
+        "en": "Go",
+        "ja": "じーおー",
+        "ja_typings": []
+      },
+      {
+        "en": "Gd",
+        "ja": "じーでぃー",
+        "ja_typings": []
+      },
+      {
+        "en": "Ag",
+        "ja": "えーじー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00809",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the chemical symbol for gold?",
+      "ja": "きんのかがくきごうは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mount Everest",
+        "ja": "えべれすとさん",
+        "ja_typings": []
+      },
+      {
+        "en": "K2",
+        "ja": "けーつー",
+        "ja_typings": []
+      },
+      {
+        "en": "Kilimanjaro",
+        "ja": "きりまんじゃろ",
+        "ja_typings": []
+      },
+      {
+        "en": "Mont Blanc",
+        "ja": "もんぶらん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00810",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the tallest mountain in the world?",
+      "ja": "せかいでもっともたかいやまは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "206",
+        "ja": "にひゃくろく",
+        "ja_typings": []
+      },
+      {
+        "en": "206",
+        "ja": "にひゃくろく",
+        "ja_typings": []
+      },
+      {
+        "en": "198",
+        "ja": "ひゃくきゅうじゅうはち",
+        "ja_typings": []
+      },
+      {
+        "en": "213",
+        "ja": "にひゃくじゅうさん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00811",
+    "image_path": null,
+    "question_text": {
+      "en": "How many bones are in the adult human body?",
+      "ja": "おとなのにんげんのほねはいくつ？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "about 300,000 km/s",
+        "ja": "やく30まんきろ/びょう",
+        "ja_typings": []
+      },
+      {
+        "en": "about 150,000 km/s",
+        "ja": "やく15まんきろ/びょう",
+        "ja_typings": []
+      },
+      {
+        "en": "about 600,000 km/s",
+        "ja": "やく60まんきろ/びょう",
+        "ja_typings": []
+      },
+      {
+        "en": "about 100,000 km/s",
+        "ja": "やく10まんきろ/びょう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00812",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the speed of light?",
+      "ja": "ひかりのそくどは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "8",
+        "ja": "はち",
+        "ja_typings": []
+      },
+      {
+        "en": "9",
+        "ja": "きゅう",
+        "ja_typings": []
+      },
+      {
+        "en": "7",
+        "ja": "なな",
+        "ja_typings": []
+      },
+      {
+        "en": "10",
+        "ja": "じゅう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00813",
+    "image_path": null,
+    "question_text": {
+      "en": "How many planets are in our solar system?",
+      "ja": "たいようけいにはなんこのわくせいがあるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "carbon dioxide",
+        "ja": "にさんかたんそ",
+        "ja_typings": []
+      },
+      {
+        "en": "oxygen",
+        "ja": "さんそ",
+        "ja_typings": []
+      },
+      {
+        "en": "nitrogen",
+        "ja": "ちっそ",
+        "ja_typings": []
+      },
+      {
+        "en": "hydrogen",
+        "ja": "すいそ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00814",
+    "image_path": null,
+    "question_text": {
+      "en": "What gas do plants absorb from the air?",
+      "ja": "しょくぶつはくうきからなにをきゅうしゅうするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Russia",
+        "ja": "ろしあ",
+        "ja_typings": []
+      },
+      {
+        "en": "Canada",
+        "ja": "かなだ",
+        "ja_typings": []
+      },
+      {
+        "en": "USA",
+        "ja": "あめりか",
+        "ja_typings": []
+      },
+      {
+        "en": "China",
+        "ja": "ちゅうごく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00815",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the largest country by area?",
+      "ja": "めんせきでもっともおおきなくには？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Canberra",
+        "ja": "きゃんべら",
+        "ja_typings": []
+      },
+      {
+        "en": "Sydney",
+        "ja": "しどにー",
+        "ja_typings": []
+      },
+      {
+        "en": "Melbourne",
+        "ja": "めるぼるん",
+        "ja_typings": []
+      },
+      {
+        "en": "Brisbane",
+        "ja": "ぶりすべん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00816",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Australia?",
+      "ja": "おーすとらりあのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "largest river by discharge volume",
+        "ja": "りゅうりょうせかいさいだいのかわ",
+        "ja_typings": []
+      },
+      {
+        "en": "longest river in the world",
+        "ja": "せかいさいちょうのかわ",
+        "ja_typings": []
+      },
+      {
+        "en": "deepest river",
+        "ja": "もっともふかいかわ",
+        "ja_typings": []
+      },
+      {
+        "en": "fastest flowing river",
+        "ja": "もっともながれのはやいかわ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00817",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Amazon River known for?",
+      "ja": "あまぞんがわはなにでゆうめい？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "diamond",
+        "ja": "だいやもんど",
+        "ja_typings": []
+      },
+      {
+        "en": "quartz",
+        "ja": "すいしょう",
+        "ja_typings": []
+      },
+      {
+        "en": "corundum",
+        "ja": "こらんだむ",
+        "ja_typings": []
+      },
+      {
+        "en": "topaz",
+        "ja": "とぱーず",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00818",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the hardest natural substance?",
+      "ja": "しぜんかいでもっともかたいぶっしつは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "4",
+        "ja": "よん",
+        "ja_typings": []
+      },
+      {
+        "en": "2",
+        "ja": "に",
+        "ja_typings": []
+      },
+      {
+        "en": "3",
+        "ja": "さん",
+        "ja_typings": []
+      },
+      {
+        "en": "6",
+        "ja": "ろく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00819",
+    "image_path": null,
+    "question_text": {
+      "en": "How many chambers does a human heart have?",
+      "ja": "にんげんのこころはいくつのへやにわかれているか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "yen",
+        "ja": "えん",
+        "ja_typings": []
+      },
+      {
+        "en": "won",
+        "ja": "うぉん",
+        "ja_typings": []
+      },
+      {
+        "en": "yuan",
+        "ja": "げん",
+        "ja_typings": []
+      },
+      {
+        "en": "baht",
+        "ja": "ばーつ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00820",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the currency of Japan?",
+      "ja": "にほんのつうかは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sahara",
+        "ja": "さはら",
+        "ja_typings": []
+      },
+      {
+        "en": "Gobi",
+        "ja": "ごびさばく",
+        "ja_typings": []
+      },
+      {
+        "en": "Arabian",
+        "ja": "あらびあさばく",
+        "ja_typings": []
+      },
+      {
+        "en": "Antarctica",
+        "ja": "なんきょく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00821",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the largest desert in the world?",
+      "ja": "せかいさいだいのさばくは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1945",
+        "ja": "せんきゅうひゃくよんじゅうご",
+        "ja_typings": []
+      },
+      {
+        "en": "1944",
+        "ja": "せんきゅうひゃくよんじゅうし",
+        "ja_typings": []
+      },
+      {
+        "en": "1946",
+        "ja": "せんきゅうひゃくよんじゅうろく",
+        "ja_typings": []
+      },
+      {
+        "en": "1943",
+        "ja": "せんきゅうひゃくよんじゅうさん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00822",
+    "image_path": null,
+    "question_text": {
+      "en": "What year did World War II end?",
+      "ja": "だいにじせかいたいせんはなんねんにおわったか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "100°C",
+        "ja": "ひゃくど",
+        "ja_typings": []
+      },
+      {
+        "en": "90°C",
+        "ja": "きゅうじゅうど",
+        "ja_typings": []
+      },
+      {
+        "en": "110°C",
+        "ja": "ひゃくじゅうど",
+        "ja_typings": []
+      },
+      {
+        "en": "80°C",
+        "ja": "はちじゅうど",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00823",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the boiling point of water at sea level?",
+      "ja": "かいめいでのみずのふってんは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "0°C",
+        "ja": "れいど",
+        "ja_typings": []
+      },
+      {
+        "en": "-10°C",
+        "ja": "まいなすじゅうど",
+        "ja_typings": []
+      },
+      {
+        "en": "4°C",
+        "ja": "よんど",
+        "ja_typings": []
+      },
+      {
+        "en": "10°C",
+        "ja": "じゅうど",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00824",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the freezing point of water?",
+      "ja": "みずのこおりはじめるおんどは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hydrogen",
+        "ja": "すいそ",
+        "ja_typings": []
+      },
+      {
+        "en": "Helium",
+        "ja": "へりうむ",
+        "ja_typings": []
+      },
+      {
+        "en": "Lithium",
+        "ja": "りちうむ",
+        "ja_typings": []
+      },
+      {
+        "en": "Carbon",
+        "ja": "たんそ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00825",
+    "image_path": null,
+    "question_text": {
+      "en": "What element has the atomic number 1?",
+      "ja": "げんしばんごう1のげんそは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "process by which plants make food from sunlight",
+        "ja": "しょくぶつがたいようのひかりからしょくもつをつくるかてい",
+        "ja_typings": []
+      },
+      {
+        "en": "process of plant respiration",
+        "ja": "しょくぶつのこきゅうのかてい",
+        "ja_typings": []
+      },
+      {
+        "en": "process of plant reproduction",
+        "ja": "しょくぶつのはんしょくのかてい",
+        "ja_typings": []
+      },
+      {
+        "en": "process of nutrient absorption",
+        "ja": "えいようきゅうしゅうのかてい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00826",
+    "image_path": null,
+    "question_text": {
+      "en": "What is photosynthesis?",
+      "ja": "こうごうせいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Spanish",
+        "ja": "すぺいんご",
+        "ja_typings": []
+      },
+      {
+        "en": "Portuguese",
+        "ja": "ぽるとがるご",
+        "ja_typings": []
+      },
+      {
+        "en": "Italian",
+        "ja": "いたりあご",
+        "ja_typings": []
+      },
+      {
+        "en": "French",
+        "ja": "ふらんすご",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00827",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the main language spoken in Argentina?",
+      "ja": "あるぜんちんでつかわれるしゅのことばは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "femur (thigh bone)",
+        "ja": "だいたいこつ",
+        "ja_typings": []
+      },
+      {
+        "en": "tibia (shin bone)",
+        "ja": "けいこつ",
+        "ja_typings": []
+      },
+      {
+        "en": "humerus (upper arm)",
+        "ja": "じょうわんこつ",
+        "ja_typings": []
+      },
+      {
+        "en": "spine",
+        "ja": "せきちゅう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00828",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the longest bone in the human body?",
+      "ja": "にんげんのからだでもっともながいほねは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Alexander Graham Bell",
+        "ja": "あれくさんだー・ぐらはむ・べる",
+        "ja_typings": []
+      },
+      {
+        "en": "Thomas Edison",
+        "ja": "とーます・えじそん",
+        "ja_typings": []
+      },
+      {
+        "en": "Nikola Tesla",
+        "ja": "にこら・てすら",
+        "ja_typings": []
+      },
+      {
+        "en": "Guglielmo Marconi",
+        "ja": "ぐりえるも・まるこーに",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00829",
+    "image_path": null,
+    "question_text": {
+      "en": "Who invented the telephone?",
+      "ja": "でんわをはつめいしたのはだれ？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "nitrogen",
+        "ja": "ちっそ",
+        "ja_typings": []
+      },
+      {
+        "en": "oxygen",
+        "ja": "さんそ",
+        "ja_typings": []
+      },
+      {
+        "en": "carbon dioxide",
+        "ja": "にさんかたんそ",
+        "ja_typings": []
+      },
+      {
+        "en": "argon",
+        "ja": "あるごん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00830",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the most abundant gas in Earth's atmosphere?",
+      "ja": "ちきゅうのたいきでもっともおおいきたいは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "16",
+        "ja": "じゅうろく",
+        "ja_typings": []
+      },
+      {
+        "en": "14",
+        "ja": "じゅうし",
+        "ja_typings": []
+      },
+      {
+        "en": "18",
+        "ja": "じゅうはち",
+        "ja_typings": []
+      },
+      {
+        "en": "12",
+        "ja": "じゅうに",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00831",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the square root of 256?",
+      "ja": "256のへいほうこんは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "32",
+        "ja": "さんじゅうに",
+        "ja_typings": []
+      },
+      {
+        "en": "28",
+        "ja": "にじゅうはち",
+        "ja_typings": []
+      },
+      {
+        "en": "30",
+        "ja": "さんじゅう",
+        "ja_typings": []
+      },
+      {
+        "en": "34",
+        "ja": "さんじゅうし",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00832",
+    "image_path": null,
+    "question_text": {
+      "en": "How many teeth does an adult human have?",
+      "ja": "おとなのにんげんのはは何本？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jupiter",
+        "ja": "もくせい",
+        "ja_typings": []
+      },
+      {
+        "en": "Saturn",
+        "ja": "どせい",
+        "ja_typings": []
+      },
+      {
+        "en": "Neptune",
+        "ja": "かいおうせい",
+        "ja_typings": []
+      },
+      {
+        "en": "Uranus",
+        "ja": "てんのうせい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00833",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the largest planet in our solar system?",
+      "ja": "たいようけいでもっともおおきいわくせいは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "O",
+        "ja": "おー",
+        "ja_typings": []
+      },
+      {
+        "en": "Ox",
+        "ja": "おっくす",
+        "ja_typings": []
+      },
+      {
+        "en": "Og",
+        "ja": "おーじー",
+        "ja_typings": []
+      },
+      {
+        "en": "On",
+        "ja": "おーえぬ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00834",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the symbol for the element oxygen?",
+      "ja": "さんそのげんそきごうは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mercury",
+        "ja": "すいせい",
+        "ja_typings": []
+      },
+      {
+        "en": "Venus",
+        "ja": "きんせい",
+        "ja_typings": []
+      },
+      {
+        "en": "Earth",
+        "ja": "ちきゅう",
+        "ja_typings": []
+      },
+      {
+        "en": "Mars",
+        "ja": "かせい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00835",
+    "image_path": null,
+    "question_text": {
+      "en": "Which planet is closest to the sun?",
+      "ja": "もっともたいようにちかいわくせいは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vatican City",
+        "ja": "ばちかんしこっか",
+        "ja_typings": []
+      },
+      {
+        "en": "Monaco",
+        "ja": "もなこ",
+        "ja_typings": []
+      },
+      {
+        "en": "Liechtenstein",
+        "ja": "りひてんしゅたいん",
+        "ja_typings": []
+      },
+      {
+        "en": "San Marino",
+        "ja": "さんまりの",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00836",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the smallest country in the world?",
+      "ja": "せかいでもっともちいさなくには？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "6",
+        "ja": "ろく",
+        "ja_typings": []
+      },
+      {
+        "en": "4",
+        "ja": "よん",
+        "ja_typings": []
+      },
+      {
+        "en": "8",
+        "ja": "はち",
+        "ja_typings": []
+      },
+      {
+        "en": "12",
+        "ja": "じゅうに",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00837",
+    "image_path": null,
+    "question_text": {
+      "en": "How many strings does a standard guitar have?",
+      "ja": "ふつうのぎたーはなんほんのげんをもつか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Deoxyribonucleic Acid",
+        "ja": "でおきしりぼかくさん",
+        "ja_typings": []
+      },
+      {
+        "en": "Dynamic Nucleic Acid",
+        "ja": "だいなみっくかくさん",
+        "ja_typings": []
+      },
+      {
+        "en": "Deoxyribose Nuclease Acid",
+        "ja": "でおきしりぼーすかくさん",
+        "ja_typings": []
+      },
+      {
+        "en": "Double Nucleic Array",
+        "ja": "だぶるかくさんのはいれつ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00838",
+    "image_path": null,
+    "question_text": {
+      "en": "What does DNA stand for?",
+      "ja": "DNAのりゃくしょうのせいしきめいは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NaCl",
+        "ja": "えぬえーしーえる",
+        "ja_typings": []
+      },
+      {
+        "en": "NaF",
+        "ja": "えぬえーえふ",
+        "ja_typings": []
+      },
+      {
+        "en": "KCl",
+        "ja": "けーしーえる",
+        "ja_typings": []
+      },
+      {
+        "en": "CaCl₂",
+        "ja": "しーえーしーえるに",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00839",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the chemical formula for table salt?",
+      "ja": "しょくえんのかがくしきは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sumo",
+        "ja": "すもう",
+        "ja_typings": []
+      },
+      {
+        "en": "baseball",
+        "ja": "やきゅう",
+        "ja_typings": []
+      },
+      {
+        "en": "judo",
+        "ja": "じゅうどう",
+        "ja_typings": []
+      },
+      {
+        "en": "kendo",
+        "ja": "けんどう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00840",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the national sport of Japan?",
+      "ja": "にほんのこくぎは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "earthquake magnitude",
+        "ja": "じしんのきぼ",
+        "ja_typings": []
+      },
+      {
+        "en": "wind speed",
+        "ja": "ふうそく",
+        "ja_typings": []
+      },
+      {
+        "en": "rainfall amount",
+        "ja": "こうすいりょう",
+        "ja_typings": []
+      },
+      {
+        "en": "temperature",
+        "ja": "きおん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00841",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the Richter scale measure?",
+      "ja": "りひたーすけーるはなにをはかるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1969",
+        "ja": "せんきゅうひゃくろくじゅうきゅう",
+        "ja_typings": []
+      },
+      {
+        "en": "1967",
+        "ja": "せんきゅうひゃくろくじゅうなな",
+        "ja_typings": []
+      },
+      {
+        "en": "1971",
+        "ja": "せんきゅうひゃくななじゅういち",
+        "ja_typings": []
+      },
+      {
+        "en": "1965",
+        "ja": "せんきゅうひゃくろくじゅうご",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00842",
+    "image_path": null,
+    "question_text": {
+      "en": "What year did the first moon landing occur?",
+      "ja": "はつのつきへのちゃくりくはなんねん？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fe",
+        "ja": "えふいー",
+        "ja_typings": []
+      },
+      {
+        "en": "Ir",
+        "ja": "あいあーる",
+        "ja_typings": []
+      },
+      {
+        "en": "In",
+        "ja": "あいえぬ",
+        "ja_typings": []
+      },
+      {
+        "en": "Ie",
+        "ja": "あいいー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00843",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the symbol for the element iron?",
+      "ja": "てつのげんそきごうは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sperm whale",
+        "ja": "まっこうくじら",
+        "ja_typings": []
+      },
+      {
+        "en": "blue whale",
+        "ja": "しろながすくじら",
+        "ja_typings": []
+      },
+      {
+        "en": "elephant",
+        "ja": "ぞう",
+        "ja_typings": []
+      },
+      {
+        "en": "howler monkey",
+        "ja": "ほえざる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00844",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the loudest animal on Earth?",
+      "ja": "ちきゅうでもっともおおきなこえをだすどうぶつは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ampere",
+        "ja": "あんぺあ",
+        "ja_typings": []
+      },
+      {
+        "en": "volt",
+        "ja": "ぼると",
+        "ja_typings": []
+      },
+      {
+        "en": "watt",
+        "ja": "わっと",
+        "ja_typings": []
+      },
+      {
+        "en": "ohm",
+        "ja": "おーむ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00845",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the unit of electric current?",
+      "ja": "でんりゅうのたんいは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "virtual YouTuber using avatar",
+        "ja": "あばたーをつかうばーちゃるゆーちゅーばー",
+        "ja_typings": []
+      },
+      {
+        "en": "video game streamer",
+        "ja": "びでおげーむすとりーまー",
+        "ja_typings": []
+      },
+      {
+        "en": "virtual reality developer",
+        "ja": "ばーちゃるりありてぃかいはつしゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "music video creator",
+        "ja": "みゅーじっくびでおくりえいたー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00846",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a VTuber?",
+      "ja": "ぶいちゅーばーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cover Corp",
+        "ja": "かばーこーぽれーしょん",
+        "ja_typings": []
+      },
+      {
+        "en": "Nijisanji",
+        "ja": "にじさんじ",
+        "ja_typings": []
+      },
+      {
+        "en": "Sony Music",
+        "ja": "そにーみゅーじっく",
+        "ja_typings": []
+      },
+      {
+        "en": "Kadokawa",
+        "ja": "かどかわ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00847",
+    "image_path": null,
+    "question_text": {
+      "en": "What company is Hololive associated with?",
+      "ja": "ほろらいぶはどのかいしゃ？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "VTuber agency by Anycolor",
+        "ja": "えにーからーのぶいちゅーばーじむしょ",
+        "ja_typings": []
+      },
+      {
+        "en": "anime production studio",
+        "ja": "あにめせいさくすたじお",
+        "ja_typings": []
+      },
+      {
+        "en": "game development company",
+        "ja": "げーむかいはつかいしゃ",
+        "ja_typings": []
+      },
+      {
+        "en": "music label",
+        "ja": "おんがくれーべる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00848",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Nijisanji?",
+      "ja": "にじさんじとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "overseas fans",
+        "ja": "かいがいのふぁん",
+        "ja_typings": []
+      },
+      {
+        "en": "Japanese idol fans",
+        "ja": "にほんのあいどるふぁん",
+        "ja_typings": []
+      },
+      {
+        "en": "anime reviewers",
+        "ja": "あにめひょうろんか",
+        "ja_typings": []
+      },
+      {
+        "en": "foreign critics",
+        "ja": "がいこくのひひょうか",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00849",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'kaigai niki' mean?",
+      "ja": "かいがいにきとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "paid donation message on YouTube",
+        "ja": "ゆーちゅーぶでのゆうりょうきふめっせーじ",
+        "ja_typings": []
+      },
+      {
+        "en": "premium subscription plan",
+        "ja": "ぷれみあむさぶすくりぷしょん",
+        "ja_typings": []
+      },
+      {
+        "en": "exclusive fan club",
+        "ja": "せんようふぁんくらぶ",
+        "ja_typings": []
+      },
+      {
+        "en": "live concert ticket",
+        "ja": "らいぶこんさーとちけっと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00850",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'superchat'?",
+      "ja": "すーぱーちゃっととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "revealing someone's private info online",
+        "ja": "ひとのしんじょうをねっとにばらすこと",
+        "ja_typings": []
+      },
+      {
+        "en": "deleting account data",
+        "ja": "あかうんとでーたのさくじょ",
+        "ja_typings": []
+      },
+      {
+        "en": "sending spam messages",
+        "ja": "すぱむめっせーじのそうしん",
+        "ja_typings": []
+      },
+      {
+        "en": "mass following on social media",
+        "ja": "すーしゃるめでぃあでたいりょうふぉろー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00851",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'doxxing'?",
+      "ja": "どっくしんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Good Game",
+        "ja": "ぐっどげーむ",
+        "ja_typings": []
+      },
+      {
+        "en": "Get Good",
+        "ja": "げっとぐっど",
+        "ja_typings": []
+      },
+      {
+        "en": "Game Goal",
+        "ja": "げーむごーる",
+        "ja_typings": []
+      },
+      {
+        "en": "Gear Group",
+        "ja": "ぎあぐるーぷ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00852",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'GG' stand for in gaming?",
+      "ja": "げーみんぐでGGとはどういういみ？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "broadcasting live content online",
+        "ja": "おんらいんでらいぶこんてんつをほうそうすること",
+        "ja_typings": []
+      },
+      {
+        "en": "downloading large files",
+        "ja": "だいきなふぁいるのだうんろーど",
+        "ja_typings": []
+      },
+      {
+        "en": "editing video content",
+        "ja": "びでおこんてんつのへんしゅう",
+        "ja_typings": []
+      },
+      {
+        "en": "uploading to video archive",
+        "ja": "びでおあーかいぶへのあっぷろーど",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00853",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'streaming'?",
+      "ja": "すとりーみんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "short edited portion of a stream",
+        "ja": "すとりーむのみじかくへんしゅうしたぶぶん",
+        "ja_typings": []
+      },
+      {
+        "en": "full archive recording",
+        "ja": "かんぜんなあーかいぶろくが",
+        "ja_typings": []
+      },
+      {
+        "en": "official music video",
+        "ja": "こうしきみゅーじっくびでお",
+        "ja_typings": []
+      },
+      {
+        "en": "original game soundtrack",
+        "ja": "げーむのおりじなるさうんどとらっく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00854",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'clip' in VTuber culture?",
+      "ja": "ぶいちゅーばーぶんかでのくりっぷとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "artwork created by fans of a character",
+        "ja": "きゃらくたーのふぁんがつくったえ",
+        "ja_typings": []
+      },
+      {
+        "en": "official promotional art",
+        "ja": "こうしきぷろもーしょんあーと",
+        "ja_typings": []
+      },
+      {
+        "en": "AI-generated images",
+        "ja": "えーあいがせいせいしたがぞう",
+        "ja_typings": []
+      },
+      {
+        "en": "commercial illustration",
+        "ja": "しょうぎょうてきいらすと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00855",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'fan art'?",
+      "ja": "ふぁんあーととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "live streaming platform",
+        "ja": "らいぶすとりーみんぐぷらっとふぉーむ",
+        "ja_typings": []
+      },
+      {
+        "en": "social media platform",
+        "ja": "そーしゃるめでぃあぷらっとふぉーむ",
+        "ja_typings": []
+      },
+      {
+        "en": "video sharing site",
+        "ja": "どうがきょうゆうさいと",
+        "ja_typings": []
+      },
+      {
+        "en": "messaging app",
+        "ja": "めっせーじんぐあぷり",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00856",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Twitch?",
+      "ja": "ついっちとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "chat and voice platform for communities",
+        "ja": "こみゅにてぃのちゃっととぼいすぷらっとふぉーむ",
+        "ja_typings": []
+      },
+      {
+        "en": "streaming platform",
+        "ja": "すとりーみんぐぷらっとふぉーむ",
+        "ja_typings": []
+      },
+      {
+        "en": "game development tool",
+        "ja": "げーむかいはつつーる",
+        "ja_typings": []
+      },
+      {
+        "en": "video editing software",
+        "ja": "びでおへんしゅうそふと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00857",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Discord?",
+      "ja": "でぃすこーどとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "something controversial or embarrassing",
+        "ja": "こんとろばーしゃるまたははずかしいこと",
+        "ja_typings": []
+      },
+      {
+        "en": "a great performance",
+        "ja": "すばらしいぱふぉーまんす",
+        "ja_typings": []
+      },
+      {
+        "en": "a new debut",
+        "ja": "しんきでびゅー",
+        "ja_typings": []
+      },
+      {
+        "en": "a popular song",
+        "ja": "にんきのうた",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00858",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'yab' in VTuber slang?",
+      "ja": "ぶいちゅーばーすらんぐでやばいとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "first public stream",
+        "ja": "はじめてのこうかいすとりーむ",
+        "ja_typings": []
+      },
+      {
+        "en": "first solo concert",
+        "ja": "はじめてのそろこんさーと",
+        "ja_typings": []
+      },
+      {
+        "en": "first merchandise release",
+        "ja": "はじめてのぐっずはんばい",
+        "ja_typings": []
+      },
+      {
+        "en": "first collaboration",
+        "ja": "はじめてのこらぼれーしょん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00859",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'debut' for a VTuber?",
+      "ja": "ぶいちゅーばーのでびゅーとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "dedicated superfan in Japanese internet culture",
+        "ja": "にほんのねっとぶんかでのねっしんなちょうふぁん",
+        "ja_typings": []
+      },
+      {
+        "en": "aggressive trolling",
+        "ja": "あぐれっしぶなとろーりんぐ",
+        "ja_typings": []
+      },
+      {
+        "en": "popular music genre",
+        "ja": "にんきのおんがくじゃんる",
+        "ja_typings": []
+      },
+      {
+        "en": "gaming achievement",
+        "ja": "げーみんぐのじつせき",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00860",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'GachiBASS' mean?",
+      "ja": "がちばすとはどんないみ？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "software for animating 2D characters",
+        "ja": "2Dきゃらくたーをあにめーとするそふとうぇあ",
+        "ja_typings": []
+      },
+      {
+        "en": "2D game engine",
+        "ja": "2Dげーむえんじん",
+        "ja_typings": []
+      },
+      {
+        "en": "video editing tool",
+        "ja": "びでおへんしゅうつーる",
+        "ja_typings": []
+      },
+      {
+        "en": "streaming plugin",
+        "ja": "すとりーみんぐぷらぐいん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00861",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'live2D'?",
+      "ja": "らいぶつーでぃーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "paid subscription to a channel",
+        "ja": "ちゃんねるへのゆうりょうさぶすくりぷしょん",
+        "ja_typings": []
+      },
+      {
+        "en": "free follower account",
+        "ja": "むりょうのふぉろわーあかうんと",
+        "ja_typings": []
+      },
+      {
+        "en": "official partner status",
+        "ja": "こうしきぱーとなーのすてーたす",
+        "ja_typings": []
+      },
+      {
+        "en": "staff role",
+        "ja": "すたっふのやくわり",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00862",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'membership' on YouTube?",
+      "ja": "ゆーちゅーぶでのめんばーしっぷとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "favorite VTuber or idol",
+        "ja": "おきにいりのぶいちゅーばーやあいどる",
+        "ja_typings": []
+      },
+      {
+        "en": "Japanese greeting",
+        "ja": "にほんごのあいさつ",
+        "ja_typings": []
+      },
+      {
+        "en": "gift item",
+        "ja": "ぷれぜんとひん",
+        "ja_typings": []
+      },
+      {
+        "en": "streaming schedule",
+        "ja": "すとりーみんぐすけじゅーる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00863",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'oshi'?",
+      "ja": "おしとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "TL",
+        "ja": "てぃーえる",
+        "ja_typings": []
+      },
+      {
+        "en": "Sub",
+        "ja": "さぶ",
+        "ja_typings": []
+      },
+      {
+        "en": "Clip",
+        "ja": "くりっぷ",
+        "ja_typings": []
+      },
+      {
+        "en": "EN",
+        "ja": "いーえぬ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00864",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the term for simultaneous translator in VTuber culture?",
+      "ja": "ぶいちゅーばーぶんかでどうじほんやくしゃのことをなんというか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "casual talk stream with no specific topic",
+        "ja": "とくていのわだいのないかいわすとりーむ",
+        "ja_typings": []
+      },
+      {
+        "en": "game stream",
+        "ja": "げーむすとりーむ",
+        "ja_typings": []
+      },
+      {
+        "en": "singing concert",
+        "ja": "うたこんさーと",
+        "ja_typings": []
+      },
+      {
+        "en": "drawing stream",
+        "ja": "おえかきすとりーむ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00865",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'zatsudan'?",
+      "ja": "ざつだんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "expression of excitement or amazement",
+        "ja": "こうふんやおどろきのひょうげん",
+        "ja_typings": []
+      },
+      {
+        "en": "greeting",
+        "ja": "あいさつ",
+        "ja_typings": []
+      },
+      {
+        "en": "expression of sadness",
+        "ja": "かなしみのひょうげん",
+        "ja_typings": []
+      },
+      {
+        "en": "request to repeat",
+        "ja": "くりかえしのようきゅう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00866",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'pog' or 'poggers' mean in chat?",
+      "ja": "ちゃっとでぽぐやぽがーずとはどういういみ？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "laughing emote on Twitch",
+        "ja": "ついっちでのわらいのえもーと",
+        "ja_typings": []
+      },
+      {
+        "en": "crying emote",
+        "ja": "なきのえもーと",
+        "ja_typings": []
+      },
+      {
+        "en": "angry emote",
+        "ja": "おこりのえもーと",
+        "ja_typings": []
+      },
+      {
+        "en": "love emote",
+        "ja": "あいのえもーと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00867",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'KEKW'?",
+      "ja": "けくわとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sending your audience to another streamer",
+        "ja": "かんきゃくをほかのすとりーまーにおくること",
+        "ja_typings": []
+      },
+      {
+        "en": "attacking another streamer's chat",
+        "ja": "ほかのすとりーまーのちゃっとをこうげき",
+        "ja_typings": []
+      },
+      {
+        "en": "copyright striking content",
+        "ja": "ちょさくけんしんこく",
+        "ja_typings": []
+      },
+      {
+        "en": "banning viewers",
+        "ja": "びゅわーのばん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00868",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'raid' on Twitch?",
+      "ja": "ついっちでのれいどとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "character's backstory and world-building",
+        "ja": "きゃらくたーのばっくすとーりーとせかいかん",
+        "ja_typings": []
+      },
+      {
+        "en": "stream schedule",
+        "ja": "すとりーむすけじゅーる",
+        "ja_typings": []
+      },
+      {
+        "en": "fan community rules",
+        "ja": "ふぁんこみゅにてぃのるーる",
+        "ja_typings": []
+      },
+      {
+        "en": "merchandise collection",
+        "ja": "ぐっずのこれくしょん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00869",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'lore' in VTuber context?",
+      "ja": "ぶいちゅーばーぶんみゃくでのろあとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "first stream with a 3D model",
+        "ja": "さんじげんもでるではじめてすとりーむ",
+        "ja_typings": []
+      },
+      {
+        "en": "first collaboration in 3D space",
+        "ja": "さんじげんくうかんではじめてのこらぼ",
+        "ja_typings": []
+      },
+      {
+        "en": "debut in 3D VR world",
+        "ja": "3Dぶいあーるせかいにでびゅー",
+        "ja_typings": []
+      },
+      {
+        "en": "first IRL stream",
+        "ja": "はじめてのりあるいちじょうすとりーむ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00870",
+    "image_path": null,
+    "question_text": {
+      "en": "What is '3D debut' for a VTuber?",
+      "ja": "ぶいちゅーばーのさんでぃーでびゅーとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "In Real Life",
+        "ja": "げんじつせかい",
+        "ja_typings": []
+      },
+      {
+        "en": "Internet Relay Link",
+        "ja": "いんたーねっとりれーりんく",
+        "ja_typings": []
+      },
+      {
+        "en": "In Reference Level",
+        "ja": "さんしょうのれべる",
+        "ja_typings": []
+      },
+      {
+        "en": "Interactive Reality Layer",
+        "ja": "そうほうてきりある",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00871",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'IRL' stand for?",
+      "ja": "IRLとはなにのりゃく？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Japanese video sharing website",
+        "ja": "にほんのどうがきょうゆうさいと",
+        "ja_typings": []
+      },
+      {
+        "en": "Japanese social media",
+        "ja": "にほんのそーしゃるめでぃあ",
+        "ja_typings": []
+      },
+      {
+        "en": "Japanese streaming platform",
+        "ja": "にほんのすとりーみんぐぷらっとふぉーむ",
+        "ja_typings": []
+      },
+      {
+        "en": "Japanese music platform",
+        "ja": "にほんのおんがくぷらっとふぉーむ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00872",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'NicoNico Douga'?",
+      "ja": "にこにこどうがとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "voice synthesizer software featuring virtual singers",
+        "ja": "かそうかしゅとくみあわせたこえごうせいそふと",
+        "ja_typings": []
+      },
+      {
+        "en": "virtual idol group",
+        "ja": "ばーちゃるあいどるぐるーぷ",
+        "ja_typings": []
+      },
+      {
+        "en": "VTuber agency",
+        "ja": "ぶいちゅーばーじむしょ",
+        "ja_typings": []
+      },
+      {
+        "en": "music streaming app",
+        "ja": "おんがくすとりーみんぐあぷり",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00873",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Vocaloid'?",
+      "ja": "ぼーかろいどとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hatsune Miku",
+        "ja": "はつねみく",
+        "ja_typings": []
+      },
+      {
+        "en": "Kagamine Rin",
+        "ja": "かがみねりん",
+        "ja_typings": []
+      },
+      {
+        "en": "Megurine Luka",
+        "ja": "めぐりんるか",
+        "ja_typings": []
+      },
+      {
+        "en": "Kaito",
+        "ja": "かいと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00874",
+    "image_path": null,
+    "question_text": {
+      "en": "What character is the most famous Vocaloid?",
+      "ja": "もっともゆうめいなぼーかろいどのきゃらくたーは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "humorous image or idea spread online",
+        "ja": "おんらいんでひろがるゆーもらすがぞうやかんがえ",
+        "ja_typings": []
+      },
+      {
+        "en": "official advertisement",
+        "ja": "こうしきこうこく",
+        "ja_typings": []
+      },
+      {
+        "en": "news article",
+        "ja": "にゅーすきじ",
+        "ja_typings": []
+      },
+      {
+        "en": "computer virus",
+        "ja": "こんぴゅーたういるす",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00875",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'meme' on the internet?",
+      "ja": "いんたーねっとでみーむとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "deliberately provoking others online",
+        "ja": "おんらいんでいとてきにひとをちょはつすること",
+        "ja_typings": []
+      },
+      {
+        "en": "sharing positive content",
+        "ja": "ぽじてぃぶなこんてんつをきょうゆう",
+        "ja_typings": []
+      },
+      {
+        "en": "promoting products",
+        "ja": "せいひんのぷろもーしょん",
+        "ja_typings": []
+      },
+      {
+        "en": "building online communities",
+        "ja": "おんらいんこみゅにてぃのけいせい",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00876",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'trolling' online?",
+      "ja": "おんらいんでとろーりんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Away From Keyboard",
+        "ja": "きーぼーどをはなれている",
+        "ja_typings": []
+      },
+      {
+        "en": "Active For Killers",
+        "ja": "あくてぃぶふぉーきらーず",
+        "ja_typings": []
+      },
+      {
+        "en": "Awaiting Feedback Kindly",
+        "ja": "へんじまちのれいきんもーど",
+        "ja_typings": []
+      },
+      {
+        "en": "All Friends Known",
+        "ja": "すべてのともだちはいどく",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00877",
+    "image_path": null,
+    "question_text": {
+      "en": "What does AFK stand for?",
+      "ja": "AFKとはなにのりゃく？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "randomized loot mechanic inspired by capsule toys",
+        "ja": "かぷせるがちゃからのらんだむほうしゅうしすてむ",
+        "ja_typings": []
+      },
+      {
+        "en": "guaranteed rare item drop",
+        "ja": "かならずレアあいてむがでるじすてむ",
+        "ja_typings": []
+      },
+      {
+        "en": "battle pass system",
+        "ja": "ばとるぱすしすてむ",
+        "ja_typings": []
+      },
+      {
+        "en": "game difficulty system",
+        "ja": "むずかしさのしすてむ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00878",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'gacha' in gaming?",
+      "ja": "げーみんぐでがちゃとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Massively Multiplayer Online (game)",
+        "ja": "まっしぶりーまるちぷれいやーおんらいんげーむ",
+        "ja_typings": []
+      },
+      {
+        "en": "Mobile Multiplayer Online",
+        "ja": "もばいるまるちぷれいやーおんらいん",
+        "ja_typings": []
+      },
+      {
+        "en": "Managed Multiplayer Offline",
+        "ja": "かんりされたおふらいんたいせん",
+        "ja_typings": []
+      },
+      {
+        "en": "Modern Multiplayer Option",
+        "ja": "もだんなたいせんのおぷしょん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00879",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'MMO'?",
+      "ja": "えむえむおーとはなに？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "latency between player and server",
+        "ja": "ぷれいやーとさーばーかんのちえん",
+        "ja_typings": []
+      },
+      {
+        "en": "number of players online",
+        "ja": "おんらいんのぷれいやーすう",
+        "ja_typings": []
+      },
+      {
+        "en": "player ranking score",
+        "ja": "ぷれいやーのらんきんぐすこあ",
+        "ja_typings": []
+      },
+      {
+        "en": "message notification",
+        "ja": "めっせーじのつうち",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00880",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'ping' in online gaming?",
+      "ja": "おんらいんげーみんぐでぴんぐとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "competitive video gaming",
+        "ja": "きょうぎてきびでおげーみんぐ",
+        "ja_typings": []
+      },
+      {
+        "en": "electronic exercise equipment",
+        "ja": "でんしてきうんどうきぐ",
+        "ja_typings": []
+      },
+      {
+        "en": "electric motor racing",
+        "ja": "でんきもーたーれーす",
+        "ja_typings": []
+      },
+      {
+        "en": "online sports betting",
+        "ja": "おんらいんすぽーつとうひょう",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00881",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'esports'?",
+      "ja": "いーすぽーつとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "First Person Shooter",
+        "ja": "ふぁーすとぱーそんしゅーたー",
+        "ja_typings": []
+      },
+      {
+        "en": "Frames Per Second",
+        "ja": "ふれーむぱーせかんど",
+        "ja_typings": []
+      },
+      {
+        "en": "Fantasy Player System",
+        "ja": "ふぁんたじーぷれいやーしすてむ",
+        "ja_typings": []
+      },
+      {
+        "en": "Final Player Score",
+        "ja": "ふぁいなるぷれいやーすこあ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00882",
+    "image_path": null,
+    "question_text": {
+      "en": "What does FPS stand for in gaming?",
+      "ja": "げーみんぐでFPSとはなにのりゃく？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hit Points / Health Points",
+        "ja": "ひっとぽいんつ・へるすぽいんつ",
+        "ja_typings": []
+      },
+      {
+        "en": "Hero Power",
+        "ja": "ひーろーぱわー",
+        "ja_typings": []
+      },
+      {
+        "en": "High Power",
+        "ja": "はいぱわー",
+        "ja_typings": []
+      },
+      {
+        "en": "Healing Potion",
+        "ja": "ひーりんぐぽーしょん",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00883",
+    "image_path": null,
+    "question_text": {
+      "en": "What does HP stand for in games?",
+      "ja": "げーむでHPとはなにのりゃく？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "completing a game as fast as possible",
+        "ja": "できるだけはやくげーむをクリアすること",
+        "ja_typings": []
+      },
+      {
+        "en": "reviewing games quickly",
+        "ja": "はやくげーむをひょうかすること",
+        "ja_typings": []
+      },
+      {
+        "en": "streaming at high frame rate",
+        "ja": "こうふれーむれーとですとりーむ",
+        "ja_typings": []
+      },
+      {
+        "en": "running in virtual reality games",
+        "ja": "ぶぁーちゃるりありてぃげーむでのらんにんぐ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00884",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'speedrunning'?",
+      "ja": "すぴーどらんにんぐとは何か？"
+    }
   }
 ]

--- a/data/questions_ja.json
+++ b/data/questions_ja.json
@@ -2,50 +2,483 @@
   {
     "choices": [
       {
-        "en": "sort()",
-        "ja": "sort()",
+        "en": "CO2",
+        "ja": "CO2",
         "ja_typings": [
-          "sort()"
+          "co2"
         ]
       },
       {
-        "en": "order()",
-        "ja": "order()",
+        "en": "H2O",
+        "ja": "H2O",
         "ja_typings": [
-          "order()"
+          "h2o"
         ]
       },
       {
-        "en": "arrange()",
-        "ja": "arrange()",
+        "en": "O2",
+        "ja": "O2",
         "ja_typings": [
-          "arrange()"
+          "o2"
         ]
       },
       {
-        "en": "organize()",
-        "ja": "organize()",
+        "en": "N2",
+        "ja": "N2",
         "ja_typings": [
-          "organize()"
+          "n2"
         ]
       }
     ],
-    "correct_answer_index": 0,
-    "genre": "programming",
-    "id": "q00001",
+    "correct_answer_index": 1,
+    "genre": "science",
+    "id": "q001",
     "image_path": null,
     "question_text": {
-      "en": "What method sorts a list in Python?",
-      "ja": "Pythonでリストをソートするメソッドは？"
+      "en": "What is the chemical formula for water?",
+      "ja": "水の化学式は？"
     }
   },
   {
     "choices": [
       {
-        "en": "let mut",
-        "ja": "let mut",
+        "en": "Osaka",
+        "ja": "大阪",
+        "ja_typings": []
+      },
+      {
+        "en": "Tokyo",
+        "ja": "東京",
+        "ja_typings": []
+      },
+      {
+        "en": "Kyoto",
+        "ja": "京都",
+        "ja_typings": []
+      },
+      {
+        "en": "Nagoya",
+        "ja": "名古屋",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 1,
+    "genre": "geography",
+    "id": "q002",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Japan?",
+      "ja": "日本の首都は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "<class 'list'>",
+        "ja": "<class 'list'>",
         "ja_typings": [
-          "let mut"
+          "<class 'list'>"
+        ]
+      },
+      {
+        "en": "<class 'array'>",
+        "ja": "<class 'array'>",
+        "ja_typings": [
+          "<class 'array'>"
+        ]
+      },
+      {
+        "en": "<class 'tuple'>",
+        "ja": "<class 'tuple'>",
+        "ja_typings": [
+          "<class 'tuple'>"
+        ]
+      },
+      {
+        "en": "<class 'dict'>",
+        "ja": "<class 'dict'>",
+        "ja_typings": [
+          "<class 'dict'>"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00003",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the output of `print(type([]))`?",
+      "ja": "Pythonで`print(type([]))`の出力は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "def",
+        "ja": "でふ",
+        "ja_typings": [
+          "defu"
+        ]
+      },
+      {
+        "en": "function",
+        "ja": "function",
+        "ja_typings": [
+          "function"
+        ]
+      },
+      {
+        "en": "fn",
+        "ja": "fn",
+        "ja_typings": [
+          "fn"
+        ]
+      },
+      {
+        "en": "func keyword",
+        "ja": "ふぁんくきーわーど",
+        "ja_typings": [
+          "fankukiwado"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00004",
+    "image_path": null,
+    "question_text": {
+      "en": "Which keyword defines a function in Python?",
+      "ja": "Pythonで関数を定義するキーワードは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "3",
+        "ja": "3",
+        "ja_typings": [
+          "3"
+        ]
+      },
+      {
+        "en": "2",
+        "ja": "2",
+        "ja_typings": [
+          "2"
+        ]
+      },
+      {
+        "en": "4",
+        "ja": "4",
+        "ja_typings": [
+          "4"
+        ]
+      },
+      {
+        "en": "0",
+        "ja": "0",
+        "ja_typings": [
+          "0"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00005",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `len([1,2,3])` return?",
+      "ja": "`len([1,2,3])`の戻り値は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "dict",
+        "ja": "dict",
+        "ja_typings": [
+          "dict"
+        ]
+      },
+      {
+        "en": "list",
+        "ja": "list",
+        "ja_typings": [
+          "list"
+        ]
+      },
+      {
+        "en": "tuple",
+        "ja": "tuple",
+        "ja_typings": [
+          "tuple"
+        ]
+      },
+      {
+        "en": "set",
+        "ja": "set",
+        "ja_typings": [
+          "set"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00006",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Python data structure uses key-value pairs?",
+      "ja": "Pythonでキーと値のペアを使うデータ構造は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "open()",
+        "ja": "open()",
+        "ja_typings": [
+          "open()"
+        ]
+      },
+      {
+        "en": "file()",
+        "ja": "file()",
+        "ja_typings": [
+          "file()"
+        ]
+      },
+      {
+        "en": "read()",
+        "ja": "read()",
+        "ja_typings": [
+          "read()"
+        ]
+      },
+      {
+        "en": "load()",
+        "ja": "load()",
+        "ja_typings": [
+          "load()"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00007",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the correct way to open a file in Python?",
+      "ja": "Pythonでファイルを開く正しい方法は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "//",
+        "ja": "どうぶるすらっしゅ",
+        "ja_typings": [
+          "doburusurasshu",
+          "douburusurasshu"
+        ]
+      },
+      {
+        "en": "single /",
+        "ja": "しんぐるすらっしゅ",
+        "ja_typings": [
+          "shingurusurasshu"
+        ]
+      },
+      {
+        "en": "%",
+        "ja": "%",
+        "ja_typings": [
+          "%"
+        ]
+      },
+      {
+        "en": "**",
+        "ja": "**",
+        "ja_typings": [
+          "**"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00008",
+    "image_path": null,
+    "question_text": {
+      "en": "Which operator is used for floor division in Python?",
+      "ja": "Pythonで切り捨て除算に使う演算子は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "integers 0 to 4",
+        "ja": "れいからよんのせいすう",
+        "ja_typings": [
+          "reikarayonnoseisuu"
+        ]
+      },
+      {
+        "en": "integers 1 to 5",
+        "ja": "いちからごのせいすう",
+        "ja_typings": [
+          "ichikaragonoseisuu"
+        ]
+      },
+      {
+        "en": "integers 0 to 5",
+        "ja": "れいからごのせいすう",
+        "ja_typings": [
+          "reikaragonoseisuu"
+        ]
+      },
+      {
+        "en": "integers 1 to 4",
+        "ja": "いちからよんのせいすう",
+        "ja_typings": [
+          "ichikarayonnoseisuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00009",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `range(5)` produce?",
+      "ja": "`range(5)`が生成するのは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "append()",
+        "ja": "append()",
+        "ja_typings": [
+          "append()"
+        ]
+      },
+      {
+        "en": "add()",
+        "ja": "add()",
+        "ja_typings": [
+          "add()"
+        ]
+      },
+      {
+        "en": "push()",
+        "ja": "push()",
+        "ja_typings": [
+          "push()"
+        ]
+      },
+      {
+        "en": "insert_end()",
+        "ja": "insert_end()",
+        "ja_typings": [
+          "insert_end()"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00010",
+    "image_path": null,
+    "question_text": {
+      "en": "Which method adds an element to a list in Python?",
+      "ja": "Pythonでリストに要素を追加するメソッドは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "anonymous function",
+        "ja": "むめいかんすう",
+        "ja_typings": [
+          "mumeikansuu"
+        ]
+      },
+      {
+        "en": "a loop",
+        "ja": "ループ",
+        "ja_typings": [
+          "rupu"
+        ]
+      },
+      {
+        "en": "a class",
+        "ja": "クラス",
+        "ja_typings": [
+          "kurasu"
+        ]
+      },
+      {
+        "en": "a module",
+        "ja": "もじゅーる",
+        "ja_typings": [
+          "mojuru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00011",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a lambda in Python?",
+      "ja": "Pythonのlambdaとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "max()",
+        "ja": "max()",
+        "ja_typings": [
+          "max()"
+        ]
+      },
+      {
+        "en": "top()",
+        "ja": "top()",
+        "ja_typings": [
+          "top()"
+        ]
+      },
+      {
+        "en": "largest()",
+        "ja": "largest()",
+        "ja_typings": [
+          "largest()"
+        ]
+      },
+      {
+        "en": "greatest()",
+        "ja": "greatest()",
+        "ja_typings": [
+          "greatest()"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00012",
+    "image_path": null,
+    "question_text": {
+      "en": "Which built-in function returns the largest value?",
+      "ja": "最大値を返すpython組み込み関数は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "let",
+        "ja": "let",
+        "ja_typings": [
+          "let"
         ]
       },
       {
@@ -63,232 +496,1003 @@
         ]
       },
       {
-        "en": "mut",
-        "ja": "mut",
+        "en": "val",
+        "ja": "val",
         "ja_typings": [
-          "mut"
+          "val"
         ]
       }
     ],
     "correct_answer_index": 0,
     "genre": "programming",
-    "id": "q00002",
+    "id": "q00013",
     "image_path": null,
     "question_text": {
-      "en": "What keyword declares a mutable variable in Rust?",
-      "ja": "Rustで可変変数を宣言するキーワードは？"
+      "en": "What keyword declares an immutable variable in Rust?",
+      "ja": "Rustで不変変数を宣言するキーワードは？"
     }
   },
   {
     "choices": [
       {
-        "en": "async/await",
-        "ja": "async/await",
+        "en": "each value has one owner",
+        "ja": "かくちはひとつのおーなーをもつ",
         "ja_typings": [
-          "async/await"
+          "kakuchihahitotsunonaomotsu",
+          "kakuchihahitotsunoonaomotsu"
         ]
       },
       {
-        "en": "thread/join",
-        "ja": "thread/join",
+        "en": "values are shared freely",
+        "ja": "ちはじゆうにきょうゆうされる",
         "ja_typings": [
-          "thread/join"
+          "chihajiyuunikyoyuusareru",
+          "chihajiyuunikyouyuusareru"
         ]
       },
       {
-        "en": "parallel/sync",
-        "ja": "parallel/sync",
+        "en": "no memory management",
+        "ja": "めもりかんりなし",
         "ja_typings": [
-          "parallel/sync"
+          "memorikanrinashi"
         ]
       },
       {
-        "en": "defer/resume",
-        "ja": "defer/resume",
+        "en": "garbage collected",
+        "ja": "がーびっじこれくしょん",
         "ja_typings": [
-          "defer/resume"
+          "gabijjikorekushon"
         ]
       }
     ],
     "correct_answer_index": 0,
     "genre": "programming",
-    "id": "q00003",
+    "id": "q00014",
     "image_path": null,
     "question_text": {
-      "en": "What syntax handles async operations in JavaScript?",
-      "ja": "JavaScriptで非同期処理を扱う構文は？"
+      "en": "What is the Rust ownership rule?",
+      "ja": "Rustのオーナーシップの基本ルールは？"
     }
   },
   {
     "choices": [
       {
-        "en": "linear search",
-        "ja": "せんけいたんさく",
+        "en": "&",
+        "ja": "&",
         "ja_typings": [
-          "senkeitansaku"
+          "&"
         ]
       },
       {
-        "en": "binary search",
-        "ja": "にぶんたんさく",
+        "en": "*",
+        "ja": "*",
         "ja_typings": [
-          "nibuntansaku"
+          "*"
         ]
       },
       {
-        "en": "hash search",
-        "ja": "はっしゅたんさく",
+        "en": "@",
+        "ja": "@",
         "ja_typings": [
-          "hasshutansaku"
+          "@"
         ]
       },
       {
-        "en": "exhaustive search",
-        "ja": "ぜんたんさく",
+        "en": "#",
+        "ja": "#",
         "ja_typings": [
-          "zentansaku"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
-    "genre": "programming",
-    "id": "q00004",
-    "image_path": null,
-    "question_text": {
-      "en": "Which search algorithm has O(log n) complexity?",
-      "ja": "O(log n)の計算量を持つ探索アルゴリズムは？"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "Only one instance",
-        "ja": "インスタンスを1つだけにする",
-        "ja_typings": [
-          "insutansuo1tsudakenisuru"
-        ]
-      },
-      {
-        "en": "Easy inheritance",
-        "ja": "けいしょうをかんたんにする",
-        "ja_typings": [
-          "keishookantannisuru",
-          "keishouokantannisuru"
-        ]
-      },
-      {
-        "en": "Parallel processing",
-        "ja": "へいれつしょりをする",
-        "ja_typings": [
-          "heiretsushoriosuru"
-        ]
-      },
-      {
-        "en": "Save memory",
-        "ja": "めもりをせつやくする",
-        "ja_typings": [
-          "memoriosetsuyakusuru"
+          "#"
         ]
       }
     ],
     "correct_answer_index": 0,
     "genre": "programming",
-    "id": "q00005",
+    "id": "q00015",
     "image_path": null,
     "question_text": {
-      "en": "What is the purpose of Singleton pattern?",
-      "ja": "デザインパターンのシングルトンの目的は？"
+      "en": "Which symbol denotes a reference in Rust?",
+      "ja": "Rustで参照を示す記号は？"
     }
   },
   {
     "choices": [
       {
-        "en": "side effects",
-        "ja": "ふくさよう",
+        "en": "nullable value",
+        "ja": "null許容の値",
         "ja_typings": [
-          "fukusayo",
-          "fukusayou"
+          "nullno"
         ]
       },
       {
-        "en": "recursion",
-        "ja": "さいきてきよびだし",
+        "en": "error handling",
+        "ja": "えらーはんどりんぐ",
         "ja_typings": [
-          "saikitekiyobidashi"
+          "erahandoringu"
         ]
       },
       {
-        "en": "higher-order functions",
-        "ja": "こうかいかんすう",
+        "en": "iteration",
+        "ja": "いてれーしょん",
         "ja_typings": [
-          "kokaikansuu",
-          "koukaikansuu"
+          "itereshon"
         ]
       },
       {
-        "en": "immutability",
-        "ja": "ふへんせい",
+        "en": "concurrency",
+        "ja": "へいこうせい",
         "ja_typings": [
-          "fuhensei"
+          "heikosei",
+          "heikousei"
         ]
       }
     ],
     "correct_answer_index": 0,
     "genre": "programming",
-    "id": "q00006",
+    "id": "q00016",
     "image_path": null,
     "question_text": {
-      "en": "What should be avoided in functional programming?",
-      "ja": "関数型プログラミングで避けるべきものは？"
+      "en": "What is `Option<T>` used for in Rust?",
+      "ja": "Rustの`Option<T>`の用途は？"
     }
   },
   {
     "choices": [
       {
-        "en": "keys()",
-        "ja": "keys()",
+        "en": "compiles the project",
+        "ja": "ぷろじぇくとをこんぱいる",
         "ja_typings": [
-          "keys()"
+          "purojekutokonpairu",
+          "purojekutookonpairu"
         ]
       },
       {
-        "en": "getkeys()",
-        "ja": "getkeys()",
+        "en": "runs tests",
+        "ja": "てすとをじっこう",
         "ja_typings": [
-          "getkeys()"
+          "tesutojikko",
+          "tesutoojikkou"
         ]
       },
       {
-        "en": "keylist()",
-        "ja": "keylist()",
+        "en": "publishes crate",
+        "ja": "くれーとをこうかい",
         "ja_typings": [
-          "keylist()"
+          "kuretokokai",
+          "kuretookoukai"
         ]
       },
       {
-        "en": "allkeys()",
-        "ja": "allkeys()",
+        "en": "formats code",
+        "ja": "こーどをふぉーまっと",
         "ja_typings": [
-          "allkeys()"
+          "kodofomatto",
+          "kodoofomatto"
         ]
       }
     ],
     "correct_answer_index": 0,
     "genre": "programming",
-    "id": "q00007",
+    "id": "q00017",
     "image_path": null,
     "question_text": {
-      "en": "Method to get dictionary keys in Python?",
-      "ja": "Pythonでディクショナリのキーを取得するメソッドは？"
+      "en": "What does `cargo build` do?",
+      "ja": "`cargo build`は何をするコマンドか？"
     }
   },
   {
     "choices": [
+      {
+        "en": "Debug",
+        "ja": "Debug",
+        "ja_typings": [
+          "debug"
+        ]
+      },
+      {
+        "en": "Display",
+        "ja": "Display",
+        "ja_typings": [
+          "display"
+        ]
+      },
+      {
+        "en": "Print",
+        "ja": "Print",
+        "ja_typings": [
+          "print"
+        ]
+      },
+      {
+        "en": "Format",
+        "ja": "Format",
+        "ja_typings": [
+          "format"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00018",
+    "image_path": null,
+    "question_text": {
+      "en": "Which trait enables printing with `{:?}` in Rust?",
+      "ja": "Rustで`{:?}`による表示を可能にするとれーとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "growable array",
+        "ja": "かちょうかのうなはいれつ",
+        "ja_typings": [
+          "kachokanonahairetsu",
+          "kachoukanounahairetsu"
+        ]
+      },
+      {
+        "en": "hash map",
+        "ja": "はっしゅまっぷ",
+        "ja_typings": [
+          "hasshumappu"
+        ]
+      },
+      {
+        "en": "linked list",
+        "ja": "れんけつりすと",
+        "ja_typings": [
+          "renketsurisuto"
+        ]
+      },
+      {
+        "en": "fixed array",
+        "ja": "こていはいれつ",
+        "ja_typings": [
+          "koteihairetsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00019",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a `Vec<T>` in Rust?",
+      "ja": "Rustの`Vec<T>`とは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Result type",
+        "ja": "Resultがた",
+        "ja_typings": [
+          "resultgata"
+        ]
+      },
+      {
+        "en": "exceptions",
+        "ja": "れいがい",
+        "ja_typings": [
+          "reigai"
+        ]
+      },
+      {
+        "en": "error codes",
+        "ja": "えらーこーど",
+        "ja_typings": [
+          "erakodo"
+        ]
+      },
+      {
+        "en": "panic always",
+        "ja": "つねにぱにっく",
+        "ja_typings": [
+          "tsunenipanikku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00020",
+    "image_path": null,
+    "question_text": {
+      "en": "How do you handle errors in Rust idiomatically?",
+      "ja": "Rustでエラーを慣用的に扱う方法は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "implements methods for a type",
+        "ja": "かたにめそっどをじっそう",
+        "ja_typings": [
+          "katanimesoddojisso",
+          "katanimesoddoojissou"
+        ]
+      },
+      {
+        "en": "imports a module",
+        "ja": "もじゅーるをいんぽーと",
+        "ja_typings": [
+          "mojuruoinpoto"
+        ]
+      },
+      {
+        "en": "declares interface",
+        "ja": "いんたーふぇーすをせんげん",
+        "ja_typings": [
+          "intafesuosengen"
+        ]
+      },
+      {
+        "en": "creates enum",
+        "ja": "えぬむをさくせい",
+        "ja_typings": [
+          "enumuosakusei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00021",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `impl` keyword do in Rust?",
+      "ja": "Rustの`impl`キーワードの役割は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "fn main()",
+        "ja": "fn main()",
+        "ja_typings": [
+          "fn main()"
+        ]
+      },
+      {
+        "en": "fn start()",
+        "ja": "fn start()",
+        "ja_typings": [
+          "fn start()"
+        ]
+      },
+      {
+        "en": "fn run()",
+        "ja": "fn run()",
+        "ja_typings": [
+          "fn run()"
+        ]
+      },
+      {
+        "en": "fn init()",
+        "ja": "fn init()",
+        "ja_typings": [
+          "fn init()"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00022",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the entry point of a Rust program?",
+      "ja": "Rustプログラムのエントリーポイントは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "let",
+        "ja": "let",
+        "ja_typings": [
+          "let"
+        ]
+      },
+      {
+        "en": "var",
+        "ja": "var",
+        "ja_typings": [
+          "var"
+        ]
+      },
+      {
+        "en": "dim",
+        "ja": "dim",
+        "ja_typings": [
+          "dim"
+        ]
+      },
+      {
+        "en": "define",
+        "ja": "define",
+        "ja_typings": [
+          "define"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00023",
+    "image_path": null,
+    "question_text": {
+      "en": "Which keyword declares a block-scoped variable in JS?",
+      "ja": "JSでブロックスコープ変数を宣言するキーワードは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "strict equality",
+        "ja": "げんみつなどうち",
+        "ja_typings": [
+          "genmitsunadochi",
+          "genmitsunadouchi"
+        ]
+      },
+      {
+        "en": "assignment",
+        "ja": "だいにゅう",
+        "ja_typings": [
+          "dainyuu"
+        ]
+      },
+      {
+        "en": "loose equality",
+        "ja": "ゆるやかなどうち",
+        "ja_typings": [
+          "yuruyakanadochi",
+          "yuruyakanadouchi"
+        ]
+      },
+      {
+        "en": "comparison",
+        "ja": "ひかく",
+        "ja_typings": [
+          "hikaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00024",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `===` check in JavaScript?",
+      "ja": "JavaScriptの`===`は何を確認するか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "() => {}",
+        "ja": "() => {}",
+        "ja_typings": [
+          "() => {}"
+        ]
+      },
+      {
+        "en": "function() {}",
+        "ja": "function() {}",
+        "ja_typings": [
+          "function() {}"
+        ]
+      },
+      {
+        "en": "fn() {}",
+        "ja": "fn() {}",
+        "ja_typings": [
+          "fn() {}"
+        ]
+      },
+      {
+        "en": "def() {}",
+        "ja": "def() {}",
+        "ja_typings": [
+          "def() {}"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00025",
+    "image_path": null,
+    "question_text": {
+      "en": "How do you create an arrow function in JS?",
+      "ja": "JSでアロー関数を作る構文は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Not a Number",
+        "ja": "すうちでない",
+        "ja_typings": [
+          "suuchidenai"
+        ]
+      },
+      {
+        "en": "Null and None",
+        "ja": "nullとnone",
+        "ja_typings": [
+          "nulltonone"
+        ]
+      },
+      {
+        "en": "New Array Node",
+        "ja": "あたらしいはいれつのーど",
+        "ja_typings": [
+          "atarashiihairetsunodo"
+        ]
+      },
+      {
+        "en": "Not an Object",
+        "ja": "おぶじぇくとでない",
+        "ja_typings": [
+          "obujekutodenai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00026",
+    "image_path": null,
+    "question_text": {
+      "en": "What is `NaN` in JavaScript?",
+      "ja": "JavaScriptの`NaN`とは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JSON.parse()",
+        "ja": "JSON.parse()",
+        "ja_typings": [
+          "json.parse()"
+        ]
+      },
+      {
+        "en": "JSON.stringify()",
+        "ja": "JSON.stringify()",
+        "ja_typings": [
+          "json.stringify()"
+        ]
+      },
+      {
+        "en": "JSON.convert()",
+        "ja": "JSON.convert()",
+        "ja_typings": [
+          "json.convert()"
+        ]
+      },
+      {
+        "en": "JSON.decode()",
+        "ja": "JSON.decode()",
+        "ja_typings": [
+          "json.decode()"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00027",
+    "image_path": null,
+    "question_text": {
+      "en": "Which method converts JSON string to object?",
+      "ja": "JSON文字列をオブジェクトに変換するメソッドは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "waits for all promises",
+        "ja": "すべてのぷろみすをまつ",
+        "ja_typings": [
+          "subetenopuromisuomatsu"
+        ]
+      },
+      {
+        "en": "cancels all promises",
+        "ja": "すべてのぷろみすをきゃんせる",
+        "ja_typings": [
+          "subetenopuromisuokyanseru"
+        ]
+      },
+      {
+        "en": "runs promises in series",
+        "ja": "ぷろみすをじゅんじにじっこう",
+        "ja_typings": [
+          "puromisuojunjinijikko",
+          "puromisuojunjinijikkou"
+        ]
+      },
+      {
+        "en": "rejects all promises",
+        "ja": "すべてのぷろみすをきゃく",
+        "ja_typings": [
+          "subetenopuromisuokyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00028",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `Promise.all()` do?",
+      "ja": "`Promise.all()`は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "extends",
+        "ja": "extends",
+        "ja_typings": [
+          "extends"
+        ]
+      },
+      {
+        "en": "inherits",
+        "ja": "inherits",
+        "ja_typings": [
+          "inherits"
+        ]
+      },
+      {
+        "en": "implements",
+        "ja": "implements",
+        "ja_typings": [
+          "implements"
+        ]
+      },
+      {
+        "en": "derives",
+        "ja": "derives",
+        "ja_typings": [
+          "derives"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00029",
+    "image_path": null,
+    "question_text": {
+      "en": "Which keyword is used for class inheritance in JS?",
+      "ja": "JSでクラスの継承に使うキーワードは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "object",
+        "ja": "object",
+        "ja_typings": [
+          "object"
+        ]
+      },
+      {
+        "en": "null",
+        "ja": "null",
+        "ja_typings": [
+          "null"
+        ]
+      },
+      {
+        "en": "undefined",
+        "ja": "undefined",
+        "ja_typings": [
+          "undefined"
+        ]
+      },
+      {
+        "en": "boolean",
+        "ja": "boolean",
+        "ja_typings": [
+          "boolean"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00030",
+    "image_path": null,
+    "question_text": {
+      "en": "What is `typeof null` in JavaScript?",
+      "ja": "JavaScriptで`typeof null`の結果は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "map()",
+        "ja": "map()",
+        "ja_typings": [
+          "map()"
+        ]
+      },
+      {
+        "en": "filter()",
+        "ja": "filter()",
+        "ja_typings": [
+          "filter()"
+        ]
+      },
+      {
+        "en": "reduce()",
+        "ja": "reduce()",
+        "ja_typings": [
+          "reduce()"
+        ]
+      },
+      {
+        "en": "forEach()",
+        "ja": "forEach()",
+        "ja_typings": [
+          "foreach()"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00031",
+    "image_path": null,
+    "question_text": {
+      "en": "Which array method creates a new array by transforming each element?",
+      "ja": "各要素を変換して新配列を作るはいれつメソッドは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "true",
+        "ja": "true",
+        "ja_typings": [
+          "true"
+        ]
+      },
+      {
+        "en": "false",
+        "ja": "false",
+        "ja_typings": [
+          "false"
+        ]
+      },
+      {
+        "en": "undefined",
+        "ja": "undefined",
+        "ja_typings": [
+          "undefined"
+        ]
+      },
+      {
+        "en": "1",
+        "ja": "1",
+        "ja_typings": [
+          "1"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00032",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `Array.isArray([])` return?",
+      "ja": "`Array.isArray([])`の戻り値は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "O(1)",
+        "ja": "O(1)",
+        "ja_typings": [
+          "o(1)"
+        ]
+      },
       {
         "en": "O(n)",
         "ja": "O(n)",
         "ja_typings": [
           "o(n)"
+        ]
+      },
+      {
+        "en": "O(log n)",
+        "ja": "O(log n)",
+        "ja_typings": [
+          "o(log n)"
+        ]
+      },
+      {
+        "en": "O(n²)",
+        "ja": "O(n²)",
+        "ja_typings": [
+          "o n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00033",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the time complexity of accessing an array element by index?",
+      "ja": "はいれつのいんでくすによるアクセスの計算量は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "stack",
+        "ja": "すたっく",
+        "ja_typings": [
+          "sutakku"
+        ]
+      },
+      {
+        "en": "queue",
+        "ja": "きゅー",
+        "ja_typings": [
+          "kyu"
+        ]
+      },
+      {
+        "en": "heap",
+        "ja": "ひーぷ",
+        "ja_typings": [
+          "hipu"
+        ]
+      },
+      {
+        "en": "tree",
+        "ja": "つりー",
+        "ja_typings": [
+          "tsuri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00034",
+    "image_path": null,
+    "question_text": {
+      "en": "Which data structure uses LIFO order?",
+      "ja": "LIFO順を使うでーたこうぞうは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "data and pointer",
+        "ja": "でーたとぽいんたー",
+        "ja_typings": [
+          "detatopointa"
+        ]
+      },
+      {
+        "en": "key and value",
+        "ja": "きーとちー",
+        "ja_typings": [
+          "kitochi"
+        ]
+      },
+      {
+        "en": "index and value",
+        "ja": "いんでくすとち",
+        "ja_typings": [
+          "indekusutochi"
+        ]
+      },
+      {
+        "en": "hash and data",
+        "ja": "はっしゅとでーた",
+        "ja_typings": [
+          "hasshutodeta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00035",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a linked list node composed of?",
+      "ja": "れんけつりすとののーどは何で構成されるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "pre-order",
+        "ja": "まえじゅん",
+        "ja_typings": [
+          "maejun"
+        ]
+      },
+      {
+        "en": "in-order",
+        "ja": "ちゅうじゅん",
+        "ja_typings": [
+          "chuujun"
+        ]
+      },
+      {
+        "en": "post-order",
+        "ja": "こうじゅん",
+        "ja_typings": [
+          "kojun",
+          "koujun"
+        ]
+      },
+      {
+        "en": "level-order",
+        "ja": "れべるじゅん",
+        "ja_typings": [
+          "reberujun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00036",
+    "image_path": null,
+    "question_text": {
+      "en": "Which tree traversal visits root first?",
+      "ja": "ねをさいしょにたどる木の探索順は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "two keys map to same bucket",
+        "ja": "ふたつのきーがどうじはっしゅ",
+        "ja_typings": [
+          "futatsunokigadojihasshu",
+          "futatsunokigadoujihasshu"
+        ]
+      },
+      {
+        "en": "hash value is zero",
+        "ja": "はっしゅがぜろになる",
+        "ja_typings": [
+          "hasshugazeroninaru"
+        ]
+      },
+      {
+        "en": "hash function crashes",
+        "ja": "はっしゅかんすうがくらっしゅ",
+        "ja_typings": [
+          "hasshukansuugakurasshu"
+        ]
+      },
+      {
+        "en": "key is not found",
+        "ja": "きーがみつからない",
+        "ja_typings": [
+          "kigamitsukaranai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00037",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a hash collision?",
+      "ja": "はっしゅしょうとつとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "O(n²)",
+        "ja": "O(n²)",
+        "ja_typings": [
+          "o n"
         ]
       },
       {
@@ -299,10 +1503,10 @@
         ]
       },
       {
-        "en": "O(n^2)",
-        "ja": "O(n^2)",
+        "en": "O(n)",
+        "ja": "O(n)",
         "ja_typings": [
-          "o(n^2)"
+          "o(n)"
         ]
       },
       {
@@ -313,343 +1517,554 @@
         ]
       }
     ],
-    "correct_answer_index": 1,
+    "correct_answer_index": 0,
     "genre": "programming",
-    "id": "q00008",
+    "id": "q00038",
     "image_path": null,
     "question_text": {
-      "en": "Average time complexity of quicksort?",
-      "ja": "クイックソートの平均計算量は？"
+      "en": "What is the worst-case complexity of quicksort?",
+      "ja": "くいっくそーとの最悪計算量は？"
     }
   },
   {
     "choices": [
       {
-        "en": "FIFO",
-        "ja": "FIFO",
+        "en": "queue",
+        "ja": "きゅー",
         "ja_typings": [
-          "fifo"
+          "kyu"
         ]
       },
       {
-        "en": "LIFO",
-        "ja": "LIFO",
+        "en": "stack",
+        "ja": "すたっく",
         "ja_typings": [
-          "lifo"
+          "sutakku"
         ]
       },
       {
-        "en": "Random access",
-        "ja": "ランダムアクセス",
+        "en": "array",
+        "ja": "はいれつ",
         "ja_typings": [
-          "randamuakusesu"
+          "hairetsu"
         ]
       },
       {
-        "en": "Sorted",
-        "ja": "そーとずみ",
+        "en": "tree",
+        "ja": "つりー",
         "ja_typings": [
-          "sotozumi"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
-    "genre": "programming",
-    "id": "q00009",
-    "image_path": null,
-    "question_text": {
-      "en": "Characteristic of stack data structure?",
-      "ja": "スタックのデータ構造の特徴は？"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "null is intentional empty",
-        "ja": "nullはいとてきなくうち",
-        "ja_typings": [
-          "nullhaitotekinakuuchi"
-        ]
-      },
-      {
-        "en": "Same meaning",
-        "ja": "おなじいみ",
-        "ja_typings": [
-          "onajiimi"
-        ]
-      },
-      {
-        "en": "undefined is error",
-        "ja": "undefinedはえらー",
-        "ja_typings": [
-          "undefinedhaera"
-        ]
-      },
-      {
-        "en": "No difference",
-        "ja": "ちがいはない",
-        "ja_typings": [
-          "chigaihanai"
+          "tsuri"
         ]
       }
     ],
     "correct_answer_index": 0,
     "genre": "programming",
-    "id": "q00010",
+    "id": "q00039",
     "image_path": null,
     "question_text": {
-      "en": "Difference between null and undefined in JS?",
-      "ja": "JavaScriptのnullとundefinedの違いは？"
+      "en": "Which data structure supports BFS traversal naturally?",
+      "ja": "はばゆうせんたんさくを自然にサポートするでーたこうぞうは？"
     }
   },
   {
     "choices": [
       {
-        "en": "git reset HEAD~1",
-        "ja": "git reset HEAD~1",
+        "en": "left < root < right",
+        "ja": "ひだり < ね < みぎ",
         "ja_typings": [
-          "git reset head~1"
+          "hidari ne migi"
         ]
       },
       {
-        "en": "git revert HEAD",
-        "ja": "git revert HEAD",
+        "en": "left > root > right",
+        "ja": "ひだり > ね > みぎ",
         "ja_typings": [
-          "git revert head"
+          "hidari ne migi"
         ]
       },
       {
-        "en": "git undo",
-        "ja": "git undo",
+        "en": "all nodes equal",
+        "ja": "すべてのーどがひとしい",
         "ja_typings": [
-          "git undo"
+          "subetenodogahitoshii"
         ]
       },
       {
-        "en": "git remove HEAD",
-        "ja": "git remove HEAD",
+        "en": "sorted by insertion order",
+        "ja": "そうにゅうじゅんにせいれつ",
         "ja_typings": [
-          "git remove head"
+          "sonyuujunniseiretsu",
+          "sounyuujunniseiretsu"
         ]
       }
     ],
     "correct_answer_index": 0,
     "genre": "programming",
-    "id": "q00011",
+    "id": "q00040",
     "image_path": null,
     "question_text": {
-      "en": "Which Git command undoes the latest commit?",
-      "ja": "Gitでさいしんのこみっとをとりけすこまんどは?"
+      "en": "What is a binary search tree property?",
+      "ja": "にぶんたんさくきのせいしつは？"
     }
   },
   {
     "choices": [
       {
-        "en": "{x for x in range}",
-        "ja": "{x for x in range}",
+        "en": "minimum value",
+        "ja": "さいしょうち",
         "ja_typings": [
-          "{x for x in range}"
+          "saishochi",
+          "saishouchi"
         ]
       },
       {
-        "en": "[x for x in range]",
-        "ja": "[x for x in range]",
+        "en": "maximum value",
+        "ja": "さいだいち",
         "ja_typings": [
-          "[x for x in range]"
+          "saidaichi"
         ]
       },
       {
-        "en": "(x for x in range)",
-        "ja": "(x for x in range)",
+        "en": "median value",
+        "ja": "ちゅうかんち",
         "ja_typings": [
-          "(x for x in range)"
+          "chuukanchi"
         ]
       },
       {
-        "en": "<x for x in range>",
-        "ja": "<x for x in range>",
+        "en": "random value",
+        "ja": "らんだむち",
         "ja_typings": [
-          "<x for x in range>"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
-    "genre": "programming",
-    "id": "q00012",
-    "image_path": null,
-    "question_text": {
-      "en": "What is the syntax for list comprehension in Python?",
-      "ja": "Pythonでりすとないほうをつくるしんたっくすは?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "useEffect",
-        "ja": "useEffect",
-        "ja_typings": [
-          "useeffect"
-        ]
-      },
-      {
-        "en": "useState",
-        "ja": "useState",
-        "ja_typings": [
-          "usestate"
-        ]
-      },
-      {
-        "en": "useContext",
-        "ja": "useContext",
-        "ja_typings": [
-          "usecontext"
-        ]
-      },
-      {
-        "en": "useMemo",
-        "ja": "useMemo",
-        "ja_typings": [
-          "usememo"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
-    "genre": "web_development",
-    "id": "q00013",
-    "image_path": null,
-    "question_text": {
-      "en": "Which React hook is used for state management?",
-      "ja": "Reactでじょうたいかんりにつかうフックは?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "PRIMARY KEY",
-        "ja": "PRIMARY KEY",
-        "ja_typings": [
-          "primary key"
-        ]
-      },
-      {
-        "en": "FOREIGN KEY",
-        "ja": "FOREIGN KEY",
-        "ja_typings": [
-          "foreign key"
-        ]
-      },
-      {
-        "en": "CHECK",
-        "ja": "CHECK",
-        "ja_typings": [
-          "check"
-        ]
-      },
-      {
-        "en": "DEFAULT",
-        "ja": "DEFAULT",
-        "ja_typings": [
-          "default"
+          "randamuchi"
         ]
       }
     ],
     "correct_answer_index": 0,
     "genre": "programming",
-    "id": "q00014",
+    "id": "q00041",
     "image_path": null,
     "question_text": {
-      "en": "Which SQL constraint ensures unique values?",
-      "ja": "SQLでゆにーくなちをせいやくするのは?"
+      "en": "What does a min-heap guarantee at the root?",
+      "ja": "みにひーぷはねに何を保証するか？"
     }
   },
   {
     "choices": [
       {
-        "en": "Server Error",
-        "ja": "さーばーえらー",
+        "en": "adjacency list",
+        "ja": "となりあいりすと",
         "ja_typings": [
-          "sabaera"
+          "tonariairisuto"
         ]
       },
       {
-        "en": "Not Found",
-        "ja": "みつかりません",
+        "en": "adjacency matrix",
+        "ja": "となりあいぎょうれつ",
         "ja_typings": [
-          "mitsukarimasen"
+          "tonariaigyoretsu",
+          "tonariaigyouretsu"
         ]
       },
       {
-        "en": "Authentication Required",
-        "ja": "みにんしょうひつよう",
+        "en": "edge list",
+        "ja": "へんりすと",
         "ja_typings": [
-          "mininshohitsuyo",
-          "mininshouhitsuyou"
+          "henrisuto"
         ]
       },
       {
-        "en": "Redirect",
-        "ja": "りだいれくと",
+        "en": "incidence matrix",
+        "ja": "そくしぎょうれつ",
         "ja_typings": [
-          "ridairekuto"
+          "sokushigyoretsu",
+          "sokushigyouretsu"
         ]
       }
     ],
-    "correct_answer_index": 1,
-    "genre": "web_development",
-    "id": "q00015",
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00042",
     "image_path": null,
     "question_text": {
-      "en": "What does HTTP status code 404 mean?",
-      "ja": "HTTPすてーたすこーど404のいみは?"
+      "en": "Which graph representation uses adjacency lists?",
+      "ja": "となりあいりすとをつかうグラフひょうげんは？"
     }
   },
   {
     "choices": [
       {
-        "en": "display: flex",
-        "ja": "display: flex",
+        "en": "solving by storing subproblem results",
+        "ja": "ぶぶんもんだいをほぞんしてかいく",
         "ja_typings": [
-          "display: flex"
+          "bubunmondaiohozonshitekaiku"
         ]
       },
       {
-        "en": "position: absolute",
-        "ja": "position: absolute",
+        "en": "randomized algorithm",
+        "ja": "らんだまいずどあるごりずむ",
         "ja_typings": [
-          "position: absolute"
+          "randamaizudoarugorizumu"
         ]
       },
       {
-        "en": "float: left",
-        "ja": "float: left",
+        "en": "brute force search",
+        "ja": "ぜんけんさく",
         "ja_typings": [
-          "float: left"
+          "zenkensaku"
         ]
       },
       {
-        "en": "All of them",
-        "ja": "すべて",
+        "en": "greedy selection",
+        "ja": "どんよくほう",
         "ja_typings": [
-          "subete"
+          "donyokuho",
+          "donyokuhou"
         ]
       }
     ],
-    "correct_answer_index": 3,
-    "genre": "web_development",
-    "id": "q00016",
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00043",
     "image_path": null,
     "question_text": {
-      "en": "Which CSS property arranges items horizontally?",
-      "ja": "CSSでよこならびにするぷろぱてぃは?"
+      "en": "What is dynamic programming?",
+      "ja": "どうてきけいかくほうとは何か？"
     }
   },
   {
     "choices": [
       {
-        "en": "O(n)",
-        "ja": "O(n)",
+        "en": "merge sort",
+        "ja": "まーじそーと",
         "ja_typings": [
-          "o(n)"
+          "majisoto"
+        ]
+      },
+      {
+        "en": "quick sort",
+        "ja": "くいっくそーと",
+        "ja_typings": [
+          "kuikkusoto"
+        ]
+      },
+      {
+        "en": "heap sort",
+        "ja": "ひーぷそーと",
+        "ja_typings": [
+          "hipusoto"
+        ]
+      },
+      {
+        "en": "selection sort",
+        "ja": "せんたくそーと",
+        "ja_typings": [
+          "sentakusoto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00044",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sorting algorithm is stable and O(n log n)?",
+      "ja": "あんていでO(n log n)のせいれつあるごりずむは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "describing algorithm complexity",
+        "ja": "あるごりずむのけいさんりょうをひょうげん",
+        "ja_typings": [
+          "arugorizumunokeisanryoohyogen",
+          "arugorizumunokeisanryouohyougen"
+        ]
+      },
+      {
+        "en": "measuring memory size",
+        "ja": "めもりしょうひをそくてい",
+        "ja_typings": [
+          "memorishohiosokutei",
+          "memorishouhiosokutei"
+        ]
+      },
+      {
+        "en": "defining variable scope",
+        "ja": "へんすうのすこーぷをていぎ",
+        "ja_typings": [
+          "hensuunosukopuoteigi"
+        ]
+      },
+      {
+        "en": "declaring constants",
+        "ja": "ていすうをせんげん",
+        "ja_typings": [
+          "teisuuosengen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00045",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Big O notation used for?",
+      "ja": "Big O記法は何のために使うか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "shortest path",
+        "ja": "さいたんけいろ",
+        "ja_typings": [
+          "saitankeiro"
+        ]
+      },
+      {
+        "en": "minimum spanning tree",
+        "ja": "さいしょうぜんいきき",
+        "ja_typings": [
+          "saishozenikiki",
+          "saishouzenikiki"
+        ]
+      },
+      {
+        "en": "topological order",
+        "ja": "いそがきじゅん",
+        "ja_typings": [
+          "isogakijun"
+        ]
+      },
+      {
+        "en": "strongly connected components",
+        "ja": "きょうれんけつせいぶん",
+        "ja_typings": [
+          "kyorenketsuseibun",
+          "kyourenketsuseibun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00046",
+    "image_path": null,
+    "question_text": {
+      "en": "What does Dijkstra's algorithm find?",
+      "ja": "ダイクストラのあるごりずむは何を求めるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "caching computed results",
+        "ja": "けいさんけっかをきゃっしゅ",
+        "ja_typings": [
+          "keisankekkaokyasshu"
+        ]
+      },
+      {
+        "en": "memory allocation",
+        "ja": "めもりかくほ",
+        "ja_typings": [
+          "memorikakuho"
+        ]
+      },
+      {
+        "en": "garbage collection",
+        "ja": "がーびっじこれくしょん",
+        "ja_typings": [
+          "gabijjikorekushon"
+        ]
+      },
+      {
+        "en": "code optimization",
+        "ja": "こーどさいてきか",
+        "ja_typings": [
+          "kodosaitekika"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00047",
+    "image_path": null,
+    "question_text": {
+      "en": "What is memoization?",
+      "ja": "めもいぜーしょんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "merge sort",
+        "ja": "まーじそーと",
+        "ja_typings": [
+          "majisoto"
+        ]
+      },
+      {
+        "en": "bubble sort",
+        "ja": "ばぶるそーと",
+        "ja_typings": [
+          "baburusoto"
+        ]
+      },
+      {
+        "en": "insertion sort",
+        "ja": "そうにゅうそーと",
+        "ja_typings": [
+          "sonyuusoto",
+          "sounyuusoto"
+        ]
+      },
+      {
+        "en": "counting sort",
+        "ja": "かうんとそーと",
+        "ja_typings": [
+          "kauntosoto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00048",
+    "image_path": null,
+    "question_text": {
+      "en": "Which algorithm uses divide and conquer?",
+      "ja": "ぶんちしほうを使うあるごりずむは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "a function calling itself",
+        "ja": "じぶんじしんをよびだすかんすう",
+        "ja_typings": [
+          "jibunjishinoyobidasukansuu"
+        ]
+      },
+      {
+        "en": "a loop structure",
+        "ja": "るーぷこうぞう",
+        "ja_typings": [
+          "rupukozo",
+          "rupukouzou"
+        ]
+      },
+      {
+        "en": "a data type",
+        "ja": "でーたがた",
+        "ja_typings": [
+          "detagata"
+        ]
+      },
+      {
+        "en": "an error handler",
+        "ja": "えらーはんどらー",
+        "ja_typings": [
+          "erahandora"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00049",
+    "image_path": null,
+    "question_text": {
+      "en": "What is recursion?",
+      "ja": "さいきとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "the condition to stop recursion",
+        "ja": "さいきをとめるじょうけん",
+        "ja_typings": [
+          "saikiotomerujoken",
+          "saikiotomerujouken"
+        ]
+      },
+      {
+        "en": "the first recursive call",
+        "ja": "さいしょのさいきよびだし",
+        "ja_typings": [
+          "saishonosaikiyobidashi"
+        ]
+      },
+      {
+        "en": "the input parameter",
+        "ja": "にゅうりょくぱらめーた",
+        "ja_typings": [
+          "nyuuryokuparameta"
+        ]
+      },
+      {
+        "en": "the return value",
+        "ja": "もどりち",
+        "ja_typings": [
+          "modorichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00050",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the base case in recursion?",
+      "ja": "さいきのきていじょうけんとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "binary search",
+        "ja": "にぶんたんさく",
+        "ja_typings": [
+          "nibuntansaku"
+        ]
+      },
+      {
+        "en": "linear search",
+        "ja": "せんけいたんさく",
+        "ja_typings": [
+          "senkeitansaku"
+        ]
+      },
+      {
+        "en": "depth-first search",
+        "ja": "ふかさゆうせんたんさく",
+        "ja_typings": [
+          "fukasayuusentansaku"
+        ]
+      },
+      {
+        "en": "breadth-first search",
+        "ja": "はばゆうせんたんさく",
+        "ja_typings": [
+          "habayuusentansaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00051",
+    "image_path": null,
+    "question_text": {
+      "en": "Which search requires a sorted array?",
+      "ja": "せいれつされたはいれつが必要な探索は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "O(n²)",
+        "ja": "O(n²)",
+        "ja_typings": [
+          "o n"
         ]
       },
       {
@@ -660,10 +2075,10 @@
         ]
       },
       {
-        "en": "O(n^2)",
-        "ja": "O(n^2)",
+        "en": "O(n)",
+        "ja": "O(n)",
         "ja_typings": [
-          "o(n^2)"
+          "o(n)"
         ]
       },
       {
@@ -674,298 +2089,1727 @@
         ]
       }
     ],
-    "correct_answer_index": 2,
+    "correct_answer_index": 0,
     "genre": "programming",
-    "id": "q00017",
+    "id": "q00052",
     "image_path": null,
     "question_text": {
-      "en": "What is the time complexity of Bubble Sort?",
-      "ja": "バブルソートのじかんけいさんりょうは?"
+      "en": "What is the time complexity of bubble sort?",
+      "ja": "ばぶるそーとの計算量は？"
     }
   },
   {
     "choices": [
       {
-        "en": "Multiple instances",
-        "ja": "ふくすうのいんすたんす",
+        "en": "hiding internal details",
+        "ja": "ないぶしょうさいをかくす",
         "ja_typings": [
-          "fukusuunoinsutansu"
+          "naibushosaiokakusu",
+          "naibushousaiokakusu"
         ]
       },
       {
-        "en": "Only one instance",
-        "ja": "1このいんすたんすのみ",
+        "en": "inheriting properties",
+        "ja": "ぷろぱてぃをけいしょう",
         "ja_typings": [
-          "1konoinsutansunomi"
+          "puropatiokeisho",
+          "puropatiokeishou"
         ]
       },
       {
-        "en": "Inheritance management",
-        "ja": "けいしょうのかんり",
+        "en": "overriding methods",
+        "ja": "めそっどをおーばーらいど",
         "ja_typings": [
-          "keishonokanri",
-          "keishounokanri"
+          "mesoddoobaraido",
+          "mesoddooobaraido"
         ]
       },
       {
-        "en": "Undefined",
-        "ja": "ひていぎ",
+        "en": "creating instances",
+        "ja": "いんすたんすをさくせい",
         "ja_typings": [
-          "hiteigi"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
-    "genre": "programming",
-    "id": "q00018",
-    "image_path": null,
-    "question_text": {
-      "en": "What is the purpose of the Singleton pattern?",
-      "ja": "デザインパターンでシングルトンのもくてきは?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "cd",
-        "ja": "cd",
-        "ja_typings": [
-          "cd"
-        ]
-      },
-      {
-        "en": "ls",
-        "ja": "ls",
-        "ja_typings": [
-          "ls"
-        ]
-      },
-      {
-        "en": "pwd",
-        "ja": "pwd",
-        "ja_typings": [
-          "pwd"
-        ]
-      },
-      {
-        "en": "mkdir",
-        "ja": "mkdir",
-        "ja_typings": [
-          "mkdir"
-        ]
-      }
-    ],
-    "correct_answer_index": 2,
-    "genre": "technology",
-    "id": "q00019",
-    "image_path": null,
-    "question_text": {
-      "en": "Which Linux command shows the current directory?",
-      "ja": "Linuxでかれんとでぃれくとりをひょうじするこまんどは?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "Borrowing",
-        "ja": "かりる",
-        "ja_typings": [
-          "kariru"
-        ]
-      },
-      {
-        "en": "Move",
-        "ja": "むーぶ",
-        "ja_typings": [
-          "mubu"
-        ]
-      },
-      {
-        "en": "Copy",
-        "ja": "こぴー",
-        "ja_typings": [
-          "kopi"
-        ]
-      },
-      {
-        "en": "Clone",
-        "ja": "くろーん",
-        "ja_typings": [
-          "kuron"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
-    "genre": "programming",
-    "id": "q00020",
-    "image_path": null,
-    "question_text": {
-      "en": "How do you transfer ownership in Rust?",
-      "ja": "Rustでしょゆうけんをうつすのは?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "Promise",
-        "ja": "Promise",
-        "ja_typings": [
-          "promise"
-        ]
-      },
-      {
-        "en": "Array",
-        "ja": "Array",
-        "ja_typings": [
-          "array"
-        ]
-      },
-      {
-        "en": "Object",
-        "ja": "Object",
-        "ja_typings": [
-          "object"
-        ]
-      },
-      {
-        "en": "String",
-        "ja": "String",
-        "ja_typings": [
-          "string"
+          "insutansuosakusei"
         ]
       }
     ],
     "correct_answer_index": 0,
-    "genre": "web_development",
-    "id": "q00021",
-    "image_path": null,
-    "question_text": {
-      "en": "What is used for asynchronous processing in JavaScript?",
-      "ja": "JavaScriptでひどうしょりにつかうのは?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "docker build",
-        "ja": "docker build",
-        "ja_typings": [
-          "docker build"
-        ]
-      },
-      {
-        "en": "docker run",
-        "ja": "docker run",
-        "ja_typings": [
-          "docker run"
-        ]
-      },
-      {
-        "en": "docker pull",
-        "ja": "docker pull",
-        "ja_typings": [
-          "docker pull"
-        ]
-      },
-      {
-        "en": "docker push",
-        "ja": "docker push",
-        "ja_typings": [
-          "docker push"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
     "genre": "programming",
-    "id": "q00022",
+    "id": "q00053",
     "image_path": null,
     "question_text": {
-      "en": "Which Docker command starts a container?",
-      "ja": "dockerでこんてなをきどうするこまんどは?"
+      "en": "What is encapsulation?",
+      "ja": "かぷせるかとは何か？"
     }
   },
   {
     "choices": [
       {
-        "en": "Application",
-        "ja": "Application",
+        "en": "same interface, different behaviors",
+        "ja": "どうじいんたーふぇーす、ことなるどうさ",
         "ja_typings": [
-          "application"
+          "dojiintafesu kotonarudosa",
+          "doujiintafesu kotonarudousa"
         ]
       },
       {
-        "en": "Algorithm",
-        "ja": "Algorithm",
+        "en": "one class one method",
+        "ja": "いちくらすいちめそっど",
         "ja_typings": [
-          "algorithm"
+          "ichikurasuichimesoddo"
         ]
       },
       {
-        "en": "Automatic",
-        "ja": "Automatic",
+        "en": "multiple inheritance",
+        "ja": "たじゅうけいしょう",
         "ja_typings": [
-          "automatic"
+          "tajuukeisho",
+          "tajuukeishou"
         ]
       },
       {
-        "en": "Advanced",
-        "ja": "Advanced",
+        "en": "static typing",
+        "ja": "せいてきがたずけ",
         "ja_typings": [
-          "advanced"
+          "seitekigatazuke"
         ]
       }
     ],
     "correct_answer_index": 0,
-    "genre": "it_terminology",
-    "id": "q00023",
+    "genre": "programming",
+    "id": "q00054",
     "image_path": null,
     "question_text": {
-      "en": "What does the 'A' in API stand for?",
-      "ja": "APIのAはなにのりゃくしょう?"
+      "en": "What is polymorphism?",
+      "ja": "たたいせいとは何か？"
     }
   },
   {
     "choices": [
       {
-        "en": "class",
-        "ja": "class",
+        "en": "calls parent class",
+        "ja": "おやくらすをよびだす",
         "ja_typings": [
-          "class"
+          "oyakurasuoyobidasu"
         ]
       },
       {
-        "en": "type",
-        "ja": "type",
+        "en": "creates subclass",
+        "ja": "さぶくらすをさくせい",
         "ja_typings": [
-          "type"
+          "sabukurasuosakusei"
         ]
       },
       {
-        "en": "var",
-        "ja": "var",
+        "en": "deletes instance",
+        "ja": "いんすたんすをさくじょ",
         "ja_typings": [
-          "var"
+          "insutansuosakujo"
         ]
       },
       {
-        "en": "const",
-        "ja": "const",
+        "en": "copies object",
+        "ja": "おぶじぇくとをこぴー",
         "ja_typings": [
-          "const"
+          "obujekutokopi",
+          "obujekutookopi"
         ]
       }
     ],
-    "correct_answer_index": 1,
+    "correct_answer_index": 0,
     "genre": "programming",
-    "id": "q00024",
+    "id": "q00055",
     "image_path": null,
     "question_text": {
-      "en": "Which keyword defines types in TypeScript?",
-      "ja": "TypeScriptでかたをていぎするきーわーどは?"
+      "en": "What does `super()` do in OOP?",
+      "ja": "OOPで`super()`は何をするか？"
     }
   },
   {
     "choices": [
+      {
+        "en": "cannot be instantiated directly",
+        "ja": "ちょくせつしてきれつかできない",
+        "ja_typings": [
+          "chokusetsushitekiretsukadekinai"
+        ]
+      },
+      {
+        "en": "has no methods",
+        "ja": "めそっどがない",
+        "ja_typings": [
+          "mesoddoganai"
+        ]
+      },
+      {
+        "en": "is always static",
+        "ja": "つねにすたてぃっく",
+        "ja_typings": [
+          "tsunenisutatikku"
+        ]
+      },
+      {
+        "en": "inherits from interface",
+        "ja": "いんたーふぇーすからけいしょう",
+        "ja_typings": [
+          "intafesukarakeisho",
+          "intafesukarakeishou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00056",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an abstract class?",
+      "ja": "ちゅうしょうくらすとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "contract of method signatures",
+        "ja": "めそっどしぐにちゃのけいやく",
+        "ja_typings": [
+          "mesoddoshigunichanokeiyaku"
+        ]
+      },
+      {
+        "en": "a concrete class",
+        "ja": "きゅうしょうてきなくらす",
+        "ja_typings": [
+          "kyuushotekinakurasu",
+          "kyuushoutekinakurasu"
+        ]
+      },
+      {
+        "en": "a data container",
+        "ja": "でーたこんてな",
+        "ja_typings": [
+          "detakontena"
+        ]
+      },
+      {
+        "en": "a static method",
+        "ja": "すたてぃっくめそっど",
+        "ja_typings": [
+          "sutatikkumesoddo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00057",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an interface in OOP?",
+      "ja": "OOPのいんたーふぇーすとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Singleton",
+        "ja": "Singleton",
+        "ja_typings": [
+          "singleton"
+        ]
+      },
+      {
+        "en": "Factory",
+        "ja": "Factory",
+        "ja_typings": [
+          "factory"
+        ]
+      },
+      {
+        "en": "Observer",
+        "ja": "Observer",
+        "ja_typings": [
+          "observer"
+        ]
+      },
+      {
+        "en": "Strategy",
+        "ja": "Strategy",
+        "ja_typings": [
+          "strategy"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00058",
+    "image_path": null,
+    "question_text": {
+      "en": "What pattern ensures a class has only one instance?",
+      "ja": "クラスのいんすたんすをひとつにするぱたーんは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Strategy",
+        "ja": "Strategy",
+        "ja_typings": [
+          "strategy"
+        ]
+      },
+      {
+        "en": "Singleton",
+        "ja": "Singleton",
+        "ja_typings": [
+          "singleton"
+        ]
+      },
+      {
+        "en": "Decorator",
+        "ja": "Decorator",
+        "ja_typings": [
+          "decorator"
+        ]
+      },
+      {
+        "en": "Command",
+        "ja": "Command",
+        "ja_typings": [
+          "command"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00059",
+    "image_path": null,
+    "question_text": {
+      "en": "What pattern defines a family of algorithms?",
+      "ja": "あるごりずむのかぞくをていぎするぱたーんは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "notifies subscribers of changes",
+        "ja": "こうどくしゃにへんかをつうち",
+        "ja_typings": [
+          "kodokushanihenkaotsuuchi",
+          "koudokushanihenkaotsuuchi"
+        ]
+      },
+      {
+        "en": "creates objects",
+        "ja": "おぶじぇくとをさくせい",
+        "ja_typings": [
+          "obujekutosakusei",
+          "obujekutoosakusei"
+        ]
+      },
+      {
+        "en": "wraps objects",
+        "ja": "おぶじぇくとをらっぷ",
+        "ja_typings": [
+          "obujekutorappu",
+          "obujekutoorappu"
+        ]
+      },
+      {
+        "en": "restricts instances",
+        "ja": "いんすたんすをせいげん",
+        "ja_typings": [
+          "insutansuoseigen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00060",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the Observer pattern do?",
+      "ja": "おぶざーばーぱたーんは何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "creates objects without specifying class",
+        "ja": "くらすをしていせずおぶじぇくとさくせい",
+        "ja_typings": [
+          "kurasuoshiteisezuobujekutosakusei"
+        ]
+      },
+      {
+        "en": "observes state changes",
+        "ja": "じょうたいへんかをかんさつ",
+        "ja_typings": [
+          "jotaihenkaokansatsu",
+          "joutaihenkaokansatsu"
+        ]
+      },
+      {
+        "en": "adds behavior dynamically",
+        "ja": "どうてきにどうさをついか",
+        "ja_typings": [
+          "dotekinidosaotsuika",
+          "doutekinidousaotsuika"
+        ]
+      },
+      {
+        "en": "reduces coupling",
+        "ja": "けつごうをへらす",
+        "ja_typings": [
+          "ketsugooherasu",
+          "ketsugouoherasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00061",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Factory pattern?",
+      "ja": "ふぁくとりーぱたーんとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Decorator",
+        "ja": "Decorator",
+        "ja_typings": [
+          "decorator"
+        ]
+      },
+      {
+        "en": "Singleton",
+        "ja": "Singleton",
+        "ja_typings": [
+          "singleton"
+        ]
+      },
+      {
+        "en": "Facade",
+        "ja": "Facade",
+        "ja_typings": [
+          "facade"
+        ]
+      },
+      {
+        "en": "Template",
+        "ja": "Template",
+        "ja_typings": [
+          "template"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00062",
+    "image_path": null,
+    "question_text": {
+      "en": "Which pattern adds behavior without modifying class?",
+      "ja": "くらすをへんこうせずにどうさをついかするぱたーんは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "saves work temporarily",
+        "ja": "さぎょうをいじてきほぞん",
+        "ja_typings": [
+          "sagyooijitekihozon",
+          "sagyouoijitekihozon"
+        ]
+      },
+      {
+        "en": "deletes branch",
+        "ja": "ぶらんちをさくじょ",
+        "ja_typings": [
+          "buranchiosakujo"
+        ]
+      },
+      {
+        "en": "merges branches",
+        "ja": "ぶらんちをがったい",
+        "ja_typings": [
+          "buranchiogattai"
+        ]
+      },
+      {
+        "en": "creates tag",
+        "ja": "たぐをさくせい",
+        "ja_typings": [
+          "taguosakusei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00063",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `git stash` do?",
+      "ja": "`git stash`は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "personal copy of a repo",
+        "ja": "りぽのこじんようこぴー",
+        "ja_typings": [
+          "riponokojinyokopi",
+          "riponokojinyoukopi"
+        ]
+      },
+      {
+        "en": "a branch name",
+        "ja": "ぶらんちめい",
+        "ja_typings": [
+          "buranchimei"
+        ]
+      },
+      {
+        "en": "a commit hash",
+        "ja": "こみっとはっしゅ",
+        "ja_typings": [
+          "komittohasshu"
+        ]
+      },
+      {
+        "en": "a merge strategy",
+        "ja": "がったいせんりゃく",
+        "ja_typings": [
+          "gattaisenryaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00064",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a git fork?",
+      "ja": "git forkとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "applies a specific commit",
+        "ja": "とくていのこみっとをてきよう",
+        "ja_typings": [
+          "tokuteinokomittotekiyo",
+          "tokuteinokomittootekiyou"
+        ]
+      },
+      {
+        "en": "removes a commit",
+        "ja": "こみっとをさくじょ",
+        "ja_typings": [
+          "komittosakujo",
+          "komittoosakujo"
+        ]
+      },
+      {
+        "en": "lists all commits",
+        "ja": "こみっとをいちらん",
+        "ja_typings": [
+          "komittoichiran",
+          "komittooichiran"
+        ]
+      },
+      {
+        "en": "creates a branch",
+        "ja": "ぶらんちをさくせい",
+        "ja_typings": [
+          "buranchiosakusei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00065",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `git cherry-pick` do?",
+      "ja": "`git cherry-pick`は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "named reference to a commit",
+        "ja": "こみっとへのなまえつきさんしょう",
+        "ja_typings": [
+          "komittohenonamaetsukisansho",
+          "komittohenonamaetsukisanshou"
+        ]
+      },
+      {
+        "en": "a branch alias",
+        "ja": "ぶらんちのべつめい",
+        "ja_typings": [
+          "buranchinobetsumei"
+        ]
+      },
+      {
+        "en": "a merge request",
+        "ja": "まーじりくえすと",
+        "ja_typings": [
+          "majirikuesuto"
+        ]
+      },
+      {
+        "en": "a remote name",
+        "ja": "りもーとめい",
+        "ja_typings": [
+          "rimotomei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00066",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a git tag?",
+      "ja": "git tagとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "reapplies commits on new base",
+        "ja": "こみっとをあたらしいきていにてきよう",
+        "ja_typings": [
+          "komittoatarashiikiteinitekiyo",
+          "komittooatarashiikiteinitekiyou"
+        ]
+      },
+      {
+        "en": "reverts all changes",
+        "ja": "すべてのへんこうをもとにもどす",
+        "ja_typings": [
+          "subetenohenkoomotonimodosu",
+          "subetenohenkouomotonimodosu"
+        ]
+      },
+      {
+        "en": "creates a new branch",
+        "ja": "あたらしいぶらんちをさくせい",
+        "ja_typings": [
+          "atarashiiburanchiosakusei"
+        ]
+      },
+      {
+        "en": "pushes to remote",
+        "ja": "りもーとにぷっしゅ",
+        "ja_typings": [
+          "rimotonipusshu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00067",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `git rebase` do?",
+      "ja": "`git rebase`は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "testing individual components",
+        "ja": "こぶひんのてすと",
+        "ja_typings": [
+          "kobuhinnotesuto"
+        ]
+      },
+      {
+        "en": "testing entire system",
+        "ja": "しすてむぜんたいのてすと",
+        "ja_typings": [
+          "shisutemuzentainotesuto"
+        ]
+      },
+      {
+        "en": "testing user interface",
+        "ja": "ゆーざーいんたーふぇーすのてすと",
+        "ja_typings": [
+          "yuzaintafesunotesuto"
+        ]
+      },
+      {
+        "en": "testing performance",
+        "ja": "ぱふぉーまんすのてすと",
+        "ja_typings": [
+          "pafomansunotesuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00068",
+    "image_path": null,
+    "question_text": {
+      "en": "What is unit testing?",
+      "ja": "ゆにっとてすととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Test Driven Development",
+        "ja": "てすときどうかいはつ",
+        "ja_typings": [
+          "tesutokidokaihatsu",
+          "tesutokidoukaihatsu"
+        ]
+      },
+      {
+        "en": "Type Definition Document",
+        "ja": "かたていぎどきゅめんと",
+        "ja_typings": [
+          "katateigidokyumento"
+        ]
+      },
+      {
+        "en": "Tool Deployment Design",
+        "ja": "つーるはいひせっけい",
+        "ja_typings": [
+          "tsuruhaihisekkei"
+        ]
+      },
+      {
+        "en": "Total Data Delivery",
+        "ja": "そうでーたはいそう",
+        "ja_typings": [
+          "sodetahaiso",
+          "soudetahaisou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00069",
+    "image_path": null,
+    "question_text": {
+      "en": "What does TDD stand for?",
+      "ja": "TDDの略語の意味は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "simulated dependency",
+        "ja": "ぎそのいぞんかんけい",
+        "ja_typings": [
+          "gisonoizonkankei"
+        ]
+      },
+      {
+        "en": "real database",
+        "ja": "じっさいのでーたべーす",
+        "ja_typings": [
+          "jissainodetabesu"
+        ]
+      },
+      {
+        "en": "test runner",
+        "ja": "てすとじっこうき",
+        "ja_typings": [
+          "tesutojikkoki",
+          "tesutojikkouki"
+        ]
+      },
+      {
+        "en": "assertion library",
+        "ja": "あさーしょんらいぶらり",
+        "ja_typings": [
+          "asashonraiburari"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00070",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a mock in testing?",
+      "ja": "テストのもっくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "testing component interactions",
+        "ja": "こんぽーねんとのれんけいをてすと",
+        "ja_typings": [
+          "konponentonorenkeiotesuto"
+        ]
+      },
+      {
+        "en": "testing one function",
+        "ja": "ひとつのかんすうをてすと",
+        "ja_typings": [
+          "hitotsunokansuuotesuto"
+        ]
+      },
+      {
+        "en": "testing UI only",
+        "ja": "UIのみてすと",
+        "ja_typings": [
+          "uinomitesuto"
+        ]
+      },
+      {
+        "en": "testing code style",
+        "ja": "こーどすたいるをてすと",
+        "ja_typings": [
+          "kodosutairuotesuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00071",
+    "image_path": null,
+    "question_text": {
+      "en": "What is integration testing?",
+      "ja": "とうごうてすととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "checks expected condition",
+        "ja": "きたいするじょうけんをかくにん",
+        "ja_typings": [
+          "kitaisurujokenokakunin",
+          "kitaisurujoukenokakunin"
+        ]
+      },
+      {
+        "en": "runs the test",
+        "ja": "てすとをじっこう",
+        "ja_typings": [
+          "tesutojikko",
+          "tesutoojikkou"
+        ]
+      },
+      {
+        "en": "logs a message",
+        "ja": "めっせーじをきろく",
+        "ja_typings": [
+          "messejiokiroku"
+        ]
+      },
+      {
+        "en": "skips the test",
+        "ja": "てすとをすきっぷ",
+        "ja_typings": [
+          "tesutosukippu",
+          "tesutoosukippu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00072",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `assert` do in testing?",
+      "ja": "テストで`assert`は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "no side effects, same input = same output",
+        "ja": "ふくさよううなし、どうにゅうりょく=どうしゅつりょく",
+        "ja_typings": [
+          "fukusayounashi donyuuryokudoshutsuryoku",
+          "fukusayouunashi dounyuuryokudoushutsuryoku"
+        ]
+      },
+      {
+        "en": "modifies global state",
+        "ja": "ぐろーばるじょうたいをへんこう",
+        "ja_typings": [
+          "gurobarujotaiohenko",
+          "gurobarujoutaiohenkou"
+        ]
+      },
+      {
+        "en": "uses external variables",
+        "ja": "がいぶへんすうをしよう",
+        "ja_typings": [
+          "gaibuhensuuoshiyo",
+          "gaibuhensuuoshiyou"
+        ]
+      },
+      {
+        "en": "called only once",
+        "ja": "いちどしかよびだせない",
+        "ja_typings": [
+          "ichidoshikayobidasenai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00073",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a pure function?",
+      "ja": "じゅんすいかんすうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "takes or returns a function",
+        "ja": "かんすうをうけとるかかえす",
+        "ja_typings": [
+          "kansuuoketorukakaesu",
+          "kansuuouketorukakaesu"
+        ]
+      },
+      {
+        "en": "runs faster than normal",
+        "ja": "ふつうよりはやくじっこう",
+        "ja_typings": [
+          "futsuuyorihayakujikko",
+          "futsuuyorihayakujikkou"
+        ]
+      },
+      {
+        "en": "has more parameters",
+        "ja": "よりおおくのぱらめーたをもつ",
+        "ja_typings": [
+          "yoriokunoparametaomotsu",
+          "yoriookunoparametaomotsu"
+        ]
+      },
+      {
+        "en": "is recursive",
+        "ja": "さいきてき",
+        "ja_typings": [
+          "saikiteki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00074",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a higher-order function?",
+      "ja": "こうかいかんすうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "combining elements into one value",
+        "ja": "ようそをひとつのちにまとめる",
+        "ja_typings": [
+          "yosohitotsunochinimatomeru",
+          "yousoohitotsunochinimatomeru"
+        ]
+      },
+      {
+        "en": "filtering elements",
+        "ja": "ようそをふぃるたりんぐ",
+        "ja_typings": [
+          "yosofirutaringu",
+          "yousoofirutaringu"
+        ]
+      },
+      {
+        "en": "sorting elements",
+        "ja": "ようそをせいれつ",
+        "ja_typings": [
+          "yososeiretsu",
+          "yousooseiretsu"
+        ]
+      },
+      {
+        "en": "mapping elements",
+        "ja": "ようそをまっぴんぐ",
+        "ja_typings": [
+          "yosomappingu",
+          "yousoomappingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00075",
+    "image_path": null,
+    "question_text": {
+      "en": "What is `reduce` used for?",
+      "ja": "`reduce`は何に使うか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "data cannot be changed after creation",
+        "ja": "さくせいごにでーたをかえられない",
+        "ja_typings": [
+          "sakuseigonidetaokaerarenai"
+        ]
+      },
+      {
+        "en": "data is always null",
+        "ja": "でーたはつねにnull",
+        "ja_typings": [
+          "detahatsuneninull"
+        ]
+      },
+      {
+        "en": "variables are global",
+        "ja": "へんすうはぐろーばる",
+        "ja_typings": [
+          "hensuuhagurobaru"
+        ]
+      },
+      {
+        "en": "functions have no return",
+        "ja": "かんすうはもどらない",
+        "ja_typings": [
+          "kansuuhamodoranai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00076",
+    "image_path": null,
+    "question_text": {
+      "en": "What is immutability?",
+      "ja": "ふへんせいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "combining functions to build new ones",
+        "ja": "かんすうをくみあわせてあたらしいかんすうをつくる",
+        "ja_typings": [
+          "kansuuokumiawaseteatarashiikansuuotsukuru"
+        ]
+      },
+      {
+        "en": "calling all functions at once",
+        "ja": "すべてのかんすうをいちどによびだす",
+        "ja_typings": [
+          "subetenokansuuoichidoniyobidasu"
+        ]
+      },
+      {
+        "en": "defining functions inside loops",
+        "ja": "るーぷないにかんすうをていぎ",
+        "ja_typings": [
+          "rupunainikansuuoteigi"
+        ]
+      },
+      {
+        "en": "converting functions to strings",
+        "ja": "かんすうをもじれつにへんかん",
+        "ja_typings": [
+          "kansuuomojiretsunihenkan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00077",
+    "image_path": null,
+    "question_text": {
+      "en": "What is function composition?",
+      "ja": "かんすうごうせいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "types checked at compile time",
+        "ja": "かんぱいるじにがたをかくにん",
+        "ja_typings": [
+          "kanpairujinigataokakunin"
+        ]
+      },
+      {
+        "en": "types checked at runtime",
+        "ja": "じっこうじにがたをかくにん",
+        "ja_typings": [
+          "jikkojinigataokakunin",
+          "jikkoujinigataokakunin"
+        ]
+      },
+      {
+        "en": "no type checking",
+        "ja": "がたかくにんなし",
+        "ja_typings": [
+          "gatakakuninnashi"
+        ]
+      },
+      {
+        "en": "types inferred by AI",
+        "ja": "AIがたをすいろん",
+        "ja_typings": [
+          "aigataosuiron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00078",
+    "image_path": null,
+    "question_text": {
+      "en": "What is static typing?",
+      "ja": "せいてきがたずけとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "compiler deduces type from context",
+        "ja": "こんぱいらがぶんみゃくからがたをすいてい",
+        "ja_typings": [
+          "konpairagabunmyakukaragataosuitei"
+        ]
+      },
+      {
+        "en": "developer declares every type",
+        "ja": "かいはつしゃがすべてのがたをせんげん",
+        "ja_typings": [
+          "kaihatsushagasubetenogataosengen"
+        ]
+      },
+      {
+        "en": "runtime assigns types",
+        "ja": "じっこうじにがたをわりあて",
+        "ja_typings": [
+          "jikkojinigataowariate",
+          "jikkoujinigataowariate"
+        ]
+      },
+      {
+        "en": "types are always strings",
+        "ja": "がたはつねにもじれつ",
+        "ja_typings": [
+          "gatahatsunenimojiretsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00079",
+    "image_path": null,
+    "question_text": {
+      "en": "What is type inference?",
+      "ja": "がたすいろんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "type that works with many types",
+        "ja": "おおくのがたにたいおうするがた",
+        "ja_typings": [
+          "okunogatanitaiosurugata",
+          "ookunogatanitaiousurugata"
+        ]
+      },
+      {
+        "en": "always integer type",
+        "ja": "つねにせいすうがた",
+        "ja_typings": [
+          "tsuneniseisuugata"
+        ]
+      },
+      {
+        "en": "a string template",
+        "ja": "もじれつてんぷれーと",
+        "ja_typings": [
+          "mojiretsutenpureto"
+        ]
+      },
+      {
+        "en": "a null type",
+        "ja": "nullがた",
+        "ja_typings": [
+          "nullgata"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00080",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a generic type?",
+      "ja": "じぇねりっくがたとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "two processes wait for each other",
+        "ja": "ふたつのぷろせすがたがいにまちつづける",
+        "ja_typings": [
+          "futatsunopurosesugatagainimachitsuzukeru"
+        ]
+      },
+      {
+        "en": "process running too fast",
+        "ja": "ぷろせすがはやすぎるじっこう",
+        "ja_typings": [
+          "purosesugahayasugirujikko",
+          "purosesugahayasugirujikkou"
+        ]
+      },
+      {
+        "en": "memory overflow",
+        "ja": "めもりおーばーふろー",
+        "ja_typings": [
+          "memoriobafuro"
+        ]
+      },
+      {
+        "en": "CPU overload",
+        "ja": "CPUかふか",
+        "ja_typings": [
+          "cpukafuka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00081",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a deadlock?",
+      "ja": "でっどろっくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "mutual exclusion lock",
+        "ja": "そうごはいたじょきょのろっく",
+        "ja_typings": [
+          "sogohaitajokyonorokku",
+          "sougohaitajokyonorokku"
+        ]
+      },
+      {
+        "en": "multiple threads running",
+        "ja": "ふくすうすれっどじっこう",
+        "ja_typings": [
+          "fukusuusureddojikko",
+          "fukusuusureddojikkou"
+        ]
+      },
+      {
+        "en": "memory allocation unit",
+        "ja": "めもりかくほたんい",
+        "ja_typings": [
+          "memorikakuhotani"
+        ]
+      },
+      {
+        "en": "message queue",
+        "ja": "めっせーじきゅー",
+        "ja_typings": [
+          "messejikyu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00082",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a mutex?",
+      "ja": "みゅーてっくすとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "outcome depends on thread timing",
+        "ja": "けっかがすれっどのたいみんぐによる",
+        "ja_typings": [
+          "kekkagasureddonotaiminguniyoru"
+        ]
+      },
+      {
+        "en": "two threads with same speed",
+        "ja": "どうじそくどのふたつのすれっど",
+        "ja_typings": [
+          "dojisokudonofutatsunosureddo",
+          "doujisokudonofutatsunosureddo"
+        ]
+      },
+      {
+        "en": "process priority conflict",
+        "ja": "ぷろせすゆうせんどのこんぐりくと",
+        "ja_typings": [
+          "purosesuyuusendonokongurikuto"
+        ]
+      },
+      {
+        "en": "infinite loop",
+        "ja": "むげんるーぷ",
+        "ja_typings": [
+          "mugenrupu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00083",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a race condition?",
+      "ja": "れーすじょうけんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "non-blocking asynchronous code",
+        "ja": "ふぶろっきんぐのひどうきこーど",
+        "ja_typings": [
+          "fuburokkingunohidokikodo",
+          "fuburokkingunohidoukikodo"
+        ]
+      },
+      {
+        "en": "parallel computing",
+        "ja": "へいこうけいさん",
+        "ja_typings": [
+          "heikokeisan",
+          "heikoukeisan"
+        ]
+      },
+      {
+        "en": "synchronous locking",
+        "ja": "どうきてきろっく",
+        "ja_typings": [
+          "dokitekirokku",
+          "doukitekirokku"
+        ]
+      },
+      {
+        "en": "error catching",
+        "ja": "えらーきゃっち",
+        "ja_typings": [
+          "erakyatchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00084",
+    "image_path": null,
+    "question_text": {
+      "en": "What is async/await used for?",
+      "ja": "async/awaitは何のために使うか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "smallest unit of execution",
+        "ja": "さいしょうのじっこうたんい",
+        "ja_typings": [
+          "saishonojikkotani",
+          "saishounojikkoutani"
+        ]
+      },
+      {
+        "en": "a type of variable",
+        "ja": "へんすうのしゅるい",
+        "ja_typings": [
+          "hensuunoshurui"
+        ]
+      },
+      {
+        "en": "a network connection",
+        "ja": "ねっとわーくせつぞく",
+        "ja_typings": [
+          "nettowakusetsuzoku"
+        ]
+      },
+      {
+        "en": "a file handle",
+        "ja": "ふぁいるはんどる",
+        "ja_typings": [
+          "fairuhandoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00085",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a thread?",
+      "ja": "すれっどとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "memory not freed after use",
+        "ja": "しようごにかいほうされないめもり",
+        "ja_typings": [
+          "shiyogonikaihosarenaimemori",
+          "shiyougonikaihousarenaimemori"
+        ]
+      },
+      {
+        "en": "reading wrong memory",
+        "ja": "まちがっためもりをよむ",
+        "ja_typings": [
+          "machigattamemorioyomu"
+        ]
+      },
+      {
+        "en": "writing beyond array bounds",
+        "ja": "はいれつはんいがいへきおく",
+        "ja_typings": [
+          "hairetsuhanigaihekioku"
+        ]
+      },
+      {
+        "en": "accessing null pointer",
+        "ja": "nullぽいんたーにあくせす",
+        "ja_typings": [
+          "nullpointaniakusesu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00086",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a memory leak?",
+      "ja": "めもりりーくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "automatic memory management",
+        "ja": "じどうめもりかんり",
+        "ja_typings": [
+          "jidomemorikanri",
+          "jidoumemorikanri"
+        ]
+      },
+      {
+        "en": "manual memory freeing",
+        "ja": "てどうめもりかいほう",
+        "ja_typings": [
+          "tedomemorikaiho",
+          "tedoumemorikaihou"
+        ]
+      },
+      {
+        "en": "disk cleanup",
+        "ja": "でぃすくせいそう",
+        "ja_typings": [
+          "disukuseiso",
+          "disukuseisou"
+        ]
+      },
+      {
+        "en": "removing dead code",
+        "ja": "でっどこーどさくじょ",
+        "ja_typings": [
+          "deddokodosakujo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00087",
+    "image_path": null,
+    "question_text": {
+      "en": "What is garbage collection?",
+      "ja": "がーびっじこれくしょんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "call stack exceeds its limit",
+        "ja": "こーるすたっくがかぎりをこえる",
+        "ja_typings": [
+          "korusutakkugakagiriokoeru"
+        ]
+      },
+      {
+        "en": "array index out of bounds",
+        "ja": "はいれつのいんでくすがはんいがい",
+        "ja_typings": [
+          "hairetsunoindekusugahanigai"
+        ]
+      },
+      {
+        "en": "heap memory full",
+        "ja": "ひーぷめもりまんぱい",
+        "ja_typings": [
+          "hipumemorimanpai"
+        ]
+      },
+      {
+        "en": "too many variables",
+        "ja": "へんすうがおおすぎる",
+        "ja_typings": [
+          "hensuugaosugiru",
+          "hensuugaoosugiru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00088",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a stack overflow?",
+      "ja": "すたっくおーばーふろーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "dynamic memory allocation area",
+        "ja": "どうてきめもりかくほりょういき",
+        "ja_typings": [
+          "dotekimemorikakuhoryoiki",
+          "doutekimemorikakuhoryouiki"
+        ]
+      },
+      {
+        "en": "function call memory",
+        "ja": "かんすうよびだしめもり",
+        "ja_typings": [
+          "kansuuyobidashimemori"
+        ]
+      },
+      {
+        "en": "code storage area",
+        "ja": "こーどほぞんりょういき",
+        "ja_typings": [
+          "kodohozonryoiki",
+          "kodohozonryouiki"
+        ]
+      },
+      {
+        "en": "CPU register",
+        "ja": "CPUれじすた",
+        "ja_typings": [
+          "cpurejisuta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00089",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the heap in memory?",
+      "ja": "めもりのひーぷとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HyperText Transfer Protocol",
+        "ja": "はいぱーてきすとてんそうぷろとこる",
+        "ja_typings": [
+          "haipatekisutotensopurotokoru",
+          "haipatekisutotensoupurotokoru"
+        ]
+      },
+      {
+        "en": "High Traffic TCP Protocol",
+        "ja": "こうとらふぃっくTCPぷろとこる",
+        "ja_typings": [
+          "kotorafikkutcppurotokoru",
+          "koutorafikkutcppurotokoru"
+        ]
+      },
+      {
+        "en": "Hosted Text Transfer Process",
+        "ja": "ほすてっどてきすとてんそうぷろせす",
+        "ja_typings": [
+          "hosuteddotekisutotensopurosesu",
+          "hosuteddotekisutotensoupurosesu"
+        ]
+      },
+      {
+        "en": "HyperText Transport Process",
+        "ja": "はいぱーてきすとてんそうぷろせす",
+        "ja_typings": [
+          "haipatekisutotensopurosesu",
+          "haipatekisutotensoupurosesu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00090",
+    "image_path": null,
+    "question_text": {
+      "en": "What does HTTP stand for?",
+      "ja": "HTTPの略語の意味は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "unique device identifier on network",
+        "ja": "ねっとわーくじょうのゆにーくなそうちしきべつし",
+        "ja_typings": [
+          "nettowakujonoyunikunasochishikibetsushi",
+          "nettowakujounoyunikunasouchishikibetsushi"
+        ]
+      },
+      {
+        "en": "website domain name",
+        "ja": "うぇぶさいとどめいんめい",
+        "ja_typings": [
+          "webusaitodomeinmei"
+        ]
+      },
+      {
+        "en": "MAC address alias",
+        "ja": "MACあどれすのべつめい",
+        "ja_typings": [
+          "macadoresunobetsumei"
+        ]
+      },
+      {
+        "en": "user login name",
+        "ja": "ゆーざーろぐいんめい",
+        "ja_typings": [
+          "yuzaroguinmei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00091",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an IP address?",
+      "ja": "IPあどれすとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "translates domain to IP",
+        "ja": "どめいんをIPにへんかん",
+        "ja_typings": [
+          "domeinoipnihenkan"
+        ]
+      },
+      {
+        "en": "stores web pages",
+        "ja": "うぇぶぺーじをほぞん",
+        "ja_typings": [
+          "webupejiohozon"
+        ]
+      },
+      {
+        "en": "encrypts traffic",
+        "ja": "つうしんをあんごうか",
+        "ja_typings": [
+          "tsuushinoangoka",
+          "tsuushinoangouka"
+        ]
+      },
+      {
+        "en": "assigns MAC addresses",
+        "ja": "MACあどれすをわりあて",
+        "ja_typings": [
+          "macadoresuowariate"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00092",
+    "image_path": null,
+    "question_text": {
+      "en": "What does DNS do?",
+      "ja": "DNSは何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "stateless web API standard",
+        "ja": "むじょうたいのうぇぶAPIきじゅん",
+        "ja_typings": [
+          "mujotainowebuapikijun",
+          "mujoutainowebuapikijun"
+        ]
+      },
+      {
+        "en": "database query language",
+        "ja": "でーたべーすくえりげんご",
+        "ja_typings": [
+          "detabesukuerigengo"
+        ]
+      },
+      {
+        "en": "frontend framework",
+        "ja": "ふろんとえんどふれーむわーく",
+        "ja_typings": [
+          "furontoendofuremuwaku"
+        ]
+      },
+      {
+        "en": "server-side rendering",
+        "ja": "さーばーさいどれんだりんぐ",
+        "ja_typings": [
+          "sabasaidorendaringu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00093",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a REST API?",
+      "ja": "REST APIとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PUT",
+        "ja": "PUT",
+        "ja_typings": [
+          "put"
+        ]
+      },
       {
         "en": "GET",
         "ja": "GET",
@@ -986,1254 +3830,12080 @@
         "ja_typings": [
           "delete"
         ]
-      },
-      {
-        "en": "PUT",
-        "ja": "PUT",
-        "ja_typings": [
-          "put"
-        ]
-      }
-    ],
-    "correct_answer_index": 2,
-    "genre": "web_development",
-    "id": "q00025",
-    "image_path": null,
-    "question_text": {
-      "en": "Which HTTP method represents deletion in RESTful API?",
-      "ja": "RESTfulAPIでさくじょをあらわすHTTPめそっどは?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "MySQL",
-        "ja": "MySQL",
-        "ja_typings": [
-          "mysql"
-        ]
-      },
-      {
-        "en": "PostgreSQL",
-        "ja": "PostgreSQL",
-        "ja_typings": [
-          "postgresql"
-        ]
-      },
-      {
-        "en": "MongoDB",
-        "ja": "MongoDB",
-        "ja_typings": [
-          "mongodb"
-        ]
-      },
-      {
-        "en": "Oracle",
-        "ja": "Oracle",
-        "ja_typings": [
-          "oracle"
-        ]
-      }
-    ],
-    "correct_answer_index": 2,
-    "genre": "programming",
-    "id": "q00026",
-    "image_path": null,
-    "question_text": {
-      "en": "Which is an example of a NoSQL database?",
-      "ja": "NoSQLでーたべーすのれいは?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "Continuous Integration",
-        "ja": "Continuous Integration",
-        "ja_typings": [
-          "continuous integration"
-        ]
-      },
-      {
-        "en": "Code Inspection",
-        "ja": "Code Inspection",
-        "ja_typings": [
-          "code inspection"
-        ]
-      },
-      {
-        "en": "Container Image",
-        "ja": "Container Image",
-        "ja_typings": [
-          "container image"
-        ]
-      },
-      {
-        "en": "Cloud Infrastructure",
-        "ja": "Cloud Infrastructure",
-        "ja_typings": [
-          "cloud infrastructure"
-        ]
       }
     ],
     "correct_answer_index": 0,
-    "genre": "technology",
-    "id": "q00027",
-    "image_path": null,
-    "question_text": {
-      "en": "What does CI stand for in CI/CD?",
-      "ja": "CI/CDのCIはなんのりゃく?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "if-else",
-        "ja": "if-else",
-        "ja_typings": [
-          "if-else"
-        ]
-      },
-      {
-        "en": "try-except",
-        "ja": "try-except",
-        "ja_typings": [
-          "try-except"
-        ]
-      },
-      {
-        "en": "while",
-        "ja": "while",
-        "ja_typings": [
-          "while"
-        ]
-      },
-      {
-        "en": "for",
-        "ja": "for",
-        "ja_typings": [
-          "for"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
     "genre": "programming",
-    "id": "q00028",
+    "id": "q00094",
     "image_path": null,
     "question_text": {
-      "en": "What is used for exception handling in Python?",
-      "ja": "Pythonでれいがいしょりにつかうのは?"
+      "en": "What HTTP method is used to update a resource?",
+      "ja": "りそーすをこうしんするHTTPめそっどは？"
     }
   },
   {
     "choices": [
       {
-        "en": "import",
-        "ja": "import",
+        "en": "ls",
+        "ja": "ls",
         "ja_typings": [
-          "import"
+          "ls"
         ]
       },
       {
-        "en": "include",
-        "ja": "include",
+        "en": "dir",
+        "ja": "dir",
         "ja_typings": [
-          "include"
+          "dir"
         ]
       },
       {
-        "en": "require",
-        "ja": "require",
+        "en": "list",
+        "ja": "list",
         "ja_typings": [
-          "require"
+          "list"
         ]
       },
       {
-        "en": "All methods",
-        "ja": "すべて",
+        "en": "show",
+        "ja": "show",
         "ja_typings": [
-          "subete"
-        ]
-      }
-    ],
-    "correct_answer_index": 0,
-    "genre": "web_development",
-    "id": "q00029",
-    "image_path": null,
-    "question_text": {
-      "en": "How do you reuse components in Vue.js?",
-      "ja": "Vue.jsでこんぽーねんとをさいりようするには?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "O(n)",
-        "ja": "O(n)",
-        "ja_typings": [
-          "o(n)"
-        ]
-      },
-      {
-        "en": "O(n log n)",
-        "ja": "O(n log n)",
-        "ja_typings": [
-          "o(n log n)"
-        ]
-      },
-      {
-        "en": "O(n^2)",
-        "ja": "O(n^2)",
-        "ja_typings": [
-          "o(n^2)"
-        ]
-      },
-      {
-        "en": "O(log n)",
-        "ja": "O(log n)",
-        "ja_typings": [
-          "o(log n)"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
-    "genre": "programming",
-    "id": "q00030",
-    "image_path": null,
-    "question_text": {
-      "en": "What is the average time complexity of Quick Sort?",
-      "ja": "くいっくそーとのへいきんけいさんりょうは?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "Java SE",
-        "ja": "Java SE",
-        "ja_typings": [
-          "java se"
-        ]
-      },
-      {
-        "en": "JavaScript",
-        "ja": "JavaScript",
-        "ja_typings": [
-          "javascript"
-        ]
-      },
-      {
-        "en": "jQuery",
-        "ja": "jQuery",
-        "ja_typings": [
-          "jquery"
-        ]
-      },
-      {
-        "en": "Join",
-        "ja": "Join",
-        "ja_typings": [
-          "join"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
-    "genre": "it_terminology",
-    "id": "q00031",
-    "image_path": null,
-    "question_text": {
-      "en": "What does the 'J' in JSON stand for?",
-      "ja": "JSONのJはなにをいみする?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "Thread",
-        "ja": "Thread",
-        "ja_typings": [
-          "thread"
-        ]
-      },
-      {
-        "en": "Goroutine",
-        "ja": "Goroutine",
-        "ja_typings": [
-          "goroutine"
-        ]
-      },
-      {
-        "en": "Process",
-        "ja": "Process",
-        "ja_typings": [
-          "process"
-        ]
-      },
-      {
-        "en": "Async",
-        "ja": "Async",
-        "ja_typings": [
-          "async"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
-    "genre": "programming",
-    "id": "q00032",
-    "image_path": null,
-    "question_text": {
-      "en": "What is Go's concurrency feature called?",
-      "ja": "Goげんごのどうじっせいぎのうは?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "padding",
-        "ja": "padding",
-        "ja_typings": [
-          "padding"
-        ]
-      },
-      {
-        "en": "margin",
-        "ja": "margin",
-        "ja_typings": [
-          "margin"
-        ]
-      },
-      {
-        "en": "border",
-        "ja": "border",
-        "ja_typings": [
-          "border"
-        ]
-      },
-      {
-        "en": "content",
-        "ja": "content",
-        "ja_typings": [
-          "content"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
-    "genre": "web_development",
-    "id": "q00033",
-    "image_path": null,
-    "question_text": {
-      "en": "What is the outer margin in CSS box model?",
-      "ja": "CSSでぼっくすもでるのそとがわまーじんは?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "malloc",
-        "ja": "malloc",
-        "ja_typings": [
-          "malloc"
-        ]
-      },
-      {
-        "en": "new",
-        "ja": "new",
-        "ja_typings": [
-          "new"
-        ]
-      },
-      {
-        "en": "alloc",
-        "ja": "alloc",
-        "ja_typings": [
-          "alloc"
-        ]
-      },
-      {
-        "en": "create",
-        "ja": "create",
-        "ja_typings": [
-          "create"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
-    "genre": "programming",
-    "id": "q00034",
-    "image_path": null,
-    "question_text": {
-      "en": "How do you dynamically allocate memory in C++?",
-      "ja": "C++でめもりをどうてきにかくほするのは?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "Container",
-        "ja": "Container",
-        "ja_typings": [
-          "container"
-        ]
-      },
-      {
-        "en": "Pod",
-        "ja": "Pod",
-        "ja_typings": [
-          "pod"
-        ]
-      },
-      {
-        "en": "Node",
-        "ja": "Node",
-        "ja_typings": [
-          "node"
-        ]
-      },
-      {
-        "en": "Cluster",
-        "ja": "Cluster",
-        "ja_typings": [
-          "cluster"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
-    "genre": "technology",
-    "id": "q00035",
-    "image_path": null,
-    "question_text": {
-      "en": "What is the smallest unit in Kubernetes?",
-      "ja": "kubernetesでさいしょうたんいは?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "class",
-        "ja": "class",
-        "ja_typings": [
-          "class"
-        ]
-      },
-      {
-        "en": "interface",
-        "ja": "interface",
-        "ja_typings": [
-          "interface"
-        ]
-      },
-      {
-        "en": "abstract",
-        "ja": "abstract",
-        "ja_typings": [
-          "abstract"
-        ]
-      },
-      {
-        "en": "extends",
-        "ja": "extends",
-        "ja_typings": [
-          "extends"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
-    "genre": "programming",
-    "id": "q00036",
-    "image_path": null,
-    "question_text": {
-      "en": "Which keyword defines an interface in Java?",
-      "ja": "Javaでいんたーふぇーすをていぎするきーわーどは?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "Fetch only needed data",
-        "ja": "ひつようなでーたのみしゅとく",
-        "ja_typings": [
-          "hitsuyonadetanomishutoku",
-          "hitsuyounadetanomishutoku"
-        ]
-      },
-      {
-        "en": "Fetch all data",
-        "ja": "すべてのでーたしゅとく",
-        "ja_typings": [
-          "subetenodetashutoku"
-        ]
-      },
-      {
-        "en": "Only delete data",
-        "ja": "でーたさくじょのみ",
-        "ja_typings": [
-          "detasakujonomi"
-        ]
-      },
-      {
-        "en": "Nothing",
-        "ja": "なにもできない",
-        "ja_typings": [
-          "nanimodekinai"
-        ]
-      }
-    ],
-    "correct_answer_index": 0,
-    "genre": "web_development",
-    "id": "q00037",
-    "image_path": null,
-    "question_text": {
-      "en": "What can you do with GraphQL queries?",
-      "ja": "GraphQLのくえりでできることは?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "Secure Shell",
-        "ja": "Secure Shell",
-        "ja_typings": [
-          "secure shell"
-        ]
-      },
-      {
-        "en": "Super Shell",
-        "ja": "Super Shell",
-        "ja_typings": [
-          "super shell"
-        ]
-      },
-      {
-        "en": "System Shell",
-        "ja": "System Shell",
-        "ja_typings": [
-          "system shell"
-        ]
-      },
-      {
-        "en": "Safe Shell",
-        "ja": "Safe Shell",
-        "ja_typings": [
-          "safe shell"
-        ]
-      }
-    ],
-    "correct_answer_index": 0,
-    "genre": "it_terminology",
-    "id": "q00038",
-    "image_path": null,
-    "question_text": {
-      "en": "What does SSH stand for?",
-      "ja": "SSHはなんのりゃくしょう?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "Blockchain",
-        "ja": "Blockchain",
-        "ja_typings": [
-          "blockchain"
-        ]
-      },
-      {
-        "en": "Cloud",
-        "ja": "Cloud",
-        "ja_typings": [
-          "cloud"
-        ]
-      },
-      {
-        "en": "IoT",
-        "ja": "IoT",
-        "ja_typings": [
-          "iot"
-        ]
-      },
-      {
-        "en": "5G",
-        "ja": "5G",
-        "ja_typings": [
-          "5g"
+          "show"
         ]
       }
     ],
     "correct_answer_index": 0,
     "genre": "programming",
-    "id": "q00039",
+    "id": "q00095",
     "image_path": null,
     "question_text": {
-      "en": "What technology is used in Bitcoin?",
-      "ja": "びっとこいんでつかわれるぎじゅつは?"
+      "en": "Which command lists files in Linux?",
+      "ja": "Linuxでふぁいるをいちらんするこまんどは？"
     }
   },
   {
     "choices": [
       {
-        "en": "HTML",
-        "ja": "HTML",
+        "en": "sets file permissions",
+        "ja": "ふぁいるのけんげんをせってい",
         "ja_typings": [
-          "html"
+          "fairunokengenosettei"
         ]
       },
       {
-        "en": "CSS",
-        "ja": "CSS",
+        "en": "changes file owner",
+        "ja": "ふぁいるのおーなーをへんこう",
+        "ja_typings": [
+          "fairunonaohenko",
+          "fairunoonaohenkou"
+        ]
+      },
+      {
+        "en": "creates directory",
+        "ja": "でぃれくとりをさくせい",
+        "ja_typings": [
+          "direkutoriosakusei"
+        ]
+      },
+      {
+        "en": "deletes file",
+        "ja": "ふぁいるをさくじょ",
+        "ja_typings": [
+          "fairuosakujo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00096",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `chmod 755` do?",
+      "ja": "`chmod 755`は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "first line specifying interpreter",
+        "ja": "いんたーぷりたをしていするさいしょのぎょう",
+        "ja_typings": [
+          "intapuritaoshiteisurusaishonogyo",
+          "intapuritaoshiteisurusaishonogyou"
+        ]
+      },
+      {
+        "en": "comment in shell script",
+        "ja": "しぇるすくりぷとのこめんと",
+        "ja_typings": [
+          "sherusukuriputonokomento"
+        ]
+      },
+      {
+        "en": "variable declaration",
+        "ja": "へんすうせんげん",
+        "ja_typings": [
+          "hensuusengen"
+        ]
+      },
+      {
+        "en": "function definition",
+        "ja": "かんすうていぎ",
+        "ja_typings": [
+          "kansuuteigi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00097",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a shebang line?",
+      "ja": "しぇばんらいんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "searches text patterns",
+        "ja": "てきすとぱたーんをけんさく",
+        "ja_typings": [
+          "tekisutopatanokensaku"
+        ]
+      },
+      {
+        "en": "copies files",
+        "ja": "ふぁいるをこぴー",
+        "ja_typings": [
+          "fairuokopi"
+        ]
+      },
+      {
+        "en": "compresses files",
+        "ja": "ふぁいるをあっしゅく",
+        "ja_typings": [
+          "fairuoasshuku"
+        ]
+      },
+      {
+        "en": "monitors processes",
+        "ja": "ぷろせすをかんし",
+        "ja_typings": [
+          "purosesuokanshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00098",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `grep` do?",
+      "ja": "`grep`は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sends output to next command",
+        "ja": "しゅつりょくをつぎのこまんどにおくる",
+        "ja_typings": [
+          "shutsuryokuotsuginokomandoniokuru"
+        ]
+      },
+      {
+        "en": "runs commands in background",
+        "ja": "こまんどをばっくぐらうんどでじっこう",
+        "ja_typings": [
+          "komandobakkuguraundodejikko",
+          "komandoobakkuguraundodejikkou"
+        ]
+      },
+      {
+        "en": "redirects to file",
+        "ja": "ふぁいるにりだいれくと",
+        "ja_typings": [
+          "fairuniridairekuto"
+        ]
+      },
+      {
+        "en": "separates arguments",
+        "ja": "ひきすうをくぎる",
+        "ja_typings": [
+          "hikisuuokugiru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00099",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `|` (pipe) do in shell?",
+      "ja": "しぇるの`|`（ぱいぷ）は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Structured Query Language",
+        "ja": "こうぞうかくえりげんご",
+        "ja_typings": [
+          "kozokakuerigengo",
+          "kouzoukakuerigengo"
+        ]
+      },
+      {
+        "en": "Simple Query Logic",
+        "ja": "かんたんくえりろじっく",
+        "ja_typings": [
+          "kantankuerirojikku"
+        ]
+      },
+      {
+        "en": "Server Query Layer",
+        "ja": "さーばーくえりそう",
+        "ja_typings": [
+          "sabakueriso",
+          "sabakuerisou"
+        ]
+      },
+      {
+        "en": "Stored Query Library",
+        "ja": "ほぞんずみくえりらいぶらり",
+        "ja_typings": [
+          "hozonzumikueriraiburari"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00100",
+    "image_path": null,
+    "question_text": {
+      "en": "What does SQL stand for?",
+      "ja": "SQLの略語の意味は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "unique identifier for each row",
+        "ja": "かくぎょうのゆにーくしきべつし",
+        "ja_typings": [
+          "kakugyonoyunikushikibetsushi",
+          "kakugyounoyunikushikibetsushi"
+        ]
+      },
+      {
+        "en": "first column in table",
+        "ja": "てーぶるのさいしょのれつ",
+        "ja_typings": [
+          "teburunosaishonoretsu"
+        ]
+      },
+      {
+        "en": "encrypted field",
+        "ja": "あんごうかふぃーるど",
+        "ja_typings": [
+          "angokafirudo",
+          "angoukafirudo"
+        ]
+      },
+      {
+        "en": "foreign reference",
+        "ja": "がいぶさんしょう",
+        "ja_typings": [
+          "gaibusansho",
+          "gaibusanshou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00101",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a primary key?",
+      "ja": "しゅきーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "combines rows from multiple tables",
+        "ja": "ふくすうてーぶるのぎょうをけつごう",
+        "ja_typings": [
+          "fukusuuteburunogyooketsugo",
+          "fukusuuteburunogyouoketsugou"
+        ]
+      },
+      {
+        "en": "creates a new table",
+        "ja": "あたらしいてーぶるをさくせい",
+        "ja_typings": [
+          "atarashiiteburuosakusei"
+        ]
+      },
+      {
+        "en": "deletes duplicate rows",
+        "ja": "じゅうふくぎょうをさくじょ",
+        "ja_typings": [
+          "juufukugyoosakujo",
+          "juufukugyouosakujo"
+        ]
+      },
+      {
+        "en": "sorts table data",
+        "ja": "てーぶるでーたをせいれつ",
+        "ja_typings": [
+          "teburudetaoseiretsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00102",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a JOIN in SQL?",
+      "ja": "SQLのJOINとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "speeds up data retrieval",
+        "ja": "でーたけんさくをこうそくか",
+        "ja_typings": [
+          "detakensakuokosokuka",
+          "detakensakuokousokuka"
+        ]
+      },
+      {
+        "en": "ensures data integrity",
+        "ja": "でーたのせいごうせいをほしょう",
+        "ja_typings": [
+          "detanoseigoseiohosho",
+          "detanoseigouseiohoshou"
+        ]
+      },
+      {
+        "en": "compresses table data",
+        "ja": "てーぶるでーたをあっしゅく",
+        "ja_typings": [
+          "teburudetaoasshuku"
+        ]
+      },
+      {
+        "en": "backs up the database",
+        "ja": "でーたべーすをばっくあっぷ",
+        "ja_typings": [
+          "detabesuobakkuappu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00103",
+    "image_path": null,
+    "question_text": {
+      "en": "What is indexing in databases?",
+      "ja": "でーたべーすのいんでくすとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "atomic set of operations",
+        "ja": "げんしてきなそうさのあつまり",
+        "ja_typings": [
+          "genshitekinasosanoatsumari",
+          "genshitekinasousanoatsumari"
+        ]
+      },
+      {
+        "en": "a single SQL query",
+        "ja": "ひとつのSQLくえり",
+        "ja_typings": [
+          "hitotsunosqlkueri"
+        ]
+      },
+      {
+        "en": "database backup process",
+        "ja": "でーたべーすばっくあっぷぷろせす",
+        "ja_typings": [
+          "detabesubakkuappupurosesu"
+        ]
+      },
+      {
+        "en": "user authentication",
+        "ja": "ゆーざーにんしょう",
+        "ja_typings": [
+          "yuzaninsho",
+          "yuzaninshou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00104",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a transaction in databases?",
+      "ja": "でーたべーすのとらんざくしょんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Atomicity Consistency Isolation Durability",
+        "ja": "げんしせいいっかんせいどくりつせいもちぞくせい",
+        "ja_typings": [
+          "genshiseiikkanseidokuritsuseimochizokusei"
+        ]
+      },
+      {
+        "en": "All Conditions In Database",
+        "ja": "でーたべーすのすべてのじょうけん",
+        "ja_typings": [
+          "detabesunosubetenojoken",
+          "detabesunosubetenojouken"
+        ]
+      },
+      {
+        "en": "Automatic Cache Index Design",
+        "ja": "じどうきゃっしゅいんでくすせっけい",
+        "ja_typings": [
+          "jidokyasshuindekususekkei",
+          "jidoukyasshuindekususekkei"
+        ]
+      },
+      {
+        "en": "Access Control Identity Domain",
+        "ja": "あくせすせいぎょしきべつどめいん",
+        "ja_typings": [
+          "akusesuseigyoshikibetsudomein"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00105",
+    "image_path": null,
+    "question_text": {
+      "en": "What does ACID stand for?",
+      "ja": "ACIDの略語の意味は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "injecting malicious SQL into queries",
+        "ja": "くえりにあくいのあるSQLをそうにゅう",
+        "ja_typings": [
+          "kueriniakuinoarusqlosonyuu",
+          "kueriniakuinoarusqlosounyuu"
+        ]
+      },
+      {
+        "en": "optimizing SQL queries",
+        "ja": "SQLくえりをさいてきか",
+        "ja_typings": [
+          "sqlkueriosaitekika"
+        ]
+      },
+      {
+        "en": "importing SQL data",
+        "ja": "SQLでーたをいんぽーと",
+        "ja_typings": [
+          "sqldetaoinpoto"
+        ]
+      },
+      {
+        "en": "encrypting SQL data",
+        "ja": "SQLでーたをあんごうか",
+        "ja_typings": [
+          "sqldetaoangoka",
+          "sqldetaoangouka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00106",
+    "image_path": null,
+    "question_text": {
+      "en": "What is SQL injection?",
+      "ja": "SQLいんじぇくしょんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cross-Site Scripting attack",
+        "ja": "くろすさいとすくりぷてぃんぐこうげき",
+        "ja_typings": [
+          "kurosusaitosukuriputingukogeki",
+          "kurosusaitosukuriputingukougeki"
+        ]
+      },
+      {
+        "en": "Extra Security System",
+        "ja": "きょうかせきゅりてぃしすてむ",
+        "ja_typings": [
+          "kyokasekyuritishisutemu",
+          "kyoukasekyuritishisutemu"
+        ]
+      },
+      {
+        "en": "XML Style Sheet",
+        "ja": "XMLすたいるしーと",
+        "ja_typings": [
+          "xmlsutairushito"
+        ]
+      },
+      {
+        "en": "External Source Server",
+        "ja": "がいぶそーすさーばー",
+        "ja_typings": [
+          "gaibusosusaba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00107",
+    "image_path": null,
+    "question_text": {
+      "en": "What is XSS?",
+      "ja": "XSSとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HTTP over TLS/SSL",
+        "ja": "TLS/SSLによるあんごうかHTTP",
+        "ja_typings": [
+          "tls/sslniyoruangokahttp",
+          "tls/sslniyoruangoukahttp"
+        ]
+      },
+      {
+        "en": "HTTP with speed boost",
+        "ja": "そくどこうかHTTP",
+        "ja_typings": [
+          "sokudokokahttp",
+          "sokudokoukahttp"
+        ]
+      },
+      {
+        "en": "HTTP for servers only",
+        "ja": "さーばーせんようHTTP",
+        "ja_typings": [
+          "sabasenyohttp",
+          "sabasenyouhttp"
+        ]
+      },
+      {
+        "en": "HTTP with caching",
+        "ja": "きゃっしゅつきHTTP",
+        "ja_typings": [
+          "kyasshutsukihttp"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00108",
+    "image_path": null,
+    "question_text": {
+      "en": "What is HTTPS?",
+      "ja": "HTTPSとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "forcing user to make unintended request",
+        "ja": "ゆーざーにひとしらずのりくえすとをさせる",
+        "ja_typings": [
+          "yuzanihitoshirazunorikuesutosaseru",
+          "yuzanihitoshirazunorikuesutoosaseru"
+        ]
+      },
+      {
+        "en": "stealing database credentials",
+        "ja": "でーたべーすのにんしょうじょうほうをぬすむ",
+        "ja_typings": [
+          "detabesunoninshojohoonusumu",
+          "detabesunoninshoujouhouonusumu"
+        ]
+      },
+      {
+        "en": "injecting scripts into pages",
+        "ja": "ぺーじにすくりぷとをそうにゅう",
+        "ja_typings": [
+          "pejinisukuriputosonyuu",
+          "pejinisukuriputoosounyuu"
+        ]
+      },
+      {
+        "en": "overloading server with traffic",
+        "ja": "さーばーにとらふぃっくをかける",
+        "ja_typings": [
+          "sabanitorafikkuokakeru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00109",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a CSRF attack?",
+      "ja": "CSRF攻撃とは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "one-way transformation of data",
+        "ja": "でーたのいっぽうこうへんかん",
+        "ja_typings": [
+          "detanoippokohenkan",
+          "detanoippoukouhenkan"
+        ]
+      },
+      {
+        "en": "two-way encryption",
+        "ja": "そうほうこうあんごうか",
+        "ja_typings": [
+          "sohokoangoka",
+          "souhoukouangouka"
+        ]
+      },
+      {
+        "en": "data compression",
+        "ja": "でーたあっしゅく",
+        "ja_typings": [
+          "detaasshuku"
+        ]
+      },
+      {
+        "en": "data storage",
+        "ja": "でーたほぞん",
+        "ja_typings": [
+          "detahozon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00110",
+    "image_path": null,
+    "question_text": {
+      "en": "What is hashing in security?",
+      "ja": "せきゅりてぃのはっしゅかとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "containerization platform",
+        "ja": "こんてなかぷらっとふぉーむ",
+        "ja_typings": [
+          "kontenakapurattofomu"
+        ]
+      },
+      {
+        "en": "virtual machine software",
+        "ja": "かそうましんそふとうぇあ",
+        "ja_typings": [
+          "kasomashinsofutowea",
+          "kasoumashinsofutowea"
+        ]
+      },
+      {
+        "en": "cloud storage service",
+        "ja": "くらうどすとれーじさーびす",
+        "ja_typings": [
+          "kuraudosutorejisabisu"
+        ]
+      },
+      {
+        "en": "CI/CD pipeline tool",
+        "ja": "CI/CDぱいぷらいんつーる",
+        "ja_typings": [
+          "ci/cdpaipuraintsuru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00111",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Docker?",
+      "ja": "Dockerとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "container orchestration system",
+        "ja": "こんてなおーけすとれーしょんしすてむ",
+        "ja_typings": [
+          "kontenaokesutoreshonshisutemu"
+        ]
+      },
+      {
+        "en": "database management system",
+        "ja": "でーたべーすかんりしすてむ",
+        "ja_typings": [
+          "detabesukanrishisutemu"
+        ]
+      },
+      {
+        "en": "code review tool",
+        "ja": "こーどれびゅーつーる",
+        "ja_typings": [
+          "kodorebyutsuru"
+        ]
+      },
+      {
+        "en": "monitoring platform",
+        "ja": "もにたりんぐぷらっとふぉーむ",
+        "ja_typings": [
+          "monitaringupurattofomu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00112",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Kubernetes?",
+      "ja": "Kubernetesとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Continuous Integration/Delivery",
+        "ja": "けいぞくてきとうごう/はいそう",
+        "ja_typings": [
+          "keizokutekitogo/haiso",
+          "keizokutekitougou/haisou"
+        ]
+      },
+      {
+        "en": "Code Inspection/Change Deploy",
+        "ja": "こーどけんさ/へんこうはいひ",
+        "ja_typings": [
+          "kodokensa/henkohaihi",
+          "kodokensa/henkouhaihi"
+        ]
+      },
+      {
+        "en": "Container Integration/Distribution",
+        "ja": "こんてなとうごう/はいふ",
+        "ja_typings": [
+          "kontenatogo/haifu",
+          "kontenatougou/haifu"
+        ]
+      },
+      {
+        "en": "Cloud Infrastructure/Design",
+        "ja": "くらうどきばんせっけい",
+        "ja_typings": [
+          "kuraudokibansekkei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00113",
+    "image_path": null,
+    "question_text": {
+      "en": "What is CI/CD?",
+      "ja": "CI/CDとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "managing infra through code",
+        "ja": "こーどをつうじてきばんをかんり",
+        "ja_typings": [
+          "kodotsuujitekibanokanri",
+          "kodootsuujitekibanokanri"
+        ]
+      },
+      {
+        "en": "writing code on servers",
+        "ja": "さーばーでこーどをかく",
+        "ja_typings": [
+          "sabadekodokaku",
+          "sabadekodookaku"
+        ]
+      },
+      {
+        "en": "converting code to hardware",
+        "ja": "こーどをはーどうぇあにへんかん",
+        "ja_typings": [
+          "kodohadoweanihenkan",
+          "kodoohadoweanihenkan"
+        ]
+      },
+      {
+        "en": "hosting code in cloud",
+        "ja": "くらうどでこーどをほすと",
+        "ja_typings": [
+          "kuraudodekodohosuto",
+          "kuraudodekodoohosuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00114",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Infrastructure as Code?",
+      "ja": "Infrastructure as Codeとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "small independently deployable service",
+        "ja": "しょうきぼのどくりつはいひかのうなさーびす",
+        "ja_typings": [
+          "shokibonodokuritsuhaihikanonasabisu",
+          "shoukibonodokuritsuhaihikanounasabisu"
+        ]
+      },
+      {
+        "en": "a small VM",
+        "ja": "しょうきぼかそうましん",
+        "ja_typings": [
+          "shokibokasomashin",
+          "shoukibokasoumashin"
+        ]
+      },
+      {
+        "en": "a lightweight database",
+        "ja": "けいりょうでーたべーす",
+        "ja_typings": [
+          "keiryodetabesu",
+          "keiryoudetabesu"
+        ]
+      },
+      {
+        "en": "a frontend component",
+        "ja": "ふろんとえんどこんぽーねんと",
+        "ja_typings": [
+          "furontoendokonponento"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00115",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a microservice?",
+      "ja": "まいくろさーびすとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "interface for software to communicate",
+        "ja": "そふとうぇあがつうしんするためのいんたーふぇーす",
+        "ja_typings": [
+          "sofutoweagatsuushinsurutamenointafesu"
+        ]
+      },
+      {
+        "en": "a programming language",
+        "ja": "ぷろぐらみんぐげんご",
+        "ja_typings": [
+          "puroguramingugengo"
+        ]
+      },
+      {
+        "en": "a database type",
+        "ja": "でーたべーすのしゅるい",
+        "ja_typings": [
+          "detabesunoshurui"
+        ]
+      },
+      {
+        "en": "a design pattern",
+        "ja": "せっけいぱたーん",
+        "ja_typings": [
+          "sekkeipatan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00116",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an API?",
+      "ja": "APIとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "software with public source code",
+        "ja": "そーすこーどがこうかいされているそふとうぇあ",
+        "ja_typings": [
+          "sosukodogakokaisareteirusofutowea",
+          "sosukodogakoukaisareteirusofutowea"
+        ]
+      },
+      {
+        "en": "free commercial software",
+        "ja": "むりょうしょうようそふとうぇあ",
+        "ja_typings": [
+          "muryoshoyosofutowea",
+          "muryoushouyousofutowea"
+        ]
+      },
+      {
+        "en": "software without license",
+        "ja": "らいせんすなしそふとうぶ",
+        "ja_typings": [
+          "raisensunashisofutobu",
+          "raisensunashisofutoubu"
+        ]
+      },
+      {
+        "en": "browser-based software",
+        "ja": "ぶらうざーべーすそふとうぇあ",
+        "ja_typings": [
+          "burauzabesusofutowea"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00117",
+    "image_path": null,
+    "question_text": {
+      "en": "What is open source software?",
+      "ja": "おーぷんそーすそふとうぇあとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MAJOR.MINOR.PATCH version numbering",
+        "ja": "MAJOR.MINOR.PATCHばんごうつけ",
+        "ja_typings": [
+          "major.minor.patchbangotsuke",
+          "major.minor.patchbangoutsuke"
+        ]
+      },
+      {
+        "en": "random version numbers",
+        "ja": "らんだむなばーじょんばんごう",
+        "ja_typings": [
+          "randamunabajonbango",
+          "randamunabajonbangou"
+        ]
+      },
+      {
+        "en": "date-based versioning",
+        "ja": "にちつきばーじょにんぐ",
+        "ja_typings": [
+          "nichitsukibajoningu"
+        ]
+      },
+      {
+        "en": "letter-based versioning",
+        "ja": "もじつきばーじょにんぐ",
+        "ja_typings": [
+          "mojitsukibajoningu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00118",
+    "image_path": null,
+    "question_text": {
+      "en": "What is semantic versioning?",
+      "ja": "せまんてぃっくばーじょにんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "tool that checks code style",
+        "ja": "こーどすたいるをかくにんするつーる",
+        "ja_typings": [
+          "kodosutairuokakuninsurutsuru"
+        ]
+      },
+      {
+        "en": "tool that runs tests",
+        "ja": "てすとをじっこうするつーる",
+        "ja_typings": [
+          "tesutojikkosurutsuru",
+          "tesutoojikkousurutsuru"
+        ]
+      },
+      {
+        "en": "tool that compiles code",
+        "ja": "こーどをこんぱいるするつーる",
+        "ja_typings": [
+          "kodokonpairusurutsuru",
+          "kodookonpairusurutsuru"
+        ]
+      },
+      {
+        "en": "tool that deploys code",
+        "ja": "こーどをはいひするつーる",
+        "ja_typings": [
+          "kodohaihisurutsuru",
+          "kodoohaihisurutsuru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00119",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a linter?",
+      "ja": "りんたーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "improving code without changing behavior",
+        "ja": "どうさをかえずにこーどをかいぜん",
+        "ja_typings": [
+          "dosaokaezunikodokaizen",
+          "dousaokaezunikodookaizen"
+        ]
+      },
+      {
+        "en": "adding new features",
+        "ja": "あたらしいきのうをついか",
+        "ja_typings": [
+          "atarashiikinootsuika",
+          "atarashiikinouotsuika"
+        ]
+      },
+      {
+        "en": "fixing bugs",
+        "ja": "ばぐをしゅうせい",
+        "ja_typings": [
+          "baguoshuusei"
+        ]
+      },
+      {
+        "en": "rewriting from scratch",
+        "ja": "さいしょからかきなおす",
+        "ja_typings": [
+          "saishokarakakinaosu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00120",
+    "image_path": null,
+    "question_text": {
+      "en": "What is refactoring?",
+      "ja": "りふぁくたりんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "future cost of shortcuts taken now",
+        "ja": "いまとったちかみちのみらいのこすと",
+        "ja_typings": [
+          "imatottachikamichinomirainokosuto"
+        ]
+      },
+      {
+        "en": "money owed for software licenses",
+        "ja": "そふとうぇあらいせんすのさいむ",
+        "ja_typings": [
+          "sofutowearaisensunosaimu"
+        ]
+      },
+      {
+        "en": "bugs introduced by new features",
+        "ja": "あたらしいきのうによるばぐ",
+        "ja_typings": [
+          "atarashiikinoniyorubagu",
+          "atarashiikinouniyorubagu"
+        ]
+      },
+      {
+        "en": "outdated documentation",
+        "ja": "ふるいどきゅめんとしょ",
+        "ja_typings": [
+          "furuidokyumentosho"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00121",
+    "image_path": null,
+    "question_text": {
+      "en": "What is technical debt?",
+      "ja": "ぎじゅつてきふさいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "examining code for quality",
+        "ja": "ひんしつのためにこーどをけんとう",
+        "ja_typings": [
+          "hinshitsunotamenikodokento",
+          "hinshitsunotamenikodookentou"
+        ]
+      },
+      {
+        "en": "running automated tests",
+        "ja": "じどうてすとをじっこう",
+        "ja_typings": [
+          "jidotesutojikko",
+          "jidoutesutoojikkou"
+        ]
+      },
+      {
+        "en": "deploying code to production",
+        "ja": "こーどをほんばんにはいひ",
+        "ja_typings": [
+          "kodohonbannihaihi",
+          "kodoohonbannihaihi"
+        ]
+      },
+      {
+        "en": "deleting unused code",
+        "ja": "つかわないこーどをさくじょ",
+        "ja_typings": [
+          "tsukawanaikodosakujo",
+          "tsukawanaikodoosakujo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00122",
+    "image_path": null,
+    "question_text": {
+      "en": "What is code review?",
+      "ja": "こーどれびゅーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "automates compilation and packaging",
+        "ja": "こんぱいるとぱっけーじをじどうか",
+        "ja_typings": [
+          "konpairutopakkejiojidoka",
+          "konpairutopakkejiojidouka"
+        ]
+      },
+      {
+        "en": "stores source code",
+        "ja": "そーすこーどをほぞん",
+        "ja_typings": [
+          "sosukodohozon",
+          "sosukodoohozon"
+        ]
+      },
+      {
+        "en": "monitors application health",
+        "ja": "あぷりのけんこうをかんし",
+        "ja_typings": [
+          "apurinokenkookanshi",
+          "apurinokenkouokanshi"
+        ]
+      },
+      {
+        "en": "manages user accounts",
+        "ja": "ゆーざーあかうんとをかんり",
+        "ja_typings": [
+          "yuzaakauntokanri",
+          "yuzaakauntookanri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00123",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a build system?",
+      "ja": "びるどしすてむとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "providing dependencies from outside",
+        "ja": "がいぶからいぞんかんけいをていきょう",
+        "ja_typings": [
+          "gaibukaraizonkankeioteikyo",
+          "gaibukaraizonkankeioteikyou"
+        ]
+      },
+      {
+        "en": "installing npm packages",
+        "ja": "npmぱっけーじをいんすとーる",
+        "ja_typings": [
+          "npmpakkejioinsutoru"
+        ]
+      },
+      {
+        "en": "injecting code at runtime",
+        "ja": "じっこうじにこーどをそうにゅう",
+        "ja_typings": [
+          "jikkojinikodosonyuu",
+          "jikkoujinikodoosounyuu"
+        ]
+      },
+      {
+        "en": "caching function results",
+        "ja": "かんすうけっかをきゃっしゅ",
+        "ja_typings": [
+          "kansuukekkaokyasshu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00124",
+    "image_path": null,
+    "question_text": {
+      "en": "What is dependency injection?",
+      "ja": "いぞんせいのちゅうにゅうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "mechanism for handling async events",
+        "ja": "ひどうきいべんとをしょりするしくみ",
+        "ja_typings": [
+          "hidokiibentoshorisurushikumi",
+          "hidoukiibentooshorisurushikumi"
+        ]
+      },
+      {
+        "en": "a type of loop statement",
+        "ja": "るーぷぶんのしゅるい",
+        "ja_typings": [
+          "rupubunnoshurui"
+        ]
+      },
+      {
+        "en": "error handling mechanism",
+        "ja": "えらーしょりのしくみ",
+        "ja_typings": [
+          "erashorinoshikumi"
+        ]
+      },
+      {
+        "en": "UI rendering cycle",
+        "ja": "UIれんだりんぐのしゅき",
+        "ja_typings": [
+          "uirendaringunoshuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00125",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an event loop?",
+      "ja": "いべんとるーぷとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Document Object Model",
+        "ja": "どきゅめんとおぶじぇくともでる",
+        "ja_typings": [
+          "dokyumentobujekutomoderu",
+          "dokyumentoobujekutomoderu"
+        ]
+      },
+      {
+        "en": "Data Object Management",
+        "ja": "でーたおぶじぇくとかんり",
+        "ja_typings": [
+          "detaobujekutokanri"
+        ]
+      },
+      {
+        "en": "Dynamic Output Module",
+        "ja": "どうてきしゅつりょくもじゅーる",
+        "ja_typings": [
+          "dotekishutsuryokumojuru",
+          "doutekishutsuryokumojuru"
+        ]
+      },
+      {
+        "en": "Distributed Object Method",
+        "ja": "ぶんさんおぶじぇくとめそっど",
+        "ja_typings": [
+          "bunsanobujekutomesoddo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00126",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the DOM?",
+      "ja": "DOMとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "event propagates up the DOM tree",
+        "ja": "いべんとがDOMツリーをのぼる",
+        "ja_typings": [
+          "ibentogadomtsurionoboru"
+        ]
+      },
+      {
+        "en": "events are queued",
+        "ja": "いべんとがきゅーにはいる",
+        "ja_typings": [
+          "ibentogakyunihairu"
+        ]
+      },
+      {
+        "en": "events are cancelled",
+        "ja": "いべんとがキャンセルされる",
+        "ja_typings": [
+          "ibentogakyanserusareru"
+        ]
+      },
+      {
+        "en": "events repeat in loop",
+        "ja": "いべんとがるーぷでくりかえす",
+        "ja_typings": [
+          "ibentogarupudekurikaesu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00127",
+    "image_path": null,
+    "question_text": {
+      "en": "What is event bubbling?",
+      "ja": "いべんとばぶりんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "loading resources only when needed",
+        "ja": "ひつようなときだけりそーすをろーど",
+        "ja_typings": [
+          "hitsuyonatokidakerisosuorodo",
+          "hitsuyounatokidakerisosuorodo"
+        ]
+      },
+      {
+        "en": "loading all resources at start",
+        "ja": "きどうじにすべてのりそーすをろーど",
+        "ja_typings": [
+          "kidojinisubetenorisosuorodo",
+          "kidoujinisubetenorisosuorodo"
+        ]
+      },
+      {
+        "en": "loading in random order",
+        "ja": "らんだむなじゅんでろーど",
+        "ja_typings": [
+          "randamunajunderodo"
+        ]
+      },
+      {
+        "en": "loading from local cache only",
+        "ja": "ろーかるきゃっしゅからのみろーど",
+        "ja_typings": [
+          "rokarukyasshukaranomirodo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00128",
+    "image_path": null,
+    "question_text": {
+      "en": "What is lazy loading?",
+      "ja": "れいじーろーでぃんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "removing unused code from bundles",
+        "ja": "ばんどるからつかわないこーどをさくじょ",
+        "ja_typings": [
+          "bandorukaratsukawanaikodosakujo",
+          "bandorukaratsukawanaikodoosakujo"
+        ]
+      },
+      {
+        "en": "optimizing recursive algorithms",
+        "ja": "さいきあるごりずむのさいてきか",
+        "ja_typings": [
+          "saikiarugorizumunosaitekika"
+        ]
+      },
+      {
+        "en": "sorting import statements",
+        "ja": "いんぽーとのせいれつ",
+        "ja_typings": [
+          "inpotonoseiretsu"
+        ]
+      },
+      {
+        "en": "caching dependency trees",
+        "ja": "いぞんかんけいつりーのきゃっしゅ",
+        "ja_typings": [
+          "izonkankeitsurinokyasshu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00129",
+    "image_path": null,
+    "question_text": {
+      "en": "What is tree shaking?",
+      "ja": "つりーしぇいきんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "indication of deeper problem in code",
+        "ja": "こーどのふかいもんだいのしょうこう",
+        "ja_typings": [
+          "kodonofukaimondainoshoko",
+          "kodonofukaimondainoshoukou"
+        ]
+      },
+      {
+        "en": "runtime error message",
+        "ja": "じっこうじえらーめっせーじ",
+        "ja_typings": [
+          "jikkojieramesseji",
+          "jikkoujieramesseji"
+        ]
+      },
+      {
+        "en": "compiler warning",
+        "ja": "こんぱいらけいこく",
+        "ja_typings": [
+          "konpairakeikoku"
+        ]
+      },
+      {
+        "en": "style guide violation",
+        "ja": "すたいるがいどのいはん",
+        "ja_typings": [
+          "sutairugaidonoihan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00130",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a code smell?",
+      "ja": "こーどすめるとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "two developers working on same code",
+        "ja": "ふたりがどうじにどうじこーどをさぎょう",
+        "ja_typings": [
+          "futarigadojinidojikodosagyo",
+          "futarigadoujinidoujikodoosagyou"
+        ]
+      },
+      {
+        "en": "programming in two languages",
+        "ja": "ふたつのげんごでぷろぐらみんぐ",
+        "ja_typings": [
+          "futatsunogengodepuroguramingu"
+        ]
+      },
+      {
+        "en": "using two machines",
+        "ja": "ふたつのましんをしよう",
+        "ja_typings": [
+          "futatsunomashinoshiyo",
+          "futatsunomashinoshiyou"
+        ]
+      },
+      {
+        "en": "writing code twice for safety",
+        "ja": "あんぜんのためこーどをにかいかく",
+        "ja_typings": [
+          "anzennotamekodonikaikaku",
+          "anzennotamekodoonikaikaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00131",
+    "image_path": null,
+    "question_text": {
+      "en": "What is pair programming?",
+      "ja": "ぺあぷろぐらみんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Integrated Development Environment",
+        "ja": "とうごうかいはつかんきょう",
+        "ja_typings": [
+          "togokaihatsukankyo",
+          "tougoukaihatsukankyou"
+        ]
+      },
+      {
+        "en": "Internet Data Exchange",
+        "ja": "いんたーねっとでーたこうかん",
+        "ja_typings": [
+          "intanettodetakokan",
+          "intanettodetakoukan"
+        ]
+      },
+      {
+        "en": "Internal Deploy Engine",
+        "ja": "ないぶはいひえんじん",
+        "ja_typings": [
+          "naibuhaihienjin"
+        ]
+      },
+      {
+        "en": "Interface Design Element",
+        "ja": "いんたーふぇーすせっけいようそ",
+        "ja_typings": [
+          "intafesusekkeiyoso",
+          "intafesusekkeiyouso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00132",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an IDE?",
+      "ja": "IDEとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "type determined by interface not class",
+        "ja": "くらすでなくいんたーふぇーすでがたをはんてい",
+        "ja_typings": [
+          "kurasudenakuintafesudegataohantei"
+        ]
+      },
+      {
+        "en": "converting string to number",
+        "ja": "もじれつをすうちにへんかん",
+        "ja_typings": [
+          "mojiretsuosuuchinihenkan"
+        ]
+      },
+      {
+        "en": "strict type checking",
+        "ja": "きびしいがたかくにん",
+        "ja_typings": [
+          "kibishiigatakakunin"
+        ]
+      },
+      {
+        "en": "defining types at compile time",
+        "ja": "かんぱいるじにがたをていぎ",
+        "ja_typings": [
+          "kanpairujinigataoteigi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00133",
+    "image_path": null,
+    "question_text": {
+      "en": "What is duck typing?",
+      "ja": "だっくたいぴんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "function with its captured environment",
+        "ja": "かんきょうをほじしたかんすう",
+        "ja_typings": [
+          "kankyoohojishitakansuu",
+          "kankyouohojishitakansuu"
+        ]
+      },
+      {
+        "en": "a sealed class",
+        "ja": "ふいんされたくらす",
+        "ja_typings": [
+          "fuinsaretakurasu"
+        ]
+      },
+      {
+        "en": "end of function scope",
+        "ja": "かんすうのすこーぷのおわり",
+        "ja_typings": [
+          "kansuunosukopunowari",
+          "kansuunosukopunoowari"
+        ]
+      },
+      {
+        "en": "an anonymous object",
+        "ja": "むめいおぶじぇくと",
+        "ja_typings": [
+          "mumeiobujekuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00134",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a closure?",
+      "ja": "くろーじゃとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "transforming f(a,b) into f(a)(b)",
+        "ja": "f(a,b)をf(a)(b)にへんかん",
+        "ja_typings": [
+          "f a b of a b nihenkan"
+        ]
+      },
+      {
+        "en": "adding curry to code",
+        "ja": "こーどにかりーをついか",
+        "ja_typings": [
+          "kodonikariotsuika"
+        ]
+      },
+      {
+        "en": "memoizing function results",
+        "ja": "かんすうけっかをきおく",
+        "ja_typings": [
+          "kansuukekkaokioku"
+        ]
+      },
+      {
+        "en": "defining variadic functions",
+        "ja": "かへいすうかんすうをていぎ",
+        "ja_typings": [
+          "kaheisuukansuuoteigi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00135",
+    "image_path": null,
+    "question_text": {
+      "en": "What is currying?",
+      "ja": "かりーかとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "binary instruction format for browsers",
+        "ja": "ぶらうざーようのばいなりめいれいけいしき",
+        "ja_typings": [
+          "burauzayonobainarimeireikeishiki",
+          "burauzayounobainarimeireikeishiki"
+        ]
+      },
+      {
+        "en": "a JavaScript framework",
+        "ja": "JavaScriptふれーむわーく",
+        "ja_typings": [
+          "javascriptfuremuwaku"
+        ]
+      },
+      {
+        "en": "a CSS preprocessor",
+        "ja": "CSSぷりぷろせっさ",
+        "ja_typings": [
+          "csspuripurosessa"
+        ]
+      },
+      {
+        "en": "a server runtime",
+        "ja": "さーばーじっこうかんきょう",
+        "ja_typings": [
+          "sabajikkokankyo",
+          "sabajikkoukankyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00136",
+    "image_path": null,
+    "question_text": {
+      "en": "What is WebAssembly (WASM)?",
+      "ja": "WebAssembly (WASM)とは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "object from which others inherit",
+        "ja": "ほかのおぶじぇくとがけいしょうするおぶじぇくと",
+        "ja_typings": [
+          "hokanobujekutogakeishosuruobujekuto",
+          "hokanoobujekutogakeishousuruobujekuto"
+        ]
+      },
+      {
+        "en": "first version of software",
+        "ja": "そふとうぇあのさいしょのばーじょん",
+        "ja_typings": [
+          "sofutoweanosaishonobajon"
+        ]
+      },
+      {
+        "en": "a constructor function",
+        "ja": "こんすとらくたかんすう",
+        "ja_typings": [
+          "konsutorakutakansuu"
+        ]
+      },
+      {
+        "en": "a static method",
+        "ja": "すたてぃっくめそっど",
+        "ja_typings": [
+          "sutatikkumesoddo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00137",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a prototype in JavaScript?",
+      "ja": "JavaScriptのぷろとたいぷとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "calling multiple methods in sequence",
+        "ja": "めそっどをれんけつしてよびだす",
+        "ja_typings": [
+          "mesoddorenketsushiteyobidasu",
+          "mesoddoorenketsushiteyobidasu"
+        ]
+      },
+      {
+        "en": "inheriting methods from parent",
+        "ja": "おやからめそっどをけいしょう",
+        "ja_typings": [
+          "oyakaramesoddokeisho",
+          "oyakaramesoddookeishou"
+        ]
+      },
+      {
+        "en": "linking two objects",
+        "ja": "ふたつのおぶじぇくとをれんけつ",
+        "ja_typings": [
+          "futatsunobujekutorenketsu",
+          "futatsunoobujekutoorenketsu"
+        ]
+      },
+      {
+        "en": "calling same method twice",
+        "ja": "どうじめそっどをにかいよびだす",
+        "ja_typings": [
+          "dojimesoddonikaiyobidasu",
+          "doujimesoddoonikaiyobidasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00138",
+    "image_path": null,
+    "question_text": {
+      "en": "What is method chaining?",
+      "ja": "めそっどちぇーにんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "five OOP design principles",
+        "ja": "ごつのOOPせっけいげんそく",
+        "ja_typings": [
+          "gotsunoopsekkeigensoku",
+          "gotsunooopsekkeigensoku"
+        ]
+      },
+      {
+        "en": "a security standard",
+        "ja": "せきゅりてぃきじゅん",
+        "ja_typings": [
+          "sekyuritikijun"
+        ]
+      },
+      {
+        "en": "a testing framework",
+        "ja": "てすとふれーむわーく",
+        "ja_typings": [
+          "tesutofuremuwaku"
+        ]
+      },
+      {
+        "en": "a data format",
+        "ja": "でーたけいしき",
+        "ja_typings": [
+          "detakeishiki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00139",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the SOLID principle?",
+      "ja": "SOLIDげんそくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Don't Repeat Yourself",
+        "ja": "じぶんじしんをくりかえさない",
+        "ja_typings": [
+          "jibunjishinokurikaesanai"
+        ]
+      },
+      {
+        "en": "Design Reusable Years",
+        "ja": "さいりようかのうなねんのせっけい",
+        "ja_typings": [
+          "sairiyokanonanennosekkei",
+          "sairiyoukanounanennosekkei"
+        ]
+      },
+      {
+        "en": "Deploy Rapidly Yearly",
+        "ja": "まいとしはやくはいひ",
+        "ja_typings": [
+          "maitoshihayakuhaihi"
+        ]
+      },
+      {
+        "en": "Define Register Yield",
+        "ja": "さいじぇいきゅうをていぎ",
+        "ja_typings": [
+          "saijeikyuuoteigi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00140",
+    "image_path": null,
+    "question_text": {
+      "en": "What is DRY principle?",
+      "ja": "DRYげんそくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Keep It Simple Stupid",
+        "ja": "かんたんにしておけ",
+        "ja_typings": [
+          "kantannishiteoke"
+        ]
+      },
+      {
+        "en": "Keys In Secure Storage",
+        "ja": "かぎをあんぜんにほぞん",
+        "ja_typings": [
+          "kagioanzennihozon"
+        ]
+      },
+      {
+        "en": "Keep Iterations Short Strong",
+        "ja": "いてれーしょんをみじかくつよく",
+        "ja_typings": [
+          "itereshonomijikakutsuyoku"
+        ]
+      },
+      {
+        "en": "Kill Invalid Session States",
+        "ja": "ふせいせっしょんをさくじょ",
+        "ja_typings": [
+          "fuseisesshonosakujo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00141",
+    "image_path": null,
+    "question_text": {
+      "en": "What is KISS principle?",
+      "ja": "KISSげんそくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HTTP callback when event occurs",
+        "ja": "いべんとはっせいじのHTTPこーるばっく",
+        "ja_typings": [
+          "ibentohasseijinohttpkorubakku"
+        ]
+      },
+      {
+        "en": "a browser plugin",
+        "ja": "ぶらうざーぷらぐいん",
+        "ja_typings": [
+          "burauzapuraguin"
+        ]
+      },
+      {
+        "en": "a type of API key",
+        "ja": "APIきーのしゅるい",
+        "ja_typings": [
+          "apikinoshurui"
+        ]
+      },
+      {
+        "en": "a frontend hook",
+        "ja": "ふろんとえんどふっく",
+        "ja_typings": [
+          "furontoendofukku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00142",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a webhook?",
+      "ja": "うぇぶふっくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "query language for APIs",
+        "ja": "APIのためのくえりげんご",
+        "ja_typings": [
+          "apinotamenokuerigengo"
+        ]
+      },
+      {
+        "en": "graph database query",
+        "ja": "ぐらふでーたべーすくえり",
+        "ja_typings": [
+          "gurafudetabesukueri"
+        ]
+      },
+      {
+        "en": "frontend rendering library",
+        "ja": "ふろんとえんどれんだりんぐらいぶらり",
+        "ja_typings": [
+          "furontoendorendaringuraiburari"
+        ]
+      },
+      {
+        "en": "CSS animation library",
+        "ja": "CSSあにめーしょんらいぶらり",
+        "ja_typings": [
+          "cssanimeshonraiburari"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00143",
+    "image_path": null,
+    "question_text": {
+      "en": "What is GraphQL?",
+      "ja": "GraphQLとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "rendering HTML on server",
+        "ja": "さーばーでHTMLをせいせい",
+        "ja_typings": [
+          "sabadehtmloseisei"
+        ]
+      },
+      {
+        "en": "rendering CSS on server",
+        "ja": "さーばーでCSSをせいせい",
+        "ja_typings": [
+          "sabadecssoseisei"
+        ]
+      },
+      {
+        "en": "processing data on client",
+        "ja": "くらいあんとでもにょりをしょり",
+        "ja_typings": [
+          "kuraiantodemonyorioshori"
+        ]
+      },
+      {
+        "en": "caching on server",
+        "ja": "さーばーできゃっしゅ",
+        "ja_typings": [
+          "sabadekyasshu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00144",
+    "image_path": null,
+    "question_text": {
+      "en": "What is server-side rendering?",
+      "ja": "さーばーさいどれんだりんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "attaching JS to server-rendered HTML",
+        "ja": "さーばーせいせいHTMLにJSをてんぷ",
+        "ja_typings": [
+          "sabaseiseihtmlnijsotenpu"
+        ]
+      },
+      {
+        "en": "loading CSS styles",
+        "ja": "CSSすたいるのろーど",
+        "ja_typings": [
+          "csssutairunorodo"
+        ]
+      },
+      {
+        "en": "compressing images",
+        "ja": "がぞうのあっしゅく",
+        "ja_typings": [
+          "gazonoasshuku",
+          "gazounoasshuku"
+        ]
+      },
+      {
+        "en": "managing cookies",
+        "ja": "くっきーのかんり",
+        "ja_typings": [
+          "kukkinokanri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00145",
+    "image_path": null,
+    "question_text": {
+      "en": "What is hydration in web development?",
+      "ja": "うぇぶかいはつのはいどれーしょんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "self-contained unit of code",
+        "ja": "どくりつしたこーどのたんい",
+        "ja_typings": [
+          "dokuritsushitakodonotani"
+        ]
+      },
+      {
+        "en": "a hardware component",
+        "ja": "はーどうぇあこんぽーねんと",
+        "ja_typings": [
+          "hadoweakonponento"
+        ]
+      },
+      {
+        "en": "a CSS class",
+        "ja": "CSSくらす",
+        "ja_typings": [
+          "csskurasu"
+        ]
+      },
+      {
+        "en": "a database table",
+        "ja": "でーたべーすてーぶる",
+        "ja_typings": [
+          "detabesuteburu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00146",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a module in programming?",
+      "ja": "ぷろぐらみんぐのもじゅーるとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "installing and managing libraries",
+        "ja": "らいぶらりのいんすとーるとかんり",
+        "ja_typings": [
+          "raiburarinoinsutorutokanri"
+        ]
+      },
+      {
+        "en": "organizing files in folders",
+        "ja": "ふぁいるをふぉるだでせいり",
+        "ja_typings": [
+          "fairuoforudadeseiri"
+        ]
+      },
+      {
+        "en": "managing server packages",
+        "ja": "さーばーぱっけーじのかんり",
+        "ja_typings": [
+          "sabapakkejinokanri"
+        ]
+      },
+      {
+        "en": "shipping software updates",
+        "ja": "そふとうぇあこうしんのはいそう",
+        "ja_typings": [
+          "sofutoweakoshinnohaiso",
+          "sofutoweakoushinnohaisou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00147",
+    "image_path": null,
+    "question_text": {
+      "en": "What is package management?",
+      "ja": "ぱっけーじかんりとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "OS-level configuration value",
+        "ja": "OSれべるのせってちち",
+        "ja_typings": [
+          "osreberunosettechichi"
+        ]
+      },
+      {
+        "en": "local variable in function",
+        "ja": "かんすうのろーかるへんすう",
+        "ja_typings": [
+          "kansuunorokaruhensuu"
+        ]
+      },
+      {
+        "en": "global JS variable",
+        "ja": "ぐろーばるJS変数",
+        "ja_typings": [
+          "gurobarujs"
+        ]
+      },
+      {
+        "en": "CSS variable",
+        "ja": "CSS変数",
         "ja_typings": [
           "css"
         ]
-      },
-      {
-        "en": "JavaScript",
-        "ja": "JavaScript",
-        "ja_typings": [
-          "javascript"
-        ]
-      },
-      {
-        "en": "XML",
-        "ja": "XML",
-        "ja_typings": [
-          "xml"
-        ]
       }
     ],
-    "correct_answer_index": 1,
-    "genre": "web_development",
-    "id": "q00040",
-    "image_path": null,
-    "question_text": {
-      "en": "What does Sass extend?",
-      "ja": "Sassはなにをかくちょうしたもの?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "Mutable state",
-        "ja": "みゅーたぶるなじょうたい",
-        "ja_typings": [
-          "myutaburunajotai",
-          "myutaburunajoutai"
-        ]
-      },
-      {
-        "en": "Immutable data",
-        "ja": "いみゅーたぶるなでーた",
-        "ja_typings": [
-          "imyutaburunadeta"
-        ]
-      },
-      {
-        "en": "Global variables",
-        "ja": "ぐろーばるへんすう",
-        "ja_typings": [
-          "gurobaruhensuu"
-        ]
-      },
-      {
-        "en": "goto statements",
-        "ja": "goto ぶん",
-        "ja_typings": [
-          "goto bun"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
+    "correct_answer_index": 0,
     "genre": "programming",
-    "id": "q00041",
+    "id": "q00148",
     "image_path": null,
     "question_text": {
-      "en": "What is a characteristic of functional programming?",
-      "ja": "かんすうがたぷろぐらみんぐのとくちょうは?"
+      "en": "What is environment variable?",
+      "ja": "かんきょうへんすうとは何か？"
     }
   },
   {
     "choices": [
       {
-        "en": "Compute",
-        "ja": "こんぴゅーと",
+        "en": "inconsistency from concurrent access",
+        "ja": "どうじあくせすによるふせいごうせい",
         "ja_typings": [
-          "konpyuto"
+          "dojiakusesuniyorufuseigosei",
+          "doujiakusesuniyorufuseigousei"
         ]
       },
       {
-        "en": "Storage",
-        "ja": "すとれーじ",
+        "en": "slow query execution",
+        "ja": "くえりのおそいじっこう",
         "ja_typings": [
-          "sutoreji"
+          "kuerinosoijikko",
+          "kuerinoosoijikkou"
         ]
       },
       {
-        "en": "Database",
-        "ja": "でーたべーす",
+        "en": "index corruption",
+        "ja": "いんでくすのそんしょう",
         "ja_typings": [
-          "detabesu"
+          "indekusunosonsho",
+          "indekusunosonshou"
         ]
       },
       {
-        "en": "Network",
-        "ja": "ねっとわーく",
+        "en": "data type mismatch",
+        "ja": "でーたがたのふいっち",
         "ja_typings": [
-          "nettowaku"
+          "detagatanofuitchi"
         ]
       }
     ],
-    "correct_answer_index": 1,
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00149",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a race condition in databases?",
+      "ja": "でーたべーすのれーすじょうけんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "organizing data to reduce redundancy",
+        "ja": "じょうちょうをへらすでーたのせいり",
+        "ja_typings": [
+          "jochooherasudetanoseiri",
+          "jouchouoherasudetanoseiri"
+        ]
+      },
+      {
+        "en": "sorting table rows",
+        "ja": "てーぶるぎょうのせいれつ",
+        "ja_typings": [
+          "teburugyonoseiretsu",
+          "teburugyounoseiretsu"
+        ]
+      },
+      {
+        "en": "encrypting sensitive data",
+        "ja": "きみつでーたのあんごうか",
+        "ja_typings": [
+          "kimitsudetanoangoka",
+          "kimitsudetanoangouka"
+        ]
+      },
+      {
+        "en": "compressing table data",
+        "ja": "てーぶるでーたのあっしゅく",
+        "ja_typings": [
+          "teburudetanoasshuku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00150",
+    "image_path": null,
+    "question_text": {
+      "en": "What is normalization in databases?",
+      "ja": "でーたべーすのせいきかとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cascading Style Sheets",
+        "ja": "かすけーでぃんぐすたいるしーと",
+        "ja_typings": [
+          "kasukedingusutairushito"
+        ]
+      },
+      {
+        "en": "Computer Style System",
+        "ja": "こんぴゅーたすたいるしすてむ",
+        "ja_typings": [
+          "konpyutasutairushisutemu"
+        ]
+      },
+      {
+        "en": "Content Style Standard",
+        "ja": "こんてんつすたいるきじゅん",
+        "ja_typings": [
+          "kontentsusutairukijun"
+        ]
+      },
+      {
+        "en": "Creative Style Syntax",
+        "ja": "くりえいてぃぶすたいるこうもん",
+        "ja_typings": [
+          "kurieitibusutairukomon",
+          "kurieitibusutairukoumon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00151",
+    "image_path": null,
+    "question_text": {
+      "en": "What does CSS stand for?",
+      "ja": "CSSのふりがなの意味は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "<a>",
+        "ja": "<a>",
+        "ja_typings": [
+          "<a>"
+        ]
+      },
+      {
+        "en": "<link>",
+        "ja": "<link>",
+        "ja_typings": [
+          "<link>"
+        ]
+      },
+      {
+        "en": "<href>",
+        "ja": "<href>",
+        "ja_typings": [
+          "<href>"
+        ]
+      },
+      {
+        "en": "<url>",
+        "ja": "<url>",
+        "ja_typings": [
+          "<url>"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00152",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML tag creates a hyperlink?",
+      "ja": "ハイパーリンクをつくるHTMLたぐは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "content, padding, border, margin",
+        "ja": "こんてんつぱでぃんぐぼーだーまーじん",
+        "ja_typings": [
+          "kontentsupadingubodamajin"
+        ]
+      },
+      {
+        "en": "width, height, color, font",
+        "ja": "はばたかさいろふぉんと",
+        "ja_typings": [
+          "habatakasairofonto"
+        ]
+      },
+      {
+        "en": "display, position, float, clear",
+        "ja": "ひょうじいちふろーとくりあ",
+        "ja_typings": [
+          "hyojiichifurotokuria",
+          "hyoujiichifurotokuria"
+        ]
+      },
+      {
+        "en": "flex, grid, block, inline",
+        "ja": "ふれっくすぐりっどぶろっくいんらいん",
+        "ja_typings": [
+          "furekkusuguriddoburokkuinrain"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00153",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the CSS box model?",
+      "ja": "CSSのぼっくすもでるとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "flexible layout model",
+        "ja": "ふれきしぶるれいあうともでる",
+        "ja_typings": [
+          "furekishiburureiautomoderu"
+        ]
+      },
+      {
+        "en": "fixed grid layout",
+        "ja": "こていぐりっどれいあうと",
+        "ja_typings": [
+          "koteiguriddoreiauto"
+        ]
+      },
+      {
+        "en": "absolute positioning",
+        "ja": "ぜったいいちしてい",
+        "ja_typings": [
+          "zettaiichishitei"
+        ]
+      },
+      {
+        "en": "full-screen mode",
+        "ja": "ふるすくりーんもーど",
+        "ja_typings": [
+          "furusukurinmodo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00154",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `display: flex` enable?",
+      "ja": "`display: flex`は何を可能にするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "rules applied at specific screen sizes",
+        "ja": "とくていがめんさいずにてきようするるーる",
+        "ja_typings": [
+          "tokuteigamensaizunitekiyosurururu",
+          "tokuteigamensaizunitekiyousurururu"
+        ]
+      },
+      {
+        "en": "querying a database",
+        "ja": "でーたべーすをくえり",
+        "ja_typings": [
+          "detabesuokueri"
+        ]
+      },
+      {
+        "en": "fetching media files",
+        "ja": "めでぃあふぁいるをとりこむ",
+        "ja_typings": [
+          "mediafairuotorikomu"
+        ]
+      },
+      {
+        "en": "importing stylesheets",
+        "ja": "すたいるしーとをいんぽーと",
+        "ja_typings": [
+          "sutairushitoinpoto",
+          "sutairushitooinpoto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00155",
+    "image_path": null,
+    "question_text": {
+      "en": "What is media query in CSS?",
+      "ja": "CSSのめでぃあくえりとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JavaScript UI library",
+        "ja": "JavaScriptのUIらいぶらり",
+        "ja_typings": [
+          "javascriptnoiraiburari",
+          "javascriptnouiraiburari"
+        ]
+      },
+      {
+        "en": "CSS framework",
+        "ja": "CSSふれーむわーく",
+        "ja_typings": [
+          "cssfuremuwaku"
+        ]
+      },
+      {
+        "en": "database ORM",
+        "ja": "でーたべーすORM",
+        "ja_typings": [
+          "detabesuorm"
+        ]
+      },
+      {
+        "en": "backend framework",
+        "ja": "ばっくえんどふれーむわーく",
+        "ja_typings": [
+          "bakkuendofuremuwaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00156",
+    "image_path": null,
+    "question_text": {
+      "en": "What is React?",
+      "ja": "Reactとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "reusable UI building block",
+        "ja": "さいりようかのうなUIのたんい",
+        "ja_typings": [
+          "sairiyokanonauinotani",
+          "sairiyoukanounauinotani"
+        ]
+      },
+      {
+        "en": "CSS animation",
+        "ja": "CSSあにめーしょん",
+        "ja_typings": [
+          "cssanimeshon"
+        ]
+      },
+      {
+        "en": "database model",
+        "ja": "でーたべーすもでる",
+        "ja_typings": [
+          "detabesumoderu"
+        ]
+      },
+      {
+        "en": "server endpoint",
+        "ja": "さーばーえんどぽいんと",
+        "ja_typings": [
+          "sabaendopointo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00157",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a React component?",
+      "ja": "Reactこんぽーねんととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JavaScript XML syntax extension",
+        "ja": "JavaScript XMLこうもんかくちょう",
+        "ja_typings": [
+          "javascript xmlkomonkakucho",
+          "javascript xmlkoumonkakuchou"
+        ]
+      },
+      {
+        "en": "Java Scripting Extension",
+        "ja": "Javaすくりぷとかくちょう",
+        "ja_typings": [
+          "javasukuriputokakucho",
+          "javasukuriputokakuchou"
+        ]
+      },
+      {
+        "en": "JSON Exchange Format",
+        "ja": "JSONこうかんけいしき",
+        "ja_typings": [
+          "jsonkokankeishiki",
+          "jsonkoukankeishiki"
+        ]
+      },
+      {
+        "en": "JavaScript Index",
+        "ja": "JavaScriptいんでくす",
+        "ja_typings": [
+          "javascriptindekusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00158",
+    "image_path": null,
+    "question_text": {
+      "en": "What is JSX?",
+      "ja": "JSXとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "lightweight copy of real DOM",
+        "ja": "じっさいDOMのかるいこぴー",
+        "ja_typings": [
+          "jissaidomnokaruikopi"
+        ]
+      },
+      {
+        "en": "server-side DOM rendering",
+        "ja": "さーばーさいどDOMれんだりんぐ",
+        "ja_typings": [
+          "sabasaidodomrendaringu"
+        ]
+      },
+      {
+        "en": "DOM created by CSS",
+        "ja": "CSSがさくせいしたDOM",
+        "ja_typings": [
+          "cssgasakuseishitadom"
+        ]
+      },
+      {
+        "en": "cached DOM snapshot",
+        "ja": "DOMのきゃっしゅすなっぷしょっと",
+        "ja_typings": [
+          "domnokyasshusunappushotto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00159",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the virtual DOM in React?",
+      "ja": "Reactのばーちゃるどむとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "manages component local state",
+        "ja": "こんぽーねんとのろーかるじょうたいをかんり",
+        "ja_typings": [
+          "konponentonorokarujotaiokanri",
+          "konponentonorokarujoutaiokanri"
+        ]
+      },
+      {
+        "en": "fetches API data",
+        "ja": "APIでーたをとりこむ",
+        "ja_typings": [
+          "apidetaotorikomu"
+        ]
+      },
+      {
+        "en": "creates new component",
+        "ja": "あたらしいこんぽーねんとをさくせい",
+        "ja_typings": [
+          "atarashiikonponentosakusei",
+          "atarashiikonponentoosakusei"
+        ]
+      },
+      {
+        "en": "handles routing",
+        "ja": "るーてぃんぐをしょり",
+        "ja_typings": [
+          "rutinguoshori"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00160",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `useState` do in React?",
+      "ja": "Reactの`useState`は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "runs side effects after render",
+        "ja": "れんだーごにふくさようをじっこう",
+        "ja_typings": [
+          "rendagonifukusayoojikko",
+          "rendagonifukusayouojikkou"
+        ]
+      },
+      {
+        "en": "updates component styles",
+        "ja": "こんぽーねんとのすたいるをこうしん",
+        "ja_typings": [
+          "konponentonosutairuokoshin",
+          "konponentonosutairuokoushin"
+        ]
+      },
+      {
+        "en": "creates global state",
+        "ja": "ぐろーばるじょうたいをさくせい",
+        "ja_typings": [
+          "gurobarujotaiosakusei",
+          "gurobarujoutaiosakusei"
+        ]
+      },
+      {
+        "en": "handles form input",
+        "ja": "ふぉーむにゅうりょくをしょり",
+        "ja_typings": [
+          "fomunyuuryokuoshori"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00161",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `useEffect` do in React?",
+      "ja": "Reactの`useEffect`は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "progressive JavaScript framework",
+        "ja": "ぷろぐれっしぶJavaScriptふれーむわーく",
+        "ja_typings": [
+          "puroguresshibujavascriptfuremuwaku"
+        ]
+      },
+      {
+        "en": "backend Node.js framework",
+        "ja": "ばっくえんどNode.jsふれーむわーく",
+        "ja_typings": [
+          "bakkuendonode.jsfuremuwaku"
+        ]
+      },
+      {
+        "en": "CSS preprocessor",
+        "ja": "CSSぷりぷろせっさ",
+        "ja_typings": [
+          "csspuripurosessa"
+        ]
+      },
+      {
+        "en": "database query builder",
+        "ja": "でーたべーすくえりびるだー",
+        "ja_typings": [
+          "detabesukueribiruda"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00162",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Vue.js?",
+      "ja": "Vue.jsとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "typed superset of JavaScript",
+        "ja": "がたつきJavaScriptのすーぱーせっと",
+        "ja_typings": [
+          "gatatsukijavascriptnosupasetto"
+        ]
+      },
+      {
+        "en": "JavaScript backend runtime",
+        "ja": "JavaScriptばっくえんどじっこうかんきょう",
+        "ja_typings": [
+          "javascriptbakkuendojikkokankyo",
+          "javascriptbakkuendojikkoukankyou"
+        ]
+      },
+      {
+        "en": "CSS framework",
+        "ja": "CSSふれーむわーく",
+        "ja_typings": [
+          "cssfuremuwaku"
+        ]
+      },
+      {
+        "en": "HTML template engine",
+        "ja": "HTMLてんぷれーとえんじん",
+        "ja_typings": [
+          "htmltenpuretoenjin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00163",
+    "image_path": null,
+    "question_text": {
+      "en": "What is TypeScript?",
+      "ja": "TypeScriptとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Node.js package manager",
+        "ja": "Node.jsぱっけーじまねーじゃ",
+        "ja_typings": [
+          "node.jspakkejimaneja"
+        ]
+      },
+      {
+        "en": "network protocol manager",
+        "ja": "ねっとわーくぷろとこるまねーじゃ",
+        "ja_typings": [
+          "nettowakupurotokorumaneja"
+        ]
+      },
+      {
+        "en": "new project module",
+        "ja": "あたらしいぷろじぇくとのもじゅーる",
+        "ja_typings": [
+          "atarashiipurojekutonomojuru"
+        ]
+      },
+      {
+        "en": "null pointer method",
+        "ja": "nullぽいんたーめそっど",
+        "ja_typings": [
+          "nullpointamesoddo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00164",
+    "image_path": null,
+    "question_text": {
+      "en": "What is npm?",
+      "ja": "npmとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JavaScript server-side runtime",
+        "ja": "JavaScriptのさーばーがわじっこうかんきょう",
+        "ja_typings": [
+          "javascriptnosabagawajikkokankyo",
+          "javascriptnosabagawajikkoukankyou"
+        ]
+      },
+      {
+        "en": "browser JavaScript engine",
+        "ja": "ぶらうざーJavaScriptえんじん",
+        "ja_typings": [
+          "burauzajavascriptenjin"
+        ]
+      },
+      {
+        "en": "database for JSON",
+        "ja": "JSONのでーたべーす",
+        "ja_typings": [
+          "jsonnodetabesu"
+        ]
+      },
+      {
+        "en": "CSS compiler",
+        "ja": "CSSこんぱいら",
+        "ja_typings": [
+          "csskonpaira"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00165",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Node.js?",
+      "ja": "Node.jsとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "module bundler for JavaScript",
+        "ja": "JavaScriptのもじゅーるばんどらー",
+        "ja_typings": [
+          "javascriptnomojurubandora"
+        ]
+      },
+      {
+        "en": "web server software",
+        "ja": "うぇぶさーばーそふとうぇあ",
+        "ja_typings": [
+          "webusabasofutowea"
+        ]
+      },
+      {
+        "en": "CSS framework",
+        "ja": "CSSふれーむわーく",
+        "ja_typings": [
+          "cssfuremuwaku"
+        ]
+      },
+      {
+        "en": "backend framework",
+        "ja": "ばっくえんどふれーむわーく",
+        "ja_typings": [
+          "bakkuendofuremuwaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00166",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Webpack?",
+      "ja": "Webpackとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Single Page Application",
+        "ja": "しんぐるぺーじあぷりけーしょん",
+        "ja_typings": [
+          "shingurupejiapurikeshon"
+        ]
+      },
+      {
+        "en": "Server-side PHP Application",
+        "ja": "さーばーがわPHPあぷり",
+        "ja_typings": [
+          "sabagawaphpapuri"
+        ]
+      },
+      {
+        "en": "Secure Protocol API",
+        "ja": "あんぜんぷろとこるAPI",
+        "ja_typings": [
+          "anzenpurotokoruapi"
+        ]
+      },
+      {
+        "en": "Static Page Archive",
+        "ja": "せいてきぺーじあーかいぶ",
+        "ja_typings": [
+          "seitekipejiakaibu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00167",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a SPA?",
+      "ja": "SPAとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Server-Side Rendering",
+        "ja": "さーばーさいどれんだりんぐ",
+        "ja_typings": [
+          "sabasaidorendaringu"
+        ]
+      },
+      {
+        "en": "Static Style Rules",
+        "ja": "せいてきすたいるるーる",
+        "ja_typings": [
+          "seitekisutairururu"
+        ]
+      },
+      {
+        "en": "Shared Script Resources",
+        "ja": "きょうゆうすくりぷとりそーす",
+        "ja_typings": [
+          "kyoyuusukuriputorisosu",
+          "kyouyuusukuriputorisosu"
+        ]
+      },
+      {
+        "en": "Secure Session Registry",
+        "ja": "あんぜんせっしょんとうろく",
+        "ja_typings": [
+          "anzensesshontoroku",
+          "anzensesshontouroku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00168",
+    "image_path": null,
+    "question_text": {
+      "en": "What is SSR in web?",
+      "ja": "うぇぶのSSRとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "small data stored in browser",
+        "ja": "ぶらうざーにほぞんされるしょうさなでーた",
+        "ja_typings": [
+          "burauzanihozonsarerushosanadeta",
+          "burauzanihozonsarerushousanadeta"
+        ]
+      },
+      {
+        "en": "server-side session",
+        "ja": "さーばーがわせっしょん",
+        "ja_typings": [
+          "sabagawasesshon"
+        ]
+      },
+      {
+        "en": "encrypted token",
+        "ja": "あんごうかされたとーくん",
+        "ja_typings": [
+          "angokasaretatokun",
+          "angoukasaretatokun"
+        ]
+      },
+      {
+        "en": "database record",
+        "ja": "でーたべーすのれこーど",
+        "ja_typings": [
+          "detabesunorekodo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00169",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a cookie?",
+      "ja": "くっきーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "browser-based persistent key-value store",
+        "ja": "ぶらうざーのきーちストレージ",
+        "ja_typings": [
+          "burauzanokichisutoreji"
+        ]
+      },
+      {
+        "en": "local database server",
+        "ja": "ろーかるでーたべーすさーばー",
+        "ja_typings": [
+          "rokarudetabesusaba"
+        ]
+      },
+      {
+        "en": "server-side cache",
+        "ja": "さーばーがわきゃっしゅ",
+        "ja_typings": [
+          "sabagawakyasshu"
+        ]
+      },
+      {
+        "en": "file system API",
+        "ja": "ふぁいるしすてむAPI",
+        "ja_typings": [
+          "fairushisutemuapi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00170",
+    "image_path": null,
+    "question_text": {
+      "en": "What is localStorage?",
+      "ja": "localStorageとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "makes HTTP requests",
+        "ja": "HTTPりくえすとをおこなう",
+        "ja_typings": [
+          "httprikuesutookonau",
+          "httprikuesutoookonau"
+        ]
+      },
+      {
+        "en": "reads local files",
+        "ja": "ろーかるふぁいるをよむ",
+        "ja_typings": [
+          "rokarufairuoyomu"
+        ]
+      },
+      {
+        "en": "queries database",
+        "ja": "でーたべーすをくえり",
+        "ja_typings": [
+          "detabesuokueri"
+        ]
+      },
+      {
+        "en": "renders HTML",
+        "ja": "HTMLをれんだー",
+        "ja_typings": [
+          "htmlorenda"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00171",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `fetch()` do in JS?",
+      "ja": "JSの`fetch()`は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cross-Origin Resource Sharing",
+        "ja": "くろすおりじんりそーすきょうゆう",
+        "ja_typings": [
+          "kurosuorijinrisosukyoyuu",
+          "kurosuorijinrisosukyouyuu"
+        ]
+      },
+      {
+        "en": "Content Oriented Rendering System",
+        "ja": "こんてんつしこうれんだりんぐしすてむ",
+        "ja_typings": [
+          "kontentsushikorendaringushisutemu",
+          "kontentsushikourendaringushisutemu"
+        ]
+      },
+      {
+        "en": "Cache Override Request Scheme",
+        "ja": "きゃっしゅおーばーらいどりくえすとけいしき",
+        "ja_typings": [
+          "kyasshuobaraidorikuesutokeishiki"
+        ]
+      },
+      {
+        "en": "Client Origin Response Standard",
+        "ja": "くらいあんとおりじんおうとうきじゅん",
+        "ja_typings": [
+          "kuraiantorijinotokijun",
+          "kuraiantoorijinoutoukijun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00172",
+    "image_path": null,
+    "question_text": {
+      "en": "What is CORS?",
+      "ja": "CORSとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Content Delivery Network",
+        "ja": "こんてんつはいしんねっとわーく",
+        "ja_typings": [
+          "kontentsuhaishinnettowaku"
+        ]
+      },
+      {
+        "en": "Centralized Data Node",
+        "ja": "ちゅうおうかでーたのーど",
+        "ja_typings": [
+          "chuuokadetanodo",
+          "chuuoukadetanodo"
+        ]
+      },
+      {
+        "en": "Cloud Database Network",
+        "ja": "くらうどでーたべーすねっとわーく",
+        "ja_typings": [
+          "kuraudodetabesunettowaku"
+        ]
+      },
+      {
+        "en": "Client Domain Name",
+        "ja": "くらいあんとどめいんめい",
+        "ja_typings": [
+          "kuraiantodomeinmei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00173",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a CDN?",
+      "ja": "CDNとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HTML that conveys meaning",
+        "ja": "いみをつたえるHTML",
+        "ja_typings": [
+          "imiotsutaeruhtml"
+        ]
+      },
+      {
+        "en": "HTML with inline styles",
+        "ja": "いんらいんすたいるつきHTML",
+        "ja_typings": [
+          "inrainsutairutsukihtml"
+        ]
+      },
+      {
+        "en": "HTML without CSS",
+        "ja": "CSSなしHTML",
+        "ja_typings": [
+          "cssnashihtml"
+        ]
+      },
+      {
+        "en": "compressed HTML",
+        "ja": "あっしゅくされたHTML",
+        "ja_typings": [
+          "asshukusaretahtml"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00174",
+    "image_path": null,
+    "question_text": {
+      "en": "What is semantic HTML?",
+      "ja": "せまんてぃっくHTMLとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "declares character encoding",
+        "ja": "もじぶんにょくをせんげん",
+        "ja_typings": [
+          "mojibunnyokuosengen"
+        ]
+      },
+      {
+        "en": "sets page title",
+        "ja": "ぺーじのたいとるをせってい",
+        "ja_typings": [
+          "pejinotaitoruosettei"
+        ]
+      },
+      {
+        "en": "defines CSS styles",
+        "ja": "CSSすたいるをていぎ",
+        "ja_typings": [
+          "csssutairuoteigi"
+        ]
+      },
+      {
+        "en": "links JavaScript file",
+        "ja": "JavaScriptふぁいるをりんく",
+        "ja_typings": [
+          "javascriptfairuorinku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00175",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the purpose of `<meta charset>`?",
+      "ja": "`<meta charset>`の目的は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "loads content only when needed",
+        "ja": "ひつようなときだけこんてんつをろーど",
+        "ja_typings": [
+          "hitsuyonatokidakekontentsuorodo",
+          "hitsuyounatokidakekontentsuorodo"
+        ]
+      },
+      {
+        "en": "caches all content",
+        "ja": "すべてのこんてんつをきゃっしゅ",
+        "ja_typings": [
+          "subetenokontentsuokyasshu"
+        ]
+      },
+      {
+        "en": "preloads all images",
+        "ja": "すべてのがぞうをじぜんろーど",
+        "ja_typings": [
+          "subetenogazoojizenrodo",
+          "subetenogazouojizenrodo"
+        ]
+      },
+      {
+        "en": "loads on first visit only",
+        "ja": "さいしょのほうもんのみろーど",
+        "ja_typings": [
+          "saishonohomonnomirodo",
+          "saishonohoumonnomirodo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00176",
+    "image_path": null,
+    "question_text": {
+      "en": "What is lazy loading in web?",
+      "ja": "うぇぶのれいじーろーでぃんぐとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "build from basic to enhanced",
+        "ja": "きほんからこうきのうへきちく",
+        "ja_typings": [
+          "kihonkarakokinohekichiku",
+          "kihonkarakoukinouhekichiku"
+        ]
+      },
+      {
+        "en": "add features progressively over time",
+        "ja": "じかんとともにきのうをついか",
+        "ja_typings": [
+          "jikantotomonikinootsuika",
+          "jikantotomonikinouotsuika"
+        ]
+      },
+      {
+        "en": "enhance CSS over HTML",
+        "ja": "HTMLよりCSSをきょうか",
+        "ja_typings": [
+          "htmlyoricssokyoka",
+          "htmlyoricssokyouka"
+        ]
+      },
+      {
+        "en": "upgrade to latest browser only",
+        "ja": "さいしんぶらうざーのみたいおう",
+        "ja_typings": [
+          "saishinburauzanomitaio",
+          "saishinburauzanomitaiou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00177",
+    "image_path": null,
+    "question_text": {
+      "en": "What is progressive enhancement?",
+      "ja": "ぷろぐれっしぶえんはんすめんととは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "extends CSS with variables and nesting",
+        "ja": "へんすうとねすとでCSSをかくちょう",
+        "ja_typings": [
+          "hensuutonesutodecssokakucho",
+          "hensuutonesutodecssokakuchou"
+        ]
+      },
+      {
+        "en": "compresses CSS files",
+        "ja": "CSSふぁいるをあっしゅく",
+        "ja_typings": [
+          "cssfairuoasshuku"
+        ]
+      },
+      {
+        "en": "converts CSS to JavaScript",
+        "ja": "CSSをJavaScriptにへんかん",
+        "ja_typings": [
+          "cssojavascriptnihenkan"
+        ]
+      },
+      {
+        "en": "generates CSS from images",
+        "ja": "がぞうからCSSをせいせい",
+        "ja_typings": [
+          "gazokaracssoseisei",
+          "gazoukaracssoseisei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00178",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a CSS preprocessor?",
+      "ja": "CSSぷりぷろせっさとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "utility-first CSS framework",
+        "ja": "ゆーてぃりてぃおしのCSSふれーむわーく",
+        "ja_typings": [
+          "yutiritioshinocssfuremuwaku"
+        ]
+      },
+      {
+        "en": "component-based UI library",
+        "ja": "こんぽーねんとべーすのUIらいぶらり",
+        "ja_typings": [
+          "konponentobesunoiraiburari",
+          "konponentobesunouiraiburari"
+        ]
+      },
+      {
+        "en": "CSS-in-JS solution",
+        "ja": "CSS-in-JSそりゅーしょん",
+        "ja_typings": [
+          "cssinjssoryushon"
+        ]
+      },
+      {
+        "en": "CSS animation library",
+        "ja": "CSSあにめーしょんらいぶらり",
+        "ja_typings": [
+          "cssanimeshonraiburari"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00179",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Tailwind CSS?",
+      "ja": "Tailwind CSSとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "removing unused JS from bundle",
+        "ja": "つかわないJSをばんどるからのぞく",
+        "ja_typings": [
+          "tsukawanaijsobandorukaranozoku"
+        ]
+      },
+      {
+        "en": "optimizing CSS selectors",
+        "ja": "CSSせれくたをさいてきか",
+        "ja_typings": [
+          "cssserekutaosaitekika"
+        ]
+      },
+      {
+        "en": "caching static assets",
+        "ja": "せいてきあせっとをきゃっしゅ",
+        "ja_typings": [
+          "seitekiasettokyasshu",
+          "seitekiasettookyasshu"
+        ]
+      },
+      {
+        "en": "sorting DOM elements",
+        "ja": "DOMようそをせいれつ",
+        "ja_typings": [
+          "domyososeiretsu",
+          "domyousooseiretsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00180",
+    "image_path": null,
+    "question_text": {
+      "en": "What is tree shaking in frontend?",
+      "ja": "ふろんとえんどのつりーしぇいきんぐとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "metadata and resource links",
+        "ja": "めたでーたとりそーすりんく",
+        "ja_typings": [
+          "metadetatorisosurinku"
+        ]
+      },
+      {
+        "en": "visible page content",
+        "ja": "ひょうじされるぺーじこんてんつ",
+        "ja_typings": [
+          "hyojisarerupejikontentsu",
+          "hyoujisarerupejikontentsu"
+        ]
+      },
+      {
+        "en": "JavaScript functions",
+        "ja": "JavaScriptかんすう",
+        "ja_typings": [
+          "javascriptkansuu"
+        ]
+      },
+      {
+        "en": "CSS styles",
+        "ja": "CSSすたいる",
+        "ja_typings": [
+          "csssutairu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00181",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the purpose of `<head>` in HTML?",
+      "ja": "HTMLの`<head>`の役割は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "positions relative to nearest positioned ancestor",
+        "ja": "もっともちかいいちしていそせんへのそうたいいち",
+        "ja_typings": [
+          "mottomochikaiichishiteisosenhenosotaiichi",
+          "mottomochikaiichishiteisosenhenosoutaiichi"
+        ]
+      },
+      {
+        "en": "positions relative to viewport",
+        "ja": "びゅーぽーとへのそうたいいち",
+        "ja_typings": [
+          "byupotohenosotaiichi",
+          "byupotohenosoutaiichi"
+        ]
+      },
+      {
+        "en": "stacks with other elements",
+        "ja": "ほかのようそとかさなる",
+        "ja_typings": [
+          "hokanoyosotokasanaru",
+          "hokanoyousotokasanaru"
+        ]
+      },
+      {
+        "en": "removes from document flow",
+        "ja": "ぶんしょうのふろーからとりのぞく",
+        "ja_typings": [
+          "bunshonofurokaratorinozoku",
+          "bunshounofurokaratorinozoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00182",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `position: absolute` do in CSS?",
+      "ja": "CSSの`position: absolute`は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "controls stacking order of elements",
+        "ja": "ようそのかさなりじゅんをせいぎょ",
+        "ja_typings": [
+          "yosonokasanarijunoseigyo",
+          "yousonokasanarijunoseigyo"
+        ]
+      },
+      {
+        "en": "sets element zoom level",
+        "ja": "ようそのずーむをせってい",
+        "ja_typings": [
+          "yosonozumuosettei",
+          "yousonozumuosettei"
+        ]
+      },
+      {
+        "en": "defines CSS grid zones",
+        "ja": "CSSぐりっどのぞーんをていぎ",
+        "ja_typings": [
+          "cssguriddonozonoteigi"
+        ]
+      },
+      {
+        "en": "sets animation delay",
+        "ja": "あにめーしょんのおくれをせってい",
+        "ja_typings": [
+          "animeshonnokureosettei",
+          "animeshonnookureosettei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00183",
+    "image_path": null,
+    "question_text": {
+      "en": "What is z-index in CSS?",
+      "ja": "CSSのz-indexとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Block Element Modifier naming convention",
+        "ja": "ぶろっくようそもでぃふぁいやめいめいきやく",
+        "ja_typings": [
+          "burokkuyosomodifaiyameimeikiyaku",
+          "burokkuyousomodifaiyameimeikiyaku"
+        ]
+      },
+      {
+        "en": "Browser Event Model",
+        "ja": "ぶらうざーいべんともでる",
+        "ja_typings": [
+          "burauzaibentomoderu"
+        ]
+      },
+      {
+        "en": "Built-in Extension Method",
+        "ja": "そなわったかくちょうめそっど",
+        "ja_typings": [
+          "sonawattakakuchomesoddo",
+          "sonawattakakuchoumesoddo"
+        ]
+      },
+      {
+        "en": "Background Effect Mode",
+        "ja": "はいけいこうかもーど",
+        "ja_typings": [
+          "haikeikokamodo",
+          "haikeikoukamodo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00184",
+    "image_path": null,
+    "question_text": {
+      "en": "What is BEM in CSS?",
+      "ja": "CSSのBEMとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "custom property storing a value",
+        "ja": "ちをほぞんするかすたむぷろぱてぃ",
+        "ja_typings": [
+          "chiohozonsurukasutamupuropati"
+        ]
+      },
+      {
+        "en": "JavaScript variable in CSS",
+        "ja": "CSSのJavaScriptへんすう",
+        "ja_typings": [
+          "cssnojavascripthensuu"
+        ]
+      },
+      {
+        "en": "random CSS value",
+        "ja": "らんだむCSSち",
+        "ja_typings": [
+          "randamucsschi"
+        ]
+      },
+      {
+        "en": "inherited CSS property",
+        "ja": "けいしょうするCSSぷろぱてぃ",
+        "ja_typings": [
+          "keishosurucsspuropati",
+          "keishousurucsspuropati"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00185",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a CSS variable?",
+      "ja": "CSS変数とは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "making web usable for everyone",
+        "ja": "ウェブをすべての人が使えるよう",
+        "ja_typings": [
+          "webuosubetenogaeruyo",
+          "webuosubetenogaeruyou"
+        ]
+      },
+      {
+        "en": "URL shortening",
+        "ja": "URLたんしゅく",
+        "ja_typings": [
+          "urltanshuku"
+        ]
+      },
+      {
+        "en": "caching strategy",
+        "ja": "きゃっしゅせんりゃく",
+        "ja_typings": [
+          "kyasshusenryaku"
+        ]
+      },
+      {
+        "en": "server-side security",
+        "ja": "さーばーがわせきゅりてぃ",
+        "ja_typings": [
+          "sabagawasekyuriti"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00186",
+    "image_path": null,
+    "question_text": {
+      "en": "What is accessibility (a11y) in web?",
+      "ja": "うぇぶのアクセシビリティとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Accessible Rich Internet Applications",
+        "ja": "アクセスしやすいりちなインターネットアプリ",
+        "ja_typings": [
+          "akusesushiyasuirichinaintanettoapuri"
+        ]
+      },
+      {
+        "en": "Automated Rendering Index API",
+        "ja": "じどうれんだりんぐしすう",
+        "ja_typings": [
+          "jidorendaringushisuu",
+          "jidourendaringushisuu"
+        ]
+      },
+      {
+        "en": "Advanced Resource Integration Architecture",
+        "ja": "こうきゅうりそーすとうごうあーきてくちゃ",
+        "ja_typings": [
+          "kokyuurisosutogoakitekucha",
+          "koukyuurisosutougouakitekucha"
+        ]
+      },
+      {
+        "en": "Application Route Inspection Agent",
+        "ja": "あぷりるーとけんさえーじぇんと",
+        "ja_typings": [
+          "apurirutokensaejento"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00187",
+    "image_path": null,
+    "question_text": {
+      "en": "What is ARIA in web accessibility?",
+      "ja": "うぇぶのARIAとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Progressive Web App",
+        "ja": "ぷろぐれっしぶうぇぶあぷり",
+        "ja_typings": [
+          "puroguresshibuwebuapuri"
+        ]
+      },
+      {
+        "en": "Private Web Archive",
+        "ja": "ぷらいべーとうぇぶあーかいぶ",
+        "ja_typings": [
+          "puraibetowebuakaibu"
+        ]
+      },
+      {
+        "en": "Public Webpack Agent",
+        "ja": "こうかいWebpackえーじぇんと",
+        "ja_typings": [
+          "kokaiwebpackejento",
+          "koukaiwebpackejento"
+        ]
+      },
+      {
+        "en": "Preloaded Web Asset",
+        "ja": "じぜんろーどされたうぇぶあせっと",
+        "ja_typings": [
+          "jizenrodosaretawebuasetto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00188",
+    "image_path": null,
+    "question_text": {
+      "en": "What is PWA?",
+      "ja": "PWAとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "background script for offline support",
+        "ja": "おふらいんたいおうのばっくぐらうんどすくりぷと",
+        "ja_typings": [
+          "ofuraintaionobakkuguraundosukuriputo",
+          "ofuraintaiounobakkuguraundosukuriputo"
+        ]
+      },
+      {
+        "en": "server-side worker process",
+        "ja": "さーばーがわわーかーぷろせす",
+        "ja_typings": [
+          "sabagawawakapurosesu"
+        ]
+      },
+      {
+        "en": "CSS animation worker",
+        "ja": "CSSあにめーしょんわーかー",
+        "ja_typings": [
+          "cssanimeshonwaka"
+        ]
+      },
+      {
+        "en": "database connection pool",
+        "ja": "でーたべーすせつぞくぷーる",
+        "ja_typings": [
+          "detabesusetsuzokupuru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00189",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a service worker?",
+      "ja": "さーびすわーかーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "React framework with SSR and SSG",
+        "ja": "SSRとSSGのReactふれーむわーく",
+        "ja_typings": [
+          "ssrtossgnoreactfuremuwaku"
+        ]
+      },
+      {
+        "en": "Node.js web server",
+        "ja": "Node.jsうぇぶさーばー",
+        "ja_typings": [
+          "node.jswebusaba"
+        ]
+      },
+      {
+        "en": "CSS framework",
+        "ja": "CSSふれーむわーく",
+        "ja_typings": [
+          "cssfuremuwaku"
+        ]
+      },
+      {
+        "en": "JavaScript test runner",
+        "ja": "JavaScriptてすとじっこうき",
+        "ja_typings": [
+          "javascripttesutojikkoki",
+          "javascripttesutojikkouki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00190",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Next.js?",
+      "ja": "Next.jsとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "full-stack Svelte framework",
+        "ja": "ふるすたっくSvelteふれーむわーく",
+        "ja_typings": [
+          "furusutakkusveltefuremuwaku"
+        ]
+      },
+      {
+        "en": "CSS animation toolkit",
+        "ja": "CSSあにめーしょんつーるきっと",
+        "ja_typings": [
+          "cssanimeshontsurukitto"
+        ]
+      },
+      {
+        "en": "JavaScript bundler",
+        "ja": "JavaScriptばんどらー",
+        "ja_typings": [
+          "javascriptbandora"
+        ]
+      },
+      {
+        "en": "headless CMS",
+        "ja": "へっどれすCMS",
+        "ja_typings": [
+          "heddoresucms"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00191",
+    "image_path": null,
+    "question_text": {
+      "en": "What is SvelteKit?",
+      "ja": "SvelteKitとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "describes image for accessibility",
+        "ja": "アクセシビリティのためにがぞうをせつめい",
+        "ja_typings": [
+          "akuseshibiritinotamenigazoosetsumei",
+          "akuseshibiritinotamenigazouosetsumei"
+        ]
+      },
+      {
+        "en": "sets image alignment",
+        "ja": "がぞうのいちをせってい",
+        "ja_typings": [
+          "gazonoichiosettei",
+          "gazounoichiosettei"
+        ]
+      },
+      {
+        "en": "defines image source",
+        "ja": "がぞうのそーすをていぎ",
+        "ja_typings": [
+          "gazonososuoteigi",
+          "gazounososuoteigi"
+        ]
+      },
+      {
+        "en": "sets image size",
+        "ja": "がぞうのさいずをせってい",
+        "ja_typings": [
+          "gazonosaizuosettei",
+          "gazounosaizuosettei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00192",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the purpose of `alt` attribute in `<img>`?",
+      "ja": "`<img>`の`alt`属性の目的は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "multiplexing multiple requests",
+        "ja": "ふくすうりくえすとをたじゅうか",
+        "ja_typings": [
+          "fukusuurikuesutotajuuka",
+          "fukusuurikuesutootajuuka"
+        ]
+      },
+      {
+        "en": "removing all headers",
+        "ja": "すべてのへっだーをさくじょ",
+        "ja_typings": [
+          "subetenoheddaosakujo"
+        ]
+      },
+      {
+        "en": "using UDP instead of TCP",
+        "ja": "TCPのかわりにUDPをしよう",
+        "ja_typings": [
+          "tcpnokawariniudposhiyo",
+          "tcpnokawariniudposhiyou"
+        ]
+      },
+      {
+        "en": "encrypting by default",
+        "ja": "きほんであんごうか",
+        "ja_typings": [
+          "kihondeangoka",
+          "kihondeangouka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00193",
+    "image_path": null,
+    "question_text": {
+      "en": "What is HTTP/2 improvement?",
+      "ja": "HTTP/2の改善点は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "full-duplex communication protocol",
+        "ja": "ぜんにほうこうつうしんぷろとこる",
+        "ja_typings": [
+          "zennihokotsuushinpurotokoru",
+          "zennihoukoutsuushinpurotokoru"
+        ]
+      },
+      {
+        "en": "unidirectional HTTP streaming",
+        "ja": "いっぽうこうHTTPすとりーみんぐ",
+        "ja_typings": [
+          "ippokohttpsutorimingu",
+          "ippoukouhttpsutorimingu"
+        ]
+      },
+      {
+        "en": "REST API standard",
+        "ja": "REST APIきじゅん",
+        "ja_typings": [
+          "rest apikijun"
+        ]
+      },
+      {
+        "en": "WebAssembly socket",
+        "ja": "WebAssemblyそけっと",
+        "ja_typings": [
+          "webassemblysoketto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00194",
+    "image_path": null,
+    "question_text": {
+      "en": "What is WebSocket?",
+      "ja": "WebSocketとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "encapsulated DOM sub-tree",
+        "ja": "かぷせるかされたDOMのさぶつりー",
+        "ja_typings": [
+          "kapuserukasaretadomnosabutsuri"
+        ]
+      },
+      {
+        "en": "invisible DOM elements",
+        "ja": "みえないDOMようそ",
+        "ja_typings": [
+          "mienaidomyoso",
+          "mienaidomyouso"
+        ]
+      },
+      {
+        "en": "server-side DOM",
+        "ja": "さーばーがわDOM",
+        "ja_typings": [
+          "sabagawadom"
+        ]
+      },
+      {
+        "en": "cached DOM snapshot",
+        "ja": "きゃっしゅされたDOMすなっぷしょっと",
+        "ja_typings": [
+          "kyasshusaretadomsunappushotto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00195",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Shadow DOM?",
+      "ja": "シャドウDOMとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "user-defined HTML tag",
+        "ja": "ゆーざーていぎのHTMLたぐ",
+        "ja_typings": [
+          "yuzateiginohtmltagu"
+        ]
+      },
+      {
+        "en": "styled HTML element",
+        "ja": "すたいるつきHTMLようそ",
+        "ja_typings": [
+          "sutairutsukihtmlyoso",
+          "sutairutsukihtmlyouso"
+        ]
+      },
+      {
+        "en": "hidden HTML element",
+        "ja": "かくされたHTMLようそ",
+        "ja_typings": [
+          "kakusaretahtmlyoso",
+          "kakusaretahtmlyouso"
+        ]
+      },
+      {
+        "en": "dynamic HTML element",
+        "ja": "どうてきHTMLようそ",
+        "ja_typings": [
+          "dotekihtmlyoso",
+          "doutekihtmlyouso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00196",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a custom HTML element?",
+      "ja": "かすたむHTMLようそとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "loads script after HTML parsing",
+        "ja": "HTMLかいせきごにすくりぷとをろーど",
+        "ja_typings": [
+          "htmlkaisekigonisukuriputorodo",
+          "htmlkaisekigonisukuriputoorodo"
+        ]
+      },
+      {
+        "en": "disables script execution",
+        "ja": "すくりぷとじっこうをむこうか",
+        "ja_typings": [
+          "sukuriputojikkoomukoka",
+          "sukuriputojikkouomukouka"
+        ]
+      },
+      {
+        "en": "loads script before HTML",
+        "ja": "HTMLのまえにすくりぷとをろーど",
+        "ja_typings": [
+          "htmlnomaenisukuriputorodo",
+          "htmlnomaenisukuriputoorodo"
+        ]
+      },
+      {
+        "en": "compresses script file",
+        "ja": "すくりぷとふぁいるをあっしゅく",
+        "ja_typings": [
+          "sukuriputofairuoasshuku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00197",
+    "image_path": null,
+    "question_text": {
+      "en": "What is `defer` attribute in `<script>`?",
+      "ja": "`<script>`の`defer`属性は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "em is parent-relative, rem is root-relative",
+        "ja": "emはおや、remはるーとからそうたい",
+        "ja_typings": [
+          "emhaoya remharutokarasotai",
+          "emhaoya remharutokarasoutai"
+        ]
+      },
+      {
+        "en": "em is pixels, rem is percentages",
+        "ja": "emはぴくせる、remはぱーせんと",
+        "ja_typings": [
+          "emhapikuseru remhapasento"
+        ]
+      },
+      {
+        "en": "em is for fonts, rem is for margins",
+        "ja": "emはふぉんと、remはまーじん",
+        "ja_typings": [
+          "emhafonto remhamajin"
+        ]
+      },
+      {
+        "en": "em is absolute, rem is relative",
+        "ja": "emはぜったい、remはそうたい",
+        "ja_typings": [
+          "emhazettai remhasotai",
+          "emhazettai remhasoutai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00198",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the difference between `em` and `rem` in CSS?",
+      "ja": "CSSの`em`と`rem`のちがいは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "two-dimensional layout system",
+        "ja": "にじげんれいあうとしすてむ",
+        "ja_typings": [
+          "nijigenreiautoshisutemu"
+        ]
+      },
+      {
+        "en": "one-dimensional flex layout",
+        "ja": "いちじげんふれっくすれいあうと",
+        "ja_typings": [
+          "ichijigenfurekkusureiauto"
+        ]
+      },
+      {
+        "en": "table-based layout",
+        "ja": "てーぶるべーすれいあうと",
+        "ja_typings": [
+          "teburubesureiauto"
+        ]
+      },
+      {
+        "en": "fixed-position system",
+        "ja": "こていいちしすてむ",
+        "ja_typings": [
+          "koteiichishisutemu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00199",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a CSS grid?",
+      "ja": "CSSぐりっどとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "visible area of browser window",
+        "ja": "ぶらうざーうぃんどうのひょうじりょういき",
+        "ja_typings": [
+          "burauzawindonohyojiryoiki",
+          "burauzawindounohyoujiryouiki"
+        ]
+      },
+      {
+        "en": "screen resolution setting",
+        "ja": "がめんかいぞうどせってい",
+        "ja_typings": [
+          "gamenkaizodosettei",
+          "gamenkaizoudosettei"
+        ]
+      },
+      {
+        "en": "full page width",
+        "ja": "ぺーじのぜんはば",
+        "ja_typings": [
+          "pejinozenhaba"
+        ]
+      },
+      {
+        "en": "CSS container unit",
+        "ja": "CSSこんてなたんい",
+        "ja_typings": [
+          "csskontenatani"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00200",
+    "image_path": null,
+    "question_text": {
+      "en": "What is viewport in CSS?",
+      "ja": "CSSのびゅーぽーととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "removing unnecessary characters from code",
+        "ja": "こーどから不要文字をとりのぞく",
+        "ja_typings": [
+          "kodokaraotorinozoku"
+        ]
+      },
+      {
+        "en": "compressing images",
+        "ja": "がぞうをあっしゅく",
+        "ja_typings": [
+          "gazooasshuku",
+          "gazouoasshuku"
+        ]
+      },
+      {
+        "en": "caching static files",
+        "ja": "せいてきふぁいるをきゃっしゅ",
+        "ja_typings": [
+          "seitekifairuokyasshu"
+        ]
+      },
+      {
+        "en": "splitting code into chunks",
+        "ja": "こーどをちゃんくにぶんかつ",
+        "ja_typings": [
+          "kodochankunibunkatsu",
+          "kodoochankunibunkatsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00201",
+    "image_path": null,
+    "question_text": {
+      "en": "What is minification in web?",
+      "ja": "うぇぶのみにふぁいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "dividing bundle into smaller chunks",
+        "ja": "ばんどるをしょうさなちゃんくにぶんかつ",
+        "ja_typings": [
+          "bandoruoshosanachankunibunkatsu",
+          "bandoruoshousanachankunibunkatsu"
+        ]
+      },
+      {
+        "en": "splitting CSS from JS",
+        "ja": "JSからCSSをわける",
+        "ja_typings": [
+          "jskaracssowakeru"
+        ]
+      },
+      {
+        "en": "separating test code",
+        "ja": "てすとこーどをきりはなす",
+        "ja_typings": [
+          "tesutokodokirihanasu",
+          "tesutokodookirihanasu"
+        ]
+      },
+      {
+        "en": "dividing HTML sections",
+        "ja": "HTMLせくしょんをぶんかつ",
+        "ja_typings": [
+          "htmlsekushonobunkatsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00202",
+    "image_path": null,
+    "question_text": {
+      "en": "What is code splitting?",
+      "ja": "こーどすぷりってぃんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "loads and executes script asynchronously",
+        "ja": "すくりぷとをひどうきにろーどじっこう",
+        "ja_typings": [
+          "sukuriputohidokinirodojikko",
+          "sukuriputoohidoukinirodojikkou"
+        ]
+      },
+      {
+        "en": "prevents script execution",
+        "ja": "すくりぷとじっこうをぼうし",
+        "ja_typings": [
+          "sukuriputojikkooboshi",
+          "sukuriputojikkouoboushi"
+        ]
+      },
+      {
+        "en": "caches the script",
+        "ja": "すくりぷとをきゃっしゅ",
+        "ja_typings": [
+          "sukuriputokyasshu",
+          "sukuriputookyasshu"
+        ]
+      },
+      {
+        "en": "loads script synchronously",
+        "ja": "どうきにすくりぷとをろーど",
+        "ja_typings": [
+          "dokinisukuriputorodo",
+          "doukinisukuriputoorodo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00203",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `async` attribute do in `<script>`?",
+      "ja": "`<script>`の`async`属性は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "open standard for authorization",
+        "ja": "にんかのおーぷんきじゅん",
+        "ja_typings": [
+          "ninkanopunkijun",
+          "ninkanoopunkijun"
+        ]
+      },
+      {
+        "en": "password encryption method",
+        "ja": "ぱすわーどあんごうかほうほう",
+        "ja_typings": [
+          "pasuwadoangokahoho",
+          "pasuwadoangoukahouhou"
+        ]
+      },
+      {
+        "en": "object authentication",
+        "ja": "おぶじぇくとにんしょう",
+        "ja_typings": [
+          "obujekutoninsho",
+          "obujekutoninshou"
+        ]
+      },
+      {
+        "en": "online API handler",
+        "ja": "おんらいんAPIはんどらー",
+        "ja_typings": [
+          "onrainapihandora"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00204",
+    "image_path": null,
+    "question_text": {
+      "en": "What is OAuth?",
+      "ja": "OAuthとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JSON Web Token for auth",
+        "ja": "にんしょうようのJSONうぇぶとーくん",
+        "ja_typings": [
+          "ninshoyonojsonwebutokun",
+          "ninshouyounojsonwebutokun"
+        ]
+      },
+      {
+        "en": "JavaScript Web Tool",
+        "ja": "JavaScriptうぶえぶつーる",
+        "ja_typings": [
+          "javascriptubuebutsuru"
+        ]
+      },
+      {
+        "en": "JSON Writer Template",
+        "ja": "JSONきじゅつてんぷれーと",
+        "ja_typings": [
+          "jsonkijutsutenpureto"
+        ]
+      },
+      {
+        "en": "Java Web Transaction",
+        "ja": "Javaうぇぶとらんざくしょん",
+        "ja_typings": [
+          "javawebutoranzakushon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00205",
+    "image_path": null,
+    "question_text": {
+      "en": "What is JWT?",
+      "ja": "JWTとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "backend content management without frontend",
+        "ja": "ふろんとえんどなしのCMS",
+        "ja_typings": [
+          "furontoendonashinocms"
+        ]
+      },
+      {
+        "en": "CMS without user interface",
+        "ja": "ゆーざーいんたーふぇーすなしCMS",
+        "ja_typings": [
+          "yuzaintafesunashicms"
+        ]
+      },
+      {
+        "en": "CMS stored in cloud",
+        "ja": "くらうどほぞんのCMS",
+        "ja_typings": [
+          "kuraudohozonnocms"
+        ]
+      },
+      {
+        "en": "CMS for static sites only",
+        "ja": "せいてきさいとのみのCMS",
+        "ja_typings": [
+          "seitekisaitonominocms"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00206",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a headless CMS?",
+      "ja": "へっどれすCMSとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "XML file listing site pages",
+        "ja": "さいとのぺーじをいちらんするXMLふぁいる",
+        "ja_typings": [
+          "saitonopejioichiransuruxmlfairu"
+        ]
+      },
+      {
+        "en": "visual site design",
+        "ja": "びじゅあるなさいとせっけい",
+        "ja_typings": [
+          "bijuarunasaitosekkei"
+        ]
+      },
+      {
+        "en": "HTML navigation menu",
+        "ja": "HTMLなびげーしょんめにゅー",
+        "ja_typings": [
+          "htmlnabigeshonmenyu"
+        ]
+      },
+      {
+        "en": "Google Analytics report",
+        "ja": "Googleアナリティクスレポート",
+        "ja_typings": [
+          "gogleanaritikusurepoto",
+          "googleanaritikusurepoto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00207",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a sitemap?",
+      "ja": "さいとまっぷとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Search Engine Optimization",
+        "ja": "けんさくえんじんさいてきか",
+        "ja_typings": [
+          "kensakuenjinsaitekika"
+        ]
+      },
+      {
+        "en": "Secure Encoded Output",
+        "ja": "あんぜんなえんこーどしゅつりょく",
+        "ja_typings": [
+          "anzennaenkodoshutsuryoku"
+        ]
+      },
+      {
+        "en": "Server Environment Options",
+        "ja": "さーばーかんきょうせってい",
+        "ja_typings": [
+          "sabakankyosettei",
+          "sabakankyousettei"
+        ]
+      },
+      {
+        "en": "Static Element Object",
+        "ja": "せいてきようそおぶじぇくと",
+        "ja_typings": [
+          "seitekiyosobujekuto",
+          "seitekiyousoobujekuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00208",
+    "image_path": null,
+    "question_text": {
+      "en": "What is SEO?",
+      "ja": "SEOとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Google's page experience metrics",
+        "ja": "Googleのぺーじたいけんしひょう",
+        "ja_typings": [
+          "goglenopejitaikenshihyo",
+          "googlenopejitaikenshihyou"
+        ]
+      },
+      {
+        "en": "browser security standards",
+        "ja": "ぶらうざーせきゅりてぃきじゅん",
+        "ja_typings": [
+          "burauzasekyuritikijun"
+        ]
+      },
+      {
+        "en": "web development checklist",
+        "ja": "うぇぶかいはつちぇっくりすと",
+        "ja_typings": [
+          "webukaihatsuchekkurisuto"
+        ]
+      },
+      {
+        "en": "CSS performance metrics",
+        "ja": "CSSぱふぉーまんすしひょう",
+        "ja_typings": [
+          "csspafomansushihyo",
+          "csspafomansushihyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00209",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Core Web Vitals?",
+      "ja": "コアうぇぶばいたるずとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Largest Contentful Paint",
+        "ja": "さいだいこんてんつのびょうが",
+        "ja_typings": [
+          "saidaikontentsunobyoga",
+          "saidaikontentsunobyouga"
+        ]
+      },
+      {
+        "en": "Lowest CPU Processing",
+        "ja": "さいていCPUしょり",
+        "ja_typings": [
+          "saiteicpushori"
+        ]
+      },
+      {
+        "en": "Longest Cache Period",
+        "ja": "さいちょうきゃっしゅきかん",
+        "ja_typings": [
+          "saichokyasshukikan",
+          "saichoukyasshukikan"
+        ]
+      },
+      {
+        "en": "Last Click Position",
+        "ja": "さいごのくりっくいち",
+        "ja_typings": [
+          "saigonokurikkuichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00210",
+    "image_path": null,
+    "question_text": {
+      "en": "What does LCP stand for in web performance?",
+      "ja": "うぇぶぱふぉーまんすのLCPとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JSON file describing PWA app",
+        "ja": "PWAを説明するJSONふぁいる",
+        "ja_typings": [
+          "pwaosurujsonfairu"
+        ]
+      },
+      {
+        "en": "CSS configuration file",
+        "ja": "CSS設定ふぁいる",
+        "ja_typings": [
+          "cssfairu"
+        ]
+      },
+      {
+        "en": "server routing config",
+        "ja": "さーばーるーてぃんぐせってい",
+        "ja_typings": [
+          "sabarutingusettei"
+        ]
+      },
+      {
+        "en": "list of site dependencies",
+        "ja": "さいとのいぞんかんけいいちらん",
+        "ja_typings": [
+          "saitonoizonkankeiichiran"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00211",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a web manifest file?",
+      "ja": "うぇぶましふぇすとふぁいるとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "same code renders on server and client",
+        "ja": "どうじこーどをさーばーとくらいあんとでれんだー",
+        "ja_typings": [
+          "dojikodosabatokuraiantoderenda",
+          "doujikodoosabatokuraiantoderenda"
+        ]
+      },
+      {
+        "en": "rendering only on client",
+        "ja": "くらいあんとのみれんだー",
+        "ja_typings": [
+          "kuraiantonomirenda"
+        ]
+      },
+      {
+        "en": "rendering only on server",
+        "ja": "さーばーのみれんだー",
+        "ja_typings": [
+          "sabanomirenda"
+        ]
+      },
+      {
+        "en": "rendering in parallel",
+        "ja": "へいこうれんだー",
+        "ja_typings": [
+          "heikorenda",
+          "heikourenda"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00212",
+    "image_path": null,
+    "question_text": {
+      "en": "What is isomorphic rendering?",
+      "ja": "あいそもーふぃっくれんだりんぐとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "fast frontend build tool",
+        "ja": "こうそくふろんとえんどびるどつーる",
+        "ja_typings": [
+          "kosokufurontoendobirudotsuru",
+          "kousokufurontoendobirudotsuru"
+        ]
+      },
+      {
+        "en": "Vue.js only bundler",
+        "ja": "Vue.jsせんようばんどらー",
+        "ja_typings": [
+          "vue.jssenyobandora",
+          "vue.jssenyoubandora"
+        ]
+      },
+      {
+        "en": "CSS preprocessor",
+        "ja": "CSSぷりぷろせっさ",
+        "ja_typings": [
+          "csspuripurosessa"
+        ]
+      },
+      {
+        "en": "backend web server",
+        "ja": "ばっくえんどうぇぶさーばー",
+        "ja_typings": [
+          "bakkuendowebusaba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00213",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Vite?",
+      "ja": "Viteとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JavaScript linting tool",
+        "ja": "JavaScriptのりんたー",
+        "ja_typings": [
+          "javascriptnorinta"
+        ]
+      },
+      {
+        "en": "ES6 compiler",
+        "ja": "ES6こんぱいら",
+        "ja_typings": [
+          "es6konpaira"
+        ]
+      },
+      {
+        "en": "JavaScript bundler",
+        "ja": "JavaScriptばんどらー",
+        "ja_typings": [
+          "javascriptbandora"
+        ]
+      },
+      {
+        "en": "Express server middleware",
+        "ja": "Expressさーばーみどるうぇあ",
+        "ja_typings": [
+          "expresssabamidoruwea"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00214",
+    "image_path": null,
+    "question_text": {
+      "en": "What is ESLint?",
+      "ja": "ESLintとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "opinionated code formatter",
+        "ja": "独自方針のこーどふぉーまったー",
+        "ja_typings": [
+          "nokodofomatta"
+        ]
+      },
+      {
+        "en": "CSS preprocessor",
+        "ja": "CSSぷりぷろせっさ",
+        "ja_typings": [
+          "csspuripurosessa"
+        ]
+      },
+      {
+        "en": "JavaScript linter",
+        "ja": "JavaScriptりんたー",
+        "ja_typings": [
+          "javascriptrinta"
+        ]
+      },
+      {
+        "en": "package manager",
+        "ja": "ぱっけーじまねーじゃ",
+        "ja_typings": [
+          "pakkejimaneja"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00215",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Prettier?",
+      "ja": "Prettierとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "metadata sent with request/response",
+        "ja": "りくえすと/おうとうとともにおくるめたでーた",
+        "ja_typings": [
+          "rikuesuto/otototomoniokurumetadeta",
+          "rikuesuto/outoutotomoniokurumetadeta"
+        ]
+      },
+      {
+        "en": "page title in HTML",
+        "ja": "HTMLのぺーじたいとる",
+        "ja_typings": [
+          "htmlnopejitaitoru"
+        ]
+      },
+      {
+        "en": "CSS heading style",
+        "ja": "CSSのみだしすたいる",
+        "ja_typings": [
+          "cssnomidashisutairu"
+        ]
+      },
+      {
+        "en": "database column header",
+        "ja": "でーたべーすれつみだし",
+        "ja_typings": [
+          "detabesuretsumidashi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00216",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an HTTP header?",
+      "ja": "HTTPへっだーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "resource not found",
+        "ja": "りそーすがみつからない",
+        "ja_typings": [
+          "risosugamitsukaranai"
+        ]
+      },
+      {
+        "en": "server internal error",
+        "ja": "さーばーないぶえらー",
+        "ja_typings": [
+          "sabanaibuera"
+        ]
+      },
+      {
+        "en": "access forbidden",
+        "ja": "アクセスきんし",
+        "ja_typings": [
+          "akusesukinshi"
+        ]
+      },
+      {
+        "en": "connection timeout",
+        "ja": "せつぞくたいむあうと",
+        "ja_typings": [
+          "setsuzokutaimuauto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00217",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 404 error?",
+      "ja": "404えらーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "internal server error",
+        "ja": "さーばーないぶえらー",
+        "ja_typings": [
+          "sabanaibuera"
+        ]
+      },
+      {
+        "en": "resource not found",
+        "ja": "りそーすがみつからない",
+        "ja_typings": [
+          "risosugamitsukaranai"
+        ]
+      },
+      {
+        "en": "access forbidden",
+        "ja": "アクセスきんし",
+        "ja_typings": [
+          "akusesukinshi"
+        ]
+      },
+      {
+        "en": "redirect response",
+        "ja": "りだいれくとおうとう",
+        "ja_typings": [
+          "ridairekutouto",
+          "ridairekutooutou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00218",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 500 error?",
+      "ja": "500えらーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "response telling client to go to new URL",
+        "ja": "あたらしいURLへいどうするおうとう",
+        "ja_typings": [
+          "atarashiiurlheidosuruoto",
+          "atarashiiurlheidousuruoutou"
+        ]
+      },
+      {
+        "en": "caching server response",
+        "ja": "さーばーおうとうをきゃっしゅ",
+        "ja_typings": [
+          "sabaotookyasshu",
+          "sabaoutouokyasshu"
+        ]
+      },
+      {
+        "en": "compressing response body",
+        "ja": "おうとうぼでぃをあっしゅく",
+        "ja_typings": [
+          "otobodioasshuku",
+          "outoubodioasshuku"
+        ]
+      },
+      {
+        "en": "blocking client request",
+        "ja": "くらいあんとりくえすとをそしょ",
+        "ja_typings": [
+          "kuraiantorikuesutososho",
+          "kuraiantorikuesutoososho"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00219",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a redirect in HTTP?",
+      "ja": "HTTPのりだいれくととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "escaping user input",
+        "ja": "ゆーざーにゅうりょくをえすけーぷ",
+        "ja_typings": [
+          "yuzanyuuryokuoesukepu"
+        ]
+      },
+      {
+        "en": "encrypting all data",
+        "ja": "すべてのでーたをあんごうか",
+        "ja_typings": [
+          "subetenodetaoangoka",
+          "subetenodetaoangouka"
+        ]
+      },
+      {
+        "en": "using HTTPS",
+        "ja": "HTTPSをつかう",
+        "ja_typings": [
+          "httpsotsukau"
+        ]
+      },
+      {
+        "en": "disabling JavaScript",
+        "ja": "JavaScriptをむこうか",
+        "ja_typings": [
+          "javascriptomukoka",
+          "javascriptomukouka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00220",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Cross-Site Scripting (XSS) prevented by?",
+      "ja": "XSSを防ぐには何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HTTP header controlling resource loading",
+        "ja": "りそーすろーどをせいぎょするHTTPへっだー",
+        "ja_typings": [
+          "risosurodoseigyosuruhttphedda",
+          "risosurodooseigyosuruhttphedda"
+        ]
+      },
+      {
+        "en": "cookie security setting",
+        "ja": "くっきーのせきゅりてぃせってい",
+        "ja_typings": [
+          "kukkinosekyuritisettei"
+        ]
+      },
+      {
+        "en": "CORS configuration",
+        "ja": "CORSのせってい",
+        "ja_typings": [
+          "corsnosettei"
+        ]
+      },
+      {
+        "en": "SSL certificate policy",
+        "ja": "SSLしょうめいしょのぽりしー",
+        "ja_typings": [
+          "sslshomeishonoporishi",
+          "sslshoumeishonoporishi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00221",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Content Security Policy?",
+      "ja": "コンテンツせきゅりてぃぽりしーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "URL that accepts API requests",
+        "ja": "APIりくえすとをうけつけるURL",
+        "ja_typings": [
+          "apirikuesutouketsukeruurl",
+          "apirikuesutoouketsukeruurl"
+        ]
+      },
+      {
+        "en": "server hostname",
+        "ja": "さーばーのほすとめい",
+        "ja_typings": [
+          "sabanohosutomei"
+        ]
+      },
+      {
+        "en": "database connection string",
+        "ja": "でーたべーすせつぞくもじれつ",
+        "ja_typings": [
+          "detabesusetsuzokumojiretsu"
+        ]
+      },
+      {
+        "en": "frontend route",
+        "ja": "ふろんとえんどるーと",
+        "ja_typings": [
+          "furontoendoruto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00222",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a REST endpoint?",
+      "ja": "RESTえんどぽいんととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "handling events on parent for children",
+        "ja": "おやがこどもののいべんとをしょり",
+        "ja_typings": [
+          "oyagakodomononoibentoshori",
+          "oyagakodomononoibentooshori"
+        ]
+      },
+      {
+        "en": "delegating events to server",
+        "ja": "いべんとをさーばーにいにん",
+        "ja_typings": [
+          "ibentosabaniinin",
+          "ibentoosabaniinin"
+        ]
+      },
+      {
+        "en": "preventing event bubbling",
+        "ja": "いべんとばぶりんぐをぼうし",
+        "ja_typings": [
+          "ibentobaburinguoboshi",
+          "ibentobaburinguoboushi"
+        ]
+      },
+      {
+        "en": "creating custom events",
+        "ja": "かすたむいべんとをさくせい",
+        "ja_typings": [
+          "kasutamuibentosakusei",
+          "kasutamuibentoosakusei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00223",
+    "image_path": null,
+    "question_text": {
+      "en": "What is event delegation in JS?",
+      "ja": "JSのいべんとでりげーしょんとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "delaying function until input stops",
+        "ja": "にゅうりょくがとまるまでかんすうをおくらす",
+        "ja_typings": [
+          "nyuuryokugatomarumadekansuuokurasu",
+          "nyuuryokugatomarumadekansuuookurasu"
+        ]
+      },
+      {
+        "en": "cancelling previous function call",
+        "ja": "まえのかんすうよびだしをキャンセル",
+        "ja_typings": [
+          "maenokansuuyobidashiokyanseru"
+        ]
+      },
+      {
+        "en": "batching multiple events",
+        "ja": "ふくすうのいべんとをまとめる",
+        "ja_typings": [
+          "fukusuunoibentomatomeru",
+          "fukusuunoibentoomatomeru"
+        ]
+      },
+      {
+        "en": "filtering duplicate events",
+        "ja": "じゅうふくいべんとをふぃるたー",
+        "ja_typings": [
+          "juufukuibentofiruta",
+          "juufukuibentoofiruta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00224",
+    "image_path": null,
+    "question_text": {
+      "en": "What is debouncing in JS?",
+      "ja": "JSのでばうんすとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "limiting function call frequency",
+        "ja": "かんすうよびだしのひんどをせいげん",
+        "ja_typings": [
+          "kansuuyobidashinohindoseigen",
+          "kansuuyobidashinohindooseigen"
+        ]
+      },
+      {
+        "en": "slowing network speed",
+        "ja": "ねっとわーくそくどをおとす",
+        "ja_typings": [
+          "nettowakusokudootosu",
+          "nettowakusokudoootosu"
+        ]
+      },
+      {
+        "en": "compressing data transfer",
+        "ja": "でーたてんそうをあっしゅく",
+        "ja_typings": [
+          "detatensooasshuku",
+          "detatensouoasshuku"
+        ]
+      },
+      {
+        "en": "delaying API response",
+        "ja": "APIおうとうをおくらす",
+        "ja_typings": [
+          "apiotookurasu",
+          "apioutouookurasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00225",
+    "image_path": null,
+    "question_text": {
+      "en": "What is throttling in JS?",
+      "ja": "JSのすろっとりんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "reusable custom HTML element",
+        "ja": "さいりようかのうなかすたむHTMLようそ",
+        "ja_typings": [
+          "sairiyokanonakasutamuhtmlyoso",
+          "sairiyoukanounakasutamuhtmlyouso"
+        ]
+      },
+      {
+        "en": "React component",
+        "ja": "Reactこんぽーねんと",
+        "ja_typings": [
+          "reactkonponento"
+        ]
+      },
+      {
+        "en": "server-side component",
+        "ja": "さーばーがわこんぽーねんと",
+        "ja_typings": [
+          "sabagawakonponento"
+        ]
+      },
+      {
+        "en": "CSS design component",
+        "ja": "CSSせっけいこんぽーねんと",
+        "ja_typings": [
+          "csssekkeikonponento"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00226",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a web component?",
+      "ja": "うぇぶこんぽーねんととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "storing responses to avoid refetching",
+        "ja": "さいとりこみをさけるおうとうのほぞん",
+        "ja_typings": [
+          "saitorikomiosakeruotonohozon",
+          "saitorikomiosakeruoutounohozon"
+        ]
+      },
+      {
+        "en": "server-side database cache",
+        "ja": "さーばーがわでーたべーすきゃっしゅ",
+        "ja_typings": [
+          "sabagawadetabesukyasshu"
+        ]
+      },
+      {
+        "en": "browser memory allocation",
+        "ja": "ぶらうざーめもりかくほ",
+        "ja_typings": [
+          "burauzamemorikakuho"
+        ]
+      },
+      {
+        "en": "CDN configuration",
+        "ja": "CDNのせってい",
+        "ja_typings": [
+          "cdnnosettei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00227",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an HTTP cache?",
+      "ja": "HTTPきゃっしゅとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "stateless authentication",
+        "ja": "むじょうたいにんしょう",
+        "ja_typings": [
+          "mujotaininsho",
+          "mujoutaininshou"
+        ]
+      },
+      {
+        "en": "data encryption",
+        "ja": "でーたあんごうか",
+        "ja_typings": [
+          "detaangoka",
+          "detaangouka"
+        ]
+      },
+      {
+        "en": "database connection",
+        "ja": "でーたべーすせつぞく",
+        "ja_typings": [
+          "detabesusetsuzoku"
+        ]
+      },
+      {
+        "en": "HTML template rendering",
+        "ja": "HTMLてんぷれーとれんだー",
+        "ja_typings": [
+          "htmltenpuretorenda"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00228",
+    "image_path": null,
+    "question_text": {
+      "en": "What is JSON Web Token (JWT) used for?",
+      "ja": "JWTは何のために使うか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vue.js full-stack framework",
+        "ja": "Vue.jsふるすたっくふれーむわーく",
+        "ja_typings": [
+          "vue.jsfurusutakkufuremuwaku"
+        ]
+      },
+      {
+        "en": "Node.js web server",
+        "ja": "Node.jsうぇぶさーばー",
+        "ja_typings": [
+          "node.jswebusaba"
+        ]
+      },
+      {
+        "en": "React SSR framework",
+        "ja": "ReactSSRふれーむわーく",
+        "ja_typings": [
+          "reactssrfuremuwaku"
+        ]
+      },
+      {
+        "en": "JavaScript bundler",
+        "ja": "JavaScriptばんどらー",
+        "ja_typings": [
+          "javascriptbandora"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00229",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Nuxt.js?",
+      "ja": "Nuxt.jsとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "static site builder with islands",
+        "ja": "あいらんどあーきてくちゃのせいてきさいとびるだー",
+        "ja_typings": [
+          "airandoakitekuchanoseitekisaitobiruda"
+        ]
+      },
+      {
+        "en": "JavaScript runtime",
+        "ja": "JavaScriptじっこうかんきょう",
+        "ja_typings": [
+          "javascriptjikkokankyo",
+          "javascriptjikkoukankyou"
+        ]
+      },
+      {
+        "en": "CSS framework",
+        "ja": "CSSふれーむわーく",
+        "ja_typings": [
+          "cssfuremuwaku"
+        ]
+      },
+      {
+        "en": "database ORM",
+        "ja": "でーたべーすORM",
+        "ja_typings": [
+          "detabesuorm"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00230",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Astro?",
+      "ja": "Astroとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "single repo containing multiple projects",
+        "ja": "ふくすうぷろじぇくトをふくむひとつのりぽ",
+        "ja_typings": [
+          "fukusuupurojekutofukumuhitotsunoripo",
+          "fukusuupurojekutoofukumuhitotsunoripo"
+        ]
+      },
+      {
+        "en": "read-only repository",
+        "ja": "どくとりのりぽじとり",
+        "ja_typings": [
+          "dokutorinoripojitori"
+        ]
+      },
+      {
+        "en": "monolithic backend app",
+        "ja": "ものりしっくばっくえんどあぷり",
+        "ja_typings": [
+          "monorishikkubakkuendoapuri"
+        ]
+      },
+      {
+        "en": "private fork repository",
+        "ja": "ぷらいべーとふぉーくりぽ",
+        "ja_typings": [
+          "puraibetofokuripo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00231",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a monorepo?",
+      "ja": "ものりぽとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "tool for developing UI components in isolation",
+        "ja": "こんぽーねんたをとくりつかいはつするつーる",
+        "ja_typings": [
+          "konponentaotokuritsukaihatsusurutsuru"
+        ]
+      },
+      {
+        "en": "documentation generator",
+        "ja": "どきゅめんとせいせいき",
+        "ja_typings": [
+          "dokyumentoseiseiki"
+        ]
+      },
+      {
+        "en": "e2e testing framework",
+        "ja": "e2eてすとふれーむわーく",
+        "ja_typings": [
+          "e2etesutofuremuwaku"
+        ]
+      },
+      {
+        "en": "CSS component library",
+        "ja": "CSSこんぽーねんとらいぶらり",
+        "ja_typings": [
+          "csskonponentoraiburari"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00232",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Storybook?",
+      "ja": "Storybookとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "browser automation and e2e testing tool",
+        "ja": "ぶらうざーじどうかとe2eてすとつーる",
+        "ja_typings": [
+          "burauzajidokatoe2etesutotsuru",
+          "burauzajidoukatoe2etesutotsuru"
+        ]
+      },
+      {
+        "en": "React component library",
+        "ja": "Reactこんぽーねんとらいぶらり",
+        "ja_typings": [
+          "reactkonponentoraiburari"
+        ]
+      },
+      {
+        "en": "JavaScript bundler",
+        "ja": "JavaScriptばんどらー",
+        "ja_typings": [
+          "javascriptbandora"
+        ]
+      },
+      {
+        "en": "CSS animation framework",
+        "ja": "CSSあにめーしょんふれーむわーく",
+        "ja_typings": [
+          "cssanimeshonfuremuwaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00233",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Playwright?",
+      "ja": "Playwrightとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "end-to-end type-safe API",
+        "ja": "えんどつーえんどがたあんぜんAPI",
+        "ja_typings": [
+          "endotsuendogataanzenapi"
+        ]
+      },
+      {
+        "en": "TypeScript RPC library",
+        "ja": "TypeScriptRPCらいぶらり",
+        "ja_typings": [
+          "typescriptrpcraiburari"
+        ]
+      },
+      {
+        "en": "remote database client",
+        "ja": "りもーとでーたべーすくらいあんと",
+        "ja_typings": [
+          "rimotodetabesukuraianto"
+        ]
+      },
+      {
+        "en": "React state manager",
+        "ja": "Reactじょうたいかんり",
+        "ja_typings": [
+          "reactjotaikanri",
+          "reactjoutaikanri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00234",
+    "image_path": null,
+    "question_text": {
+      "en": "What is tRPC?",
+      "ja": "tRPCとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "serverless compute at edge",
+        "ja": "えっじのさーばーれすけいさん",
+        "ja_typings": [
+          "ejjinosabaresukeisan"
+        ]
+      },
+      {
+        "en": "cloud storage service",
+        "ja": "くらうどすとれーじさーびす",
+        "ja_typings": [
+          "kuraudosutorejisabisu"
+        ]
+      },
+      {
+        "en": "DNS management tool",
+        "ja": "DNSかんりつーる",
+        "ja_typings": [
+          "dnskanritsuru"
+        ]
+      },
+      {
+        "en": "CDN only service",
+        "ja": "CDNのみのさーびす",
+        "ja_typings": [
+          "cdnnominosabisu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00235",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Cloudflare Workers?",
+      "ja": "Cloudflare Workersとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "frontend cloud deployment platform",
+        "ja": "ふろんとえんどくらうどはいひぷらっとふぉーむ",
+        "ja_typings": [
+          "furontoendokuraudohaihipurattofomu"
+        ]
+      },
+      {
+        "en": "backend server framework",
+        "ja": "ばっくえんどさーばーふれーむわーく",
+        "ja_typings": [
+          "bakkuendosabafuremuwaku"
+        ]
+      },
+      {
+        "en": "containerization service",
+        "ja": "こんてなかさーびす",
+        "ja_typings": [
+          "kontenakasabisu"
+        ]
+      },
+      {
+        "en": "database hosting",
+        "ja": "でーたべーすほすてぃんぐ",
+        "ja_typings": [
+          "detabesuhosutingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00236",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Vercel?",
+      "ja": "Vercelとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "tells crawlers which pages to skip",
+        "ja": "くろーらーにどのぺーじをとばすかつたえる",
+        "ja_typings": [
+          "kuroranidonopejiotobasukatsutaeru"
+        ]
+      },
+      {
+        "en": "defines site security rules",
+        "ja": "さいとのせきゅりてぃるーるをていぎ",
+        "ja_typings": [
+          "saitonosekyuritiruruoteigi"
+        ]
+      },
+      {
+        "en": "configures web server",
+        "ja": "うぇぶさーばーをせってい",
+        "ja_typings": [
+          "webusabaosettei"
+        ]
+      },
+      {
+        "en": "lists all site pages",
+        "ja": "すべてのさいとぺーじをいちらん",
+        "ja_typings": [
+          "subetenosaitopejioichiran"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00237",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the purpose of `robots.txt`?",
+      "ja": "`robots.txt`の目的は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "metadata for social sharing previews",
+        "ja": "SNSしぇあのぷれびゅーめたでーた",
+        "ja_typings": [
+          "snssheanopurebyumetadeta"
+        ]
+      },
+      {
+        "en": "graph database protocol",
+        "ja": "ぐらふでーたべーすぷろとこる",
+        "ja_typings": [
+          "gurafudetabesupurotokoru"
+        ]
+      },
+      {
+        "en": "open source API standard",
+        "ja": "おーぷんそーすAPIきじゅん",
+        "ja_typings": [
+          "opunsosuapikijun"
+        ]
+      },
+      {
+        "en": "network graph routing",
+        "ja": "ねっとわーくぐらふるーてぃんぐ",
+        "ja_typings": [
+          "nettowakugurafurutingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00238",
+    "image_path": null,
+    "question_text": {
+      "en": "What is open graph protocol?",
+      "ja": "おーぷんぐらふぷろとこるとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "software managing hardware and software",
+        "ja": "はーどとそふとをかんりするそふとうぇあ",
+        "ja_typings": [
+          "hadotosofutokanrisurusofutowea",
+          "hadotosofutookanrisurusofutowea"
+        ]
+      },
+      {
+        "en": "programming language",
+        "ja": "ぷろぐらみんぐげんご",
+        "ja_typings": [
+          "puroguramingugengo"
+        ]
+      },
+      {
+        "en": "database management system",
+        "ja": "でーたべーすかんりしすてむ",
+        "ja_typings": [
+          "detabesukanrishisutemu"
+        ]
+      },
+      {
+        "en": "network protocol",
+        "ja": "ねっとわーくぷろとこる",
+        "ja_typings": [
+          "nettowakupurotokoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
     "genre": "technology",
-    "id": "q00042",
+    "id": "q00239",
     "image_path": null,
     "question_text": {
-      "en": "What service is AWS S3?",
-      "ja": "AWSのS3はなにのさーびす?"
+      "en": "What is an operating system?",
+      "ja": "おぺれーてぃんぐしすてむとは何か？"
     }
   },
   {
     "choices": [
       {
-        "en": "Variable",
-        "ja": "Variable",
+        "en": "running multiple OS on one hardware",
+        "ja": "いちはーどでふくすうOSをじっこう",
         "ja_typings": [
-          "variable"
+          "ichihadodefukusuuosojikko",
+          "ichihadodefukusuuosojikkou"
         ]
       },
       {
-        "en": "View",
-        "ja": "View",
+        "en": "increasing CPU speed",
+        "ja": "CPUそくどをあげる",
         "ja_typings": [
-          "view"
+          "cpusokudoageru",
+          "cpusokudooageru"
         ]
       },
       {
-        "en": "Value",
-        "ja": "Value",
+        "en": "compressing disk data",
+        "ja": "でぃすくでーたをあっしゅく",
         "ja_typings": [
-          "value"
+          "disukudetaoasshuku"
         ]
       },
       {
-        "en": "Vector",
-        "ja": "Vector",
+        "en": "networking two computers",
+        "ja": "にたいのPCをつなぐ",
         "ja_typings": [
-          "vector"
+          "nitainopcotsunagu"
         ]
       }
     ],
-    "correct_answer_index": 1,
-    "genre": "programming",
-    "id": "q00043",
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00240",
     "image_path": null,
     "question_text": {
-      "en": "What does the 'V' in MVC pattern stand for?",
-      "ja": "えむぶいしーぱたーんのVはなに?"
+      "en": "What is virtualization?",
+      "ja": "かそうかとは何か？"
     }
   },
   {
     "choices": [
       {
-        "en": "Testing",
-        "ja": "てすと",
+        "en": "core of operating system",
+        "ja": "OSのかくしん",
         "ja_typings": [
-          "tesuto"
+          "osnokakushin"
         ]
       },
       {
-        "en": "Bundling",
-        "ja": "ばんどる",
+        "en": "user application",
+        "ja": "ゆーざーあぷりけーしょん",
         "ja_typings": [
-          "bandoru"
+          "yuzaapurikeshon"
         ]
       },
       {
-        "en": "Debugging",
-        "ja": "でばっぐ",
+        "en": "network driver",
+        "ja": "ねっとわーくどらいばー",
         "ja_typings": [
-          "debaggu"
+          "nettowakudoraiba"
         ]
       },
       {
-        "en": "Deployment",
-        "ja": "でぷろい",
+        "en": "file system type",
+        "ja": "ふぁいるしすてむのしゅるい",
         "ja_typings": [
-          "depuroi"
+          "fairushisutemunoshurui"
         ]
       }
     ],
-    "correct_answer_index": 1,
-    "genre": "web_development",
-    "id": "q00044",
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00241",
     "image_path": null,
     "question_text": {
-      "en": "What does Webpack do?",
-      "ja": "Webpackはなにをするつーる?"
+      "en": "What is a kernel?",
+      "ja": "かーねるとは何か？"
     }
   },
   {
     "choices": [
       {
-        "en": "Django",
-        "ja": "Django",
+        "en": "firmware initializing hardware at boot",
+        "ja": "きどうじにはーどをしょきかするふぁーむうぇあ",
         "ja_typings": [
-          "django"
+          "kidojinihadoshokikasurufamuwea",
+          "kidoujinihadooshokikasurufamuwea"
         ]
       },
       {
-        "en": "Rails",
-        "ja": "Rails",
+        "en": "operating system kernel",
+        "ja": "OSかーねる",
         "ja_typings": [
-          "rails"
+          "oskaneru"
         ]
       },
       {
-        "en": "Laravel",
-        "ja": "Laravel",
+        "en": "disk partition tool",
+        "ja": "でぃすくぱーてぃしょんつーる",
         "ja_typings": [
-          "laravel"
+          "disukupatishontsuru"
         ]
       },
       {
-        "en": "Express",
-        "ja": "Express",
+        "en": "network configuration",
+        "ja": "ねっとわーくせってい",
         "ja_typings": [
-          "express"
+          "nettowakusettei"
         ]
       }
     ],
-    "correct_answer_index": 1,
-    "genre": "programming",
-    "id": "q00045",
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00242",
     "image_path": null,
     "question_text": {
-      "en": "Which is a famous Ruby framework?",
-      "ja": "Rubyのふれーむわーくでゆうめいなのは?"
+      "en": "What is BIOS?",
+      "ja": "BIOSとは何か？"
     }
   },
   {
     "choices": [
       {
-        "en": "Authentication",
-        "ja": "にんしょう",
+        "en": "Solid State Drive",
+        "ja": "そりっどすてーとどらいぶ",
         "ja_typings": [
-          "ninsho",
-          "ninshou"
+          "soriddosutetodoraibu"
         ]
       },
       {
-        "en": "Encryption",
-        "ja": "あんごう",
+        "en": "Secure Storage Device",
+        "ja": "あんぜんすとれーじでばいす",
         "ja_typings": [
-          "ango",
-          "angou"
+          "anzensutorejidebaisu"
         ]
       },
       {
-        "en": "Compression",
-        "ja": "あっしゅく",
+        "en": "Software Simulation Disk",
+        "ja": "そふとうぇあしみゅれーしょんでぃすく",
         "ja_typings": [
-          "asshuku"
+          "sofutoweashimyureshondisuku"
         ]
       },
       {
-        "en": "Debugging",
-        "ja": "でばっぐ",
+        "en": "System Status Drive",
+        "ja": "しすてむじょうたいどらいぶ",
         "ja_typings": [
-          "debaggu"
+          "shisutemujotaidoraibu",
+          "shisutemujoutaidoraibu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00243",
+    "image_path": null,
+    "question_text": {
+      "en": "What is SSD?",
+      "ja": "SSDとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Random Access Memory",
+        "ja": "らんだむあくせすめもり",
+        "ja_typings": [
+          "randamuakusesumemori"
+        ]
+      },
+      {
+        "en": "Read-only Archive Memory",
+        "ja": "どくとりあーかいぶめもり",
+        "ja_typings": [
+          "dokutoriakaibumemori"
+        ]
+      },
+      {
+        "en": "Rapid Application Module",
+        "ja": "こうそくあぷりけーしょんもじゅーる",
+        "ja_typings": [
+          "kosokuapurikeshonmojuru",
+          "kousokuapurikeshonmojuru"
+        ]
+      },
+      {
+        "en": "Remote Access Machine",
+        "ja": "りもーとあくせすましん",
+        "ja_typings": [
+          "rimotoakusesumashin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00244",
+    "image_path": null,
+    "question_text": {
+      "en": "What is RAM?",
+      "ja": "RAMとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Central Processing Unit",
+        "ja": "ちゅうおうしょりそうち",
+        "ja_typings": [
+          "chuuoshorisochi",
+          "chuuoushorisouchi"
+        ]
+      },
+      {
+        "en": "Core Processing Utility",
+        "ja": "かーしょりゆーてぃりてぃ",
+        "ja_typings": [
+          "kashoriyutiriti"
+        ]
+      },
+      {
+        "en": "Computer Power Unit",
+        "ja": "こんぴゅーたでんりょくたんい",
+        "ja_typings": [
+          "konpyutadenryokutani"
+        ]
+      },
+      {
+        "en": "Cache Processing Unit",
+        "ja": "きゃっしゅしょりそうち",
+        "ja_typings": [
+          "kyasshushorisochi",
+          "kyasshushorisouchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00245",
+    "image_path": null,
+    "question_text": {
+      "en": "What is CPU?",
+      "ja": "CPUとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Graphics Processing Unit",
+        "ja": "ぐらふぃっくすしょりそうち",
+        "ja_typings": [
+          "gurafikkusushorisochi",
+          "gurafikkusushorisouchi"
+        ]
+      },
+      {
+        "en": "General Program Utility",
+        "ja": "はんようぷろぐらむゆーてぃりてぃ",
+        "ja_typings": [
+          "hanyopuroguramuyutiriti",
+          "hanyoupuroguramuyutiriti"
+        ]
+      },
+      {
+        "en": "Global Power Unit",
+        "ja": "ぐろーばるでんりょくたんい",
+        "ja_typings": [
+          "gurobarudenryokutani"
+        ]
+      },
+      {
+        "en": "Grid Processing Unit",
+        "ja": "ぐりっどしょりそうち",
+        "ja_typings": [
+          "guriddoshorisochi",
+          "guriddoshorisouchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00246",
+    "image_path": null,
+    "question_text": {
+      "en": "What is GPU?",
+      "ja": "GPUとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "internet communication protocol suite",
+        "ja": "いんたーねっとつうしんぷろとこるぐん",
+        "ja_typings": [
+          "intanettotsuushinpurotokorugun"
+        ]
+      },
+      {
+        "en": "type of CPU instruction",
+        "ja": "CPUめいれいのしゅるい",
+        "ja_typings": [
+          "cpumeireinoshurui"
+        ]
+      },
+      {
+        "en": "file transfer standard",
+        "ja": "ふぁいるてんそうきじゅん",
+        "ja_typings": [
+          "fairutensokijun",
+          "fairutensoukijun"
+        ]
+      },
+      {
+        "en": "terminal control protocol",
+        "ja": "たーみなるせいぎょぷろとこる",
+        "ja_typings": [
+          "taminaruseigyopurotokoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00247",
+    "image_path": null,
+    "question_text": {
+      "en": "What is TCP/IP?",
+      "ja": "TCP/IPとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "network security barrier",
+        "ja": "ねっとわーくせきゅりてぃのかべ",
+        "ja_typings": [
+          "nettowakusekyuritinokabe"
+        ]
+      },
+      {
+        "en": "database access control",
+        "ja": "でーたべーすあくせすせいぎょ",
+        "ja_typings": [
+          "detabesuakusesuseigyo"
+        ]
+      },
+      {
+        "en": "antivirus software",
+        "ja": "あんちういるすそふとうぇあ",
+        "ja_typings": [
+          "anchiuirususofutowea"
+        ]
+      },
+      {
+        "en": "CPU heat protection",
+        "ja": "CPUねつほご",
+        "ja_typings": [
+          "cpunetsuhogo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00248",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a firewall?",
+      "ja": "ふぁいあうぉーるとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "automatically assigns IP addresses",
+        "ja": "IPあどれすをじどうわりあて",
+        "ja_typings": [
+          "ipadoresuojidowariate",
+          "ipadoresuojidouwariate"
+        ]
+      },
+      {
+        "en": "encrypts network traffic",
+        "ja": "ねっとわーくつうしんをあんごうか",
+        "ja_typings": [
+          "nettowakutsuushinoangoka",
+          "nettowakutsuushinoangouka"
+        ]
+      },
+      {
+        "en": "resolves domain names",
+        "ja": "どめいんめいをかいけつ",
+        "ja_typings": [
+          "domeinmeiokaiketsu"
+        ]
+      },
+      {
+        "en": "manages user accounts",
+        "ja": "ゆーざーあかうんとをかんり",
+        "ja_typings": [
+          "yuzaakauntokanri",
+          "yuzaakauntookanri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00249",
+    "image_path": null,
+    "question_text": {
+      "en": "What is DHCP?",
+      "ja": "DHCPとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "unique hardware network identifier",
+        "ja": "はーどのゆにーくなねっとわーくしきべつし",
+        "ja_typings": [
+          "hadonoyunikunanettowakushikibetsushi"
+        ]
+      },
+      {
+        "en": "IP address alias",
+        "ja": "IPあどれすのべつめい",
+        "ja_typings": [
+          "ipadoresunobetsumei"
+        ]
+      },
+      {
+        "en": "domain name record",
+        "ja": "どめいんめいのれこーど",
+        "ja_typings": [
+          "domeinmeinorekodo"
+        ]
+      },
+      {
+        "en": "router configuration",
+        "ja": "るーたーのせってい",
+        "ja_typings": [
+          "rutanosettei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00250",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a MAC address?",
+      "ja": "MACあどれすとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Virtual Private Network",
+        "ja": "かそうぷらいべーとねっとわーく",
+        "ja_typings": [
+          "kasopuraibetonettowaku",
+          "kasoupuraibetonettowaku"
+        ]
+      },
+      {
+        "en": "Verified Protocol Node",
+        "ja": "けんしょうずみぷろとこるのーど",
+        "ja_typings": [
+          "kenshozumipurotokorunodo",
+          "kenshouzumipurotokorunodo"
+        ]
+      },
+      {
+        "en": "Variable Port Number",
+        "ja": "かへんぽーとばんごう",
+        "ja_typings": [
+          "kahenpotobango",
+          "kahenpotobangou"
+        ]
+      },
+      {
+        "en": "Visual Page Navigator",
+        "ja": "びじゅあるぺーじなびげーたー",
+        "ja_typings": [
+          "bijuarupejinabigeta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00251",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a VPN?",
+      "ja": "VPNとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "translates private to public IP",
+        "ja": "しにゅうりょくIPをこうかいIPにへんかん",
+        "ja_typings": [
+          "shinyuuryokuipokokaiipnihenkan",
+          "shinyuuryokuipokoukaiipnihenkan"
+        ]
+      },
+      {
+        "en": "assigns domain names",
+        "ja": "どめいんめいをわりあて",
+        "ja_typings": [
+          "domeinmeiowariate"
+        ]
+      },
+      {
+        "en": "encrypts network packets",
+        "ja": "ねっとわーくぱけっとをあんごうか",
+        "ja_typings": [
+          "nettowakupakettoangoka",
+          "nettowakupakettooangouka"
+        ]
+      },
+      {
+        "en": "monitors network traffic",
+        "ja": "ねっとわーくつうしんをかんし",
+        "ja_typings": [
+          "nettowakutsuushinokanshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00252",
+    "image_path": null,
+    "question_text": {
+      "en": "What is NAT in networking?",
+      "ja": "ねっとわーくのNATとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "logical subdivision of a network",
+        "ja": "ねっとわーくの論理的な細分",
+        "ja_typings": [
+          "nettowakunona"
+        ]
+      },
+      {
+        "en": "type of network cable",
+        "ja": "ねっとわーくけーぶるのしゅるい",
+        "ja_typings": [
+          "nettowakukeburunoshurui"
+        ]
+      },
+      {
+        "en": "wireless network protocol",
+        "ja": "むせんねっとわーくぷろとこる",
+        "ja_typings": [
+          "musennettowakupurotokoru"
+        ]
+      },
+      {
+        "en": "network security zone",
+        "ja": "ねっとわーくせきゅりてぃぞーん",
+        "ja_typings": [
+          "nettowakusekyuritizon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00253",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a subnet?",
+      "ja": "さぶねっととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "redundant array of independent disks",
+        "ja": "どくりつでぃすくのじょうちょうはいれつ",
+        "ja_typings": [
+          "dokuritsudisukunojochohairetsu",
+          "dokuritsudisukunojouchouhairetsu"
+        ]
+      },
+      {
+        "en": "random access index drive",
+        "ja": "らんだむあくせすいんでくすどらいぶ",
+        "ja_typings": [
+          "randamuakusesuindekusudoraibu"
+        ]
+      },
+      {
+        "en": "remote access interface device",
+        "ja": "りもーとあくせすいんたーふぇーすでばいす",
+        "ja_typings": [
+          "rimotoakusesuintafesudebaisu"
+        ]
+      },
+      {
+        "en": "real-time AI data",
+        "ja": "りあるたいむAIでーた",
+        "ja_typings": [
+          "riarutaimuaideta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00254",
+    "image_path": null,
+    "question_text": {
+      "en": "What is RAID in storage?",
+      "ja": "すとれーじのRAIDとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "distributes traffic across servers",
+        "ja": "さーばーにつうしんをぶんさん",
+        "ja_typings": [
+          "sabanitsuushinobunsan"
+        ]
+      },
+      {
+        "en": "monitors CPU load",
+        "ja": "CPUふかをかんし",
+        "ja_typings": [
+          "cpufukaokanshi"
+        ]
+      },
+      {
+        "en": "balances database queries",
+        "ja": "でーたべーすくえりをちょうせい",
+        "ja_typings": [
+          "detabesukueriochosei",
+          "detabesukueriochousei"
+        ]
+      },
+      {
+        "en": "manages server power",
+        "ja": "さーばーでんりょくをかんり",
+        "ja_typings": [
+          "sabadenryokuokanri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00255",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a load balancer?",
+      "ja": "ろーどばらんさーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "intermediary between client and server",
+        "ja": "くらいあんととさーばーのちゅうかい",
+        "ja_typings": [
+          "kuraiantotosabanochuukai"
+        ]
+      },
+      {
+        "en": "backup server",
+        "ja": "ばっくあっぷさーばー",
+        "ja_typings": [
+          "bakkuappusaba"
+        ]
+      },
+      {
+        "en": "DNS server",
+        "ja": "DNSさーばー",
+        "ja_typings": [
+          "dnssaba"
+        ]
+      },
+      {
+        "en": "mail server",
+        "ja": "めーるさーばー",
+        "ja_typings": [
+          "merusaba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00256",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a proxy server?",
+      "ja": "ぷろくしさーばーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sits in front of servers",
+        "ja": "さーばーのまえにいちする",
+        "ja_typings": [
+          "sabanomaeniichisuru"
+        ]
+      },
+      {
+        "en": "sits in front of clients",
+        "ja": "くらいあんとのまえにいちする",
+        "ja_typings": [
+          "kuraiantonomaeniichisuru"
+        ]
+      },
+      {
+        "en": "caches client data",
+        "ja": "くらいあんとでーたをきゃっしゅ",
+        "ja_typings": [
+          "kuraiantodetaokyasshu"
+        ]
+      },
+      {
+        "en": "monitors server logs",
+        "ja": "さーばーろぐをかんし",
+        "ja_typings": [
+          "sabaroguokanshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00257",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a reverse proxy?",
+      "ja": "りばーすぷろくしとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Secure Shell remote protocol",
+        "ja": "あんぜんなしぇるりもーとぷろとこる",
+        "ja_typings": [
+          "anzennasherurimotopurotokoru"
+        ]
+      },
+      {
+        "en": "Simple Service Handler",
+        "ja": "かんたんなさーびすはんどらー",
+        "ja_typings": [
+          "kantannasabisuhandora"
+        ]
+      },
+      {
+        "en": "Secure Script Host",
+        "ja": "あんぜんなすくりぷとほすと",
+        "ja_typings": [
+          "anzennasukuriputohosuto"
+        ]
+      },
+      {
+        "en": "Shared Server Hub",
+        "ja": "きょうゆうさーばーはぶ",
+        "ja_typings": [
+          "kyoyuusabahabu",
+          "kyouyuusabahabu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00258",
+    "image_path": null,
+    "question_text": {
+      "en": "What is SSH?",
+      "ja": "SSHとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "software creating and managing VMs",
+        "ja": "VMをさくせいかんりするそふとうぇあ",
+        "ja_typings": [
+          "vmosakuseikanrisurusofutowea"
+        ]
+      },
+      {
+        "en": "high-speed processor",
+        "ja": "こうそくしょりそうち",
+        "ja_typings": [
+          "kosokushorisochi",
+          "kousokushorisouchi"
+        ]
+      },
+      {
+        "en": "network monitoring tool",
+        "ja": "ねっとわーくかんしつーる",
+        "ja_typings": [
+          "nettowakukanshitsuru"
+        ]
+      },
+      {
+        "en": "database indexer",
+        "ja": "でーたべーすいんでくさー",
+        "ja_typings": [
+          "detabesuindekusa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00259",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a hypervisor?",
+      "ja": "はいぱーばいざーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "immutable snapshot of container filesystem",
+        "ja": "こんてなふぁいるしすてむのふへんすなっぷ",
+        "ja_typings": [
+          "kontenafairushisutemunofuhensunappu"
+        ]
+      },
+      {
+        "en": "virtual machine backup",
+        "ja": "かそうましんばっくあっぷ",
+        "ja_typings": [
+          "kasomashinbakkuappu",
+          "kasoumashinbakkuappu"
+        ]
+      },
+      {
+        "en": "disk partition image",
+        "ja": "でぃすくぱーてぃしょんいめーじ",
+        "ja_typings": [
+          "disukupatishonimeji"
+        ]
+      },
+      {
+        "en": "OS installation disk",
+        "ja": "OSいんすとーるでぃすく",
+        "ja_typings": [
+          "osinsutorudisuku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00260",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a container image?",
+      "ja": "こんてないめーじとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "running code without managing servers",
+        "ja": "さーばーかんりなしでこーどをじっこう",
+        "ja_typings": [
+          "sabakanrinashidekodojikko",
+          "sabakanrinashidekodoojikkou"
+        ]
+      },
+      {
+        "en": "computing with no power",
+        "ja": "でんりょくなしのけいさん",
+        "ja_typings": [
+          "denryokunashinokeisan"
+        ]
+      },
+      {
+        "en": "computing on local machine only",
+        "ja": "ろーかるましんのみけいさん",
+        "ja_typings": [
+          "rokarumashinnomikeisan"
+        ]
+      },
+      {
+        "en": "computing without internet",
+        "ja": "いんたーねっとなしけいさん",
+        "ja_typings": [
+          "intanettonashikeisan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00261",
+    "image_path": null,
+    "question_text": {
+      "en": "What is serverless computing?",
+      "ja": "さーばーれすけいさんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "processing data near the source",
+        "ja": "でーたそーすのちかくでしょり",
+        "ja_typings": [
+          "detasosunochikakudeshori"
+        ]
+      },
+      {
+        "en": "computing on blockchain",
+        "ja": "ぶろっくちぇーんでけいさん",
+        "ja_typings": [
+          "burokkuchendekeisan"
+        ]
+      },
+      {
+        "en": "computing on GPU only",
+        "ja": "GPUのみけいさん",
+        "ja_typings": [
+          "gpunomikeisan"
+        ]
+      },
+      {
+        "en": "computing at data center",
+        "ja": "でーたせんたーでけいさん",
+        "ja_typings": [
+          "detasentadekeisan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00262",
+    "image_path": null,
+    "question_text": {
+      "en": "What is edge computing?",
+      "ja": "えっじけいさんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "delivering content with low latency",
+        "ja": "ていれいてんしーでこんてんつはいしん",
+        "ja_typings": [
+          "teireitenshidekontentsuhaishin"
+        ]
+      },
+      {
+        "en": "storing large databases",
+        "ja": "だいきぼでーたべーすのほぞん",
+        "ja_typings": [
+          "daikibodetabesunohozon"
+        ]
+      },
+      {
+        "en": "processing complex queries",
+        "ja": "ふくざつくえりのしょり",
+        "ja_typings": [
+          "fukuzatsukuerinoshori"
+        ]
+      },
+      {
+        "en": "running server-side code",
+        "ja": "さーばーがわこーどのじっこう",
+        "ja_typings": [
+          "sabagawakodonojikko",
+          "sabagawakodonojikkou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00263",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a content delivery network optimized for?",
+      "ja": "CDNは何のために最適化されているか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "storing frequently accessed data for speed",
+        "ja": "こうひんどでーたをほぞんして高速化",
+        "ja_typings": [
+          "kohindodetaohozonshite",
+          "kouhindodetaohozonshite"
+        ]
+      },
+      {
+        "en": "encrypting stored data",
+        "ja": "ほぞんでーたをあんごうか",
+        "ja_typings": [
+          "hozondetaoangoka",
+          "hozondetaoangouka"
+        ]
+      },
+      {
+        "en": "compressing stored data",
+        "ja": "ほぞんでーたをあっしゅく",
+        "ja_typings": [
+          "hozondetaoasshuku"
+        ]
+      },
+      {
+        "en": "backing up stored data",
+        "ja": "ほぞんでーたをばっくあっぷ",
+        "ja_typings": [
+          "hozondetaobakkuappu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00264",
+    "image_path": null,
+    "question_text": {
+      "en": "What is caching in computing?",
+      "ja": "けいさんきのきゃっしゅとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "async communication buffer between services",
+        "ja": "さーびす間の非同期通信バッファ",
+        "ja_typings": [
+          "sabisunobaffa"
+        ]
+      },
+      {
+        "en": "user notification queue",
+        "ja": "ゆーざーつうちきゅー",
+        "ja_typings": [
+          "yuzatsuuchikyu"
+        ]
+      },
+      {
+        "en": "database write buffer",
+        "ja": "でーたべーすきおみこみばっふぁ",
+        "ja_typings": [
+          "detabesukiomikomibaffa"
+        ]
+      },
+      {
+        "en": "email sending queue",
+        "ja": "めーるそうしんきゅー",
+        "ja_typings": [
+          "merusoshinkyu",
+          "merusoushinkyu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00265",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a message queue?",
+      "ja": "めっせーじきゅーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "publishers send to topics, subscribers receive",
+        "ja": "しゅっぱんしゃがそうしん、こうどくしゃがじゅしん",
+        "ja_typings": [
+          "shuppanshagasoshin kodokushagajushin",
+          "shuppanshagasoushin koudokushagajushin"
+        ]
+      },
+      {
+        "en": "point-to-point messaging",
+        "ja": "いちたいいちめっせーじんぐ",
+        "ja_typings": [
+          "ichitaiichimessejingu"
+        ]
+      },
+      {
+        "en": "broadcast to all users",
+        "ja": "ぜんゆーざーにほうそう",
+        "ja_typings": [
+          "zenyuzanihoso",
+          "zenyuzanihousou"
+        ]
+      },
+      {
+        "en": "encrypted direct messaging",
+        "ja": "あんごうかちょくせつめっせーじ",
+        "ja_typings": [
+          "angokachokusetsumesseji",
+          "angoukachokusetsumesseji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00266",
+    "image_path": null,
+    "question_text": {
+      "en": "What is pub/sub messaging?",
+      "ja": "pub/subめっせーじんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "server located close to users",
+        "ja": "ゆーざーのちかくにあるさーばー",
+        "ja_typings": [
+          "yuzanochikakuniarusaba"
+        ]
+      },
+      {
+        "en": "cloud data node",
+        "ja": "くらうどでーたのーど",
+        "ja_typings": [
+          "kuraudodetanodo"
+        ]
+      },
+      {
+        "en": "database replica",
+        "ja": "でーたべーすのれぷりか",
+        "ja_typings": [
+          "detabesunorepurika"
+        ]
+      },
+      {
+        "en": "network router",
+        "ja": "ねっとわーくるーたー",
+        "ja_typings": [
+          "nettowakuruta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00267",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a CDN edge node?",
+      "ja": "CDNのえっじのーどとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "adding more servers",
+        "ja": "さーばーをふやす",
+        "ja_typings": [
+          "sabaofuyasu"
+        ]
+      },
+      {
+        "en": "upgrading existing server",
+        "ja": "きそんさーばーをきょうか",
+        "ja_typings": [
+          "kisonsabaokyoka",
+          "kisonsabaokyouka"
+        ]
+      },
+      {
+        "en": "compressing server data",
+        "ja": "さーばーでーたをあっしゅく",
+        "ja_typings": [
+          "sabadetaoasshuku"
+        ]
+      },
+      {
+        "en": "adding more CPU cores",
+        "ja": "CPUこあをふやす",
+        "ja_typings": [
+          "cpukoaofuyasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00268",
+    "image_path": null,
+    "question_text": {
+      "en": "What is horizontal scaling?",
+      "ja": "すいへいすけーりんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "upgrading existing server resources",
+        "ja": "きそんさーばーのりそーすをきょうか",
+        "ja_typings": [
+          "kisonsabanorisosuokyoka",
+          "kisonsabanorisosuokyouka"
+        ]
+      },
+      {
+        "en": "adding more servers",
+        "ja": "さーばーをふやす",
+        "ja_typings": [
+          "sabaofuyasu"
+        ]
+      },
+      {
+        "en": "adding more data centers",
+        "ja": "でーたせんたーをふやす",
+        "ja_typings": [
+          "detasentaofuyasu"
+        ]
+      },
+      {
+        "en": "upgrading network speed",
+        "ja": "ねっとわーくそくどをきょうか",
+        "ja_typings": [
+          "nettowakusokudokyoka",
+          "nettowakusokudookyouka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00269",
+    "image_path": null,
+    "question_text": {
+      "en": "What is vertical scaling?",
+      "ja": "すいちょくすけーりんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "facility housing computing infrastructure",
+        "ja": "けいさんきばんをほうじょするしせつ",
+        "ja_typings": [
+          "keisankibanohojosurushisetsu",
+          "keisankibanohoujosurushisetsu"
+        ]
+      },
+      {
+        "en": "company headquarters",
+        "ja": "かいしゃのほんしゃ",
+        "ja_typings": [
+          "kaishanohonsha"
+        ]
+      },
+      {
+        "en": "cloud storage account",
+        "ja": "くらうどすとれーじあかうんと",
+        "ja_typings": [
+          "kuraudosutorejiakaunto"
+        ]
+      },
+      {
+        "en": "network operations center",
+        "ja": "ねっとわーくうんようせんたー",
+        "ja_typings": [
+          "nettowakuunyosenta",
+          "nettowakuunyousenta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00270",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a data center?",
+      "ja": "でーたせんたーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "time system runs without failure",
+        "ja": "しすてむがふぐなくどうさしているじかん",
+        "ja_typings": [
+          "shisutemugafugunakudosashiteirujikan",
+          "shisutemugafugunakudousashiteirujikan"
+        ]
+      },
+      {
+        "en": "time to complete an update",
+        "ja": "こうしんにかかるじかん",
+        "ja_typings": [
+          "koshinnikakarujikan",
+          "koushinnikakarujikan"
+        ]
+      },
+      {
+        "en": "CPU processing time",
+        "ja": "CPUしょりじかん",
+        "ja_typings": [
+          "cpushorijikan"
+        ]
+      },
+      {
+        "en": "network connection time",
+        "ja": "ねっとわーくせつぞくじかん",
+        "ja_typings": [
+          "nettowakusetsuzokujikan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00271",
+    "image_path": null,
+    "question_text": {
+      "en": "What is uptime in computing?",
+      "ja": "けいさんきのあっぷたいむとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Service Level Agreement",
+        "ja": "さーびすすいじゅんのけいやく",
+        "ja_typings": [
+          "sabisusuijunnokeiyaku"
+        ]
+      },
+      {
+        "en": "System Load Average",
+        "ja": "しすてむふかへいきん",
+        "ja_typings": [
+          "shisutemufukaheikin"
+        ]
+      },
+      {
+        "en": "Secure Login API",
+        "ja": "あんぜんなろぐいんAPI",
+        "ja_typings": [
+          "anzennaroguinapi"
+        ]
+      },
+      {
+        "en": "Software License Archive",
+        "ja": "そふとうぇあらいせんすあーかいぶ",
+        "ja_typings": [
+          "sofutowearaisensuakaibu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00272",
+    "image_path": null,
+    "question_text": {
+      "en": "What is SLA?",
+      "ja": "SLAとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "tracking system health and performance",
+        "ja": "しすてむのけんこうとぱふぉーまんすをついせき",
+        "ja_typings": [
+          "shisutemunokenkotopafomansuotsuiseki",
+          "shisutemunokenkoutopafomansuotsuiseki"
+        ]
+      },
+      {
+        "en": "monitoring code quality",
+        "ja": "こーどひんしつをかんし",
+        "ja_typings": [
+          "kodohinshitsuokanshi"
+        ]
+      },
+      {
+        "en": "watching user behavior",
+        "ja": "ゆーざーこうどうをかんし",
+        "ja_typings": [
+          "yuzakodookanshi",
+          "yuzakoudouokanshi"
+        ]
+      },
+      {
+        "en": "checking database integrity",
+        "ja": "でーたべーすせいごうせいをかくにん",
+        "ja_typings": [
+          "detabesuseigoseiokakunin",
+          "detabesuseigouseiokakunin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00273",
+    "image_path": null,
+    "question_text": {
+      "en": "What is monitoring in DevOps?",
+      "ja": "DevOpsのもにたりんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "running two identical environments",
+        "ja": "ふたつのどうじかんきょうをじっこう",
+        "ja_typings": [
+          "futatsunodojikankyoojikko",
+          "futatsunodoujikankyouojikkou"
+        ]
+      },
+      {
+        "en": "gradual traffic rollout",
+        "ja": "だんかいてきなつうしんきりかえ",
+        "ja_typings": [
+          "dankaitekinatsuushinkirikae"
+        ]
+      },
+      {
+        "en": "color-coded code deployment",
+        "ja": "いろわけのこーどはいひ",
+        "ja_typings": [
+          "irowakenokodohaihi"
+        ]
+      },
+      {
+        "en": "server room color system",
+        "ja": "さーばールームのいろわけ",
+        "ja_typings": [
+          "sabarumunoirowake"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00274",
+    "image_path": null,
+    "question_text": {
+      "en": "What is blue-green deployment?",
+      "ja": "ぶるーぐりーんはいひとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "releasing to small user subset first",
+        "ja": "さきにしょうすうのゆーざーにリリース",
+        "ja_typings": [
+          "sakinishosuunoyuzaniririsu",
+          "sakinishousuunoyuzaniririsu"
+        ]
+      },
+      {
+        "en": "deploying to all users at once",
+        "ja": "いちどにぜんゆーざーにはいひ",
+        "ja_typings": [
+          "ichidonizenyuzanihaihi"
+        ]
+      },
+      {
+        "en": "deploying without testing",
+        "ja": "てすとなしにはいひ",
+        "ja_typings": [
+          "tesutonashinihaihi"
+        ]
+      },
+      {
+        "en": "automated rollback deployment",
+        "ja": "じどうろーるばっくはいひ",
+        "ja_typings": [
+          "jidororubakkuhaihi",
+          "jidourorubakkuhaihi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00275",
+    "image_path": null,
+    "question_text": {
+      "en": "What is canary deployment?",
+      "ja": "かなりあはいひとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "storage for container images",
+        "ja": "こんてないめーじのほぞんばしょ",
+        "ja_typings": [
+          "kontenaimejinohozonbasho"
+        ]
+      },
+      {
+        "en": "database for containers",
+        "ja": "こんてなのでーたべーす",
+        "ja_typings": [
+          "kontenanodetabesu"
+        ]
+      },
+      {
+        "en": "OS registry for apps",
+        "ja": "OSのあぷりとうろく",
+        "ja_typings": [
+          "osnoapuritoroku",
+          "osnoapuritouroku"
+        ]
+      },
+      {
+        "en": "network DNS registry",
+        "ja": "ネットワークDNSとうろく",
+        "ja_typings": [
+          "nettowakudnstoroku",
+          "nettowakudnstouroku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00276",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a container registry?",
+      "ja": "こんてなれじすとりとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "infrastructure as code tool",
+        "ja": "インフラをコードで管理するツール",
+        "ja_typings": [
+          "infuraokododesurutsuru"
+        ]
+      },
+      {
+        "en": "container runtime",
+        "ja": "こんてなじっこうかんきょう",
+        "ja_typings": [
+          "kontenajikkokankyo",
+          "kontenajikkoukankyou"
+        ]
+      },
+      {
+        "en": "CI/CD pipeline tool",
+        "ja": "CI/CDぱいぷらいんつーる",
+        "ja_typings": [
+          "ci/cdpaipuraintsuru"
+        ]
+      },
+      {
+        "en": "monitoring platform",
+        "ja": "もにたりんぐぷらっとふぉーむ",
+        "ja_typings": [
+          "monitaringupurattofomu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00277",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Terraform?",
+      "ja": "Terraformとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "IT automation and config management tool",
+        "ja": "ITじどうかとせってかんりつーる",
+        "ja_typings": [
+          "itjidokatosettekanritsuru",
+          "itjidoukatosettekanritsuru"
+        ]
+      },
+      {
+        "en": "container orchestration tool",
+        "ja": "こんてなおーけすとれーしょんつーる",
+        "ja_typings": [
+          "kontenaokesutoreshontsuru"
+        ]
+      },
+      {
+        "en": "log analysis platform",
+        "ja": "ろぐぶんせきぷらっとふぉーむ",
+        "ja_typings": [
+          "rogubunsekipurattofomu"
+        ]
+      },
+      {
+        "en": "network packet analyzer",
+        "ja": "ねっとわーくぱけっとかいせき",
+        "ja_typings": [
+          "nettowakupakettokaiseki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00278",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Ansible?",
+      "ja": "Ansibleとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "monitoring and alerting toolkit",
+        "ja": "もにたりんぐとあらーとのつーるきっと",
+        "ja_typings": [
+          "monitaringutoaratonotsurukitto"
+        ]
+      },
+      {
+        "en": "container platform",
+        "ja": "こんてなぷらっとふぉーむ",
+        "ja_typings": [
+          "kontenapurattofomu"
+        ]
+      },
+      {
+        "en": "log management system",
+        "ja": "ろぐかんりしすてむ",
+        "ja_typings": [
+          "rogukanrishisutemu"
+        ]
+      },
+      {
+        "en": "infrastructure provisioner",
+        "ja": "きばんぷろびじょにんぐ",
+        "ja_typings": [
+          "kibanpurobijoningu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00279",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Prometheus?",
+      "ja": "Prometheusとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "visualization and dashboard tool",
+        "ja": "びじゅあらいぜーしょんとだっしゅぼーどつーる",
+        "ja_typings": [
+          "bijuaraizeshontodasshubodotsuru"
+        ]
+      },
+      {
+        "en": "database backup tool",
+        "ja": "でーたべーすばっくあっぷつーる",
+        "ja_typings": [
+          "detabesubakkuapputsuru"
+        ]
+      },
+      {
+        "en": "code quality analyzer",
+        "ja": "こーどひんしつかいせきつーる",
+        "ja_typings": [
+          "kodohinshitsukaisekitsuru"
+        ]
+      },
+      {
+        "en": "network configuration tool",
+        "ja": "ねっとわーくせってつーる",
+        "ja_typings": [
+          "nettowakusettetsuru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00280",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Grafana?",
+      "ja": "Grafanaとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Elasticsearch Logstash Kibana",
+        "ja": "Elasticsearchろぐすたっしゅきばな",
+        "ja_typings": [
+          "elasticsearchrogusutasshukibana"
+        ]
+      },
+      {
+        "en": "Edge Load Kubernetes",
+        "ja": "えっじろーどくーばねてぃす",
+        "ja_typings": [
+          "ejjirodokubanetisu"
+        ]
+      },
+      {
+        "en": "Event Log Kernel",
+        "ja": "いべんとろぐかーねる",
+        "ja_typings": [
+          "ibentorogukaneru"
+        ]
+      },
+      {
+        "en": "Elastic Linux Kernel",
+        "ja": "えらすてぃっくLinuxかーねる",
+        "ja_typings": [
+          "erasutikkulinuxkaneru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00281",
+    "image_path": null,
+    "question_text": {
+      "en": "What is ELK stack?",
+      "ja": "ELKすたっくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ability to understand system state from outputs",
+        "ja": "しゅつりょくからじょうたいをりかいできること",
+        "ja_typings": [
+          "shutsuryokukarajotaiorikaidekirukoto",
+          "shutsuryokukarajoutaiorikaidekirukoto"
+        ]
+      },
+      {
+        "en": "ability to monitor CPU usage",
+        "ja": "CPU使用率をかんしできること",
+        "ja_typings": [
+          "cpuokanshidekirukoto"
+        ]
+      },
+      {
+        "en": "ability to view source code",
+        "ja": "そーすこーどをみられること",
+        "ja_typings": [
+          "sosukodomirarerukoto",
+          "sosukodoomirarerukoto"
+        ]
+      },
+      {
+        "en": "ability to access logs",
+        "ja": "ろぐにアクセスできること",
+        "ja_typings": [
+          "roguniakusesudekirukoto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00282",
+    "image_path": null,
+    "question_text": {
+      "en": "What is observability in systems?",
+      "ja": "しすてむのかんそくかのうせいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "smallest deployable unit in K8s",
+        "ja": "K8sのさいしょうはいひたんい",
+        "ja_typings": [
+          "k8snosaishohaihitani",
+          "k8snosaishouhaihitani"
+        ]
+      },
+      {
+        "en": "K8s database unit",
+        "ja": "K8sのでーたべーすたんい",
+        "ja_typings": [
+          "k8snodetabesutani"
+        ]
+      },
+      {
+        "en": "K8s network unit",
+        "ja": "K8sのねっとわーくたんい",
+        "ja_typings": [
+          "k8snonettowakutani"
+        ]
+      },
+      {
+        "en": "K8s storage unit",
+        "ja": "K8sのすとれーじたんい",
+        "ja_typings": [
+          "k8snosutorejitani"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00283",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a container pod in Kubernetes?",
+      "ja": "Kubernetesのぽっどとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "script defining container image",
+        "ja": "こんてないめーじをていぎするすくりぷと",
+        "ja_typings": [
+          "kontenaimejioteigisurusukuriputo"
+        ]
+      },
+      {
+        "en": "Docker network config",
+        "ja": "Dockerねっとわーくせってい",
+        "ja_typings": [
+          "dockernettowakusettei"
+        ]
+      },
+      {
+        "en": "Docker volume config",
+        "ja": "Dockerぼりゅーむせってい",
+        "ja_typings": [
+          "dockerboryumusettei"
+        ]
+      },
+      {
+        "en": "Docker compose file",
+        "ja": "Dockerこんぽーずふぁいる",
+        "ja_typings": [
+          "dockerkonpozufairu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00284",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a Dockerfile?",
+      "ja": "Dockerfileとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "tool for multi-container applications",
+        "ja": "ふくすうこんてなあぷりのつーる",
+        "ja_typings": [
+          "fukusuukontenaapurinotsuru"
+        ]
+      },
+      {
+        "en": "Docker installation script",
+        "ja": "Dockerいんすとーるすくりぷと",
+        "ja_typings": [
+          "dockerinsutorusukuriputo"
+        ]
+      },
+      {
+        "en": "Docker image builder",
+        "ja": "Dockerいめーじびるだー",
+        "ja_typings": [
+          "dockerimejibiruda"
+        ]
+      },
+      {
+        "en": "Docker networking tool",
+        "ja": "Dockerねっとわーくつーる",
+        "ja_typings": [
+          "dockernettowakutsuru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00285",
+    "image_path": null,
+    "question_text": {
+      "en": "What is `docker-compose`?",
+      "ja": "`docker-compose`とは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "logical isolation within cluster",
+        "ja": "くらすたないのろんりてきかくり",
+        "ja_typings": [
+          "kurasutanainoronritekikakuri"
+        ]
+      },
+      {
+        "en": "global cluster name",
+        "ja": "くらすたのぐろーばるめい",
+        "ja_typings": [
+          "kurasutanogurobarumei"
+        ]
+      },
+      {
+        "en": "network isolation zone",
+        "ja": "ねっとわーくかくりぞーん",
+        "ja_typings": [
+          "nettowakukakurizon"
+        ]
+      },
+      {
+        "en": "storage partition",
+        "ja": "すとれーじぱーてぃしょん",
+        "ja_typings": [
+          "sutorejipatishon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00286",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a Kubernetes namespace?",
+      "ja": "Kubernetesのなめすぺーすとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kubernetes application package",
+        "ja": "Kubernetesあぷりぱっけーじ",
+        "ja_typings": [
+          "kubernetesapuripakkeji"
+        ]
+      },
+      {
+        "en": "monitoring dashboard",
+        "ja": "もにたりんぐだっしゅぼーど",
+        "ja_typings": [
+          "monitaringudasshubodo"
+        ]
+      },
+      {
+        "en": "Docker image format",
+        "ja": "Dockerいめーじけいしき",
+        "ja_typings": [
+          "dockerimejikeishiki"
+        ]
+      },
+      {
+        "en": "CI pipeline config",
+        "ja": "CIぱいぷらいんせってい",
+        "ja_typings": [
+          "cipaipurainsettei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00287",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a Helm chart?",
+      "ja": "Helmちゃーととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "using Git as source of truth for infra",
+        "ja": "きばんのせいしんとしてGitをつかう",
+        "ja_typings": [
+          "kibannoseishintoshitegitotsukau"
+        ]
+      },
+      {
+        "en": "Git-based CI/CD only",
+        "ja": "GitべースのCI/CDのみ",
+        "ja_typings": [
+          "gitbesunoci/cdnomi"
+        ]
+      },
+      {
+        "en": "GitLab operations",
+        "ja": "GitLabのうんよう",
+        "ja_typings": [
+          "gitlabnonyo",
+          "gitlabnounyou"
+        ]
+      },
+      {
+        "en": "Git security operations",
+        "ja": "Gitのせきゅりてぃうんよう",
+        "ja_typings": [
+          "gitnosekyuritiunyo",
+          "gitnosekyuritiunyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00288",
+    "image_path": null,
+    "question_text": {
+      "en": "What is GitOps?",
+      "ja": "GitOpsとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "intentionally injecting failures to test resilience",
+        "ja": "たいきゅうせいをためすためにいとてきにしょうがいそうにゅう",
+        "ja_typings": [
+          "taikyuuseiotamesutameniitotekinishogaisonyuu",
+          "taikyuuseiotamesutameniitotekinishougaisounyuu"
+        ]
+      },
+      {
+        "en": "random code changes",
+        "ja": "らんだむなこーどへんこう",
+        "ja_typings": [
+          "randamunakodohenko",
+          "randamunakodohenkou"
+        ]
+      },
+      {
+        "en": "disorganized development process",
+        "ja": "ふせいりなかいはつぷろせす",
+        "ja_typings": [
+          "fuseirinakaihatsupurosesu"
+        ]
+      },
+      {
+        "en": "testing on production only",
+        "ja": "ほんばんのみでてすと",
+        "ja_typings": [
+          "honbannomidetesuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00289",
+    "image_path": null,
+    "question_text": {
+      "en": "What is chaos engineering?",
+      "ja": "かおすえんじにありんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HTTP callback triggered by events",
+        "ja": "いべんとにトリガーされるHTTPこーるばっく",
+        "ja_typings": [
+          "ibentonitorigasareruhttpkorubakku"
+        ]
+      },
+      {
+        "en": "frontend JavaScript hook",
+        "ja": "ふろんとえんどJavaScriptふっく",
+        "ja_typings": [
+          "furontoendojavascriptfukku"
+        ]
+      },
+      {
+        "en": "backend API endpoint",
+        "ja": "ばっくえんどAPIえんどぽいんと",
+        "ja_typings": [
+          "bakkuendoapiendopointo"
+        ]
+      },
+      {
+        "en": "browser event listener",
+        "ja": "ぶらうざーいべんとりすなー",
+        "ja_typings": [
+          "burauzaibentorisuna"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00290",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a webhook?",
+      "ja": "うぇぶふっくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "time delay before transfer begins",
+        "ja": "てんそうが始まるまでの時間遅延",
+        "ja_typings": [
+          "tensogamarumadeno",
+          "tensougamarumadeno"
+        ]
+      },
+      {
+        "en": "network throughput",
+        "ja": "ねっとわーくすいといっぷりょう",
+        "ja_typings": [
+          "nettowakusuitoippuryo",
+          "nettowakusuitoippuryou"
+        ]
+      },
+      {
+        "en": "CPU processing speed",
+        "ja": "CPUしょりそくど",
+        "ja_typings": [
+          "cpushorisokudo"
+        ]
+      },
+      {
+        "en": "disk read speed",
+        "ja": "でぃすくよみとりそくど",
+        "ja_typings": [
+          "disukuyomitorisokudo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00291",
+    "image_path": null,
+    "question_text": {
+      "en": "What is latency in computing?",
+      "ja": "けいさんきのれいてんしーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "amount of work done per unit time",
+        "ja": "たんいじかんあたりのさぎょうりょう",
+        "ja_typings": [
+          "tanijikanatarinosagyoryo",
+          "tanijikanatarinosagyouryou"
+        ]
+      },
+      {
+        "en": "time to process one task",
+        "ja": "いちさぎょうのしょりじかん",
+        "ja_typings": [
+          "ichisagyonoshorijikan",
+          "ichisagyounoshorijikan"
+        ]
+      },
+      {
+        "en": "memory bandwidth",
+        "ja": "めもりたいいき",
+        "ja_typings": [
+          "memoritaiiki"
+        ]
+      },
+      {
+        "en": "disk capacity",
+        "ja": "でぃすくようりょう",
+        "ja_typings": [
+          "disukuyoryo",
+          "disukuyouryou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q00292",
+    "image_path": null,
+    "question_text": {
+      "en": "What is throughput in computing?",
+      "ja": "けいさんきのすいとうっぷりょうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Application Programming Interface",
+        "ja": "あぷりけーしょんぷろぐらみんぐいんたーふぇーす",
+        "ja_typings": [
+          "apurikeshonpuroguraminguintafesu"
+        ]
+      },
+      {
+        "en": "Advanced Protocol Integration",
+        "ja": "こうきゅうぷろとこるとうごう",
+        "ja_typings": [
+          "kokyuupurotokorutogo",
+          "koukyuupurotokorutougou"
+        ]
+      },
+      {
+        "en": "Automated Process Interface",
+        "ja": "じどうぷろせすいんたーふぇーす",
+        "ja_typings": [
+          "jidopurosesuintafesu",
+          "jidoupurosesuintafesu"
+        ]
+      },
+      {
+        "en": "Application Protocol Index",
+        "ja": "あぷりけーしょんぷろとこるいんでくす",
+        "ja_typings": [
+          "apurikeshonpurotokoruindekusu"
         ]
       }
     ],
     "correct_answer_index": 0,
     "genre": "it_terminology",
-    "id": "q00046",
+    "id": "q00293",
     "image_path": null,
     "question_text": {
-      "en": "What is OAuth used for?",
-      "ja": "OAuthはなににつかう?"
+      "en": "What does API stand for?",
+      "ja": "APIのりゃくごのいみは？"
     }
   },
   {
     "choices": [
       {
-        "en": "Google",
-        "ja": "Google",
+        "en": "Uniform Resource Locator",
+        "ja": "とういつりそーすいちしかし",
         "ja_typings": [
-          "google"
+          "toitsurisosuichishikashi",
+          "touitsurisosuichishikashi"
         ]
       },
       {
-        "en": "Microsoft",
-        "ja": "Microsoft",
+        "en": "Universal Request Link",
+        "ja": "はんようりくえすとりんく",
         "ja_typings": [
-          "microsoft"
+          "hanyorikuesutorinku",
+          "hanyourikuesutorinku"
         ]
       },
       {
-        "en": "Apple",
-        "ja": "Apple",
+        "en": "Unified Route Label",
+        "ja": "とういつるーとらべる",
         "ja_typings": [
-          "apple"
+          "toitsurutoraberu",
+          "touitsurutoraberu"
         ]
       },
       {
-        "en": "Amazon",
-        "ja": "Amazon",
+        "en": "User Resource Library",
+        "ja": "ゆーざーりそーすらいぶらり",
         "ja_typings": [
-          "amazon"
+          "yuzarisosuraiburari"
         ]
       }
     ],
-    "correct_answer_index": 2,
-    "genre": "programming",
-    "id": "q00047",
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00294",
     "image_path": null,
     "question_text": {
-      "en": "Which company developed Swift?",
-      "ja": "Swiftはどこのかいしゃがかいはつ?"
+      "en": "What does URL stand for?",
+      "ja": "URLのりゃくごのいみは？"
     }
   },
   {
     "choices": [
       {
-        "en": "Technology",
-        "ja": "Technology",
+        "en": "Integrated Development Environment",
+        "ja": "とうごうかいはつかんきょう",
         "ja_typings": [
-          "technology"
+          "togokaihatsukankyo",
+          "tougoukaihatsukankyou"
         ]
       },
       {
-        "en": "Things",
-        "ja": "Things",
+        "en": "Internal Debug Engine",
+        "ja": "ないぶでばっぐえんじん",
         "ja_typings": [
-          "things"
+          "naibudebagguenjin"
         ]
       },
       {
-        "en": "Transfer",
-        "ja": "Transfer",
+        "en": "Interface Design Element",
+        "ja": "いんたーふぇーすせっけいようそ",
         "ja_typings": [
-          "transfer"
+          "intafesusekkeiyoso",
+          "intafesusekkeiyouso"
         ]
       },
       {
-        "en": "Terminal",
-        "ja": "Terminal",
+        "en": "Iterative Deployment Engine",
+        "ja": "はんぷくはいひえんじん",
         "ja_typings": [
-          "terminal"
+          "hanpukuhaihienjin"
         ]
       }
     ],
-    "correct_answer_index": 1,
-    "genre": "technology",
-    "id": "q00048",
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00295",
     "image_path": null,
     "question_text": {
-      "en": "What does the 'T' in IoT stand for?",
-      "ja": "IoTのTはなにをいみする?"
+      "en": "What does IDE stand for?",
+      "ja": "IDEのりゃくごのいみは？"
     }
   },
   {
     "choices": [
       {
-        "en": "Vue",
-        "ja": "Vue",
+        "en": "Object-Relational Mapping",
+        "ja": "おぶじぇくとかんけいしゃぞう",
         "ja_typings": [
-          "vue"
+          "obujekutokankeishazo",
+          "obujekutokankeishazou"
         ]
       },
       {
-        "en": "React",
-        "ja": "React",
+        "en": "Open Resource Management",
+        "ja": "おーぷんりそーすかんり",
         "ja_typings": [
-          "react"
+          "opunrisosukanri"
         ]
       },
       {
-        "en": "Angular",
-        "ja": "Angular",
+        "en": "Optimized Request Module",
+        "ja": "さいてきかりくえすともじゅーる",
         "ja_typings": [
-          "angular"
+          "saitekikarikuesutomojuru"
         ]
       },
       {
-        "en": "Svelte",
-        "ja": "Svelte",
+        "en": "Output Response Model",
+        "ja": "しゅつりょくおうとうもでる",
         "ja_typings": [
-          "svelte"
+          "shutsuryokuotomoderu",
+          "shutsuryokuoutoumoderu"
         ]
       }
     ],
-    "correct_answer_index": 1,
-    "genre": "web_development",
-    "id": "q00049",
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00296",
     "image_path": null,
     "question_text": {
-      "en": "What is Next.js based on?",
-      "ja": "Next.jsのべーすになっているのは?"
+      "en": "What does ORM stand for?",
+      "ja": "ORMのりゃくごのいみは？"
     }
   },
   {
     "choices": [
       {
-        "en": "New code",
-        "ja": "あたらしいこーど",
+        "en": "Model View Controller",
+        "ja": "もでるびゅーこんとろーらー",
         "ja_typings": [
-          "atarashiikodo"
+          "moderubyukontorora"
         ]
       },
       {
-        "en": "Old code",
-        "ja": "ふるいこーど",
+        "en": "Main Version Code",
+        "ja": "めいんばーじょんこーど",
         "ja_typings": [
-          "furuikodo"
+          "meinbajonkodo"
         ]
       },
       {
-        "en": "Test code",
-        "ja": "てすとこーど",
+        "en": "Mobile View Component",
+        "ja": "もばいるびゅーこんぽーねんと",
         "ja_typings": [
-          "tesutokodo"
+          "mobairubyukonponento"
         ]
       },
       {
-        "en": "Sample code",
-        "ja": "さんぷるこーど",
+        "en": "Multi Value Cache",
+        "ja": "たちかんりきゃっしゅ",
         "ja_typings": [
-          "sanpurukodo"
+          "tachikanrikyasshu"
         ]
       }
     ],
-    "correct_answer_index": 1,
-    "genre": "programming",
-    "id": "q00050",
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00297",
     "image_path": null,
     "question_text": {
-      "en": "What does legacy code mean?",
-      "ja": "れがしーこーどのいみは?"
+      "en": "What does MVC stand for?",
+      "ja": "MVCのりゃくごのいみは？"
     }
   },
   {
     "choices": [
-    {
-      "en": "Eren Yeager",
-      "ja": "エレン・イェーガー",
-      "ja_typings": [
-        "eren yega",
-        "eren yeager"
-      ]
-    },
-    {
-      "en": "Levi",
-      "ja": "リヴァイ",
-      "ja_typings": [
-        "rivai",
-        "levi"
-      ]
-    },
       {
-        "en": "Mikasa",
-        "ja": "ミカサ",
+        "en": "Software as a Service",
+        "ja": "さーびすとしてのそふとうぇあ",
         "ja_typings": [
-          "mikasa"
+          "sabisutoshitenosofutowea"
         ]
       },
-    {
-      "en": "Armin",
-      "ja": "アルミン",
-      "ja_typings": [
-        "arumin",
-        "armin"
-      ]
+      {
+        "en": "Security as a System",
+        "ja": "しすてむとしてのせきゅりてぃ",
+        "ja_typings": [
+          "shisutemutoshitenosekyuriti"
+        ]
+      },
+      {
+        "en": "Storage and a Server",
+        "ja": "すとれーじとさーばー",
+        "ja_typings": [
+          "sutorejitosaba"
+        ]
+      },
+      {
+        "en": "Scalable API Service",
+        "ja": "すけーらぶるAPIさーびす",
+        "ja_typings": [
+          "sukeraburuapisabisu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00298",
+    "image_path": null,
+    "question_text": {
+      "en": "What does SaaS stand for?",
+      "ja": "SaaSのりゃくごのいみは？"
     }
+  },
+  {
+    "choices": [
+      {
+        "en": "Infrastructure as a Service",
+        "ja": "さーびすとしてのきばん",
+        "ja_typings": [
+          "sabisutoshitenokiban"
+        ]
+      },
+      {
+        "en": "Integration and a System",
+        "ja": "とうごうとしすてむ",
+        "ja_typings": [
+          "togotoshisutemu",
+          "tougoutoshisutemu"
+        ]
+      },
+      {
+        "en": "Interface as a Standard",
+        "ja": "きじゅんとしてのいんたーふぇーす",
+        "ja_typings": [
+          "kijuntoshitenointafesu"
+        ]
+      },
+      {
+        "en": "Identity and a Server",
+        "ja": "しきべつとさーばー",
+        "ja_typings": [
+          "shikibetsutosaba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00299",
+    "image_path": null,
+    "question_text": {
+      "en": "What does IaaS stand for?",
+      "ja": "IaaSのりゃくごのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Platform as a Service",
+        "ja": "さーびすとしてのぷらっとふぉーむ",
+        "ja_typings": [
+          "sabisutoshitenopurattofomu"
+        ]
+      },
+      {
+        "en": "Privacy and a System",
+        "ja": "ぷらいばしーとしすてむ",
+        "ja_typings": [
+          "puraibashitoshisutemu"
+        ]
+      },
+      {
+        "en": "Process as a Service",
+        "ja": "さーびすとしてのぷろせす",
+        "ja_typings": [
+          "sabisutoshitenopurosesu"
+        ]
+      },
+      {
+        "en": "Package as a Server",
+        "ja": "さーばーとしてのぱっけーじ",
+        "ja_typings": [
+          "sabatoshitenopakkeji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00300",
+    "image_path": null,
+    "question_text": {
+      "en": "What does PaaS stand for?",
+      "ja": "PaaSのりゃくごのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Create Read Update Delete",
+        "ja": "さくせいよみこうしんさくじょ",
+        "ja_typings": [
+          "sakuseiyomikoshinsakujo",
+          "sakuseiyomikoushinsakujo"
+        ]
+      },
+      {
+        "en": "Copy Refresh Update Deploy",
+        "ja": "こぴーこうしんはいひ",
+        "ja_typings": [
+          "kopikoshinhaihi",
+          "kopikoushinhaihi"
+        ]
+      },
+      {
+        "en": "Cache Read Update Delete",
+        "ja": "きゃっしゅよみこうしんさくじょ",
+        "ja_typings": [
+          "kyasshuyomikoshinsakujo",
+          "kyasshuyomikoushinsakujo"
+        ]
+      },
+      {
+        "en": "Create Run Update Dump",
+        "ja": "さくせいじっこうこうしんだんぷ",
+        "ja_typings": [
+          "sakuseijikkokoshindanpu",
+          "sakuseijikkoukoushindanpu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00301",
+    "image_path": null,
+    "question_text": {
+      "en": "What does CRUD stand for?",
+      "ja": "CRUDのりゃくごのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Object-Oriented Programming",
+        "ja": "おぶじぇくとしこうぷろぐらみんぐ",
+        "ja_typings": [
+          "obujekutoshikopuroguramingu",
+          "obujekutoshikoupuroguramingu"
+        ]
+      },
+      {
+        "en": "Open Operation Protocol",
+        "ja": "おーぷんそうさぷろとこる",
+        "ja_typings": [
+          "opunsosapurotokoru",
+          "opunsousapurotokoru"
+        ]
+      },
+      {
+        "en": "Ordered Output Process",
+        "ja": "じゅんじょつきしゅつりょくぷろせす",
+        "ja_typings": [
+          "junjotsukishutsuryokupurosesu"
+        ]
+      },
+      {
+        "en": "Object Output Port",
+        "ja": "おぶじぇくとしゅつりょくぽーと",
+        "ja_typings": [
+          "obujekutoshutsuryokupoto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00302",
+    "image_path": null,
+    "question_text": {
+      "en": "What does OOP stand for?",
+      "ja": "OOPのりゃくごのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Command Line Interface",
+        "ja": "こまんどらいんいんたーふぇーす",
+        "ja_typings": [
+          "komandorainintafesu"
+        ]
+      },
+      {
+        "en": "Client Logic Integration",
+        "ja": "くらいあんとろじっくとうごう",
+        "ja_typings": [
+          "kuraiantorojikkutogo",
+          "kuraiantorojikkutougou"
+        ]
+      },
+      {
+        "en": "Core Library Index",
+        "ja": "こあらいぶらりいんでくす",
+        "ja_typings": [
+          "koaraiburariindekusu"
+        ]
+      },
+      {
+        "en": "Compiled Language Input",
+        "ja": "こんぱいるでごにゅうりょく",
+        "ja_typings": [
+          "konpairudegonyuuryoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00303",
+    "image_path": null,
+    "question_text": {
+      "en": "What does CLI stand for?",
+      "ja": "CLIのりゃくごのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Graphical User Interface",
+        "ja": "ぐらふぃかるゆーざーいんたーふぇーす",
+        "ja_typings": [
+          "gurafikaruyuzaintafesu"
+        ]
+      },
+      {
+        "en": "General Utility Index",
+        "ja": "はんようゆーてぃりてぃいんでくす",
+        "ja_typings": [
+          "hanyoyutiritiindekusu",
+          "hanyouyutiritiindekusu"
+        ]
+      },
+      {
+        "en": "Global Update Interface",
+        "ja": "ぐろーばるこうしんいんたーふぇーす",
+        "ja_typings": [
+          "gurobarukoshinintafesu",
+          "gurobarukoushinintafesu"
+        ]
+      },
+      {
+        "en": "Grid UI Integration",
+        "ja": "ぐりっどUIとうごう",
+        "ja_typings": [
+          "guriddoitogo",
+          "guriddouitougou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00304",
+    "image_path": null,
+    "question_text": {
+      "en": "What does GUI stand for?",
+      "ja": "GUIのりゃくごのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Software Development Kit",
+        "ja": "そふとうぇあかいはつきっと",
+        "ja_typings": [
+          "sofutoweakaihatsukitto"
+        ]
+      },
+      {
+        "en": "Secure Data Key",
+        "ja": "あんぜんなでーたきー",
+        "ja_typings": [
+          "anzennadetaki"
+        ]
+      },
+      {
+        "en": "System Deployment Kit",
+        "ja": "しすてむはいひきっと",
+        "ja_typings": [
+          "shisutemuhaihikitto"
+        ]
+      },
+      {
+        "en": "Service Discovery Key",
+        "ja": "さーびすはっけんきー",
+        "ja_typings": [
+          "sabisuhakkenki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00305",
+    "image_path": null,
+    "question_text": {
+      "en": "What does SDK stand for?",
+      "ja": "SDKのりゃくごのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "End of File",
+        "ja": "ふぁいるのおわり",
+        "ja_typings": [
+          "fairunowari",
+          "fairunoowari"
+        ]
+      },
+      {
+        "en": "Error on Function",
+        "ja": "かんすうのえらー",
+        "ja_typings": [
+          "kansuunoera"
+        ]
+      },
+      {
+        "en": "Execute Other Function",
+        "ja": "べつのかんすうをじっこう",
+        "ja_typings": [
+          "betsunokansuuojikko",
+          "betsunokansuuojikkou"
+        ]
+      },
+      {
+        "en": "Event on Failure",
+        "ja": "しっぱいのいべんと",
+        "ja_typings": [
+          "shippainoibento"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00306",
+    "image_path": null,
+    "question_text": {
+      "en": "What does EOF stand for in programming?",
+      "ja": "ぷろぐらみんぐのEOFのりゃくごのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "true/false data type",
+        "ja": "しんぎゃくのでーたがた",
+        "ja_typings": [
+          "shingyakunodetagata"
+        ]
+      },
+      {
+        "en": "integer type",
+        "ja": "せいすうがた",
+        "ja_typings": [
+          "seisuugata"
+        ]
+      },
+      {
+        "en": "string type",
+        "ja": "もじれつがた",
+        "ja_typings": [
+          "mojiretsugata"
+        ]
+      },
+      {
+        "en": "array type",
+        "ja": "はいれつがた",
+        "ja_typings": [
+          "hairetsugata"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00307",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a boolean?",
+      "ja": "ぶーりあんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "absence of a value",
+        "ja": "ちが存在しないこと",
+        "ja_typings": [
+          "chigashinaikoto"
+        ]
+      },
+      {
+        "en": "zero integer",
+        "ja": "ゼロのせいすう",
+        "ja_typings": [
+          "zeronoseisuu"
+        ]
+      },
+      {
+        "en": "empty string",
+        "ja": "くうのもじれつ",
+        "ja_typings": [
+          "kuunomojiretsu"
+        ]
+      },
+      {
+        "en": "false boolean",
+        "ja": "falseのぶーりあん",
+        "ja_typings": [
+          "falsenoburian"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00308",
+    "image_path": null,
+    "question_text": {
+      "en": "What is null?",
+      "ja": "nullとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "variable declared but not assigned",
+        "ja": "せんげんされたがだいにゅうされていないへんすう",
+        "ja_typings": [
+          "sengensaretagadainyuusareteinaihensuu"
+        ]
+      },
+      {
+        "en": "null value",
+        "ja": "nullのち",
+        "ja_typings": [
+          "nullnochi"
+        ]
+      },
+      {
+        "en": "false value",
+        "ja": "falseのち",
+        "ja_typings": [
+          "falsenochi"
+        ]
+      },
+      {
+        "en": "zero value",
+        "ja": "ぜろのち",
+        "ja_typings": [
+          "zeronochi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00309",
+    "image_path": null,
+    "question_text": {
+      "en": "What is undefined in JavaScript?",
+      "ja": "JavaScriptのundefinedとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "converting a value to another type",
+        "ja": "ちをべつのかたにへんかん",
+        "ja_typings": [
+          "chiobetsunokatanihenkan"
+        ]
+      },
+      {
+        "en": "checking if types match",
+        "ja": "かたがいっちするかかくにん",
+        "ja_typings": [
+          "katagaitchisurukakakunin"
+        ]
+      },
+      {
+        "en": "declaring a new type",
+        "ja": "あたらしいかたをせんげん",
+        "ja_typings": [
+          "atarashiikataosengen"
+        ]
+      },
+      {
+        "en": "deleting a variable type",
+        "ja": "へんすうのかたをさくじょ",
+        "ja_typings": [
+          "hensuunokataosakujo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00310",
+    "image_path": null,
+    "question_text": {
+      "en": "What is type casting?",
+      "ja": "かたへんかんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "container preventing name conflicts",
+        "ja": "なまえのしょうとつをふせぐこんてな",
+        "ja_typings": [
+          "namaenoshototsuofusegukontena",
+          "namaenoshoutotsuofusegukontena"
+        ]
+      },
+      {
+        "en": "network address space",
+        "ja": "ねっとわーくあどれすくうかん",
+        "ja_typings": [
+          "nettowakuadoresukuukan"
+        ]
+      },
+      {
+        "en": "database schema",
+        "ja": "でーたべーすすきーま",
+        "ja_typings": [
+          "detabesusukima"
+        ]
+      },
+      {
+        "en": "variable scope",
+        "ja": "へんすうのすこーぷ",
+        "ja_typings": [
+          "hensuunosukopu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00311",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a namespace?",
+      "ja": "なめすぺーすとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "set of named constants",
+        "ja": "なまえつきていすうのあつまり",
+        "ja_typings": [
+          "namaetsukiteisuunoatsumari"
+        ]
+      },
+      {
+        "en": "dynamic array",
+        "ja": "どうてきはいれつ",
+        "ja_typings": [
+          "dotekihairetsu",
+          "doutekihairetsu"
+        ]
+      },
+      {
+        "en": "error number type",
+        "ja": "えらーばんごうがた",
+        "ja_typings": [
+          "erabangogata",
+          "erabangougata"
+        ]
+      },
+      {
+        "en": "network enumeration",
+        "ja": "ねっとわーくれっきょ",
+        "ja_typings": [
+          "nettowakurekkyo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00312",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an enum?",
+      "ja": "えぬむとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "custom data type grouping fields",
+        "ja": "ふぃーるどをまとめたかすたむでーたがた",
+        "ja_typings": [
+          "firudomatometakasutamudetagata",
+          "firudoomatometakasutamudetagata"
+        ]
+      },
+      {
+        "en": "built-in array type",
+        "ja": "そなわったはいれつがた",
+        "ja_typings": [
+          "sonawattahairetsugata"
+        ]
+      },
+      {
+        "en": "function signature",
+        "ja": "かんすうのしぐにちゃ",
+        "ja_typings": [
+          "kansuunoshigunicha"
+        ]
+      },
+      {
+        "en": "class without methods",
+        "ja": "めそっどなしのくらす",
+        "ja_typings": [
+          "mesoddonashinokurasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00313",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a struct?",
+      "ja": "すとらくととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "prints formatted output",
+        "ja": "しょしきつきしゅつりょく",
+        "ja_typings": [
+          "shoshikitsukishutsuryoku"
+        ]
+      },
+      {
+        "en": "reads formatted input",
+        "ja": "しょしきつきにゅうりょくよみこみ",
+        "ja_typings": [
+          "shoshikitsukinyuuryokuyomikomi"
+        ]
+      },
+      {
+        "en": "allocates memory",
+        "ja": "めもりをかくほ",
+        "ja_typings": [
+          "memoriokakuho"
+        ]
+      },
+      {
+        "en": "defines format string",
+        "ja": "しょしきもじれつをていぎ",
+        "ja_typings": [
+          "shoshikimojiretsuoteigi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00314",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `printf` do in C?",
+      "ja": "Cの`printf`は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "variable storing memory address",
+        "ja": "めもりあどれすをほぞんするへんすう",
+        "ja_typings": [
+          "memoriadoresuohozonsuruhensuu"
+        ]
+      },
+      {
+        "en": "index into an array",
+        "ja": "はいれつのいんでくす",
+        "ja_typings": [
+          "hairetsunoindekusu"
+        ]
+      },
+      {
+        "en": "reference to a function",
+        "ja": "かんすうのさんしょう",
+        "ja_typings": [
+          "kansuunosansho",
+          "kansuunosanshou"
+        ]
+      },
+      {
+        "en": "null value",
+        "ja": "nullのち",
+        "ja_typings": [
+          "nullnochi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00315",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a pointer in C?",
+      "ja": "Cのぽいんたーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "includes a header file",
+        "ja": "へっだーふぁいるをとりこむ",
+        "ja_typings": [
+          "heddafairuotorikomu"
+        ]
+      },
+      {
+        "en": "defines a macro",
+        "ja": "まくろをていぎ",
+        "ja_typings": [
+          "makuroteigi",
+          "makurooteigi"
+        ]
+      },
+      {
+        "en": "starts a comment",
+        "ja": "こめんとをかいし",
+        "ja_typings": [
+          "komentokaishi",
+          "komentookaishi"
+        ]
+      },
+      {
+        "en": "imports a library",
+        "ja": "らいぶらりをいんぽーと",
+        "ja_typings": [
+          "raiburarioinpoto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00316",
+    "image_path": null,
+    "question_text": {
+      "en": "What does `#include` do in C?",
+      "ja": "Cの`#include`は何をするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "error before program runs",
+        "ja": "ぷろぐらむじっこうまえのえらー",
+        "ja_typings": [
+          "puroguramujikkomaenoera",
+          "puroguramujikkoumaenoera"
+        ]
+      },
+      {
+        "en": "error during execution",
+        "ja": "じっこうちゅうのえらー",
+        "ja_typings": [
+          "jikkochuunoera",
+          "jikkouchuunoera"
+        ]
+      },
+      {
+        "en": "error in test code",
+        "ja": "てすとこーどのえらー",
+        "ja_typings": [
+          "tesutokodonoera"
+        ]
+      },
+      {
+        "en": "error in database",
+        "ja": "でーたべーすのえらー",
+        "ja_typings": [
+          "detabesunoera"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00317",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a compile error?",
+      "ja": "かんぱいるえらーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "error during program execution",
+        "ja": "ぷろぐらむじっこうちゅうのえらー",
+        "ja_typings": [
+          "puroguramujikkochuunoera",
+          "puroguramujikkouchuunoera"
+        ]
+      },
+      {
+        "en": "error before compilation",
+        "ja": "かんぱいるまえのえらー",
+        "ja_typings": [
+          "kanpairumaenoera"
+        ]
+      },
+      {
+        "en": "error in source code format",
+        "ja": "そーすこーどけいしきのえらー",
+        "ja_typings": [
+          "sosukodokeishikinoera"
+        ]
+      },
+      {
+        "en": "error in test output",
+        "ja": "てすとしゅつりょくのえらー",
+        "ja_typings": [
+          "tesutoshutsuryokunoera"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00318",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a runtime error?",
+      "ja": "じっこうじえらーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "program runs but produces wrong results",
+        "ja": "じっこうはするが結果がまちがい",
+        "ja_typings": [
+          "jikkohasurugagamachigai",
+          "jikkouhasurugagamachigai"
+        ]
+      },
+      {
+        "en": "program fails to compile",
+        "ja": "かんぱいるに失敗",
+        "ja_typings": [
+          "kanpairuni"
+        ]
+      },
+      {
+        "en": "program crashes at runtime",
+        "ja": "じっこうちゅうにくらっしゅ",
+        "ja_typings": [
+          "jikkochuunikurasshu",
+          "jikkouchuunikurasshu"
+        ]
+      },
+      {
+        "en": "program has syntax error",
+        "ja": "こうもんえらーがある",
+        "ja_typings": [
+          "komoneragaaru",
+          "koumoneragaaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00319",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a logic error?",
+      "ja": "ろじっくえらーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "standard input stream",
+        "ja": "ひょうじゅんにゅうりょくすとりーむ",
+        "ja_typings": [
+          "hyojunnyuuryokusutorimu",
+          "hyoujunnyuuryokusutorimu"
+        ]
+      },
+      {
+        "en": "static input definition",
+        "ja": "せいてきにゅうりょくていぎ",
+        "ja_typings": [
+          "seitekinyuuryokuteigi"
+        ]
+      },
+      {
+        "en": "string input module",
+        "ja": "もじれつにゅうりょくもじゅーる",
+        "ja_typings": [
+          "mojiretsunyuuryokumojuru"
+        ]
+      },
+      {
+        "en": "system info node",
+        "ja": "しすてむじょうほうのーど",
+        "ja_typings": [
+          "shisutemujohonodo",
+          "shisutemujouhounodo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00320",
+    "image_path": null,
+    "question_text": {
+      "en": "What is `stdin`?",
+      "ja": "`stdin`とは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "standard output stream",
+        "ja": "ひょうじゅんしゅつりょくすとりーむ",
+        "ja_typings": [
+          "hyojunshutsuryokusutorimu",
+          "hyoujunshutsuryokusutorimu"
+        ]
+      },
+      {
+        "en": "static output definition",
+        "ja": "せいてきしゅつりょくていぎ",
+        "ja_typings": [
+          "seitekishutsuryokuteigi"
+        ]
+      },
+      {
+        "en": "string output module",
+        "ja": "もじれつしゅつりょくもじゅーる",
+        "ja_typings": [
+          "mojiretsushutsuryokumojuru"
+        ]
+      },
+      {
+        "en": "system traffic output",
+        "ja": "しすてむつうしんしゅつりょく",
+        "ja_typings": [
+          "shisutemutsuushinshutsuryoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00321",
+    "image_path": null,
+    "question_text": {
+      "en": "What is `stdout`?",
+      "ja": "`stdout`とは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "standard error stream",
+        "ja": "ひょうじゅんえらーすとりーむ",
+        "ja_typings": [
+          "hyojunerasutorimu",
+          "hyoujunerasutorimu"
+        ]
+      },
+      {
+        "en": "static error report",
+        "ja": "せいてきえらーほうこく",
+        "ja_typings": [
+          "seitekierahokoku",
+          "seitekierahoukoku"
+        ]
+      },
+      {
+        "en": "string error module",
+        "ja": "もじれつえらーもじゅーる",
+        "ja_typings": [
+          "mojiretsueramojuru"
+        ]
+      },
+      {
+        "en": "system task error",
+        "ja": "しすてむたすくえらー",
+        "ja_typings": [
+          "shisutemutasukuera"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00322",
+    "image_path": null,
+    "question_text": {
+      "en": "What is `stderr`?",
+      "ja": "`stderr`とは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "named storage location for data",
+        "ja": "でーたのなまえつきほぞんばしょ",
+        "ja_typings": [
+          "detanonamaetsukihozonbasho"
+        ]
+      },
+      {
+        "en": "fixed constant value",
+        "ja": "こていのていすうち",
+        "ja_typings": [
+          "koteinoteisuuchi"
+        ]
+      },
+      {
+        "en": "function parameter",
+        "ja": "かんすうぱらめーた",
+        "ja_typings": [
+          "kansuuparameta"
+        ]
+      },
+      {
+        "en": "loop counter",
+        "ja": "るーぷかうんたー",
+        "ja_typings": [
+          "rupukaunta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00323",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a variable?",
+      "ja": "へんすうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "value that cannot change",
+        "ja": "かえられないち",
+        "ja_typings": [
+          "kaerarenaichi"
+        ]
+      },
+      {
+        "en": "variable with fixed type",
+        "ja": "かたこていのへんすう",
+        "ja_typings": [
+          "katakoteinohensuu"
+        ]
+      },
+      {
+        "en": "loop limit value",
+        "ja": "るーぷのかぎりち",
+        "ja_typings": [
+          "rupunokagirichi"
+        ]
+      },
+      {
+        "en": "function return value",
+        "ja": "かんすうのもどりち",
+        "ja_typings": [
+          "kansuunomodorichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00324",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a constant?",
+      "ja": "ていすうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "order in which operators are evaluated",
+        "ja": "えんざんしがひょうかされるじゅん",
+        "ja_typings": [
+          "enzanshigahyokasarerujun",
+          "enzanshigahyoukasarerujun"
+        ]
+      },
+      {
+        "en": "strength of an operator",
+        "ja": "えんざんしのちから",
+        "ja_typings": [
+          "enzanshinochikara"
+        ]
+      },
+      {
+        "en": "number of operands required",
+        "ja": "ひつようなオペランドのかず",
+        "ja_typings": [
+          "hitsuyonaoperandonokazu",
+          "hitsuyounaoperandonokazu"
+        ]
+      },
+      {
+        "en": "speed of operator execution",
+        "ja": "えんざんしじっこうのそくど",
+        "ja_typings": [
+          "enzanshijikkonosokudo",
+          "enzanshijikkounosokudo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00325",
+    "image_path": null,
+    "question_text": {
+      "en": "What is operator precedence?",
+      "ja": "えんざんしのゆうせんじゅんいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "stopping evaluation when result is determined",
+        "ja": "けっかがきまるとひょうかをとめる",
+        "ja_typings": [
+          "kekkagakimarutohyokaotomeru",
+          "kekkagakimarutohyoukaotomeru"
+        ]
+      },
+      {
+        "en": "fast execution optimization",
+        "ja": "こうそくじっこうのさいてきか",
+        "ja_typings": [
+          "kosokujikkonosaitekika",
+          "kousokujikkounosaitekika"
+        ]
+      },
+      {
+        "en": "evaluating only one operand",
+        "ja": "いちオペランドのみひょうか",
+        "ja_typings": [
+          "ichioperandonomihyoka",
+          "ichioperandonomihyouka"
+        ]
+      },
+      {
+        "en": "ignoring second operand always",
+        "ja": "つねにだいにオペランドをむし",
+        "ja_typings": [
+          "tsunenidainioperandomushi",
+          "tsunenidainioperandoomushi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00326",
+    "image_path": null,
+    "question_text": {
+      "en": "What is short-circuit evaluation?",
+      "ja": "たんらくひょうかとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "condition ? value_if_true : value_if_false",
+        "ja": "じょうけん?しんのち:ぎのち",
+        "ja_typings": [
+          "joken shinnochi ginochi",
+          "jouken shinnochi ginochi"
+        ]
+      },
+      {
+        "en": "operator with three operands only",
+        "ja": "さんつのオペランドのみのえんざんし",
+        "ja_typings": [
+          "santsunoperandonominoenzanshi",
+          "santsunooperandonominoenzanshi"
+        ]
+      },
+      {
+        "en": "third operator in expression",
+        "ja": "しきのさんばんめのえんざんし",
+        "ja_typings": [
+          "shikinosanbanmenoenzanshi"
+        ]
+      },
+      {
+        "en": "triple assignment operator",
+        "ja": "みっつだいにゅうえんざんし",
+        "ja_typings": [
+          "mittsudainyuuenzanshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00327",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a ternary operator?",
+      "ja": "さんこうえんざんしとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Death Note",
+        "ja": "でーすのーと",
+        "ja_typings": [
+          "desunoto"
+        ]
+      },
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": [
+          "burichi"
+        ]
+      },
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": [
+          "naruto"
+        ]
+      },
+      {
+        "en": "One Piece",
+        "ja": "わんぴーす",
+        "ja_typings": [
+          "wanpisu"
+        ]
+      }
     ],
     "correct_answer_index": 0,
     "genre": "anime",
-    "id": "q00051",
+    "id": "q00328",
     "image_path": null,
     "question_text": {
-      "en": "Who is the protagonist of 'Attack on Titan'?",
-      "ja": "「しんげきのきょじん」のしゅじんこうは?"
+      "en": "Which anime features a boy who gains power from a Death Note?",
+      "ja": "しのちょうからちからをえる少年のアニメは？"
     }
   },
   {
     "choices": [
       {
-        "en": "Fire",
-        "ja": "ほのお",
+        "en": "Naruto Uzumaki",
+        "ja": "うずまきなると",
         "ja_typings": [
-          "hono",
-          "honoo"
+          "uzumakinaruto"
         ]
       },
       {
-        "en": "Grass",
-        "ja": "くさ",
+        "en": "Sasuke Uchiha",
+        "ja": "うちはさすけ",
         "ja_typings": [
-          "kusa"
+          "uchihasasuke"
         ]
       },
       {
-        "en": "Ground",
-        "ja": "じめん",
+        "en": "Sakura Haruno",
+        "ja": "はるのさくら",
         "ja_typings": [
-          "jimen"
+          "harunosakura"
         ]
       },
       {
-        "en": "Flying",
+        "en": "Kakashi Hatake",
+        "ja": "はたけかかし",
+        "ja_typings": [
+          "hatakekakashi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00329",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the name of the protagonist in Naruto?",
+      "ja": "Narutoのしゅじんこうのなまえは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Attack on Titan",
+        "ja": "しんげきのきょじん",
+        "ja_typings": [
+          "shingekinokyojin"
+        ]
+      },
+      {
+        "en": "Fullmetal Alchemist",
+        "ja": "はがねのれんきんじゅつし",
+        "ja_typings": [
+          "haganenorenkinjutsushi"
+        ]
+      },
+      {
+        "en": "Dragon Ball Z",
+        "ja": "どらごんぼーるぜっと",
+        "ja_typings": [
+          "doragonboruzetto"
+        ]
+      },
+      {
+        "en": "Sword Art Online",
+        "ja": "そーどあーとおんらいん",
+        "ja_typings": [
+          "sodoatonrain",
+          "sodoatoonrain"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00330",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is set in a world where humans live inside walls to avoid Titans?",
+      "ja": "きょじんからのがれるためにかべのなかでくらすせかいのアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Spirited Away",
+        "ja": "せんとちひろのかみかくし",
+        "ja_typings": [
+          "sentochihironokamikakushi"
+        ]
+      },
+      {
+        "en": "My Neighbor Totoro",
+        "ja": "となりのトトロ",
+        "ja_typings": [
+          "tonarinototoro"
+        ]
+      },
+      {
+        "en": "Princess Mononoke",
+        "ja": "もののけひめ",
+        "ja_typings": [
+          "mononokehime"
+        ]
+      },
+      {
+        "en": "Howl's Moving Castle",
+        "ja": "ハウルのうごくしろ",
+        "ja_typings": [
+          "haurunogokushiro",
+          "haurunougokushiro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00331",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Studio Ghibli film features a girl who works in a bathhouse for spirits?",
+      "ja": "せいれいのゆやではたらくしょうじょのスタジオジブリえいがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "one punch defeats any enemy",
+        "ja": "いちげきですべてのてきをたおす",
+        "ja_typings": [
+          "ichigekidesubetenotekiotaosu"
+        ]
+      },
+      {
+        "en": "super speed",
+        "ja": "ちょうそくど",
+        "ja_typings": [
+          "chosokudo",
+          "chousokudo"
+        ]
+      },
+      {
+        "en": "flight",
         "ja": "ひこう",
         "ja_typings": [
           "hiko",
           "hikou"
         ]
-      }
-    ],
-    "correct_answer_index": 1,
-    "genre": "game",
-    "id": "q00052",
-    "image_path": null,
-    "question_text": {
-      "en": "Which Pokemon type is strong against Water?",
-      "ja": "ポケモンのタイプでみずにつよいのは?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "Pirate King",
-        "ja": "かいぞくおう",
-        "ja_typings": [
-          "kaizokuo",
-          "kaizokuou"
-        ]
       },
       {
-        "en": "Marine Admiral",
-        "ja": "ほかいし",
+        "en": "telepathy",
+        "ja": "てれぱしー",
         "ja_typings": [
-          "hokaishi"
-        ]
-      },
-      {
-        "en": "Merchant",
-        "ja": "しょうにん",
-        "ja_typings": [
-          "shonin",
-          "shounin"
-        ]
-      },
-      {
-        "en": "Explorer",
-        "ja": "たんけんか",
-        "ja_typings": [
-          "tankenka"
-        ]
-      }
-    ],
-    "correct_answer_index": 0,
-    "genre": "manga",
-    "id": "q00053",
-    "image_path": null,
-    "question_text": {
-      "en": "What is the protagonist's dream in 'One Piece'?",
-      "ja": "「ワンピース」のしゅじんこうのゆめは?"
-    }
-  },
-  {
-    "choices": [
-    {
-      "en": "Ryuk",
-      "ja": "リューク",
-      "ja_typings": [
-        "ryuku",
-        "ryuk"
-      ]
-    },
-      {
-        "en": "Light",
-        "ja": "ライト",
-        "ja_typings": [
-          "raito"
-        ]
-      },
-    {
-      "en": "L (Lawliet)",
-      "ja": "エル（Lawliet）",
-      "ja_typings": [
-        "eru lawliet",
-        "lawliet"
-      ]
-    },
-      {
-        "en": "Misa",
-        "ja": "ミサ",
-        "ja_typings": [
-          "misa"
+          "terepashi"
         ]
       }
     ],
     "correct_answer_index": 0,
     "genre": "anime",
-    "id": "q00054",
+    "id": "q00332",
     "image_path": null,
     "question_text": {
-      "en": "What is the name of the Shinigami in 'Death Note'?",
-      "ja": "「デスノート」のしにがみのなまえは?"
+      "en": "What power does Saitama from One Punch Man have?",
+      "ja": "わんぱんまんのさいたまのちからは？"
     }
   },
   {
     "choices": [
-    {
-      "en": "Luigi",
-      "ja": "ルイージ",
-      "ja_typings": [
-        "ruiji",
-        "luigi"
-      ]
-    },
       {
-        "en": "Wario",
-        "ja": "ワリオ",
+        "en": "One Piece",
+        "ja": "わんぴーす",
         "ja_typings": [
-          "wario"
+          "wanpisu"
         ]
       },
-    {
-      "en": "Yoshi",
-      "ja": "ヨッシー",
-      "ja_typings": [
-        "yosshi",
-        "yoshi"
-      ]
-    },
-    {
-      "en": "Toad",
-      "ja": "キノピオ",
-      "ja_typings": [
-        "kinopio",
-        "toad"
-      ]
-    }
+      {
+        "en": "Fairy Tail",
+        "ja": "ふぇありーている",
+        "ja_typings": [
+          "feariteiru"
+        ]
+      },
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": [
+          "burichi"
+        ]
+      },
+      {
+        "en": "Dragon Ball",
+        "ja": "どらごんぼーる",
+        "ja_typings": [
+          "doragonboru"
+        ]
+      }
     ],
     "correct_answer_index": 0,
-    "genre": "game",
-    "id": "q00055",
+    "genre": "anime",
+    "id": "q00333",
     "image_path": null,
     "question_text": {
-      "en": "What is Mario's brother's name?",
-      "ja": "マリオのきょうだいのなまえは?"
+      "en": "Which anime features the Straw Hat Pirates?",
+      "ja": "むぎわらかいぞくだんのアニメは？"
     }
   },
   {
     "choices": [
       {
-        "en": "Kanao",
-        "ja": "カナヲ",
+        "en": "Akira Toriyama",
+        "ja": "とりやまあきら",
         "ja_typings": [
-          "kanao"
+          "toriyamaakira"
         ]
       },
+      {
+        "en": "Eiichiro Oda",
+        "ja": "おだえいいちろう",
+        "ja_typings": [
+          "odaeiichiro",
+          "odaeiichirou"
+        ]
+      },
+      {
+        "en": "Masashi Kishimoto",
+        "ja": "きしもとまさし",
+        "ja_typings": [
+          "kishimotomasashi"
+        ]
+      },
+      {
+        "en": "Tite Kubo",
+        "ja": "くぼたいと",
+        "ja_typings": [
+          "kubotaito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00334",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Dragon Ball?",
+      "ja": "ドラゴンボールのさくしゃは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Demon Slayer",
+        "ja": "きめつのやいば",
+        "ja_typings": [
+          "kimetsunoyaiba"
+        ]
+      },
+      {
+        "en": "Jujutsu Kaisen",
+        "ja": "じゅじゅつかいせん",
+        "ja_typings": [
+          "jujutsukaisen"
+        ]
+      },
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": [
+          "burichi"
+        ]
+      },
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": [
+          "naruto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00335",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is about a boy named Tanjiro fighting demons?",
+      "ja": "たんじろうというしょうねんがおにとたたかうアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "virtual reality MMORPG",
+        "ja": "ばーちゃるりありてぃMMORPG",
+        "ja_typings": [
+          "bacharuriaritimmorpg"
+        ]
+      },
+      {
+        "en": "feudal Japan",
+        "ja": "えどじだいのにほん",
+        "ja_typings": [
+          "edojidainonihon"
+        ]
+      },
+      {
+        "en": "outer space",
+        "ja": "うちゅう",
+        "ja_typings": [
+          "uchuu"
+        ]
+      },
+      {
+        "en": "post-apocalyptic earth",
+        "ja": "ぶんめいほうかいごのちきゅう",
+        "ja_typings": [
+          "bunmeihokaigonochikyuu",
+          "bunmeihoukaigonochikyuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00336",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the setting of Sword Art Online?",
+      "ja": "ソードアートオンラインのぶたいは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pokemon",
+        "ja": "ぽけもん",
+        "ja_typings": [
+          "pokemon"
+        ]
+      },
+      {
+        "en": "Digimon",
+        "ja": "でじもん",
+        "ja_typings": [
+          "dejimon"
+        ]
+      },
+      {
+        "en": "Beyblade",
+        "ja": "べいぶれーど",
+        "ja_typings": [
+          "beiburedo"
+        ]
+      },
+      {
+        "en": "Yu-Gi-Oh",
+        "ja": "ゆうぎおー",
+        "ja_typings": [
+          "yuugio"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00337",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime follows a boy who wants to be the best Pokemon trainer?",
+      "ja": "さいきょうのぽけもんとれーなーをめざすしょうねんのアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hideaki Anno",
+        "ja": "あんのひであき",
+        "ja_typings": [
+          "annohideaki"
+        ]
+      },
+      {
+        "en": "Hayao Miyazaki",
+        "ja": "みやざきはやお",
+        "ja_typings": [
+          "miyazakihayao"
+        ]
+      },
+      {
+        "en": "Satoshi Kon",
+        "ja": "こんさとし",
+        "ja_typings": [
+          "konsatoshi"
+        ]
+      },
+      {
+        "en": "Osamu Tezuka",
+        "ja": "てづかおさむ",
+        "ja_typings": [
+          "tezukaosamu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00338",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created the Evangelion series?",
+      "ja": "えんがえりおんしりーずをつくったのは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Attack on Titan",
+        "ja": "しんげきのきょじん",
+        "ja_typings": [
+          "shingekinokyojin"
+        ]
+      },
+      {
+        "en": "Fullmetal Alchemist",
+        "ja": "はがねのれんきんじゅつし",
+        "ja_typings": [
+          "haganenorenkinjutsushi"
+        ]
+      },
+      {
+        "en": "My Hero Academia",
+        "ja": "ぼくのひーろーあかでみあ",
+        "ja_typings": [
+          "bokunohiroakademia"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ぶらっくくろーばー",
+        "ja_typings": [
+          "burakkukuroba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00339",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features the Survey Corps?",
+      "ja": "ちょうさへいだんがとうじょうするアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Izuku Midoriya",
+        "ja": "みどりやいずく",
+        "ja_typings": [
+          "midoriyaizuku"
+        ]
+      },
+      {
+        "en": "Katsuki Bakugo",
+        "ja": "ばくごうかつき",
+        "ja_typings": [
+          "bakugokatsuki",
+          "bakugoukatsuki"
+        ]
+      },
+      {
+        "en": "Shouto Todoroki",
+        "ja": "とどろきしょうと",
+        "ja_typings": [
+          "todorokishoto",
+          "todorokishouto"
+        ]
+      },
+      {
+        "en": "Tenya Iida",
+        "ja": "いいだてんや",
+        "ja_typings": [
+          "iidatenya"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00340",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the full name of the protagonist in My Hero Academia?",
+      "ja": "ぼくのひーろーあかでみあのしゅじんこうのフルネームは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": [
+          "naruto"
+        ]
+      },
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": [
+          "burichi"
+        ]
+      },
+      {
+        "en": "Dragon Ball",
+        "ja": "どらごんぼーる",
+        "ja_typings": [
+          "doragonboru"
+        ]
+      },
+      {
+        "en": "One Piece",
+        "ja": "わんぴーす",
+        "ja_typings": [
+          "wanpisu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00341",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features ninjas with special chakra abilities?",
+      "ja": "とくべつなちゃくらのうりょくをもつにんじゃのアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gainax",
+        "ja": "がいなっくす",
+        "ja_typings": [
+          "gainakkusu"
+        ]
+      },
+      {
+        "en": "Toei Animation",
+        "ja": "とうえいあにめーしょん",
+        "ja_typings": [
+          "toeianimeshon",
+          "toueianimeshon"
+        ]
+      },
+      {
+        "en": "Madhouse",
+        "ja": "まっどはうす",
+        "ja_typings": [
+          "maddohausu"
+        ]
+      },
+      {
+        "en": "Kyoto Animation",
+        "ja": "きょーとあにめーしょん",
+        "ja_typings": [
+          "kyotoanimeshon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00342",
+    "image_path": null,
+    "question_text": {
+      "en": "What studio produced Neon Genesis Evangelion?",
+      "ja": "しんせいきえんがえりおんをせいさくしたすたじおは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dragon Ball",
+        "ja": "どらごんぼーる",
+        "ja_typings": [
+          "doragonboru"
+        ]
+      },
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": [
+          "naruto"
+        ]
+      },
+      {
+        "en": "One Piece",
+        "ja": "わんぴーす",
+        "ja_typings": [
+          "wanpisu"
+        ]
+      },
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": [
+          "burichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00343",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime series is known for the 'Kamehameha' attack?",
+      "ja": "かめはめはこうげきでゆうめいなアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "magical girl",
+        "ja": "まほうしょうじょ",
+        "ja_typings": [
+          "mahoshojo",
+          "mahoushoujo"
+        ]
+      },
+      {
+        "en": "mecha",
+        "ja": "めか",
+        "ja_typings": [
+          "meka"
+        ]
+      },
+      {
+        "en": "isekai",
+        "ja": "いせかい",
+        "ja_typings": [
+          "isekai"
+        ]
+      },
+      {
+        "en": "sports",
+        "ja": "すぽーつ",
+        "ja_typings": [
+          "supotsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00344",
+    "image_path": null,
+    "question_text": {
+      "en": "What genre is Sailor Moon?",
+      "ja": "せーらーむーんのジャンルは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ash Ketchum",
+        "ja": "さとし",
+        "ja_typings": [
+          "satoshi"
+        ]
+      },
+      {
+        "en": "Misty",
+        "ja": "かすみ",
+        "ja_typings": [
+          "kasumi"
+        ]
+      },
+      {
+        "en": "Brock",
+        "ja": "たけし",
+        "ja_typings": [
+          "takeshi"
+        ]
+      },
+      {
+        "en": "Gary",
+        "ja": "しげる",
+        "ja_typings": [
+          "shigeru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00345",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is Pikachu's trainer in Pokemon anime?",
+      "ja": "ポケモンアニメでぴかちゅうのとれーなーは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Haikyuu!!",
+        "ja": "はいきゅー!!",
+        "ja_typings": [
+          "haikyu"
+        ]
+      },
+      {
+        "en": "Slam Dunk",
+        "ja": "すらむだんく",
+        "ja_typings": [
+          "suramudanku"
+        ]
+      },
+      {
+        "en": "Kuroko's Basketball",
+        "ja": "くろこのバスケ",
+        "ja_typings": [
+          "kurokonobasuke"
+        ]
+      },
+      {
+        "en": "Captain Tsubasa",
+        "ja": "きゃぷてんつばさ",
+        "ja_typings": [
+          "kyaputentsubasa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00346",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is set in a sports high school for volleyball?",
+      "ja": "ばれーぼーるのこうこうのアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "genre where character is transported to another world",
+        "ja": "べつのせかいにうつされるジャンル",
+        "ja_typings": [
+          "betsunosekainiutsusarerujanru"
+        ]
+      },
+      {
+        "en": "genre about samurai",
+        "ja": "さむらいのジャンル",
+        "ja_typings": [
+          "samurainojanru"
+        ]
+      },
+      {
+        "en": "genre about sports",
+        "ja": "すぽーつのジャンル",
+        "ja_typings": [
+          "supotsunojanru"
+        ]
+      },
+      {
+        "en": "genre about mecha robots",
+        "ja": "めかろぼっとのジャンル",
+        "ja_typings": [
+          "mekarobottonojanru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00347",
+    "image_path": null,
+    "question_text": {
+      "en": "What is isekai?",
+      "ja": "いせかいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "One Piece",
+        "ja": "わんぴーす",
+        "ja_typings": [
+          "wanpisu"
+        ]
+      },
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": [
+          "naruto"
+        ]
+      },
+      {
+        "en": "Dragon Ball",
+        "ja": "どらごんぼーる",
+        "ja_typings": [
+          "doragonboru"
+        ]
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "ふぇありーている",
+        "ja_typings": [
+          "feariteiru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00348",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features Monkey D. Luffy?",
+      "ja": "もんきーでぃーるふぃーがとうじょうするアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "U.A. High School",
+        "ja": "ゆーえいこうこう",
+        "ja_typings": [
+          "yueikoko",
+          "yueikoukou"
+        ]
+      },
+      {
+        "en": "Shiketsu High",
+        "ja": "しけつこうこう",
+        "ja_typings": [
+          "shiketsukoko",
+          "shiketsukoukou"
+        ]
+      },
+      {
+        "en": "Ketsubutsu Academy",
+        "ja": "けつぶつがくえん",
+        "ja_typings": [
+          "ketsubutsugakuen"
+        ]
+      },
+      {
+        "en": "Seiai Academy",
+        "ja": "せいあいがくえん",
+        "ja_typings": [
+          "seiaigakuen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00349",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the name of the school in My Hero Academia?",
+      "ja": "ぼくのひーろーあかでみあのがっこうのなまえは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Death Note",
+        "ja": "でーすのーと",
+        "ja_typings": [
+          "desunoto"
+        ]
+      },
+      {
+        "en": "Monster",
+        "ja": "もんすたー",
+        "ja_typings": [
+          "monsuta"
+        ]
+      },
+      {
+        "en": "Psycho-Pass",
+        "ja": "さいこぱす",
+        "ja_typings": [
+          "saikopasu"
+        ]
+      },
+      {
+        "en": "Detective Conan",
+        "ja": "めいたんていこなん",
+        "ja_typings": [
+          "meitanteikonan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00350",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime follows L and Light's cat-and-mouse detective game?",
+      "ja": "Lとライトのかくれんぼのようなすいりのアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": [
+          "naruto"
+        ]
+      },
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": [
+          "burichi"
+        ]
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "ふぇありーている",
+        "ja_typings": [
+          "feariteiru"
+        ]
+      },
+      {
+        "en": "Attack on Titan",
+        "ja": "しんげきのきょじん",
+        "ja_typings": [
+          "shingekinokyojin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00351",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is set in the fictional Konoha village?",
+      "ja": "かそうのこのははのむらが舞台のアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Naruto, Bleach, One Piece",
+        "ja": "なるとぶりーちわんぴーす",
+        "ja_typings": [
+          "narutoburichiwanpisu"
+        ]
+      },
+      {
+        "en": "Dragon Ball, Naruto, One Piece",
+        "ja": "どらごんぼーるなるとわんぴーす",
+        "ja_typings": [
+          "doragonborunarutowanpisu"
+        ]
+      },
+      {
+        "en": "Bleach, Dragon Ball, Fairy Tail",
+        "ja": "ぶりーちどらごんぼーるふぇありーている",
+        "ja_typings": [
+          "burichidoragonborufeariteiru"
+        ]
+      },
+      {
+        "en": "One Piece, My Hero, Attack on Titan",
+        "ja": "わんぴーすひーろーきょじん",
+        "ja_typings": [
+          "wanpisuhirokyojin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00352",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the 'Big Three' of older Shonen Jump anime?",
+      "ja": "むかしのじゃんぷのさんだいアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "anime featuring giant robots",
+        "ja": "きょだいろぼっとがとうじょうするアニメ",
+        "ja_typings": [
+          "kyodairobottogatojosuruanime",
+          "kyodairobottogatoujousuruanime"
+        ]
+      },
+      {
+        "en": "anime about magic users",
+        "ja": "まほうつかいのアニメ",
+        "ja_typings": [
+          "mahotsukainoanime",
+          "mahoutsukainoanime"
+        ]
+      },
+      {
+        "en": "anime set in feudal Japan",
+        "ja": "えどじだいのアニメ",
+        "ja_typings": [
+          "edojidainoanime"
+        ]
+      },
+      {
+        "en": "anime about cooking",
+        "ja": "りょうりのアニメ",
+        "ja_typings": [
+          "ryorinoanime",
+          "ryourinoanime"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00353",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a mecha anime?",
+      "ja": "めかアニメとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kiki's Delivery Service",
+        "ja": "まじょのたっきゅうびん",
+        "ja_typings": [
+          "majonotakkyuubin"
+        ]
+      },
+      {
+        "en": "Spirited Away",
+        "ja": "せんとちひろのかみかくし",
+        "ja_typings": [
+          "sentochihironokamikakushi"
+        ]
+      },
+      {
+        "en": "Nausicaa",
+        "ja": "なうしか",
+        "ja_typings": [
+          "naushika"
+        ]
+      },
+      {
+        "en": "Castle in the Sky",
+        "ja": "てんくうのしろらぴゅた",
+        "ja_typings": [
+          "tenkuunoshirorapyuta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00354",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Ghibli film features a young witch who delivers by broomstick?",
+      "ja": "ほうきではいたつするわかいまじょのジブリえいがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": [
+          "burichi"
+        ]
+      },
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": [
+          "naruto"
+        ]
+      },
+      {
+        "en": "Dragon Ball",
+        "ja": "どらごんぼーる",
+        "ja_typings": [
+          "doragonboru"
+        ]
+      },
+      {
+        "en": "One Piece",
+        "ja": "わんぴーす",
+        "ja_typings": [
+          "wanpisu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00355",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime follows Ichigo Kurosaki, a Soul Reaper?",
+      "ja": "いちごくろさきというしにがみのアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "anime targeted at young male audience",
+        "ja": "わかいだんせいむけアニメ",
+        "ja_typings": [
+          "wakaidanseimukeanime"
+        ]
+      },
+      {
+        "en": "anime targeted at young female audience",
+        "ja": "わかいじょせいむけアニメ",
+        "ja_typings": [
+          "wakaijoseimukeanime"
+        ]
+      },
+      {
+        "en": "anime for adult men",
+        "ja": "おとなのだんせいむけアニメ",
+        "ja_typings": [
+          "otonanodanseimukeanime"
+        ]
+      },
+      {
+        "en": "anime for children",
+        "ja": "こどもむけアニメ",
+        "ja_typings": [
+          "kodomomukeanime"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00356",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'shonen' anime?",
+      "ja": "しょうねんアニメとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "anime targeted at young female audience",
+        "ja": "わかいじょせいむけアニメ",
+        "ja_typings": [
+          "wakaijoseimukeanime"
+        ]
+      },
+      {
+        "en": "anime targeted at young male audience",
+        "ja": "わかいだんせいむけアニメ",
+        "ja_typings": [
+          "wakaidanseimukeanime"
+        ]
+      },
+      {
+        "en": "anime about romance only",
+        "ja": "れんあいのみのアニメ",
+        "ja_typings": [
+          "renainominoanime"
+        ]
+      },
+      {
+        "en": "anime with female protagonists only",
+        "ja": "じょしゅじんこうのみのアニメ",
+        "ja_typings": [
+          "joshujinkonominoanime",
+          "joshujinkounominoanime"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00357",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'shoujo' anime?",
+      "ja": "しょうじょアニメとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dragon Ball",
+        "ja": "どらごんぼーる",
+        "ja_typings": [
+          "doragonboru"
+        ]
+      },
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": [
+          "naruto"
+        ]
+      },
+      {
+        "en": "One Piece",
+        "ja": "わんぴーす",
+        "ja_typings": [
+          "wanpisu"
+        ]
+      },
+      {
+        "en": "Baki",
+        "ja": "ばき",
+        "ja_typings": [
+          "baki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00358",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is about a boy named Goku who trains in martial arts?",
+      "ja": "ごくうというしょうねんがぶどうをきわめるアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Original Video Animation",
+        "ja": "おりじなるびでおあにめーしょん",
+        "ja_typings": [
+          "orijinarubideoanimeshon"
+        ]
+      },
+      {
+        "en": "Official Voice Acting",
+        "ja": "こうしきせいゆうえんぎ",
+        "ja_typings": [
+          "koshikiseiyuuengi",
+          "koushikiseiyuuengi"
+        ]
+      },
+      {
+        "en": "Online Visual Archive",
+        "ja": "おんらいんびじゅあるあーかいぶ",
+        "ja_typings": [
+          "onrainbijuaruakaibu"
+        ]
+      },
+      {
+        "en": "Overseas Video Animation",
+        "ja": "かいがいびでおあにめーしょん",
+        "ja_typings": [
+          "kaigaibideoanimeshon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00359",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'OVA' stand for in anime?",
+      "ja": "アニメのOVAのりゃくごのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "One Piece",
+        "ja": "わんぴーす",
+        "ja_typings": [
+          "wanpisu"
+        ]
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "ふぇありーている",
+        "ja_typings": [
+          "feariteiru"
+        ]
+      },
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": [
+          "naruto"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ぶらっくくろーばー",
+        "ja_typings": [
+          "burakkukuroba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00360",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is famous for the 'Thousand Sunny' ship?",
+      "ja": "さうざんどさにーごうでゆうめいなアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JoJo's Bizarre Adventure",
+        "ja": "じょじょのきみょうなぼうけん",
+        "ja_typings": [
+          "jojonokimyonaboken",
+          "jojonokimyounabouken"
+        ]
+      },
+      {
+        "en": "Fullmetal Alchemist",
+        "ja": "はがねのれんきんじゅつし",
+        "ja_typings": [
+          "haganenorenkinjutsushi"
+        ]
+      },
+      {
+        "en": "Noragami",
+        "ja": "のらがみ",
+        "ja_typings": [
+          "noragami"
+        ]
+      },
+      {
+        "en": "Blue Exorcist",
+        "ja": "あおのえくそしすと",
+        "ja_typings": [
+          "aonoekusoshisuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00361",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime series has 'Stand' abilities as its main power system?",
+      "ja": "すたんどのうりょくがメインのアニメシリーズは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "a quirk that can be passed to others",
+        "ja": "ひとにわたせるこせい",
+        "ja_typings": [
+          "hitoniwataserukosei"
+        ]
+      },
+      {
+        "en": "a villain's ultimate power",
+        "ja": "ヴィランのさいきょうのちから",
+        "ja_typings": [
+          "virannosaikyonochikara",
+          "virannosaikyounochikara"
+        ]
+      },
+      {
+        "en": "a hero association rank",
+        "ja": "ひーろーきょうかいのくらす",
+        "ja_typings": [
+          "hirokyokainokurasu",
+          "hirokyoukainokurasu"
+        ]
+      },
+      {
+        "en": "a special move name",
+        "ja": "とくしゅわざのなまえ",
+        "ja_typings": [
+          "tokushuwazanonamae"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00362",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'One For All' in My Hero Academia?",
+      "ja": "ぼくのひーろーあかでみあのわんふぉーおーるとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Food Wars",
+        "ja": "しょくげきのそうま",
+        "ja_typings": [
+          "shokugekinosoma",
+          "shokugekinosouma"
+        ]
+      },
+      {
+        "en": "Silver Spoon",
+        "ja": "ぎんのさじ",
+        "ja_typings": [
+          "ginnosaji"
+        ]
+      },
+      {
+        "en": "Sweetness and Lightning",
+        "ja": "あまあまといなずま",
+        "ja_typings": [
+          "amaamatoinazuma"
+        ]
+      },
+      {
+        "en": "Cooking Master Boy",
+        "ja": "ちゅうかいちばん",
+        "ja_typings": [
+          "chuukaichiban"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00363",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is set in a cooking high school?",
+      "ja": "りょうりのこうこうのアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Raditz",
+        "ja": "らでぃっつ",
+        "ja_typings": [
+          "radittsu"
+        ]
+      },
+      {
+        "en": "Frieza",
+        "ja": "ふりーざ",
+        "ja_typings": [
+          "furiza"
+        ]
+      },
+      {
+        "en": "Cell",
+        "ja": "せる",
+        "ja_typings": [
+          "seru"
+        ]
+      },
+      {
+        "en": "Beerus",
+        "ja": "びーるす",
+        "ja_typings": [
+          "birusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00364",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the villain in the first arc of Dragon Ball Z?",
+      "ja": "ドラゴンボールZさいしょのあーくのヴィランは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "science of transmuting matter",
+        "ja": "ぶっしつへんかんのかがく",
+        "ja_typings": [
+          "busshitsuhenkannokagaku"
+        ]
+      },
+      {
+        "en": "magic spells",
+        "ja": "まほうのじゅもん",
+        "ja_typings": [
+          "mahonojumon",
+          "mahounojumon"
+        ]
+      },
+      {
+        "en": "martial arts style",
+        "ja": "ぶどうのりゅうは",
+        "ja_typings": [
+          "budonoryuuha",
+          "budounoryuuha"
+        ]
+      },
+      {
+        "en": "alchemy potions",
+        "ja": "れんきんやく",
+        "ja_typings": [
+          "renkinyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00365",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Alchemy' in Fullmetal Alchemist?",
+      "ja": "はがねのれんきんじゅつしのれんきんじゅつとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Attack on Titan",
+        "ja": "しんげきのきょじん",
+        "ja_typings": [
+          "shingekinokyojin"
+        ]
+      },
+      {
+        "en": "Jujutsu Kaisen",
+        "ja": "じゅじゅつかいせん",
+        "ja_typings": [
+          "jujutsukaisen"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ぶらっくくろーばー",
+        "ja_typings": [
+          "burakkukuroba"
+        ]
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "ふぇありーている",
+        "ja_typings": [
+          "feariteiru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00366",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features the 'Survey Corps' fighting Titans?",
+      "ja": "ちょうさへいだんがきょじんとたたかうアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "romantic fantasy",
+        "ja": "ろまんてぃっくふぁんたじー",
+        "ja_typings": [
+          "romantikkufantaji"
+        ]
+      },
+      {
+        "en": "action shonen",
+        "ja": "あくしょんしょうねん",
+        "ja_typings": [
+          "akushonshonen",
+          "akushonshounen"
+        ]
+      },
+      {
+        "en": "mecha",
+        "ja": "めか",
+        "ja_typings": [
+          "meka"
+        ]
+      },
+      {
+        "en": "horror",
+        "ja": "ほらー",
+        "ja_typings": [
+          "hora"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00367",
+    "image_path": null,
+    "question_text": {
+      "en": "What genre is 'Your Name (Kimi no Na wa)'?",
+      "ja": "きみのなわのジャンルは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hayao Miyazaki",
+        "ja": "みやざきはやお",
+        "ja_typings": [
+          "miyazakihayao"
+        ]
+      },
+      {
+        "en": "Isao Takahata",
+        "ja": "たかはたいさお",
+        "ja_typings": [
+          "takahataisao"
+        ]
+      },
+      {
+        "en": "Satoshi Kon",
+        "ja": "こんさとし",
+        "ja_typings": [
+          "konsatoshi"
+        ]
+      },
+      {
+        "en": "Mamoru Oshii",
+        "ja": "おしいまもる",
+        "ja_typings": [
+          "oshiimamoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00368",
+    "image_path": null,
+    "question_text": {
+      "en": "Who directed Spirited Away?",
+      "ja": "もののけひめをかんとくしたのは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Catbus",
+        "ja": "ねこばす",
+        "ja_typings": [
+          "nekobasu"
+        ]
+      },
+      {
+        "en": "Totoro Bus",
+        "ja": "トトロバス",
+        "ja_typings": [
+          "totorobasu"
+        ]
+      },
+      {
+        "en": "Meow Train",
+        "ja": "にゃーれっしゃ",
+        "ja_typings": [
+          "nyaressha"
+        ]
+      },
+      {
+        "en": "Nyanko Express",
+        "ja": "にゃんこえくすぷれす",
+        "ja_typings": [
+          "nyankoekusupuresu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00369",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the name of the cat bus in My Neighbor Totoro?",
+      "ja": "となりのトトロのねこばすのなまえは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Demon Slayer",
+        "ja": "きめつのやいば",
+        "ja_typings": [
+          "kimetsunoyaiba"
+        ]
+      },
+      {
+        "en": "My Hero Academia",
+        "ja": "ぼくのひーろーあかでみあ",
+        "ja_typings": [
+          "bokunohiroakademia"
+        ]
+      },
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": [
+          "naruto"
+        ]
+      },
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": [
+          "burichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00370",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features heroes called 'Hashira'?",
+      "ja": "はしらとよばれるひーろーたちのアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shadow Clone Jutsu",
+        "ja": "かげぶんしんのじゅつ",
+        "ja_typings": [
+          "kagebunshinnojutsu"
+        ]
+      },
+      {
+        "en": "Rasengan",
+        "ja": "らせんがん",
+        "ja_typings": [
+          "rasengan"
+        ]
+      },
+      {
+        "en": "Chidori",
+        "ja": "ちどり",
+        "ja_typings": [
+          "chidori"
+        ]
+      },
+      {
+        "en": "Fire Style",
+        "ja": "かとん",
+        "ja_typings": [
+          "katon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00371",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the name of Naruto's signature technique?",
+      "ja": "なるとのとくいわざのなまえは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sword Art Online",
+        "ja": "そーどあーとおんらいん",
+        "ja_typings": [
+          "sodoatonrain",
+          "sodoatoonrain"
+        ]
+      },
+      {
+        "en": "Log Horizon",
+        "ja": "ろぐほらいずん",
+        "ja_typings": [
+          "roguhoraizun"
+        ]
+      },
+      {
+        "en": ".hack//Sign",
+        "ja": ".hack//サイン",
+        "ja_typings": [
+          ".hack//sain"
+        ]
+      },
+      {
+        "en": "No Game No Life",
+        "ja": "のーげーむのーらいふ",
+        "ja_typings": [
+          "nogemunoraifu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00372",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is about a virtual game where dying in-game means death in real life?",
+      "ja": "げーむないしすると現実でもしぬアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "writing names to kill people",
+        "ja": "なまえをかいてひとをころす",
+        "ja_typings": [
+          "namaeokaitehitokorosu",
+          "namaeokaitehitookorosu"
+        ]
+      },
+      {
+        "en": "seeing the future",
+        "ja": "みらいをみる",
+        "ja_typings": [
+          "miraiomiru"
+        ]
+      },
+      {
+        "en": "mind control",
+        "ja": "せんのうする",
+        "ja_typings": [
+          "sennosuru",
+          "sennousuru"
+        ]
+      },
+      {
+        "en": "time travel",
+        "ja": "じかんりょこう",
+        "ja_typings": [
+          "jikanryoko",
+          "jikanryokou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00373",
+    "image_path": null,
+    "question_text": {
+      "en": "What power does Light Yagami use in Death Note?",
+      "ja": "デスノートでやがみらいとが使うちからは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": [
+          "naruto"
+        ]
+      },
+      {
+        "en": "Boruto",
+        "ja": "ぼると",
+        "ja_typings": [
+          "boruto"
+        ]
+      },
+      {
+        "en": "Dragon Ball",
+        "ja": "どらごんぼーる",
+        "ja_typings": [
+          "doragonboru"
+        ]
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "ふぇありーている",
+        "ja_typings": [
+          "feariteiru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00374",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is set in the Hidden Leaf Village?",
+      "ja": "かくれこのはのさとをぶたいにしたアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "a superpower",
+        "ja": "ちょうのうりょく",
+        "ja_typings": [
+          "chonoryoku",
+          "chounouryoku"
+        ]
+      },
+      {
+        "en": "a school rule",
+        "ja": "がっこうのきまり",
+        "ja_typings": [
+          "gakkonokimari",
+          "gakkounokimari"
+        ]
+      },
+      {
+        "en": "a villain title",
+        "ja": "ヴィランのしょうごう",
+        "ja_typings": [
+          "virannoshogo",
+          "virannoshougou"
+        ]
+      },
+      {
+        "en": "a fighting technique",
+        "ja": "ぶとうのわざ",
+        "ja_typings": [
+          "butonowaza",
+          "butounowaza"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00375",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the 'Quirk' in My Hero Academia?",
+      "ja": "ぼくのひーろーあかでみあのこせいとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Death Note",
+        "ja": "でーすのーと",
+        "ja_typings": [
+          "desunoto"
+        ]
+      },
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": [
+          "burichi"
+        ]
+      },
+      {
+        "en": "Noragami",
+        "ja": "のらがみ",
+        "ja_typings": [
+          "noragami"
+        ]
+      },
+      {
+        "en": "Soul Eater",
+        "ja": "そうるいーたー",
+        "ja_typings": [
+          "soruita",
+          "souruita"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00376",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features Ryuk, a death god?",
+      "ja": "りゅーくというしにがみがとうじょうするアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "giant humanoid creature",
+        "ja": "きょだいなにんげんがたいきもの",
+        "ja_typings": [
+          "kyodainaningengataikimono"
+        ]
+      },
+      {
+        "en": "large robot",
+        "ja": "きょだいなろぼっと",
+        "ja_typings": [
+          "kyodainarobotto"
+        ]
+      },
+      {
+        "en": "supernatural spirit",
+        "ja": "ちょうしぜんのれい",
+        "ja_typings": [
+          "choshizennorei",
+          "choushizennorei"
+        ]
+      },
+      {
+        "en": "ancient warrior",
+        "ja": "こだいのせんし",
+        "ja_typings": [
+          "kodainosenshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00377",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Titan' in Attack on Titan?",
+      "ja": "しんげきのきょじんのきょじんとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yu-Gi-Oh",
+        "ja": "ゆうぎおー",
+        "ja_typings": [
+          "yuugio"
+        ]
+      },
+      {
+        "en": "Pokemon",
+        "ja": "ぽけもん",
+        "ja_typings": [
+          "pokemon"
+        ]
+      },
+      {
+        "en": "Beyblade",
+        "ja": "べいぶれーど",
+        "ja_typings": [
+          "beiburedo"
+        ]
+      },
+      {
+        "en": "Digimon",
+        "ja": "でじもん",
+        "ja_typings": [
+          "dejimon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00378",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is based on a card game?",
+      "ja": "かーどげーむをもとにしたアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Frieza",
+        "ja": "ふりーざ",
+        "ja_typings": [
+          "furiza"
+        ]
+      },
+      {
+        "en": "Cell",
+        "ja": "せる",
+        "ja_typings": [
+          "seru"
+        ]
+      },
+      {
+        "en": "Buu",
+        "ja": "ぶう",
+        "ja_typings": [
+          "buu"
+        ]
+      },
+      {
+        "en": "Vegeta",
+        "ja": "べじーた",
+        "ja_typings": [
+          "bejita"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00379",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the main antagonist of the Frieza arc in Dragon Ball Z?",
+      "ja": "ドラゴンボールZのふりーざへんのしゅてきは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "world where everything is decided by games",
+        "ja": "ゲームですべてがきめられるせかい",
+        "ja_typings": [
+          "gemudesubetegakimerarerusekai"
+        ]
+      },
+      {
+        "en": "virtual MMORPG",
+        "ja": "ばーちゃるMMORPG",
+        "ja_typings": [
+          "bacharummorpg"
+        ]
+      },
+      {
+        "en": "feudal Japan",
+        "ja": "えどじだいのにほん",
+        "ja_typings": [
+          "edojidainonihon"
+        ]
+      },
+      {
+        "en": "post-apocalyptic earth",
+        "ja": "ぶんめいほうかいごのちきゅう",
+        "ja_typings": [
+          "bunmeihokaigonochikyuu",
+          "bunmeihoukaigonochikyuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00380",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the setting of 'No Game No Life'?",
+      "ja": "のーげーむのーらいふの舞台は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hiromu Arakawa",
+        "ja": "あらかわひろむ",
+        "ja_typings": [
+          "arakawahiromu"
+        ]
+      },
+      {
+        "en": "Masashi Kishimoto",
+        "ja": "きしもとまさし",
+        "ja_typings": [
+          "kishimotomasashi"
+        ]
+      },
+      {
+        "en": "Tite Kubo",
+        "ja": "くぼたいと",
+        "ja_typings": [
+          "kubotaito"
+        ]
+      },
+      {
+        "en": "Akira Toriyama",
+        "ja": "とりやまあきら",
+        "ja_typings": [
+          "toriyamaakira"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00381",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote the manga 'Fullmetal Alchemist'?",
+      "ja": "はがねのれんきんじゅつしをかいたのは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "voice actor",
+        "ja": "せいゆう",
+        "ja_typings": [
+          "seiyuu"
+        ]
+      },
+      {
+        "en": "anime director",
+        "ja": "かんとく",
+        "ja_typings": [
+          "kantoku"
+        ]
+      },
+      {
+        "en": "character designer",
+        "ja": "きゃらくたーでざいなー",
+        "ja_typings": [
+          "kyarakutadezaina"
+        ]
+      },
+      {
+        "en": "soundtrack composer",
+        "ja": "おんがくさっきょくか",
+        "ja_typings": [
+          "ongakusakkyokuka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00382",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'seiyuu' in anime?",
+      "ja": "アニメのせいゆうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "dubbed has translated voice, subbed has subtitles",
+        "ja": "だぶどはほんやくおんせい、さぶどはじまく",
+        "ja_typings": [
+          "dabudohahonyakuonsei sabudohajimaku"
+        ]
+      },
+      {
+        "en": "dubbed is the original, subbed is translated",
+        "ja": "だぶどはげんさく、さぶどはほんやく",
+        "ja_typings": [
+          "dabudohagensaku sabudohahonyaku"
+        ]
+      },
+      {
+        "en": "dubbed is higher quality",
+        "ja": "だぶどのほうがこうひん",
+        "ja_typings": [
+          "dabudonohogakohin",
+          "dabudonohougakouhin"
+        ]
+      },
+      {
+        "en": "subbed has no audio",
+        "ja": "さぶどにはおとがない",
+        "ja_typings": [
+          "sabudonihaotoganai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00383",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the difference between dubbed and subbed anime?",
+      "ja": "だぶどとさぶどのアニメのちがいは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Black Butler",
+        "ja": "くろしつじ",
+        "ja_typings": [
+          "kuroshitsuji"
+        ]
+      },
+      {
+        "en": "Overlord",
+        "ja": "おーばーろーど",
+        "ja_typings": [
+          "obarodo"
+        ]
+      },
+      {
+        "en": "Moriarty the Patriot",
+        "ja": "ゆうこくのもりあーてぃ",
+        "ja_typings": [
+          "yuukokunomoriati"
+        ]
+      },
+      {
+        "en": "The Case Study of Vanitas",
+        "ja": "ヴァニタスのカルテ",
+        "ja_typings": [
+          "vanitasunokarute"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00384",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime series is set in 19th century England with a demon butler?",
+      "ja": "あくまのしつじがいる19せいきえいこくのアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "popular manga magazine",
+        "ja": "にんきまんがざっし",
+        "ja_typings": [
+          "ninkimangazasshi"
+        ]
+      },
+      {
+        "en": "anime streaming service",
+        "ja": "アニメはいしんさーびす",
+        "ja_typings": [
+          "animehaishinsabisu"
+        ]
+      },
+      {
+        "en": "anime convention",
+        "ja": "アニメのいべんと",
+        "ja_typings": [
+          "animenoibento"
+        ]
+      },
+      {
+        "en": "anime film studio",
+        "ja": "アニメえいがすたじお",
+        "ja_typings": [
+          "animeeigasutajio"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00385",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Shounen Jump'?",
+      "ja": "しょうねんじゃんぷとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jujutsu Kaisen",
+        "ja": "じゅじゅつかいせん",
+        "ja_typings": [
+          "jujutsukaisen"
+        ]
+      },
+      {
+        "en": "Noragami",
+        "ja": "のらがみ",
+        "ja_typings": [
+          "noragami"
+        ]
+      },
+      {
+        "en": "Blue Exorcist",
+        "ja": "あおのえくそしすと",
+        "ja_typings": [
+          "aonoekusoshisuto"
+        ]
+      },
+      {
+        "en": "Soul Eater",
+        "ja": "そうるいーたー",
+        "ja_typings": [
+          "soruita",
+          "souruita"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00386",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime follows a group of exorcists called 'jujutsu sorcerers'?",
+      "ja": "じゅじゅつしのようしゃたちのアニメは？"
+    }
+  },
+  {
+    "choices": [
       {
         "en": "Nezuko",
         "ja": "ねずこ",
         "ja_typings": [
           "nezuko"
+        ]
+      },
+      {
+        "en": "Aoi",
+        "ja": "あおい",
+        "ja_typings": [
+          "aoi"
         ]
       },
       {
@@ -2244,972 +15914,6647 @@
         ]
       },
       {
-        "en": "Aoi",
-        "ja": "あおい",
+        "en": "Kanao",
+        "ja": "かなお",
         "ja_typings": [
-          "aoi"
+          "kanao"
         ]
       }
     ],
-    "correct_answer_index": 1,
+    "correct_answer_index": 0,
     "genre": "anime",
-    "id": "q00056",
+    "id": "q00387",
     "image_path": null,
     "question_text": {
-      "en": "Who is the protagonist's sister in 'Demon Slayer'?",
-      "ja": "「きめつのやいば」のしゅじんこうのいもうとは?"
-    }
-  },
-  {
-    "choices": [
-    {
-      "en": "Zelda",
-      "ja": "ゼルダ",
-      "ja_typings": [
-        "zeruda",
-        "zelda"
-      ]
-    },
-    {
-      "en": "Link",
-      "ja": "リンク",
-      "ja_typings": [
-        "rinku",
-        "link"
-      ]
-    },
-      {
-        "en": "Ganon",
-        "ja": "ガノン",
-        "ja_typings": [
-          "ganon"
-        ]
-      },
-    {
-      "en": "Impa",
-      "ja": "インパ",
-      "ja_typings": [
-        "inpa",
-        "impa"
-      ]
-    }
-    ],
-    "correct_answer_index": 1,
-    "genre": "game",
-    "id": "q00057",
-    "image_path": null,
-    "question_text": {
-      "en": "Who is the protagonist of 'The Legend of Zelda'?",
-      "ja": "ゼルダのでんせつのしゅじんこうは?"
+      "en": "What is the name of Tanjiro's sister in Demon Slayer?",
+      "ja": "きめつのやいばでたんじろうのいもうとのなまえは？"
     }
   },
   {
     "choices": [
       {
-        "en": "Shinji",
-        "ja": "シンジ",
+        "en": "Naruto",
+        "ja": "なると",
         "ja_typings": [
-          "shinji"
-        ]
-      },
-    {
-      "en": "Gendo",
-      "ja": "ゲンドウ",
-      "ja_typings": [
-        "gendo",
-        "gendou"
-      ]
-    },
-      {
-        "en": "Misato",
-        "ja": "ミサト",
-        "ja_typings": [
-          "misato"
+          "naruto"
         ]
       },
       {
-        "en": "Ritsuko",
-        "ja": "リツコ",
+        "en": "Fairy Tail",
+        "ja": "ふぇありーている",
         "ja_typings": [
-          "ritsuko"
+          "feariteiru"
+        ]
+      },
+      {
+        "en": "Inuyasha",
+        "ja": "いぬやしゃ",
+        "ja_typings": [
+          "inuyasha"
+        ]
+      },
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": [
+          "burichi"
         ]
       }
     ],
-    "correct_answer_index": 1,
+    "correct_answer_index": 0,
     "genre": "anime",
-    "id": "q00058",
+    "id": "q00388",
     "image_path": null,
     "question_text": {
-      "en": "Who is the commander in 'Evangelion'?",
-      "ja": "「エヴァンゲリオン」のしきれいしゃは?"
+      "en": "Which anime features the 'Nine-Tails Fox' sealed inside a character?",
+      "ja": "きゅうびがふういんされたキャラのアニメは？"
     }
   },
   {
     "choices": [
       {
-        "en": "Black Mage",
-        "ja": "くろまどうし",
+        "en": "depicting everyday life",
+        "ja": "にちじょうせいかつをえがく",
         "ja_typings": [
-          "kuromadoshi",
-          "kuromadoushi"
+          "nichijoseikatsuoegaku",
+          "nichijouseikatsuoegaku"
         ]
       },
       {
-        "en": "White Mage",
-        "ja": "しろまどうし",
+        "en": "depicting extreme action",
+        "ja": "きょくたんなあくしょんをえがく",
         "ja_typings": [
-          "shiromadoshi",
-          "shiromadoushi"
+          "kyokutannaakushonoegaku"
         ]
       },
       {
-        "en": "Red Mage",
-        "ja": "あかまどうし",
+        "en": "depicting fantasy worlds",
+        "ja": "ふぁんたじーのせかいをえがく",
         "ja_typings": [
-          "akamadoshi",
-          "akamadoushi"
+          "fantajinosekaioegaku"
         ]
       },
       {
-        "en": "Blue Mage",
-        "ja": "あおまどうし",
+        "en": "depicting sports tournaments",
+        "ja": "すぽーつたいかいをえがく",
         "ja_typings": [
-          "aomadoshi",
-          "aomadoushi"
+          "supotsutaikaioegaku"
         ]
       }
     ],
-    "correct_answer_index": 3,
-    "genre": "game",
-    "id": "q00059",
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00389",
     "image_path": null,
     "question_text": {
-      "en": "Which is NOT a job class in Final Fantasy?",
-      "ja": "ファイナルファンタジーのしょくぎょうでないのは?"
+      "en": "What is the anime genre 'slice of life'?",
+      "ja": "あにめのすらいすおぶらいふジャンルとは？"
     }
   },
   {
     "choices": [
       {
-        "en": "Hokage",
-        "ja": "ほかげ",
+        "en": "seasonal broadcast unit (~13 episodes)",
+        "ja": "きせつほうそうのたんい（やく13わ）",
         "ja_typings": [
-          "hokage"
+          "kisetsuhosonotani yaku13wa",
+          "kisetsuhousounotani yaku13wa"
         ]
       },
       {
-        "en": "ANBU",
-        "ja": "あんぶ",
+        "en": "OVA episode format",
+        "ja": "OVAわけいしき",
         "ja_typings": [
-          "anbu"
+          "ovawakeishiki"
         ]
       },
       {
-        "en": "Jonin",
-        "ja": "じょうにん",
+        "en": "anime film format",
+        "ja": "アニメえいがけいしき",
         "ja_typings": [
-          "jonin",
-          "jounin"
+          "animeeigakeishiki"
         ]
       },
       {
-        "en": "Sannin",
-        "ja": "さんにん",
+        "en": "streaming season format",
+        "ja": "はいしんきせつけいしき",
         "ja_typings": [
-          "sannin"
+          "haishinkisetsukeishiki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00390",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'cour' in anime terminology?",
+      "ja": "アニメようごのくーるとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jujutsu Kaisen",
+        "ja": "じゅじゅつかいせん",
+        "ja_typings": [
+          "jujutsukaisen"
+        ]
+      },
+      {
+        "en": "Demon Slayer",
+        "ja": "きめつのやいば",
+        "ja_typings": [
+          "kimetsunoyaiba"
+        ]
+      },
+      {
+        "en": "My Hero Academia",
+        "ja": "ぼくのひーろーあかでみあ",
+        "ja_typings": [
+          "bokunohiroakademia"
+        ]
+      },
+      {
+        "en": "One Piece",
+        "ja": "わんぴーす",
+        "ja_typings": [
+          "wanpisu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00391",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is produced by MAPPA?",
+      "ja": "MAPPAがせいさくしたアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "high-quality animation and emotional stories",
+        "ja": "こうひんなあにめーしょんとかんどうてきなはなし",
+        "ja_typings": [
+          "kohinnaanimeshontokandotekinahanashi",
+          "kouhinnaanimeshontokandoutekinahanashi"
+        ]
+      },
+      {
+        "en": "mecha anime",
+        "ja": "めかアニメ",
+        "ja_typings": [
+          "mekaanime"
+        ]
+      },
+      {
+        "en": "action-heavy shonen",
+        "ja": "あくしょんしょうねん",
+        "ja_typings": [
+          "akushonshonen",
+          "akushonshounen"
+        ]
+      },
+      {
+        "en": "violent horror anime",
+        "ja": "はきょくてきなほらーアニメ",
+        "ja_typings": [
+          "hakyokutekinahoraanime"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00392",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Kyoto Animation known for?",
+      "ja": "きょーとあにめーしょんはなにでゆうめいか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jujutsu Kaisen",
+        "ja": "じゅじゅつかいせん",
+        "ja_typings": [
+          "jujutsukaisen"
+        ]
+      },
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": [
+          "burichi"
+        ]
+      },
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": [
+          "naruto"
+        ]
+      },
+      {
+        "en": "My Hero Academia",
+        "ja": "ぼくのひーろーあかでみあ",
+        "ja_typings": [
+          "bokunohiroakademia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00393",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features Satoru Gojo?",
+      "ja": "ごじょうさとるがとうじょうするアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Eiichiro Oda",
+        "ja": "おだえいいちろう",
+        "ja_typings": [
+          "odaeiichiro",
+          "odaeiichirou"
+        ]
+      },
+      {
+        "en": "Masashi Kishimoto",
+        "ja": "きしもとまさし",
+        "ja_typings": [
+          "kishimotomasashi"
+        ]
+      },
+      {
+        "en": "Akira Toriyama",
+        "ja": "とりやまあきら",
+        "ja_typings": [
+          "toriyamaakira"
+        ]
+      },
+      {
+        "en": "Hiromu Arakawa",
+        "ja": "あらかわひろむ",
+        "ja_typings": [
+          "arakawahiromu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00394",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the creator of One Piece?",
+      "ja": "ワンピースのさくしゃは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Naruto's signature phrase",
+        "ja": "ナルトのくちぐせ",
+        "ja_typings": [
+          "narutonokuchiguse"
+        ]
+      },
+      {
+        "en": "a jutsu name",
+        "ja": "じゅつのなまえ",
+        "ja_typings": [
+          "jutsunonamae"
+        ]
+      },
+      {
+        "en": "a village name",
+        "ja": "むらのなまえ",
+        "ja_typings": [
+          "muranonamae"
+        ]
+      },
+      {
+        "en": "a character title",
+        "ja": "きゃらのしょうごう",
+        "ja_typings": [
+          "kyaranoshogo",
+          "kyaranoshougou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00395",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Dattebayo' associated with in Naruto?",
+      "ja": "ナルトで「だってばよ」はなにと関係するか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Castle in the Sky",
+        "ja": "てんくうのしろらぴゅた",
+        "ja_typings": [
+          "tenkuunoshirorapyuta"
+        ]
+      },
+      {
+        "en": "Nausicaa",
+        "ja": "かぜのたにのなうしか",
+        "ja_typings": [
+          "kazenotaninonaushika"
+        ]
+      },
+      {
+        "en": "Princess Mononoke",
+        "ja": "もののけひめ",
+        "ja_typings": [
+          "mononokehime"
+        ]
+      },
+      {
+        "en": "The Wind Rises",
+        "ja": "かぜたちぬ",
+        "ja_typings": [
+          "kazetachinu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00396",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Ghibli film features a flying island called Laputa?",
+      "ja": "ラピュタというとぶしまのジブリえいがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Doraemon",
+        "ja": "どらえもん",
+        "ja_typings": [
+          "doraemon"
+        ]
+      },
+      {
+        "en": "Nobita",
+        "ja": "のびた",
+        "ja_typings": [
+          "nobita"
+        ]
+      },
+      {
+        "en": "Shizuka",
+        "ja": "しずか",
+        "ja_typings": [
+          "shizuka"
+        ]
+      },
+      {
+        "en": "Gian",
+        "ja": "じゃいあん",
+        "ja_typings": [
+          "jaian"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00397",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the name of the robot in Doraemon?",
+      "ja": "ドラえもんのろぼっとのなまえは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Attack on Titan",
+        "ja": "しんげきのきょじん",
+        "ja_typings": [
+          "shingekinokyojin"
+        ]
+      },
+      {
+        "en": "Code Geass",
+        "ja": "こーどぎあす",
+        "ja_typings": [
+          "kodogiasu"
+        ]
+      },
+      {
+        "en": "Gurren Lagann",
+        "ja": "てんげんとっぱぐれんらがん",
+        "ja_typings": [
+          "tengentoppagurenragan"
+        ]
+      },
+      {
+        "en": "Neon Genesis Evangelion",
+        "ja": "しんせいきえんがえりおん",
+        "ja_typings": [
+          "shinseikiengaerion"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00398",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is set in a world with 'Titans' and 3D Maneuver Gear?",
+      "ja": "きょじんと立体機動装置のせかいのアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "fantasy isekai world",
+        "ja": "ふぁんたじーのいせかい",
+        "ja_typings": [
+          "fantajinoisekai"
+        ]
+      },
+      {
+        "en": "virtual MMORPG",
+        "ja": "ばーちゃるMMORPG",
+        "ja_typings": [
+          "bacharummorpg"
+        ]
+      },
+      {
+        "en": "futuristic Japan",
+        "ja": "みらいのにほん",
+        "ja_typings": [
+          "mirainonihon"
+        ]
+      },
+      {
+        "en": "post-apocalyptic world",
+        "ja": "ぶんめいほうかいごのせかい",
+        "ja_typings": [
+          "bunmeihokaigonosekai",
+          "bunmeihoukaigonosekai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00399",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the setting of 'Re:Zero'?",
+      "ja": "りぜろの舞台は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": [
+          "naruto"
+        ]
+      },
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": [
+          "burichi"
+        ]
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "ふぇありーている",
+        "ja_typings": [
+          "feariteiru"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ぶらっくくろーばー",
+        "ja_typings": [
+          "burakkukuroba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00400",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features the 'Akatsuki' organization?",
+      "ja": "あかつきというそしきがとうじょうするアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "exhibits about Studio Ghibli films",
+        "ja": "スタジオジブリさくひんのてんじ",
+        "ja_typings": [
+          "sutajiojiburisakuhinnotenji"
+        ]
+      },
+      {
+        "en": "live anime performances",
+        "ja": "アニメのらいぶぱふぉーまんす",
+        "ja_typings": [
+          "animenoraibupafomansu"
+        ]
+      },
+      {
+        "en": "anime figure collection",
+        "ja": "アニメのふぃぎゅあこれくしょん",
+        "ja_typings": [
+          "animenofigyuakorekushon"
+        ]
+      },
+      {
+        "en": "anime film production",
+        "ja": "アニメえいがせいさく",
+        "ja_typings": [
+          "animeeigaseisaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00401",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Ghibli Museum' famous for?",
+      "ja": "ジブリびじゅつかんはなにでゆうめいか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": [
+          "burichi"
+        ]
+      },
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": [
+          "naruto"
+        ]
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "ふぇありーている",
+        "ja_typings": [
+          "feariteiru"
+        ]
+      },
+      {
+        "en": "One Piece",
+        "ja": "わんぴーす",
+        "ja_typings": [
+          "wanpisu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00402",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime has 'Zanpakuto' as spirit swords?",
+      "ja": "ざんぱくとうというせいれいけんのアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1997",
+        "ja": "1997ねん",
+        "ja_typings": [
+          "1997nen"
+        ]
+      },
+      {
+        "en": "1995",
+        "ja": "1995ねん",
+        "ja_typings": [
+          "1995nen"
+        ]
+      },
+      {
+        "en": "1999",
+        "ja": "1999ねん",
+        "ja_typings": [
+          "1999nen"
+        ]
+      },
+      {
+        "en": "2001",
+        "ja": "2001ねん",
+        "ja_typings": [
+          "2001nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00403",
+    "image_path": null,
+    "question_text": {
+      "en": "What year did the original Pokemon anime first air in Japan?",
+      "ja": "ぽけもんアニメがにほんではじめてほうそうされたのはなんねんか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hunter x Hunter",
+        "ja": "はんたーはんたー",
+        "ja_typings": [
+          "hantahanta"
+        ]
+      },
+      {
+        "en": "Yu Yu Hakusho",
+        "ja": "ゆゆはくしょ",
+        "ja_typings": [
+          "yuyuhakusho"
+        ]
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "ふぇありーている",
+        "ja_typings": [
+          "feariteiru"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ぶらっくくろーばー",
+        "ja_typings": [
+          "burakkukuroba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00404",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features characters fighting with 'Nen' energy?",
+      "ja": "ねんをつかってたたかうアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Edward's automail limbs",
+        "ja": "えどわーどのぎそくしし",
+        "ja_typings": [
+          "edowadonogisokushishi"
+        ]
+      },
+      {
+        "en": "a type of alchemy",
+        "ja": "れんきんじゅつのしゅるい",
+        "ja_typings": [
+          "renkinjutsunoshurui"
+        ]
+      },
+      {
+        "en": "a city name",
+        "ja": "まちのなまえ",
+        "ja_typings": [
+          "machinonamae"
+        ]
+      },
+      {
+        "en": "a villain's title",
+        "ja": "ヴィランのしょうごう",
+        "ja_typings": [
+          "virannoshogo",
+          "virannoshougou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00405",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Fullmetal' referring to in Fullmetal Alchemist?",
+      "ja": "はがねのれんきんじゅつしの「はがねの」はなにをさすか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Re:Zero",
+        "ja": "りぜろ",
+        "ja_typings": [
+          "rizero"
+        ]
+      },
+      {
+        "en": "Overlord",
+        "ja": "おーばーろーど",
+        "ja_typings": [
+          "obarodo"
+        ]
+      },
+      {
+        "en": "That Time I Got Reincarnated as a Slime",
+        "ja": "てんせいしたらスライムだったけん",
+        "ja_typings": [
+          "tenseishitarasuraimudattaken"
+        ]
+      },
+      {
+        "en": "KonoSuba",
+        "ja": "このすばー",
+        "ja_typings": [
+          "konosuba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00406",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features the character Rem?",
+      "ja": "れむがとうじょうするアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "all animation",
+        "ja": "すべてのアニメーション",
+        "ja_typings": [
+          "subetenoanimeshon"
+        ]
+      },
+      {
+        "en": "only Japanese animation",
+        "ja": "にほんのアニメのみ",
+        "ja_typings": [
+          "nihonnoanimenomi"
+        ]
+      },
+      {
+        "en": "cartoon characters",
+        "ja": "まんがのキャラクター",
+        "ja_typings": [
+          "manganokyarakuta"
+        ]
+      },
+      {
+        "en": "motion pictures",
+        "ja": "えいが",
+        "ja_typings": [
+          "eiga"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00407",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Anime' literally referring to in Japanese?",
+      "ja": "にほんごで「アニメ」はもともと何をさすか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "My Hero Academia",
+        "ja": "ぼくのひーろーあかでみあ",
+        "ja_typings": [
+          "bokunohiroakademia"
+        ]
+      },
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": [
+          "naruto"
+        ]
+      },
+      {
+        "en": "Dragon Ball Z",
+        "ja": "どらごんぼーるZ",
+        "ja_typings": [
+          "doragonboruz"
+        ]
+      },
+      {
+        "en": "One Piece",
+        "ja": "わんぴーす",
+        "ja_typings": [
+          "wanpisu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00408",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is famous for the phrase 'Plus Ultra'?",
+      "ja": "ぷらすうるとらというフレーズでゆうめいなアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "My Hero Academia",
+        "ja": "ぼくのひーろーあかでみあ",
+        "ja_typings": [
+          "bokunohiroakademia"
+        ]
+      },
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": [
+          "naruto"
+        ]
+      },
+      {
+        "en": "Dragon Ball",
+        "ja": "どらごんぼーる",
+        "ja_typings": [
+          "doragonboru"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ぶらっくくろーばー",
+        "ja_typings": [
+          "burakkukuroba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00409",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is about a boy who discovers he can become a hero by training hard?",
+      "ja": "はげんれんしゅうでひーろーになれることをしったしょうねんのアニメは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Attack on Titan",
+        "ja": "あたっくおんたいたん",
+        "ja_typings": [
+          "atakkuontaitan"
+        ]
+      },
+      {
+        "en": "Titan Attack",
+        "ja": "たいたんあたっく",
+        "ja_typings": [
+          "taitanatakku"
+        ]
+      },
+      {
+        "en": "Rumbling Titans",
+        "ja": "らんぶりんぐたいたんず",
+        "ja_typings": [
+          "ranburingutaitanzu"
+        ]
+      },
+      {
+        "en": "Rising Titans",
+        "ja": "らいじんぐたいたんず",
+        "ja_typings": [
+          "raijingutaitanzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00410",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Shingeki no Kyojin' in English?",
+      "ja": "しんげきのきょじんの英語タイトルは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Infinity",
+        "ja": "むげん",
+        "ja_typings": [
+          "mugen"
+        ]
+      },
+      {
+        "en": "Six Eyes",
+        "ja": "ろくがん",
+        "ja_typings": [
+          "rokugan"
+        ]
+      },
+      {
+        "en": "Reverse Cursed Technique",
+        "ja": "はんてんじゅつしき",
+        "ja_typings": [
+          "hantenjutsushiki"
+        ]
+      },
+      {
+        "en": "Domain Expansion",
+        "ja": "りょういきてんかい",
+        "ja_typings": [
+          "ryoikitenkai",
+          "ryouikitenkai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00411",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the name of Satoru Gojo's special ability?",
+      "ja": "ごじょうさとるの特殊能力のなまえは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "psychological thriller",
+        "ja": "しんりさすぺんす",
+        "ja_typings": [
+          "shinrisasupensu"
+        ]
+      },
+      {
+        "en": "action shonen",
+        "ja": "あくしょんしょうねん",
+        "ja_typings": [
+          "akushonshonen",
+          "akushonshounen"
+        ]
+      },
+      {
+        "en": "romance",
+        "ja": "れんあい",
+        "ja_typings": [
+          "renai"
+        ]
+      },
+      {
+        "en": "fantasy adventure",
+        "ja": "ふぁんたじーぼうけん",
+        "ja_typings": [
+          "fantajiboken",
+          "fantajibouken"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q00412",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is a psychological thriller with 'Death Note'?",
+      "ja": "デスノートはどんなジャンルのアニメか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nintendo 64",
+        "ja": "にんてんどうろくじゅうよん",
+        "ja_typings": [
+          "nintendorokujuuyon",
+          "nintendourokujuuyon"
+        ]
+      },
+      {
+        "en": "Super Famicom",
+        "ja": "すーぱーふぁみこん",
+        "ja_typings": [
+          "supafamikon"
+        ]
+      },
+      {
+        "en": "Sega Saturn",
+        "ja": "せがさたーん",
+        "ja_typings": [
+          "segasatan"
+        ]
+      },
+      {
+        "en": "Atari 2600",
+        "ja": "あたりにせんろっぴゃく",
+        "ja_typings": [
+          "atarinisenroppyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00413",
+    "image_path": null,
+    "question_text": {
+      "en": "What console launched the modern era of 3D gaming?",
+      "ja": "3Dげーむのしんじだいをひらいたてゆきとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Legend of Zelda",
+        "ja": "ぜるだのでんせつ",
+        "ja_typings": [
+          "zerudanodensetsu"
+        ]
+      },
+      {
+        "en": "Metroid",
+        "ja": "めとろいど",
+        "ja_typings": [
+          "metoroido"
+        ]
+      },
+      {
+        "en": "Kirby",
+        "ja": "かーびぃ",
+        "ja_typings": [
+          "kabii"
+        ]
+      },
+      {
+        "en": "Star Fox",
+        "ja": "すたーふぉっくす",
+        "ja_typings": [
+          "sutafokkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00414",
+    "image_path": null,
+    "question_text": {
+      "en": "What game features Link as the protagonist?",
+      "ja": "りんくがしゅじんこうのげーむは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Minecraft",
+        "ja": "まいんくらふと",
+        "ja_typings": [
+          "mainkurafuto"
+        ]
+      },
+      {
+        "en": "Tetris",
+        "ja": "てとりす",
+        "ja_typings": [
+          "tetorisu"
+        ]
+      },
+      {
+        "en": "GTA V",
+        "ja": "GTA5",
+        "ja_typings": [
+          "gta5"
+        ]
+      },
+      {
+        "en": "Wii Sports",
+        "ja": "wiiすぽーつ",
+        "ja_typings": [
+          "wiisupotsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00415",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the best-selling video game of all time (as of 2024)?",
+      "ja": "2024ねんじてんでもっともうれたびでおげーむは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sony",
+        "ja": "そにー",
+        "ja_typings": [
+          "soni"
+        ]
+      },
+      {
+        "en": "Microsoft",
+        "ja": "まいくろそふと",
+        "ja_typings": [
+          "maikurosofuto"
+        ]
+      },
+      {
+        "en": "Nintendo",
+        "ja": "にんてんどう",
+        "ja_typings": [
+          "nintendo",
+          "nintendou"
+        ]
+      },
+      {
+        "en": "Sega",
+        "ja": "せが",
+        "ja_typings": [
+          "sega"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00416",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company makes the PlayStation?",
+      "ja": "ぷれいすてーしょんをつくっているかいしゃは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Super Mario",
+        "ja": "すーぱーまりお",
+        "ja_typings": [
+          "supamario"
+        ]
+      },
+      {
+        "en": "Donkey Kong",
+        "ja": "どんきーこんぐ",
+        "ja_typings": [
+          "donkikongu"
+        ]
+      },
+      {
+        "en": "Sonic",
+        "ja": "そにっく",
+        "ja_typings": [
+          "sonikku"
+        ]
+      },
+      {
+        "en": "Mega Man",
+        "ja": "ろっくまん",
+        "ja_typings": [
+          "rokkuman"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00417",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features Mario and Luigi?",
+      "ja": "まりおとるいーじがとうじょうするげーむは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pac-Man",
+        "ja": "ぱっくまん",
+        "ja_typings": [
+          "pakkuman"
+        ]
+      },
+      {
+        "en": "Kirby",
+        "ja": "かーびぃ",
+        "ja_typings": [
+          "kabii"
+        ]
+      },
+      {
+        "en": "Pikachu",
+        "ja": "ぴかちゅう",
+        "ja_typings": [
+          "pikachuu"
+        ]
+      },
+      {
+        "en": "Chocobo",
+        "ja": "ちょこぼ",
+        "ja_typings": [
+          "chokobo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00418",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the iconic yellow ghost-eating character?",
+      "ja": "おばけをたべるきいろいキャラクターは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Halo",
+        "ja": "へいろー",
+        "ja_typings": [
+          "heiro"
+        ]
+      },
+      {
+        "en": "Doom",
+        "ja": "どぅーむ",
+        "ja_typings": [
+          "dumu"
+        ]
+      },
+      {
+        "en": "Call of Duty",
+        "ja": "こーるおぶでゅーてぃ",
+        "ja_typings": [
+          "koruobudeyuti"
+        ]
+      },
+      {
+        "en": "Battlefield",
+        "ja": "ばとるふぃーるど",
+        "ja_typings": [
+          "batorufirudo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00419",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game series features Master Chief?",
+      "ja": "ますたーちいふがとうじょうするげーむシリーズは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PUBG",
+        "ja": "ぱぶじー",
+        "ja_typings": [
+          "pabuji"
+        ]
+      },
+      {
+        "en": "Fortnite",
+        "ja": "ふぉーとないと",
+        "ja_typings": [
+          "fotonaito"
+        ]
+      },
+      {
+        "en": "Warzone",
+        "ja": "うぉーぞーん",
+        "ja_typings": [
+          "wozon"
+        ]
+      },
+      {
+        "en": "Apex Legends",
+        "ja": "えいぺっくすれじぇんず",
+        "ja_typings": [
+          "eipekkusurejenzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00420",
+    "image_path": null,
+    "question_text": {
+      "en": "What game popularized the battle royale genre?",
+      "ja": "ばとるろわいやるジャンルをひろめたげーむは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sega",
+        "ja": "せが",
+        "ja_typings": [
+          "sega"
+        ]
+      },
+      {
+        "en": "Nintendo",
+        "ja": "にんてんどう",
+        "ja_typings": [
+          "nintendo",
+          "nintendou"
+        ]
+      },
+      {
+        "en": "Capcom",
+        "ja": "かぷこむ",
+        "ja_typings": [
+          "kapukomu"
+        ]
+      },
+      {
+        "en": "Konami",
+        "ja": "こなみ",
+        "ja_typings": [
+          "konami"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00421",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company made Sonic the Hedgehog?",
+      "ja": "そにっくざへっじほっぐをつくったかいしゃは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Halo",
+        "ja": "へいろー",
+        "ja_typings": [
+          "heiro"
+        ]
+      },
+      {
+        "en": "Gears of War",
+        "ja": "ぎあすおぶうぉー",
+        "ja_typings": [
+          "giasuobuwo"
+        ]
+      },
+      {
+        "en": "Mass Effect",
+        "ja": "ますえふぇくと",
+        "ja_typings": [
+          "masuefekuto"
+        ]
+      },
+      {
+        "en": "Destiny",
+        "ja": "ですてぃにー",
+        "ja_typings": [
+          "desutini"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00422",
+    "image_path": null,
+    "question_text": {
+      "en": "What game series features the Covenant as enemies?",
+      "ja": "こべナントがてきとしてとうじょうするげーむシリーズは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Portal",
+        "ja": "ぽーたる",
+        "ja_typings": [
+          "potaru"
+        ]
+      },
+      {
+        "en": "Half-Life",
+        "ja": "はーふらいふ",
+        "ja_typings": [
+          "hafuraifu"
+        ]
+      },
+      {
+        "en": "Mirror's Edge",
+        "ja": "みらーずえっじ",
+        "ja_typings": [
+          "mirazuejji"
+        ]
+      },
+      {
+        "en": "Bioshock",
+        "ja": "ばいおしょっく",
+        "ja_typings": [
+          "baioshokku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00423",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game is famous for the phrase 'The Cake is a Lie'?",
+      "ja": "「けーきはうそだ」というフレーズでゆうめいなげーむは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "dark fantasy medieval world",
+        "ja": "くらいちゅうせいふぁんたじーのせかい",
+        "ja_typings": [
+          "kuraichuuseifantajinosekai"
+        ]
+      },
+      {
+        "en": "futuristic space",
+        "ja": "みらいのうちゅう",
+        "ja_typings": [
+          "mirainochuu",
+          "mirainouchuu"
+        ]
+      },
+      {
+        "en": "modern day city",
+        "ja": "げんだいのとし",
+        "ja_typings": [
+          "gendainotoshi"
+        ]
+      },
+      {
+        "en": "post-apocalyptic wasteland",
+        "ja": "ぶんめいほうかいごのこうやー",
+        "ja_typings": [
+          "bunmeihokaigonokoya",
+          "bunmeihoukaigonokouya"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00424",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the setting of the Dark Souls series?",
+      "ja": "ダークソウルシリーズの舞台は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Resident Evil",
+        "ja": "ばいおはざーど",
+        "ja_typings": [
+          "baiohazado"
+        ]
+      },
+      {
+        "en": "Silent Hill",
+        "ja": "さいれんとひる",
+        "ja_typings": [
+          "sairentohiru"
+        ]
+      },
+      {
+        "en": "Alone in the Dark",
+        "ja": "あろーんいんざだーく",
+        "ja_typings": [
+          "aroninzadaku"
+        ]
+      },
+      {
+        "en": "Fatal Frame",
+        "ja": "ぜろ",
+        "ja_typings": [
+          "zero"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00425",
+    "image_path": null,
+    "question_text": {
+      "en": "What game created the 'survival horror' genre?",
+      "ja": "さばいばるほらーというジャンルをつくったげーむは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "2011",
+        "ja": "2011ねん",
+        "ja_typings": [
+          "2011nen"
+        ]
+      },
+      {
+        "en": "2009",
+        "ja": "2009ねん",
+        "ja_typings": [
+          "2009nen"
+        ]
+      },
+      {
+        "en": "2013",
+        "ja": "2013ねん",
+        "ja_typings": [
+          "2013nen"
+        ]
+      },
+      {
+        "en": "2015",
+        "ja": "2015ねん",
+        "ja_typings": [
+          "2015nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00426",
+    "image_path": null,
+    "question_text": {
+      "en": "What year was the original Minecraft released to the public?",
+      "ja": "おりじなるまいんくらふとがこうかいされたのはなんねんか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "clear lines by filling them",
+        "ja": "れつをうめてきえす",
+        "ja_typings": [
+          "retsuometekiesu",
+          "retsuoumetekiesu"
+        ]
+      },
+      {
+        "en": "defeat enemies",
+        "ja": "てきをたおす",
+        "ja_typings": [
+          "tekiotaosu"
+        ]
+      },
+      {
+        "en": "collect all pieces",
+        "ja": "すべてのぴーすをあつめる",
+        "ja_typings": [
+          "subetenopisuoatsumeru"
+        ]
+      },
+      {
+        "en": "build the tallest tower",
+        "ja": "いちばんたかいとうをたてる",
+        "ja_typings": [
+          "ichibantakaitootateru",
+          "ichibantakaitouotateru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00427",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the objective in Tetris?",
+      "ja": "テトリスのもくてきは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Red Dead Redemption",
+        "ja": "れっどでっどりでんぷしょん",
+        "ja_typings": [
+          "reddodeddoridenpushon"
+        ]
+      },
+      {
+        "en": "GTA",
+        "ja": "グランドせふとおーと",
+        "ja_typings": [
+          "gurandosefutoto",
+          "gurandosefutooto"
+        ]
+      },
+      {
+        "en": "Outlaws of the West",
+        "ja": "あうとろーずおぶざうぇすと",
+        "ja_typings": [
+          "autorozuobuzawesuto"
+        ]
+      },
+      {
+        "en": "Wild West Online",
+        "ja": "わいるどうぇすとおんらいん",
+        "ja_typings": [
+          "wairudowesutonrain",
+          "wairudowesutoonrain"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00428",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game series features Arthur Morgan or John Marston?",
+      "ja": "あーさーもるがんまたはじょんまーすとんがとうじょうするシリーズは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "life simulation",
+        "ja": "せいかつしみゅれーしょん",
+        "ja_typings": [
+          "seikatsushimyureshon"
+        ]
+      },
+      {
+        "en": "action RPG",
+        "ja": "あくしょんRPG",
+        "ja_typings": [
+          "akushonrpg"
+        ]
+      },
+      {
+        "en": "survival horror",
+        "ja": "さばいばるほらー",
+        "ja_typings": [
+          "sabaibaruhora"
+        ]
+      },
+      {
+        "en": "strategy",
+        "ja": "すとらてじー",
+        "ja_typings": [
+          "sutorateji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00429",
+    "image_path": null,
+    "question_text": {
+      "en": "What genre is 'The Sims'?",
+      "ja": "ざしむずのジャンルは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Legend of Zelda",
+        "ja": "ぜるだのでんせつ",
+        "ja_typings": [
+          "zerudanodensetsu"
+        ]
+      },
+      {
+        "en": "Fire Emblem",
+        "ja": "ふぁいあーえんぶれむ",
+        "ja_typings": [
+          "faiaenburemu"
+        ]
+      },
+      {
+        "en": "Xenoblade",
+        "ja": "ぜのぶれーど",
+        "ja_typings": [
+          "zenoburedo"
+        ]
+      },
+      {
+        "en": "Metroid",
+        "ja": "めとろいど",
+        "ja_typings": [
+          "metoroido"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00430",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nintendo franchise features Link and Zelda?",
+      "ja": "りんくとぜるだのにんてんどうフランチャイズは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "social deduction",
+        "ja": "しゃかいてきすいろん",
+        "ja_typings": [
+          "shakaitekisuiron"
+        ]
+      },
+      {
+        "en": "battle royale",
+        "ja": "ばとるろわいやる",
+        "ja_typings": [
+          "batorurowaiyaru"
+        ]
+      },
+      {
+        "en": "real-time strategy",
+        "ja": "りあるたいむすとらてじー",
+        "ja_typings": [
+          "riarutaimusutorateji"
+        ]
+      },
+      {
+        "en": "MMORPG",
+        "ja": "MMORPG",
+        "ja_typings": [
+          "mmorpg"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00431",
+    "image_path": null,
+    "question_text": {
+      "en": "What type of game is 'Among Us'?",
+      "ja": "あまんぐあすのゲームジャンルは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Color TV-Game",
+        "ja": "からーTVゲーム",
+        "ja_typings": [
+          "karatvgemu"
+        ]
+      },
+      {
+        "en": "Famicom",
+        "ja": "ふぁみこん",
+        "ja_typings": [
+          "famikon"
+        ]
+      },
+      {
+        "en": "Game & Watch",
+        "ja": "ゲームあんどうぉっち",
+        "ja_typings": [
+          "gemuandowotchi"
+        ]
+      },
+      {
+        "en": "Game Boy",
+        "ja": "ゲームぼーい",
+        "ja_typings": [
+          "gemuboi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00432",
+    "image_path": null,
+    "question_text": {
+      "en": "What was Nintendo's first game console?",
+      "ja": "にんてんどうのはじめてのゲームきは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mass Effect",
+        "ja": "ますえふぇくと",
+        "ja_typings": [
+          "masuefekuto"
+        ]
+      },
+      {
+        "en": "Halo",
+        "ja": "へいろー",
+        "ja_typings": [
+          "heiro"
+        ]
+      },
+      {
+        "en": "Destiny",
+        "ja": "ですてぃにー",
+        "ja_typings": [
+          "desutini"
+        ]
+      },
+      {
+        "en": "Gears of War",
+        "ja": "ぎあすおぶうぉー",
+        "ja_typings": [
+          "giasuobuwo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00433",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game series features Commander Shepard?",
+      "ja": "しぇぱーどさがおのシリーズは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Navi",
+        "ja": "なび",
+        "ja_typings": [
+          "nabi"
+        ]
+      },
+      {
+        "en": "Tatl",
+        "ja": "たとる",
+        "ja_typings": [
+          "tatoru"
+        ]
+      },
+      {
+        "en": "Midna",
+        "ja": "みどな",
+        "ja_typings": [
+          "midona"
+        ]
+      },
+      {
+        "en": "Fi",
+        "ja": "ふぁい",
+        "ja_typings": [
+          "fai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00434",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the name of Link's fairy companion in Ocarina of Time?",
+      "ja": "時のオカリナでりんくのようせいのなまえは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Japanese-style role-playing game",
+        "ja": "にほんしきのRPG",
+        "ja_typings": [
+          "nihonshikinorpg"
+        ]
+      },
+      {
+        "en": "Java-based RPG engine",
+        "ja": "JavaべーすのRPGえんじん",
+        "ja_typings": [
+          "javabesunorpgenjin"
+        ]
+      },
+      {
+        "en": "Junior RPG for kids",
+        "ja": "こどもむけのRPG",
+        "ja_typings": [
+          "kodomomukenorpg"
+        ]
+      },
+      {
+        "en": "jungle role-playing game",
+        "ja": "じゃんぐるRPG",
+        "ja_typings": [
+          "jangururpg"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00435",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a JRPG?",
+      "ja": "JRPGとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Square Enix",
+        "ja": "すくえあえにっくす",
+        "ja_typings": [
+          "sukueaenikkusu"
+        ]
+      },
+      {
+        "en": "Capcom",
+        "ja": "かぷこむ",
+        "ja_typings": [
+          "kapukomu"
+        ]
+      },
+      {
+        "en": "Konami",
+        "ja": "こなみ",
+        "ja_typings": [
+          "konami"
+        ]
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "ばんだいなむこ",
+        "ja_typings": [
+          "bandainamuko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00436",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game company made Final Fantasy?",
+      "ja": "ふぁいなるふぁんたじーをつくったかいしゃは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "character dies permanently when killed",
+        "ja": "しぬとキャラがえいきゅうにきえる",
+        "ja_typings": [
+          "shinutokyaragaeikyuunikieru"
+        ]
+      },
+      {
+        "en": "infinite lives system",
+        "ja": "むげんのいのちのしすてむ",
+        "ja_typings": [
+          "mugennoinochinoshisutemu"
+        ]
+      },
+      {
+        "en": "auto-save after death",
+        "ja": "しごとじどうほぞん",
+        "ja_typings": [
+          "shigotojidohozon",
+          "shigotojidouhozon"
+        ]
+      },
+      {
+        "en": "death animation system",
+        "ja": "しのあにめーしょんしすてむ",
+        "ja_typings": [
+          "shinoanimeshonshisutemu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00437",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'permadeath' in games?",
+      "ja": "ゲームのぱーまですとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "procedural generation with permadeath",
+        "ja": "じどうせいせいとぱーまです",
+        "ja_typings": [
+          "jidoseiseitopamadesu",
+          "jidouseiseitopamadesu"
+        ]
+      },
+      {
+        "en": "game about thieves",
+        "ja": "どろぼうのゲーム",
+        "ja_typings": [
+          "dorobonogemu",
+          "dorobounogemu"
+        ]
+      },
+      {
+        "en": "classic 8-bit game",
+        "ja": "クラシックはちびっとゲーム",
+        "ja_typings": [
+          "kurashikkuhachibittogemu"
+        ]
+      },
+      {
+        "en": "linear adventure game",
+        "ja": "いちじゅんのぼうけんゲーム",
+        "ja_typings": [
+          "ichijunnobokengemu",
+          "ichijunnoboukengemu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00438",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a roguelike game?",
+      "ja": "ろーぐらいくゲームとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "checkmate opponent's king",
+        "ja": "あいてのきんぐをちぇっくめーと",
+        "ja_typings": [
+          "aitenokinguochekkumeto"
+        ]
+      },
+      {
+        "en": "capture all pieces",
+        "ja": "ぜんてはつきょうする",
+        "ja_typings": [
+          "zentehatsukyosuru",
+          "zentehatsukyousuru"
+        ]
+      },
+      {
+        "en": "reach the other side",
+        "ja": "はんたいがわにとうたつ",
+        "ja_typings": [
+          "hantaigawanitotatsu",
+          "hantaigawanitoutatsu"
+        ]
+      },
+      {
+        "en": "collect most points",
+        "ja": "もっともてんすうをとる",
+        "ja_typings": [
+          "mottomotensuuotoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00439",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the objective in chess (video game version)?",
+      "ja": "チェスのもくてきは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1985",
+        "ja": "1985ねん",
+        "ja_typings": [
+          "1985nen"
+        ]
+      },
+      {
+        "en": "1983",
+        "ja": "1983ねん",
+        "ja_typings": [
+          "1983nen"
+        ]
+      },
+      {
+        "en": "1987",
+        "ja": "1987ねん",
+        "ja_typings": [
+          "1987nen"
+        ]
+      },
+      {
+        "en": "1989",
+        "ja": "1989ねん",
+        "ja_typings": [
+          "1989nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00440",
+    "image_path": null,
+    "question_text": {
+      "en": "What year was the first Super Mario Bros released?",
+      "ja": "はつのすーぱーまりおぶらざーずはいつはつばいされたか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Halo",
+        "ja": "へいろー",
+        "ja_typings": [
+          "heiro"
+        ]
+      },
+      {
+        "en": "Star Wars Battlefront",
+        "ja": "すたーうぉーずばとるふろんと",
+        "ja_typings": [
+          "sutawozubatorufuronto"
+        ]
+      },
+      {
+        "en": "Destiny",
+        "ja": "ですてぃにー",
+        "ja_typings": [
+          "desutini"
+        ]
+      },
+      {
+        "en": "Anthem",
+        "ja": "あんせむ",
+        "ja_typings": [
+          "ansemu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00441",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features the Covenant, Flood, and Forerunners?",
+      "ja": "こべナント、ふらっど、ふぉーらんなーがとうじょうするゲームは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "city building simulation",
+        "ja": "まちづくりしみゅれーしょん",
+        "ja_typings": [
+          "machizukurishimyureshon"
+        ]
+      },
+      {
+        "en": "action platformer",
+        "ja": "あくしょんぷらっとふぉーまー",
+        "ja_typings": [
+          "akushonpurattofoma"
+        ]
+      },
+      {
+        "en": "racing game",
+        "ja": "れーすゲーム",
+        "ja_typings": [
+          "resugemu"
+        ]
+      },
+      {
+        "en": "horror survival",
+        "ja": "ほらーさばいばる",
+        "ja_typings": [
+          "horasabaibaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00442",
+    "image_path": null,
+    "question_text": {
+      "en": "What type of game is 'SimCity'?",
+      "ja": "しむしてぃのゲームジャンルは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bells",
+        "ja": "ベル",
+        "ja_typings": [
+          "beru"
+        ]
+      },
+      {
+        "en": "Gold Coins",
+        "ja": "きんか",
+        "ja_typings": [
+          "kinka"
+        ]
+      },
+      {
+        "en": "Nook Miles",
+        "ja": "ぬっきーまいる",
+        "ja_typings": [
+          "nukkimairu"
+        ]
+      },
+      {
+        "en": "Rupees",
+        "ja": "るぴー",
+        "ja_typings": [
+          "rupi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00443",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the main currency in Animal Crossing?",
+      "ja": "あつまれどうぶつのもりのつうかは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pokemon",
+        "ja": "ぽけもん",
+        "ja_typings": [
+          "pokemon"
+        ]
+      },
+      {
+        "en": "Monster Hunter",
+        "ja": "もんすたーはんたー",
+        "ja_typings": [
+          "monsutahanta"
+        ]
+      },
+      {
+        "en": "Digimon",
+        "ja": "でじもん",
+        "ja_typings": [
+          "dejimon"
+        ]
+      },
+      {
+        "en": "Dragon Quest Monsters",
+        "ja": "ドラゴンクエストモンスターズ",
+        "ja_typings": [
+          "doragonkuesutomonsutazu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00444",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game is known for the catchphrase 'Gotta Catch 'Em All'?",
+      "ja": "「ぜんぶつかまえろ」というキャッチフレーズのゲームは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Microsoft",
+        "ja": "まいくろそふと",
+        "ja_typings": [
+          "maikurosofuto"
+        ]
+      },
+      {
+        "en": "Sony",
+        "ja": "そにー",
+        "ja_typings": [
+          "soni"
+        ]
+      },
+      {
+        "en": "Nintendo",
+        "ja": "にんてんどう",
+        "ja_typings": [
+          "nintendo",
+          "nintendou"
+        ]
+      },
+      {
+        "en": "Valve",
+        "ja": "ばるぶ",
+        "ja_typings": [
+          "barubu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00445",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company makes the Xbox?",
+      "ja": "えっくすぼっくすをつくっているかいしゃは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HP",
+        "ja": "HP",
+        "ja_typings": [
+          "hp"
+        ]
+      },
+      {
+        "en": "MP",
+        "ja": "MP",
+        "ja_typings": [
+          "mp"
+        ]
+      },
+      {
+        "en": "SP",
+        "ja": "SP",
+        "ja_typings": [
+          "sp"
+        ]
+      },
+      {
+        "en": "AP",
+        "ja": "AP",
+        "ja_typings": [
+          "ap"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00446",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'health points' abbreviated as in games?",
+      "ja": "ゲームでヘルスポイントのりゃくごは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MP",
+        "ja": "MP",
+        "ja_typings": [
+          "mp"
+        ]
+      },
+      {
+        "en": "HP",
+        "ja": "HP",
+        "ja_typings": [
+          "hp"
+        ]
+      },
+      {
+        "en": "SP",
+        "ja": "SP",
+        "ja_typings": [
+          "sp"
+        ]
+      },
+      {
+        "en": "FP",
+        "ja": "FP",
+        "ja_typings": [
+          "fp"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00447",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'magic points' abbreviated as in games?",
+      "ja": "ゲームでまほうぽいんとのりゃくごは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Non-Player Character",
+        "ja": "のんぷれいやーキャラクター",
+        "ja_typings": [
+          "nonpureiyakyarakuta"
+        ]
+      },
+      {
+        "en": "New Player Content",
+        "ja": "にゅーぷれいやーこんてんつ",
+        "ja_typings": [
+          "nyupureiyakontentsu"
+        ]
+      },
+      {
+        "en": "Next Play Control",
+        "ja": "ねくすとぷれいこんとろーる",
+        "ja_typings": [
+          "nekusutopureikontororu"
+        ]
+      },
+      {
+        "en": "Network Play Connection",
+        "ja": "ねっとわーくぷれいせつぞく",
+        "ja_typings": [
+          "nettowakupureisetsuzoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00448",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'NPC' mean in video games?",
+      "ja": "ビデオゲームのNPCのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Downloadable Content",
+        "ja": "だうんろーどかのうなこんてんつ",
+        "ja_typings": [
+          "daunrodokanonakontentsu",
+          "daunrodokanounakontentsu"
+        ]
+      },
+      {
+        "en": "Dynamic Level Content",
+        "ja": "どうてきれべるこんてんつ",
+        "ja_typings": [
+          "dotekireberukontentsu",
+          "doutekireberukontentsu"
+        ]
+      },
+      {
+        "en": "Direct Link Connection",
+        "ja": "ちょくせつりんくせつぞく",
+        "ja_typings": [
+          "chokusetsurinkusetsuzoku"
+        ]
+      },
+      {
+        "en": "Dual-Layer Cartridge",
+        "ja": "だぶるれいやーかーとりっじ",
+        "ja_typings": [
+          "daburureiyakatorijji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00449",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'DLC' in gaming?",
+      "ja": "ゲームのDLCのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "repeatedly fighting to gain levels",
+        "ja": "くりかえしたたかってれべるあげ",
+        "ja_typings": [
+          "kurikaeshitatakattereberuage"
+        ]
+      },
+      {
+        "en": "crafting items",
+        "ja": "どうぐをつくる",
+        "ja_typings": [
+          "doguotsukuru",
+          "douguotsukuru"
+        ]
+      },
+      {
+        "en": "exploring new areas",
+        "ja": "あたらしいりょいきをたんさく",
+        "ja_typings": [
+          "atarashiiryoikiotansaku"
+        ]
+      },
+      {
+        "en": "completing side quests",
+        "ja": "サブクエストをクリア",
+        "ja_typings": [
+          "sabukuesutokuria",
+          "sabukuesutookuria"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00450",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'grinding' in RPGs?",
+      "ja": "RPGの「ぐらいんど」とは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "random in-game reward container",
+        "ja": "らんだむなゲームないほうしゅうコンテナ",
+        "ja_typings": [
+          "randamunagemunaihoshuukontena",
+          "randamunagemunaihoushuukontena"
+        ]
+      },
+      {
+        "en": "storage for items",
+        "ja": "アイテムのほぞんぼっくす",
+        "ja_typings": [
+          "aitemunohozonbokkusu"
+        ]
+      },
+      {
+        "en": "chest with guaranteed rewards",
+        "ja": "ほしょうりわーどのはこ",
+        "ja_typings": [
+          "hoshoriwadonohako",
+          "hoshouriwadonohako"
+        ]
+      },
+      {
+        "en": "enemy drop container",
+        "ja": "てきのどろっぷコンテナ",
+        "ja_typings": [
+          "tekinodoroppukontena"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00451",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'loot box'?",
+      "ja": "るーとぼっくすとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "hidden joke or secret by developers",
+        "ja": "かいはつしゃのかくされたじょーくやひみつ",
+        "ja_typings": [
+          "kaihatsushanokakusaretajokuyahimitsu"
+        ]
+      },
+      {
+        "en": "seasonal event content",
+        "ja": "きせつイベントコンテンツ",
+        "ja_typings": [
+          "kisetsuibentokontentsu"
+        ]
+      },
+      {
+        "en": "bonus stage at the end",
+        "ja": "さいごのぼーなすすてーじ",
+        "ja_typings": [
+          "saigonobonasusuteji"
+        ]
+      },
+      {
+        "en": "collectible egg item",
+        "ja": "しゅうしゅうひんのたまご",
+        "ja_typings": [
+          "shuushuuhinnotamago"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00452",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an 'Easter egg' in games?",
+      "ja": "ゲームのイースターたまごとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "completing a game as fast as possible",
+        "ja": "できるだけはやくゲームをクリア",
+        "ja_typings": [
+          "dekirudakehayakugemuokuria"
+        ]
+      },
+      {
+        "en": "racing mini-game mode",
+        "ja": "れーすのみにゲームもーど",
+        "ja_typings": [
+          "resunominigemumodo"
+        ]
+      },
+      {
+        "en": "skipping all cutscenes",
+        "ja": "すべてのカットシーンをスキップ",
+        "ja_typings": [
+          "subetenokattoshinosukippu"
+        ]
+      },
+      {
+        "en": "playing on highest difficulty",
+        "ja": "さいこうなんどでぷれい",
+        "ja_typings": [
+          "saikonandodepurei",
+          "saikounandodepurei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00453",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'speedrunning'?",
+      "ja": "すぴーどらんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "First-Person Shooter",
+        "ja": "いちにんしょうシューター",
+        "ja_typings": [
+          "ichininshoshuta",
+          "ichininshoushuta"
+        ]
+      },
+      {
+        "en": "Fast Pacing System",
+        "ja": "こうそくぺーすしすてむ",
+        "ja_typings": [
+          "kosokupesushisutemu",
+          "kousokupesushisutemu"
+        ]
+      },
+      {
+        "en": "Full Player Score",
+        "ja": "ふるぷれいやーすこあ",
+        "ja_typings": [
+          "furupureiyasukoa"
+        ]
+      },
+      {
+        "en": "Frames Per Second gaming",
+        "ja": "ふれーむぱーせかんどゲーム",
+        "ja_typings": [
+          "furemupasekandogemu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00454",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'FPS' as a game genre?",
+      "ja": "ゲームジャンルとしてのFPSとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Multiplayer Online Battle Arena",
+        "ja": "たにんぷれいおんらいんばとるあれな",
+        "ja_typings": [
+          "taninpureionrainbatoruarena"
+        ]
+      },
+      {
+        "en": "Mobile Online Battle App",
+        "ja": "もばいるおんらいんばとるあぷ",
+        "ja_typings": [
+          "mobairuonrainbatoruapu"
+        ]
+      },
+      {
+        "en": "Modern Open Battle Action",
+        "ja": "もだんおーぷんばとるあくしょん",
+        "ja_typings": [
+          "modanopunbatoruakushon"
+        ]
+      },
+      {
+        "en": "Multi-Object Battle Assignment",
+        "ja": "ふくすうもくひょうばとるかだい",
+        "ja_typings": [
+          "fukusuumokuhyobatorukadai",
+          "fukusuumokuhyoubatorukadai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00455",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'MOBA' as a game genre?",
+      "ja": "ゲームジャンルとしてのMOBAとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Minecraft",
+        "ja": "まいんくらふと",
+        "ja_typings": [
+          "mainkurafuto"
+        ]
+      },
+      {
+        "en": "Terraria",
+        "ja": "てらりあ",
+        "ja_typings": [
+          "teraria"
+        ]
+      },
+      {
+        "en": "Fortnite",
+        "ja": "ふぉーとないと",
+        "ja_typings": [
+          "fotonaito"
+        ]
+      },
+      {
+        "en": "Roblox",
+        "ja": "ろぶろっくす",
+        "ja_typings": [
+          "roburokkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00456",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game has 'Creepers' as enemies?",
+      "ja": "クリーパーがてきとしてとうじょうするゲームは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "the classic overworld theme",
+        "ja": "クラシックなマップテーマ",
+        "ja_typings": [
+          "kurashikkunamapputema"
+        ]
+      },
+      {
+        "en": "a pop song",
+        "ja": "ぽっぷそんぐ",
+        "ja_typings": [
+          "poppusongu"
+        ]
+      },
+      {
+        "en": "a battle anthem",
+        "ja": "せんとうのひめい",
+        "ja_typings": [
+          "sentonohimei",
+          "sentounohimei"
+        ]
+      },
+      {
+        "en": "the Zelda lullaby",
+        "ja": "ぜるだのこもりうた",
+        "ja_typings": [
+          "zerudanokomoriuta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00457",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the iconic opening music of the original Legend of Zelda?",
+      "ja": "ゼルダのでんせつのアイコニックなオープニング音楽は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "defeat a boss without taking damage",
+        "ja": "ダメージをうけずにボスをたおす",
+        "ja_typings": [
+          "damejiokezunibosuotaosu",
+          "damejioukezunibosuotaosu"
+        ]
+      },
+      {
+        "en": "defeat a boss in one hit",
+        "ja": "いちげきでボスをたおす",
+        "ja_typings": [
+          "ichigekidebosuotaosu"
+        ]
+      },
+      {
+        "en": "fight boss with no weapons",
+        "ja": "ぶきなしでボスとたたかう",
+        "ja_typings": [
+          "bukinashidebosutotatakau"
+        ]
+      },
+      {
+        "en": "kill boss before it attacks",
+        "ja": "ボスがこうげきするまえにたおす",
+        "ja_typings": [
+          "bosugakogekisurumaenitaosu",
+          "bosugakougekisurumaenitaosu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00458",
+    "image_path": null,
+    "question_text": {
+      "en": "What does it mean to 'no-hit' a boss?",
+      "ja": "ボスを「のーひっと」するとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "player has failed and must restart",
+        "ja": "プレイヤーがしっぱいしてやりなおし",
+        "ja_typings": [
+          "pureiyagashippaishiteyarinaoshi"
+        ]
+      },
+      {
+        "en": "the game is completed",
+        "ja": "ゲームがクリアされた",
+        "ja_typings": [
+          "gemugakuriasareta"
+        ]
+      },
+      {
+        "en": "a multiplayer session ends",
+        "ja": "たにんぷれいのせっしょんが終わった",
+        "ja_typings": [
+          "taninpureinosesshongawatta"
+        ]
+      },
+      {
+        "en": "a loading screen appears",
+        "ja": "ろーどがめんがひょうじ",
+        "ja_typings": [
+          "rodogamengahyoji",
+          "rodogamengahyouji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00459",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Game Over' traditionally?",
+      "ja": "「ゲームオーバー」はどういいみか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "cooperative multiplayer gameplay",
+        "ja": "きょうりょくたにんぷれい",
+        "ja_typings": [
+          "kyoryokutaninpurei",
+          "kyouryokutaninpurei"
+        ]
+      },
+      {
+        "en": "competitive multiplayer",
+        "ja": "きょうそうたにんぷれい",
+        "ja_typings": [
+          "kyosotaninpurei",
+          "kyousoutaninpurei"
+        ]
+      },
+      {
+        "en": "single player with AI partner",
+        "ja": "AIぱーとなーとのたんどく",
+        "ja_typings": [
+          "aipatonatonotandoku"
+        ]
+      },
+      {
+        "en": "online ranking system",
+        "ja": "おんらいんらんきんぐしすてむ",
+        "ja_typings": [
+          "onrainrankingushisutemu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00460",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'co-op' gaming?",
+      "ja": "こおぷゲームとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "open-world with player freedom",
+        "ja": "プレイヤーのじゆうなおーぷんわーるど",
+        "ja_typings": [
+          "pureiyanojiyuunaopunwarudo"
+        ]
+      },
+      {
+        "en": "game played in physical sandbox",
+        "ja": "ぶつりてきなすなばでのゲーム",
+        "ja_typings": [
+          "butsuritekinasunabadenogemu"
+        ]
+      },
+      {
+        "en": "game with no objectives",
+        "ja": "もくてきのないゲーム",
+        "ja_typings": [
+          "mokutekinonaigemu"
+        ]
+      },
+      {
+        "en": "children's educational game",
+        "ja": "こどものきょういくゲーム",
+        "ja_typings": [
+          "kodomonokyoikugemu",
+          "kodomonokyouikugemu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00461",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'sandbox' game?",
+      "ja": "さんどぼっくすゲームとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Resident Evil",
+        "ja": "ばいおはざーど",
+        "ja_typings": [
+          "baiohazado"
+        ]
+      },
+      {
+        "en": "Devil May Cry",
+        "ja": "でびるめいくらい",
+        "ja_typings": [
+          "debirumeikurai"
+        ]
+      },
+      {
+        "en": "Street Fighter",
+        "ja": "すとりーとふぁいたー",
+        "ja_typings": [
+          "sutoritofaita"
+        ]
+      },
+      {
+        "en": "Monster Hunter",
+        "ja": "もんすたーはんたー",
+        "ja_typings": [
+          "monsutahanta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00462",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Capcom game series features Leon Kennedy and Chris Redfield?",
+      "ja": "れおんけねでぃとくりすれっどふぃーるどのカプコンシリーズは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "instant hit detection along line of sight",
+        "ja": "しやのびょうしょくにそくじあたりはんてい",
+        "ja_typings": [
+          "shiyanobyoshokunisokujiatarihantei",
+          "shiyanobyoushokunisokujiatarihantei"
+        ]
+      },
+      {
+        "en": "projectile with travel time",
+        "ja": "ひこうじかんのあるだんがん",
+        "ja_typings": [
+          "hikojikannoarudangan",
+          "hikoujikannoarudangan"
+        ]
+      },
+      {
+        "en": "melee hit detection",
+        "ja": "きんせんこうげきはんてい",
+        "ja_typings": [
+          "kinsenkogekihantei",
+          "kinsenkougekihantei"
+        ]
+      },
+      {
+        "en": "player detection system",
+        "ja": "プレイヤーはんていしすてむ",
+        "ja_typings": [
+          "pureiyahanteishisutemu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00463",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'hit scan' in FPS games?",
+      "ja": "FPSのひっとすきゃんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "high latency causing delay",
+        "ja": "こうれいてんしーによるおくれ",
+        "ja_typings": [
+          "koreitenshiniyoruokure",
+          "koureitenshiniyoruokure"
+        ]
+      },
+      {
+        "en": "slow frame rate",
+        "ja": "ていふれーむれーと",
+        "ja_typings": [
+          "teifuremureto"
+        ]
+      },
+      {
+        "en": "server maintenance window",
+        "ja": "さーばーめんてなんすのじかん",
+        "ja_typings": [
+          "sabamentenansunojikan"
+        ]
+      },
+      {
+        "en": "game crash event",
+        "ja": "ゲームのくらっしゅ",
+        "ja_typings": [
+          "gemunokurasshu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00464",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'lag' in online gaming?",
+      "ja": "おんらいんゲームのらぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "open-world action-adventure",
+        "ja": "おーぷんわーるどアクションぼうけん",
+        "ja_typings": [
+          "opunwarudoakushonboken",
+          "opunwarudoakushonbouken"
+        ]
+      },
+      {
+        "en": "linear JRPG",
+        "ja": "いちじゅんのJRPG",
+        "ja_typings": [
+          "ichijunnojrpg"
+        ]
+      },
+      {
+        "en": "turn-based strategy",
+        "ja": "ターンせいすとらてじー",
+        "ja_typings": [
+          "tanseisutorateji"
+        ]
+      },
+      {
+        "en": "racing game",
+        "ja": "れーすゲーム",
+        "ja_typings": [
+          "resugemu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00465",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game is famous for 'The Legend of Zelda: Breath of the Wild'?",
+      "ja": "ゼルダのでんせつ ブレスオブザワイルドはどんなゲームか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nintendo Switch",
+        "ja": "にんてんどうスイッチ",
+        "ja_typings": [
+          "nintendosuitchi",
+          "nintendousuitchi"
+        ]
+      },
+      {
+        "en": "Sony Switch",
+        "ja": "そにースイッチ",
+        "ja_typings": [
+          "sonisuitchi"
+        ]
+      },
+      {
+        "en": "Xbox Switch",
+        "ja": "えっくすぼっくすスイッチ",
+        "ja_typings": [
+          "ekkusubokkususuitchi"
+        ]
+      },
+      {
+        "en": "Sega Switch",
+        "ja": "せがスイッチ",
+        "ja_typings": [
+          "segasuitchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00466",
+    "image_path": null,
+    "question_text": {
+      "en": "What console is the Switch?",
+      "ja": "スイッチはどのゲームきか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "capture opponent's king",
+        "ja": "あいてのきんぐをつかまえる",
+        "ja_typings": [
+          "aitenokinguotsukamaeru"
+        ]
+      },
+      {
+        "en": "collect all opponent pieces",
+        "ja": "あいてのこまをすべてとる",
+        "ja_typings": [
+          "aitenokomaosubetetoru"
+        ]
+      },
+      {
+        "en": "reach opponent's back row",
+        "ja": "あいてのうしろのれつにとどく",
+        "ja_typings": [
+          "aitenoshironoretsunitodoku",
+          "aitenoushironoretsunitodoku"
+        ]
+      },
+      {
+        "en": "earn the most points",
+        "ja": "もっともてんすうをかくとく",
+        "ja_typings": [
+          "mottomotensuuokakutoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00467",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the objective in chess?",
+      "ja": "チェスのもくてきは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Player versus Player",
+        "ja": "プレイヤー対プレイヤー",
+        "ja_typings": [
+          "pureiyapureiya"
+        ]
+      },
+      {
+        "en": "Platform versus Platform",
+        "ja": "ぷらっとふぉーむたいぷらっとふぉーむ",
+        "ja_typings": [
+          "purattofomutaipurattofomu"
+        ]
+      },
+      {
+        "en": "Points versus Progress",
+        "ja": "てんすうたいしんちょく",
+        "ja_typings": [
+          "tensuutaishinchoku"
+        ]
+      },
+      {
+        "en": "Procedural versus Pre-made",
+        "ja": "じどうたいてづくり",
+        "ja_typings": [
+          "jidotaitezukuri",
+          "jidoutaitezukuri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00468",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'PvP' in games?",
+      "ja": "ゲームのPvPとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Player versus Environment",
+        "ja": "プレイヤー対かんきょう",
+        "ja_typings": [
+          "pureiyakankyo",
+          "pureiyakankyou"
+        ]
+      },
+      {
+        "en": "Player versus Enemy",
+        "ja": "プレイヤー対てき",
+        "ja_typings": [
+          "pureiyateki"
+        ]
+      },
+      {
+        "en": "Player versus Events",
+        "ja": "プレイヤー対イベント",
+        "ja_typings": [
+          "pureiyaibento"
+        ]
+      },
+      {
+        "en": "Points versus Experience",
+        "ja": "てんすうたいたいけんち",
+        "ja_typings": [
+          "tensuutaitaikenchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00469",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'PvE' in games?",
+      "ja": "ゲームのPvEとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "temporary enhancement to character stats",
+        "ja": "キャラのすたーつのいちじてきこうじょう",
+        "ja_typings": [
+          "kyaranosutatsunoichijitekikojo",
+          "kyaranosutatsunoichijitekikoujou"
+        ]
+      },
+      {
+        "en": "attack that hits multiple enemies",
+        "ja": "ふくすうのてきにあたるこうげき",
+        "ja_typings": [
+          "fukusuunotekiniatarukogeki",
+          "fukusuunotekiniatarukougeki"
+        ]
+      },
+      {
+        "en": "item that restores health",
+        "ja": "HPをかいふくするアイテム",
+        "ja_typings": [
+          "hpokaifukusuruaitemu"
+        ]
+      },
+      {
+        "en": "armor ability upgrade",
+        "ja": "よろいののうりょくきょうか",
+        "ja_typings": [
+          "yoroinonoryokukyoka",
+          "yoroinonouryokukyouka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00470",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'buff' in games?",
+      "ja": "ゲームのばふとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "weakening something overpowered",
+        "ja": "つよすぎるものをよわくする",
+        "ja_typings": [
+          "tsuyosugirumonoyowakusuru",
+          "tsuyosugirumonooyowakusuru"
+        ]
+      },
+      {
+        "en": "strengthening something weak",
+        "ja": "よわいものをつよくする",
+        "ja_typings": [
+          "yowaimonotsuyokusuru",
+          "yowaimonootsuyokusuru"
+        ]
+      },
+      {
+        "en": "removing a character",
+        "ja": "キャラをさくじょ",
+        "ja_typings": [
+          "kyaraosakujo"
+        ]
+      },
+      {
+        "en": "adding new content",
+        "ja": "あたらしいこんてんつをついか",
+        "ja_typings": [
+          "atarashiikontentsuotsuika"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00471",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'nerf' in game balance?",
+      "ja": "ゲームバランスのなーふとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Capcom",
+        "ja": "かぷこむ",
+        "ja_typings": [
+          "kapukomu"
+        ]
+      },
+      {
+        "en": "SNK",
+        "ja": "えすえぬけー",
+        "ja_typings": [
+          "esuenuke"
+        ]
+      },
+      {
+        "en": "Namco",
+        "ja": "なむこ",
+        "ja_typings": [
+          "namuko"
+        ]
+      },
+      {
+        "en": "Midway",
+        "ja": "みっどうぇい",
+        "ja_typings": [
+          "middowei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00472",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company made Street Fighter?",
+      "ja": "すとりーとふぁいたーをつくったかいしゃは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Breakout",
+        "ja": "ぶれいくあうと",
+        "ja_typings": [
+          "bureikuauto"
+        ]
+      },
+      {
+        "en": "Pong",
+        "ja": "ぽんぐ",
+        "ja_typings": [
+          "pongu"
+        ]
+      },
+      {
+        "en": "Space Invaders",
+        "ja": "すぺーすいんべーだーず",
+        "ja_typings": [
+          "supesuinbedazu"
+        ]
+      },
+      {
+        "en": "Galaga",
+        "ja": "ぎゃらが",
+        "ja_typings": [
+          "gyaraga"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00473",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the classic arcade game where you break bricks with a ball?",
+      "ja": "ぼーるでれんがをこわすクラシックアーケードゲームは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "League of Legends",
+        "ja": "りーぐおぶれじぇんず",
+        "ja_typings": [
+          "riguoburejenzu"
+        ]
+      },
+      {
+        "en": "Dota 2",
+        "ja": "どーたつー",
+        "ja_typings": [
+          "dotatsu"
+        ]
+      },
+      {
+        "en": "Smite",
+        "ja": "すまいと",
+        "ja_typings": [
+          "sumaito"
+        ]
+      },
+      {
+        "en": "Heroes of the Storm",
+        "ja": "ひーろーずおぶざすとーむ",
+        "ja_typings": [
+          "hirozuobuzasutomu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00474",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the most popular MOBA game?",
+      "ja": "もっとにんきのあるMOBAゲームは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "dark fantasy medieval world",
+        "ja": "くらいふぁんたじーのちゅうせいせかい",
+        "ja_typings": [
+          "kuraifantajinochuuseisekai"
+        ]
+      },
+      {
+        "en": "futuristic cyberpunk city",
+        "ja": "みらいのさいばーぱんくとし",
+        "ja_typings": [
+          "mirainosaibapankutoshi"
+        ]
+      },
+      {
+        "en": "ancient Japan",
+        "ja": "こだいのにほん",
+        "ja_typings": [
+          "kodainonihon"
+        ]
+      },
+      {
+        "en": "post-apocalyptic USA",
+        "ja": "ぶんめいほうかいごのアメリカ",
+        "ja_typings": [
+          "bunmeihokaigonoamerika",
+          "bunmeihoukaigonoamerika"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00475",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the setting of 'The Witcher' series?",
+      "ja": "ウィッチャーシリーズの舞台は？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "reviving after death to continue play",
+        "ja": "しんでもふっかつしてぷれいをつづける",
+        "ja_typings": [
+          "shindemofukkatsushitepureiotsuzukeru"
+        ]
+      },
+      {
+        "en": "loading a save file",
+        "ja": "さらにゅうのろーど",
+        "ja_typings": [
+          "saranyuunorodo"
+        ]
+      },
+      {
+        "en": "starting the game over",
+        "ja": "ゲームをさいしょからやりなおす",
+        "ja_typings": [
+          "gemuosaishokarayarinaosu"
+        ]
+      },
+      {
+        "en": "switching to a new character",
+        "ja": "あたらしいキャラにきりかえる",
+        "ja_typings": [
+          "atarashiikyaranikirikaeru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00476",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'respawning' in games?",
+      "ja": "ゲームのりすぽーんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wood, Stone, Metal",
+        "ja": "もく、いし、きんぞく",
+        "ja_typings": [
+          "moku ishi kinzoku"
+        ]
+      },
+      {
+        "en": "Gold Coins",
+        "ja": "きんか",
+        "ja_typings": [
+          "kinka"
+        ]
+      },
+      {
+        "en": "Bricks",
+        "ja": "れんが",
+        "ja_typings": [
+          "renga"
+        ]
+      },
+      {
+        "en": "Crystal",
+        "ja": "クリスタル",
+        "ja_typings": [
+          "kurisutaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00477",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the main resource in Fortnite for building?",
+      "ja": "フォートナイトでけんちくにつかうまいんりそーすは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "in-game award for completing a challenge",
+        "ja": "ちゃれんじクリアのゲームないほうしょう",
+        "ja_typings": [
+          "charenjikurianogemunaihosho",
+          "charenjikurianogemunaihoushou"
+        ]
+      },
+      {
+        "en": "final game completion screen",
+        "ja": "ゲームのさいしゅうクリアがめん",
+        "ja_typings": [
+          "gemunosaishuukuriagamen"
+        ]
+      },
+      {
+        "en": "high score record",
+        "ja": "ハイスコアきろく",
+        "ja_typings": [
+          "haisukoakiroku"
+        ]
+      },
+      {
+        "en": "unlocked weapon or item",
+        "ja": "かいじょされたぶきやアイテム",
+        "ja_typings": [
+          "kaijosaretabukiyaaitemu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00478",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an 'achievement' in games?",
+      "ja": "ゲームのあちーぶめんととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "number of frames rendered per second",
+        "ja": "いちびょうあたりのふれーむすう",
+        "ja_typings": [
+          "ichibyoatarinofuremusuu",
+          "ichibyouatarinofuremusuu"
+        ]
+      },
+      {
+        "en": "game difficulty level",
+        "ja": "ゲームのなんいどれべる",
+        "ja_typings": [
+          "gemunonanidoreberu"
+        ]
+      },
+      {
+        "en": "internet connection speed",
+        "ja": "いんたーねっとせつぞくそくど",
+        "ja_typings": [
+          "intanettosetsuzokusokudo"
+        ]
+      },
+      {
+        "en": "animation smoothness setting",
+        "ja": "あにめーしょんなめらかさのせってい",
+        "ja_typings": [
+          "animeshonnamerakasanosettei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00479",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'frame rate' in games?",
+      "ja": "ゲームのふれーむれーととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "synchronizing frame rate with display refresh",
+        "ja": "ふれーむれーとをてぃすぷれいのりふれっしゅにどうき",
+        "ja_typings": [
+          "furemuretotisupureinorifuresshunidoki",
+          "furemuretootisupureinorifuresshunidouki"
+        ]
+      },
+      {
+        "en": "vertical screen split mode",
+        "ja": "すいちょくがめんぶんかつもーど",
+        "ja_typings": [
+          "suichokugamenbunkatsumodo"
+        ]
+      },
+      {
+        "en": "voice sync for multiplayer",
+        "ja": "たにんぷれいのおんせいどうき",
+        "ja_typings": [
+          "taninpureinonseidoki",
+          "taninpureinoonseidouki"
+        ]
+      },
+      {
+        "en": "video quality setting",
+        "ja": "どうがひんしつのせってい",
+        "ja_typings": [
+          "dogahinshitsunosettei",
+          "dougahinshitsunosettei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00480",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'V-sync' in gaming?",
+      "ja": "ゲームのVsyncとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "one of the first arcade video games",
+        "ja": "さいしょきのアーケードビデオゲーム",
+        "ja_typings": [
+          "saishokinoakedobideogemu"
+        ]
+      },
+      {
+        "en": "a pinball machine",
+        "ja": "ぴんぼーるましん",
+        "ja_typings": [
+          "pinborumashin"
+        ]
+      },
+      {
+        "en": "a Nintendo handheld game",
+        "ja": "にんてんどうけいたいゲーム",
+        "ja_typings": [
+          "nintendokeitaigemu",
+          "nintendoukeitaigemu"
+        ]
+      },
+      {
+        "en": "an Atari driving game",
+        "ja": "あたりのどらいびんぐゲーム",
+        "ja_typings": [
+          "atarinodoraibingugemu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00481",
+    "image_path": null,
+    "question_text": {
+      "en": "What was Pong?",
+      "ja": "ぽんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "shooter genre with extremely dense projectiles",
+        "ja": "だんがんびっしりのシューターゲーム",
+        "ja_typings": [
+          "danganbisshirinoshutagemu"
+        ]
+      },
+      {
+        "en": "shooter with single large bullet",
+        "ja": "おおきなたまひとつのシューター",
+        "ja_typings": [
+          "okinatamahitotsunoshuta",
+          "ookinatamahitotsunoshuta"
+        ]
+      },
+      {
+        "en": "physical shooting game",
+        "ja": "ぶつりてきしゃげきゲーム",
+        "ja_typings": [
+          "butsuritekishagekigemu"
+        ]
+      },
+      {
+        "en": "sword-fighting game",
+        "ja": "けんとうゲーム",
+        "ja_typings": [
+          "kentogemu",
+          "kentougemu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00482",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'bullet hell' in games?",
+      "ja": "ゲームのたんまくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "location where game progress is saved",
+        "ja": "ゲームのしんちょくをほぞんするばしょ",
+        "ja_typings": [
+          "gemunoshinchokuohozonsurubasho"
+        ]
+      },
+      {
+        "en": "checkpoint that restores health",
+        "ja": "HPをかいふくするチェックポイント",
+        "ja_typings": [
+          "hpokaifukusuruchekkupointo"
+        ]
+      },
+      {
+        "en": "item for saving inventory",
+        "ja": "インベントリほぞんアイテム",
+        "ja_typings": [
+          "inbentorihozonaitemu"
+        ]
+      },
+      {
+        "en": "the game's final destination",
+        "ja": "ゲームのさいしゅうもくてき",
+        "ja_typings": [
+          "gemunosaishuumokuteki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00483",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'save point'?",
+      "ja": "せーぶぽいんととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "large freely explorable environment",
+        "ja": "おおきくじゆうにたんさくできるかんきょう",
+        "ja_typings": [
+          "okikujiyuunitansakudekirukankyo",
+          "ookikujiyuunitansakudekirukankyou"
+        ]
+      },
+      {
+        "en": "game with no story",
+        "ja": "ものがたりのないゲーム",
+        "ja_typings": [
+          "monogatarinonaigemu"
+        ]
+      },
+      {
+        "en": "multiplayer game world",
+        "ja": "たにんぷれいのゲームせかい",
+        "ja_typings": [
+          "taninpureinogemusekai"
+        ]
+      },
+      {
+        "en": "game with random world generation",
+        "ja": "らんだむせいせいのゲームせかい",
+        "ja_typings": [
+          "randamuseiseinogemusekai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00484",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'open world' in games?",
+      "ja": "ゲームのおーぷんわーるどとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "players take turns to act",
+        "ja": "プレイヤーがじゅんばんにこうどう",
+        "ja_typings": [
+          "pureiyagajunbannikodo",
+          "pureiyagajunbannikoudou"
+        ]
+      },
+      {
+        "en": "real-time combat",
+        "ja": "りあるたいむせんとう",
+        "ja_typings": [
+          "riarutaimusento",
+          "riarutaimusentou"
+        ]
+      },
+      {
+        "en": "automatic combat system",
+        "ja": "じどうせんとうしすてむ",
+        "ja_typings": [
+          "jidosentoshisutemu",
+          "jidousentoushisutemu"
+        ]
+      },
+      {
+        "en": "time-limited battle mode",
+        "ja": "じかんせいのバトルもーど",
+        "ja_typings": [
+          "jikanseinobatorumodo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00485",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'turn-based' combat?",
+      "ja": "ターンせいせんとうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "strategy game with real-time gameplay",
+        "ja": "りあるたいむのすとらてじーゲーム",
+        "ja_typings": [
+          "riarutaimunosutoratejigemu"
+        ]
+      },
+      {
+        "en": "racing strategy game",
+        "ja": "れーすすとらてじーゲーム",
+        "ja_typings": [
+          "resusutoratejigemu"
+        ]
+      },
+      {
+        "en": "real-world problem simulation",
+        "ja": "げんじつもんだいのしみゅれーしょん",
+        "ja_typings": [
+          "genjitsumondainoshimyureshon"
+        ]
+      },
+      {
+        "en": "online team strategy game",
+        "ja": "おんらいんちーむすとらてじー",
+        "ja_typings": [
+          "onrainchimusutorateji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00486",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'real-time strategy' (RTS)?",
+      "ja": "りあるたいむすとらてじーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "update fixing bugs or balancing",
+        "ja": "ばぐのしゅうせいやバランスのこうしん",
+        "ja_typings": [
+          "bagunoshuuseiyabaransunokoshin",
+          "bagunoshuuseiyabaransunokoushin"
+        ]
+      },
+      {
+        "en": "new game level",
+        "ja": "あたらしいゲームれべる",
+        "ja_typings": [
+          "atarashiigemureberu"
+        ]
+      },
+      {
+        "en": "skin or appearance pack",
+        "ja": "スキンやがいかんぱっく",
+        "ja_typings": [
+          "sukinyagaikanpakku"
+        ]
+      },
+      {
+        "en": "seasonal game event",
+        "ja": "きせつゲームイベント",
+        "ja_typings": [
+          "kisetsugemuibento"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00487",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'patch' in gaming?",
+      "ja": "ゲームのぱっちとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "multiplatform",
+        "ja": "まるちぷらっとふぉーむ",
+        "ja_typings": [
+          "maruchipurattofomu"
+        ]
+      },
+      {
+        "en": "cross-play",
+        "ja": "くろすぷれい",
+        "ja_typings": [
+          "kurosupurei"
+        ]
+      },
+      {
+        "en": "universal",
+        "ja": "ゆにばーさる",
+        "ja_typings": [
+          "yunibasaru"
+        ]
+      },
+      {
+        "en": "platform-agnostic",
+        "ja": "ぷらっとふぉーむぎょうとく",
+        "ja_typings": [
+          "purattofomugyotoku",
+          "purattofomugyoutoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00488",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the term for games released on multiple platforms?",
+      "ja": "ふくすうぷらっとふぉームでリリースされるゲームのようごは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "game where player jumps between platforms",
+        "ja": "プレイヤーがぷらっとふぉーむをとびわたるゲーム",
+        "ja_typings": [
+          "pureiyagapurattofomuotobiwatarugemu"
+        ]
+      },
+      {
+        "en": "game played on game console platform",
+        "ja": "ゲームきぷらっとふぉームで遊ぶゲーム",
+        "ja_typings": [
+          "gemukipurattofomudebugemu"
+        ]
+      },
+      {
+        "en": "game about building platforms",
+        "ja": "ぷらっとふぉームをけんちくするゲーム",
+        "ja_typings": [
+          "purattofomuokenchikusurugemu"
+        ]
+      },
+      {
+        "en": "game with online platform features",
+        "ja": "おんらいんぷらっとふぁむきのうつきゲーム",
+        "ja_typings": [
+          "onrainpurattofamukinotsukigemu",
+          "onrainpurattofamukinoutsukigemu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00489",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'platformer' game?",
+      "ja": "ぷらっとふぉーまーゲームとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "exploration game with abilities unlocking new areas",
+        "ja": "のうりょくかいじょで新エリアを探索",
+        "ja_typings": [
+          "noryokukaijodeeriao",
+          "nouryokukaijodeeriao"
+        ]
+      },
+      {
+        "en": "space exploration game",
+        "ja": "うちゅうたんさくゲーム",
+        "ja_typings": [
+          "uchuutansakugemu"
+        ]
+      },
+      {
+        "en": "game combining Metroid and Castlevania mechanics",
+        "ja": "めとろいどとかすとるばにあのゲームシステムを合わせたゲーム",
+        "ja_typings": [
+          "metoroidotokasutorubanianogemushisutemuowasetagemu"
+        ]
+      },
+      {
+        "en": "horror survival platformer",
+        "ja": "ほらーさばいばるぷらっとふぁーまー",
+        "ja_typings": [
+          "horasabaibarupurattofama"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00490",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Metroidvania' genre?",
+      "ja": "めとろいどばにあジャンルとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "9th generation",
+        "ja": "きゅうせだい",
+        "ja_typings": [
+          "kyuusedai"
+        ]
+      },
+      {
+        "en": "8th generation",
+        "ja": "はちせだい",
+        "ja_typings": [
+          "hachisedai"
+        ]
+      },
+      {
+        "en": "10th generation",
+        "ja": "じゅっせだい",
+        "ja_typings": [
+          "jussedai"
+        ]
+      },
+      {
+        "en": "7th generation",
+        "ja": "ななせだい",
+        "ja_typings": [
+          "nanasedai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00491",
+    "image_path": null,
+    "question_text": {
+      "en": "What console generation is the PlayStation 5?",
+      "ja": "プレイステーション5は何世代目のゲームきか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "game made without major publisher",
+        "ja": "大手ぱぶりっしゃーなしのゲーム",
+        "ja_typings": [
+          "paburisshanashinogemu"
+        ]
+      },
+      {
+        "en": "game for mobile only",
+        "ja": "モバイルのみのゲーム",
+        "ja_typings": [
+          "mobairunominogemu"
+        ]
+      },
+      {
+        "en": "foreign import game",
+        "ja": "がいこくゆにゅうゲーム",
+        "ja_typings": [
+          "gaikokuyunyuugemu"
+        ]
+      },
+      {
+        "en": "in-development unreleased game",
+        "ja": "かいはつちゅうのみリリースゲーム",
+        "ja_typings": [
+          "kaihatsuchuunomiririsugemu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00492",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an 'indie game'?",
+      "ja": "いんでぃゲームとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PC game distribution platform",
+        "ja": "PCゲームはいしんぷらっとふぁーむ",
+        "ja_typings": [
+          "pcgemuhaishinpurattofamu"
+        ]
+      },
+      {
+        "en": "game development engine",
+        "ja": "ゲーム開発エンジン",
+        "ja_typings": [
+          "gemuenjin"
+        ]
+      },
+      {
+        "en": "console by Valve",
+        "ja": "Valveのゲームき",
+        "ja_typings": [
+          "valvenogemuki"
+        ]
+      },
+      {
+        "en": "game streaming service",
+        "ja": "ゲームはいしんさーびす",
+        "ja_typings": [
+          "gemuhaishinsabisu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q00493",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Steam?",
+      "ja": "Steamとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Japanese comic book style",
+        "ja": "にほんのまんがスタイル",
+        "ja_typings": [
+          "nihonnomangasutairu"
+        ]
+      },
+      {
+        "en": "Japanese animation",
+        "ja": "にほんのアニメーション",
+        "ja_typings": [
+          "nihonnoanimeshon"
+        ]
+      },
+      {
+        "en": "Japanese novel",
+        "ja": "にほんのしょうせつ",
+        "ja_typings": [
+          "nihonnoshosetsu",
+          "nihonnoshousetsu"
+        ]
+      },
+      {
+        "en": "Japanese film",
+        "ja": "にほんのえいが",
+        "ja_typings": [
+          "nihonnoeiga"
         ]
       }
     ],
     "correct_answer_index": 0,
     "genre": "manga",
-    "id": "q00060",
+    "id": "q00494",
     "image_path": null,
     "question_text": {
-      "en": "What is the protagonist's dream in 'NARUTO'?",
-      "ja": "「NARUTO」のしゅじんこうのゆめは?"
+      "en": "What is manga?",
+      "ja": "まんがとは何か？"
     }
   },
   {
     "choices": [
       {
-        "en": "Twilight",
-        "ja": "トワイライト",
+        "en": "Akira Toriyama",
+        "ja": "とりやまあきら",
         "ja_typings": [
-          "towairaito"
+          "toriyamaakira"
         ]
       },
       {
-        "en": "Thorn Princess",
-        "ja": "いばらひめ",
+        "en": "Eiichiro Oda",
+        "ja": "おだえいいちろう",
         "ja_typings": [
-          "ibarahime"
+          "odaeiichiro",
+          "odaeiichirou"
         ]
       },
       {
-        "en": "Bond",
-        "ja": "ボンド",
+        "en": "Masashi Kishimoto",
+        "ja": "きしもとまさし",
         "ja_typings": [
-          "bondo"
+          "kishimotomasashi"
         ]
       },
       {
-        "en": "Anya",
-        "ja": "アーニャ",
+        "en": "Tite Kubo",
+        "ja": "くぼたいと",
         "ja_typings": [
-          "anya"
+          "kubotaito"
         ]
       }
     ],
     "correct_answer_index": 0,
-    "genre": "anime",
-    "id": "q00061",
+    "genre": "manga",
+    "id": "q00495",
     "image_path": null,
     "question_text": {
-      "en": "What is the father's codename in 'Spy x Family'?",
-      "ja": "「スパイファミリー」のちちのこーどねーむは?"
+      "en": "Who created Dragon Ball manga?",
+      "ja": "ドラゴンボールのまんがをかいたのは？"
     }
   },
   {
     "choices": [
       {
-        "en": "Survival",
-        "ja": "サバイバル",
+        "en": "One Piece",
+        "ja": "わんぴーす",
         "ja_typings": [
-          "sabaibaru"
+          "wanpisu"
         ]
       },
       {
-        "en": "Creative",
-        "ja": "クリエイティブ",
+        "en": "Dragon Ball",
+        "ja": "どらごんぼーる",
         "ja_typings": [
-          "kurieitibu"
+          "doragonboru"
         ]
       },
       {
-        "en": "Adventure",
-        "ja": "アドベンチャー",
+        "en": "Naruto",
+        "ja": "なると",
         "ja_typings": [
-          "adobencha"
+          "naruto"
         ]
       },
       {
-        "en": "Hardcore",
-        "ja": "ハードコア",
+        "en": "Demon Slayer",
+        "ja": "きめつのやいば",
         "ja_typings": [
-          "hadokoa"
+          "kimetsunoyaiba"
         ]
       }
-    ],
-    "correct_answer_index": 1,
-    "genre": "game",
-    "id": "q00062",
-    "image_path": null,
-    "question_text": {
-      "en": "What is the creative mode in Minecraft?",
-      "ja": "マインクラフトのせいさくもーどは?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "Weapon",
-        "ja": "ぶき",
-        "ja_typings": [
-          "buki"
-        ]
-      },
-      {
-        "en": "Ability",
-        "ja": "のうりょく",
-        "ja_typings": [
-          "noryoku",
-          "nouryoku"
-        ]
-      },
-      {
-        "en": "Organization",
-        "ja": "そしき",
-        "ja_typings": [
-          "soshiki"
-        ]
-      },
-      {
-        "en": "Location",
-        "ja": "ばしょ",
-        "ja_typings": [
-          "basho"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
-    "genre": "anime",
-    "id": "q00063",
-    "image_path": null,
-    "question_text": {
-      "en": "What is a 'Stand' in 'JoJo's Bizarre Adventure'?",
-      "ja": "「ジョジョのきみょうなぼうけん」のすたんどとは?"
-    }
-  },
-  {
-    "choices": [
-    {
-      "en": "Ryu",
-      "ja": "リュウ",
-      "ja_typings": [
-        "ryuu",
-        "ryu"
-      ]
-    },
-      {
-        "en": "Ken",
-        "ja": "ケン",
-        "ja_typings": [
-          "ken"
-        ]
-      },
-    {
-      "en": "Vega",
-      "ja": "ベガ",
-      "ja_typings": [
-        "bega",
-        "vega"
-      ]
-    },
-    {
-      "en": "Sagat",
-      "ja": "さがっと",
-      "ja_typings": [
-        "sagatto",
-        "sagat"
-      ]
-    }
     ],
     "correct_answer_index": 0,
-    "genre": "game",
-    "id": "q00064",
+    "genre": "manga",
+    "id": "q00496",
     "image_path": null,
     "question_text": {
-      "en": "Who is the main protagonist in Street Fighter?",
-      "ja": "ストリートファイターでしゅじんこうは?"
+      "en": "What is the best-selling manga of all time?",
+      "ja": "もっともうれたまんがは？"
     }
   },
   {
     "choices": [
       {
-        "en": "Video",
-        "ja": "Video",
+        "en": "Weekly Shonen Jump",
+        "ja": "しゅうかんしょうねんじゃんぷ",
         "ja_typings": [
-          "video"
+          "shuukanshonenjanpu",
+          "shuukanshounenjanpu"
         ]
       },
       {
-        "en": "Virtual",
-        "ja": "Virtual",
+        "en": "Weekly Shonen Magazine",
+        "ja": "しゅうかんしょうねんまがじん",
         "ja_typings": [
-          "virtual"
+          "shuukanshonenmagajin",
+          "shuukanshounenmagajin"
         ]
       },
       {
-        "en": "Voice",
-        "ja": "Voice",
+        "en": "Big Comic Spirits",
+        "ja": "びっぐこみっくすぴりっつ",
         "ja_typings": [
-          "voice"
+          "biggukomikkusupirittsu"
         ]
       },
       {
-        "en": "Vocal",
-        "ja": "Vocal",
+        "en": "Shonen Sunday",
+        "ja": "しょうねんさんでー",
         "ja_typings": [
-          "vocal"
+          "shonensande",
+          "shounensande"
         ]
       }
     ],
-    "correct_answer_index": 1,
-    "genre": "vtuber_net_culture",
-    "id": "q00065",
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00497",
     "image_path": null,
     "question_text": {
-      "en": "What does the 'V' in VTuber stand for?",
-      "ja": "VTuberのVはなにのりゃく?"
+      "en": "What magazine did Naruto run in?",
+      "ja": "ナルトが掲載されていたざっしは？"
     }
   },
   {
     "choices": [
       {
-        "en": "Basketball",
-        "ja": "バスケ",
+        "en": "collected manga volume",
+        "ja": "まんがのたんこうぼん",
         "ja_typings": [
-          "basuke"
+          "manganotankobon",
+          "manganotankoubon"
         ]
       },
       {
-        "en": "Volleyball",
-        "ja": "バレー",
+        "en": "chapter running in magazine",
+        "ja": "ざっしけいさいのかい",
         "ja_typings": [
-          "bare"
+          "zasshikeisainokai"
         ]
       },
       {
-        "en": "Soccer",
-        "ja": "サッカー",
+        "en": "limited edition release",
+        "ja": "かいていばんのはっぴょう",
+        "ja_typings": [
+          "kaiteibannohappyo",
+          "kaiteibannohappyou"
+        ]
+      },
+      {
+        "en": "manga digital format",
+        "ja": "まんがのでじたるけいしき",
+        "ja_typings": [
+          "manganodejitarukeishiki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00498",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'tankoubon'?",
+      "ja": "たんこうぼんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "adult men",
+        "ja": "せいじんだんせい",
+        "ja_typings": [
+          "seijindansei"
+        ]
+      },
+      {
+        "en": "young boys",
+        "ja": "しょうねん",
+        "ja_typings": [
+          "shonen",
+          "shounen"
+        ]
+      },
+      {
+        "en": "young girls",
+        "ja": "しょうじょ",
+        "ja_typings": [
+          "shojo",
+          "shoujo"
+        ]
+      },
+      {
+        "en": "adult women",
+        "ja": "せいじんじょせい",
+        "ja_typings": [
+          "seijinjosei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00499",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'seinen' manga targeted at?",
+      "ja": "せいねんまんがはなにをたいしょうとしているか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "adult women",
+        "ja": "せいじんじょせい",
+        "ja_typings": [
+          "seijinjosei"
+        ]
+      },
+      {
+        "en": "young girls",
+        "ja": "しょうじょ",
+        "ja_typings": [
+          "shojo",
+          "shoujo"
+        ]
+      },
+      {
+        "en": "adult men",
+        "ja": "せいじんだんせい",
+        "ja_typings": [
+          "seijindansei"
+        ]
+      },
+      {
+        "en": "young boys",
+        "ja": "しょうねん",
+        "ja_typings": [
+          "shonen",
+          "shounen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00500",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'josei' manga targeted at?",
+      "ja": "じょせいまんがはなにをたいしょうとしているか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "manga artist",
+        "ja": "まんがか",
+        "ja_typings": [
+          "mangaka"
+        ]
+      },
+      {
+        "en": "manga publisher",
+        "ja": "まんがのしゅっぱんしゃ",
+        "ja_typings": [
+          "manganoshuppansha"
+        ]
+      },
+      {
+        "en": "manga reader",
+        "ja": "まんがのどくしゃ",
+        "ja_typings": [
+          "manganodokusha"
+        ]
+      },
+      {
+        "en": "manga editor",
+        "ja": "まんがのへんしゅうしゃ",
+        "ja_typings": [
+          "manganohenshuusha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00501",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'manga-ka' mean?",
+      "ja": "まんがかとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "reading guide for kanji",
+        "ja": "かんじのよみがたのてびき",
+        "ja_typings": [
+          "kanjinoyomigatanotebiki"
+        ]
+      },
+      {
+        "en": "sound effect text",
+        "ja": "おんさようのてきすと",
+        "ja_typings": [
+          "onsayonotekisuto",
+          "onsayounotekisuto"
+        ]
+      },
+      {
+        "en": "speech bubble text",
+        "ja": "ふきだしのてきすと",
+        "ja_typings": [
+          "fukidashinotekisuto"
+        ]
+      },
+      {
+        "en": "character name label",
+        "ja": "キャラのなまえのらべる",
+        "ja_typings": [
+          "kyaranonamaenoraberu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00502",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'furigana' in manga?",
+      "ja": "まんがのふりがなとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kentaro Miura",
+        "ja": "みうらけんたろう",
+        "ja_typings": [
+          "miurakentaro",
+          "miurakentarou"
+        ]
+      },
+      {
+        "en": "Hajime Isayama",
+        "ja": "いさやまはじめ",
+        "ja_typings": [
+          "isayamahajime"
+        ]
+      },
+      {
+        "en": "Hirohiko Araki",
+        "ja": "あらきひろひこ",
+        "ja_typings": [
+          "arakihirohiko"
+        ]
+      },
+      {
+        "en": "Rumiko Takahashi",
+        "ja": "たかはしるみこ",
+        "ja_typings": [
+          "takahashirumiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00503",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created the manga 'Berserk'?",
+      "ja": "まんが「ベルセルク」をかいたのは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "a hero so powerful he defeats enemies in one punch",
+        "ja": "いちげきでてきをたおすひーろー",
+        "ja_typings": [
+          "ichigekidetekiotaosuhiro"
+        ]
+      },
+      {
+        "en": "a boxing champion",
+        "ja": "ぼくしんぐのチャンピオン",
+        "ja_typings": [
+          "bokushingunochanpion"
+        ]
+      },
+      {
+        "en": "a cook who fights with food",
+        "ja": "たべもので戦うりょうりにん",
+        "ja_typings": [
+          "tabemonodeuryorinin",
+          "tabemonodeuryourinin"
+        ]
+      },
+      {
+        "en": "a school delinquent",
+        "ja": "こうこうのふりょう",
+        "ja_typings": [
+          "kokonofuryo",
+          "koukounofuryou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00504",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the manga 'One Punch Man' about?",
+      "ja": "まんが「ワンパンマン」はなにについてか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Berserk",
+        "ja": "べるせるく",
+        "ja_typings": [
+          "beruseruku"
+        ]
+      },
+      {
+        "en": "Doraemon",
+        "ja": "どらえもん",
+        "ja_typings": [
+          "doraemon"
+        ]
+      },
+      {
+        "en": "Crayon Shin-chan",
+        "ja": "くれよんしんちゃん",
+        "ja_typings": [
+          "kureyonshinchan"
+        ]
+      },
+      {
+        "en": "Yotsuba",
+        "ja": "よつばと",
+        "ja_typings": [
+          "yotsubato"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00505",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga is known for its intricate artwork style?",
+      "ja": "ふくざつなえのまんがで知られるのは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Astro Boy",
+        "ja": "てつわんあとむ",
+        "ja_typings": [
+          "tetsuwanatomu"
+        ]
+      },
+      {
+        "en": "Doraemon",
+        "ja": "どらえもん",
+        "ja_typings": [
+          "doraemon"
+        ]
+      },
+      {
+        "en": "Sailor Moon",
+        "ja": "せーらーむーん",
+        "ja_typings": [
+          "seramun"
+        ]
+      },
+      {
+        "en": "Dragon Ball",
+        "ja": "どらごんぼーる",
+        "ja_typings": [
+          "doragonboru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00506",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the most famous work of Osamu Tezuka?",
+      "ja": "てづかおさむのもっともゆうめいなさくひんは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "action and adventure for young boys",
+        "ja": "しょうねんのアクションとぼうけん",
+        "ja_typings": [
+          "shonennoakushontoboken",
+          "shounennoakushontobouken"
+        ]
+      },
+      {
+        "en": "romance for young girls",
+        "ja": "しょうじょのれんあい",
+        "ja_typings": [
+          "shojonorenai",
+          "shoujonorenai"
+        ]
+      },
+      {
+        "en": "everyday life stories",
+        "ja": "にちじょうせいかつのはなし",
+        "ja_typings": [
+          "nichijoseikatsunohanashi",
+          "nichijouseikatsunohanashi"
+        ]
+      },
+      {
+        "en": "historical drama",
+        "ja": "れきしのどらま",
+        "ja_typings": [
+          "rekishinodorama"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00507",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Shonen' manga primarily about?",
+      "ja": "しょうねんまんがのおもなないようは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JoJo's Bizarre Adventure",
+        "ja": "じょじょのきみょうなぼうけん",
+        "ja_typings": [
+          "jojonokimyonaboken",
+          "jojonokimyounabouken"
+        ]
+      },
+      {
+        "en": "Fist of the North Star",
+        "ja": "ほくとのけん",
+        "ja_typings": [
+          "hokutonoken"
+        ]
+      },
+      {
+        "en": "Vinland Saga",
+        "ja": "ゔぃんらんどさが",
+        "ja_typings": [
+          "vinrandosaga"
+        ]
+      },
+      {
+        "en": "Kingdom",
+        "ja": "きんぐだむ",
+        "ja_typings": [
+          "kingudamu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00508",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga follows the Joestars across multiple generations?",
+      "ja": "じょえすたーけのものがたりのまんがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Korean-style digital vertical scroll comic",
+        "ja": "かんこくしきのたてなが電子まんが",
+        "ja_typings": [
+          "kankokushikinotatenagamanga"
+        ]
+      },
+      {
+        "en": "animated manga episode",
+        "ja": "アニメかされたまんがのわ",
+        "ja_typings": [
+          "animekasaretamanganowa"
+        ]
+      },
+      {
+        "en": "Japanese manga on web",
+        "ja": "ウェブのにほんまんが",
+        "ja_typings": [
+          "webunonihonmanga"
+        ]
+      },
+      {
+        "en": "manga with animated panels",
+        "ja": "うごくコマのまんが",
+        "ja_typings": [
+          "ugokukomanomanga"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00509",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'webtoon'?",
+      "ja": "うぇぶとぅーんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tite Kubo",
+        "ja": "くぼたいと",
+        "ja_typings": [
+          "kubotaito"
+        ]
+      },
+      {
+        "en": "Masashi Kishimoto",
+        "ja": "きしもとまさし",
+        "ja_typings": [
+          "kishimotomasashi"
+        ]
+      },
+      {
+        "en": "Akira Toriyama",
+        "ja": "とりやまあきら",
+        "ja_typings": [
+          "toriyamaakira"
+        ]
+      },
+      {
+        "en": "Eiichiro Oda",
+        "ja": "おだえいいちろう",
+        "ja_typings": [
+          "odaeiichiro",
+          "odaeiichirou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00510",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Bleach?",
+      "ja": "ブリーチをかいたのは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "psychological thriller manga",
+        "ja": "しんりすりらーまんが",
+        "ja_typings": [
+          "shinrisuriramanga"
+        ]
+      },
+      {
+        "en": "sports manga",
+        "ja": "すぽーつまんが",
+        "ja_typings": [
+          "supotsumanga"
+        ]
+      },
+      {
+        "en": "romantic comedy manga",
+        "ja": "ろまんてぃっくこめでぃまんが",
+        "ja_typings": [
+          "romantikkukomedimanga"
+        ]
+      },
+      {
+        "en": "sci-fi adventure manga",
+        "ja": "さいえんすふぃくしょんぼうけんまんが",
+        "ja_typings": [
+          "saiensufikushonbokenmanga",
+          "saiensufikushonboukenmanga"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00511",
+    "image_path": null,
+    "question_text": {
+      "en": "What type of story is 'Monster' by Naoki Urasawa?",
+      "ja": "うらさわなおきのモンスターはどんなものがたりか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "self-published fan comic",
+        "ja": "じがんのファンまんが",
+        "ja_typings": [
+          "jigannofanmanga"
+        ]
+      },
+      {
+        "en": "official manga chapter",
+        "ja": "こうしきのまんがかい",
+        "ja_typings": [
+          "koshikinomangakai",
+          "koushikinomangakai"
+        ]
+      },
+      {
+        "en": "licensed manga reprint",
+        "ja": "きょかずみのまんがさいはん",
+        "ja_typings": [
+          "kyokazuminomangasaihan"
+        ]
+      },
+      {
+        "en": "manga award winner",
+        "ja": "まんがしょうじゅしょうさく",
+        "ja_typings": [
+          "mangashojushosaku",
+          "mangashoujushousaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00512",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'doujinshi'?",
+      "ja": "どうじんしとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Inuyasha",
+        "ja": "いぬやしゃ",
+        "ja_typings": [
+          "inuyasha"
+        ]
+      },
+      {
+        "en": "Rurouni Kenshin",
+        "ja": "るろうにけんしん",
+        "ja_typings": [
+          "ruronikenshin",
+          "rurounikenshin"
+        ]
+      },
+      {
+        "en": "Vagabond",
+        "ja": "バガボンド",
+        "ja_typings": [
+          "bagabondo"
+        ]
+      },
+      {
+        "en": "Blade of the Immortal",
+        "ja": "むげんのじゅうにん",
+        "ja_typings": [
+          "mugennojuunin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00513",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga is about a time-traveling story in feudal Japan?",
+      "ja": "せんごくじだいのにほんにタイムトラベルするまんがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "a curious 5-year-old girl's daily life",
+        "ja": "ごさいのしょうじょのにちじょう",
+        "ja_typings": [
+          "gosainoshojononichijo",
+          "gosainoshoujononichijou"
+        ]
+      },
+      {
+        "en": "a fantasy adventure",
+        "ja": "ふぁんたじーぼうけん",
+        "ja_typings": [
+          "fantajiboken",
+          "fantajibouken"
+        ]
+      },
+      {
+        "en": "a high school romance",
+        "ja": "こうこうのれんあい",
+        "ja_typings": [
+          "kokonorenai",
+          "koukounorenai"
+        ]
+      },
+      {
+        "en": "a sports tournament",
+        "ja": "すぽーつたいかい",
+        "ja_typings": [
+          "supotsutaikai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00514",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the manga 'Yotsubato!' about?",
+      "ja": "まんが「よつばと!」はなにについてか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kingdom",
+        "ja": "きんぐだむ",
+        "ja_typings": [
+          "kingudamu"
+        ]
+      },
+      {
+        "en": "Vagabond",
+        "ja": "バガボンド",
+        "ja_typings": [
+          "bagabondo"
+        ]
+      },
+      {
+        "en": "Lone Wolf and Cub",
+        "ja": "こかみのおおかみ",
+        "ja_typings": [
+          "kokaminookami",
+          "kokaminoookami"
+        ]
+      },
+      {
+        "en": "Vinland Saga",
+        "ja": "ゔぃんらんどさが",
+        "ja_typings": [
+          "vinrandosaga"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00515",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga series is set in ancient China?",
+      "ja": "こだいちゅうごくをぶたいにしたまんがシリーズは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Eiichiro Oda",
+        "ja": "おだえいいちろう",
+        "ja_typings": [
+          "odaeiichiro",
+          "odaeiichirou"
+        ]
+      },
+      {
+        "en": "Masashi Kishimoto",
+        "ja": "きしもとまさし",
+        "ja_typings": [
+          "kishimotomasashi"
+        ]
+      },
+      {
+        "en": "Akira Toriyama",
+        "ja": "とりやまあきら",
+        "ja_typings": [
+          "toriyamaakira"
+        ]
+      },
+      {
+        "en": "Rumiko Takahashi",
+        "ja": "たかはしるみこ",
+        "ja_typings": [
+          "takahashirumiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00516",
+    "image_path": null,
+    "question_text": {
+      "en": "Who draws One Piece?",
+      "ja": "ワンピースをかいているのは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vikings in medieval Europe",
+        "ja": "ちゅうせいヨーロッパのバイキング",
+        "ja_typings": [
+          "chuuseiyoroppanobaikingu"
+        ]
+      },
+      {
+        "en": "Vikings in ancient Japan",
+        "ja": "こだいにほんのバイキング",
+        "ja_typings": [
+          "kodainihonnobaikingu"
+        ]
+      },
+      {
+        "en": "Samurai in medieval Japan",
+        "ja": "ちゅうせいにほんのさむらい",
+        "ja_typings": [
+          "chuuseinihonnosamurai"
+        ]
+      },
+      {
+        "en": "Warriors in ancient Greece",
+        "ja": "こだいギリシャのせんし",
+        "ja_typings": [
+          "kodaigirishanosenshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00517",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the premise of Vinland Saga?",
+      "ja": "ゔぃんらんどさがのせっていは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "dramatic realist manga for adults",
+        "ja": "おとなのためのしじつてきなまんが",
+        "ja_typings": [
+          "otonanotamenoshijitsutekinamanga"
+        ]
+      },
+      {
+        "en": "funny children's manga",
+        "ja": "こどものためのおもしろまんが",
+        "ja_typings": [
+          "kodomonotamenomoshiromanga",
+          "kodomonotamenoomoshiromanga"
+        ]
+      },
+      {
+        "en": "newspaper political cartoon",
+        "ja": "しんぶんのせいじまんが",
+        "ja_typings": [
+          "shinbunnoseijimanga"
+        ]
+      },
+      {
+        "en": "animated manga format",
+        "ja": "アニメかけいしき",
+        "ja_typings": [
+          "animekakeishiki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00518",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'gekiga'?",
+      "ja": "げきがとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fullmetal Alchemist",
+        "ja": "はがねのれんきんじゅつし",
+        "ja_typings": [
+          "haganenorenkinjutsushi"
+        ]
+      },
+      {
+        "en": "Noragami",
+        "ja": "のらがみ",
+        "ja_typings": [
+          "noragami"
+        ]
+      },
+      {
+        "en": "Blue Exorcist",
+        "ja": "あおのえくそしすと",
+        "ja_typings": [
+          "aonoekusoshisuto"
+        ]
+      },
+      {
+        "en": "Soul Eater",
+        "ja": "そうるいーたー",
+        "ja_typings": [
+          "soruita",
+          "souruita"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00519",
+    "image_path": null,
+    "question_text": {
+      "en": "What manga features Edward and Alphonse Elric?",
+      "ja": "えどわーどとあるふぉんすえるりっくのまんがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Demon Slayer",
+        "ja": "でーもんすれいやー",
+        "ja_typings": [
+          "demonsureiya"
+        ]
+      },
+      {
+        "en": "Blade of Demons",
+        "ja": "ぶれいどおぶでーもんず",
+        "ja_typings": [
+          "bureidobudemonzu",
+          "bureidoobudemonzu"
+        ]
+      },
+      {
+        "en": "Demon Sword",
+        "ja": "でーもんそーど",
+        "ja_typings": [
+          "demonsodo"
+        ]
+      },
+      {
+        "en": "Night of Demons",
+        "ja": "ないとおぶでーもんず",
+        "ja_typings": [
+          "naitobudemonzu",
+          "naitoobudemonzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00520",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Kimetsu no Yaiba known as in English?",
+      "ja": "きめつのやいばの英語タイトルは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Attack on Titan",
+        "ja": "しんげきのきょじん",
+        "ja_typings": [
+          "shingekinokyojin"
+        ]
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "ふぇありーている",
+        "ja_typings": [
+          "feariteiru"
+        ]
+      },
+      {
+        "en": "Sword Art Online",
+        "ja": "そーどあーとおんらいん",
+        "ja_typings": [
+          "sodoatonrain",
+          "sodoatoonrain"
+        ]
+      },
+      {
+        "en": "That Time I Got Reincarnated as a Slime",
+        "ja": "てんせいスライム",
+        "ja_typings": [
+          "tenseisuraimu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00521",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga is drawn by Hajime Isayama?",
+      "ja": "いさやまはじめがかいたまんがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "adult women",
+        "ja": "せいじんじょせい",
+        "ja_typings": [
+          "seijinjosei"
+        ]
+      },
+      {
+        "en": "young girls",
+        "ja": "しょうじょ",
+        "ja_typings": [
+          "shojo",
+          "shoujo"
+        ]
+      },
+      {
+        "en": "young boys",
+        "ja": "しょうねん",
+        "ja_typings": [
+          "shonen",
+          "shounen"
+        ]
+      },
+      {
+        "en": "adult men",
+        "ja": "せいじんだんせい",
+        "ja_typings": [
+          "seijindansei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00522",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Josei' manga magazine aimed at?",
+      "ja": "じょせいまんがざっしのたいしょうは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "manga adaptation of light novel",
+        "ja": "らいとのべるのまんがか",
+        "ja_typings": [
+          "raitonoberunomangaka"
+        ]
+      },
+      {
+        "en": "short manga chapter",
+        "ja": "みじかいまんがかい",
+        "ja_typings": [
+          "mijikaimangakai"
+        ]
+      },
+      {
+        "en": "manga with simple art",
+        "ja": "かんたんなえのまんが",
+        "ja_typings": [
+          "kantannaenomanga"
+        ]
+      },
+      {
+        "en": "manga for young children",
+        "ja": "ようじむけまんが",
+        "ja_typings": [
+          "yojimukemanga",
+          "youjimukemanga"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00523",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the manga equivalent of a light novel?",
+      "ja": "らいとのべるのまんがそうとうは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fullmetal Alchemist",
+        "ja": "はがねのれんきんじゅつし",
+        "ja_typings": [
+          "haganenorenkinjutsushi"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ぶらっくくろーばー",
+        "ja_typings": [
+          "burakkukuroba"
+        ]
+      },
+      {
+        "en": "Magi",
+        "ja": "まぎ",
+        "ja_typings": [
+          "magi"
+        ]
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "ふぇありーている",
+        "ja_typings": [
+          "feariteiru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00524",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga features the Elric brothers searching for the Philosopher's Stone?",
+      "ja": "けんじゃのいしをさがすえるりっくきょうだいのまんがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fujiko F. Fujio",
+        "ja": "ふじこえふふじお",
+        "ja_typings": [
+          "fujikoefufujio"
+        ]
+      },
+      {
+        "en": "Osamu Tezuka",
+        "ja": "てづかおさむ",
+        "ja_typings": [
+          "tezukaosamu"
+        ]
+      },
+      {
+        "en": "Shotaro Ishinomori",
+        "ja": "いしのもりしょうたろう",
+        "ja_typings": [
+          "ishinomorishotaro",
+          "ishinomorishoutarou"
+        ]
+      },
+      {
+        "en": "Go Nagai",
+        "ja": "ながいごう",
+        "ja_typings": [
+          "nagaigo",
+          "nagaigou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00525",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Doraemon?",
+      "ja": "ドラえもんをかいたのは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "historical samurai drama",
+        "ja": "れきしのさむらいどらま",
+        "ja_typings": [
+          "rekishinosamuraidorama"
+        ]
+      },
+      {
+        "en": "sci-fi thriller",
+        "ja": "SF/すりらー",
+        "ja_typings": [
+          "sf/surira"
+        ]
+      },
+      {
+        "en": "supernatural romance",
+        "ja": "ちょうしぜんれんあい",
+        "ja_typings": [
+          "choshizenrenai",
+          "choushizenrenai"
+        ]
+      },
+      {
+        "en": "sports manga",
+        "ja": "すぽーつまんが",
+        "ja_typings": [
+          "supotsumanga"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00526",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the genre of 'Vagabond'?",
+      "ja": "バガボンドのジャンルは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "story derived from main series featuring side characters",
+        "ja": "メインシリーズのサブキャラのはなし",
+        "ja_typings": [
+          "meinshirizunosabukyaranohanashi"
+        ]
+      },
+      {
+        "en": "sequel to original manga",
+        "ja": "オリジナルまんがのぞくへん",
+        "ja_typings": [
+          "orijinarumanganozokuhen"
+        ]
+      },
+      {
+        "en": "remix version of original",
+        "ja": "オリジナルのりみっくすばん",
+        "ja_typings": [
+          "orijinarunorimikkusuban"
+        ]
+      },
+      {
+        "en": "overseas licensed version",
+        "ja": "かいがいきょかばん",
+        "ja_typings": [
+          "kaigaikyokaban"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00527",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'spin-off' manga?",
+      "ja": "スピンオフまんがとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "right to left reading direction",
+        "ja": "みぎからひだりによむ",
+        "ja_typings": [
+          "migikarahidariniyomu"
+        ]
+      },
+      {
+        "en": "bottom to top reading",
+        "ja": "したからうえによむ",
+        "ja_typings": [
+          "shitakaraueniyomu"
+        ]
+      },
+      {
+        "en": "left to right reading",
+        "ja": "ひだりからみぎによむ",
+        "ja_typings": [
+          "hidarikaramiginiyomu"
+        ]
+      },
+      {
+        "en": "diagonal reading",
+        "ja": "ななめによむ",
+        "ja_typings": [
+          "nanameniyomu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00528",
+    "image_path": null,
+    "question_text": {
+      "en": "What makes manga read differently from Western comics?",
+      "ja": "まんがが西洋まんがとちがうよみかたは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "One Piece",
+        "ja": "わんぴーす",
+        "ja_typings": [
+          "wanpisu"
+        ]
+      },
+      {
+        "en": "Dragon Ball",
+        "ja": "どらごんぼーる",
+        "ja_typings": [
+          "doragonboru"
+        ]
+      },
+      {
+        "en": "Golgo 13",
+        "ja": "ごるごじゅうさん",
+        "ja_typings": [
+          "gorugojuusan"
+        ]
+      },
+      {
+        "en": "Naruto",
+        "ja": "なると",
+        "ja_typings": [
+          "naruto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00529",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga has the longest running story?",
+      "ja": "もっともちょうへんのまんがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "romance and emotional stories",
+        "ja": "れんあいとかんじょうのはなし",
+        "ja_typings": [
+          "renaitokanjonohanashi",
+          "renaitokanjounohanashi"
+        ]
+      },
+      {
+        "en": "intense action battles",
+        "ja": "げきれつなアクションバトル",
+        "ja_typings": [
+          "gekiretsunaakushonbatoru"
+        ]
+      },
+      {
+        "en": "historical epics",
+        "ja": "れきしのたいさく",
+        "ja_typings": [
+          "rekishinotaisaku"
+        ]
+      },
+      {
+        "en": "sports competitions",
+        "ja": "すぽーつたいかい",
+        "ja_typings": [
+          "supotsutaikai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00530",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'shojo manga' famous for?",
+      "ja": "しょうじょまんがはなにでゆうめいか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Naoko Takeuchi",
+        "ja": "たけうちなおこ",
+        "ja_typings": [
+          "takeuchinaoko"
+        ]
+      },
+      {
+        "en": "Rumiko Takahashi",
+        "ja": "たかはしるみこ",
+        "ja_typings": [
+          "takahashirumiko"
+        ]
+      },
+      {
+        "en": "CLAMP",
+        "ja": "くらんぷ",
+        "ja_typings": [
+          "kuranpu"
+        ]
+      },
+      {
+        "en": "Yoshihiro Togashi",
+        "ja": "とがしよしひろ",
+        "ja_typings": [
+          "togashiyoshihiro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00531",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the creator of Sailor Moon manga?",
+      "ja": "セーラームーンまんがのさくしゃは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "horror involving spirals",
+        "ja": "らせんをもとにしたほらー",
+        "ja_typings": [
+          "rasenomotonishitahora"
+        ]
+      },
+      {
+        "en": "comedy about cooking",
+        "ja": "りょうりのこめでぃ",
+        "ja_typings": [
+          "ryorinokomedi",
+          "ryourinokomedi"
+        ]
+      },
+      {
+        "en": "romance in high school",
+        "ja": "こうこうのれんあい",
+        "ja_typings": [
+          "kokonorenai",
+          "koukounorenai"
+        ]
+      },
+      {
+        "en": "historical action",
+        "ja": "れきしのアクション",
+        "ja_typings": [
+          "rekishinoakushon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00532",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the manga 'Uzumaki' known for?",
+      "ja": "まんが「うずまき」はなにでゆうめいか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fist of the North Star",
+        "ja": "ほくとのけん",
+        "ja_typings": [
+          "hokutonoken"
+        ]
+      },
+      {
+        "en": "Berserk",
+        "ja": "べるせるく",
+        "ja_typings": [
+          "beruseruku"
+        ]
+      },
+      {
+        "en": "Vinland Saga",
+        "ja": "ゔぃんらんどさが",
+        "ja_typings": [
+          "vinrandosaga"
+        ]
+      },
+      {
+        "en": "Kingdom",
+        "ja": "きんぐだむ",
+        "ja_typings": [
+          "kingudamu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00533",
+    "image_path": null,
+    "question_text": {
+      "en": "What manga features Kenshiro as the main character?",
+      "ja": "けんしろうがしゅじんこうのまんがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1997",
+        "ja": "1997ねん",
+        "ja_typings": [
+          "1997nen"
+        ]
+      },
+      {
+        "en": "1995",
+        "ja": "1995ねん",
+        "ja_typings": [
+          "1995nen"
+        ]
+      },
+      {
+        "en": "1999",
+        "ja": "1999ねん",
+        "ja_typings": [
+          "1999nen"
+        ]
+      },
+      {
+        "en": "2001",
+        "ja": "2001ねん",
+        "ja_typings": [
+          "2001nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00534",
+    "image_path": null,
+    "question_text": {
+      "en": "What year was the first chapter of One Piece published?",
+      "ja": "ワンピースのさいしょのかいがしゅっぱんされたのはなんねんか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jujutsu Kaisen",
+        "ja": "じゅじゅつかいせん",
+        "ja_typings": [
+          "jujutsukaisen"
+        ]
+      },
+      {
+        "en": "Bleach",
+        "ja": "ぶりーち",
+        "ja_typings": [
+          "burichi"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ぶらっくくろーばー",
+        "ja_typings": [
+          "burakkukuroba"
+        ]
+      },
+      {
+        "en": "Soul Eater",
+        "ja": "そうるいーたー",
+        "ja_typings": [
+          "soruita",
+          "souruita"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00535",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the manga about Yuji Itadori eating a cursed finger?",
+      "ja": "ゆうじいただりがじゅのゆびをたべるまんがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "basketball",
+        "ja": "ばすけっとぼーる",
+        "ja_typings": [
+          "basukettoboru"
+        ]
+      },
+      {
+        "en": "baseball",
+        "ja": "やきゅう",
+        "ja_typings": [
+          "yakyuu"
+        ]
+      },
+      {
+        "en": "soccer",
+        "ja": "さっかー",
         "ja_typings": [
           "sakka"
         ]
       },
       {
-        "en": "Baseball",
-        "ja": "やきゅう",
+        "en": "volleyball",
+        "ja": "ばれーぼーる",
         "ja_typings": [
-          "yakyuu"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
-    "genre": "anime",
-    "id": "q00066",
-    "image_path": null,
-    "question_text": {
-      "en": "What sport is featured in 'Haikyuu!!'?",
-      "ja": "「ハイキュー!!」はなにのすぽーつ?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "Complete tasks",
-        "ja": "たすくをこなす",
-        "ja_typings": [
-          "tasukuokonasu"
-        ]
-      },
-      {
-        "en": "Eliminate crew",
-        "ja": "クルーをはいじょ",
-        "ja_typings": [
-          "kuruohaijo"
-        ]
-      },
-      {
-        "en": "Repair",
-        "ja": "しゅうり",
-        "ja_typings": [
-          "shuuri"
-        ]
-      },
-      {
-        "en": "Report",
-        "ja": "ほうこく",
-        "ja_typings": [
-          "hokoku",
-          "houkoku"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
-    "genre": "game",
-    "id": "q00067",
-    "image_path": null,
-    "question_text": {
-      "en": "What is the Impostor's objective in Among Us?",
-      "ja": "Among Usでインポスターのもくてきは?"
-    }
-  },
-  {
-    "choices": [
-    {
-      "en": "Ging",
-      "ja": "ジン",
-      "ja_typings": [
-        "jin",
-        "ging"
-      ]
-    },
-    {
-      "en": "Killua",
-      "ja": "キルア",
-      "ja_typings": [
-        "kirua",
-        "killua"
-      ]
-    },
-      {
-        "en": "Kurapika",
-        "ja": "クラピカ",
-        "ja_typings": [
-          "kurapika"
-        ]
-      },
-    {
-      "en": "Leorio",
-      "ja": "レオリオ",
-      "ja_typings": [
-        "reorio",
-        "leorio"
-      ]
-    }
-    ],
-    "correct_answer_index": 0,
-    "genre": "manga",
-    "id": "q00068",
-    "image_path": null,
-    "question_text": {
-      "en": "Who is Gon's father in 'Hunter x Hunter'?",
-      "ja": "「ハンターハンター」のゴンのちちは?"
-    }
-  },
-  {
-    "choices": [
-    {
-      "en": "Vegeta",
-      "ja": "ベジータ",
-      "ja_typings": [
-        "bejita",
-        "vegeta"
-      ]
-    },
-    {
-      "en": "Goku",
-      "ja": "ゴクウ",
-      "ja_typings": [
-        "gokuu",
-        "goku"
-      ]
-    },
-    {
-      "en": "Frieza",
-      "ja": "フリーザ",
-      "ja_typings": [
-        "furiza",
-        "frieza"
-      ]
-    },
-    {
-      "en": "Piccolo",
-      "ja": "ピッコロ",
-      "ja_typings": [
-        "pikkoro",
-        "piccolo"
-      ]
-    }
-    ],
-    "correct_answer_index": 1,
-    "genre": "anime",
-    "id": "q00069",
-    "image_path": null,
-    "question_text": {
-      "en": "Who uses the Kamehameha in 'Dragon Ball'?",
-      "ja": "「ドラゴンボール」のかめはめはをうつのは?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "RPG",
-        "ja": "RPG",
-        "ja_typings": [
-          "rpg"
-        ]
-      },
-      {
-        "en": "Battle Royale",
-        "ja": "バトルロイヤル",
-        "ja_typings": [
-          "batoruroiyaru"
-        ]
-      },
-      {
-        "en": "Puzzle",
-        "ja": "パズル",
-        "ja_typings": [
-          "pazuru"
-        ]
-      },
-      {
-        "en": "Racing",
-        "ja": "レース",
-        "ja_typings": [
-          "resu"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
-    "genre": "game",
-    "id": "q00070",
-    "image_path": null,
-    "question_text": {
-      "en": "What type of game is Apex Legends?",
-      "ja": "アペックスレジェンズはなにげーむ?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "Sad",
-        "ja": "かなしい",
-        "ja_typings": [
-          "kanashii"
-        ]
-      },
-      {
-        "en": "Laughing",
-        "ja": "わらう",
-        "ja_typings": [
-          "warau"
-        ]
-      },
-      {
-        "en": "Angry",
-        "ja": "おこる",
-        "ja_typings": [
-          "okoru"
-        ]
-      },
-      {
-        "en": "Sleepy",
-        "ja": "ねむい",
-        "ja_typings": [
-          "nemui"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
-    "genre": "vtuber_net_culture",
-    "id": "q00071",
-    "image_path": null,
-    "question_text": {
-      "en": "What does 'kusa' mean in internet slang?",
-      "ja": "「草」はねっとすらんぐでなに?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "Virtual Reality",
-        "ja": "ばーちゃるりありてぃ",
-        "ja_typings": [
-          "bacharuriariti"
-        ]
-      },
-      {
-        "en": "Magic",
-        "ja": "まほう",
-        "ja_typings": [
-          "maho",
-          "mahou"
-        ]
-      },
-      {
-        "en": "Space",
-        "ja": "うちゅう",
-        "ja_typings": [
-          "uchuu"
-        ]
-      },
-      {
-        "en": "Period drama",
-        "ja": "じだいげき",
-        "ja_typings": [
-          "jidaigeki"
-        ]
-      }
-    ],
-    "correct_answer_index": 0,
-    "genre": "anime",
-    "id": "q00072",
-    "image_path": null,
-    "question_text": {
-      "en": "What is the theme of 'Sword Art Online'?",
-      "ja": "「ソードアート・オンライン」のしゅだいは?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "Fishing",
-        "ja": "つりをする",
-        "ja_typings": [
-          "tsuriosuru"
-        ]
-      },
-      {
-        "en": "Bug catching",
-        "ja": "むしとり",
-        "ja_typings": [
-          "mushitori"
-        ]
-      },
-      {
-        "en": "Fighting",
-        "ja": "たたかう",
-        "ja_typings": [
-          "tatakau"
-        ]
-      },
-      {
-        "en": "Place furniture",
-        "ja": "かぐをおく",
-        "ja_typings": [
-          "kaguoku",
-          "kaguooku"
-        ]
-      }
-    ],
-    "correct_answer_index": 2,
-    "genre": "game",
-    "id": "q00073",
-    "image_path": null,
-    "question_text": {
-      "en": "What CAN'T you do in Animal Crossing?",
-      "ja": "どうぶつのもりでできないことは?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "Zanpakuto",
-        "ja": "ザンパクトウ",
-        "ja_typings": [
-          "zanpakuto",
-          "zanpakutou"
-        ]
-      },
-      {
-        "en": "Kunai",
-        "ja": "くない",
-        "ja_typings": [
-          "kunai"
-        ]
-      },
-      {
-        "en": "Katana",
-        "ja": "かたな",
-        "ja_typings": [
-          "katana"
-        ]
-      },
-      {
-        "en": "Spear",
-        "ja": "やり",
-        "ja_typings": [
-          "yari"
+          "bareboru"
         ]
       }
     ],
     "correct_answer_index": 0,
     "genre": "manga",
-    "id": "q00074",
+    "id": "q00536",
     "image_path": null,
     "question_text": {
-      "en": "What is the protagonist's weapon in 'Bleach'?",
-      "ja": "「ブリーチ」のしゅじんこうのぶきは?"
+      "en": "What is the main theme of 'Slam Dunk'?",
+      "ja": "スラムダンクのメインテーマは？"
     }
   },
   {
     "choices": [
       {
-        "en": "Hobby",
-        "ja": "しゅみ",
+        "en": "Erased (Boku dake ga Inai Machi)",
+        "ja": "ぼくだけがいないまち",
         "ja_typings": [
-          "shumi"
+          "bokudakegainaimachi"
         ]
       },
       {
-        "en": "Superpower",
-        "ja": "ちょうのうりょく",
+        "en": "Monster",
+        "ja": "もんすたー",
         "ja_typings": [
-          "chonoryoku",
-          "chounouryoku"
+          "monsuta"
         ]
       },
       {
-        "en": "Personality",
-        "ja": "せいかく",
+        "en": "Death Note",
+        "ja": "でーすのーと",
         "ja_typings": [
-          "seikaku"
+          "desunoto"
         ]
       },
       {
-        "en": "Homework",
-        "ja": "しゅくだい",
+        "en": "20th Century Boys",
+        "ja": "20せいきしょうねん",
         "ja_typings": [
-          "shukudai"
+          "20seikishonen",
+          "20seikishounen"
         ]
       }
     ],
-    "correct_answer_index": 1,
-    "genre": "anime",
-    "id": "q00075",
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00537",
     "image_path": null,
     "question_text": {
-      "en": "What is a 'Quirk' in 'My Hero Academia'?",
-      "ja": "「ぼくのヒーローアカデミア」のこせいとは?"
+      "en": "Which manga features time-travel murder mystery?",
+      "ja": "タイムトラベルのさつじんミステリーのまんがは？"
     }
   },
   {
     "choices": [
       {
-        "en": "Mount Fuji",
-        "ja": "ふじさん",
+        "en": "complex psychological thriller manga",
+        "ja": "ふくざつなしんりすりらーまんが",
         "ja_typings": [
-          "fujisan"
+          "fukuzatsunashinrisuriramanga"
         ]
       },
-    {
-      "en": "Everest",
-      "ja": "エベレスト",
-      "ja_typings": [
-        "eberesuto",
-        "everest"
-      ]
-    },
-    {
-      "en": "Kilimanjaro",
-      "ja": "キリマンジャロ",
-      "ja_typings": [
-        "kirimanjaro",
-        "kilimanjaro"
-      ]
-    },
-    {
-      "en": "Matterhorn",
-      "ja": "マッターホルン",
-      "ja_typings": [
-        "mattahorun",
-        "matterhorn"
-      ]
-    }
+      {
+        "en": "simple action manga",
+        "ja": "かんたんなアクションまんが",
+        "ja_typings": [
+          "kantannaakushonmanga"
+        ]
+      },
+      {
+        "en": "children's manga",
+        "ja": "こどものまんが",
+        "ja_typings": [
+          "kodomonomanga"
+        ]
+      },
+      {
+        "en": "romantic comedy manga",
+        "ja": "ろまんてぃっくこめでぃまんが",
+        "ja_typings": [
+          "romantikkukomedimanga"
+        ]
+      }
     ],
-    "correct_answer_index": 1,
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00538",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Naoki Urasawa known for?",
+      "ja": "うらさわなおきはなにでゆうめいか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Weekly Shonen Jump",
+        "ja": "しゅうかんしょうねんじゃんぷ",
+        "ja_typings": [
+          "shuukanshonenjanpu",
+          "shuukanshounenjanpu"
+        ]
+      },
+      {
+        "en": "Monthly Shonen Jump",
+        "ja": "げっかんしょうねんじゃんぷ",
+        "ja_typings": [
+          "gekkanshonenjanpu",
+          "gekkanshounenjanpu"
+        ]
+      },
+      {
+        "en": "Shonen Magazine",
+        "ja": "しょうねんまがじん",
+        "ja_typings": [
+          "shonenmagajin",
+          "shounenmagajin"
+        ]
+      },
+      {
+        "en": "Young Jump",
+        "ja": "ようじゃんぷ",
+        "ja_typings": [
+          "yojanpu",
+          "youjanpu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00539",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the manga that Chainsaw Man is serialized in?",
+      "ja": "チェーンソーマンがけいさいされているまんがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yoshihiro Togashi",
+        "ja": "とがしよしひろ",
+        "ja_typings": [
+          "togashiyoshihiro"
+        ]
+      },
+      {
+        "en": "Masashi Kishimoto",
+        "ja": "きしもとまさし",
+        "ja_typings": [
+          "kishimotomasashi"
+        ]
+      },
+      {
+        "en": "Tite Kubo",
+        "ja": "くぼたいと",
+        "ja_typings": [
+          "kubotaito"
+        ]
+      },
+      {
+        "en": "Akira Toriyama",
+        "ja": "とりやまあきら",
+        "ja_typings": [
+          "toriyamaakira"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00540",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created 'Hunter x Hunter'?",
+      "ja": "ハンターハンターをかいたのは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "a boy who secretly draws shojo manga",
+        "ja": "ひそかにしょうじょまんがをかくしょうねん",
+        "ja_typings": [
+          "hisokanishojomangaokakushonen",
+          "hisokanishoujomangaokakushounen"
+        ]
+      },
+      {
+        "en": "a monthly manga magazine",
+        "ja": "げっかんのまんがざっし",
+        "ja_typings": [
+          "gekkannomangazasshi"
+        ]
+      },
+      {
+        "en": "a shonen manga artist's life",
+        "ja": "しょうねんまんがかのせいかつ",
+        "ja_typings": [
+          "shonenmangakanoseikatsu",
+          "shounenmangakanoseikatsu"
+        ]
+      },
+      {
+        "en": "a manga club in school",
+        "ja": "がっこうのまんがぶ",
+        "ja_typings": [
+          "gakkonomangabu",
+          "gakkounomangabu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00541",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Gekkan Shounen Nozaki-kun' about?",
+      "ja": "「げっかんしょうねんのざきくん」はなにについてか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hunter x Hunter",
+        "ja": "はんたーはんたー",
+        "ja_typings": [
+          "hantahanta"
+        ]
+      },
+      {
+        "en": "Yu Yu Hakusho",
+        "ja": "ゆゆはくしょ",
+        "ja_typings": [
+          "yuyuhakusho"
+        ]
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "ふぇありーている",
+        "ja_typings": [
+          "feariteiru"
+        ]
+      },
+      {
+        "en": "Magi",
+        "ja": "まぎ",
+        "ja_typings": [
+          "magi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00542",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga ran from 1999 and features Gon Freecss as protagonist?",
+      "ja": "1999ねんかられんさいのごんふりーくすがしゅじんこうのまんがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "four-panel comic strip",
+        "ja": "よんコマのまんが",
+        "ja_typings": [
+          "yonkomanomanga"
+        ]
+      },
+      {
+        "en": "manga with four main characters",
+        "ja": "しにんのメインキャラのまんが",
+        "ja_typings": [
+          "shininnomeinkyaranomanga"
+        ]
+      },
+      {
+        "en": "manga spanning four volumes",
+        "ja": "よんかんのまんが",
+        "ja_typings": [
+          "yonkannomanga"
+        ]
+      },
+      {
+        "en": "manga about four seasons",
+        "ja": "しきのまんが",
+        "ja_typings": [
+          "shikinomanga"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00543",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'yonkoma' manga?",
+      "ja": "よんこままんがとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "iyashikei (healing/soothing) manga",
+        "ja": "いやしけい（ほっこり）まんが",
+        "ja_typings": [
+          "iyashikei hokkori manga"
+        ]
+      },
+      {
+        "en": "action shonen",
+        "ja": "あくしょんしょうねん",
+        "ja_typings": [
+          "akushonshonen",
+          "akushonshounen"
+        ]
+      },
+      {
+        "en": "sports manga",
+        "ja": "すぽーつまんが",
+        "ja_typings": [
+          "supotsumanga"
+        ]
+      },
+      {
+        "en": "horror manga",
+        "ja": "ほらーまんが",
+        "ja_typings": [
+          "horamanga"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00544",
+    "image_path": null,
+    "question_text": {
+      "en": "What type of manga is 'Yuru Camp'?",
+      "ja": "ゆるキャンのまんがのしゅるいは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hiro Mashima",
+        "ja": "ましまひろ",
+        "ja_typings": [
+          "mashimahiro"
+        ]
+      },
+      {
+        "en": "Eiichiro Oda",
+        "ja": "おだえいいちろう",
+        "ja_typings": [
+          "odaeiichiro",
+          "odaeiichirou"
+        ]
+      },
+      {
+        "en": "Masashi Kishimoto",
+        "ja": "きしもとまさし",
+        "ja_typings": [
+          "kishimotomasashi"
+        ]
+      },
+      {
+        "en": "Yoshihiro Togashi",
+        "ja": "とがしよしひろ",
+        "ja_typings": [
+          "togashiyoshihiro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00545",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the creator of Fairy Tail?",
+      "ja": "フェアリーテイルをかいたのは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cardcaptor Sakura",
+        "ja": "カードキャプターさくら",
+        "ja_typings": [
+          "kadokyaputasakura"
+        ]
+      },
+      {
+        "en": "Sailor Moon",
+        "ja": "せーらーむーん",
+        "ja_typings": [
+          "seramun"
+        ]
+      },
+      {
+        "en": "Ouran High School Host Club",
+        "ja": "おうらんこうこうホストクラブ",
+        "ja_typings": [
+          "orankokohosutokurabu",
+          "ourankoukouhosutokurabu"
+        ]
+      },
+      {
+        "en": "Fruits Basket",
+        "ja": "ふるーつばすけっと",
+        "ja_typings": [
+          "furutsubasuketto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00546",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the famous manga by CLAMP?",
+      "ja": "CLAMPのゆうめいなまんがは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "mature themes for adult men",
+        "ja": "せいじんだんせいのためのおとなのテーマ",
+        "ja_typings": [
+          "seijindanseinotamenotonanotema",
+          "seijindanseinotamenootonanotema"
+        ]
+      },
+      {
+        "en": "school romance stories",
+        "ja": "がっこうのれんあいはなし",
+        "ja_typings": [
+          "gakkonorenaihanashi",
+          "gakkounorenaihanashi"
+        ]
+      },
+      {
+        "en": "magical girl themes",
+        "ja": "まほうしょうじょテーマ",
+        "ja_typings": [
+          "mahoshojotema",
+          "mahoushoujotema"
+        ]
+      },
+      {
+        "en": "tournament battle arcs",
+        "ja": "たいかいばとるへん",
+        "ja_typings": [
+          "taikaibatoruhen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00547",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Seinen' manga known for?",
+      "ja": "せいねんまんがはなにでゆうめいか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "distinctive flamboyant art style",
+        "ja": "どくとくのはなやかなえのスタイル",
+        "ja_typings": [
+          "dokutokunohanayakanaenosutairu"
+        ]
+      },
+      {
+        "en": "simple minimalist drawing",
+        "ja": "かんたんなミニマリストのえ",
+        "ja_typings": [
+          "kantannaminimarisutonoe"
+        ]
+      },
+      {
+        "en": "realistic photo-like art",
+        "ja": "しゃしんのようなリアルなえ",
+        "ja_typings": [
+          "shashinnoyonariarunae",
+          "shashinnoyounariarunae"
+        ]
+      },
+      {
+        "en": "abstract expressionist style",
+        "ja": "ちゅうしょうひょうげんしゅぎのスタイル",
+        "ja_typings": [
+          "chuushohyogenshuginosutairu",
+          "chuushouhyougenshuginosutairu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q00548",
+    "image_path": null,
+    "question_text": {
+      "en": "What makes Hirohiko Araki unique as a manga artist?",
+      "ja": "まんがかとしてのあらきひろひこのとくちょうは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Paris",
+        "ja": "ぱり",
+        "ja_typings": [
+          "pari"
+        ]
+      },
+      {
+        "en": "Lyon",
+        "ja": "りよん",
+        "ja_typings": [
+          "riyon"
+        ]
+      },
+      {
+        "en": "Marseille",
+        "ja": "まるせいゆ",
+        "ja_typings": [
+          "maruseiyu"
+        ]
+      },
+      {
+        "en": "Nice",
+        "ja": "にーす",
+        "ja_typings": [
+          "nisu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
     "genre": "geography",
-    "id": "q00076",
+    "id": "q00549",
     "image_path": null,
     "question_text": {
-      "en": "What is the world's highest mountain?",
-      "ja": "せかいでいちばんたかいやまは?"
+      "en": "What is the capital of France?",
+      "ja": "ふらんすのしゅとは？"
     }
   },
   {
     "choices": [
       {
-        "en": "1943",
-        "ja": "1943",
+        "en": "Tokyo",
+        "ja": "とうきょう",
         "ja_typings": [
-          "1943"
+          "tokyo",
+          "toukyou"
         ]
       },
-      {
-        "en": "1944",
-        "ja": "1944",
-        "ja_typings": [
-          "1944"
-        ]
-      },
-      {
-        "en": "1945",
-        "ja": "1945",
-        "ja_typings": [
-          "1945"
-        ]
-      },
-      {
-        "en": "1946",
-        "ja": "1946",
-        "ja_typings": [
-          "1946"
-        ]
-      }
-    ],
-    "correct_answer_index": 2,
-    "genre": "history",
-    "id": "q00077",
-    "image_path": null,
-    "question_text": {
-      "en": "What year did World War II end?",
-      "ja": "だいにじせかいたいせんがおわったとしは?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "About 100 million km",
-        "ja": "やく1おくkm",
-        "ja_typings": [
-          "yaku1okukm"
-        ]
-      },
-      {
-        "en": "About 150 million km",
-        "ja": "やく1.5おくkm",
-        "ja_typings": [
-          "yaku1.5okukm"
-        ]
-      },
-      {
-        "en": "About 200 million km",
-        "ja": "やく2おくkm",
-        "ja_typings": [
-          "yaku2okukm"
-        ]
-      },
-      {
-        "en": "About 300 million km",
-        "ja": "やく3おくkm",
-        "ja_typings": [
-          "yaku3okukm"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
-    "genre": "science",
-    "id": "q00078",
-    "image_path": null,
-    "question_text": {
-      "en": "What is the distance from Earth to the Sun?",
-      "ja": "ちきゅうからたいようまでのきょりは?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "2.14",
-        "ja": "2.14",
-        "ja_typings": [
-          "2.14"
-        ]
-      },
-      {
-        "en": "3.14",
-        "ja": "3.14",
-        "ja_typings": [
-          "3.14"
-        ]
-      },
-      {
-        "en": "4.14",
-        "ja": "4.14",
-        "ja_typings": [
-          "4.14"
-        ]
-      },
-      {
-        "en": "5.14",
-        "ja": "5.14",
-        "ja_typings": [
-          "5.14"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
-    "genre": "math",
-    "id": "q00079",
-    "image_path": null,
-    "question_text": {
-      "en": "What is the approximate value of pi (π)?",
-      "ja": "えんしゅうりつπのちは?"
-    }
-  },
-  {
-    "choices": [
       {
         "en": "Osaka",
         "ja": "おおさか",
@@ -3227,161 +22572,4485 @@
         ]
       },
       {
-        "en": "Tokyo",
-        "ja": "とうきょう",
+        "en": "Nagoya",
+        "ja": "なごや",
         "ja_typings": [
-          "tokyo",
-          "toukyou"
-        ]
-      },
-      {
-        "en": "Yokohama",
-        "ja": "よこはま",
-        "ja_typings": [
-          "yokohama"
+          "nagoya"
         ]
       }
     ],
-    "correct_answer_index": 2,
+    "correct_answer_index": 0,
     "genre": "geography",
-    "id": "q00080",
+    "id": "q00550",
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Japan?",
-      "ja": "にほんのしゅとは?"
+      "ja": "にほんのしゅとは？"
     }
   },
   {
     "choices": [
       {
-        "en": "0 degrees",
-        "ja": "0ど",
+        "en": "Russia",
+        "ja": "ろしあ",
         "ja_typings": [
-          "0do"
+          "roshia"
         ]
       },
       {
-        "en": "50 degrees",
-        "ja": "50ど",
+        "en": "Canada",
+        "ja": "かなだ",
         "ja_typings": [
-          "50do"
+          "kanada"
         ]
       },
       {
-        "en": "100 degrees",
-        "ja": "100ど",
+        "en": "China",
+        "ja": "ちゅうごく",
         "ja_typings": [
-          "100do"
+          "chuugoku"
         ]
       },
       {
-        "en": "150 degrees",
-        "ja": "150ど",
+        "en": "United States",
+        "ja": "あめりか",
         "ja_typings": [
-          "150do"
+          "amerika"
         ]
       }
     ],
-    "correct_answer_index": 2,
-    "genre": "science",
-    "id": "q00081",
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00551",
     "image_path": null,
     "question_text": {
-      "en": "What is the boiling point of water?",
-      "ja": "みずのふっとうてんは?"
+      "en": "What is the largest country by area?",
+      "ja": "めんせきがもっともおおきいくには？"
     }
   },
   {
     "choices": [
-    {
-      "en": "Lincoln",
-      "ja": "リンカーン",
-      "ja_typings": [
-        "rinkan",
-        "lincoln"
-      ]
-    },
-    {
-      "en": "Washington",
-      "ja": "ワシントン",
-      "ja_typings": [
-        "washinton",
-        "washington"
-      ]
-    },
-    {
-      "en": "Jefferson",
-      "ja": "ジェファーソン",
-      "ja_typings": [
-        "jefason",
-        "jefferson"
-      ]
-    },
-    {
-      "en": "Kennedy",
-      "ja": "ケネディ",
-      "ja_typings": [
-        "kenedi",
-        "kennedy"
-      ]
-    }
+      {
+        "en": "Nile",
+        "ja": "ないる",
+        "ja_typings": [
+          "nairu"
+        ]
+      },
+      {
+        "en": "Amazon",
+        "ja": "あまぞん",
+        "ja_typings": [
+          "amazon"
+        ]
+      },
+      {
+        "en": "Yangtze",
+        "ja": "ようすこう",
+        "ja_typings": [
+          "yosuko",
+          "yousukou"
+        ]
+      },
+      {
+        "en": "Mississippi",
+        "ja": "みししっぴ",
+        "ja_typings": [
+          "mishishippi"
+        ]
+      }
     ],
-    "correct_answer_index": 1,
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00552",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the longest river in the world?",
+      "ja": "せかいでもっともながいかわは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mount Everest",
+        "ja": "えべれすとさん",
+        "ja_typings": [
+          "eberesutosan"
+        ]
+      },
+      {
+        "en": "K2",
+        "ja": "けーつー",
+        "ja_typings": [
+          "ketsu"
+        ]
+      },
+      {
+        "en": "Kangchenjunga",
+        "ja": "かんちぇんじゅんがさん",
+        "ja_typings": [
+          "kanchenjungasan"
+        ]
+      },
+      {
+        "en": "Mont Blanc",
+        "ja": "もんぶらん",
+        "ja_typings": [
+          "monburan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00553",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the highest mountain in the world?",
+      "ja": "せかいでもっともたかいやまは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Africa",
+        "ja": "あふりか",
+        "ja_typings": [
+          "afurika"
+        ]
+      },
+      {
+        "en": "Asia",
+        "ja": "あじあ",
+        "ja_typings": [
+          "ajia"
+        ]
+      },
+      {
+        "en": "Middle East",
+        "ja": "ちゅうとう",
+        "ja_typings": [
+          "chuuto",
+          "chuutou"
+        ]
+      },
+      {
+        "en": "Europe",
+        "ja": "えーろっぱ",
+        "ja_typings": [
+          "eroppa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00554",
+    "image_path": null,
+    "question_text": {
+      "en": "What continent is Egypt in?",
+      "ja": "えじぷとはどのたいりくにあるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Berlin",
+        "ja": "べるりん",
+        "ja_typings": [
+          "berurin"
+        ]
+      },
+      {
+        "en": "Munich",
+        "ja": "みゅんへん",
+        "ja_typings": [
+          "myunhen"
+        ]
+      },
+      {
+        "en": "Hamburg",
+        "ja": "はんぶるく",
+        "ja_typings": [
+          "hanburuku"
+        ]
+      },
+      {
+        "en": "Frankfurt",
+        "ja": "ふらんくふると",
+        "ja_typings": [
+          "furankufuruto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00555",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Germany?",
+      "ja": "どいつのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Atlantic Ocean",
+        "ja": "たいせいよう",
+        "ja_typings": [
+          "taiseiyo",
+          "taiseiyou"
+        ]
+      },
+      {
+        "en": "Pacific Ocean",
+        "ja": "たいへいよう",
+        "ja_typings": [
+          "taiheiyo",
+          "taiheiyou"
+        ]
+      },
+      {
+        "en": "Indian Ocean",
+        "ja": "いんどよう",
+        "ja_typings": [
+          "indoyo",
+          "indoyou"
+        ]
+      },
+      {
+        "en": "Southern Ocean",
+        "ja": "なんきょくかい",
+        "ja_typings": [
+          "nankyokukai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00556",
+    "image_path": null,
+    "question_text": {
+      "en": "What ocean separates Africa from South America?",
+      "ja": "あふりかとみなみあめりかをへだてるうみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Canberra",
+        "ja": "きゃんべら",
+        "ja_typings": [
+          "kyanbera"
+        ]
+      },
+      {
+        "en": "Sydney",
+        "ja": "しどにー",
+        "ja_typings": [
+          "shidoni"
+        ]
+      },
+      {
+        "en": "Melbourne",
+        "ja": "めるぼるん",
+        "ja_typings": [
+          "meruborun"
+        ]
+      },
+      {
+        "en": "Brisbane",
+        "ja": "ぶりずべん",
+        "ja_typings": [
+          "burizuben"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00557",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Australia?",
+      "ja": "おーすとらりあのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vatican City",
+        "ja": "ばちかんし",
+        "ja_typings": [
+          "bachikanshi"
+        ]
+      },
+      {
+        "en": "Monaco",
+        "ja": "もなこ",
+        "ja_typings": [
+          "monako"
+        ]
+      },
+      {
+        "en": "San Marino",
+        "ja": "さんまりの",
+        "ja_typings": [
+          "sanmarino"
+        ]
+      },
+      {
+        "en": "Liechtenstein",
+        "ja": "りひてんしゅたいん",
+        "ja_typings": [
+          "rihitenshutain"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00558",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the smallest country in the world?",
+      "ja": "せかいでもっともちいさいくには？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Brasilia",
+        "ja": "ぶらじりあ",
+        "ja_typings": [
+          "burajiria"
+        ]
+      },
+      {
+        "en": "Rio de Janeiro",
+        "ja": "りおでじゃねいろ",
+        "ja_typings": [
+          "riodejaneiro"
+        ]
+      },
+      {
+        "en": "São Paulo",
+        "ja": "さんぱうろ",
+        "ja_typings": [
+          "sanpauro"
+        ]
+      },
+      {
+        "en": "Salvador",
+        "ja": "さるばどーる",
+        "ja_typings": [
+          "sarubadoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00559",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Brazil?",
+      "ja": "ぶらじるのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Beijing",
+        "ja": "ぺきん",
+        "ja_typings": [
+          "pekin"
+        ]
+      },
+      {
+        "en": "Shanghai",
+        "ja": "しゃんはい",
+        "ja_typings": [
+          "shanhai"
+        ]
+      },
+      {
+        "en": "Hong Kong",
+        "ja": "ほんこん",
+        "ja_typings": [
+          "honkon"
+        ]
+      },
+      {
+        "en": "Guangzhou",
+        "ja": "こうしゅう",
+        "ja_typings": [
+          "koshuu",
+          "koushuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00560",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of China?",
+      "ja": "ちゅうごくのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sahara",
+        "ja": "さはら",
+        "ja_typings": [
+          "sahara"
+        ]
+      },
+      {
+        "en": "Arabian",
+        "ja": "あらびあ",
+        "ja_typings": [
+          "arabia"
+        ]
+      },
+      {
+        "en": "Gobi",
+        "ja": "ごび",
+        "ja_typings": [
+          "gobi"
+        ]
+      },
+      {
+        "en": "Antarctic",
+        "ja": "なんきょく",
+        "ja_typings": [
+          "nankyoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00561",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the largest desert in the world?",
+      "ja": "せかいでもっともおおきいさばくは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "7",
+        "ja": "なな",
+        "ja_typings": [
+          "nana"
+        ]
+      },
+      {
+        "en": "5",
+        "ja": "ご",
+        "ja_typings": [
+          "go"
+        ]
+      },
+      {
+        "en": "6",
+        "ja": "ろく",
+        "ja_typings": [
+          "roku"
+        ]
+      },
+      {
+        "en": "8",
+        "ja": "はち",
+        "ja_typings": [
+          "hachi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00562",
+    "image_path": null,
+    "question_text": {
+      "en": "How many continents are there?",
+      "ja": "たいりくはいくつあるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Washington D.C.",
+        "ja": "わしんとんでぃーしー",
+        "ja_typings": [
+          "washintondishi"
+        ]
+      },
+      {
+        "en": "New York",
+        "ja": "にゅーよーく",
+        "ja_typings": [
+          "nyuyoku"
+        ]
+      },
+      {
+        "en": "Los Angeles",
+        "ja": "ろさんぜるす",
+        "ja_typings": [
+          "rosanzerusu"
+        ]
+      },
+      {
+        "en": "Chicago",
+        "ja": "しかご",
+        "ja_typings": [
+          "shikago"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00563",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of the USA?",
+      "ja": "アメリカのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rome",
+        "ja": "ろーま",
+        "ja_typings": [
+          "roma"
+        ]
+      },
+      {
+        "en": "Milan",
+        "ja": "みらの",
+        "ja_typings": [
+          "mirano"
+        ]
+      },
+      {
+        "en": "Naples",
+        "ja": "なぽり",
+        "ja_typings": [
+          "napori"
+        ]
+      },
+      {
+        "en": "Florence",
+        "ja": "ふぃれんつぇ",
+        "ja_typings": [
+          "firentse"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00564",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Italy?",
+      "ja": "いたりあのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Madrid",
+        "ja": "まどりーど",
+        "ja_typings": [
+          "madorido"
+        ]
+      },
+      {
+        "en": "Barcelona",
+        "ja": "ばるせろな",
+        "ja_typings": [
+          "baruserona"
+        ]
+      },
+      {
+        "en": "Seville",
+        "ja": "せびりあ",
+        "ja_typings": [
+          "sebiria"
+        ]
+      },
+      {
+        "en": "Valencia",
+        "ja": "ばれんしあ",
+        "ja_typings": [
+          "barenshia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00565",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Spain?",
+      "ja": "すぺいんのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ottawa",
+        "ja": "おたわ",
+        "ja_typings": [
+          "otawa"
+        ]
+      },
+      {
+        "en": "Toronto",
+        "ja": "とろんと",
+        "ja_typings": [
+          "toronto"
+        ]
+      },
+      {
+        "en": "Vancouver",
+        "ja": "ばんくーばー",
+        "ja_typings": [
+          "bankuba"
+        ]
+      },
+      {
+        "en": "Montreal",
+        "ja": "もんとりおーる",
+        "ja_typings": [
+          "montorioru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00566",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Canada?",
+      "ja": "かなだのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Moscow",
+        "ja": "もすくわ",
+        "ja_typings": [
+          "mosukuwa"
+        ]
+      },
+      {
+        "en": "Saint Petersburg",
+        "ja": "さんくとぺてるぶるく",
+        "ja_typings": [
+          "sankutopeteruburuku"
+        ]
+      },
+      {
+        "en": "Novosibirsk",
+        "ja": "のぼしびるすく",
+        "ja_typings": [
+          "noboshibirusuku"
+        ]
+      },
+      {
+        "en": "Vladivostok",
+        "ja": "うらじおすとく",
+        "ja_typings": [
+          "urajiosutoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00567",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Russia?",
+      "ja": "ろしあのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Seoul",
+        "ja": "そうる",
+        "ja_typings": [
+          "soru",
+          "souru"
+        ]
+      },
+      {
+        "en": "Busan",
+        "ja": "ぷさん",
+        "ja_typings": [
+          "pusan"
+        ]
+      },
+      {
+        "en": "Incheon",
+        "ja": "いんちぇおん",
+        "ja_typings": [
+          "incheon"
+        ]
+      },
+      {
+        "en": "Daegu",
+        "ja": "てぐ",
+        "ja_typings": [
+          "tegu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00568",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of South Korea?",
+      "ja": "かんこくのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "New Delhi",
+        "ja": "にゅーでりー",
+        "ja_typings": [
+          "nyuderi"
+        ]
+      },
+      {
+        "en": "Mumbai",
+        "ja": "むんばい",
+        "ja_typings": [
+          "munbai"
+        ]
+      },
+      {
+        "en": "Kolkata",
+        "ja": "こるかた",
+        "ja_typings": [
+          "korukata"
+        ]
+      },
+      {
+        "en": "Chennai",
+        "ja": "ちぇんない",
+        "ja_typings": [
+          "chennai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00569",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of India?",
+      "ja": "いんどのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mexico City",
+        "ja": "めきしこしてぃー",
+        "ja_typings": [
+          "mekishikoshiti"
+        ]
+      },
+      {
+        "en": "Guadalajara",
+        "ja": "ぐあだらはら",
+        "ja_typings": [
+          "guadarahara"
+        ]
+      },
+      {
+        "en": "Monterrey",
+        "ja": "もんてれー",
+        "ja_typings": [
+          "montere"
+        ]
+      },
+      {
+        "en": "Tijuana",
+        "ja": "てぃふあな",
+        "ja_typings": [
+          "tifuana"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00570",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Mexico?",
+      "ja": "めきしこのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "France",
+        "ja": "ふらんす",
+        "ja_typings": [
+          "furansu"
+        ]
+      },
+      {
+        "en": "Germany",
+        "ja": "どいつ",
+        "ja_typings": [
+          "doitsu"
+        ]
+      },
+      {
+        "en": "Italy",
+        "ja": "いたりあ",
+        "ja_typings": [
+          "itaria"
+        ]
+      },
+      {
+        "en": "Belgium",
+        "ja": "べるぎー",
+        "ja_typings": [
+          "berugi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00571",
+    "image_path": null,
+    "question_text": {
+      "en": "What country has the Eiffel Tower?",
+      "ja": "えっふぇるとうはどのくににあるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Italy",
+        "ja": "いたりあ",
+        "ja_typings": [
+          "itaria"
+        ]
+      },
+      {
+        "en": "Greece",
+        "ja": "ぎりしあ",
+        "ja_typings": [
+          "girishia"
+        ]
+      },
+      {
+        "en": "Spain",
+        "ja": "すぺいん",
+        "ja_typings": [
+          "supein"
+        ]
+      },
+      {
+        "en": "Turkey",
+        "ja": "とるこ",
+        "ja_typings": [
+          "toruko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00572",
+    "image_path": null,
+    "question_text": {
+      "en": "What country has the Colosseum?",
+      "ja": "ころっせおはどのくににあるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Brazil",
+        "ja": "ぶらじる",
+        "ja_typings": [
+          "burajiru"
+        ]
+      },
+      {
+        "en": "Peru",
+        "ja": "ぺるー",
+        "ja_typings": [
+          "peru"
+        ]
+      },
+      {
+        "en": "Colombia",
+        "ja": "ころんびあ",
+        "ja_typings": [
+          "koronbia"
+        ]
+      },
+      {
+        "en": "Venezuela",
+        "ja": "べねずえら",
+        "ja_typings": [
+          "benezuera"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00573",
+    "image_path": null,
+    "question_text": {
+      "en": "What country is the Amazon rainforest mostly in?",
+      "ja": "あまぞんのねったいうりんはおもにどのくににあるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mediterranean Sea",
+        "ja": "ちちゅうかい",
+        "ja_typings": [
+          "chichuukai"
+        ]
+      },
+      {
+        "en": "Red Sea",
+        "ja": "こうかい",
+        "ja_typings": [
+          "kokai",
+          "koukai"
+        ]
+      },
+      {
+        "en": "Black Sea",
+        "ja": "こっかい",
+        "ja_typings": [
+          "kokkai"
+        ]
+      },
+      {
+        "en": "Caspian Sea",
+        "ja": "かすぴかい",
+        "ja_typings": [
+          "kasupikai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00574",
+    "image_path": null,
+    "question_text": {
+      "en": "What sea is between Europe and Africa?",
+      "ja": "ゆーろっぱとあふりかのあいだのうみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ecuador",
+        "ja": "えくあどる",
+        "ja_typings": [
+          "ekuadoru"
+        ]
+      },
+      {
+        "en": "Peru",
+        "ja": "ぺるー",
+        "ja_typings": [
+          "peru"
+        ]
+      },
+      {
+        "en": "Colombia",
+        "ja": "ころんびあ",
+        "ja_typings": [
+          "koronbia"
+        ]
+      },
+      {
+        "en": "Chile",
+        "ja": "ちり",
+        "ja_typings": [
+          "chiri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00575",
+    "image_path": null,
+    "question_text": {
+      "en": "What country owns the Galapagos Islands?",
+      "ja": "がらぱごすとうはどのくにのりょうどか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Andes",
+        "ja": "あんです",
+        "ja_typings": [
+          "andesu"
+        ]
+      },
+      {
+        "en": "Himalayas",
+        "ja": "ひまらや",
+        "ja_typings": [
+          "himaraya"
+        ]
+      },
+      {
+        "en": "Rockies",
+        "ja": "ろっきー",
+        "ja_typings": [
+          "rokki"
+        ]
+      },
+      {
+        "en": "Alps",
+        "ja": "あるぷす",
+        "ja_typings": [
+          "arupusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00576",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the longest mountain range?",
+      "ja": "せかいでもっともながいさんみゃくは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lake Baikal",
+        "ja": "ばいかるこ",
+        "ja_typings": [
+          "baikaruko"
+        ]
+      },
+      {
+        "en": "Lake Superior",
+        "ja": "すぺりおるこ",
+        "ja_typings": [
+          "superioruko"
+        ]
+      },
+      {
+        "en": "Caspian Sea",
+        "ja": "かすぴかい",
+        "ja_typings": [
+          "kasupikai"
+        ]
+      },
+      {
+        "en": "Crater Lake",
+        "ja": "くれーたーれいく",
+        "ja_typings": [
+          "kuretareiku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00577",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the deepest lake in the world?",
+      "ja": "せかいでもっともふかいみずうみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "China",
+        "ja": "ちゅうごく",
+        "ja_typings": [
+          "chuugoku"
+        ]
+      },
+      {
+        "en": "Australia",
+        "ja": "おーすとらりあ",
+        "ja_typings": [
+          "osutoraria"
+        ]
+      },
+      {
+        "en": "Brazil",
+        "ja": "ぶらじる",
+        "ja_typings": [
+          "burajiru"
+        ]
+      },
+      {
+        "en": "Russia",
+        "ja": "ろしあ",
+        "ja_typings": [
+          "roshia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00578",
+    "image_path": null,
+    "question_text": {
+      "en": "What country has the most natural UNESCO World Heritage Sites?",
+      "ja": "しぜんのユネスコせかいいさんがもっともおおいくには？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pacific Ocean",
+        "ja": "たいへいよう",
+        "ja_typings": [
+          "taiheiyo",
+          "taiheiyou"
+        ]
+      },
+      {
+        "en": "Atlantic Ocean",
+        "ja": "たいせいよう",
+        "ja_typings": [
+          "taiseiyo",
+          "taiseiyou"
+        ]
+      },
+      {
+        "en": "Indian Ocean",
+        "ja": "いんどよう",
+        "ja_typings": [
+          "indoyo",
+          "indoyou"
+        ]
+      },
+      {
+        "en": "Arctic Ocean",
+        "ja": "ほっきょくかい",
+        "ja_typings": [
+          "hokkyokukai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00579",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the largest ocean?",
+      "ja": "もっともおおきいうみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "South America",
+        "ja": "みなみあめりか",
+        "ja_typings": [
+          "minamiamerika"
+        ]
+      },
+      {
+        "en": "Central America",
+        "ja": "ちゅうおうあめりか",
+        "ja_typings": [
+          "chuuoamerika",
+          "chuuouamerika"
+        ]
+      },
+      {
+        "en": "North America",
+        "ja": "きたあめりか",
+        "ja_typings": [
+          "kitaamerika"
+        ]
+      },
+      {
+        "en": "Europe",
+        "ja": "えーろっぱ",
+        "ja_typings": [
+          "eroppa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00580",
+    "image_path": null,
+    "question_text": {
+      "en": "What continent is Argentina in?",
+      "ja": "あるぜんちんはどのたいりくにあるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Japan",
+        "ja": "にほん",
+        "ja_typings": [
+          "nihon"
+        ]
+      },
+      {
+        "en": "China",
+        "ja": "ちゅうごく",
+        "ja_typings": [
+          "chuugoku"
+        ]
+      },
+      {
+        "en": "South Korea",
+        "ja": "かんこく",
+        "ja_typings": [
+          "kankoku"
+        ]
+      },
+      {
+        "en": "Thailand",
+        "ja": "たいらんど",
+        "ja_typings": [
+          "tairando"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00581",
+    "image_path": null,
+    "question_text": {
+      "en": "What country is known as the Land of the Rising Sun?",
+      "ja": "ひのでのくにといわれるのはどのくにか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cairo",
+        "ja": "かいろ",
+        "ja_typings": [
+          "kairo"
+        ]
+      },
+      {
+        "en": "Alexandria",
+        "ja": "あれくさんどりあ",
+        "ja_typings": [
+          "arekusandoria"
+        ]
+      },
+      {
+        "en": "Luxor",
+        "ja": "るくそーる",
+        "ja_typings": [
+          "rukusoru"
+        ]
+      },
+      {
+        "en": "Aswan",
+        "ja": "あすわん",
+        "ja_typings": [
+          "asuwan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00582",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Egypt?",
+      "ja": "えじぷとのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ural Mountains",
+        "ja": "うらるさんみゃく",
+        "ja_typings": [
+          "urarusanmyaku"
+        ]
+      },
+      {
+        "en": "Himalayas",
+        "ja": "ひまらや",
+        "ja_typings": [
+          "himaraya"
+        ]
+      },
+      {
+        "en": "Caucasus",
+        "ja": "こーかさすさんみゃく",
+        "ja_typings": [
+          "kokasasusanmyaku"
+        ]
+      },
+      {
+        "en": "Alps",
+        "ja": "あるぷす",
+        "ja_typings": [
+          "arupusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00583",
+    "image_path": null,
+    "question_text": {
+      "en": "What mountain range separates Europe and Asia?",
+      "ja": "ゆーろっぱとあじあをへだてるさんみゃくは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Australia",
+        "ja": "おーすとらりあ",
+        "ja_typings": [
+          "osutoraria"
+        ]
+      },
+      {
+        "en": "Indonesia",
+        "ja": "いんどねしあ",
+        "ja_typings": [
+          "indoneshia"
+        ]
+      },
+      {
+        "en": "Philippines",
+        "ja": "ふぃりぴん",
+        "ja_typings": [
+          "firipin"
+        ]
+      },
+      {
+        "en": "Papua New Guinea",
+        "ja": "ぱぷあにゅーぎにあ",
+        "ja_typings": [
+          "papuanyuginia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00584",
+    "image_path": null,
+    "question_text": {
+      "en": "What country has the Great Barrier Reef?",
+      "ja": "グレートバリアリーフはどのくににあるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ankara",
+        "ja": "あんから",
+        "ja_typings": [
+          "ankara"
+        ]
+      },
+      {
+        "en": "Istanbul",
+        "ja": "いすたんぶーる",
+        "ja_typings": [
+          "isutanburu"
+        ]
+      },
+      {
+        "en": "Izmir",
+        "ja": "いずみる",
+        "ja_typings": [
+          "izumiru"
+        ]
+      },
+      {
+        "en": "Bursa",
+        "ja": "ぶるさ",
+        "ja_typings": [
+          "burusa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00585",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Turkey?",
+      "ja": "とるこのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pretoria",
+        "ja": "ぷれとりあ",
+        "ja_typings": [
+          "puretoria"
+        ]
+      },
+      {
+        "en": "Cape Town",
+        "ja": "けいぷたうん",
+        "ja_typings": [
+          "keiputaun"
+        ]
+      },
+      {
+        "en": "Johannesburg",
+        "ja": "よはねすばーぐ",
+        "ja_typings": [
+          "yohanesubagu"
+        ]
+      },
+      {
+        "en": "Durban",
+        "ja": "だーばん",
+        "ja_typings": [
+          "daban"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00586",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of South Africa?",
+      "ja": "みなみあふりかのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Multiple countries in North Africa",
+        "ja": "きたあふりかのふくすうのくに",
+        "ja_typings": [
+          "kitaafurikanofukusuunokuni"
+        ]
+      },
+      {
+        "en": "Egypt only",
+        "ja": "えじぷとのみ",
+        "ja_typings": [
+          "ejiputonomi"
+        ]
+      },
+      {
+        "en": "Libya only",
+        "ja": "りびあのみ",
+        "ja_typings": [
+          "ribianomi"
+        ]
+      },
+      {
+        "en": "Algeria only",
+        "ja": "あるじぇりあのみ",
+        "ja_typings": [
+          "arujerianomi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00587",
+    "image_path": null,
+    "question_text": {
+      "en": "What country is the Sahara Desert mostly in?",
+      "ja": "さはらさばくはおもにどのくににあるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Buenos Aires",
+        "ja": "ぶえのすあいれす",
+        "ja_typings": [
+          "buenosuairesu"
+        ]
+      },
+      {
+        "en": "Córdoba",
+        "ja": "こるどば",
+        "ja_typings": [
+          "korudoba"
+        ]
+      },
+      {
+        "en": "Rosario",
+        "ja": "ろさりお",
+        "ja_typings": [
+          "rosario"
+        ]
+      },
+      {
+        "en": "Mendoza",
+        "ja": "めんどさ",
+        "ja_typings": [
+          "mendosa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00588",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Argentina?",
+      "ja": "あるぜんちんのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Stockholm",
+        "ja": "すとっくほるむ",
+        "ja_typings": [
+          "sutokkuhorumu"
+        ]
+      },
+      {
+        "en": "Oslo",
+        "ja": "おすろ",
+        "ja_typings": [
+          "osuro"
+        ]
+      },
+      {
+        "en": "Copenhagen",
+        "ja": "こぺんはーげん",
+        "ja_typings": [
+          "kopenhagen"
+        ]
+      },
+      {
+        "en": "Helsinki",
+        "ja": "へるしんき",
+        "ja_typings": [
+          "herushinki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00589",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Sweden?",
+      "ja": "すうぇーでんのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Athens",
+        "ja": "あてね",
+        "ja_typings": [
+          "atene"
+        ]
+      },
+      {
+        "en": "Thessaloniki",
+        "ja": "てっさろにき",
+        "ja_typings": [
+          "tessaroniki"
+        ]
+      },
+      {
+        "en": "Crete",
+        "ja": "くれーた",
+        "ja_typings": [
+          "kureta"
+        ]
+      },
+      {
+        "en": "Sparta",
+        "ja": "すぱるた",
+        "ja_typings": [
+          "suparuta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00590",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Greece?",
+      "ja": "ぎりしあのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Amsterdam",
+        "ja": "あむすてるだむ",
+        "ja_typings": [
+          "amusuterudamu"
+        ]
+      },
+      {
+        "en": "The Hague",
+        "ja": "でんはーぐ",
+        "ja_typings": [
+          "denhagu"
+        ]
+      },
+      {
+        "en": "Rotterdam",
+        "ja": "ろってるだむ",
+        "ja_typings": [
+          "rotterudamu"
+        ]
+      },
+      {
+        "en": "Utrecht",
+        "ja": "うとれひと",
+        "ja_typings": [
+          "utorehito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00591",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Netherlands?",
+      "ja": "おらんだのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Warsaw",
+        "ja": "わるしゃわ",
+        "ja_typings": [
+          "warushawa"
+        ]
+      },
+      {
+        "en": "Krakow",
+        "ja": "くらこふ",
+        "ja_typings": [
+          "kurakofu"
+        ]
+      },
+      {
+        "en": "Gdansk",
+        "ja": "グダニスク",
+        "ja_typings": [
+          "gudanisuku"
+        ]
+      },
+      {
+        "en": "Wroclaw",
+        "ja": "ぶろつわふ",
+        "ja_typings": [
+          "burotsuwafu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00592",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Poland?",
+      "ja": "ぽーらんどのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sweden",
+        "ja": "すうぇーでん",
+        "ja_typings": [
+          "suweden"
+        ]
+      },
+      {
+        "en": "Indonesia",
+        "ja": "いんどねしあ",
+        "ja_typings": [
+          "indoneshia"
+        ]
+      },
+      {
+        "en": "Philippines",
+        "ja": "ふぃりぴん",
+        "ja_typings": [
+          "firipin"
+        ]
+      },
+      {
+        "en": "Japan",
+        "ja": "にほん",
+        "ja_typings": [
+          "nihon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00593",
+    "image_path": null,
+    "question_text": {
+      "en": "What country has the most islands?",
+      "ja": "もっともおおいしまのあるくには？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wellington",
+        "ja": "うぇりんとん",
+        "ja_typings": [
+          "werinton"
+        ]
+      },
+      {
+        "en": "Auckland",
+        "ja": "おーくらんど",
+        "ja_typings": [
+          "okurando"
+        ]
+      },
+      {
+        "en": "Christchurch",
+        "ja": "くらいすとちゃーち",
+        "ja_typings": [
+          "kuraisutochachi"
+        ]
+      },
+      {
+        "en": "Dunedin",
+        "ja": "だにーでぃん",
+        "ja_typings": [
+          "danidin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00594",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of New Zealand?",
+      "ja": "にゅーじーらんどのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Abuja",
+        "ja": "あぶじゃ",
+        "ja_typings": [
+          "abuja"
+        ]
+      },
+      {
+        "en": "Lagos",
+        "ja": "らごす",
+        "ja_typings": [
+          "ragosu"
+        ]
+      },
+      {
+        "en": "Kano",
+        "ja": "かの",
+        "ja_typings": [
+          "kano"
+        ]
+      },
+      {
+        "en": "Ibadan",
+        "ja": "いばだん",
+        "ja_typings": [
+          "ibadan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00595",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Nigeria?",
+      "ja": "ないじぇりあのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bangkok",
+        "ja": "ばんこく",
+        "ja_typings": [
+          "bankoku"
+        ]
+      },
+      {
+        "en": "Chiang Mai",
+        "ja": "ちぇんまい",
+        "ja_typings": [
+          "chenmai"
+        ]
+      },
+      {
+        "en": "Pattaya",
+        "ja": "ぱたや",
+        "ja_typings": [
+          "pataya"
+        ]
+      },
+      {
+        "en": "Phuket",
+        "ja": "ぷーけっと",
+        "ja_typings": [
+          "puketto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00596",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Thailand?",
+      "ja": "たいらんどのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "India",
+        "ja": "いんど",
+        "ja_typings": [
+          "indo"
+        ]
+      },
+      {
+        "en": "Pakistan",
+        "ja": "ぱきすたん",
+        "ja_typings": [
+          "pakisutan"
+        ]
+      },
+      {
+        "en": "Bangladesh",
+        "ja": "ばんぐらでしゅ",
+        "ja_typings": [
+          "banguradeshu"
+        ]
+      },
+      {
+        "en": "Nepal",
+        "ja": "ねぱーる",
+        "ja_typings": [
+          "neparu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00597",
+    "image_path": null,
+    "question_text": {
+      "en": "What country is the Taj Mahal in?",
+      "ja": "たじまはるはどのくににあるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Riyadh",
+        "ja": "りやど",
+        "ja_typings": [
+          "riyado"
+        ]
+      },
+      {
+        "en": "Mecca",
+        "ja": "めっか",
+        "ja_typings": [
+          "mekka"
+        ]
+      },
+      {
+        "en": "Jeddah",
+        "ja": "じぇっだ",
+        "ja_typings": [
+          "jedda"
+        ]
+      },
+      {
+        "en": "Medina",
+        "ja": "めでぃな",
+        "ja_typings": [
+          "medina"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00598",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Saudi Arabia?",
+      "ja": "さうじあらびあのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nairobi",
+        "ja": "ないろびー",
+        "ja_typings": [
+          "nairobi"
+        ]
+      },
+      {
+        "en": "Mombasa",
+        "ja": "もんばさ",
+        "ja_typings": [
+          "monbasa"
+        ]
+      },
+      {
+        "en": "Kisumu",
+        "ja": "きすむ",
+        "ja_typings": [
+          "kisumu"
+        ]
+      },
+      {
+        "en": "Nakuru",
+        "ja": "なくる",
+        "ja_typings": [
+          "nakuru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00599",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Kenya?",
+      "ja": "けにあのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lagos",
+        "ja": "らごす",
+        "ja_typings": [
+          "ragosu"
+        ]
+      },
+      {
+        "en": "Cairo",
+        "ja": "かいろ",
+        "ja_typings": [
+          "kairo"
+        ]
+      },
+      {
+        "en": "Kinshasa",
+        "ja": "きんしゃさ",
+        "ja_typings": [
+          "kinshasa"
+        ]
+      },
+      {
+        "en": "Johannesburg",
+        "ja": "よはねすばーぐ",
+        "ja_typings": [
+          "yohanesubagu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00600",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the largest city in Africa by population?",
+      "ja": "じんこうがもっともおおいあふりかのとしは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "USA and Canada",
+        "ja": "あめりかとかなだ",
+        "ja_typings": [
+          "amerikatokanada"
+        ]
+      },
+      {
+        "en": "USA and Mexico",
+        "ja": "あめりかとめきしこ",
+        "ja_typings": [
+          "amerikatomekishiko"
+        ]
+      },
+      {
+        "en": "Canada and UK",
+        "ja": "かなだとえいこく",
+        "ja_typings": [
+          "kanadatoeikoku"
+        ]
+      },
+      {
+        "en": "USA and UK",
+        "ja": "あめりかとえいこく",
+        "ja_typings": [
+          "amerikatoeikoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00601",
+    "image_path": null,
+    "question_text": {
+      "en": "What two countries share Niagara Falls?",
+      "ja": "ないあがらのたきをきょうゆうするふたつのくには？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lisbon",
+        "ja": "りずぼん",
+        "ja_typings": [
+          "rizubon"
+        ]
+      },
+      {
+        "en": "Porto",
+        "ja": "ぽると",
+        "ja_typings": [
+          "poruto"
+        ]
+      },
+      {
+        "en": "Faro",
+        "ja": "ふぁろ",
+        "ja_typings": [
+          "faro"
+        ]
+      },
+      {
+        "en": "Braga",
+        "ja": "ぶらが",
+        "ja_typings": [
+          "buraga"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00602",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Portugal?",
+      "ja": "ぽるとがるのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vienna",
+        "ja": "うぃーん",
+        "ja_typings": [
+          "win"
+        ]
+      },
+      {
+        "en": "Salzburg",
+        "ja": "ざるつぶるく",
+        "ja_typings": [
+          "zarutsuburuku"
+        ]
+      },
+      {
+        "en": "Graz",
+        "ja": "ぐらーつ",
+        "ja_typings": [
+          "guratsu"
+        ]
+      },
+      {
+        "en": "Innsbruck",
+        "ja": "いんすぶるっく",
+        "ja_typings": [
+          "insuburukku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00603",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the capital of Austria?",
+      "ja": "おーすとりあのしゅとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1945",
+        "ja": "1945ねん",
+        "ja_typings": [
+          "1945nen"
+        ]
+      },
+      {
+        "en": "1943",
+        "ja": "1943ねん",
+        "ja_typings": [
+          "1943nen"
+        ]
+      },
+      {
+        "en": "1947",
+        "ja": "1947ねん",
+        "ja_typings": [
+          "1947nen"
+        ]
+      },
+      {
+        "en": "1940",
+        "ja": "1940ねん",
+        "ja_typings": [
+          "1940nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
     "genre": "history",
-    "id": "q00082",
+    "id": "q00604",
     "image_path": null,
     "question_text": {
-      "en": "Who was the first U.S. President?",
-      "ja": "アメリカのしょだいだいとうりょうは?"
+      "en": "In what year did World War II end?",
+      "ja": "だいにじせかいたいせんはなんねんにおわったか？"
     }
   },
   {
     "choices": [
       {
-        "en": "Sumimasen",
-        "ja": "Sorry",
+        "en": "George Washington",
+        "ja": "じょーじわしんとん",
         "ja_typings": [
-          "sorry"
+          "jojiwashinton"
         ]
       },
       {
-        "en": "Arigato",
-        "ja": "Thank you",
+        "en": "Abraham Lincoln",
+        "ja": "えいぶらはむりんかーん",
         "ja_typings": [
-          "thank you"
+          "eiburahamurinkan"
         ]
       },
       {
-        "en": "Konnichiwa",
-        "ja": "Hello",
+        "en": "Thomas Jefferson",
+        "ja": "とーますじぇふぁーそん",
         "ja_typings": [
-          "hello"
+          "tomasujefason"
         ]
       },
       {
-        "en": "Sayonara",
-        "ja": "Goodbye",
+        "en": "John Adams",
+        "ja": "じょんあだむず",
         "ja_typings": [
-          "goodbye"
+          "jonadamuzu"
         ]
       }
     ],
-    "correct_answer_index": 1,
-    "genre": "language",
-    "id": "q00083",
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00605",
     "image_path": null,
     "question_text": {
-      "en": "How do you say 'Thank you' in Japanese?",
-      "ja": "「ありがとう」をえいごで?"
+      "en": "Who was the first President of the United States?",
+      "ja": "アメリカのしょだいだいとうりょうは誰か？"
     }
   },
   {
     "choices": [
       {
-        "en": "Earth",
-        "ja": "ちきゅう",
+        "en": "1789",
+        "ja": "1789ねん",
         "ja_typings": [
-          "chikyuu"
+          "1789nen"
+        ]
+      },
+      {
+        "en": "1776",
+        "ja": "1776ねん",
+        "ja_typings": [
+          "1776nen"
+        ]
+      },
+      {
+        "en": "1804",
+        "ja": "1804ねん",
+        "ja_typings": [
+          "1804nen"
+        ]
+      },
+      {
+        "en": "1815",
+        "ja": "1815ねん",
+        "ja_typings": [
+          "1815nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00606",
+    "image_path": null,
+    "question_text": {
+      "en": "What year did the French Revolution begin?",
+      "ja": "ふらんすかくめいはなんねんにはじまったか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Various Chinese emperors",
+        "ja": "れきだいのちゅうごくこうてい",
+        "ja_typings": [
+          "rekidainochuugokukotei",
+          "rekidainochuugokukoutei"
+        ]
+      },
+      {
+        "en": "Genghis Khan",
+        "ja": "ちんぎすかん",
+        "ja_typings": [
+          "chingisukan"
+        ]
+      },
+      {
+        "en": "Kublai Khan",
+        "ja": "くびらいかん",
+        "ja_typings": [
+          "kubiraikan"
+        ]
+      },
+      {
+        "en": "Emperor Qin Shi Huang alone",
+        "ja": "しこうていだけ",
+        "ja_typings": [
+          "shikoteidake",
+          "shikouteidake"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00607",
+    "image_path": null,
+    "question_text": {
+      "en": "Who built the Great Wall of China?",
+      "ja": "ちゅうごくのばんりのちょうじょうをきずいたのは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ancient Egyptians",
+        "ja": "こだいえじぷとじん",
+        "ja_typings": [
+          "kodaiejiputojin"
+        ]
+      },
+      {
+        "en": "Ancient Romans",
+        "ja": "こだいろーまじん",
+        "ja_typings": [
+          "kodairomajin"
+        ]
+      },
+      {
+        "en": "Ancient Greeks",
+        "ja": "こだいぎりしあじん",
+        "ja_typings": [
+          "kodaigirishiajin"
+        ]
+      },
+      {
+        "en": "Ancient Mesopotamians",
+        "ja": "こだいめそぽたみあじん",
+        "ja_typings": [
+          "kodaimesopotamiajin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00608",
+    "image_path": null,
+    "question_text": {
+      "en": "What civilization built the pyramids of Giza?",
+      "ja": "ぎざのぴらみっどをきずいたぶんめいは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "476 AD",
+        "ja": "476ねん",
+        "ja_typings": [
+          "476nen"
+        ]
+      },
+      {
+        "en": "410 AD",
+        "ja": "410ねん",
+        "ja_typings": [
+          "410nen"
+        ]
+      },
+      {
+        "en": "565 AD",
+        "ja": "565ねん",
+        "ja_typings": [
+          "565nen"
+        ]
+      },
+      {
+        "en": "395 AD",
+        "ja": "395ねん",
+        "ja_typings": [
+          "395nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00609",
+    "image_path": null,
+    "question_text": {
+      "en": "When did the Roman Empire fall?",
+      "ja": "ろーまていこくはいつほろんだか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "French military leader and emperor",
+        "ja": "ふらんすのぐんじどうしゃとこうてい",
+        "ja_typings": [
+          "furansunogunjidoshatokotei",
+          "furansunogunjidoushatokoutei"
+        ]
+      },
+      {
+        "en": "British admiral",
+        "ja": "えいこくのかいぐんていとく",
+        "ja_typings": [
+          "eikokunokaigunteitoku"
+        ]
+      },
+      {
+        "en": "Russian tsar",
+        "ja": "ろしあのツァーリ",
+        "ja_typings": [
+          "roshianotsari"
+        ]
+      },
+      {
+        "en": "Prussian king",
+        "ja": "ぷろいせんのおう",
+        "ja_typings": [
+          "puroisennou",
+          "puroisennoou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00610",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Napoleon Bonaparte?",
+      "ja": "なぽれおんぼなぱるととは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1492",
+        "ja": "1492ねん",
+        "ja_typings": [
+          "1492nen"
+        ]
+      },
+      {
+        "en": "1498",
+        "ja": "1498ねん",
+        "ja_typings": [
+          "1498nen"
+        ]
+      },
+      {
+        "en": "1488",
+        "ja": "1488ねん",
+        "ja_typings": [
+          "1488nen"
+        ]
+      },
+      {
+        "en": "1510",
+        "ja": "1510ねん",
+        "ja_typings": [
+          "1510nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00611",
+    "image_path": null,
+    "question_text": {
+      "en": "What year did Columbus reach the Americas?",
+      "ja": "ころんぶすがアメリカにたっしたのはなんねんか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "political tension between USA and USSR",
+        "ja": "アメリカとソ連の政治的緊張",
+        "ja_typings": [
+          "amerikatosono"
+        ]
+      },
+      {
+        "en": "war fought in cold climates",
+        "ja": "さむいきこうでのせんそう",
+        "ja_typings": [
+          "samuikikodenosenso",
+          "samuikikoudenosensou"
+        ]
+      },
+      {
+        "en": "war between Northern and Southern states",
+        "ja": "ほくぶとなんぶのせんそう",
+        "ja_typings": [
+          "hokubutonanbunosenso",
+          "hokubutonanbunosensou"
+        ]
+      },
+      {
+        "en": "war without weapons",
+        "ja": "ぶきなしのせんそう",
+        "ja_typings": [
+          "bukinashinosenso",
+          "bukinashinosensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00612",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the Cold War?",
+      "ja": "れいせんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cleopatra VII",
+        "ja": "くれおぱとら7せい",
+        "ja_typings": [
+          "kureopatora7sei"
+        ]
+      },
+      {
+        "en": "Ramesses II",
+        "ja": "らめせす2せい",
+        "ja_typings": [
+          "ramesesu2sei"
+        ]
+      },
+      {
+        "en": "Tutankhamun",
+        "ja": "つたんかーめん",
+        "ja_typings": [
+          "tsutankamen"
+        ]
+      },
+      {
+        "en": "Nefertiti",
+        "ja": "ねふぇるてぃてぃ",
+        "ja_typings": [
+          "neferutiti"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00613",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the last Pharaoh of ancient Egypt?",
+      "ja": "こだいえじぷとのさいごのふぁらおは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1868",
+        "ja": "1868ねん",
+        "ja_typings": [
+          "1868nen"
+        ]
+      },
+      {
+        "en": "1853",
+        "ja": "1853ねん",
+        "ja_typings": [
+          "1853nen"
+        ]
+      },
+      {
+        "en": "1889",
+        "ja": "1889ねん",
+        "ja_typings": [
+          "1889nen"
+        ]
+      },
+      {
+        "en": "1912",
+        "ja": "1912ねん",
+        "ja_typings": [
+          "1912nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00614",
+    "image_path": null,
+    "question_text": {
+      "en": "In what year did Japan's Meiji Restoration begin?",
+      "ja": "にほんのめいじいしんははじまったのはなんねんか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "English charter limiting royal power",
+        "ja": "おうけんをせいげんするえいこくのけんしょう",
+        "ja_typings": [
+          "okenoseigensurueikokunokensho",
+          "oukenoseigensurueikokunokenshou"
+        ]
+      },
+      {
+        "en": "Roman law code",
+        "ja": "ろーまのほうてん",
+        "ja_typings": [
+          "romanohoten",
+          "romanohouten"
+        ]
+      },
+      {
+        "en": "French revolutionary document",
+        "ja": "ふらんすかくめいのぶんしょ",
+        "ja_typings": [
+          "furansukakumeinobunsho"
+        ]
+      },
+      {
+        "en": "Church constitution",
+        "ja": "きょうかいのけんぽう",
+        "ja_typings": [
+          "kyokainokenpo",
+          "kyoukainokenpou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00615",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the Magna Carta?",
+      "ja": "まぐなかるたとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mahatma Gandhi",
+        "ja": "まはとまがんじー",
+        "ja_typings": [
+          "mahatomaganji"
+        ]
+      },
+      {
+        "en": "Jawaharlal Nehru",
+        "ja": "じゃわはるらーるねるー",
+        "ja_typings": [
+          "jawaharuraruneru"
+        ]
+      },
+      {
+        "en": "Subhas Chandra Bose",
+        "ja": "すばーすちゃんどらぼーす",
+        "ja_typings": [
+          "subasuchandorabosu"
+        ]
+      },
+      {
+        "en": "Bhagat Singh",
+        "ja": "ばがとしん",
+        "ja_typings": [
+          "bagatoshin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00616",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led the Indian independence movement against Britain?",
+      "ja": "えいこくにたいするいんどどくりつうんどうをひきいたのは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "European cultural revival 14th-17th century",
+        "ja": "14-17せいきのおうしゅうぶんかのふっこう",
+        "ja_typings": [
+          "1417seikinoushuubunkanofukko",
+          "1417seikinooushuubunkanofukkou"
+        ]
+      },
+      {
+        "en": "Roman Empire's golden age",
+        "ja": "ろーまていこくのおうごんじだい",
+        "ja_typings": [
+          "romateikokunougonjidai",
+          "romateikokunoougonjidai"
+        ]
+      },
+      {
+        "en": "Medieval crusade period",
+        "ja": "ちゅうせいじゅうじぐんのじだい",
+        "ja_typings": [
+          "chuuseijuujigunnojidai"
+        ]
+      },
+      {
+        "en": "Age of Exploration",
+        "ja": "だいこうかいじだい",
+        "ja_typings": [
+          "daikokaijidai",
+          "daikoukaijidai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00617",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the Renaissance?",
+      "ja": "るねさんすとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1989",
+        "ja": "1989ねん",
+        "ja_typings": [
+          "1989nen"
+        ]
+      },
+      {
+        "en": "1991",
+        "ja": "1991ねん",
+        "ja_typings": [
+          "1991nen"
+        ]
+      },
+      {
+        "en": "1985",
+        "ja": "1985ねん",
+        "ja_typings": [
+          "1985nen"
+        ]
+      },
+      {
+        "en": "1993",
+        "ja": "1993ねん",
+        "ja_typings": [
+          "1993nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00618",
+    "image_path": null,
+    "question_text": {
+      "en": "When did the Berlin Wall fall?",
+      "ja": "べるりんのかべはいつたおれたか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "colonial protest against British taxation",
+        "ja": "えいこくかぜいへのしょくみんちのこうぎ",
+        "ja_typings": [
+          "eikokukazeihenoshokuminchinokogi",
+          "eikokukazeihenoshokuminchinokougi"
+        ]
+      },
+      {
+        "en": "tea festival in Boston",
+        "ja": "ぼすとんのちゃのさいてん",
+        "ja_typings": [
+          "bosutonnochanosaiten"
+        ]
+      },
+      {
+        "en": "British tea trade event",
+        "ja": "えいこくのちゃのぼうえきいべんと",
+        "ja_typings": [
+          "eikokunochanoboekiibento",
+          "eikokunochanobouekiibento"
+        ]
+      },
+      {
+        "en": "American tea company celebration",
+        "ja": "アメリカのちゃかいしゃのさいてん",
+        "ja_typings": [
+          "amerikanochakaishanosaiten"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00619",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the Boston Tea Party?",
+      "ja": "ぼすとんてぃーぱーてぃーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Karl Marx and Friedrich Engels",
+        "ja": "かーるまるくすとふりーどりひえんげるす",
+        "ja_typings": [
+          "karumarukusutofuridorihiengerusu"
+        ]
+      },
+      {
+        "en": "Vladimir Lenin",
+        "ja": "うらじーみるれーにん",
+        "ja_typings": [
+          "urajimirurenin"
+        ]
+      },
+      {
+        "en": "Leon Trotsky",
+        "ja": "れおんとろつきー",
+        "ja_typings": [
+          "reontorotsuki"
+        ]
+      },
+      {
+        "en": "Joseph Stalin",
+        "ja": "じょせふすたーりん",
+        "ja_typings": [
+          "josefusutarin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00620",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote the Communist Manifesto?",
+      "ja": "きょうさんとうせんげんをかいたのは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ancient trade routes connecting East and West",
+        "ja": "ひがしとにしをつなぐこだいのぼうえきろ",
+        "ja_typings": [
+          "higashitonishiotsunagukodainoboekiro",
+          "higashitonishiotsunagukodainobouekiro"
+        ]
+      },
+      {
+        "en": "Chinese imperial road",
+        "ja": "ちゅうごくこうていのどうろ",
+        "ja_typings": [
+          "chuugokukoteinodoro",
+          "chuugokukouteinodouro"
+        ]
+      },
+      {
+        "en": "road built of silk material",
+        "ja": "きぬでつくられたどうろ",
+        "ja_typings": [
+          "kinudetsukuraretadoro",
+          "kinudetsukuraretadouro"
+        ]
+      },
+      {
+        "en": "Indian spice trade route",
+        "ja": "いんどのこうしんりょうぼうえきろ",
+        "ja_typings": [
+          "indonokoshinryoboekiro",
+          "indonokoushinryoubouekiro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00621",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the Silk Road?",
+      "ja": "しるくろーどとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Roman general and dictator",
+        "ja": "ろーまのしょうぐんとどくさいしゃ",
+        "ja_typings": [
+          "romanoshoguntodokusaisha",
+          "romanoshouguntodokusaisha"
+        ]
+      },
+      {
+        "en": "Greek philosopher",
+        "ja": "ぎりしあのてつがくしゃ",
+        "ja_typings": [
+          "girishianotetsugakusha"
+        ]
+      },
+      {
+        "en": "Egyptian pharaoh",
+        "ja": "えじぷとのふぁらお",
+        "ja_typings": [
+          "ejiputonofarao"
+        ]
+      },
+      {
+        "en": "Persian king",
+        "ja": "ぺるしあのおう",
+        "ja_typings": [
+          "perushianou",
+          "perushianoou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00622",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Julius Caesar?",
+      "ja": "じゅりあすかいさーとは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1914",
+        "ja": "1914ねん",
+        "ja_typings": [
+          "1914nen"
+        ]
+      },
+      {
+        "en": "1916",
+        "ja": "1916ねん",
+        "ja_typings": [
+          "1916nen"
+        ]
+      },
+      {
+        "en": "1912",
+        "ja": "1912ねん",
+        "ja_typings": [
+          "1912nen"
+        ]
+      },
+      {
+        "en": "1918",
+        "ja": "1918ねん",
+        "ja_typings": [
+          "1918nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00623",
+    "image_path": null,
+    "question_text": {
+      "en": "What year did the first World War begin?",
+      "ja": "だいいちじせかいたいせんはなんねんにはじまったか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "founder of Mongol Empire",
+        "ja": "もんごるていこくのきそしゃ",
+        "ja_typings": [
+          "mongoruteikokunokisosha"
+        ]
+      },
+      {
+        "en": "Chinese emperor",
+        "ja": "ちゅうごくのこうてい",
+        "ja_typings": [
+          "chuugokunokotei",
+          "chuugokunokoutei"
+        ]
+      },
+      {
+        "en": "Japanese shogun",
+        "ja": "にほんのしょうぐん",
+        "ja_typings": [
+          "nihonnoshogun",
+          "nihonnoshougun"
+        ]
+      },
+      {
+        "en": "Persian conqueror",
+        "ja": "ぺるしあのせいふくしゃ",
+        "ja_typings": [
+          "perushianoseifukusha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00624",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Genghis Khan?",
+      "ja": "ちんぎすかんとは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Meiji Restoration",
+        "ja": "めいじいしん",
+        "ja_typings": [
+          "meijiishin"
+        ]
+      },
+      {
+        "en": "Mongol invasion",
+        "ja": "もんごるのしんにゅう",
+        "ja_typings": [
+          "mongorunoshinnyuu"
+        ]
+      },
+      {
+        "en": "Perry's arrival",
+        "ja": "ぺりーのらいこう",
+        "ja_typings": [
+          "perinoraiko",
+          "perinoraikou"
+        ]
+      },
+      {
+        "en": "Edo Period end",
+        "ja": "えどじだいのおわり",
+        "ja_typings": [
+          "edojidainowari",
+          "edojidainoowari"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00625",
+    "image_path": null,
+    "question_text": {
+      "en": "What ended the feudal period in Japan?",
+      "ja": "にほんのほうけんじだいをおわらせたのは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "racial segregation in South Africa",
+        "ja": "みなみあふりかのじんしゅぶんり",
+        "ja_typings": [
+          "minamiafurikanojinshubunri"
+        ]
+      },
+      {
+        "en": "South African independence movement",
+        "ja": "みなみあふりかのどくりつうんどう",
+        "ja_typings": [
+          "minamiafurikanodokuritsuundo",
+          "minamiafurikanodokuritsuundou"
+        ]
+      },
+      {
+        "en": "African traditional religion",
+        "ja": "アフリカのでんとうてきしゅうきょう",
+        "ja_typings": [
+          "afurikanodentotekishuukyo",
+          "afurikanodentoutekishuukyou"
+        ]
+      },
+      {
+        "en": "South African economic policy",
+        "ja": "みなみあふりかのけいざいせいさく",
+        "ja_typings": [
+          "minamiafurikanokeizaiseisaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00626",
+    "image_path": null,
+    "question_text": {
+      "en": "What was apartheid?",
+      "ja": "あぱるとへいととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1865",
+        "ja": "1865ねん",
+        "ja_typings": [
+          "1865nen"
+        ]
+      },
+      {
+        "en": "1863",
+        "ja": "1863ねん",
+        "ja_typings": [
+          "1863nen"
+        ]
+      },
+      {
+        "en": "1867",
+        "ja": "1867ねん",
+        "ja_typings": [
+          "1867nen"
+        ]
+      },
+      {
+        "en": "1861",
+        "ja": "1861ねん",
+        "ja_typings": [
+          "1861nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00627",
+    "image_path": null,
+    "question_text": {
+      "en": "When did the American Civil War end?",
+      "ja": "アメリカなんぼくせんそうはなんねんにおわったか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Johannes Gutenberg",
+        "ja": "よはねすぐーてんべるく",
+        "ja_typings": [
+          "yohanesugutenberuku"
+        ]
+      },
+      {
+        "en": "Leonardo da Vinci",
+        "ja": "れおなるどだびんち",
+        "ja_typings": [
+          "reonarudodabinchi"
+        ]
+      },
+      {
+        "en": "Isaac Newton",
+        "ja": "あいざっくにゅーとん",
+        "ja_typings": [
+          "aizakkunyuton"
+        ]
+      },
+      {
+        "en": "Nikola Tesla",
+        "ja": "にこらてすら",
+        "ja_typings": [
+          "nikoratesura"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00628",
+    "image_path": null,
+    "question_text": {
+      "en": "Who invented the printing press?",
+      "ja": "いんさつきをはつめいしたのは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "14th century pandemic plague",
+        "ja": "14せいきのぺすとのぱんでみっく",
+        "ja_typings": [
+          "14seikinopesutonopandemikku"
+        ]
+      },
+      {
+        "en": "World War I battle",
+        "ja": "だいいちじたいせんのせんとう",
+        "ja_typings": [
+          "daiichijitaisennosento",
+          "daiichijitaisennosentou"
+        ]
+      },
+      {
+        "en": "Medieval famine",
+        "ja": "ちゅうせいのききん",
+        "ja_typings": [
+          "chuuseinokikin"
+        ]
+      },
+      {
+        "en": "African drought event",
+        "ja": "あふりかのかんばつ",
+        "ja_typings": [
+          "afurikanokanbatsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00629",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the Black Death?",
+      "ja": "ぺすととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "American civil rights leader",
+        "ja": "アメリカのこうみんけんうんどうのしどうしゃ",
+        "ja_typings": [
+          "amerikanokominkenundonoshidosha",
+          "amerikanokouminkenundounoshidousha"
+        ]
+      },
+      {
+        "en": "British prime minister",
+        "ja": "えいこくのしゅしょう",
+        "ja_typings": [
+          "eikokunoshusho",
+          "eikokunoshushou"
+        ]
+      },
+      {
+        "en": "German reformer",
+        "ja": "どいつのかいかくしゃ",
+        "ja_typings": [
+          "doitsunokaikakusha"
+        ]
+      },
+      {
+        "en": "South African president",
+        "ja": "みなみあふりかのだいとうりょう",
+        "ja_typings": [
+          "minamiafurikanodaitoryo",
+          "minamiafurikanodaitouryou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00630",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Martin Luther King Jr.?",
+      "ja": "まーてぃんるーさーきんぐじゅにあとは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1991",
+        "ja": "1991ねん",
+        "ja_typings": [
+          "1991nen"
+        ]
+      },
+      {
+        "en": "1989",
+        "ja": "1989ねん",
+        "ja_typings": [
+          "1989nen"
+        ]
+      },
+      {
+        "en": "1993",
+        "ja": "1993ねん",
+        "ja_typings": [
+          "1993nen"
+        ]
+      },
+      {
+        "en": "1985",
+        "ja": "1985ねん",
+        "ja_typings": [
+          "1985nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00631",
+    "image_path": null,
+    "question_text": {
+      "en": "What year did the Soviet Union collapse?",
+      "ja": "ソヴィエトれんぽうはなんねんにほうかいしたか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fidel Castro",
+        "ja": "ふぃでるかすとろ",
+        "ja_typings": [
+          "fiderukasutoro"
+        ]
+      },
+      {
+        "en": "Che Guevara",
+        "ja": "ちぇげばら",
+        "ja_typings": [
+          "chegebara"
+        ]
+      },
+      {
+        "en": "Raul Castro",
+        "ja": "らうるかすとろ",
+        "ja_typings": [
+          "raurukasutoro"
+        ]
+      },
+      {
+        "en": "Fulgencio Batista",
+        "ja": "ふるへんしおばてぃすた",
+        "ja_typings": [
+          "furuhenshiobatisuta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00632",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led the Cuban Revolution?",
+      "ja": "きゅーばかくめいをひきいたのは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Allied invasion of Normandy in 1944",
+        "ja": "1944ねんのどーるのだんせんじょうりくさくせん",
+        "ja_typings": [
+          "1944nennodorunodansenjorikusakusen",
+          "1944nennodorunodansenjourikusakusen"
+        ]
+      },
+      {
+        "en": "Japanese attack on Pearl Harbor",
+        "ja": "にほんのぱーるはーばーこうげき",
+        "ja_typings": [
+          "nihonnoparuhabakogeki",
+          "nihonnoparuhabakougeki"
+        ]
+      },
+      {
+        "en": "Germany's invasion of France",
+        "ja": "どいつのふらんすしんこう",
+        "ja_typings": [
+          "doitsunofuransushinko",
+          "doitsunofuransushinkou"
+        ]
+      },
+      {
+        "en": "End of World War II",
+        "ja": "だいにじたいせんのおわり",
+        "ja_typings": [
+          "dainijitaisennowari",
+          "dainijitaisennoowari"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00633",
+    "image_path": null,
+    "question_text": {
+      "en": "What was D-Day?",
+      "ja": "でぃーでーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1912",
+        "ja": "1912ねん",
+        "ja_typings": [
+          "1912nen"
+        ]
+      },
+      {
+        "en": "1914",
+        "ja": "1914ねん",
+        "ja_typings": [
+          "1914nen"
+        ]
+      },
+      {
+        "en": "1910",
+        "ja": "1910ねん",
+        "ja_typings": [
+          "1910nen"
+        ]
+      },
+      {
+        "en": "1915",
+        "ja": "1915ねん",
+        "ja_typings": [
+          "1915nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00634",
+    "image_path": null,
+    "question_text": {
+      "en": "When did the Titanic sink?",
+      "ja": "たいたにっくはなんねんにしずんだか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "founder of modern nursing",
+        "ja": "きんだいかんごのそしゃ",
+        "ja_typings": [
+          "kindaikangonososha"
+        ]
+      },
+      {
+        "en": "British queen",
+        "ja": "えいこくのじょおう",
+        "ja_typings": [
+          "eikokunojou",
+          "eikokunojoou"
+        ]
+      },
+      {
+        "en": "American scientist",
+        "ja": "アメリカのかがくしゃ",
+        "ja_typings": [
+          "amerikanokagakusha"
+        ]
+      },
+      {
+        "en": "French artist",
+        "ja": "ふらんすのがか",
+        "ja_typings": [
+          "furansunogaka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00635",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Florence Nightingale?",
+      "ja": "ふろれんすないちんげーるとは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "vast empire from Greece to India",
+        "ja": "ぎりしあからいんどまでのきょだいなていこく",
+        "ja_typings": [
+          "girishiakaraindomadenokyodainateikoku"
+        ]
+      },
+      {
+        "en": "Roman Empire",
+        "ja": "ろーまていこく",
+        "ja_typings": [
+          "romateikoku"
+        ]
+      },
+      {
+        "en": "Persian Empire",
+        "ja": "ぺるしあていこく",
+        "ja_typings": [
+          "perushiateikoku"
+        ]
+      },
+      {
+        "en": "Macedonian city-states only",
+        "ja": "まけどにあのとしこっかのみ",
+        "ja_typings": [
+          "makedonianotoshikokkanomi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00636",
+    "image_path": null,
+    "question_text": {
+      "en": "What empire did Alexander the Great build?",
+      "ja": "アレクサンドロスだいおうはどのようなていこくをきずいたか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1941",
+        "ja": "1941ねん",
+        "ja_typings": [
+          "1941nen"
+        ]
+      },
+      {
+        "en": "1939",
+        "ja": "1939ねん",
+        "ja_typings": [
+          "1939nen"
+        ]
+      },
+      {
+        "en": "1943",
+        "ja": "1943ねん",
+        "ja_typings": [
+          "1943nen"
+        ]
+      },
+      {
+        "en": "1945",
+        "ja": "1945ねん",
+        "ja_typings": [
+          "1945nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00637",
+    "image_path": null,
+    "question_text": {
+      "en": "When did Japan attack Pearl Harbor?",
+      "ja": "にほんはなんねんにぱーるはーばーをこうげきしたか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Neil Armstrong",
+        "ja": "にーるあーむすとろんぐ",
+        "ja_typings": [
+          "niruamusutorongu"
+        ]
+      },
+      {
+        "en": "Buzz Aldrin",
+        "ja": "ばずおるどりん",
+        "ja_typings": [
+          "bazuorudorin"
+        ]
+      },
+      {
+        "en": "Yuri Gagarin",
+        "ja": "ゆーりががーりん",
+        "ja_typings": [
+          "yurigagarin"
+        ]
+      },
+      {
+        "en": "John Glenn",
+        "ja": "じょんぐれん",
+        "ja_typings": [
+          "jonguren"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00638",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first man on the moon?",
+      "ja": "はじめて月にたったのは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Medieval European religious military campaigns",
+        "ja": "ちゅうせいおうしゅうのしゅうきょうてきぐんじえんせい",
+        "ja_typings": [
+          "chuuseioshuunoshuukyotekigunjiensei",
+          "chuuseioushuunoshuukyoutekigunjiensei"
+        ]
+      },
+      {
+        "en": "Ancient Greek military alliance",
+        "ja": "こだいぎりしあのぐんじどうめい",
+        "ja_typings": [
+          "kodaigirishianogunjidomei",
+          "kodaigirishianogunjidoumei"
+        ]
+      },
+      {
+        "en": "Roman expansion campaigns",
+        "ja": "ろーまのかくちょうえんせい",
+        "ja_typings": [
+          "romanokakuchoensei",
+          "romanokakuchouensei"
+        ]
+      },
+      {
+        "en": "Viking raids on Europe",
+        "ja": "えいこくへのばいきんぐのしゅうげき",
+        "ja_typings": [
+          "eikokuhenobaikingunoshuugeki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00639",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the Crusades?",
+      "ja": "じゅうじぐんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "18th century philosophical movement emphasizing reason",
+        "ja": "18せいきのりせいをじゅうしするてつがくうんどう",
+        "ja_typings": [
+          "18seikinoriseiojuushisurutetsugakuundo",
+          "18seikinoriseiojuushisurutetsugakuundou"
+        ]
+      },
+      {
+        "en": "Ancient Greek philosophy era",
+        "ja": "こだいぎりしあてつがくのじだい",
+        "ja_typings": [
+          "kodaigirishiatetsugakunojidai"
+        ]
+      },
+      {
+        "en": "Medieval church domination",
+        "ja": "ちゅうせいのきょうかいしはい",
+        "ja_typings": [
+          "chuuseinokyokaishihai",
+          "chuuseinokyoukaishihai"
+        ]
+      },
+      {
+        "en": "Renaissance art movement",
+        "ja": "るねさんすのびじゅつうんどう",
+        "ja_typings": [
+          "runesansunobijutsuundo",
+          "runesansunobijutsuundou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00640",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the Enlightenment?",
+      "ja": "けいもうじだいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "South African anti-apartheid leader and president",
+        "ja": "みなみあふりかのはんあぱるとへいとうどうしゃとだいとうりょう",
+        "ja_typings": [
+          "minamiafurikanohanaparutoheitodoshatodaitoryo",
+          "minamiafurikanohanaparutoheitoudoushatodaitouryou"
+        ]
+      },
+      {
+        "en": "Kenyan independence leader",
+        "ja": "けにあのどくりつうんどうのしどうしゃ",
+        "ja_typings": [
+          "kenianodokuritsuundonoshidosha",
+          "kenianodokuritsuundounoshidousha"
+        ]
+      },
+      {
+        "en": "Nigerian president",
+        "ja": "ないじぇりあのだいとうりょう",
+        "ja_typings": [
+          "naijerianodaitoryo",
+          "naijerianodaitouryou"
+        ]
+      },
+      {
+        "en": "Egyptian revolutionary",
+        "ja": "えじぷとのかくめいか",
+        "ja_typings": [
+          "ejiputonokakumeika"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00641",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Nelson Mandela?",
+      "ja": "ねるそんまんでらとは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1945",
+        "ja": "1945ねん",
+        "ja_typings": [
+          "1945nen"
+        ]
+      },
+      {
+        "en": "1919",
+        "ja": "1919ねん",
+        "ja_typings": [
+          "1919nen"
+        ]
+      },
+      {
+        "en": "1950",
+        "ja": "1950ねん",
+        "ja_typings": [
+          "1950nen"
+        ]
+      },
+      {
+        "en": "1941",
+        "ja": "1941ねん",
+        "ja_typings": [
+          "1941nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00642",
+    "image_path": null,
+    "question_text": {
+      "en": "When was the United Nations founded?",
+      "ja": "こくさいれんごうはなんねんにせつりつされたか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "shift from agricultural to industrial economy",
+        "ja": "のうぎょうからこうぎょうけいざいへのてんかん",
+        "ja_typings": [
+          "nogyokarakogyokeizaihenotenkan",
+          "nougyoukarakougyoukeizaihenotenkan"
+        ]
+      },
+      {
+        "en": "political revolution in France",
+        "ja": "ふらんすのせいじかくめい",
+        "ja_typings": [
+          "furansunoseijikakumei"
+        ]
+      },
+      {
+        "en": "technology revolution in 20th century",
+        "ja": "20せいきのぎじゅつかくめい",
+        "ja_typings": [
+          "20seikinogijutsukakumei"
+        ]
+      },
+      {
+        "en": "industrial nations forming alliance",
+        "ja": "こうぎょうこくのどうめいけっせい",
+        "ja_typings": [
+          "kogyokokunodomeikessei",
+          "kougyoukokunodoumeikessei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00643",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the Industrial Revolution?",
+      "ja": "さんぎょうかくめいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "founder of People's Republic of China",
+        "ja": "ちゅうかじんみんきょうわこくのきそしゃ",
+        "ja_typings": [
+          "chuukajinminkyowakokunokisosha",
+          "chuukajinminkyouwakokunokisosha"
+        ]
+      },
+      {
+        "en": "Japanese emperor",
+        "ja": "にほんのてんのう",
+        "ja_typings": [
+          "nihonnotenno",
+          "nihonnotennou"
+        ]
+      },
+      {
+        "en": "Vietnamese communist leader",
+        "ja": "べとなむのきょうさんしゅぎしどうしゃ",
+        "ja_typings": [
+          "betonamunokyosanshugishidosha",
+          "betonamunokyousanshugishidousha"
+        ]
+      },
+      {
+        "en": "Korean war hero",
+        "ja": "ちょうせんせんそうのえいゆう",
+        "ja_typings": [
+          "chosensensonoeiyuu",
+          "chousensensounoeiyuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00644",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Mao Zedong?",
+      "ja": "もうたくとうとは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1953",
+        "ja": "1953ねん",
+        "ja_typings": [
+          "1953nen"
+        ]
+      },
+      {
+        "en": "1950",
+        "ja": "1950ねん",
+        "ja_typings": [
+          "1950nen"
+        ]
+      },
+      {
+        "en": "1955",
+        "ja": "1955ねん",
+        "ja_typings": [
+          "1955nen"
+        ]
+      },
+      {
+        "en": "1945",
+        "ja": "1945ねん",
+        "ja_typings": [
+          "1945nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00645",
+    "image_path": null,
+    "question_text": {
+      "en": "When did the Korean War end?",
+      "ja": "ちょうせんせんそうはなんねんにおわったか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "last active pharaoh of ancient Egypt",
+        "ja": "こだいえじぷとのさいごのふぁらお",
+        "ja_typings": [
+          "kodaiejiputonosaigonofarao"
+        ]
+      },
+      {
+        "en": "Roman empress",
+        "ja": "ろーまのこうごう",
+        "ja_typings": [
+          "romanokogo",
+          "romanokougou"
+        ]
+      },
+      {
+        "en": "Greek goddess",
+        "ja": "ぎりしあのめがみ",
+        "ja_typings": [
+          "girishianomegami"
+        ]
+      },
+      {
+        "en": "Persian queen",
+        "ja": "ぺるしあのじょおう",
+        "ja_typings": [
+          "perushianojou",
+          "perushianojoou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00646",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Cleopatra?",
+      "ja": "くれおぱとらとは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "war between Britain and China over trade",
+        "ja": "えいこくとちゅうごくのぼうえきせんそう",
+        "ja_typings": [
+          "eikokutochuugokunoboekisenso",
+          "eikokutochuugokunobouekisensou"
+        ]
+      },
+      {
+        "en": "war over drug prohibition",
+        "ja": "やくぶつきんしのせんそう",
+        "ja_typings": [
+          "yakubutsukinshinosenso",
+          "yakubutsukinshinosensou"
+        ]
+      },
+      {
+        "en": "war between China and Japan",
+        "ja": "ちゅうにちせんそう",
+        "ja_typings": [
+          "chuunichisenso",
+          "chuunichisensou"
+        ]
+      },
+      {
+        "en": "war in British India",
+        "ja": "えいりょういんどのせんそう",
+        "ja_typings": [
+          "eiryoindonosenso",
+          "eiryouindonosensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00647",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the Opium War?",
+      "ja": "あへんせんそうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "16th US president who abolished slavery",
+        "ja": "どれいせいをはいしした16だいアメリカだいとうりょう",
+        "ja_typings": [
+          "doreiseiohaishishita16daiamerikadaitoryo",
+          "doreiseiohaishishita16daiamerikadaitouryou"
+        ]
+      },
+      {
+        "en": "1st US president",
+        "ja": "アメリカしょだいだいとうりょう",
+        "ja_typings": [
+          "amerikashodaidaitoryo",
+          "amerikashodaidaitouryou"
+        ]
+      },
+      {
+        "en": "US president in WWI era",
+        "ja": "だいいちじたいせんきのあめりかだいとうりょう",
+        "ja_typings": [
+          "daiichijitaisenkinoamerikadaitoryo",
+          "daiichijitaisenkinoamerikadaitouryou"
+        ]
+      },
+      {
+        "en": "US president in WWII era",
+        "ja": "だいにじたいせんきのあめりかだいとうりょう",
+        "ja_typings": [
+          "dainijitaisenkinoamerikadaitoryo",
+          "dainijitaisenkinoamerikadaitouryou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00648",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Abraham Lincoln?",
+      "ja": "えいぶらはむりんかーんとは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1969",
+        "ja": "1969ねん",
+        "ja_typings": [
+          "1969nen"
+        ]
+      },
+      {
+        "en": "1967",
+        "ja": "1967ねん",
+        "ja_typings": [
+          "1967nen"
+        ]
+      },
+      {
+        "en": "1971",
+        "ja": "1971ねん",
+        "ja_typings": [
+          "1971nen"
+        ]
+      },
+      {
+        "en": "1965",
+        "ja": "1965ねん",
+        "ja_typings": [
+          "1965nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00649",
+    "image_path": null,
+    "question_text": {
+      "en": "What year did the Moon landing occur?",
+      "ja": "つきにひとがおりたのはなんねんか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "WWII US program to develop atomic bomb",
+        "ja": "だいにじたいせんのアメリカのげんしばくだんかいはつ",
+        "ja_typings": [
+          "dainijitaisennoamerikanogenshibakudankaihatsu"
+        ]
+      },
+      {
+        "en": "construction of Manhattan island",
+        "ja": "まんはったんとうのけんせつ",
+        "ja_typings": [
+          "manhattantonokensetsu",
+          "manhattantounokensetsu"
+        ]
+      },
+      {
+        "en": "Cold War spy program",
+        "ja": "れいせんのすぱいけいかく",
+        "ja_typings": [
+          "reisennosupaikeikaku"
+        ]
+      },
+      {
+        "en": "space exploration program",
+        "ja": "うちゅうたんさくけいかく",
+        "ja_typings": [
+          "uchuutansakukeikaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00650",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the Manhattan Project?",
+      "ja": "まんはったんぷろじぇくととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "inventor of AC electrical system",
+        "ja": "こうりゅうでんきのはつめいか",
+        "ja_typings": [
+          "koryuudenkinohatsumeika",
+          "kouryuudenkinohatsumeika"
+        ]
+      },
+      {
+        "en": "inventor of the telephone",
+        "ja": "でんわのはつめいか",
+        "ja_typings": [
+          "denwanohatsumeika"
+        ]
+      },
+      {
+        "en": "founder of Tesla Motors",
+        "ja": "てすらもーたーずのそうぎょうしゃ",
+        "ja_typings": [
+          "tesuramotazunosogyosha",
+          "tesuramotazunosougyousha"
+        ]
+      },
+      {
+        "en": "inventor of the light bulb",
+        "ja": "でんきゅうのはつめいか",
+        "ja_typings": [
+          "denkyuunohatsumeika"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00651",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Nikola Tesla?",
+      "ja": "にこらてすらとは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "military government led by a shogun",
+        "ja": "しょうぐんにひきいられたぶがてくせいけん",
+        "ja_typings": [
+          "shogunnihikiiraretabugatekuseiken",
+          "shougunnihikiiraretabugatekuseiken"
+        ]
+      },
+      {
+        "en": "imperial government system",
+        "ja": "こうしつのせいふしすてむ",
+        "ja_typings": [
+          "koshitsunoseifushisutemu",
+          "koushitsunoseifushisutemu"
+        ]
+      },
+      {
+        "en": "samurai martial arts school",
+        "ja": "さむらいのぶどうがっこう",
+        "ja_typings": [
+          "samurainobudogakko",
+          "samurainobudougakkou"
+        ]
+      },
+      {
+        "en": "Buddhist temple organization",
+        "ja": "ぶっきょうじのそしき",
+        "ja_typings": [
+          "bukkyojinososhiki",
+          "bukkyoujinososhiki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00652",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Shogunate in Japanese history?",
+      "ja": "にほんのしょうぐんとはどのようなものか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "series of conflicts between England and France",
+        "ja": "えいふらんかんのいちれんのぶんそう",
+        "ja_typings": [
+          "eifurankannoichirennobunso",
+          "eifurankannoichirennobunsou"
+        ]
+      },
+      {
+        "en": "war lasting exactly 100 years",
+        "ja": "ちょうど100ねんつづいたせんそう",
+        "ja_typings": [
+          "chodo100nentsuzuitasenso",
+          "choudo100nentsuzuitasensou"
+        ]
+      },
+      {
+        "en": "war between 100 nations",
+        "ja": "100のくにのせんそう",
+        "ja_typings": [
+          "100nokuninosenso",
+          "100nokuninosensou"
+        ]
+      },
+      {
+        "en": "Medieval plague lasting 100 years",
+        "ja": "100ねんつづいたちゅうせいのえきびょう",
+        "ja_typings": [
+          "100nentsuzuitachuuseinoekibyo",
+          "100nentsuzuitachuuseinoekibyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00653",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the Hundred Years' War?",
+      "ja": "ひゃくねんせんそうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "founder of the Edo shogunate",
+        "ja": "えどばくふのきそしゃ",
+        "ja_typings": [
+          "edobakufunokisosha"
+        ]
+      },
+      {
+        "en": "first emperor of Japan",
+        "ja": "にほんのしょだいてんのう",
+        "ja_typings": [
+          "nihonnoshodaitenno",
+          "nihonnoshodaitennou"
+        ]
+      },
+      {
+        "en": "samurai who unified Japan alone",
+        "ja": "にほんをたんどくでとういつしたさむらい",
+        "ja_typings": [
+          "nihonotandokudetoitsushitasamurai",
+          "nihonotandokudetouitsushitasamurai"
+        ]
+      },
+      {
+        "en": "reformer of the Meiji era",
+        "ja": "めいじじだいのかいかくしゃ",
+        "ja_typings": [
+          "meijijidainokaikakusha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00654",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Tokugawa Ieyasu?",
+      "ja": "とくがわいえやすとは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "peace treaty ending the first World War",
+        "ja": "だいいちじせかいたいせんをおわらせたへいわじょうやく",
+        "ja_typings": [
+          "daiichijisekaitaisenowarasetaheiwajoyaku",
+          "daiichijisekaitaisenoowarasetaheiwajouyaku"
+        ]
+      },
+      {
+        "en": "peace treaty ending the second World War",
+        "ja": "だいにじせかいたいせんをおわらせたへいわじょうやく",
+        "ja_typings": [
+          "dainijisekaitaisenowarasetaheiwajoyaku",
+          "dainijisekaitaisenoowarasetaheiwajouyaku"
+        ]
+      },
+      {
+        "en": "treaty dividing Europe in Cold War",
+        "ja": "れいせんでのおうしゅうのぶんかつじょうやく",
+        "ja_typings": [
+          "reisendenoushuunobunkatsujoyaku",
+          "reisendenooushuunobunkatsujouyaku"
+        ]
+      },
+      {
+        "en": "trade treaty between France and Germany",
+        "ja": "ふらんすとどいつのぼうえきじょうやく",
+        "ja_typings": [
+          "furansutodoitsunoboekijoyaku",
+          "furansutodoitsunobouekijouyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00655",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the Treaty of Versailles?",
+      "ja": "べるさいゆじょうやくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "British PM in the second World War",
+        "ja": "だいにじせかいたいせんのえいこくしゅしょう",
+        "ja_typings": [
+          "dainijisekaitaisennoeikokushusho",
+          "dainijisekaitaisennoeikokushushou"
+        ]
+      },
+      {
+        "en": "British PM in the first World War",
+        "ja": "だいいちじせかいたいせんのえいこくしゅしょう",
+        "ja_typings": [
+          "daiichijisekaitaisennoeikokushusho",
+          "daiichijisekaitaisennoeikokushushou"
+        ]
+      },
+      {
+        "en": "British king during WWII",
+        "ja": "だいにじたいせんのえいこくおう",
+        "ja_typings": [
+          "dainijitaisennoeikokuo",
+          "dainijitaisennoeikokuou"
+        ]
+      },
+      {
+        "en": "American president during WWII",
+        "ja": "だいにじたいせんのアメリカだいとうりょう",
+        "ja_typings": [
+          "dainijitaisennoamerikadaitoryo",
+          "dainijitaisennoamerikadaitouryou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00656",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Winston Churchill?",
+      "ja": "うぃんすとんちゃーちるとは誰か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1918",
+        "ja": "1918ねん",
+        "ja_typings": [
+          "1918nen"
+        ]
+      },
+      {
+        "en": "1916",
+        "ja": "1916ねん",
+        "ja_typings": [
+          "1916nen"
+        ]
+      },
+      {
+        "en": "1920",
+        "ja": "1920ねん",
+        "ja_typings": [
+          "1920nen"
+        ]
+      },
+      {
+        "en": "1919",
+        "ja": "1919ねん",
+        "ja_typings": [
+          "1919nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00657",
+    "image_path": null,
+    "question_text": {
+      "en": "When did World War I end?",
+      "ja": "だいいちじせかいたいせんはなんねんにおわったか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "water (H2O)",
+        "ja": "みずえいちにおー",
+        "ja_typings": [
+          "mizueichinio"
+        ]
+      },
+      {
+        "en": "HO₂",
+        "ja": "HO₂",
+        "ja_typings": [
+          "ho"
+        ]
+      },
+      {
+        "en": "hydrogen peroxide (H2O2)",
+        "ja": "かさんかすいそえいちにおーに",
+        "ja_typings": [
+          "kasankasuisoeichinioni"
+        ]
+      },
+      {
+        "en": "OH₂",
+        "ja": "OH₂",
+        "ja_typings": [
+          "oh"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00658",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the chemical symbol for water?",
+      "ja": "みずのかがくしきは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "object at rest stays at rest unless acted upon",
+        "ja": "がいりょくなしにせいしのぶったいはせいしをたもつ",
+        "ja_typings": [
+          "gairyokunashiniseishinobuttaihaseishiotamotsu"
+        ]
+      },
+      {
+        "en": "F = ma",
+        "ja": "F = ma",
+        "ja_typings": [
+          "f = ma"
+        ]
+      },
+      {
+        "en": "equal and opposite reactions",
+        "ja": "さようとはんさようがひとしい",
+        "ja_typings": [
+          "sayotohansayogahitoshii",
+          "sayoutohansayougahitoshii"
+        ]
+      },
+      {
+        "en": "energy cannot be created or destroyed",
+        "ja": "えねるぎーはそうせいもしょうめつもしない",
+        "ja_typings": [
+          "enerugihasoseimoshometsumoshinai",
+          "enerugihasouseimoshoumetsumoshinai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00659",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Newton's first law of motion?",
+      "ja": "にゅーとんのうんどうのだいいちほうそくは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mars",
+        "ja": "かせい",
+        "ja_typings": [
+          "kasei"
         ]
       },
       {
@@ -3399,43 +27068,337 @@
         ]
       },
       {
-        "en": "Mars",
-        "ja": "かせい",
+        "en": "Venus",
+        "ja": "きんせい",
         "ja_typings": [
-          "kasei"
+          "kinsei"
         ]
       }
     ],
-    "correct_answer_index": 1,
+    "correct_answer_index": 0,
     "genre": "science",
-    "id": "q00084",
+    "id": "q00660",
     "image_path": null,
     "question_text": {
-      "en": "What is the largest planet in our solar system?",
-      "ja": "たいようけいでいちばんおおきなわくせいは?"
+      "en": "What planet is known as the Red Planet?",
+      "ja": "あかいわくせいとよばれるのは？"
     }
   },
   {
     "choices": [
       {
-        "en": "2",
-        "ja": "2",
+        "en": "plants converting light to energy",
+        "ja": "しょくぶつがひかりをえねるぎーにへんかん",
         "ja_typings": [
-          "2"
+          "shokubutsugahikarioeneruginihenkan"
         ]
       },
       {
-        "en": "4",
-        "ja": "4",
+        "en": "animal digestion process",
+        "ja": "どうぶつのしょうかぷろせす",
         "ja_typings": [
-          "4"
+          "dobutsunoshokapurosesu",
+          "doubutsunoshoukapurosesu"
         ]
       },
+      {
+        "en": "water cycle process",
+        "ja": "みずのじゅんかんぷろせす",
+        "ja_typings": [
+          "mizunojunkanpurosesu"
+        ]
+      },
+      {
+        "en": "cellular respiration",
+        "ja": "さいぼうこきゅう",
+        "ja_typings": [
+          "saibokokyuu",
+          "saiboukokyuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00661",
+    "image_path": null,
+    "question_text": {
+      "en": "What is photosynthesis?",
+      "ja": "こうごうせいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "about 300,000 km/s",
+        "ja": "やく30まんkm/s",
+        "ja_typings": [
+          "yaku30mankm/s"
+        ]
+      },
+      {
+        "en": "about 30,000 km/s",
+        "ja": "やく3まんkm/s",
+        "ja_typings": [
+          "yaku3mankm/s"
+        ]
+      },
+      {
+        "en": "about 3,000 km/s",
+        "ja": "やく3せんkm/s",
+        "ja_typings": [
+          "yaku3senkm/s"
+        ]
+      },
+      {
+        "en": "about 3,000,000 km/s",
+        "ja": "やく300まんkm/s",
+        "ja_typings": [
+          "yaku300mankm/s"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00662",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the speed of light?",
+      "ja": "ひかりのそくどは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "molecule storing genetic information",
+        "ja": "いでんじょうほうをほぞんするぶんし",
+        "ja_typings": [
+          "idenjohoohozonsurubunshi",
+          "idenjouhouohozonsurubunshi"
+        ]
+      },
+      {
+        "en": "protein in muscles",
+        "ja": "きんにくのたんぱくしつ",
+        "ja_typings": [
+          "kinnikunotanpakushitsu"
+        ]
+      },
+      {
+        "en": "type of RNA",
+        "ja": "RNAのしゅるい",
+        "ja_typings": [
+          "rnanoshurui"
+        ]
+      },
+      {
+        "en": "cell membrane component",
+        "ja": "さいぼうまくのせいぶん",
+        "ja_typings": [
+          "saibomakunoseibun",
+          "saiboumakunoseibun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00663",
+    "image_path": null,
+    "question_text": {
+      "en": "What is DNA?",
+      "ja": "DNAとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "table organizing chemical elements",
+        "ja": "かがくげんそをせいりしたひょう",
+        "ja_typings": [
+          "kagakugensoseirishitahyo",
+          "kagakugensooseirishitahyou"
+        ]
+      },
+      {
+        "en": "table of chemical reactions",
+        "ja": "かがくはんのうのひょう",
+        "ja_typings": [
+          "kagakuhannonohyo",
+          "kagakuhannounohyou"
+        ]
+      },
+      {
+        "en": "table of atomic weights only",
+        "ja": "げんしりょうのみのひょう",
+        "ja_typings": [
+          "genshiryonominohyo",
+          "genshiryounominohyou"
+        ]
+      },
+      {
+        "en": "table of natural compounds",
+        "ja": "しぜんかごうぶつのひょう",
+        "ja_typings": [
+          "shizenkagobutsunohyo",
+          "shizenkagoubutsunohyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00664",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the periodic table?",
+      "ja": "げんそのしゅうきひょうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "rapid air expansion from lightning heat",
+        "ja": "いなびかりの熱による急速な空気膨張",
+        "ja_typings": [
+          "inabikarinoniyoruna"
+        ]
+      },
+      {
+        "en": "clouds colliding",
+        "ja": "くものしょうとつ",
+        "ja_typings": [
+          "kumonoshototsu",
+          "kumonoshoutotsu"
+        ]
+      },
+      {
+        "en": "electric discharge from clouds",
+        "ja": "くもからのほうでん",
+        "ja_typings": [
+          "kumokaranohoden",
+          "kumokaranohouden"
+        ]
+      },
+      {
+        "en": "sonic boom from rain",
+        "ja": "あめのそにっくぶーむ",
+        "ja_typings": [
+          "amenosonikkubumu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00665",
+    "image_path": null,
+    "question_text": {
+      "en": "What causes thunder?",
+      "ja": "かみなりがなるりゆうは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "region where gravity is so strong light cannot escape",
+        "ja": "光が脱出できないほど重力が強い領域",
+        "ja_typings": [
+          "gadekinaihodogai"
+        ]
+      },
+      {
+        "en": "dark star that produces no light",
+        "ja": "ひかりをだしていないくらいほし",
+        "ja_typings": [
+          "hikariodashiteinaikuraihoshi"
+        ]
+      },
+      {
+        "en": "empty space in galaxy",
+        "ja": "ぎゃらくしーのそらのくうかん",
+        "ja_typings": [
+          "gyarakushinosoranokuukan"
+        ]
+      },
+      {
+        "en": "remnant of a supernova",
+        "ja": "ちょうしんせいのなごり",
+        "ja_typings": [
+          "choshinseinonagori",
+          "choushinseinonagori"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00666",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a black hole?",
+      "ja": "ぶらっくほーるとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "change in heritable traits over generations",
+        "ja": "せだいをこえてかわるいでんてきとくせい",
+        "ja_typings": [
+          "sedaiokoetekawaruidentekitokusei"
+        ]
+      },
+      {
+        "en": "transformation within one organism's lifetime",
+        "ja": "いのちのあいだにそのどうぶつがかわること",
+        "ja_typings": [
+          "inochinoaidanisonodobutsugakawarukoto",
+          "inochinoaidanisonodoubutsugakawarukoto"
+        ]
+      },
+      {
+        "en": "adaptation to daily environment",
+        "ja": "にちじょうかんきょうへのてきおう",
+        "ja_typings": [
+          "nichijokankyohenotekio",
+          "nichijoukankyouhenotekiou"
+        ]
+      },
+      {
+        "en": "growth and development of individual",
+        "ja": "こたいのせいちょうとはったつ",
+        "ja_typings": [
+          "kotainoseichotohattatsu",
+          "kotainoseichoutohattatsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00667",
+    "image_path": null,
+    "question_text": {
+      "en": "What is evolution?",
+      "ja": "しんかとは何か？"
+    }
+  },
+  {
+    "choices": [
       {
         "en": "6",
         "ja": "6",
         "ja_typings": [
           "6"
+        ]
+      },
+      {
+        "en": "12",
+        "ja": "12",
+        "ja_typings": [
+          "12"
+        ]
+      },
+      {
+        "en": "14",
+        "ja": "14",
+        "ja_typings": [
+          "14"
         ]
       },
       {
@@ -3446,457 +27409,3879 @@
         ]
       }
     ],
-    "correct_answer_index": 1,
-    "genre": "math",
-    "id": "q00085",
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00668",
     "image_path": null,
     "question_text": {
-      "en": "What is 2 squared?",
-      "ja": "2のにじょうは?"
+      "en": "What is the atomic number of Carbon?",
+      "ja": "たんそのげんしばんごうは？"
     }
   },
   {
     "choices": [
       {
-        "en": "Africa",
-        "ja": "アフリカ",
+        "en": "attraction between masses",
+        "ja": "しつりょうかんのひきつけあい",
         "ja_typings": [
-          "afurika"
+          "shitsuryokannohikitsukeai",
+          "shitsuryoukannohikitsukeai"
         ]
       },
       {
-        "en": "Asia",
-        "ja": "アジア",
+        "en": "repulsion between charges",
+        "ja": "でんかのはんぱつりょく",
         "ja_typings": [
-          "ajia"
+          "denkanohanpatsuryoku"
         ]
       },
       {
-        "en": "Europe",
-        "ja": "ヨーロッパ",
+        "en": "electromagnetic force",
+        "ja": "でんじりょく",
         "ja_typings": [
-          "yoroppa"
+          "denjiryoku"
         ]
       },
       {
-        "en": "North America",
-        "ja": "きたアメリカ",
+        "en": "nuclear binding force",
+        "ja": "かくりょく",
         "ja_typings": [
-          "kitaamerika"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
-    "genre": "geography",
-    "id": "q00086",
-    "image_path": null,
-    "question_text": {
-      "en": "What is the world's largest continent?",
-      "ja": "せかいさいだいのたいりくは?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "2 years",
-        "ja": "2ねん",
-        "ja_typings": [
-          "2nen"
-        ]
-      },
-      {
-        "en": "4 years",
-        "ja": "4ねん",
-        "ja_typings": [
-          "4nen"
-        ]
-      },
-      {
-        "en": "5 years",
-        "ja": "5ねん",
-        "ja_typings": [
-          "5nen"
-        ]
-      },
-      {
-        "en": "10 years",
-        "ja": "10ねん",
-        "ja_typings": [
-          "10nen"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
-    "genre": "culture",
-    "id": "q00087",
-    "image_path": null,
-    "question_text": {
-      "en": "How often are the Olympics held?",
-      "ja": "おりんぴっくはなんねんごと?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "About 300,000 km/s",
-        "ja": "やく30まんkm/s",
-        "ja_typings": [
-          "yaku30mankm/s"
-        ]
-      },
-      {
-        "en": "About 30,000 km/s",
-        "ja": "やく3まんkm/s",
-        "ja_typings": [
-          "yaku3mankm/s"
-        ]
-      },
-      {
-        "en": "About 3,000 km/s",
-        "ja": "やく3せんkm/s",
-        "ja_typings": [
-          "yaku3senkm/s"
-        ]
-      },
-      {
-        "en": "About 300 km/s",
-        "ja": "やく300km/s",
-        "ja_typings": [
-          "yaku300km/s"
+          "kakuryoku"
         ]
       }
     ],
     "correct_answer_index": 0,
     "genre": "science",
-    "id": "q00088",
+    "id": "q00669",
     "image_path": null,
     "question_text": {
-      "en": "Approximately how fast is the speed of light?",
-      "ja": "ひかりのそくどはやく?"
+      "en": "What is gravity?",
+      "ja": "じゅうりょくとは何か？"
     }
   },
   {
     "choices": [
       {
-        "en": "1689",
-        "ja": "1689",
+        "en": "Einstein's theory of space, time, and gravity",
+        "ja": "アインシュタインのくうかんじかんじゅうりょくのりろん",
         "ja_typings": [
-          "1689"
+          "ainshutainnokuukanjikanjuuryokunoriron"
         ]
       },
       {
-        "en": "1789",
-        "ja": "1789",
+        "en": "theory of evolution",
+        "ja": "しんかろん",
         "ja_typings": [
-          "1789"
+          "shinkaron"
         ]
       },
       {
-        "en": "1889",
-        "ja": "1889",
+        "en": "theory of quantum mechanics",
+        "ja": "りょうしりきがく",
         "ja_typings": [
-          "1889"
+          "ryoshirikigaku",
+          "ryoushirikigaku"
         ]
       },
       {
-        "en": "1989",
-        "ja": "1989",
+        "en": "Newton's laws of motion",
+        "ja": "にゅーとんのうんどうほうそく",
         "ja_typings": [
-          "1989"
+          "nyutonnondohosoku",
+          "nyutonnoundouhousoku"
         ]
       }
     ],
-    "correct_answer_index": 1,
-    "genre": "history",
-    "id": "q00089",
-    "image_path": null,
-    "question_text": {
-      "en": "What year did the French Revolution begin?",
-      "ja": "フランスかくめいがおきたとしは?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "12",
-        "ja": "12",
-        "ja_typings": [
-          "12"
-        ]
-      },
-      {
-        "en": "24",
-        "ja": "24",
-        "ja_typings": [
-          "24"
-        ]
-      },
-      {
-        "en": "48",
-        "ja": "48",
-        "ja_typings": [
-          "48"
-        ]
-      },
-      {
-        "en": "60",
-        "ja": "60",
-        "ja_typings": [
-          "60"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
-    "genre": "general_knowledge",
-    "id": "q00090",
-    "image_path": null,
-    "question_text": {
-      "en": "How many hours are in a day?",
-      "ja": "いちにちはなんじかん?"
-    }
-  },
-  {
-    "choices": [
-    {
-      "en": "Einstein",
-      "ja": "アインシュタイン",
-      "ja_typings": [
-        "ainshutain",
-        "einstein"
-      ]
-    },
-    {
-      "en": "Watson and Crick",
-      "ja": "ワトソンとクリック",
-      "ja_typings": [
-        "watosontokurikku",
-        "watson and crick"
-      ]
-    },
-    {
-      "en": "Newton",
-      "ja": "ニュートン",
-      "ja_typings": [
-        "nyuton",
-        "newton"
-      ]
-    },
-    {
-      "en": "Darwin",
-      "ja": "ダーウィン",
-      "ja_typings": [
-        "dawin",
-        "darwin"
-      ]
-    }
-    ],
-    "correct_answer_index": 1,
+    "correct_answer_index": 0,
     "genre": "science",
-    "id": "q00091",
+    "id": "q00670",
     "image_path": null,
     "question_text": {
-      "en": "Who discovered the DNA double helix?",
-      "ja": "DNAのにじゅうらせんをはっけんしたのは?"
+      "en": "What is the theory of relativity?",
+      "ja": "そうたいせいりろんとは何か？"
     }
   },
   {
     "choices": [
       {
-        "en": "Asia",
-        "ja": "アジア",
+        "en": "Nitrogen",
+        "ja": "ちっそ",
         "ja_typings": [
-          "ajia"
+          "chisso"
         ]
       },
       {
-        "en": "Africa",
-        "ja": "アフリカ",
+        "en": "Oxygen",
+        "ja": "さんそ",
         "ja_typings": [
-          "afurika"
+          "sanso"
         ]
       },
       {
-        "en": "Europe",
-        "ja": "ヨーロッパ",
+        "en": "Carbon Dioxide",
+        "ja": "にさんかたんそ",
         "ja_typings": [
-          "yoroppa"
+          "nisankatanso"
         ]
       },
       {
-        "en": "South America",
-        "ja": "みなみアメリカ",
+        "en": "Argon",
+        "ja": "あるごん",
         "ja_typings": [
-          "minamiamerika"
+          "arugon"
         ]
       }
     ],
-    "correct_answer_index": 1,
-    "genre": "geography",
-    "id": "q00092",
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00671",
     "image_path": null,
     "question_text": {
-      "en": "Which continent does the Nile River flow through?",
-      "ja": "ないるがわがながれるたいりくは?"
+      "en": "What gas is most abundant in Earth's atmosphere?",
+      "ja": "ちきゅうのたいきにもっともおおいきたいは？"
     }
   },
   {
     "choices": [
       {
-        "en": "90 degrees",
+        "en": "nerve cell",
+        "ja": "しんけいさいぼう",
+        "ja_typings": [
+          "shinkeisaibo",
+          "shinkeisaibou"
+        ]
+      },
+      {
+        "en": "muscle cell",
+        "ja": "きんにくさいぼう",
+        "ja_typings": [
+          "kinnikusaibo",
+          "kinnikusaibou"
+        ]
+      },
+      {
+        "en": "blood cell",
+        "ja": "けっきゅう",
+        "ja_typings": [
+          "kekkyuu"
+        ]
+      },
+      {
+        "en": "skin cell",
+        "ja": "ひふさいぼう",
+        "ja_typings": [
+          "hifusaibo",
+          "hifusaibou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00672",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a neuron?",
+      "ja": "にゅーろんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "universe began from a hot dense state",
+        "ja": "うちゅうはこうおんこうみつじょうたいからはじまった",
+        "ja_typings": [
+          "uchuuhakoonkomitsujotaikarahajimatta",
+          "uchuuhakouonkoumitsujoutaikarahajimatta"
+        ]
+      },
+      {
+        "en": "universe has always existed",
+        "ja": "うちゅうはつねにそんざいしていた",
+        "ja_typings": [
+          "uchuuhatsunenisonzaishiteita"
+        ]
+      },
+      {
+        "en": "universe is contracting",
+        "ja": "うちゅうはしゅうしゅくしている",
+        "ja_typings": [
+          "uchuuhashuushukushiteiru"
+        ]
+      },
+      {
+        "en": "stars created the universe",
+        "ja": "ほしがうちゅうをつくった",
+        "ja_typings": [
+          "hoshigauchuuotsukutta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00673",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Big Bang theory?",
+      "ja": "びっぐばんりろんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "cell's powerhouse producing ATP",
+        "ja": "さいぼうのATPせいさんそうち",
+        "ja_typings": [
+          "saibonoatpseisansochi",
+          "saibounoatpseisansouchi"
+        ]
+      },
+      {
+        "en": "protein synthesis organelle",
+        "ja": "たんぱくしつごうせいのきかん",
+        "ja_typings": [
+          "tanpakushitsugoseinokikan",
+          "tanpakushitsugouseinokikan"
+        ]
+      },
+      {
+        "en": "cell's genetic material storage",
+        "ja": "さいぼうのいでんじかんり",
+        "ja_typings": [
+          "saibonoidenjikanri",
+          "saibounoidenjikanri"
+        ]
+      },
+      {
+        "en": "cell membrane pump",
+        "ja": "さいぼうまくのぽんぷ",
+        "ja_typings": [
+          "saibomakunoponpu",
+          "saiboumakunoponpu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00674",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the mitochondria?",
+      "ja": "みとこんどりあとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "water moving through semipermeable membrane",
+        "ja": "はんとうまくをこしてみずがいどうする",
+        "ja_typings": [
+          "hantomakuokoshitemizugaidosuru",
+          "hantoumakuokoshitemizugaidousuru"
+        ]
+      },
+      {
+        "en": "nutrient absorption in cells",
+        "ja": "さいぼうでのえいようきゅうしゅう",
+        "ja_typings": [
+          "saibodenoeiyokyuushuu",
+          "saiboudenoeiyoukyuushuu"
+        ]
+      },
+      {
+        "en": "gas exchange in lungs",
+        "ja": "はいでのがすこうかん",
+        "ja_typings": [
+          "haidenogasukokan",
+          "haidenogasukoukan"
+        ]
+      },
+      {
+        "en": "salt dissolving in water",
+        "ja": "しおがみずにとけること",
+        "ja_typings": [
+          "shiogamizunitokerukoto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00675",
+    "image_path": null,
+    "question_text": {
+      "en": "What is osmosis?",
+      "ja": "しんとうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "atmosphere trapping heat",
+        "ja": "たいきがねつをとじこめる",
+        "ja_typings": [
+          "taikiganetsuotojikomeru"
+        ]
+      },
+      {
+        "en": "plants using sunlight",
+        "ja": "しょくぶつがたいようこうをりようする",
+        "ja_typings": [
+          "shokubutsugataiyokooriyosuru",
+          "shokubutsugataiyoukouoriyousuru"
+        ]
+      },
+      {
+        "en": "ocean warming by sun",
+        "ja": "たいようにようる海のあたたまり",
+        "ja_typings": [
+          "taiyoniyorunoatatamari",
+          "taiyouniyourunoatatamari"
+        ]
+      },
+      {
+        "en": "volcanoes releasing CO2",
+        "ja": "かざんがCO₂をほうしゅつする",
+        "ja_typings": [
+          "kazangacohoshutsusuru",
+          "kazangacoohoushutsusuru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00676",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the greenhouse effect?",
+      "ja": "おんしつこうかとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "gravity",
+        "ja": "じゅうりょく",
+        "ja_typings": [
+          "juuryoku"
+        ]
+      },
+      {
+        "en": "magnetic force",
+        "ja": "じりょく",
+        "ja_typings": [
+          "jiryoku"
+        ]
+      },
+      {
+        "en": "nuclear force",
+        "ja": "かくりょく",
+        "ja_typings": [
+          "kakuryoku"
+        ]
+      },
+      {
+        "en": "centrifugal force",
+        "ja": "えんしんりょく",
+        "ja_typings": [
+          "enshinryoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00677",
+    "image_path": null,
+    "question_text": {
+      "en": "What force keeps planets in orbit?",
+      "ja": "わくせいをきどうにたもつりょくは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "contains DNA and controls cell activities",
+        "ja": "DNAをもちさいぼうかつどうをせいぎょ",
+        "ja_typings": [
+          "dnaomochisaibokatsudooseigyo",
+          "dnaomochisaiboukatsudouoseigyo"
+        ]
+      },
+      {
+        "en": "produces energy for the cell",
+        "ja": "さいぼうのためにえねるぎーをせいさん",
+        "ja_typings": [
+          "saibonotamenienerugioseisan",
+          "saibounotamenienerugioseisan"
+        ]
+      },
+      {
+        "en": "creates proteins for the cell",
+        "ja": "さいぼうのためにたんぱくしつをつくる",
+        "ja_typings": [
+          "saibonotamenitanpakushitsuotsukuru",
+          "saibounotamenitanpakushitsuotsukuru"
+        ]
+      },
+      {
+        "en": "controls cell movement",
+        "ja": "さいぼうのうごきをせいぎょ",
+        "ja_typings": [
+          "saibonogokioseigyo",
+          "saibounougokioseigyo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00678",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the function of the nucleus in a cell?",
+      "ja": "さいぼうのかくのやくわりは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "smallest unit of an element",
+        "ja": "げんそのさいしょうたんい",
+        "ja_typings": [
+          "gensonosaishotani",
+          "gensonosaishoutani"
+        ]
+      },
+      {
+        "en": "smallest particle of matter",
+        "ja": "ぶっしつのさいしょうりゅうし",
+        "ja_typings": [
+          "busshitsunosaishoryuushi",
+          "busshitsunosaishouryuushi"
+        ]
+      },
+      {
+        "en": "subatomic particle",
+        "ja": "そうあとみっくりゅうし",
+        "ja_typings": [
+          "soatomikkuryuushi",
+          "souatomikkuryuushi"
+        ]
+      },
+      {
+        "en": "molecule of two atoms",
+        "ja": "ふたつのげんしのぶんし",
+        "ja_typings": [
+          "futatsunogenshinobunshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00679",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an atom?",
+      "ja": "げんしとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "positively charged particle in nucleus",
+        "ja": "かくのなかのせいのでんかりゅうし",
+        "ja_typings": [
+          "kakunonakanoseinodenkaryuushi"
+        ]
+      },
+      {
+        "en": "negatively charged particle",
+        "ja": "ふのでんかりゅうし",
+        "ja_typings": [
+          "funodenkaryuushi"
+        ]
+      },
+      {
+        "en": "neutral particle in nucleus",
+        "ja": "かくのなかのちゅうせいりゅうし",
+        "ja_typings": [
+          "kakunonakanochuuseiryuushi"
+        ]
+      },
+      {
+        "en": "particle outside nucleus",
+        "ja": "かくのそとのりゅうし",
+        "ja_typings": [
+          "kakunosotonoryuushi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00680",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a proton?",
+      "ja": "ようしとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "negatively charged particle orbiting nucleus",
+        "ja": "かくをこうかいするふのでんかりゅうし",
+        "ja_typings": [
+          "kakuokokaisurufunodenkaryuushi",
+          "kakuokoukaisurufunodenkaryuushi"
+        ]
+      },
+      {
+        "en": "positively charged particle",
+        "ja": "せいのでんかりゅうし",
+        "ja_typings": [
+          "seinodenkaryuushi"
+        ]
+      },
+      {
+        "en": "particle in nucleus",
+        "ja": "かくのなかのりゅうし",
+        "ja_typings": [
+          "kakunonakanoryuushi"
+        ]
+      },
+      {
+        "en": "neutral particle",
+        "ja": "ちゅうせいりゅうし",
+        "ja_typings": [
+          "chuuseiryuushi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00681",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an electron?",
+      "ja": "でんしとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "neutral particle in the nucleus",
+        "ja": "かくのなかのちゅうせいりゅうし",
+        "ja_typings": [
+          "kakunonakanochuuseiryuushi"
+        ]
+      },
+      {
+        "en": "positively charged nuclear particle",
+        "ja": "かくのせいでんかりゅうし",
+        "ja_typings": [
+          "kakunoseidenkaryuushi"
+        ]
+      },
+      {
+        "en": "negatively charged orbital particle",
+        "ja": "ふのでんかこうかいりゅうし",
+        "ja_typings": [
+          "funodenkakokairyuushi",
+          "funodenkakoukairyuushi"
+        ]
+      },
+      {
+        "en": "particle outside the atom",
+        "ja": "げんしのそとのりゅうし",
+        "ja_typings": [
+          "genshinosotonoryuushi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00682",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a neutron?",
+      "ja": "ちゅうせいしとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "galaxy containing our solar system",
+        "ja": "たいようけいをふくむぎゃらくしー",
+        "ja_typings": [
+          "taiyokeiofukumugyarakushi",
+          "taiyoukeiofukumugyarakushi"
+        ]
+      },
+      {
+        "en": "visible path of the moon",
+        "ja": "つきのみちすじ",
+        "ja_typings": [
+          "tsukinomichisuji"
+        ]
+      },
+      {
+        "en": "meteor shower event",
+        "ja": "りゅうせいうのできごと",
+        "ja_typings": [
+          "ryuuseiunodekigoto"
+        ]
+      },
+      {
+        "en": "region of dense stars near Sun",
+        "ja": "たいようきんくのこうみつほしいき",
+        "ja_typings": [
+          "taiyokinkunokomitsuhoshiiki",
+          "taiyoukinkunokoumitsuhoshiiki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00683",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Milky Way?",
+      "ja": "あまのがわとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "waves of electric and magnetic fields",
+        "ja": "でんきとじきのは",
+        "ja_typings": [
+          "denkitojikinoha"
+        ]
+      },
+      {
+        "en": "radiation from radioactive materials",
+        "ja": "ほうしゃせいぶっしつからのほうしゃ",
+        "ja_typings": [
+          "hoshaseibusshitsukaranohosha",
+          "houshaseibusshitsukaranohousha"
+        ]
+      },
+      {
+        "en": "radiation from the sun only",
+        "ja": "たいようからのみのほうしゃ",
+        "ja_typings": [
+          "taiyokaranominohosha",
+          "taiyoukaranominohousha"
+        ]
+      },
+      {
+        "en": "radiation in Earth's core",
+        "ja": "ちきゅうのかくのほうしゃ",
+        "ja_typings": [
+          "chikyuunokakunohosha",
+          "chikyuunokakunohousha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00684",
+    "image_path": null,
+    "question_text": {
+      "en": "What is electromagnetic radiation?",
+      "ja": "でんじほうしゃとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "forces holding atoms together in molecules",
+        "ja": "ぶんしのなかでげんしをつなぐちから",
+        "ja_typings": [
+          "bunshinonakadegenshiotsunaguchikara"
+        ]
+      },
+      {
+        "en": "chemical reaction rate",
+        "ja": "かがくはんのうのそくど",
+        "ja_typings": [
+          "kagakuhannonosokudo",
+          "kagakuhannounosokudo"
+        ]
+      },
+      {
+        "en": "process of dissolving substances",
+        "ja": "ぶっしつのようかいぷろせす",
+        "ja_typings": [
+          "busshitsunoyokaipurosesu",
+          "busshitsunoyoukaipurosesu"
+        ]
+      },
+      {
+        "en": "separation of compounds",
+        "ja": "かごうぶつのぶんりかい",
+        "ja_typings": [
+          "kagobutsunobunrikai",
+          "kagoubutsunobunrikai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00685",
+    "image_path": null,
+    "question_text": {
+      "en": "What is chemical bonding?",
+      "ja": "かがくけつごうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "testable proposed explanation",
+        "ja": "けんしょう可能なかていの説明",
+        "ja_typings": [
+          "kenshonakateino",
+          "kenshounakateino"
+        ]
+      },
+      {
+        "en": "proven scientific fact",
+        "ja": "しょうめいされたかがくてきじじつ",
+        "ja_typings": [
+          "shomeisaretakagakutekijijitsu",
+          "shoumeisaretakagakutekijijitsu"
+        ]
+      },
+      {
+        "en": "experimental result",
+        "ja": "じっけんけっか",
+        "ja_typings": [
+          "jikkenkekka"
+        ]
+      },
+      {
+        "en": "scientific law",
+        "ja": "かがくてきほうそく",
+        "ja_typings": [
+          "kagakutekihosoku",
+          "kagakutekihousoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00686",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a hypothesis?",
+      "ja": "かせつとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "systematic approach to testing hypotheses",
+        "ja": "かせつをけんしょうするけいとうてきなほうほう",
+        "ja_typings": [
+          "kasetsuokenshosurukeitotekinahoho",
+          "kasetsuokenshousurukeitoutekinahouhou"
+        ]
+      },
+      {
+        "en": "collection of scientific facts",
+        "ja": "かがくてきじじつのしゅうしゅう",
+        "ja_typings": [
+          "kagakutekijijitsunoshuushuu"
+        ]
+      },
+      {
+        "en": "laboratory equipment usage",
+        "ja": "じっけんきぐのしよう",
+        "ja_typings": [
+          "jikkenkigunoshiyo",
+          "jikkenkigunoshiyou"
+        ]
+      },
+      {
+        "en": "publishing research papers",
+        "ja": "けんきゅうろんぶんのこうかい",
+        "ja_typings": [
+          "kenkyuuronbunnokokai",
+          "kenkyuuronbunnokoukai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00687",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the scientific method?",
+      "ja": "かがくてきほうほうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "unit of heredity on DNA",
+        "ja": "DNAじょうのいでんのたんい",
+        "ja_typings": [
+          "dnajonoidennotani",
+          "dnajounoidennotani"
+        ]
+      },
+      {
+        "en": "type of protein",
+        "ja": "たんぱくしつのしゅるい",
+        "ja_typings": [
+          "tanpakushitsunoshurui"
+        ]
+      },
+      {
+        "en": "cell membrane component",
+        "ja": "さいぼうまくのせいぶん",
+        "ja_typings": [
+          "saibomakunoseibun",
+          "saiboumakunoseibun"
+        ]
+      },
+      {
+        "en": "RNA molecule",
+        "ja": "RNAぶんし",
+        "ja_typings": [
+          "rnabunshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00688",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a gene?",
+      "ja": "いでんしとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "feeding relationships in ecosystem",
+        "ja": "せいたいけいのしょくじかんけい",
+        "ja_typings": [
+          "seitaikeinoshokujikankei"
+        ]
+      },
+      {
+        "en": "path food takes in digestion",
+        "ja": "しょうかのなかのしょくひんのみち",
+        "ja_typings": [
+          "shokanonakanoshokuhinnomichi",
+          "shoukanonakanoshokuhinnomichi"
+        ]
+      },
+      {
+        "en": "supply chain for food industry",
+        "ja": "しょくひんさんぎょうのさぷらいちぇーん",
+        "ja_typings": [
+          "shokuhinsangyonosapuraichen",
+          "shokuhinsangyounosapuraichen"
+        ]
+      },
+      {
+        "en": "chain of supermarkets",
+        "ja": "すーぱーのれんさ",
+        "ja_typings": [
+          "supanorensa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00689",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the food chain?",
+      "ja": "しょくもつれんさとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "100°C",
+        "ja": "100ど",
+        "ja_typings": [
+          "100do"
+        ]
+      },
+      {
+        "en": "90°C",
         "ja": "90ど",
         "ja_typings": [
           "90do"
         ]
       },
       {
-        "en": "180 degrees",
-        "ja": "180ど",
+        "en": "110°C",
+        "ja": "110ど",
         "ja_typings": [
-          "180do"
+          "110do"
         ]
       },
       {
-        "en": "270 degrees",
-        "ja": "270ど",
+        "en": "80°C",
+        "ja": "80ど",
         "ja_typings": [
-          "270do"
-        ]
-      },
-      {
-        "en": "360 degrees",
-        "ja": "360ど",
-        "ja_typings": [
-          "360do"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
-    "genre": "math",
-    "id": "q00093",
-    "image_path": null,
-    "question_text": {
-      "en": "What is the sum of angles in a triangle?",
-      "ja": "さんかくけいのないかくのわは?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "Picasso",
-        "ja": "ピカソ",
-        "ja_typings": [
-          "pikaso"
-        ]
-      },
-      {
-        "en": "Da Vinci",
-        "ja": "ダヴィンチ",
-        "ja_typings": [
-          "davinchi"
-        ]
-      },
-      {
-        "en": "Van Gogh",
-        "ja": "ゴッホ",
-        "ja_typings": [
-          "gohho"
-        ]
-      },
-      {
-        "en": "Monet",
-        "ja": "モネ",
-        "ja_typings": [
-          "mone"
-        ]
-      }
-    ],
-    "correct_answer_index": 1,
-    "genre": "culture",
-    "id": "q00094",
-    "image_path": null,
-    "question_text": {
-      "en": "Who painted the Mona Lisa?",
-      "ja": "モナリザをかいたがかは?"
-    }
-  },
-  {
-    "choices": [
-      {
-        "en": "Oxygen",
-        "ja": "酸素",
-        "ja_typings": [
-          "sanso"
-        ]
-      },
-      {
-        "en": "Osmium",
-        "ja": "オスミウム",
-        "ja_typings": [
-          "osumiumu"
-        ]
-      },
-      {
-        "en": "Oganesson",
-        "ja": "オガネソン",
-        "ja_typings": [
-          "oganeson"
-        ]
-      },
-      {
-        "en": "Iron",
-        "ja": "鉄",
-        "ja_typings": [
-          "tetsu"
+          "80do"
         ]
       }
     ],
     "correct_answer_index": 0,
     "genre": "science",
-    "id": "q00095",
+    "id": "q00690",
     "image_path": null,
     "question_text": {
-      "en": "Which element does the chemical symbol 'O' represent?",
-      "ja": "げんそきごう「O」がしめすげんそは?"
+      "en": "What is the boiling point of water at sea level?",
+      "ja": "かいめんでのみずのふってんは？"
     }
   },
   {
     "choices": [
       {
-        "en": "1392",
-        "ja": "1392",
+        "en": "substances transform into new substances",
+        "ja": "ぶっしつがあたらしいぶっしつにへんかん",
         "ja_typings": [
-          "1392"
+          "busshitsugaatarashiibusshitsunihenkan"
         ]
       },
       {
-        "en": "1492",
-        "ja": "1492",
+        "en": "physical change in matter",
+        "ja": "ぶっしつのぶつりてきへんか",
         "ja_typings": [
-          "1492"
+          "busshitsunobutsuritekihenka"
         ]
       },
       {
-        "en": "1592",
-        "ja": "1592",
+        "en": "mixing two liquids",
+        "ja": "ふたつのえきたいをまぜる",
         "ja_typings": [
-          "1592"
+          "futatsunoekitaiomazeru"
         ]
       },
       {
-        "en": "1692",
-        "ja": "1692",
+        "en": "dissolving a solid",
+        "ja": "こたいをようかいする",
         "ja_typings": [
-          "1692"
+          "kotaioyokaisuru",
+          "kotaioyoukaisuru"
         ]
       }
     ],
-    "correct_answer_index": 1,
-    "genre": "history",
-    "id": "q00096",
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00691",
     "image_path": null,
     "question_text": {
-      "en": "What year did Columbus reach America?",
-      "ja": "コロンブスがアメリカにとうたつしたとしは?"
+      "en": "What is a chemical reaction?",
+      "ja": "かがくはんのうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "time for half of atoms to decay",
+        "ja": "げんしのはんぶんがほうかいするまでのじかん",
+        "ja_typings": [
+          "genshinohanbungahokaisurumadenojikan",
+          "genshinohanbungahoukaisurumadenojikan"
+        ]
+      },
+      {
+        "en": "half the element's lifespan",
+        "ja": "げんそのじゅみょうのはんぶん",
+        "ja_typings": [
+          "gensonojumyonohanbun",
+          "gensonojumyounohanbun"
+        ]
+      },
+      {
+        "en": "time for element to double",
+        "ja": "げんそが2ばいになるじかん",
+        "ja_typings": [
+          "gensoga2baininarujikan"
+        ]
+      },
+      {
+        "en": "half the atomic weight",
+        "ja": "げんしりょうのはんぶん",
+        "ja_typings": [
+          "genshiryonohanbun",
+          "genshiryounohanbun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00692",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the half-life of a radioactive element?",
+      "ja": "ほうしゃせいげんそのはんぶんきとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "substance that speeds up reaction without being consumed",
+        "ja": "じぶんはへらずにはんのうをはやめるぶっしつ",
+        "ja_typings": [
+          "jibunhaherazunihannoohayamerubusshitsu",
+          "jibunhaherazunihannouohayamerubusshitsu"
+        ]
+      },
+      {
+        "en": "substance consumed in reaction",
+        "ja": "はんのうでしょうひされるぶっしつ",
+        "ja_typings": [
+          "hannodeshohisarerubusshitsu",
+          "hannoudeshouhisarerubusshitsu"
+        ]
+      },
+      {
+        "en": "substance that stops reaction",
+        "ja": "はんのうをとめるぶっしつ",
+        "ja_typings": [
+          "hannootomerubusshitsu",
+          "hannouotomerubusshitsu"
+        ]
+      },
+      {
+        "en": "substance produced by reaction",
+        "ja": "はんのうでせいせいされるぶっしつ",
+        "ja_typings": [
+          "hannodeseiseisarerubusshitsu",
+          "hannoudeseiseisarerubusshitsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00693",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a catalyst?",
+      "ja": "しょくばいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "energy of motion",
+        "ja": "うんどうのえねるぎー",
+        "ja_typings": [
+          "undonoenerugi",
+          "undounoenerugi"
+        ]
+      },
+      {
+        "en": "stored potential energy",
+        "ja": "たくわえられたいねるぎー",
+        "ja_typings": [
+          "takuwaeraretainerugi"
+        ]
+      },
+      {
+        "en": "thermal energy",
+        "ja": "ねつえねるぎー",
+        "ja_typings": [
+          "netsuenerugi"
+        ]
+      },
+      {
+        "en": "chemical energy",
+        "ja": "かがくえねるぎー",
+        "ja_typings": [
+          "kagakuenerugi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00694",
+    "image_path": null,
+    "question_text": {
+      "en": "What is kinetic energy?",
+      "ja": "うんどうえねるぎーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "stored energy due to position or state",
+        "ja": "いちやじょうたいによるたくわえられたえねるぎー",
+        "ja_typings": [
+          "ichiyajotainiyorutakuwaeraretaenerugi",
+          "ichiyajoutainiyorutakuwaeraretaenerugi"
+        ]
+      },
+      {
+        "en": "energy of motion",
+        "ja": "うんどうのえねるぎー",
+        "ja_typings": [
+          "undonoenerugi",
+          "undounoenerugi"
+        ]
+      },
+      {
+        "en": "electrical energy",
+        "ja": "でんきえねるぎー",
+        "ja_typings": [
+          "denkienerugi"
+        ]
+      },
+      {
+        "en": "nuclear energy",
+        "ja": "かくえねるぎー",
+        "ja_typings": [
+          "kakuenerugi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00695",
+    "image_path": null,
+    "question_text": {
+      "en": "What is potential energy?",
+      "ja": "いねるぎーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "energy cannot be created or destroyed",
+        "ja": "えねるぎーはそうせいもしょうめつもしない",
+        "ja_typings": [
+          "enerugihasoseimoshometsumoshinai",
+          "enerugihasouseimoshoumetsumoshinai"
+        ]
+      },
+      {
+        "en": "energy increases in closed systems",
+        "ja": "へいさいけいでえねるぎーはふえる",
+        "ja_typings": [
+          "heisaikeideenerugihafueru"
+        ]
+      },
+      {
+        "en": "energy is always converted to heat",
+        "ja": "えねるぎーはつねにねつにへんかん",
+        "ja_typings": [
+          "enerugihatsuneninetsunihenkan"
+        ]
+      },
+      {
+        "en": "energy is constant only in space",
+        "ja": "えねるぎーはうちゅうでのみいってい",
+        "ja_typings": [
+          "enerugihauchuudenomiittei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00696",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the law of conservation of energy?",
+      "ja": "えねるぎーほぞんのほうそくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "carry oxygen through the body",
+        "ja": "さんそをからだにはこぶ",
+        "ja_typings": [
+          "sansokaradanihakobu",
+          "sansookaradanihakobu"
+        ]
+      },
+      {
+        "en": "fight infections",
+        "ja": "かんせんしょうとたたかう",
+        "ja_typings": [
+          "kansenshototatakau",
+          "kansenshoutotatakau"
+        ]
+      },
+      {
+        "en": "form blood clots",
+        "ja": "けっせんをつくる",
+        "ja_typings": [
+          "kessenotsukuru"
+        ]
+      },
+      {
+        "en": "produce hormones",
+        "ja": "ほるもんをせいさん",
+        "ja_typings": [
+          "horumonoseisan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00697",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the role of red blood cells?",
+      "ja": "せっけっきゅうのやくわりは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "fight infections and foreign bodies",
+        "ja": "かんせんしょうとがいぶしんたいとたたかう",
+        "ja_typings": [
+          "kansenshotogaibushintaitotatakau",
+          "kansenshoutogaibushintaitotatakau"
+        ]
+      },
+      {
+        "en": "carry oxygen",
+        "ja": "さんそをはこぶ",
+        "ja_typings": [
+          "sansohakobu",
+          "sansoohakobu"
+        ]
+      },
+      {
+        "en": "clot blood",
+        "ja": "ちをかたまらせる",
+        "ja_typings": [
+          "chiokatamaraseru"
+        ]
+      },
+      {
+        "en": "store nutrients",
+        "ja": "えいようをちょくせつほぞん",
+        "ja_typings": [
+          "eiyoochokusetsuhozon",
+          "eiyouochokusetsuhozon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00698",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the function of white blood cells?",
+      "ja": "はっけっきゅうのやくわりは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "pancreas",
+        "ja": "すいぞう",
+        "ja_typings": [
+          "suizo",
+          "suizou"
+        ]
+      },
+      {
+        "en": "liver",
+        "ja": "かんぞう",
+        "ja_typings": [
+          "kanzo",
+          "kanzou"
+        ]
+      },
+      {
+        "en": "kidney",
+        "ja": "じんぞう",
+        "ja_typings": [
+          "jinzo",
+          "jinzou"
+        ]
+      },
+      {
+        "en": "spleen",
+        "ja": "ひぞう",
+        "ja_typings": [
+          "hizo",
+          "hizou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00699",
+    "image_path": null,
+    "question_text": {
+      "en": "What organ produces insulin?",
+      "ja": "いんすりんをせいさんするきかんは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "filter blood and produce urine",
+        "ja": "けつえきをこしてにょうをつくる",
+        "ja_typings": [
+          "ketsuekiokoshitenyootsukuru",
+          "ketsuekiokoshitenyouotsukuru"
+        ]
+      },
+      {
+        "en": "digest food",
+        "ja": "しょくぶつをしょうか",
+        "ja_typings": [
+          "shokubutsuoshoka",
+          "shokubutsuoshouka"
+        ]
+      },
+      {
+        "en": "produce oxygen",
+        "ja": "さんそをせいさん",
+        "ja_typings": [
+          "sansoseisan",
+          "sansooseisan"
+        ]
+      },
+      {
+        "en": "control heartbeat",
+        "ja": "しんぱくをせいぎょ",
+        "ja_typings": [
+          "shinpakuoseigyo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00700",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the function of the kidney?",
+      "ja": "じんぞうのやくわりは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "substance stimulating immune response",
+        "ja": "めんえきはんのうをうながすぶっしつ",
+        "ja_typings": [
+          "menekihannoonagasubusshitsu",
+          "menekihannouounagasubusshitsu"
+        ]
+      },
+      {
+        "en": "medicine killing bacteria directly",
+        "ja": "さいきんをちょくせつころすやくざい",
+        "ja_typings": [
+          "saikinochokusetsukorosuyakuzai"
+        ]
+      },
+      {
+        "en": "medicine reducing fever",
+        "ja": "ねつをさげるやくざい",
+        "ja_typings": [
+          "netsuosageruyakuzai"
+        ]
+      },
+      {
+        "en": "medicine for pain relief",
+        "ja": "いたみどめのやくざい",
+        "ja_typings": [
+          "itamidomenoyakuzai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00701",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a vaccine?",
+      "ja": "ワクチンとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "measure of acidity or alkalinity",
+        "ja": "さんせいやアルカリせいのはかりかた",
+        "ja_typings": [
+          "sanseiyaarukariseinohakarikata"
+        ]
+      },
+      {
+        "en": "measure of chemical purity",
+        "ja": "かがくじゅんすいどのはかりかた",
+        "ja_typings": [
+          "kagakujunsuidonohakarikata"
+        ]
+      },
+      {
+        "en": "measure of temperature",
+        "ja": "おんどのはかりかた",
+        "ja_typings": [
+          "ondonohakarikata"
+        ]
+      },
+      {
+        "en": "measure of pressure",
+        "ja": "あつりょくのはかりかた",
+        "ja_typings": [
+          "atsuryokunohakarikata"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00702",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the pH scale?",
+      "ja": "pHすけーるとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "rain with high acidity from pollution",
+        "ja": "おせんによるさんせいのつよいあめ",
+        "ja_typings": [
+          "osenniyorusanseinotsuyoiame"
+        ]
+      },
+      {
+        "en": "rain in tropical areas",
+        "ja": "ねったいちほうのあめ",
+        "ja_typings": [
+          "nettaichihonoame",
+          "nettaichihounoame"
+        ]
+      },
+      {
+        "en": "rain with heavy metal content",
+        "ja": "じゅうきんぞくをふくむあめ",
+        "ja_typings": [
+          "juukinzokuofukumuame"
+        ]
+      },
+      {
+        "en": "rain during volcanic eruption",
+        "ja": "かざんふんかちゅうのあめ",
+        "ja_typings": [
+          "kazanfunkachuunoame"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00703",
+    "image_path": null,
+    "question_text": {
+      "en": "What is acid rain?",
+      "ja": "さんせいうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "splitting an atom releasing energy",
+        "ja": "げんしをわってえねるぎーをかいほう",
+        "ja_typings": [
+          "genshiowatteenerugiokaiho",
+          "genshiowatteenerugiokaihou"
+        ]
+      },
+      {
+        "en": "combining atoms to release energy",
+        "ja": "げんしをあわせてえねるぎーをかいほう",
+        "ja_typings": [
+          "genshioawaseteenerugiokaiho",
+          "genshioawaseteenerugiokaihou"
+        ]
+      },
+      {
+        "en": "radioactive decay of atoms",
+        "ja": "げんしのほうしゃせいほうかい",
+        "ja_typings": [
+          "genshinohoshaseihokai",
+          "genshinohoushaseihoukai"
+        ]
+      },
+      {
+        "en": "chemical breakdown of molecules",
+        "ja": "ぶんしのかがくてきぶんかい",
+        "ja_typings": [
+          "bunshinokagakutekibunkai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00704",
+    "image_path": null,
+    "question_text": {
+      "en": "What is nuclear fission?",
+      "ja": "かくぶんれつとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "combining nuclei to release energy",
+        "ja": "かくをあわせてえねるぎーをかいほう",
+        "ja_typings": [
+          "kakuoawaseteenerugiokaiho",
+          "kakuoawaseteenerugiokaihou"
+        ]
+      },
+      {
+        "en": "splitting nucleus to release energy",
+        "ja": "かくをわってえねるぎーをかいほう",
+        "ja_typings": [
+          "kakuowatteenerugiokaiho",
+          "kakuowatteenerugiokaihou"
+        ]
+      },
+      {
+        "en": "radioactive emission from nucleus",
+        "ja": "かくからのほうしゃせいはっしゃ",
+        "ja_typings": [
+          "kakukaranohoshaseihassha",
+          "kakukaranohoushaseihassha"
+        ]
+      },
+      {
+        "en": "nuclear chain reaction",
+        "ja": "かくれんさはんのう",
+        "ja_typings": [
+          "kakurensahanno",
+          "kakurensahannou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00705",
+    "image_path": null,
+    "question_text": {
+      "en": "What is nuclear fusion?",
+      "ja": "かくゆうごうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "massive sections of Earth's crust",
+        "ja": "ちきゅうのちかくのきょだいなぶぶん",
+        "ja_typings": [
+          "chikyuunochikakunokyodainabubun"
+        ]
+      },
+      {
+        "en": "layers of the atmosphere",
+        "ja": "たいきのそう",
+        "ja_typings": [
+          "taikinoso",
+          "taikinosou"
+        ]
+      },
+      {
+        "en": "ocean floor sections",
+        "ja": "かいていのぶぶん",
+        "ja_typings": [
+          "kaiteinobubun"
+        ]
+      },
+      {
+        "en": "continental shelf regions",
+        "ja": "たいりくだなのりょういき",
+        "ja_typings": [
+          "tairikudananoryoiki",
+          "tairikudananoryouiki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00706",
+    "image_path": null,
+    "question_text": {
+      "en": "What is tectonic plates?",
+      "ja": "プレートとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "movement of tectonic plates",
+        "ja": "プレートのうごき",
+        "ja_typings": [
+          "puretonogoki",
+          "puretonougoki"
+        ]
+      },
+      {
+        "en": "underground explosions",
+        "ja": "ちかのばくはつ",
+        "ja_typings": [
+          "chikanobakuhatsu"
+        ]
+      },
+      {
+        "en": "volcanic activity",
+        "ja": "かざんかつどう",
+        "ja_typings": [
+          "kazankatsudo",
+          "kazankatsudou"
+        ]
+      },
+      {
+        "en": "ocean tides",
+        "ja": "うみのしおか",
+        "ja_typings": [
+          "uminoshioka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00707",
+    "image_path": null,
+    "question_text": {
+      "en": "What causes an earthquake?",
+      "ja": "じしんのげんいんは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "layer absorbing UV radiation",
+        "ja": "しがいせんをきゅうしゅうするそう",
+        "ja_typings": [
+          "shigaisenokyuushuusuruso",
+          "shigaisenokyuushuusurusou"
+        ]
+      },
+      {
+        "en": "layer containing most oxygen",
+        "ja": "さんそをもっともふくむそう",
+        "ja_typings": [
+          "sansomottomofukumuso",
+          "sansoomottomofukumusou"
+        ]
+      },
+      {
+        "en": "layer reflecting radio waves",
+        "ja": "でんぱをはんしゃするそう",
+        "ja_typings": [
+          "denpaohanshasuruso",
+          "denpaohanshasurusou"
+        ]
+      },
+      {
+        "en": "layer containing greenhouse gases",
+        "ja": "おんしつこうかがすをふくむそう",
+        "ja_typings": [
+          "onshitsukokagasuofukumuso",
+          "onshitsukoukagasuofukumusou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00708",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the ozone layer?",
+      "ja": "おぞんそうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "energy from naturally replenishing sources",
+        "ja": "しぜんにおぎなわれるみなもとのえねるぎー",
+        "ja_typings": [
+          "shizennioginawareruminamotonoenerugi"
+        ]
+      },
+      {
+        "en": "energy from oil and gas",
+        "ja": "せきゆとがすのえねるぎー",
+        "ja_typings": [
+          "sekiyutogasunoenerugi"
+        ]
+      },
+      {
+        "en": "energy from nuclear fission",
+        "ja": "かくぶんれつのえねるぎー",
+        "ja_typings": [
+          "kakubunretsunoenerugi"
+        ]
+      },
+      {
+        "en": "energy from coal",
+        "ja": "せきたんのえねるぎー",
+        "ja_typings": [
+          "sekitannoenerugi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00709",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a renewable energy source?",
+      "ja": "さいせいかのうなえねるぎーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "4",
+        "ja": "よん",
+        "ja_typings": [
+          "yon"
+        ]
+      },
+      {
+        "en": "3",
+        "ja": "さん",
+        "ja_typings": [
+          "san"
+        ]
+      },
+      {
+        "en": "5",
+        "ja": "ご",
+        "ja_typings": [
+          "go"
+        ]
+      },
+      {
+        "en": "6",
+        "ja": "ろく",
+        "ja_typings": [
+          "roku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00710",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 2 + 2?",
+      "ja": "2たす2はいくつ？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "12",
+        "ja": "じゅうに",
+        "ja_typings": [
+          "juuni"
+        ]
+      },
+      {
+        "en": "11",
+        "ja": "じゅういち",
+        "ja_typings": [
+          "juuichi"
+        ]
+      },
+      {
+        "en": "13",
+        "ja": "じゅうさん",
+        "ja_typings": [
+          "juusan"
+        ]
+      },
+      {
+        "en": "14",
+        "ja": "じゅうし",
+        "ja_typings": [
+          "juushi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00711",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the square root of 144?",
+      "ja": "144のへいほうこんは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "3.14159",
+        "ja": "さんてんいちよんいちごきゅう",
+        "ja_typings": [
+          "santenichiyonichigokyuu"
+        ]
+      },
+      {
+        "en": "2.71828",
+        "ja": "にてんなないちはちにはち",
+        "ja_typings": [
+          "nitennanaichihachinihachi"
+        ]
+      },
+      {
+        "en": "1.41421",
+        "ja": "いちてんよんいちよんにいち",
+        "ja_typings": [
+          "ichitenyonichiyonniichi"
+        ]
+      },
+      {
+        "en": "1.73205",
+        "ja": "いちてんななさんにれい",
+        "ja_typings": [
+          "ichitennanasannirei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00712",
+    "image_path": null,
+    "question_text": {
+      "en": "What is pi approximately equal to?",
+      "ja": "えんしゅうりつπはおよそいくつ？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "a²+b²=c²",
+        "ja": "えーじじょうたすびーじじょうはしーじじょう",
+        "ja_typings": [
+          "ejijotasubijijohashijijo",
+          "ejijoutasubijijouhashijijou"
+        ]
+      },
+      {
+        "en": "a+b=c",
+        "ja": "えーたすびーはしー",
+        "ja_typings": [
+          "etasubihashi"
+        ]
+      },
+      {
+        "en": "a×b=c",
+        "ja": "えーかけるびーはしー",
+        "ja_typings": [
+          "ekakerubihashi"
+        ]
+      },
+      {
+        "en": "a²-b²=c",
+        "ja": "えーじじょうひくびーじじょうはしー",
+        "ja_typings": [
+          "ejijohikubijijohashi",
+          "ejijouhikubijijouhashi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00713",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Pythagorean theorem?",
+      "ja": "ぴたごらすのていりとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "a number divisible only by 1 and itself",
+        "ja": "1とじぶんじしんでのみわりきれるかず",
+        "ja_typings": [
+          "1tojibunjishindenomiwarikirerukazu"
+        ]
+      },
+      {
+        "en": "a number divisible by 2",
+        "ja": "2でわりきれるかず",
+        "ja_typings": [
+          "2dewarikirerukazu"
+        ]
+      },
+      {
+        "en": "a number greater than 100",
+        "ja": "100よりおおきいかず",
+        "ja_typings": [
+          "100yoriokiikazu",
+          "100yoriookiikazu"
+        ]
+      },
+      {
+        "en": "a negative number",
+        "ja": "ふのかず",
+        "ja_typings": [
+          "funokazu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00714",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a prime number?",
+      "ja": "そすうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "three million six hundred twenty-eight thousand eight hundred",
+        "ja": "さんびゃくろくじゅうにまんはっせん",
+        "ja_typings": [
+          "sanbyakurokujuunimanhassen"
+        ]
+      },
+      {
+        "en": "3628000",
+        "ja": "さんびゃくろくじゅうにまんぜろ",
+        "ja_typings": [
+          "sanbyakurokujuunimanzero"
+        ]
+      },
+      {
+        "en": "thirty-six million two hundred eighty-eight thousand",
+        "ja": "さんぜんろっぴゃくにじゅうはちまん",
+        "ja_typings": [
+          "sanzenroppyakunijuuhachiman"
+        ]
+      },
+      {
+        "en": "three hundred sixty-two thousand eight hundred eighty",
+        "ja": "さんじゅうろくまんにせんはっぴゃくはちじゅう",
+        "ja_typings": [
+          "sanjuurokumannisenhappyakuhachijuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00715",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 10 factorial (10!)?",
+      "ja": "10の かいじょう(10!)はいくつ？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "180 degrees",
+        "ja": "ひゃくはちじゅうど",
+        "ja_typings": [
+          "hyakuhachijuudo"
+        ]
+      },
+      {
+        "en": "90 degrees",
+        "ja": "きゅうじゅうど",
+        "ja_typings": [
+          "kyuujuudo"
+        ]
+      },
+      {
+        "en": "270 degrees",
+        "ja": "にひゃくななじゅうど",
+        "ja_typings": [
+          "nihyakunanajuudo"
+        ]
+      },
+      {
+        "en": "360 degrees",
+        "ja": "さんびゃくろくじゅうど",
+        "ja_typings": [
+          "sanbyakurokujuudo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00716",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the sum of angles in a triangle?",
+      "ja": "さんかっけいのないかくのわは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "πr squared",
+        "ja": "ぱいあーるじじょう",
+        "ja_typings": [
+          "paiarujijo",
+          "paiarujijou"
+        ]
+      },
+      {
+        "en": "two pi r",
+        "ja": "にぱいあーる",
+        "ja_typings": [
+          "nipaiaru"
+        ]
+      },
+      {
+        "en": "πr (no square)",
+        "ja": "ぱいかけるあーる",
+        "ja_typings": [
+          "paikakeruaru"
+        ]
+      },
+      {
+        "en": "pi times d",
+        "ja": "ぱいかけるでぃー",
+        "ja_typings": [
+          "paikakerudi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00717",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the area of a circle?",
+      "ja": "えんのめんせきは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "two pi r",
+        "ja": "にぱいあーる",
+        "ja_typings": [
+          "nipaiaru"
+        ]
+      },
+      {
+        "en": "πr squared",
+        "ja": "ぱいあーるじじょう",
+        "ja_typings": [
+          "paiarujijo",
+          "paiarujijou"
+        ]
+      },
+      {
+        "en": "πr (no square)",
+        "ja": "ぱいかけるあーる",
+        "ja_typings": [
+          "paikakeruaru"
+        ]
+      },
+      {
+        "en": "four pi r",
+        "ja": "よんぱいあーる",
+        "ja_typings": [
+          "yonpaiaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00718",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the circumference of a circle?",
+      "ja": "えんのしゅうちょうは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "0, 1, 1, 2, 3, 5",
+        "ja": "れい いち いち に さん ご",
+        "ja_typings": [
+          "rei ichi ichi ni san go"
+        ]
+      },
+      {
+        "en": "1, 2, 3, 5, 8",
+        "ja": "いち に さん ご はち",
+        "ja_typings": [
+          "ichi ni san go hachi"
+        ]
+      },
+      {
+        "en": "0, 1, 2, 3, 5",
+        "ja": "れい いち に さん ご",
+        "ja_typings": [
+          "rei ichi ni san go"
+        ]
+      },
+      {
+        "en": "1, 1, 2, 4, 8",
+        "ja": "いち いち に よん はち",
+        "ja_typings": [
+          "ichi ichi ni yon hachi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00719",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Fibonacci sequence starting with?",
+      "ja": "ふぃぼなっちすうれつのはじまりは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "average of values",
+        "ja": "あたいのへいきん",
+        "ja_typings": [
+          "atainoheikin"
+        ]
+      },
+      {
+        "en": "middle value",
+        "ja": "まんなかのあたい",
+        "ja_typings": [
+          "mannakanoatai"
+        ]
+      },
+      {
+        "en": "most frequent value",
+        "ja": "もっともひんぱんなあたい",
+        "ja_typings": [
+          "mottomohinpannaatai"
+        ]
+      },
+      {
+        "en": "range of values",
+        "ja": "あたいのはんい",
+        "ja_typings": [
+          "atainohani"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00720",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'mean' refer to in statistics?",
+      "ja": "とうけいでのへいきんとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "middle value in sorted data",
+        "ja": "せいれつされたでーたのまんなかのあたい",
+        "ja_typings": [
+          "seiretsusaretadetanomannakanoatai"
+        ]
+      },
+      {
+        "en": "average of all values",
+        "ja": "すべてのあたいのへいきん",
+        "ja_typings": [
+          "subetenoatainoheikin"
+        ]
+      },
+      {
+        "en": "most common value",
+        "ja": "もっともよくでるあたい",
+        "ja_typings": [
+          "mottomoyokuderuatai"
+        ]
+      },
+      {
+        "en": "difference between max and min",
+        "ja": "さいだいとさいしょうのさ",
+        "ja_typings": [
+          "saidaitosaishonosa",
+          "saidaitosaishounosa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00721",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the median?",
+      "ja": "ちゅうおうちとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "most frequently occurring value",
+        "ja": "もっともひんぱんにでるあたい",
+        "ja_typings": [
+          "mottomohinpannideruatai"
+        ]
+      },
+      {
+        "en": "average value",
+        "ja": "へいきんち",
+        "ja_typings": [
+          "heikinchi"
+        ]
+      },
+      {
+        "en": "middle value",
+        "ja": "なかまのち",
+        "ja_typings": [
+          "nakamanochi"
+        ]
+      },
+      {
+        "en": "range of values",
+        "ja": "はんい",
+        "ja_typings": [
+          "hani"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00722",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the mode in statistics?",
+      "ja": "とうけいでのさいひんちとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "equation with x²",
+        "ja": "えっくすじじょうをふくむほうていしき",
+        "ja_typings": [
+          "ekkusujijoofukumuhoteishiki",
+          "ekkusujijouofukumuhouteishiki"
+        ]
+      },
+      {
+        "en": "equation with x³",
+        "ja": "えっくすさんじょうをふくむほうていしき",
+        "ja_typings": [
+          "ekkususanjoofukumuhoteishiki",
+          "ekkususanjouofukumuhouteishiki"
+        ]
+      },
+      {
+        "en": "equation with no variables",
+        "ja": "へんすうのないほうていしき",
+        "ja_typings": [
+          "hensuunonaihoteishiki",
+          "hensuunonaihouteishiki"
+        ]
+      },
+      {
+        "en": "equation with only addition",
+        "ja": "たしざんだけのほうていしき",
+        "ja_typings": [
+          "tashizandakenohoteishiki",
+          "tashizandakenohouteishiki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00723",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a quadratic equation?",
+      "ja": "にじほうていしきとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "x = (-b ± √(b²-4ac)) / 2a",
+        "ja": "えっくすはまいなすびーぷらすまいなするーとびーじじょうひくよんえーしーわるにえー",
+        "ja_typings": [
+          "ekkusuhamainasubipurasumainasurutobijijohikuyoneshiwarunie",
+          "ekkusuhamainasubipurasumainasurutobijijouhikuyoneshiwarunie"
+        ]
+      },
+      {
+        "en": "x = -b/a",
+        "ja": "えっくすはまいなすびーわるえー",
+        "ja_typings": [
+          "ekkusuhamainasubiwarue"
+        ]
+      },
+      {
+        "en": "x = b/2a",
+        "ja": "えっくすはびーわるにえー",
+        "ja_typings": [
+          "ekkusuhabiwarunie"
+        ]
+      },
+      {
+        "en": "x = √b/a",
+        "ja": "えっくすはるーとびーわるえー",
+        "ja_typings": [
+          "ekkusuharutobiwarue"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00724",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the quadratic formula?",
+      "ja": "にじほうていしきのかいのこうしきは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "inverse of exponentiation",
+        "ja": "べきじょうのぎゃくさん",
+        "ja_typings": [
+          "bekijonogyakusan",
+          "bekijounogyakusan"
+        ]
+      },
+      {
+        "en": "square root operation",
+        "ja": "へいほうこんのけいさん",
+        "ja_typings": [
+          "heihokonnokeisan",
+          "heihoukonnokeisan"
+        ]
+      },
+      {
+        "en": "sum of a series",
+        "ja": "すうれつのわ",
+        "ja_typings": [
+          "suuretsunowa"
+        ]
+      },
+      {
+        "en": "ratio of two numbers",
+        "ja": "にすうのひ",
+        "ja_typings": [
+          "nisuunohi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00725",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a logarithm?",
+      "ja": "たいすうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "rate of change of a function",
+        "ja": "かんすうのへんかのわりあい",
+        "ja_typings": [
+          "kansuunohenkanowariai"
+        ]
+      },
+      {
+        "en": "area under a curve",
+        "ja": "きょくせんのしたのめんせき",
+        "ja_typings": [
+          "kyokusennoshitanomenseki"
+        ]
+      },
+      {
+        "en": "sum of a function",
+        "ja": "かんすうのわ",
+        "ja_typings": [
+          "kansuunowa"
+        ]
+      },
+      {
+        "en": "inverse of a function",
+        "ja": "かんすうのぎゃく",
+        "ja_typings": [
+          "kansuunogyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00726",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the derivative in calculus?",
+      "ja": "びぶんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "area under a curve",
+        "ja": "きょくせんのしたのめんせき",
+        "ja_typings": [
+          "kyokusennoshitanomenseki"
+        ]
+      },
+      {
+        "en": "rate of change",
+        "ja": "へんかのわりあい",
+        "ja_typings": [
+          "henkanowariai"
+        ]
+      },
+      {
+        "en": "slope of a function",
+        "ja": "かんすうのかたむき",
+        "ja_typings": [
+          "kansuunokatamuki"
+        ]
+      },
+      {
+        "en": "maximum of a function",
+        "ja": "かんすうのさいだいち",
+        "ja_typings": [
+          "kansuunosaidaichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00727",
+    "image_path": null,
+    "question_text": {
+      "en": "What is integration in calculus?",
+      "ja": "せきぶんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "quantity with magnitude and direction",
+        "ja": "おおきさとむきをもつりょう",
+        "ja_typings": [
+          "okisatomukiomotsuryo",
+          "ookisatomukiomotsuryou"
+        ]
+      },
+      {
+        "en": "quantity with magnitude only",
+        "ja": "おおきさだけをもつりょう",
+        "ja_typings": [
+          "okisadakeomotsuryo",
+          "ookisadakeomotsuryou"
+        ]
+      },
+      {
+        "en": "a type of matrix",
+        "ja": "ぎょうれつのいっしゅ",
+        "ja_typings": [
+          "gyoretsunoisshu",
+          "gyouretsunoisshu"
+        ]
+      },
+      {
+        "en": "a scalar value",
+        "ja": "すからーのあたい",
+        "ja_typings": [
+          "sukaranoatai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00728",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a vector?",
+      "ja": "べくとるとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "rectangular array of numbers",
+        "ja": "すうのちょうほうけいのはいれつ",
+        "ja_typings": [
+          "suunochohokeinohairetsu",
+          "suunochouhoukeinohairetsu"
+        ]
+      },
+      {
+        "en": "single row of numbers",
+        "ja": "すうのいちぎょう",
+        "ja_typings": [
+          "suunoichigyo",
+          "suunoichigyou"
+        ]
+      },
+      {
+        "en": "a polynomial",
+        "ja": "たこうしき",
+        "ja_typings": [
+          "takoshiki",
+          "takoushiki"
+        ]
+      },
+      {
+        "en": "a prime number set",
+        "ja": "そすうのしゅうごう",
+        "ja_typings": [
+          "sosuunoshuugo",
+          "sosuunoshuugou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00729",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a matrix in mathematics?",
+      "ja": "すうがくでのぎょうれつとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "likelihood of an event",
+        "ja": "できごとのおこりやすさ",
+        "ja_typings": [
+          "dekigotonokoriyasusa",
+          "dekigotonookoriyasusa"
+        ]
+      },
+      {
+        "en": "frequency of an event",
+        "ja": "できごとのひんど",
+        "ja_typings": [
+          "dekigotonohindo"
+        ]
+      },
+      {
+        "en": "certainty of an event",
+        "ja": "できごとのかくじつせい",
+        "ja_typings": [
+          "dekigotonokakujitsusei"
+        ]
+      },
+      {
+        "en": "range of outcomes",
+        "ja": "けっかのはんい",
+        "ja_typings": [
+          "kekkanohani"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00730",
+    "image_path": null,
+    "question_text": {
+      "en": "What is probability?",
+      "ja": "かくりつとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1/6",
+        "ja": "ろくぶんのいち",
+        "ja_typings": [
+          "rokubunnoichi"
+        ]
+      },
+      {
+        "en": "1/2",
+        "ja": "にぶんのいち",
+        "ja_typings": [
+          "nibunnoichi"
+        ]
+      },
+      {
+        "en": "1/3",
+        "ja": "さんぶんのいち",
+        "ja_typings": [
+          "sanbunnoichi"
+        ]
+      },
+      {
+        "en": "1/4",
+        "ja": "よんぶんのいち",
+        "ja_typings": [
+          "yonbunnoichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00731",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the probability of rolling a 6 on a die?",
+      "ja": "さいころで6がでるかくりつは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "collection of distinct objects",
+        "ja": "ことなるものの あつまり",
+        "ja_typings": [
+          "kotonarumonono atsumari"
+        ]
+      },
+      {
+        "en": "ordered sequence",
+        "ja": "じゅんじょのあるならび",
+        "ja_typings": [
+          "junjonoarunarabi"
+        ]
+      },
+      {
+        "en": "mathematical function",
+        "ja": "すうがくてきかんすう",
+        "ja_typings": [
+          "suugakutekikansuu"
+        ]
+      },
+      {
+        "en": "pair of numbers",
+        "ja": "すうのくみ",
+        "ja_typings": [
+          "suunokumi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00732",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a set in mathematics?",
+      "ja": "すうがくでのしゅうごうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "all elements in either set",
+        "ja": "どちらかのしゅうごうにあるすべての要素",
+        "ja_typings": [
+          "dochirakanoshuugoniarusubeteno",
+          "dochirakanoshuugouniarusubeteno"
+        ]
+      },
+      {
+        "en": "elements in both sets",
+        "ja": "りょうほうにあるようそ",
+        "ja_typings": [
+          "ryohoniaruyoso",
+          "ryouhouniaruyouso"
+        ]
+      },
+      {
+        "en": "elements in only one set",
+        "ja": "いっぽうにしかないようそ",
+        "ja_typings": [
+          "ipponishikanaiyoso",
+          "ippounishikanaiyouso"
+        ]
+      },
+      {
+        "en": "the empty set",
+        "ja": "くうしゅうごう",
+        "ja_typings": [
+          "kuushuugo",
+          "kuushuugou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00733",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the union of two sets?",
+      "ja": "につのしゅうごうのわしゅうごうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "elements common to both sets",
+        "ja": "りょうほうのしゅうごうにふくまれるようそ",
+        "ja_typings": [
+          "ryohonoshuugonifukumareruyoso",
+          "ryouhounoshuugounifukumareruyouso"
+        ]
+      },
+      {
+        "en": "all elements in either set",
+        "ja": "どちらかにあるすべてのようそ",
+        "ja_typings": [
+          "dochirakaniarusubetenoyoso",
+          "dochirakaniarusubetenoyouso"
+        ]
+      },
+      {
+        "en": "elements in only one set",
+        "ja": "いっぽうにしかないようそ",
+        "ja_typings": [
+          "ipponishikanaiyoso",
+          "ippounishikanaiyouso"
+        ]
+      },
+      {
+        "en": "the complement set",
+        "ja": "ほごしゅうごう",
+        "ja_typings": [
+          "hogoshuugo",
+          "hogoshuugou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00734",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the intersection of two sets?",
+      "ja": "につのしゅうごうのせきしゅうごうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "relation mapping input to output",
+        "ja": "にゅうりょくをしゅつりょくにたいおうさせるかんけい",
+        "ja_typings": [
+          "nyuuryokuoshutsuryokunitaiosaserukankei",
+          "nyuuryokuoshutsuryokunitaiousaserukankei"
+        ]
+      },
+      {
+        "en": "a type of matrix",
+        "ja": "ぎょうれつのいっしゅ",
+        "ja_typings": [
+          "gyoretsunoisshu",
+          "gyouretsunoisshu"
+        ]
+      },
+      {
+        "en": "a polynomial expression",
+        "ja": "たこうしきひょうげん",
+        "ja_typings": [
+          "takoshikihyogen",
+          "takoushikihyougen"
+        ]
+      },
+      {
+        "en": "a geometric shape",
+        "ja": "きかがくてきけいじょう",
+        "ja_typings": [
+          "kikagakutekikeijo",
+          "kikagakutekikeijou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00735",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a function in math?",
+      "ja": "すうがくでのかんすうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "number with real and imaginary parts",
+        "ja": "じつぶぶんときょぶぶんをもつかず",
+        "ja_typings": [
+          "jitsububuntokyobubunomotsukazu"
+        ]
+      },
+      {
+        "en": "number greater than 1000",
+        "ja": "1000よりおおきいかず",
+        "ja_typings": [
+          "1000yoriokiikazu",
+          "1000yoriookiikazu"
+        ]
+      },
+      {
+        "en": "negative integer",
+        "ja": "ふのせいすう",
+        "ja_typings": [
+          "funoseisuu"
+        ]
+      },
+      {
+        "en": "irrational number",
+        "ja": "むりすう",
+        "ja_typings": [
+          "murisuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00736",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a complex number?",
+      "ja": "ふくそすうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "number that cannot be expressed as fraction",
+        "ja": "ぶんすうでひょうせないかず",
+        "ja_typings": [
+          "bunsuudehyosenaikazu",
+          "bunsuudehyousenaikazu"
+        ]
+      },
+      {
+        "en": "negative number",
+        "ja": "ふのかず",
+        "ja_typings": [
+          "funokazu"
+        ]
+      },
+      {
+        "en": "very large number",
+        "ja": "とてもおおきいかず",
+        "ja_typings": [
+          "totemookiikazu",
+          "totemoookiikazu"
+        ]
+      },
+      {
+        "en": "number divisible by prime",
+        "ja": "そすうでわれるかず",
+        "ja_typings": [
+          "sosuudewarerukazu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00737",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an irrational number?",
+      "ja": "むりすうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "7",
+        "ja": "なな",
+        "ja_typings": [
+          "nana"
+        ]
+      },
+      {
+        "en": "-7",
+        "ja": "まいなすなな",
+        "ja_typings": [
+          "mainasunana"
+        ]
+      },
+      {
+        "en": "0",
+        "ja": "れい",
+        "ja_typings": [
+          "rei"
+        ]
+      },
+      {
+        "en": "49",
+        "ja": "よんじゅうきゅう",
+        "ja_typings": [
+          "yonjuukyuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00738",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the absolute value of -7?",
+      "ja": "-7のぜったいちは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "0",
+        "ja": "れい",
+        "ja_typings": [
+          "rei"
+        ]
+      },
+      {
+        "en": "1",
+        "ja": "いち",
+        "ja_typings": [
+          "ichi"
+        ]
+      },
+      {
+        "en": "-1",
+        "ja": "まいなすいち",
+        "ja_typings": [
+          "mainasuichi"
+        ]
+      },
+      {
+        "en": "undefined",
+        "ja": "ていぎされていない",
+        "ja_typings": [
+          "teigisareteinai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00739",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the slope of a horizontal line?",
+      "ja": "すいへいせんのかたむきは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "undefined",
+        "ja": "ていぎされていない",
+        "ja_typings": [
+          "teigisareteinai"
+        ]
+      },
+      {
+        "en": "0",
+        "ja": "れい",
+        "ja_typings": [
+          "rei"
+        ]
+      },
+      {
+        "en": "1",
+        "ja": "いち",
+        "ja_typings": [
+          "ichi"
+        ]
+      },
+      {
+        "en": "-1",
+        "ja": "まいなすいち",
+        "ja_typings": [
+          "mainasuichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00740",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the slope of a vertical line?",
+      "ja": "すいちょくせんのかたむきは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sequence where each term is multiplied by a constant",
+        "ja": "かくこうをていすうでかけるすうれつ",
+        "ja_typings": [
+          "kakukooteisuudekakerusuuretsu",
+          "kakukouoteisuudekakerusuuretsu"
+        ]
+      },
+      {
+        "en": "sequence where each term adds a constant",
+        "ja": "かくこうにていすうをたすすうれつ",
+        "ja_typings": [
+          "kakukoniteisuuotasusuuretsu",
+          "kakukouniteisuuotasusuuretsu"
+        ]
+      },
+      {
+        "en": "sequence of prime numbers",
+        "ja": "そすうのすうれつ",
+        "ja_typings": [
+          "sosuunosuuretsu"
+        ]
+      },
+      {
+        "en": "sequence of squares",
+        "ja": "じじょうのすうれつ",
+        "ja_typings": [
+          "jijonosuuretsu",
+          "jijounosuuretsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00741",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a geometric progression?",
+      "ja": "とうひすうれつとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sequence where each term adds a constant",
+        "ja": "かくこうにていすうをたすすうれつ",
+        "ja_typings": [
+          "kakukoniteisuuotasusuuretsu",
+          "kakukouniteisuuotasusuuretsu"
+        ]
+      },
+      {
+        "en": "sequence where each term is multiplied",
+        "ja": "かくこうをかけるすうれつ",
+        "ja_typings": [
+          "kakukookakerusuuretsu",
+          "kakukouokakerusuuretsu"
+        ]
+      },
+      {
+        "en": "decreasing sequence",
+        "ja": "げんしょうするすうれつ",
+        "ja_typings": [
+          "genshosurusuuretsu",
+          "genshousurusuuretsu"
+        ]
+      },
+      {
+        "en": "random number sequence",
+        "ja": "らんすうのすうれつ",
+        "ja_typings": [
+          "ransuunosuuretsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00742",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an arithmetic progression?",
+      "ja": "とうさすうれつとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "(4/3)πr³",
+        "ja": "よんさんぶんのぱいあーるさんじょう",
+        "ja_typings": [
+          "yonsanbunnopaiarusanjo",
+          "yonsanbunnopaiarusanjou"
+        ]
+      },
+      {
+        "en": "πr²",
+        "ja": "ぱいあーるじじょう",
+        "ja_typings": [
+          "paiarujijo",
+          "paiarujijou"
+        ]
+      },
+      {
+        "en": "(4/3)πr²",
+        "ja": "よんさんぶんのぱいあーるじじょう",
+        "ja_typings": [
+          "yonsanbunnopaiarujijo",
+          "yonsanbunnopaiarujijou"
+        ]
+      },
+      {
+        "en": "πr³",
+        "ja": "ぱいあーるさんじょう",
+        "ja_typings": [
+          "paiarusanjo",
+          "paiarusanjou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00743",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the formula for the volume of a sphere?",
+      "ja": "きゅうのたいせきのこうしきは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "2.71828",
+        "ja": "にてんなないちはちにはち",
+        "ja_typings": [
+          "nitennanaichihachinihachi"
+        ]
+      },
+      {
+        "en": "3.14159",
+        "ja": "さんてんいちよんいちごきゅう",
+        "ja_typings": [
+          "santenichiyonichigokyuu"
+        ]
+      },
+      {
+        "en": "1.41421",
+        "ja": "いちてんよんいちよんにいち",
+        "ja_typings": [
+          "ichitenyonichiyonniichi"
+        ]
+      },
+      {
+        "en": "1.61803",
+        "ja": "いちてんろくいちはちれいさん",
+        "ja_typings": [
+          "ichitenrokuichihachireisan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00744",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Euler's number 'e'?",
+      "ja": "おいらーのすうeはおよそいくつ？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "triangular array of binomial coefficients",
+        "ja": "にこうけいすうのさんかっけいはいれつ",
+        "ja_typings": [
+          "nikokeisuunosankakkeihairetsu",
+          "nikoukeisuunosankakkeihairetsu"
+        ]
+      },
+      {
+        "en": "triangle with all sides equal",
+        "ja": "すべてのへんがひとしいさんかっけい",
+        "ja_typings": [
+          "subetenohengahitoshiisankakkei"
+        ]
+      },
+      {
+        "en": "triangle used in geometry proofs",
+        "ja": "きかがくのしょうめいにつかうさんかっけい",
+        "ja_typings": [
+          "kikagakunoshomeinitsukausankakkei",
+          "kikagakunoshoumeinitsukausankakkei"
+        ]
+      },
+      {
+        "en": "a graph type in statistics",
+        "ja": "とうけいのぐらふのいっしゅ",
+        "ja_typings": [
+          "tokeinogurafunoisshu",
+          "toukeinogurafunoisshu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00745",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Pascal's triangle?",
+      "ja": "ぱすかるのさんかっけいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "arrangement of items in order",
+        "ja": "こうもくをじゅんじょよくならべたもの",
+        "ja_typings": [
+          "komokuojunjoyokunarabetamono",
+          "koumokuojunjoyokunarabetamono"
+        ]
+      },
+      {
+        "en": "selection without order",
+        "ja": "じゅんじょをきにしないせんたく",
+        "ja_typings": [
+          "junjokinishinaisentaku",
+          "junjookinishinaisentaku"
+        ]
+      },
+      {
+        "en": "multiplication of all integers to n",
+        "ja": "nまでのせいすうのせき",
+        "ja_typings": [
+          "nmadenoseisuunoseki"
+        ]
+      },
+      {
+        "en": "sum of a series",
+        "ja": "すうれつのわ",
+        "ja_typings": [
+          "suuretsunowa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00746",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a permutation?",
+      "ja": "じゅんれつとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "selection without regard to order",
+        "ja": "じゅんじょをきにしないせんたく",
+        "ja_typings": [
+          "junjokinishinaisentaku",
+          "junjookinishinaisentaku"
+        ]
+      },
+      {
+        "en": "arrangement in specific order",
+        "ja": "とくていのじゅんじょによるならべかた",
+        "ja_typings": [
+          "tokuteinojunjoniyorunarabekata"
+        ]
+      },
+      {
+        "en": "sum of elements",
+        "ja": "ようそのわ",
+        "ja_typings": [
+          "yosonowa",
+          "yousonowa"
+        ]
+      },
+      {
+        "en": "product of elements",
+        "ja": "ようそのせき",
+        "ja_typings": [
+          "yosonoseki",
+          "yousonoseki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q00747",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a combination?",
+      "ja": "くみあわせとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mandarin Chinese",
+        "ja": "まんだりんちゃいにーず",
+        "ja_typings": [
+          "mandarinchainizu"
+        ]
+      },
+      {
+        "en": "English",
+        "ja": "えいご",
+        "ja_typings": [
+          "eigo"
+        ]
+      },
+      {
+        "en": "Spanish",
+        "ja": "すぺいんご",
+        "ja_typings": [
+          "supeingo"
+        ]
+      },
+      {
+        "en": "Hindi",
+        "ja": "ひんでぃーご",
+        "ja_typings": [
+          "hindigo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00748",
+    "image_path": null,
+    "question_text": {
+      "en": "What language has the most native speakers?",
+      "ja": "もっともおおくのぼごわしゃをもつげんごは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "26",
+        "ja": "にじゅうろく",
+        "ja_typings": [
+          "nijuuroku"
+        ]
+      },
+      {
+        "en": "24",
+        "ja": "にじゅうし",
+        "ja_typings": [
+          "nijuushi"
+        ]
+      },
+      {
+        "en": "28",
+        "ja": "にじゅうはち",
+        "ja_typings": [
+          "nijuuhachi"
+        ]
+      },
+      {
+        "en": "30",
+        "ja": "さんじゅう",
+        "ja_typings": [
+          "sanjuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00749",
+    "image_path": null,
+    "question_text": {
+      "en": "How many letters are in the English alphabet?",
+      "ja": "えいごのあるふぁべっとはなんもじ？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Portuguese",
+        "ja": "ぽるとがるご",
+        "ja_typings": [
+          "porutogarugo"
+        ]
+      },
+      {
+        "en": "Spanish",
+        "ja": "すぺいんご",
+        "ja_typings": [
+          "supeingo"
+        ]
+      },
+      {
+        "en": "English",
+        "ja": "えいご",
+        "ja_typings": [
+          "eigo"
+        ]
+      },
+      {
+        "en": "French",
+        "ja": "ふらんすご",
+        "ja_typings": [
+          "furansugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00750",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the official language of Brazil?",
+      "ja": "ぶらじるのこうようごは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Arabic",
+        "ja": "あらびあご",
+        "ja_typings": [
+          "arabiago"
+        ]
+      },
+      {
+        "en": "Hebrew",
+        "ja": "へぶらいご",
+        "ja_typings": [
+          "heburaigo"
+        ]
+      },
+      {
+        "en": "Turkish",
+        "ja": "とるこご",
+        "ja_typings": [
+          "torukogo"
+        ]
+      },
+      {
+        "en": "Persian",
+        "ja": "ぺるしあご",
+        "ja_typings": [
+          "perushiago"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00751",
+    "image_path": null,
+    "question_text": {
+      "en": "What language is spoken in Egypt?",
+      "ja": "えじぷとでつかわれるげんごは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kanji, Hiragana, Katakana",
+        "ja": "かんじ、ひらがな、かたかな",
+        "ja_typings": [
+          "kanji hiragana katakana"
+        ]
+      },
+      {
+        "en": "Latin alphabet only",
+        "ja": "らてんもじのみ",
+        "ja_typings": [
+          "ratenmojinomi"
+        ]
+      },
+      {
+        "en": "Arabic script",
+        "ja": "あらびあもじ",
+        "ja_typings": [
+          "arabiamoji"
+        ]
+      },
+      {
+        "en": "Cyrillic script",
+        "ja": "きりるもじ",
+        "ja_typings": [
+          "kirirumoji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00752",
+    "image_path": null,
+    "question_text": {
+      "en": "What script is used for Japanese?",
+      "ja": "にほんごではどのもじをつかうか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "word with similar meaning",
+        "ja": "にたいみのことば",
+        "ja_typings": [
+          "nitaiminokotoba"
+        ]
+      },
+      {
+        "en": "word with opposite meaning",
+        "ja": "はんたいのいみのことば",
+        "ja_typings": [
+          "hantainoiminokotoba"
+        ]
+      },
+      {
+        "en": "word that sounds the same",
+        "ja": "おなじおとのことば",
+        "ja_typings": [
+          "onajiotonokotoba"
+        ]
+      },
+      {
+        "en": "word from another language",
+        "ja": "べつのげんごからのことば",
+        "ja_typings": [
+          "betsunogengokaranokotoba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00753",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a synonym?",
+      "ja": "どうぎごとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "word with opposite meaning",
+        "ja": "はんたいのいみのことば",
+        "ja_typings": [
+          "hantainoiminokotoba"
+        ]
+      },
+      {
+        "en": "word with similar meaning",
+        "ja": "にたいみのことば",
+        "ja_typings": [
+          "nitaiminokotoba"
+        ]
+      },
+      {
+        "en": "word from another language",
+        "ja": "べつのげんごからのことば",
+        "ja_typings": [
+          "betsunogengokaranokotoba"
+        ]
+      },
+      {
+        "en": "a foreign word",
+        "ja": "がいこくご",
+        "ja_typings": [
+          "gaikokugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00754",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an antonym?",
+      "ja": "はんたいごとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Japanese poem with 5-7-5 syllables",
+        "ja": "ごしちごのおんのにほんのし",
+        "ja_typings": [
+          "goshichigononnonihonnoshi",
+          "goshichigonoonnonihonnoshi"
+        ]
+      },
+      {
+        "en": "Chinese poem form",
+        "ja": "ちゅうごくのしのけいしき",
+        "ja_typings": [
+          "chuugokunoshinokeishiki"
+        ]
+      },
+      {
+        "en": "free verse poem",
+        "ja": "じゆうし",
+        "ja_typings": [
+          "jiyuushi"
+        ]
+      },
+      {
+        "en": "rhyming couplet",
+        "ja": "ぐいんをそろえたにれんく",
+        "ja_typings": [
+          "guinosoroetanirenku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00755",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a haiku?",
+      "ja": "はいくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "word borrowed from another language",
+        "ja": "べつのげんごからかりたことば",
+        "ja_typings": [
+          "betsunogengokarakaritakotoba"
+        ]
+      },
+      {
+        "en": "word used in legal documents",
+        "ja": "ほうりつぶんしょにつかうことば",
+        "ja_typings": [
+          "horitsubunshonitsukaukotoba",
+          "houritsubunshonitsukaukotoba"
+        ]
+      },
+      {
+        "en": "made-up word",
+        "ja": "つくりことば",
+        "ja_typings": [
+          "tsukurikotoba"
+        ]
+      },
+      {
+        "en": "archaic word",
+        "ja": "ふるいことば",
+        "ja_typings": [
+          "furuikotoba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00756",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'loanword' mean?",
+      "ja": "がいらいごとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "word that imitates a sound",
+        "ja": "おとをまねることば",
+        "ja_typings": [
+          "otomanerukotoba",
+          "otoomanerukotoba"
+        ]
+      },
+      {
+        "en": "very long word",
+        "ja": "とてもながいことば",
+        "ja_typings": [
+          "totemonagaikotoba"
+        ]
+      },
+      {
+        "en": "a silent letter",
+        "ja": "さいれんとれたー",
+        "ja_typings": [
+          "sairentoreta"
+        ]
+      },
+      {
+        "en": "compound word",
+        "ja": "ふくごうご",
+        "ja_typings": [
+          "fukugogo",
+          "fukugougo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00757",
+    "image_path": null,
+    "question_text": {
+      "en": "What is onomatopoeia?",
+      "ja": "おのまとぺとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "aqua",
+        "ja": "あくあ",
+        "ja_typings": [
+          "akua"
+        ]
+      },
+      {
+        "en": "terra",
+        "ja": "てら",
+        "ja_typings": [
+          "tera"
+        ]
+      },
+      {
+        "en": "ignis",
+        "ja": "いぐにす",
+        "ja_typings": [
+          "igunisu"
+        ]
+      },
+      {
+        "en": "aer",
+        "ja": "あえる",
+        "ja_typings": [
+          "aeru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00758",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Latin word for water?",
+      "ja": "みずのらてんごは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Indo-European",
+        "ja": "いんどーよーろっぱごぞく",
+        "ja_typings": [
+          "indoyoroppagozoku"
+        ]
+      },
+      {
+        "en": "Afro-Asiatic",
+        "ja": "あふろあじあごぞく",
+        "ja_typings": [
+          "afuroajiagozoku"
+        ]
+      },
+      {
+        "en": "Sino-Tibetan",
+        "ja": "ちゅうごくちべっとごぞく",
+        "ja_typings": [
+          "chuugokuchibettogozoku"
+        ]
+      },
+      {
+        "en": "Austronesian",
+        "ja": "おーすとろねしあごぞく",
+        "ja_typings": [
+          "osutoroneshiagozoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00759",
+    "image_path": null,
+    "question_text": {
+      "en": "What language family does English belong to?",
+      "ja": "えいごはどのごぞくか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "word that reads same forwards and backwards",
+        "ja": "まえからもうしろからもよめることば",
+        "ja_typings": [
+          "maekaramoshirokaramoyomerukotoba",
+          "maekaramoushirokaramoyomerukotoba"
+        ]
+      },
+      {
+        "en": "word with silent letters",
+        "ja": "さいれんとれたーのあることば",
+        "ja_typings": [
+          "sairentoretanoarukotoba"
+        ]
+      },
+      {
+        "en": "compound word",
+        "ja": "ふくごうご",
+        "ja_typings": [
+          "fukugogo",
+          "fukugougo"
+        ]
+      },
+      {
+        "en": "a very short word",
+        "ja": "とてもみじかいことば",
+        "ja_typings": [
+          "totemomijikaikotoba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00760",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a palindrome?",
+      "ja": "かいぶんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Early Modern English",
+        "ja": "そうききんだいえいご",
+        "ja_typings": [
+          "sokikindaieigo",
+          "soukikindaieigo"
+        ]
+      },
+      {
+        "en": "Old English",
+        "ja": "こえいご",
+        "ja_typings": [
+          "koeigo"
+        ]
+      },
+      {
+        "en": "Middle English",
+        "ja": "ちゅうえいご",
+        "ja_typings": [
+          "chuueigo"
+        ]
+      },
+      {
+        "en": "Latin",
+        "ja": "らてんご",
+        "ja_typings": [
+          "ratengo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00761",
+    "image_path": null,
+    "question_text": {
+      "en": "What language did Shakespeare write in?",
+      "ja": "しぇいくすぴあはなにごでかいたか？"
     }
   },
   {
@@ -3909,158 +31294,5039 @@
         ]
       },
       {
-        "en": "Chinese",
-        "ja": "ちゅうごくご",
-        "ja_typings": [
-          "chuugokugo"
-        ]
-      },
-      {
         "en": "Spanish",
-        "ja": "スペインご",
+        "ja": "すぺいんご",
         "ja_typings": [
           "supeingo"
         ]
       },
       {
-        "en": "Arabic",
-        "ja": "アラビアご",
+        "en": "Mandarin",
+        "ja": "まんだりん",
         "ja_typings": [
-          "arabiago"
+          "mandarin"
+        ]
+      },
+      {
+        "en": "French",
+        "ja": "ふらんすご",
+        "ja_typings": [
+          "furansugo"
         ]
       }
     ],
-    "correct_answer_index": 1,
+    "correct_answer_index": 0,
     "genre": "language",
-    "id": "q00097",
+    "id": "q00762",
     "image_path": null,
     "question_text": {
-      "en": "What is the most spoken language in the world?",
-      "ja": "せかいでもっともはなされているげんごは?"
+      "en": "What is the most studied second language globally?",
+      "ja": "せかいでもっともまなばれているだいにげんごは？"
     }
   },
   {
     "choices": [
       {
+        "en": "study of word origins",
+        "ja": "ことばのおこりのがくもん",
+        "ja_typings": [
+          "kotobanokorinogakumon",
+          "kotobanookorinogakumon"
+        ]
+      },
+      {
+        "en": "study of grammar",
+        "ja": "ぶんぽうのがくもん",
+        "ja_typings": [
+          "bunponogakumon",
+          "bunpounogakumon"
+        ]
+      },
+      {
+        "en": "study of dialects",
+        "ja": "ほうげんのがくもん",
+        "ja_typings": [
+          "hogennogakumon",
+          "hougennogakumon"
+        ]
+      },
+      {
+        "en": "study of pronunciation",
+        "ja": "はつおんのがくもん",
+        "ja_typings": [
+          "hatsuonnogakumon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00763",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'etymology' mean?",
+      "ja": "ごげんがくとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "rules for structure of language",
+        "ja": "げんごのこうぞうのきそく",
+        "ja_typings": [
+          "gengonokozonokisoku",
+          "gengonokouzounokisoku"
+        ]
+      },
+      {
+        "en": "vocabulary of a language",
+        "ja": "げんごのごい",
+        "ja_typings": [
+          "gengonogoi"
+        ]
+      },
+      {
+        "en": "pronunciation system",
+        "ja": "はつおんのしすてむ",
+        "ja_typings": [
+          "hatsuonnoshisutemu"
+        ]
+      },
+      {
+        "en": "writing system",
+        "ja": "ひょうきほう",
+        "ja_typings": [
+          "hyokiho",
+          "hyoukihou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00764",
+    "image_path": null,
+    "question_text": {
+      "en": "What is grammar?",
+      "ja": "ぶんぽうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "rules about sentence structure",
+        "ja": "ぶんのこうぞうにかんするきそく",
+        "ja_typings": [
+          "bunnokozonikansurukisoku",
+          "bunnokouzounikansurukisoku"
+        ]
+      },
+      {
+        "en": "study of word meaning",
+        "ja": "ことばのいみのけんきゅう",
+        "ja_typings": [
+          "kotobanoiminokenkyuu"
+        ]
+      },
+      {
+        "en": "pronunciation rules",
+        "ja": "はつおんのきそく",
+        "ja_typings": [
+          "hatsuonnokisoku"
+        ]
+      },
+      {
+        "en": "origin of words",
+        "ja": "ことばのおこり",
+        "ja_typings": [
+          "kotobanokori",
+          "kotobanookori"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00765",
+    "image_path": null,
+    "question_text": {
+      "en": "What is syntax?",
+      "ja": "こうぶんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "study of meaning in language",
+        "ja": "げんごのいみのけんきゅう",
+        "ja_typings": [
+          "gengonoiminokenkyuu"
+        ]
+      },
+      {
+        "en": "study of sentence structure",
+        "ja": "ぶんのこうぞうのけんきゅう",
+        "ja_typings": [
+          "bunnokozonokenkyuu",
+          "bunnokouzounokenkyuu"
+        ]
+      },
+      {
+        "en": "study of sounds",
+        "ja": "おとのけんきゅう",
+        "ja_typings": [
+          "otonokenkyuu"
+        ]
+      },
+      {
+        "en": "study of dialects",
+        "ja": "ほうげんのけんきゅう",
+        "ja_typings": [
+          "hogennokenkyuu",
+          "hougennokenkyuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00766",
+    "image_path": null,
+    "question_text": {
+      "en": "What is semantics?",
+      "ja": "いみろんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "regional variation of a language",
+        "ja": "げんごのちいきてきへんたい",
+        "ja_typings": [
+          "gengonochiikitekihentai"
+        ]
+      },
+      {
+        "en": "simplified form of language",
+        "ja": "げんごのかんりゃくけい",
+        "ja_typings": [
+          "gengonokanryakukei"
+        ]
+      },
+      {
+        "en": "foreign language",
+        "ja": "がいこくご",
+        "ja_typings": [
+          "gaikokugo"
+        ]
+      },
+      {
+        "en": "written form of language",
+        "ja": "ごのきじゅつけい",
+        "ja_typings": [
+          "gonokijutsukei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00767",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a dialect?",
+      "ja": "ほうげんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "constructed international language",
+        "ja": "じんこうてきなこくさいきょうつうご",
+        "ja_typings": [
+          "jinkotekinakokusaikyotsuugo",
+          "jinkoutekinakokusaikyoutsuugo"
+        ]
+      },
+      {
+        "en": "ancient Latin dialect",
+        "ja": "こだいらてんのほうげん",
+        "ja_typings": [
+          "kodairatennohogen",
+          "kodairatennohougen"
+        ]
+      },
+      {
+        "en": "Spanish dialect",
+        "ja": "すぺいんごのほうげん",
+        "ja_typings": [
+          "supeingonohogen",
+          "supeingonohougen"
+        ]
+      },
+      {
+        "en": "mix of French and Italian",
+        "ja": "ふらんすごとイタリアごのまぜ",
+        "ja_typings": [
+          "furansugotoitariagonomaze"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00768",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Esperanto?",
+      "ja": "えすぺらんととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "smallest unit of sound in language",
+        "ja": "げんごでもっともちいさなおとのたんい",
+        "ja_typings": [
+          "gengodemottomochiisanaotonotani"
+        ]
+      },
+      {
+        "en": "written letter",
+        "ja": "きじゅつもじ",
+        "ja_typings": [
+          "kijutsumoji"
+        ]
+      },
+      {
+        "en": "unit of meaning",
+        "ja": "いみのたんい",
+        "ja_typings": [
+          "iminotani"
+        ]
+      },
+      {
+        "en": "sentence structure unit",
+        "ja": "ぶんこうぞうのたんい",
+        "ja_typings": [
+          "bunkozonotani",
+          "bunkouzounotani"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00769",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a phoneme?",
+      "ja": "おんそとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Russian",
+        "ja": "ろしあご",
+        "ja_typings": [
+          "roshiago"
+        ]
+      },
+      {
+        "en": "Greek",
+        "ja": "ぎりしあご",
+        "ja_typings": [
+          "girishiago"
+        ]
+      },
+      {
+        "en": "Arabic",
+        "ja": "あらびあご",
+        "ja_typings": [
+          "arabiago"
+        ]
+      },
+      {
+        "en": "Hebrew",
+        "ja": "へぶらいご",
+        "ja_typings": [
+          "heburaigo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00770",
+    "image_path": null,
+    "question_text": {
+      "en": "What language uses the Cyrillic alphabet?",
+      "ja": "きりるもじをつかうげんごは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "word describing an action or state",
+        "ja": "こうどうやじょうたいをあらわすことば",
+        "ja_typings": [
+          "kodoyajotaioarawasukotoba",
+          "koudouyajoutaioarawasukotoba"
+        ]
+      },
+      {
+        "en": "word describing a noun",
+        "ja": "めいしをせつめいすることば",
+        "ja_typings": [
+          "meishiosetsumeisurukotoba"
+        ]
+      },
+      {
+        "en": "name of a person or thing",
+        "ja": "ひとやものの なまえ",
+        "ja_typings": [
+          "hitoyamonono namae"
+        ]
+      },
+      {
+        "en": "connecting word",
+        "ja": "つなぎことば",
+        "ja_typings": [
+          "tsunagikotoba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00771",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a verb?",
+      "ja": "どうしとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "word that describes a noun",
+        "ja": "めいしをしゅうしょくすることば",
+        "ja_typings": [
+          "meishioshuushokusurukotoba"
+        ]
+      },
+      {
+        "en": "word describing an action",
+        "ja": "こうどうをあらわすことば",
+        "ja_typings": [
+          "kodooarawasukotoba",
+          "koudouoarawasukotoba"
+        ]
+      },
+      {
+        "en": "a type of pronoun",
+        "ja": "だいめいしのいっしゅ",
+        "ja_typings": [
+          "daimeishinoisshu"
+        ]
+      },
+      {
+        "en": "word connecting clauses",
+        "ja": "せつをつなぐことば",
+        "ja_typings": [
+          "setsuotsunagukotoba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00772",
+    "image_path": null,
+    "question_text": {
+      "en": "What is an adjective?",
+      "ja": "けいようしとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "word naming a person, place, or thing",
+        "ja": "ひとやばしょやものをなまえづけることば",
+        "ja_typings": [
+          "hitoyabashoyamononamaezukerukotoba",
+          "hitoyabashoyamonoonamaezukerukotoba"
+        ]
+      },
+      {
+        "en": "word describing an action",
+        "ja": "こうどうをあらわすことば",
+        "ja_typings": [
+          "kodooarawasukotoba",
+          "koudouoarawasukotoba"
+        ]
+      },
+      {
+        "en": "word modifying verbs",
+        "ja": "どうしをしゅうしょくすることば",
+        "ja_typings": [
+          "doshioshuushokusurukotoba",
+          "doushioshuushokusurukotoba"
+        ]
+      },
+      {
+        "en": "connecting word",
+        "ja": "つなぐことば",
+        "ja_typings": [
+          "tsunagukotoba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00773",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a noun?",
+      "ja": "めいしとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "word showing relationship between nouns",
+        "ja": "めいしかんのかんけいをしめすことば",
+        "ja_typings": [
+          "meishikannokankeioshimesukotoba"
+        ]
+      },
+      {
+        "en": "word describing action",
+        "ja": "こうどうをあらわすことば",
+        "ja_typings": [
+          "kodooarawasukotoba",
+          "koudouoarawasukotoba"
+        ]
+      },
+      {
+        "en": "plural noun form",
+        "ja": "めいしのふくすうけい",
+        "ja_typings": [
+          "meishinofukusuukei"
+        ]
+      },
+      {
+        "en": "type of adjective",
+        "ja": "けいようしのいっしゅ",
+        "ja_typings": [
+          "keiyoshinoisshu",
+          "keiyoushinoisshu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00774",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a preposition?",
+      "ja": "ぜんちしとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "direct comparison without 'like' or 'as'",
+        "ja": "likeやasをつかわないちょくせつのひかく",
+        "ja_typings": [
+          "likeyaasotsukawanaichokusetsunohikaku"
+        ]
+      },
+      {
+        "en": "comparison using 'like' or 'as'",
+        "ja": "likeやasをつかったひかく",
+        "ja_typings": [
+          "likeyaasotsukattahikaku"
+        ]
+      },
+      {
+        "en": "giving human traits to non-humans",
+        "ja": "にんげんいがいのものにじんかくをもたせること",
+        "ja_typings": [
+          "ningenigainomononijinkakuomotaserukoto"
+        ]
+      },
+      {
+        "en": "exaggeration for effect",
+        "ja": "こうかのためのこちょう",
+        "ja_typings": [
+          "kokanotamenokocho",
+          "koukanotamenokochou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00775",
+    "image_path": null,
+    "question_text": {
+      "en": "What is metaphor?",
+      "ja": "いんゆとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "comparison using 'like' or 'as'",
+        "ja": "likeやasをつかったひかく",
+        "ja_typings": [
+          "likeyaasotsukattahikaku"
+        ]
+      },
+      {
+        "en": "direct comparison without 'like' or 'as'",
+        "ja": "likeやasをつかわないひかく",
+        "ja_typings": [
+          "likeyaasotsukawanaihikaku"
+        ]
+      },
+      {
+        "en": "repetition of initial sounds",
+        "ja": "しょきおんのくりかえし",
+        "ja_typings": [
+          "shokionnokurikaeshi"
+        ]
+      },
+      {
+        "en": "word imitating sound",
+        "ja": "おとをまねることば",
+        "ja_typings": [
+          "otomanerukotoba",
+          "otoomanerukotoba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00776",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a simile?",
+      "ja": "しみりとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "repetition of initial consonant sounds",
+        "ja": "しょきしいんのくりかえし",
+        "ja_typings": [
+          "shokishiinnokurikaeshi"
+        ]
+      },
+      {
+        "en": "comparison using 'like'",
+        "ja": "likeをつかったひかく",
+        "ja_typings": [
+          "likeotsukattahikaku"
+        ]
+      },
+      {
+        "en": "word with same spelling, different meaning",
+        "ja": "つづりがおなじでいみがちがうことば",
+        "ja_typings": [
+          "tsuzurigaonajideimigachigaukotoba"
+        ]
+      },
+      {
+        "en": "giving objects human traits",
+        "ja": "ものにじんかくをもたせること",
+        "ja_typings": [
+          "mononijinkakuomotaserukoto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00777",
+    "image_path": null,
+    "question_text": {
+      "en": "What is alliteration?",
+      "ja": "どうじしゅんぷうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Japan",
+        "ja": "にほん",
+        "ja_typings": [
+          "nihon"
+        ]
+      },
+      {
+        "en": "China",
+        "ja": "ちゅうごく",
+        "ja_typings": [
+          "chuugoku"
+        ]
+      },
+      {
+        "en": "Korea",
+        "ja": "かんこく",
+        "ja_typings": [
+          "kankoku"
+        ]
+      },
+      {
+        "en": "Thailand",
+        "ja": "たいらんど",
+        "ja_typings": [
+          "tairando"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00778",
+    "image_path": null,
+    "question_text": {
+      "en": "What country is sushi originally from?",
+      "ja": "すしのげんちはどこ？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sitar",
+        "ja": "したーる",
+        "ja_typings": [
+          "shitaru"
+        ]
+      },
+      {
+        "en": "shamisen",
+        "ja": "しゃみせん",
+        "ja_typings": [
+          "shamisen"
+        ]
+      },
+      {
+        "en": "erhu",
+        "ja": "にこ",
+        "ja_typings": [
+          "niko"
+        ]
+      },
+      {
+        "en": "didgeridoo",
+        "ja": "でぃじゅりどぅー",
+        "ja_typings": [
+          "dijuridu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00779",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the traditional instrument of India?",
+      "ja": "いんどのでんとうがっきは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Spanish dance and music style",
+        "ja": "すぺいんのぶようとおんがくのすたいる",
+        "ja_typings": [
+          "supeinnobuyotongakunosutairu",
+          "supeinnobuyoutoongakunosutairu"
+        ]
+      },
+      {
+        "en": "Italian opera style",
+        "ja": "いたりあのおぺらすたいる",
+        "ja_typings": [
+          "itarianoperasutairu",
+          "itarianooperasutairu"
+        ]
+      },
+      {
+        "en": "Brazilian dance",
+        "ja": "ぶらじるのぶよう",
+        "ja_typings": [
+          "burajirunobuyo",
+          "burajirunobuyou"
+        ]
+      },
+      {
+        "en": "Mexican folk music",
+        "ja": "めきしこのみんぞくおんがく",
+        "ja_typings": [
+          "mekishikonominzokuongaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00780",
+    "image_path": null,
+    "question_text": {
+      "en": "What is flamenco?",
+      "ja": "ふらめんことは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "annual festival with samba parades",
+        "ja": "さんばぱれーどのねんかんまつり",
+        "ja_typings": [
+          "sanbaparedononenkanmatsuri"
+        ]
+      },
+      {
+        "en": "Christmas celebration",
+        "ja": "くりすますのいわい",
+        "ja_typings": [
+          "kurisumasunoiwai"
+        ]
+      },
+      {
+        "en": "harvest festival",
+        "ja": "しゅうかくまつり",
+        "ja_typings": [
+          "shuukakumatsuri"
+        ]
+      },
+      {
+        "en": "water festival",
+        "ja": "みずまつり",
+        "ja_typings": [
+          "mizumatsuri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00781",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Carnival in Brazil?",
+      "ja": "ぶらじるのかーにばるとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ancient Roman amphitheater",
+        "ja": "こだいろーまのえんけいきょうぎじょう",
+        "ja_typings": [
+          "kodairomanoenkeikyogijo",
+          "kodairomanoenkeikyougijou"
+        ]
+      },
+      {
+        "en": "Egyptian pyramid",
+        "ja": "えじぷとのぴらみっど",
+        "ja_typings": [
+          "ejiputonopiramiddo"
+        ]
+      },
+      {
+        "en": "Greek temple",
+        "ja": "ぎりしあのしんでん",
+        "ja_typings": [
+          "girishianoshinden"
+        ]
+      },
+      {
+        "en": "Medieval castle",
+        "ja": "ちゅうせいのしろ",
+        "ja_typings": [
+          "chuuseinoshiro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00782",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Colosseum?",
+      "ja": "ころっせうむとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Japanese art of flower arranging",
+        "ja": "にほんのかどう",
+        "ja_typings": [
+          "nihonnokado",
+          "nihonnokadou"
+        ]
+      },
+      {
+        "en": "Japanese sword art",
+        "ja": "にほんのけんじゅつ",
+        "ja_typings": [
+          "nihonnokenjutsu"
+        ]
+      },
+      {
+        "en": "Korean paper folding",
+        "ja": "かんこくのおりがみ",
+        "ja_typings": [
+          "kankokunorigami",
+          "kankokunoorigami"
+        ]
+      },
+      {
+        "en": "Chinese tea ceremony",
+        "ja": "ちゅうごくのちゃのゆ",
+        "ja_typings": [
+          "chuugokunochanoyu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00783",
+    "image_path": null,
+    "question_text": {
+      "en": "What is ikebana?",
+      "ja": "いけばなとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Scotland",
+        "ja": "すこっとらんど",
+        "ja_typings": [
+          "sukottorando"
+        ]
+      },
+      {
+        "en": "Ireland",
+        "ja": "あいるらんど",
+        "ja_typings": [
+          "airurando"
+        ]
+      },
+      {
+        "en": "Wales",
+        "ja": "うぇーるず",
+        "ja_typings": [
+          "weruzu"
+        ]
+      },
+      {
+        "en": "England",
+        "ja": "いんぐらんど",
+        "ja_typings": [
+          "ingurando"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00784",
+    "image_path": null,
+    "question_text": {
+      "en": "What country does the kilt come from?",
+      "ja": "きるとはどこのくにのもの？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "chado",
+        "ja": "ちゃどう",
+        "ja_typings": [
+          "chado",
+          "chadou"
+        ]
+      },
+      {
+        "en": "kabuki",
+        "ja": "かぶき",
+        "ja_typings": [
+          "kabuki"
+        ]
+      },
+      {
+        "en": "noh",
+        "ja": "のう",
+        "ja_typings": [
+          "no",
+          "nou"
+        ]
+      },
+      {
+        "en": "sumo",
+        "ja": "すもう",
+        "ja_typings": [
+          "sumo",
+          "sumou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00785",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the traditional Japanese tea ceremony called?",
+      "ja": "にほんのちゃどうのこうしきめいしょうは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Halloween",
+        "ja": "はろうぃん",
+        "ja_typings": [
+          "harowin"
+        ]
+      },
+      {
+        "en": "Thanksgiving",
+        "ja": "さんくすぎびんぐ",
+        "ja_typings": [
+          "sankusugibingu"
+        ]
+      },
+      {
+        "en": "Christmas",
+        "ja": "くりすます",
+        "ja_typings": [
+          "kurisumasu"
+        ]
+      },
+      {
+        "en": "Easter",
+        "ja": "いーすたー",
+        "ja_typings": [
+          "isuta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00786",
+    "image_path": null,
+    "question_text": {
+      "en": "What festival is celebrated on October 31?",
+      "ja": "10がつ31にちにいわわれるまつりは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hindu festival of lights",
+        "ja": "ひんどうきょうのひかりのまつり",
+        "ja_typings": [
+          "hindokyonohikarinomatsuri",
+          "hindoukyounohikarinomatsuri"
+        ]
+      },
+      {
+        "en": "Muslim new year",
+        "ja": "いすらむのしんねん",
+        "ja_typings": [
+          "isuramunoshinnen"
+        ]
+      },
+      {
+        "en": "Buddhist harvest festival",
+        "ja": "ぶっきょうのしゅうかくまつり",
+        "ja_typings": [
+          "bukkyonoshuukakumatsuri",
+          "bukkyounoshuukakumatsuri"
+        ]
+      },
+      {
+        "en": "Sikh water festival",
+        "ja": "しっきょうのみずまつり",
+        "ja_typings": [
+          "shikkyonomizumatsuri",
+          "shikkyounomizumatsuri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00787",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Diwali?",
+      "ja": "でぃわりとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mexican holiday honoring deceased",
+        "ja": "しにょにけいいをひょうするめきしこのしゅくじつ",
+        "ja_typings": [
+          "shinyonikeiiohyosurumekishikonoshukujitsu",
+          "shinyonikeiiohyousurumekishikonoshukujitsu"
+        ]
+      },
+      {
+        "en": "Spanish funeral rite",
+        "ja": "すぺいんのそうぎのぎしき",
+        "ja_typings": [
+          "supeinnosoginogishiki",
+          "supeinnosouginogishiki"
+        ]
+      },
+      {
+        "en": "Halloween-inspired festival",
+        "ja": "はろうぃんにもとづくまつり",
+        "ja_typings": [
+          "harowinnimotozukumatsuri"
+        ]
+      },
+      {
+        "en": "South American harvest day",
+        "ja": "なんべいのしゅうかくのひ",
+        "ja_typings": [
+          "nanbeinoshuukakunohi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00788",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Day of the Dead (Día de los Muertos)?",
+      "ja": "しゃのひ（でぃーあでろすむえるとす）とは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Japanese art of paper folding",
+        "ja": "かみをおるにほんのげいじゅつ",
+        "ja_typings": [
+          "kamiorunihonnogeijutsu",
+          "kamioorunihonnogeijutsu"
+        ]
+      },
+      {
+        "en": "Chinese ink painting",
+        "ja": "ちゅうごくのすみえ",
+        "ja_typings": [
+          "chuugokunosumie"
+        ]
+      },
+      {
+        "en": "Korean pottery art",
+        "ja": "かんこくのとうじ",
+        "ja_typings": [
+          "kankokunotoji",
+          "kankokunotouji"
+        ]
+      },
+      {
+        "en": "Japanese wood carving",
+        "ja": "にほんのもくちょう",
+        "ja_typings": [
+          "nihonnomokucho",
+          "nihonnomokuchou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00789",
+    "image_path": null,
+    "question_text": {
+      "en": "What is origami?",
+      "ja": "おりがみとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Spring Festival",
+        "ja": "しゅんせつ",
+        "ja_typings": [
+          "shunsetsu"
+        ]
+      },
+      {
+        "en": "Moon Festival",
+        "ja": "つきまつり",
+        "ja_typings": [
+          "tsukimatsuri"
+        ]
+      },
+      {
+        "en": "Dragon Festival",
+        "ja": "りゅうまつり",
+        "ja_typings": [
+          "ryuumatsuri"
+        ]
+      },
+      {
+        "en": "Harvest Festival",
+        "ja": "しゅうかくまつり",
+        "ja_typings": [
+          "shuukakumatsuri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00790",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Chinese New Year also called?",
+      "ja": "ちゅうごくのしんねんはなんともいわれるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "soccer (football)",
+        "ja": "さっかーふっとぼーる",
+        "ja_typings": [
+          "sakkafuttoboru"
+        ]
+      },
+      {
+        "en": "basketball",
+        "ja": "ばすけっとぼーる",
+        "ja_typings": [
+          "basukettoboru"
+        ]
+      },
+      {
+        "en": "cricket",
+        "ja": "くりけっと",
+        "ja_typings": [
+          "kuriketto"
+        ]
+      },
+      {
+        "en": "baseball",
+        "ja": "やきゅう",
+        "ja_typings": [
+          "yakyuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00791",
+    "image_path": null,
+    "question_text": {
+      "en": "What sport is most popular globally?",
+      "ja": "せかいでもっとものきんのすぽーつは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "kimono",
+        "ja": "きもの",
+        "ja_typings": [
+          "kimono"
+        ]
+      },
+      {
+        "en": "hanbok",
+        "ja": "はんぼく",
+        "ja_typings": [
+          "hanboku"
+        ]
+      },
+      {
+        "en": "cheongsam",
+        "ja": "ちょんさむ",
+        "ja_typings": [
+          "chonsamu"
+        ]
+      },
+      {
+        "en": "sari",
+        "ja": "さりー",
+        "ja_typings": [
+          "sari"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00792",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the traditional clothing of Japan?",
+      "ja": "にほんのでんとうてきなぎは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ancient Indian practice of mind and body",
+        "ja": "こだいいんどのこころとからだのしょう",
+        "ja_typings": [
+          "kodaiindonokokorotokaradanosho",
+          "kodaiindonokokorotokaradanoshou"
+        ]
+      },
+      {
+        "en": "Chinese martial art",
+        "ja": "ちゅうごくのぶどう",
+        "ja_typings": [
+          "chuugokunobudo",
+          "chuugokunobudou"
+        ]
+      },
+      {
+        "en": "Japanese meditation technique",
+        "ja": "にほんのめでぃてーしょんぎほう",
+        "ja_typings": [
+          "nihonnomediteshongiho",
+          "nihonnomediteshongihou"
+        ]
+      },
+      {
+        "en": "Korean breathing exercise",
+        "ja": "かんこくのこきゅうたいそう",
+        "ja_typings": [
+          "kankokunokokyuutaiso",
+          "kankokunokokyuutaisou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00793",
+    "image_path": null,
+    "question_text": {
+      "en": "What is yoga?",
+      "ja": "よがとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Korean fermented vegetable dish",
+        "ja": "かんこくのはっこうやさいりょうり",
+        "ja_typings": [
+          "kankokunohakkoyasairyori",
+          "kankokunohakkouyasairyouri"
+        ]
+      },
+      {
+        "en": "Japanese pickled vegetables",
+        "ja": "にほんのつけもの",
+        "ja_typings": [
+          "nihonnotsukemono"
+        ]
+      },
+      {
+        "en": "Chinese noodle dish",
+        "ja": "ちゅうごくのめんりょうり",
+        "ja_typings": [
+          "chuugokunomenryori",
+          "chuugokunomenryouri"
+        ]
+      },
+      {
+        "en": "Thai spicy soup",
+        "ja": "たいのからいすーぷ",
+        "ja_typings": [
+          "tainokaraisupu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00794",
+    "image_path": null,
+    "question_text": {
+      "en": "What is kimchi?",
+      "ja": "きむちとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "respectful greeting in Hindu culture",
+        "ja": "ひんどぅーぶんかのそんけいのあいさつ",
+        "ja_typings": [
+          "hindubunkanosonkeinoaisatsu"
+        ]
+      },
+      {
+        "en": "goodbye in Japanese",
+        "ja": "にほんごのさようなら",
+        "ja_typings": [
+          "nihongonosayonara",
+          "nihongonosayounara"
+        ]
+      },
+      {
+        "en": "thank you in Arabic",
+        "ja": "あらびあごのありがとう",
+        "ja_typings": [
+          "arabiagonoarigato",
+          "arabiagonoarigatou"
+        ]
+      },
+      {
+        "en": "good morning in Swahili",
+        "ja": "すわひりごのおはよう",
+        "ja_typings": [
+          "suwahirigonohayo",
+          "suwahirigonoohayou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00795",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the meaning of 'namaste'?",
+      "ja": "なますてのいみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Italy",
+        "ja": "いたりあ",
+        "ja_typings": [
+          "itaria"
+        ]
+      },
+      {
+        "en": "China",
+        "ja": "ちゅうごく",
+        "ja_typings": [
+          "chuugoku"
+        ]
+      },
+      {
+        "en": "France",
+        "ja": "ふらんす",
+        "ja_typings": [
+          "furansu"
+        ]
+      },
+      {
+        "en": "Spain",
+        "ja": "すぺいん",
+        "ja_typings": [
+          "supein"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00796",
+    "image_path": null,
+    "question_text": {
+      "en": "What country did pasta originally come from?",
+      "ja": "ぱすたのげんちはどこ？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "famous painting by Leonardo da Vinci",
+        "ja": "れおなるど・だ・ゔぃんちのゆうめいなえ",
+        "ja_typings": [
+          "reonarudo da vinchinoyuumeinae"
+        ]
+      },
+      {
+        "en": "ancient Greek sculpture",
+        "ja": "こだいぎりしあのちょうこく",
+        "ja_typings": [
+          "kodaigirishianochokoku",
+          "kodaigirishianochoukoku"
+        ]
+      },
+      {
+        "en": "Renaissance building",
+        "ja": "るねっさんすけんちく",
+        "ja_typings": [
+          "runessansukenchiku"
+        ]
+      },
+      {
+        "en": "Egyptian artifact",
+        "ja": "えじぷとのこうぶつ",
+        "ja_typings": [
+          "ejiputonokobutsu",
+          "ejiputonokoubutsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00797",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Mona Lisa?",
+      "ja": "もなりざとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "mausoleum in India",
+        "ja": "いんどのびょうびょう",
+        "ja_typings": [
+          "indonobyobyo",
+          "indonobyoubyou"
+        ]
+      },
+      {
+        "en": "temple in Thailand",
+        "ja": "たいのしんでん",
+        "ja_typings": [
+          "tainoshinden"
+        ]
+      },
+      {
+        "en": "palace in China",
+        "ja": "ちゅうごくのきゅうでん",
+        "ja_typings": [
+          "chuugokunokyuuden"
+        ]
+      },
+      {
+        "en": "fortress in Pakistan",
+        "ja": "ぱきすたんのとりで",
+        "ja_typings": [
+          "pakisutannotoride"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00798",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Taj Mahal?",
+      "ja": "たじまはるとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Russian nesting doll",
+        "ja": "ろしあのだるまにんぎょう",
+        "ja_typings": [
+          "roshianodarumaningyo",
+          "roshianodarumaningyou"
+        ]
+      },
+      {
+        "en": "Japanese puzzle box",
+        "ja": "にほんのひみつはこ",
+        "ja_typings": [
+          "nihonnohimitsuhako"
+        ]
+      },
+      {
+        "en": "Chinese porcelain figure",
+        "ja": "ちゅうごくのとうじにんぎょう",
+        "ja_typings": [
+          "chuugokunotojiningyo",
+          "chuugokunotoujiningyou"
+        ]
+      },
+      {
+        "en": "German wooden toy",
+        "ja": "どいつのもくせいおもちゃ",
+        "ja_typings": [
+          "doitsunomokuseiomocha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00799",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a matryoshka?",
+      "ja": "まとりょーしかとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "China",
+        "ja": "ちゅうごく",
+        "ja_typings": [
+          "chuugoku"
+        ]
+      },
+      {
+        "en": "India",
+        "ja": "いんど",
+        "ja_typings": [
+          "indo"
+        ]
+      },
+      {
+        "en": "Europe",
+        "ja": "ゆーろっぱ",
+        "ja_typings": [
+          "yuroppa"
+        ]
+      },
+      {
+        "en": "Middle East",
+        "ja": "ちゅうとう",
+        "ja_typings": [
+          "chuuto",
+          "chuutou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00800",
+    "image_path": null,
+    "question_text": {
+      "en": "What country is known for inventing gunpowder?",
+      "ja": "かやくをはつめいしたとされるくには？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "decorative handwriting or lettering",
+        "ja": "かざりもじのてがき",
+        "ja_typings": [
+          "kazarimojinotegaki"
+        ]
+      },
+      {
+        "en": "painted silk art",
+        "ja": "ぬのにえをかくげいじゅつ",
+        "ja_typings": [
+          "nunonieokakugeijutsu"
+        ]
+      },
+      {
+        "en": "stone carving art",
+        "ja": "いしぼりのげいじゅつ",
+        "ja_typings": [
+          "ishiborinogeijutsu"
+        ]
+      },
+      {
+        "en": "weaving pattern art",
+        "ja": "おりものもようのげいじゅつ",
+        "ja_typings": [
+          "orimonomoyonogeijutsu",
+          "orimonomoyounogeijutsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00801",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the art of calligraphy?",
+      "ja": "しょどうとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Japanese warrior class",
+        "ja": "にほんのぶし",
+        "ja_typings": [
+          "nihonnobushi"
+        ]
+      },
+      {
+        "en": "Chinese noble class",
+        "ja": "ちゅうごくのきぞく",
+        "ja_typings": [
+          "chuugokunokizoku"
+        ]
+      },
+      {
+        "en": "Korean royal guard",
+        "ja": "かんこくのきんえいたい",
+        "ja_typings": [
+          "kankokunokineitai"
+        ]
+      },
+      {
+        "en": "Mongolian cavalry soldier",
+        "ja": "もうこのきへいへいし",
+        "ja_typings": [
+          "mokonokiheiheishi",
+          "moukonokiheiheishi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00802",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a samurai?",
+      "ja": "さむらいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "symbol of Olympic games",
+        "ja": "おりんぴっくのしょうちょう",
+        "ja_typings": [
+          "orinpikkunoshocho",
+          "orinpikkunoshouchou"
+        ]
+      },
+      {
+        "en": "torch used to signal race start",
+        "ja": "れーすのすたーとのしんごうたいまつ",
+        "ja_typings": [
+          "resunosutatonoshingotaimatsu",
+          "resunosutatonoshingoutaimatsu"
+        ]
+      },
+      {
+        "en": "fire kept in ancient Rome",
+        "ja": "こだいろーまでともされたひ",
+        "ja_typings": [
+          "kodairomadetomosaretahi"
+        ]
+      },
+      {
+        "en": "eternal flame of peace",
+        "ja": "えいきゅうへいわのほのお",
+        "ja_typings": [
+          "eikyuuheiwanohono",
+          "eikyuuheiwanohonoo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00803",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Olympic flame?",
+      "ja": "おりんぴっくのほのおとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Japanese style comics",
+        "ja": "にほんすたいるのまんが",
+        "ja_typings": [
+          "nihonsutairunomanga"
+        ]
+      },
+      {
+        "en": "Korean animation",
+        "ja": "かんこくのあにめ",
+        "ja_typings": [
+          "kankokunoanime"
+        ]
+      },
+      {
+        "en": "Chinese illustrated novel",
+        "ja": "ちゅうごくのさしえしょうせつ",
+        "ja_typings": [
+          "chuugokunosashieshosetsu",
+          "chuugokunosashieshousetsu"
+        ]
+      },
+      {
+        "en": "Japanese film genre",
+        "ja": "にほんのえいがじゃんる",
+        "ja_typings": [
+          "nihonnoeigajanru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00804",
+    "image_path": null,
+    "question_text": {
+      "en": "What is manga?",
+      "ja": "まんがとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "urban culture with rap, DJing, breakdancing",
+        "ja": "らっぷ、でぃーじぇい、ぶれいくだんすのあーばんぶんか",
+        "ja_typings": [
+          "rappu dijei bureikudansunoabanbunka"
+        ]
+      },
+      {
+        "en": "Japanese street fashion",
+        "ja": "にほんのすとりーとふぁっしょん",
+        "ja_typings": [
+          "nihonnosutoritofasshon"
+        ]
+      },
+      {
+        "en": "Latin music movement",
+        "ja": "らてんおんがくのうんどう",
+        "ja_typings": [
+          "ratenongakunondo",
+          "ratenongakunoundou"
+        ]
+      },
+      {
+        "en": "European folk culture revival",
+        "ja": "ゆーろっぱのみんぞくぶんかのふっかつ",
+        "ja_typings": [
+          "yuroppanominzokubunkanofukkatsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00805",
+    "image_path": null,
+    "question_text": {
+      "en": "What is hip-hop culture?",
+      "ja": "ひっぷほっぷぶんかとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "7",
+        "ja": "なな",
+        "ja_typings": [
+          "nana"
+        ]
+      },
+      {
+        "en": "6",
+        "ja": "ろく",
+        "ja_typings": [
+          "roku"
+        ]
+      },
+      {
+        "en": "5",
+        "ja": "ご",
+        "ja_typings": [
+          "go"
+        ]
+      },
+      {
+        "en": "8",
+        "ja": "はち",
+        "ja_typings": [
+          "hachi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00806",
+    "image_path": null,
+    "question_text": {
+      "en": "How many continents are there on Earth?",
+      "ja": "ちきゅうにはいくつのたいりくがあるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pacific Ocean",
+        "ja": "たいへいよう",
+        "ja_typings": [
+          "taiheiyo",
+          "taiheiyou"
+        ]
+      },
+      {
+        "en": "Atlantic Ocean",
+        "ja": "たいせいよう",
+        "ja_typings": [
+          "taiseiyo",
+          "taiseiyou"
+        ]
+      },
+      {
+        "en": "Indian Ocean",
+        "ja": "いんどよう",
+        "ja_typings": [
+          "indoyo",
+          "indoyou"
+        ]
+      },
+      {
+        "en": "Arctic Ocean",
+        "ja": "ほっきょくかい",
+        "ja_typings": [
+          "hokkyokukai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00807",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the largest ocean?",
+      "ja": "もっともおおきなうみは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "366",
+        "ja": "さんびゃくろくじゅうろく",
+        "ja_typings": [
+          "sanbyakurokujuuroku"
+        ]
+      },
+      {
+        "en": "365",
+        "ja": "さんびゃくろくじゅうご",
+        "ja_typings": [
+          "sanbyakurokujuugo"
+        ]
+      },
+      {
+        "en": "367",
+        "ja": "さんびゃくろくじゅうなな",
+        "ja_typings": [
+          "sanbyakurokujuunana"
+        ]
+      },
+      {
+        "en": "364",
+        "ja": "さんびゃくろくじゅうし",
+        "ja_typings": [
+          "sanbyakurokujuushi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00808",
+    "image_path": null,
+    "question_text": {
+      "en": "How many days are in a leap year?",
+      "ja": "うるうどしはなんにち？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Au",
+        "ja": "おーゆー",
+        "ja_typings": [
+          "oyu"
+        ]
+      },
+      {
+        "en": "Go",
+        "ja": "じーおー",
+        "ja_typings": [
+          "jio"
+        ]
+      },
+      {
+        "en": "Gd",
+        "ja": "じーでぃー",
+        "ja_typings": [
+          "jidi"
+        ]
+      },
+      {
+        "en": "Ag",
+        "ja": "えーじー",
+        "ja_typings": [
+          "eji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00809",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the chemical symbol for gold?",
+      "ja": "きんのかがくきごうは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mount Everest",
+        "ja": "えべれすとさん",
+        "ja_typings": [
+          "eberesutosan"
+        ]
+      },
+      {
+        "en": "K2",
+        "ja": "けーつー",
+        "ja_typings": [
+          "ketsu"
+        ]
+      },
+      {
+        "en": "Kilimanjaro",
+        "ja": "きりまんじゃろ",
+        "ja_typings": [
+          "kirimanjaro"
+        ]
+      },
+      {
+        "en": "Mont Blanc",
+        "ja": "もんぶらん",
+        "ja_typings": [
+          "monburan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00810",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the tallest mountain in the world?",
+      "ja": "せかいでもっともたかいやまは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "206",
+        "ja": "にひゃくろく",
+        "ja_typings": [
+          "nihyakuroku"
+        ]
+      },
+      {
+        "en": "206",
+        "ja": "にひゃくろく",
+        "ja_typings": [
+          "nihyakuroku"
+        ]
+      },
+      {
+        "en": "198",
+        "ja": "ひゃくきゅうじゅうはち",
+        "ja_typings": [
+          "hyakukyuujuuhachi"
+        ]
+      },
+      {
+        "en": "213",
+        "ja": "にひゃくじゅうさん",
+        "ja_typings": [
+          "nihyakujuusan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00811",
+    "image_path": null,
+    "question_text": {
+      "en": "How many bones are in the adult human body?",
+      "ja": "おとなのにんげんのほねはいくつ？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "about 300,000 km/s",
+        "ja": "やく30まんきろ/びょう",
+        "ja_typings": [
+          "yaku30mankiro/byo",
+          "yaku30mankiro/byou"
+        ]
+      },
+      {
+        "en": "about 150,000 km/s",
+        "ja": "やく15まんきろ/びょう",
+        "ja_typings": [
+          "yaku15mankiro/byo",
+          "yaku15mankiro/byou"
+        ]
+      },
+      {
+        "en": "about 600,000 km/s",
+        "ja": "やく60まんきろ/びょう",
+        "ja_typings": [
+          "yaku60mankiro/byo",
+          "yaku60mankiro/byou"
+        ]
+      },
+      {
+        "en": "about 100,000 km/s",
+        "ja": "やく10まんきろ/びょう",
+        "ja_typings": [
+          "yaku10mankiro/byo",
+          "yaku10mankiro/byou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00812",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the speed of light?",
+      "ja": "ひかりのそくどは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "8",
+        "ja": "はち",
+        "ja_typings": [
+          "hachi"
+        ]
+      },
+      {
+        "en": "9",
+        "ja": "きゅう",
+        "ja_typings": [
+          "kyuu"
+        ]
+      },
+      {
+        "en": "7",
+        "ja": "なな",
+        "ja_typings": [
+          "nana"
+        ]
+      },
+      {
+        "en": "10",
+        "ja": "じゅう",
+        "ja_typings": [
+          "juu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00813",
+    "image_path": null,
+    "question_text": {
+      "en": "How many planets are in our solar system?",
+      "ja": "たいようけいにはなんこのわくせいがあるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "carbon dioxide",
+        "ja": "にさんかたんそ",
+        "ja_typings": [
+          "nisankatanso"
+        ]
+      },
+      {
+        "en": "oxygen",
+        "ja": "さんそ",
+        "ja_typings": [
+          "sanso"
+        ]
+      },
+      {
+        "en": "nitrogen",
+        "ja": "ちっそ",
+        "ja_typings": [
+          "chisso"
+        ]
+      },
+      {
+        "en": "hydrogen",
+        "ja": "すいそ",
+        "ja_typings": [
+          "suiso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00814",
+    "image_path": null,
+    "question_text": {
+      "en": "What gas do plants absorb from the air?",
+      "ja": "しょくぶつはくうきからなにをきゅうしゅうするか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Russia",
+        "ja": "ろしあ",
+        "ja_typings": [
+          "roshia"
+        ]
+      },
+      {
+        "en": "Canada",
+        "ja": "かなだ",
+        "ja_typings": [
+          "kanada"
+        ]
+      },
+      {
+        "en": "USA",
+        "ja": "あめりか",
+        "ja_typings": [
+          "amerika"
+        ]
+      },
+      {
+        "en": "China",
+        "ja": "ちゅうごく",
+        "ja_typings": [
+          "chuugoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00815",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the largest country by area?",
+      "ja": "めんせきでもっともおおきなくには？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Canberra",
+        "ja": "きゃんべら",
+        "ja_typings": [
+          "kyanbera"
+        ]
+      },
+      {
         "en": "Sydney",
-        "ja": "シドニー",
+        "ja": "しどにー",
         "ja_typings": [
           "shidoni"
         ]
       },
       {
         "en": "Melbourne",
-        "ja": "メルボルン",
+        "ja": "めるぼるん",
         "ja_typings": [
           "meruborun"
         ]
       },
       {
-        "en": "Canberra",
-        "ja": "キャンベラ",
-        "ja_typings": [
-          "kyanbera"
-        ]
-      },
-      {
         "en": "Brisbane",
-        "ja": "ブリスベン",
+        "ja": "ぶりすべん",
         "ja_typings": [
           "burisuben"
         ]
       }
     ],
-    "correct_answer_index": 2,
-    "genre": "geography",
-    "id": "q00098",
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00816",
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Australia?",
-      "ja": "オーストラリアのしゅとは?"
-    }
-  },
-  {
-    "choices": [
-    {
-      "en": "Galileo",
-      "ja": "ガリレオ",
-      "ja_typings": [
-        "garireo",
-        "galileo"
-      ]
-    },
-    {
-      "en": "Newton",
-      "ja": "ニュートン",
-      "ja_typings": [
-        "nyuton",
-        "newton"
-      ]
-    },
-    {
-      "en": "Einstein",
-      "ja": "アインシュタイン",
-      "ja_typings": [
-        "ainshutain",
-        "einstein"
-      ]
-    },
-    {
-      "en": "Hawking",
-      "ja": "ホーキング",
-      "ja_typings": [
-        "hokingu",
-        "hawking"
-      ]
-    }
-    ],
-    "correct_answer_index": 1,
-    "genre": "science",
-    "id": "q00099",
-    "image_path": null,
-    "question_text": {
-      "en": "Who discovered gravity?",
-      "ja": "じゅうりょくをはっけんしたのは?"
+      "ja": "おーすとらりあのしゅとは？"
     }
   },
   {
     "choices": [
       {
-        "en": "360",
-        "ja": "360",
+        "en": "largest river by discharge volume",
+        "ja": "りゅうりょうせかいさいだいのかわ",
         "ja_typings": [
-          "360"
+          "ryuuryosekaisaidainokawa",
+          "ryuuryousekaisaidainokawa"
         ]
       },
       {
-        "en": "365",
-        "ja": "365",
+        "en": "longest river in the world",
+        "ja": "せかいさいちょうのかわ",
         "ja_typings": [
-          "365"
+          "sekaisaichonokawa",
+          "sekaisaichounokawa"
         ]
       },
       {
-        "en": "366",
-        "ja": "366",
+        "en": "deepest river",
+        "ja": "もっともふかいかわ",
         "ja_typings": [
-          "366"
+          "mottomofukaikawa"
         ]
       },
       {
-        "en": "400",
-        "ja": "400",
+        "en": "fastest flowing river",
+        "ja": "もっともながれのはやいかわ",
         "ja_typings": [
-          "400"
+          "mottomonagarenohayaikawa"
         ]
       }
     ],
-    "correct_answer_index": 1,
+    "correct_answer_index": 0,
     "genre": "general_knowledge",
-    "id": "q00100",
+    "id": "q00817",
     "image_path": null,
     "question_text": {
-      "en": "How many days are in a year?",
-      "ja": "いちねんはなんにち?"
+      "en": "What is the Amazon River known for?",
+      "ja": "あまぞんがわはなにでゆうめい？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "diamond",
+        "ja": "だいやもんど",
+        "ja_typings": [
+          "daiyamondo"
+        ]
+      },
+      {
+        "en": "quartz",
+        "ja": "すいしょう",
+        "ja_typings": [
+          "suisho",
+          "suishou"
+        ]
+      },
+      {
+        "en": "corundum",
+        "ja": "こらんだむ",
+        "ja_typings": [
+          "korandamu"
+        ]
+      },
+      {
+        "en": "topaz",
+        "ja": "とぱーず",
+        "ja_typings": [
+          "topazu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00818",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the hardest natural substance?",
+      "ja": "しぜんかいでもっともかたいぶっしつは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "4",
+        "ja": "よん",
+        "ja_typings": [
+          "yon"
+        ]
+      },
+      {
+        "en": "2",
+        "ja": "に",
+        "ja_typings": [
+          "ni"
+        ]
+      },
+      {
+        "en": "3",
+        "ja": "さん",
+        "ja_typings": [
+          "san"
+        ]
+      },
+      {
+        "en": "6",
+        "ja": "ろく",
+        "ja_typings": [
+          "roku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00819",
+    "image_path": null,
+    "question_text": {
+      "en": "How many chambers does a human heart have?",
+      "ja": "にんげんのこころはいくつのへやにわかれているか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "yen",
+        "ja": "えん",
+        "ja_typings": [
+          "en"
+        ]
+      },
+      {
+        "en": "won",
+        "ja": "うぉん",
+        "ja_typings": [
+          "won"
+        ]
+      },
+      {
+        "en": "yuan",
+        "ja": "げん",
+        "ja_typings": [
+          "gen"
+        ]
+      },
+      {
+        "en": "baht",
+        "ja": "ばーつ",
+        "ja_typings": [
+          "batsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00820",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the currency of Japan?",
+      "ja": "にほんのつうかは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sahara",
+        "ja": "さはら",
+        "ja_typings": [
+          "sahara"
+        ]
+      },
+      {
+        "en": "Gobi",
+        "ja": "ごびさばく",
+        "ja_typings": [
+          "gobisabaku"
+        ]
+      },
+      {
+        "en": "Arabian",
+        "ja": "あらびあさばく",
+        "ja_typings": [
+          "arabiasabaku"
+        ]
+      },
+      {
+        "en": "Antarctica",
+        "ja": "なんきょく",
+        "ja_typings": [
+          "nankyoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00821",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the largest desert in the world?",
+      "ja": "せかいさいだいのさばくは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1945",
+        "ja": "せんきゅうひゃくよんじゅうご",
+        "ja_typings": [
+          "senkyuuhyakuyonjuugo"
+        ]
+      },
+      {
+        "en": "1944",
+        "ja": "せんきゅうひゃくよんじゅうし",
+        "ja_typings": [
+          "senkyuuhyakuyonjuushi"
+        ]
+      },
+      {
+        "en": "1946",
+        "ja": "せんきゅうひゃくよんじゅうろく",
+        "ja_typings": [
+          "senkyuuhyakuyonjuuroku"
+        ]
+      },
+      {
+        "en": "1943",
+        "ja": "せんきゅうひゃくよんじゅうさん",
+        "ja_typings": [
+          "senkyuuhyakuyonjuusan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00822",
+    "image_path": null,
+    "question_text": {
+      "en": "What year did World War II end?",
+      "ja": "だいにじせかいたいせんはなんねんにおわったか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "100°C",
+        "ja": "ひゃくど",
+        "ja_typings": [
+          "hyakudo"
+        ]
+      },
+      {
+        "en": "90°C",
+        "ja": "きゅうじゅうど",
+        "ja_typings": [
+          "kyuujuudo"
+        ]
+      },
+      {
+        "en": "110°C",
+        "ja": "ひゃくじゅうど",
+        "ja_typings": [
+          "hyakujuudo"
+        ]
+      },
+      {
+        "en": "80°C",
+        "ja": "はちじゅうど",
+        "ja_typings": [
+          "hachijuudo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00823",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the boiling point of water at sea level?",
+      "ja": "かいめいでのみずのふってんは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "0°C",
+        "ja": "れいど",
+        "ja_typings": [
+          "reido"
+        ]
+      },
+      {
+        "en": "-10°C",
+        "ja": "まいなすじゅうど",
+        "ja_typings": [
+          "mainasujuudo"
+        ]
+      },
+      {
+        "en": "4°C",
+        "ja": "よんど",
+        "ja_typings": [
+          "yondo"
+        ]
+      },
+      {
+        "en": "10°C",
+        "ja": "じゅうど",
+        "ja_typings": [
+          "juudo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00824",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the freezing point of water?",
+      "ja": "みずのこおりはじめるおんどは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hydrogen",
+        "ja": "すいそ",
+        "ja_typings": [
+          "suiso"
+        ]
+      },
+      {
+        "en": "Helium",
+        "ja": "へりうむ",
+        "ja_typings": [
+          "heriumu"
+        ]
+      },
+      {
+        "en": "Lithium",
+        "ja": "りちうむ",
+        "ja_typings": [
+          "richiumu"
+        ]
+      },
+      {
+        "en": "Carbon",
+        "ja": "たんそ",
+        "ja_typings": [
+          "tanso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00825",
+    "image_path": null,
+    "question_text": {
+      "en": "What element has the atomic number 1?",
+      "ja": "げんしばんごう1のげんそは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "process by which plants make food from sunlight",
+        "ja": "しょくぶつがたいようのひかりからしょくもつをつくるかてい",
+        "ja_typings": [
+          "shokubutsugataiyonohikarikarashokumotsuotsukurukatei",
+          "shokubutsugataiyounohikarikarashokumotsuotsukurukatei"
+        ]
+      },
+      {
+        "en": "process of plant respiration",
+        "ja": "しょくぶつのこきゅうのかてい",
+        "ja_typings": [
+          "shokubutsunokokyuunokatei"
+        ]
+      },
+      {
+        "en": "process of plant reproduction",
+        "ja": "しょくぶつのはんしょくのかてい",
+        "ja_typings": [
+          "shokubutsunohanshokunokatei"
+        ]
+      },
+      {
+        "en": "process of nutrient absorption",
+        "ja": "えいようきゅうしゅうのかてい",
+        "ja_typings": [
+          "eiyokyuushuunokatei",
+          "eiyoukyuushuunokatei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00826",
+    "image_path": null,
+    "question_text": {
+      "en": "What is photosynthesis?",
+      "ja": "こうごうせいとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Spanish",
+        "ja": "すぺいんご",
+        "ja_typings": [
+          "supeingo"
+        ]
+      },
+      {
+        "en": "Portuguese",
+        "ja": "ぽるとがるご",
+        "ja_typings": [
+          "porutogarugo"
+        ]
+      },
+      {
+        "en": "Italian",
+        "ja": "いたりあご",
+        "ja_typings": [
+          "itariago"
+        ]
+      },
+      {
+        "en": "French",
+        "ja": "ふらんすご",
+        "ja_typings": [
+          "furansugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00827",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the main language spoken in Argentina?",
+      "ja": "あるぜんちんでつかわれるしゅのことばは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "femur (thigh bone)",
+        "ja": "だいたいこつ",
+        "ja_typings": [
+          "daitaikotsu"
+        ]
+      },
+      {
+        "en": "tibia (shin bone)",
+        "ja": "けいこつ",
+        "ja_typings": [
+          "keikotsu"
+        ]
+      },
+      {
+        "en": "humerus (upper arm)",
+        "ja": "じょうわんこつ",
+        "ja_typings": [
+          "jowankotsu",
+          "jouwankotsu"
+        ]
+      },
+      {
+        "en": "spine",
+        "ja": "せきちゅう",
+        "ja_typings": [
+          "sekichuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00828",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the longest bone in the human body?",
+      "ja": "にんげんのからだでもっともながいほねは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Alexander Graham Bell",
+        "ja": "あれくさんだー・ぐらはむ・べる",
+        "ja_typings": [
+          "arekusanda gurahamu beru"
+        ]
+      },
+      {
+        "en": "Thomas Edison",
+        "ja": "とーます・えじそん",
+        "ja_typings": [
+          "tomasu ejison"
+        ]
+      },
+      {
+        "en": "Nikola Tesla",
+        "ja": "にこら・てすら",
+        "ja_typings": [
+          "nikora tesura"
+        ]
+      },
+      {
+        "en": "Guglielmo Marconi",
+        "ja": "ぐりえるも・まるこーに",
+        "ja_typings": [
+          "gurierumo marukoni"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00829",
+    "image_path": null,
+    "question_text": {
+      "en": "Who invented the telephone?",
+      "ja": "でんわをはつめいしたのはだれ？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "nitrogen",
+        "ja": "ちっそ",
+        "ja_typings": [
+          "chisso"
+        ]
+      },
+      {
+        "en": "oxygen",
+        "ja": "さんそ",
+        "ja_typings": [
+          "sanso"
+        ]
+      },
+      {
+        "en": "carbon dioxide",
+        "ja": "にさんかたんそ",
+        "ja_typings": [
+          "nisankatanso"
+        ]
+      },
+      {
+        "en": "argon",
+        "ja": "あるごん",
+        "ja_typings": [
+          "arugon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00830",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the most abundant gas in Earth's atmosphere?",
+      "ja": "ちきゅうのたいきでもっともおおいきたいは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "16",
+        "ja": "じゅうろく",
+        "ja_typings": [
+          "juuroku"
+        ]
+      },
+      {
+        "en": "14",
+        "ja": "じゅうし",
+        "ja_typings": [
+          "juushi"
+        ]
+      },
+      {
+        "en": "18",
+        "ja": "じゅうはち",
+        "ja_typings": [
+          "juuhachi"
+        ]
+      },
+      {
+        "en": "12",
+        "ja": "じゅうに",
+        "ja_typings": [
+          "juuni"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00831",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the square root of 256?",
+      "ja": "256のへいほうこんは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "32",
+        "ja": "さんじゅうほんに",
+        "ja_typings": [
+          "sanjuuhonni"
+        ]
+      },
+      {
+        "en": "28",
+        "ja": "にじゅうはっぽん",
+        "ja_typings": [
+          "nijuuhappon"
+        ]
+      },
+      {
+        "en": "30",
+        "ja": "さんじゅっぽん",
+        "ja_typings": [
+          "sanjuppon"
+        ]
+      },
+      {
+        "en": "34",
+        "ja": "さんじゅうよんほん",
+        "ja_typings": [
+          "sanjuuyonhon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00832",
+    "image_path": null,
+    "question_text": {
+      "en": "How many teeth does an adult human have?",
+      "ja": "おとなのにんげんのはは何本？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jupiter",
+        "ja": "もくせい",
+        "ja_typings": [
+          "mokusei"
+        ]
+      },
+      {
+        "en": "Saturn",
+        "ja": "どせい",
+        "ja_typings": [
+          "dosei"
+        ]
+      },
+      {
+        "en": "Neptune",
+        "ja": "かいおうせい",
+        "ja_typings": [
+          "kaiosei",
+          "kaiousei"
+        ]
+      },
+      {
+        "en": "Uranus",
+        "ja": "てんのうせい",
+        "ja_typings": [
+          "tennosei",
+          "tennousei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00833",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the largest planet in our solar system?",
+      "ja": "たいようけいでもっともおおきいわくせいは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "O (oxygen)",
+        "ja": "おーさんそ",
+        "ja_typings": [
+          "osanso"
+        ]
+      },
+      {
+        "en": "Ox",
+        "ja": "おっくす",
+        "ja_typings": [
+          "okkusu"
+        ]
+      },
+      {
+        "en": "Og",
+        "ja": "おーじー",
+        "ja_typings": [
+          "oji"
+        ]
+      },
+      {
+        "en": "On",
+        "ja": "おーえぬ",
+        "ja_typings": [
+          "oenu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00834",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the symbol for the element oxygen?",
+      "ja": "さんそのげんそきごうは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mercury",
+        "ja": "すいせい",
+        "ja_typings": [
+          "suisei"
+        ]
+      },
+      {
+        "en": "Venus",
+        "ja": "きんせい",
+        "ja_typings": [
+          "kinsei"
+        ]
+      },
+      {
+        "en": "Earth",
+        "ja": "ちきゅう",
+        "ja_typings": [
+          "chikyuu"
+        ]
+      },
+      {
+        "en": "Mars",
+        "ja": "かせい",
+        "ja_typings": [
+          "kasei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00835",
+    "image_path": null,
+    "question_text": {
+      "en": "Which planet is closest to the sun?",
+      "ja": "もっともたいようにちかいわくせいは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vatican City",
+        "ja": "ばちかんしこっか",
+        "ja_typings": [
+          "bachikanshikokka"
+        ]
+      },
+      {
+        "en": "Monaco",
+        "ja": "もなこ",
+        "ja_typings": [
+          "monako"
+        ]
+      },
+      {
+        "en": "Liechtenstein",
+        "ja": "りひてんしゅたいん",
+        "ja_typings": [
+          "rihitenshutain"
+        ]
+      },
+      {
+        "en": "San Marino",
+        "ja": "さんまりの",
+        "ja_typings": [
+          "sanmarino"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00836",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the smallest country in the world?",
+      "ja": "せかいでもっともちいさなくには？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "6",
+        "ja": "ろく",
+        "ja_typings": [
+          "roku"
+        ]
+      },
+      {
+        "en": "4",
+        "ja": "よん",
+        "ja_typings": [
+          "yon"
+        ]
+      },
+      {
+        "en": "8",
+        "ja": "はち",
+        "ja_typings": [
+          "hachi"
+        ]
+      },
+      {
+        "en": "12",
+        "ja": "じゅうに",
+        "ja_typings": [
+          "juuni"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00837",
+    "image_path": null,
+    "question_text": {
+      "en": "How many strings does a standard guitar have?",
+      "ja": "ふつうのぎたーはなんほんのげんをもつか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Deoxyribonucleic Acid",
+        "ja": "でおきしりぼかくさん",
+        "ja_typings": [
+          "deokishiribokakusan"
+        ]
+      },
+      {
+        "en": "Dynamic Nucleic Acid",
+        "ja": "だいなみっくかくさん",
+        "ja_typings": [
+          "dainamikkukakusan"
+        ]
+      },
+      {
+        "en": "Deoxyribose Nuclease Acid",
+        "ja": "でおきしりぼーすかくさん",
+        "ja_typings": [
+          "deokishiribosukakusan"
+        ]
+      },
+      {
+        "en": "Double Nucleic Array",
+        "ja": "だぶるかくさんのはいれつ",
+        "ja_typings": [
+          "daburukakusannohairetsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00838",
+    "image_path": null,
+    "question_text": {
+      "en": "What does DNA stand for?",
+      "ja": "DNAのりゃくしょうのせいしきめいは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NaCl",
+        "ja": "えぬえーしーえる",
+        "ja_typings": [
+          "enueshieru"
+        ]
+      },
+      {
+        "en": "NaF",
+        "ja": "えぬえーえふ",
+        "ja_typings": [
+          "enueefu"
+        ]
+      },
+      {
+        "en": "KCl",
+        "ja": "けーしーえる",
+        "ja_typings": [
+          "keshieru"
+        ]
+      },
+      {
+        "en": "CaCl₂",
+        "ja": "しーえーしーえるに",
+        "ja_typings": [
+          "shieshieruni"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00839",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the chemical formula for table salt?",
+      "ja": "しょくえんのかがくしきは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sumo",
+        "ja": "すもう",
+        "ja_typings": [
+          "sumo",
+          "sumou"
+        ]
+      },
+      {
+        "en": "baseball",
+        "ja": "やきゅう",
+        "ja_typings": [
+          "yakyuu"
+        ]
+      },
+      {
+        "en": "judo",
+        "ja": "じゅうどう",
+        "ja_typings": [
+          "juudo",
+          "juudou"
+        ]
+      },
+      {
+        "en": "kendo",
+        "ja": "けんどう",
+        "ja_typings": [
+          "kendo",
+          "kendou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00840",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the national sport of Japan?",
+      "ja": "にほんのこくぎは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "earthquake magnitude",
+        "ja": "じしんのきぼ",
+        "ja_typings": [
+          "jishinnokibo"
+        ]
+      },
+      {
+        "en": "wind speed",
+        "ja": "ふうそく",
+        "ja_typings": [
+          "fuusoku"
+        ]
+      },
+      {
+        "en": "rainfall amount",
+        "ja": "こうすいりょう",
+        "ja_typings": [
+          "kosuiryo",
+          "kousuiryou"
+        ]
+      },
+      {
+        "en": "temperature",
+        "ja": "きおん",
+        "ja_typings": [
+          "kion"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00841",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the Richter scale measure?",
+      "ja": "りひたーすけーるはなにをはかるか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1969",
+        "ja": "せんきゅうひゃくろくじゅうきゅう",
+        "ja_typings": [
+          "senkyuuhyakurokujuukyuu"
+        ]
+      },
+      {
+        "en": "1967",
+        "ja": "せんきゅうひゃくろくじゅうなな",
+        "ja_typings": [
+          "senkyuuhyakurokujuunana"
+        ]
+      },
+      {
+        "en": "1971",
+        "ja": "せんきゅうひゃくななじゅういち",
+        "ja_typings": [
+          "senkyuuhyakunanajuuichi"
+        ]
+      },
+      {
+        "en": "1965",
+        "ja": "せんきゅうひゃくろくじゅうご",
+        "ja_typings": [
+          "senkyuuhyakurokujuugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00842",
+    "image_path": null,
+    "question_text": {
+      "en": "What year did the first moon landing occur?",
+      "ja": "はつのつきへのちゃくりくはなんねん？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fe",
+        "ja": "えふいー",
+        "ja_typings": [
+          "efui"
+        ]
+      },
+      {
+        "en": "Ir",
+        "ja": "あいあーる",
+        "ja_typings": [
+          "aiaru"
+        ]
+      },
+      {
+        "en": "In",
+        "ja": "あいえぬ",
+        "ja_typings": [
+          "aienu"
+        ]
+      },
+      {
+        "en": "Ie",
+        "ja": "あいいー",
+        "ja_typings": [
+          "aii"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00843",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the symbol for the element iron?",
+      "ja": "てつのげんそきごうは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sperm whale",
+        "ja": "まっこうくじら",
+        "ja_typings": [
+          "makkokujira",
+          "makkoukujira"
+        ]
+      },
+      {
+        "en": "blue whale",
+        "ja": "しろながすくじら",
+        "ja_typings": [
+          "shironagasukujira"
+        ]
+      },
+      {
+        "en": "elephant",
+        "ja": "ぞう",
+        "ja_typings": [
+          "zo",
+          "zou"
+        ]
+      },
+      {
+        "en": "howler monkey",
+        "ja": "ほえざる",
+        "ja_typings": [
+          "hoezaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00844",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the loudest animal on Earth?",
+      "ja": "ちきゅうでもっともおおきなこえをだすどうぶつは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ampere",
+        "ja": "あんぺあ",
+        "ja_typings": [
+          "anpea"
+        ]
+      },
+      {
+        "en": "volt",
+        "ja": "ぼると",
+        "ja_typings": [
+          "boruto"
+        ]
+      },
+      {
+        "en": "watt",
+        "ja": "わっと",
+        "ja_typings": [
+          "watto"
+        ]
+      },
+      {
+        "en": "ohm",
+        "ja": "おーむ",
+        "ja_typings": [
+          "omu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q00845",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the unit of electric current?",
+      "ja": "でんりゅうのたんいは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "virtual YouTuber using avatar",
+        "ja": "あばたーをつかうばーちゃるゆーちゅーばー",
+        "ja_typings": [
+          "abataotsukaubacharuyuchuba"
+        ]
+      },
+      {
+        "en": "video game streamer",
+        "ja": "びでおげーむすとりーまー",
+        "ja_typings": [
+          "bideogemusutorima"
+        ]
+      },
+      {
+        "en": "virtual reality developer",
+        "ja": "ばーちゃるりありてぃかいはつしゃ",
+        "ja_typings": [
+          "bacharuriaritikaihatsusha"
+        ]
+      },
+      {
+        "en": "music video creator",
+        "ja": "みゅーじっくびでおくりえいたー",
+        "ja_typings": [
+          "myujikkubideokurieita"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00846",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a VTuber?",
+      "ja": "ぶいちゅーばーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cover Corp",
+        "ja": "かばーこーぽれーしょん",
+        "ja_typings": [
+          "kabakoporeshon"
+        ]
+      },
+      {
+        "en": "Nijisanji",
+        "ja": "にじさんじ",
+        "ja_typings": [
+          "nijisanji"
+        ]
+      },
+      {
+        "en": "Sony Music",
+        "ja": "そにーみゅーじっく",
+        "ja_typings": [
+          "sonimyujikku"
+        ]
+      },
+      {
+        "en": "Kadokawa",
+        "ja": "かどかわ",
+        "ja_typings": [
+          "kadokawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00847",
+    "image_path": null,
+    "question_text": {
+      "en": "What company is Hololive associated with?",
+      "ja": "ほろらいぶはどのかいしゃ？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "VTuber agency by Anycolor",
+        "ja": "えにーからーのぶいちゅーばーじむしょ",
+        "ja_typings": [
+          "enikaranobuichubajimusho"
+        ]
+      },
+      {
+        "en": "anime production studio",
+        "ja": "あにめせいさくすたじお",
+        "ja_typings": [
+          "animeseisakusutajio"
+        ]
+      },
+      {
+        "en": "game development company",
+        "ja": "げーむかいはつかいしゃ",
+        "ja_typings": [
+          "gemukaihatsukaisha"
+        ]
+      },
+      {
+        "en": "music label",
+        "ja": "おんがくれーべる",
+        "ja_typings": [
+          "ongakureberu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00848",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Nijisanji?",
+      "ja": "にじさんじとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "overseas fans",
+        "ja": "かいがいのふぁん",
+        "ja_typings": [
+          "kaigainofan"
+        ]
+      },
+      {
+        "en": "Japanese idol fans",
+        "ja": "にほんのあいどるふぁん",
+        "ja_typings": [
+          "nihonnoaidorufan"
+        ]
+      },
+      {
+        "en": "anime reviewers",
+        "ja": "あにめひょうろんか",
+        "ja_typings": [
+          "animehyoronka",
+          "animehyouronka"
+        ]
+      },
+      {
+        "en": "foreign critics",
+        "ja": "がいこくのひひょうか",
+        "ja_typings": [
+          "gaikokunohihyoka",
+          "gaikokunohihyouka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00849",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'kaigai niki' mean?",
+      "ja": "かいがいにきとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "paid donation message on YouTube",
+        "ja": "ゆーちゅーぶでのゆうりょうきふめっせーじ",
+        "ja_typings": [
+          "yuchubudenoyuuryokifumesseji",
+          "yuchubudenoyuuryoukifumesseji"
+        ]
+      },
+      {
+        "en": "premium subscription plan",
+        "ja": "ぷれみあむさぶすくりぷしょん",
+        "ja_typings": [
+          "puremiamusabusukuripushon"
+        ]
+      },
+      {
+        "en": "exclusive fan club",
+        "ja": "せんようふぁんくらぶ",
+        "ja_typings": [
+          "senyofankurabu",
+          "senyoufankurabu"
+        ]
+      },
+      {
+        "en": "live concert ticket",
+        "ja": "らいぶこんさーとちけっと",
+        "ja_typings": [
+          "raibukonsatochiketto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00850",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'superchat'?",
+      "ja": "すーぱーちゃっととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "revealing someone's private info online",
+        "ja": "ひとのしんじょうをねっとにばらすこと",
+        "ja_typings": [
+          "hitonoshinjoonettonibarasukoto",
+          "hitonoshinjouonettonibarasukoto"
+        ]
+      },
+      {
+        "en": "deleting account data",
+        "ja": "あかうんとでーたのさくじょ",
+        "ja_typings": [
+          "akauntodetanosakujo"
+        ]
+      },
+      {
+        "en": "sending spam messages",
+        "ja": "すぱむめっせーじのそうしん",
+        "ja_typings": [
+          "supamumessejinososhin",
+          "supamumessejinosoushin"
+        ]
+      },
+      {
+        "en": "mass following on social media",
+        "ja": "すーしゃるめでぃあでたいりょうふぉろー",
+        "ja_typings": [
+          "susharumediadetairyoforo",
+          "susharumediadetairyouforo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00851",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'doxxing'?",
+      "ja": "どっくしんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Good Game",
+        "ja": "ぐっどげーむ",
+        "ja_typings": [
+          "guddogemu"
+        ]
+      },
+      {
+        "en": "Get Good",
+        "ja": "げっとぐっど",
+        "ja_typings": [
+          "gettoguddo"
+        ]
+      },
+      {
+        "en": "Game Goal",
+        "ja": "げーむごーる",
+        "ja_typings": [
+          "gemugoru"
+        ]
+      },
+      {
+        "en": "Gear Group",
+        "ja": "ぎあぐるーぷ",
+        "ja_typings": [
+          "giagurupu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00852",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'GG' stand for in gaming?",
+      "ja": "げーみんぐでGGとはどういういみ？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "broadcasting live content online",
+        "ja": "おんらいんでらいぶこんてんつをほうそうすること",
+        "ja_typings": [
+          "onrainderaibukontentsuohososurukoto",
+          "onrainderaibukontentsuohousousurukoto"
+        ]
+      },
+      {
+        "en": "downloading large files",
+        "ja": "だいきなふぁいるのだうんろーど",
+        "ja_typings": [
+          "daikinafairunodaunrodo"
+        ]
+      },
+      {
+        "en": "editing video content",
+        "ja": "びでおこんてんつのへんしゅう",
+        "ja_typings": [
+          "bideokontentsunohenshuu"
+        ]
+      },
+      {
+        "en": "uploading to video archive",
+        "ja": "びでおあーかいぶへのあっぷろーど",
+        "ja_typings": [
+          "bideoakaibuhenoappurodo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00853",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'streaming'?",
+      "ja": "すとりーみんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "short edited portion of a stream",
+        "ja": "すとりーむのみじかくへんしゅうしたぶぶん",
+        "ja_typings": [
+          "sutorimunomijikakuhenshuushitabubun"
+        ]
+      },
+      {
+        "en": "full archive recording",
+        "ja": "かんぜんなあーかいぶろくが",
+        "ja_typings": [
+          "kanzennaakaiburokuga"
+        ]
+      },
+      {
+        "en": "official music video",
+        "ja": "こうしきみゅーじっくびでお",
+        "ja_typings": [
+          "koshikimyujikkubideo",
+          "koushikimyujikkubideo"
+        ]
+      },
+      {
+        "en": "original game soundtrack",
+        "ja": "げーむのおりじなるさうんどとらっく",
+        "ja_typings": [
+          "gemunorijinarusaundotorakku",
+          "gemunoorijinarusaundotorakku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00854",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'clip' in VTuber culture?",
+      "ja": "ぶいちゅーばーぶんかでのくりっぷとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "artwork created by fans of a character",
+        "ja": "きゃらくたーのふぁんがつくったえ",
+        "ja_typings": [
+          "kyarakutanofangatsukuttae"
+        ]
+      },
+      {
+        "en": "official promotional art",
+        "ja": "こうしきぷろもーしょんあーと",
+        "ja_typings": [
+          "koshikipuromoshonato",
+          "koushikipuromoshonato"
+        ]
+      },
+      {
+        "en": "AI-generated images",
+        "ja": "えーあいがせいせいしたがぞう",
+        "ja_typings": [
+          "eaigaseiseishitagazo",
+          "eaigaseiseishitagazou"
+        ]
+      },
+      {
+        "en": "commercial illustration",
+        "ja": "しょうぎょうてきいらすと",
+        "ja_typings": [
+          "shogyotekiirasuto",
+          "shougyoutekiirasuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00855",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'fan art'?",
+      "ja": "ふぁんあーととは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "live streaming platform",
+        "ja": "らいぶすとりーみんぐぷらっとふぉーむ",
+        "ja_typings": [
+          "raibusutorimingupurattofomu"
+        ]
+      },
+      {
+        "en": "social media platform",
+        "ja": "そーしゃるめでぃあぷらっとふぉーむ",
+        "ja_typings": [
+          "sosharumediapurattofomu"
+        ]
+      },
+      {
+        "en": "video sharing site",
+        "ja": "どうがきょうゆうさいと",
+        "ja_typings": [
+          "dogakyoyuusaito",
+          "dougakyouyuusaito"
+        ]
+      },
+      {
+        "en": "messaging app",
+        "ja": "めっせーじんぐあぷり",
+        "ja_typings": [
+          "messejinguapuri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00856",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Twitch?",
+      "ja": "ついっちとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "chat and voice platform for communities",
+        "ja": "こみゅにてぃのちゃっととぼいすぷらっとふぉーむ",
+        "ja_typings": [
+          "komyunitinochattotoboisupurattofomu"
+        ]
+      },
+      {
+        "en": "streaming platform",
+        "ja": "すとりーみんぐぷらっとふぉーむ",
+        "ja_typings": [
+          "sutorimingupurattofomu"
+        ]
+      },
+      {
+        "en": "game development tool",
+        "ja": "げーむかいはつつーる",
+        "ja_typings": [
+          "gemukaihatsutsuru"
+        ]
+      },
+      {
+        "en": "video editing software",
+        "ja": "びでおへんしゅうそふと",
+        "ja_typings": [
+          "bideohenshuusofuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00857",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Discord?",
+      "ja": "でぃすこーどとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "something controversial or embarrassing",
+        "ja": "こんとろばーしゃるまたははずかしいこと",
+        "ja_typings": [
+          "kontorobasharumatahahazukashiikoto"
+        ]
+      },
+      {
+        "en": "a great performance",
+        "ja": "すばらしいぱふぉーまんす",
+        "ja_typings": [
+          "subarashiipafomansu"
+        ]
+      },
+      {
+        "en": "a new debut",
+        "ja": "しんきでびゅー",
+        "ja_typings": [
+          "shinkidebyu"
+        ]
+      },
+      {
+        "en": "a popular song",
+        "ja": "にんきのうた",
+        "ja_typings": [
+          "ninkinota",
+          "ninkinouta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00858",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'yab' in VTuber slang?",
+      "ja": "ぶいちゅーばーすらんぐでやばいとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "first public stream",
+        "ja": "はじめてのこうかいすとりーむ",
+        "ja_typings": [
+          "hajimetenokokaisutorimu",
+          "hajimetenokoukaisutorimu"
+        ]
+      },
+      {
+        "en": "first solo concert",
+        "ja": "はじめてのそろこんさーと",
+        "ja_typings": [
+          "hajimetenosorokonsato"
+        ]
+      },
+      {
+        "en": "first merchandise release",
+        "ja": "はじめてのぐっずはんばい",
+        "ja_typings": [
+          "hajimetenoguzzuhanbai"
+        ]
+      },
+      {
+        "en": "first collaboration",
+        "ja": "はじめてのこらぼれーしょん",
+        "ja_typings": [
+          "hajimetenokoraboreshon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00859",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'debut' for a VTuber?",
+      "ja": "ぶいちゅーばーのでびゅーとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "dedicated superfan in Japanese internet culture",
+        "ja": "にほんのねっとぶんかでのねっしんなちょうふぁん",
+        "ja_typings": [
+          "nihonnonettobunkadenonesshinnachofan",
+          "nihonnonettobunkadenonesshinnachoufan"
+        ]
+      },
+      {
+        "en": "aggressive trolling",
+        "ja": "あぐれっしぶなとろーりんぐ",
+        "ja_typings": [
+          "aguresshibunatororingu"
+        ]
+      },
+      {
+        "en": "popular music genre",
+        "ja": "にんきのおんがくじゃんる",
+        "ja_typings": [
+          "ninkinongakujanru",
+          "ninkinoongakujanru"
+        ]
+      },
+      {
+        "en": "gaming achievement",
+        "ja": "げーみんぐのじつせき",
+        "ja_typings": [
+          "gemingunojitsuseki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00860",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'GachiBASS' mean?",
+      "ja": "がちばすとはどんないみ？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "software for animating 2D characters",
+        "ja": "2Dきゃらくたーをあにめーとするそふとうぇあ",
+        "ja_typings": [
+          "2dkyarakutaoanimetosurusofutowea"
+        ]
+      },
+      {
+        "en": "2D game engine",
+        "ja": "2Dげーむえんじん",
+        "ja_typings": [
+          "2dgemuenjin"
+        ]
+      },
+      {
+        "en": "video editing tool",
+        "ja": "びでおへんしゅうつーる",
+        "ja_typings": [
+          "bideohenshuutsuru"
+        ]
+      },
+      {
+        "en": "streaming plugin",
+        "ja": "すとりーみんぐぷらぐいん",
+        "ja_typings": [
+          "sutorimingupuraguin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00861",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'live2D'?",
+      "ja": "らいぶつーでぃーとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "paid subscription to a channel",
+        "ja": "ちゃんねるへのゆうりょうさぶすくりぷしょん",
+        "ja_typings": [
+          "channeruhenoyuuryosabusukuripushon",
+          "channeruhenoyuuryousabusukuripushon"
+        ]
+      },
+      {
+        "en": "free follower account",
+        "ja": "むりょうのふぉろわーあかうんと",
+        "ja_typings": [
+          "muryonoforowaakaunto",
+          "muryounoforowaakaunto"
+        ]
+      },
+      {
+        "en": "official partner status",
+        "ja": "こうしきぱーとなーのすてーたす",
+        "ja_typings": [
+          "koshikipatonanosutetasu",
+          "koushikipatonanosutetasu"
+        ]
+      },
+      {
+        "en": "staff role",
+        "ja": "すたっふのやくわり",
+        "ja_typings": [
+          "sutaffunoyakuwari"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00862",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'membership' on YouTube?",
+      "ja": "ゆーちゅーぶでのめんばーしっぷとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "favorite VTuber or idol",
+        "ja": "おきにいりのぶいちゅーばーやあいどる",
+        "ja_typings": [
+          "okiniirinobuichubayaaidoru"
+        ]
+      },
+      {
+        "en": "Japanese greeting",
+        "ja": "にほんごのあいさつ",
+        "ja_typings": [
+          "nihongonoaisatsu"
+        ]
+      },
+      {
+        "en": "gift item",
+        "ja": "ぷれぜんとひん",
+        "ja_typings": [
+          "purezentohin"
+        ]
+      },
+      {
+        "en": "streaming schedule",
+        "ja": "すとりーみんぐすけじゅーる",
+        "ja_typings": [
+          "sutorimingusukejuru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00863",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'oshi'?",
+      "ja": "おしとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "TL",
+        "ja": "てぃーえる",
+        "ja_typings": [
+          "tieru"
+        ]
+      },
+      {
+        "en": "Sub",
+        "ja": "さぶ",
+        "ja_typings": [
+          "sabu"
+        ]
+      },
+      {
+        "en": "Clip",
+        "ja": "くりっぷ",
+        "ja_typings": [
+          "kurippu"
+        ]
+      },
+      {
+        "en": "EN",
+        "ja": "いーえぬ",
+        "ja_typings": [
+          "ienu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00864",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the term for simultaneous translator in VTuber culture?",
+      "ja": "ぶいちゅーばーぶんかでどうじほんやくしゃのことをなんというか？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "casual talk stream with no specific topic",
+        "ja": "とくていのわだいのないかいわすとりーむ",
+        "ja_typings": [
+          "tokuteinowadainonaikaiwasutorimu"
+        ]
+      },
+      {
+        "en": "game stream",
+        "ja": "げーむすとりーむ",
+        "ja_typings": [
+          "gemusutorimu"
+        ]
+      },
+      {
+        "en": "singing concert",
+        "ja": "うたこんさーと",
+        "ja_typings": [
+          "utakonsato"
+        ]
+      },
+      {
+        "en": "drawing stream",
+        "ja": "おえかきすとりーむ",
+        "ja_typings": [
+          "oekakisutorimu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00865",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'zatsudan'?",
+      "ja": "ざつだんとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "expression of excitement or amazement",
+        "ja": "こうふんやおどろきのひょうげん",
+        "ja_typings": [
+          "kofunyaodorokinohyogen",
+          "koufunyaodorokinohyougen"
+        ]
+      },
+      {
+        "en": "greeting",
+        "ja": "あいさつ",
+        "ja_typings": [
+          "aisatsu"
+        ]
+      },
+      {
+        "en": "expression of sadness",
+        "ja": "かなしみのひょうげん",
+        "ja_typings": [
+          "kanashiminohyogen",
+          "kanashiminohyougen"
+        ]
+      },
+      {
+        "en": "request to repeat",
+        "ja": "くりかえしのようきゅう",
+        "ja_typings": [
+          "kurikaeshinoyokyuu",
+          "kurikaeshinoyoukyuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00866",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'pog' or 'poggers' mean in chat?",
+      "ja": "ちゃっとでぽぐやぽがーずとはどういういみ？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "laughing emote on Twitch",
+        "ja": "ついっちでのわらいのえもーと",
+        "ja_typings": [
+          "tsuitchidenowarainoemoto"
+        ]
+      },
+      {
+        "en": "crying emote",
+        "ja": "なきのえもーと",
+        "ja_typings": [
+          "nakinoemoto"
+        ]
+      },
+      {
+        "en": "angry emote",
+        "ja": "おこりのえもーと",
+        "ja_typings": [
+          "okorinoemoto"
+        ]
+      },
+      {
+        "en": "love emote",
+        "ja": "あいのえもーと",
+        "ja_typings": [
+          "ainoemoto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00867",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'KEKW'?",
+      "ja": "けくわとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sending your audience to another streamer",
+        "ja": "かんきゃくをほかのすとりーまーにおくること",
+        "ja_typings": [
+          "kankyakuohokanosutorimaniokurukoto"
+        ]
+      },
+      {
+        "en": "attacking another streamer's chat",
+        "ja": "ほかのすとりーまーのちゃっとをこうげき",
+        "ja_typings": [
+          "hokanosutorimanochattokogeki",
+          "hokanosutorimanochattookougeki"
+        ]
+      },
+      {
+        "en": "copyright striking content",
+        "ja": "ちょさくけんしんこく",
+        "ja_typings": [
+          "chosakukenshinkoku"
+        ]
+      },
+      {
+        "en": "banning viewers",
+        "ja": "びゅわーのばん",
+        "ja_typings": [
+          "byuwanoban"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00868",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'raid' on Twitch?",
+      "ja": "ついっちでのれいどとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "character's backstory and world-building",
+        "ja": "きゃらくたーのばっくすとーりーとせかいかん",
+        "ja_typings": [
+          "kyarakutanobakkusutoritosekaikan"
+        ]
+      },
+      {
+        "en": "stream schedule",
+        "ja": "すとりーむすけじゅーる",
+        "ja_typings": [
+          "sutorimusukejuru"
+        ]
+      },
+      {
+        "en": "fan community rules",
+        "ja": "ふぁんこみゅにてぃのるーる",
+        "ja_typings": [
+          "fankomyunitinoruru"
+        ]
+      },
+      {
+        "en": "merchandise collection",
+        "ja": "ぐっずのこれくしょん",
+        "ja_typings": [
+          "guzzunokorekushon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00869",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'lore' in VTuber context?",
+      "ja": "ぶいちゅーばーぶんみゃくでのろあとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "first stream with a 3D model",
+        "ja": "さんじげんもでるではじめてすとりーむ",
+        "ja_typings": [
+          "sanjigenmoderudehajimetesutorimu"
+        ]
+      },
+      {
+        "en": "first collaboration in 3D space",
+        "ja": "さんじげんくうかんではじめてのこらぼ",
+        "ja_typings": [
+          "sanjigenkuukandehajimetenokorabo"
+        ]
+      },
+      {
+        "en": "debut in 3D VR world",
+        "ja": "3Dぶいあーるせかいにでびゅー",
+        "ja_typings": [
+          "3dbuiarusekainidebyu"
+        ]
+      },
+      {
+        "en": "first IRL stream",
+        "ja": "はじめてのりあるいちじょうすとりーむ",
+        "ja_typings": [
+          "hajimetenoriaruichijosutorimu",
+          "hajimetenoriaruichijousutorimu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00870",
+    "image_path": null,
+    "question_text": {
+      "en": "What is '3D debut' for a VTuber?",
+      "ja": "ぶいちゅーばーのさんでぃーでびゅーとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "In Real Life",
+        "ja": "げんじつせかい",
+        "ja_typings": [
+          "genjitsusekai"
+        ]
+      },
+      {
+        "en": "Internet Relay Link",
+        "ja": "いんたーねっとりれーりんく",
+        "ja_typings": [
+          "intanettorirerinku"
+        ]
+      },
+      {
+        "en": "In Reference Level",
+        "ja": "さんしょうのれべる",
+        "ja_typings": [
+          "sanshonoreberu",
+          "sanshounoreberu"
+        ]
+      },
+      {
+        "en": "Interactive Reality Layer",
+        "ja": "そうほうてきりある",
+        "ja_typings": [
+          "sohotekiriaru",
+          "souhoutekiriaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00871",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'IRL' stand for?",
+      "ja": "IRLとはなにのりゃく？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Japanese video sharing website",
+        "ja": "にほんのどうがきょうゆうさいと",
+        "ja_typings": [
+          "nihonnodogakyoyuusaito",
+          "nihonnodougakyouyuusaito"
+        ]
+      },
+      {
+        "en": "Japanese social media",
+        "ja": "にほんのそーしゃるめでぃあ",
+        "ja_typings": [
+          "nihonnososharumedia"
+        ]
+      },
+      {
+        "en": "Japanese streaming platform",
+        "ja": "にほんのすとりーみんぐぷらっとふぉーむ",
+        "ja_typings": [
+          "nihonnosutorimingupurattofomu"
+        ]
+      },
+      {
+        "en": "Japanese music platform",
+        "ja": "にほんのおんがくぷらっとふぉーむ",
+        "ja_typings": [
+          "nihonnongakupurattofomu",
+          "nihonnoongakupurattofomu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00872",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'NicoNico Douga'?",
+      "ja": "にこにこどうがとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "voice synthesizer software featuring virtual singers",
+        "ja": "かそうかしゅとくみあわせたこえごうせいそふと",
+        "ja_typings": [
+          "kasokashutokumiawasetakoegoseisofuto",
+          "kasoukashutokumiawasetakoegouseisofuto"
+        ]
+      },
+      {
+        "en": "virtual idol group",
+        "ja": "ばーちゃるあいどるぐるーぷ",
+        "ja_typings": [
+          "bacharuaidorugurupu"
+        ]
+      },
+      {
+        "en": "VTuber agency",
+        "ja": "ぶいちゅーばーじむしょ",
+        "ja_typings": [
+          "buichubajimusho"
+        ]
+      },
+      {
+        "en": "music streaming app",
+        "ja": "おんがくすとりーみんぐあぷり",
+        "ja_typings": [
+          "ongakusutoriminguapuri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00873",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'Vocaloid'?",
+      "ja": "ぼーかろいどとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hatsune Miku",
+        "ja": "はつねみく",
+        "ja_typings": [
+          "hatsunemiku"
+        ]
+      },
+      {
+        "en": "Kagamine Rin",
+        "ja": "かがみねりん",
+        "ja_typings": [
+          "kagaminerin"
+        ]
+      },
+      {
+        "en": "Megurine Luka",
+        "ja": "めぐりんるか",
+        "ja_typings": [
+          "megurinruka"
+        ]
+      },
+      {
+        "en": "Kaito",
+        "ja": "かいと",
+        "ja_typings": [
+          "kaito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00874",
+    "image_path": null,
+    "question_text": {
+      "en": "What character is the most famous Vocaloid?",
+      "ja": "もっともゆうめいなぼーかろいどのきゃらくたーは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "humorous image or idea spread online",
+        "ja": "おんらいんでひろがるゆーもらすがぞうやかんがえ",
+        "ja_typings": [
+          "onraindehirogaruyumorasugazoyakangae",
+          "onraindehirogaruyumorasugazouyakangae"
+        ]
+      },
+      {
+        "en": "official advertisement",
+        "ja": "こうしきこうこく",
+        "ja_typings": [
+          "koshikikokoku",
+          "koushikikoukoku"
+        ]
+      },
+      {
+        "en": "news article",
+        "ja": "にゅーすきじ",
+        "ja_typings": [
+          "nyusukiji"
+        ]
+      },
+      {
+        "en": "computer virus",
+        "ja": "こんぴゅーたういるす",
+        "ja_typings": [
+          "konpyutauirusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00875",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'meme' on the internet?",
+      "ja": "いんたーねっとでみーむとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "deliberately provoking others online",
+        "ja": "おんらいんでいとてきにひとをちょはつすること",
+        "ja_typings": [
+          "onraindeitotekinihitochohatsusurukoto",
+          "onraindeitotekinihitoochohatsusurukoto"
+        ]
+      },
+      {
+        "en": "sharing positive content",
+        "ja": "ぽじてぃぶなこんてんつをきょうゆう",
+        "ja_typings": [
+          "pojitibunakontentsuokyoyuu",
+          "pojitibunakontentsuokyouyuu"
+        ]
+      },
+      {
+        "en": "promoting products",
+        "ja": "せいひんのぷろもーしょん",
+        "ja_typings": [
+          "seihinnopuromoshon"
+        ]
+      },
+      {
+        "en": "building online communities",
+        "ja": "おんらいんこみゅにてぃのけいせい",
+        "ja_typings": [
+          "onrainkomyunitinokeisei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00876",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'trolling' online?",
+      "ja": "おんらいんでとろーりんぐとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Away From Keyboard",
+        "ja": "きーぼーどをはなれている",
+        "ja_typings": [
+          "kibodohanareteiru",
+          "kibodoohanareteiru"
+        ]
+      },
+      {
+        "en": "Active For Killers",
+        "ja": "あくてぃぶふぉーきらーず",
+        "ja_typings": [
+          "akutibufokirazu"
+        ]
+      },
+      {
+        "en": "Awaiting Feedback Kindly",
+        "ja": "へんじまちのれいきんもーど",
+        "ja_typings": [
+          "henjimachinoreikinmodo"
+        ]
+      },
+      {
+        "en": "All Friends Known",
+        "ja": "すべてのともだちはいどく",
+        "ja_typings": [
+          "subetenotomodachihaidoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00877",
+    "image_path": null,
+    "question_text": {
+      "en": "What does AFK stand for?",
+      "ja": "AFKとはなにのりゃく？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "randomized loot mechanic inspired by capsule toys",
+        "ja": "かぷせるがちゃからのらんだむほうしゅうしすてむ",
+        "ja_typings": [
+          "kapuserugachakaranorandamuhoshuushisutemu",
+          "kapuserugachakaranorandamuhoushuushisutemu"
+        ]
+      },
+      {
+        "en": "guaranteed rare item drop",
+        "ja": "かならずレアあいてむがでるじすてむ",
+        "ja_typings": [
+          "kanarazureaaitemugaderujisutemu"
+        ]
+      },
+      {
+        "en": "battle pass system",
+        "ja": "ばとるぱすしすてむ",
+        "ja_typings": [
+          "batorupasushisutemu"
+        ]
+      },
+      {
+        "en": "game difficulty system",
+        "ja": "むずかしさのしすてむ",
+        "ja_typings": [
+          "muzukashisanoshisutemu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00878",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'gacha' in gaming?",
+      "ja": "げーみんぐでがちゃとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Massively Multiplayer Online (game)",
+        "ja": "まっしぶりーまるちぷれいやーおんらいんげーむ",
+        "ja_typings": [
+          "masshiburimaruchipureiyaonraingemu"
+        ]
+      },
+      {
+        "en": "Mobile Multiplayer Online",
+        "ja": "もばいるまるちぷれいやーおんらいん",
+        "ja_typings": [
+          "mobairumaruchipureiyaonrain"
+        ]
+      },
+      {
+        "en": "Managed Multiplayer Offline",
+        "ja": "かんりされたおふらいんたいせん",
+        "ja_typings": [
+          "kanrisaretaofuraintaisen"
+        ]
+      },
+      {
+        "en": "Modern Multiplayer Option",
+        "ja": "もだんなたいせんのおぷしょん",
+        "ja_typings": [
+          "modannataisennopushon",
+          "modannataisennoopushon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00879",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'MMO'?",
+      "ja": "えむえむおーとはなに？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "latency between player and server",
+        "ja": "ぷれいやーとさーばーかんのちえん",
+        "ja_typings": [
+          "pureiyatosabakannochien"
+        ]
+      },
+      {
+        "en": "number of players online",
+        "ja": "おんらいんのぷれいやーすう",
+        "ja_typings": [
+          "onrainnopureiyasuu"
+        ]
+      },
+      {
+        "en": "player ranking score",
+        "ja": "ぷれいやーのらんきんぐすこあ",
+        "ja_typings": [
+          "pureiyanorankingusukoa"
+        ]
+      },
+      {
+        "en": "message notification",
+        "ja": "めっせーじのつうち",
+        "ja_typings": [
+          "messejinotsuuchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00880",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'ping' in online gaming?",
+      "ja": "おんらいんげーみんぐでぴんぐとは？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "competitive video gaming",
+        "ja": "きょうぎてきびでおげーみんぐ",
+        "ja_typings": [
+          "kyogitekibideogemingu",
+          "kyougitekibideogemingu"
+        ]
+      },
+      {
+        "en": "electronic exercise equipment",
+        "ja": "でんしてきうんどうきぐ",
+        "ja_typings": [
+          "denshitekiundokigu",
+          "denshitekiundoukigu"
+        ]
+      },
+      {
+        "en": "electric motor racing",
+        "ja": "でんきもーたーれーす",
+        "ja_typings": [
+          "denkimotaresu"
+        ]
+      },
+      {
+        "en": "online sports betting",
+        "ja": "おんらいんすぽーつとうひょう",
+        "ja_typings": [
+          "onrainsupotsutohyo",
+          "onrainsupotsutouhyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00881",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'esports'?",
+      "ja": "いーすぽーつとは何か？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "First Person Shooter",
+        "ja": "ふぁーすとぱーそんしゅーたー",
+        "ja_typings": [
+          "fasutopasonshuta"
+        ]
+      },
+      {
+        "en": "Frames Per Second",
+        "ja": "ふれーむぱーせかんど",
+        "ja_typings": [
+          "furemupasekando"
+        ]
+      },
+      {
+        "en": "Fantasy Player System",
+        "ja": "ふぁんたじーぷれいやーしすてむ",
+        "ja_typings": [
+          "fantajipureiyashisutemu"
+        ]
+      },
+      {
+        "en": "Final Player Score",
+        "ja": "ふぁいなるぷれいやーすこあ",
+        "ja_typings": [
+          "fainarupureiyasukoa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00882",
+    "image_path": null,
+    "question_text": {
+      "en": "What does FPS stand for in gaming?",
+      "ja": "げーみんぐでFPSとはなにのりゃく？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hit Points / Health Points",
+        "ja": "ひっとぽいんつ・へるすぽいんつ",
+        "ja_typings": [
+          "hittopointsu herusupointsu"
+        ]
+      },
+      {
+        "en": "Hero Power",
+        "ja": "ひーろーぱわー",
+        "ja_typings": [
+          "hiropawa"
+        ]
+      },
+      {
+        "en": "High Power",
+        "ja": "はいぱわー",
+        "ja_typings": [
+          "haipawa"
+        ]
+      },
+      {
+        "en": "Healing Potion",
+        "ja": "ひーりんぐぽーしょん",
+        "ja_typings": [
+          "hiringuposhon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00883",
+    "image_path": null,
+    "question_text": {
+      "en": "What does HP stand for in games?",
+      "ja": "げーむでHPとはなにのりゃく？"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "completing a game as fast as possible",
+        "ja": "できるだけはやくげーむをクリアすること",
+        "ja_typings": [
+          "dekirudakehayakugemuokuriasurukoto"
+        ]
+      },
+      {
+        "en": "reviewing games quickly",
+        "ja": "はやくげーむをひょうかすること",
+        "ja_typings": [
+          "hayakugemuohyokasurukoto",
+          "hayakugemuohyoukasurukoto"
+        ]
+      },
+      {
+        "en": "streaming at high frame rate",
+        "ja": "こうふれーむれーとですとりーむ",
+        "ja_typings": [
+          "kofuremuretodesutorimu",
+          "koufuremuretodesutorimu"
+        ]
+      },
+      {
+        "en": "running in virtual reality games",
+        "ja": "ぶぁーちゃるりありてぃげーむでのらんにんぐ",
+        "ja_typings": [
+          "buacharuriaritigemudenoranningu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q00884",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'speedrunning'?",
+      "ja": "すぴーどらんにんぐとは何か？"
     }
   }
 ]


### PR DESCRIPTION
## Summary

- `questions_ja.json` / `questions_en.json` の問題数を 100問 → 884問に拡充
- 全ジャンルに問題を追加（programming, web_development, technology, it_terminology, anime, game, manga, geography, history, science, math, language, culture, general_knowledge, vtuber_net_culture）
- `backfill-ja-typing` で `ja_typings` を補完済み
- `lint-questions` でバリデーション済み（prefix conflict 0件）
- `cargo test` 124テスト全pass確認済み

Closes #45
Closes #46