### PR TITLE
feat: サブコマンドで特定モード即開始

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ src/
 ├── game/
 │   ├── quiz.rs          # 「打って選択」+ exact match 自動確定
 │   ├── time_attack.rs   # 5x5 パネル + CPU 対戦
-│   └── hack.rs          # リスニング × RPG（10問サイクル）
+│   └── rpg.rs           # リスニング × RPG（10問サイクル）
 ├── audio/
 │   └── tts.rs           # `tts` crate ラッパー、言語ルーティング
 ├── io/
@@ -52,7 +52,7 @@ src/
 └── ui/
     ├── menu.rs
     ├── quiz.rs          # 3ペイン
-    ├── hack.rs          # 4ペイン
+    ├── rpg.rs           # 4ペイン
     ├── time_attack.rs
     ├── records.rs
     └── help_line.rs     # 常時表示ヘルプ

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +241,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cocoa-foundation"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +293,12 @@ dependencies = [
  "libc",
  "objc",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -560,6 +656,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,6 +983,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oxilangtag"
@@ -1409,6 +1517,7 @@ name = "type-globe"
 version = "0.3.1"
 dependencies = [
  "cargo-husky",
+ "clap",
  "crossterm",
  "rand",
  "ratatui",
@@ -1454,6 +1563,12 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 rand = "0.8"
+clap = { version = "4", features = ["derive"] }
 unicode-segmentation = "1.11"
 tts = "0.26"
 rodio = { version = "0.19", default-features = false }

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -256,7 +256,7 @@ src/
 │   ├── mod.rs
 │   ├── quiz.rs          # quiz presentation + "type-to-select" logic
 │   ├── time_attack.rs   # 5x5 panel battle
-│   └── hack.rs          # listening × RPG run loop
+│   └── rpg.rs           # listening × RPG run loop
 ├── audio/
 │   ├── mod.rs
 │   └── tts.rs           # `tts` crate wrapper, language routing
@@ -268,7 +268,7 @@ src/
     ├── mod.rs
     ├── menu.rs
     ├── quiz.rs          # 3-pane layout
-    ├── hack.rs          # 4-pane layout
+    ├── rpg.rs           # 4-pane layout
     ├── time_attack.rs
     ├── records.rs
     └── help_line.rs     # always-on bottom helpline

--- a/src/game/listening.rs
+++ b/src/game/listening.rs
@@ -1,7 +1,7 @@
 //! Listening-mode game logic (#30 / #31).
 //!
 //! Single-prompt session for the v0.2.0 "listening foundation" epic.
-//! The full hack-and-slash run (10 prompts, HP/EXP, boss placement)
+//! The full RPG run (10 prompts, HP/EXP, boss placement)
 //! lives in #32-#37 and will compose this module rather than replacing
 //! it.
 //!

--- a/src/main.rs
+++ b/src/main.rs
@@ -356,13 +356,19 @@ mod tests {
     #[test]
     fn parse_language_zh_returns_err_containing_input() {
         let err = parse_language("zh").unwrap_err();
-        assert!(err.contains("zh"), "error message should contain input 'zh': {err}");
+        assert!(
+            err.contains("zh"),
+            "error message should contain input 'zh': {err}"
+        );
     }
 
     #[test]
     fn parse_language_uppercase_ja_returns_err_containing_input() {
         let err = parse_language("JA").unwrap_err();
-        assert!(err.contains("JA"), "error message should contain input 'JA': {err}");
+        assert!(
+            err.contains("JA"),
+            "error message should contain input 'JA': {err}"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod types;
 mod ui;
 
 use audio::TtsEngine;
+use clap::{Parser, Subcommand};
 use config::Config;
 use game::ListeningSession;
 use io::{DataLoader, Storage};
@@ -14,11 +15,175 @@ use std::io::{stdin, stdout, Write};
 use types::{AnswerKind, GameMode, Language, ListeningPrompt, Question};
 use ui::{tts_unavailable_message, ListenUI, MenuUI, QuizUI, RecordsUI};
 
+// ---------------------------------------------------------------------------
+// CLI definition (#48)
+// ---------------------------------------------------------------------------
+
+/// type-globe — terminal typing game
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Subcommand, Debug)]
+enum Commands {
+    /// クイズモードを即開始
+    Quiz {
+        /// 言語を指定（ja / en）。省略時はメニューで選択
+        #[arg(long, value_parser = parse_language)]
+        lang: Option<Language>,
+
+        /// 出題順を固定するシード値（スタブ: 受け取るが未実装）
+        #[arg(long)]
+        seed: Option<u64>,
+
+        /// 特定の問題IDから開始（スタブ: 受け取るが未実装）
+        #[arg(long)]
+        question: Option<String>,
+    },
+
+    /// ハクスラRPGモードを即開始
+    Rpg {
+        /// 言語を指定（ja / en）。省略時はメニューで選択
+        #[arg(long, value_parser = parse_language)]
+        lang: Option<Language>,
+
+        /// 出題順を固定するシード値（スタブ: 受け取るが未実装）
+        #[arg(long)]
+        seed: Option<u64>,
+
+        /// 指定フロアから開始（スタブ: 受け取るが未実装）
+        #[arg(long)]
+        floor: Option<u32>,
+
+        /// TTS 読み上げをスキップする
+        #[arg(long)]
+        no_tts: bool,
+    },
+
+    /// Time Attack 25 を即開始
+    Ta25 {
+        /// 言語を指定（ja / en）。省略時はメニューで選択
+        #[arg(long, value_parser = parse_language)]
+        lang: Option<Language>,
+
+        /// 出題順を固定するシード値（スタブ: 受け取るが未実装）
+        #[arg(long)]
+        seed: Option<u64>,
+    },
+
+    /// ランキングを表示
+    Ranking {
+        /// 言語を指定（ja / en）。省略時はメニューで選択
+        #[arg(long, value_parser = parse_language)]
+        lang: Option<Language>,
+    },
+}
+
+fn parse_language(s: &str) -> Result<Language, String> {
+    match s {
+        "ja" => Ok(Language::Japanese),
+        "en" => Ok(Language::English),
+        other => Err(format!("不明な言語コード: '{other}'. ja または en を指定してください")),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
     let config = Config::default();
-    let mut menu = MenuUI::new();
 
     Storage::ensure_data_directory(&config.data_dir)?;
+
+    match cli.command {
+        // ---- サブコマンドなし: 従来どおりメインメニューへ ----
+        None => run_menu_loop(&config),
+
+        // ---- quiz サブコマンド ----
+        Some(Commands::Quiz { lang, seed, question }) => {
+            // TODO(#48): --seed は未実装。引数を受け取るのみ。
+            if seed.is_some() {
+                eprintln!("note: --seed は現在未実装です（スタブ）");
+            }
+            // TODO(#48): --question は未実装。引数を受け取るのみ。
+            if question.is_some() {
+                eprintln!("note: --question は現在未実装です（スタブ）");
+            }
+
+            let language = resolve_language_or_select(lang)?;
+            run_quiz_mode(&config, &language)?;
+            Ok(())
+        }
+
+        // ---- rpg サブコマンド ----
+        Some(Commands::Rpg { lang, seed, floor, no_tts }) => {
+            // TODO(#48): --seed は未実装。引数を受け取るのみ。
+            if seed.is_some() {
+                eprintln!("note: --seed は現在未実装です（スタブ）");
+            }
+            // TODO(#48): --floor は未実装。引数を受け取るのみ。
+            if floor.is_some() {
+                eprintln!("note: --floor は現在未実装です（スタブ）");
+            }
+
+            let language = resolve_language_or_select(lang)?;
+            run_listening_practice(&config, &language, no_tts)?;
+            Ok(())
+        }
+
+        // ---- ta25 サブコマンド ----
+        Some(Commands::Ta25 { lang, seed }) => {
+            // TODO(#48): --seed は未実装。引数を受け取るのみ。
+            if seed.is_some() {
+                eprintln!("note: --seed は現在未実装です（スタブ）");
+            }
+
+            let _language = resolve_language_or_select(lang)?;
+            show_return_to_menu_message("Time Attack 25 is not implemented yet.")?;
+            Ok(())
+        }
+
+        // ---- ranking サブコマンド ----
+        Some(Commands::Ranking { lang }) => {
+            let language = resolve_language_or_select(lang)?;
+            let records_path = config.records_file_path(&language);
+            let mut records_ui = RecordsUI::load(&records_path)?;
+            records_ui.run()?;
+            Ok(())
+        }
+    }
+}
+
+/// サブコマンドで --lang が省略された場合、簡易選択プロンプトを表示する。
+fn resolve_language_or_select(lang: Option<Language>) -> Result<Language, Box<dyn std::error::Error>> {
+    if let Some(l) = lang {
+        return Ok(l);
+    }
+    // 簡易プロンプト（メニュー TUI を経由しない）
+    loop {
+        print!("言語を選択してください (ja/en): ");
+        stdout().flush()?;
+        let mut input = String::new();
+        stdin().read_line(&mut input)?;
+        match input.trim() {
+            "ja" => return Ok(Language::Japanese),
+            "en" => return Ok(Language::English),
+            _ => println!("ja または en を入力してください。"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// メニューループ（サブコマンドなし時の従来フロー）
+// ---------------------------------------------------------------------------
+
+fn run_menu_loop(config: &Config) -> Result<(), Box<dyn std::error::Error>> {
+    let mut menu = MenuUI::new();
 
     loop {
         let (language, mode) = match menu.run() {
@@ -28,28 +193,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         match mode {
             GameMode::Quiz => {
-                let questions_file = config.questions_file_path(&language);
-
-                if !std::path::Path::new(&questions_file).exists() {
-                    println!("問題ファイルが見つかりません。サンプル問題を作成しています...");
-                    let sample_questions = DataLoader::create_sample_questions();
-                    Storage::save_sample_questions(&questions_file, &sample_questions)?;
-                    println!("サンプル問題を作成しました: {questions_file}");
-                }
-
-                let questions = load_questions_with_warnings(&questions_file)?;
-                if questions.is_empty() {
-                    println!("問題が見つかりません。");
-                    return Ok(());
-                }
-
-                // 10-question sampled run + result screen + Records save are
-                // all owned by QuizUI now (#26). main.rs only supplies the
-                // pool and the records file path.
-                let records_path = config.records_file_path(&language);
-                let mut quiz_ui = QuizUI::from_pool(&questions, language.clone(), records_path);
-                let _final_score = quiz_ui.run()?;
-
+                run_quiz_mode(config, &language)?;
                 menu.return_to_mode_selection(language);
             }
             GameMode::TimeAttack25 => {
@@ -57,7 +201,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 menu.return_to_mode_selection(language);
             }
             GameMode::HackAndSlashRpg => {
-                run_listening_practice(&config, &language)?;
+                run_listening_practice(config, &language, false)?;
                 menu.return_to_mode_selection(language);
             }
             GameMode::Records => {
@@ -68,6 +212,32 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// モード実装ヘルパー
+// ---------------------------------------------------------------------------
+
+fn run_quiz_mode(config: &Config, language: &Language) -> Result<(), Box<dyn std::error::Error>> {
+    let questions_file = config.questions_file_path(language);
+
+    if !std::path::Path::new(&questions_file).exists() {
+        println!("問題ファイルが見つかりません。サンプル問題を作成しています...");
+        let sample_questions = DataLoader::create_sample_questions();
+        Storage::save_sample_questions(&questions_file, &sample_questions)?;
+        println!("サンプル問題を作成しました: {questions_file}");
+    }
+
+    let questions = load_questions_with_warnings(&questions_file)?;
+    if questions.is_empty() {
+        println!("問題が見つかりません。");
+        return Ok(());
+    }
+
+    let records_path = config.records_file_path(language);
+    let mut quiz_ui = QuizUI::from_pool(&questions, language.clone(), records_path);
+    let _final_score = quiz_ui.run()?;
+    Ok(())
 }
 
 /// Load a question bank and warn (non-fatally) on any prefix conflicts in
@@ -97,9 +267,14 @@ fn show_return_to_menu_message(message: &str) -> Result<(), Box<dyn std::error::
 /// `word`-kind prompts because Space is reserved for replay (per
 /// `docs/spec.md`); phrase / sentence input mapping is part of the
 /// run-loop work and is intentionally out of scope here.
+///
+/// `skip_tts`: when `true` (set via `rpg --no-tts`), the TTS engine is
+/// not initialised and the session runs silently. Useful for debugging
+/// in environments where TTS is unavailable or undesirable.
 fn run_listening_practice(
     config: &Config,
     language: &Language,
+    skip_tts: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let path = config.listening_file_path(language);
     let prompts = DataLoader::load_listening_prompts(&path)?;
@@ -122,6 +297,13 @@ fn run_listening_practice(
             return Ok(());
         }
     };
+
+    if skip_tts {
+        // --no-tts: TTS を初期化せずサイレント実行
+        let mut ui = ListenUI::new_without_tts(session, language.clone());
+        let _ = ui.run()?;
+        return Ok(());
+    }
 
     let tts = match TtsEngine::new() {
         Ok(t) => t,

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,13 +148,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
 
         // ---- ta25 サブコマンド ----
-        Some(Commands::Ta25 { lang, seed }) => {
+        Some(Commands::Ta25 { lang: _, seed }) => {
             // TODO(#48): --seed は未実装。引数を受け取るのみ。
             if seed.is_some() {
                 eprintln!("note: --seed は現在未実装です（スタブ）");
             }
 
-            let _language = resolve_language_or_select(lang)?;
+            // Ta25 は未実装のため言語選択プロンプトを出さずに即メッセージ表示。
             show_return_to_menu_message("Time Attack 25 is not implemented yet.")?;
             Ok(())
         }
@@ -385,12 +385,6 @@ mod tests {
     fn parse_language_empty_string_returns_err_without_panic() {
         let result = parse_language("");
         assert!(result.is_err(), "empty string must not parse successfully");
-    }
-
-    // --- TC-05: "JA" (uppercase) is not accepted ---
-    #[test]
-    fn parse_language_uppercase_ja_is_rejected() {
-        assert!(parse_language("JA").is_err());
     }
 
     // --- TC-27: --seed u64::MAX does not cause a parse error ---

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,9 @@ fn parse_language(s: &str) -> Result<Language, String> {
     match s {
         "ja" => Ok(Language::Japanese),
         "en" => Ok(Language::English),
-        other => Err(format!("不明な言語コード: '{other}'. ja または en を指定してください")),
+        other => Err(format!(
+            "不明な言語コード: '{other}'. ja または en を指定してください"
+        )),
     }
 }
 
@@ -105,7 +107,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         None => run_menu_loop(&config),
 
         // ---- quiz サブコマンド ----
-        Some(Commands::Quiz { lang, seed, question }) => {
+        Some(Commands::Quiz {
+            lang,
+            seed,
+            question,
+        }) => {
             // TODO(#48): --seed は未実装。引数を受け取るのみ。
             if seed.is_some() {
                 eprintln!("note: --seed は現在未実装です（スタブ）");
@@ -121,7 +127,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
 
         // ---- rpg サブコマンド ----
-        Some(Commands::Rpg { lang, seed, floor, no_tts }) => {
+        Some(Commands::Rpg {
+            lang,
+            seed,
+            floor,
+            no_tts,
+        }) => {
             // TODO(#48): --seed は未実装。引数を受け取るのみ。
             if seed.is_some() {
                 eprintln!("note: --seed は現在未実装です（スタブ）");
@@ -160,7 +171,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 /// サブコマンドで --lang が省略された場合、簡易選択プロンプトを表示する。
-fn resolve_language_or_select(lang: Option<Language>) -> Result<Language, Box<dyn std::error::Error>> {
+fn resolve_language_or_select(
+    lang: Option<Language>,
+) -> Result<Language, Box<dyn std::error::Error>> {
     if let Some(l) = lang {
         return Ok(l);
     }
@@ -316,4 +329,95 @@ fn run_listening_practice(
     let mut ui = ListenUI::new(session, tts, language.clone());
     let _ = ui.run()?;
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    // --- TC-01: "ja" → Language::Japanese ---
+    #[test]
+    fn parse_language_ja_returns_japanese() {
+        assert!(matches!(parse_language("ja"), Ok(Language::Japanese)));
+    }
+
+    // --- TC-02: "en" → Language::English ---
+    #[test]
+    fn parse_language_en_returns_english() {
+        assert!(matches!(parse_language("en"), Ok(Language::English)));
+    }
+
+    // --- TC-03: invalid inputs return Err containing the input value ---
+    #[test]
+    fn parse_language_zh_returns_err_containing_input() {
+        let err = parse_language("zh").unwrap_err();
+        assert!(err.contains("zh"), "error message should contain input 'zh': {err}");
+    }
+
+    #[test]
+    fn parse_language_uppercase_ja_returns_err_containing_input() {
+        let err = parse_language("JA").unwrap_err();
+        assert!(err.contains("JA"), "error message should contain input 'JA': {err}");
+    }
+
+    #[test]
+    fn parse_language_spelled_out_returns_err_containing_input() {
+        let err = parse_language("japanese").unwrap_err();
+        assert!(
+            err.contains("japanese"),
+            "error message should contain input 'japanese': {err}"
+        );
+    }
+
+    // --- TC-04: empty string returns Err without panicking ---
+    #[test]
+    fn parse_language_empty_string_returns_err_without_panic() {
+        let result = parse_language("");
+        assert!(result.is_err(), "empty string must not parse successfully");
+    }
+
+    // --- TC-05: "JA" (uppercase) is not accepted ---
+    #[test]
+    fn parse_language_uppercase_ja_is_rejected() {
+        assert!(parse_language("JA").is_err());
+    }
+
+    // --- TC-27: --seed u64::MAX does not cause a parse error ---
+    #[test]
+    fn cli_seed_u64_max_parses_without_error() {
+        let args = ["type-globe", "quiz", "--seed", "18446744073709551615"];
+        let cli = Cli::parse_from(args);
+        match cli.command {
+            Some(Commands::Quiz { seed, .. }) => {
+                assert_eq!(seed, Some(u64::MAX));
+            }
+            other => panic!("expected Quiz subcommand, got {:?}", other),
+        }
+    }
+
+    // --- TC-28: --floor u32::MAX does not cause a parse error ---
+    #[test]
+    fn cli_floor_u32_max_parses_without_error() {
+        let args = ["type-globe", "rpg", "--floor", "4294967295"];
+        let cli = Cli::parse_from(args);
+        match cli.command {
+            Some(Commands::Rpg { floor, .. }) => {
+                assert_eq!(floor, Some(u32::MAX));
+            }
+            other => panic!("expected Rpg subcommand, got {:?}", other),
+        }
+    }
+
+    // --- TC-29: --seed -1 causes clap to return an error (negative not accepted for u64) ---
+    #[test]
+    fn cli_seed_negative_one_fails_to_parse() {
+        let args = ["type-globe", "quiz", "--seed", "-1"];
+        let result = Cli::try_parse_from(args);
+        assert!(result.is_err(), "--seed -1 should be rejected by clap");
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -19,7 +19,7 @@ pub struct Choice {
     pub ja_typings: Vec<String>,
 }
 
-/// Answer-form classification per `docs/spec.md`. Drives hack-and-slash
+/// Answer-form classification per `docs/spec.md`. Drives the RPG
 /// boss placement (#33-#37: prompts 1-7 word, 8-9 phrase, 10 sentence)
 /// and gives the renderer a hint for enemy size / visuals. `Question`
 /// will gain this field when the YAML migration lands; `ListeningPrompt`

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -14,10 +14,10 @@
 //!
 //! ## Bottom stack
 //!
-//! Both quiz and hack frames carry a 1-line `input_echo` (renders the
+//! Both quiz and rpg frames carry a 1-line `input_echo` (renders the
 //! typed answer / sentence) immediately below the top panes, and an
 //! always-on 1-line `help_line` at the very bottom rendered by the
-//! `ui::HelpLine` component (#18). For hack mode, a 5-line `log` slot
+//! `ui::HelpLine` component (#18). For rpg mode, a 5-line `log` slot
 //! sits between the input echo and the help line.
 
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
@@ -25,7 +25,7 @@ use ratatui::layout::{Constraint, Direction, Layout, Rect};
 /// Geometric breakdown of a mode's screen.
 ///
 /// `main`, `side`, `input_echo`, and `help_line` are always present;
-/// `log` is filled only by hack-and-slash runs (it carries the battle log
+/// `log` is filled only by RPG runs (it carries the battle log
 /// per `docs/spec.md`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PaneFrame {
@@ -69,12 +69,12 @@ impl PaneFrame {
         }
     }
 
-    /// 4-pane layout for the hack-and-slash listening RPG.
+    /// 4-pane layout for the listening RPG.
     ///
-    /// TODO(#11): wire this up once the hack UI lands; the `#[allow(dead_code)]`
+    /// TODO(#11): wire this up once the rpg UI lands; the `#[allow(dead_code)]`
     /// can come off then.
     #[allow(dead_code)]
-    pub fn hack(area: Rect) -> Self {
+    pub fn rpg(area: Rect) -> Self {
         let outer = Layout::default()
             .direction(Direction::Vertical)
             .margin(1)
@@ -132,16 +132,16 @@ mod tests {
     }
 
     #[test]
-    fn hack_layout_has_four_panes() {
+    fn rpg_layout_has_four_panes() {
         let area = Rect::new(0, 0, 100, 30);
-        let frame = PaneFrame::hack(area);
+        let frame = PaneFrame::rpg(area);
 
         let inner_width = area.width - MARGIN * 2;
         assert_eq!(frame.side.width, SIDE_WIDTH);
         assert_eq!(frame.main.width, inner_width - SIDE_WIDTH);
         assert_eq!(frame.input_echo.height, INPUT_ECHO_HEIGHT);
         assert_eq!(frame.help_line.height, HELP_LINE_HEIGHT);
-        let log = frame.log.expect("hack log pane");
+        let log = frame.log.expect("rpg log pane");
         assert_eq!(log.height, HACK_LOG_HEIGHT);
         assert_eq!(log.width, inner_width);
         assert!(frame.input_echo.y < log.y);
@@ -156,8 +156,8 @@ mod tests {
     }
 
     #[test]
-    fn hack_layout_does_not_panic_on_small_terminal() {
-        let frame = PaneFrame::hack(Rect::new(0, 0, 60, 24));
+    fn rpg_layout_does_not_panic_on_small_terminal() {
+        let frame = PaneFrame::rpg(Rect::new(0, 0, 60, 24));
         assert!(frame.main.width >= 1);
         assert!(frame.log.is_some());
     }

--- a/src/ui/listen.rs
+++ b/src/ui/listen.rs
@@ -209,8 +209,9 @@ impl ListenUI {
                 eprintln!("warning: TTS replay failed: {err}");
                 return;
             }
-            self.plays += 1;
         }
+        // plays counts replay attempts regardless of TTS availability.
+        self.plays += 1;
         // Restart the visual pulse on each replay so the breathing
         // anchors to the new utterance.
         self.pulse = Some(PulseHandle::start("♪", PulseOpts::default_listening()));

--- a/src/ui/listen.rs
+++ b/src/ui/listen.rs
@@ -2,7 +2,7 @@
 //!
 //! Single-prompt foundation that exercises the TTS engine (#28), the
 //! listening data structure (#29), and the blind-input judge (#31)
-//! end-to-end. The full hack-and-slash run (#32-#37) will compose
+//! end-to-end. The full RPG run (#32-#37) will compose
 //! `ListeningSession` repeatedly inside this same 4-pane layout; for
 //! now the side pane shows placeholder run info ("Practice — RPG run
 //! lands in #32+").
@@ -65,7 +65,7 @@ pub struct ListenUI {
     /// Number of times the player has triggered audio (initial play +
     /// each Space replay). Per spec there is no penalty, but exposing
     /// the count for the next UI iteration is cheap and mirrors what
-    /// the hack-and-slash run is going to want for telemetry.
+    /// the RPG run is going to want for telemetry.
     plays: u32,
     rejected_char: Option<char>,
     reject_flash_until: Option<Instant>,
@@ -218,7 +218,7 @@ impl ListenUI {
     }
 
     fn ui(&mut self, f: &mut Frame) {
-        let frame = PaneFrame::hack(f.area());
+        let frame = PaneFrame::rpg(f.area());
         self.render_main_pane(f, frame.main);
         self.render_status_pane(f, frame.side);
         self.render_input_echo(f, frame.input_echo);

--- a/src/ui/listen.rs
+++ b/src/ui/listen.rs
@@ -474,6 +474,64 @@ impl ListenUI {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::ListeningSession;
+    use crate::types::{AnswerKind, Language, ListeningPrompt};
+
+    fn stub_prompt() -> ListeningPrompt {
+        ListeningPrompt {
+            id: "test".into(),
+            text: "apple".into(),
+            kind: AnswerKind::Word,
+        }
+    }
+
+    fn stub_session() -> ListeningSession {
+        ListeningSession::new(stub_prompt(), Language::English)
+    }
+
+    // --- TC-12: new_without_tts → tts field is None ---
+    #[test]
+    fn new_without_tts_has_no_tts_engine() {
+        let ui = ListenUI::new_without_tts(stub_session(), Language::English);
+        assert!(ui.tts.is_none(), "tts should be None when built without TTS");
+    }
+
+    // --- TC-13: new (with TTS engine) → tts field is Some ---
+    #[test]
+    fn new_with_tts_engine_has_some_tts() {
+        // We cannot guarantee TtsEngine::new() succeeds in all CI environments,
+        // so we skip this test if TTS initialisation fails.
+        match crate::audio::TtsEngine::new() {
+            Ok(tts) => {
+                let ui = ListenUI::new(stub_session(), tts, Language::English);
+                assert!(ui.tts.is_some(), "tts should be Some when built with a TTS engine");
+            }
+            Err(_) => {
+                // TTS unavailable in this environment — skip rather than fail.
+                eprintln!("TC-13: TtsEngine::new() failed; skipping assertion (TTS unavailable)");
+            }
+        }
+    }
+
+    // --- TC-14: replay() without TTS increments plays (bug-fix guard) ---
+    #[test]
+    fn replay_without_tts_increments_plays_count() {
+        let mut ui = ListenUI::new_without_tts(stub_session(), Language::English);
+        assert_eq!(ui.plays, 0);
+        ui.replay();
+        assert_eq!(ui.plays, 1, "plays should be +1 after replay() even without TTS");
+        ui.replay();
+        assert_eq!(ui.plays, 2, "plays should be +2 after second replay()");
+    }
+}
+
 /// Build a one-line message for callers that want to surface a TTS
 /// init failure to the player without crashing the run. Shared so the
 /// menu and any future entry points format it consistently.

--- a/src/ui/listen.rs
+++ b/src/ui/listen.rs
@@ -500,7 +500,10 @@ mod tests {
     #[test]
     fn new_without_tts_has_no_tts_engine() {
         let ui = ListenUI::new_without_tts(stub_session(), Language::English);
-        assert!(ui.tts.is_none(), "tts should be None when built without TTS");
+        assert!(
+            ui.tts.is_none(),
+            "tts should be None when built without TTS"
+        );
     }
 
     // --- TC-13: new (with TTS engine) → tts field is Some ---
@@ -511,7 +514,10 @@ mod tests {
         match crate::audio::TtsEngine::new() {
             Ok(tts) => {
                 let ui = ListenUI::new(stub_session(), tts, Language::English);
-                assert!(ui.tts.is_some(), "tts should be Some when built with a TTS engine");
+                assert!(
+                    ui.tts.is_some(),
+                    "tts should be Some when built with a TTS engine"
+                );
             }
             Err(_) => {
                 // TTS unavailable in this environment — skip rather than fail.
@@ -526,7 +532,10 @@ mod tests {
         let mut ui = ListenUI::new_without_tts(stub_session(), Language::English);
         assert_eq!(ui.plays, 0);
         ui.replay();
-        assert_eq!(ui.plays, 1, "plays should be +1 after replay() even without TTS");
+        assert_eq!(
+            ui.plays, 1,
+            "plays should be +1 after replay() even without TTS"
+        );
         ui.replay();
         assert_eq!(ui.plays, 2, "plays should be +2 after second replay()");
     }

--- a/src/ui/listen.rs
+++ b/src/ui/listen.rs
@@ -53,7 +53,8 @@ enum Phase {
 
 pub struct ListenUI {
     session: ListeningSession,
-    tts: TtsEngine,
+    /// `None` when the caller passed `--no-tts` (#48).
+    tts: Option<TtsEngine>,
     language: Language,
     phase: Phase,
     /// `♪` pulse for the active prompt — anchors per-frame color.
@@ -74,7 +75,23 @@ impl ListenUI {
     pub fn new(session: ListeningSession, tts: TtsEngine, language: Language) -> Self {
         Self {
             session,
-            tts,
+            tts: Some(tts),
+            language,
+            phase: Phase::Playing,
+            pulse: Some(PulseHandle::start("♪", PulseOpts::default_listening())),
+            started_at: Instant::now(),
+            plays: 0,
+            rejected_char: None,
+            reject_flash_until: None,
+        }
+    }
+
+    /// Construct a `ListenUI` without a TTS engine. Audio calls are
+    /// silently skipped. Activated by `rpg --no-tts` (#48).
+    pub fn new_without_tts(session: ListeningSession, language: Language) -> Self {
+        Self {
+            session,
+            tts: None,
             language,
             phase: Phase::Playing,
             pulse: Some(PulseHandle::start("♪", PulseOpts::default_listening())),
@@ -95,16 +112,20 @@ impl ListenUI {
         // Speak the prompt once on entry. Failure here is non-fatal —
         // the player can still try Space-replay, and the result screen
         // works even if no audio came out (helps debug TTS issues).
-        if let Err(err) = self.tts.speak(&self.session.prompt().text, &self.language) {
-            eprintln!("warning: initial TTS speak failed: {err}");
-        } else {
-            self.plays += 1;
+        if let Some(tts) = self.tts.as_mut() {
+            if let Err(err) = tts.speak(&self.session.prompt().text, &self.language) {
+                eprintln!("warning: initial TTS speak failed: {err}");
+            } else {
+                self.plays += 1;
+            }
         }
 
         let result = self.run_app(&mut terminal);
 
         // Stop any in-flight utterance so the terminal returns silently.
-        let _ = self.tts.stop();
+        if let Some(tts) = self.tts.as_mut() {
+            let _ = tts.stop();
+        }
         disable_raw_mode()?;
         execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
         terminal.show_cursor()?;
@@ -183,11 +204,13 @@ impl ListenUI {
     }
 
     fn replay(&mut self) {
-        if let Err(err) = self.tts.speak(&self.session.prompt().text, &self.language) {
-            eprintln!("warning: TTS replay failed: {err}");
-            return;
+        if let Some(tts) = self.tts.as_mut() {
+            if let Err(err) = tts.speak(&self.session.prompt().text, &self.language) {
+                eprintln!("warning: TTS replay failed: {err}");
+                return;
+            }
+            self.plays += 1;
         }
-        self.plays += 1;
         // Restart the visual pulse on each replay so the breathing
         // anchors to the new utterance.
         self.pulse = Some(PulseHandle::start("♪", PulseOpts::default_listening()));
@@ -416,7 +439,9 @@ impl ListenUI {
             self.session.submit();
             self.pulse = None;
             self.phase = Phase::Result;
-            let _ = self.tts.stop();
+            if let Some(tts) = self.tts.as_mut() {
+                let _ = tts.stop();
+            }
         }
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -14,6 +14,6 @@ pub use listen::{tts_unavailable_message, ListenUI};
 pub use menu::MenuUI;
 pub use quiz::QuizUI;
 pub use records::RecordsUI;
-// TODO(#11): drop this allow once hack UI wires up ProgressBar / StatusItem.
+// TODO(#11): drop this allow once rpg UI wires up ProgressBar / StatusItem.
 #[allow(unused_imports)]
 pub use status::{ProgressBar, StatusItem, StatusPane};

--- a/src/ui/records.rs
+++ b/src/ui/records.rs
@@ -41,7 +41,7 @@ pub struct RecordsUI {
     /// spot "the run I just saved" without scrolling.
     latest_quiz_ts: Option<u64>,
     latest_ta25_ts: Option<u64>,
-    latest_hack_ts: Option<u64>,
+    latest_rpg_ts: Option<u64>,
 }
 
 impl RecordsUI {
@@ -56,12 +56,12 @@ impl RecordsUI {
     fn from_records(records: Records) -> Self {
         let latest_quiz_ts = records.quiz_mode.iter().map(|e| e.ts).max();
         let latest_ta25_ts = records.time_attack_25.iter().map(|e| e.ts).max();
-        let latest_hack_ts = records.hack_and_slash_rpg.iter().map(|e| e.ts).max();
+        let latest_rpg_ts = records.hack_and_slash_rpg.iter().map(|e| e.ts).max();
         Self {
             records,
             latest_quiz_ts,
             latest_ta25_ts,
-            latest_hack_ts,
+            latest_rpg_ts,
         }
     }
 
@@ -162,7 +162,7 @@ impl RecordsUI {
             chunks[2],
             "Listening RPG",
             &self.records.hack_and_slash_rpg,
-            self.latest_hack_ts,
+            self.latest_rpg_ts,
         );
     }
 
@@ -304,7 +304,7 @@ mod tests {
 
         let ui = RecordsUI::from_records(records);
         assert_eq!(ui.latest_quiz_ts, Some(30));
-        assert_eq!(ui.latest_hack_ts, Some(5));
+        assert_eq!(ui.latest_rpg_ts, Some(5));
         assert_eq!(ui.latest_ta25_ts, None);
     }
 
@@ -313,7 +313,7 @@ mod tests {
         let ui = RecordsUI::from_records(Records::default());
         assert_eq!(ui.latest_quiz_ts, None);
         assert_eq!(ui.latest_ta25_ts, None);
-        assert_eq!(ui.latest_hack_ts, None);
+        assert_eq!(ui.latest_rpg_ts, None);
     }
 
     #[test]

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -47,8 +47,8 @@ pub enum StatusItem {
         label: String,
         value: String,
     },
-    /// Used by hack-and-slash; quiz mode never produces bars.
-    /// TODO(#11): drop this allow when hack UI lands.
+    /// Used by RPG mode; quiz mode never produces bars.
+    /// TODO(#11): drop this allow when rpg UI lands.
     #[allow(dead_code)]
     Bar(ProgressBar),
 }
@@ -61,7 +61,7 @@ impl StatusItem {
         }
     }
 
-    /// TODO(#11): drop this `allow(dead_code)` once the hack UI wires it up.
+    /// TODO(#11): drop this `allow(dead_code)` once the rpg UI wires it up.
     #[allow(dead_code)]
     pub fn bar(label: impl Into<String>, current: u32, max: u32) -> Self {
         Self::Bar(ProgressBar {
@@ -110,9 +110,9 @@ impl StatusPane {
     /// Hack-and-slash status: Lv / EXP / HP / Floor / Run time
     /// (per `docs/spec.md`).
     ///
-    /// TODO(#11): drop this `allow(dead_code)` once the hack UI wires it up.
+    /// TODO(#11): drop this `allow(dead_code)` once the rpg UI wires it up.
     #[allow(dead_code)]
-    pub fn hack(
+    pub fn rpg(
         level: u32,
         exp: ProgressBar,
         hp: ProgressBar,
@@ -246,8 +246,8 @@ mod tests {
     }
 
     #[test]
-    fn hack_pane_mixes_values_and_bars() {
-        let pane = StatusPane::hack(
+    fn rpg_pane_mixes_values_and_bars() {
+        let pane = StatusPane::rpg(
             5,
             ProgressBar {
                 label: "EXP".into(),
@@ -299,8 +299,8 @@ mod tests {
     }
 
     #[test]
-    fn hack_pane_renders_lv_and_floor() {
-        let pane = StatusPane::hack(
+    fn rpg_pane_renders_lv_and_floor() {
+        let pane = StatusPane::rpg(
             5,
             ProgressBar {
                 label: "EXP".into(),


### PR DESCRIPTION
## 関連 Issue
closes #48

## 変更内容
- `clap` を追加し、サブコマンド (`quiz` / `rpg` / `ta25` / `ranking`) を実装
- 共通オプション: `--lang ja|en`, `--seed <u64>`（スタブ）
- `quiz` 固有: `--question <id>`（スタブ）
- `rpg` 固有: `--floor <n>`（スタブ）、`--no-tts`（実動作）
- サブコマンド省略時は従来どおりメインメニューに遷移
- `--no-tts` 時も `replay()` の `plays` カウントを正しく加算するバグを修正
- `parse_language` / `Cli` / `ListenUI` のテスト13件を追加
- CLAUDE.md の `hack.rs` 記述を `rpg.rs` に修正

## 備考
- `--seed` / `--question` / `--floor` はスタブ。受け取るが未実装の旨を stderr に出力
- サブコマンド名に `hack` は使用していない（`rpg` を採用）