### PR TITLE
feat: RecordsをYAMLに移行・Top10切り捨てロジック追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,6 +1286,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1524,6 +1537,7 @@ dependencies = [
  "rodio",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tokio",
  "tts",
  "unicode-segmentation",
@@ -1563,6 +1577,12 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ ratatui = "0.29"
 crossterm = "0.28"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_yaml = "0.9"
 tokio = { version = "1.0", features = ["full"] }
 rand = "0.8"
 clap = { version = "4", features = ["derive"] }

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3,7 +3,7 @@
 > Version: v0.2.0 (offline-first blind-typing edition).
 > This document supersedes all v0.1.x specs. The previous "display-and-type" mode has been removed.
 >
-> Note: `main` now ships this blind-typing interaction model. Storage still uses JSON/`serde_json` in this release line; the YAML migration remains future work.
+> Note: `main` now ships this blind-typing interaction model. Storage uses YAML/`serde_yaml` for Player and Records files; question banks remain JSON.
 
 ## Core Principle
 
@@ -66,7 +66,7 @@ Quiz is paired with score-attack modes; listening is paired with the RPG. The tw
 - A single logical answer may accept **multiple typed spellings**.
 - In JA mode, romanized aliases may be accepted for the same answer (for example `tokyo` and `toukyou`, `osaka` and `oosaka`). Question data may declare these explicitly with `ja_typings`. When a choice has a well-established official Latin spelling (for example a proper name), that spelling may also be accepted. The implementation may also derive additional common ASCII aliases from kana as long as it never reveals the answer string before typing.
 - Score = function(CPM, accuracy, correctness).
-- One run is fixed at **10 questions** (constant `QUIZ_RUN_LENGTH`), sampled from the language's question pool. The total Time is **frozen at the last correct keystroke** of the final question (or at the moment the final question is skipped via Tab) — it does not keep ticking on the Summary / Records-entry screens. After the 10th question, the UI shows a Summary (Score / Correct / Accuracy / CPM / WPM / Time), then a Records-entry screen prompts for a name and writes a `ScoreEntry` to `records_<lang>.json` (Top 10 by score; ts as tiebreaker). Esc on either screen returns to the menu without saving.
+- One run is fixed at **10 questions** (constant `QUIZ_RUN_LENGTH`), sampled from the language's question pool. The total Time is **frozen at the last correct keystroke** of the final question (or at the moment the final question is skipped via Tab) — it does not keep ticking on the Summary / Records-entry screens. After the 10th question, the UI shows a Summary (Score / Correct / Accuracy / CPM / WPM / Time), then a Records-entry screen prompts for a name and writes a `ScoreEntry` to `records_<lang>.yaml` (Top 10 by score; ts as tiebreaker). Esc on either screen returns to the menu without saving.
 
 ### Time Attack 25
 
@@ -119,13 +119,11 @@ Both **CPM** (characters per minute) and **WPM** (words per minute) are displaye
 
 ## Data Structures
 
-Target v0.2.0 direction: all data files use **YAML** for readability and inline comments, with Rust side moved to `serde_yaml`.
-
-Current `main` branch status: question banks / player progress / records are still JSON-backed and use `serde_json`.
+All persistent data files use **YAML** (`serde_yaml`). Question banks (`data/questions_<lang>.json`, `data/listening_<lang>.json`) remain JSON because they are authored/generated externally.
 
 ### Answer-form classification (`kind`)
 
-Every answer string is classified into one of three forms. This drives the hack-and-slash boss placement and lets the renderer choose appropriate enemy visuals.
+Every answer string is classified into one of three forms. This drives the RPG boss placement and lets the renderer choose appropriate enemy visuals.
 
 | kind | form | examples | role |
 |---|---|---|---|
@@ -224,7 +222,7 @@ rpg_stats:
 ### Records (`records_<lang>.yaml`)
 
 ```yaml
-quiz_single:
+quiz_mode:
   - name: Player1
     score: 1500
     cpm: 230
@@ -234,6 +232,12 @@ time_attack_25:
   - name: PlayerX
     time_seconds: 180
     ts: 2026-04-30T10:05:00Z
+rpg:
+  - name: Player1
+    score: 800
+    cpm: 180
+    wpm: 36
+    ts: 2026-04-30T10:10:00Z
 ```
 
 Top 10 per mode per language. This is a local self-best file — never call it a "ranking". World ranking (Nostralgic Ranking) is wired in the v0.3.0+ `type-globe-online` build and submits the same entries to a Nostr-relay-backed feed.

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,8 +18,8 @@ impl Default for Config {
             data_dir: "data".to_string(),
             default_language: Language::Japanese,
             questions_file_pattern: "questions_{}.json".to_string(),
-            player_data_file: "player.json".to_string(),
-            records_file_pattern: "records_{}.json".to_string(),
+            player_data_file: "player.yaml".to_string(),
+            records_file_pattern: "records_{}.yaml".to_string(),
             listening_file_pattern: "listening_{}.json".to_string(),
         }
     }

--- a/src/io/storage.rs
+++ b/src/io/storage.rs
@@ -111,4 +111,61 @@ mod tests {
 
         let _ = std::fs::remove_file(&path);
     }
+
+    #[test]
+    fn save_then_load_records_rpg_round_trip() {
+        let path = unique_path("rpg-roundtrip");
+        let mut records = Records::default();
+        records.rpg.push(ScoreEntry {
+            name: "Bob".into(),
+            score: 2500,
+            cpm: 310,
+            wpm: 62,
+            ts: "2025-05-11T10:00:00Z".into(),
+        });
+        Storage::save_records(&path, &records).expect("save");
+
+        let loaded = Storage::load_records(&path).expect("load");
+        assert_eq!(loaded.rpg.len(), 1);
+        assert_eq!(loaded.rpg[0].name, "Bob");
+        assert_eq!(loaded.rpg[0].score, 2500);
+        assert_eq!(loaded.rpg[0].cpm, 310);
+        assert_eq!(loaded.rpg[0].wpm, 62);
+        assert_eq!(loaded.rpg[0].ts, "2025-05-11T10:00:00Z");
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn save_then_load_records_quiz_mode_round_trip() {
+        let path = unique_path("quiz-roundtrip");
+        let mut records = Records::default();
+        records.quiz_mode.push(ScoreEntry {
+            name: "Carol".into(),
+            score: 1800,
+            cpm: 270,
+            wpm: 54,
+            ts: "2025-05-11T11:00:00Z".into(),
+        });
+        Storage::save_records(&path, &records).expect("save");
+
+        let loaded = Storage::load_records(&path).expect("load");
+        assert_eq!(loaded.quiz_mode.len(), 1);
+        assert_eq!(loaded.quiz_mode[0].name, "Carol");
+        assert_eq!(loaded.quiz_mode[0].score, 1800);
+        assert_eq!(loaded.quiz_mode[0].ts, "2025-05-11T11:00:00Z");
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn load_records_file_absent_returns_default() {
+        let path = unique_path("absent-yaml");
+        // Ensure the file does not exist
+        let _ = std::fs::remove_file(&path);
+        let records = Storage::load_records(&path).expect("load");
+        assert!(records.quiz_mode.is_empty());
+        assert!(records.time_attack_25.is_empty());
+        assert!(records.rpg.is_empty());
+    }
 }

--- a/src/io/storage.rs
+++ b/src/io/storage.rs
@@ -19,7 +19,7 @@ impl Storage {
         }
 
         let content = fs::read_to_string(file_path)?;
-        let player: Player = serde_json::from_str(&content)?;
+        let player: Player = serde_yaml::from_str(&content)?;
         Ok(player)
     }
 
@@ -28,7 +28,7 @@ impl Storage {
         file_path: &str,
         player: &Player,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let content = serde_json::to_string_pretty(player)?;
+        let content = serde_yaml::to_string(player)?;
         fs::write(file_path, content)?;
         Ok(())
     }
@@ -40,7 +40,7 @@ impl Storage {
         }
 
         let content = fs::read_to_string(file_path)?;
-        let records: Records = serde_json::from_str(&content)?;
+        let records: Records = serde_yaml::from_str(&content)?;
         Ok(records)
     }
 
@@ -49,7 +49,7 @@ impl Storage {
         file_path: &str,
         records: &Records,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let content = serde_json::to_string_pretty(records)?;
+        let content = serde_yaml::to_string(records)?;
         fs::write(file_path, content)?;
         Ok(())
     }
@@ -71,14 +71,12 @@ mod tests {
     use std::env::temp_dir;
 
     fn unique_path(prefix: &str) -> String {
-        // Nanosecond clock as a quick unique suffix — good enough for the
-        // single-process test runner; std lacks a built-in tempfile helper.
         let nanos = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_nanos())
             .unwrap_or(0);
         let dir = temp_dir();
-        format!("{}/type-globe-{prefix}-{nanos}.json", dir.display())
+        format!("{}/type-globe-{prefix}-{nanos}.yaml", dir.display())
     }
 
     #[test]
@@ -87,7 +85,7 @@ mod tests {
         let records = Storage::load_records(&path).expect("load");
         assert!(records.quiz_mode.is_empty());
         assert!(records.time_attack_25.is_empty());
-        assert!(records.hack_and_slash_rpg.is_empty());
+        assert!(records.rpg.is_empty());
     }
 
     #[test]
@@ -99,7 +97,7 @@ mod tests {
             score: 1500,
             cpm: 230,
             wpm: 46,
-            ts: 17_280_000,
+            ts: "2025-05-11T00:00:00Z".into(),
         });
         Storage::save_records(&path, &records).expect("save");
 
@@ -109,7 +107,7 @@ mod tests {
         assert_eq!(loaded.quiz_mode[0].score, 1500);
         assert_eq!(loaded.quiz_mode[0].cpm, 230);
         assert_eq!(loaded.quiz_mode[0].wpm, 46);
-        assert_eq!(loaded.quiz_mode[0].ts, 17_280_000);
+        assert_eq!(loaded.quiz_mode[0].ts, "2025-05-11T00:00:00Z");
 
         let _ = std::fs::remove_file(&path);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -213,7 +213,7 @@ fn run_menu_loop(config: &Config) -> Result<(), Box<dyn std::error::Error>> {
                 show_return_to_menu_message("Time Attack 25 is not implemented yet.")?;
                 menu.return_to_mode_selection(language);
             }
-            GameMode::HackAndSlashRpg => {
+            GameMode::Rpg => {
                 run_listening_practice(config, &language, false)?;
                 menu.return_to_mode_selection(language);
             }

--- a/src/types.rs
+++ b/src/types.rs
@@ -233,7 +233,7 @@ mod tests {
 pub enum GameMode {
     Quiz,
     TimeAttack25,
-    HackAndSlashRpg,
+    Rpg,
     Records,
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -122,6 +122,113 @@ impl Records {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn score_entry(name: &str, score: u32) -> ScoreEntry {
+        ScoreEntry {
+            name: name.into(),
+            score,
+            cpm: 0,
+            wpm: 0,
+            ts: "2025-01-01T00:00:00Z".into(),
+        }
+    }
+
+    fn time_entry(name: &str, time_seconds: u32) -> TimeEntry {
+        TimeEntry {
+            name: name.into(),
+            time_seconds,
+            ts: "2025-01-01T00:00:00Z".into(),
+        }
+    }
+
+    #[test]
+    fn push_quiz_11_entries_truncates_to_10() {
+        let mut records = Records::default();
+        for i in 0..11 {
+            records.push_quiz(score_entry(&format!("p{i}"), i as u32 * 10));
+        }
+        assert_eq!(records.quiz_mode.len(), 10);
+    }
+
+    #[test]
+    fn push_quiz_sorted_score_descending() {
+        let mut records = Records::default();
+        records.push_quiz(score_entry("low", 100));
+        records.push_quiz(score_entry("high", 500));
+        records.push_quiz(score_entry("mid", 300));
+        assert_eq!(records.quiz_mode[0].score, 500);
+        assert_eq!(records.quiz_mode[1].score, 300);
+        assert_eq!(records.quiz_mode[2].score, 100);
+    }
+
+    #[test]
+    fn push_quiz_lowest_score_is_dropped() {
+        let mut records = Records::default();
+        for i in 0..10 {
+            records.push_quiz(score_entry(&format!("p{i}"), (i as u32 + 1) * 100));
+        }
+        // Score 50 is below the minimum (100), should be discarded
+        records.push_quiz(score_entry("loser", 50));
+        assert_eq!(records.quiz_mode.len(), 10);
+        assert!(records.quiz_mode.iter().all(|e| e.score >= 100));
+    }
+
+    #[test]
+    fn push_rpg_11_entries_truncates_to_10() {
+        let mut records = Records::default();
+        for i in 0..11 {
+            records.push_rpg(score_entry(&format!("p{i}"), i as u32 * 10));
+        }
+        assert_eq!(records.rpg.len(), 10);
+    }
+
+    #[test]
+    fn push_rpg_sorted_score_descending() {
+        let mut records = Records::default();
+        records.push_rpg(score_entry("low", 200));
+        records.push_rpg(score_entry("high", 800));
+        records.push_rpg(score_entry("mid", 500));
+        assert_eq!(records.rpg[0].score, 800);
+        assert_eq!(records.rpg[1].score, 500);
+        assert_eq!(records.rpg[2].score, 200);
+    }
+
+    #[test]
+    fn push_ta25_11_entries_truncates_to_10() {
+        let mut records = Records::default();
+        for i in 0..11 {
+            records.push_ta25(time_entry(&format!("p{i}"), (i as u32 + 1) * 10));
+        }
+        assert_eq!(records.time_attack_25.len(), 10);
+    }
+
+    #[test]
+    fn push_ta25_sorted_time_ascending() {
+        let mut records = Records::default();
+        records.push_ta25(time_entry("slow", 120));
+        records.push_ta25(time_entry("fast", 40));
+        records.push_ta25(time_entry("mid", 80));
+        assert_eq!(records.time_attack_25[0].time_seconds, 40);
+        assert_eq!(records.time_attack_25[1].time_seconds, 80);
+        assert_eq!(records.time_attack_25[2].time_seconds, 120);
+    }
+
+    #[test]
+    fn push_ta25_slowest_is_dropped() {
+        let mut records = Records::default();
+        for i in 0..10 {
+            records.push_ta25(time_entry(&format!("p{i}"), (i as u32 + 1) * 10));
+        }
+        // Time 9999 is above the maximum kept (100s), should be discarded
+        records.push_ta25(time_entry("tortoise", 9999));
+        assert_eq!(records.time_attack_25.len(), 10);
+        assert!(records.time_attack_25.iter().all(|e| e.time_seconds <= 100));
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum GameMode {
     Quiz,

--- a/src/types.rs
+++ b/src/types.rs
@@ -56,8 +56,7 @@ pub struct RpgStats {
     pub exp: u32,
 }
 
-/// One row in a Records list. `ts` is Unix epoch seconds; the v0.2.0 YAML
-/// migration will format it as RFC3339 per `docs/spec.md`.
+/// One row in a Records list. `ts` is RFC3339 format (e.g. "2025-05-11T12:34:56Z").
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ScoreEntry {
     pub name: String,
@@ -67,7 +66,7 @@ pub struct ScoreEntry {
     #[serde(default)]
     pub wpm: u32,
     #[serde(default)]
-    pub ts: u64,
+    pub ts: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -75,7 +74,7 @@ pub struct TimeEntry {
     pub name: String,
     pub time_seconds: u32,
     #[serde(default)]
-    pub ts: u64,
+    pub ts: String,
 }
 
 /// Self-best history per language. Local file only — global ordering of
@@ -87,7 +86,40 @@ pub struct TimeEntry {
 pub struct Records {
     pub quiz_mode: Vec<ScoreEntry>,
     pub time_attack_25: Vec<TimeEntry>,
-    pub hack_and_slash_rpg: Vec<ScoreEntry>,
+    pub rpg: Vec<ScoreEntry>,
+}
+
+const RECORDS_TOP_N: usize = 10;
+
+impl Records {
+    /// Insert into `quiz_mode`, sort by score descending (ts descending as
+    /// tiebreaker), and keep only the top 10.
+    pub fn push_quiz(&mut self, entry: ScoreEntry) {
+        self.quiz_mode.push(entry);
+        self.quiz_mode
+            .sort_by(|a, b| b.score.cmp(&a.score).then(b.ts.cmp(&a.ts)));
+        self.quiz_mode.truncate(RECORDS_TOP_N);
+    }
+
+    /// Insert into `rpg`, sort by score descending (ts descending as
+    /// tiebreaker), and keep only the top 10.
+    #[allow(dead_code)]
+    pub fn push_rpg(&mut self, entry: ScoreEntry) {
+        self.rpg.push(entry);
+        self.rpg
+            .sort_by(|a, b| b.score.cmp(&a.score).then(b.ts.cmp(&a.ts)));
+        self.rpg.truncate(RECORDS_TOP_N);
+    }
+
+    /// Insert into `time_attack_25`, sort by time ascending (shorter = better,
+    /// ts descending as tiebreaker), and keep only the top 10.
+    #[allow(dead_code)]
+    pub fn push_ta25(&mut self, entry: TimeEntry) {
+        self.time_attack_25.push(entry);
+        self.time_attack_25
+            .sort_by(|a, b| a.time_seconds.cmp(&b.time_seconds).then(b.ts.cmp(&a.ts)));
+        self.time_attack_25.truncate(RECORDS_TOP_N);
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -222,7 +222,7 @@ impl MenuUI {
                     let mode = match self.selected_mode {
                         0 => GameMode::Quiz,
                         1 => GameMode::TimeAttack25,
-                        2 => GameMode::HackAndSlashRpg,
+                        2 => GameMode::Rpg,
                         3 => GameMode::Records,
                         _ => GameMode::Quiz,
                     };

--- a/src/ui/quiz.rs
+++ b/src/ui/quiz.rs
@@ -21,8 +21,37 @@ use ratatui::{
 use std::io;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-/// Top-N self-best entries kept per mode in `records_<lang>.json`.
-const RECORDS_TOP_N: usize = 10;
+fn now_rfc3339() -> String {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    // Format as RFC3339 UTC: YYYY-MM-DDTHH:MM:SSZ
+    let s = secs;
+    let sec = s % 60;
+    let min = (s / 60) % 60;
+    let hour = (s / 3600) % 24;
+    let days = s / 86400;
+    // Days since Unix epoch → Gregorian date (proleptic)
+    let (year, month, day) = days_to_ymd(days);
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}Z")
+}
+
+fn days_to_ymd(days: u64) -> (u64, u64, u64) {
+    // Algorithm from https://howardhinnant.github.io/date_algorithms.html
+    let z = days + 719468;
+    let era = z / 146097;
+    let doe = z % 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}
+
 /// Maximum characters the player can type into the name-entry field.
 /// Sized to fit comfortably in the side pane / Records list rendering.
 const NAME_MAX_CHARS: usize = 16;
@@ -279,18 +308,9 @@ impl QuizUI {
             score: self.quiz_game.get_final_score(),
             cpm: self.quiz_game.get_cpm(),
             wpm: self.quiz_game.get_wpm(),
-            ts: SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .map(|d| d.as_secs())
-                .unwrap_or(0),
+            ts: now_rfc3339(),
         };
-        records.quiz_mode.push(entry);
-        // Highest score first, then ts descending as a stable tiebreaker
-        // so the most recent attempt at a tied score wins display order.
-        records
-            .quiz_mode
-            .sort_by(|a, b| b.score.cmp(&a.score).then(b.ts.cmp(&a.ts)));
-        records.quiz_mode.truncate(RECORDS_TOP_N);
+        records.push_quiz(entry);
         Storage::save_records(&self.records_file_path, &records)?;
         Ok(())
     }

--- a/src/ui/quiz.rs
+++ b/src/ui/quiz.rs
@@ -39,9 +39,10 @@ fn now_rfc3339() -> String {
 
 fn days_to_ymd(days: u64) -> (u64, u64, u64) {
     // Algorithm from https://howardhinnant.github.io/date_algorithms.html
-    let z = days + 719468;
-    let era = z / 146097;
-    let doe = z % 146097;
+    // Uses i64 internally to avoid underflow in intermediate subtractions.
+    let z = days as i64 + 719468;
+    let era = z.div_euclid(146097);
+    let doe = z.rem_euclid(146097);
     let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
     let y = yoe + era * 400;
     let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
@@ -49,7 +50,7 @@ fn days_to_ymd(days: u64) -> (u64, u64, u64) {
     let d = doy - (153 * mp + 2) / 5 + 1;
     let m = if mp < 10 { mp + 3 } else { mp - 9 };
     let y = if m <= 2 { y + 1 } else { y };
-    (y, m, d)
+    (y as u64, m as u64, d as u64)
 }
 
 /// Maximum characters the player can type into the name-entry field.

--- a/src/ui/quiz.rs
+++ b/src/ui/quiz.rs
@@ -744,3 +744,26 @@ fn lerp_rgb_color(from: Rgb, to: Rgb, t: f32) -> Color {
     let Rgb(r, g, b) = lerp_rgb(from, to, t);
     Color::Rgb(r, g, b)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn now_rfc3339_matches_format() {
+        let ts = now_rfc3339();
+        // Expected: YYYY-MM-DDTHH:MM:SSZ (20 chars)
+        assert_eq!(ts.len(), 20, "unexpected length: {ts}");
+        assert_eq!(&ts[4..5], "-", "missing dash after year: {ts}");
+        assert_eq!(&ts[7..8], "-", "missing dash after month: {ts}");
+        assert_eq!(&ts[10..11], "T", "missing T separator: {ts}");
+        assert_eq!(&ts[13..14], ":", "missing colon after hour: {ts}");
+        assert_eq!(&ts[16..17], ":", "missing colon after minute: {ts}");
+        assert_eq!(&ts[19..20], "Z", "missing Z suffix: {ts}");
+        // All digit positions must be numeric
+        for pos in [0, 1, 2, 3, 5, 6, 8, 9, 11, 12, 14, 15, 17, 18] {
+            let ch = ts.as_bytes()[pos];
+            assert!(ch.is_ascii_digit(), "non-digit at pos {pos} in {ts}");
+        }
+    }
+}

--- a/src/ui/records.rs
+++ b/src/ui/records.rs
@@ -36,12 +36,12 @@ const STYLE_HIGHLIGHT: Style = Style::new().fg(Color::Yellow).add_modifier(Modif
 
 pub struct RecordsUI {
     records: Records,
-    /// `ts` (epoch seconds) of the latest entry in each section. Each
+    /// `ts` (RFC3339) of the latest entry in each section. Each
     /// section's row carrying that ts is highlighted, so the user can
     /// spot "the run I just saved" without scrolling.
-    latest_quiz_ts: Option<u64>,
-    latest_ta25_ts: Option<u64>,
-    latest_rpg_ts: Option<u64>,
+    latest_quiz_ts: Option<String>,
+    latest_ta25_ts: Option<String>,
+    latest_rpg_ts: Option<String>,
 }
 
 impl RecordsUI {
@@ -54,9 +54,9 @@ impl RecordsUI {
     }
 
     fn from_records(records: Records) -> Self {
-        let latest_quiz_ts = records.quiz_mode.iter().map(|e| e.ts).max();
-        let latest_ta25_ts = records.time_attack_25.iter().map(|e| e.ts).max();
-        let latest_rpg_ts = records.hack_and_slash_rpg.iter().map(|e| e.ts).max();
+        let latest_quiz_ts = records.quiz_mode.iter().map(|e| e.ts.clone()).max();
+        let latest_ta25_ts = records.time_attack_25.iter().map(|e| e.ts.clone()).max();
+        let latest_rpg_ts = records.rpg.iter().map(|e| e.ts.clone()).max();
         Self {
             records,
             latest_quiz_ts,
@@ -148,21 +148,21 @@ impl RecordsUI {
             chunks[0],
             "Quiz (single-run)",
             &self.records.quiz_mode,
-            self.latest_quiz_ts,
+            self.latest_quiz_ts.as_deref(),
         );
         self.render_time_section(
             f,
             chunks[1],
             "Time Attack 25",
             &self.records.time_attack_25,
-            self.latest_ta25_ts,
+            self.latest_ta25_ts.as_deref(),
         );
         self.render_score_section(
             f,
             chunks[2],
             "Listening RPG",
-            &self.records.hack_and_slash_rpg,
-            self.latest_rpg_ts,
+            &self.records.rpg,
+            self.latest_rpg_ts.as_deref(),
         );
     }
 
@@ -172,7 +172,7 @@ impl RecordsUI {
         area: Rect,
         title: &str,
         entries: &[ScoreEntry],
-        highlight_ts: Option<u64>,
+        highlight_ts: Option<&str>,
     ) {
         let lines = if entries.is_empty() {
             vec![Line::from(Span::styled("  (no records yet)", STYLE_DIM))]
@@ -181,7 +181,7 @@ impl RecordsUI {
                 .iter()
                 .enumerate()
                 .map(|(i, e)| {
-                    let style = if Some(e.ts) == highlight_ts {
+                    let style = if highlight_ts.is_some() && e.ts.as_str() == highlight_ts.unwrap() {
                         STYLE_HIGHLIGHT
                     } else {
                         STYLE_NORMAL
@@ -216,7 +216,7 @@ impl RecordsUI {
         area: Rect,
         title: &str,
         entries: &[TimeEntry],
-        highlight_ts: Option<u64>,
+        highlight_ts: Option<&str>,
     ) {
         let lines = if entries.is_empty() {
             vec![Line::from(Span::styled("  (no records yet)", STYLE_DIM))]
@@ -225,7 +225,8 @@ impl RecordsUI {
                 .iter()
                 .enumerate()
                 .map(|(i, e)| {
-                    let style = if Some(e.ts) == highlight_ts {
+                    let style = if highlight_ts.is_some() && e.ts.as_str() == highlight_ts.unwrap()
+                    {
                         STYLE_HIGHLIGHT
                     } else {
                         STYLE_NORMAL
@@ -290,7 +291,7 @@ mod tests {
             score,
             cpm: 0,
             wpm: 0,
-            ts,
+            ts: format!("1970-01-01T{:02}:00:00Z", ts),
         }
     }
 
@@ -300,11 +301,11 @@ mod tests {
         records.quiz_mode.push(entry("a", 100, 10));
         records.quiz_mode.push(entry("b", 200, 30));
         records.quiz_mode.push(entry("c", 150, 20));
-        records.hack_and_slash_rpg.push(entry("z", 50, 5));
+        records.rpg.push(entry("z", 50, 5));
 
         let ui = RecordsUI::from_records(records);
-        assert_eq!(ui.latest_quiz_ts, Some(30));
-        assert_eq!(ui.latest_rpg_ts, Some(5));
+        assert_eq!(ui.latest_quiz_ts, Some("1970-01-01T30:00:00Z".to_string()));
+        assert_eq!(ui.latest_rpg_ts, Some("1970-01-01T05:00:00Z".to_string()));
         assert_eq!(ui.latest_ta25_ts, None);
     }
 


### PR DESCRIPTION
## 関連 Issue
closes #38
closes #39

## 変更内容
- `serde_yaml` を追加し、Records・Player の読み書きを JSON → YAML に完全移行（後方互換なし）
- `records_<lang>.yaml` / `player.yaml` に拡張子変更
- `Records.hack_and_slash_rpg` → `rpg` にリネーム
- `GameMode::HackAndSlashRpg` → `GameMode::Rpg` にリネーム
- `ScoreEntry.ts` / `TimeEntry.ts` を `u64`（Unix epoch秒）→ `String`（RFC3339 UTC）に変更
- `Records::push_quiz` / `push_rpg` → スコア降順・Top10切り捨て
- `Records::push_ta25` → 時間昇順・Top10切り捨て
- `days_to_ymd` の `u64` 演算を `i64` に変更してアンダーフローを防止
- `docs/spec.md` の JSON 残存記述・`quiz_single`・`rpg` セクション欠落を修正
- テスト12件追加（Top10ロジック・ラウンドトリップ・RFC3339形式）