### PR TITLE
fix(#92): JA問題文の漢字かな混じり表記を復元 + question_text_reading 追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,33 @@ cargo build --release
 - An OS TTS backend for Listening mode (macOS / Windows work out of the box; on Linux, install and start `speech-dispatcher`)
 - Rust 1.78+ to build from source (Linux build also needs `libspeechd-dev`)
 
+## Maintenance scripts
+
+The bundled question banks (`data/questions_<lang>.json`) ship with both a
+display form (`question_text.<lang>`) and a phonetic reading
+(`question_text_reading.<lang>`). When the JA display form drifts toward
+hiragana-heavy phrasing, refresh it with the migration scripts under
+`scripts/`. They expect a local Ollama at `http://127.0.0.1:11434` running
+`gemma4:e4b` (or a model name you pass via `--model`).
+
+```sh
+# 1. preserve current display as reading (idempotent, safe to re-run)
+uv run python3 scripts/backfill_question_text_reading.py data/questions_ja.json data/questions_en.json
+
+# 2. survey what needs work
+uv run python3 scripts/question_text_stats.py data/questions_ja.json
+
+# 3. rewrite hiragana-heavy display forms via local LLM (reading is preserved)
+uv run python3 scripts/restore_ja_question_texts_with_ollama.py data/questions_ja.json --dry-run
+uv run python3 scripts/restore_ja_question_texts_with_ollama.py data/questions_ja.json
+
+# 4. list any stragglers for manual review
+uv run python3 scripts/list_suspect_question_texts.py data/questions_ja.json
+
+# 5. final lint
+cargo run --bin lint-questions -- data/questions_ja.json data/questions_en.json
+```
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -147,9 +147,14 @@ uv run python3 scripts/backfill_question_text_reading.py data/questions_ja.json 
 # 2. survey what needs work
 uv run python3 scripts/question_text_stats.py data/questions_ja.json
 
-# 3. rewrite hiragana-heavy display forms via local LLM (reading is preserved)
+# 3. rewrite hiragana-heavy question display forms via local LLM (reading is preserved)
 uv run python3 scripts/restore_ja_question_texts_with_ollama.py data/questions_ja.json --dry-run
 uv run python3 scripts/restore_ja_question_texts_with_ollama.py data/questions_ja.json
+
+# Or refresh every JA question and answer display label through the same model path.
+# This preserves question_text_reading.ja and choices[].ja_typings.
+uv run python3 scripts/restore_ja_question_texts_with_ollama.py data/questions_ja.json --all --include-choices --dry-run
+uv run python3 scripts/restore_ja_question_texts_with_ollama.py data/questions_ja.json --all --include-choices
 
 # 4. list any stragglers for manual review
 uv run python3 scripts/list_suspect_question_texts.py data/questions_ja.json

--- a/data/questions_en.json
+++ b/data/questions_en.json
@@ -29,7 +29,11 @@
       }
     ],
     "correct_answer_index": 1,
-    "image_path": null
+    "image_path": null,
+    "question_text_reading": {
+      "ja": "水の化学式は？",
+      "en": "What is the chemical formula for water?"
+    }
   },
   {
     "id": "q002",
@@ -72,7 +76,11 @@
       }
     ],
     "correct_answer_index": 1,
-    "image_path": null
+    "image_path": null,
+    "question_text_reading": {
+      "ja": "日本の首都は？",
+      "en": "What is the capital of Japan?"
+    }
   },
   {
     "choices": [
@@ -102,6 +110,10 @@
     "id": "q00003",
     "image_path": null,
     "question_text": {
+      "en": "What is the output of `print(type([]))`?",
+      "ja": "Pythonで`print(type([]))`の出力は？"
+    },
+    "question_text_reading": {
       "en": "What is the output of `print(type([]))`?",
       "ja": "Pythonで`print(type([]))`の出力は？"
     }
@@ -136,6 +148,10 @@
     "question_text": {
       "en": "Which keyword defines a function in Python?",
       "ja": "Pythonで関数を定義するキーワードは？"
+    },
+    "question_text_reading": {
+      "en": "Which keyword defines a function in Python?",
+      "ja": "Pythonで関数を定義するキーワードは？"
     }
   },
   {
@@ -166,6 +182,10 @@
     "id": "q00005",
     "image_path": null,
     "question_text": {
+      "en": "What does `len([1,2,3])` return?",
+      "ja": "`len([1,2,3])`の戻り値は？"
+    },
+    "question_text_reading": {
       "en": "What does `len([1,2,3])` return?",
       "ja": "`len([1,2,3])`の戻り値は？"
     }
@@ -200,6 +220,10 @@
     "question_text": {
       "en": "Which Python data structure uses key-value pairs?",
       "ja": "Pythonでキーと値のペアを使うデータ構造は？"
+    },
+    "question_text_reading": {
+      "en": "Which Python data structure uses key-value pairs?",
+      "ja": "Pythonでキーと値のペアを使うデータ構造は？"
     }
   },
   {
@@ -230,6 +254,10 @@
     "id": "q00007",
     "image_path": null,
     "question_text": {
+      "en": "What is the correct way to open a file in Python?",
+      "ja": "Pythonでファイルを開く正しい方法は？"
+    },
+    "question_text_reading": {
       "en": "What is the correct way to open a file in Python?",
       "ja": "Pythonでファイルを開く正しい方法は？"
     }
@@ -264,6 +292,10 @@
     "question_text": {
       "en": "Which operator is used for floor division in Python?",
       "ja": "Pythonで切り捨て除算に使う演算子は？"
+    },
+    "question_text_reading": {
+      "en": "Which operator is used for floor division in Python?",
+      "ja": "Pythonで切り捨て除算に使う演算子は？"
     }
   },
   {
@@ -294,6 +326,10 @@
     "id": "q00009",
     "image_path": null,
     "question_text": {
+      "en": "What does `range(5)` produce?",
+      "ja": "`range(5)`が生成するのは？"
+    },
+    "question_text_reading": {
       "en": "What does `range(5)` produce?",
       "ja": "`range(5)`が生成するのは？"
     }
@@ -328,6 +364,10 @@
     "question_text": {
       "en": "Which method adds an element to a list in Python?",
       "ja": "Pythonでリストに要素を追加するメソッドは？"
+    },
+    "question_text_reading": {
+      "en": "Which method adds an element to a list in Python?",
+      "ja": "Pythonでリストに要素を追加するメソッドは？"
     }
   },
   {
@@ -358,6 +398,10 @@
     "id": "q00011",
     "image_path": null,
     "question_text": {
+      "en": "What is a lambda in Python?",
+      "ja": "Pythonのlambdaとは？"
+    },
+    "question_text_reading": {
       "en": "What is a lambda in Python?",
       "ja": "Pythonのlambdaとは？"
     }
@@ -392,6 +436,10 @@
     "question_text": {
       "en": "Which built-in function returns the largest value?",
       "ja": "最大値を返すpython組み込み関数は？"
+    },
+    "question_text_reading": {
+      "en": "Which built-in function returns the largest value?",
+      "ja": "最大値を返すpython組み込み関数は？"
     }
   },
   {
@@ -422,6 +470,10 @@
     "id": "q00013",
     "image_path": null,
     "question_text": {
+      "en": "What keyword declares an immutable variable in Rust?",
+      "ja": "Rustで不変変数を宣言するキーワードは？"
+    },
+    "question_text_reading": {
       "en": "What keyword declares an immutable variable in Rust?",
       "ja": "Rustで不変変数を宣言するキーワードは？"
     }
@@ -456,6 +508,10 @@
     "question_text": {
       "en": "What is the Rust ownership rule?",
       "ja": "Rustのオーナーシップの基本ルールは？"
+    },
+    "question_text_reading": {
+      "en": "What is the Rust ownership rule?",
+      "ja": "Rustのオーナーシップの基本ルールは？"
     }
   },
   {
@@ -486,6 +542,10 @@
     "id": "q00015",
     "image_path": null,
     "question_text": {
+      "en": "Which symbol denotes a reference in Rust?",
+      "ja": "Rustで参照を示す記号は？"
+    },
+    "question_text_reading": {
       "en": "Which symbol denotes a reference in Rust?",
       "ja": "Rustで参照を示す記号は？"
     }
@@ -520,6 +580,10 @@
     "question_text": {
       "en": "What is `Option<T>` used for in Rust?",
       "ja": "Rustの`Option<T>`の用途は？"
+    },
+    "question_text_reading": {
+      "en": "What is `Option<T>` used for in Rust?",
+      "ja": "Rustの`Option<T>`の用途は？"
     }
   },
   {
@@ -550,6 +614,10 @@
     "id": "q00017",
     "image_path": null,
     "question_text": {
+      "en": "What does `cargo build` do?",
+      "ja": "`cargo build`は何をするコマンドか？"
+    },
+    "question_text_reading": {
       "en": "What does `cargo build` do?",
       "ja": "`cargo build`は何をするコマンドか？"
     }
@@ -584,6 +652,10 @@
     "question_text": {
       "en": "Which trait enables printing with `{:?}` in Rust?",
       "ja": "Rustで`{:?}`による表示を可能にするとれーとは？"
+    },
+    "question_text_reading": {
+      "en": "Which trait enables printing with `{:?}` in Rust?",
+      "ja": "Rustで`{:?}`による表示を可能にするとれーとは？"
     }
   },
   {
@@ -614,6 +686,10 @@
     "id": "q00019",
     "image_path": null,
     "question_text": {
+      "en": "What is a `Vec<T>` in Rust?",
+      "ja": "Rustの`Vec<T>`とは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a `Vec<T>` in Rust?",
       "ja": "Rustの`Vec<T>`とは何か？"
     }
@@ -648,6 +724,10 @@
     "question_text": {
       "en": "How do you handle errors in Rust idiomatically?",
       "ja": "Rustでエラーを慣用的に扱う方法は？"
+    },
+    "question_text_reading": {
+      "en": "How do you handle errors in Rust idiomatically?",
+      "ja": "Rustでエラーを慣用的に扱う方法は？"
     }
   },
   {
@@ -678,6 +758,10 @@
     "id": "q00021",
     "image_path": null,
     "question_text": {
+      "en": "What does `impl` keyword do in Rust?",
+      "ja": "Rustの`impl`キーワードの役割は？"
+    },
+    "question_text_reading": {
       "en": "What does `impl` keyword do in Rust?",
       "ja": "Rustの`impl`キーワードの役割は？"
     }
@@ -712,6 +796,10 @@
     "question_text": {
       "en": "What is the entry point of a Rust program?",
       "ja": "Rustプログラムのエントリーポイントは？"
+    },
+    "question_text_reading": {
+      "en": "What is the entry point of a Rust program?",
+      "ja": "Rustプログラムのエントリーポイントは？"
     }
   },
   {
@@ -742,6 +830,10 @@
     "id": "q00023",
     "image_path": null,
     "question_text": {
+      "en": "Which keyword declares a block-scoped variable in JS?",
+      "ja": "JSでブロックスコープ変数を宣言するキーワードは？"
+    },
+    "question_text_reading": {
       "en": "Which keyword declares a block-scoped variable in JS?",
       "ja": "JSでブロックスコープ変数を宣言するキーワードは？"
     }
@@ -776,6 +868,10 @@
     "question_text": {
       "en": "What does `===` check in JavaScript?",
       "ja": "JavaScriptの`===`は何を確認するか？"
+    },
+    "question_text_reading": {
+      "en": "What does `===` check in JavaScript?",
+      "ja": "JavaScriptの`===`は何を確認するか？"
     }
   },
   {
@@ -806,6 +902,10 @@
     "id": "q00025",
     "image_path": null,
     "question_text": {
+      "en": "How do you create an arrow function in JS?",
+      "ja": "JSでアロー関数を作る構文は？"
+    },
+    "question_text_reading": {
       "en": "How do you create an arrow function in JS?",
       "ja": "JSでアロー関数を作る構文は？"
     }
@@ -840,6 +940,10 @@
     "question_text": {
       "en": "What is `NaN` in JavaScript?",
       "ja": "JavaScriptの`NaN`とは？"
+    },
+    "question_text_reading": {
+      "en": "What is `NaN` in JavaScript?",
+      "ja": "JavaScriptの`NaN`とは？"
     }
   },
   {
@@ -870,6 +974,10 @@
     "id": "q00027",
     "image_path": null,
     "question_text": {
+      "en": "Which method converts JSON string to object?",
+      "ja": "JSON文字列をオブジェクトに変換するメソッドは？"
+    },
+    "question_text_reading": {
       "en": "Which method converts JSON string to object?",
       "ja": "JSON文字列をオブジェクトに変換するメソッドは？"
     }
@@ -904,6 +1012,10 @@
     "question_text": {
       "en": "What does `Promise.all()` do?",
       "ja": "`Promise.all()`は何をするか？"
+    },
+    "question_text_reading": {
+      "en": "What does `Promise.all()` do?",
+      "ja": "`Promise.all()`は何をするか？"
     }
   },
   {
@@ -934,6 +1046,10 @@
     "id": "q00029",
     "image_path": null,
     "question_text": {
+      "en": "Which keyword is used for class inheritance in JS?",
+      "ja": "JSでクラスの継承に使うキーワードは？"
+    },
+    "question_text_reading": {
       "en": "Which keyword is used for class inheritance in JS?",
       "ja": "JSでクラスの継承に使うキーワードは？"
     }
@@ -968,6 +1084,10 @@
     "question_text": {
       "en": "What is `typeof null` in JavaScript?",
       "ja": "JavaScriptで`typeof null`の結果は？"
+    },
+    "question_text_reading": {
+      "en": "What is `typeof null` in JavaScript?",
+      "ja": "JavaScriptで`typeof null`の結果は？"
     }
   },
   {
@@ -998,6 +1118,10 @@
     "id": "q00031",
     "image_path": null,
     "question_text": {
+      "en": "Which array method creates a new array by transforming each element?",
+      "ja": "各要素を変換して新配列を作るはいれつメソッドは？"
+    },
+    "question_text_reading": {
       "en": "Which array method creates a new array by transforming each element?",
       "ja": "各要素を変換して新配列を作るはいれつメソッドは？"
     }
@@ -1032,6 +1156,10 @@
     "question_text": {
       "en": "What does `Array.isArray([])` return?",
       "ja": "`Array.isArray([])`の戻り値は？"
+    },
+    "question_text_reading": {
+      "en": "What does `Array.isArray([])` return?",
+      "ja": "`Array.isArray([])`の戻り値は？"
     }
   },
   {
@@ -1062,6 +1190,10 @@
     "id": "q00033",
     "image_path": null,
     "question_text": {
+      "en": "What is the time complexity of accessing an array element by index?",
+      "ja": "はいれつのいんでくすによるアクセスの計算量は？"
+    },
+    "question_text_reading": {
       "en": "What is the time complexity of accessing an array element by index?",
       "ja": "はいれつのいんでくすによるアクセスの計算量は？"
     }
@@ -1096,6 +1228,10 @@
     "question_text": {
       "en": "Which data structure uses LIFO order?",
       "ja": "LIFO順を使うでーたこうぞうは？"
+    },
+    "question_text_reading": {
+      "en": "Which data structure uses LIFO order?",
+      "ja": "LIFO順を使うでーたこうぞうは？"
     }
   },
   {
@@ -1126,6 +1262,10 @@
     "id": "q00035",
     "image_path": null,
     "question_text": {
+      "en": "What is a linked list node composed of?",
+      "ja": "れんけつりすとののーどは何で構成されるか？"
+    },
+    "question_text_reading": {
       "en": "What is a linked list node composed of?",
       "ja": "れんけつりすとののーどは何で構成されるか？"
     }
@@ -1160,6 +1300,10 @@
     "question_text": {
       "en": "Which tree traversal visits root first?",
       "ja": "ねをさいしょにたどる木の探索順は？"
+    },
+    "question_text_reading": {
+      "en": "Which tree traversal visits root first?",
+      "ja": "ねをさいしょにたどる木の探索順は？"
     }
   },
   {
@@ -1190,6 +1334,10 @@
     "id": "q00037",
     "image_path": null,
     "question_text": {
+      "en": "What is a hash collision?",
+      "ja": "はっしゅしょうとつとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a hash collision?",
       "ja": "はっしゅしょうとつとは何か？"
     }
@@ -1224,6 +1372,10 @@
     "question_text": {
       "en": "What is the worst-case complexity of quicksort?",
       "ja": "くいっくそーとの最悪計算量は？"
+    },
+    "question_text_reading": {
+      "en": "What is the worst-case complexity of quicksort?",
+      "ja": "くいっくそーとの最悪計算量は？"
     }
   },
   {
@@ -1254,6 +1406,10 @@
     "id": "q00039",
     "image_path": null,
     "question_text": {
+      "en": "Which data structure supports BFS traversal naturally?",
+      "ja": "はばゆうせんたんさくを自然にサポートするでーたこうぞうは？"
+    },
+    "question_text_reading": {
       "en": "Which data structure supports BFS traversal naturally?",
       "ja": "はばゆうせんたんさくを自然にサポートするでーたこうぞうは？"
     }
@@ -1288,6 +1444,10 @@
     "question_text": {
       "en": "What is a binary search tree property?",
       "ja": "にぶんたんさくきのせいしつは？"
+    },
+    "question_text_reading": {
+      "en": "What is a binary search tree property?",
+      "ja": "にぶんたんさくきのせいしつは？"
     }
   },
   {
@@ -1318,6 +1478,10 @@
     "id": "q00041",
     "image_path": null,
     "question_text": {
+      "en": "What does a min-heap guarantee at the root?",
+      "ja": "みにひーぷはねに何を保証するか？"
+    },
+    "question_text_reading": {
       "en": "What does a min-heap guarantee at the root?",
       "ja": "みにひーぷはねに何を保証するか？"
     }
@@ -1352,6 +1516,10 @@
     "question_text": {
       "en": "Which graph representation uses adjacency lists?",
       "ja": "となりあいりすとをつかうグラフひょうげんは？"
+    },
+    "question_text_reading": {
+      "en": "Which graph representation uses adjacency lists?",
+      "ja": "となりあいりすとをつかうグラフひょうげんは？"
     }
   },
   {
@@ -1382,6 +1550,10 @@
     "id": "q00043",
     "image_path": null,
     "question_text": {
+      "en": "What is dynamic programming?",
+      "ja": "どうてきけいかくほうとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is dynamic programming?",
       "ja": "どうてきけいかくほうとは何か？"
     }
@@ -1416,6 +1588,10 @@
     "question_text": {
       "en": "Which sorting algorithm is stable and O(n log n)?",
       "ja": "あんていでO(n log n)のせいれつあるごりずむは？"
+    },
+    "question_text_reading": {
+      "en": "Which sorting algorithm is stable and O(n log n)?",
+      "ja": "あんていでO(n log n)のせいれつあるごりずむは？"
     }
   },
   {
@@ -1446,6 +1622,10 @@
     "id": "q00045",
     "image_path": null,
     "question_text": {
+      "en": "What is Big O notation used for?",
+      "ja": "Big O記法は何のために使うか？"
+    },
+    "question_text_reading": {
       "en": "What is Big O notation used for?",
       "ja": "Big O記法は何のために使うか？"
     }
@@ -1480,6 +1660,10 @@
     "question_text": {
       "en": "What does Dijkstra's algorithm find?",
       "ja": "ダイクストラのあるごりずむは何を求めるか？"
+    },
+    "question_text_reading": {
+      "en": "What does Dijkstra's algorithm find?",
+      "ja": "ダイクストラのあるごりずむは何を求めるか？"
     }
   },
   {
@@ -1510,6 +1694,10 @@
     "id": "q00047",
     "image_path": null,
     "question_text": {
+      "en": "What is memoization?",
+      "ja": "めもいぜーしょんとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is memoization?",
       "ja": "めもいぜーしょんとは何か？"
     }
@@ -1544,6 +1732,10 @@
     "question_text": {
       "en": "Which algorithm uses divide and conquer?",
       "ja": "ぶんちしほうを使うあるごりずむは？"
+    },
+    "question_text_reading": {
+      "en": "Which algorithm uses divide and conquer?",
+      "ja": "ぶんちしほうを使うあるごりずむは？"
     }
   },
   {
@@ -1574,6 +1766,10 @@
     "id": "q00049",
     "image_path": null,
     "question_text": {
+      "en": "What is recursion?",
+      "ja": "さいきとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is recursion?",
       "ja": "さいきとは何か？"
     }
@@ -1608,6 +1804,10 @@
     "question_text": {
       "en": "What is the base case in recursion?",
       "ja": "さいきのきていじょうけんとは？"
+    },
+    "question_text_reading": {
+      "en": "What is the base case in recursion?",
+      "ja": "さいきのきていじょうけんとは？"
     }
   },
   {
@@ -1638,6 +1838,10 @@
     "id": "q00051",
     "image_path": null,
     "question_text": {
+      "en": "Which search requires a sorted array?",
+      "ja": "せいれつされたはいれつが必要な探索は？"
+    },
+    "question_text_reading": {
       "en": "Which search requires a sorted array?",
       "ja": "せいれつされたはいれつが必要な探索は？"
     }
@@ -1672,6 +1876,10 @@
     "question_text": {
       "en": "What is the time complexity of bubble sort?",
       "ja": "ばぶるそーとの計算量は？"
+    },
+    "question_text_reading": {
+      "en": "What is the time complexity of bubble sort?",
+      "ja": "ばぶるそーとの計算量は？"
     }
   },
   {
@@ -1702,6 +1910,10 @@
     "id": "q00053",
     "image_path": null,
     "question_text": {
+      "en": "What is encapsulation?",
+      "ja": "かぷせるかとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is encapsulation?",
       "ja": "かぷせるかとは何か？"
     }
@@ -1736,6 +1948,10 @@
     "question_text": {
       "en": "What is polymorphism?",
       "ja": "たたいせいとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is polymorphism?",
+      "ja": "たたいせいとは何か？"
     }
   },
   {
@@ -1766,6 +1982,10 @@
     "id": "q00055",
     "image_path": null,
     "question_text": {
+      "en": "What does `super()` do in OOP?",
+      "ja": "OOPで`super()`は何をするか？"
+    },
+    "question_text_reading": {
       "en": "What does `super()` do in OOP?",
       "ja": "OOPで`super()`は何をするか？"
     }
@@ -1800,6 +2020,10 @@
     "question_text": {
       "en": "What is an abstract class?",
       "ja": "ちゅうしょうくらすとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is an abstract class?",
+      "ja": "ちゅうしょうくらすとは何か？"
     }
   },
   {
@@ -1830,6 +2054,10 @@
     "id": "q00057",
     "image_path": null,
     "question_text": {
+      "en": "What is an interface in OOP?",
+      "ja": "OOPのいんたーふぇーすとは？"
+    },
+    "question_text_reading": {
       "en": "What is an interface in OOP?",
       "ja": "OOPのいんたーふぇーすとは？"
     }
@@ -1864,6 +2092,10 @@
     "question_text": {
       "en": "What pattern ensures a class has only one instance?",
       "ja": "クラスのいんすたんすをひとつにするぱたーんは？"
+    },
+    "question_text_reading": {
+      "en": "What pattern ensures a class has only one instance?",
+      "ja": "クラスのいんすたんすをひとつにするぱたーんは？"
     }
   },
   {
@@ -1894,6 +2126,10 @@
     "id": "q00059",
     "image_path": null,
     "question_text": {
+      "en": "What pattern defines a family of algorithms?",
+      "ja": "あるごりずむのかぞくをていぎするぱたーんは？"
+    },
+    "question_text_reading": {
       "en": "What pattern defines a family of algorithms?",
       "ja": "あるごりずむのかぞくをていぎするぱたーんは？"
     }
@@ -1928,6 +2164,10 @@
     "question_text": {
       "en": "What does the Observer pattern do?",
       "ja": "おぶざーばーぱたーんは何をするか？"
+    },
+    "question_text_reading": {
+      "en": "What does the Observer pattern do?",
+      "ja": "おぶざーばーぱたーんは何をするか？"
     }
   },
   {
@@ -1958,6 +2198,10 @@
     "id": "q00061",
     "image_path": null,
     "question_text": {
+      "en": "What is the Factory pattern?",
+      "ja": "ふぁくとりーぱたーんとは？"
+    },
+    "question_text_reading": {
       "en": "What is the Factory pattern?",
       "ja": "ふぁくとりーぱたーんとは？"
     }
@@ -1992,6 +2236,10 @@
     "question_text": {
       "en": "Which pattern adds behavior without modifying class?",
       "ja": "くらすをへんこうせずにどうさをついかするぱたーんは？"
+    },
+    "question_text_reading": {
+      "en": "Which pattern adds behavior without modifying class?",
+      "ja": "くらすをへんこうせずにどうさをついかするぱたーんは？"
     }
   },
   {
@@ -2022,6 +2270,10 @@
     "id": "q00063",
     "image_path": null,
     "question_text": {
+      "en": "What does `git stash` do?",
+      "ja": "`git stash`は何をするか？"
+    },
+    "question_text_reading": {
       "en": "What does `git stash` do?",
       "ja": "`git stash`は何をするか？"
     }
@@ -2056,6 +2308,10 @@
     "question_text": {
       "en": "What is a git fork?",
       "ja": "git forkとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a git fork?",
+      "ja": "git forkとは何か？"
     }
   },
   {
@@ -2086,6 +2342,10 @@
     "id": "q00065",
     "image_path": null,
     "question_text": {
+      "en": "What does `git cherry-pick` do?",
+      "ja": "`git cherry-pick`は何をするか？"
+    },
+    "question_text_reading": {
       "en": "What does `git cherry-pick` do?",
       "ja": "`git cherry-pick`は何をするか？"
     }
@@ -2120,6 +2380,10 @@
     "question_text": {
       "en": "What is a git tag?",
       "ja": "git tagとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a git tag?",
+      "ja": "git tagとは何か？"
     }
   },
   {
@@ -2150,6 +2414,10 @@
     "id": "q00067",
     "image_path": null,
     "question_text": {
+      "en": "What does `git rebase` do?",
+      "ja": "`git rebase`は何をするか？"
+    },
+    "question_text_reading": {
       "en": "What does `git rebase` do?",
       "ja": "`git rebase`は何をするか？"
     }
@@ -2184,6 +2452,10 @@
     "question_text": {
       "en": "What is unit testing?",
       "ja": "ゆにっとてすととは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is unit testing?",
+      "ja": "ゆにっとてすととは何か？"
     }
   },
   {
@@ -2214,6 +2486,10 @@
     "id": "q00069",
     "image_path": null,
     "question_text": {
+      "en": "What does TDD stand for?",
+      "ja": "TDDの略語の意味は？"
+    },
+    "question_text_reading": {
       "en": "What does TDD stand for?",
       "ja": "TDDの略語の意味は？"
     }
@@ -2248,6 +2524,10 @@
     "question_text": {
       "en": "What is a mock in testing?",
       "ja": "テストのもっくとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a mock in testing?",
+      "ja": "テストのもっくとは何か？"
     }
   },
   {
@@ -2278,6 +2558,10 @@
     "id": "q00071",
     "image_path": null,
     "question_text": {
+      "en": "What is integration testing?",
+      "ja": "とうごうてすととは何か？"
+    },
+    "question_text_reading": {
       "en": "What is integration testing?",
       "ja": "とうごうてすととは何か？"
     }
@@ -2312,6 +2596,10 @@
     "question_text": {
       "en": "What does `assert` do in testing?",
       "ja": "テストで`assert`は何をするか？"
+    },
+    "question_text_reading": {
+      "en": "What does `assert` do in testing?",
+      "ja": "テストで`assert`は何をするか？"
     }
   },
   {
@@ -2342,6 +2630,10 @@
     "id": "q00073",
     "image_path": null,
     "question_text": {
+      "en": "What is a pure function?",
+      "ja": "じゅんすいかんすうとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a pure function?",
       "ja": "じゅんすいかんすうとは何か？"
     }
@@ -2376,6 +2668,10 @@
     "question_text": {
       "en": "What is a higher-order function?",
       "ja": "こうかいかんすうとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a higher-order function?",
+      "ja": "こうかいかんすうとは何か？"
     }
   },
   {
@@ -2406,6 +2702,10 @@
     "id": "q00075",
     "image_path": null,
     "question_text": {
+      "en": "What is `reduce` used for?",
+      "ja": "`reduce`は何に使うか？"
+    },
+    "question_text_reading": {
       "en": "What is `reduce` used for?",
       "ja": "`reduce`は何に使うか？"
     }
@@ -2440,6 +2740,10 @@
     "question_text": {
       "en": "What is immutability?",
       "ja": "ふへんせいとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is immutability?",
+      "ja": "ふへんせいとは何か？"
     }
   },
   {
@@ -2470,6 +2774,10 @@
     "id": "q00077",
     "image_path": null,
     "question_text": {
+      "en": "What is function composition?",
+      "ja": "かんすうごうせいとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is function composition?",
       "ja": "かんすうごうせいとは何か？"
     }
@@ -2504,6 +2812,10 @@
     "question_text": {
       "en": "What is static typing?",
       "ja": "せいてきがたずけとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is static typing?",
+      "ja": "せいてきがたずけとは何か？"
     }
   },
   {
@@ -2534,6 +2846,10 @@
     "id": "q00079",
     "image_path": null,
     "question_text": {
+      "en": "What is type inference?",
+      "ja": "がたすいろんとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is type inference?",
       "ja": "がたすいろんとは何か？"
     }
@@ -2568,6 +2884,10 @@
     "question_text": {
       "en": "What is a generic type?",
       "ja": "じぇねりっくがたとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a generic type?",
+      "ja": "じぇねりっくがたとは何か？"
     }
   },
   {
@@ -2598,6 +2918,10 @@
     "id": "q00081",
     "image_path": null,
     "question_text": {
+      "en": "What is a deadlock?",
+      "ja": "でっどろっくとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a deadlock?",
       "ja": "でっどろっくとは何か？"
     }
@@ -2632,6 +2956,10 @@
     "question_text": {
       "en": "What is a mutex?",
       "ja": "みゅーてっくすとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a mutex?",
+      "ja": "みゅーてっくすとは何か？"
     }
   },
   {
@@ -2662,6 +2990,10 @@
     "id": "q00083",
     "image_path": null,
     "question_text": {
+      "en": "What is a race condition?",
+      "ja": "れーすじょうけんとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a race condition?",
       "ja": "れーすじょうけんとは何か？"
     }
@@ -2696,6 +3028,10 @@
     "question_text": {
       "en": "What is async/await used for?",
       "ja": "async/awaitは何のために使うか？"
+    },
+    "question_text_reading": {
+      "en": "What is async/await used for?",
+      "ja": "async/awaitは何のために使うか？"
     }
   },
   {
@@ -2726,6 +3062,10 @@
     "id": "q00085",
     "image_path": null,
     "question_text": {
+      "en": "What is a thread?",
+      "ja": "すれっどとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a thread?",
       "ja": "すれっどとは何か？"
     }
@@ -2760,6 +3100,10 @@
     "question_text": {
       "en": "What is a memory leak?",
       "ja": "めもりりーくとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a memory leak?",
+      "ja": "めもりりーくとは何か？"
     }
   },
   {
@@ -2790,6 +3134,10 @@
     "id": "q00087",
     "image_path": null,
     "question_text": {
+      "en": "What is garbage collection?",
+      "ja": "がーびっじこれくしょんとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is garbage collection?",
       "ja": "がーびっじこれくしょんとは何か？"
     }
@@ -2824,6 +3172,10 @@
     "question_text": {
       "en": "What is a stack overflow?",
       "ja": "すたっくおーばーふろーとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a stack overflow?",
+      "ja": "すたっくおーばーふろーとは何か？"
     }
   },
   {
@@ -2854,6 +3206,10 @@
     "id": "q00089",
     "image_path": null,
     "question_text": {
+      "en": "What is the heap in memory?",
+      "ja": "めもりのひーぷとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is the heap in memory?",
       "ja": "めもりのひーぷとは何か？"
     }
@@ -2888,6 +3244,10 @@
     "question_text": {
       "en": "What does HTTP stand for?",
       "ja": "HTTPの略語の意味は？"
+    },
+    "question_text_reading": {
+      "en": "What does HTTP stand for?",
+      "ja": "HTTPの略語の意味は？"
     }
   },
   {
@@ -2918,6 +3278,10 @@
     "id": "q00091",
     "image_path": null,
     "question_text": {
+      "en": "What is an IP address?",
+      "ja": "IPあどれすとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is an IP address?",
       "ja": "IPあどれすとは何か？"
     }
@@ -2952,6 +3316,10 @@
     "question_text": {
       "en": "What does DNS do?",
       "ja": "DNSは何をするか？"
+    },
+    "question_text_reading": {
+      "en": "What does DNS do?",
+      "ja": "DNSは何をするか？"
     }
   },
   {
@@ -2982,6 +3350,10 @@
     "id": "q00093",
     "image_path": null,
     "question_text": {
+      "en": "What is a REST API?",
+      "ja": "REST APIとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a REST API?",
       "ja": "REST APIとは何か？"
     }
@@ -3016,6 +3388,10 @@
     "question_text": {
       "en": "What HTTP method is used to update a resource?",
       "ja": "りそーすをこうしんするHTTPめそっどは？"
+    },
+    "question_text_reading": {
+      "en": "What HTTP method is used to update a resource?",
+      "ja": "りそーすをこうしんするHTTPめそっどは？"
     }
   },
   {
@@ -3046,6 +3422,10 @@
     "id": "q00095",
     "image_path": null,
     "question_text": {
+      "en": "Which command lists files in Linux?",
+      "ja": "Linuxでふぁいるをいちらんするこまんどは？"
+    },
+    "question_text_reading": {
       "en": "Which command lists files in Linux?",
       "ja": "Linuxでふぁいるをいちらんするこまんどは？"
     }
@@ -3080,6 +3460,10 @@
     "question_text": {
       "en": "What does `chmod 755` do?",
       "ja": "`chmod 755`は何をするか？"
+    },
+    "question_text_reading": {
+      "en": "What does `chmod 755` do?",
+      "ja": "`chmod 755`は何をするか？"
     }
   },
   {
@@ -3110,6 +3494,10 @@
     "id": "q00097",
     "image_path": null,
     "question_text": {
+      "en": "What is a shebang line?",
+      "ja": "しぇばんらいんとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a shebang line?",
       "ja": "しぇばんらいんとは何か？"
     }
@@ -3144,6 +3532,10 @@
     "question_text": {
       "en": "What does `grep` do?",
       "ja": "`grep`は何をするか？"
+    },
+    "question_text_reading": {
+      "en": "What does `grep` do?",
+      "ja": "`grep`は何をするか？"
     }
   },
   {
@@ -3174,6 +3566,10 @@
     "id": "q00099",
     "image_path": null,
     "question_text": {
+      "en": "What does `|` (pipe) do in shell?",
+      "ja": "しぇるの`|`（ぱいぷ）は何をするか？"
+    },
+    "question_text_reading": {
       "en": "What does `|` (pipe) do in shell?",
       "ja": "しぇるの`|`（ぱいぷ）は何をするか？"
     }
@@ -3208,6 +3604,10 @@
     "question_text": {
       "en": "What does SQL stand for?",
       "ja": "SQLの略語の意味は？"
+    },
+    "question_text_reading": {
+      "en": "What does SQL stand for?",
+      "ja": "SQLの略語の意味は？"
     }
   },
   {
@@ -3238,6 +3638,10 @@
     "id": "q00101",
     "image_path": null,
     "question_text": {
+      "en": "What is a primary key?",
+      "ja": "しゅきーとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a primary key?",
       "ja": "しゅきーとは何か？"
     }
@@ -3272,6 +3676,10 @@
     "question_text": {
       "en": "What is a JOIN in SQL?",
       "ja": "SQLのJOINとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a JOIN in SQL?",
+      "ja": "SQLのJOINとは何か？"
     }
   },
   {
@@ -3302,6 +3710,10 @@
     "id": "q00103",
     "image_path": null,
     "question_text": {
+      "en": "What is indexing in databases?",
+      "ja": "でーたべーすのいんでくすとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is indexing in databases?",
       "ja": "でーたべーすのいんでくすとは何か？"
     }
@@ -3336,6 +3748,10 @@
     "question_text": {
       "en": "What is a transaction in databases?",
       "ja": "でーたべーすのとらんざくしょんとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a transaction in databases?",
+      "ja": "でーたべーすのとらんざくしょんとは何か？"
     }
   },
   {
@@ -3366,6 +3782,10 @@
     "id": "q00105",
     "image_path": null,
     "question_text": {
+      "en": "What does ACID stand for?",
+      "ja": "ACIDの略語の意味は？"
+    },
+    "question_text_reading": {
       "en": "What does ACID stand for?",
       "ja": "ACIDの略語の意味は？"
     }
@@ -3400,6 +3820,10 @@
     "question_text": {
       "en": "What is SQL injection?",
       "ja": "SQLいんじぇくしょんとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is SQL injection?",
+      "ja": "SQLいんじぇくしょんとは何か？"
     }
   },
   {
@@ -3430,6 +3854,10 @@
     "id": "q00107",
     "image_path": null,
     "question_text": {
+      "en": "What is XSS?",
+      "ja": "XSSとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is XSS?",
       "ja": "XSSとは何か？"
     }
@@ -3464,6 +3892,10 @@
     "question_text": {
       "en": "What is HTTPS?",
       "ja": "HTTPSとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is HTTPS?",
+      "ja": "HTTPSとは何か？"
     }
   },
   {
@@ -3494,6 +3926,10 @@
     "id": "q00109",
     "image_path": null,
     "question_text": {
+      "en": "What is a CSRF attack?",
+      "ja": "CSRF攻撃とは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a CSRF attack?",
       "ja": "CSRF攻撃とは何か？"
     }
@@ -3528,6 +3964,10 @@
     "question_text": {
       "en": "What is hashing in security?",
       "ja": "せきゅりてぃのはっしゅかとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is hashing in security?",
+      "ja": "せきゅりてぃのはっしゅかとは何か？"
     }
   },
   {
@@ -3558,6 +3998,10 @@
     "id": "q00111",
     "image_path": null,
     "question_text": {
+      "en": "What is Docker?",
+      "ja": "Dockerとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is Docker?",
       "ja": "Dockerとは何か？"
     }
@@ -3592,6 +4036,10 @@
     "question_text": {
       "en": "What is Kubernetes?",
       "ja": "Kubernetesとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is Kubernetes?",
+      "ja": "Kubernetesとは何か？"
     }
   },
   {
@@ -3622,6 +4070,10 @@
     "id": "q00113",
     "image_path": null,
     "question_text": {
+      "en": "What is CI/CD?",
+      "ja": "CI/CDとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is CI/CD?",
       "ja": "CI/CDとは何か？"
     }
@@ -3656,6 +4108,10 @@
     "question_text": {
       "en": "What is Infrastructure as Code?",
       "ja": "Infrastructure as Codeとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is Infrastructure as Code?",
+      "ja": "Infrastructure as Codeとは何か？"
     }
   },
   {
@@ -3686,6 +4142,10 @@
     "id": "q00115",
     "image_path": null,
     "question_text": {
+      "en": "What is a microservice?",
+      "ja": "まいくろさーびすとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a microservice?",
       "ja": "まいくろさーびすとは何か？"
     }
@@ -3720,6 +4180,10 @@
     "question_text": {
       "en": "What is an API?",
       "ja": "APIとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is an API?",
+      "ja": "APIとは何か？"
     }
   },
   {
@@ -3750,6 +4214,10 @@
     "id": "q00117",
     "image_path": null,
     "question_text": {
+      "en": "What is open source software?",
+      "ja": "おーぷんそーすそふとうぇあとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is open source software?",
       "ja": "おーぷんそーすそふとうぇあとは何か？"
     }
@@ -3784,6 +4252,10 @@
     "question_text": {
       "en": "What is semantic versioning?",
       "ja": "せまんてぃっくばーじょにんぐとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is semantic versioning?",
+      "ja": "せまんてぃっくばーじょにんぐとは何か？"
     }
   },
   {
@@ -3814,6 +4286,10 @@
     "id": "q00119",
     "image_path": null,
     "question_text": {
+      "en": "What is a linter?",
+      "ja": "りんたーとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a linter?",
       "ja": "りんたーとは何か？"
     }
@@ -3848,6 +4324,10 @@
     "question_text": {
       "en": "What is refactoring?",
       "ja": "りふぁくたりんぐとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is refactoring?",
+      "ja": "りふぁくたりんぐとは何か？"
     }
   },
   {
@@ -3878,6 +4358,10 @@
     "id": "q00121",
     "image_path": null,
     "question_text": {
+      "en": "What is technical debt?",
+      "ja": "ぎじゅつてきふさいとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is technical debt?",
       "ja": "ぎじゅつてきふさいとは何か？"
     }
@@ -3912,6 +4396,10 @@
     "question_text": {
       "en": "What is code review?",
       "ja": "こーどれびゅーとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is code review?",
+      "ja": "こーどれびゅーとは何か？"
     }
   },
   {
@@ -3942,6 +4430,10 @@
     "id": "q00123",
     "image_path": null,
     "question_text": {
+      "en": "What is a build system?",
+      "ja": "びるどしすてむとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a build system?",
       "ja": "びるどしすてむとは何か？"
     }
@@ -3976,6 +4468,10 @@
     "question_text": {
       "en": "What is dependency injection?",
       "ja": "いぞんせいのちゅうにゅうとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is dependency injection?",
+      "ja": "いぞんせいのちゅうにゅうとは何か？"
     }
   },
   {
@@ -4006,6 +4502,10 @@
     "id": "q00125",
     "image_path": null,
     "question_text": {
+      "en": "What is an event loop?",
+      "ja": "いべんとるーぷとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is an event loop?",
       "ja": "いべんとるーぷとは何か？"
     }
@@ -4040,6 +4540,10 @@
     "question_text": {
       "en": "What is the DOM?",
       "ja": "DOMとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is the DOM?",
+      "ja": "DOMとは何か？"
     }
   },
   {
@@ -4070,6 +4574,10 @@
     "id": "q00127",
     "image_path": null,
     "question_text": {
+      "en": "What is event bubbling?",
+      "ja": "いべんとばぶりんぐとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is event bubbling?",
       "ja": "いべんとばぶりんぐとは何か？"
     }
@@ -4104,6 +4612,10 @@
     "question_text": {
       "en": "What is lazy loading?",
       "ja": "れいじーろーでぃんぐとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is lazy loading?",
+      "ja": "れいじーろーでぃんぐとは何か？"
     }
   },
   {
@@ -4134,6 +4646,10 @@
     "id": "q00129",
     "image_path": null,
     "question_text": {
+      "en": "What is tree shaking?",
+      "ja": "つりーしぇいきんぐとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is tree shaking?",
       "ja": "つりーしぇいきんぐとは何か？"
     }
@@ -4168,6 +4684,10 @@
     "question_text": {
       "en": "What is a code smell?",
       "ja": "こーどすめるとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a code smell?",
+      "ja": "こーどすめるとは何か？"
     }
   },
   {
@@ -4198,6 +4718,10 @@
     "id": "q00131",
     "image_path": null,
     "question_text": {
+      "en": "What is pair programming?",
+      "ja": "ぺあぷろぐらみんぐとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is pair programming?",
       "ja": "ぺあぷろぐらみんぐとは何か？"
     }
@@ -4232,6 +4756,10 @@
     "question_text": {
       "en": "What is an IDE?",
       "ja": "IDEとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is an IDE?",
+      "ja": "IDEとは何か？"
     }
   },
   {
@@ -4262,6 +4790,10 @@
     "id": "q00133",
     "image_path": null,
     "question_text": {
+      "en": "What is duck typing?",
+      "ja": "だっくたいぴんぐとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is duck typing?",
       "ja": "だっくたいぴんぐとは何か？"
     }
@@ -4296,6 +4828,10 @@
     "question_text": {
       "en": "What is a closure?",
       "ja": "くろーじゃとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a closure?",
+      "ja": "くろーじゃとは何か？"
     }
   },
   {
@@ -4326,6 +4862,10 @@
     "id": "q00135",
     "image_path": null,
     "question_text": {
+      "en": "What is currying?",
+      "ja": "かりーかとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is currying?",
       "ja": "かりーかとは何か？"
     }
@@ -4360,6 +4900,10 @@
     "question_text": {
       "en": "What is WebAssembly (WASM)?",
       "ja": "WebAssembly (WASM)とは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is WebAssembly (WASM)?",
+      "ja": "WebAssembly (WASM)とは何か？"
     }
   },
   {
@@ -4390,6 +4934,10 @@
     "id": "q00137",
     "image_path": null,
     "question_text": {
+      "en": "What is a prototype in JavaScript?",
+      "ja": "JavaScriptのぷろとたいぷとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a prototype in JavaScript?",
       "ja": "JavaScriptのぷろとたいぷとは何か？"
     }
@@ -4424,6 +4972,10 @@
     "question_text": {
       "en": "What is method chaining?",
       "ja": "めそっどちぇーにんぐとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is method chaining?",
+      "ja": "めそっどちぇーにんぐとは何か？"
     }
   },
   {
@@ -4454,6 +5006,10 @@
     "id": "q00139",
     "image_path": null,
     "question_text": {
+      "en": "What is the SOLID principle?",
+      "ja": "SOLIDげんそくとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is the SOLID principle?",
       "ja": "SOLIDげんそくとは何か？"
     }
@@ -4488,6 +5044,10 @@
     "question_text": {
       "en": "What is DRY principle?",
       "ja": "DRYげんそくとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is DRY principle?",
+      "ja": "DRYげんそくとは何か？"
     }
   },
   {
@@ -4518,6 +5078,10 @@
     "id": "q00141",
     "image_path": null,
     "question_text": {
+      "en": "What is KISS principle?",
+      "ja": "KISSげんそくとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is KISS principle?",
       "ja": "KISSげんそくとは何か？"
     }
@@ -4552,6 +5116,10 @@
     "question_text": {
       "en": "What is a webhook?",
       "ja": "うぇぶふっくとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a webhook?",
+      "ja": "うぇぶふっくとは何か？"
     }
   },
   {
@@ -4582,6 +5150,10 @@
     "id": "q00143",
     "image_path": null,
     "question_text": {
+      "en": "What is GraphQL?",
+      "ja": "GraphQLとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is GraphQL?",
       "ja": "GraphQLとは何か？"
     }
@@ -4616,6 +5188,10 @@
     "question_text": {
       "en": "What is server-side rendering?",
       "ja": "さーばーさいどれんだりんぐとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is server-side rendering?",
+      "ja": "さーばーさいどれんだりんぐとは何か？"
     }
   },
   {
@@ -4646,6 +5222,10 @@
     "id": "q00145",
     "image_path": null,
     "question_text": {
+      "en": "What is hydration in web development?",
+      "ja": "うぇぶかいはつのはいどれーしょんとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is hydration in web development?",
       "ja": "うぇぶかいはつのはいどれーしょんとは何か？"
     }
@@ -4680,6 +5260,10 @@
     "question_text": {
       "en": "What is a module in programming?",
       "ja": "ぷろぐらみんぐのもじゅーるとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a module in programming?",
+      "ja": "ぷろぐらみんぐのもじゅーるとは何か？"
     }
   },
   {
@@ -4710,6 +5294,10 @@
     "id": "q00147",
     "image_path": null,
     "question_text": {
+      "en": "What is package management?",
+      "ja": "ぱっけーじかんりとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is package management?",
       "ja": "ぱっけーじかんりとは何か？"
     }
@@ -4744,6 +5332,10 @@
     "question_text": {
       "en": "What is environment variable?",
       "ja": "かんきょうへんすうとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is environment variable?",
+      "ja": "かんきょうへんすうとは何か？"
     }
   },
   {
@@ -4774,6 +5366,10 @@
     "id": "q00149",
     "image_path": null,
     "question_text": {
+      "en": "What is a race condition in databases?",
+      "ja": "でーたべーすのれーすじょうけんとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a race condition in databases?",
       "ja": "でーたべーすのれーすじょうけんとは何か？"
     }
@@ -4808,6 +5404,10 @@
     "question_text": {
       "en": "What is normalization in databases?",
       "ja": "でーたべーすのせいきかとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is normalization in databases?",
+      "ja": "でーたべーすのせいきかとは何か？"
     }
   },
   {
@@ -4838,6 +5438,10 @@
     "id": "q00151",
     "image_path": null,
     "question_text": {
+      "en": "What does CSS stand for?",
+      "ja": "CSSのふりがなの意味は？"
+    },
+    "question_text_reading": {
       "en": "What does CSS stand for?",
       "ja": "CSSのふりがなの意味は？"
     }
@@ -4872,6 +5476,10 @@
     "question_text": {
       "en": "Which HTML tag creates a hyperlink?",
       "ja": "ハイパーリンクをつくるHTMLたぐは？"
+    },
+    "question_text_reading": {
+      "en": "Which HTML tag creates a hyperlink?",
+      "ja": "ハイパーリンクをつくるHTMLたぐは？"
     }
   },
   {
@@ -4902,6 +5510,10 @@
     "id": "q00153",
     "image_path": null,
     "question_text": {
+      "en": "What is the CSS box model?",
+      "ja": "CSSのぼっくすもでるとは？"
+    },
+    "question_text_reading": {
       "en": "What is the CSS box model?",
       "ja": "CSSのぼっくすもでるとは？"
     }
@@ -4936,6 +5548,10 @@
     "question_text": {
       "en": "What does `display: flex` enable?",
       "ja": "`display: flex`は何を可能にするか？"
+    },
+    "question_text_reading": {
+      "en": "What does `display: flex` enable?",
+      "ja": "`display: flex`は何を可能にするか？"
     }
   },
   {
@@ -4966,6 +5582,10 @@
     "id": "q00155",
     "image_path": null,
     "question_text": {
+      "en": "What is media query in CSS?",
+      "ja": "CSSのめでぃあくえりとは？"
+    },
+    "question_text_reading": {
       "en": "What is media query in CSS?",
       "ja": "CSSのめでぃあくえりとは？"
     }
@@ -5000,6 +5620,10 @@
     "question_text": {
       "en": "What is React?",
       "ja": "Reactとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is React?",
+      "ja": "Reactとは何か？"
     }
   },
   {
@@ -5030,6 +5654,10 @@
     "id": "q00157",
     "image_path": null,
     "question_text": {
+      "en": "What is a React component?",
+      "ja": "Reactこんぽーねんととは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a React component?",
       "ja": "Reactこんぽーねんととは何か？"
     }
@@ -5064,6 +5692,10 @@
     "question_text": {
       "en": "What is JSX?",
       "ja": "JSXとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is JSX?",
+      "ja": "JSXとは何か？"
     }
   },
   {
@@ -5094,6 +5726,10 @@
     "id": "q00159",
     "image_path": null,
     "question_text": {
+      "en": "What is the virtual DOM in React?",
+      "ja": "Reactのばーちゃるどむとは？"
+    },
+    "question_text_reading": {
       "en": "What is the virtual DOM in React?",
       "ja": "Reactのばーちゃるどむとは？"
     }
@@ -5128,6 +5764,10 @@
     "question_text": {
       "en": "What does `useState` do in React?",
       "ja": "Reactの`useState`は何をするか？"
+    },
+    "question_text_reading": {
+      "en": "What does `useState` do in React?",
+      "ja": "Reactの`useState`は何をするか？"
     }
   },
   {
@@ -5158,6 +5798,10 @@
     "id": "q00161",
     "image_path": null,
     "question_text": {
+      "en": "What does `useEffect` do in React?",
+      "ja": "Reactの`useEffect`は何をするか？"
+    },
+    "question_text_reading": {
       "en": "What does `useEffect` do in React?",
       "ja": "Reactの`useEffect`は何をするか？"
     }
@@ -5192,6 +5836,10 @@
     "question_text": {
       "en": "What is Vue.js?",
       "ja": "Vue.jsとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is Vue.js?",
+      "ja": "Vue.jsとは何か？"
     }
   },
   {
@@ -5222,6 +5870,10 @@
     "id": "q00163",
     "image_path": null,
     "question_text": {
+      "en": "What is TypeScript?",
+      "ja": "TypeScriptとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is TypeScript?",
       "ja": "TypeScriptとは何か？"
     }
@@ -5256,6 +5908,10 @@
     "question_text": {
       "en": "What is npm?",
       "ja": "npmとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is npm?",
+      "ja": "npmとは何か？"
     }
   },
   {
@@ -5286,6 +5942,10 @@
     "id": "q00165",
     "image_path": null,
     "question_text": {
+      "en": "What is Node.js?",
+      "ja": "Node.jsとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is Node.js?",
       "ja": "Node.jsとは何か？"
     }
@@ -5320,6 +5980,10 @@
     "question_text": {
       "en": "What is Webpack?",
       "ja": "Webpackとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is Webpack?",
+      "ja": "Webpackとは何か？"
     }
   },
   {
@@ -5350,6 +6014,10 @@
     "id": "q00167",
     "image_path": null,
     "question_text": {
+      "en": "What is a SPA?",
+      "ja": "SPAとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a SPA?",
       "ja": "SPAとは何か？"
     }
@@ -5384,6 +6052,10 @@
     "question_text": {
       "en": "What is SSR in web?",
       "ja": "うぇぶのSSRとは？"
+    },
+    "question_text_reading": {
+      "en": "What is SSR in web?",
+      "ja": "うぇぶのSSRとは？"
     }
   },
   {
@@ -5414,6 +6086,10 @@
     "id": "q00169",
     "image_path": null,
     "question_text": {
+      "en": "What is a cookie?",
+      "ja": "くっきーとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a cookie?",
       "ja": "くっきーとは何か？"
     }
@@ -5448,6 +6124,10 @@
     "question_text": {
       "en": "What is localStorage?",
       "ja": "localStorageとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is localStorage?",
+      "ja": "localStorageとは何か？"
     }
   },
   {
@@ -5478,6 +6158,10 @@
     "id": "q00171",
     "image_path": null,
     "question_text": {
+      "en": "What does `fetch()` do in JS?",
+      "ja": "JSの`fetch()`は何をするか？"
+    },
+    "question_text_reading": {
       "en": "What does `fetch()` do in JS?",
       "ja": "JSの`fetch()`は何をするか？"
     }
@@ -5512,6 +6196,10 @@
     "question_text": {
       "en": "What is CORS?",
       "ja": "CORSとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is CORS?",
+      "ja": "CORSとは何か？"
     }
   },
   {
@@ -5542,6 +6230,10 @@
     "id": "q00173",
     "image_path": null,
     "question_text": {
+      "en": "What is a CDN?",
+      "ja": "CDNとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a CDN?",
       "ja": "CDNとは何か？"
     }
@@ -5576,6 +6268,10 @@
     "question_text": {
       "en": "What is semantic HTML?",
       "ja": "せまんてぃっくHTMLとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is semantic HTML?",
+      "ja": "せまんてぃっくHTMLとは何か？"
     }
   },
   {
@@ -5606,6 +6302,10 @@
     "id": "q00175",
     "image_path": null,
     "question_text": {
+      "en": "What is the purpose of `<meta charset>`?",
+      "ja": "`<meta charset>`の目的は？"
+    },
+    "question_text_reading": {
       "en": "What is the purpose of `<meta charset>`?",
       "ja": "`<meta charset>`の目的は？"
     }
@@ -5640,6 +6340,10 @@
     "question_text": {
       "en": "What is lazy loading in web?",
       "ja": "うぇぶのれいじーろーでぃんぐとは？"
+    },
+    "question_text_reading": {
+      "en": "What is lazy loading in web?",
+      "ja": "うぇぶのれいじーろーでぃんぐとは？"
     }
   },
   {
@@ -5670,6 +6374,10 @@
     "id": "q00177",
     "image_path": null,
     "question_text": {
+      "en": "What is progressive enhancement?",
+      "ja": "ぷろぐれっしぶえんはんすめんととは？"
+    },
+    "question_text_reading": {
       "en": "What is progressive enhancement?",
       "ja": "ぷろぐれっしぶえんはんすめんととは？"
     }
@@ -5704,6 +6412,10 @@
     "question_text": {
       "en": "What is a CSS preprocessor?",
       "ja": "CSSぷりぷろせっさとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a CSS preprocessor?",
+      "ja": "CSSぷりぷろせっさとは何か？"
     }
   },
   {
@@ -5734,6 +6446,10 @@
     "id": "q00179",
     "image_path": null,
     "question_text": {
+      "en": "What is Tailwind CSS?",
+      "ja": "Tailwind CSSとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is Tailwind CSS?",
       "ja": "Tailwind CSSとは何か？"
     }
@@ -5768,6 +6484,10 @@
     "question_text": {
       "en": "What is tree shaking in frontend?",
       "ja": "ふろんとえんどのつりーしぇいきんぐとは？"
+    },
+    "question_text_reading": {
+      "en": "What is tree shaking in frontend?",
+      "ja": "ふろんとえんどのつりーしぇいきんぐとは？"
     }
   },
   {
@@ -5798,6 +6518,10 @@
     "id": "q00181",
     "image_path": null,
     "question_text": {
+      "en": "What is the purpose of `<head>` in HTML?",
+      "ja": "HTMLの`<head>`の役割は？"
+    },
+    "question_text_reading": {
       "en": "What is the purpose of `<head>` in HTML?",
       "ja": "HTMLの`<head>`の役割は？"
     }
@@ -5832,6 +6556,10 @@
     "question_text": {
       "en": "What does `position: absolute` do in CSS?",
       "ja": "CSSの`position: absolute`は何をするか？"
+    },
+    "question_text_reading": {
+      "en": "What does `position: absolute` do in CSS?",
+      "ja": "CSSの`position: absolute`は何をするか？"
     }
   },
   {
@@ -5862,6 +6590,10 @@
     "id": "q00183",
     "image_path": null,
     "question_text": {
+      "en": "What is z-index in CSS?",
+      "ja": "CSSのz-indexとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is z-index in CSS?",
       "ja": "CSSのz-indexとは何か？"
     }
@@ -5896,6 +6628,10 @@
     "question_text": {
       "en": "What is BEM in CSS?",
       "ja": "CSSのBEMとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is BEM in CSS?",
+      "ja": "CSSのBEMとは何か？"
     }
   },
   {
@@ -5926,6 +6662,10 @@
     "id": "q00185",
     "image_path": null,
     "question_text": {
+      "en": "What is a CSS variable?",
+      "ja": "CSS変数とは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a CSS variable?",
       "ja": "CSS変数とは何か？"
     }
@@ -5960,6 +6700,10 @@
     "question_text": {
       "en": "What is accessibility (a11y) in web?",
       "ja": "うぇぶのアクセシビリティとは？"
+    },
+    "question_text_reading": {
+      "en": "What is accessibility (a11y) in web?",
+      "ja": "うぇぶのアクセシビリティとは？"
     }
   },
   {
@@ -5990,6 +6734,10 @@
     "id": "q00187",
     "image_path": null,
     "question_text": {
+      "en": "What is ARIA in web accessibility?",
+      "ja": "うぇぶのARIAとは？"
+    },
+    "question_text_reading": {
       "en": "What is ARIA in web accessibility?",
       "ja": "うぇぶのARIAとは？"
     }
@@ -6024,6 +6772,10 @@
     "question_text": {
       "en": "What is PWA?",
       "ja": "PWAとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is PWA?",
+      "ja": "PWAとは何か？"
     }
   },
   {
@@ -6054,6 +6806,10 @@
     "id": "q00189",
     "image_path": null,
     "question_text": {
+      "en": "What is a service worker?",
+      "ja": "さーびすわーかーとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a service worker?",
       "ja": "さーびすわーかーとは何か？"
     }
@@ -6088,6 +6844,10 @@
     "question_text": {
       "en": "What is Next.js?",
       "ja": "Next.jsとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is Next.js?",
+      "ja": "Next.jsとは何か？"
     }
   },
   {
@@ -6118,6 +6878,10 @@
     "id": "q00191",
     "image_path": null,
     "question_text": {
+      "en": "What is SvelteKit?",
+      "ja": "SvelteKitとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is SvelteKit?",
       "ja": "SvelteKitとは何か？"
     }
@@ -6152,6 +6916,10 @@
     "question_text": {
       "en": "What is the purpose of `alt` attribute in `<img>`?",
       "ja": "`<img>`の`alt`属性の目的は？"
+    },
+    "question_text_reading": {
+      "en": "What is the purpose of `alt` attribute in `<img>`?",
+      "ja": "`<img>`の`alt`属性の目的は？"
     }
   },
   {
@@ -6182,6 +6950,10 @@
     "id": "q00193",
     "image_path": null,
     "question_text": {
+      "en": "What is HTTP/2 improvement?",
+      "ja": "HTTP/2の改善点は？"
+    },
+    "question_text_reading": {
       "en": "What is HTTP/2 improvement?",
       "ja": "HTTP/2の改善点は？"
     }
@@ -6216,6 +6988,10 @@
     "question_text": {
       "en": "What is WebSocket?",
       "ja": "WebSocketとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is WebSocket?",
+      "ja": "WebSocketとは何か？"
     }
   },
   {
@@ -6246,6 +7022,10 @@
     "id": "q00195",
     "image_path": null,
     "question_text": {
+      "en": "What is the Shadow DOM?",
+      "ja": "シャドウDOMとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is the Shadow DOM?",
       "ja": "シャドウDOMとは何か？"
     }
@@ -6280,6 +7060,10 @@
     "question_text": {
       "en": "What is a custom HTML element?",
       "ja": "かすたむHTMLようそとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a custom HTML element?",
+      "ja": "かすたむHTMLようそとは何か？"
     }
   },
   {
@@ -6310,6 +7094,10 @@
     "id": "q00197",
     "image_path": null,
     "question_text": {
+      "en": "What is `defer` attribute in `<script>`?",
+      "ja": "`<script>`の`defer`属性は何をするか？"
+    },
+    "question_text_reading": {
       "en": "What is `defer` attribute in `<script>`?",
       "ja": "`<script>`の`defer`属性は何をするか？"
     }
@@ -6344,6 +7132,10 @@
     "question_text": {
       "en": "What is the difference between `em` and `rem` in CSS?",
       "ja": "CSSの`em`と`rem`のちがいは？"
+    },
+    "question_text_reading": {
+      "en": "What is the difference between `em` and `rem` in CSS?",
+      "ja": "CSSの`em`と`rem`のちがいは？"
     }
   },
   {
@@ -6374,6 +7166,10 @@
     "id": "q00199",
     "image_path": null,
     "question_text": {
+      "en": "What is a CSS grid?",
+      "ja": "CSSぐりっどとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a CSS grid?",
       "ja": "CSSぐりっどとは何か？"
     }
@@ -6408,6 +7204,10 @@
     "question_text": {
       "en": "What is viewport in CSS?",
       "ja": "CSSのびゅーぽーととは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is viewport in CSS?",
+      "ja": "CSSのびゅーぽーととは何か？"
     }
   },
   {
@@ -6438,6 +7238,10 @@
     "id": "q00201",
     "image_path": null,
     "question_text": {
+      "en": "What is minification in web?",
+      "ja": "うぇぶのみにふぁいとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is minification in web?",
       "ja": "うぇぶのみにふぁいとは何か？"
     }
@@ -6472,6 +7276,10 @@
     "question_text": {
       "en": "What is code splitting?",
       "ja": "こーどすぷりってぃんぐとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is code splitting?",
+      "ja": "こーどすぷりってぃんぐとは何か？"
     }
   },
   {
@@ -6502,6 +7310,10 @@
     "id": "q00203",
     "image_path": null,
     "question_text": {
+      "en": "What does `async` attribute do in `<script>`?",
+      "ja": "`<script>`の`async`属性は何をするか？"
+    },
+    "question_text_reading": {
       "en": "What does `async` attribute do in `<script>`?",
       "ja": "`<script>`の`async`属性は何をするか？"
     }
@@ -6536,6 +7348,10 @@
     "question_text": {
       "en": "What is OAuth?",
       "ja": "OAuthとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is OAuth?",
+      "ja": "OAuthとは何か？"
     }
   },
   {
@@ -6566,6 +7382,10 @@
     "id": "q00205",
     "image_path": null,
     "question_text": {
+      "en": "What is JWT?",
+      "ja": "JWTとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is JWT?",
       "ja": "JWTとは何か？"
     }
@@ -6600,6 +7420,10 @@
     "question_text": {
       "en": "What is a headless CMS?",
       "ja": "へっどれすCMSとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a headless CMS?",
+      "ja": "へっどれすCMSとは何か？"
     }
   },
   {
@@ -6630,6 +7454,10 @@
     "id": "q00207",
     "image_path": null,
     "question_text": {
+      "en": "What is a sitemap?",
+      "ja": "さいとまっぷとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a sitemap?",
       "ja": "さいとまっぷとは何か？"
     }
@@ -6664,6 +7492,10 @@
     "question_text": {
       "en": "What is SEO?",
       "ja": "SEOとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is SEO?",
+      "ja": "SEOとは何か？"
     }
   },
   {
@@ -6694,6 +7526,10 @@
     "id": "q00209",
     "image_path": null,
     "question_text": {
+      "en": "What is Core Web Vitals?",
+      "ja": "コアうぇぶばいたるずとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is Core Web Vitals?",
       "ja": "コアうぇぶばいたるずとは何か？"
     }
@@ -6728,6 +7564,10 @@
     "question_text": {
       "en": "What does LCP stand for in web performance?",
       "ja": "うぇぶぱふぉーまんすのLCPとは？"
+    },
+    "question_text_reading": {
+      "en": "What does LCP stand for in web performance?",
+      "ja": "うぇぶぱふぉーまんすのLCPとは？"
     }
   },
   {
@@ -6758,6 +7598,10 @@
     "id": "q00211",
     "image_path": null,
     "question_text": {
+      "en": "What is a web manifest file?",
+      "ja": "うぇぶましふぇすとふぁいるとは？"
+    },
+    "question_text_reading": {
       "en": "What is a web manifest file?",
       "ja": "うぇぶましふぇすとふぁいるとは？"
     }
@@ -6792,6 +7636,10 @@
     "question_text": {
       "en": "What is isomorphic rendering?",
       "ja": "あいそもーふぃっくれんだりんぐとは？"
+    },
+    "question_text_reading": {
+      "en": "What is isomorphic rendering?",
+      "ja": "あいそもーふぃっくれんだりんぐとは？"
     }
   },
   {
@@ -6822,6 +7670,10 @@
     "id": "q00213",
     "image_path": null,
     "question_text": {
+      "en": "What is Vite?",
+      "ja": "Viteとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is Vite?",
       "ja": "Viteとは何か？"
     }
@@ -6856,6 +7708,10 @@
     "question_text": {
       "en": "What is ESLint?",
       "ja": "ESLintとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is ESLint?",
+      "ja": "ESLintとは何か？"
     }
   },
   {
@@ -6886,6 +7742,10 @@
     "id": "q00215",
     "image_path": null,
     "question_text": {
+      "en": "What is Prettier?",
+      "ja": "Prettierとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is Prettier?",
       "ja": "Prettierとは何か？"
     }
@@ -6920,6 +7780,10 @@
     "question_text": {
       "en": "What is an HTTP header?",
       "ja": "HTTPへっだーとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is an HTTP header?",
+      "ja": "HTTPへっだーとは何か？"
     }
   },
   {
@@ -6950,6 +7814,10 @@
     "id": "q00217",
     "image_path": null,
     "question_text": {
+      "en": "What is a 404 error?",
+      "ja": "404えらーとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a 404 error?",
       "ja": "404えらーとは何か？"
     }
@@ -6984,6 +7852,10 @@
     "question_text": {
       "en": "What is a 500 error?",
       "ja": "500えらーとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a 500 error?",
+      "ja": "500えらーとは何か？"
     }
   },
   {
@@ -7014,6 +7886,10 @@
     "id": "q00219",
     "image_path": null,
     "question_text": {
+      "en": "What is a redirect in HTTP?",
+      "ja": "HTTPのりだいれくととは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a redirect in HTTP?",
       "ja": "HTTPのりだいれくととは何か？"
     }
@@ -7048,6 +7924,10 @@
     "question_text": {
       "en": "What is Cross-Site Scripting (XSS) prevented by?",
       "ja": "XSSを防ぐには何をするか？"
+    },
+    "question_text_reading": {
+      "en": "What is Cross-Site Scripting (XSS) prevented by?",
+      "ja": "XSSを防ぐには何をするか？"
     }
   },
   {
@@ -7078,6 +7958,10 @@
     "id": "q00221",
     "image_path": null,
     "question_text": {
+      "en": "What is Content Security Policy?",
+      "ja": "コンテンツせきゅりてぃぽりしーとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is Content Security Policy?",
       "ja": "コンテンツせきゅりてぃぽりしーとは何か？"
     }
@@ -7112,6 +7996,10 @@
     "question_text": {
       "en": "What is a REST endpoint?",
       "ja": "RESTえんどぽいんととは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a REST endpoint?",
+      "ja": "RESTえんどぽいんととは何か？"
     }
   },
   {
@@ -7142,6 +8030,10 @@
     "id": "q00223",
     "image_path": null,
     "question_text": {
+      "en": "What is event delegation in JS?",
+      "ja": "JSのいべんとでりげーしょんとは？"
+    },
+    "question_text_reading": {
       "en": "What is event delegation in JS?",
       "ja": "JSのいべんとでりげーしょんとは？"
     }
@@ -7176,6 +8068,10 @@
     "question_text": {
       "en": "What is debouncing in JS?",
       "ja": "JSのでばうんすとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is debouncing in JS?",
+      "ja": "JSのでばうんすとは何か？"
     }
   },
   {
@@ -7206,6 +8102,10 @@
     "id": "q00225",
     "image_path": null,
     "question_text": {
+      "en": "What is throttling in JS?",
+      "ja": "JSのすろっとりんぐとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is throttling in JS?",
       "ja": "JSのすろっとりんぐとは何か？"
     }
@@ -7240,6 +8140,10 @@
     "question_text": {
       "en": "What is a web component?",
       "ja": "うぇぶこんぽーねんととは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a web component?",
+      "ja": "うぇぶこんぽーねんととは何か？"
     }
   },
   {
@@ -7270,6 +8174,10 @@
     "id": "q00227",
     "image_path": null,
     "question_text": {
+      "en": "What is an HTTP cache?",
+      "ja": "HTTPきゃっしゅとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is an HTTP cache?",
       "ja": "HTTPきゃっしゅとは何か？"
     }
@@ -7304,6 +8212,10 @@
     "question_text": {
       "en": "What is JSON Web Token (JWT) used for?",
       "ja": "JWTは何のために使うか？"
+    },
+    "question_text_reading": {
+      "en": "What is JSON Web Token (JWT) used for?",
+      "ja": "JWTは何のために使うか？"
     }
   },
   {
@@ -7334,6 +8246,10 @@
     "id": "q00229",
     "image_path": null,
     "question_text": {
+      "en": "What is Nuxt.js?",
+      "ja": "Nuxt.jsとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is Nuxt.js?",
       "ja": "Nuxt.jsとは何か？"
     }
@@ -7368,6 +8284,10 @@
     "question_text": {
       "en": "What is Astro?",
       "ja": "Astroとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is Astro?",
+      "ja": "Astroとは何か？"
     }
   },
   {
@@ -7398,6 +8318,10 @@
     "id": "q00231",
     "image_path": null,
     "question_text": {
+      "en": "What is a monorepo?",
+      "ja": "ものりぽとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a monorepo?",
       "ja": "ものりぽとは何か？"
     }
@@ -7432,6 +8356,10 @@
     "question_text": {
       "en": "What is Storybook?",
       "ja": "Storybookとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is Storybook?",
+      "ja": "Storybookとは何か？"
     }
   },
   {
@@ -7462,6 +8390,10 @@
     "id": "q00233",
     "image_path": null,
     "question_text": {
+      "en": "What is Playwright?",
+      "ja": "Playwrightとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is Playwright?",
       "ja": "Playwrightとは何か？"
     }
@@ -7496,6 +8428,10 @@
     "question_text": {
       "en": "What is tRPC?",
       "ja": "tRPCとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is tRPC?",
+      "ja": "tRPCとは何か？"
     }
   },
   {
@@ -7526,6 +8462,10 @@
     "id": "q00235",
     "image_path": null,
     "question_text": {
+      "en": "What is Cloudflare Workers?",
+      "ja": "Cloudflare Workersとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is Cloudflare Workers?",
       "ja": "Cloudflare Workersとは何か？"
     }
@@ -7560,6 +8500,10 @@
     "question_text": {
       "en": "What is Vercel?",
       "ja": "Vercelとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is Vercel?",
+      "ja": "Vercelとは何か？"
     }
   },
   {
@@ -7590,6 +8534,10 @@
     "id": "q00237",
     "image_path": null,
     "question_text": {
+      "en": "What is the purpose of `robots.txt`?",
+      "ja": "`robots.txt`の目的は？"
+    },
+    "question_text_reading": {
       "en": "What is the purpose of `robots.txt`?",
       "ja": "`robots.txt`の目的は？"
     }
@@ -7624,6 +8572,10 @@
     "question_text": {
       "en": "What is open graph protocol?",
       "ja": "おーぷんぐらふぷろとこるとは？"
+    },
+    "question_text_reading": {
+      "en": "What is open graph protocol?",
+      "ja": "おーぷんぐらふぷろとこるとは？"
     }
   },
   {
@@ -7654,6 +8606,10 @@
     "id": "q00239",
     "image_path": null,
     "question_text": {
+      "en": "What is an operating system?",
+      "ja": "おぺれーてぃんぐしすてむとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is an operating system?",
       "ja": "おぺれーてぃんぐしすてむとは何か？"
     }
@@ -7688,6 +8644,10 @@
     "question_text": {
       "en": "What is virtualization?",
       "ja": "かそうかとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is virtualization?",
+      "ja": "かそうかとは何か？"
     }
   },
   {
@@ -7718,6 +8678,10 @@
     "id": "q00241",
     "image_path": null,
     "question_text": {
+      "en": "What is a kernel?",
+      "ja": "かーねるとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a kernel?",
       "ja": "かーねるとは何か？"
     }
@@ -7752,6 +8716,10 @@
     "question_text": {
       "en": "What is BIOS?",
       "ja": "BIOSとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is BIOS?",
+      "ja": "BIOSとは何か？"
     }
   },
   {
@@ -7782,6 +8750,10 @@
     "id": "q00243",
     "image_path": null,
     "question_text": {
+      "en": "What is SSD?",
+      "ja": "SSDとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is SSD?",
       "ja": "SSDとは何か？"
     }
@@ -7816,6 +8788,10 @@
     "question_text": {
       "en": "What is RAM?",
       "ja": "RAMとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is RAM?",
+      "ja": "RAMとは何か？"
     }
   },
   {
@@ -7846,6 +8822,10 @@
     "id": "q00245",
     "image_path": null,
     "question_text": {
+      "en": "What is CPU?",
+      "ja": "CPUとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is CPU?",
       "ja": "CPUとは何か？"
     }
@@ -7880,6 +8860,10 @@
     "question_text": {
       "en": "What is GPU?",
       "ja": "GPUとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is GPU?",
+      "ja": "GPUとは何か？"
     }
   },
   {
@@ -7910,6 +8894,10 @@
     "id": "q00247",
     "image_path": null,
     "question_text": {
+      "en": "What is TCP/IP?",
+      "ja": "TCP/IPとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is TCP/IP?",
       "ja": "TCP/IPとは何か？"
     }
@@ -7944,6 +8932,10 @@
     "question_text": {
       "en": "What is a firewall?",
       "ja": "ふぁいあうぉーるとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a firewall?",
+      "ja": "ふぁいあうぉーるとは何か？"
     }
   },
   {
@@ -7974,6 +8966,10 @@
     "id": "q00249",
     "image_path": null,
     "question_text": {
+      "en": "What is DHCP?",
+      "ja": "DHCPとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is DHCP?",
       "ja": "DHCPとは何か？"
     }
@@ -8008,6 +9004,10 @@
     "question_text": {
       "en": "What is a MAC address?",
       "ja": "MACあどれすとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a MAC address?",
+      "ja": "MACあどれすとは何か？"
     }
   },
   {
@@ -8038,6 +9038,10 @@
     "id": "q00251",
     "image_path": null,
     "question_text": {
+      "en": "What is a VPN?",
+      "ja": "VPNとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a VPN?",
       "ja": "VPNとは何か？"
     }
@@ -8072,6 +9076,10 @@
     "question_text": {
       "en": "What is NAT in networking?",
       "ja": "ねっとわーくのNATとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is NAT in networking?",
+      "ja": "ねっとわーくのNATとは何か？"
     }
   },
   {
@@ -8102,6 +9110,10 @@
     "id": "q00253",
     "image_path": null,
     "question_text": {
+      "en": "What is a subnet?",
+      "ja": "さぶねっととは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a subnet?",
       "ja": "さぶねっととは何か？"
     }
@@ -8136,6 +9148,10 @@
     "question_text": {
       "en": "What is RAID in storage?",
       "ja": "すとれーじのRAIDとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is RAID in storage?",
+      "ja": "すとれーじのRAIDとは何か？"
     }
   },
   {
@@ -8166,6 +9182,10 @@
     "id": "q00255",
     "image_path": null,
     "question_text": {
+      "en": "What is a load balancer?",
+      "ja": "ろーどばらんさーとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a load balancer?",
       "ja": "ろーどばらんさーとは何か？"
     }
@@ -8200,6 +9220,10 @@
     "question_text": {
       "en": "What is a proxy server?",
       "ja": "ぷろくしさーばーとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a proxy server?",
+      "ja": "ぷろくしさーばーとは何か？"
     }
   },
   {
@@ -8230,6 +9254,10 @@
     "id": "q00257",
     "image_path": null,
     "question_text": {
+      "en": "What is a reverse proxy?",
+      "ja": "りばーすぷろくしとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a reverse proxy?",
       "ja": "りばーすぷろくしとは何か？"
     }
@@ -8264,6 +9292,10 @@
     "question_text": {
       "en": "What is SSH?",
       "ja": "SSHとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is SSH?",
+      "ja": "SSHとは何か？"
     }
   },
   {
@@ -8294,6 +9326,10 @@
     "id": "q00259",
     "image_path": null,
     "question_text": {
+      "en": "What is a hypervisor?",
+      "ja": "はいぱーばいざーとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a hypervisor?",
       "ja": "はいぱーばいざーとは何か？"
     }
@@ -8328,6 +9364,10 @@
     "question_text": {
       "en": "What is a container image?",
       "ja": "こんてないめーじとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a container image?",
+      "ja": "こんてないめーじとは何か？"
     }
   },
   {
@@ -8358,6 +9398,10 @@
     "id": "q00261",
     "image_path": null,
     "question_text": {
+      "en": "What is serverless computing?",
+      "ja": "さーばーれすけいさんとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is serverless computing?",
       "ja": "さーばーれすけいさんとは何か？"
     }
@@ -8392,6 +9436,10 @@
     "question_text": {
       "en": "What is edge computing?",
       "ja": "えっじけいさんとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is edge computing?",
+      "ja": "えっじけいさんとは何か？"
     }
   },
   {
@@ -8422,6 +9470,10 @@
     "id": "q00263",
     "image_path": null,
     "question_text": {
+      "en": "What is a content delivery network optimized for?",
+      "ja": "CDNは何のために最適化されているか？"
+    },
+    "question_text_reading": {
       "en": "What is a content delivery network optimized for?",
       "ja": "CDNは何のために最適化されているか？"
     }
@@ -8456,6 +9508,10 @@
     "question_text": {
       "en": "What is caching in computing?",
       "ja": "けいさんきのきゃっしゅとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is caching in computing?",
+      "ja": "けいさんきのきゃっしゅとは何か？"
     }
   },
   {
@@ -8486,6 +9542,10 @@
     "id": "q00265",
     "image_path": null,
     "question_text": {
+      "en": "What is a message queue?",
+      "ja": "めっせーじきゅーとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a message queue?",
       "ja": "めっせーじきゅーとは何か？"
     }
@@ -8520,6 +9580,10 @@
     "question_text": {
       "en": "What is pub/sub messaging?",
       "ja": "pub/subめっせーじんぐとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is pub/sub messaging?",
+      "ja": "pub/subめっせーじんぐとは何か？"
     }
   },
   {
@@ -8550,6 +9614,10 @@
     "id": "q00267",
     "image_path": null,
     "question_text": {
+      "en": "What is a CDN edge node?",
+      "ja": "CDNのえっじのーどとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a CDN edge node?",
       "ja": "CDNのえっじのーどとは何か？"
     }
@@ -8584,6 +9652,10 @@
     "question_text": {
       "en": "What is horizontal scaling?",
       "ja": "すいへいすけーりんぐとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is horizontal scaling?",
+      "ja": "すいへいすけーりんぐとは何か？"
     }
   },
   {
@@ -8614,6 +9686,10 @@
     "id": "q00269",
     "image_path": null,
     "question_text": {
+      "en": "What is vertical scaling?",
+      "ja": "すいちょくすけーりんぐとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is vertical scaling?",
       "ja": "すいちょくすけーりんぐとは何か？"
     }
@@ -8648,6 +9724,10 @@
     "question_text": {
       "en": "What is a data center?",
       "ja": "でーたせんたーとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a data center?",
+      "ja": "でーたせんたーとは何か？"
     }
   },
   {
@@ -8678,6 +9758,10 @@
     "id": "q00271",
     "image_path": null,
     "question_text": {
+      "en": "What is uptime in computing?",
+      "ja": "けいさんきのあっぷたいむとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is uptime in computing?",
       "ja": "けいさんきのあっぷたいむとは何か？"
     }
@@ -8712,6 +9796,10 @@
     "question_text": {
       "en": "What is SLA?",
       "ja": "SLAとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is SLA?",
+      "ja": "SLAとは何か？"
     }
   },
   {
@@ -8742,6 +9830,10 @@
     "id": "q00273",
     "image_path": null,
     "question_text": {
+      "en": "What is monitoring in DevOps?",
+      "ja": "DevOpsのもにたりんぐとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is monitoring in DevOps?",
       "ja": "DevOpsのもにたりんぐとは何か？"
     }
@@ -8776,6 +9868,10 @@
     "question_text": {
       "en": "What is blue-green deployment?",
       "ja": "ぶるーぐりーんはいひとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is blue-green deployment?",
+      "ja": "ぶるーぐりーんはいひとは何か？"
     }
   },
   {
@@ -8806,6 +9902,10 @@
     "id": "q00275",
     "image_path": null,
     "question_text": {
+      "en": "What is canary deployment?",
+      "ja": "かなりあはいひとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is canary deployment?",
       "ja": "かなりあはいひとは何か？"
     }
@@ -8840,6 +9940,10 @@
     "question_text": {
       "en": "What is a container registry?",
       "ja": "こんてなれじすとりとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a container registry?",
+      "ja": "こんてなれじすとりとは何か？"
     }
   },
   {
@@ -8870,6 +9974,10 @@
     "id": "q00277",
     "image_path": null,
     "question_text": {
+      "en": "What is Terraform?",
+      "ja": "Terraformとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is Terraform?",
       "ja": "Terraformとは何か？"
     }
@@ -8904,6 +10012,10 @@
     "question_text": {
       "en": "What is Ansible?",
       "ja": "Ansibleとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is Ansible?",
+      "ja": "Ansibleとは何か？"
     }
   },
   {
@@ -8934,6 +10046,10 @@
     "id": "q00279",
     "image_path": null,
     "question_text": {
+      "en": "What is Prometheus?",
+      "ja": "Prometheusとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is Prometheus?",
       "ja": "Prometheusとは何か？"
     }
@@ -8968,6 +10084,10 @@
     "question_text": {
       "en": "What is Grafana?",
       "ja": "Grafanaとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is Grafana?",
+      "ja": "Grafanaとは何か？"
     }
   },
   {
@@ -8998,6 +10118,10 @@
     "id": "q00281",
     "image_path": null,
     "question_text": {
+      "en": "What is ELK stack?",
+      "ja": "ELKすたっくとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is ELK stack?",
       "ja": "ELKすたっくとは何か？"
     }
@@ -9032,6 +10156,10 @@
     "question_text": {
       "en": "What is observability in systems?",
       "ja": "しすてむのかんそくかのうせいとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is observability in systems?",
+      "ja": "しすてむのかんそくかのうせいとは何か？"
     }
   },
   {
@@ -9062,6 +10190,10 @@
     "id": "q00283",
     "image_path": null,
     "question_text": {
+      "en": "What is a container pod in Kubernetes?",
+      "ja": "Kubernetesのぽっどとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a container pod in Kubernetes?",
       "ja": "Kubernetesのぽっどとは何か？"
     }
@@ -9096,6 +10228,10 @@
     "question_text": {
       "en": "What is a Dockerfile?",
       "ja": "Dockerfileとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a Dockerfile?",
+      "ja": "Dockerfileとは何か？"
     }
   },
   {
@@ -9126,6 +10262,10 @@
     "id": "q00285",
     "image_path": null,
     "question_text": {
+      "en": "What is `docker-compose`?",
+      "ja": "`docker-compose`とは何か？"
+    },
+    "question_text_reading": {
       "en": "What is `docker-compose`?",
       "ja": "`docker-compose`とは何か？"
     }
@@ -9160,6 +10300,10 @@
     "question_text": {
       "en": "What is a Kubernetes namespace?",
       "ja": "Kubernetesのなめすぺーすとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a Kubernetes namespace?",
+      "ja": "Kubernetesのなめすぺーすとは何か？"
     }
   },
   {
@@ -9190,6 +10334,10 @@
     "id": "q00287",
     "image_path": null,
     "question_text": {
+      "en": "What is a Helm chart?",
+      "ja": "Helmちゃーととは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a Helm chart?",
       "ja": "Helmちゃーととは何か？"
     }
@@ -9224,6 +10372,10 @@
     "question_text": {
       "en": "What is GitOps?",
       "ja": "GitOpsとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is GitOps?",
+      "ja": "GitOpsとは何か？"
     }
   },
   {
@@ -9254,6 +10406,10 @@
     "id": "q00289",
     "image_path": null,
     "question_text": {
+      "en": "What is chaos engineering?",
+      "ja": "かおすえんじにありんぐとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is chaos engineering?",
       "ja": "かおすえんじにありんぐとは何か？"
     }
@@ -9288,6 +10444,10 @@
     "question_text": {
       "en": "What is a webhook?",
       "ja": "うぇぶふっくとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a webhook?",
+      "ja": "うぇぶふっくとは何か？"
     }
   },
   {
@@ -9318,6 +10478,10 @@
     "id": "q00291",
     "image_path": null,
     "question_text": {
+      "en": "What is latency in computing?",
+      "ja": "けいさんきのれいてんしーとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is latency in computing?",
       "ja": "けいさんきのれいてんしーとは何か？"
     }
@@ -9352,6 +10516,10 @@
     "question_text": {
       "en": "What is throughput in computing?",
       "ja": "けいさんきのすいとうっぷりょうとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is throughput in computing?",
+      "ja": "けいさんきのすいとうっぷりょうとは何か？"
     }
   },
   {
@@ -9382,6 +10550,10 @@
     "id": "q00293",
     "image_path": null,
     "question_text": {
+      "en": "What does API stand for?",
+      "ja": "APIのりゃくごのいみは？"
+    },
+    "question_text_reading": {
       "en": "What does API stand for?",
       "ja": "APIのりゃくごのいみは？"
     }
@@ -9416,6 +10588,10 @@
     "question_text": {
       "en": "What does URL stand for?",
       "ja": "URLのりゃくごのいみは？"
+    },
+    "question_text_reading": {
+      "en": "What does URL stand for?",
+      "ja": "URLのりゃくごのいみは？"
     }
   },
   {
@@ -9446,6 +10622,10 @@
     "id": "q00295",
     "image_path": null,
     "question_text": {
+      "en": "What does IDE stand for?",
+      "ja": "IDEのりゃくごのいみは？"
+    },
+    "question_text_reading": {
       "en": "What does IDE stand for?",
       "ja": "IDEのりゃくごのいみは？"
     }
@@ -9480,6 +10660,10 @@
     "question_text": {
       "en": "What does ORM stand for?",
       "ja": "ORMのりゃくごのいみは？"
+    },
+    "question_text_reading": {
+      "en": "What does ORM stand for?",
+      "ja": "ORMのりゃくごのいみは？"
     }
   },
   {
@@ -9510,6 +10694,10 @@
     "id": "q00297",
     "image_path": null,
     "question_text": {
+      "en": "What does MVC stand for?",
+      "ja": "MVCのりゃくごのいみは？"
+    },
+    "question_text_reading": {
       "en": "What does MVC stand for?",
       "ja": "MVCのりゃくごのいみは？"
     }
@@ -9544,6 +10732,10 @@
     "question_text": {
       "en": "What does SaaS stand for?",
       "ja": "SaaSのりゃくごのいみは？"
+    },
+    "question_text_reading": {
+      "en": "What does SaaS stand for?",
+      "ja": "SaaSのりゃくごのいみは？"
     }
   },
   {
@@ -9574,6 +10766,10 @@
     "id": "q00299",
     "image_path": null,
     "question_text": {
+      "en": "What does IaaS stand for?",
+      "ja": "IaaSのりゃくごのいみは？"
+    },
+    "question_text_reading": {
       "en": "What does IaaS stand for?",
       "ja": "IaaSのりゃくごのいみは？"
     }
@@ -9608,6 +10804,10 @@
     "question_text": {
       "en": "What does PaaS stand for?",
       "ja": "PaaSのりゃくごのいみは？"
+    },
+    "question_text_reading": {
+      "en": "What does PaaS stand for?",
+      "ja": "PaaSのりゃくごのいみは？"
     }
   },
   {
@@ -9638,6 +10838,10 @@
     "id": "q00301",
     "image_path": null,
     "question_text": {
+      "en": "What does CRUD stand for?",
+      "ja": "CRUDのりゃくごのいみは？"
+    },
+    "question_text_reading": {
       "en": "What does CRUD stand for?",
       "ja": "CRUDのりゃくごのいみは？"
     }
@@ -9672,6 +10876,10 @@
     "question_text": {
       "en": "What does OOP stand for?",
       "ja": "OOPのりゃくごのいみは？"
+    },
+    "question_text_reading": {
+      "en": "What does OOP stand for?",
+      "ja": "OOPのりゃくごのいみは？"
     }
   },
   {
@@ -9702,6 +10910,10 @@
     "id": "q00303",
     "image_path": null,
     "question_text": {
+      "en": "What does CLI stand for?",
+      "ja": "CLIのりゃくごのいみは？"
+    },
+    "question_text_reading": {
       "en": "What does CLI stand for?",
       "ja": "CLIのりゃくごのいみは？"
     }
@@ -9736,6 +10948,10 @@
     "question_text": {
       "en": "What does GUI stand for?",
       "ja": "GUIのりゃくごのいみは？"
+    },
+    "question_text_reading": {
+      "en": "What does GUI stand for?",
+      "ja": "GUIのりゃくごのいみは？"
     }
   },
   {
@@ -9766,6 +10982,10 @@
     "id": "q00305",
     "image_path": null,
     "question_text": {
+      "en": "What does SDK stand for?",
+      "ja": "SDKのりゃくごのいみは？"
+    },
+    "question_text_reading": {
       "en": "What does SDK stand for?",
       "ja": "SDKのりゃくごのいみは？"
     }
@@ -9800,6 +11020,10 @@
     "question_text": {
       "en": "What does EOF stand for in programming?",
       "ja": "ぷろぐらみんぐのEOFのりゃくごのいみは？"
+    },
+    "question_text_reading": {
+      "en": "What does EOF stand for in programming?",
+      "ja": "ぷろぐらみんぐのEOFのりゃくごのいみは？"
     }
   },
   {
@@ -9830,6 +11054,10 @@
     "id": "q00307",
     "image_path": null,
     "question_text": {
+      "en": "What is a boolean?",
+      "ja": "ぶーりあんとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a boolean?",
       "ja": "ぶーりあんとは何か？"
     }
@@ -9864,6 +11092,10 @@
     "question_text": {
       "en": "What is null?",
       "ja": "nullとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is null?",
+      "ja": "nullとは何か？"
     }
   },
   {
@@ -9894,6 +11126,10 @@
     "id": "q00309",
     "image_path": null,
     "question_text": {
+      "en": "What is undefined in JavaScript?",
+      "ja": "JavaScriptのundefinedとは？"
+    },
+    "question_text_reading": {
       "en": "What is undefined in JavaScript?",
       "ja": "JavaScriptのundefinedとは？"
     }
@@ -9928,6 +11164,10 @@
     "question_text": {
       "en": "What is type casting?",
       "ja": "かたへんかんとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is type casting?",
+      "ja": "かたへんかんとは何か？"
     }
   },
   {
@@ -9958,6 +11198,10 @@
     "id": "q00311",
     "image_path": null,
     "question_text": {
+      "en": "What is a namespace?",
+      "ja": "なめすぺーすとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a namespace?",
       "ja": "なめすぺーすとは何か？"
     }
@@ -9992,6 +11236,10 @@
     "question_text": {
       "en": "What is an enum?",
       "ja": "えぬむとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is an enum?",
+      "ja": "えぬむとは何か？"
     }
   },
   {
@@ -10022,6 +11270,10 @@
     "id": "q00313",
     "image_path": null,
     "question_text": {
+      "en": "What is a struct?",
+      "ja": "すとらくととは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a struct?",
       "ja": "すとらくととは何か？"
     }
@@ -10056,6 +11308,10 @@
     "question_text": {
       "en": "What does `printf` do in C?",
       "ja": "Cの`printf`は何をするか？"
+    },
+    "question_text_reading": {
+      "en": "What does `printf` do in C?",
+      "ja": "Cの`printf`は何をするか？"
     }
   },
   {
@@ -10086,6 +11342,10 @@
     "id": "q00315",
     "image_path": null,
     "question_text": {
+      "en": "What is a pointer in C?",
+      "ja": "Cのぽいんたーとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a pointer in C?",
       "ja": "Cのぽいんたーとは何か？"
     }
@@ -10120,6 +11380,10 @@
     "question_text": {
       "en": "What does `#include` do in C?",
       "ja": "Cの`#include`は何をするか？"
+    },
+    "question_text_reading": {
+      "en": "What does `#include` do in C?",
+      "ja": "Cの`#include`は何をするか？"
     }
   },
   {
@@ -10150,6 +11414,10 @@
     "id": "q00317",
     "image_path": null,
     "question_text": {
+      "en": "What is a compile error?",
+      "ja": "かんぱいるえらーとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a compile error?",
       "ja": "かんぱいるえらーとは何か？"
     }
@@ -10184,6 +11452,10 @@
     "question_text": {
       "en": "What is a runtime error?",
       "ja": "じっこうじえらーとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a runtime error?",
+      "ja": "じっこうじえらーとは何か？"
     }
   },
   {
@@ -10214,6 +11486,10 @@
     "id": "q00319",
     "image_path": null,
     "question_text": {
+      "en": "What is a logic error?",
+      "ja": "ろじっくえらーとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a logic error?",
       "ja": "ろじっくえらーとは何か？"
     }
@@ -10248,6 +11524,10 @@
     "question_text": {
       "en": "What is `stdin`?",
       "ja": "`stdin`とは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is `stdin`?",
+      "ja": "`stdin`とは何か？"
     }
   },
   {
@@ -10278,6 +11558,10 @@
     "id": "q00321",
     "image_path": null,
     "question_text": {
+      "en": "What is `stdout`?",
+      "ja": "`stdout`とは何か？"
+    },
+    "question_text_reading": {
       "en": "What is `stdout`?",
       "ja": "`stdout`とは何か？"
     }
@@ -10312,6 +11596,10 @@
     "question_text": {
       "en": "What is `stderr`?",
       "ja": "`stderr`とは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is `stderr`?",
+      "ja": "`stderr`とは何か？"
     }
   },
   {
@@ -10342,6 +11630,10 @@
     "id": "q00323",
     "image_path": null,
     "question_text": {
+      "en": "What is a variable?",
+      "ja": "へんすうとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a variable?",
       "ja": "へんすうとは何か？"
     }
@@ -10376,6 +11668,10 @@
     "question_text": {
       "en": "What is a constant?",
       "ja": "ていすうとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a constant?",
+      "ja": "ていすうとは何か？"
     }
   },
   {
@@ -10406,6 +11702,10 @@
     "id": "q00325",
     "image_path": null,
     "question_text": {
+      "en": "What is operator precedence?",
+      "ja": "えんざんしのゆうせんじゅんいとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is operator precedence?",
       "ja": "えんざんしのゆうせんじゅんいとは何か？"
     }
@@ -10440,6 +11740,10 @@
     "question_text": {
       "en": "What is short-circuit evaluation?",
       "ja": "たんらくひょうかとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is short-circuit evaluation?",
+      "ja": "たんらくひょうかとは何か？"
     }
   },
   {
@@ -10470,6 +11774,10 @@
     "id": "q00327",
     "image_path": null,
     "question_text": {
+      "en": "What is a ternary operator?",
+      "ja": "さんこうえんざんしとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a ternary operator?",
       "ja": "さんこうえんざんしとは何か？"
     }
@@ -10504,6 +11812,10 @@
     "question_text": {
       "en": "Which anime features a boy who gains power from a Death Note?",
       "ja": "しのちょうからちからをえる少年のアニメは？"
+    },
+    "question_text_reading": {
+      "en": "Which anime features a boy who gains power from a Death Note?",
+      "ja": "しのちょうからちからをえる少年のアニメは？"
     }
   },
   {
@@ -10534,6 +11846,10 @@
     "id": "q00329",
     "image_path": null,
     "question_text": {
+      "en": "What is the name of the protagonist in Naruto?",
+      "ja": "Narutoのしゅじんこうのなまえは？"
+    },
+    "question_text_reading": {
       "en": "What is the name of the protagonist in Naruto?",
       "ja": "Narutoのしゅじんこうのなまえは？"
     }
@@ -10568,6 +11884,10 @@
     "question_text": {
       "en": "Which anime is set in a world where humans live inside walls to avoid Titans?",
       "ja": "きょじんからのがれるためにかべのなかでくらすせかいのアニメは？"
+    },
+    "question_text_reading": {
+      "en": "Which anime is set in a world where humans live inside walls to avoid Titans?",
+      "ja": "きょじんからのがれるためにかべのなかでくらすせかいのアニメは？"
     }
   },
   {
@@ -10598,6 +11918,10 @@
     "id": "q00331",
     "image_path": null,
     "question_text": {
+      "en": "Which Studio Ghibli film features a girl who works in a bathhouse for spirits?",
+      "ja": "せいれいのゆやではたらくしょうじょのスタジオジブリえいがは？"
+    },
+    "question_text_reading": {
       "en": "Which Studio Ghibli film features a girl who works in a bathhouse for spirits?",
       "ja": "せいれいのゆやではたらくしょうじょのスタジオジブリえいがは？"
     }
@@ -10632,6 +11956,10 @@
     "question_text": {
       "en": "What power does Saitama from One Punch Man have?",
       "ja": "わんぱんまんのさいたまのちからは？"
+    },
+    "question_text_reading": {
+      "en": "What power does Saitama from One Punch Man have?",
+      "ja": "わんぱんまんのさいたまのちからは？"
     }
   },
   {
@@ -10662,6 +11990,10 @@
     "id": "q00333",
     "image_path": null,
     "question_text": {
+      "en": "Which anime features the Straw Hat Pirates?",
+      "ja": "むぎわらかいぞくだんのアニメは？"
+    },
+    "question_text_reading": {
       "en": "Which anime features the Straw Hat Pirates?",
       "ja": "むぎわらかいぞくだんのアニメは？"
     }
@@ -10696,6 +12028,10 @@
     "question_text": {
       "en": "Who is the author of Dragon Ball?",
       "ja": "ドラゴンボールのさくしゃは？"
+    },
+    "question_text_reading": {
+      "en": "Who is the author of Dragon Ball?",
+      "ja": "ドラゴンボールのさくしゃは？"
     }
   },
   {
@@ -10726,6 +12062,10 @@
     "id": "q00335",
     "image_path": null,
     "question_text": {
+      "en": "Which anime is about a boy named Tanjiro fighting demons?",
+      "ja": "たんじろうというしょうねんがおにとたたかうアニメは？"
+    },
+    "question_text_reading": {
       "en": "Which anime is about a boy named Tanjiro fighting demons?",
       "ja": "たんじろうというしょうねんがおにとたたかうアニメは？"
     }
@@ -10760,6 +12100,10 @@
     "question_text": {
       "en": "What is the setting of Sword Art Online?",
       "ja": "ソードアートオンラインのぶたいは？"
+    },
+    "question_text_reading": {
+      "en": "What is the setting of Sword Art Online?",
+      "ja": "ソードアートオンラインのぶたいは？"
     }
   },
   {
@@ -10790,6 +12134,10 @@
     "id": "q00337",
     "image_path": null,
     "question_text": {
+      "en": "Which anime follows a boy who wants to be the best Pokemon trainer?",
+      "ja": "さいきょうのぽけもんとれーなーをめざすしょうねんのアニメは？"
+    },
+    "question_text_reading": {
       "en": "Which anime follows a boy who wants to be the best Pokemon trainer?",
       "ja": "さいきょうのぽけもんとれーなーをめざすしょうねんのアニメは？"
     }
@@ -10824,6 +12172,10 @@
     "question_text": {
       "en": "Who created the Evangelion series?",
       "ja": "えんがえりおんしりーずをつくったのは？"
+    },
+    "question_text_reading": {
+      "en": "Who created the Evangelion series?",
+      "ja": "えんがえりおんしりーずをつくったのは？"
     }
   },
   {
@@ -10854,6 +12206,10 @@
     "id": "q00339",
     "image_path": null,
     "question_text": {
+      "en": "Which anime features the Survey Corps?",
+      "ja": "ちょうさへいだんがとうじょうするアニメは？"
+    },
+    "question_text_reading": {
       "en": "Which anime features the Survey Corps?",
       "ja": "ちょうさへいだんがとうじょうするアニメは？"
     }
@@ -10888,6 +12244,10 @@
     "question_text": {
       "en": "What is the full name of the protagonist in My Hero Academia?",
       "ja": "ぼくのひーろーあかでみあのしゅじんこうのフルネームは？"
+    },
+    "question_text_reading": {
+      "en": "What is the full name of the protagonist in My Hero Academia?",
+      "ja": "ぼくのひーろーあかでみあのしゅじんこうのフルネームは？"
     }
   },
   {
@@ -10918,6 +12278,10 @@
     "id": "q00341",
     "image_path": null,
     "question_text": {
+      "en": "Which anime features ninjas with special chakra abilities?",
+      "ja": "とくべつなちゃくらのうりょくをもつにんじゃのアニメは？"
+    },
+    "question_text_reading": {
       "en": "Which anime features ninjas with special chakra abilities?",
       "ja": "とくべつなちゃくらのうりょくをもつにんじゃのアニメは？"
     }
@@ -10952,6 +12316,10 @@
     "question_text": {
       "en": "What studio produced Neon Genesis Evangelion?",
       "ja": "しんせいきえんがえりおんをせいさくしたすたじおは？"
+    },
+    "question_text_reading": {
+      "en": "What studio produced Neon Genesis Evangelion?",
+      "ja": "しんせいきえんがえりおんをせいさくしたすたじおは？"
     }
   },
   {
@@ -10982,6 +12350,10 @@
     "id": "q00343",
     "image_path": null,
     "question_text": {
+      "en": "Which anime series is known for the 'Kamehameha' attack?",
+      "ja": "かめはめはこうげきでゆうめいなアニメは？"
+    },
+    "question_text_reading": {
       "en": "Which anime series is known for the 'Kamehameha' attack?",
       "ja": "かめはめはこうげきでゆうめいなアニメは？"
     }
@@ -11016,6 +12388,10 @@
     "question_text": {
       "en": "What genre is Sailor Moon?",
       "ja": "せーらーむーんのジャンルは？"
+    },
+    "question_text_reading": {
+      "en": "What genre is Sailor Moon?",
+      "ja": "せーらーむーんのジャンルは？"
     }
   },
   {
@@ -11046,6 +12422,10 @@
     "id": "q00345",
     "image_path": null,
     "question_text": {
+      "en": "Who is Pikachu's trainer in Pokemon anime?",
+      "ja": "ポケモンアニメでぴかちゅうのとれーなーは？"
+    },
+    "question_text_reading": {
       "en": "Who is Pikachu's trainer in Pokemon anime?",
       "ja": "ポケモンアニメでぴかちゅうのとれーなーは？"
     }
@@ -11080,6 +12460,10 @@
     "question_text": {
       "en": "Which anime is set in a sports high school for volleyball?",
       "ja": "ばれーぼーるのこうこうのアニメは？"
+    },
+    "question_text_reading": {
+      "en": "Which anime is set in a sports high school for volleyball?",
+      "ja": "ばれーぼーるのこうこうのアニメは？"
     }
   },
   {
@@ -11110,6 +12494,10 @@
     "id": "q00347",
     "image_path": null,
     "question_text": {
+      "en": "What is isekai?",
+      "ja": "いせかいとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is isekai?",
       "ja": "いせかいとは何か？"
     }
@@ -11144,6 +12532,10 @@
     "question_text": {
       "en": "Which anime features Monkey D. Luffy?",
       "ja": "もんきーでぃーるふぃーがとうじょうするアニメは？"
+    },
+    "question_text_reading": {
+      "en": "Which anime features Monkey D. Luffy?",
+      "ja": "もんきーでぃーるふぃーがとうじょうするアニメは？"
     }
   },
   {
@@ -11174,6 +12566,10 @@
     "id": "q00349",
     "image_path": null,
     "question_text": {
+      "en": "What is the name of the school in My Hero Academia?",
+      "ja": "ぼくのひーろーあかでみあのがっこうのなまえは？"
+    },
+    "question_text_reading": {
       "en": "What is the name of the school in My Hero Academia?",
       "ja": "ぼくのひーろーあかでみあのがっこうのなまえは？"
     }
@@ -11208,6 +12604,10 @@
     "question_text": {
       "en": "Which anime follows L and Light's cat-and-mouse detective game?",
       "ja": "Lとライトのかくれんぼのようなすいりのアニメは？"
+    },
+    "question_text_reading": {
+      "en": "Which anime follows L and Light's cat-and-mouse detective game?",
+      "ja": "Lとライトのかくれんぼのようなすいりのアニメは？"
     }
   },
   {
@@ -11238,6 +12638,10 @@
     "id": "q00351",
     "image_path": null,
     "question_text": {
+      "en": "Which anime is set in the fictional Konoha village?",
+      "ja": "かそうのこのははのむらが舞台のアニメは？"
+    },
+    "question_text_reading": {
       "en": "Which anime is set in the fictional Konoha village?",
       "ja": "かそうのこのははのむらが舞台のアニメは？"
     }
@@ -11272,6 +12676,10 @@
     "question_text": {
       "en": "What is the 'Big Three' of older Shonen Jump anime?",
       "ja": "むかしのじゃんぷのさんだいアニメは？"
+    },
+    "question_text_reading": {
+      "en": "What is the 'Big Three' of older Shonen Jump anime?",
+      "ja": "むかしのじゃんぷのさんだいアニメは？"
     }
   },
   {
@@ -11302,6 +12710,10 @@
     "id": "q00353",
     "image_path": null,
     "question_text": {
+      "en": "What is a mecha anime?",
+      "ja": "めかアニメとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a mecha anime?",
       "ja": "めかアニメとは何か？"
     }
@@ -11336,6 +12748,10 @@
     "question_text": {
       "en": "Which Ghibli film features a young witch who delivers by broomstick?",
       "ja": "ほうきではいたつするわかいまじょのジブリえいがは？"
+    },
+    "question_text_reading": {
+      "en": "Which Ghibli film features a young witch who delivers by broomstick?",
+      "ja": "ほうきではいたつするわかいまじょのジブリえいがは？"
     }
   },
   {
@@ -11366,6 +12782,10 @@
     "id": "q00355",
     "image_path": null,
     "question_text": {
+      "en": "Which anime follows Ichigo Kurosaki, a Soul Reaper?",
+      "ja": "いちごくろさきというしにがみのアニメは？"
+    },
+    "question_text_reading": {
       "en": "Which anime follows Ichigo Kurosaki, a Soul Reaper?",
       "ja": "いちごくろさきというしにがみのアニメは？"
     }
@@ -11400,6 +12820,10 @@
     "question_text": {
       "en": "What is a 'shonen' anime?",
       "ja": "しょうねんアニメとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a 'shonen' anime?",
+      "ja": "しょうねんアニメとは何か？"
     }
   },
   {
@@ -11430,6 +12854,10 @@
     "id": "q00357",
     "image_path": null,
     "question_text": {
+      "en": "What is a 'shoujo' anime?",
+      "ja": "しょうじょアニメとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a 'shoujo' anime?",
       "ja": "しょうじょアニメとは何か？"
     }
@@ -11464,6 +12892,10 @@
     "question_text": {
       "en": "Which anime is about a boy named Goku who trains in martial arts?",
       "ja": "ごくうというしょうねんがぶどうをきわめるアニメは？"
+    },
+    "question_text_reading": {
+      "en": "Which anime is about a boy named Goku who trains in martial arts?",
+      "ja": "ごくうというしょうねんがぶどうをきわめるアニメは？"
     }
   },
   {
@@ -11494,6 +12926,10 @@
     "id": "q00359",
     "image_path": null,
     "question_text": {
+      "en": "What does 'OVA' stand for in anime?",
+      "ja": "アニメのOVAのりゃくごのいみは？"
+    },
+    "question_text_reading": {
       "en": "What does 'OVA' stand for in anime?",
       "ja": "アニメのOVAのりゃくごのいみは？"
     }
@@ -11528,6 +12964,10 @@
     "question_text": {
       "en": "Which anime is famous for the 'Thousand Sunny' ship?",
       "ja": "さうざんどさにーごうでゆうめいなアニメは？"
+    },
+    "question_text_reading": {
+      "en": "Which anime is famous for the 'Thousand Sunny' ship?",
+      "ja": "さうざんどさにーごうでゆうめいなアニメは？"
     }
   },
   {
@@ -11558,6 +12998,10 @@
     "id": "q00361",
     "image_path": null,
     "question_text": {
+      "en": "Which anime series has 'Stand' abilities as its main power system?",
+      "ja": "すたんどのうりょくがメインのアニメシリーズは？"
+    },
+    "question_text_reading": {
       "en": "Which anime series has 'Stand' abilities as its main power system?",
       "ja": "すたんどのうりょくがメインのアニメシリーズは？"
     }
@@ -11592,6 +13036,10 @@
     "question_text": {
       "en": "What is 'One For All' in My Hero Academia?",
       "ja": "ぼくのひーろーあかでみあのわんふぉーおーるとは？"
+    },
+    "question_text_reading": {
+      "en": "What is 'One For All' in My Hero Academia?",
+      "ja": "ぼくのひーろーあかでみあのわんふぉーおーるとは？"
     }
   },
   {
@@ -11622,6 +13070,10 @@
     "id": "q00363",
     "image_path": null,
     "question_text": {
+      "en": "Which anime is set in a cooking high school?",
+      "ja": "りょうりのこうこうのアニメは？"
+    },
+    "question_text_reading": {
       "en": "Which anime is set in a cooking high school?",
       "ja": "りょうりのこうこうのアニメは？"
     }
@@ -11656,6 +13108,10 @@
     "question_text": {
       "en": "Who is the villain in the first arc of Dragon Ball Z?",
       "ja": "ドラゴンボールZさいしょのあーくのヴィランは？"
+    },
+    "question_text_reading": {
+      "en": "Who is the villain in the first arc of Dragon Ball Z?",
+      "ja": "ドラゴンボールZさいしょのあーくのヴィランは？"
     }
   },
   {
@@ -11686,6 +13142,10 @@
     "id": "q00365",
     "image_path": null,
     "question_text": {
+      "en": "What is 'Alchemy' in Fullmetal Alchemist?",
+      "ja": "はがねのれんきんじゅつしのれんきんじゅつとは？"
+    },
+    "question_text_reading": {
       "en": "What is 'Alchemy' in Fullmetal Alchemist?",
       "ja": "はがねのれんきんじゅつしのれんきんじゅつとは？"
     }
@@ -11720,6 +13180,10 @@
     "question_text": {
       "en": "Which anime features the 'Survey Corps' fighting Titans?",
       "ja": "ちょうさへいだんがきょじんとたたかうアニメは？"
+    },
+    "question_text_reading": {
+      "en": "Which anime features the 'Survey Corps' fighting Titans?",
+      "ja": "ちょうさへいだんがきょじんとたたかうアニメは？"
     }
   },
   {
@@ -11750,6 +13214,10 @@
     "id": "q00367",
     "image_path": null,
     "question_text": {
+      "en": "What genre is 'Your Name (Kimi no Na wa)'?",
+      "ja": "きみのなわのジャンルは？"
+    },
+    "question_text_reading": {
       "en": "What genre is 'Your Name (Kimi no Na wa)'?",
       "ja": "きみのなわのジャンルは？"
     }
@@ -11784,6 +13252,10 @@
     "question_text": {
       "en": "Who directed Spirited Away?",
       "ja": "もののけひめをかんとくしたのは？"
+    },
+    "question_text_reading": {
+      "en": "Who directed Spirited Away?",
+      "ja": "もののけひめをかんとくしたのは？"
     }
   },
   {
@@ -11814,6 +13286,10 @@
     "id": "q00369",
     "image_path": null,
     "question_text": {
+      "en": "What is the name of the cat bus in My Neighbor Totoro?",
+      "ja": "となりのトトロのねこばすのなまえは？"
+    },
+    "question_text_reading": {
       "en": "What is the name of the cat bus in My Neighbor Totoro?",
       "ja": "となりのトトロのねこばすのなまえは？"
     }
@@ -11848,6 +13324,10 @@
     "question_text": {
       "en": "Which anime features heroes called 'Hashira'?",
       "ja": "はしらとよばれるひーろーたちのアニメは？"
+    },
+    "question_text_reading": {
+      "en": "Which anime features heroes called 'Hashira'?",
+      "ja": "はしらとよばれるひーろーたちのアニメは？"
     }
   },
   {
@@ -11878,6 +13358,10 @@
     "id": "q00371",
     "image_path": null,
     "question_text": {
+      "en": "What is the name of Naruto's signature technique?",
+      "ja": "なるとのとくいわざのなまえは？"
+    },
+    "question_text_reading": {
       "en": "What is the name of Naruto's signature technique?",
       "ja": "なるとのとくいわざのなまえは？"
     }
@@ -11912,6 +13396,10 @@
     "question_text": {
       "en": "Which anime is about a virtual game where dying in-game means death in real life?",
       "ja": "げーむないしすると現実でもしぬアニメは？"
+    },
+    "question_text_reading": {
+      "en": "Which anime is about a virtual game where dying in-game means death in real life?",
+      "ja": "げーむないしすると現実でもしぬアニメは？"
     }
   },
   {
@@ -11942,6 +13430,10 @@
     "id": "q00373",
     "image_path": null,
     "question_text": {
+      "en": "What power does Light Yagami use in Death Note?",
+      "ja": "デスノートでやがみらいとが使うちからは？"
+    },
+    "question_text_reading": {
       "en": "What power does Light Yagami use in Death Note?",
       "ja": "デスノートでやがみらいとが使うちからは？"
     }
@@ -11976,6 +13468,10 @@
     "question_text": {
       "en": "Which anime is set in the Hidden Leaf Village?",
       "ja": "かくれこのはのさとをぶたいにしたアニメは？"
+    },
+    "question_text_reading": {
+      "en": "Which anime is set in the Hidden Leaf Village?",
+      "ja": "かくれこのはのさとをぶたいにしたアニメは？"
     }
   },
   {
@@ -12006,6 +13502,10 @@
     "id": "q00375",
     "image_path": null,
     "question_text": {
+      "en": "What is the 'Quirk' in My Hero Academia?",
+      "ja": "ぼくのひーろーあかでみあのこせいとは？"
+    },
+    "question_text_reading": {
       "en": "What is the 'Quirk' in My Hero Academia?",
       "ja": "ぼくのひーろーあかでみあのこせいとは？"
     }
@@ -12040,6 +13540,10 @@
     "question_text": {
       "en": "Which anime features Ryuk, a death god?",
       "ja": "りゅーくというしにがみがとうじょうするアニメは？"
+    },
+    "question_text_reading": {
+      "en": "Which anime features Ryuk, a death god?",
+      "ja": "りゅーくというしにがみがとうじょうするアニメは？"
     }
   },
   {
@@ -12070,6 +13574,10 @@
     "id": "q00377",
     "image_path": null,
     "question_text": {
+      "en": "What is 'Titan' in Attack on Titan?",
+      "ja": "しんげきのきょじんのきょじんとは？"
+    },
+    "question_text_reading": {
       "en": "What is 'Titan' in Attack on Titan?",
       "ja": "しんげきのきょじんのきょじんとは？"
     }
@@ -12104,6 +13612,10 @@
     "question_text": {
       "en": "Which anime is based on a card game?",
       "ja": "かーどげーむをもとにしたアニメは？"
+    },
+    "question_text_reading": {
+      "en": "Which anime is based on a card game?",
+      "ja": "かーどげーむをもとにしたアニメは？"
     }
   },
   {
@@ -12134,6 +13646,10 @@
     "id": "q00379",
     "image_path": null,
     "question_text": {
+      "en": "Who is the main antagonist of the Frieza arc in Dragon Ball Z?",
+      "ja": "ドラゴンボールZのふりーざへんのしゅてきは？"
+    },
+    "question_text_reading": {
       "en": "Who is the main antagonist of the Frieza arc in Dragon Ball Z?",
       "ja": "ドラゴンボールZのふりーざへんのしゅてきは？"
     }
@@ -12168,6 +13684,10 @@
     "question_text": {
       "en": "What is the setting of 'No Game No Life'?",
       "ja": "のーげーむのーらいふの舞台は？"
+    },
+    "question_text_reading": {
+      "en": "What is the setting of 'No Game No Life'?",
+      "ja": "のーげーむのーらいふの舞台は？"
     }
   },
   {
@@ -12198,6 +13718,10 @@
     "id": "q00381",
     "image_path": null,
     "question_text": {
+      "en": "Who wrote the manga 'Fullmetal Alchemist'?",
+      "ja": "はがねのれんきんじゅつしをかいたのは？"
+    },
+    "question_text_reading": {
       "en": "Who wrote the manga 'Fullmetal Alchemist'?",
       "ja": "はがねのれんきんじゅつしをかいたのは？"
     }
@@ -12232,6 +13756,10 @@
     "question_text": {
       "en": "What is a 'seiyuu' in anime?",
       "ja": "アニメのせいゆうとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a 'seiyuu' in anime?",
+      "ja": "アニメのせいゆうとは何か？"
     }
   },
   {
@@ -12262,6 +13790,10 @@
     "id": "q00383",
     "image_path": null,
     "question_text": {
+      "en": "What is the difference between dubbed and subbed anime?",
+      "ja": "だぶどとさぶどのアニメのちがいは？"
+    },
+    "question_text_reading": {
       "en": "What is the difference between dubbed and subbed anime?",
       "ja": "だぶどとさぶどのアニメのちがいは？"
     }
@@ -12296,6 +13828,10 @@
     "question_text": {
       "en": "Which anime series is set in 19th century England with a demon butler?",
       "ja": "あくまのしつじがいる19せいきえいこくのアニメは？"
+    },
+    "question_text_reading": {
+      "en": "Which anime series is set in 19th century England with a demon butler?",
+      "ja": "あくまのしつじがいる19せいきえいこくのアニメは？"
     }
   },
   {
@@ -12326,6 +13862,10 @@
     "id": "q00385",
     "image_path": null,
     "question_text": {
+      "en": "What is 'Shounen Jump'?",
+      "ja": "しょうねんじゃんぷとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is 'Shounen Jump'?",
       "ja": "しょうねんじゃんぷとは何か？"
     }
@@ -12360,6 +13900,10 @@
     "question_text": {
       "en": "Which anime follows a group of exorcists called 'jujutsu sorcerers'?",
       "ja": "じゅじゅつしのようしゃたちのアニメは？"
+    },
+    "question_text_reading": {
+      "en": "Which anime follows a group of exorcists called 'jujutsu sorcerers'?",
+      "ja": "じゅじゅつしのようしゃたちのアニメは？"
     }
   },
   {
@@ -12390,6 +13934,10 @@
     "id": "q00387",
     "image_path": null,
     "question_text": {
+      "en": "What is the name of Tanjiro's sister in Demon Slayer?",
+      "ja": "きめつのやいばでたんじろうのいもうとのなまえは？"
+    },
+    "question_text_reading": {
       "en": "What is the name of Tanjiro's sister in Demon Slayer?",
       "ja": "きめつのやいばでたんじろうのいもうとのなまえは？"
     }
@@ -12424,6 +13972,10 @@
     "question_text": {
       "en": "Which anime features the 'Nine-Tails Fox' sealed inside a character?",
       "ja": "きゅうびがふういんされたキャラのアニメは？"
+    },
+    "question_text_reading": {
+      "en": "Which anime features the 'Nine-Tails Fox' sealed inside a character?",
+      "ja": "きゅうびがふういんされたキャラのアニメは？"
     }
   },
   {
@@ -12454,6 +14006,10 @@
     "id": "q00389",
     "image_path": null,
     "question_text": {
+      "en": "What is the anime genre 'slice of life'?",
+      "ja": "あにめのすらいすおぶらいふジャンルとは？"
+    },
+    "question_text_reading": {
       "en": "What is the anime genre 'slice of life'?",
       "ja": "あにめのすらいすおぶらいふジャンルとは？"
     }
@@ -12488,6 +14044,10 @@
     "question_text": {
       "en": "What is 'cour' in anime terminology?",
       "ja": "アニメようごのくーるとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is 'cour' in anime terminology?",
+      "ja": "アニメようごのくーるとは何か？"
     }
   },
   {
@@ -12518,6 +14078,10 @@
     "id": "q00391",
     "image_path": null,
     "question_text": {
+      "en": "Which anime is produced by MAPPA?",
+      "ja": "MAPPAがせいさくしたアニメは？"
+    },
+    "question_text_reading": {
       "en": "Which anime is produced by MAPPA?",
       "ja": "MAPPAがせいさくしたアニメは？"
     }
@@ -12552,6 +14116,10 @@
     "question_text": {
       "en": "What is Kyoto Animation known for?",
       "ja": "きょーとあにめーしょんはなにでゆうめいか？"
+    },
+    "question_text_reading": {
+      "en": "What is Kyoto Animation known for?",
+      "ja": "きょーとあにめーしょんはなにでゆうめいか？"
     }
   },
   {
@@ -12582,6 +14150,10 @@
     "id": "q00393",
     "image_path": null,
     "question_text": {
+      "en": "Which anime features Satoru Gojo?",
+      "ja": "ごじょうさとるがとうじょうするアニメは？"
+    },
+    "question_text_reading": {
       "en": "Which anime features Satoru Gojo?",
       "ja": "ごじょうさとるがとうじょうするアニメは？"
     }
@@ -12616,6 +14188,10 @@
     "question_text": {
       "en": "Who is the creator of One Piece?",
       "ja": "ワンピースのさくしゃは？"
+    },
+    "question_text_reading": {
+      "en": "Who is the creator of One Piece?",
+      "ja": "ワンピースのさくしゃは？"
     }
   },
   {
@@ -12646,6 +14222,10 @@
     "id": "q00395",
     "image_path": null,
     "question_text": {
+      "en": "What is 'Dattebayo' associated with in Naruto?",
+      "ja": "ナルトで「だってばよ」はなにと関係するか？"
+    },
+    "question_text_reading": {
       "en": "What is 'Dattebayo' associated with in Naruto?",
       "ja": "ナルトで「だってばよ」はなにと関係するか？"
     }
@@ -12680,6 +14260,10 @@
     "question_text": {
       "en": "Which Ghibli film features a flying island called Laputa?",
       "ja": "ラピュタというとぶしまのジブリえいがは？"
+    },
+    "question_text_reading": {
+      "en": "Which Ghibli film features a flying island called Laputa?",
+      "ja": "ラピュタというとぶしまのジブリえいがは？"
     }
   },
   {
@@ -12710,6 +14294,10 @@
     "id": "q00397",
     "image_path": null,
     "question_text": {
+      "en": "What is the name of the robot in Doraemon?",
+      "ja": "ドラえもんのろぼっとのなまえは？"
+    },
+    "question_text_reading": {
       "en": "What is the name of the robot in Doraemon?",
       "ja": "ドラえもんのろぼっとのなまえは？"
     }
@@ -12744,6 +14332,10 @@
     "question_text": {
       "en": "Which anime is set in a world with 'Titans' and 3D Maneuver Gear?",
       "ja": "きょじんと立体機動装置のせかいのアニメは？"
+    },
+    "question_text_reading": {
+      "en": "Which anime is set in a world with 'Titans' and 3D Maneuver Gear?",
+      "ja": "きょじんと立体機動装置のせかいのアニメは？"
     }
   },
   {
@@ -12774,6 +14366,10 @@
     "id": "q00399",
     "image_path": null,
     "question_text": {
+      "en": "What is the setting of 'Re:Zero'?",
+      "ja": "りぜろの舞台は？"
+    },
+    "question_text_reading": {
       "en": "What is the setting of 'Re:Zero'?",
       "ja": "りぜろの舞台は？"
     }
@@ -12808,6 +14404,10 @@
     "question_text": {
       "en": "Which anime features the 'Akatsuki' organization?",
       "ja": "あかつきというそしきがとうじょうするアニメは？"
+    },
+    "question_text_reading": {
+      "en": "Which anime features the 'Akatsuki' organization?",
+      "ja": "あかつきというそしきがとうじょうするアニメは？"
     }
   },
   {
@@ -12838,6 +14438,10 @@
     "id": "q00401",
     "image_path": null,
     "question_text": {
+      "en": "What is 'Ghibli Museum' famous for?",
+      "ja": "ジブリびじゅつかんはなにでゆうめいか？"
+    },
+    "question_text_reading": {
       "en": "What is 'Ghibli Museum' famous for?",
       "ja": "ジブリびじゅつかんはなにでゆうめいか？"
     }
@@ -12872,6 +14476,10 @@
     "question_text": {
       "en": "Which anime has 'Zanpakuto' as spirit swords?",
       "ja": "ざんぱくとうというせいれいけんのアニメは？"
+    },
+    "question_text_reading": {
+      "en": "Which anime has 'Zanpakuto' as spirit swords?",
+      "ja": "ざんぱくとうというせいれいけんのアニメは？"
     }
   },
   {
@@ -12902,6 +14510,10 @@
     "id": "q00403",
     "image_path": null,
     "question_text": {
+      "en": "What year did the original Pokemon anime first air in Japan?",
+      "ja": "ぽけもんアニメがにほんではじめてほうそうされたのはなんねんか？"
+    },
+    "question_text_reading": {
       "en": "What year did the original Pokemon anime first air in Japan?",
       "ja": "ぽけもんアニメがにほんではじめてほうそうされたのはなんねんか？"
     }
@@ -12936,6 +14548,10 @@
     "question_text": {
       "en": "Which anime features characters fighting with 'Nen' energy?",
       "ja": "ねんをつかってたたかうアニメは？"
+    },
+    "question_text_reading": {
+      "en": "Which anime features characters fighting with 'Nen' energy?",
+      "ja": "ねんをつかってたたかうアニメは？"
     }
   },
   {
@@ -12966,6 +14582,10 @@
     "id": "q00405",
     "image_path": null,
     "question_text": {
+      "en": "What is 'Fullmetal' referring to in Fullmetal Alchemist?",
+      "ja": "はがねのれんきんじゅつしの「はがねの」はなにをさすか？"
+    },
+    "question_text_reading": {
       "en": "What is 'Fullmetal' referring to in Fullmetal Alchemist?",
       "ja": "はがねのれんきんじゅつしの「はがねの」はなにをさすか？"
     }
@@ -13000,6 +14620,10 @@
     "question_text": {
       "en": "Which anime features the character Rem?",
       "ja": "れむがとうじょうするアニメは？"
+    },
+    "question_text_reading": {
+      "en": "Which anime features the character Rem?",
+      "ja": "れむがとうじょうするアニメは？"
     }
   },
   {
@@ -13030,6 +14654,10 @@
     "id": "q00407",
     "image_path": null,
     "question_text": {
+      "en": "What is 'Anime' literally referring to in Japanese?",
+      "ja": "にほんごで「アニメ」はもともと何をさすか？"
+    },
+    "question_text_reading": {
       "en": "What is 'Anime' literally referring to in Japanese?",
       "ja": "にほんごで「アニメ」はもともと何をさすか？"
     }
@@ -13064,6 +14692,10 @@
     "question_text": {
       "en": "Which anime is famous for the phrase 'Plus Ultra'?",
       "ja": "ぷらすうるとらというフレーズでゆうめいなアニメは？"
+    },
+    "question_text_reading": {
+      "en": "Which anime is famous for the phrase 'Plus Ultra'?",
+      "ja": "ぷらすうるとらというフレーズでゆうめいなアニメは？"
     }
   },
   {
@@ -13094,6 +14726,10 @@
     "id": "q00409",
     "image_path": null,
     "question_text": {
+      "en": "Which anime is about a boy who discovers he can become a hero by training hard?",
+      "ja": "はげんれんしゅうでひーろーになれることをしったしょうねんのアニメは？"
+    },
+    "question_text_reading": {
       "en": "Which anime is about a boy who discovers he can become a hero by training hard?",
       "ja": "はげんれんしゅうでひーろーになれることをしったしょうねんのアニメは？"
     }
@@ -13128,6 +14764,10 @@
     "question_text": {
       "en": "What is 'Shingeki no Kyojin' in English?",
       "ja": "しんげきのきょじんの英語タイトルは？"
+    },
+    "question_text_reading": {
+      "en": "What is 'Shingeki no Kyojin' in English?",
+      "ja": "しんげきのきょじんの英語タイトルは？"
     }
   },
   {
@@ -13158,6 +14798,10 @@
     "id": "q00411",
     "image_path": null,
     "question_text": {
+      "en": "What is the name of Satoru Gojo's special ability?",
+      "ja": "ごじょうさとるの特殊能力のなまえは？"
+    },
+    "question_text_reading": {
       "en": "What is the name of Satoru Gojo's special ability?",
       "ja": "ごじょうさとるの特殊能力のなまえは？"
     }
@@ -13192,6 +14836,10 @@
     "question_text": {
       "en": "Which anime is a psychological thriller with 'Death Note'?",
       "ja": "デスノートはどんなジャンルのアニメか？"
+    },
+    "question_text_reading": {
+      "en": "Which anime is a psychological thriller with 'Death Note'?",
+      "ja": "デスノートはどんなジャンルのアニメか？"
     }
   },
   {
@@ -13222,6 +14870,10 @@
     "id": "q00413",
     "image_path": null,
     "question_text": {
+      "en": "What console launched the modern era of 3D gaming?",
+      "ja": "3Dげーむのしんじだいをひらいたてゆきとは？"
+    },
+    "question_text_reading": {
       "en": "What console launched the modern era of 3D gaming?",
       "ja": "3Dげーむのしんじだいをひらいたてゆきとは？"
     }
@@ -13256,6 +14908,10 @@
     "question_text": {
       "en": "What game features Link as the protagonist?",
       "ja": "りんくがしゅじんこうのげーむは？"
+    },
+    "question_text_reading": {
+      "en": "What game features Link as the protagonist?",
+      "ja": "りんくがしゅじんこうのげーむは？"
     }
   },
   {
@@ -13286,6 +14942,10 @@
     "id": "q00415",
     "image_path": null,
     "question_text": {
+      "en": "What is the best-selling video game of all time (as of 2024)?",
+      "ja": "2024ねんじてんでもっともうれたびでおげーむは？"
+    },
+    "question_text_reading": {
       "en": "What is the best-selling video game of all time (as of 2024)?",
       "ja": "2024ねんじてんでもっともうれたびでおげーむは？"
     }
@@ -13320,6 +14980,10 @@
     "question_text": {
       "en": "Which company makes the PlayStation?",
       "ja": "ぷれいすてーしょんをつくっているかいしゃは？"
+    },
+    "question_text_reading": {
+      "en": "Which company makes the PlayStation?",
+      "ja": "ぷれいすてーしょんをつくっているかいしゃは？"
     }
   },
   {
@@ -13350,6 +15014,10 @@
     "id": "q00417",
     "image_path": null,
     "question_text": {
+      "en": "Which game features Mario and Luigi?",
+      "ja": "まりおとるいーじがとうじょうするげーむは？"
+    },
+    "question_text_reading": {
       "en": "Which game features Mario and Luigi?",
       "ja": "まりおとるいーじがとうじょうするげーむは？"
     }
@@ -13384,6 +15052,10 @@
     "question_text": {
       "en": "What is the iconic yellow ghost-eating character?",
       "ja": "おばけをたべるきいろいキャラクターは？"
+    },
+    "question_text_reading": {
+      "en": "What is the iconic yellow ghost-eating character?",
+      "ja": "おばけをたべるきいろいキャラクターは？"
     }
   },
   {
@@ -13414,6 +15086,10 @@
     "id": "q00419",
     "image_path": null,
     "question_text": {
+      "en": "Which game series features Master Chief?",
+      "ja": "ますたーちいふがとうじょうするげーむシリーズは？"
+    },
+    "question_text_reading": {
       "en": "Which game series features Master Chief?",
       "ja": "ますたーちいふがとうじょうするげーむシリーズは？"
     }
@@ -13448,6 +15124,10 @@
     "question_text": {
       "en": "What game popularized the battle royale genre?",
       "ja": "ばとるろわいやるジャンルをひろめたげーむは？"
+    },
+    "question_text_reading": {
+      "en": "What game popularized the battle royale genre?",
+      "ja": "ばとるろわいやるジャンルをひろめたげーむは？"
     }
   },
   {
@@ -13478,6 +15158,10 @@
     "id": "q00421",
     "image_path": null,
     "question_text": {
+      "en": "Which company made Sonic the Hedgehog?",
+      "ja": "そにっくざへっじほっぐをつくったかいしゃは？"
+    },
+    "question_text_reading": {
       "en": "Which company made Sonic the Hedgehog?",
       "ja": "そにっくざへっじほっぐをつくったかいしゃは？"
     }
@@ -13512,6 +15196,10 @@
     "question_text": {
       "en": "What game series features the Covenant as enemies?",
       "ja": "こべナントがてきとしてとうじょうするげーむシリーズは？"
+    },
+    "question_text_reading": {
+      "en": "What game series features the Covenant as enemies?",
+      "ja": "こべナントがてきとしてとうじょうするげーむシリーズは？"
     }
   },
   {
@@ -13542,6 +15230,10 @@
     "id": "q00423",
     "image_path": null,
     "question_text": {
+      "en": "Which game is famous for the phrase 'The Cake is a Lie'?",
+      "ja": "「けーきはうそだ」というフレーズでゆうめいなげーむは？"
+    },
+    "question_text_reading": {
       "en": "Which game is famous for the phrase 'The Cake is a Lie'?",
       "ja": "「けーきはうそだ」というフレーズでゆうめいなげーむは？"
     }
@@ -13576,6 +15268,10 @@
     "question_text": {
       "en": "What is the setting of the Dark Souls series?",
       "ja": "ダークソウルシリーズの舞台は？"
+    },
+    "question_text_reading": {
+      "en": "What is the setting of the Dark Souls series?",
+      "ja": "ダークソウルシリーズの舞台は？"
     }
   },
   {
@@ -13606,6 +15302,10 @@
     "id": "q00425",
     "image_path": null,
     "question_text": {
+      "en": "What game created the 'survival horror' genre?",
+      "ja": "さばいばるほらーというジャンルをつくったげーむは？"
+    },
+    "question_text_reading": {
       "en": "What game created the 'survival horror' genre?",
       "ja": "さばいばるほらーというジャンルをつくったげーむは？"
     }
@@ -13640,6 +15340,10 @@
     "question_text": {
       "en": "What year was the original Minecraft released to the public?",
       "ja": "おりじなるまいんくらふとがこうかいされたのはなんねんか？"
+    },
+    "question_text_reading": {
+      "en": "What year was the original Minecraft released to the public?",
+      "ja": "おりじなるまいんくらふとがこうかいされたのはなんねんか？"
     }
   },
   {
@@ -13670,6 +15374,10 @@
     "id": "q00427",
     "image_path": null,
     "question_text": {
+      "en": "What is the objective in Tetris?",
+      "ja": "テトリスのもくてきは何か？"
+    },
+    "question_text_reading": {
       "en": "What is the objective in Tetris?",
       "ja": "テトリスのもくてきは何か？"
     }
@@ -13704,6 +15412,10 @@
     "question_text": {
       "en": "Which game series features Arthur Morgan or John Marston?",
       "ja": "あーさーもるがんまたはじょんまーすとんがとうじょうするシリーズは？"
+    },
+    "question_text_reading": {
+      "en": "Which game series features Arthur Morgan or John Marston?",
+      "ja": "あーさーもるがんまたはじょんまーすとんがとうじょうするシリーズは？"
     }
   },
   {
@@ -13734,6 +15446,10 @@
     "id": "q00429",
     "image_path": null,
     "question_text": {
+      "en": "What genre is 'The Sims'?",
+      "ja": "ざしむずのジャンルは？"
+    },
+    "question_text_reading": {
       "en": "What genre is 'The Sims'?",
       "ja": "ざしむずのジャンルは？"
     }
@@ -13768,6 +15484,10 @@
     "question_text": {
       "en": "Which Nintendo franchise features Link and Zelda?",
       "ja": "りんくとぜるだのにんてんどうフランチャイズは？"
+    },
+    "question_text_reading": {
+      "en": "Which Nintendo franchise features Link and Zelda?",
+      "ja": "りんくとぜるだのにんてんどうフランチャイズは？"
     }
   },
   {
@@ -13798,6 +15518,10 @@
     "id": "q00431",
     "image_path": null,
     "question_text": {
+      "en": "What type of game is 'Among Us'?",
+      "ja": "あまんぐあすのゲームジャンルは？"
+    },
+    "question_text_reading": {
       "en": "What type of game is 'Among Us'?",
       "ja": "あまんぐあすのゲームジャンルは？"
     }
@@ -13832,6 +15556,10 @@
     "question_text": {
       "en": "What was Nintendo's first game console?",
       "ja": "にんてんどうのはじめてのゲームきは？"
+    },
+    "question_text_reading": {
+      "en": "What was Nintendo's first game console?",
+      "ja": "にんてんどうのはじめてのゲームきは？"
     }
   },
   {
@@ -13862,6 +15590,10 @@
     "id": "q00433",
     "image_path": null,
     "question_text": {
+      "en": "Which game series features Commander Shepard?",
+      "ja": "しぇぱーどさがおのシリーズは？"
+    },
+    "question_text_reading": {
       "en": "Which game series features Commander Shepard?",
       "ja": "しぇぱーどさがおのシリーズは？"
     }
@@ -13896,6 +15628,10 @@
     "question_text": {
       "en": "What is the name of Link's fairy companion in Ocarina of Time?",
       "ja": "時のオカリナでりんくのようせいのなまえは？"
+    },
+    "question_text_reading": {
+      "en": "What is the name of Link's fairy companion in Ocarina of Time?",
+      "ja": "時のオカリナでりんくのようせいのなまえは？"
     }
   },
   {
@@ -13926,6 +15662,10 @@
     "id": "q00435",
     "image_path": null,
     "question_text": {
+      "en": "What is a JRPG?",
+      "ja": "JRPGとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a JRPG?",
       "ja": "JRPGとは何か？"
     }
@@ -13960,6 +15700,10 @@
     "question_text": {
       "en": "Which game company made Final Fantasy?",
       "ja": "ふぁいなるふぁんたじーをつくったかいしゃは？"
+    },
+    "question_text_reading": {
+      "en": "Which game company made Final Fantasy?",
+      "ja": "ふぁいなるふぁんたじーをつくったかいしゃは？"
     }
   },
   {
@@ -13990,6 +15734,10 @@
     "id": "q00437",
     "image_path": null,
     "question_text": {
+      "en": "What is 'permadeath' in games?",
+      "ja": "ゲームのぱーまですとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is 'permadeath' in games?",
       "ja": "ゲームのぱーまですとは何か？"
     }
@@ -14024,6 +15772,10 @@
     "question_text": {
       "en": "What is a roguelike game?",
       "ja": "ろーぐらいくゲームとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a roguelike game?",
+      "ja": "ろーぐらいくゲームとは何か？"
     }
   },
   {
@@ -14054,6 +15806,10 @@
     "id": "q00439",
     "image_path": null,
     "question_text": {
+      "en": "What is the objective in chess (video game version)?",
+      "ja": "チェスのもくてきは何か？"
+    },
+    "question_text_reading": {
       "en": "What is the objective in chess (video game version)?",
       "ja": "チェスのもくてきは何か？"
     }
@@ -14088,6 +15844,10 @@
     "question_text": {
       "en": "What year was the first Super Mario Bros released?",
       "ja": "はつのすーぱーまりおぶらざーずはいつはつばいされたか？"
+    },
+    "question_text_reading": {
+      "en": "What year was the first Super Mario Bros released?",
+      "ja": "はつのすーぱーまりおぶらざーずはいつはつばいされたか？"
     }
   },
   {
@@ -14118,6 +15878,10 @@
     "id": "q00441",
     "image_path": null,
     "question_text": {
+      "en": "Which game features the Covenant, Flood, and Forerunners?",
+      "ja": "こべナント、ふらっど、ふぉーらんなーがとうじょうするゲームは？"
+    },
+    "question_text_reading": {
       "en": "Which game features the Covenant, Flood, and Forerunners?",
       "ja": "こべナント、ふらっど、ふぉーらんなーがとうじょうするゲームは？"
     }
@@ -14152,6 +15916,10 @@
     "question_text": {
       "en": "What type of game is 'SimCity'?",
       "ja": "しむしてぃのゲームジャンルは？"
+    },
+    "question_text_reading": {
+      "en": "What type of game is 'SimCity'?",
+      "ja": "しむしてぃのゲームジャンルは？"
     }
   },
   {
@@ -14182,6 +15950,10 @@
     "id": "q00443",
     "image_path": null,
     "question_text": {
+      "en": "What is the main currency in Animal Crossing?",
+      "ja": "あつまれどうぶつのもりのつうかは？"
+    },
+    "question_text_reading": {
       "en": "What is the main currency in Animal Crossing?",
       "ja": "あつまれどうぶつのもりのつうかは？"
     }
@@ -14216,6 +15988,10 @@
     "question_text": {
       "en": "Which game is known for the catchphrase 'Gotta Catch 'Em All'?",
       "ja": "「ぜんぶつかまえろ」というキャッチフレーズのゲームは？"
+    },
+    "question_text_reading": {
+      "en": "Which game is known for the catchphrase 'Gotta Catch 'Em All'?",
+      "ja": "「ぜんぶつかまえろ」というキャッチフレーズのゲームは？"
     }
   },
   {
@@ -14246,6 +16022,10 @@
     "id": "q00445",
     "image_path": null,
     "question_text": {
+      "en": "Which company makes the Xbox?",
+      "ja": "えっくすぼっくすをつくっているかいしゃは？"
+    },
+    "question_text_reading": {
       "en": "Which company makes the Xbox?",
       "ja": "えっくすぼっくすをつくっているかいしゃは？"
     }
@@ -14280,6 +16060,10 @@
     "question_text": {
       "en": "What is 'health points' abbreviated as in games?",
       "ja": "ゲームでヘルスポイントのりゃくごは？"
+    },
+    "question_text_reading": {
+      "en": "What is 'health points' abbreviated as in games?",
+      "ja": "ゲームでヘルスポイントのりゃくごは？"
     }
   },
   {
@@ -14310,6 +16094,10 @@
     "id": "q00447",
     "image_path": null,
     "question_text": {
+      "en": "What is 'magic points' abbreviated as in games?",
+      "ja": "ゲームでまほうぽいんとのりゃくごは？"
+    },
+    "question_text_reading": {
       "en": "What is 'magic points' abbreviated as in games?",
       "ja": "ゲームでまほうぽいんとのりゃくごは？"
     }
@@ -14344,6 +16132,10 @@
     "question_text": {
       "en": "What does 'NPC' mean in video games?",
       "ja": "ビデオゲームのNPCのいみは？"
+    },
+    "question_text_reading": {
+      "en": "What does 'NPC' mean in video games?",
+      "ja": "ビデオゲームのNPCのいみは？"
     }
   },
   {
@@ -14374,6 +16166,10 @@
     "id": "q00449",
     "image_path": null,
     "question_text": {
+      "en": "What is 'DLC' in gaming?",
+      "ja": "ゲームのDLCのいみは？"
+    },
+    "question_text_reading": {
       "en": "What is 'DLC' in gaming?",
       "ja": "ゲームのDLCのいみは？"
     }
@@ -14408,6 +16204,10 @@
     "question_text": {
       "en": "What is 'grinding' in RPGs?",
       "ja": "RPGの「ぐらいんど」とは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is 'grinding' in RPGs?",
+      "ja": "RPGの「ぐらいんど」とは何か？"
     }
   },
   {
@@ -14438,6 +16238,10 @@
     "id": "q00451",
     "image_path": null,
     "question_text": {
+      "en": "What is a 'loot box'?",
+      "ja": "るーとぼっくすとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a 'loot box'?",
       "ja": "るーとぼっくすとは何か？"
     }
@@ -14472,6 +16276,10 @@
     "question_text": {
       "en": "What is an 'Easter egg' in games?",
       "ja": "ゲームのイースターたまごとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is an 'Easter egg' in games?",
+      "ja": "ゲームのイースターたまごとは何か？"
     }
   },
   {
@@ -14502,6 +16310,10 @@
     "id": "q00453",
     "image_path": null,
     "question_text": {
+      "en": "What is 'speedrunning'?",
+      "ja": "すぴーどらんとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is 'speedrunning'?",
       "ja": "すぴーどらんとは何か？"
     }
@@ -14536,6 +16348,10 @@
     "question_text": {
       "en": "What is 'FPS' as a game genre?",
       "ja": "ゲームジャンルとしてのFPSとは？"
+    },
+    "question_text_reading": {
+      "en": "What is 'FPS' as a game genre?",
+      "ja": "ゲームジャンルとしてのFPSとは？"
     }
   },
   {
@@ -14566,6 +16382,10 @@
     "id": "q00455",
     "image_path": null,
     "question_text": {
+      "en": "What is 'MOBA' as a game genre?",
+      "ja": "ゲームジャンルとしてのMOBAとは？"
+    },
+    "question_text_reading": {
       "en": "What is 'MOBA' as a game genre?",
       "ja": "ゲームジャンルとしてのMOBAとは？"
     }
@@ -14600,6 +16420,10 @@
     "question_text": {
       "en": "Which game has 'Creepers' as enemies?",
       "ja": "クリーパーがてきとしてとうじょうするゲームは？"
+    },
+    "question_text_reading": {
+      "en": "Which game has 'Creepers' as enemies?",
+      "ja": "クリーパーがてきとしてとうじょうするゲームは？"
     }
   },
   {
@@ -14630,6 +16454,10 @@
     "id": "q00457",
     "image_path": null,
     "question_text": {
+      "en": "What is the iconic opening music of the original Legend of Zelda?",
+      "ja": "ゼルダのでんせつのアイコニックなオープニング音楽は？"
+    },
+    "question_text_reading": {
       "en": "What is the iconic opening music of the original Legend of Zelda?",
       "ja": "ゼルダのでんせつのアイコニックなオープニング音楽は？"
     }
@@ -14664,6 +16492,10 @@
     "question_text": {
       "en": "What does it mean to 'no-hit' a boss?",
       "ja": "ボスを「のーひっと」するとは？"
+    },
+    "question_text_reading": {
+      "en": "What does it mean to 'no-hit' a boss?",
+      "ja": "ボスを「のーひっと」するとは？"
     }
   },
   {
@@ -14694,6 +16526,10 @@
     "id": "q00459",
     "image_path": null,
     "question_text": {
+      "en": "What is 'Game Over' traditionally?",
+      "ja": "「ゲームオーバー」はどういいみか？"
+    },
+    "question_text_reading": {
       "en": "What is 'Game Over' traditionally?",
       "ja": "「ゲームオーバー」はどういいみか？"
     }
@@ -14728,6 +16564,10 @@
     "question_text": {
       "en": "What is 'co-op' gaming?",
       "ja": "こおぷゲームとは？"
+    },
+    "question_text_reading": {
+      "en": "What is 'co-op' gaming?",
+      "ja": "こおぷゲームとは？"
     }
   },
   {
@@ -14758,6 +16598,10 @@
     "id": "q00461",
     "image_path": null,
     "question_text": {
+      "en": "What is a 'sandbox' game?",
+      "ja": "さんどぼっくすゲームとは？"
+    },
+    "question_text_reading": {
       "en": "What is a 'sandbox' game?",
       "ja": "さんどぼっくすゲームとは？"
     }
@@ -14792,6 +16636,10 @@
     "question_text": {
       "en": "Which Capcom game series features Leon Kennedy and Chris Redfield?",
       "ja": "れおんけねでぃとくりすれっどふぃーるどのカプコンシリーズは？"
+    },
+    "question_text_reading": {
+      "en": "Which Capcom game series features Leon Kennedy and Chris Redfield?",
+      "ja": "れおんけねでぃとくりすれっどふぃーるどのカプコンシリーズは？"
     }
   },
   {
@@ -14822,6 +16670,10 @@
     "id": "q00463",
     "image_path": null,
     "question_text": {
+      "en": "What is a 'hit scan' in FPS games?",
+      "ja": "FPSのひっとすきゃんとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a 'hit scan' in FPS games?",
       "ja": "FPSのひっとすきゃんとは何か？"
     }
@@ -14856,6 +16708,10 @@
     "question_text": {
       "en": "What is 'lag' in online gaming?",
       "ja": "おんらいんゲームのらぐとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is 'lag' in online gaming?",
+      "ja": "おんらいんゲームのらぐとは何か？"
     }
   },
   {
@@ -14886,6 +16742,10 @@
     "id": "q00465",
     "image_path": null,
     "question_text": {
+      "en": "Which game is famous for 'The Legend of Zelda: Breath of the Wild'?",
+      "ja": "ゼルダのでんせつ ブレスオブザワイルドはどんなゲームか？"
+    },
+    "question_text_reading": {
       "en": "Which game is famous for 'The Legend of Zelda: Breath of the Wild'?",
       "ja": "ゼルダのでんせつ ブレスオブザワイルドはどんなゲームか？"
     }
@@ -14920,6 +16780,10 @@
     "question_text": {
       "en": "What console is the Switch?",
       "ja": "スイッチはどのゲームきか？"
+    },
+    "question_text_reading": {
+      "en": "What console is the Switch?",
+      "ja": "スイッチはどのゲームきか？"
     }
   },
   {
@@ -14950,6 +16814,10 @@
     "id": "q00467",
     "image_path": null,
     "question_text": {
+      "en": "What is the objective in chess?",
+      "ja": "チェスのもくてきは何か？"
+    },
+    "question_text_reading": {
       "en": "What is the objective in chess?",
       "ja": "チェスのもくてきは何か？"
     }
@@ -14984,6 +16852,10 @@
     "question_text": {
       "en": "What is 'PvP' in games?",
       "ja": "ゲームのPvPとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is 'PvP' in games?",
+      "ja": "ゲームのPvPとは何か？"
     }
   },
   {
@@ -15014,6 +16886,10 @@
     "id": "q00469",
     "image_path": null,
     "question_text": {
+      "en": "What is 'PvE' in games?",
+      "ja": "ゲームのPvEとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is 'PvE' in games?",
       "ja": "ゲームのPvEとは何か？"
     }
@@ -15048,6 +16924,10 @@
     "question_text": {
       "en": "What is a 'buff' in games?",
       "ja": "ゲームのばふとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a 'buff' in games?",
+      "ja": "ゲームのばふとは何か？"
     }
   },
   {
@@ -15078,6 +16958,10 @@
     "id": "q00471",
     "image_path": null,
     "question_text": {
+      "en": "What is a 'nerf' in game balance?",
+      "ja": "ゲームバランスのなーふとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a 'nerf' in game balance?",
       "ja": "ゲームバランスのなーふとは何か？"
     }
@@ -15112,6 +16996,10 @@
     "question_text": {
       "en": "Which company made Street Fighter?",
       "ja": "すとりーとふぁいたーをつくったかいしゃは？"
+    },
+    "question_text_reading": {
+      "en": "Which company made Street Fighter?",
+      "ja": "すとりーとふぁいたーをつくったかいしゃは？"
     }
   },
   {
@@ -15142,6 +17030,10 @@
     "id": "q00473",
     "image_path": null,
     "question_text": {
+      "en": "What is the classic arcade game where you break bricks with a ball?",
+      "ja": "ぼーるでれんがをこわすクラシックアーケードゲームは？"
+    },
+    "question_text_reading": {
       "en": "What is the classic arcade game where you break bricks with a ball?",
       "ja": "ぼーるでれんがをこわすクラシックアーケードゲームは？"
     }
@@ -15176,6 +17068,10 @@
     "question_text": {
       "en": "What is the most popular MOBA game?",
       "ja": "もっとにんきのあるMOBAゲームは？"
+    },
+    "question_text_reading": {
+      "en": "What is the most popular MOBA game?",
+      "ja": "もっとにんきのあるMOBAゲームは？"
     }
   },
   {
@@ -15206,6 +17102,10 @@
     "id": "q00475",
     "image_path": null,
     "question_text": {
+      "en": "What is the setting of 'The Witcher' series?",
+      "ja": "ウィッチャーシリーズの舞台は？"
+    },
+    "question_text_reading": {
       "en": "What is the setting of 'The Witcher' series?",
       "ja": "ウィッチャーシリーズの舞台は？"
     }
@@ -15240,6 +17140,10 @@
     "question_text": {
       "en": "What is 'respawning' in games?",
       "ja": "ゲームのりすぽーんとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is 'respawning' in games?",
+      "ja": "ゲームのりすぽーんとは何か？"
     }
   },
   {
@@ -15270,6 +17174,10 @@
     "id": "q00477",
     "image_path": null,
     "question_text": {
+      "en": "What is the main resource in Fortnite for building?",
+      "ja": "フォートナイトでけんちくにつかうまいんりそーすは？"
+    },
+    "question_text_reading": {
       "en": "What is the main resource in Fortnite for building?",
       "ja": "フォートナイトでけんちくにつかうまいんりそーすは？"
     }
@@ -15304,6 +17212,10 @@
     "question_text": {
       "en": "What is an 'achievement' in games?",
       "ja": "ゲームのあちーぶめんととは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is an 'achievement' in games?",
+      "ja": "ゲームのあちーぶめんととは何か？"
     }
   },
   {
@@ -15334,6 +17246,10 @@
     "id": "q00479",
     "image_path": null,
     "question_text": {
+      "en": "What is 'frame rate' in games?",
+      "ja": "ゲームのふれーむれーととは何か？"
+    },
+    "question_text_reading": {
       "en": "What is 'frame rate' in games?",
       "ja": "ゲームのふれーむれーととは何か？"
     }
@@ -15368,6 +17284,10 @@
     "question_text": {
       "en": "What is 'V-sync' in gaming?",
       "ja": "ゲームのVsyncとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is 'V-sync' in gaming?",
+      "ja": "ゲームのVsyncとは何か？"
     }
   },
   {
@@ -15398,6 +17318,10 @@
     "id": "q00481",
     "image_path": null,
     "question_text": {
+      "en": "What was Pong?",
+      "ja": "ぽんぐとは何か？"
+    },
+    "question_text_reading": {
       "en": "What was Pong?",
       "ja": "ぽんぐとは何か？"
     }
@@ -15432,6 +17356,10 @@
     "question_text": {
       "en": "What is 'bullet hell' in games?",
       "ja": "ゲームのたんまくとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is 'bullet hell' in games?",
+      "ja": "ゲームのたんまくとは何か？"
     }
   },
   {
@@ -15462,6 +17390,10 @@
     "id": "q00483",
     "image_path": null,
     "question_text": {
+      "en": "What is a 'save point'?",
+      "ja": "せーぶぽいんととは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a 'save point'?",
       "ja": "せーぶぽいんととは何か？"
     }
@@ -15496,6 +17428,10 @@
     "question_text": {
       "en": "What is 'open world' in games?",
       "ja": "ゲームのおーぷんわーるどとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is 'open world' in games?",
+      "ja": "ゲームのおーぷんわーるどとは何か？"
     }
   },
   {
@@ -15526,6 +17462,10 @@
     "id": "q00485",
     "image_path": null,
     "question_text": {
+      "en": "What is 'turn-based' combat?",
+      "ja": "ターンせいせんとうとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is 'turn-based' combat?",
       "ja": "ターンせいせんとうとは何か？"
     }
@@ -15560,6 +17500,10 @@
     "question_text": {
       "en": "What is 'real-time strategy' (RTS)?",
       "ja": "りあるたいむすとらてじーとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is 'real-time strategy' (RTS)?",
+      "ja": "りあるたいむすとらてじーとは何か？"
     }
   },
   {
@@ -15590,6 +17534,10 @@
     "id": "q00487",
     "image_path": null,
     "question_text": {
+      "en": "What is a 'patch' in gaming?",
+      "ja": "ゲームのぱっちとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a 'patch' in gaming?",
       "ja": "ゲームのぱっちとは何か？"
     }
@@ -15624,6 +17572,10 @@
     "question_text": {
       "en": "What is the term for games released on multiple platforms?",
       "ja": "ふくすうぷらっとふぉームでリリースされるゲームのようごは？"
+    },
+    "question_text_reading": {
+      "en": "What is the term for games released on multiple platforms?",
+      "ja": "ふくすうぷらっとふぉームでリリースされるゲームのようごは？"
     }
   },
   {
@@ -15654,6 +17606,10 @@
     "id": "q00489",
     "image_path": null,
     "question_text": {
+      "en": "What is a 'platformer' game?",
+      "ja": "ぷらっとふぉーまーゲームとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a 'platformer' game?",
       "ja": "ぷらっとふぉーまーゲームとは何か？"
     }
@@ -15688,6 +17644,10 @@
     "question_text": {
       "en": "What is 'Metroidvania' genre?",
       "ja": "めとろいどばにあジャンルとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is 'Metroidvania' genre?",
+      "ja": "めとろいどばにあジャンルとは何か？"
     }
   },
   {
@@ -15718,6 +17678,10 @@
     "id": "q00491",
     "image_path": null,
     "question_text": {
+      "en": "What console generation is the PlayStation 5?",
+      "ja": "プレイステーション5は何世代目のゲームきか？"
+    },
+    "question_text_reading": {
       "en": "What console generation is the PlayStation 5?",
       "ja": "プレイステーション5は何世代目のゲームきか？"
     }
@@ -15752,6 +17716,10 @@
     "question_text": {
       "en": "What is an 'indie game'?",
       "ja": "いんでぃゲームとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is an 'indie game'?",
+      "ja": "いんでぃゲームとは何か？"
     }
   },
   {
@@ -15782,6 +17750,10 @@
     "id": "q00493",
     "image_path": null,
     "question_text": {
+      "en": "What is Steam?",
+      "ja": "Steamとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is Steam?",
       "ja": "Steamとは何か？"
     }
@@ -15816,6 +17788,10 @@
     "question_text": {
       "en": "What is manga?",
       "ja": "まんがとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is manga?",
+      "ja": "まんがとは何か？"
     }
   },
   {
@@ -15846,6 +17822,10 @@
     "id": "q00495",
     "image_path": null,
     "question_text": {
+      "en": "Who created Dragon Ball manga?",
+      "ja": "ドラゴンボールのまんがをかいたのは？"
+    },
+    "question_text_reading": {
       "en": "Who created Dragon Ball manga?",
       "ja": "ドラゴンボールのまんがをかいたのは？"
     }
@@ -15880,6 +17860,10 @@
     "question_text": {
       "en": "What is the best-selling manga of all time?",
       "ja": "もっともうれたまんがは？"
+    },
+    "question_text_reading": {
+      "en": "What is the best-selling manga of all time?",
+      "ja": "もっともうれたまんがは？"
     }
   },
   {
@@ -15910,6 +17894,10 @@
     "id": "q00497",
     "image_path": null,
     "question_text": {
+      "en": "What magazine did Naruto run in?",
+      "ja": "ナルトが掲載されていたざっしは？"
+    },
+    "question_text_reading": {
       "en": "What magazine did Naruto run in?",
       "ja": "ナルトが掲載されていたざっしは？"
     }
@@ -15944,6 +17932,10 @@
     "question_text": {
       "en": "What is 'tankoubon'?",
       "ja": "たんこうぼんとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is 'tankoubon'?",
+      "ja": "たんこうぼんとは何か？"
     }
   },
   {
@@ -15974,6 +17966,10 @@
     "id": "q00499",
     "image_path": null,
     "question_text": {
+      "en": "What is 'seinen' manga targeted at?",
+      "ja": "せいねんまんがはなにをたいしょうとしているか？"
+    },
+    "question_text_reading": {
       "en": "What is 'seinen' manga targeted at?",
       "ja": "せいねんまんがはなにをたいしょうとしているか？"
     }
@@ -16008,6 +18004,10 @@
     "question_text": {
       "en": "What is 'josei' manga targeted at?",
       "ja": "じょせいまんがはなにをたいしょうとしているか？"
+    },
+    "question_text_reading": {
+      "en": "What is 'josei' manga targeted at?",
+      "ja": "じょせいまんがはなにをたいしょうとしているか？"
     }
   },
   {
@@ -16038,6 +18038,10 @@
     "id": "q00501",
     "image_path": null,
     "question_text": {
+      "en": "What does 'manga-ka' mean?",
+      "ja": "まんがかとは何か？"
+    },
+    "question_text_reading": {
       "en": "What does 'manga-ka' mean?",
       "ja": "まんがかとは何か？"
     }
@@ -16072,6 +18076,10 @@
     "question_text": {
       "en": "What is 'furigana' in manga?",
       "ja": "まんがのふりがなとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is 'furigana' in manga?",
+      "ja": "まんがのふりがなとは何か？"
     }
   },
   {
@@ -16102,6 +18110,10 @@
     "id": "q00503",
     "image_path": null,
     "question_text": {
+      "en": "Who created the manga 'Berserk'?",
+      "ja": "まんが「ベルセルク」をかいたのは？"
+    },
+    "question_text_reading": {
       "en": "Who created the manga 'Berserk'?",
       "ja": "まんが「ベルセルク」をかいたのは？"
     }
@@ -16136,6 +18148,10 @@
     "question_text": {
       "en": "What is the manga 'One Punch Man' about?",
       "ja": "まんが「ワンパンマン」はなにについてか？"
+    },
+    "question_text_reading": {
+      "en": "What is the manga 'One Punch Man' about?",
+      "ja": "まんが「ワンパンマン」はなにについてか？"
     }
   },
   {
@@ -16166,6 +18182,10 @@
     "id": "q00505",
     "image_path": null,
     "question_text": {
+      "en": "Which manga is known for its intricate artwork style?",
+      "ja": "ふくざつなえのまんがで知られるのは？"
+    },
+    "question_text_reading": {
       "en": "Which manga is known for its intricate artwork style?",
       "ja": "ふくざつなえのまんがで知られるのは？"
     }
@@ -16200,6 +18220,10 @@
     "question_text": {
       "en": "What is the most famous work of Osamu Tezuka?",
       "ja": "てづかおさむのもっともゆうめいなさくひんは？"
+    },
+    "question_text_reading": {
+      "en": "What is the most famous work of Osamu Tezuka?",
+      "ja": "てづかおさむのもっともゆうめいなさくひんは？"
     }
   },
   {
@@ -16230,6 +18254,10 @@
     "id": "q00507",
     "image_path": null,
     "question_text": {
+      "en": "What is 'Shonen' manga primarily about?",
+      "ja": "しょうねんまんがのおもなないようは？"
+    },
+    "question_text_reading": {
       "en": "What is 'Shonen' manga primarily about?",
       "ja": "しょうねんまんがのおもなないようは？"
     }
@@ -16264,6 +18292,10 @@
     "question_text": {
       "en": "Which manga follows the Joestars across multiple generations?",
       "ja": "じょえすたーけのものがたりのまんがは？"
+    },
+    "question_text_reading": {
+      "en": "Which manga follows the Joestars across multiple generations?",
+      "ja": "じょえすたーけのものがたりのまんがは？"
     }
   },
   {
@@ -16294,6 +18326,10 @@
     "id": "q00509",
     "image_path": null,
     "question_text": {
+      "en": "What is 'webtoon'?",
+      "ja": "うぇぶとぅーんとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is 'webtoon'?",
       "ja": "うぇぶとぅーんとは何か？"
     }
@@ -16328,6 +18364,10 @@
     "question_text": {
       "en": "Who created Bleach?",
       "ja": "ブリーチをかいたのは？"
+    },
+    "question_text_reading": {
+      "en": "Who created Bleach?",
+      "ja": "ブリーチをかいたのは？"
     }
   },
   {
@@ -16358,6 +18398,10 @@
     "id": "q00511",
     "image_path": null,
     "question_text": {
+      "en": "What type of story is 'Monster' by Naoki Urasawa?",
+      "ja": "うらさわなおきのモンスターはどんなものがたりか？"
+    },
+    "question_text_reading": {
       "en": "What type of story is 'Monster' by Naoki Urasawa?",
       "ja": "うらさわなおきのモンスターはどんなものがたりか？"
     }
@@ -16392,6 +18436,10 @@
     "question_text": {
       "en": "What is 'doujinshi'?",
       "ja": "どうじんしとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is 'doujinshi'?",
+      "ja": "どうじんしとは何か？"
     }
   },
   {
@@ -16422,6 +18470,10 @@
     "id": "q00513",
     "image_path": null,
     "question_text": {
+      "en": "Which manga is about a time-traveling story in feudal Japan?",
+      "ja": "せんごくじだいのにほんにタイムトラベルするまんがは？"
+    },
+    "question_text_reading": {
       "en": "Which manga is about a time-traveling story in feudal Japan?",
       "ja": "せんごくじだいのにほんにタイムトラベルするまんがは？"
     }
@@ -16456,6 +18508,10 @@
     "question_text": {
       "en": "What is the manga 'Yotsubato!' about?",
       "ja": "まんが「よつばと!」はなにについてか？"
+    },
+    "question_text_reading": {
+      "en": "What is the manga 'Yotsubato!' about?",
+      "ja": "まんが「よつばと!」はなにについてか？"
     }
   },
   {
@@ -16486,6 +18542,10 @@
     "id": "q00515",
     "image_path": null,
     "question_text": {
+      "en": "Which manga series is set in ancient China?",
+      "ja": "こだいちゅうごくをぶたいにしたまんがシリーズは？"
+    },
+    "question_text_reading": {
       "en": "Which manga series is set in ancient China?",
       "ja": "こだいちゅうごくをぶたいにしたまんがシリーズは？"
     }
@@ -16520,6 +18580,10 @@
     "question_text": {
       "en": "Who draws One Piece?",
       "ja": "ワンピースをかいているのは誰か？"
+    },
+    "question_text_reading": {
+      "en": "Who draws One Piece?",
+      "ja": "ワンピースをかいているのは誰か？"
     }
   },
   {
@@ -16550,6 +18614,10 @@
     "id": "q00517",
     "image_path": null,
     "question_text": {
+      "en": "What is the premise of Vinland Saga?",
+      "ja": "ゔぃんらんどさがのせっていは？"
+    },
+    "question_text_reading": {
       "en": "What is the premise of Vinland Saga?",
       "ja": "ゔぃんらんどさがのせっていは？"
     }
@@ -16584,6 +18652,10 @@
     "question_text": {
       "en": "What is 'gekiga'?",
       "ja": "げきがとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is 'gekiga'?",
+      "ja": "げきがとは何か？"
     }
   },
   {
@@ -16614,6 +18686,10 @@
     "id": "q00519",
     "image_path": null,
     "question_text": {
+      "en": "What manga features Edward and Alphonse Elric?",
+      "ja": "えどわーどとあるふぉんすえるりっくのまんがは？"
+    },
+    "question_text_reading": {
       "en": "What manga features Edward and Alphonse Elric?",
       "ja": "えどわーどとあるふぉんすえるりっくのまんがは？"
     }
@@ -16648,6 +18724,10 @@
     "question_text": {
       "en": "What is Kimetsu no Yaiba known as in English?",
       "ja": "きめつのやいばの英語タイトルは？"
+    },
+    "question_text_reading": {
+      "en": "What is Kimetsu no Yaiba known as in English?",
+      "ja": "きめつのやいばの英語タイトルは？"
     }
   },
   {
@@ -16678,6 +18758,10 @@
     "id": "q00521",
     "image_path": null,
     "question_text": {
+      "en": "Which manga is drawn by Hajime Isayama?",
+      "ja": "いさやまはじめがかいたまんがは？"
+    },
+    "question_text_reading": {
       "en": "Which manga is drawn by Hajime Isayama?",
       "ja": "いさやまはじめがかいたまんがは？"
     }
@@ -16712,6 +18796,10 @@
     "question_text": {
       "en": "What is 'Josei' manga magazine aimed at?",
       "ja": "じょせいまんがざっしのたいしょうは？"
+    },
+    "question_text_reading": {
+      "en": "What is 'Josei' manga magazine aimed at?",
+      "ja": "じょせいまんがざっしのたいしょうは？"
     }
   },
   {
@@ -16742,6 +18830,10 @@
     "id": "q00523",
     "image_path": null,
     "question_text": {
+      "en": "What is the manga equivalent of a light novel?",
+      "ja": "らいとのべるのまんがそうとうは？"
+    },
+    "question_text_reading": {
       "en": "What is the manga equivalent of a light novel?",
       "ja": "らいとのべるのまんがそうとうは？"
     }
@@ -16776,6 +18868,10 @@
     "question_text": {
       "en": "Which manga features the Elric brothers searching for the Philosopher's Stone?",
       "ja": "けんじゃのいしをさがすえるりっくきょうだいのまんがは？"
+    },
+    "question_text_reading": {
+      "en": "Which manga features the Elric brothers searching for the Philosopher's Stone?",
+      "ja": "けんじゃのいしをさがすえるりっくきょうだいのまんがは？"
     }
   },
   {
@@ -16806,6 +18902,10 @@
     "id": "q00525",
     "image_path": null,
     "question_text": {
+      "en": "Who created Doraemon?",
+      "ja": "ドラえもんをかいたのは？"
+    },
+    "question_text_reading": {
       "en": "Who created Doraemon?",
       "ja": "ドラえもんをかいたのは？"
     }
@@ -16840,6 +18940,10 @@
     "question_text": {
       "en": "What is the genre of 'Vagabond'?",
       "ja": "バガボンドのジャンルは？"
+    },
+    "question_text_reading": {
+      "en": "What is the genre of 'Vagabond'?",
+      "ja": "バガボンドのジャンルは？"
     }
   },
   {
@@ -16870,6 +18974,10 @@
     "id": "q00527",
     "image_path": null,
     "question_text": {
+      "en": "What is a 'spin-off' manga?",
+      "ja": "スピンオフまんがとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a 'spin-off' manga?",
       "ja": "スピンオフまんがとは何か？"
     }
@@ -16904,6 +19012,10 @@
     "question_text": {
       "en": "What makes manga read differently from Western comics?",
       "ja": "まんがが西洋まんがとちがうよみかたは？"
+    },
+    "question_text_reading": {
+      "en": "What makes manga read differently from Western comics?",
+      "ja": "まんがが西洋まんがとちがうよみかたは？"
     }
   },
   {
@@ -16934,6 +19046,10 @@
     "id": "q00529",
     "image_path": null,
     "question_text": {
+      "en": "Which manga has the longest running story?",
+      "ja": "もっともちょうへんのまんがは？"
+    },
+    "question_text_reading": {
       "en": "Which manga has the longest running story?",
       "ja": "もっともちょうへんのまんがは？"
     }
@@ -16968,6 +19084,10 @@
     "question_text": {
       "en": "What is 'shojo manga' famous for?",
       "ja": "しょうじょまんがはなにでゆうめいか？"
+    },
+    "question_text_reading": {
+      "en": "What is 'shojo manga' famous for?",
+      "ja": "しょうじょまんがはなにでゆうめいか？"
     }
   },
   {
@@ -16998,6 +19118,10 @@
     "id": "q00531",
     "image_path": null,
     "question_text": {
+      "en": "Who is the creator of Sailor Moon manga?",
+      "ja": "セーラームーンまんがのさくしゃは？"
+    },
+    "question_text_reading": {
       "en": "Who is the creator of Sailor Moon manga?",
       "ja": "セーラームーンまんがのさくしゃは？"
     }
@@ -17032,6 +19156,10 @@
     "question_text": {
       "en": "What is the manga 'Uzumaki' known for?",
       "ja": "まんが「うずまき」はなにでゆうめいか？"
+    },
+    "question_text_reading": {
+      "en": "What is the manga 'Uzumaki' known for?",
+      "ja": "まんが「うずまき」はなにでゆうめいか？"
     }
   },
   {
@@ -17062,6 +19190,10 @@
     "id": "q00533",
     "image_path": null,
     "question_text": {
+      "en": "What manga features Kenshiro as the main character?",
+      "ja": "けんしろうがしゅじんこうのまんがは？"
+    },
+    "question_text_reading": {
       "en": "What manga features Kenshiro as the main character?",
       "ja": "けんしろうがしゅじんこうのまんがは？"
     }
@@ -17096,6 +19228,10 @@
     "question_text": {
       "en": "What year was the first chapter of One Piece published?",
       "ja": "ワンピースのさいしょのかいがしゅっぱんされたのはなんねんか？"
+    },
+    "question_text_reading": {
+      "en": "What year was the first chapter of One Piece published?",
+      "ja": "ワンピースのさいしょのかいがしゅっぱんされたのはなんねんか？"
     }
   },
   {
@@ -17126,6 +19262,10 @@
     "id": "q00535",
     "image_path": null,
     "question_text": {
+      "en": "What is the manga about Yuji Itadori eating a cursed finger?",
+      "ja": "ゆうじいただりがじゅのゆびをたべるまんがは？"
+    },
+    "question_text_reading": {
       "en": "What is the manga about Yuji Itadori eating a cursed finger?",
       "ja": "ゆうじいただりがじゅのゆびをたべるまんがは？"
     }
@@ -17160,6 +19300,10 @@
     "question_text": {
       "en": "What is the main theme of 'Slam Dunk'?",
       "ja": "スラムダンクのメインテーマは？"
+    },
+    "question_text_reading": {
+      "en": "What is the main theme of 'Slam Dunk'?",
+      "ja": "スラムダンクのメインテーマは？"
     }
   },
   {
@@ -17190,6 +19334,10 @@
     "id": "q00537",
     "image_path": null,
     "question_text": {
+      "en": "Which manga features time-travel murder mystery?",
+      "ja": "タイムトラベルのさつじんミステリーのまんがは？"
+    },
+    "question_text_reading": {
       "en": "Which manga features time-travel murder mystery?",
       "ja": "タイムトラベルのさつじんミステリーのまんがは？"
     }
@@ -17224,6 +19372,10 @@
     "question_text": {
       "en": "What is Naoki Urasawa known for?",
       "ja": "うらさわなおきはなにでゆうめいか？"
+    },
+    "question_text_reading": {
+      "en": "What is Naoki Urasawa known for?",
+      "ja": "うらさわなおきはなにでゆうめいか？"
     }
   },
   {
@@ -17254,6 +19406,10 @@
     "id": "q00539",
     "image_path": null,
     "question_text": {
+      "en": "What is the manga that Chainsaw Man is serialized in?",
+      "ja": "チェーンソーマンがけいさいされているまんがは？"
+    },
+    "question_text_reading": {
       "en": "What is the manga that Chainsaw Man is serialized in?",
       "ja": "チェーンソーマンがけいさいされているまんがは？"
     }
@@ -17288,6 +19444,10 @@
     "question_text": {
       "en": "Who created 'Hunter x Hunter'?",
       "ja": "ハンターハンターをかいたのは？"
+    },
+    "question_text_reading": {
+      "en": "Who created 'Hunter x Hunter'?",
+      "ja": "ハンターハンターをかいたのは？"
     }
   },
   {
@@ -17318,6 +19478,10 @@
     "id": "q00541",
     "image_path": null,
     "question_text": {
+      "en": "What is 'Gekkan Shounen Nozaki-kun' about?",
+      "ja": "「げっかんしょうねんのざきくん」はなにについてか？"
+    },
+    "question_text_reading": {
       "en": "What is 'Gekkan Shounen Nozaki-kun' about?",
       "ja": "「げっかんしょうねんのざきくん」はなにについてか？"
     }
@@ -17352,6 +19516,10 @@
     "question_text": {
       "en": "Which manga ran from 1999 and features Gon Freecss as protagonist?",
       "ja": "1999ねんかられんさいのごんふりーくすがしゅじんこうのまんがは？"
+    },
+    "question_text_reading": {
+      "en": "Which manga ran from 1999 and features Gon Freecss as protagonist?",
+      "ja": "1999ねんかられんさいのごんふりーくすがしゅじんこうのまんがは？"
     }
   },
   {
@@ -17382,6 +19550,10 @@
     "id": "q00543",
     "image_path": null,
     "question_text": {
+      "en": "What is 'yonkoma' manga?",
+      "ja": "よんこままんがとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is 'yonkoma' manga?",
       "ja": "よんこままんがとは何か？"
     }
@@ -17416,6 +19588,10 @@
     "question_text": {
       "en": "What type of manga is 'Yuru Camp'?",
       "ja": "ゆるキャンのまんがのしゅるいは？"
+    },
+    "question_text_reading": {
+      "en": "What type of manga is 'Yuru Camp'?",
+      "ja": "ゆるキャンのまんがのしゅるいは？"
     }
   },
   {
@@ -17446,6 +19622,10 @@
     "id": "q00545",
     "image_path": null,
     "question_text": {
+      "en": "Who is the creator of Fairy Tail?",
+      "ja": "フェアリーテイルをかいたのは？"
+    },
+    "question_text_reading": {
       "en": "Who is the creator of Fairy Tail?",
       "ja": "フェアリーテイルをかいたのは？"
     }
@@ -17480,6 +19660,10 @@
     "question_text": {
       "en": "What is the famous manga by CLAMP?",
       "ja": "CLAMPのゆうめいなまんがは？"
+    },
+    "question_text_reading": {
+      "en": "What is the famous manga by CLAMP?",
+      "ja": "CLAMPのゆうめいなまんがは？"
     }
   },
   {
@@ -17510,6 +19694,10 @@
     "id": "q00547",
     "image_path": null,
     "question_text": {
+      "en": "What is 'Seinen' manga known for?",
+      "ja": "せいねんまんがはなにでゆうめいか？"
+    },
+    "question_text_reading": {
       "en": "What is 'Seinen' manga known for?",
       "ja": "せいねんまんがはなにでゆうめいか？"
     }
@@ -17544,6 +19732,10 @@
     "question_text": {
       "en": "What makes Hirohiko Araki unique as a manga artist?",
       "ja": "まんがかとしてのあらきひろひこのとくちょうは？"
+    },
+    "question_text_reading": {
+      "en": "What makes Hirohiko Araki unique as a manga artist?",
+      "ja": "まんがかとしてのあらきひろひこのとくちょうは？"
     }
   },
   {
@@ -17574,6 +19766,10 @@
     "id": "q00549",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of France?",
+      "ja": "ふらんすのしゅとは？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of France?",
       "ja": "ふらんすのしゅとは？"
     }
@@ -17608,6 +19804,10 @@
     "question_text": {
       "en": "What is the capital of Japan?",
       "ja": "にほんのしゅとは？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of Japan?",
+      "ja": "にほんのしゅとは？"
     }
   },
   {
@@ -17638,6 +19838,10 @@
     "id": "q00551",
     "image_path": null,
     "question_text": {
+      "en": "What is the largest country by area?",
+      "ja": "めんせきがもっともおおきいくには？"
+    },
+    "question_text_reading": {
       "en": "What is the largest country by area?",
       "ja": "めんせきがもっともおおきいくには？"
     }
@@ -17672,6 +19876,10 @@
     "question_text": {
       "en": "What is the longest river in the world?",
       "ja": "せかいでもっともながいかわは？"
+    },
+    "question_text_reading": {
+      "en": "What is the longest river in the world?",
+      "ja": "せかいでもっともながいかわは？"
     }
   },
   {
@@ -17702,6 +19910,10 @@
     "id": "q00553",
     "image_path": null,
     "question_text": {
+      "en": "What is the highest mountain in the world?",
+      "ja": "せかいでもっともたかいやまは？"
+    },
+    "question_text_reading": {
       "en": "What is the highest mountain in the world?",
       "ja": "せかいでもっともたかいやまは？"
     }
@@ -17736,6 +19948,10 @@
     "question_text": {
       "en": "What continent is Egypt in?",
       "ja": "えじぷとはどのたいりくにあるか？"
+    },
+    "question_text_reading": {
+      "en": "What continent is Egypt in?",
+      "ja": "えじぷとはどのたいりくにあるか？"
     }
   },
   {
@@ -17766,6 +19982,10 @@
     "id": "q00555",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of Germany?",
+      "ja": "どいつのしゅとは？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of Germany?",
       "ja": "どいつのしゅとは？"
     }
@@ -17800,6 +20020,10 @@
     "question_text": {
       "en": "What ocean separates Africa from South America?",
       "ja": "あふりかとみなみあめりかをへだてるうみは？"
+    },
+    "question_text_reading": {
+      "en": "What ocean separates Africa from South America?",
+      "ja": "あふりかとみなみあめりかをへだてるうみは？"
     }
   },
   {
@@ -17830,6 +20054,10 @@
     "id": "q00557",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of Australia?",
+      "ja": "おーすとらりあのしゅとは？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of Australia?",
       "ja": "おーすとらりあのしゅとは？"
     }
@@ -17864,6 +20092,10 @@
     "question_text": {
       "en": "What is the smallest country in the world?",
       "ja": "せかいでもっともちいさいくには？"
+    },
+    "question_text_reading": {
+      "en": "What is the smallest country in the world?",
+      "ja": "せかいでもっともちいさいくには？"
     }
   },
   {
@@ -17894,6 +20126,10 @@
     "id": "q00559",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of Brazil?",
+      "ja": "ぶらじるのしゅとは？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of Brazil?",
       "ja": "ぶらじるのしゅとは？"
     }
@@ -17928,6 +20164,10 @@
     "question_text": {
       "en": "What is the capital of China?",
       "ja": "ちゅうごくのしゅとは？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of China?",
+      "ja": "ちゅうごくのしゅとは？"
     }
   },
   {
@@ -17958,6 +20198,10 @@
     "id": "q00561",
     "image_path": null,
     "question_text": {
+      "en": "What is the largest desert in the world?",
+      "ja": "せかいでもっともおおきいさばくは？"
+    },
+    "question_text_reading": {
       "en": "What is the largest desert in the world?",
       "ja": "せかいでもっともおおきいさばくは？"
     }
@@ -17992,6 +20236,10 @@
     "question_text": {
       "en": "How many continents are there?",
       "ja": "たいりくはいくつあるか？"
+    },
+    "question_text_reading": {
+      "en": "How many continents are there?",
+      "ja": "たいりくはいくつあるか？"
     }
   },
   {
@@ -18022,6 +20270,10 @@
     "id": "q00563",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of the USA?",
+      "ja": "アメリカのしゅとは？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of the USA?",
       "ja": "アメリカのしゅとは？"
     }
@@ -18056,6 +20308,10 @@
     "question_text": {
       "en": "What is the capital of Italy?",
       "ja": "いたりあのしゅとは？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of Italy?",
+      "ja": "いたりあのしゅとは？"
     }
   },
   {
@@ -18086,6 +20342,10 @@
     "id": "q00565",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of Spain?",
+      "ja": "すぺいんのしゅとは？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of Spain?",
       "ja": "すぺいんのしゅとは？"
     }
@@ -18120,6 +20380,10 @@
     "question_text": {
       "en": "What is the capital of Canada?",
       "ja": "かなだのしゅとは？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of Canada?",
+      "ja": "かなだのしゅとは？"
     }
   },
   {
@@ -18150,6 +20414,10 @@
     "id": "q00567",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of Russia?",
+      "ja": "ろしあのしゅとは？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of Russia?",
       "ja": "ろしあのしゅとは？"
     }
@@ -18184,6 +20452,10 @@
     "question_text": {
       "en": "What is the capital of South Korea?",
       "ja": "かんこくのしゅとは？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of South Korea?",
+      "ja": "かんこくのしゅとは？"
     }
   },
   {
@@ -18214,6 +20486,10 @@
     "id": "q00569",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of India?",
+      "ja": "いんどのしゅとは？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of India?",
       "ja": "いんどのしゅとは？"
     }
@@ -18248,6 +20524,10 @@
     "question_text": {
       "en": "What is the capital of Mexico?",
       "ja": "めきしこのしゅとは？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of Mexico?",
+      "ja": "めきしこのしゅとは？"
     }
   },
   {
@@ -18278,6 +20558,10 @@
     "id": "q00571",
     "image_path": null,
     "question_text": {
+      "en": "What country has the Eiffel Tower?",
+      "ja": "えっふぇるとうはどのくににあるか？"
+    },
+    "question_text_reading": {
       "en": "What country has the Eiffel Tower?",
       "ja": "えっふぇるとうはどのくににあるか？"
     }
@@ -18312,6 +20596,10 @@
     "question_text": {
       "en": "What country has the Colosseum?",
       "ja": "ころっせおはどのくににあるか？"
+    },
+    "question_text_reading": {
+      "en": "What country has the Colosseum?",
+      "ja": "ころっせおはどのくににあるか？"
     }
   },
   {
@@ -18342,6 +20630,10 @@
     "id": "q00573",
     "image_path": null,
     "question_text": {
+      "en": "What country is the Amazon rainforest mostly in?",
+      "ja": "あまぞんのねったいうりんはおもにどのくににあるか？"
+    },
+    "question_text_reading": {
       "en": "What country is the Amazon rainforest mostly in?",
       "ja": "あまぞんのねったいうりんはおもにどのくににあるか？"
     }
@@ -18376,6 +20668,10 @@
     "question_text": {
       "en": "What sea is between Europe and Africa?",
       "ja": "ゆーろっぱとあふりかのあいだのうみは？"
+    },
+    "question_text_reading": {
+      "en": "What sea is between Europe and Africa?",
+      "ja": "ゆーろっぱとあふりかのあいだのうみは？"
     }
   },
   {
@@ -18406,6 +20702,10 @@
     "id": "q00575",
     "image_path": null,
     "question_text": {
+      "en": "What country owns the Galapagos Islands?",
+      "ja": "がらぱごすとうはどのくにのりょうどか？"
+    },
+    "question_text_reading": {
       "en": "What country owns the Galapagos Islands?",
       "ja": "がらぱごすとうはどのくにのりょうどか？"
     }
@@ -18440,6 +20740,10 @@
     "question_text": {
       "en": "What is the longest mountain range?",
       "ja": "せかいでもっともながいさんみゃくは？"
+    },
+    "question_text_reading": {
+      "en": "What is the longest mountain range?",
+      "ja": "せかいでもっともながいさんみゃくは？"
     }
   },
   {
@@ -18470,6 +20774,10 @@
     "id": "q00577",
     "image_path": null,
     "question_text": {
+      "en": "What is the deepest lake in the world?",
+      "ja": "せかいでもっともふかいみずうみは？"
+    },
+    "question_text_reading": {
       "en": "What is the deepest lake in the world?",
       "ja": "せかいでもっともふかいみずうみは？"
     }
@@ -18504,6 +20812,10 @@
     "question_text": {
       "en": "What country has the most natural UNESCO World Heritage Sites?",
       "ja": "しぜんのユネスコせかいいさんがもっともおおいくには？"
+    },
+    "question_text_reading": {
+      "en": "What country has the most natural UNESCO World Heritage Sites?",
+      "ja": "しぜんのユネスコせかいいさんがもっともおおいくには？"
     }
   },
   {
@@ -18534,6 +20846,10 @@
     "id": "q00579",
     "image_path": null,
     "question_text": {
+      "en": "What is the largest ocean?",
+      "ja": "もっともおおきいうみは？"
+    },
+    "question_text_reading": {
       "en": "What is the largest ocean?",
       "ja": "もっともおおきいうみは？"
     }
@@ -18568,6 +20884,10 @@
     "question_text": {
       "en": "What continent is Argentina in?",
       "ja": "あるぜんちんはどのたいりくにあるか？"
+    },
+    "question_text_reading": {
+      "en": "What continent is Argentina in?",
+      "ja": "あるぜんちんはどのたいりくにあるか？"
     }
   },
   {
@@ -18598,6 +20918,10 @@
     "id": "q00581",
     "image_path": null,
     "question_text": {
+      "en": "What country is known as the Land of the Rising Sun?",
+      "ja": "ひのでのくにといわれるのはどのくにか？"
+    },
+    "question_text_reading": {
       "en": "What country is known as the Land of the Rising Sun?",
       "ja": "ひのでのくにといわれるのはどのくにか？"
     }
@@ -18632,6 +20956,10 @@
     "question_text": {
       "en": "What is the capital of Egypt?",
       "ja": "えじぷとのしゅとは？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of Egypt?",
+      "ja": "えじぷとのしゅとは？"
     }
   },
   {
@@ -18662,6 +20990,10 @@
     "id": "q00583",
     "image_path": null,
     "question_text": {
+      "en": "What mountain range separates Europe and Asia?",
+      "ja": "ゆーろっぱとあじあをへだてるさんみゃくは？"
+    },
+    "question_text_reading": {
       "en": "What mountain range separates Europe and Asia?",
       "ja": "ゆーろっぱとあじあをへだてるさんみゃくは？"
     }
@@ -18696,6 +21028,10 @@
     "question_text": {
       "en": "What country has the Great Barrier Reef?",
       "ja": "グレートバリアリーフはどのくににあるか？"
+    },
+    "question_text_reading": {
+      "en": "What country has the Great Barrier Reef?",
+      "ja": "グレートバリアリーフはどのくににあるか？"
     }
   },
   {
@@ -18726,6 +21062,10 @@
     "id": "q00585",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of Turkey?",
+      "ja": "とるこのしゅとは？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of Turkey?",
       "ja": "とるこのしゅとは？"
     }
@@ -18760,6 +21100,10 @@
     "question_text": {
       "en": "What is the capital of South Africa?",
       "ja": "みなみあふりかのしゅとは？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of South Africa?",
+      "ja": "みなみあふりかのしゅとは？"
     }
   },
   {
@@ -18790,6 +21134,10 @@
     "id": "q00587",
     "image_path": null,
     "question_text": {
+      "en": "What country is the Sahara Desert mostly in?",
+      "ja": "さはらさばくはおもにどのくににあるか？"
+    },
+    "question_text_reading": {
       "en": "What country is the Sahara Desert mostly in?",
       "ja": "さはらさばくはおもにどのくににあるか？"
     }
@@ -18824,6 +21172,10 @@
     "question_text": {
       "en": "What is the capital of Argentina?",
       "ja": "あるぜんちんのしゅとは？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of Argentina?",
+      "ja": "あるぜんちんのしゅとは？"
     }
   },
   {
@@ -18854,6 +21206,10 @@
     "id": "q00589",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of Sweden?",
+      "ja": "すうぇーでんのしゅとは？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of Sweden?",
       "ja": "すうぇーでんのしゅとは？"
     }
@@ -18888,6 +21244,10 @@
     "question_text": {
       "en": "What is the capital of Greece?",
       "ja": "ぎりしあのしゅとは？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of Greece?",
+      "ja": "ぎりしあのしゅとは？"
     }
   },
   {
@@ -18918,6 +21278,10 @@
     "id": "q00591",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of Netherlands?",
+      "ja": "おらんだのしゅとは？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of Netherlands?",
       "ja": "おらんだのしゅとは？"
     }
@@ -18952,6 +21316,10 @@
     "question_text": {
       "en": "What is the capital of Poland?",
       "ja": "ぽーらんどのしゅとは？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of Poland?",
+      "ja": "ぽーらんどのしゅとは？"
     }
   },
   {
@@ -18982,6 +21350,10 @@
     "id": "q00593",
     "image_path": null,
     "question_text": {
+      "en": "What country has the most islands?",
+      "ja": "もっともおおいしまのあるくには？"
+    },
+    "question_text_reading": {
       "en": "What country has the most islands?",
       "ja": "もっともおおいしまのあるくには？"
     }
@@ -19016,6 +21388,10 @@
     "question_text": {
       "en": "What is the capital of New Zealand?",
       "ja": "にゅーじーらんどのしゅとは？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of New Zealand?",
+      "ja": "にゅーじーらんどのしゅとは？"
     }
   },
   {
@@ -19046,6 +21422,10 @@
     "id": "q00595",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of Nigeria?",
+      "ja": "ないじぇりあのしゅとは？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of Nigeria?",
       "ja": "ないじぇりあのしゅとは？"
     }
@@ -19080,6 +21460,10 @@
     "question_text": {
       "en": "What is the capital of Thailand?",
       "ja": "たいらんどのしゅとは？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of Thailand?",
+      "ja": "たいらんどのしゅとは？"
     }
   },
   {
@@ -19110,6 +21494,10 @@
     "id": "q00597",
     "image_path": null,
     "question_text": {
+      "en": "What country is the Taj Mahal in?",
+      "ja": "たじまはるはどのくににあるか？"
+    },
+    "question_text_reading": {
       "en": "What country is the Taj Mahal in?",
       "ja": "たじまはるはどのくににあるか？"
     }
@@ -19144,6 +21532,10 @@
     "question_text": {
       "en": "What is the capital of Saudi Arabia?",
       "ja": "さうじあらびあのしゅとは？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of Saudi Arabia?",
+      "ja": "さうじあらびあのしゅとは？"
     }
   },
   {
@@ -19174,6 +21566,10 @@
     "id": "q00599",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of Kenya?",
+      "ja": "けにあのしゅとは？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of Kenya?",
       "ja": "けにあのしゅとは？"
     }
@@ -19208,6 +21604,10 @@
     "question_text": {
       "en": "What is the largest city in Africa by population?",
       "ja": "じんこうがもっともおおいあふりかのとしは？"
+    },
+    "question_text_reading": {
+      "en": "What is the largest city in Africa by population?",
+      "ja": "じんこうがもっともおおいあふりかのとしは？"
     }
   },
   {
@@ -19238,6 +21638,10 @@
     "id": "q00601",
     "image_path": null,
     "question_text": {
+      "en": "What two countries share Niagara Falls?",
+      "ja": "ないあがらのたきをきょうゆうするふたつのくには？"
+    },
+    "question_text_reading": {
       "en": "What two countries share Niagara Falls?",
       "ja": "ないあがらのたきをきょうゆうするふたつのくには？"
     }
@@ -19272,6 +21676,10 @@
     "question_text": {
       "en": "What is the capital of Portugal?",
       "ja": "ぽるとがるのしゅとは？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of Portugal?",
+      "ja": "ぽるとがるのしゅとは？"
     }
   },
   {
@@ -19302,6 +21710,10 @@
     "id": "q00603",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of Austria?",
+      "ja": "おーすとりあのしゅとは？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of Austria?",
       "ja": "おーすとりあのしゅとは？"
     }
@@ -19336,6 +21748,10 @@
     "question_text": {
       "en": "In what year did World War II end?",
       "ja": "だいにじせかいたいせんはなんねんにおわったか？"
+    },
+    "question_text_reading": {
+      "en": "In what year did World War II end?",
+      "ja": "だいにじせかいたいせんはなんねんにおわったか？"
     }
   },
   {
@@ -19366,6 +21782,10 @@
     "id": "q00605",
     "image_path": null,
     "question_text": {
+      "en": "Who was the first President of the United States?",
+      "ja": "アメリカのしょだいだいとうりょうは誰か？"
+    },
+    "question_text_reading": {
       "en": "Who was the first President of the United States?",
       "ja": "アメリカのしょだいだいとうりょうは誰か？"
     }
@@ -19400,6 +21820,10 @@
     "question_text": {
       "en": "What year did the French Revolution begin?",
       "ja": "ふらんすかくめいはなんねんにはじまったか？"
+    },
+    "question_text_reading": {
+      "en": "What year did the French Revolution begin?",
+      "ja": "ふらんすかくめいはなんねんにはじまったか？"
     }
   },
   {
@@ -19430,6 +21854,10 @@
     "id": "q00607",
     "image_path": null,
     "question_text": {
+      "en": "Who built the Great Wall of China?",
+      "ja": "ちゅうごくのばんりのちょうじょうをきずいたのは誰か？"
+    },
+    "question_text_reading": {
       "en": "Who built the Great Wall of China?",
       "ja": "ちゅうごくのばんりのちょうじょうをきずいたのは誰か？"
     }
@@ -19464,6 +21892,10 @@
     "question_text": {
       "en": "What civilization built the pyramids of Giza?",
       "ja": "ぎざのぴらみっどをきずいたぶんめいは？"
+    },
+    "question_text_reading": {
+      "en": "What civilization built the pyramids of Giza?",
+      "ja": "ぎざのぴらみっどをきずいたぶんめいは？"
     }
   },
   {
@@ -19494,6 +21926,10 @@
     "id": "q00609",
     "image_path": null,
     "question_text": {
+      "en": "When did the Roman Empire fall?",
+      "ja": "ろーまていこくはいつほろんだか？"
+    },
+    "question_text_reading": {
       "en": "When did the Roman Empire fall?",
       "ja": "ろーまていこくはいつほろんだか？"
     }
@@ -19528,6 +21964,10 @@
     "question_text": {
       "en": "Who was Napoleon Bonaparte?",
       "ja": "なぽれおんぼなぱるととは誰か？"
+    },
+    "question_text_reading": {
+      "en": "Who was Napoleon Bonaparte?",
+      "ja": "なぽれおんぼなぱるととは誰か？"
     }
   },
   {
@@ -19558,6 +21998,10 @@
     "id": "q00611",
     "image_path": null,
     "question_text": {
+      "en": "What year did Columbus reach the Americas?",
+      "ja": "ころんぶすがアメリカにたっしたのはなんねんか？"
+    },
+    "question_text_reading": {
       "en": "What year did Columbus reach the Americas?",
       "ja": "ころんぶすがアメリカにたっしたのはなんねんか？"
     }
@@ -19592,6 +22036,10 @@
     "question_text": {
       "en": "What was the Cold War?",
       "ja": "れいせんとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What was the Cold War?",
+      "ja": "れいせんとは何か？"
     }
   },
   {
@@ -19622,6 +22070,10 @@
     "id": "q00613",
     "image_path": null,
     "question_text": {
+      "en": "Who was the last Pharaoh of ancient Egypt?",
+      "ja": "こだいえじぷとのさいごのふぁらおは誰か？"
+    },
+    "question_text_reading": {
       "en": "Who was the last Pharaoh of ancient Egypt?",
       "ja": "こだいえじぷとのさいごのふぁらおは誰か？"
     }
@@ -19656,6 +22108,10 @@
     "question_text": {
       "en": "In what year did Japan's Meiji Restoration begin?",
       "ja": "にほんのめいじいしんははじまったのはなんねんか？"
+    },
+    "question_text_reading": {
+      "en": "In what year did Japan's Meiji Restoration begin?",
+      "ja": "にほんのめいじいしんははじまったのはなんねんか？"
     }
   },
   {
@@ -19686,6 +22142,10 @@
     "id": "q00615",
     "image_path": null,
     "question_text": {
+      "en": "What was the Magna Carta?",
+      "ja": "まぐなかるたとは何か？"
+    },
+    "question_text_reading": {
       "en": "What was the Magna Carta?",
       "ja": "まぐなかるたとは何か？"
     }
@@ -19720,6 +22180,10 @@
     "question_text": {
       "en": "Who led the Indian independence movement against Britain?",
       "ja": "えいこくにたいするいんどどくりつうんどうをひきいたのは誰か？"
+    },
+    "question_text_reading": {
+      "en": "Who led the Indian independence movement against Britain?",
+      "ja": "えいこくにたいするいんどどくりつうんどうをひきいたのは誰か？"
     }
   },
   {
@@ -19750,6 +22214,10 @@
     "id": "q00617",
     "image_path": null,
     "question_text": {
+      "en": "What was the Renaissance?",
+      "ja": "るねさんすとは何か？"
+    },
+    "question_text_reading": {
       "en": "What was the Renaissance?",
       "ja": "るねさんすとは何か？"
     }
@@ -19784,6 +22252,10 @@
     "question_text": {
       "en": "When did the Berlin Wall fall?",
       "ja": "べるりんのかべはいつたおれたか？"
+    },
+    "question_text_reading": {
+      "en": "When did the Berlin Wall fall?",
+      "ja": "べるりんのかべはいつたおれたか？"
     }
   },
   {
@@ -19814,6 +22286,10 @@
     "id": "q00619",
     "image_path": null,
     "question_text": {
+      "en": "What was the Boston Tea Party?",
+      "ja": "ぼすとんてぃーぱーてぃーとは何か？"
+    },
+    "question_text_reading": {
       "en": "What was the Boston Tea Party?",
       "ja": "ぼすとんてぃーぱーてぃーとは何か？"
     }
@@ -19848,6 +22324,10 @@
     "question_text": {
       "en": "Who wrote the Communist Manifesto?",
       "ja": "きょうさんとうせんげんをかいたのは誰か？"
+    },
+    "question_text_reading": {
+      "en": "Who wrote the Communist Manifesto?",
+      "ja": "きょうさんとうせんげんをかいたのは誰か？"
     }
   },
   {
@@ -19878,6 +22358,10 @@
     "id": "q00621",
     "image_path": null,
     "question_text": {
+      "en": "What was the Silk Road?",
+      "ja": "しるくろーどとは何か？"
+    },
+    "question_text_reading": {
       "en": "What was the Silk Road?",
       "ja": "しるくろーどとは何か？"
     }
@@ -19912,6 +22396,10 @@
     "question_text": {
       "en": "Who was Julius Caesar?",
       "ja": "じゅりあすかいさーとは誰か？"
+    },
+    "question_text_reading": {
+      "en": "Who was Julius Caesar?",
+      "ja": "じゅりあすかいさーとは誰か？"
     }
   },
   {
@@ -19942,6 +22430,10 @@
     "id": "q00623",
     "image_path": null,
     "question_text": {
+      "en": "What year did the first World War begin?",
+      "ja": "だいいちじせかいたいせんはなんねんにはじまったか？"
+    },
+    "question_text_reading": {
       "en": "What year did the first World War begin?",
       "ja": "だいいちじせかいたいせんはなんねんにはじまったか？"
     }
@@ -19976,6 +22468,10 @@
     "question_text": {
       "en": "Who was Genghis Khan?",
       "ja": "ちんぎすかんとは誰か？"
+    },
+    "question_text_reading": {
+      "en": "Who was Genghis Khan?",
+      "ja": "ちんぎすかんとは誰か？"
     }
   },
   {
@@ -20006,6 +22502,10 @@
     "id": "q00625",
     "image_path": null,
     "question_text": {
+      "en": "What ended the feudal period in Japan?",
+      "ja": "にほんのほうけんじだいをおわらせたのは何か？"
+    },
+    "question_text_reading": {
       "en": "What ended the feudal period in Japan?",
       "ja": "にほんのほうけんじだいをおわらせたのは何か？"
     }
@@ -20040,6 +22540,10 @@
     "question_text": {
       "en": "What was apartheid?",
       "ja": "あぱるとへいととは何か？"
+    },
+    "question_text_reading": {
+      "en": "What was apartheid?",
+      "ja": "あぱるとへいととは何か？"
     }
   },
   {
@@ -20070,6 +22574,10 @@
     "id": "q00627",
     "image_path": null,
     "question_text": {
+      "en": "When did the American Civil War end?",
+      "ja": "アメリカなんぼくせんそうはなんねんにおわったか？"
+    },
+    "question_text_reading": {
       "en": "When did the American Civil War end?",
       "ja": "アメリカなんぼくせんそうはなんねんにおわったか？"
     }
@@ -20104,6 +22612,10 @@
     "question_text": {
       "en": "Who invented the printing press?",
       "ja": "いんさつきをはつめいしたのは誰か？"
+    },
+    "question_text_reading": {
+      "en": "Who invented the printing press?",
+      "ja": "いんさつきをはつめいしたのは誰か？"
     }
   },
   {
@@ -20134,6 +22646,10 @@
     "id": "q00629",
     "image_path": null,
     "question_text": {
+      "en": "What was the Black Death?",
+      "ja": "ぺすととは何か？"
+    },
+    "question_text_reading": {
       "en": "What was the Black Death?",
       "ja": "ぺすととは何か？"
     }
@@ -20168,6 +22684,10 @@
     "question_text": {
       "en": "Who was Martin Luther King Jr.?",
       "ja": "まーてぃんるーさーきんぐじゅにあとは誰か？"
+    },
+    "question_text_reading": {
+      "en": "Who was Martin Luther King Jr.?",
+      "ja": "まーてぃんるーさーきんぐじゅにあとは誰か？"
     }
   },
   {
@@ -20198,6 +22718,10 @@
     "id": "q00631",
     "image_path": null,
     "question_text": {
+      "en": "What year did the Soviet Union collapse?",
+      "ja": "ソヴィエトれんぽうはなんねんにほうかいしたか？"
+    },
+    "question_text_reading": {
       "en": "What year did the Soviet Union collapse?",
       "ja": "ソヴィエトれんぽうはなんねんにほうかいしたか？"
     }
@@ -20232,6 +22756,10 @@
     "question_text": {
       "en": "Who led the Cuban Revolution?",
       "ja": "きゅーばかくめいをひきいたのは誰か？"
+    },
+    "question_text_reading": {
+      "en": "Who led the Cuban Revolution?",
+      "ja": "きゅーばかくめいをひきいたのは誰か？"
     }
   },
   {
@@ -20262,6 +22790,10 @@
     "id": "q00633",
     "image_path": null,
     "question_text": {
+      "en": "What was D-Day?",
+      "ja": "でぃーでーとは何か？"
+    },
+    "question_text_reading": {
       "en": "What was D-Day?",
       "ja": "でぃーでーとは何か？"
     }
@@ -20296,6 +22828,10 @@
     "question_text": {
       "en": "When did the Titanic sink?",
       "ja": "たいたにっくはなんねんにしずんだか？"
+    },
+    "question_text_reading": {
+      "en": "When did the Titanic sink?",
+      "ja": "たいたにっくはなんねんにしずんだか？"
     }
   },
   {
@@ -20326,6 +22862,10 @@
     "id": "q00635",
     "image_path": null,
     "question_text": {
+      "en": "Who was Florence Nightingale?",
+      "ja": "ふろれんすないちんげーるとは誰か？"
+    },
+    "question_text_reading": {
       "en": "Who was Florence Nightingale?",
       "ja": "ふろれんすないちんげーるとは誰か？"
     }
@@ -20360,6 +22900,10 @@
     "question_text": {
       "en": "What empire did Alexander the Great build?",
       "ja": "アレクサンドロスだいおうはどのようなていこくをきずいたか？"
+    },
+    "question_text_reading": {
+      "en": "What empire did Alexander the Great build?",
+      "ja": "アレクサンドロスだいおうはどのようなていこくをきずいたか？"
     }
   },
   {
@@ -20390,6 +22934,10 @@
     "id": "q00637",
     "image_path": null,
     "question_text": {
+      "en": "When did Japan attack Pearl Harbor?",
+      "ja": "にほんはなんねんにぱーるはーばーをこうげきしたか？"
+    },
+    "question_text_reading": {
       "en": "When did Japan attack Pearl Harbor?",
       "ja": "にほんはなんねんにぱーるはーばーをこうげきしたか？"
     }
@@ -20424,6 +22972,10 @@
     "question_text": {
       "en": "Who was the first man on the moon?",
       "ja": "はじめて月にたったのは誰か？"
+    },
+    "question_text_reading": {
+      "en": "Who was the first man on the moon?",
+      "ja": "はじめて月にたったのは誰か？"
     }
   },
   {
@@ -20454,6 +23006,10 @@
     "id": "q00639",
     "image_path": null,
     "question_text": {
+      "en": "What was the Crusades?",
+      "ja": "じゅうじぐんとは何か？"
+    },
+    "question_text_reading": {
       "en": "What was the Crusades?",
       "ja": "じゅうじぐんとは何か？"
     }
@@ -20488,6 +23044,10 @@
     "question_text": {
       "en": "What was the Enlightenment?",
       "ja": "けいもうじだいとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What was the Enlightenment?",
+      "ja": "けいもうじだいとは何か？"
     }
   },
   {
@@ -20518,6 +23078,10 @@
     "id": "q00641",
     "image_path": null,
     "question_text": {
+      "en": "Who was Nelson Mandela?",
+      "ja": "ねるそんまんでらとは誰か？"
+    },
+    "question_text_reading": {
       "en": "Who was Nelson Mandela?",
       "ja": "ねるそんまんでらとは誰か？"
     }
@@ -20552,6 +23116,10 @@
     "question_text": {
       "en": "When was the United Nations founded?",
       "ja": "こくさいれんごうはなんねんにせつりつされたか？"
+    },
+    "question_text_reading": {
+      "en": "When was the United Nations founded?",
+      "ja": "こくさいれんごうはなんねんにせつりつされたか？"
     }
   },
   {
@@ -20582,6 +23150,10 @@
     "id": "q00643",
     "image_path": null,
     "question_text": {
+      "en": "What was the Industrial Revolution?",
+      "ja": "さんぎょうかくめいとは何か？"
+    },
+    "question_text_reading": {
       "en": "What was the Industrial Revolution?",
       "ja": "さんぎょうかくめいとは何か？"
     }
@@ -20616,6 +23188,10 @@
     "question_text": {
       "en": "Who was Mao Zedong?",
       "ja": "もうたくとうとは誰か？"
+    },
+    "question_text_reading": {
+      "en": "Who was Mao Zedong?",
+      "ja": "もうたくとうとは誰か？"
     }
   },
   {
@@ -20646,6 +23222,10 @@
     "id": "q00645",
     "image_path": null,
     "question_text": {
+      "en": "When did the Korean War end?",
+      "ja": "ちょうせんせんそうはなんねんにおわったか？"
+    },
+    "question_text_reading": {
       "en": "When did the Korean War end?",
       "ja": "ちょうせんせんそうはなんねんにおわったか？"
     }
@@ -20680,6 +23260,10 @@
     "question_text": {
       "en": "Who was Cleopatra?",
       "ja": "くれおぱとらとは誰か？"
+    },
+    "question_text_reading": {
+      "en": "Who was Cleopatra?",
+      "ja": "くれおぱとらとは誰か？"
     }
   },
   {
@@ -20710,6 +23294,10 @@
     "id": "q00647",
     "image_path": null,
     "question_text": {
+      "en": "What was the Opium War?",
+      "ja": "あへんせんそうとは何か？"
+    },
+    "question_text_reading": {
       "en": "What was the Opium War?",
       "ja": "あへんせんそうとは何か？"
     }
@@ -20744,6 +23332,10 @@
     "question_text": {
       "en": "Who was Abraham Lincoln?",
       "ja": "えいぶらはむりんかーんとは誰か？"
+    },
+    "question_text_reading": {
+      "en": "Who was Abraham Lincoln?",
+      "ja": "えいぶらはむりんかーんとは誰か？"
     }
   },
   {
@@ -20774,6 +23366,10 @@
     "id": "q00649",
     "image_path": null,
     "question_text": {
+      "en": "What year did the Moon landing occur?",
+      "ja": "つきにひとがおりたのはなんねんか？"
+    },
+    "question_text_reading": {
       "en": "What year did the Moon landing occur?",
       "ja": "つきにひとがおりたのはなんねんか？"
     }
@@ -20808,6 +23404,10 @@
     "question_text": {
       "en": "What was the Manhattan Project?",
       "ja": "まんはったんぷろじぇくととは何か？"
+    },
+    "question_text_reading": {
+      "en": "What was the Manhattan Project?",
+      "ja": "まんはったんぷろじぇくととは何か？"
     }
   },
   {
@@ -20838,6 +23438,10 @@
     "id": "q00651",
     "image_path": null,
     "question_text": {
+      "en": "Who was Nikola Tesla?",
+      "ja": "にこらてすらとは誰か？"
+    },
+    "question_text_reading": {
       "en": "Who was Nikola Tesla?",
       "ja": "にこらてすらとは誰か？"
     }
@@ -20872,6 +23476,10 @@
     "question_text": {
       "en": "What is the Shogunate in Japanese history?",
       "ja": "にほんのしょうぐんとはどのようなものか？"
+    },
+    "question_text_reading": {
+      "en": "What is the Shogunate in Japanese history?",
+      "ja": "にほんのしょうぐんとはどのようなものか？"
     }
   },
   {
@@ -20902,6 +23510,10 @@
     "id": "q00653",
     "image_path": null,
     "question_text": {
+      "en": "What was the Hundred Years' War?",
+      "ja": "ひゃくねんせんそうとは何か？"
+    },
+    "question_text_reading": {
       "en": "What was the Hundred Years' War?",
       "ja": "ひゃくねんせんそうとは何か？"
     }
@@ -20936,6 +23548,10 @@
     "question_text": {
       "en": "Who was Tokugawa Ieyasu?",
       "ja": "とくがわいえやすとは誰か？"
+    },
+    "question_text_reading": {
+      "en": "Who was Tokugawa Ieyasu?",
+      "ja": "とくがわいえやすとは誰か？"
     }
   },
   {
@@ -20966,6 +23582,10 @@
     "id": "q00655",
     "image_path": null,
     "question_text": {
+      "en": "What was the Treaty of Versailles?",
+      "ja": "べるさいゆじょうやくとは何か？"
+    },
+    "question_text_reading": {
       "en": "What was the Treaty of Versailles?",
       "ja": "べるさいゆじょうやくとは何か？"
     }
@@ -21000,6 +23620,10 @@
     "question_text": {
       "en": "Who was Winston Churchill?",
       "ja": "うぃんすとんちゃーちるとは誰か？"
+    },
+    "question_text_reading": {
+      "en": "Who was Winston Churchill?",
+      "ja": "うぃんすとんちゃーちるとは誰か？"
     }
   },
   {
@@ -21030,6 +23654,10 @@
     "id": "q00657",
     "image_path": null,
     "question_text": {
+      "en": "When did World War I end?",
+      "ja": "だいいちじせかいたいせんはなんねんにおわったか？"
+    },
+    "question_text_reading": {
       "en": "When did World War I end?",
       "ja": "だいいちじせかいたいせんはなんねんにおわったか？"
     }
@@ -21064,6 +23692,10 @@
     "question_text": {
       "en": "What is the chemical symbol for water?",
       "ja": "みずのかがくしきは？"
+    },
+    "question_text_reading": {
+      "en": "What is the chemical symbol for water?",
+      "ja": "みずのかがくしきは？"
     }
   },
   {
@@ -21094,6 +23726,10 @@
     "id": "q00659",
     "image_path": null,
     "question_text": {
+      "en": "What is Newton's first law of motion?",
+      "ja": "にゅーとんのうんどうのだいいちほうそくは？"
+    },
+    "question_text_reading": {
       "en": "What is Newton's first law of motion?",
       "ja": "にゅーとんのうんどうのだいいちほうそくは？"
     }
@@ -21128,6 +23764,10 @@
     "question_text": {
       "en": "What planet is known as the Red Planet?",
       "ja": "あかいわくせいとよばれるのは？"
+    },
+    "question_text_reading": {
+      "en": "What planet is known as the Red Planet?",
+      "ja": "あかいわくせいとよばれるのは？"
     }
   },
   {
@@ -21158,6 +23798,10 @@
     "id": "q00661",
     "image_path": null,
     "question_text": {
+      "en": "What is photosynthesis?",
+      "ja": "こうごうせいとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is photosynthesis?",
       "ja": "こうごうせいとは何か？"
     }
@@ -21192,6 +23836,10 @@
     "question_text": {
       "en": "What is the speed of light?",
       "ja": "ひかりのそくどは？"
+    },
+    "question_text_reading": {
+      "en": "What is the speed of light?",
+      "ja": "ひかりのそくどは？"
     }
   },
   {
@@ -21222,6 +23870,10 @@
     "id": "q00663",
     "image_path": null,
     "question_text": {
+      "en": "What is DNA?",
+      "ja": "DNAとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is DNA?",
       "ja": "DNAとは何か？"
     }
@@ -21256,6 +23908,10 @@
     "question_text": {
       "en": "What is the periodic table?",
       "ja": "げんそのしゅうきひょうとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is the periodic table?",
+      "ja": "げんそのしゅうきひょうとは何か？"
     }
   },
   {
@@ -21286,6 +23942,10 @@
     "id": "q00665",
     "image_path": null,
     "question_text": {
+      "en": "What causes thunder?",
+      "ja": "かみなりがなるりゆうは？"
+    },
+    "question_text_reading": {
       "en": "What causes thunder?",
       "ja": "かみなりがなるりゆうは？"
     }
@@ -21320,6 +23980,10 @@
     "question_text": {
       "en": "What is a black hole?",
       "ja": "ぶらっくほーるとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a black hole?",
+      "ja": "ぶらっくほーるとは何か？"
     }
   },
   {
@@ -21350,6 +24014,10 @@
     "id": "q00667",
     "image_path": null,
     "question_text": {
+      "en": "What is evolution?",
+      "ja": "しんかとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is evolution?",
       "ja": "しんかとは何か？"
     }
@@ -21384,6 +24052,10 @@
     "question_text": {
       "en": "What is the atomic number of Carbon?",
       "ja": "たんそのげんしばんごうは？"
+    },
+    "question_text_reading": {
+      "en": "What is the atomic number of Carbon?",
+      "ja": "たんそのげんしばんごうは？"
     }
   },
   {
@@ -21414,6 +24086,10 @@
     "id": "q00669",
     "image_path": null,
     "question_text": {
+      "en": "What is gravity?",
+      "ja": "じゅうりょくとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is gravity?",
       "ja": "じゅうりょくとは何か？"
     }
@@ -21448,6 +24124,10 @@
     "question_text": {
       "en": "What is the theory of relativity?",
       "ja": "そうたいせいりろんとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is the theory of relativity?",
+      "ja": "そうたいせいりろんとは何か？"
     }
   },
   {
@@ -21478,6 +24158,10 @@
     "id": "q00671",
     "image_path": null,
     "question_text": {
+      "en": "What gas is most abundant in Earth's atmosphere?",
+      "ja": "ちきゅうのたいきにもっともおおいきたいは？"
+    },
+    "question_text_reading": {
       "en": "What gas is most abundant in Earth's atmosphere?",
       "ja": "ちきゅうのたいきにもっともおおいきたいは？"
     }
@@ -21512,6 +24196,10 @@
     "question_text": {
       "en": "What is a neuron?",
       "ja": "にゅーろんとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a neuron?",
+      "ja": "にゅーろんとは何か？"
     }
   },
   {
@@ -21542,6 +24230,10 @@
     "id": "q00673",
     "image_path": null,
     "question_text": {
+      "en": "What is the Big Bang theory?",
+      "ja": "びっぐばんりろんとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is the Big Bang theory?",
       "ja": "びっぐばんりろんとは何か？"
     }
@@ -21576,6 +24268,10 @@
     "question_text": {
       "en": "What is the mitochondria?",
       "ja": "みとこんどりあとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is the mitochondria?",
+      "ja": "みとこんどりあとは何か？"
     }
   },
   {
@@ -21606,6 +24302,10 @@
     "id": "q00675",
     "image_path": null,
     "question_text": {
+      "en": "What is osmosis?",
+      "ja": "しんとうとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is osmosis?",
       "ja": "しんとうとは何か？"
     }
@@ -21640,6 +24340,10 @@
     "question_text": {
       "en": "What is the greenhouse effect?",
       "ja": "おんしつこうかとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is the greenhouse effect?",
+      "ja": "おんしつこうかとは何か？"
     }
   },
   {
@@ -21670,6 +24374,10 @@
     "id": "q00677",
     "image_path": null,
     "question_text": {
+      "en": "What force keeps planets in orbit?",
+      "ja": "わくせいをきどうにたもつりょくは？"
+    },
+    "question_text_reading": {
       "en": "What force keeps planets in orbit?",
       "ja": "わくせいをきどうにたもつりょくは？"
     }
@@ -21704,6 +24412,10 @@
     "question_text": {
       "en": "What is the function of the nucleus in a cell?",
       "ja": "さいぼうのかくのやくわりは？"
+    },
+    "question_text_reading": {
+      "en": "What is the function of the nucleus in a cell?",
+      "ja": "さいぼうのかくのやくわりは？"
     }
   },
   {
@@ -21734,6 +24446,10 @@
     "id": "q00679",
     "image_path": null,
     "question_text": {
+      "en": "What is an atom?",
+      "ja": "げんしとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is an atom?",
       "ja": "げんしとは何か？"
     }
@@ -21768,6 +24484,10 @@
     "question_text": {
       "en": "What is a proton?",
       "ja": "ようしとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a proton?",
+      "ja": "ようしとは何か？"
     }
   },
   {
@@ -21798,6 +24518,10 @@
     "id": "q00681",
     "image_path": null,
     "question_text": {
+      "en": "What is an electron?",
+      "ja": "でんしとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is an electron?",
       "ja": "でんしとは何か？"
     }
@@ -21832,6 +24556,10 @@
     "question_text": {
       "en": "What is a neutron?",
       "ja": "ちゅうせいしとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a neutron?",
+      "ja": "ちゅうせいしとは何か？"
     }
   },
   {
@@ -21862,6 +24590,10 @@
     "id": "q00683",
     "image_path": null,
     "question_text": {
+      "en": "What is the Milky Way?",
+      "ja": "あまのがわとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is the Milky Way?",
       "ja": "あまのがわとは何か？"
     }
@@ -21896,6 +24628,10 @@
     "question_text": {
       "en": "What is electromagnetic radiation?",
       "ja": "でんじほうしゃとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is electromagnetic radiation?",
+      "ja": "でんじほうしゃとは何か？"
     }
   },
   {
@@ -21926,6 +24662,10 @@
     "id": "q00685",
     "image_path": null,
     "question_text": {
+      "en": "What is chemical bonding?",
+      "ja": "かがくけつごうとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is chemical bonding?",
       "ja": "かがくけつごうとは何か？"
     }
@@ -21960,6 +24700,10 @@
     "question_text": {
       "en": "What is a hypothesis?",
       "ja": "かせつとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a hypothesis?",
+      "ja": "かせつとは何か？"
     }
   },
   {
@@ -21990,6 +24734,10 @@
     "id": "q00687",
     "image_path": null,
     "question_text": {
+      "en": "What is the scientific method?",
+      "ja": "かがくてきほうほうとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is the scientific method?",
       "ja": "かがくてきほうほうとは何か？"
     }
@@ -22024,6 +24772,10 @@
     "question_text": {
       "en": "What is a gene?",
       "ja": "いでんしとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a gene?",
+      "ja": "いでんしとは何か？"
     }
   },
   {
@@ -22054,6 +24806,10 @@
     "id": "q00689",
     "image_path": null,
     "question_text": {
+      "en": "What is the food chain?",
+      "ja": "しょくもつれんさとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is the food chain?",
       "ja": "しょくもつれんさとは何か？"
     }
@@ -22088,6 +24844,10 @@
     "question_text": {
       "en": "What is the boiling point of water at sea level?",
       "ja": "かいめんでのみずのふってんは？"
+    },
+    "question_text_reading": {
+      "en": "What is the boiling point of water at sea level?",
+      "ja": "かいめんでのみずのふってんは？"
     }
   },
   {
@@ -22118,6 +24878,10 @@
     "id": "q00691",
     "image_path": null,
     "question_text": {
+      "en": "What is a chemical reaction?",
+      "ja": "かがくはんのうとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a chemical reaction?",
       "ja": "かがくはんのうとは何か？"
     }
@@ -22152,6 +24916,10 @@
     "question_text": {
       "en": "What is the half-life of a radioactive element?",
       "ja": "ほうしゃせいげんそのはんぶんきとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is the half-life of a radioactive element?",
+      "ja": "ほうしゃせいげんそのはんぶんきとは何か？"
     }
   },
   {
@@ -22182,6 +24950,10 @@
     "id": "q00693",
     "image_path": null,
     "question_text": {
+      "en": "What is a catalyst?",
+      "ja": "しょくばいとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a catalyst?",
       "ja": "しょくばいとは何か？"
     }
@@ -22216,6 +24988,10 @@
     "question_text": {
       "en": "What is kinetic energy?",
       "ja": "うんどうえねるぎーとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is kinetic energy?",
+      "ja": "うんどうえねるぎーとは何か？"
     }
   },
   {
@@ -22246,6 +25022,10 @@
     "id": "q00695",
     "image_path": null,
     "question_text": {
+      "en": "What is potential energy?",
+      "ja": "いねるぎーとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is potential energy?",
       "ja": "いねるぎーとは何か？"
     }
@@ -22280,6 +25060,10 @@
     "question_text": {
       "en": "What is the law of conservation of energy?",
       "ja": "えねるぎーほぞんのほうそくとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is the law of conservation of energy?",
+      "ja": "えねるぎーほぞんのほうそくとは何か？"
     }
   },
   {
@@ -22310,6 +25094,10 @@
     "id": "q00697",
     "image_path": null,
     "question_text": {
+      "en": "What is the role of red blood cells?",
+      "ja": "せっけっきゅうのやくわりは？"
+    },
+    "question_text_reading": {
       "en": "What is the role of red blood cells?",
       "ja": "せっけっきゅうのやくわりは？"
     }
@@ -22344,6 +25132,10 @@
     "question_text": {
       "en": "What is the function of white blood cells?",
       "ja": "はっけっきゅうのやくわりは？"
+    },
+    "question_text_reading": {
+      "en": "What is the function of white blood cells?",
+      "ja": "はっけっきゅうのやくわりは？"
     }
   },
   {
@@ -22374,6 +25166,10 @@
     "id": "q00699",
     "image_path": null,
     "question_text": {
+      "en": "What organ produces insulin?",
+      "ja": "いんすりんをせいさんするきかんは？"
+    },
+    "question_text_reading": {
       "en": "What organ produces insulin?",
       "ja": "いんすりんをせいさんするきかんは？"
     }
@@ -22408,6 +25204,10 @@
     "question_text": {
       "en": "What is the function of the kidney?",
       "ja": "じんぞうのやくわりは？"
+    },
+    "question_text_reading": {
+      "en": "What is the function of the kidney?",
+      "ja": "じんぞうのやくわりは？"
     }
   },
   {
@@ -22438,6 +25238,10 @@
     "id": "q00701",
     "image_path": null,
     "question_text": {
+      "en": "What is a vaccine?",
+      "ja": "ワクチンとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a vaccine?",
       "ja": "ワクチンとは何か？"
     }
@@ -22472,6 +25276,10 @@
     "question_text": {
       "en": "What is the pH scale?",
       "ja": "pHすけーるとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is the pH scale?",
+      "ja": "pHすけーるとは何か？"
     }
   },
   {
@@ -22502,6 +25310,10 @@
     "id": "q00703",
     "image_path": null,
     "question_text": {
+      "en": "What is acid rain?",
+      "ja": "さんせいうとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is acid rain?",
       "ja": "さんせいうとは何か？"
     }
@@ -22536,6 +25348,10 @@
     "question_text": {
       "en": "What is nuclear fission?",
       "ja": "かくぶんれつとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is nuclear fission?",
+      "ja": "かくぶんれつとは何か？"
     }
   },
   {
@@ -22566,6 +25382,10 @@
     "id": "q00705",
     "image_path": null,
     "question_text": {
+      "en": "What is nuclear fusion?",
+      "ja": "かくゆうごうとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is nuclear fusion?",
       "ja": "かくゆうごうとは何か？"
     }
@@ -22600,6 +25420,10 @@
     "question_text": {
       "en": "What is tectonic plates?",
       "ja": "プレートとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is tectonic plates?",
+      "ja": "プレートとは何か？"
     }
   },
   {
@@ -22630,6 +25454,10 @@
     "id": "q00707",
     "image_path": null,
     "question_text": {
+      "en": "What causes an earthquake?",
+      "ja": "じしんのげんいんは？"
+    },
+    "question_text_reading": {
       "en": "What causes an earthquake?",
       "ja": "じしんのげんいんは？"
     }
@@ -22664,6 +25492,10 @@
     "question_text": {
       "en": "What is the ozone layer?",
       "ja": "おぞんそうとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is the ozone layer?",
+      "ja": "おぞんそうとは何か？"
     }
   },
   {
@@ -22694,6 +25526,10 @@
     "id": "q00709",
     "image_path": null,
     "question_text": {
+      "en": "What is a renewable energy source?",
+      "ja": "さいせいかのうなえねるぎーとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a renewable energy source?",
       "ja": "さいせいかのうなえねるぎーとは何か？"
     }
@@ -22728,6 +25564,10 @@
     "question_text": {
       "en": "What is 2 + 2?",
       "ja": "2たす2はいくつ？"
+    },
+    "question_text_reading": {
+      "en": "What is 2 + 2?",
+      "ja": "2たす2はいくつ？"
     }
   },
   {
@@ -22758,6 +25598,10 @@
     "id": "q00711",
     "image_path": null,
     "question_text": {
+      "en": "What is the square root of 144?",
+      "ja": "144のへいほうこんは？"
+    },
+    "question_text_reading": {
       "en": "What is the square root of 144?",
       "ja": "144のへいほうこんは？"
     }
@@ -22792,6 +25636,10 @@
     "question_text": {
       "en": "What is pi approximately equal to?",
       "ja": "えんしゅうりつπはおよそいくつ？"
+    },
+    "question_text_reading": {
+      "en": "What is pi approximately equal to?",
+      "ja": "えんしゅうりつπはおよそいくつ？"
     }
   },
   {
@@ -22822,6 +25670,10 @@
     "id": "q00713",
     "image_path": null,
     "question_text": {
+      "en": "What is the Pythagorean theorem?",
+      "ja": "ぴたごらすのていりとは？"
+    },
+    "question_text_reading": {
       "en": "What is the Pythagorean theorem?",
       "ja": "ぴたごらすのていりとは？"
     }
@@ -22856,6 +25708,10 @@
     "question_text": {
       "en": "What is a prime number?",
       "ja": "そすうとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a prime number?",
+      "ja": "そすうとは何か？"
     }
   },
   {
@@ -22886,6 +25742,10 @@
     "id": "q00715",
     "image_path": null,
     "question_text": {
+      "en": "What is 10 factorial (10!)?",
+      "ja": "10の かいじょう(10!)はいくつ？"
+    },
+    "question_text_reading": {
       "en": "What is 10 factorial (10!)?",
       "ja": "10の かいじょう(10!)はいくつ？"
     }
@@ -22920,6 +25780,10 @@
     "question_text": {
       "en": "What is the sum of angles in a triangle?",
       "ja": "さんかっけいのないかくのわは？"
+    },
+    "question_text_reading": {
+      "en": "What is the sum of angles in a triangle?",
+      "ja": "さんかっけいのないかくのわは？"
     }
   },
   {
@@ -22950,6 +25814,10 @@
     "id": "q00717",
     "image_path": null,
     "question_text": {
+      "en": "What is the area of a circle?",
+      "ja": "えんのめんせきは？"
+    },
+    "question_text_reading": {
       "en": "What is the area of a circle?",
       "ja": "えんのめんせきは？"
     }
@@ -22984,6 +25852,10 @@
     "question_text": {
       "en": "What is the circumference of a circle?",
       "ja": "えんのしゅうちょうは？"
+    },
+    "question_text_reading": {
+      "en": "What is the circumference of a circle?",
+      "ja": "えんのしゅうちょうは？"
     }
   },
   {
@@ -23014,6 +25886,10 @@
     "id": "q00719",
     "image_path": null,
     "question_text": {
+      "en": "What is the Fibonacci sequence starting with?",
+      "ja": "ふぃぼなっちすうれつのはじまりは？"
+    },
+    "question_text_reading": {
       "en": "What is the Fibonacci sequence starting with?",
       "ja": "ふぃぼなっちすうれつのはじまりは？"
     }
@@ -23048,6 +25924,10 @@
     "question_text": {
       "en": "What does 'mean' refer to in statistics?",
       "ja": "とうけいでのへいきんとは？"
+    },
+    "question_text_reading": {
+      "en": "What does 'mean' refer to in statistics?",
+      "ja": "とうけいでのへいきんとは？"
     }
   },
   {
@@ -23078,6 +25958,10 @@
     "id": "q00721",
     "image_path": null,
     "question_text": {
+      "en": "What is the median?",
+      "ja": "ちゅうおうちとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is the median?",
       "ja": "ちゅうおうちとは何か？"
     }
@@ -23112,6 +25996,10 @@
     "question_text": {
       "en": "What is the mode in statistics?",
       "ja": "とうけいでのさいひんちとは？"
+    },
+    "question_text_reading": {
+      "en": "What is the mode in statistics?",
+      "ja": "とうけいでのさいひんちとは？"
     }
   },
   {
@@ -23142,6 +26030,10 @@
     "id": "q00723",
     "image_path": null,
     "question_text": {
+      "en": "What is a quadratic equation?",
+      "ja": "にじほうていしきとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a quadratic equation?",
       "ja": "にじほうていしきとは何か？"
     }
@@ -23176,6 +26068,10 @@
     "question_text": {
       "en": "What is the quadratic formula?",
       "ja": "にじほうていしきのかいのこうしきは？"
+    },
+    "question_text_reading": {
+      "en": "What is the quadratic formula?",
+      "ja": "にじほうていしきのかいのこうしきは？"
     }
   },
   {
@@ -23206,6 +26102,10 @@
     "id": "q00725",
     "image_path": null,
     "question_text": {
+      "en": "What is a logarithm?",
+      "ja": "たいすうとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a logarithm?",
       "ja": "たいすうとは何か？"
     }
@@ -23240,6 +26140,10 @@
     "question_text": {
       "en": "What is the derivative in calculus?",
       "ja": "びぶんとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is the derivative in calculus?",
+      "ja": "びぶんとは何か？"
     }
   },
   {
@@ -23270,6 +26174,10 @@
     "id": "q00727",
     "image_path": null,
     "question_text": {
+      "en": "What is integration in calculus?",
+      "ja": "せきぶんとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is integration in calculus?",
       "ja": "せきぶんとは何か？"
     }
@@ -23304,6 +26212,10 @@
     "question_text": {
       "en": "What is a vector?",
       "ja": "べくとるとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a vector?",
+      "ja": "べくとるとは何か？"
     }
   },
   {
@@ -23334,6 +26246,10 @@
     "id": "q00729",
     "image_path": null,
     "question_text": {
+      "en": "What is a matrix in mathematics?",
+      "ja": "すうがくでのぎょうれつとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a matrix in mathematics?",
       "ja": "すうがくでのぎょうれつとは何か？"
     }
@@ -23368,6 +26284,10 @@
     "question_text": {
       "en": "What is probability?",
       "ja": "かくりつとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is probability?",
+      "ja": "かくりつとは何か？"
     }
   },
   {
@@ -23398,6 +26318,10 @@
     "id": "q00731",
     "image_path": null,
     "question_text": {
+      "en": "What is the probability of rolling a 6 on a die?",
+      "ja": "さいころで6がでるかくりつは？"
+    },
+    "question_text_reading": {
       "en": "What is the probability of rolling a 6 on a die?",
       "ja": "さいころで6がでるかくりつは？"
     }
@@ -23432,6 +26356,10 @@
     "question_text": {
       "en": "What is a set in mathematics?",
       "ja": "すうがくでのしゅうごうとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a set in mathematics?",
+      "ja": "すうがくでのしゅうごうとは何か？"
     }
   },
   {
@@ -23462,6 +26390,10 @@
     "id": "q00733",
     "image_path": null,
     "question_text": {
+      "en": "What is the union of two sets?",
+      "ja": "につのしゅうごうのわしゅうごうとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is the union of two sets?",
       "ja": "につのしゅうごうのわしゅうごうとは何か？"
     }
@@ -23496,6 +26428,10 @@
     "question_text": {
       "en": "What is the intersection of two sets?",
       "ja": "につのしゅうごうのせきしゅうごうとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is the intersection of two sets?",
+      "ja": "につのしゅうごうのせきしゅうごうとは何か？"
     }
   },
   {
@@ -23526,6 +26462,10 @@
     "id": "q00735",
     "image_path": null,
     "question_text": {
+      "en": "What is a function in math?",
+      "ja": "すうがくでのかんすうとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a function in math?",
       "ja": "すうがくでのかんすうとは何か？"
     }
@@ -23560,6 +26500,10 @@
     "question_text": {
       "en": "What is a complex number?",
       "ja": "ふくそすうとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a complex number?",
+      "ja": "ふくそすうとは何か？"
     }
   },
   {
@@ -23590,6 +26534,10 @@
     "id": "q00737",
     "image_path": null,
     "question_text": {
+      "en": "What is an irrational number?",
+      "ja": "むりすうとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is an irrational number?",
       "ja": "むりすうとは何か？"
     }
@@ -23624,6 +26572,10 @@
     "question_text": {
       "en": "What is the absolute value of -7?",
       "ja": "-7のぜったいちは？"
+    },
+    "question_text_reading": {
+      "en": "What is the absolute value of -7?",
+      "ja": "-7のぜったいちは？"
     }
   },
   {
@@ -23654,6 +26606,10 @@
     "id": "q00739",
     "image_path": null,
     "question_text": {
+      "en": "What is the slope of a horizontal line?",
+      "ja": "すいへいせんのかたむきは？"
+    },
+    "question_text_reading": {
       "en": "What is the slope of a horizontal line?",
       "ja": "すいへいせんのかたむきは？"
     }
@@ -23688,6 +26644,10 @@
     "question_text": {
       "en": "What is the slope of a vertical line?",
       "ja": "すいちょくせんのかたむきは？"
+    },
+    "question_text_reading": {
+      "en": "What is the slope of a vertical line?",
+      "ja": "すいちょくせんのかたむきは？"
     }
   },
   {
@@ -23718,6 +26678,10 @@
     "id": "q00741",
     "image_path": null,
     "question_text": {
+      "en": "What is a geometric progression?",
+      "ja": "とうひすうれつとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a geometric progression?",
       "ja": "とうひすうれつとは何か？"
     }
@@ -23752,6 +26716,10 @@
     "question_text": {
       "en": "What is an arithmetic progression?",
       "ja": "とうさすうれつとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is an arithmetic progression?",
+      "ja": "とうさすうれつとは何か？"
     }
   },
   {
@@ -23782,6 +26750,10 @@
     "id": "q00743",
     "image_path": null,
     "question_text": {
+      "en": "What is the formula for the volume of a sphere?",
+      "ja": "きゅうのたいせきのこうしきは？"
+    },
+    "question_text_reading": {
       "en": "What is the formula for the volume of a sphere?",
       "ja": "きゅうのたいせきのこうしきは？"
     }
@@ -23816,6 +26788,10 @@
     "question_text": {
       "en": "What is Euler's number 'e'?",
       "ja": "おいらーのすうeはおよそいくつ？"
+    },
+    "question_text_reading": {
+      "en": "What is Euler's number 'e'?",
+      "ja": "おいらーのすうeはおよそいくつ？"
     }
   },
   {
@@ -23846,6 +26822,10 @@
     "id": "q00745",
     "image_path": null,
     "question_text": {
+      "en": "What is Pascal's triangle?",
+      "ja": "ぱすかるのさんかっけいとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is Pascal's triangle?",
       "ja": "ぱすかるのさんかっけいとは何か？"
     }
@@ -23880,6 +26860,10 @@
     "question_text": {
       "en": "What is a permutation?",
       "ja": "じゅんれつとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a permutation?",
+      "ja": "じゅんれつとは何か？"
     }
   },
   {
@@ -23910,6 +26894,10 @@
     "id": "q00747",
     "image_path": null,
     "question_text": {
+      "en": "What is a combination?",
+      "ja": "くみあわせとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a combination?",
       "ja": "くみあわせとは何か？"
     }
@@ -23944,6 +26932,10 @@
     "question_text": {
       "en": "What language has the most native speakers?",
       "ja": "もっともおおくのぼごわしゃをもつげんごは？"
+    },
+    "question_text_reading": {
+      "en": "What language has the most native speakers?",
+      "ja": "もっともおおくのぼごわしゃをもつげんごは？"
     }
   },
   {
@@ -23974,6 +26966,10 @@
     "id": "q00749",
     "image_path": null,
     "question_text": {
+      "en": "How many letters are in the English alphabet?",
+      "ja": "えいごのあるふぁべっとはなんもじ？"
+    },
+    "question_text_reading": {
       "en": "How many letters are in the English alphabet?",
       "ja": "えいごのあるふぁべっとはなんもじ？"
     }
@@ -24008,6 +27004,10 @@
     "question_text": {
       "en": "What is the official language of Brazil?",
       "ja": "ぶらじるのこうようごは？"
+    },
+    "question_text_reading": {
+      "en": "What is the official language of Brazil?",
+      "ja": "ぶらじるのこうようごは？"
     }
   },
   {
@@ -24038,6 +27038,10 @@
     "id": "q00751",
     "image_path": null,
     "question_text": {
+      "en": "What language is spoken in Egypt?",
+      "ja": "えじぷとでつかわれるげんごは？"
+    },
+    "question_text_reading": {
       "en": "What language is spoken in Egypt?",
       "ja": "えじぷとでつかわれるげんごは？"
     }
@@ -24072,6 +27076,10 @@
     "question_text": {
       "en": "What script is used for Japanese?",
       "ja": "にほんごではどのもじをつかうか？"
+    },
+    "question_text_reading": {
+      "en": "What script is used for Japanese?",
+      "ja": "にほんごではどのもじをつかうか？"
     }
   },
   {
@@ -24102,6 +27110,10 @@
     "id": "q00753",
     "image_path": null,
     "question_text": {
+      "en": "What is a synonym?",
+      "ja": "どうぎごとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a synonym?",
       "ja": "どうぎごとは何か？"
     }
@@ -24136,6 +27148,10 @@
     "question_text": {
       "en": "What is an antonym?",
       "ja": "はんたいごとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is an antonym?",
+      "ja": "はんたいごとは何か？"
     }
   },
   {
@@ -24166,6 +27182,10 @@
     "id": "q00755",
     "image_path": null,
     "question_text": {
+      "en": "What is a haiku?",
+      "ja": "はいくとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a haiku?",
       "ja": "はいくとは何か？"
     }
@@ -24200,6 +27220,10 @@
     "question_text": {
       "en": "What does 'loanword' mean?",
       "ja": "がいらいごとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What does 'loanword' mean?",
+      "ja": "がいらいごとは何か？"
     }
   },
   {
@@ -24230,6 +27254,10 @@
     "id": "q00757",
     "image_path": null,
     "question_text": {
+      "en": "What is onomatopoeia?",
+      "ja": "おのまとぺとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is onomatopoeia?",
       "ja": "おのまとぺとは何か？"
     }
@@ -24264,6 +27292,10 @@
     "question_text": {
       "en": "What is the Latin word for water?",
       "ja": "みずのらてんごは？"
+    },
+    "question_text_reading": {
+      "en": "What is the Latin word for water?",
+      "ja": "みずのらてんごは？"
     }
   },
   {
@@ -24294,6 +27326,10 @@
     "id": "q00759",
     "image_path": null,
     "question_text": {
+      "en": "What language family does English belong to?",
+      "ja": "えいごはどのごぞくか？"
+    },
+    "question_text_reading": {
       "en": "What language family does English belong to?",
       "ja": "えいごはどのごぞくか？"
     }
@@ -24328,6 +27364,10 @@
     "question_text": {
       "en": "What is a palindrome?",
       "ja": "かいぶんとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a palindrome?",
+      "ja": "かいぶんとは何か？"
     }
   },
   {
@@ -24358,6 +27398,10 @@
     "id": "q00761",
     "image_path": null,
     "question_text": {
+      "en": "What language did Shakespeare write in?",
+      "ja": "しぇいくすぴあはなにごでかいたか？"
+    },
+    "question_text_reading": {
       "en": "What language did Shakespeare write in?",
       "ja": "しぇいくすぴあはなにごでかいたか？"
     }
@@ -24392,6 +27436,10 @@
     "question_text": {
       "en": "What is the most studied second language globally?",
       "ja": "せかいでもっともまなばれているだいにげんごは？"
+    },
+    "question_text_reading": {
+      "en": "What is the most studied second language globally?",
+      "ja": "せかいでもっともまなばれているだいにげんごは？"
     }
   },
   {
@@ -24422,6 +27470,10 @@
     "id": "q00763",
     "image_path": null,
     "question_text": {
+      "en": "What does 'etymology' mean?",
+      "ja": "ごげんがくとは何か？"
+    },
+    "question_text_reading": {
       "en": "What does 'etymology' mean?",
       "ja": "ごげんがくとは何か？"
     }
@@ -24456,6 +27508,10 @@
     "question_text": {
       "en": "What is grammar?",
       "ja": "ぶんぽうとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is grammar?",
+      "ja": "ぶんぽうとは何か？"
     }
   },
   {
@@ -24486,6 +27542,10 @@
     "id": "q00765",
     "image_path": null,
     "question_text": {
+      "en": "What is syntax?",
+      "ja": "こうぶんとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is syntax?",
       "ja": "こうぶんとは何か？"
     }
@@ -24520,6 +27580,10 @@
     "question_text": {
       "en": "What is semantics?",
       "ja": "いみろんとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is semantics?",
+      "ja": "いみろんとは何か？"
     }
   },
   {
@@ -24550,6 +27614,10 @@
     "id": "q00767",
     "image_path": null,
     "question_text": {
+      "en": "What is a dialect?",
+      "ja": "ほうげんとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a dialect?",
       "ja": "ほうげんとは何か？"
     }
@@ -24584,6 +27652,10 @@
     "question_text": {
       "en": "What is Esperanto?",
       "ja": "えすぺらんととは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is Esperanto?",
+      "ja": "えすぺらんととは何か？"
     }
   },
   {
@@ -24614,6 +27686,10 @@
     "id": "q00769",
     "image_path": null,
     "question_text": {
+      "en": "What is a phoneme?",
+      "ja": "おんそとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a phoneme?",
       "ja": "おんそとは何か？"
     }
@@ -24648,6 +27724,10 @@
     "question_text": {
       "en": "What language uses the Cyrillic alphabet?",
       "ja": "きりるもじをつかうげんごは？"
+    },
+    "question_text_reading": {
+      "en": "What language uses the Cyrillic alphabet?",
+      "ja": "きりるもじをつかうげんごは？"
     }
   },
   {
@@ -24678,6 +27758,10 @@
     "id": "q00771",
     "image_path": null,
     "question_text": {
+      "en": "What is a verb?",
+      "ja": "どうしとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a verb?",
       "ja": "どうしとは何か？"
     }
@@ -24712,6 +27796,10 @@
     "question_text": {
       "en": "What is an adjective?",
       "ja": "けいようしとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is an adjective?",
+      "ja": "けいようしとは何か？"
     }
   },
   {
@@ -24742,6 +27830,10 @@
     "id": "q00773",
     "image_path": null,
     "question_text": {
+      "en": "What is a noun?",
+      "ja": "めいしとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a noun?",
       "ja": "めいしとは何か？"
     }
@@ -24776,6 +27868,10 @@
     "question_text": {
       "en": "What is a preposition?",
       "ja": "ぜんちしとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a preposition?",
+      "ja": "ぜんちしとは何か？"
     }
   },
   {
@@ -24806,6 +27902,10 @@
     "id": "q00775",
     "image_path": null,
     "question_text": {
+      "en": "What is metaphor?",
+      "ja": "いんゆとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is metaphor?",
       "ja": "いんゆとは何か？"
     }
@@ -24840,6 +27940,10 @@
     "question_text": {
       "en": "What is a simile?",
       "ja": "しみりとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a simile?",
+      "ja": "しみりとは何か？"
     }
   },
   {
@@ -24870,6 +27974,10 @@
     "id": "q00777",
     "image_path": null,
     "question_text": {
+      "en": "What is alliteration?",
+      "ja": "どうじしゅんぷうとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is alliteration?",
       "ja": "どうじしゅんぷうとは何か？"
     }
@@ -24904,6 +28012,10 @@
     "question_text": {
       "en": "What country is sushi originally from?",
       "ja": "すしのげんちはどこ？"
+    },
+    "question_text_reading": {
+      "en": "What country is sushi originally from?",
+      "ja": "すしのげんちはどこ？"
     }
   },
   {
@@ -24934,6 +28046,10 @@
     "id": "q00779",
     "image_path": null,
     "question_text": {
+      "en": "What is the traditional instrument of India?",
+      "ja": "いんどのでんとうがっきは？"
+    },
+    "question_text_reading": {
       "en": "What is the traditional instrument of India?",
       "ja": "いんどのでんとうがっきは？"
     }
@@ -24968,6 +28084,10 @@
     "question_text": {
       "en": "What is flamenco?",
       "ja": "ふらめんことは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is flamenco?",
+      "ja": "ふらめんことは何か？"
     }
   },
   {
@@ -24998,6 +28118,10 @@
     "id": "q00781",
     "image_path": null,
     "question_text": {
+      "en": "What is Carnival in Brazil?",
+      "ja": "ぶらじるのかーにばるとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is Carnival in Brazil?",
       "ja": "ぶらじるのかーにばるとは何か？"
     }
@@ -25032,6 +28156,10 @@
     "question_text": {
       "en": "What is the Colosseum?",
       "ja": "ころっせうむとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is the Colosseum?",
+      "ja": "ころっせうむとは何か？"
     }
   },
   {
@@ -25062,6 +28190,10 @@
     "id": "q00783",
     "image_path": null,
     "question_text": {
+      "en": "What is ikebana?",
+      "ja": "いけばなとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is ikebana?",
       "ja": "いけばなとは何か？"
     }
@@ -25096,6 +28228,10 @@
     "question_text": {
       "en": "What country does the kilt come from?",
       "ja": "きるとはどこのくにのもの？"
+    },
+    "question_text_reading": {
+      "en": "What country does the kilt come from?",
+      "ja": "きるとはどこのくにのもの？"
     }
   },
   {
@@ -25126,6 +28262,10 @@
     "id": "q00785",
     "image_path": null,
     "question_text": {
+      "en": "What is the traditional Japanese tea ceremony called?",
+      "ja": "にほんのちゃどうのこうしきめいしょうは？"
+    },
+    "question_text_reading": {
       "en": "What is the traditional Japanese tea ceremony called?",
       "ja": "にほんのちゃどうのこうしきめいしょうは？"
     }
@@ -25160,6 +28300,10 @@
     "question_text": {
       "en": "What festival is celebrated on October 31?",
       "ja": "10がつ31にちにいわわれるまつりは？"
+    },
+    "question_text_reading": {
+      "en": "What festival is celebrated on October 31?",
+      "ja": "10がつ31にちにいわわれるまつりは？"
     }
   },
   {
@@ -25190,6 +28334,10 @@
     "id": "q00787",
     "image_path": null,
     "question_text": {
+      "en": "What is Diwali?",
+      "ja": "でぃわりとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is Diwali?",
       "ja": "でぃわりとは何か？"
     }
@@ -25224,6 +28372,10 @@
     "question_text": {
       "en": "What is the Day of the Dead (Día de los Muertos)?",
       "ja": "しゃのひ（でぃーあでろすむえるとす）とは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is the Day of the Dead (Día de los Muertos)?",
+      "ja": "しゃのひ（でぃーあでろすむえるとす）とは何か？"
     }
   },
   {
@@ -25254,6 +28406,10 @@
     "id": "q00789",
     "image_path": null,
     "question_text": {
+      "en": "What is origami?",
+      "ja": "おりがみとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is origami?",
       "ja": "おりがみとは何か？"
     }
@@ -25288,6 +28444,10 @@
     "question_text": {
       "en": "What is the Chinese New Year also called?",
       "ja": "ちゅうごくのしんねんはなんともいわれるか？"
+    },
+    "question_text_reading": {
+      "en": "What is the Chinese New Year also called?",
+      "ja": "ちゅうごくのしんねんはなんともいわれるか？"
     }
   },
   {
@@ -25318,6 +28478,10 @@
     "id": "q00791",
     "image_path": null,
     "question_text": {
+      "en": "What sport is most popular globally?",
+      "ja": "せかいでもっとものきんのすぽーつは？"
+    },
+    "question_text_reading": {
       "en": "What sport is most popular globally?",
       "ja": "せかいでもっとものきんのすぽーつは？"
     }
@@ -25352,6 +28516,10 @@
     "question_text": {
       "en": "What is the traditional clothing of Japan?",
       "ja": "にほんのでんとうてきなぎは？"
+    },
+    "question_text_reading": {
+      "en": "What is the traditional clothing of Japan?",
+      "ja": "にほんのでんとうてきなぎは？"
     }
   },
   {
@@ -25382,6 +28550,10 @@
     "id": "q00793",
     "image_path": null,
     "question_text": {
+      "en": "What is yoga?",
+      "ja": "よがとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is yoga?",
       "ja": "よがとは何か？"
     }
@@ -25416,6 +28588,10 @@
     "question_text": {
       "en": "What is kimchi?",
       "ja": "きむちとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is kimchi?",
+      "ja": "きむちとは何か？"
     }
   },
   {
@@ -25446,6 +28622,10 @@
     "id": "q00795",
     "image_path": null,
     "question_text": {
+      "en": "What is the meaning of 'namaste'?",
+      "ja": "なますてのいみは？"
+    },
+    "question_text_reading": {
       "en": "What is the meaning of 'namaste'?",
       "ja": "なますてのいみは？"
     }
@@ -25480,6 +28660,10 @@
     "question_text": {
       "en": "What country did pasta originally come from?",
       "ja": "ぱすたのげんちはどこ？"
+    },
+    "question_text_reading": {
+      "en": "What country did pasta originally come from?",
+      "ja": "ぱすたのげんちはどこ？"
     }
   },
   {
@@ -25510,6 +28694,10 @@
     "id": "q00797",
     "image_path": null,
     "question_text": {
+      "en": "What is the Mona Lisa?",
+      "ja": "もなりざとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is the Mona Lisa?",
       "ja": "もなりざとは何か？"
     }
@@ -25544,6 +28732,10 @@
     "question_text": {
       "en": "What is the Taj Mahal?",
       "ja": "たじまはるとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is the Taj Mahal?",
+      "ja": "たじまはるとは何か？"
     }
   },
   {
@@ -25574,6 +28766,10 @@
     "id": "q00799",
     "image_path": null,
     "question_text": {
+      "en": "What is a matryoshka?",
+      "ja": "まとりょーしかとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a matryoshka?",
       "ja": "まとりょーしかとは何か？"
     }
@@ -25608,6 +28804,10 @@
     "question_text": {
       "en": "What country is known for inventing gunpowder?",
       "ja": "かやくをはつめいしたとされるくには？"
+    },
+    "question_text_reading": {
+      "en": "What country is known for inventing gunpowder?",
+      "ja": "かやくをはつめいしたとされるくには？"
     }
   },
   {
@@ -25638,6 +28838,10 @@
     "id": "q00801",
     "image_path": null,
     "question_text": {
+      "en": "What is the art of calligraphy?",
+      "ja": "しょどうとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is the art of calligraphy?",
       "ja": "しょどうとは何か？"
     }
@@ -25672,6 +28876,10 @@
     "question_text": {
       "en": "What is a samurai?",
       "ja": "さむらいとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a samurai?",
+      "ja": "さむらいとは何か？"
     }
   },
   {
@@ -25702,6 +28910,10 @@
     "id": "q00803",
     "image_path": null,
     "question_text": {
+      "en": "What is the Olympic flame?",
+      "ja": "おりんぴっくのほのおとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is the Olympic flame?",
       "ja": "おりんぴっくのほのおとは何か？"
     }
@@ -25736,6 +28948,10 @@
     "question_text": {
       "en": "What is manga?",
       "ja": "まんがとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is manga?",
+      "ja": "まんがとは何か？"
     }
   },
   {
@@ -25766,6 +28982,10 @@
     "id": "q00805",
     "image_path": null,
     "question_text": {
+      "en": "What is hip-hop culture?",
+      "ja": "ひっぷほっぷぶんかとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is hip-hop culture?",
       "ja": "ひっぷほっぷぶんかとは何か？"
     }
@@ -25800,6 +29020,10 @@
     "question_text": {
       "en": "How many continents are there on Earth?",
       "ja": "ちきゅうにはいくつのたいりくがあるか？"
+    },
+    "question_text_reading": {
+      "en": "How many continents are there on Earth?",
+      "ja": "ちきゅうにはいくつのたいりくがあるか？"
     }
   },
   {
@@ -25830,6 +29054,10 @@
     "id": "q00807",
     "image_path": null,
     "question_text": {
+      "en": "What is the largest ocean?",
+      "ja": "もっともおおきなうみは？"
+    },
+    "question_text_reading": {
       "en": "What is the largest ocean?",
       "ja": "もっともおおきなうみは？"
     }
@@ -25864,6 +29092,10 @@
     "question_text": {
       "en": "How many days are in a leap year?",
       "ja": "うるうどしはなんにち？"
+    },
+    "question_text_reading": {
+      "en": "How many days are in a leap year?",
+      "ja": "うるうどしはなんにち？"
     }
   },
   {
@@ -25894,6 +29126,10 @@
     "id": "q00809",
     "image_path": null,
     "question_text": {
+      "en": "What is the chemical symbol for gold?",
+      "ja": "きんのかがくきごうは？"
+    },
+    "question_text_reading": {
       "en": "What is the chemical symbol for gold?",
       "ja": "きんのかがくきごうは？"
     }
@@ -25928,6 +29164,10 @@
     "question_text": {
       "en": "What is the tallest mountain in the world?",
       "ja": "せかいでもっともたかいやまは？"
+    },
+    "question_text_reading": {
+      "en": "What is the tallest mountain in the world?",
+      "ja": "せかいでもっともたかいやまは？"
     }
   },
   {
@@ -25958,6 +29198,10 @@
     "id": "q00811",
     "image_path": null,
     "question_text": {
+      "en": "How many bones are in the adult human body?",
+      "ja": "おとなのにんげんのほねはいくつ？"
+    },
+    "question_text_reading": {
       "en": "How many bones are in the adult human body?",
       "ja": "おとなのにんげんのほねはいくつ？"
     }
@@ -25992,6 +29236,10 @@
     "question_text": {
       "en": "What is the speed of light?",
       "ja": "ひかりのそくどは？"
+    },
+    "question_text_reading": {
+      "en": "What is the speed of light?",
+      "ja": "ひかりのそくどは？"
     }
   },
   {
@@ -26022,6 +29270,10 @@
     "id": "q00813",
     "image_path": null,
     "question_text": {
+      "en": "How many planets are in our solar system?",
+      "ja": "たいようけいにはなんこのわくせいがあるか？"
+    },
+    "question_text_reading": {
       "en": "How many planets are in our solar system?",
       "ja": "たいようけいにはなんこのわくせいがあるか？"
     }
@@ -26056,6 +29308,10 @@
     "question_text": {
       "en": "What gas do plants absorb from the air?",
       "ja": "しょくぶつはくうきからなにをきゅうしゅうするか？"
+    },
+    "question_text_reading": {
+      "en": "What gas do plants absorb from the air?",
+      "ja": "しょくぶつはくうきからなにをきゅうしゅうするか？"
     }
   },
   {
@@ -26086,6 +29342,10 @@
     "id": "q00815",
     "image_path": null,
     "question_text": {
+      "en": "What is the largest country by area?",
+      "ja": "めんせきでもっともおおきなくには？"
+    },
+    "question_text_reading": {
       "en": "What is the largest country by area?",
       "ja": "めんせきでもっともおおきなくには？"
     }
@@ -26120,6 +29380,10 @@
     "question_text": {
       "en": "What is the capital of Australia?",
       "ja": "おーすとらりあのしゅとは？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of Australia?",
+      "ja": "おーすとらりあのしゅとは？"
     }
   },
   {
@@ -26150,6 +29414,10 @@
     "id": "q00817",
     "image_path": null,
     "question_text": {
+      "en": "What is the Amazon River known for?",
+      "ja": "あまぞんがわはなにでゆうめい？"
+    },
+    "question_text_reading": {
       "en": "What is the Amazon River known for?",
       "ja": "あまぞんがわはなにでゆうめい？"
     }
@@ -26184,6 +29452,10 @@
     "question_text": {
       "en": "What is the hardest natural substance?",
       "ja": "しぜんかいでもっともかたいぶっしつは？"
+    },
+    "question_text_reading": {
+      "en": "What is the hardest natural substance?",
+      "ja": "しぜんかいでもっともかたいぶっしつは？"
     }
   },
   {
@@ -26214,6 +29486,10 @@
     "id": "q00819",
     "image_path": null,
     "question_text": {
+      "en": "How many chambers does a human heart have?",
+      "ja": "にんげんのこころはいくつのへやにわかれているか？"
+    },
+    "question_text_reading": {
       "en": "How many chambers does a human heart have?",
       "ja": "にんげんのこころはいくつのへやにわかれているか？"
     }
@@ -26248,6 +29524,10 @@
     "question_text": {
       "en": "What is the currency of Japan?",
       "ja": "にほんのつうかは？"
+    },
+    "question_text_reading": {
+      "en": "What is the currency of Japan?",
+      "ja": "にほんのつうかは？"
     }
   },
   {
@@ -26278,6 +29558,10 @@
     "id": "q00821",
     "image_path": null,
     "question_text": {
+      "en": "What is the largest desert in the world?",
+      "ja": "せかいさいだいのさばくは？"
+    },
+    "question_text_reading": {
       "en": "What is the largest desert in the world?",
       "ja": "せかいさいだいのさばくは？"
     }
@@ -26312,6 +29596,10 @@
     "question_text": {
       "en": "What year did World War II end?",
       "ja": "だいにじせかいたいせんはなんねんにおわったか？"
+    },
+    "question_text_reading": {
+      "en": "What year did World War II end?",
+      "ja": "だいにじせかいたいせんはなんねんにおわったか？"
     }
   },
   {
@@ -26342,6 +29630,10 @@
     "id": "q00823",
     "image_path": null,
     "question_text": {
+      "en": "What is the boiling point of water at sea level?",
+      "ja": "かいめいでのみずのふってんは？"
+    },
+    "question_text_reading": {
       "en": "What is the boiling point of water at sea level?",
       "ja": "かいめいでのみずのふってんは？"
     }
@@ -26376,6 +29668,10 @@
     "question_text": {
       "en": "What is the freezing point of water?",
       "ja": "みずのこおりはじめるおんどは？"
+    },
+    "question_text_reading": {
+      "en": "What is the freezing point of water?",
+      "ja": "みずのこおりはじめるおんどは？"
     }
   },
   {
@@ -26406,6 +29702,10 @@
     "id": "q00825",
     "image_path": null,
     "question_text": {
+      "en": "What element has the atomic number 1?",
+      "ja": "げんしばんごう1のげんそは？"
+    },
+    "question_text_reading": {
       "en": "What element has the atomic number 1?",
       "ja": "げんしばんごう1のげんそは？"
     }
@@ -26440,6 +29740,10 @@
     "question_text": {
       "en": "What is photosynthesis?",
       "ja": "こうごうせいとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is photosynthesis?",
+      "ja": "こうごうせいとは何か？"
     }
   },
   {
@@ -26470,6 +29774,10 @@
     "id": "q00827",
     "image_path": null,
     "question_text": {
+      "en": "What is the main language spoken in Argentina?",
+      "ja": "あるぜんちんでつかわれるしゅのことばは？"
+    },
+    "question_text_reading": {
       "en": "What is the main language spoken in Argentina?",
       "ja": "あるぜんちんでつかわれるしゅのことばは？"
     }
@@ -26504,6 +29812,10 @@
     "question_text": {
       "en": "What is the longest bone in the human body?",
       "ja": "にんげんのからだでもっともながいほねは？"
+    },
+    "question_text_reading": {
+      "en": "What is the longest bone in the human body?",
+      "ja": "にんげんのからだでもっともながいほねは？"
     }
   },
   {
@@ -26534,6 +29846,10 @@
     "id": "q00829",
     "image_path": null,
     "question_text": {
+      "en": "Who invented the telephone?",
+      "ja": "でんわをはつめいしたのはだれ？"
+    },
+    "question_text_reading": {
       "en": "Who invented the telephone?",
       "ja": "でんわをはつめいしたのはだれ？"
     }
@@ -26568,6 +29884,10 @@
     "question_text": {
       "en": "What is the most abundant gas in Earth's atmosphere?",
       "ja": "ちきゅうのたいきでもっともおおいきたいは？"
+    },
+    "question_text_reading": {
+      "en": "What is the most abundant gas in Earth's atmosphere?",
+      "ja": "ちきゅうのたいきでもっともおおいきたいは？"
     }
   },
   {
@@ -26598,6 +29918,10 @@
     "id": "q00831",
     "image_path": null,
     "question_text": {
+      "en": "What is the square root of 256?",
+      "ja": "256のへいほうこんは？"
+    },
+    "question_text_reading": {
       "en": "What is the square root of 256?",
       "ja": "256のへいほうこんは？"
     }
@@ -26632,6 +29956,10 @@
     "question_text": {
       "en": "How many teeth does an adult human have?",
       "ja": "おとなのにんげんのはは何本？"
+    },
+    "question_text_reading": {
+      "en": "How many teeth does an adult human have?",
+      "ja": "おとなのにんげんのはは何本？"
     }
   },
   {
@@ -26662,6 +29990,10 @@
     "id": "q00833",
     "image_path": null,
     "question_text": {
+      "en": "What is the largest planet in our solar system?",
+      "ja": "たいようけいでもっともおおきいわくせいは？"
+    },
+    "question_text_reading": {
       "en": "What is the largest planet in our solar system?",
       "ja": "たいようけいでもっともおおきいわくせいは？"
     }
@@ -26696,6 +30028,10 @@
     "question_text": {
       "en": "What is the symbol for the element oxygen?",
       "ja": "さんそのげんそきごうは？"
+    },
+    "question_text_reading": {
+      "en": "What is the symbol for the element oxygen?",
+      "ja": "さんそのげんそきごうは？"
     }
   },
   {
@@ -26726,6 +30062,10 @@
     "id": "q00835",
     "image_path": null,
     "question_text": {
+      "en": "Which planet is closest to the sun?",
+      "ja": "もっともたいようにちかいわくせいは？"
+    },
+    "question_text_reading": {
       "en": "Which planet is closest to the sun?",
       "ja": "もっともたいようにちかいわくせいは？"
     }
@@ -26760,6 +30100,10 @@
     "question_text": {
       "en": "What is the smallest country in the world?",
       "ja": "せかいでもっともちいさなくには？"
+    },
+    "question_text_reading": {
+      "en": "What is the smallest country in the world?",
+      "ja": "せかいでもっともちいさなくには？"
     }
   },
   {
@@ -26790,6 +30134,10 @@
     "id": "q00837",
     "image_path": null,
     "question_text": {
+      "en": "How many strings does a standard guitar have?",
+      "ja": "ふつうのぎたーはなんほんのげんをもつか？"
+    },
+    "question_text_reading": {
       "en": "How many strings does a standard guitar have?",
       "ja": "ふつうのぎたーはなんほんのげんをもつか？"
     }
@@ -26824,6 +30172,10 @@
     "question_text": {
       "en": "What does DNA stand for?",
       "ja": "DNAのりゃくしょうのせいしきめいは？"
+    },
+    "question_text_reading": {
+      "en": "What does DNA stand for?",
+      "ja": "DNAのりゃくしょうのせいしきめいは？"
     }
   },
   {
@@ -26854,6 +30206,10 @@
     "id": "q00839",
     "image_path": null,
     "question_text": {
+      "en": "What is the chemical formula for table salt?",
+      "ja": "しょくえんのかがくしきは？"
+    },
+    "question_text_reading": {
       "en": "What is the chemical formula for table salt?",
       "ja": "しょくえんのかがくしきは？"
     }
@@ -26888,6 +30244,10 @@
     "question_text": {
       "en": "What is the national sport of Japan?",
       "ja": "にほんのこくぎは？"
+    },
+    "question_text_reading": {
+      "en": "What is the national sport of Japan?",
+      "ja": "にほんのこくぎは？"
     }
   },
   {
@@ -26918,6 +30278,10 @@
     "id": "q00841",
     "image_path": null,
     "question_text": {
+      "en": "What does the Richter scale measure?",
+      "ja": "りひたーすけーるはなにをはかるか？"
+    },
+    "question_text_reading": {
       "en": "What does the Richter scale measure?",
       "ja": "りひたーすけーるはなにをはかるか？"
     }
@@ -26952,6 +30316,10 @@
     "question_text": {
       "en": "What year did the first moon landing occur?",
       "ja": "はつのつきへのちゃくりくはなんねん？"
+    },
+    "question_text_reading": {
+      "en": "What year did the first moon landing occur?",
+      "ja": "はつのつきへのちゃくりくはなんねん？"
     }
   },
   {
@@ -26982,6 +30350,10 @@
     "id": "q00843",
     "image_path": null,
     "question_text": {
+      "en": "What is the symbol for the element iron?",
+      "ja": "てつのげんそきごうは？"
+    },
+    "question_text_reading": {
       "en": "What is the symbol for the element iron?",
       "ja": "てつのげんそきごうは？"
     }
@@ -27016,6 +30388,10 @@
     "question_text": {
       "en": "What is the loudest animal on Earth?",
       "ja": "ちきゅうでもっともおおきなこえをだすどうぶつは？"
+    },
+    "question_text_reading": {
+      "en": "What is the loudest animal on Earth?",
+      "ja": "ちきゅうでもっともおおきなこえをだすどうぶつは？"
     }
   },
   {
@@ -27046,6 +30422,10 @@
     "id": "q00845",
     "image_path": null,
     "question_text": {
+      "en": "What is the unit of electric current?",
+      "ja": "でんりゅうのたんいは？"
+    },
+    "question_text_reading": {
       "en": "What is the unit of electric current?",
       "ja": "でんりゅうのたんいは？"
     }
@@ -27080,6 +30460,10 @@
     "question_text": {
       "en": "What is a VTuber?",
       "ja": "ぶいちゅーばーとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a VTuber?",
+      "ja": "ぶいちゅーばーとは何か？"
     }
   },
   {
@@ -27110,6 +30494,10 @@
     "id": "q00847",
     "image_path": null,
     "question_text": {
+      "en": "What company is Hololive associated with?",
+      "ja": "ほろらいぶはどのかいしゃ？"
+    },
+    "question_text_reading": {
       "en": "What company is Hololive associated with?",
       "ja": "ほろらいぶはどのかいしゃ？"
     }
@@ -27144,6 +30532,10 @@
     "question_text": {
       "en": "What is Nijisanji?",
       "ja": "にじさんじとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is Nijisanji?",
+      "ja": "にじさんじとは何か？"
     }
   },
   {
@@ -27174,6 +30566,10 @@
     "id": "q00849",
     "image_path": null,
     "question_text": {
+      "en": "What does 'kaigai niki' mean?",
+      "ja": "かいがいにきとは何か？"
+    },
+    "question_text_reading": {
       "en": "What does 'kaigai niki' mean?",
       "ja": "かいがいにきとは何か？"
     }
@@ -27208,6 +30604,10 @@
     "question_text": {
       "en": "What is 'superchat'?",
       "ja": "すーぱーちゃっととは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is 'superchat'?",
+      "ja": "すーぱーちゃっととは何か？"
     }
   },
   {
@@ -27238,6 +30638,10 @@
     "id": "q00851",
     "image_path": null,
     "question_text": {
+      "en": "What is 'doxxing'?",
+      "ja": "どっくしんぐとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is 'doxxing'?",
       "ja": "どっくしんぐとは何か？"
     }
@@ -27272,6 +30676,10 @@
     "question_text": {
       "en": "What does 'GG' stand for in gaming?",
       "ja": "げーみんぐでGGとはどういういみ？"
+    },
+    "question_text_reading": {
+      "en": "What does 'GG' stand for in gaming?",
+      "ja": "げーみんぐでGGとはどういういみ？"
     }
   },
   {
@@ -27302,6 +30710,10 @@
     "id": "q00853",
     "image_path": null,
     "question_text": {
+      "en": "What is 'streaming'?",
+      "ja": "すとりーみんぐとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is 'streaming'?",
       "ja": "すとりーみんぐとは何か？"
     }
@@ -27336,6 +30748,10 @@
     "question_text": {
       "en": "What is a 'clip' in VTuber culture?",
       "ja": "ぶいちゅーばーぶんかでのくりっぷとは？"
+    },
+    "question_text_reading": {
+      "en": "What is a 'clip' in VTuber culture?",
+      "ja": "ぶいちゅーばーぶんかでのくりっぷとは？"
     }
   },
   {
@@ -27366,6 +30782,10 @@
     "id": "q00855",
     "image_path": null,
     "question_text": {
+      "en": "What is 'fan art'?",
+      "ja": "ふぁんあーととは何か？"
+    },
+    "question_text_reading": {
       "en": "What is 'fan art'?",
       "ja": "ふぁんあーととは何か？"
     }
@@ -27400,6 +30820,10 @@
     "question_text": {
       "en": "What is Twitch?",
       "ja": "ついっちとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is Twitch?",
+      "ja": "ついっちとは何か？"
     }
   },
   {
@@ -27430,6 +30854,10 @@
     "id": "q00857",
     "image_path": null,
     "question_text": {
+      "en": "What is Discord?",
+      "ja": "でぃすこーどとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is Discord?",
       "ja": "でぃすこーどとは何か？"
     }
@@ -27464,6 +30892,10 @@
     "question_text": {
       "en": "What is 'yab' in VTuber slang?",
       "ja": "ぶいちゅーばーすらんぐでやばいとは？"
+    },
+    "question_text_reading": {
+      "en": "What is 'yab' in VTuber slang?",
+      "ja": "ぶいちゅーばーすらんぐでやばいとは？"
     }
   },
   {
@@ -27494,6 +30926,10 @@
     "id": "q00859",
     "image_path": null,
     "question_text": {
+      "en": "What is a 'debut' for a VTuber?",
+      "ja": "ぶいちゅーばーのでびゅーとは？"
+    },
+    "question_text_reading": {
       "en": "What is a 'debut' for a VTuber?",
       "ja": "ぶいちゅーばーのでびゅーとは？"
     }
@@ -27528,6 +30964,10 @@
     "question_text": {
       "en": "What does 'GachiBASS' mean?",
       "ja": "がちばすとはどんないみ？"
+    },
+    "question_text_reading": {
+      "en": "What does 'GachiBASS' mean?",
+      "ja": "がちばすとはどんないみ？"
     }
   },
   {
@@ -27558,6 +30998,10 @@
     "id": "q00861",
     "image_path": null,
     "question_text": {
+      "en": "What is 'live2D'?",
+      "ja": "らいぶつーでぃーとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is 'live2D'?",
       "ja": "らいぶつーでぃーとは何か？"
     }
@@ -27592,6 +31036,10 @@
     "question_text": {
       "en": "What is a 'membership' on YouTube?",
       "ja": "ゆーちゅーぶでのめんばーしっぷとは？"
+    },
+    "question_text_reading": {
+      "en": "What is a 'membership' on YouTube?",
+      "ja": "ゆーちゅーぶでのめんばーしっぷとは？"
     }
   },
   {
@@ -27622,6 +31070,10 @@
     "id": "q00863",
     "image_path": null,
     "question_text": {
+      "en": "What is 'oshi'?",
+      "ja": "おしとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is 'oshi'?",
       "ja": "おしとは何か？"
     }
@@ -27656,6 +31108,10 @@
     "question_text": {
       "en": "What is the term for simultaneous translator in VTuber culture?",
       "ja": "ぶいちゅーばーぶんかでどうじほんやくしゃのことをなんというか？"
+    },
+    "question_text_reading": {
+      "en": "What is the term for simultaneous translator in VTuber culture?",
+      "ja": "ぶいちゅーばーぶんかでどうじほんやくしゃのことをなんというか？"
     }
   },
   {
@@ -27686,6 +31142,10 @@
     "id": "q00865",
     "image_path": null,
     "question_text": {
+      "en": "What is 'zatsudan'?",
+      "ja": "ざつだんとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is 'zatsudan'?",
       "ja": "ざつだんとは何か？"
     }
@@ -27720,6 +31180,10 @@
     "question_text": {
       "en": "What does 'pog' or 'poggers' mean in chat?",
       "ja": "ちゃっとでぽぐやぽがーずとはどういういみ？"
+    },
+    "question_text_reading": {
+      "en": "What does 'pog' or 'poggers' mean in chat?",
+      "ja": "ちゃっとでぽぐやぽがーずとはどういういみ？"
     }
   },
   {
@@ -27750,6 +31214,10 @@
     "id": "q00867",
     "image_path": null,
     "question_text": {
+      "en": "What is 'KEKW'?",
+      "ja": "けくわとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is 'KEKW'?",
       "ja": "けくわとは何か？"
     }
@@ -27784,6 +31252,10 @@
     "question_text": {
       "en": "What is a 'raid' on Twitch?",
       "ja": "ついっちでのれいどとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a 'raid' on Twitch?",
+      "ja": "ついっちでのれいどとは何か？"
     }
   },
   {
@@ -27814,6 +31286,10 @@
     "id": "q00869",
     "image_path": null,
     "question_text": {
+      "en": "What is 'lore' in VTuber context?",
+      "ja": "ぶいちゅーばーぶんみゃくでのろあとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is 'lore' in VTuber context?",
       "ja": "ぶいちゅーばーぶんみゃくでのろあとは何か？"
     }
@@ -27848,6 +31324,10 @@
     "question_text": {
       "en": "What is '3D debut' for a VTuber?",
       "ja": "ぶいちゅーばーのさんでぃーでびゅーとは？"
+    },
+    "question_text_reading": {
+      "en": "What is '3D debut' for a VTuber?",
+      "ja": "ぶいちゅーばーのさんでぃーでびゅーとは？"
     }
   },
   {
@@ -27878,6 +31358,10 @@
     "id": "q00871",
     "image_path": null,
     "question_text": {
+      "en": "What does 'IRL' stand for?",
+      "ja": "IRLとはなにのりゃく？"
+    },
+    "question_text_reading": {
       "en": "What does 'IRL' stand for?",
       "ja": "IRLとはなにのりゃく？"
     }
@@ -27912,6 +31396,10 @@
     "question_text": {
       "en": "What is 'NicoNico Douga'?",
       "ja": "にこにこどうがとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is 'NicoNico Douga'?",
+      "ja": "にこにこどうがとは何か？"
     }
   },
   {
@@ -27942,6 +31430,10 @@
     "id": "q00873",
     "image_path": null,
     "question_text": {
+      "en": "What is 'Vocaloid'?",
+      "ja": "ぼーかろいどとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is 'Vocaloid'?",
       "ja": "ぼーかろいどとは何か？"
     }
@@ -27976,6 +31468,10 @@
     "question_text": {
       "en": "What character is the most famous Vocaloid?",
       "ja": "もっともゆうめいなぼーかろいどのきゃらくたーは？"
+    },
+    "question_text_reading": {
+      "en": "What character is the most famous Vocaloid?",
+      "ja": "もっともゆうめいなぼーかろいどのきゃらくたーは？"
     }
   },
   {
@@ -28006,6 +31502,10 @@
     "id": "q00875",
     "image_path": null,
     "question_text": {
+      "en": "What is 'meme' on the internet?",
+      "ja": "いんたーねっとでみーむとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is 'meme' on the internet?",
       "ja": "いんたーねっとでみーむとは何か？"
     }
@@ -28040,6 +31540,10 @@
     "question_text": {
       "en": "What is 'trolling' online?",
       "ja": "おんらいんでとろーりんぐとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is 'trolling' online?",
+      "ja": "おんらいんでとろーりんぐとは何か？"
     }
   },
   {
@@ -28070,6 +31574,10 @@
     "id": "q00877",
     "image_path": null,
     "question_text": {
+      "en": "What does AFK stand for?",
+      "ja": "AFKとはなにのりゃく？"
+    },
+    "question_text_reading": {
       "en": "What does AFK stand for?",
       "ja": "AFKとはなにのりゃく？"
     }
@@ -28104,6 +31612,10 @@
     "question_text": {
       "en": "What is 'gacha' in gaming?",
       "ja": "げーみんぐでがちゃとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is 'gacha' in gaming?",
+      "ja": "げーみんぐでがちゃとは何か？"
     }
   },
   {
@@ -28134,6 +31646,10 @@
     "id": "q00879",
     "image_path": null,
     "question_text": {
+      "en": "What is 'MMO'?",
+      "ja": "えむえむおーとはなに？"
+    },
+    "question_text_reading": {
       "en": "What is 'MMO'?",
       "ja": "えむえむおーとはなに？"
     }
@@ -28168,6 +31684,10 @@
     "question_text": {
       "en": "What is 'ping' in online gaming?",
       "ja": "おんらいんげーみんぐでぴんぐとは？"
+    },
+    "question_text_reading": {
+      "en": "What is 'ping' in online gaming?",
+      "ja": "おんらいんげーみんぐでぴんぐとは？"
     }
   },
   {
@@ -28198,6 +31718,10 @@
     "id": "q00881",
     "image_path": null,
     "question_text": {
+      "en": "What is 'esports'?",
+      "ja": "いーすぽーつとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is 'esports'?",
       "ja": "いーすぽーつとは何か？"
     }
@@ -28232,6 +31756,10 @@
     "question_text": {
       "en": "What does FPS stand for in gaming?",
       "ja": "げーみんぐでFPSとはなにのりゃく？"
+    },
+    "question_text_reading": {
+      "en": "What does FPS stand for in gaming?",
+      "ja": "げーみんぐでFPSとはなにのりゃく？"
     }
   },
   {
@@ -28264,6 +31792,10 @@
     "question_text": {
       "en": "What does HP stand for in games?",
       "ja": "げーむでHPとはなにのりゃく？"
+    },
+    "question_text_reading": {
+      "en": "What does HP stand for in games?",
+      "ja": "げーむでHPとはなにのりゃく？"
     }
   },
   {
@@ -28294,6 +31826,10 @@
     "id": "q00884",
     "image_path": null,
     "question_text": {
+      "en": "What is 'speedrunning'?",
+      "ja": "すぴーどらんにんぐとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is 'speedrunning'?",
       "ja": "すぴーどらんにんぐとは何か？"
     }

--- a/data/questions_ja.json
+++ b/data/questions_ja.json
@@ -37,6 +37,10 @@
     "question_text": {
       "en": "What is the chemical formula for water?",
       "ja": "水の化学式は？"
+    },
+    "question_text_reading": {
+      "en": "What is the chemical formula for water?",
+      "ja": "水の化学式は？"
     }
   },
   {
@@ -80,6 +84,10 @@
     "question_text": {
       "en": "What is the capital of Japan?",
       "ja": "日本の首都は？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of Japan?",
+      "ja": "日本の首都は？"
     }
   },
   {
@@ -118,6 +126,10 @@
     "id": "q00003",
     "image_path": null,
     "question_text": {
+      "en": "What is the output of `print(type([]))`?",
+      "ja": "Pythonで`print(type([]))`の出力は？"
+    },
+    "question_text_reading": {
       "en": "What is the output of `print(type([]))`?",
       "ja": "Pythonで`print(type([]))`の出力は？"
     }
@@ -160,6 +172,10 @@
     "question_text": {
       "en": "Which keyword defines a function in Python?",
       "ja": "Pythonで関数を定義するキーワードは？"
+    },
+    "question_text_reading": {
+      "en": "Which keyword defines a function in Python?",
+      "ja": "Pythonで関数を定義するキーワードは？"
     }
   },
   {
@@ -198,6 +214,10 @@
     "id": "q00005",
     "image_path": null,
     "question_text": {
+      "en": "What does `len([1,2,3])` return?",
+      "ja": "`len([1,2,3])`の戻り値は？"
+    },
+    "question_text_reading": {
       "en": "What does `len([1,2,3])` return?",
       "ja": "`len([1,2,3])`の戻り値は？"
     }
@@ -240,6 +260,10 @@
     "question_text": {
       "en": "Which Python data structure uses key-value pairs?",
       "ja": "Pythonでキーと値のペアを使うデータ構造は？"
+    },
+    "question_text_reading": {
+      "en": "Which Python data structure uses key-value pairs?",
+      "ja": "Pythonでキーと値のペアを使うデータ構造は？"
     }
   },
   {
@@ -278,6 +302,10 @@
     "id": "q00007",
     "image_path": null,
     "question_text": {
+      "en": "What is the correct way to open a file in Python?",
+      "ja": "Pythonでファイルを開く正しい方法は？"
+    },
+    "question_text_reading": {
       "en": "What is the correct way to open a file in Python?",
       "ja": "Pythonでファイルを開く正しい方法は？"
     }
@@ -321,6 +349,10 @@
     "question_text": {
       "en": "Which operator is used for floor division in Python?",
       "ja": "Pythonで切り捨て除算に使う演算子は？"
+    },
+    "question_text_reading": {
+      "en": "Which operator is used for floor division in Python?",
+      "ja": "Pythonで切り捨て除算に使う演算子は？"
     }
   },
   {
@@ -359,6 +391,10 @@
     "id": "q00009",
     "image_path": null,
     "question_text": {
+      "en": "What does `range(5)` produce?",
+      "ja": "`range(5)`が生成するのは？"
+    },
+    "question_text_reading": {
       "en": "What does `range(5)` produce?",
       "ja": "`range(5)`が生成するのは？"
     }
@@ -401,6 +437,10 @@
     "question_text": {
       "en": "Which method adds an element to a list in Python?",
       "ja": "Pythonでリストに要素を追加するメソッドは？"
+    },
+    "question_text_reading": {
+      "en": "Which method adds an element to a list in Python?",
+      "ja": "Pythonでリストに要素を追加するメソッドは？"
     }
   },
   {
@@ -439,6 +479,10 @@
     "id": "q00011",
     "image_path": null,
     "question_text": {
+      "en": "What is a lambda in Python?",
+      "ja": "Pythonのlambdaとは？"
+    },
+    "question_text_reading": {
       "en": "What is a lambda in Python?",
       "ja": "Pythonのlambdaとは？"
     }
@@ -481,6 +525,10 @@
     "question_text": {
       "en": "Which built-in function returns the largest value?",
       "ja": "最大値を返すpython組み込み関数は？"
+    },
+    "question_text_reading": {
+      "en": "Which built-in function returns the largest value?",
+      "ja": "最大値を返すpython組み込み関数は？"
     }
   },
   {
@@ -519,6 +567,10 @@
     "id": "q00013",
     "image_path": null,
     "question_text": {
+      "en": "What keyword declares an immutable variable in Rust?",
+      "ja": "Rustで不変変数を宣言するキーワードは？"
+    },
+    "question_text_reading": {
       "en": "What keyword declares an immutable variable in Rust?",
       "ja": "Rustで不変変数を宣言するキーワードは？"
     }
@@ -563,6 +615,10 @@
     "question_text": {
       "en": "What is the Rust ownership rule?",
       "ja": "Rustのオーナーシップの基本ルールは？"
+    },
+    "question_text_reading": {
+      "en": "What is the Rust ownership rule?",
+      "ja": "Rustのオーナーシップの基本ルールは？"
     }
   },
   {
@@ -601,6 +657,10 @@
     "id": "q00015",
     "image_path": null,
     "question_text": {
+      "en": "Which symbol denotes a reference in Rust?",
+      "ja": "Rustで参照を示す記号は？"
+    },
+    "question_text_reading": {
       "en": "Which symbol denotes a reference in Rust?",
       "ja": "Rustで参照を示す記号は？"
     }
@@ -642,6 +702,10 @@
     "id": "q00016",
     "image_path": null,
     "question_text": {
+      "en": "What is `Option<T>` used for in Rust?",
+      "ja": "Rustの`Option<T>`の用途は？"
+    },
+    "question_text_reading": {
       "en": "What is `Option<T>` used for in Rust?",
       "ja": "Rustの`Option<T>`の用途は？"
     }
@@ -688,6 +752,10 @@
     "question_text": {
       "en": "What does `cargo build` do?",
       "ja": "`cargo build`は何をするコマンドか？"
+    },
+    "question_text_reading": {
+      "en": "What does `cargo build` do?",
+      "ja": "`cargo build`は何をするコマンドか？"
     }
   },
   {
@@ -726,6 +794,10 @@
     "id": "q00018",
     "image_path": null,
     "question_text": {
+      "en": "Which trait enables printing with `{:?}` in Rust?",
+      "ja": "Rustで`{:?}`による表示を可能にするとれーとは？"
+    },
+    "question_text_reading": {
       "en": "Which trait enables printing with `{:?}` in Rust?",
       "ja": "Rustで`{:?}`による表示を可能にするとれーとは？"
     }
@@ -769,6 +841,10 @@
     "question_text": {
       "en": "What is a `Vec<T>` in Rust?",
       "ja": "Rustの`Vec<T>`とは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a `Vec<T>` in Rust?",
+      "ja": "Rustの`Vec<T>`とは何か？"
     }
   },
   {
@@ -807,6 +883,10 @@
     "id": "q00020",
     "image_path": null,
     "question_text": {
+      "en": "How do you handle errors in Rust idiomatically?",
+      "ja": "Rustでエラーを慣用的に扱う方法は？"
+    },
+    "question_text_reading": {
       "en": "How do you handle errors in Rust idiomatically?",
       "ja": "Rustでエラーを慣用的に扱う方法は？"
     }
@@ -850,6 +930,10 @@
     "question_text": {
       "en": "What does `impl` keyword do in Rust?",
       "ja": "Rustの`impl`キーワードの役割は？"
+    },
+    "question_text_reading": {
+      "en": "What does `impl` keyword do in Rust?",
+      "ja": "Rustの`impl`キーワードの役割は？"
     }
   },
   {
@@ -890,6 +974,10 @@
     "question_text": {
       "en": "What is the entry point of a Rust program?",
       "ja": "Rustプログラムのエントリーポイントは？"
+    },
+    "question_text_reading": {
+      "en": "What is the entry point of a Rust program?",
+      "ja": "Rustプログラムのエントリーポイントは？"
     }
   },
   {
@@ -928,6 +1016,10 @@
     "id": "q00023",
     "image_path": null,
     "question_text": {
+      "en": "Which keyword declares a block-scoped variable in JS?",
+      "ja": "JSでブロックスコープ変数を宣言するキーワードは？"
+    },
+    "question_text_reading": {
       "en": "Which keyword declares a block-scoped variable in JS?",
       "ja": "JSでブロックスコープ変数を宣言するキーワードは？"
     }
@@ -972,6 +1064,10 @@
     "question_text": {
       "en": "What does `===` check in JavaScript?",
       "ja": "JavaScriptの`===`は何を確認するか？"
+    },
+    "question_text_reading": {
+      "en": "What does `===` check in JavaScript?",
+      "ja": "JavaScriptの`===`は何を確認するか？"
     }
   },
   {
@@ -1010,6 +1106,10 @@
     "id": "q00025",
     "image_path": null,
     "question_text": {
+      "en": "How do you create an arrow function in JS?",
+      "ja": "JSでアロー関数を作る構文は？"
+    },
+    "question_text_reading": {
       "en": "How do you create an arrow function in JS?",
       "ja": "JSでアロー関数を作る構文は？"
     }
@@ -1052,6 +1152,10 @@
     "question_text": {
       "en": "What is `NaN` in JavaScript?",
       "ja": "JavaScriptの`NaN`とは？"
+    },
+    "question_text_reading": {
+      "en": "What is `NaN` in JavaScript?",
+      "ja": "JavaScriptの`NaN`とは？"
     }
   },
   {
@@ -1090,6 +1194,10 @@
     "id": "q00027",
     "image_path": null,
     "question_text": {
+      "en": "Which method converts JSON string to object?",
+      "ja": "JSON文字列をオブジェクトに変換するメソッドは？"
+    },
+    "question_text_reading": {
       "en": "Which method converts JSON string to object?",
       "ja": "JSON文字列をオブジェクトに変換するメソッドは？"
     }
@@ -1133,6 +1241,10 @@
     "question_text": {
       "en": "What does `Promise.all()` do?",
       "ja": "`Promise.all()`は何をするか？"
+    },
+    "question_text_reading": {
+      "en": "What does `Promise.all()` do?",
+      "ja": "`Promise.all()`は何をするか？"
     }
   },
   {
@@ -1171,6 +1283,10 @@
     "id": "q00029",
     "image_path": null,
     "question_text": {
+      "en": "Which keyword is used for class inheritance in JS?",
+      "ja": "JSでクラスの継承に使うキーワードは？"
+    },
+    "question_text_reading": {
       "en": "Which keyword is used for class inheritance in JS?",
       "ja": "JSでクラスの継承に使うキーワードは？"
     }
@@ -1213,6 +1329,10 @@
     "question_text": {
       "en": "What is `typeof null` in JavaScript?",
       "ja": "JavaScriptで`typeof null`の結果は？"
+    },
+    "question_text_reading": {
+      "en": "What is `typeof null` in JavaScript?",
+      "ja": "JavaScriptで`typeof null`の結果は？"
     }
   },
   {
@@ -1251,6 +1371,10 @@
     "id": "q00031",
     "image_path": null,
     "question_text": {
+      "en": "Which array method creates a new array by transforming each element?",
+      "ja": "各要素を変換して新配列を作るはいれつメソッドは？"
+    },
+    "question_text_reading": {
       "en": "Which array method creates a new array by transforming each element?",
       "ja": "各要素を変換して新配列を作るはいれつメソッドは？"
     }
@@ -1293,6 +1417,10 @@
     "question_text": {
       "en": "What does `Array.isArray([])` return?",
       "ja": "`Array.isArray([])`の戻り値は？"
+    },
+    "question_text_reading": {
+      "en": "What does `Array.isArray([])` return?",
+      "ja": "`Array.isArray([])`の戻り値は？"
     }
   },
   {
@@ -1331,6 +1459,10 @@
     "id": "q00033",
     "image_path": null,
     "question_text": {
+      "en": "What is the time complexity of accessing an array element by index?",
+      "ja": "はいれつのいんでくすによるアクセスの計算量は？"
+    },
+    "question_text_reading": {
       "en": "What is the time complexity of accessing an array element by index?",
       "ja": "はいれつのいんでくすによるアクセスの計算量は？"
     }
@@ -1373,6 +1505,10 @@
     "question_text": {
       "en": "Which data structure uses LIFO order?",
       "ja": "LIFO順を使うでーたこうぞうは？"
+    },
+    "question_text_reading": {
+      "en": "Which data structure uses LIFO order?",
+      "ja": "LIFO順を使うでーたこうぞうは？"
     }
   },
   {
@@ -1411,6 +1547,10 @@
     "id": "q00035",
     "image_path": null,
     "question_text": {
+      "en": "What is a linked list node composed of?",
+      "ja": "れんけつりすとののーどは何で構成されるか？"
+    },
+    "question_text_reading": {
       "en": "What is a linked list node composed of?",
       "ja": "れんけつりすとののーどは何で構成されるか？"
     }
@@ -1454,6 +1594,10 @@
     "question_text": {
       "en": "Which tree traversal visits root first?",
       "ja": "ねをさいしょにたどる木の探索順は？"
+    },
+    "question_text_reading": {
+      "en": "Which tree traversal visits root first?",
+      "ja": "ねをさいしょにたどる木の探索順は？"
     }
   },
   {
@@ -1493,6 +1637,10 @@
     "id": "q00037",
     "image_path": null,
     "question_text": {
+      "en": "What is a hash collision?",
+      "ja": "ハッシュ衝突（hash collision）とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a hash collision?",
       "ja": "はっしゅしょうとつとは何か？"
     }
@@ -1535,6 +1683,10 @@
     "question_text": {
       "en": "What is the worst-case complexity of quicksort?",
       "ja": "くいっくそーとの最悪計算量は？"
+    },
+    "question_text_reading": {
+      "en": "What is the worst-case complexity of quicksort?",
+      "ja": "くいっくそーとの最悪計算量は？"
     }
   },
   {
@@ -1573,6 +1725,10 @@
     "id": "q00039",
     "image_path": null,
     "question_text": {
+      "en": "Which data structure supports BFS traversal naturally?",
+      "ja": "はばゆうせんたんさくを自然にサポートするでーたこうぞうは？"
+    },
+    "question_text_reading": {
       "en": "Which data structure supports BFS traversal naturally?",
       "ja": "はばゆうせんたんさくを自然にサポートするでーたこうぞうは？"
     }
@@ -1614,6 +1770,10 @@
     "id": "q00040",
     "image_path": null,
     "question_text": {
+      "en": "What is a binary search tree property?",
+      "ja": "二分探索木（binary search tree）の性質とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a binary search tree property?",
       "ja": "にぶんたんさくきのせいしつは？"
     }
@@ -1657,6 +1817,10 @@
     "question_text": {
       "en": "What does a min-heap guarantee at the root?",
       "ja": "みにひーぷはねに何を保証するか？"
+    },
+    "question_text_reading": {
+      "en": "What does a min-heap guarantee at the root?",
+      "ja": "みにひーぷはねに何を保証するか？"
     }
   },
   {
@@ -1697,6 +1861,10 @@
     "id": "q00042",
     "image_path": null,
     "question_text": {
+      "en": "Which graph representation uses adjacency lists?",
+      "ja": "隣接リスト（adjacency lists）を用いるグラフ表現はどれですか？"
+    },
+    "question_text_reading": {
       "en": "Which graph representation uses adjacency lists?",
       "ja": "となりあいりすとをつかうグラフひょうげんは？"
     }
@@ -1739,6 +1907,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is dynamic programming?",
+      "ja": "動的計画法（dynamic programming）とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is dynamic programming?",
       "ja": "どうてきけいかくほうとは何か？"
     }
   },
@@ -1778,6 +1950,10 @@
     "id": "q00044",
     "image_path": null,
     "question_text": {
+      "en": "Which sorting algorithm is stable and O(n log n)?",
+      "ja": "安定していて、時間計算量が $O(n \\log n)$ のソートアルゴリズムはどれですか？"
+    },
+    "question_text_reading": {
       "en": "Which sorting algorithm is stable and O(n log n)?",
       "ja": "あんていでO(n log n)のせいれつあるごりずむは？"
     }
@@ -1822,6 +1998,10 @@
     "question_text": {
       "en": "What is Big O notation used for?",
       "ja": "Big O記法は何のために使うか？"
+    },
+    "question_text_reading": {
+      "en": "What is Big O notation used for?",
+      "ja": "Big O記法は何のために使うか？"
     }
   },
   {
@@ -1864,6 +2044,10 @@
     "question_text": {
       "en": "What does Dijkstra's algorithm find?",
       "ja": "ダイクストラのあるごりずむは何を求めるか？"
+    },
+    "question_text_reading": {
+      "en": "What does Dijkstra's algorithm find?",
+      "ja": "ダイクストラのあるごりずむは何を求めるか？"
     }
   },
   {
@@ -1902,6 +2086,10 @@
     "id": "q00047",
     "image_path": null,
     "question_text": {
+      "en": "What is memoization?",
+      "ja": "メモ化とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is memoization?",
       "ja": "めもいぜーしょんとは何か？"
     }
@@ -1944,6 +2132,10 @@
     "image_path": null,
     "question_text": {
       "en": "Which algorithm uses divide and conquer?",
+      "ja": "分割統治法を用いるアルゴリズムはどれですか？"
+    },
+    "question_text_reading": {
+      "en": "Which algorithm uses divide and conquer?",
       "ja": "ぶんちしほうを使うあるごりずむは？"
     }
   },
@@ -1984,6 +2176,10 @@
     "id": "q00049",
     "image_path": null,
     "question_text": {
+      "en": "What is recursion?",
+      "ja": "再帰（recursion）とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is recursion?",
       "ja": "さいきとは何か？"
     }
@@ -2026,6 +2222,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the base case in recursion?",
+      "ja": "再帰におけるベースケースとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the base case in recursion?",
       "ja": "さいきのきていじょうけんとは？"
     }
   },
@@ -2067,6 +2267,10 @@
     "question_text": {
       "en": "Which search requires a sorted array?",
       "ja": "せいれつされたはいれつが必要な探索は？"
+    },
+    "question_text_reading": {
+      "en": "Which search requires a sorted array?",
+      "ja": "せいれつされたはいれつが必要な探索は？"
     }
   },
   {
@@ -2105,6 +2309,10 @@
     "id": "q00052",
     "image_path": null,
     "question_text": {
+      "en": "What is the time complexity of bubble sort?",
+      "ja": "ばぶるそーとの計算量は？"
+    },
+    "question_text_reading": {
       "en": "What is the time complexity of bubble sort?",
       "ja": "ばぶるそーとの計算量は？"
     }
@@ -2149,6 +2357,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is encapsulation?",
+      "ja": "カプセル化とは、どのような概念ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is encapsulation?",
       "ja": "かぷせるかとは何か？"
     }
   },
@@ -2190,6 +2402,10 @@
     "id": "q00054",
     "image_path": null,
     "question_text": {
+      "en": "What is polymorphism?",
+      "ja": "ポリモーフィズムとはどのような概念ですか？"
+    },
+    "question_text_reading": {
       "en": "What is polymorphism?",
       "ja": "たたいせいとは何か？"
     }
@@ -2233,6 +2449,10 @@
     "question_text": {
       "en": "What does `super()` do in OOP?",
       "ja": "OOPで`super()`は何をするか？"
+    },
+    "question_text_reading": {
+      "en": "What does `super()` do in OOP?",
+      "ja": "OOPで`super()`は何をするか？"
     }
   },
   {
@@ -2272,6 +2492,10 @@
     "id": "q00056",
     "image_path": null,
     "question_text": {
+      "en": "What is an abstract class?",
+      "ja": "抽象クラスとはどのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is an abstract class?",
       "ja": "ちゅうしょうくらすとは何か？"
     }
@@ -2314,6 +2538,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is an interface in OOP?",
+      "ja": "OOPにおけるインターフェースとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is an interface in OOP?",
       "ja": "OOPのいんたーふぇーすとは？"
     }
   },
@@ -2354,6 +2582,10 @@
     "image_path": null,
     "question_text": {
       "en": "What pattern ensures a class has only one instance?",
+      "ja": "クラスにインスタンスが一つしか存在しないことを保証するパターンは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What pattern ensures a class has only one instance?",
       "ja": "クラスのいんすたんすをひとつにするぱたーんは？"
     }
   },
@@ -2393,6 +2625,10 @@
     "id": "q00059",
     "image_path": null,
     "question_text": {
+      "en": "What pattern defines a family of algorithms?",
+      "ja": "アルゴリズムの「ファミリー」を定義するパターンとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What pattern defines a family of algorithms?",
       "ja": "あるごりずむのかぞくをていぎするぱたーんは？"
     }
@@ -2437,6 +2673,10 @@
     "image_path": null,
     "question_text": {
       "en": "What does the Observer pattern do?",
+      "ja": "Observerパターンはどのような役割を果たしますか？"
+    },
+    "question_text_reading": {
+      "en": "What does the Observer pattern do?",
       "ja": "おぶざーばーぱたーんは何をするか？"
     }
   },
@@ -2480,6 +2720,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the Factory pattern?",
+      "ja": "ファクトリーパターンとは、どのような設計パターンですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the Factory pattern?",
       "ja": "ふぁくとりーぱたーんとは？"
     }
   },
@@ -2519,6 +2763,10 @@
     "id": "q00062",
     "image_path": null,
     "question_text": {
+      "en": "Which pattern adds behavior without modifying class?",
+      "ja": "クラスのコードを変更せずに振る舞いを追加するパターンはどれ？"
+    },
+    "question_text_reading": {
       "en": "Which pattern adds behavior without modifying class?",
       "ja": "くらすをへんこうせずにどうさをついかするぱたーんは？"
     }
@@ -2562,6 +2810,10 @@
     "question_text": {
       "en": "What does `git stash` do?",
       "ja": "`git stash`は何をするか？"
+    },
+    "question_text_reading": {
+      "en": "What does `git stash` do?",
+      "ja": "`git stash`は何をするか？"
     }
   },
   {
@@ -2601,6 +2853,10 @@
     "id": "q00064",
     "image_path": null,
     "question_text": {
+      "en": "What is a git fork?",
+      "ja": "git forkとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a git fork?",
       "ja": "git forkとは何か？"
     }
@@ -2646,6 +2902,10 @@
     "question_text": {
       "en": "What does `git cherry-pick` do?",
       "ja": "`git cherry-pick`は何をするか？"
+    },
+    "question_text_reading": {
+      "en": "What does `git cherry-pick` do?",
+      "ja": "`git cherry-pick`は何をするか？"
     }
   },
   {
@@ -2685,6 +2945,10 @@
     "id": "q00066",
     "image_path": null,
     "question_text": {
+      "en": "What is a git tag?",
+      "ja": "git tagとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a git tag?",
       "ja": "git tagとは何か？"
     }
@@ -2729,6 +2993,10 @@
     "question_text": {
       "en": "What does `git rebase` do?",
       "ja": "`git rebase`は何をするか？"
+    },
+    "question_text_reading": {
+      "en": "What does `git rebase` do?",
+      "ja": "`git rebase`は何をするか？"
     }
   },
   {
@@ -2767,6 +3035,10 @@
     "id": "q00068",
     "image_path": null,
     "question_text": {
+      "en": "What is unit testing?",
+      "ja": "ユニットテストとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is unit testing?",
       "ja": "ゆにっとてすととは何か？"
     }
@@ -2811,6 +3083,10 @@
     "question_text": {
       "en": "What does TDD stand for?",
       "ja": "TDDの略語の意味は？"
+    },
+    "question_text_reading": {
+      "en": "What does TDD stand for?",
+      "ja": "TDDの略語の意味は？"
     }
   },
   {
@@ -2851,6 +3127,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a mock in testing?",
+      "ja": "テストにおける「mock」とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a mock in testing?",
       "ja": "テストのもっくとは何か？"
     }
   },
@@ -2890,6 +3170,10 @@
     "id": "q00071",
     "image_path": null,
     "question_text": {
+      "en": "What is integration testing?",
+      "ja": "統合テストとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is integration testing?",
       "ja": "とうごうてすととは何か？"
     }
@@ -2935,6 +3219,10 @@
     "question_text": {
       "en": "What does `assert` do in testing?",
       "ja": "テストで`assert`は何をするか？"
+    },
+    "question_text_reading": {
+      "en": "What does `assert` do in testing?",
+      "ja": "テストで`assert`は何をするか？"
     }
   },
   {
@@ -2976,6 +3264,10 @@
     "id": "q00073",
     "image_path": null,
     "question_text": {
+      "en": "What is a pure function?",
+      "ja": "純粋関数（pure function）とはどのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is a pure function?",
       "ja": "じゅんすいかんすうとは何か？"
     }
@@ -3019,6 +3311,10 @@
     "id": "q00074",
     "image_path": null,
     "question_text": {
+      "en": "What is a higher-order function?",
+      "ja": "高階関数（higher-order function）とはどのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is a higher-order function?",
       "ja": "こうかいかんすうとは何か？"
     }
@@ -3065,6 +3361,10 @@
     "question_text": {
       "en": "What is `reduce` used for?",
       "ja": "`reduce`は何に使うか？"
+    },
+    "question_text_reading": {
+      "en": "What is `reduce` used for?",
+      "ja": "`reduce`は何に使うか？"
     }
   },
   {
@@ -3103,6 +3403,10 @@
     "id": "q00076",
     "image_path": null,
     "question_text": {
+      "en": "What is immutability?",
+      "ja": "不変性（immutability）とは、どのような概念ですか？"
+    },
+    "question_text_reading": {
       "en": "What is immutability?",
       "ja": "ふへんせいとは何か？"
     }
@@ -3143,6 +3447,10 @@
     "id": "q00077",
     "image_path": null,
     "question_text": {
+      "en": "What is function composition?",
+      "ja": "関数合成とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is function composition?",
       "ja": "かんすうごうせいとは何か？"
     }
@@ -3185,6 +3493,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is static typing?",
+      "ja": "静的型付けとは、どのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is static typing?",
       "ja": "せいてきがたずけとは何か？"
     }
   },
@@ -3225,6 +3537,10 @@
     "id": "q00079",
     "image_path": null,
     "question_text": {
+      "en": "What is type inference?",
+      "ja": "型推論とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is type inference?",
       "ja": "がたすいろんとは何か？"
     }
@@ -3267,6 +3583,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a generic type?",
+      "ja": "ジェネリック型とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a generic type?",
       "ja": "じぇねりっくがたとは何か？"
     }
   },
@@ -3307,6 +3627,10 @@
     "id": "q00081",
     "image_path": null,
     "question_text": {
+      "en": "What is a deadlock?",
+      "ja": "デッドロックとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a deadlock?",
       "ja": "でっどろっくとは何か？"
     }
@@ -3350,6 +3674,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a mutex?",
+      "ja": "mutexとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a mutex?",
       "ja": "みゅーてっくすとは何か？"
     }
   },
@@ -3390,6 +3718,10 @@
     "id": "q00083",
     "image_path": null,
     "question_text": {
+      "en": "What is a race condition?",
+      "ja": "競合状態とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a race condition?",
       "ja": "れーすじょうけんとは何か？"
     }
@@ -3435,6 +3767,10 @@
     "question_text": {
       "en": "What is async/await used for?",
       "ja": "async/awaitは何のために使うか？"
+    },
+    "question_text_reading": {
+      "en": "What is async/await used for?",
+      "ja": "async/awaitは何のために使うか？"
     }
   },
   {
@@ -3474,6 +3810,10 @@
     "id": "q00085",
     "image_path": null,
     "question_text": {
+      "en": "What is a thread?",
+      "ja": "スレッドとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a thread?",
       "ja": "すれっどとは何か？"
     }
@@ -3515,6 +3855,10 @@
     "id": "q00086",
     "image_path": null,
     "question_text": {
+      "en": "What is a memory leak?",
+      "ja": "メモリリークとはどのような現象ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a memory leak?",
       "ja": "めもりりーくとは何か？"
     }
@@ -3559,6 +3903,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is garbage collection?",
+      "ja": "ガベージコレクションとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is garbage collection?",
       "ja": "がーびっじこれくしょんとは何か？"
     }
   },
@@ -3599,6 +3947,10 @@
     "id": "q00088",
     "image_path": null,
     "question_text": {
+      "en": "What is a stack overflow?",
+      "ja": "スタックオーバーフローとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a stack overflow?",
       "ja": "すたっくおーばーふろーとは何か？"
     }
@@ -3641,6 +3993,10 @@
     "id": "q00089",
     "image_path": null,
     "question_text": {
+      "en": "What is the heap in memory?",
+      "ja": "メモリにおけるヒープとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the heap in memory?",
       "ja": "めもりのひーぷとは何か？"
     }
@@ -3687,6 +4043,10 @@
     "question_text": {
       "en": "What does HTTP stand for?",
       "ja": "HTTPの略語の意味は？"
+    },
+    "question_text_reading": {
+      "en": "What does HTTP stand for?",
+      "ja": "HTTPの略語の意味は？"
     }
   },
   {
@@ -3726,6 +4086,10 @@
     "id": "q00091",
     "image_path": null,
     "question_text": {
+      "en": "What is an IP address?",
+      "ja": "IPアドレスとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is an IP address?",
       "ja": "IPあどれすとは何か？"
     }
@@ -3769,6 +4133,10 @@
     "question_text": {
       "en": "What does DNS do?",
       "ja": "DNSは何をするか？"
+    },
+    "question_text_reading": {
+      "en": "What does DNS do?",
+      "ja": "DNSは何をするか？"
     }
   },
   {
@@ -3810,6 +4178,10 @@
     "question_text": {
       "en": "What is a REST API?",
       "ja": "REST APIとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a REST API?",
+      "ja": "REST APIとは何か？"
     }
   },
   {
@@ -3848,6 +4220,10 @@
     "id": "q00094",
     "image_path": null,
     "question_text": {
+      "en": "What HTTP method is used to update a resource?",
+      "ja": "リソースを更新するために使用されるHTTPメソッドはどれですか？"
+    },
+    "question_text_reading": {
       "en": "What HTTP method is used to update a resource?",
       "ja": "りそーすをこうしんするHTTPめそっどは？"
     }
@@ -3888,6 +4264,10 @@
     "id": "q00095",
     "image_path": null,
     "question_text": {
+      "en": "Which command lists files in Linux?",
+      "ja": "Linuxでファイル一覧を表示するコマンドは何ですか？"
+    },
+    "question_text_reading": {
       "en": "Which command lists files in Linux?",
       "ja": "Linuxでふぁいるをいちらんするこまんどは？"
     }
@@ -3931,6 +4311,10 @@
     "question_text": {
       "en": "What does `chmod 755` do?",
       "ja": "`chmod 755`は何をするか？"
+    },
+    "question_text_reading": {
+      "en": "What does `chmod 755` do?",
+      "ja": "`chmod 755`は何をするか？"
     }
   },
   {
@@ -3970,6 +4354,10 @@
     "id": "q00097",
     "image_path": null,
     "question_text": {
+      "en": "What is a shebang line?",
+      "ja": "shebang lineとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a shebang line?",
       "ja": "しぇばんらいんとは何か？"
     }
@@ -4012,6 +4400,10 @@
     "question_text": {
       "en": "What does `grep` do?",
       "ja": "`grep`は何をするか？"
+    },
+    "question_text_reading": {
+      "en": "What does `grep` do?",
+      "ja": "`grep`は何をするか？"
     }
   },
   {
@@ -4051,6 +4443,10 @@
     "id": "q00099",
     "image_path": null,
     "question_text": {
+      "en": "What does `|` (pipe) do in shell?",
+      "ja": "シェルにおけるパイプ記号「|」は何の役割を果たしますか？"
+    },
+    "question_text_reading": {
       "en": "What does `|` (pipe) do in shell?",
       "ja": "しぇるの`|`（ぱいぷ）は何をするか？"
     }
@@ -4095,6 +4491,10 @@
     "question_text": {
       "en": "What does SQL stand for?",
       "ja": "SQLの略語の意味は？"
+    },
+    "question_text_reading": {
+      "en": "What does SQL stand for?",
+      "ja": "SQLの略語の意味は？"
     }
   },
   {
@@ -4136,6 +4536,10 @@
     "id": "q00101",
     "image_path": null,
     "question_text": {
+      "en": "What is a primary key?",
+      "ja": "プライマリキーとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a primary key?",
       "ja": "しゅきーとは何か？"
     }
@@ -4180,6 +4584,10 @@
     "question_text": {
       "en": "What is a JOIN in SQL?",
       "ja": "SQLのJOINとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a JOIN in SQL?",
+      "ja": "SQLのJOINとは何か？"
     }
   },
   {
@@ -4220,6 +4628,10 @@
     "id": "q00103",
     "image_path": null,
     "question_text": {
+      "en": "What is indexing in databases?",
+      "ja": "データベースにおけるインデックスとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is indexing in databases?",
       "ja": "でーたべーすのいんでくすとは何か？"
     }
@@ -4262,6 +4674,10 @@
     "id": "q00104",
     "image_path": null,
     "question_text": {
+      "en": "What is a transaction in databases?",
+      "ja": "データベースにおけるトランザクションとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a transaction in databases?",
       "ja": "でーたべーすのとらんざくしょんとは何か？"
     }
@@ -4306,6 +4722,10 @@
     "question_text": {
       "en": "What does ACID stand for?",
       "ja": "ACIDの略語の意味は？"
+    },
+    "question_text_reading": {
+      "en": "What does ACID stand for?",
+      "ja": "ACIDの略語の意味は？"
     }
   },
   {
@@ -4346,6 +4766,10 @@
     "id": "q00106",
     "image_path": null,
     "question_text": {
+      "en": "What is SQL injection?",
+      "ja": "SQL injectionとは、どのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is SQL injection?",
       "ja": "SQLいんじぇくしょんとは何か？"
     }
@@ -4388,6 +4812,10 @@
     "id": "q00107",
     "image_path": null,
     "question_text": {
+      "en": "What is XSS?",
+      "ja": "XSSとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is XSS?",
       "ja": "XSSとは何か？"
     }
@@ -4433,6 +4861,10 @@
     "question_text": {
       "en": "What is HTTPS?",
       "ja": "HTTPSとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is HTTPS?",
+      "ja": "HTTPSとは何か？"
     }
   },
   {
@@ -4476,6 +4908,10 @@
     "question_text": {
       "en": "What is a CSRF attack?",
       "ja": "CSRF攻撃とは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a CSRF attack?",
+      "ja": "CSRF攻撃とは何か？"
     }
   },
   {
@@ -4516,6 +4952,10 @@
     "id": "q00110",
     "image_path": null,
     "question_text": {
+      "en": "What is hashing in security?",
+      "ja": "セキュリティにおけるハッシュとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is hashing in security?",
       "ja": "せきゅりてぃのはっしゅかとは何か？"
     }
@@ -4559,6 +4999,10 @@
     "question_text": {
       "en": "What is Docker?",
       "ja": "Dockerとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is Docker?",
+      "ja": "Dockerとは何か？"
     }
   },
   {
@@ -4597,6 +5041,10 @@
     "id": "q00112",
     "image_path": null,
     "question_text": {
+      "en": "What is Kubernetes?",
+      "ja": "Kubernetesとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is Kubernetes?",
       "ja": "Kubernetesとは何か？"
     }
@@ -4640,6 +5088,10 @@
     "id": "q00113",
     "image_path": null,
     "question_text": {
+      "en": "What is CI/CD?",
+      "ja": "CI/CDとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is CI/CD?",
       "ja": "CI/CDとは何か？"
     }
@@ -4686,6 +5138,10 @@
     "question_text": {
       "en": "What is Infrastructure as Code?",
       "ja": "Infrastructure as Codeとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is Infrastructure as Code?",
+      "ja": "Infrastructure as Codeとは何か？"
     }
   },
   {
@@ -4728,6 +5184,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a microservice?",
+      "ja": "マイクロサービスとはどのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a microservice?",
       "ja": "まいくろさーびすとは何か？"
     }
   },
@@ -4767,6 +5227,10 @@
     "id": "q00116",
     "image_path": null,
     "question_text": {
+      "en": "What is an API?",
+      "ja": "APIとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is an API?",
       "ja": "APIとは何か？"
     }
@@ -4811,6 +5275,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is open source software?",
+      "ja": "オープンソースソフトウェアとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is open source software?",
       "ja": "おーぷんそーすそふとうぇあとは何か？"
     }
   },
@@ -4852,6 +5320,10 @@
     "id": "q00118",
     "image_path": null,
     "question_text": {
+      "en": "What is semantic versioning?",
+      "ja": "セマンティックバージョニングとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is semantic versioning?",
       "ja": "せまんてぃっくばーじょにんぐとは何か？"
     }
@@ -4896,6 +5368,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a linter?",
+      "ja": "リンターとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a linter?",
       "ja": "りんたーとは何か？"
     }
   },
@@ -4938,6 +5414,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is refactoring?",
+      "ja": "リファクタリングとは、どのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is refactoring?",
       "ja": "りふぁくたりんぐとは何か？"
     }
   },
@@ -4978,6 +5458,10 @@
     "id": "q00121",
     "image_path": null,
     "question_text": {
+      "en": "What is technical debt?",
+      "ja": "技術的負債とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is technical debt?",
       "ja": "ぎじゅつてきふさいとは何か？"
     }
@@ -5023,6 +5507,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is code review?",
+      "ja": "コードレビューとは、どのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is code review?",
       "ja": "こーどれびゅーとは何か？"
     }
   },
@@ -5067,6 +5555,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a build system?",
+      "ja": "ビルドシステムとは、どのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a build system?",
       "ja": "びるどしすてむとは何か？"
     }
   },
@@ -5109,6 +5601,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is dependency injection?",
+      "ja": "依存性の注入とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is dependency injection?",
       "ja": "いぞんせいのちゅうにゅうとは何か？"
     }
   },
@@ -5149,6 +5645,10 @@
     "id": "q00125",
     "image_path": null,
     "question_text": {
+      "en": "What is an event loop?",
+      "ja": "イベントループとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is an event loop?",
       "ja": "いべんとるーぷとは何か？"
     }
@@ -5193,6 +5693,10 @@
     "question_text": {
       "en": "What is the DOM?",
       "ja": "DOMとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is the DOM?",
+      "ja": "DOMとは何か？"
     }
   },
   {
@@ -5231,6 +5735,10 @@
     "id": "q00127",
     "image_path": null,
     "question_text": {
+      "en": "What is event bubbling?",
+      "ja": "イベントバブリングとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is event bubbling?",
       "ja": "いべんとばぶりんぐとは何か？"
     }
@@ -5274,6 +5782,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is lazy loading?",
+      "ja": "遅延読み込みとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is lazy loading?",
       "ja": "れいじーろーでぃんぐとは何か？"
     }
   },
@@ -5314,6 +5826,10 @@
     "id": "q00129",
     "image_path": null,
     "question_text": {
+      "en": "What is tree shaking?",
+      "ja": "ツリーシェイキングとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is tree shaking?",
       "ja": "つりーしぇいきんぐとは何か？"
     }
@@ -5357,6 +5873,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a code smell?",
+      "ja": "コードスメルとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a code smell?",
       "ja": "こーどすめるとは何か？"
     }
   },
@@ -5399,6 +5919,10 @@
     "id": "q00131",
     "image_path": null,
     "question_text": {
+      "en": "What is pair programming?",
+      "ja": "ペアプログラミングとはどのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is pair programming?",
       "ja": "ぺあぷろぐらみんぐとは何か？"
     }
@@ -5444,6 +5968,10 @@
     "question_text": {
       "en": "What is an IDE?",
       "ja": "IDEとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is an IDE?",
+      "ja": "IDEとは何か？"
     }
   },
   {
@@ -5482,6 +6010,10 @@
     "id": "q00133",
     "image_path": null,
     "question_text": {
+      "en": "What is duck typing?",
+      "ja": "ダックタイピングとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is duck typing?",
       "ja": "だっくたいぴんぐとは何か？"
     }
@@ -5525,6 +6057,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a closure?",
+      "ja": "クローズ（closure）とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a closure?",
       "ja": "くろーじゃとは何か？"
     }
   },
@@ -5564,6 +6100,10 @@
     "id": "q00135",
     "image_path": null,
     "question_text": {
+      "en": "What is currying?",
+      "ja": "カリー化とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is currying?",
       "ja": "かりーかとは何か？"
     }
@@ -5608,6 +6148,10 @@
     "question_text": {
       "en": "What is WebAssembly (WASM)?",
       "ja": "WebAssembly (WASM)とは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is WebAssembly (WASM)?",
+      "ja": "WebAssembly (WASM)とは何か？"
     }
   },
   {
@@ -5647,6 +6191,10 @@
     "id": "q00137",
     "image_path": null,
     "question_text": {
+      "en": "What is a prototype in JavaScript?",
+      "ja": "JavaScriptのぷろとたいぷとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a prototype in JavaScript?",
       "ja": "JavaScriptのぷろとたいぷとは何か？"
     }
@@ -5692,6 +6240,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is method chaining?",
+      "ja": "メソッドチェーンとは、どのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is method chaining?",
       "ja": "めそっどちぇーにんぐとは何か？"
     }
   },
@@ -5734,6 +6286,10 @@
     "question_text": {
       "en": "What is the SOLID principle?",
       "ja": "SOLIDげんそくとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is the SOLID principle?",
+      "ja": "SOLIDげんそくとは何か？"
     }
   },
   {
@@ -5773,6 +6329,10 @@
     "id": "q00140",
     "image_path": null,
     "question_text": {
+      "en": "What is DRY principle?",
+      "ja": "DRY原則とは、どのような考え方ですか？"
+    },
+    "question_text_reading": {
       "en": "What is DRY principle?",
       "ja": "DRYげんそくとは何か？"
     }
@@ -5815,6 +6375,10 @@
     "question_text": {
       "en": "What is KISS principle?",
       "ja": "KISSげんそくとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is KISS principle?",
+      "ja": "KISSげんそくとは何か？"
     }
   },
   {
@@ -5853,6 +6417,10 @@
     "id": "q00142",
     "image_path": null,
     "question_text": {
+      "en": "What is a webhook?",
+      "ja": "webhookとはどのような仕組みですか？"
+    },
+    "question_text_reading": {
       "en": "What is a webhook?",
       "ja": "うぇぶふっくとは何か？"
     }
@@ -5895,6 +6463,10 @@
     "question_text": {
       "en": "What is GraphQL?",
       "ja": "GraphQLとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is GraphQL?",
+      "ja": "GraphQLとは何か？"
     }
   },
   {
@@ -5933,6 +6505,10 @@
     "id": "q00144",
     "image_path": null,
     "question_text": {
+      "en": "What is server-side rendering?",
+      "ja": "サーバーサイドレンダリングとは、どのような仕組みのことですか？"
+    },
+    "question_text_reading": {
       "en": "What is server-side rendering?",
       "ja": "さーばーさいどれんだりんぐとは何か？"
     }
@@ -5975,6 +6551,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is hydration in web development?",
+      "ja": "Web開発における「hydration」とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is hydration in web development?",
       "ja": "うぇぶかいはつのはいどれーしょんとは何か？"
     }
   },
@@ -6014,6 +6594,10 @@
     "id": "q00146",
     "image_path": null,
     "question_text": {
+      "en": "What is a module in programming?",
+      "ja": "プログラミングにおける「モジュール」とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a module in programming?",
       "ja": "ぷろぐらみんぐのもじゅーるとは何か？"
     }
@@ -6056,6 +6640,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is package management?",
+      "ja": "パッケージ管理とは、どのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is package management?",
       "ja": "ぱっけーじかんりとは何か？"
     }
   },
@@ -6095,6 +6683,10 @@
     "id": "q00148",
     "image_path": null,
     "question_text": {
+      "en": "What is environment variable?",
+      "ja": "環境変数とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is environment variable?",
       "ja": "かんきょうへんすうとは何か？"
     }
@@ -6139,6 +6731,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a race condition in databases?",
+      "ja": "データベースにおける「race condition」とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a race condition in databases?",
       "ja": "でーたべーすのれーすじょうけんとは何か？"
     }
   },
@@ -6182,6 +6778,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is normalization in databases?",
+      "ja": "データベースにおける正規化（normalization）とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is normalization in databases?",
       "ja": "でーたべーすのせいきかとは何か？"
     }
   },
@@ -6224,6 +6824,10 @@
     "question_text": {
       "en": "What does CSS stand for?",
       "ja": "CSSのふりがなの意味は？"
+    },
+    "question_text_reading": {
+      "en": "What does CSS stand for?",
+      "ja": "CSSのふりがなの意味は？"
     }
   },
   {
@@ -6262,6 +6866,10 @@
     "id": "q00152",
     "image_path": null,
     "question_text": {
+      "en": "Which HTML tag creates a hyperlink?",
+      "ja": "ハイパーリンクをつくるHTMLたぐは？"
+    },
+    "question_text_reading": {
       "en": "Which HTML tag creates a hyperlink?",
       "ja": "ハイパーリンクをつくるHTMLたぐは？"
     }
@@ -6304,6 +6912,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the CSS box model?",
+      "ja": "CSSのボックスモデルとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the CSS box model?",
       "ja": "CSSのぼっくすもでるとは？"
     }
   },
@@ -6343,6 +6955,10 @@
     "id": "q00154",
     "image_path": null,
     "question_text": {
+      "en": "What does `display: flex` enable?",
+      "ja": "`display: flex`は何を可能にするか？"
+    },
+    "question_text_reading": {
       "en": "What does `display: flex` enable?",
       "ja": "`display: flex`は何を可能にするか？"
     }
@@ -6386,6 +7002,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is media query in CSS?",
+      "ja": "CSSにおけるメディアクエリとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is media query in CSS?",
       "ja": "CSSのめでぃあくえりとは？"
     }
   },
@@ -6428,6 +7048,10 @@
     "question_text": {
       "en": "What is React?",
       "ja": "Reactとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is React?",
+      "ja": "Reactとは何か？"
     }
   },
   {
@@ -6467,6 +7091,10 @@
     "id": "q00157",
     "image_path": null,
     "question_text": {
+      "en": "What is a React component?",
+      "ja": "Reactこんぽーねんととは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a React component?",
       "ja": "Reactこんぽーねんととは何か？"
     }
@@ -6512,6 +7140,10 @@
     "question_text": {
       "en": "What is JSX?",
       "ja": "JSXとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is JSX?",
+      "ja": "JSXとは何か？"
     }
   },
   {
@@ -6550,6 +7182,10 @@
     "id": "q00159",
     "image_path": null,
     "question_text": {
+      "en": "What is the virtual DOM in React?",
+      "ja": "Reactにおける仮想DOMとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the virtual DOM in React?",
       "ja": "Reactのばーちゃるどむとは？"
     }
@@ -6592,6 +7228,10 @@
     "id": "q00160",
     "image_path": null,
     "question_text": {
+      "en": "What does `useState` do in React?",
+      "ja": "Reactの`useState`は何をするか？"
+    },
+    "question_text_reading": {
       "en": "What does `useState` do in React?",
       "ja": "Reactの`useState`は何をするか？"
     }
@@ -6637,6 +7277,10 @@
     "question_text": {
       "en": "What does `useEffect` do in React?",
       "ja": "Reactの`useEffect`は何をするか？"
+    },
+    "question_text_reading": {
+      "en": "What does `useEffect` do in React?",
+      "ja": "Reactの`useEffect`は何をするか？"
     }
   },
   {
@@ -6675,6 +7319,10 @@
     "id": "q00162",
     "image_path": null,
     "question_text": {
+      "en": "What is Vue.js?",
+      "ja": "Vue.jsとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is Vue.js?",
       "ja": "Vue.jsとは何か？"
     }
@@ -6718,6 +7366,10 @@
     "question_text": {
       "en": "What is TypeScript?",
       "ja": "TypeScriptとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is TypeScript?",
+      "ja": "TypeScriptとは何か？"
     }
   },
   {
@@ -6756,6 +7408,10 @@
     "id": "q00164",
     "image_path": null,
     "question_text": {
+      "en": "What is npm?",
+      "ja": "npmとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is npm?",
       "ja": "npmとは何か？"
     }
@@ -6799,6 +7455,10 @@
     "question_text": {
       "en": "What is Node.js?",
       "ja": "Node.jsとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is Node.js?",
+      "ja": "Node.jsとは何か？"
     }
   },
   {
@@ -6839,6 +7499,10 @@
     "question_text": {
       "en": "What is Webpack?",
       "ja": "Webpackとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is Webpack?",
+      "ja": "Webpackとは何か？"
     }
   },
   {
@@ -6877,6 +7541,10 @@
     "id": "q00167",
     "image_path": null,
     "question_text": {
+      "en": "What is a SPA?",
+      "ja": "SPAとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a SPA?",
       "ja": "SPAとは何か？"
     }
@@ -6920,6 +7588,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is SSR in web?",
+      "ja": "WebにおけるSSRとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is SSR in web?",
       "ja": "うぇぶのSSRとは？"
     }
   },
@@ -6962,6 +7634,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a cookie?",
+      "ja": "クッキーとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a cookie?",
       "ja": "くっきーとは何か？"
     }
   },
@@ -7003,6 +7679,10 @@
     "question_text": {
       "en": "What is localStorage?",
       "ja": "localStorageとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is localStorage?",
+      "ja": "localStorageとは何か？"
     }
   },
   {
@@ -7042,6 +7722,10 @@
     "id": "q00171",
     "image_path": null,
     "question_text": {
+      "en": "What does `fetch()` do in JS?",
+      "ja": "JSの`fetch()`は何をするか？"
+    },
+    "question_text_reading": {
       "en": "What does `fetch()` do in JS?",
       "ja": "JSの`fetch()`は何をするか？"
     }
@@ -7087,6 +7771,10 @@
     "question_text": {
       "en": "What is CORS?",
       "ja": "CORSとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is CORS?",
+      "ja": "CORSとは何か？"
     }
   },
   {
@@ -7128,6 +7816,10 @@
     "question_text": {
       "en": "What is a CDN?",
       "ja": "CDNとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a CDN?",
+      "ja": "CDNとは何か？"
     }
   },
   {
@@ -7166,6 +7858,10 @@
     "id": "q00174",
     "image_path": null,
     "question_text": {
+      "en": "What is semantic HTML?",
+      "ja": "セマンティックHTMLとは、どのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is semantic HTML?",
       "ja": "せまんてぃっくHTMLとは何か？"
     }
@@ -7206,6 +7902,10 @@
     "id": "q00175",
     "image_path": null,
     "question_text": {
+      "en": "What is the purpose of `<meta charset>`?",
+      "ja": "`<meta charset>`の目的は？"
+    },
+    "question_text_reading": {
       "en": "What is the purpose of `<meta charset>`?",
       "ja": "`<meta charset>`の目的は？"
     }
@@ -7249,6 +7949,10 @@
     "id": "q00176",
     "image_path": null,
     "question_text": {
+      "en": "What is lazy loading in web?",
+      "ja": "Webにおける「lazy loading」とは、どのような仕組みのことですか？"
+    },
+    "question_text_reading": {
       "en": "What is lazy loading in web?",
       "ja": "うぇぶのれいじーろーでぃんぐとは？"
     }
@@ -7294,6 +7998,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is progressive enhancement?",
+      "ja": "プログレッシブエンハンスメントとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is progressive enhancement?",
       "ja": "ぷろぐれっしぶえんはんすめんととは？"
     }
   },
@@ -7335,6 +8043,10 @@
     "id": "q00178",
     "image_path": null,
     "question_text": {
+      "en": "What is a CSS preprocessor?",
+      "ja": "CSSプリプロセッサとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a CSS preprocessor?",
       "ja": "CSSぷりぷろせっさとは何か？"
     }
@@ -7378,6 +8090,10 @@
     "question_text": {
       "en": "What is Tailwind CSS?",
       "ja": "Tailwind CSSとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is Tailwind CSS?",
+      "ja": "Tailwind CSSとは何か？"
     }
   },
   {
@@ -7419,6 +8135,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is tree shaking in frontend?",
+      "ja": "フロントエンドにおけるツリーシェイキングとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is tree shaking in frontend?",
       "ja": "ふろんとえんどのつりーしぇいきんぐとは？"
     }
   },
@@ -7459,6 +8179,10 @@
     "id": "q00181",
     "image_path": null,
     "question_text": {
+      "en": "What is the purpose of `<head>` in HTML?",
+      "ja": "HTMLの`<head>`の役割は？"
+    },
+    "question_text_reading": {
       "en": "What is the purpose of `<head>` in HTML?",
       "ja": "HTMLの`<head>`の役割は？"
     }
@@ -7505,6 +8229,10 @@
     "question_text": {
       "en": "What does `position: absolute` do in CSS?",
       "ja": "CSSの`position: absolute`は何をするか？"
+    },
+    "question_text_reading": {
+      "en": "What does `position: absolute` do in CSS?",
+      "ja": "CSSの`position: absolute`は何をするか？"
     }
   },
   {
@@ -7546,6 +8274,10 @@
     "id": "q00183",
     "image_path": null,
     "question_text": {
+      "en": "What is z-index in CSS?",
+      "ja": "CSSのz-indexとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is z-index in CSS?",
       "ja": "CSSのz-indexとは何か？"
     }
@@ -7591,6 +8323,10 @@
     "question_text": {
       "en": "What is BEM in CSS?",
       "ja": "CSSのBEMとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is BEM in CSS?",
+      "ja": "CSSのBEMとは何か？"
     }
   },
   {
@@ -7630,6 +8366,10 @@
     "id": "q00185",
     "image_path": null,
     "question_text": {
+      "en": "What is a CSS variable?",
+      "ja": "CSS変数とは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a CSS variable?",
       "ja": "CSS変数とは何か？"
     }
@@ -7673,6 +8413,10 @@
     "question_text": {
       "en": "What is accessibility (a11y) in web?",
       "ja": "うぇぶのアクセシビリティとは？"
+    },
+    "question_text_reading": {
+      "en": "What is accessibility (a11y) in web?",
+      "ja": "うぇぶのアクセシビリティとは？"
     }
   },
   {
@@ -7713,6 +8457,10 @@
     "id": "q00187",
     "image_path": null,
     "question_text": {
+      "en": "What is ARIA in web accessibility?",
+      "ja": "ウェブアクセシビリティにおけるARIAとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is ARIA in web accessibility?",
       "ja": "うぇぶのARIAとは？"
     }
@@ -7756,6 +8504,10 @@
     "question_text": {
       "en": "What is PWA?",
       "ja": "PWAとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is PWA?",
+      "ja": "PWAとは何か？"
     }
   },
   {
@@ -7795,6 +8547,10 @@
     "id": "q00189",
     "image_path": null,
     "question_text": {
+      "en": "What is a service worker?",
+      "ja": "サービスワーカーとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a service worker?",
       "ja": "さーびすわーかーとは何か？"
     }
@@ -7838,6 +8594,10 @@
     "question_text": {
       "en": "What is Next.js?",
       "ja": "Next.jsとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is Next.js?",
+      "ja": "Next.jsとは何か？"
     }
   },
   {
@@ -7876,6 +8636,10 @@
     "id": "q00191",
     "image_path": null,
     "question_text": {
+      "en": "What is SvelteKit?",
+      "ja": "SvelteKitとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is SvelteKit?",
       "ja": "SvelteKitとは何か？"
     }
@@ -7922,6 +8686,10 @@
     "question_text": {
       "en": "What is the purpose of `alt` attribute in `<img>`?",
       "ja": "`<img>`の`alt`属性の目的は？"
+    },
+    "question_text_reading": {
+      "en": "What is the purpose of `alt` attribute in `<img>`?",
+      "ja": "`<img>`の`alt`属性の目的は？"
     }
   },
   {
@@ -7963,6 +8731,10 @@
     "id": "q00193",
     "image_path": null,
     "question_text": {
+      "en": "What is HTTP/2 improvement?",
+      "ja": "HTTP/2の改善点は？"
+    },
+    "question_text_reading": {
       "en": "What is HTTP/2 improvement?",
       "ja": "HTTP/2の改善点は？"
     }
@@ -8007,6 +8779,10 @@
     "question_text": {
       "en": "What is WebSocket?",
       "ja": "WebSocketとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is WebSocket?",
+      "ja": "WebSocketとは何か？"
     }
   },
   {
@@ -8046,6 +8822,10 @@
     "id": "q00195",
     "image_path": null,
     "question_text": {
+      "en": "What is the Shadow DOM?",
+      "ja": "シャドウDOMとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is the Shadow DOM?",
       "ja": "シャドウDOMとは何か？"
     }
@@ -8089,6 +8869,10 @@
     "id": "q00196",
     "image_path": null,
     "question_text": {
+      "en": "What is a custom HTML element?",
+      "ja": "カスタムHTML要素とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a custom HTML element?",
       "ja": "かすたむHTMLようそとは何か？"
     }
@@ -8134,6 +8918,10 @@
     "question_text": {
       "en": "What is `defer` attribute in `<script>`?",
       "ja": "`<script>`の`defer`属性は何をするか？"
+    },
+    "question_text_reading": {
+      "en": "What is `defer` attribute in `<script>`?",
+      "ja": "`<script>`の`defer`属性は何をするか？"
     }
   },
   {
@@ -8176,6 +8964,10 @@
     "question_text": {
       "en": "What is the difference between `em` and `rem` in CSS?",
       "ja": "CSSの`em`と`rem`のちがいは？"
+    },
+    "question_text_reading": {
+      "en": "What is the difference between `em` and `rem` in CSS?",
+      "ja": "CSSの`em`と`rem`のちがいは？"
     }
   },
   {
@@ -8214,6 +9006,10 @@
     "id": "q00199",
     "image_path": null,
     "question_text": {
+      "en": "What is a CSS grid?",
+      "ja": "CSS gridとはどのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is a CSS grid?",
       "ja": "CSSぐりっどとは何か？"
     }
@@ -8258,6 +9054,10 @@
     "question_text": {
       "en": "What is viewport in CSS?",
       "ja": "CSSのびゅーぽーととは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is viewport in CSS?",
+      "ja": "CSSのびゅーぽーととは何か？"
     }
   },
   {
@@ -8298,6 +9098,10 @@
     "id": "q00201",
     "image_path": null,
     "question_text": {
+      "en": "What is minification in web?",
+      "ja": "ウェブにおける「minification」とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is minification in web?",
       "ja": "うぇぶのみにふぁいとは何か？"
     }
@@ -8340,6 +9144,10 @@
     "id": "q00202",
     "image_path": null,
     "question_text": {
+      "en": "What is code splitting?",
+      "ja": "コードスプリッティングとは、どのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is code splitting?",
       "ja": "こーどすぷりってぃんぐとは何か？"
     }
@@ -8386,6 +9194,10 @@
     "question_text": {
       "en": "What does `async` attribute do in `<script>`?",
       "ja": "`<script>`の`async`属性は何をするか？"
+    },
+    "question_text_reading": {
+      "en": "What does `async` attribute do in `<script>`?",
+      "ja": "`<script>`の`async`属性は何をするか？"
     }
   },
   {
@@ -8429,6 +9241,10 @@
     "question_text": {
       "en": "What is OAuth?",
       "ja": "OAuthとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is OAuth?",
+      "ja": "OAuthとは何か？"
     }
   },
   {
@@ -8470,6 +9286,10 @@
     "question_text": {
       "en": "What is JWT?",
       "ja": "JWTとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is JWT?",
+      "ja": "JWTとは何か？"
     }
   },
   {
@@ -8508,6 +9328,10 @@
     "id": "q00206",
     "image_path": null,
     "question_text": {
+      "en": "What is a headless CMS?",
+      "ja": "ヘッドレスCMSとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a headless CMS?",
       "ja": "へっどれすCMSとは何か？"
     }
@@ -8549,6 +9373,10 @@
     "id": "q00207",
     "image_path": null,
     "question_text": {
+      "en": "What is a sitemap?",
+      "ja": "sitemapとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a sitemap?",
       "ja": "さいとまっぷとは何か？"
     }
@@ -8593,6 +9421,10 @@
     "question_text": {
       "en": "What is SEO?",
       "ja": "SEOとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is SEO?",
+      "ja": "SEOとは何か？"
     }
   },
   {
@@ -8633,6 +9465,10 @@
     "id": "q00209",
     "image_path": null,
     "question_text": {
+      "en": "What is Core Web Vitals?",
+      "ja": "Core Web Vitalsとは、どのような指標のことですか？"
+    },
+    "question_text_reading": {
       "en": "What is Core Web Vitals?",
       "ja": "コアうぇぶばいたるずとは何か？"
     }
@@ -8676,6 +9512,10 @@
     "image_path": null,
     "question_text": {
       "en": "What does LCP stand for in web performance?",
+      "ja": "ウェブパフォーマンスにおけるLCPとは何の略ですか？"
+    },
+    "question_text_reading": {
+      "en": "What does LCP stand for in web performance?",
       "ja": "うぇぶぱふぉーまんすのLCPとは？"
     }
   },
@@ -8715,6 +9555,10 @@
     "id": "q00211",
     "image_path": null,
     "question_text": {
+      "en": "What is a web manifest file?",
+      "ja": "ウェブマニフェストファイルとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a web manifest file?",
       "ja": "うぇぶましふぇすとふぁいるとは？"
     }
@@ -8757,6 +9601,10 @@
     "id": "q00212",
     "image_path": null,
     "question_text": {
+      "en": "What is isomorphic rendering?",
+      "ja": "isomorphic renderingとはどのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is isomorphic rendering?",
       "ja": "あいそもーふぃっくれんだりんぐとは？"
     }
@@ -8801,6 +9649,10 @@
     "question_text": {
       "en": "What is Vite?",
       "ja": "Viteとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is Vite?",
+      "ja": "Viteとは何か？"
     }
   },
   {
@@ -8841,6 +9693,10 @@
     "question_text": {
       "en": "What is ESLint?",
       "ja": "ESLintとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is ESLint?",
+      "ja": "ESLintとは何か？"
     }
   },
   {
@@ -8879,6 +9735,10 @@
     "id": "q00215",
     "image_path": null,
     "question_text": {
+      "en": "What is Prettier?",
+      "ja": "Prettierとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is Prettier?",
       "ja": "Prettierとは何か？"
     }
@@ -8922,6 +9782,10 @@
     "question_text": {
       "en": "What is an HTTP header?",
       "ja": "HTTPへっだーとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is an HTTP header?",
+      "ja": "HTTPへっだーとは何か？"
     }
   },
   {
@@ -8960,6 +9824,10 @@
     "id": "q00217",
     "image_path": null,
     "question_text": {
+      "en": "What is a 404 error?",
+      "ja": "404えらーとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a 404 error?",
       "ja": "404えらーとは何か？"
     }
@@ -9001,6 +9869,10 @@
     "id": "q00218",
     "image_path": null,
     "question_text": {
+      "en": "What is a 500 error?",
+      "ja": "500えらーとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a 500 error?",
       "ja": "500えらーとは何か？"
     }
@@ -9046,6 +9918,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a redirect in HTTP?",
+      "ja": "HTTPにおけるリダイレクトとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a redirect in HTTP?",
       "ja": "HTTPのりだいれくととは何か？"
     }
   },
@@ -9089,6 +9965,10 @@
     "question_text": {
       "en": "What is Cross-Site Scripting (XSS) prevented by?",
       "ja": "XSSを防ぐには何をするか？"
+    },
+    "question_text_reading": {
+      "en": "What is Cross-Site Scripting (XSS) prevented by?",
+      "ja": "XSSを防ぐには何をするか？"
     }
   },
   {
@@ -9130,6 +10010,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is Content Security Policy?",
+      "ja": "Content Security Policy（CSP）とは、どのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is Content Security Policy?",
       "ja": "コンテンツせきゅりてぃぽりしーとは何か？"
     }
   },
@@ -9170,6 +10054,10 @@
     "id": "q00222",
     "image_path": null,
     "question_text": {
+      "en": "What is a REST endpoint?",
+      "ja": "RESTエンドポイントとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a REST endpoint?",
       "ja": "RESTえんどぽいんととは何か？"
     }
@@ -9215,6 +10103,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is event delegation in JS?",
+      "ja": "JSにおけるイベントデリゲーションとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is event delegation in JS?",
       "ja": "JSのいべんとでりげーしょんとは？"
     }
   },
@@ -9257,6 +10149,10 @@
     "id": "q00224",
     "image_path": null,
     "question_text": {
+      "en": "What is debouncing in JS?",
+      "ja": "JSにおける「デバウンス（debouncing）」とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is debouncing in JS?",
       "ja": "JSのでばうんすとは何か？"
     }
@@ -9302,6 +10198,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is throttling in JS?",
+      "ja": "JSにおける「throttling」とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is throttling in JS?",
       "ja": "JSのすろっとりんぐとは何か？"
     }
   },
@@ -9343,6 +10243,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a web component?",
+      "ja": "Web Componentとはどのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a web component?",
       "ja": "うぇぶこんぽーねんととは何か？"
     }
   },
@@ -9383,6 +10287,10 @@
     "id": "q00227",
     "image_path": null,
     "question_text": {
+      "en": "What is an HTTP cache?",
+      "ja": "HTTPキャッシュとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is an HTTP cache?",
       "ja": "HTTPきゃっしゅとは何か？"
     }
@@ -9427,6 +10335,10 @@
     "question_text": {
       "en": "What is JSON Web Token (JWT) used for?",
       "ja": "JWTは何のために使うか？"
+    },
+    "question_text_reading": {
+      "en": "What is JSON Web Token (JWT) used for?",
+      "ja": "JWTは何のために使うか？"
     }
   },
   {
@@ -9465,6 +10377,10 @@
     "id": "q00229",
     "image_path": null,
     "question_text": {
+      "en": "What is Nuxt.js?",
+      "ja": "Nuxt.jsとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is Nuxt.js?",
       "ja": "Nuxt.jsとは何か？"
     }
@@ -9508,6 +10424,10 @@
     "question_text": {
       "en": "What is Astro?",
       "ja": "Astroとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is Astro?",
+      "ja": "Astroとは何か？"
     }
   },
   {
@@ -9548,6 +10468,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a monorepo?",
+      "ja": "モノレポとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a monorepo?",
       "ja": "ものりぽとは何か？"
     }
   },
@@ -9587,6 +10511,10 @@
     "id": "q00232",
     "image_path": null,
     "question_text": {
+      "en": "What is Storybook?",
+      "ja": "Storybookとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is Storybook?",
       "ja": "Storybookとは何か？"
     }
@@ -9630,6 +10558,10 @@
     "question_text": {
       "en": "What is Playwright?",
       "ja": "Playwrightとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is Playwright?",
+      "ja": "Playwrightとは何か？"
     }
   },
   {
@@ -9669,6 +10601,10 @@
     "id": "q00234",
     "image_path": null,
     "question_text": {
+      "en": "What is tRPC?",
+      "ja": "tRPCとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is tRPC?",
       "ja": "tRPCとは何か？"
     }
@@ -9711,6 +10647,10 @@
     "question_text": {
       "en": "What is Cloudflare Workers?",
       "ja": "Cloudflare Workersとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is Cloudflare Workers?",
+      "ja": "Cloudflare Workersとは何か？"
     }
   },
   {
@@ -9749,6 +10689,10 @@
     "id": "q00236",
     "image_path": null,
     "question_text": {
+      "en": "What is Vercel?",
+      "ja": "Vercelとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is Vercel?",
       "ja": "Vercelとは何か？"
     }
@@ -9791,6 +10735,10 @@
     "question_text": {
       "en": "What is the purpose of `robots.txt`?",
       "ja": "`robots.txt`の目的は？"
+    },
+    "question_text_reading": {
+      "en": "What is the purpose of `robots.txt`?",
+      "ja": "`robots.txt`の目的は？"
     }
   },
   {
@@ -9829,6 +10777,10 @@
     "id": "q00238",
     "image_path": null,
     "question_text": {
+      "en": "What is open graph protocol?",
+      "ja": "open graph protocolとはどのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is open graph protocol?",
       "ja": "おーぷんぐらふぷろとこるとは？"
     }
@@ -9870,6 +10822,10 @@
     "id": "q00239",
     "image_path": null,
     "question_text": {
+      "en": "What is an operating system?",
+      "ja": "オペレーティングシステム（OS）とは、どのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is an operating system?",
       "ja": "おぺれーてぃんぐしすてむとは何か？"
     }
@@ -9913,6 +10869,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is virtualization?",
+      "ja": "仮想化とはどのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is virtualization?",
       "ja": "かそうかとは何か？"
     }
   },
@@ -9952,6 +10912,10 @@
     "id": "q00241",
     "image_path": null,
     "question_text": {
+      "en": "What is a kernel?",
+      "ja": "カーネルとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a kernel?",
       "ja": "かーねるとは何か？"
     }
@@ -9995,6 +10959,10 @@
     "question_text": {
       "en": "What is BIOS?",
       "ja": "BIOSとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is BIOS?",
+      "ja": "BIOSとは何か？"
     }
   },
   {
@@ -10034,6 +11002,10 @@
     "id": "q00243",
     "image_path": null,
     "question_text": {
+      "en": "What is SSD?",
+      "ja": "SSDとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is SSD?",
       "ja": "SSDとは何か？"
     }
@@ -10077,6 +11049,10 @@
     "question_text": {
       "en": "What is RAM?",
       "ja": "RAMとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is RAM?",
+      "ja": "RAMとは何か？"
     }
   },
   {
@@ -10117,6 +11093,10 @@
     "id": "q00245",
     "image_path": null,
     "question_text": {
+      "en": "What is CPU?",
+      "ja": "CPUとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is CPU?",
       "ja": "CPUとは何か？"
     }
@@ -10162,6 +11142,10 @@
     "question_text": {
       "en": "What is GPU?",
       "ja": "GPUとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is GPU?",
+      "ja": "GPUとは何か？"
     }
   },
   {
@@ -10203,6 +11187,10 @@
     "question_text": {
       "en": "What is TCP/IP?",
       "ja": "TCP/IPとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is TCP/IP?",
+      "ja": "TCP/IPとは何か？"
     }
   },
   {
@@ -10241,6 +11229,10 @@
     "id": "q00248",
     "image_path": null,
     "question_text": {
+      "en": "What is a firewall?",
+      "ja": "ファイアウォールとはどのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is a firewall?",
       "ja": "ふぁいあうぉーるとは何か？"
     }
@@ -10286,6 +11278,10 @@
     "question_text": {
       "en": "What is DHCP?",
       "ja": "DHCPとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is DHCP?",
+      "ja": "DHCPとは何か？"
     }
   },
   {
@@ -10324,6 +11320,10 @@
     "id": "q00250",
     "image_path": null,
     "question_text": {
+      "en": "What is a MAC address?",
+      "ja": "MACアドレスとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a MAC address?",
       "ja": "MACあどれすとは何か？"
     }
@@ -10369,6 +11369,10 @@
     "question_text": {
       "en": "What is a VPN?",
       "ja": "VPNとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a VPN?",
+      "ja": "VPNとは何か？"
     }
   },
   {
@@ -10410,6 +11414,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is NAT in networking?",
+      "ja": "ネットワークにおけるNATとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is NAT in networking?",
       "ja": "ねっとわーくのNATとは何か？"
     }
   },
@@ -10449,6 +11457,10 @@
     "id": "q00253",
     "image_path": null,
     "question_text": {
+      "en": "What is a subnet?",
+      "ja": "サブネットとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a subnet?",
       "ja": "さぶねっととは何か？"
     }
@@ -10492,6 +11504,10 @@
     "question_text": {
       "en": "What is RAID in storage?",
       "ja": "すとれーじのRAIDとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is RAID in storage?",
+      "ja": "すとれーじのRAIDとは何か？"
     }
   },
   {
@@ -10531,6 +11547,10 @@
     "id": "q00255",
     "image_path": null,
     "question_text": {
+      "en": "What is a load balancer?",
+      "ja": "ロードバランサーとはどのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is a load balancer?",
       "ja": "ろーどばらんさーとは何か？"
     }
@@ -10572,6 +11592,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a proxy server?",
+      "ja": "プロキシサーバーとは、どのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a proxy server?",
       "ja": "ぷろくしさーばーとは何か？"
     }
   },
@@ -10611,6 +11635,10 @@
     "id": "q00257",
     "image_path": null,
     "question_text": {
+      "en": "What is a reverse proxy?",
+      "ja": "リバースプロキシとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a reverse proxy?",
       "ja": "りばーすぷろくしとは何か？"
     }
@@ -10654,6 +11682,10 @@
     "question_text": {
       "en": "What is SSH?",
       "ja": "SSHとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is SSH?",
+      "ja": "SSHとは何か？"
     }
   },
   {
@@ -10693,6 +11725,10 @@
     "id": "q00259",
     "image_path": null,
     "question_text": {
+      "en": "What is a hypervisor?",
+      "ja": "ハイパーバイザーとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a hypervisor?",
       "ja": "はいぱーばいざーとは何か？"
     }
@@ -10735,6 +11771,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a container image?",
+      "ja": "コンテナイメージとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a container image?",
       "ja": "こんてないめーじとは何か？"
     }
   },
@@ -10776,6 +11816,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is serverless computing?",
+      "ja": "サーバーレスコンピューティングとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is serverless computing?",
       "ja": "さーばーれすけいさんとは何か？"
     }
   },
@@ -10815,6 +11859,10 @@
     "id": "q00262",
     "image_path": null,
     "question_text": {
+      "en": "What is edge computing?",
+      "ja": "エッジコンピューティングとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is edge computing?",
       "ja": "えっじけいさんとは何か？"
     }
@@ -10858,6 +11906,10 @@
     "question_text": {
       "en": "What is a content delivery network optimized for?",
       "ja": "CDNは何のために最適化されているか？"
+    },
+    "question_text_reading": {
+      "en": "What is a content delivery network optimized for?",
+      "ja": "CDNは何のために最適化されているか？"
     }
   },
   {
@@ -10899,6 +11951,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is caching in computing?",
+      "ja": "コンピューティングにおけるキャッシングとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is caching in computing?",
       "ja": "けいさんきのきゃっしゅとは何か？"
     }
   },
@@ -10939,6 +11995,10 @@
     "id": "q00265",
     "image_path": null,
     "question_text": {
+      "en": "What is a message queue?",
+      "ja": "メッセージキューとはどのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is a message queue?",
       "ja": "めっせーじきゅーとは何か？"
     }
@@ -10984,6 +12044,10 @@
     "question_text": {
       "en": "What is pub/sub messaging?",
       "ja": "pub/subめっせーじんぐとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is pub/sub messaging?",
+      "ja": "pub/subめっせーじんぐとは何か？"
     }
   },
   {
@@ -11022,6 +12086,10 @@
     "id": "q00267",
     "image_path": null,
     "question_text": {
+      "en": "What is a CDN edge node?",
+      "ja": "CDNの「エッジノード」とはどのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is a CDN edge node?",
       "ja": "CDNのえっじのーどとは何か？"
     }
@@ -11063,6 +12131,10 @@
     "id": "q00268",
     "image_path": null,
     "question_text": {
+      "en": "What is horizontal scaling?",
+      "ja": "水平スケーリングとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is horizontal scaling?",
       "ja": "すいへいすけーりんぐとは何か？"
     }
@@ -11107,6 +12179,10 @@
     "question_text": {
       "en": "What is vertical scaling?",
       "ja": "すいちょくすけーりんぐとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is vertical scaling?",
+      "ja": "すいちょくすけーりんぐとは何か？"
     }
   },
   {
@@ -11147,6 +12223,10 @@
     "id": "q00270",
     "image_path": null,
     "question_text": {
+      "en": "What is a data center?",
+      "ja": "データセンターとはどのような施設ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a data center?",
       "ja": "でーたせんたーとは何か？"
     }
@@ -11190,6 +12270,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is uptime in computing?",
+      "ja": "コンピューティングにおける「uptime」とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is uptime in computing?",
       "ja": "けいさんきのあっぷたいむとは何か？"
     }
   },
@@ -11229,6 +12313,10 @@
     "id": "q00272",
     "image_path": null,
     "question_text": {
+      "en": "What is SLA?",
+      "ja": "SLAとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is SLA?",
       "ja": "SLAとは何か？"
     }
@@ -11274,6 +12362,10 @@
     "question_text": {
       "en": "What is monitoring in DevOps?",
       "ja": "DevOpsのもにたりんぐとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is monitoring in DevOps?",
+      "ja": "DevOpsのもにたりんぐとは何か？"
     }
   },
   {
@@ -11313,6 +12405,10 @@
     "id": "q00274",
     "image_path": null,
     "question_text": {
+      "en": "What is blue-green deployment?",
+      "ja": "ブルーグリーンデプロイメントとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is blue-green deployment?",
       "ja": "ぶるーぐりーんはいひとは何か？"
     }
@@ -11356,6 +12452,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is canary deployment?",
+      "ja": "カナリアデプロイメントとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is canary deployment?",
       "ja": "かなりあはいひとは何か？"
     }
   },
@@ -11397,6 +12497,10 @@
     "id": "q00276",
     "image_path": null,
     "question_text": {
+      "en": "What is a container registry?",
+      "ja": "コンテナレジストリとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a container registry?",
       "ja": "こんてなれじすとりとは何か？"
     }
@@ -11440,6 +12544,10 @@
     "question_text": {
       "en": "What is Terraform?",
       "ja": "Terraformとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is Terraform?",
+      "ja": "Terraformとは何か？"
     }
   },
   {
@@ -11479,6 +12587,10 @@
     "id": "q00278",
     "image_path": null,
     "question_text": {
+      "en": "What is Ansible?",
+      "ja": "Ansibleとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is Ansible?",
       "ja": "Ansibleとは何か？"
     }
@@ -11521,6 +12633,10 @@
     "question_text": {
       "en": "What is Prometheus?",
       "ja": "Prometheusとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is Prometheus?",
+      "ja": "Prometheusとは何か？"
     }
   },
   {
@@ -11561,6 +12677,10 @@
     "question_text": {
       "en": "What is Grafana?",
       "ja": "Grafanaとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is Grafana?",
+      "ja": "Grafanaとは何か？"
     }
   },
   {
@@ -11599,6 +12719,10 @@
     "id": "q00281",
     "image_path": null,
     "question_text": {
+      "en": "What is ELK stack?",
+      "ja": "ELKスタックとはどのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is ELK stack?",
       "ja": "ELKすたっくとは何か？"
     }
@@ -11642,6 +12766,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is observability in systems?",
+      "ja": "システムにおける「observability」とは何でしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What is observability in systems?",
       "ja": "しすてむのかんそくかのうせいとは何か？"
     }
   },
@@ -11684,6 +12812,10 @@
     "question_text": {
       "en": "What is a container pod in Kubernetes?",
       "ja": "Kubernetesのぽっどとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a container pod in Kubernetes?",
+      "ja": "Kubernetesのぽっどとは何か？"
     }
   },
   {
@@ -11722,6 +12854,10 @@
     "id": "q00284",
     "image_path": null,
     "question_text": {
+      "en": "What is a Dockerfile?",
+      "ja": "Dockerfileとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a Dockerfile?",
       "ja": "Dockerfileとは何か？"
     }
@@ -11764,6 +12900,10 @@
     "question_text": {
       "en": "What is `docker-compose`?",
       "ja": "`docker-compose`とは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is `docker-compose`?",
+      "ja": "`docker-compose`とは何か？"
     }
   },
   {
@@ -11804,6 +12944,10 @@
     "question_text": {
       "en": "What is a Kubernetes namespace?",
       "ja": "Kubernetesのなめすぺーすとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a Kubernetes namespace?",
+      "ja": "Kubernetesのなめすぺーすとは何か？"
     }
   },
   {
@@ -11842,6 +12986,10 @@
     "id": "q00287",
     "image_path": null,
     "question_text": {
+      "en": "What is a Helm chart?",
+      "ja": "Helmちゃーととは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a Helm chart?",
       "ja": "Helmちゃーととは何か？"
     }
@@ -11886,6 +13034,10 @@
     "question_text": {
       "en": "What is GitOps?",
       "ja": "GitOpsとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is GitOps?",
+      "ja": "GitOpsとは何か？"
     }
   },
   {
@@ -11927,6 +13079,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is chaos engineering?",
+      "ja": "カオスエンジニアリングとは、具体的にどのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is chaos engineering?",
       "ja": "かおすえんじにありんぐとは何か？"
     }
   },
@@ -11966,6 +13122,10 @@
     "id": "q00290",
     "image_path": null,
     "question_text": {
+      "en": "What is a webhook?",
+      "ja": "webhookとはどのような仕組みのことですか？"
+    },
+    "question_text_reading": {
       "en": "What is a webhook?",
       "ja": "うぇぶふっくとは何か？"
     }
@@ -12008,6 +13168,10 @@
     "id": "q00291",
     "image_path": null,
     "question_text": {
+      "en": "What is latency in computing?",
+      "ja": "コンピューティングにおけるレイテンシとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is latency in computing?",
       "ja": "けいさんきのれいてんしーとは何か？"
     }
@@ -12052,6 +13216,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is throughput in computing?",
+      "ja": "コンピューティングにおける「throughput」とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is throughput in computing?",
       "ja": "けいさんきのすいとうっぷりょうとは何か？"
     }
   },
@@ -12093,6 +13261,10 @@
     "id": "q00293",
     "image_path": null,
     "question_text": {
+      "en": "What does API stand for?",
+      "ja": "APIとは何の略語ですか？"
+    },
+    "question_text_reading": {
       "en": "What does API stand for?",
       "ja": "APIのりゃくごのいみは？"
     }
@@ -12137,6 +13309,10 @@
     "image_path": null,
     "question_text": {
       "en": "What does URL stand for?",
+      "ja": "URLは何の略語ですか？"
+    },
+    "question_text_reading": {
+      "en": "What does URL stand for?",
       "ja": "URLのりゃくごのいみは？"
     }
   },
@@ -12178,6 +13354,10 @@
     "id": "q00295",
     "image_path": null,
     "question_text": {
+      "en": "What does IDE stand for?",
+      "ja": "IDEとは何の略語ですか？"
+    },
+    "question_text_reading": {
       "en": "What does IDE stand for?",
       "ja": "IDEのりゃくごのいみは？"
     }
@@ -12221,6 +13401,10 @@
     "image_path": null,
     "question_text": {
       "en": "What does ORM stand for?",
+      "ja": "ORMとは何の略語ですか？"
+    },
+    "question_text_reading": {
+      "en": "What does ORM stand for?",
       "ja": "ORMのりゃくごのいみは？"
     }
   },
@@ -12261,6 +13445,10 @@
     "image_path": null,
     "question_text": {
       "en": "What does MVC stand for?",
+      "ja": "MVCは何の略語ですか？"
+    },
+    "question_text_reading": {
+      "en": "What does MVC stand for?",
       "ja": "MVCのりゃくごのいみは？"
     }
   },
@@ -12300,6 +13488,10 @@
     "id": "q00298",
     "image_path": null,
     "question_text": {
+      "en": "What does SaaS stand for?",
+      "ja": "SaaSとは何の略語ですか？"
+    },
+    "question_text_reading": {
       "en": "What does SaaS stand for?",
       "ja": "SaaSのりゃくごのいみは？"
     }
@@ -12342,6 +13534,10 @@
     "image_path": null,
     "question_text": {
       "en": "What does IaaS stand for?",
+      "ja": "IaaSとは何の略語ですか？"
+    },
+    "question_text_reading": {
+      "en": "What does IaaS stand for?",
       "ja": "IaaSのりゃくごのいみは？"
     }
   },
@@ -12381,6 +13577,10 @@
     "id": "q00300",
     "image_path": null,
     "question_text": {
+      "en": "What does PaaS stand for?",
+      "ja": "PaaSとは何の略語ですか？"
+    },
+    "question_text_reading": {
       "en": "What does PaaS stand for?",
       "ja": "PaaSのりゃくごのいみは？"
     }
@@ -12426,6 +13626,10 @@
     "image_path": null,
     "question_text": {
       "en": "What does CRUD stand for?",
+      "ja": "CRUDは何の頭文字ですか？"
+    },
+    "question_text_reading": {
+      "en": "What does CRUD stand for?",
       "ja": "CRUDのりゃくごのいみは？"
     }
   },
@@ -12468,6 +13672,10 @@
     "image_path": null,
     "question_text": {
       "en": "What does OOP stand for?",
+      "ja": "OOPは何の略語ですか？"
+    },
+    "question_text_reading": {
+      "en": "What does OOP stand for?",
       "ja": "OOPのりゃくごのいみは？"
     }
   },
@@ -12508,6 +13716,10 @@
     "id": "q00303",
     "image_path": null,
     "question_text": {
+      "en": "What does CLI stand for?",
+      "ja": "CLIとは何の略語ですか？"
+    },
+    "question_text_reading": {
       "en": "What does CLI stand for?",
       "ja": "CLIのりゃくごのいみは？"
     }
@@ -12552,6 +13764,10 @@
     "image_path": null,
     "question_text": {
       "en": "What does GUI stand for?",
+      "ja": "GUIは何の略語ですか？"
+    },
+    "question_text_reading": {
+      "en": "What does GUI stand for?",
       "ja": "GUIのりゃくごのいみは？"
     }
   },
@@ -12591,6 +13807,10 @@
     "id": "q00305",
     "image_path": null,
     "question_text": {
+      "en": "What does SDK stand for?",
+      "ja": "SDKとは何の略語ですか？"
+    },
+    "question_text_reading": {
       "en": "What does SDK stand for?",
       "ja": "SDKのりゃくごのいみは？"
     }
@@ -12634,6 +13854,10 @@
     "image_path": null,
     "question_text": {
       "en": "What does EOF stand for in programming?",
+      "ja": "プログラミングにおける「EOF」は何の略語ですか？"
+    },
+    "question_text_reading": {
+      "en": "What does EOF stand for in programming?",
       "ja": "ぷろぐらみんぐのEOFのりゃくごのいみは？"
     }
   },
@@ -12673,6 +13897,10 @@
     "id": "q00307",
     "image_path": null,
     "question_text": {
+      "en": "What is a boolean?",
+      "ja": "ブーリアンとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a boolean?",
       "ja": "ぶーりあんとは何か？"
     }
@@ -12715,6 +13943,10 @@
     "question_text": {
       "en": "What is null?",
       "ja": "nullとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is null?",
+      "ja": "nullとは何か？"
     }
   },
   {
@@ -12753,6 +13985,10 @@
     "id": "q00309",
     "image_path": null,
     "question_text": {
+      "en": "What is undefined in JavaScript?",
+      "ja": "JavaScriptのundefinedとは？"
+    },
+    "question_text_reading": {
       "en": "What is undefined in JavaScript?",
       "ja": "JavaScriptのundefinedとは？"
     }
@@ -12794,6 +14030,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is type casting?",
+      "ja": "型キャストとは、どのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is type casting?",
       "ja": "かたへんかんとは何か？"
     }
   },
@@ -12834,6 +14074,10 @@
     "id": "q00311",
     "image_path": null,
     "question_text": {
+      "en": "What is a namespace?",
+      "ja": "名前空間とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a namespace?",
       "ja": "なめすぺーすとは何か？"
     }
@@ -12877,6 +14121,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is an enum?",
+      "ja": "enumとはどのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is an enum?",
       "ja": "えぬむとは何か？"
     }
   },
@@ -12917,6 +14165,10 @@
     "id": "q00313",
     "image_path": null,
     "question_text": {
+      "en": "What is a struct?",
+      "ja": "structとはどのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is a struct?",
       "ja": "すとらくととは何か？"
     }
@@ -12959,6 +14211,10 @@
     "question_text": {
       "en": "What does `printf` do in C?",
       "ja": "Cの`printf`は何をするか？"
+    },
+    "question_text_reading": {
+      "en": "What does `printf` do in C?",
+      "ja": "Cの`printf`は何をするか？"
     }
   },
   {
@@ -12998,6 +14254,10 @@
     "id": "q00315",
     "image_path": null,
     "question_text": {
+      "en": "What is a pointer in C?",
+      "ja": "C言語におけるポインターとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a pointer in C?",
       "ja": "Cのぽいんたーとは何か？"
     }
@@ -13042,6 +14302,10 @@
     "question_text": {
       "en": "What does `#include` do in C?",
       "ja": "Cの`#include`は何をするか？"
+    },
+    "question_text_reading": {
+      "en": "What does `#include` do in C?",
+      "ja": "Cの`#include`は何をするか？"
     }
   },
   {
@@ -13083,6 +14347,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a compile error?",
+      "ja": "compile errorとはどのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a compile error?",
       "ja": "かんぱいるえらーとは何か？"
     }
   },
@@ -13123,6 +14391,10 @@
     "id": "q00318",
     "image_path": null,
     "question_text": {
+      "en": "What is a runtime error?",
+      "ja": "ランタイムエラーとは、どのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is a runtime error?",
       "ja": "じっこうじえらーとは何か？"
     }
@@ -13167,6 +14439,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a logic error?",
+      "ja": "ロジックエラーとは、どのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a logic error?",
       "ja": "ろじっくえらーとは何か？"
     }
   },
@@ -13210,6 +14486,10 @@
     "question_text": {
       "en": "What is `stdin`?",
       "ja": "`stdin`とは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is `stdin`?",
+      "ja": "`stdin`とは何か？"
     }
   },
   {
@@ -13249,6 +14529,10 @@
     "id": "q00321",
     "image_path": null,
     "question_text": {
+      "en": "What is `stdout`?",
+      "ja": "`stdout`とは何か？"
+    },
+    "question_text_reading": {
       "en": "What is `stdout`?",
       "ja": "`stdout`とは何か？"
     }
@@ -13293,6 +14577,10 @@
     "question_text": {
       "en": "What is `stderr`?",
       "ja": "`stderr`とは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is `stderr`?",
+      "ja": "`stderr`とは何か？"
     }
   },
   {
@@ -13331,6 +14619,10 @@
     "id": "q00323",
     "image_path": null,
     "question_text": {
+      "en": "What is a variable?",
+      "ja": "変数（variable）とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a variable?",
       "ja": "へんすうとは何か？"
     }
@@ -13371,6 +14663,10 @@
     "id": "q00324",
     "image_path": null,
     "question_text": {
+      "en": "What is a constant?",
+      "ja": "定数とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a constant?",
       "ja": "ていすうとは何か？"
     }
@@ -13414,6 +14710,10 @@
     "id": "q00325",
     "image_path": null,
     "question_text": {
+      "en": "What is operator precedence?",
+      "ja": "演算子の優先順位とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is operator precedence?",
       "ja": "えんざんしのゆうせんじゅんいとは何か？"
     }
@@ -13459,6 +14759,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is short-circuit evaluation?",
+      "ja": "ショートサーキット評価とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is short-circuit evaluation?",
       "ja": "たんらくひょうかとは何か？"
     }
   },
@@ -13501,6 +14805,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a ternary operator?",
+      "ja": "三項演算子とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a ternary operator?",
       "ja": "さんこうえんざんしとは何か？"
     }
   },
@@ -13542,6 +14850,10 @@
     "question_text": {
       "en": "Which anime features a boy who gains power from a Death Note?",
       "ja": "しのちょうからちからをえる少年のアニメは？"
+    },
+    "question_text_reading": {
+      "en": "Which anime features a boy who gains power from a Death Note?",
+      "ja": "しのちょうからちからをえる少年のアニメは？"
     }
   },
   {
@@ -13580,6 +14892,10 @@
     "id": "q00329",
     "image_path": null,
     "question_text": {
+      "en": "What is the name of the protagonist in Naruto?",
+      "ja": "『NARUTO -ナルト-』の主人公の名前は何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the name of the protagonist in Naruto?",
       "ja": "Narutoのしゅじんこうのなまえは？"
     }
@@ -13622,6 +14938,10 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime is set in a world where humans live inside walls to avoid Titans?",
+      "ja": "タイタンから身を守るため、人類が壁の中に暮らす世界を舞台にしたアニメはどれ？"
+    },
+    "question_text_reading": {
+      "en": "Which anime is set in a world where humans live inside walls to avoid Titans?",
       "ja": "きょじんからのがれるためにかべのなかでくらすせかいのアニメは？"
     }
   },
@@ -13662,6 +14982,10 @@
     "id": "q00331",
     "image_path": null,
     "question_text": {
+      "en": "Which Studio Ghibli film features a girl who works in a bathhouse for spirits?",
+      "ja": "精霊の湯屋で働く少女が登場するスタジオジブリの作品はどれ？"
+    },
+    "question_text_reading": {
       "en": "Which Studio Ghibli film features a girl who works in a bathhouse for spirits?",
       "ja": "せいれいのゆやではたらくしょうじょのスタジオジブリえいがは？"
     }
@@ -13705,6 +15029,10 @@
     "image_path": null,
     "question_text": {
       "en": "What power does Saitama from One Punch Man have?",
+      "ja": "『ワンパンマン』の埼玉が持つ力は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What power does Saitama from One Punch Man have?",
       "ja": "わんぱんまんのさいたまのちからは？"
     }
   },
@@ -13744,6 +15072,10 @@
     "id": "q00333",
     "image_path": null,
     "question_text": {
+      "en": "Which anime features the Straw Hat Pirates?",
+      "ja": "ストローハットの海賊が登場するアニメはどれ？"
+    },
+    "question_text_reading": {
       "en": "Which anime features the Straw Hat Pirates?",
       "ja": "むぎわらかいぞくだんのアニメは？"
     }
@@ -13787,6 +15119,10 @@
     "question_text": {
       "en": "Who is the author of Dragon Ball?",
       "ja": "ドラゴンボールのさくしゃは？"
+    },
+    "question_text_reading": {
+      "en": "Who is the author of Dragon Ball?",
+      "ja": "ドラゴンボールのさくしゃは？"
     }
   },
   {
@@ -13825,6 +15161,10 @@
     "id": "q00335",
     "image_path": null,
     "question_text": {
+      "en": "Which anime is about a boy named Tanjiro fighting demons?",
+      "ja": "炭治郎という少年が鬼と戦うアニメはどれ？"
+    },
+    "question_text_reading": {
       "en": "Which anime is about a boy named Tanjiro fighting demons?",
       "ja": "たんじろうというしょうねんがおにとたたかうアニメは？"
     }
@@ -13868,6 +15208,10 @@
     "question_text": {
       "en": "What is the setting of Sword Art Online?",
       "ja": "ソードアートオンラインのぶたいは？"
+    },
+    "question_text_reading": {
+      "en": "What is the setting of Sword Art Online?",
+      "ja": "ソードアートオンラインのぶたいは？"
     }
   },
   {
@@ -13906,6 +15250,10 @@
     "id": "q00337",
     "image_path": null,
     "question_text": {
+      "en": "Which anime follows a boy who wants to be the best Pokemon trainer?",
+      "ja": "最強のポケモントレーナーを目指す少年を描いたアニメはどれ？"
+    },
+    "question_text_reading": {
       "en": "Which anime follows a boy who wants to be the best Pokemon trainer?",
       "ja": "さいきょうのぽけもんとれーなーをめざすしょうねんのアニメは？"
     }
@@ -13947,6 +15295,10 @@
     "image_path": null,
     "question_text": {
       "en": "Who created the Evangelion series?",
+      "ja": "エヴァンゲリオンシリーズを制作したのは誰ですか？"
+    },
+    "question_text_reading": {
+      "en": "Who created the Evangelion series?",
       "ja": "えんがえりおんしりーずをつくったのは？"
     }
   },
@@ -13986,6 +15338,10 @@
     "id": "q00339",
     "image_path": null,
     "question_text": {
+      "en": "Which anime features the Survey Corps?",
+      "ja": "ちょうさへいだんがとうじょうするアニメは？"
+    },
+    "question_text_reading": {
       "en": "Which anime features the Survey Corps?",
       "ja": "ちょうさへいだんがとうじょうするアニメは？"
     }
@@ -14029,6 +15385,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the full name of the protagonist in My Hero Academia?",
+      "ja": "『僕のヒーローアカデミア』の主人公のフルネームは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the full name of the protagonist in My Hero Academia?",
       "ja": "ぼくのひーろーあかでみあのしゅじんこうのフルネームは？"
     }
   },
@@ -14068,6 +15428,10 @@
     "id": "q00341",
     "image_path": null,
     "question_text": {
+      "en": "Which anime features ninjas with special chakra abilities?",
+      "ja": "特殊なチャクラの能力を持つ忍者が登場するアニメはどれ？"
+    },
+    "question_text_reading": {
       "en": "Which anime features ninjas with special chakra abilities?",
       "ja": "とくべつなちゃくらのうりょくをもつにんじゃのアニメは？"
     }
@@ -14110,6 +15474,10 @@
     "image_path": null,
     "question_text": {
       "en": "What studio produced Neon Genesis Evangelion?",
+      "ja": "『新世紀エヴァンゲリオン』を制作したスタジオはどこ？"
+    },
+    "question_text_reading": {
+      "en": "What studio produced Neon Genesis Evangelion?",
       "ja": "しんせいきえんがえりおんをせいさくしたすたじおは？"
     }
   },
@@ -14149,6 +15517,10 @@
     "id": "q00343",
     "image_path": null,
     "question_text": {
+      "en": "Which anime series is known for the 'Kamehameha' attack?",
+      "ja": "かめはめはの技で知られるアニメシリーズはどれですか？"
+    },
+    "question_text_reading": {
       "en": "Which anime series is known for the 'Kamehameha' attack?",
       "ja": "かめはめはこうげきでゆうめいなアニメは？"
     }
@@ -14192,6 +15564,10 @@
     "question_text": {
       "en": "What genre is Sailor Moon?",
       "ja": "せーらーむーんのジャンルは？"
+    },
+    "question_text_reading": {
+      "en": "What genre is Sailor Moon?",
+      "ja": "せーらーむーんのジャンルは？"
     }
   },
   {
@@ -14230,6 +15606,10 @@
     "id": "q00345",
     "image_path": null,
     "question_text": {
+      "en": "Who is Pikachu's trainer in Pokemon anime?",
+      "ja": "ポケモンアニメでぴかちゅうのとれーなーは？"
+    },
+    "question_text_reading": {
       "en": "Who is Pikachu's trainer in Pokemon anime?",
       "ja": "ポケモンアニメでぴかちゅうのとれーなーは？"
     }
@@ -14271,6 +15651,10 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime is set in a sports high school for volleyball?",
+      "ja": "バレーボールをテーマにしたスポーツ高校を舞台にしているアニメはどれ？"
+    },
+    "question_text_reading": {
+      "en": "Which anime is set in a sports high school for volleyball?",
       "ja": "ばれーぼーるのこうこうのアニメは？"
     }
   },
@@ -14311,6 +15695,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is isekai?",
+      "ja": "異世界（いせかい）とは、どのようなジャンルを指すのでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What is isekai?",
       "ja": "いせかいとは何か？"
     }
   },
@@ -14350,6 +15738,10 @@
     "id": "q00348",
     "image_path": null,
     "question_text": {
+      "en": "Which anime features Monkey D. Luffy?",
+      "ja": "モンキー・D・ルフィが登場するアニメはどれ？"
+    },
+    "question_text_reading": {
       "en": "Which anime features Monkey D. Luffy?",
       "ja": "もんきーでぃーるふぃーがとうじょうするアニメは？"
     }
@@ -14393,6 +15785,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the name of the school in My Hero Academia?",
+      "ja": "僕のヒーローアカデミアに登場する学校の名前は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the name of the school in My Hero Academia?",
       "ja": "ぼくのひーろーあかでみあのがっこうのなまえは？"
     }
   },
@@ -14432,6 +15828,10 @@
     "id": "q00350",
     "image_path": null,
     "question_text": {
+      "en": "Which anime follows L and Light's cat-and-mouse detective game?",
+      "ja": "Lとライトの猫とネズミのような推理ゲームを描いたアニメはどれ？"
+    },
+    "question_text_reading": {
       "en": "Which anime follows L and Light's cat-and-mouse detective game?",
       "ja": "Lとライトのかくれんぼのようなすいりのアニメは？"
     }
@@ -14474,6 +15874,10 @@
     "question_text": {
       "en": "Which anime is set in the fictional Konoha village?",
       "ja": "かそうのこのははのむらが舞台のアニメは？"
+    },
+    "question_text_reading": {
+      "en": "Which anime is set in the fictional Konoha village?",
+      "ja": "かそうのこのははのむらが舞台のアニメは？"
     }
   },
   {
@@ -14512,6 +15916,10 @@
     "id": "q00352",
     "image_path": null,
     "question_text": {
+      "en": "What is the 'Big Three' of older Shonen Jump anime?",
+      "ja": "むかしのじゃんぷのさんだいアニメは？"
+    },
+    "question_text_reading": {
       "en": "What is the 'Big Three' of older Shonen Jump anime?",
       "ja": "むかしのじゃんぷのさんだいアニメは？"
     }
@@ -14557,6 +15965,10 @@
     "question_text": {
       "en": "What is a mecha anime?",
       "ja": "めかアニメとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a mecha anime?",
+      "ja": "めかアニメとは何か？"
     }
   },
   {
@@ -14595,6 +16007,10 @@
     "id": "q00354",
     "image_path": null,
     "question_text": {
+      "en": "Which Ghibli film features a young witch who delivers by broomstick?",
+      "ja": "ほうきで飛ぶ若い魔女が登場するジブリ映画はどれでしょう？"
+    },
+    "question_text_reading": {
       "en": "Which Ghibli film features a young witch who delivers by broomstick?",
       "ja": "ほうきではいたつするわかいまじょのジブリえいがは？"
     }
@@ -14636,6 +16052,10 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime follows Ichigo Kurosaki, a Soul Reaper?",
+      "ja": "主人公が死神（Soul Reaper）であるイチゴ・クロサキを追うアニメはどれ？"
+    },
+    "question_text_reading": {
+      "en": "Which anime follows Ichigo Kurosaki, a Soul Reaper?",
       "ja": "いちごくろさきというしにがみのアニメは？"
     }
   },
@@ -14675,6 +16095,10 @@
     "id": "q00356",
     "image_path": null,
     "question_text": {
+      "en": "What is a 'shonen' anime?",
+      "ja": "少年（shonen）アニメとはどのようなジャンルですか？"
+    },
+    "question_text_reading": {
       "en": "What is a 'shonen' anime?",
       "ja": "しょうねんアニメとは何か？"
     }
@@ -14717,6 +16141,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a 'shoujo' anime?",
+      "ja": "shoujoアニメとは、どのようなジャンルを指すものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a 'shoujo' anime?",
       "ja": "しょうじょアニメとは何か？"
     }
   },
@@ -14756,6 +16184,10 @@
     "id": "q00358",
     "image_path": null,
     "question_text": {
+      "en": "Which anime is about a boy named Goku who trains in martial arts?",
+      "ja": "武術を極める少年、孫悟空（Goku）を主人公としたアニメはどれ？"
+    },
+    "question_text_reading": {
       "en": "Which anime is about a boy named Goku who trains in martial arts?",
       "ja": "ごくうというしょうねんがぶどうをきわめるアニメは？"
     }
@@ -14798,6 +16230,10 @@
     "image_path": null,
     "question_text": {
       "en": "What does 'OVA' stand for in anime?",
+      "ja": "アニメにおける「OVA」は何の略語ですか？"
+    },
+    "question_text_reading": {
+      "en": "What does 'OVA' stand for in anime?",
       "ja": "アニメのOVAのりゃくごのいみは？"
     }
   },
@@ -14837,6 +16273,10 @@
     "id": "q00360",
     "image_path": null,
     "question_text": {
+      "en": "Which anime is famous for the 'Thousand Sunny' ship?",
+      "ja": "サン・サニー号で有名なアニメはどれ？"
+    },
+    "question_text_reading": {
       "en": "Which anime is famous for the 'Thousand Sunny' ship?",
       "ja": "さうざんどさにーごうでゆうめいなアニメは？"
     }
@@ -14880,6 +16320,10 @@
     "question_text": {
       "en": "Which anime series has 'Stand' abilities as its main power system?",
       "ja": "すたんどのうりょくがメインのアニメシリーズは？"
+    },
+    "question_text_reading": {
+      "en": "Which anime series has 'Stand' abilities as its main power system?",
+      "ja": "すたんどのうりょくがメインのアニメシリーズは？"
     }
   },
   {
@@ -14920,6 +16364,10 @@
     "id": "q00362",
     "image_path": null,
     "question_text": {
+      "en": "What is 'One For All' in My Hero Academia?",
+      "ja": "『僕のヒーローアカデミア』における「One For All」とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is 'One For All' in My Hero Academia?",
       "ja": "ぼくのひーろーあかでみあのわんふぉーおーるとは？"
     }
@@ -14962,6 +16410,10 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime is set in a cooking high school?",
+      "ja": "料理をテーマにした高校を舞台とするアニメはどれですか？"
+    },
+    "question_text_reading": {
+      "en": "Which anime is set in a cooking high school?",
       "ja": "りょうりのこうこうのアニメは？"
     }
   },
@@ -15001,6 +16453,10 @@
     "id": "q00364",
     "image_path": null,
     "question_text": {
+      "en": "Who is the villain in the first arc of Dragon Ball Z?",
+      "ja": "ドラゴンボールZさいしょのあーくのヴィランは？"
+    },
+    "question_text_reading": {
       "en": "Who is the villain in the first arc of Dragon Ball Z?",
       "ja": "ドラゴンボールZさいしょのあーくのヴィランは？"
     }
@@ -15044,6 +16500,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'Alchemy' in Fullmetal Alchemist?",
+      "ja": "『鋼の錬金術師』における「錬金術（Alchemy）」とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is 'Alchemy' in Fullmetal Alchemist?",
       "ja": "はがねのれんきんじゅつしのれんきんじゅつとは？"
     }
   },
@@ -15083,6 +16543,10 @@
     "id": "q00366",
     "image_path": null,
     "question_text": {
+      "en": "Which anime features the 'Survey Corps' fighting Titans?",
+      "ja": "タイタンと戦う「調査兵団（Survey Corps）」が登場するアニメはどれ？"
+    },
+    "question_text_reading": {
       "en": "Which anime features the 'Survey Corps' fighting Titans?",
       "ja": "ちょうさへいだんがきょじんとたたかうアニメは？"
     }
@@ -15125,6 +16589,10 @@
     "image_path": null,
     "question_text": {
       "en": "What genre is 'Your Name (Kimi no Na wa)'?",
+      "ja": "君の名ははどのジャンルの作品ですか？"
+    },
+    "question_text_reading": {
+      "en": "What genre is 'Your Name (Kimi no Na wa)'?",
       "ja": "きみのなわのジャンルは？"
     }
   },
@@ -15164,6 +16632,10 @@
     "id": "q00368",
     "image_path": null,
     "question_text": {
+      "en": "Who directed Spirited Away?",
+      "ja": "もののけ姫を監督したのは誰ですか？"
+    },
+    "question_text_reading": {
       "en": "Who directed Spirited Away?",
       "ja": "もののけひめをかんとくしたのは？"
     }
@@ -15205,6 +16677,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the name of the cat bus in My Neighbor Totoro?",
+      "ja": "となりのトトロに登場するねこバスの名前は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the name of the cat bus in My Neighbor Totoro?",
       "ja": "となりのトトロのねこばすのなまえは？"
     }
   },
@@ -15244,6 +16720,10 @@
     "id": "q00370",
     "image_path": null,
     "question_text": {
+      "en": "Which anime features heroes called 'Hashira'?",
+      "ja": "柱（Hashira）と呼ばれるヒーローが登場するアニメはどれ？"
+    },
+    "question_text_reading": {
       "en": "Which anime features heroes called 'Hashira'?",
       "ja": "はしらとよばれるひーろーたちのアニメは？"
     }
@@ -15285,6 +16765,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the name of Naruto's signature technique?",
+      "ja": "ナルトの代名詞的な術の名前は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the name of Naruto's signature technique?",
       "ja": "なるとのとくいわざのなまえは？"
     }
   },
@@ -15325,6 +16809,10 @@
     "id": "q00372",
     "image_path": null,
     "question_text": {
+      "en": "Which anime is about a virtual game where dying in-game means death in real life?",
+      "ja": "げーむないしすると現実でもしぬアニメは？"
+    },
+    "question_text_reading": {
       "en": "Which anime is about a virtual game where dying in-game means death in real life?",
       "ja": "げーむないしすると現実でもしぬアニメは？"
     }
@@ -15369,6 +16857,10 @@
     "image_path": null,
     "question_text": {
       "en": "What power does Light Yagami use in Death Note?",
+      "ja": "デスノートで夜神月が使用する力は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What power does Light Yagami use in Death Note?",
       "ja": "デスノートでやがみらいとが使うちからは？"
     }
   },
@@ -15408,6 +16900,10 @@
     "id": "q00374",
     "image_path": null,
     "question_text": {
+      "en": "Which anime is set in the Hidden Leaf Village?",
+      "ja": "隠された葉の里を舞台にしているアニメはどれですか？"
+    },
+    "question_text_reading": {
       "en": "Which anime is set in the Hidden Leaf Village?",
       "ja": "かくれこのはのさとをぶたいにしたアニメは？"
     }
@@ -15453,6 +16949,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the 'Quirk' in My Hero Academia?",
+      "ja": "『僕のヒーローアカデミア』における「個性（Quirk）」とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the 'Quirk' in My Hero Academia?",
       "ja": "ぼくのひーろーあかでみあのこせいとは？"
     }
   },
@@ -15495,6 +16995,10 @@
     "question_text": {
       "en": "Which anime features Ryuk, a death god?",
       "ja": "りゅーくというしにがみがとうじょうするアニメは？"
+    },
+    "question_text_reading": {
+      "en": "Which anime features Ryuk, a death god?",
+      "ja": "りゅーくというしにがみがとうじょうするアニメは？"
     }
   },
   {
@@ -15534,6 +17038,10 @@
     "id": "q00377",
     "image_path": null,
     "question_text": {
+      "en": "What is 'Titan' in Attack on Titan?",
+      "ja": "進撃の巨人における「タイタン」とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is 'Titan' in Attack on Titan?",
       "ja": "しんげきのきょじんのきょじんとは？"
     }
@@ -15575,6 +17083,10 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime is based on a card game?",
+      "ja": "カードゲームを原作としたアニメはどれですか？"
+    },
+    "question_text_reading": {
+      "en": "Which anime is based on a card game?",
       "ja": "かーどげーむをもとにしたアニメは？"
     }
   },
@@ -15614,6 +17126,10 @@
     "id": "q00379",
     "image_path": null,
     "question_text": {
+      "en": "Who is the main antagonist of the Frieza arc in Dragon Ball Z?",
+      "ja": "ドラゴンボールZのふりーざへんのしゅてきは？"
+    },
+    "question_text_reading": {
       "en": "Who is the main antagonist of the Frieza arc in Dragon Ball Z?",
       "ja": "ドラゴンボールZのふりーざへんのしゅてきは？"
     }
@@ -15657,6 +17173,10 @@
     "question_text": {
       "en": "What is the setting of 'No Game No Life'?",
       "ja": "のーげーむのーらいふの舞台は？"
+    },
+    "question_text_reading": {
+      "en": "What is the setting of 'No Game No Life'?",
+      "ja": "のーげーむのーらいふの舞台は？"
     }
   },
   {
@@ -15695,6 +17215,10 @@
     "id": "q00381",
     "image_path": null,
     "question_text": {
+      "en": "Who wrote the manga 'Fullmetal Alchemist'?",
+      "ja": "『鋼の錬金術師』の漫画を書いたのは誰？"
+    },
+    "question_text_reading": {
       "en": "Who wrote the manga 'Fullmetal Alchemist'?",
       "ja": "はがねのれんきんじゅつしをかいたのは？"
     }
@@ -15735,6 +17259,10 @@
     "id": "q00382",
     "image_path": null,
     "question_text": {
+      "en": "What is a 'seiyuu' in anime?",
+      "ja": "アニメにおける「seiyuu」とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a 'seiyuu' in anime?",
       "ja": "アニメのせいゆうとは何か？"
     }
@@ -15777,6 +17305,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the difference between dubbed and subbed anime?",
+      "ja": "吹替版と字幕版のアニメの違いは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the difference between dubbed and subbed anime?",
       "ja": "だぶどとさぶどのアニメのちがいは？"
     }
   },
@@ -15817,6 +17349,10 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime series is set in 19th century England with a demon butler?",
+      "ja": "19世紀のイングランドを舞台に、悪魔の執事が登場するアニメシリーズはどれ？"
+    },
+    "question_text_reading": {
+      "en": "Which anime series is set in 19th century England with a demon butler?",
       "ja": "あくまのしつじがいる19せいきえいこくのアニメは？"
     }
   },
@@ -15856,6 +17392,10 @@
     "id": "q00385",
     "image_path": null,
     "question_text": {
+      "en": "What is 'Shounen Jump'?",
+      "ja": "少年ジャンプとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is 'Shounen Jump'?",
       "ja": "しょうねんじゃんぷとは何か？"
     }
@@ -15898,6 +17438,10 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime follows a group of exorcists called 'jujutsu sorcerers'?",
+      "ja": "呪術師（jujutsu sorcerers）と呼ばれる祓魔師のグループを追うアニメはどれですか？"
+    },
+    "question_text_reading": {
+      "en": "Which anime follows a group of exorcists called 'jujutsu sorcerers'?",
       "ja": "じゅじゅつしのようしゃたちのアニメは？"
     }
   },
@@ -15938,6 +17482,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the name of Tanjiro's sister in Demon Slayer?",
+      "ja": "鬼滅の刃に登場する炭治郎の妹の名前は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the name of Tanjiro's sister in Demon Slayer?",
       "ja": "きめつのやいばでたんじろうのいもうとのなまえは？"
     }
   },
@@ -15977,6 +17525,10 @@
     "id": "q00388",
     "image_path": null,
     "question_text": {
+      "en": "Which anime features the 'Nine-Tails Fox' sealed inside a character?",
+      "ja": "九尾の狐がキャラクターの内部に封印されているアニメはどれ？"
+    },
+    "question_text_reading": {
       "en": "Which anime features the 'Nine-Tails Fox' sealed inside a character?",
       "ja": "きゅうびがふういんされたキャラのアニメは？"
     }
@@ -16019,6 +17571,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the anime genre 'slice of life'?",
+      "ja": "アニメのジャンルである「slice of life」とはどのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the anime genre 'slice of life'?",
       "ja": "あにめのすらいすおぶらいふジャンルとは？"
     }
   },
@@ -16060,6 +17616,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'cour' in anime terminology?",
+      "ja": "アニメの専門用語における「cour」とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is 'cour' in anime terminology?",
       "ja": "アニメようごのくーるとは何か？"
     }
   },
@@ -16099,6 +17659,10 @@
     "id": "q00391",
     "image_path": null,
     "question_text": {
+      "en": "Which anime is produced by MAPPA?",
+      "ja": "MAPPAがせいさくしたアニメは？"
+    },
+    "question_text_reading": {
       "en": "Which anime is produced by MAPPA?",
       "ja": "MAPPAがせいさくしたアニメは？"
     }
@@ -16142,6 +17706,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is Kyoto Animation known for?",
+      "ja": "京都アニメーションはどのようなことで知られているでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What is Kyoto Animation known for?",
       "ja": "きょーとあにめーしょんはなにでゆうめいか？"
     }
   },
@@ -16181,6 +17749,10 @@
     "id": "q00393",
     "image_path": null,
     "question_text": {
+      "en": "Which anime features Satoru Gojo?",
+      "ja": "サトル・ゴジョが登場するアニメはどれ？"
+    },
+    "question_text_reading": {
       "en": "Which anime features Satoru Gojo?",
       "ja": "ごじょうさとるがとうじょうするアニメは？"
     }
@@ -16224,6 +17796,10 @@
     "question_text": {
       "en": "Who is the creator of One Piece?",
       "ja": "ワンピースのさくしゃは？"
+    },
+    "question_text_reading": {
+      "en": "Who is the creator of One Piece?",
+      "ja": "ワンピースのさくしゃは？"
     }
   },
   {
@@ -16265,6 +17841,10 @@
     "question_text": {
       "en": "What is 'Dattebayo' associated with in Naruto?",
       "ja": "ナルトで「だってばよ」はなにと関係するか？"
+    },
+    "question_text_reading": {
+      "en": "What is 'Dattebayo' associated with in Naruto?",
+      "ja": "ナルトで「だってばよ」はなにと関係するか？"
     }
   },
   {
@@ -16303,6 +17883,10 @@
     "id": "q00396",
     "image_path": null,
     "question_text": {
+      "en": "Which Ghibli film features a flying island called Laputa?",
+      "ja": "ラピュタという空飛ぶ島が登場するジブリ映画はどれ？"
+    },
+    "question_text_reading": {
       "en": "Which Ghibli film features a flying island called Laputa?",
       "ja": "ラピュタというとぶしまのジブリえいがは？"
     }
@@ -16344,6 +17928,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the name of the robot in Doraemon?",
+      "ja": "ドラえもんという漫画に登場するロボットの名前は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the name of the robot in Doraemon?",
       "ja": "ドラえもんのろぼっとのなまえは？"
     }
   },
@@ -16383,6 +17971,10 @@
     "id": "q00398",
     "image_path": null,
     "question_text": {
+      "en": "Which anime is set in a world with 'Titans' and 3D Maneuver Gear?",
+      "ja": "きょじんと立体機動装置のせかいのアニメは？"
+    },
+    "question_text_reading": {
       "en": "Which anime is set in a world with 'Titans' and 3D Maneuver Gear?",
       "ja": "きょじんと立体機動装置のせかいのアニメは？"
     }
@@ -16426,6 +18018,10 @@
     "question_text": {
       "en": "What is the setting of 'Re:Zero'?",
       "ja": "りぜろの舞台は？"
+    },
+    "question_text_reading": {
+      "en": "What is the setting of 'Re:Zero'?",
+      "ja": "りぜろの舞台は？"
     }
   },
   {
@@ -16464,6 +18060,10 @@
     "id": "q00400",
     "image_path": null,
     "question_text": {
+      "en": "Which anime features the 'Akatsuki' organization?",
+      "ja": "暁（あかつき）という組織が登場するアニメはどれ？"
+    },
+    "question_text_reading": {
       "en": "Which anime features the 'Akatsuki' organization?",
       "ja": "あかつきというそしきがとうじょうするアニメは？"
     }
@@ -16505,6 +18105,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'Ghibli Museum' famous for?",
+      "ja": "ジブリ美術館は、何で有名なのでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What is 'Ghibli Museum' famous for?",
       "ja": "ジブリびじゅつかんはなにでゆうめいか？"
     }
   },
@@ -16544,6 +18148,10 @@
     "id": "q00402",
     "image_path": null,
     "question_text": {
+      "en": "Which anime has 'Zanpakuto' as spirit swords?",
+      "ja": "斬魄刀（ざんぱくとう）という名の霊剣が登場するアニメはどれ？"
+    },
+    "question_text_reading": {
       "en": "Which anime has 'Zanpakuto' as spirit swords?",
       "ja": "ざんぱくとうというせいれいけんのアニメは？"
     }
@@ -16585,6 +18193,10 @@
     "image_path": null,
     "question_text": {
       "en": "What year did the original Pokemon anime first air in Japan?",
+      "ja": "オリジナルのポケモンアニメが日本で初めて放送されたのは何年ですか？"
+    },
+    "question_text_reading": {
+      "en": "What year did the original Pokemon anime first air in Japan?",
       "ja": "ぽけもんアニメがにほんではじめてほうそうされたのはなんねんか？"
     }
   },
@@ -16624,6 +18236,10 @@
     "id": "q00404",
     "image_path": null,
     "question_text": {
+      "en": "Which anime features characters fighting with 'Nen' energy?",
+      "ja": "Nenというエネルギーを使って戦うキャラクターが登場するアニメはどれ？"
+    },
+    "question_text_reading": {
       "en": "Which anime features characters fighting with 'Nen' energy?",
       "ja": "ねんをつかってたたかうアニメは？"
     }
@@ -16666,6 +18282,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'Fullmetal' referring to in Fullmetal Alchemist?",
+      "ja": "『鋼の錬金術師』における「Fullmetal」は、何を指しているのでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What is 'Fullmetal' referring to in Fullmetal Alchemist?",
       "ja": "はがねのれんきんじゅつしの「はがねの」はなにをさすか？"
     }
   },
@@ -16705,6 +18325,10 @@
     "id": "q00406",
     "image_path": null,
     "question_text": {
+      "en": "Which anime features the character Rem?",
+      "ja": "キャラクター「レム」が登場するアニメはどれ？"
+    },
+    "question_text_reading": {
       "en": "Which anime features the character Rem?",
       "ja": "れむがとうじょうするアニメは？"
     }
@@ -16746,6 +18370,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'Anime' literally referring to in Japanese?",
+      "ja": "日本語で「Anime」という言葉は、文字通り何を指しているのでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What is 'Anime' literally referring to in Japanese?",
       "ja": "にほんごで「アニメ」はもともと何をさすか？"
     }
   },
@@ -16786,6 +18414,10 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime is famous for the phrase 'Plus Ultra'?",
+      "ja": "Plus Ultraというフレーズで有名なアニメはどれ？"
+    },
+    "question_text_reading": {
+      "en": "Which anime is famous for the phrase 'Plus Ultra'?",
       "ja": "ぷらすうるとらというフレーズでゆうめいなアニメは？"
     }
   },
@@ -16825,6 +18457,10 @@
     "id": "q00409",
     "image_path": null,
     "question_text": {
+      "en": "Which anime is about a boy who discovers he can become a hero by training hard?",
+      "ja": "一生懸命トレーニングを積むことでヒーローになれることを知った少年を描いたアニメはどれ？"
+    },
+    "question_text_reading": {
       "en": "Which anime is about a boy who discovers he can become a hero by training hard?",
       "ja": "はげんれんしゅうでひーろーになれることをしったしょうねんのアニメは？"
     }
@@ -16867,6 +18503,10 @@
     "question_text": {
       "en": "What is 'Shingeki no Kyojin' in English?",
       "ja": "しんげきのきょじんの英語タイトルは？"
+    },
+    "question_text_reading": {
+      "en": "What is 'Shingeki no Kyojin' in English?",
+      "ja": "しんげきのきょじんの英語タイトルは？"
     }
   },
   {
@@ -16906,6 +18546,10 @@
     "id": "q00411",
     "image_path": null,
     "question_text": {
+      "en": "What is the name of Satoru Gojo's special ability?",
+      "ja": "ごじょうさとるの特殊能力のなまえは？"
+    },
+    "question_text_reading": {
       "en": "What is the name of Satoru Gojo's special ability?",
       "ja": "ごじょうさとるの特殊能力のなまえは？"
     }
@@ -16950,6 +18594,10 @@
     "question_text": {
       "en": "Which anime is a psychological thriller with 'Death Note'?",
       "ja": "デスノートはどんなジャンルのアニメか？"
+    },
+    "question_text_reading": {
+      "en": "Which anime is a psychological thriller with 'Death Note'?",
+      "ja": "デスノートはどんなジャンルのアニメか？"
     }
   },
   {
@@ -16990,6 +18638,10 @@
     "image_path": null,
     "question_text": {
       "en": "What console launched the modern era of 3D gaming?",
+      "ja": "3Dゲームの現代的な時代を切り開いたゲーム機は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What console launched the modern era of 3D gaming?",
       "ja": "3Dげーむのしんじだいをひらいたてゆきとは？"
     }
   },
@@ -17029,6 +18681,10 @@
     "id": "q00414",
     "image_path": null,
     "question_text": {
+      "en": "What game features Link as the protagonist?",
+      "ja": "リンクが主人公のゲームはどれ？"
+    },
+    "question_text_reading": {
       "en": "What game features Link as the protagonist?",
       "ja": "りんくがしゅじんこうのげーむは？"
     }
@@ -17071,6 +18727,10 @@
     "question_text": {
       "en": "What is the best-selling video game of all time (as of 2024)?",
       "ja": "2024ねんじてんでもっともうれたびでおげーむは？"
+    },
+    "question_text_reading": {
+      "en": "What is the best-selling video game of all time (as of 2024)?",
+      "ja": "2024ねんじてんでもっともうれたびでおげーむは？"
     }
   },
   {
@@ -17110,6 +18770,10 @@
     "id": "q00416",
     "image_path": null,
     "question_text": {
+      "en": "Which company makes the PlayStation?",
+      "ja": "PlayStationを製造している会社はどこですか？"
+    },
+    "question_text_reading": {
       "en": "Which company makes the PlayStation?",
       "ja": "ぷれいすてーしょんをつくっているかいしゃは？"
     }
@@ -17151,6 +18815,10 @@
     "image_path": null,
     "question_text": {
       "en": "Which game features Mario and Luigi?",
+      "ja": "マリオとルイージが登場するゲームはどれですか？"
+    },
+    "question_text_reading": {
+      "en": "Which game features Mario and Luigi?",
       "ja": "まりおとるいーじがとうじょうするげーむは？"
     }
   },
@@ -17190,6 +18858,10 @@
     "id": "q00418",
     "image_path": null,
     "question_text": {
+      "en": "What is the iconic yellow ghost-eating character?",
+      "ja": "象徴的な黄色い、お化けを食べるキャラクターは何でしょう？"
+    },
+    "question_text_reading": {
       "en": "What is the iconic yellow ghost-eating character?",
       "ja": "おばけをたべるきいろいキャラクターは？"
     }
@@ -17231,6 +18903,10 @@
     "image_path": null,
     "question_text": {
       "en": "Which game series features Master Chief?",
+      "ja": "マスターチーフが登場するゲームシリーズはどれですか？"
+    },
+    "question_text_reading": {
+      "en": "Which game series features Master Chief?",
       "ja": "ますたーちいふがとうじょうするげーむシリーズは？"
     }
   },
@@ -17270,6 +18946,10 @@
     "id": "q00420",
     "image_path": null,
     "question_text": {
+      "en": "What game popularized the battle royale genre?",
+      "ja": "バトルロイヤルというジャンルを広めたゲームは何でしょう？"
+    },
+    "question_text_reading": {
       "en": "What game popularized the battle royale genre?",
       "ja": "ばとるろわいやるジャンルをひろめたげーむは？"
     }
@@ -17312,6 +18992,10 @@
     "image_path": null,
     "question_text": {
       "en": "Which company made Sonic the Hedgehog?",
+      "ja": "ソニック・ザ・ヘッジホッグを制作した会社はどこですか？"
+    },
+    "question_text_reading": {
+      "en": "Which company made Sonic the Hedgehog?",
       "ja": "そにっくざへっじほっぐをつくったかいしゃは？"
     }
   },
@@ -17352,6 +19036,10 @@
     "image_path": null,
     "question_text": {
       "en": "What game series features the Covenant as enemies?",
+      "ja": "コヴェナントという敵が登場するゲームシリーズはどれ？"
+    },
+    "question_text_reading": {
+      "en": "What game series features the Covenant as enemies?",
       "ja": "こべナントがてきとしてとうじょうするげーむシリーズは？"
     }
   },
@@ -17391,6 +19079,10 @@
     "id": "q00423",
     "image_path": null,
     "question_text": {
+      "en": "Which game is famous for the phrase 'The Cake is a Lie'?",
+      "ja": "The Cake is a Lieというフレーズで有名なゲームはどれですか？"
+    },
+    "question_text_reading": {
       "en": "Which game is famous for the phrase 'The Cake is a Lie'?",
       "ja": "「けーきはうそだ」というフレーズでゆうめいなげーむは？"
     }
@@ -17435,6 +19127,10 @@
     "question_text": {
       "en": "What is the setting of the Dark Souls series?",
       "ja": "ダークソウルシリーズの舞台は？"
+    },
+    "question_text_reading": {
+      "en": "What is the setting of the Dark Souls series?",
+      "ja": "ダークソウルシリーズの舞台は？"
     }
   },
   {
@@ -17473,6 +19169,10 @@
     "id": "q00425",
     "image_path": null,
     "question_text": {
+      "en": "What game created the 'survival horror' genre?",
+      "ja": "サバイバルホラーというジャンルを確立したゲームはどれでしょう？"
+    },
+    "question_text_reading": {
       "en": "What game created the 'survival horror' genre?",
       "ja": "さばいばるほらーというジャンルをつくったげーむは？"
     }
@@ -17513,6 +19213,10 @@
     "id": "q00426",
     "image_path": null,
     "question_text": {
+      "en": "What year was the original Minecraft released to the public?",
+      "ja": "オリジナルのMinecraftが一般に公開されたのは何年ですか？"
+    },
+    "question_text_reading": {
       "en": "What year was the original Minecraft released to the public?",
       "ja": "おりじなるまいんくらふとがこうかいされたのはなんねんか？"
     }
@@ -17557,6 +19261,10 @@
     "question_text": {
       "en": "What is the objective in Tetris?",
       "ja": "テトリスのもくてきは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is the objective in Tetris?",
+      "ja": "テトリスのもくてきは何か？"
     }
   },
   {
@@ -17598,6 +19306,10 @@
     "image_path": null,
     "question_text": {
       "en": "Which game series features Arthur Morgan or John Marston?",
+      "ja": "アーサー・モルガンやジョン・マストンが登場するゲームシリーズはどれ？"
+    },
+    "question_text_reading": {
+      "en": "Which game series features Arthur Morgan or John Marston?",
       "ja": "あーさーもるがんまたはじょんまーすとんがとうじょうするシリーズは？"
     }
   },
@@ -17638,6 +19350,10 @@
     "image_path": null,
     "question_text": {
       "en": "What genre is 'The Sims'?",
+      "ja": "『The Sims』はどのようなジャンルのゲームですか？"
+    },
+    "question_text_reading": {
+      "en": "What genre is 'The Sims'?",
       "ja": "ざしむずのジャンルは？"
     }
   },
@@ -17677,6 +19393,10 @@
     "id": "q00430",
     "image_path": null,
     "question_text": {
+      "en": "Which Nintendo franchise features Link and Zelda?",
+      "ja": "リンクとゼルダが登場する任天堂のフランチャイズはどれですか？"
+    },
+    "question_text_reading": {
       "en": "Which Nintendo franchise features Link and Zelda?",
       "ja": "りんくとぜるだのにんてんどうフランチャイズは？"
     }
@@ -17719,6 +19439,10 @@
     "question_text": {
       "en": "What type of game is 'Among Us'?",
       "ja": "あまんぐあすのゲームジャンルは？"
+    },
+    "question_text_reading": {
+      "en": "What type of game is 'Among Us'?",
+      "ja": "あまんぐあすのゲームジャンルは？"
     }
   },
   {
@@ -17757,6 +19481,10 @@
     "id": "q00432",
     "image_path": null,
     "question_text": {
+      "en": "What was Nintendo's first game console?",
+      "ja": "任天堂が発売した最初のゲーム機は何ですか？"
+    },
+    "question_text_reading": {
       "en": "What was Nintendo's first game console?",
       "ja": "にんてんどうのはじめてのゲームきは？"
     }
@@ -17798,6 +19526,10 @@
     "image_path": null,
     "question_text": {
       "en": "Which game series features Commander Shepard?",
+      "ja": "コマンドー・シェパードが登場するゲームシリーズはどれ？"
+    },
+    "question_text_reading": {
+      "en": "Which game series features Commander Shepard?",
       "ja": "しぇぱーどさがおのシリーズは？"
     }
   },
@@ -17837,6 +19569,10 @@
     "id": "q00434",
     "image_path": null,
     "question_text": {
+      "en": "What is the name of Link's fairy companion in Ocarina of Time?",
+      "ja": "時のオカリナに登場するリンクの妖精の名前は何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the name of Link's fairy companion in Ocarina of Time?",
       "ja": "時のオカリナでりんくのようせいのなまえは？"
     }
@@ -17879,6 +19615,10 @@
     "question_text": {
       "en": "What is a JRPG?",
       "ja": "JRPGとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a JRPG?",
+      "ja": "JRPGとは何か？"
     }
   },
   {
@@ -17917,6 +19657,10 @@
     "id": "q00436",
     "image_path": null,
     "question_text": {
+      "en": "Which game company made Final Fantasy?",
+      "ja": "ファイナルファンタジーを制作したゲーム会社はどこですか？"
+    },
+    "question_text_reading": {
       "en": "Which game company made Final Fantasy?",
       "ja": "ふぁいなるふぁんたじーをつくったかいしゃは？"
     }
@@ -17958,6 +19702,10 @@
     "id": "q00437",
     "image_path": null,
     "question_text": {
+      "en": "What is 'permadeath' in games?",
+      "ja": "ゲームにおける「permadeath」とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is 'permadeath' in games?",
       "ja": "ゲームのぱーまですとは何か？"
     }
@@ -18002,6 +19750,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a roguelike game?",
+      "ja": "ローグライクゲームとはどのようなジャンルのゲームですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a roguelike game?",
       "ja": "ろーぐらいくゲームとは何か？"
     }
   },
@@ -18044,6 +19796,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the objective in chess (video game version)?",
+      "ja": "チェス（ビデオゲーム版）における目的は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the objective in chess (video game version)?",
       "ja": "チェスのもくてきは何か？"
     }
   },
@@ -18084,6 +19840,10 @@
     "image_path": null,
     "question_text": {
       "en": "What year was the first Super Mario Bros released?",
+      "ja": "スーパーマリオブラザーズが最初に発売されたのは何年ですか？"
+    },
+    "question_text_reading": {
+      "en": "What year was the first Super Mario Bros released?",
       "ja": "はつのすーぱーまりおぶらざーずはいつはつばいされたか？"
     }
   },
@@ -18123,6 +19883,10 @@
     "id": "q00441",
     "image_path": null,
     "question_text": {
+      "en": "Which game features the Covenant, Flood, and Forerunners?",
+      "ja": "コベナント、フラッド、フォレナーナーが登場するゲームはどれですか？"
+    },
+    "question_text_reading": {
       "en": "Which game features the Covenant, Flood, and Forerunners?",
       "ja": "こべナント、ふらっど、ふぉーらんなーがとうじょうするゲームは？"
     }
@@ -18165,6 +19929,10 @@
     "question_text": {
       "en": "What type of game is 'SimCity'?",
       "ja": "しむしてぃのゲームジャンルは？"
+    },
+    "question_text_reading": {
+      "en": "What type of game is 'SimCity'?",
+      "ja": "しむしてぃのゲームジャンルは？"
     }
   },
   {
@@ -18203,6 +19971,10 @@
     "id": "q00443",
     "image_path": null,
     "question_text": {
+      "en": "What is the main currency in Animal Crossing?",
+      "ja": "あつまれどうぶつのもりの主な通貨は何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the main currency in Animal Crossing?",
       "ja": "あつまれどうぶつのもりのつうかは？"
     }
@@ -18245,6 +20017,10 @@
     "question_text": {
       "en": "Which game is known for the catchphrase 'Gotta Catch 'Em All'?",
       "ja": "「ぜんぶつかまえろ」というキャッチフレーズのゲームは？"
+    },
+    "question_text_reading": {
+      "en": "Which game is known for the catchphrase 'Gotta Catch 'Em All'?",
+      "ja": "「ぜんぶつかまえろ」というキャッチフレーズのゲームは？"
     }
   },
   {
@@ -18284,6 +20060,10 @@
     "id": "q00445",
     "image_path": null,
     "question_text": {
+      "en": "Which company makes the Xbox?",
+      "ja": "Xboxを製造しているのはどの会社ですか？"
+    },
+    "question_text_reading": {
       "en": "Which company makes the Xbox?",
       "ja": "えっくすぼっくすをつくっているかいしゃは？"
     }
@@ -18326,6 +20106,10 @@
     "question_text": {
       "en": "What is 'health points' abbreviated as in games?",
       "ja": "ゲームでヘルスポイントのりゃくごは？"
+    },
+    "question_text_reading": {
+      "en": "What is 'health points' abbreviated as in games?",
+      "ja": "ゲームでヘルスポイントのりゃくごは？"
     }
   },
   {
@@ -18364,6 +20148,10 @@
     "id": "q00447",
     "image_path": null,
     "question_text": {
+      "en": "What is 'magic points' abbreviated as in games?",
+      "ja": "ゲームで「magic points」は略して何と呼ぶ？"
+    },
+    "question_text_reading": {
       "en": "What is 'magic points' abbreviated as in games?",
       "ja": "ゲームでまほうぽいんとのりゃくごは？"
     }
@@ -18404,6 +20192,10 @@
     "id": "q00448",
     "image_path": null,
     "question_text": {
+      "en": "What does 'NPC' mean in video games?",
+      "ja": "ビデオゲームのNPCのいみは？"
+    },
+    "question_text_reading": {
       "en": "What does 'NPC' mean in video games?",
       "ja": "ビデオゲームのNPCのいみは？"
     }
@@ -18448,6 +20240,10 @@
     "question_text": {
       "en": "What is 'DLC' in gaming?",
       "ja": "ゲームのDLCのいみは？"
+    },
+    "question_text_reading": {
+      "en": "What is 'DLC' in gaming?",
+      "ja": "ゲームのDLCのいみは？"
     }
   },
   {
@@ -18488,6 +20284,10 @@
     "id": "q00450",
     "image_path": null,
     "question_text": {
+      "en": "What is 'grinding' in RPGs?",
+      "ja": "RPGにおける「grinding」とはどのような行為ですか？"
+    },
+    "question_text_reading": {
       "en": "What is 'grinding' in RPGs?",
       "ja": "RPGの「ぐらいんど」とは何か？"
     }
@@ -18531,6 +20331,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a 'loot box'?",
+      "ja": "loot boxとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a 'loot box'?",
       "ja": "るーとぼっくすとは何か？"
     }
   },
@@ -18572,6 +20376,10 @@
     "question_text": {
       "en": "What is an 'Easter egg' in games?",
       "ja": "ゲームのイースターたまごとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is an 'Easter egg' in games?",
+      "ja": "ゲームのイースターたまごとは何か？"
     }
   },
   {
@@ -18611,6 +20419,10 @@
     "id": "q00453",
     "image_path": null,
     "question_text": {
+      "en": "What is 'speedrunning'?",
+      "ja": "speedrunningとはどのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is 'speedrunning'?",
       "ja": "すぴーどらんとは何か？"
     }
@@ -18655,6 +20467,10 @@
     "question_text": {
       "en": "What is 'FPS' as a game genre?",
       "ja": "ゲームジャンルとしてのFPSとは？"
+    },
+    "question_text_reading": {
+      "en": "What is 'FPS' as a game genre?",
+      "ja": "ゲームジャンルとしてのFPSとは？"
     }
   },
   {
@@ -18696,6 +20512,10 @@
     "question_text": {
       "en": "What is 'MOBA' as a game genre?",
       "ja": "ゲームジャンルとしてのMOBAとは？"
+    },
+    "question_text_reading": {
+      "en": "What is 'MOBA' as a game genre?",
+      "ja": "ゲームジャンルとしてのMOBAとは？"
     }
   },
   {
@@ -18734,6 +20554,10 @@
     "id": "q00456",
     "image_path": null,
     "question_text": {
+      "en": "Which game has 'Creepers' as enemies?",
+      "ja": "敵として「Creepers」が登場するゲームはどれ？"
+    },
+    "question_text_reading": {
       "en": "Which game has 'Creepers' as enemies?",
       "ja": "クリーパーがてきとしてとうじょうするゲームは？"
     }
@@ -18777,6 +20601,10 @@
     "question_text": {
       "en": "What is the iconic opening music of the original Legend of Zelda?",
       "ja": "ゼルダのでんせつのアイコニックなオープニング音楽は？"
+    },
+    "question_text_reading": {
+      "en": "What is the iconic opening music of the original Legend of Zelda?",
+      "ja": "ゼルダのでんせつのアイコニックなオープニング音楽は？"
     }
   },
   {
@@ -18818,6 +20646,10 @@
     "image_path": null,
     "question_text": {
       "en": "What does it mean to 'no-hit' a boss?",
+      "ja": "ボスを「no-hit」するとは、具体的にどのような状態を指すのでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What does it mean to 'no-hit' a boss?",
       "ja": "ボスを「のーひっと」するとは？"
     }
   },
@@ -18858,6 +20690,10 @@
     "id": "q00459",
     "image_path": null,
     "question_text": {
+      "en": "What is 'Game Over' traditionally?",
+      "ja": "「ゲームオーバー」はどういいみか？"
+    },
+    "question_text_reading": {
       "en": "What is 'Game Over' traditionally?",
       "ja": "「ゲームオーバー」はどういいみか？"
     }
@@ -18902,6 +20738,10 @@
     "question_text": {
       "en": "What is 'co-op' gaming?",
       "ja": "こおぷゲームとは？"
+    },
+    "question_text_reading": {
+      "en": "What is 'co-op' gaming?",
+      "ja": "こおぷゲームとは？"
     }
   },
   {
@@ -18942,6 +20782,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a 'sandbox' game?",
+      "ja": "サンドボックスゲームとはどのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a 'sandbox' game?",
       "ja": "さんどぼっくすゲームとは？"
     }
   },
@@ -18981,6 +20825,10 @@
     "id": "q00462",
     "image_path": null,
     "question_text": {
+      "en": "Which Capcom game series features Leon Kennedy and Chris Redfield?",
+      "ja": "カプコンのゲームシリーズで、リーオン・ケネディとクリス・レッドフィールドが登場するのはどれですか？"
+    },
+    "question_text_reading": {
       "en": "Which Capcom game series features Leon Kennedy and Chris Redfield?",
       "ja": "れおんけねでぃとくりすれっどふぃーるどのカプコンシリーズは？"
     }
@@ -19025,6 +20873,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a 'hit scan' in FPS games?",
+      "ja": "FPSゲームにおける「hit scan」とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a 'hit scan' in FPS games?",
       "ja": "FPSのひっとすきゃんとは何か？"
     }
   },
@@ -19065,6 +20917,10 @@
     "id": "q00464",
     "image_path": null,
     "question_text": {
+      "en": "What is 'lag' in online gaming?",
+      "ja": "オンラインゲームにおける「lag」とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is 'lag' in online gaming?",
       "ja": "おんらいんゲームのらぐとは何か？"
     }
@@ -19108,6 +20964,10 @@
     "question_text": {
       "en": "Which game is famous for 'The Legend of Zelda: Breath of the Wild'?",
       "ja": "ゼルダのでんせつ ブレスオブザワイルドはどんなゲームか？"
+    },
+    "question_text_reading": {
+      "en": "Which game is famous for 'The Legend of Zelda: Breath of the Wild'?",
+      "ja": "ゼルダのでんせつ ブレスオブザワイルドはどんなゲームか？"
     }
   },
   {
@@ -19149,6 +21009,10 @@
     "question_text": {
       "en": "What console is the Switch?",
       "ja": "スイッチはどのゲームきか？"
+    },
+    "question_text_reading": {
+      "en": "What console is the Switch?",
+      "ja": "スイッチはどのゲームきか？"
     }
   },
   {
@@ -19188,6 +21052,10 @@
     "id": "q00467",
     "image_path": null,
     "question_text": {
+      "en": "What is the objective in chess?",
+      "ja": "チェスにおける目的は何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the objective in chess?",
       "ja": "チェスのもくてきは何か？"
     }
@@ -19231,6 +21099,10 @@
     "question_text": {
       "en": "What is 'PvP' in games?",
       "ja": "ゲームのPvPとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is 'PvP' in games?",
+      "ja": "ゲームのPvPとは何か？"
     }
   },
   {
@@ -19270,6 +21142,10 @@
     "id": "q00469",
     "image_path": null,
     "question_text": {
+      "en": "What is 'PvE' in games?",
+      "ja": "ゲームのPvEとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is 'PvE' in games?",
       "ja": "ゲームのPvEとは何か？"
     }
@@ -19314,6 +21190,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a 'buff' in games?",
+      "ja": "ゲームにおける「buff」とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a 'buff' in games?",
       "ja": "ゲームのばふとは何か？"
     }
   },
@@ -19357,6 +21237,10 @@
     "question_text": {
       "en": "What is a 'nerf' in game balance?",
       "ja": "ゲームバランスのなーふとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a 'nerf' in game balance?",
+      "ja": "ゲームバランスのなーふとは何か？"
     }
   },
   {
@@ -19395,6 +21279,10 @@
     "id": "q00472",
     "image_path": null,
     "question_text": {
+      "en": "Which company made Street Fighter?",
+      "ja": "ストリートファイターを開発した会社はどこですか？"
+    },
+    "question_text_reading": {
       "en": "Which company made Street Fighter?",
       "ja": "すとりーとふぁいたーをつくったかいしゃは？"
     }
@@ -19437,6 +21325,10 @@
     "question_text": {
       "en": "What is the classic arcade game where you break bricks with a ball?",
       "ja": "ぼーるでれんがをこわすクラシックアーケードゲームは？"
+    },
+    "question_text_reading": {
+      "en": "What is the classic arcade game where you break bricks with a ball?",
+      "ja": "ぼーるでれんがをこわすクラシックアーケードゲームは？"
     }
   },
   {
@@ -19475,6 +21367,10 @@
     "id": "q00474",
     "image_path": null,
     "question_text": {
+      "en": "What is the most popular MOBA game?",
+      "ja": "もっとにんきのあるMOBAゲームは？"
+    },
+    "question_text_reading": {
       "en": "What is the most popular MOBA game?",
       "ja": "もっとにんきのあるMOBAゲームは？"
     }
@@ -19518,6 +21414,10 @@
     "question_text": {
       "en": "What is the setting of 'The Witcher' series?",
       "ja": "ウィッチャーシリーズの舞台は？"
+    },
+    "question_text_reading": {
+      "en": "What is the setting of 'The Witcher' series?",
+      "ja": "ウィッチャーシリーズの舞台は？"
     }
   },
   {
@@ -19556,6 +21456,10 @@
     "id": "q00476",
     "image_path": null,
     "question_text": {
+      "en": "What is 'respawning' in games?",
+      "ja": "ゲームにおける「respawning」とはどういう意味ですか？"
+    },
+    "question_text_reading": {
       "en": "What is 'respawning' in games?",
       "ja": "ゲームのりすぽーんとは何か？"
     }
@@ -19596,6 +21500,10 @@
     "id": "q00477",
     "image_path": null,
     "question_text": {
+      "en": "What is the main resource in Fortnite for building?",
+      "ja": "フォートナイトで建築に使う主な資源は何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the main resource in Fortnite for building?",
       "ja": "フォートナイトでけんちくにつかうまいんりそーすは？"
     }
@@ -19638,6 +21546,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is an 'achievement' in games?",
+      "ja": "ゲームにおける「achievement」とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is an 'achievement' in games?",
       "ja": "ゲームのあちーぶめんととは何か？"
     }
   },
@@ -19678,6 +21590,10 @@
     "id": "q00479",
     "image_path": null,
     "question_text": {
+      "en": "What is 'frame rate' in games?",
+      "ja": "ゲームにおける「frame rate」とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is 'frame rate' in games?",
       "ja": "ゲームのふれーむれーととは何か？"
     }
@@ -19723,6 +21639,10 @@
     "question_text": {
       "en": "What is 'V-sync' in gaming?",
       "ja": "ゲームのVsyncとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is 'V-sync' in gaming?",
+      "ja": "ゲームのVsyncとは何か？"
     }
   },
   {
@@ -19762,6 +21682,10 @@
     "id": "q00481",
     "image_path": null,
     "question_text": {
+      "en": "What was Pong?",
+      "ja": "Pongとはどのようなゲームでしたか？"
+    },
+    "question_text_reading": {
       "en": "What was Pong?",
       "ja": "ぽんぐとは何か？"
     }
@@ -19805,6 +21729,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'bullet hell' in games?",
+      "ja": "ゲームにおける「bullet hell」とはどのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is 'bullet hell' in games?",
       "ja": "ゲームのたんまくとは何か？"
     }
   },
@@ -19844,6 +21772,10 @@
     "id": "q00483",
     "image_path": null,
     "question_text": {
+      "en": "What is a 'save point'?",
+      "ja": "save pointとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a 'save point'?",
       "ja": "せーぶぽいんととは何か？"
     }
@@ -19885,6 +21817,10 @@
     "id": "q00484",
     "image_path": null,
     "question_text": {
+      "en": "What is 'open world' in games?",
+      "ja": "ゲームにおける「open world」とはどのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is 'open world' in games?",
       "ja": "ゲームのおーぷんわーるどとは何か？"
     }
@@ -19929,6 +21865,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'turn-based' combat?",
+      "ja": "ターン制の戦闘とはどのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is 'turn-based' combat?",
       "ja": "ターンせいせんとうとは何か？"
     }
   },
@@ -19968,6 +21908,10 @@
     "id": "q00486",
     "image_path": null,
     "question_text": {
+      "en": "What is 'real-time strategy' (RTS)?",
+      "ja": "リアルタイムストラテジー（RTS）とは、どのようなジャンルのゲームのことですか？"
+    },
+    "question_text_reading": {
       "en": "What is 'real-time strategy' (RTS)?",
       "ja": "りあるたいむすとらてじーとは何か？"
     }
@@ -20010,6 +21954,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a 'patch' in gaming?",
+      "ja": "ゲームにおける「patch」とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a 'patch' in gaming?",
       "ja": "ゲームのぱっちとは何か？"
     }
   },
@@ -20051,6 +21999,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the term for games released on multiple platforms?",
+      "ja": "複数のプラットフォームでリリースされるゲームの総称は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the term for games released on multiple platforms?",
       "ja": "ふくすうぷらっとふぉームでリリースされるゲームのようごは？"
     }
   },
@@ -20091,6 +22043,10 @@
     "id": "q00489",
     "image_path": null,
     "question_text": {
+      "en": "What is a 'platformer' game?",
+      "ja": "プラットフォーマーゲームとはどのようなジャンルですか？"
+    },
+    "question_text_reading": {
       "en": "What is a 'platformer' game?",
       "ja": "ぷらっとふぉーまーゲームとは何か？"
     }
@@ -20134,6 +22090,10 @@
     "question_text": {
       "en": "What is 'Metroidvania' genre?",
       "ja": "めとろいどばにあジャンルとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is 'Metroidvania' genre?",
+      "ja": "めとろいどばにあジャンルとは何か？"
     }
   },
   {
@@ -20174,6 +22134,10 @@
     "question_text": {
       "en": "What console generation is the PlayStation 5?",
       "ja": "プレイステーション5は何世代目のゲームきか？"
+    },
+    "question_text_reading": {
+      "en": "What console generation is the PlayStation 5?",
+      "ja": "プレイステーション5は何世代目のゲームきか？"
     }
   },
   {
@@ -20212,6 +22176,10 @@
     "id": "q00492",
     "image_path": null,
     "question_text": {
+      "en": "What is an 'indie game'?",
+      "ja": "indie gameとはどのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is an 'indie game'?",
       "ja": "いんでぃゲームとは何か？"
     }
@@ -20254,6 +22222,10 @@
     "question_text": {
       "en": "What is Steam?",
       "ja": "Steamとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is Steam?",
+      "ja": "Steamとは何か？"
     }
   },
   {
@@ -20293,6 +22265,10 @@
     "id": "q00494",
     "image_path": null,
     "question_text": {
+      "en": "What is manga?",
+      "ja": "マンガとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is manga?",
       "ja": "まんがとは何か？"
     }
@@ -20336,6 +22312,10 @@
     "question_text": {
       "en": "Who created Dragon Ball manga?",
       "ja": "ドラゴンボールのまんがをかいたのは？"
+    },
+    "question_text_reading": {
+      "en": "Who created Dragon Ball manga?",
+      "ja": "ドラゴンボールのまんがをかいたのは？"
     }
   },
   {
@@ -20374,6 +22354,10 @@
     "id": "q00496",
     "image_path": null,
     "question_text": {
+      "en": "What is the best-selling manga of all time?",
+      "ja": "史上最も売れた漫画は何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the best-selling manga of all time?",
       "ja": "もっともうれたまんがは？"
     }
@@ -20419,6 +22403,10 @@
     "question_text": {
       "en": "What magazine did Naruto run in?",
       "ja": "ナルトが掲載されていたざっしは？"
+    },
+    "question_text_reading": {
+      "en": "What magazine did Naruto run in?",
+      "ja": "ナルトが掲載されていたざっしは？"
     }
   },
   {
@@ -20459,6 +22447,10 @@
     "id": "q00498",
     "image_path": null,
     "question_text": {
+      "en": "What is 'tankoubon'?",
+      "ja": "たんこうぼんとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is 'tankoubon'?",
       "ja": "たんこうぼんとは何か？"
     }
@@ -20502,6 +22494,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'seinen' manga targeted at?",
+      "ja": "seinen漫画は、どのような読者を主なターゲットとしているのでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What is 'seinen' manga targeted at?",
       "ja": "せいねんまんがはなにをたいしょうとしているか？"
     }
   },
@@ -20544,6 +22540,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'josei' manga targeted at?",
+      "ja": "joseiマンガは、どのような読者を主なターゲットとしているのでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What is 'josei' manga targeted at?",
       "ja": "じょせいまんがはなにをたいしょうとしているか？"
     }
   },
@@ -20583,6 +22583,10 @@
     "id": "q00501",
     "image_path": null,
     "question_text": {
+      "en": "What does 'manga-ka' mean?",
+      "ja": "manga-kaとは、どのような意味ですか？"
+    },
+    "question_text_reading": {
       "en": "What does 'manga-ka' mean?",
       "ja": "まんがかとは何か？"
     }
@@ -20625,6 +22629,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'furigana' in manga?",
+      "ja": "漫画における「ふりがな」とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is 'furigana' in manga?",
       "ja": "まんがのふりがなとは何か？"
     }
   },
@@ -20665,6 +22673,10 @@
     "id": "q00503",
     "image_path": null,
     "question_text": {
+      "en": "Who created the manga 'Berserk'?",
+      "ja": "漫画『ベルセルク』の作者は誰ですか？"
+    },
+    "question_text_reading": {
       "en": "Who created the manga 'Berserk'?",
       "ja": "まんが「ベルセルク」をかいたのは？"
     }
@@ -20708,6 +22720,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the manga 'One Punch Man' about?",
+      "ja": "漫画『ワンパンマン』は、どのような物語を描いているのでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What is the manga 'One Punch Man' about?",
       "ja": "まんが「ワンパンマン」はなにについてか？"
     }
   },
@@ -20748,6 +22764,10 @@
     "image_path": null,
     "question_text": {
       "en": "Which manga is known for its intricate artwork style?",
+      "ja": "緻密な作画スタイルで知られる漫画はどれですか？"
+    },
+    "question_text_reading": {
+      "en": "Which manga is known for its intricate artwork style?",
       "ja": "ふくざつなえのまんがで知られるのは？"
     }
   },
@@ -20787,6 +22807,10 @@
     "id": "q00506",
     "image_path": null,
     "question_text": {
+      "en": "What is the most famous work of Osamu Tezuka?",
+      "ja": "手塚治虫の最も有名な作品は何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the most famous work of Osamu Tezuka?",
       "ja": "てづかおさむのもっともゆうめいなさくひんは？"
     }
@@ -20832,6 +22856,10 @@
     "question_text": {
       "en": "What is 'Shonen' manga primarily about?",
       "ja": "しょうねんまんがのおもなないようは？"
+    },
+    "question_text_reading": {
+      "en": "What is 'Shonen' manga primarily about?",
+      "ja": "しょうねんまんがのおもなないようは？"
     }
   },
   {
@@ -20871,6 +22899,10 @@
     "id": "q00508",
     "image_path": null,
     "question_text": {
+      "en": "Which manga follows the Joestars across multiple generations?",
+      "ja": "ジョースター家の物語を、何世代にもわたって追う漫画はどれだろう？"
+    },
+    "question_text_reading": {
       "en": "Which manga follows the Joestars across multiple generations?",
       "ja": "じょえすたーけのものがたりのまんがは？"
     }
@@ -20913,6 +22945,10 @@
     "question_text": {
       "en": "What is 'webtoon'?",
       "ja": "うぇぶとぅーんとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is 'webtoon'?",
+      "ja": "うぇぶとぅーんとは何か？"
     }
   },
   {
@@ -20952,6 +22988,10 @@
     "id": "q00510",
     "image_path": null,
     "question_text": {
+      "en": "Who created Bleach?",
+      "ja": "Bleach（ブリーチ）を創造したのは誰ですか？"
+    },
+    "question_text_reading": {
       "en": "Who created Bleach?",
       "ja": "ブリーチをかいたのは？"
     }
@@ -20993,6 +23033,10 @@
     "id": "q00511",
     "image_path": null,
     "question_text": {
+      "en": "What type of story is 'Monster' by Naoki Urasawa?",
+      "ja": "浦沢直樹の『MONSTER』は、どのようなジャンルの物語ですか？"
+    },
+    "question_text_reading": {
       "en": "What type of story is 'Monster' by Naoki Urasawa?",
       "ja": "うらさわなおきのモンスターはどんなものがたりか？"
     }
@@ -21037,6 +23081,10 @@
     "question_text": {
       "en": "What is 'doujinshi'?",
       "ja": "どうじんしとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is 'doujinshi'?",
+      "ja": "どうじんしとは何か？"
     }
   },
   {
@@ -21076,6 +23124,10 @@
     "id": "q00513",
     "image_path": null,
     "question_text": {
+      "en": "Which manga is about a time-traveling story in feudal Japan?",
+      "ja": "戦国時代を舞台に、タイムトラベルする漫画はどれ？"
+    },
+    "question_text_reading": {
       "en": "Which manga is about a time-traveling story in feudal Japan?",
       "ja": "せんごくじだいのにほんにタイムトラベルするまんがは？"
     }
@@ -21120,6 +23172,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the manga 'Yotsubato!' about?",
+      "ja": "漫画『よつばと!』は、どのような物語を描いているの？"
+    },
+    "question_text_reading": {
+      "en": "What is the manga 'Yotsubato!' about?",
       "ja": "まんが「よつばと!」はなにについてか？"
     }
   },
@@ -21160,6 +23216,10 @@
     "id": "q00515",
     "image_path": null,
     "question_text": {
+      "en": "Which manga series is set in ancient China?",
+      "ja": "古代中国を舞台にしている漫画シリーズはどれですか？"
+    },
+    "question_text_reading": {
       "en": "Which manga series is set in ancient China?",
       "ja": "こだいちゅうごくをぶたいにしたまんがシリーズは？"
     }
@@ -21202,6 +23262,10 @@
     "image_path": null,
     "question_text": {
       "en": "Who draws One Piece?",
+      "ja": "ワンピースの作者は誰ですか？"
+    },
+    "question_text_reading": {
+      "en": "Who draws One Piece?",
       "ja": "ワンピースをかいているのは誰か？"
     }
   },
@@ -21241,6 +23305,10 @@
     "id": "q00517",
     "image_path": null,
     "question_text": {
+      "en": "What is the premise of Vinland Saga?",
+      "ja": "『ヴィンランド・サガ』の物語の前提となるものは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the premise of Vinland Saga?",
       "ja": "ゔぃんらんどさがのせっていは？"
     }
@@ -21284,6 +23352,10 @@
     "question_text": {
       "en": "What is 'gekiga'?",
       "ja": "げきがとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is 'gekiga'?",
+      "ja": "げきがとは何か？"
     }
   },
   {
@@ -21323,6 +23395,10 @@
     "id": "q00519",
     "image_path": null,
     "question_text": {
+      "en": "What manga features Edward and Alphonse Elric?",
+      "ja": "エドワードとアルフォンス・エルリックが登場する漫画は何ですか？"
+    },
+    "question_text_reading": {
       "en": "What manga features Edward and Alphonse Elric?",
       "ja": "えどわーどとあるふぉんすえるりっくのまんがは？"
     }
@@ -21367,6 +23443,10 @@
     "question_text": {
       "en": "What is Kimetsu no Yaiba known as in English?",
       "ja": "きめつのやいばの英語タイトルは？"
+    },
+    "question_text_reading": {
+      "en": "What is Kimetsu no Yaiba known as in English?",
+      "ja": "きめつのやいばの英語タイトルは？"
     }
   },
   {
@@ -21406,6 +23486,10 @@
     "id": "q00521",
     "image_path": null,
     "question_text": {
+      "en": "Which manga is drawn by Hajime Isayama?",
+      "ja": "ハジメ・イサヤマが描いた漫画はどれですか？"
+    },
+    "question_text_reading": {
       "en": "Which manga is drawn by Hajime Isayama?",
       "ja": "いさやまはじめがかいたまんがは？"
     }
@@ -21449,6 +23533,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'Josei' manga magazine aimed at?",
+      "ja": "女性向けの漫画雑誌は、どのような層を対象としているのでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What is 'Josei' manga magazine aimed at?",
       "ja": "じょせいまんがざっしのたいしょうは？"
     }
   },
@@ -21490,6 +23578,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the manga equivalent of a light novel?",
+      "ja": "ライトノベルに相当する漫画は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the manga equivalent of a light novel?",
       "ja": "らいとのべるのまんがそうとうは？"
     }
   },
@@ -21529,6 +23621,10 @@
     "id": "q00524",
     "image_path": null,
     "question_text": {
+      "en": "Which manga features the Elric brothers searching for the Philosopher's Stone?",
+      "ja": "けんじゃのいしをさがすえるりっくきょうだいのまんがは？"
+    },
+    "question_text_reading": {
       "en": "Which manga features the Elric brothers searching for the Philosopher's Stone?",
       "ja": "けんじゃのいしをさがすえるりっくきょうだいのまんがは？"
     }
@@ -21572,6 +23668,10 @@
     "image_path": null,
     "question_text": {
       "en": "Who created Doraemon?",
+      "ja": "ドラえもんを創造したのは誰ですか？"
+    },
+    "question_text_reading": {
+      "en": "Who created Doraemon?",
       "ja": "ドラえもんをかいたのは？"
     }
   },
@@ -21614,6 +23714,10 @@
     "question_text": {
       "en": "What is the genre of 'Vagabond'?",
       "ja": "バガボンドのジャンルは？"
+    },
+    "question_text_reading": {
+      "en": "What is the genre of 'Vagabond'?",
+      "ja": "バガボンドのジャンルは？"
     }
   },
   {
@@ -21652,6 +23756,10 @@
     "id": "q00527",
     "image_path": null,
     "question_text": {
+      "en": "What is a 'spin-off' manga?",
+      "ja": "スピンオフまんがとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is a 'spin-off' manga?",
       "ja": "スピンオフまんがとは何か？"
     }
@@ -21694,6 +23802,10 @@
     "question_text": {
       "en": "What makes manga read differently from Western comics?",
       "ja": "まんがが西洋まんがとちがうよみかたは？"
+    },
+    "question_text_reading": {
+      "en": "What makes manga read differently from Western comics?",
+      "ja": "まんがが西洋まんがとちがうよみかたは？"
     }
   },
   {
@@ -21732,6 +23844,10 @@
     "id": "q00529",
     "image_path": null,
     "question_text": {
+      "en": "Which manga has the longest running story?",
+      "ja": "最も連載期間が長い漫画はどれですか？"
+    },
+    "question_text_reading": {
       "en": "Which manga has the longest running story?",
       "ja": "もっともちょうへんのまんがは？"
     }
@@ -21774,6 +23890,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'shojo manga' famous for?",
+      "ja": "少女漫画は、どのような点で有名なのでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What is 'shojo manga' famous for?",
       "ja": "しょうじょまんがはなにでゆうめいか？"
     }
   },
@@ -21813,6 +23933,10 @@
     "id": "q00531",
     "image_path": null,
     "question_text": {
+      "en": "Who is the creator of Sailor Moon manga?",
+      "ja": "セーラームーンまんがのさくしゃは？"
+    },
+    "question_text_reading": {
       "en": "Who is the creator of Sailor Moon manga?",
       "ja": "セーラームーンまんがのさくしゃは？"
     }
@@ -21856,6 +23980,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the manga 'Uzumaki' known for?",
+      "ja": "漫画『うずまき』は、何で知られているのでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What is the manga 'Uzumaki' known for?",
       "ja": "まんが「うずまき」はなにでゆうめいか？"
     }
   },
@@ -21896,6 +24024,10 @@
     "image_path": null,
     "question_text": {
       "en": "What manga features Kenshiro as the main character?",
+      "ja": "ケンシロウが主人公の漫画はどれ？"
+    },
+    "question_text_reading": {
+      "en": "What manga features Kenshiro as the main character?",
       "ja": "けんしろうがしゅじんこうのまんがは？"
     }
   },
@@ -21935,6 +24067,10 @@
     "id": "q00534",
     "image_path": null,
     "question_text": {
+      "en": "What year was the first chapter of One Piece published?",
+      "ja": "ワンピースの最初の章が刊行されたのは何年ですか？"
+    },
+    "question_text_reading": {
       "en": "What year was the first chapter of One Piece published?",
       "ja": "ワンピースのさいしょのかいがしゅっぱんされたのはなんねんか？"
     }
@@ -21977,6 +24113,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the manga about Yuji Itadori eating a cursed finger?",
+      "ja": "呪いの指を食べる虎杖悠仁（ゆうじ・いたどり）に関する漫画は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the manga about Yuji Itadori eating a cursed finger?",
       "ja": "ゆうじいただりがじゅのゆびをたべるまんがは？"
     }
   },
@@ -22016,6 +24156,10 @@
     "id": "q00536",
     "image_path": null,
     "question_text": {
+      "en": "What is the main theme of 'Slam Dunk'?",
+      "ja": "スラムダンクのメインテーマは？"
+    },
+    "question_text_reading": {
       "en": "What is the main theme of 'Slam Dunk'?",
       "ja": "スラムダンクのメインテーマは？"
     }
@@ -22059,6 +24203,10 @@
     "question_text": {
       "en": "Which manga features time-travel murder mystery?",
       "ja": "タイムトラベルのさつじんミステリーのまんがは？"
+    },
+    "question_text_reading": {
+      "en": "Which manga features time-travel murder mystery?",
+      "ja": "タイムトラベルのさつじんミステリーのまんがは？"
     }
   },
   {
@@ -22097,6 +24245,10 @@
     "id": "q00538",
     "image_path": null,
     "question_text": {
+      "en": "What is Naoki Urasawa known for?",
+      "ja": "浦沢直樹はどのような作品で知られているだろうか？"
+    },
+    "question_text_reading": {
       "en": "What is Naoki Urasawa known for?",
       "ja": "うらさわなおきはなにでゆうめいか？"
     }
@@ -22142,6 +24294,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the manga that Chainsaw Man is serialized in?",
+      "ja": "『チェンソーマン』が連載されている漫画のタイトルは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the manga that Chainsaw Man is serialized in?",
       "ja": "チェーンソーマンがけいさいされているまんがは？"
     }
   },
@@ -22181,6 +24337,10 @@
     "id": "q00540",
     "image_path": null,
     "question_text": {
+      "en": "Who created 'Hunter x Hunter'?",
+      "ja": "ハンターハンターをかいたのは？"
+    },
+    "question_text_reading": {
       "en": "Who created 'Hunter x Hunter'?",
       "ja": "ハンターハンターをかいたのは？"
     }
@@ -22225,6 +24385,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'Gekkan Shounen Nozaki-kun' about?",
+      "ja": "『月刊少年ノ崎くん』は、どのような物語ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is 'Gekkan Shounen Nozaki-kun' about?",
       "ja": "「げっかんしょうねんのざきくん」はなにについてか？"
     }
   },
@@ -22264,6 +24428,10 @@
     "id": "q00542",
     "image_path": null,
     "question_text": {
+      "en": "Which manga ran from 1999 and features Gon Freecss as protagonist?",
+      "ja": "1999年から連載され、主人公がGon Freecssの漫画はどれ？"
+    },
+    "question_text_reading": {
       "en": "Which manga ran from 1999 and features Gon Freecss as protagonist?",
       "ja": "1999ねんかられんさいのごんふりーくすがしゅじんこうのまんがは？"
     }
@@ -22305,6 +24473,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'yonkoma' manga?",
+      "ja": "よんコマ漫画とは、どのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is 'yonkoma' manga?",
       "ja": "よんこままんがとは何か？"
     }
   },
@@ -22345,6 +24517,10 @@
     "id": "q00544",
     "image_path": null,
     "question_text": {
+      "en": "What type of manga is 'Yuru Camp'?",
+      "ja": "『ゆるキャン△』はどのようなジャンルの漫画ですか？"
+    },
+    "question_text_reading": {
       "en": "What type of manga is 'Yuru Camp'?",
       "ja": "ゆるキャンのまんがのしゅるいは？"
     }
@@ -22388,6 +24564,10 @@
     "question_text": {
       "en": "Who is the creator of Fairy Tail?",
       "ja": "フェアリーテイルをかいたのは？"
+    },
+    "question_text_reading": {
+      "en": "Who is the creator of Fairy Tail?",
+      "ja": "フェアリーテイルをかいたのは？"
     }
   },
   {
@@ -22427,6 +24607,10 @@
     "id": "q00546",
     "image_path": null,
     "question_text": {
+      "en": "What is the famous manga by CLAMP?",
+      "ja": "CLAMPによる有名な漫画作品は何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the famous manga by CLAMP?",
       "ja": "CLAMPのゆうめいなまんがは？"
     }
@@ -22471,6 +24655,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'Seinen' manga known for?",
+      "ja": "青年（せいねん）向け漫画は、どのようなジャンルで知られているだろうか？"
+    },
+    "question_text_reading": {
+      "en": "What is 'Seinen' manga known for?",
       "ja": "せいねんまんがはなにでゆうめいか？"
     }
   },
@@ -22513,6 +24701,10 @@
     "image_path": null,
     "question_text": {
       "en": "What makes Hirohiko Araki unique as a manga artist?",
+      "ja": "漫画家として荒木飛呂彦の独自性はどこにあるだろうか？"
+    },
+    "question_text_reading": {
+      "en": "What makes Hirohiko Araki unique as a manga artist?",
       "ja": "まんがかとしてのあらきひろひこのとくちょうは？"
     }
   },
@@ -22552,6 +24744,10 @@
     "id": "q00549",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of France?",
+      "ja": "フランスの首都はどこですか？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of France?",
       "ja": "ふらんすのしゅとは？"
     }
@@ -22596,6 +24792,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Japan?",
+      "ja": "日本の首都はどこですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of Japan?",
       "ja": "にほんのしゅとは？"
     }
   },
@@ -22635,6 +24835,10 @@
     "id": "q00551",
     "image_path": null,
     "question_text": {
+      "en": "What is the largest country by area?",
+      "ja": "面積が最も大きい国はどこですか？"
+    },
+    "question_text_reading": {
       "en": "What is the largest country by area?",
       "ja": "めんせきがもっともおおきいくには？"
     }
@@ -22677,6 +24881,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the longest river in the world?",
+      "ja": "世界で最も長い川は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the longest river in the world?",
       "ja": "せかいでもっともながいかわは？"
     }
   },
@@ -22716,6 +24924,10 @@
     "id": "q00553",
     "image_path": null,
     "question_text": {
+      "en": "What is the highest mountain in the world?",
+      "ja": "世界で最も高い山は何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the highest mountain in the world?",
       "ja": "せかいでもっともたかいやまは？"
     }
@@ -22758,6 +24970,10 @@
     "image_path": null,
     "question_text": {
       "en": "What continent is Egypt in?",
+      "ja": "エジプトはどの大陸に位置していますか？"
+    },
+    "question_text_reading": {
+      "en": "What continent is Egypt in?",
       "ja": "えじぷとはどのたいりくにあるか？"
     }
   },
@@ -22797,6 +25013,10 @@
     "id": "q00555",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of Germany?",
+      "ja": "ドイツの首都はどこですか？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of Germany?",
       "ja": "どいつのしゅとは？"
     }
@@ -22841,6 +25061,10 @@
     "image_path": null,
     "question_text": {
       "en": "What ocean separates Africa from South America?",
+      "ja": "アフリカ大陸と南米大陸を隔てている海はどこですか？"
+    },
+    "question_text_reading": {
+      "en": "What ocean separates Africa from South America?",
       "ja": "あふりかとみなみあめりかをへだてるうみは？"
     }
   },
@@ -22880,6 +25104,10 @@
     "id": "q00557",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of Australia?",
+      "ja": "オーストラリアの首都はどこですか？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of Australia?",
       "ja": "おーすとらりあのしゅとは？"
     }
@@ -22921,6 +25149,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the smallest country in the world?",
+      "ja": "世界で最も面積が小さい国はどこですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the smallest country in the world?",
       "ja": "せかいでもっともちいさいくには？"
     }
   },
@@ -22960,6 +25192,10 @@
     "id": "q00559",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of Brazil?",
+      "ja": "ブラジルの首都はどこですか？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of Brazil?",
       "ja": "ぶらじるのしゅとは？"
     }
@@ -23002,6 +25238,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of China?",
+      "ja": "中国の首都はどこですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of China?",
       "ja": "ちゅうごくのしゅとは？"
     }
   },
@@ -23042,6 +25282,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the largest desert in the world?",
+      "ja": "世界で最も広い砂漠はどこですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the largest desert in the world?",
       "ja": "せかいでもっともおおきいさばくは？"
     }
   },
@@ -23081,6 +25325,10 @@
     "id": "q00562",
     "image_path": null,
     "question_text": {
+      "en": "How many continents are there?",
+      "ja": "地球上には何大陸ありますか？"
+    },
+    "question_text_reading": {
       "en": "How many continents are there?",
       "ja": "たいりくはいくつあるか？"
     }
@@ -23123,6 +25371,10 @@
     "question_text": {
       "en": "What is the capital of the USA?",
       "ja": "アメリカのしゅとは？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of the USA?",
+      "ja": "アメリカのしゅとは？"
     }
   },
   {
@@ -23161,6 +25413,10 @@
     "id": "q00564",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of Italy?",
+      "ja": "イタリアの首都はどこですか？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of Italy?",
       "ja": "いたりあのしゅとは？"
     }
@@ -23202,6 +25458,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Spain?",
+      "ja": "スペインの首都はどこですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of Spain?",
       "ja": "すぺいんのしゅとは？"
     }
   },
@@ -23242,6 +25502,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Canada?",
+      "ja": "カナダの首都はどこですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of Canada?",
       "ja": "かなだのしゅとは？"
     }
   },
@@ -23281,6 +25545,10 @@
     "id": "q00567",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of Russia?",
+      "ja": "ロシアの首都はどこですか？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of Russia?",
       "ja": "ろしあのしゅとは？"
     }
@@ -23323,6 +25591,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of South Korea?",
+      "ja": "韓国の首都はどこですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of South Korea?",
       "ja": "かんこくのしゅとは？"
     }
   },
@@ -23362,6 +25634,10 @@
     "id": "q00569",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of India?",
+      "ja": "インドの首都はどこですか？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of India?",
       "ja": "いんどのしゅとは？"
     }
@@ -23403,6 +25679,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Mexico?",
+      "ja": "メキシコの首都はどこですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of Mexico?",
       "ja": "めきしこのしゅとは？"
     }
   },
@@ -23442,6 +25722,10 @@
     "id": "q00571",
     "image_path": null,
     "question_text": {
+      "en": "What country has the Eiffel Tower?",
+      "ja": "エッフェル塔がある国はどこでしょう？"
+    },
+    "question_text_reading": {
       "en": "What country has the Eiffel Tower?",
       "ja": "えっふぇるとうはどのくににあるか？"
     }
@@ -23483,6 +25767,10 @@
     "image_path": null,
     "question_text": {
       "en": "What country has the Colosseum?",
+      "ja": "コロッセオがある国はどこですか？"
+    },
+    "question_text_reading": {
+      "en": "What country has the Colosseum?",
       "ja": "ころっせおはどのくににあるか？"
     }
   },
@@ -23522,6 +25810,10 @@
     "id": "q00573",
     "image_path": null,
     "question_text": {
+      "en": "What country is the Amazon rainforest mostly in?",
+      "ja": "アマゾン熱帯雨林は、主にどの国に位置していますか？"
+    },
+    "question_text_reading": {
       "en": "What country is the Amazon rainforest mostly in?",
       "ja": "あまぞんのねったいうりんはおもにどのくににあるか？"
     }
@@ -23564,6 +25856,10 @@
     "image_path": null,
     "question_text": {
       "en": "What sea is between Europe and Africa?",
+      "ja": "ヨーロッパとアフリカの間にある海はどこですか？"
+    },
+    "question_text_reading": {
+      "en": "What sea is between Europe and Africa?",
       "ja": "ゆーろっぱとあふりかのあいだのうみは？"
     }
   },
@@ -23603,6 +25899,10 @@
     "id": "q00575",
     "image_path": null,
     "question_text": {
+      "en": "What country owns the Galapagos Islands?",
+      "ja": "ガラパゴス諸島はどの国の領土ですか？"
+    },
+    "question_text_reading": {
       "en": "What country owns the Galapagos Islands?",
       "ja": "がらぱごすとうはどのくにのりょうどか？"
     }
@@ -23644,6 +25944,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the longest mountain range?",
+      "ja": "世界で最も長い山脈は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the longest mountain range?",
       "ja": "せかいでもっともながいさんみゃくは？"
     }
   },
@@ -23684,6 +25988,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the deepest lake in the world?",
+      "ja": "世界で最も深い湖の名前は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the deepest lake in the world?",
       "ja": "せかいでもっともふかいみずうみは？"
     }
   },
@@ -23723,6 +26031,10 @@
     "id": "q00578",
     "image_path": null,
     "question_text": {
+      "en": "What country has the most natural UNESCO World Heritage Sites?",
+      "ja": "自然のUNESCO世界遺産が最も多い国はどこでしょう？"
+    },
+    "question_text_reading": {
       "en": "What country has the most natural UNESCO World Heritage Sites?",
       "ja": "しぜんのユネスコせかいいさんがもっともおおいくには？"
     }
@@ -23767,6 +26079,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the largest ocean?",
+      "ja": "世界で一番大きな海はどれでしょう？"
+    },
+    "question_text_reading": {
+      "en": "What is the largest ocean?",
       "ja": "もっともおおきいうみは？"
     }
   },
@@ -23808,6 +26124,10 @@
     "image_path": null,
     "question_text": {
       "en": "What continent is Argentina in?",
+      "ja": "アルゼンチンはどの大陸に位置していますか？"
+    },
+    "question_text_reading": {
+      "en": "What continent is Argentina in?",
       "ja": "あるぜんちんはどのたいりくにあるか？"
     }
   },
@@ -23847,6 +26167,10 @@
     "id": "q00581",
     "image_path": null,
     "question_text": {
+      "en": "What country is known as the Land of the Rising Sun?",
+      "ja": "日の出の国として知られる国はどこですか？"
+    },
+    "question_text_reading": {
       "en": "What country is known as the Land of the Rising Sun?",
       "ja": "ひのでのくにといわれるのはどのくにか？"
     }
@@ -23888,6 +26212,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Egypt?",
+      "ja": "エジプトの首都はどこですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of Egypt?",
       "ja": "えじぷとのしゅとは？"
     }
   },
@@ -23927,6 +26255,10 @@
     "id": "q00583",
     "image_path": null,
     "question_text": {
+      "en": "What mountain range separates Europe and Asia?",
+      "ja": "ヨーロッパとアジアを隔てている山脈はどれでしょう？"
+    },
+    "question_text_reading": {
       "en": "What mountain range separates Europe and Asia?",
       "ja": "ゆーろっぱとあじあをへだてるさんみゃくは？"
     }
@@ -23969,6 +26301,10 @@
     "question_text": {
       "en": "What country has the Great Barrier Reef?",
       "ja": "グレートバリアリーフはどのくににあるか？"
+    },
+    "question_text_reading": {
+      "en": "What country has the Great Barrier Reef?",
+      "ja": "グレートバリアリーフはどのくににあるか？"
     }
   },
   {
@@ -24007,6 +26343,10 @@
     "id": "q00585",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of Turkey?",
+      "ja": "トルコの首都はどこですか？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of Turkey?",
       "ja": "とるこのしゅとは？"
     }
@@ -24048,6 +26388,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of South Africa?",
+      "ja": "南アフリカの首都はどこですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of South Africa?",
       "ja": "みなみあふりかのしゅとは？"
     }
   },
@@ -24087,6 +26431,10 @@
     "id": "q00587",
     "image_path": null,
     "question_text": {
+      "en": "What country is the Sahara Desert mostly in?",
+      "ja": "サハラ砂漠は、主にどの国に位置していますか？"
+    },
+    "question_text_reading": {
       "en": "What country is the Sahara Desert mostly in?",
       "ja": "さはらさばくはおもにどのくににあるか？"
     }
@@ -24128,6 +26476,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Argentina?",
+      "ja": "アルゼンチンの首都はどこですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of Argentina?",
       "ja": "あるぜんちんのしゅとは？"
     }
   },
@@ -24167,6 +26519,10 @@
     "id": "q00589",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of Sweden?",
+      "ja": "スウェーデンの首都はどこですか？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of Sweden?",
       "ja": "すうぇーでんのしゅとは？"
     }
@@ -24208,6 +26564,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Greece?",
+      "ja": "ギリシャの首都はどこですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of Greece?",
       "ja": "ぎりしあのしゅとは？"
     }
   },
@@ -24247,6 +26607,10 @@
     "id": "q00591",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of Netherlands?",
+      "ja": "オランダの首都はどこですか？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of Netherlands?",
       "ja": "おらんだのしゅとは？"
     }
@@ -24288,6 +26652,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Poland?",
+      "ja": "ポーランドの首都はどこですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of Poland?",
       "ja": "ぽーらんどのしゅとは？"
     }
   },
@@ -24327,6 +26695,10 @@
     "id": "q00593",
     "image_path": null,
     "question_text": {
+      "en": "What country has the most islands?",
+      "ja": "最も多くの島を持つ国はどこでしょう？"
+    },
+    "question_text_reading": {
       "en": "What country has the most islands?",
       "ja": "もっともおおいしまのあるくには？"
     }
@@ -24368,6 +26740,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of New Zealand?",
+      "ja": "ニュージーランドの首都はどこですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of New Zealand?",
       "ja": "にゅーじーらんどのしゅとは？"
     }
   },
@@ -24407,6 +26783,10 @@
     "id": "q00595",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of Nigeria?",
+      "ja": "ナイジェリアの首都はどこですか？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of Nigeria?",
       "ja": "ないじぇりあのしゅとは？"
     }
@@ -24448,6 +26828,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Thailand?",
+      "ja": "タイの首都はどこですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of Thailand?",
       "ja": "たいらんどのしゅとは？"
     }
   },
@@ -24487,6 +26871,10 @@
     "id": "q00597",
     "image_path": null,
     "question_text": {
+      "en": "What country is the Taj Mahal in?",
+      "ja": "タージ・マハルはどの国にありますか？"
+    },
+    "question_text_reading": {
       "en": "What country is the Taj Mahal in?",
       "ja": "たじまはるはどのくににあるか？"
     }
@@ -24528,6 +26916,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Saudi Arabia?",
+      "ja": "サウジアラビアの首都はどこですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of Saudi Arabia?",
       "ja": "さうじあらびあのしゅとは？"
     }
   },
@@ -24567,6 +26959,10 @@
     "id": "q00599",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of Kenya?",
+      "ja": "ケニアの首都はどこですか？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of Kenya?",
       "ja": "けにあのしゅとは？"
     }
@@ -24608,6 +27004,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the largest city in Africa by population?",
+      "ja": "アフリカで人口が最も多い都市はどこですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the largest city in Africa by population?",
       "ja": "じんこうがもっともおおいあふりかのとしは？"
     }
   },
@@ -24647,6 +27047,10 @@
     "id": "q00601",
     "image_path": null,
     "question_text": {
+      "en": "What two countries share Niagara Falls?",
+      "ja": "ナイアガラ滝を共有している二つの国はどこでしょう？"
+    },
+    "question_text_reading": {
       "en": "What two countries share Niagara Falls?",
       "ja": "ないあがらのたきをきょうゆうするふたつのくには？"
     }
@@ -24688,6 +27092,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Portugal?",
+      "ja": "ポルトガルの首都はどこですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the capital of Portugal?",
       "ja": "ぽるとがるのしゅとは？"
     }
   },
@@ -24727,6 +27135,10 @@
     "id": "q00603",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of Austria?",
+      "ja": "オーストリアの首都はどこですか？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of Austria?",
       "ja": "おーすとりあのしゅとは？"
     }
@@ -24768,6 +27180,10 @@
     "image_path": null,
     "question_text": {
       "en": "In what year did World War II end?",
+      "ja": "第二次世界大戦は、何年に終結したのでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "In what year did World War II end?",
       "ja": "だいにじせかいたいせんはなんねんにおわったか？"
     }
   },
@@ -24808,6 +27224,10 @@
     "image_path": null,
     "question_text": {
       "en": "Who was the first President of the United States?",
+      "ja": "アメリカ合衆国初の大統領は誰ですか？"
+    },
+    "question_text_reading": {
+      "en": "Who was the first President of the United States?",
       "ja": "アメリカのしょだいだいとうりょうは誰か？"
     }
   },
@@ -24847,6 +27267,10 @@
     "id": "q00606",
     "image_path": null,
     "question_text": {
+      "en": "What year did the French Revolution begin?",
+      "ja": "フランス革命は何年頃に始まったのでしょうか？"
+    },
+    "question_text_reading": {
       "en": "What year did the French Revolution begin?",
       "ja": "ふらんすかくめいはなんねんにはじまったか？"
     }
@@ -24890,6 +27314,10 @@
     "image_path": null,
     "question_text": {
       "en": "Who built the Great Wall of China?",
+      "ja": "万里の長城を築いたのは誰ですか？"
+    },
+    "question_text_reading": {
+      "en": "Who built the Great Wall of China?",
       "ja": "ちゅうごくのばんりのちょうじょうをきずいたのは誰か？"
     }
   },
@@ -24930,6 +27358,10 @@
     "image_path": null,
     "question_text": {
       "en": "What civilization built the pyramids of Giza?",
+      "ja": "ギザのピラミッドを建設したのはどの文明ですか？"
+    },
+    "question_text_reading": {
+      "en": "What civilization built the pyramids of Giza?",
       "ja": "ぎざのぴらみっどをきずいたぶんめいは？"
     }
   },
@@ -24969,6 +27401,10 @@
     "id": "q00609",
     "image_path": null,
     "question_text": {
+      "en": "When did the Roman Empire fall?",
+      "ja": "ローマ帝国はいつ滅亡したのでしょうか？"
+    },
+    "question_text_reading": {
       "en": "When did the Roman Empire fall?",
       "ja": "ろーまていこくはいつほろんだか？"
     }
@@ -25012,6 +27448,10 @@
     "image_path": null,
     "question_text": {
       "en": "Who was Napoleon Bonaparte?",
+      "ja": "ナポレオン・ボナパルトとはどのような人物ですか？"
+    },
+    "question_text_reading": {
+      "en": "Who was Napoleon Bonaparte?",
       "ja": "なぽれおんぼなぱるととは誰か？"
     }
   },
@@ -25051,6 +27491,10 @@
     "id": "q00611",
     "image_path": null,
     "question_text": {
+      "en": "What year did Columbus reach the Americas?",
+      "ja": "コロンブスがアメリカ大陸に到達したのは何年ですか？"
+    },
+    "question_text_reading": {
       "en": "What year did Columbus reach the Americas?",
       "ja": "ころんぶすがアメリカにたっしたのはなんねんか？"
     }
@@ -25095,6 +27539,10 @@
     "image_path": null,
     "question_text": {
       "en": "What was the Cold War?",
+      "ja": "冷戦とは、どのような時代のことだったのでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What was the Cold War?",
       "ja": "れいせんとは何か？"
     }
   },
@@ -25135,6 +27583,10 @@
     "image_path": null,
     "question_text": {
       "en": "Who was the last Pharaoh of ancient Egypt?",
+      "ja": "古代エジプトの最後のファラオは誰ですか？"
+    },
+    "question_text_reading": {
+      "en": "Who was the last Pharaoh of ancient Egypt?",
       "ja": "こだいえじぷとのさいごのふぁらおは誰か？"
     }
   },
@@ -25174,6 +27626,10 @@
     "id": "q00614",
     "image_path": null,
     "question_text": {
+      "en": "In what year did Japan's Meiji Restoration begin?",
+      "ja": "日本の明治維新は何年頃に始まったのでしょうか？"
+    },
+    "question_text_reading": {
       "en": "In what year did Japan's Meiji Restoration begin?",
       "ja": "にほんのめいじいしんははじまったのはなんねんか？"
     }
@@ -25218,6 +27674,10 @@
     "image_path": null,
     "question_text": {
       "en": "What was the Magna Carta?",
+      "ja": "マグナ・カルタとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What was the Magna Carta?",
       "ja": "まぐなかるたとは何か？"
     }
   },
@@ -25257,6 +27717,10 @@
     "id": "q00616",
     "image_path": null,
     "question_text": {
+      "en": "Who led the Indian independence movement against Britain?",
+      "ja": "イギリスに対するインドの独立運動を主導したのは誰ですか？"
+    },
+    "question_text_reading": {
       "en": "Who led the Indian independence movement against Britain?",
       "ja": "えいこくにたいするいんどどくりつうんどうをひきいたのは誰か？"
     }
@@ -25301,6 +27765,10 @@
     "image_path": null,
     "question_text": {
       "en": "What was the Renaissance?",
+      "ja": "ルネサンスとは、どのような時代のことですか？"
+    },
+    "question_text_reading": {
+      "en": "What was the Renaissance?",
       "ja": "るねさんすとは何か？"
     }
   },
@@ -25340,6 +27808,10 @@
     "id": "q00618",
     "image_path": null,
     "question_text": {
+      "en": "When did the Berlin Wall fall?",
+      "ja": "ベルリンの壁はいつ崩壊したのでしょうか？"
+    },
+    "question_text_reading": {
       "en": "When did the Berlin Wall fall?",
       "ja": "べるりんのかべはいつたおれたか？"
     }
@@ -25383,6 +27855,10 @@
     "image_path": null,
     "question_text": {
       "en": "What was the Boston Tea Party?",
+      "ja": "ボストン茶会事件とは、どのような出来事だったのでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What was the Boston Tea Party?",
       "ja": "ぼすとんてぃーぱーてぃーとは何か？"
     }
   },
@@ -25422,6 +27898,10 @@
     "id": "q00620",
     "image_path": null,
     "question_text": {
+      "en": "Who wrote the Communist Manifesto?",
+      "ja": "『共産党宣言』を著したのは誰ですか？"
+    },
+    "question_text_reading": {
       "en": "Who wrote the Communist Manifesto?",
       "ja": "きょうさんとうせんげんをかいたのは誰か？"
     }
@@ -25467,6 +27947,10 @@
     "image_path": null,
     "question_text": {
       "en": "What was the Silk Road?",
+      "ja": "シルクロードとは、どのようなものだったのでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What was the Silk Road?",
       "ja": "しるくろーどとは何か？"
     }
   },
@@ -25509,6 +27993,10 @@
     "image_path": null,
     "question_text": {
       "en": "Who was Julius Caesar?",
+      "ja": "ジュリアス・カエサルとはどのような人物ですか？"
+    },
+    "question_text_reading": {
+      "en": "Who was Julius Caesar?",
       "ja": "じゅりあすかいさーとは誰か？"
     }
   },
@@ -25548,6 +28036,10 @@
     "id": "q00623",
     "image_path": null,
     "question_text": {
+      "en": "What year did the first World War begin?",
+      "ja": "第一次世界大戦は何年に始まったの？"
+    },
+    "question_text_reading": {
       "en": "What year did the first World War begin?",
       "ja": "だいいちじせかいたいせんはなんねんにはじまったか？"
     }
@@ -25591,6 +28083,10 @@
     "image_path": null,
     "question_text": {
       "en": "Who was Genghis Khan?",
+      "ja": "チンギス・ハンとはどのような人物ですか？"
+    },
+    "question_text_reading": {
+      "en": "Who was Genghis Khan?",
       "ja": "ちんぎすかんとは誰か？"
     }
   },
@@ -25632,6 +28128,10 @@
     "id": "q00625",
     "image_path": null,
     "question_text": {
+      "en": "What ended the feudal period in Japan?",
+      "ja": "日本の封建時代を終わらせたのは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What ended the feudal period in Japan?",
       "ja": "にほんのほうけんじだいをおわらせたのは何か？"
     }
@@ -25675,6 +28175,10 @@
     "image_path": null,
     "question_text": {
       "en": "What was apartheid?",
+      "ja": "アパルトヘイトとはどのような制度だったのでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What was apartheid?",
       "ja": "あぱるとへいととは何か？"
     }
   },
@@ -25714,6 +28218,10 @@
     "id": "q00627",
     "image_path": null,
     "question_text": {
+      "en": "When did the American Civil War end?",
+      "ja": "アメリカ南北戦争はいつ終わったの？"
+    },
+    "question_text_reading": {
       "en": "When did the American Civil War end?",
       "ja": "アメリカなんぼくせんそうはなんねんにおわったか？"
     }
@@ -25755,6 +28263,10 @@
     "image_path": null,
     "question_text": {
       "en": "Who invented the printing press?",
+      "ja": "印刷機（printing press）を発明したのは誰ですか？"
+    },
+    "question_text_reading": {
+      "en": "Who invented the printing press?",
       "ja": "いんさつきをはつめいしたのは誰か？"
     }
   },
@@ -25795,6 +28307,10 @@
     "id": "q00629",
     "image_path": null,
     "question_text": {
+      "en": "What was the Black Death?",
+      "ja": "黒死病とは、どのような病気でしたか？"
+    },
+    "question_text_reading": {
       "en": "What was the Black Death?",
       "ja": "ぺすととは何か？"
     }
@@ -25839,6 +28355,10 @@
     "image_path": null,
     "question_text": {
       "en": "Who was Martin Luther King Jr.?",
+      "ja": "マーティン・ルーサー・キング・ジュニアとはどのような人物ですか？"
+    },
+    "question_text_reading": {
+      "en": "Who was Martin Luther King Jr.?",
       "ja": "まーてぃんるーさーきんぐじゅにあとは誰か？"
     }
   },
@@ -25879,6 +28399,10 @@
     "image_path": null,
     "question_text": {
       "en": "What year did the Soviet Union collapse?",
+      "ja": "ソビエト連邦が崩壊したのは何年ですか？"
+    },
+    "question_text_reading": {
+      "en": "What year did the Soviet Union collapse?",
       "ja": "ソヴィエトれんぽうはなんねんにほうかいしたか？"
     }
   },
@@ -25918,6 +28442,10 @@
     "id": "q00632",
     "image_path": null,
     "question_text": {
+      "en": "Who led the Cuban Revolution?",
+      "ja": "キューバ革命を主導したのは誰ですか？"
+    },
+    "question_text_reading": {
       "en": "Who led the Cuban Revolution?",
       "ja": "きゅーばかくめいをひきいたのは誰か？"
     }
@@ -25963,6 +28491,10 @@
     "image_path": null,
     "question_text": {
       "en": "What was D-Day?",
+      "ja": "D-Dayとは、どのような出来事だったのでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What was D-Day?",
       "ja": "でぃーでーとは何か？"
     }
   },
@@ -26002,6 +28534,10 @@
     "id": "q00634",
     "image_path": null,
     "question_text": {
+      "en": "When did the Titanic sink?",
+      "ja": "タイタニック号はいつ沈没したの？"
+    },
+    "question_text_reading": {
       "en": "When did the Titanic sink?",
       "ja": "たいたにっくはなんねんにしずんだか？"
     }
@@ -26044,6 +28580,10 @@
     "image_path": null,
     "question_text": {
       "en": "Who was Florence Nightingale?",
+      "ja": "フローレンス・ナイチンゲールとはどのような人物ですか？"
+    },
+    "question_text_reading": {
+      "en": "Who was Florence Nightingale?",
       "ja": "ふろれんすないちんげーるとは誰か？"
     }
   },
@@ -26083,6 +28623,10 @@
     "id": "q00636",
     "image_path": null,
     "question_text": {
+      "en": "What empire did Alexander the Great build?",
+      "ja": "アレクサンドロス大王が築いた帝国はどれでしょう？"
+    },
+    "question_text_reading": {
       "en": "What empire did Alexander the Great build?",
       "ja": "アレクサンドロスだいおうはどのようなていこくをきずいたか？"
     }
@@ -26124,6 +28668,10 @@
     "image_path": null,
     "question_text": {
       "en": "When did Japan attack Pearl Harbor?",
+      "ja": "日本がパールハーバーを攻撃したのはいつですか？"
+    },
+    "question_text_reading": {
+      "en": "When did Japan attack Pearl Harbor?",
       "ja": "にほんはなんねんにぱーるはーばーをこうげきしたか？"
     }
   },
@@ -26163,6 +28711,10 @@
     "id": "q00638",
     "image_path": null,
     "question_text": {
+      "en": "Who was the first man on the moon?",
+      "ja": "はじめて月にたったのは誰か？"
+    },
+    "question_text_reading": {
       "en": "Who was the first man on the moon?",
       "ja": "はじめて月にたったのは誰か？"
     }
@@ -26207,6 +28759,10 @@
     "image_path": null,
     "question_text": {
       "en": "What was the Crusades?",
+      "ja": "十字軍とはどのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What was the Crusades?",
       "ja": "じゅうじぐんとは何か？"
     }
   },
@@ -26249,6 +28805,10 @@
     "id": "q00640",
     "image_path": null,
     "question_text": {
+      "en": "What was the Enlightenment?",
+      "ja": "啓蒙時代とは、どのようなものだったのでしょうか？"
+    },
+    "question_text_reading": {
       "en": "What was the Enlightenment?",
       "ja": "けいもうじだいとは何か？"
     }
@@ -26293,6 +28853,10 @@
     "image_path": null,
     "question_text": {
       "en": "Who was Nelson Mandela?",
+      "ja": "ネルソン・マンデラとはどのような人物ですか？"
+    },
+    "question_text_reading": {
+      "en": "Who was Nelson Mandela?",
       "ja": "ねるそんまんでらとは誰か？"
     }
   },
@@ -26332,6 +28896,10 @@
     "id": "q00642",
     "image_path": null,
     "question_text": {
+      "en": "When was the United Nations founded?",
+      "ja": "国連はいつ設立されたのでしょうか？"
+    },
+    "question_text_reading": {
       "en": "When was the United Nations founded?",
       "ja": "こくさいれんごうはなんねんにせつりつされたか？"
     }
@@ -26374,6 +28942,10 @@
     "id": "q00643",
     "image_path": null,
     "question_text": {
+      "en": "What was the Industrial Revolution?",
+      "ja": "産業革命とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What was the Industrial Revolution?",
       "ja": "さんぎょうかくめいとは何か？"
     }
@@ -26419,6 +28991,10 @@
     "image_path": null,
     "question_text": {
       "en": "Who was Mao Zedong?",
+      "ja": "毛沢東とはどのような人物ですか？"
+    },
+    "question_text_reading": {
+      "en": "Who was Mao Zedong?",
       "ja": "もうたくとうとは誰か？"
     }
   },
@@ -26458,6 +29034,10 @@
     "id": "q00645",
     "image_path": null,
     "question_text": {
+      "en": "When did the Korean War end?",
+      "ja": "朝鮮戦争はいつ終わったの？"
+    },
+    "question_text_reading": {
       "en": "When did the Korean War end?",
       "ja": "ちょうせんせんそうはなんねんにおわったか？"
     }
@@ -26500,6 +29080,10 @@
     "id": "q00646",
     "image_path": null,
     "question_text": {
+      "en": "Who was Cleopatra?",
+      "ja": "クレオパトラとは、いったいどんな人物だったのでしょうか？"
+    },
+    "question_text_reading": {
       "en": "Who was Cleopatra?",
       "ja": "くれおぱとらとは誰か？"
     }
@@ -26545,6 +29129,10 @@
     "image_path": null,
     "question_text": {
       "en": "What was the Opium War?",
+      "ja": "アヘン戦争とは、どのような戦争だったのでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What was the Opium War?",
       "ja": "あへんせんそうとは何か？"
     }
   },
@@ -26589,6 +29177,10 @@
     "image_path": null,
     "question_text": {
       "en": "Who was Abraham Lincoln?",
+      "ja": "エイブラハム・リンカーンとはどのような人物ですか？"
+    },
+    "question_text_reading": {
+      "en": "Who was Abraham Lincoln?",
       "ja": "えいぶらはむりんかーんとは誰か？"
     }
   },
@@ -26628,6 +29220,10 @@
     "id": "q00649",
     "image_path": null,
     "question_text": {
+      "en": "What year did the Moon landing occur?",
+      "ja": "月面着陸は何年でしたか？"
+    },
+    "question_text_reading": {
       "en": "What year did the Moon landing occur?",
       "ja": "つきにひとがおりたのはなんねんか？"
     }
@@ -26670,6 +29266,10 @@
     "image_path": null,
     "question_text": {
       "en": "What was the Manhattan Project?",
+      "ja": "マンハッタン計画とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What was the Manhattan Project?",
       "ja": "まんはったんぷろじぇくととは何か？"
     }
   },
@@ -26711,6 +29311,10 @@
     "id": "q00651",
     "image_path": null,
     "question_text": {
+      "en": "Who was Nikola Tesla?",
+      "ja": "ニコラ・テスラとはどのような人物ですか？"
+    },
+    "question_text_reading": {
       "en": "Who was Nikola Tesla?",
       "ja": "にこらてすらとは誰か？"
     }
@@ -26756,6 +29360,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the Shogunate in Japanese history?",
+      "ja": "日本の歴史における「幕府（Shogunate）」とはどのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the Shogunate in Japanese history?",
       "ja": "にほんのしょうぐんとはどのようなものか？"
     }
   },
@@ -26800,6 +29408,10 @@
     "image_path": null,
     "question_text": {
       "en": "What was the Hundred Years' War?",
+      "ja": "百年戦争とは、どのような戦いだったのでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What was the Hundred Years' War?",
       "ja": "ひゃくねんせんそうとは何か？"
     }
   },
@@ -26841,6 +29453,10 @@
     "id": "q00654",
     "image_path": null,
     "question_text": {
+      "en": "Who was Tokugawa Ieyasu?",
+      "ja": "徳川家康とはどのような人物ですか？"
+    },
+    "question_text_reading": {
       "en": "Who was Tokugawa Ieyasu?",
       "ja": "とくがわいえやすとは誰か？"
     }
@@ -26886,6 +29502,10 @@
     "image_path": null,
     "question_text": {
       "en": "What was the Treaty of Versailles?",
+      "ja": "ヴェルサイユ条約とはどのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What was the Treaty of Versailles?",
       "ja": "べるさいゆじょうやくとは何か？"
     }
   },
@@ -26930,6 +29550,10 @@
     "image_path": null,
     "question_text": {
       "en": "Who was Winston Churchill?",
+      "ja": "ウィンストン・チャーチルとはどのような人物ですか？"
+    },
+    "question_text_reading": {
+      "en": "Who was Winston Churchill?",
       "ja": "うぃんすとんちゃーちるとは誰か？"
     }
   },
@@ -26970,6 +29594,10 @@
     "image_path": null,
     "question_text": {
       "en": "When did World War I end?",
+      "ja": "第一次世界大戦はいつ終わったの？"
+    },
+    "question_text_reading": {
+      "en": "When did World War I end?",
       "ja": "だいいちじせかいたいせんはなんねんにおわったか？"
     }
   },
@@ -27009,6 +29637,10 @@
     "id": "q00658",
     "image_path": null,
     "question_text": {
+      "en": "What is the chemical symbol for water?",
+      "ja": "水は何の化学記号ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the chemical symbol for water?",
       "ja": "みずのかがくしきは？"
     }
@@ -27052,6 +29684,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is Newton's first law of motion?",
+      "ja": "ニュートンの運動の第1法則とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is Newton's first law of motion?",
       "ja": "にゅーとんのうんどうのだいいちほうそくは？"
     }
   },
@@ -27091,6 +29727,10 @@
     "id": "q00660",
     "image_path": null,
     "question_text": {
+      "en": "What planet is known as the Red Planet?",
+      "ja": "赤い惑星として知られているのはどの惑星ですか？"
+    },
+    "question_text_reading": {
       "en": "What planet is known as the Red Planet?",
       "ja": "あかいわくせいとよばれるのは？"
     }
@@ -27134,6 +29774,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is photosynthesis?",
+      "ja": "光合成とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is photosynthesis?",
       "ja": "こうごうせいとは何か？"
     }
   },
@@ -27173,6 +29817,10 @@
     "id": "q00662",
     "image_path": null,
     "question_text": {
+      "en": "What is the speed of light?",
+      "ja": "光の速さはどれくらいですか？"
+    },
+    "question_text_reading": {
       "en": "What is the speed of light?",
       "ja": "ひかりのそくどは？"
     }
@@ -27215,6 +29863,10 @@
     "id": "q00663",
     "image_path": null,
     "question_text": {
+      "en": "What is DNA?",
+      "ja": "DNAとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is DNA?",
       "ja": "DNAとは何か？"
     }
@@ -27260,6 +29912,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the periodic table?",
+      "ja": "周期表とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the periodic table?",
       "ja": "げんそのしゅうきひょうとは何か？"
     }
   },
@@ -27302,6 +29958,10 @@
     "image_path": null,
     "question_text": {
       "en": "What causes thunder?",
+      "ja": "雷はなぜ鳴るのでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What causes thunder?",
       "ja": "かみなりがなるりゆうは？"
     }
   },
@@ -27342,6 +30002,10 @@
     "id": "q00666",
     "image_path": null,
     "question_text": {
+      "en": "What is a black hole?",
+      "ja": "ブラックホールとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a black hole?",
       "ja": "ぶらっくほーるとは何か？"
     }
@@ -27386,6 +30050,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is evolution?",
+      "ja": "進化とは、どのような現象ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is evolution?",
       "ja": "しんかとは何か？"
     }
   },
@@ -27425,6 +30093,10 @@
     "id": "q00668",
     "image_path": null,
     "question_text": {
+      "en": "What is the atomic number of Carbon?",
+      "ja": "炭素の原子番号は何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the atomic number of Carbon?",
       "ja": "たんそのげんしばんごうは？"
     }
@@ -27466,6 +30138,10 @@
     "id": "q00669",
     "image_path": null,
     "question_text": {
+      "en": "What is gravity?",
+      "ja": "重力とは、どのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is gravity?",
       "ja": "じゅうりょくとは何か？"
     }
@@ -27509,6 +30185,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the theory of relativity?",
+      "ja": "相対性理論とはどのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the theory of relativity?",
       "ja": "そうたいせいりろんとは何か？"
     }
   },
@@ -27548,6 +30228,10 @@
     "id": "q00671",
     "image_path": null,
     "question_text": {
+      "en": "What gas is most abundant in Earth's atmosphere?",
+      "ja": "地球の大気中に最も豊富に存在する気体は何ですか？"
+    },
+    "question_text_reading": {
       "en": "What gas is most abundant in Earth's atmosphere?",
       "ja": "ちきゅうのたいきにもっともおおいきたいは？"
     }
@@ -27592,6 +30276,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a neuron?",
+      "ja": "ニューロンとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a neuron?",
       "ja": "にゅーろんとは何か？"
     }
   },
@@ -27632,6 +30320,10 @@
     "id": "q00673",
     "image_path": null,
     "question_text": {
+      "en": "What is the Big Bang theory?",
+      "ja": "ビッグバン理論とは、どのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is the Big Bang theory?",
       "ja": "びっぐばんりろんとは何か？"
     }
@@ -27677,6 +30369,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the mitochondria?",
+      "ja": "ミトコンドリアとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the mitochondria?",
       "ja": "みとこんどりあとは何か？"
     }
   },
@@ -27719,6 +30415,10 @@
     "id": "q00675",
     "image_path": null,
     "question_text": {
+      "en": "What is osmosis?",
+      "ja": "浸透圧とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is osmosis?",
       "ja": "しんとうとは何か？"
     }
@@ -27763,6 +30463,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the greenhouse effect?",
+      "ja": "温室効果とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the greenhouse effect?",
       "ja": "おんしつこうかとは何か？"
     }
   },
@@ -27802,6 +30506,10 @@
     "id": "q00677",
     "image_path": null,
     "question_text": {
+      "en": "What force keeps planets in orbit?",
+      "ja": "惑星を軌道に留めている力は何ですか？"
+    },
+    "question_text_reading": {
       "en": "What force keeps planets in orbit?",
       "ja": "わくせいをきどうにたもつりょくは？"
     }
@@ -27847,6 +30555,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the function of the nucleus in a cell?",
+      "ja": "細胞の核はどのような役割を果たしているのでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What is the function of the nucleus in a cell?",
       "ja": "さいぼうのかくのやくわりは？"
     }
   },
@@ -27890,6 +30602,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is an atom?",
+      "ja": "原子とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is an atom?",
       "ja": "げんしとは何か？"
     }
   },
@@ -27929,6 +30645,10 @@
     "id": "q00680",
     "image_path": null,
     "question_text": {
+      "en": "What is a proton?",
+      "ja": "陽子とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a proton?",
       "ja": "ようしとは何か？"
     }
@@ -27971,6 +30691,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is an electron?",
+      "ja": "電子とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is an electron?",
       "ja": "でんしとは何か？"
     }
   },
@@ -28011,6 +30735,10 @@
     "id": "q00682",
     "image_path": null,
     "question_text": {
+      "en": "What is a neutron?",
+      "ja": "中性子とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a neutron?",
       "ja": "ちゅうせいしとは何か？"
     }
@@ -28053,6 +30781,10 @@
     "id": "q00683",
     "image_path": null,
     "question_text": {
+      "en": "What is the Milky Way?",
+      "ja": "天の川銀河とはどのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is the Milky Way?",
       "ja": "あまのがわとは何か？"
     }
@@ -28097,6 +30829,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is electromagnetic radiation?",
+      "ja": "電磁放射とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is electromagnetic radiation?",
       "ja": "でんじほうしゃとは何か？"
     }
   },
@@ -28139,6 +30875,10 @@
     "id": "q00685",
     "image_path": null,
     "question_text": {
+      "en": "What is chemical bonding?",
+      "ja": "化学結合とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is chemical bonding?",
       "ja": "かがくけつごうとは何か？"
     }
@@ -28183,6 +30923,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a hypothesis?",
+      "ja": "仮説とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a hypothesis?",
       "ja": "かせつとは何か？"
     }
   },
@@ -28226,6 +30970,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the scientific method?",
+      "ja": "科学的な手法とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the scientific method?",
       "ja": "かがくてきほうほうとは何か？"
     }
   },
@@ -28267,6 +31015,10 @@
     "id": "q00688",
     "image_path": null,
     "question_text": {
+      "en": "What is a gene?",
+      "ja": "遺伝子とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a gene?",
       "ja": "いでんしとは何か？"
     }
@@ -28310,6 +31062,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the food chain?",
+      "ja": "食物連鎖とは、どのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the food chain?",
       "ja": "しょくもつれんさとは何か？"
     }
   },
@@ -28349,6 +31105,10 @@
     "id": "q00690",
     "image_path": null,
     "question_text": {
+      "en": "What is the boiling point of water at sea level?",
+      "ja": "海面における水の沸点は何度ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the boiling point of water at sea level?",
       "ja": "かいめんでのみずのふってんは？"
     }
@@ -28390,6 +31150,10 @@
     "id": "q00691",
     "image_path": null,
     "question_text": {
+      "en": "What is a chemical reaction?",
+      "ja": "化学反応とは、どのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is a chemical reaction?",
       "ja": "かがくはんのうとは何か？"
     }
@@ -28433,6 +31197,10 @@
     "id": "q00692",
     "image_path": null,
     "question_text": {
+      "en": "What is the half-life of a radioactive element?",
+      "ja": "放射性元素の半減期とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the half-life of a radioactive element?",
       "ja": "ほうしゃせいげんそのはんぶんきとは何か？"
     }
@@ -28478,6 +31246,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a catalyst?",
+      "ja": "触媒とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a catalyst?",
       "ja": "しょくばいとは何か？"
     }
   },
@@ -28518,6 +31290,10 @@
     "id": "q00694",
     "image_path": null,
     "question_text": {
+      "en": "What is kinetic energy?",
+      "ja": "運動エネルギーとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is kinetic energy?",
       "ja": "うんどうえねるぎーとは何か？"
     }
@@ -28561,6 +31337,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is potential energy?",
+      "ja": "ポテンシャルエネルギーとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is potential energy?",
       "ja": "いねるぎーとは何か？"
     }
   },
@@ -28601,6 +31381,10 @@
     "id": "q00696",
     "image_path": null,
     "question_text": {
+      "en": "What is the law of conservation of energy?",
+      "ja": "エネルギー保存の法則とは、どのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is the law of conservation of energy?",
       "ja": "えねるぎーほぞんのほうそくとは何か？"
     }
@@ -28644,6 +31428,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the role of red blood cells?",
+      "ja": "赤血球の役割は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the role of red blood cells?",
       "ja": "せっけっきゅうのやくわりは？"
     }
   },
@@ -28686,6 +31474,10 @@
     "id": "q00698",
     "image_path": null,
     "question_text": {
+      "en": "What is the function of white blood cells?",
+      "ja": "白血球の主な役割は何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the function of white blood cells?",
       "ja": "はっけっきゅうのやくわりは？"
     }
@@ -28731,6 +31523,10 @@
     "image_path": null,
     "question_text": {
       "en": "What organ produces insulin?",
+      "ja": "インスリンを分泌する臓器はどれですか？"
+    },
+    "question_text_reading": {
+      "en": "What organ produces insulin?",
       "ja": "いんすりんをせいさんするきかんは？"
     }
   },
@@ -28774,6 +31570,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the function of the kidney?",
+      "ja": "腎臓の主な機能は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the function of the kidney?",
       "ja": "じんぞうのやくわりは？"
     }
   },
@@ -28816,6 +31616,10 @@
     "question_text": {
       "en": "What is a vaccine?",
       "ja": "ワクチンとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is a vaccine?",
+      "ja": "ワクチンとは何か？"
     }
   },
   {
@@ -28854,6 +31658,10 @@
     "id": "q00702",
     "image_path": null,
     "question_text": {
+      "en": "What is the pH scale?",
+      "ja": "pHスケールとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the pH scale?",
       "ja": "pHすけーるとは何か？"
     }
@@ -28895,6 +31703,10 @@
     "id": "q00703",
     "image_path": null,
     "question_text": {
+      "en": "What is acid rain?",
+      "ja": "酸性雨とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is acid rain?",
       "ja": "さんせいうとは何か？"
     }
@@ -28938,6 +31750,10 @@
     "id": "q00704",
     "image_path": null,
     "question_text": {
+      "en": "What is nuclear fission?",
+      "ja": "核分裂とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is nuclear fission?",
       "ja": "かくぶんれつとは何か？"
     }
@@ -28983,6 +31799,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is nuclear fusion?",
+      "ja": "核融合とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is nuclear fusion?",
       "ja": "かくゆうごうとは何か？"
     }
   },
@@ -29026,6 +31846,10 @@
     "question_text": {
       "en": "What is tectonic plates?",
       "ja": "プレートとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is tectonic plates?",
+      "ja": "プレートとは何か？"
     }
   },
   {
@@ -29066,6 +31890,10 @@
     "id": "q00707",
     "image_path": null,
     "question_text": {
+      "en": "What causes an earthquake?",
+      "ja": "地震の原因は何ですか？"
+    },
+    "question_text_reading": {
       "en": "What causes an earthquake?",
       "ja": "じしんのげんいんは？"
     }
@@ -29111,6 +31939,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the ozone layer?",
+      "ja": "オゾン層とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the ozone layer?",
       "ja": "おぞんそうとは何か？"
     }
   },
@@ -29150,6 +31982,10 @@
     "id": "q00709",
     "image_path": null,
     "question_text": {
+      "en": "What is a renewable energy source?",
+      "ja": "再生可能エネルギー源とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a renewable energy source?",
       "ja": "さいせいかのうなえねるぎーとは何か？"
     }
@@ -29191,6 +32027,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is 2 + 2?",
+      "ja": "2足す2はいくつですか？"
+    },
+    "question_text_reading": {
+      "en": "What is 2 + 2?",
       "ja": "2たす2はいくつ？"
     }
   },
@@ -29231,6 +32071,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the square root of 144?",
+      "ja": "144の平方根は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the square root of 144?",
       "ja": "144のへいほうこんは？"
     }
   },
@@ -29270,6 +32114,10 @@
     "id": "q00712",
     "image_path": null,
     "question_text": {
+      "en": "What is pi approximately equal to?",
+      "ja": "円周率 pi はおよそいくつですか？"
+    },
+    "question_text_reading": {
       "en": "What is pi approximately equal to?",
       "ja": "えんしゅうりつπはおよそいくつ？"
     }
@@ -29313,6 +32161,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the Pythagorean theorem?",
+      "ja": "ピタゴラスの定理とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the Pythagorean theorem?",
       "ja": "ぴたごらすのていりとは？"
     }
   },
@@ -29354,6 +32206,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a prime number?",
+      "ja": "素数とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a prime number?",
       "ja": "そすうとは何か？"
     }
   },
@@ -29394,6 +32250,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is 10 factorial (10!)?",
+      "ja": "10の階乗（10!）はいくつですか？"
+    },
+    "question_text_reading": {
+      "en": "What is 10 factorial (10!)?",
       "ja": "10の かいじょう(10!)はいくつ？"
     }
   },
@@ -29433,6 +32293,10 @@
     "id": "q00716",
     "image_path": null,
     "question_text": {
+      "en": "What is the sum of angles in a triangle?",
+      "ja": "三角形の内角の和は何度ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the sum of angles in a triangle?",
       "ja": "さんかっけいのないかくのわは？"
     }
@@ -29475,6 +32339,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the area of a circle?",
+      "ja": "円の面積を求める公式は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the area of a circle?",
       "ja": "えんのめんせきは？"
     }
   },
@@ -29516,6 +32384,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the circumference of a circle?",
+      "ja": "円の円周（circumference）とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the circumference of a circle?",
       "ja": "えんのしゅうちょうは？"
     }
   },
@@ -29556,6 +32428,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the Fibonacci sequence starting with?",
+      "ja": "フィボナッチ数列は、何から始まるでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What is the Fibonacci sequence starting with?",
       "ja": "ふぃぼなっちすうれつのはじまりは？"
     }
   },
@@ -29595,6 +32471,10 @@
     "id": "q00720",
     "image_path": null,
     "question_text": {
+      "en": "What does 'mean' refer to in statistics?",
+      "ja": "統計学における「mean」とは何を指すのでしょうか？"
+    },
+    "question_text_reading": {
       "en": "What does 'mean' refer to in statistics?",
       "ja": "とうけいでのへいきんとは？"
     }
@@ -29637,6 +32517,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the median?",
+      "ja": "中央値とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the median?",
       "ja": "ちゅうおうちとは何か？"
     }
   },
@@ -29676,6 +32560,10 @@
     "id": "q00722",
     "image_path": null,
     "question_text": {
+      "en": "What is the mode in statistics?",
+      "ja": "統計学における「mode」とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the mode in statistics?",
       "ja": "とうけいでのさいひんちとは？"
     }
@@ -29721,6 +32609,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a quadratic equation?",
+      "ja": "二次方程式とはどのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a quadratic equation?",
       "ja": "にじほうていしきとは何か？"
     }
   },
@@ -29761,6 +32653,10 @@
     "id": "q00724",
     "image_path": null,
     "question_text": {
+      "en": "What is the quadratic formula?",
+      "ja": "二次方程式の解の公式とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the quadratic formula?",
       "ja": "にじほうていしきのかいのこうしきは？"
     }
@@ -29804,6 +32700,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a logarithm?",
+      "ja": "対数（logarithm）とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a logarithm?",
       "ja": "たいすうとは何か？"
     }
   },
@@ -29844,6 +32744,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the derivative in calculus?",
+      "ja": "微積分学における「微分」とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the derivative in calculus?",
       "ja": "びぶんとは何か？"
     }
   },
@@ -29883,6 +32787,10 @@
     "id": "q00727",
     "image_path": null,
     "question_text": {
+      "en": "What is integration in calculus?",
+      "ja": "微積分学における「integration」とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is integration in calculus?",
       "ja": "せきぶんとは何か？"
     }
@@ -29926,6 +32834,10 @@
     "id": "q00728",
     "image_path": null,
     "question_text": {
+      "en": "What is a vector?",
+      "ja": "ベクトルとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a vector?",
       "ja": "べくとるとは何か？"
     }
@@ -29971,6 +32883,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a matrix in mathematics?",
+      "ja": "数学における行列とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a matrix in mathematics?",
       "ja": "すうがくでのぎょうれつとは何か？"
     }
   },
@@ -30012,6 +32928,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is probability?",
+      "ja": "確率とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is probability?",
       "ja": "かくりつとは何か？"
     }
   },
@@ -30052,6 +32972,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the probability of rolling a 6 on a die?",
+      "ja": "サイコロを振って6が出る確率はどれくらいですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the probability of rolling a 6 on a die?",
       "ja": "さいころで6がでるかくりつは？"
     }
   },
@@ -30091,6 +33015,10 @@
     "id": "q00732",
     "image_path": null,
     "question_text": {
+      "en": "What is a set in mathematics?",
+      "ja": "数学における「set」とはどのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is a set in mathematics?",
       "ja": "すうがくでのしゅうごうとは何か？"
     }
@@ -30136,6 +33064,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the union of two sets?",
+      "ja": "二つの集合の和集合とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the union of two sets?",
       "ja": "につのしゅうごうのわしゅうごうとは何か？"
     }
   },
@@ -30179,6 +33111,10 @@
     "id": "q00734",
     "image_path": null,
     "question_text": {
+      "en": "What is the intersection of two sets?",
+      "ja": "二つの集合の共通部分とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the intersection of two sets?",
       "ja": "につのしゅうごうのせきしゅうごうとは何か？"
     }
@@ -30224,6 +33160,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a function in math?",
+      "ja": "数学における「関数（function）」とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a function in math?",
       "ja": "すうがくでのかんすうとは何か？"
     }
   },
@@ -30264,6 +33204,10 @@
     "id": "q00736",
     "image_path": null,
     "question_text": {
+      "en": "What is a complex number?",
+      "ja": "複素数とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a complex number?",
       "ja": "ふくそすうとは何か？"
     }
@@ -30307,6 +33251,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is an irrational number?",
+      "ja": "無理数とはどのような数ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is an irrational number?",
       "ja": "むりすうとは何か？"
     }
   },
@@ -30346,6 +33294,10 @@
     "id": "q00738",
     "image_path": null,
     "question_text": {
+      "en": "What is the absolute value of -7?",
+      "ja": "-7の絶対値はいくつですか？"
+    },
+    "question_text_reading": {
       "en": "What is the absolute value of -7?",
       "ja": "-7のぜったいちは？"
     }
@@ -30387,6 +33339,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the slope of a horizontal line?",
+      "ja": "水平な直線の傾きはいくつですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the slope of a horizontal line?",
       "ja": "すいへいせんのかたむきは？"
     }
   },
@@ -30426,6 +33382,10 @@
     "id": "q00740",
     "image_path": null,
     "question_text": {
+      "en": "What is the slope of a vertical line?",
+      "ja": "垂直な直線の傾きはいくつですか？"
+    },
+    "question_text_reading": {
       "en": "What is the slope of a vertical line?",
       "ja": "すいちょくせんのかたむきは？"
     }
@@ -30470,6 +33430,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a geometric progression?",
+      "ja": "幾何数列とはどのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a geometric progression?",
       "ja": "とうひすうれつとは何か？"
     }
   },
@@ -30512,6 +33476,10 @@
     "id": "q00742",
     "image_path": null,
     "question_text": {
+      "en": "What is an arithmetic progression?",
+      "ja": "等差数列とは、どのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is an arithmetic progression?",
       "ja": "とうさすうれつとは何か？"
     }
@@ -30557,6 +33525,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the formula for the volume of a sphere?",
+      "ja": "球の体積を求める公式は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the formula for the volume of a sphere?",
       "ja": "きゅうのたいせきのこうしきは？"
     }
   },
@@ -30596,6 +33568,10 @@
     "id": "q00744",
     "image_path": null,
     "question_text": {
+      "en": "What is Euler's number 'e'?",
+      "ja": "オイラー数「e」とは、どのような値ですか？"
+    },
+    "question_text_reading": {
       "en": "What is Euler's number 'e'?",
       "ja": "おいらーのすうeはおよそいくつ？"
     }
@@ -30640,6 +33616,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is Pascal's triangle?",
+      "ja": "パスカルの三角形とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is Pascal's triangle?",
       "ja": "ぱすかるのさんかっけいとは何か？"
     }
   },
@@ -30681,6 +33661,10 @@
     "id": "q00746",
     "image_path": null,
     "question_text": {
+      "en": "What is a permutation?",
+      "ja": "順列（permutation）とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a permutation?",
       "ja": "じゅんれつとは何か？"
     }
@@ -30725,6 +33709,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a combination?",
+      "ja": "組み合わせとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a combination?",
       "ja": "くみあわせとは何か？"
     }
   },
@@ -30764,6 +33752,10 @@
     "id": "q00748",
     "image_path": null,
     "question_text": {
+      "en": "What language has the most native speakers?",
+      "ja": "最も多くのネイティブスピーカーを持つ言語はどれでしょう？"
+    },
+    "question_text_reading": {
       "en": "What language has the most native speakers?",
       "ja": "もっともおおくのぼごわしゃをもつげんごは？"
     }
@@ -30805,6 +33797,10 @@
     "image_path": null,
     "question_text": {
       "en": "How many letters are in the English alphabet?",
+      "ja": "英語のアルファベットには、いくつ文字がありますか？"
+    },
+    "question_text_reading": {
+      "en": "How many letters are in the English alphabet?",
       "ja": "えいごのあるふぁべっとはなんもじ？"
     }
   },
@@ -30844,6 +33840,10 @@
     "id": "q00750",
     "image_path": null,
     "question_text": {
+      "en": "What is the official language of Brazil?",
+      "ja": "ブラジルの公用語は何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the official language of Brazil?",
       "ja": "ぶらじるのこうようごは？"
     }
@@ -30885,6 +33885,10 @@
     "image_path": null,
     "question_text": {
       "en": "What language is spoken in Egypt?",
+      "ja": "エジプトで話されている言語は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What language is spoken in Egypt?",
       "ja": "えじぷとでつかわれるげんごは？"
     }
   },
@@ -30924,6 +33928,10 @@
     "id": "q00752",
     "image_path": null,
     "question_text": {
+      "en": "What script is used for Japanese?",
+      "ja": "日本語の文字を扱うのに使われるスクリプトはどれですか？"
+    },
+    "question_text_reading": {
       "en": "What script is used for Japanese?",
       "ja": "にほんごではどのもじをつかうか？"
     }
@@ -30965,6 +33973,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a synonym?",
+      "ja": "同義語とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a synonym?",
       "ja": "どうぎごとは何か？"
     }
   },
@@ -31004,6 +34016,10 @@
     "id": "q00754",
     "image_path": null,
     "question_text": {
+      "en": "What is an antonym?",
+      "ja": "類義語の対義語とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is an antonym?",
       "ja": "はんたいごとは何か？"
     }
@@ -31045,6 +34061,10 @@
     "id": "q00755",
     "image_path": null,
     "question_text": {
+      "en": "What is a haiku?",
+      "ja": "俳句とはどのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is a haiku?",
       "ja": "はいくとは何か？"
     }
@@ -31088,6 +34108,10 @@
     "question_text": {
       "en": "What does 'loanword' mean?",
       "ja": "がいらいごとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What does 'loanword' mean?",
+      "ja": "がいらいごとは何か？"
     }
   },
   {
@@ -31129,6 +34153,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is onomatopoeia?",
+      "ja": "擬音語（おのまとご）とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is onomatopoeia?",
       "ja": "おのまとぺとは何か？"
     }
   },
@@ -31169,6 +34197,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the Latin word for water?",
+      "ja": "水を表すラテン語は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the Latin word for water?",
       "ja": "みずのらてんごは？"
     }
   },
@@ -31208,6 +34240,10 @@
     "id": "q00759",
     "image_path": null,
     "question_text": {
+      "en": "What language family does English belong to?",
+      "ja": "英語はどの言語族に属しますか？"
+    },
+    "question_text_reading": {
       "en": "What language family does English belong to?",
       "ja": "えいごはどのごぞくか？"
     }
@@ -31251,6 +34287,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a palindrome?",
+      "ja": "回文（palindrome）とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a palindrome?",
       "ja": "かいぶんとは何か？"
     }
   },
@@ -31292,6 +34332,10 @@
     "image_path": null,
     "question_text": {
       "en": "What language did Shakespeare write in?",
+      "ja": "シェイクスピアはどの言語で作品を書いたのでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What language did Shakespeare write in?",
       "ja": "しぇいくすぴあはなにごでかいたか？"
     }
   },
@@ -31331,6 +34375,10 @@
     "id": "q00762",
     "image_path": null,
     "question_text": {
+      "en": "What is the most studied second language globally?",
+      "ja": "世界で最も学習されている第二言語は何でしょう？"
+    },
+    "question_text_reading": {
       "en": "What is the most studied second language globally?",
       "ja": "せかいでもっともまなばれているだいにげんごは？"
     }
@@ -31375,6 +34423,10 @@
     "image_path": null,
     "question_text": {
       "en": "What does 'etymology' mean?",
+      "ja": "etymologyとは、どのような意味ですか？"
+    },
+    "question_text_reading": {
+      "en": "What does 'etymology' mean?",
       "ja": "ごげんがくとは何か？"
     }
   },
@@ -31416,6 +34468,10 @@
     "id": "q00764",
     "image_path": null,
     "question_text": {
+      "en": "What is grammar?",
+      "ja": "文法とは一体何でしょうか？"
+    },
+    "question_text_reading": {
       "en": "What is grammar?",
       "ja": "ぶんぽうとは何か？"
     }
@@ -31459,6 +34515,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is syntax?",
+      "ja": "構文とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is syntax?",
       "ja": "こうぶんとは何か？"
     }
   },
@@ -31501,6 +34561,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is semantics?",
+      "ja": "意味論（semantics）とは、どのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is semantics?",
       "ja": "いみろんとは何か？"
     }
   },
@@ -31540,6 +34604,10 @@
     "id": "q00767",
     "image_path": null,
     "question_text": {
+      "en": "What is a dialect?",
+      "ja": "方言とは、どのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is a dialect?",
       "ja": "ほうげんとは何か？"
     }
@@ -31584,6 +34652,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is Esperanto?",
+      "ja": "エスペラントとは、どのような言語ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is Esperanto?",
       "ja": "えすぺらんととは何か？"
     }
   },
@@ -31625,6 +34697,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a phoneme?",
+      "ja": "音素（phoneme）とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a phoneme?",
       "ja": "おんそとは何か？"
     }
   },
@@ -31664,6 +34740,10 @@
     "id": "q00770",
     "image_path": null,
     "question_text": {
+      "en": "What language uses the Cyrillic alphabet?",
+      "ja": "キリル文字を使う言語は何ですか？"
+    },
+    "question_text_reading": {
       "en": "What language uses the Cyrillic alphabet?",
       "ja": "きりるもじをつかうげんごは？"
     }
@@ -31706,6 +34786,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a verb?",
+      "ja": "動詞（verb）とは、どのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a verb?",
       "ja": "どうしとは何か？"
     }
   },
@@ -31746,6 +34830,10 @@
     "id": "q00772",
     "image_path": null,
     "question_text": {
+      "en": "What is an adjective?",
+      "ja": "形容詞とは、どのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is an adjective?",
       "ja": "けいようしとは何か？"
     }
@@ -31790,6 +34878,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a noun?",
+      "ja": "名詞とはどのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a noun?",
       "ja": "めいしとは何か？"
     }
   },
@@ -31832,6 +34924,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a preposition?",
+      "ja": "前置詞（preposition）とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a preposition?",
       "ja": "ぜんちしとは何か？"
     }
   },
@@ -31872,6 +34968,10 @@
     "id": "q00775",
     "image_path": null,
     "question_text": {
+      "en": "What is metaphor?",
+      "ja": "メタファーとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is metaphor?",
       "ja": "いんゆとは何か？"
     }
@@ -31914,6 +35014,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a simile?",
+      "ja": "simileとはどのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a simile?",
       "ja": "しみりとは何か？"
     }
   },
@@ -31953,6 +35057,10 @@
     "id": "q00777",
     "image_path": null,
     "question_text": {
+      "en": "What is alliteration?",
+      "ja": "頭韻（alliteration）とは、どのような現象ですか？"
+    },
+    "question_text_reading": {
       "en": "What is alliteration?",
       "ja": "どうじしゅんぷうとは何か？"
     }
@@ -31994,6 +35102,10 @@
     "image_path": null,
     "question_text": {
       "en": "What country is sushi originally from?",
+      "ja": "寿司はどの国が発祥ですか？"
+    },
+    "question_text_reading": {
+      "en": "What country is sushi originally from?",
       "ja": "すしのげんちはどこ？"
     }
   },
@@ -32033,6 +35145,10 @@
     "id": "q00779",
     "image_path": null,
     "question_text": {
+      "en": "What is the traditional instrument of India?",
+      "ja": "インドの伝統的な楽器は何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the traditional instrument of India?",
       "ja": "いんどのでんとうがっきは？"
     }
@@ -32077,6 +35193,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is flamenco?",
+      "ja": "フラメンコとはどのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is flamenco?",
       "ja": "ふらめんことは何か？"
     }
   },
@@ -32116,6 +35236,10 @@
     "id": "q00781",
     "image_path": null,
     "question_text": {
+      "en": "What is Carnival in Brazil?",
+      "ja": "ブラジルのカーニバルとはどのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is Carnival in Brazil?",
       "ja": "ぶらじるのかーにばるとは何か？"
     }
@@ -32157,6 +35281,10 @@
     "id": "q00782",
     "image_path": null,
     "question_text": {
+      "en": "What is the Colosseum?",
+      "ja": "コロッセオとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the Colosseum?",
       "ja": "ころっせうむとは何か？"
     }
@@ -32200,6 +35328,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is ikebana?",
+      "ja": "生け花とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is ikebana?",
       "ja": "いけばなとは何か？"
     }
   },
@@ -32239,6 +35371,10 @@
     "id": "q00784",
     "image_path": null,
     "question_text": {
+      "en": "What country does the kilt come from?",
+      "ja": "キルトはどの国発祥のものですか？"
+    },
+    "question_text_reading": {
       "en": "What country does the kilt come from?",
       "ja": "きるとはどこのくにのもの？"
     }
@@ -32283,6 +35419,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the traditional Japanese tea ceremony called?",
+      "ja": "日本の伝統的なお茶の儀式は何と呼ばれますか？"
+    },
+    "question_text_reading": {
+      "en": "What is the traditional Japanese tea ceremony called?",
       "ja": "にほんのちゃどうのこうしきめいしょうは？"
     }
   },
@@ -32322,6 +35462,10 @@
     "id": "q00786",
     "image_path": null,
     "question_text": {
+      "en": "What festival is celebrated on October 31?",
+      "ja": "10月31日に祝われる祭りは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What festival is celebrated on October 31?",
       "ja": "10がつ31にちにいわわれるまつりは？"
     }
@@ -32366,6 +35510,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is Diwali?",
+      "ja": "ディワリとは、どのようなお祭りですか？"
+    },
+    "question_text_reading": {
+      "en": "What is Diwali?",
       "ja": "でぃわりとは何か？"
     }
   },
@@ -32407,6 +35555,10 @@
     "id": "q00788",
     "image_path": null,
     "question_text": {
+      "en": "What is the Day of the Dead (Día de los Muertos)?",
+      "ja": "Day of the Dead（ディア・デ・ロス・ムエルトス）とは、どのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is the Day of the Dead (Día de los Muertos)?",
       "ja": "しゃのひ（でぃーあでろすむえるとす）とは何か？"
     }
@@ -32451,6 +35603,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is origami?",
+      "ja": "折り紙とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is origami?",
       "ja": "おりがみとは何か？"
     }
   },
@@ -32490,6 +35646,10 @@
     "id": "q00790",
     "image_path": null,
     "question_text": {
+      "en": "What is the Chinese New Year also called?",
+      "ja": "中国の正月は他に何というのでしょうか？"
+    },
+    "question_text_reading": {
       "en": "What is the Chinese New Year also called?",
       "ja": "ちゅうごくのしんねんはなんともいわれるか？"
     }
@@ -32531,6 +35691,10 @@
     "image_path": null,
     "question_text": {
       "en": "What sport is most popular globally?",
+      "ja": "世界で最も人気のあるスポーツは何でしょう？"
+    },
+    "question_text_reading": {
+      "en": "What sport is most popular globally?",
       "ja": "せかいでもっとものきんのすぽーつは？"
     }
   },
@@ -32570,6 +35734,10 @@
     "id": "q00792",
     "image_path": null,
     "question_text": {
+      "en": "What is the traditional clothing of Japan?",
+      "ja": "日本の伝統的な衣装は何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the traditional clothing of Japan?",
       "ja": "にほんのでんとうてきなぎは？"
     }
@@ -32615,6 +35783,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is yoga?",
+      "ja": "ヨガとは、どのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is yoga?",
       "ja": "よがとは何か？"
     }
   },
@@ -32656,6 +35828,10 @@
     "id": "q00794",
     "image_path": null,
     "question_text": {
+      "en": "What is kimchi?",
+      "ja": "キムチとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is kimchi?",
       "ja": "きむちとは何か？"
     }
@@ -32700,6 +35876,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the meaning of 'namaste'?",
+      "ja": "namasteはどのような意味ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the meaning of 'namaste'?",
       "ja": "なますてのいみは？"
     }
   },
@@ -32739,6 +35919,10 @@
     "id": "q00796",
     "image_path": null,
     "question_text": {
+      "en": "What country did pasta originally come from?",
+      "ja": "パスタは、元々どの国で食べられていたのでしょうか？"
+    },
+    "question_text_reading": {
       "en": "What country did pasta originally come from?",
       "ja": "ぱすたのげんちはどこ？"
     }
@@ -32782,6 +35966,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the Mona Lisa?",
+      "ja": "モナ・リザとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the Mona Lisa?",
       "ja": "もなりざとは何か？"
     }
   },
@@ -32822,6 +36010,10 @@
     "id": "q00798",
     "image_path": null,
     "question_text": {
+      "en": "What is the Taj Mahal?",
+      "ja": "タージ・マハルとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the Taj Mahal?",
       "ja": "たじまはるとは何か？"
     }
@@ -32865,6 +36057,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a matryoshka?",
+      "ja": "マトリョーシカとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a matryoshka?",
       "ja": "まとりょーしかとは何か？"
     }
   },
@@ -32905,6 +36101,10 @@
     "id": "q00800",
     "image_path": null,
     "question_text": {
+      "en": "What country is known for inventing gunpowder?",
+      "ja": "火薬を発明したとされる国はどこですか？"
+    },
+    "question_text_reading": {
       "en": "What country is known for inventing gunpowder?",
       "ja": "かやくをはつめいしたとされるくには？"
     }
@@ -32947,6 +36147,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the art of calligraphy?",
+      "ja": "書道とは、どのような芸術なのでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What is the art of calligraphy?",
       "ja": "しょどうとは何か？"
     }
   },
@@ -32987,6 +36191,10 @@
     "id": "q00802",
     "image_path": null,
     "question_text": {
+      "en": "What is a samurai?",
+      "ja": "侍とはどのような存在ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a samurai?",
       "ja": "さむらいとは何か？"
     }
@@ -33031,6 +36239,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the Olympic flame?",
+      "ja": "オリンピックの炎とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the Olympic flame?",
       "ja": "おりんぴっくのほのおとは何か？"
     }
   },
@@ -33071,6 +36283,10 @@
     "id": "q00804",
     "image_path": null,
     "question_text": {
+      "en": "What is manga?",
+      "ja": "漫画とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is manga?",
       "ja": "まんがとは何か？"
     }
@@ -33113,6 +36329,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is hip-hop culture?",
+      "ja": "ヒップホップカルチャーとは、どのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is hip-hop culture?",
       "ja": "ひっぷほっぷぶんかとは何か？"
     }
   },
@@ -33152,6 +36372,10 @@
     "id": "q00806",
     "image_path": null,
     "question_text": {
+      "en": "How many continents are there on Earth?",
+      "ja": "地球上には何大陸ありますか？"
+    },
+    "question_text_reading": {
       "en": "How many continents are there on Earth?",
       "ja": "ちきゅうにはいくつのたいりくがあるか？"
     }
@@ -33196,6 +36420,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the largest ocean?",
+      "ja": "世界で一番大きな海はどれでしょう？"
+    },
+    "question_text_reading": {
+      "en": "What is the largest ocean?",
       "ja": "もっともおおきなうみは？"
     }
   },
@@ -33235,6 +36463,10 @@
     "id": "q00808",
     "image_path": null,
     "question_text": {
+      "en": "How many days are in a leap year?",
+      "ja": "うるうどしには何日ありますか？"
+    },
+    "question_text_reading": {
       "en": "How many days are in a leap year?",
       "ja": "うるうどしはなんにち？"
     }
@@ -33276,6 +36508,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the chemical symbol for gold?",
+      "ja": "金（ゴールド）の化学記号は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the chemical symbol for gold?",
       "ja": "きんのかがくきごうは？"
     }
   },
@@ -33316,6 +36552,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the tallest mountain in the world?",
+      "ja": "世界で最も高い山は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the tallest mountain in the world?",
       "ja": "せかいでもっともたかいやまは？"
     }
   },
@@ -33355,6 +36595,10 @@
     "id": "q00811",
     "image_path": null,
     "question_text": {
+      "en": "How many bones are in the adult human body?",
+      "ja": "成人の人体には、骨がいくつあるでしょうか？"
+    },
+    "question_text_reading": {
       "en": "How many bones are in the adult human body?",
       "ja": "おとなのにんげんのほねはいくつ？"
     }
@@ -33400,6 +36644,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the speed of light?",
+      "ja": "光の速さはどれくらいですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the speed of light?",
       "ja": "ひかりのそくどは？"
     }
   },
@@ -33439,6 +36687,10 @@
     "id": "q00813",
     "image_path": null,
     "question_text": {
+      "en": "How many planets are in our solar system?",
+      "ja": "太陽系には何個の惑星がありますか？"
+    },
+    "question_text_reading": {
       "en": "How many planets are in our solar system?",
       "ja": "たいようけいにはなんこのわくせいがあるか？"
     }
@@ -33480,6 +36732,10 @@
     "image_path": null,
     "question_text": {
       "en": "What gas do plants absorb from the air?",
+      "ja": "植物は空気中からどのようなガスを吸収するのでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What gas do plants absorb from the air?",
       "ja": "しょくぶつはくうきからなにをきゅうしゅうするか？"
     }
   },
@@ -33520,6 +36776,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the largest country by area?",
+      "ja": "面積が一番大きい国はどこですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the largest country by area?",
       "ja": "めんせきでもっともおおきなくには？"
     }
   },
@@ -33559,6 +36819,10 @@
     "id": "q00816",
     "image_path": null,
     "question_text": {
+      "en": "What is the capital of Australia?",
+      "ja": "オーストラリアの首都はどこですか？"
+    },
+    "question_text_reading": {
       "en": "What is the capital of Australia?",
       "ja": "おーすとらりあのしゅとは？"
     }
@@ -33602,6 +36866,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the Amazon River known for?",
+      "ja": "アマゾン川は、何で有名でしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What is the Amazon River known for?",
       "ja": "あまぞんがわはなにでゆうめい？"
     }
   },
@@ -33643,6 +36911,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the hardest natural substance?",
+      "ja": "自然界で最も硬い物質は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the hardest natural substance?",
       "ja": "しぜんかいでもっともかたいぶっしつは？"
     }
   },
@@ -33682,6 +36954,10 @@
     "id": "q00819",
     "image_path": null,
     "question_text": {
+      "en": "How many chambers does a human heart have?",
+      "ja": "人間の心臓は、何つの部屋に分かれていますか？"
+    },
+    "question_text_reading": {
       "en": "How many chambers does a human heart have?",
       "ja": "にんげんのこころはいくつのへやにわかれているか？"
     }
@@ -33723,6 +36999,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the currency of Japan?",
+      "ja": "日本の通貨は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the currency of Japan?",
       "ja": "にほんのつうかは？"
     }
   },
@@ -33762,6 +37042,10 @@
     "id": "q00821",
     "image_path": null,
     "question_text": {
+      "en": "What is the largest desert in the world?",
+      "ja": "世界で最も広い砂漠はどこですか？"
+    },
+    "question_text_reading": {
       "en": "What is the largest desert in the world?",
       "ja": "せかいさいだいのさばくは？"
     }
@@ -33803,6 +37087,10 @@
     "image_path": null,
     "question_text": {
       "en": "What year did World War II end?",
+      "ja": "第二次世界大戦は、何年終わったのでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What year did World War II end?",
       "ja": "だいにじせかいたいせんはなんねんにおわったか？"
     }
   },
@@ -33842,6 +37130,10 @@
     "id": "q00823",
     "image_path": null,
     "question_text": {
+      "en": "What is the boiling point of water at sea level?",
+      "ja": "海面における水の沸点は何度ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the boiling point of water at sea level?",
       "ja": "かいめいでのみずのふってんは？"
     }
@@ -33883,6 +37175,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the freezing point of water?",
+      "ja": "水の凝固点は何度ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the freezing point of water?",
       "ja": "みずのこおりはじめるおんどは？"
     }
   },
@@ -33922,6 +37218,10 @@
     "id": "q00825",
     "image_path": null,
     "question_text": {
+      "en": "What element has the atomic number 1?",
+      "ja": "原子番号が1の元素は何ですか？"
+    },
+    "question_text_reading": {
       "en": "What element has the atomic number 1?",
       "ja": "げんしばんごう1のげんそは？"
     }
@@ -33965,6 +37265,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is photosynthesis?",
+      "ja": "光合成とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is photosynthesis?",
       "ja": "こうごうせいとは何か？"
     }
   },
@@ -34004,6 +37308,10 @@
     "id": "q00827",
     "image_path": null,
     "question_text": {
+      "en": "What is the main language spoken in Argentina?",
+      "ja": "アルゼンチンで主に話されている言語は何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the main language spoken in Argentina?",
       "ja": "あるぜんちんでつかわれるしゅのことばは？"
     }
@@ -34046,6 +37354,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the longest bone in the human body?",
+      "ja": "人体で最も長い骨は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the longest bone in the human body?",
       "ja": "にんげんのからだでもっともながいほねは？"
     }
   },
@@ -34085,6 +37397,10 @@
     "id": "q00829",
     "image_path": null,
     "question_text": {
+      "en": "Who invented the telephone?",
+      "ja": "電話を最初に発明したのは誰でしょう？"
+    },
+    "question_text_reading": {
       "en": "Who invented the telephone?",
       "ja": "でんわをはつめいしたのはだれ？"
     }
@@ -34126,6 +37442,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the most abundant gas in Earth's atmosphere?",
+      "ja": "地球の大気中で最も豊富に存在する気体は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the most abundant gas in Earth's atmosphere?",
       "ja": "ちきゅうのたいきでもっともおおいきたいは？"
     }
   },
@@ -34166,6 +37486,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the square root of 256?",
+      "ja": "256の平方根は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the square root of 256?",
       "ja": "256のへいほうこんは？"
     }
   },
@@ -34205,6 +37529,10 @@
     "id": "q00832",
     "image_path": null,
     "question_text": {
+      "en": "How many teeth does an adult human have?",
+      "ja": "おとなのにんげんのはは何本？"
+    },
+    "question_text_reading": {
       "en": "How many teeth does an adult human have?",
       "ja": "おとなのにんげんのはは何本？"
     }
@@ -34248,6 +37576,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the largest planet in our solar system?",
+      "ja": "太陽系の中で最も大きな惑星は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the largest planet in our solar system?",
       "ja": "たいようけいでもっともおおきいわくせいは？"
     }
   },
@@ -34287,6 +37619,10 @@
     "id": "q00834",
     "image_path": null,
     "question_text": {
+      "en": "What is the symbol for the element oxygen?",
+      "ja": "酸素の元素記号は何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the symbol for the element oxygen?",
       "ja": "さんそのげんそきごうは？"
     }
@@ -34328,6 +37664,10 @@
     "image_path": null,
     "question_text": {
       "en": "Which planet is closest to the sun?",
+      "ja": "太陽に最も近い惑星はどれですか？"
+    },
+    "question_text_reading": {
+      "en": "Which planet is closest to the sun?",
       "ja": "もっともたいようにちかいわくせいは？"
     }
   },
@@ -34367,6 +37707,10 @@
     "id": "q00836",
     "image_path": null,
     "question_text": {
+      "en": "What is the smallest country in the world?",
+      "ja": "世界で最も小さい国はどこですか？"
+    },
+    "question_text_reading": {
       "en": "What is the smallest country in the world?",
       "ja": "せかいでもっともちいさなくには？"
     }
@@ -34408,6 +37752,10 @@
     "image_path": null,
     "question_text": {
       "en": "How many strings does a standard guitar have?",
+      "ja": "標準的なギターは、何本の弦を持っていますか？"
+    },
+    "question_text_reading": {
+      "en": "How many strings does a standard guitar have?",
       "ja": "ふつうのぎたーはなんほんのげんをもつか？"
     }
   },
@@ -34448,6 +37796,10 @@
     "image_path": null,
     "question_text": {
       "en": "What does DNA stand for?",
+      "ja": "DNAは何の略語ですか？"
+    },
+    "question_text_reading": {
+      "en": "What does DNA stand for?",
       "ja": "DNAのりゃくしょうのせいしきめいは？"
     }
   },
@@ -34487,6 +37839,10 @@
     "id": "q00839",
     "image_path": null,
     "question_text": {
+      "en": "What is the chemical formula for table salt?",
+      "ja": "食塩の化学式は何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the chemical formula for table salt?",
       "ja": "しょくえんのかがくしきは？"
     }
@@ -34531,6 +37887,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the national sport of Japan?",
+      "ja": "日本の国技は何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is the national sport of Japan?",
       "ja": "にほんのこくぎは？"
     }
   },
@@ -34572,6 +37932,10 @@
     "image_path": null,
     "question_text": {
       "en": "What does the Richter scale measure?",
+      "ja": "リヒタースケールは、何を示すものですか？"
+    },
+    "question_text_reading": {
+      "en": "What does the Richter scale measure?",
       "ja": "りひたーすけーるはなにをはかるか？"
     }
   },
@@ -34612,6 +37976,10 @@
     "image_path": null,
     "question_text": {
       "en": "What year did the first moon landing occur?",
+      "ja": "初めて月面に着陸したのは何年ですか？"
+    },
+    "question_text_reading": {
+      "en": "What year did the first moon landing occur?",
       "ja": "はつのつきへのちゃくりくはなんねん？"
     }
   },
@@ -34651,6 +38019,10 @@
     "id": "q00843",
     "image_path": null,
     "question_text": {
+      "en": "What is the symbol for the element iron?",
+      "ja": "鉄の元素記号は何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the symbol for the element iron?",
       "ja": "てつのげんそきごうは？"
     }
@@ -34694,6 +38066,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the loudest animal on Earth?",
+      "ja": "地球上で最も大きな音を出す動物は何でしょう？"
+    },
+    "question_text_reading": {
+      "en": "What is the loudest animal on Earth?",
       "ja": "ちきゅうでもっともおおきなこえをだすどうぶつは？"
     }
   },
@@ -34733,6 +38109,10 @@
     "id": "q00845",
     "image_path": null,
     "question_text": {
+      "en": "What is the unit of electric current?",
+      "ja": "電気電流の単位は何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is the unit of electric current?",
       "ja": "でんりゅうのたんいは？"
     }
@@ -34774,6 +38154,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a VTuber?",
+      "ja": "VTuberとはどのような存在ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a VTuber?",
       "ja": "ぶいちゅーばーとは何か？"
     }
   },
@@ -34814,6 +38198,10 @@
     "image_path": null,
     "question_text": {
       "en": "What company is Hololive associated with?",
+      "ja": "Hololiveはどの会社と関連していますか？"
+    },
+    "question_text_reading": {
+      "en": "What company is Hololive associated with?",
       "ja": "ほろらいぶはどのかいしゃ？"
     }
   },
@@ -34853,6 +38241,10 @@
     "id": "q00848",
     "image_path": null,
     "question_text": {
+      "en": "What is Nijisanji?",
+      "ja": "Nijisanjiとはどのような存在ですか？"
+    },
+    "question_text_reading": {
       "en": "What is Nijisanji?",
       "ja": "にじさんじとは何か？"
     }
@@ -34897,6 +38289,10 @@
     "question_text": {
       "en": "What does 'kaigai niki' mean?",
       "ja": "かいがいにきとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What does 'kaigai niki' mean?",
+      "ja": "かいがいにきとは何か？"
     }
   },
   {
@@ -34937,6 +38333,10 @@
     "id": "q00850",
     "image_path": null,
     "question_text": {
+      "en": "What is 'superchat'?",
+      "ja": "すーぱーちゃっととは何か？"
+    },
+    "question_text_reading": {
       "en": "What is 'superchat'?",
       "ja": "すーぱーちゃっととは何か？"
     }
@@ -34981,6 +38381,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'doxxing'?",
+      "ja": "ドクシングとは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is 'doxxing'?",
       "ja": "どっくしんぐとは何か？"
     }
   },
@@ -35020,6 +38424,10 @@
     "id": "q00852",
     "image_path": null,
     "question_text": {
+      "en": "What does 'GG' stand for in gaming?",
+      "ja": "ゲーミングにおける「GG」は、何の略語ですか？"
+    },
+    "question_text_reading": {
       "en": "What does 'GG' stand for in gaming?",
       "ja": "げーみんぐでGGとはどういういみ？"
     }
@@ -35062,6 +38470,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'streaming'?",
+      "ja": "ストリーミングとは、どのような概念ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is 'streaming'?",
       "ja": "すとりーみんぐとは何か？"
     }
   },
@@ -35103,6 +38515,10 @@
     "id": "q00854",
     "image_path": null,
     "question_text": {
+      "en": "What is a 'clip' in VTuber culture?",
+      "ja": "VTuber文化における「clip」とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is a 'clip' in VTuber culture?",
       "ja": "ぶいちゅーばーぶんかでのくりっぷとは？"
     }
@@ -35147,6 +38563,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'fan art'?",
+      "ja": "ファンアートとはどのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is 'fan art'?",
       "ja": "ふぁんあーととは何か？"
     }
   },
@@ -35188,6 +38608,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is Twitch?",
+      "ja": "Twitchとはどのようなサービスですか？"
+    },
+    "question_text_reading": {
+      "en": "What is Twitch?",
       "ja": "ついっちとは何か？"
     }
   },
@@ -35227,6 +38651,10 @@
     "id": "q00857",
     "image_path": null,
     "question_text": {
+      "en": "What is Discord?",
+      "ja": "Discordとはどのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is Discord?",
       "ja": "でぃすこーどとは何か？"
     }
@@ -35269,6 +38697,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'yab' in VTuber slang?",
+      "ja": "VTuberのスラングにおける「yab」とはどういう意味ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is 'yab' in VTuber slang?",
       "ja": "ぶいちゅーばーすらんぐでやばいとは？"
     }
   },
@@ -35309,6 +38741,10 @@
     "id": "q00859",
     "image_path": null,
     "question_text": {
+      "en": "What is a 'debut' for a VTuber?",
+      "ja": "VTuberにおける「デビュー」とは、どのような意味を持つのでしょうか？"
+    },
+    "question_text_reading": {
       "en": "What is a 'debut' for a VTuber?",
       "ja": "ぶいちゅーばーのでびゅーとは？"
     }
@@ -35352,6 +38788,10 @@
     "image_path": null,
     "question_text": {
       "en": "What does 'GachiBASS' mean?",
+      "ja": "GachiBASSとはどういう意味ですか？"
+    },
+    "question_text_reading": {
+      "en": "What does 'GachiBASS' mean?",
       "ja": "がちばすとはどんないみ？"
     }
   },
@@ -35391,6 +38831,10 @@
     "id": "q00861",
     "image_path": null,
     "question_text": {
+      "en": "What is 'live2D'?",
+      "ja": "らいぶつーでぃーとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is 'live2D'?",
       "ja": "らいぶつーでぃーとは何か？"
     }
@@ -35435,6 +38879,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a 'membership' on YouTube?",
+      "ja": "YouTubeにおける「membership」とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a 'membership' on YouTube?",
       "ja": "ゆーちゅーぶでのめんばーしっぷとは？"
     }
   },
@@ -35474,6 +38922,10 @@
     "id": "q00863",
     "image_path": null,
     "question_text": {
+      "en": "What is 'oshi'?",
+      "ja": "推しとは、具体的にどのようなものを指すのでしょうか？"
+    },
+    "question_text_reading": {
       "en": "What is 'oshi'?",
       "ja": "おしとは何か？"
     }
@@ -35515,6 +38967,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is the term for simultaneous translator in VTuber culture?",
+      "ja": "VTuber文化における同時通訳者を何と呼ぶのでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What is the term for simultaneous translator in VTuber culture?",
       "ja": "ぶいちゅーばーぶんかでどうじほんやくしゃのことをなんというか？"
     }
   },
@@ -35554,6 +39010,10 @@
     "id": "q00865",
     "image_path": null,
     "question_text": {
+      "en": "What is 'zatsudan'?",
+      "ja": "ざつだんとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is 'zatsudan'?",
       "ja": "ざつだんとは何か？"
     }
@@ -35598,6 +39058,10 @@
     "image_path": null,
     "question_text": {
       "en": "What does 'pog' or 'poggers' mean in chat?",
+      "ja": "チャットで「pog」や「poggers」はどのような意味ですか？"
+    },
+    "question_text_reading": {
+      "en": "What does 'pog' or 'poggers' mean in chat?",
       "ja": "ちゃっとでぽぐやぽがーずとはどういういみ？"
     }
   },
@@ -35637,6 +39101,10 @@
     "id": "q00867",
     "image_path": null,
     "question_text": {
+      "en": "What is 'KEKW'?",
+      "ja": "KEKWとは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is 'KEKW'?",
       "ja": "けくわとは何か？"
     }
@@ -35679,6 +39147,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is a 'raid' on Twitch?",
+      "ja": "Twitchにおける「raid」とはどのようなものですか？"
+    },
+    "question_text_reading": {
+      "en": "What is a 'raid' on Twitch?",
       "ja": "ついっちでのれいどとは何か？"
     }
   },
@@ -35718,6 +39190,10 @@
     "id": "q00869",
     "image_path": null,
     "question_text": {
+      "en": "What is 'lore' in VTuber context?",
+      "ja": "VTuberにおける「lore」とは、どのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is 'lore' in VTuber context?",
       "ja": "ぶいちゅーばーぶんみゃくでのろあとは何か？"
     }
@@ -35759,6 +39235,10 @@
     "id": "q00870",
     "image_path": null,
     "question_text": {
+      "en": "What is '3D debut' for a VTuber?",
+      "ja": "VTuberにとっての「3D debut」とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is '3D debut' for a VTuber?",
       "ja": "ぶいちゅーばーのさんでぃーでびゅーとは？"
     }
@@ -35802,6 +39282,10 @@
     "image_path": null,
     "question_text": {
       "en": "What does 'IRL' stand for?",
+      "ja": "IRLとは何の略語ですか？"
+    },
+    "question_text_reading": {
+      "en": "What does 'IRL' stand for?",
       "ja": "IRLとはなにのりゃく？"
     }
   },
@@ -35843,6 +39327,10 @@
     "id": "q00872",
     "image_path": null,
     "question_text": {
+      "en": "What is 'NicoNico Douga'?",
+      "ja": "NicoNico Dougaとはどのようなものですか？"
+    },
+    "question_text_reading": {
       "en": "What is 'NicoNico Douga'?",
       "ja": "にこにこどうがとは何か？"
     }
@@ -35886,6 +39374,10 @@
     "question_text": {
       "en": "What is 'Vocaloid'?",
       "ja": "ぼーかろいどとは何か？"
+    },
+    "question_text_reading": {
+      "en": "What is 'Vocaloid'?",
+      "ja": "ぼーかろいどとは何か？"
     }
   },
   {
@@ -35924,6 +39416,10 @@
     "id": "q00874",
     "image_path": null,
     "question_text": {
+      "en": "What character is the most famous Vocaloid?",
+      "ja": "最も有名なボーカロイドのキャラクターは誰でしょう？"
+    },
+    "question_text_reading": {
       "en": "What character is the most famous Vocaloid?",
       "ja": "もっともゆうめいなぼーかろいどのきゃらくたーは？"
     }
@@ -35967,6 +39463,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'meme' on the internet?",
+      "ja": "インターネットにおける「meme」とは何ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is 'meme' on the internet?",
       "ja": "いんたーねっとでみーむとは何か？"
     }
   },
@@ -36009,6 +39509,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'trolling' online?",
+      "ja": "オンラインで「trolling」とはどういう行為ですか？"
+    },
+    "question_text_reading": {
+      "en": "What is 'trolling' online?",
       "ja": "おんらいんでとろーりんぐとは何か？"
     }
   },
@@ -36050,6 +39554,10 @@
     "image_path": null,
     "question_text": {
       "en": "What does AFK stand for?",
+      "ja": "AFKとは何の略語ですか？"
+    },
+    "question_text_reading": {
+      "en": "What does AFK stand for?",
       "ja": "AFKとはなにのりゃく？"
     }
   },
@@ -36090,6 +39598,10 @@
     "id": "q00878",
     "image_path": null,
     "question_text": {
+      "en": "What is 'gacha' in gaming?",
+      "ja": "ゲームにおける「ガチャ」とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is 'gacha' in gaming?",
       "ja": "げーみんぐでがちゃとは何か？"
     }
@@ -36133,6 +39645,10 @@
     "question_text": {
       "en": "What is 'MMO'?",
       "ja": "えむえむおーとはなに？"
+    },
+    "question_text_reading": {
+      "en": "What is 'MMO'?",
+      "ja": "えむえむおーとはなに？"
     }
   },
   {
@@ -36171,6 +39687,10 @@
     "id": "q00880",
     "image_path": null,
     "question_text": {
+      "en": "What is 'ping' in online gaming?",
+      "ja": "オンラインゲームにおける「ping」とは何ですか？"
+    },
+    "question_text_reading": {
       "en": "What is 'ping' in online gaming?",
       "ja": "おんらいんげーみんぐでぴんぐとは？"
     }
@@ -36215,6 +39735,10 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'esports'?",
+      "ja": "esportsとは、具体的にどのようなものを指すのでしょうか？"
+    },
+    "question_text_reading": {
+      "en": "What is 'esports'?",
       "ja": "いーすぽーつとは何か？"
     }
   },
@@ -36255,6 +39779,10 @@
     "image_path": null,
     "question_text": {
       "en": "What does FPS stand for in gaming?",
+      "ja": "ゲームにおける「FPS」は何の略語ですか？"
+    },
+    "question_text_reading": {
+      "en": "What does FPS stand for in gaming?",
       "ja": "げーみんぐでFPSとはなにのりゃく？"
     }
   },
@@ -36294,6 +39822,10 @@
     "id": "q00883",
     "image_path": null,
     "question_text": {
+      "en": "What does HP stand for in games?",
+      "ja": "ゲームにおけるHPとは何の略語ですか？"
+    },
+    "question_text_reading": {
       "en": "What does HP stand for in games?",
       "ja": "げーむでHPとはなにのりゃく？"
     }
@@ -36336,6 +39868,10 @@
     "id": "q00884",
     "image_path": null,
     "question_text": {
+      "en": "What is 'speedrunning'?",
+      "ja": "すぴーどらんにんぐとは何か？"
+    },
+    "question_text_reading": {
       "en": "What is 'speedrunning'?",
       "ja": "すぴーどらんにんぐとは何か？"
     }

--- a/data/questions_ja.json
+++ b/data/questions_ja.json
@@ -138,7 +138,7 @@
     "choices": [
       {
         "en": "def",
-        "ja": "でふ",
+        "ja": "def",
         "ja_typings": [
           "defu"
         ]
@@ -159,7 +159,7 @@
       },
       {
         "en": "func keyword",
-        "ja": "ふぁんくきーわーど",
+        "ja": "func keyword",
         "ja_typings": [
           "fankukiwado"
         ]
@@ -233,21 +233,21 @@
       },
       {
         "en": "list",
-        "ja": "list",
+        "ja": "リスト",
         "ja_typings": [
           "list"
         ]
       },
       {
         "en": "tuple",
-        "ja": "tuple",
+        "ja": "タプル",
         "ja_typings": [
           "tuple"
         ]
       },
       {
         "en": "set",
-        "ja": "set",
+        "ja": "セット",
         "ja_typings": [
           "set"
         ]
@@ -314,7 +314,7 @@
     "choices": [
       {
         "en": "//",
-        "ja": "どうぶるすらっしゅ",
+        "ja": "ダブルスラッシュ",
         "ja_typings": [
           "doburusurasshu",
           "douburusurasshu"
@@ -322,21 +322,21 @@
       },
       {
         "en": "single /",
-        "ja": "しんぐるすらっしゅ",
+        "ja": "シングルスラッシュ",
         "ja_typings": [
           "shingurusurasshu"
         ]
       },
       {
         "en": "%",
-        "ja": "%",
+        "ja": "きていじょうけん",
         "ja_typings": [
           "%"
         ]
       },
       {
         "en": "**",
-        "ja": "**",
+        "ja": "きていじょうけん",
         "ja_typings": [
           "**"
         ]
@@ -359,28 +359,28 @@
     "choices": [
       {
         "en": "integers 0 to 4",
-        "ja": "れいからよんのせいすう",
+        "ja": "0から4の整数",
         "ja_typings": [
           "reikarayonnoseisuu"
         ]
       },
       {
         "en": "integers 1 to 5",
-        "ja": "いちからごのせいすう",
+        "ja": "1から5の整数",
         "ja_typings": [
           "ichikaragonoseisuu"
         ]
       },
       {
         "en": "integers 0 to 5",
-        "ja": "れいからごのせいすう",
+        "ja": "0から5の整数",
         "ja_typings": [
           "reikaragonoseisuu"
         ]
       },
       {
         "en": "integers 1 to 4",
-        "ja": "いちからよんのせいすう",
+        "ja": "1から4の整数",
         "ja_typings": [
           "ichikarayonnoseisuu"
         ]
@@ -447,7 +447,7 @@
     "choices": [
       {
         "en": "anonymous function",
-        "ja": "むめいかんすう",
+        "ja": "無名関数",
         "ja_typings": [
           "mumeikansuu"
         ]
@@ -468,7 +468,7 @@
       },
       {
         "en": "a module",
-        "ja": "もじゅーる",
+        "ja": "モジュール",
         "ja_typings": [
           "mojuru"
         ]
@@ -579,7 +579,7 @@
     "choices": [
       {
         "en": "each value has one owner",
-        "ja": "かくちはひとつのおーなーをもつ",
+        "ja": "各値は一つのおーなーを持つ",
         "ja_typings": [
           "kakuchihahitotsunonaomotsu",
           "kakuchihahitotsunoonaomotsu"
@@ -587,7 +587,7 @@
       },
       {
         "en": "values are shared freely",
-        "ja": "ちはじゆうにきょうゆうされる",
+        "ja": "値は自由に共有される",
         "ja_typings": [
           "chihajiyuunikyoyuusareru",
           "chihajiyuunikyouyuusareru"
@@ -595,14 +595,14 @@
       },
       {
         "en": "no memory management",
-        "ja": "めもりかんりなし",
+        "ja": "メモリ管理なし",
         "ja_typings": [
           "memorikanrinashi"
         ]
       },
       {
         "en": "garbage collected",
-        "ja": "がーびっじこれくしょん",
+        "ja": "ガービッジコレクション",
         "ja_typings": [
           "gabijjikorekushon"
         ]
@@ -632,7 +632,7 @@
       },
       {
         "en": "*",
-        "ja": "*",
+        "ja": "きていじょうけん",
         "ja_typings": [
           "*"
         ]
@@ -646,7 +646,7 @@
       },
       {
         "en": "#",
-        "ja": "#",
+        "ja": "きていじょうけん",
         "ja_typings": [
           "#"
         ]
@@ -676,21 +676,21 @@
       },
       {
         "en": "error handling",
-        "ja": "えらーはんどりんぐ",
+        "ja": "エラーハンドリング",
         "ja_typings": [
           "erahandoringu"
         ]
       },
       {
         "en": "iteration",
-        "ja": "いてれーしょん",
+        "ja": "イテレーション",
         "ja_typings": [
           "itereshon"
         ]
       },
       {
         "en": "concurrency",
-        "ja": "へいこうせい",
+        "ja": "並行性",
         "ja_typings": [
           "heikosei",
           "heikousei"
@@ -714,7 +714,7 @@
     "choices": [
       {
         "en": "compiles the project",
-        "ja": "ぷろじぇくとをこんぱいる",
+        "ja": "プロジェクトをコンパイル",
         "ja_typings": [
           "purojekutokonpairu",
           "purojekutookonpairu"
@@ -722,7 +722,7 @@
       },
       {
         "en": "runs tests",
-        "ja": "てすとをじっこう",
+        "ja": "テストを実行",
         "ja_typings": [
           "tesutojikko",
           "tesutoojikkou"
@@ -730,7 +730,7 @@
       },
       {
         "en": "publishes crate",
-        "ja": "くれーとをこうかい",
+        "ja": "クレートを公開",
         "ja_typings": [
           "kuretokokai",
           "kuretookoukai"
@@ -738,7 +738,7 @@
       },
       {
         "en": "formats code",
-        "ja": "こーどをふぉーまっと",
+        "ja": "コードをフォーマット",
         "ja_typings": [
           "kodofomatto",
           "kodoofomatto"
@@ -783,7 +783,7 @@
       },
       {
         "en": "Format",
-        "ja": "Format",
+        "ja": "フォーマット",
         "ja_typings": [
           "format"
         ]
@@ -795,7 +795,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which trait enables printing with `{:?}` in Rust?",
-      "ja": "Rustで`{:?}`による表示を可能にするとれーとは？"
+      "ja": "Rustで`{:?}`による表示を可能にするトレイトは？"
     },
     "question_text_reading": {
       "en": "Which trait enables printing with `{:?}` in Rust?",
@@ -806,7 +806,7 @@
     "choices": [
       {
         "en": "growable array",
-        "ja": "かちょうかのうなはいれつ",
+        "ja": "可変長の配列",
         "ja_typings": [
           "kachokanonahairetsu",
           "kachoukanounahairetsu"
@@ -814,21 +814,21 @@
       },
       {
         "en": "hash map",
-        "ja": "はっしゅまっぷ",
+        "ja": "ハッシュマップ",
         "ja_typings": [
           "hasshumappu"
         ]
       },
       {
         "en": "linked list",
-        "ja": "れんけつりすと",
+        "ja": "連結リスト",
         "ja_typings": [
           "renketsurisuto"
         ]
       },
       {
         "en": "fixed array",
-        "ja": "こていはいれつ",
+        "ja": "固定配列",
         "ja_typings": [
           "koteihairetsu"
         ]
@@ -851,28 +851,28 @@
     "choices": [
       {
         "en": "Result type",
-        "ja": "Resultがた",
+        "ja": "結果型",
         "ja_typings": [
           "resultgata"
         ]
       },
       {
         "en": "exceptions",
-        "ja": "れいがい",
+        "ja": "例外",
         "ja_typings": [
           "reigai"
         ]
       },
       {
         "en": "error codes",
-        "ja": "えらーこーど",
+        "ja": "エラーコード",
         "ja_typings": [
           "erakodo"
         ]
       },
       {
         "en": "panic always",
-        "ja": "つねにぱにっく",
+        "ja": "常にパニック",
         "ja_typings": [
           "tsunenipanikku"
         ]
@@ -895,7 +895,7 @@
     "choices": [
       {
         "en": "implements methods for a type",
-        "ja": "かたにめそっどをじっそう",
+        "ja": "型にメソッドを実装",
         "ja_typings": [
           "katanimesoddojisso",
           "katanimesoddoojissou"
@@ -903,21 +903,21 @@
       },
       {
         "en": "imports a module",
-        "ja": "もじゅーるをいんぽーと",
+        "ja": "モジュールをインポート",
         "ja_typings": [
           "mojuruoinpoto"
         ]
       },
       {
         "en": "declares interface",
-        "ja": "いんたーふぇーすをせんげん",
+        "ja": "インターフェースを宣言",
         "ja_typings": [
           "intafesuosengen"
         ]
       },
       {
         "en": "creates enum",
-        "ja": "えぬむをさくせい",
+        "ja": "enumを作成",
         "ja_typings": [
           "enumuosakusei"
         ]
@@ -1005,7 +1005,7 @@
       },
       {
         "en": "define",
-        "ja": "define",
+        "ja": "定義",
         "ja_typings": [
           "define"
         ]
@@ -1028,7 +1028,7 @@
     "choices": [
       {
         "en": "strict equality",
-        "ja": "げんみつなどうち",
+        "ja": "厳密な等値",
         "ja_typings": [
           "genmitsunadochi",
           "genmitsunadouchi"
@@ -1036,14 +1036,14 @@
       },
       {
         "en": "assignment",
-        "ja": "だいにゅう",
+        "ja": "第２入",
         "ja_typings": [
           "dainyuu"
         ]
       },
       {
         "en": "loose equality",
-        "ja": "ゆるやかなどうち",
+        "ja": "緩やかななどうち",
         "ja_typings": [
           "yuruyakanadochi",
           "yuruyakanadouchi"
@@ -1051,7 +1051,7 @@
       },
       {
         "en": "comparison",
-        "ja": "ひかく",
+        "ja": "比較",
         "ja_typings": [
           "hikaku"
         ]
@@ -1074,7 +1074,7 @@
     "choices": [
       {
         "en": "() => {}",
-        "ja": "() => {}",
+        "ja": "きていじょうけん() => {}",
         "ja_typings": [
           "() => {}"
         ]
@@ -1118,28 +1118,28 @@
     "choices": [
       {
         "en": "Not a Number",
-        "ja": "すうちでない",
+        "ja": "数値でない",
         "ja_typings": [
           "suuchidenai"
         ]
       },
       {
         "en": "Null and None",
-        "ja": "nullとnone",
+        "ja": "NullとNone",
         "ja_typings": [
           "nulltonone"
         ]
       },
       {
         "en": "New Array Node",
-        "ja": "あたらしいはいれつのーど",
+        "ja": "新しいノード",
         "ja_typings": [
           "atarashiihairetsunodo"
         ]
       },
       {
         "en": "Not an Object",
-        "ja": "おぶじぇくとでない",
+        "ja": "オブジェクトでない",
         "ja_typings": [
           "obujekutodenai"
         ]
@@ -1206,21 +1206,21 @@
     "choices": [
       {
         "en": "waits for all promises",
-        "ja": "すべてのぷろみすをまつ",
+        "ja": "すべてのプロミスを待つ",
         "ja_typings": [
           "subetenopuromisuomatsu"
         ]
       },
       {
         "en": "cancels all promises",
-        "ja": "すべてのぷろみすをきゃんせる",
+        "ja": "すべてのプロミスをキャンセル",
         "ja_typings": [
           "subetenopuromisuokyanseru"
         ]
       },
       {
         "en": "runs promises in series",
-        "ja": "ぷろみすをじゅんじにじっこう",
+        "ja": "プロミスを順次実行",
         "ja_typings": [
           "puromisuojunjinijikko",
           "puromisuojunjinijikkou"
@@ -1228,7 +1228,7 @@
       },
       {
         "en": "rejects all promises",
-        "ja": "すべてのぷろみすをきゃく",
+        "ja": "すべてのプロミスを却",
         "ja_typings": [
           "subetenopuromisuokyaku"
         ]
@@ -1258,21 +1258,21 @@
       },
       {
         "en": "inherits",
-        "ja": "inherits",
+        "ja": "インヘリツズ",
         "ja_typings": [
           "inherits"
         ]
       },
       {
         "en": "implements",
-        "ja": "implements",
+        "ja": "インプリメンツ",
         "ja_typings": [
           "implements"
         ]
       },
       {
         "en": "derives",
-        "ja": "derives",
+        "ja": "デライヴズ",
         "ja_typings": [
           "derives"
         ]
@@ -1295,14 +1295,14 @@
     "choices": [
       {
         "en": "object",
-        "ja": "object",
+        "ja": "オブジェクト",
         "ja_typings": [
           "object"
         ]
       },
       {
         "en": "null",
-        "ja": "null",
+        "ja": "空のひらがな読みクイズ回答候補を、読みを変えずに自然な漢字かな交じり表記へ直してください",
         "ja_typings": [
           "null"
         ]
@@ -1372,7 +1372,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which array method creates a new array by transforming each element?",
-      "ja": "各要素を変換して新配列を作るはいれつメソッドは？"
+      "ja": "各要素を変換して新配列を作る配列メソッドは？"
     },
     "question_text_reading": {
       "en": "Which array method creates a new array by transforming each element?",
@@ -1460,7 +1460,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the time complexity of accessing an array element by index?",
-      "ja": "はいれつのいんでくすによるアクセスの計算量は？"
+      "ja": "配列のインデックスによるアクセスの計算量は？"
     },
     "question_text_reading": {
       "en": "What is the time complexity of accessing an array element by index?",
@@ -1471,28 +1471,28 @@
     "choices": [
       {
         "en": "stack",
-        "ja": "すたっく",
+        "ja": "スタック",
         "ja_typings": [
           "sutakku"
         ]
       },
       {
         "en": "queue",
-        "ja": "きゅー",
+        "ja": "キュー",
         "ja_typings": [
           "kyu"
         ]
       },
       {
         "en": "heap",
-        "ja": "ひーぷ",
+        "ja": "ヒープ",
         "ja_typings": [
           "hipu"
         ]
       },
       {
         "en": "tree",
-        "ja": "つりー",
+        "ja": "ツリー",
         "ja_typings": [
           "tsuri"
         ]
@@ -1504,7 +1504,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which data structure uses LIFO order?",
-      "ja": "LIFO順を使うでーたこうぞうは？"
+      "ja": "LIFO順を使うデータ構造は？"
     },
     "question_text_reading": {
       "en": "Which data structure uses LIFO order?",
@@ -1515,28 +1515,28 @@
     "choices": [
       {
         "en": "data and pointer",
-        "ja": "でーたとぽいんたー",
+        "ja": "データとポインター",
         "ja_typings": [
           "detatopointa"
         ]
       },
       {
         "en": "key and value",
-        "ja": "きーとちー",
+        "ja": "キーと値",
         "ja_typings": [
           "kitochi"
         ]
       },
       {
         "en": "index and value",
-        "ja": "いんでくすとち",
+        "ja": "インデックスと値",
         "ja_typings": [
           "indekusutochi"
         ]
       },
       {
         "en": "hash and data",
-        "ja": "はっしゅとでーた",
+        "ja": "ハッシュとデータ",
         "ja_typings": [
           "hasshutodeta"
         ]
@@ -1548,7 +1548,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a linked list node composed of?",
-      "ja": "れんけつりすとののーどは何で構成されるか？"
+      "ja": "連結リストのノードは何で構成されるか？"
     },
     "question_text_reading": {
       "en": "What is a linked list node composed of?",
@@ -1559,21 +1559,21 @@
     "choices": [
       {
         "en": "pre-order",
-        "ja": "まえじゅん",
+        "ja": "前順",
         "ja_typings": [
           "maejun"
         ]
       },
       {
         "en": "in-order",
-        "ja": "ちゅうじゅん",
+        "ja": "中順",
         "ja_typings": [
           "chuujun"
         ]
       },
       {
         "en": "post-order",
-        "ja": "こうじゅん",
+        "ja": "構築準",
         "ja_typings": [
           "kojun",
           "koujun"
@@ -1581,7 +1581,7 @@
       },
       {
         "en": "level-order",
-        "ja": "れべるじゅん",
+        "ja": "レベル順",
         "ja_typings": [
           "reberujun"
         ]
@@ -1593,7 +1593,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which tree traversal visits root first?",
-      "ja": "ねをさいしょにたどる木の探索順は？"
+      "ja": "根を最初にたどる木の探索順は？"
     },
     "question_text_reading": {
       "en": "Which tree traversal visits root first?",
@@ -1604,7 +1604,7 @@
     "choices": [
       {
         "en": "two keys map to same bucket",
-        "ja": "ふたつのきーがどうじはっしゅ",
+        "ja": "二つのキーが同時発出",
         "ja_typings": [
           "futatsunokigadojihasshu",
           "futatsunokigadoujihasshu"
@@ -1612,21 +1612,21 @@
       },
       {
         "en": "hash value is zero",
-        "ja": "はっしゅがぜろになる",
+        "ja": "ハッシュ値がゼロになる",
         "ja_typings": [
           "hasshugazeroninaru"
         ]
       },
       {
         "en": "hash function crashes",
-        "ja": "はっしゅかんすうがくらっしゅ",
+        "ja": "ハッシュ関数がクラッシュ",
         "ja_typings": [
           "hasshukansuugakurasshu"
         ]
       },
       {
         "en": "key is not found",
-        "ja": "きーがみつからない",
+        "ja": "キーが見つからない",
         "ja_typings": [
           "kigamitsukaranai"
         ]
@@ -1638,7 +1638,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a hash collision?",
-      "ja": "ハッシュ衝突（hash collision）とは何ですか？"
+      "ja": "ハッシュ衝突とは何か？"
     },
     "question_text_reading": {
       "en": "What is a hash collision?",
@@ -1682,7 +1682,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the worst-case complexity of quicksort?",
-      "ja": "くいっくそーとの最悪計算量は？"
+      "ja": "クイックソートの最悪計算量は？"
     },
     "question_text_reading": {
       "en": "What is the worst-case complexity of quicksort?",
@@ -1693,28 +1693,28 @@
     "choices": [
       {
         "en": "queue",
-        "ja": "きゅー",
+        "ja": "キュー",
         "ja_typings": [
           "kyu"
         ]
       },
       {
         "en": "stack",
-        "ja": "すたっく",
+        "ja": "スタック",
         "ja_typings": [
           "sutakku"
         ]
       },
       {
         "en": "array",
-        "ja": "はいれつ",
+        "ja": "配列",
         "ja_typings": [
           "hairetsu"
         ]
       },
       {
         "en": "tree",
-        "ja": "つりー",
+        "ja": "ツリー",
         "ja_typings": [
           "tsuri"
         ]
@@ -1726,7 +1726,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which data structure supports BFS traversal naturally?",
-      "ja": "はばゆうせんたんさくを自然にサポートするでーたこうぞうは？"
+      "ja": "幅優先探索を自然にサポートするデータ構造は？"
     },
     "question_text_reading": {
       "en": "Which data structure supports BFS traversal naturally?",
@@ -1737,28 +1737,28 @@
     "choices": [
       {
         "en": "left < root < right",
-        "ja": "ひだり < ね < みぎ",
+        "ja": "左 < 根 < 右",
         "ja_typings": [
           "hidari ne migi"
         ]
       },
       {
         "en": "left > root > right",
-        "ja": "ひだり > ね > みぎ",
+        "ja": "左 > 根 > 右",
         "ja_typings": [
           "hidari ne migi"
         ]
       },
       {
         "en": "all nodes equal",
-        "ja": "すべてのーどがひとしい",
+        "ja": "すべてのノードが等しい",
         "ja_typings": [
           "subetenodogahitoshii"
         ]
       },
       {
         "en": "sorted by insertion order",
-        "ja": "そうにゅうじゅんにせいれつ",
+        "ja": "挿入順に並べ",
         "ja_typings": [
           "sonyuujunniseiretsu",
           "sounyuujunniseiretsu"
@@ -1771,7 +1771,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a binary search tree property?",
-      "ja": "二分探索木（binary search tree）の性質とは何ですか？"
+      "ja": "二分探索木の性質は？"
     },
     "question_text_reading": {
       "en": "What is a binary search tree property?",
@@ -1782,7 +1782,7 @@
     "choices": [
       {
         "en": "minimum value",
-        "ja": "さいしょうち",
+        "ja": "最小値",
         "ja_typings": [
           "saishochi",
           "saishouchi"
@@ -1790,21 +1790,21 @@
       },
       {
         "en": "maximum value",
-        "ja": "さいだいち",
+        "ja": "最大値",
         "ja_typings": [
           "saidaichi"
         ]
       },
       {
         "en": "median value",
-        "ja": "ちゅうかんち",
+        "ja": "中間値",
         "ja_typings": [
           "chuukanchi"
         ]
       },
       {
         "en": "random value",
-        "ja": "らんだむち",
+        "ja": "ランダム値",
         "ja_typings": [
           "randamuchi"
         ]
@@ -1816,7 +1816,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does a min-heap guarantee at the root?",
-      "ja": "みにひーぷはねに何を保証するか？"
+      "ja": "Min-heapは根に何を保証するか？"
     },
     "question_text_reading": {
       "en": "What does a min-heap guarantee at the root?",
@@ -1827,14 +1827,14 @@
     "choices": [
       {
         "en": "adjacency list",
-        "ja": "となりあいりすと",
+        "ja": "隣接リスト",
         "ja_typings": [
           "tonariairisuto"
         ]
       },
       {
         "en": "adjacency matrix",
-        "ja": "となりあいぎょうれつ",
+        "ja": "隣接行列",
         "ja_typings": [
           "tonariaigyoretsu",
           "tonariaigyouretsu"
@@ -1842,14 +1842,14 @@
       },
       {
         "en": "edge list",
-        "ja": "へんりすと",
+        "ja": "エッジリスト",
         "ja_typings": [
           "henrisuto"
         ]
       },
       {
         "en": "incidence matrix",
-        "ja": "そくしぎょうれつ",
+        "ja": "側面行列",
         "ja_typings": [
           "sokushigyoretsu",
           "sokushigyouretsu"
@@ -1862,7 +1862,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which graph representation uses adjacency lists?",
-      "ja": "隣接リスト（adjacency lists）を用いるグラフ表現はどれですか？"
+      "ja": "隣接リストを使うグラフ表現は？"
     },
     "question_text_reading": {
       "en": "Which graph representation uses adjacency lists?",
@@ -1873,28 +1873,28 @@
     "choices": [
       {
         "en": "solving by storing subproblem results",
-        "ja": "ぶぶんもんだいをほぞんしてかいく",
+        "ja": "部分問題を保存して解く",
         "ja_typings": [
           "bubunmondaiohozonshitekaiku"
         ]
       },
       {
         "en": "randomized algorithm",
-        "ja": "らんだまいずどあるごりずむ",
+        "ja": "ランダマイズドアルゴリズム",
         "ja_typings": [
           "randamaizudoarugorizumu"
         ]
       },
       {
         "en": "brute force search",
-        "ja": "ぜんけんさく",
+        "ja": "全探索",
         "ja_typings": [
           "zenkensaku"
         ]
       },
       {
         "en": "greedy selection",
-        "ja": "どんよくほう",
+        "ja": "貪欲法",
         "ja_typings": [
           "donyokuho",
           "donyokuhou"
@@ -1907,7 +1907,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is dynamic programming?",
-      "ja": "動的計画法（dynamic programming）とは何ですか？"
+      "ja": "動的計画法とは何か？"
     },
     "question_text_reading": {
       "en": "What is dynamic programming?",
@@ -1918,28 +1918,28 @@
     "choices": [
       {
         "en": "merge sort",
-        "ja": "まーじそーと",
+        "ja": "マージソート",
         "ja_typings": [
           "majisoto"
         ]
       },
       {
         "en": "quick sort",
-        "ja": "くいっくそーと",
+        "ja": "クイックソート",
         "ja_typings": [
           "kuikkusoto"
         ]
       },
       {
         "en": "heap sort",
-        "ja": "ひーぷそーと",
+        "ja": "ヒープソート",
         "ja_typings": [
           "hipusoto"
         ]
       },
       {
         "en": "selection sort",
-        "ja": "せんたくそーと",
+        "ja": "選択ソート",
         "ja_typings": [
           "sentakusoto"
         ]
@@ -1951,7 +1951,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which sorting algorithm is stable and O(n log n)?",
-      "ja": "安定していて、時間計算量が $O(n \\log n)$ のソートアルゴリズムはどれですか？"
+      "ja": "安定でO(n log n)のソートアルゴリズムは？"
     },
     "question_text_reading": {
       "en": "Which sorting algorithm is stable and O(n log n)?",
@@ -1962,7 +1962,7 @@
     "choices": [
       {
         "en": "describing algorithm complexity",
-        "ja": "あるごりずむのけいさんりょうをひょうげん",
+        "ja": "アルゴリズムの計算量を表現",
         "ja_typings": [
           "arugorizumunokeisanryoohyogen",
           "arugorizumunokeisanryouohyougen"
@@ -1970,7 +1970,7 @@
       },
       {
         "en": "measuring memory size",
-        "ja": "めもりしょうひをそくてい",
+        "ja": "メモリ消費を測定",
         "ja_typings": [
           "memorishohiosokutei",
           "memorishouhiosokutei"
@@ -1978,14 +1978,14 @@
       },
       {
         "en": "defining variable scope",
-        "ja": "へんすうのすこーぷをていぎ",
+        "ja": "変数のスコープを定義",
         "ja_typings": [
           "hensuunosukopuoteigi"
         ]
       },
       {
         "en": "declaring constants",
-        "ja": "ていすうをせんげん",
+        "ja": "定数を宣言",
         "ja_typings": [
           "teisuuosengen"
         ]
@@ -2008,14 +2008,14 @@
     "choices": [
       {
         "en": "shortest path",
-        "ja": "さいたんけいろ",
+        "ja": "最短経路",
         "ja_typings": [
           "saitankeiro"
         ]
       },
       {
         "en": "minimum spanning tree",
-        "ja": "さいしょうぜんいきき",
+        "ja": "最小全域木",
         "ja_typings": [
           "saishozenikiki",
           "saishouzenikiki"
@@ -2023,14 +2023,14 @@
       },
       {
         "en": "topological order",
-        "ja": "いそがきじゅん",
+        "ja": "位相幾何学順序",
         "ja_typings": [
           "isogakijun"
         ]
       },
       {
         "en": "strongly connected components",
-        "ja": "きょうれんけつせいぶん",
+        "ja": "強連結成分",
         "ja_typings": [
           "kyorenketsuseibun",
           "kyourenketsuseibun"
@@ -2043,7 +2043,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does Dijkstra's algorithm find?",
-      "ja": "ダイクストラのあるごりずむは何を求めるか？"
+      "ja": "ダイクストラのあるごりずむはなにをもとめるか？"
     },
     "question_text_reading": {
       "en": "What does Dijkstra's algorithm find?",
@@ -2054,28 +2054,28 @@
     "choices": [
       {
         "en": "caching computed results",
-        "ja": "けいさんけっかをきゃっしゅ",
+        "ja": "計算結果をキャッシュ",
         "ja_typings": [
           "keisankekkaokyasshu"
         ]
       },
       {
         "en": "memory allocation",
-        "ja": "めもりかくほ",
+        "ja": "メモリ確保",
         "ja_typings": [
           "memorikakuho"
         ]
       },
       {
         "en": "garbage collection",
-        "ja": "がーびっじこれくしょん",
+        "ja": "ガーベッジコレクション",
         "ja_typings": [
           "gabijjikorekushon"
         ]
       },
       {
         "en": "code optimization",
-        "ja": "こーどさいてきか",
+        "ja": "コード最適化",
         "ja_typings": [
           "kodosaitekika"
         ]
@@ -2087,7 +2087,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is memoization?",
-      "ja": "メモ化とは何ですか？"
+      "ja": "メモ化とは何か？"
     },
     "question_text_reading": {
       "en": "What is memoization?",
@@ -2098,21 +2098,21 @@
     "choices": [
       {
         "en": "merge sort",
-        "ja": "まーじそーと",
+        "ja": "マージソート",
         "ja_typings": [
           "majisoto"
         ]
       },
       {
         "en": "bubble sort",
-        "ja": "ばぶるそーと",
+        "ja": "バブルソート",
         "ja_typings": [
           "baburusoto"
         ]
       },
       {
         "en": "insertion sort",
-        "ja": "そうにゅうそーと",
+        "ja": "挿入ソート",
         "ja_typings": [
           "sonyuusoto",
           "sounyuusoto"
@@ -2120,7 +2120,7 @@
       },
       {
         "en": "counting sort",
-        "ja": "かうんとそーと",
+        "ja": "カウントソート",
         "ja_typings": [
           "kauntosoto"
         ]
@@ -2132,7 +2132,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which algorithm uses divide and conquer?",
-      "ja": "分割統治法を用いるアルゴリズムはどれですか？"
+      "ja": "分割統治法を使うアルゴリズムは？"
     },
     "question_text_reading": {
       "en": "Which algorithm uses divide and conquer?",
@@ -2143,14 +2143,14 @@
     "choices": [
       {
         "en": "a function calling itself",
-        "ja": "じぶんじしんをよびだすかんすう",
+        "ja": "自分自身を呼び出す関数",
         "ja_typings": [
           "jibunjishinoyobidasukansuu"
         ]
       },
       {
         "en": "a loop structure",
-        "ja": "るーぷこうぞう",
+        "ja": "ループ構造",
         "ja_typings": [
           "rupukozo",
           "rupukouzou"
@@ -2158,14 +2158,14 @@
       },
       {
         "en": "a data type",
-        "ja": "でーたがた",
+        "ja": "データ型",
         "ja_typings": [
           "detagata"
         ]
       },
       {
         "en": "an error handler",
-        "ja": "えらーはんどらー",
+        "ja": "エラーハンドラー",
         "ja_typings": [
           "erahandora"
         ]
@@ -2177,7 +2177,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is recursion?",
-      "ja": "再帰（recursion）とは何ですか？"
+      "ja": "再帰とは何か？"
     },
     "question_text_reading": {
       "en": "What is recursion?",
@@ -2188,7 +2188,7 @@
     "choices": [
       {
         "en": "the condition to stop recursion",
-        "ja": "さいきをとめるじょうけん",
+        "ja": "再帰を止める条件",
         "ja_typings": [
           "saikiotomerujoken",
           "saikiotomerujouken"
@@ -2196,21 +2196,21 @@
       },
       {
         "en": "the first recursive call",
-        "ja": "さいしょのさいきよびだし",
+        "ja": "最初の再帰呼び出し",
         "ja_typings": [
           "saishonosaikiyobidashi"
         ]
       },
       {
         "en": "the input parameter",
-        "ja": "にゅうりょくぱらめーた",
+        "ja": "入力パラメータ",
         "ja_typings": [
           "nyuuryokuparameta"
         ]
       },
       {
         "en": "the return value",
-        "ja": "もどりち",
+        "ja": "戻り値",
         "ja_typings": [
           "modorichi"
         ]
@@ -2222,7 +2222,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the base case in recursion?",
-      "ja": "再帰におけるベースケースとは何ですか？"
+      "ja": "再帰の基底条件とは？"
     },
     "question_text_reading": {
       "en": "What is the base case in recursion?",
@@ -2233,28 +2233,28 @@
     "choices": [
       {
         "en": "binary search",
-        "ja": "にぶんたんさく",
+        "ja": "二分探索",
         "ja_typings": [
           "nibuntansaku"
         ]
       },
       {
         "en": "linear search",
-        "ja": "せんけいたんさく",
+        "ja": "線形探索",
         "ja_typings": [
           "senkeitansaku"
         ]
       },
       {
         "en": "depth-first search",
-        "ja": "ふかさゆうせんたんさく",
+        "ja": "深さ優先探索",
         "ja_typings": [
           "fukasayuusentansaku"
         ]
       },
       {
         "en": "breadth-first search",
-        "ja": "はばゆうせんたんさく",
+        "ja": "幅優先探索",
         "ja_typings": [
           "habayuusentansaku"
         ]
@@ -2266,7 +2266,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which search requires a sorted array?",
-      "ja": "せいれつされたはいれつが必要な探索は？"
+      "ja": "整列された配列が必要な探索は？"
     },
     "question_text_reading": {
       "en": "Which search requires a sorted array?",
@@ -2310,7 +2310,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the time complexity of bubble sort?",
-      "ja": "ばぶるそーとの計算量は？"
+      "ja": "バブルソートの計算量は？"
     },
     "question_text_reading": {
       "en": "What is the time complexity of bubble sort?",
@@ -2321,7 +2321,7 @@
     "choices": [
       {
         "en": "hiding internal details",
-        "ja": "ないぶしょうさいをかくす",
+        "ja": "内部詳細を隠す",
         "ja_typings": [
           "naibushosaiokakusu",
           "naibushousaiokakusu"
@@ -2329,7 +2329,7 @@
       },
       {
         "en": "inheriting properties",
-        "ja": "ぷろぱてぃをけいしょう",
+        "ja": "プロパティを継承",
         "ja_typings": [
           "puropatiokeisho",
           "puropatiokeishou"
@@ -2337,7 +2337,7 @@
       },
       {
         "en": "overriding methods",
-        "ja": "めそっどをおーばーらいど",
+        "ja": "メソッドをオーバーライド",
         "ja_typings": [
           "mesoddoobaraido",
           "mesoddooobaraido"
@@ -2345,7 +2345,7 @@
       },
       {
         "en": "creating instances",
-        "ja": "いんすたんすをさくせい",
+        "ja": "インスタンスを生成",
         "ja_typings": [
           "insutansuosakusei"
         ]
@@ -2357,7 +2357,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is encapsulation?",
-      "ja": "カプセル化とは、どのような概念ですか？"
+      "ja": "カプセル化とは何か？"
     },
     "question_text_reading": {
       "en": "What is encapsulation?",
@@ -2368,7 +2368,7 @@
     "choices": [
       {
         "en": "same interface, different behaviors",
-        "ja": "どうじいんたーふぇーす、ことなるどうさ",
+        "ja": "同一インターフェース、異なる動作",
         "ja_typings": [
           "dojiintafesu kotonarudosa",
           "doujiintafesu kotonarudousa"
@@ -2376,14 +2376,14 @@
       },
       {
         "en": "one class one method",
-        "ja": "いちくらすいちめそっど",
+        "ja": "一クラス一メソッド",
         "ja_typings": [
           "ichikurasuichimesoddo"
         ]
       },
       {
         "en": "multiple inheritance",
-        "ja": "たじゅうけいしょう",
+        "ja": "多重継承",
         "ja_typings": [
           "tajuukeisho",
           "tajuukeishou"
@@ -2391,7 +2391,7 @@
       },
       {
         "en": "static typing",
-        "ja": "せいてきがたずけ",
+        "ja": "静的型付け",
         "ja_typings": [
           "seitekigatazuke"
         ]
@@ -2403,7 +2403,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is polymorphism?",
-      "ja": "ポリモーフィズムとはどのような概念ですか？"
+      "ja": "多態性とは何か？"
     },
     "question_text_reading": {
       "en": "What is polymorphism?",
@@ -2414,28 +2414,28 @@
     "choices": [
       {
         "en": "calls parent class",
-        "ja": "おやくらすをよびだす",
+        "ja": "親クラスを呼び出す",
         "ja_typings": [
           "oyakurasuoyobidasu"
         ]
       },
       {
         "en": "creates subclass",
-        "ja": "さぶくらすをさくせい",
+        "ja": "サブクラスを作成",
         "ja_typings": [
           "sabukurasuosakusei"
         ]
       },
       {
         "en": "deletes instance",
-        "ja": "いんすたんすをさくじょ",
+        "ja": "インスタンスを削除",
         "ja_typings": [
           "insutansuosakujo"
         ]
       },
       {
         "en": "copies object",
-        "ja": "おぶじぇくとをこぴー",
+        "ja": "オブジェクトをコピー",
         "ja_typings": [
           "obujekutokopi",
           "obujekutookopi"
@@ -2459,28 +2459,28 @@
     "choices": [
       {
         "en": "cannot be instantiated directly",
-        "ja": "ちょくせつしてきれつかできない",
+        "ja": "直接して記述化できない",
         "ja_typings": [
           "chokusetsushitekiretsukadekinai"
         ]
       },
       {
         "en": "has no methods",
-        "ja": "めそっどがない",
+        "ja": "メソッドがない",
         "ja_typings": [
           "mesoddoganai"
         ]
       },
       {
         "en": "is always static",
-        "ja": "つねにすたてぃっく",
+        "ja": "常にスタティック",
         "ja_typings": [
           "tsunenisutatikku"
         ]
       },
       {
         "en": "inherits from interface",
-        "ja": "いんたーふぇーすからけいしょう",
+        "ja": "インターフェースから継承",
         "ja_typings": [
           "intafesukarakeisho",
           "intafesukarakeishou"
@@ -2493,7 +2493,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is an abstract class?",
-      "ja": "抽象クラスとはどのようなものですか？"
+      "ja": "抽象クラスとは何か？"
     },
     "question_text_reading": {
       "en": "What is an abstract class?",
@@ -2504,14 +2504,14 @@
     "choices": [
       {
         "en": "contract of method signatures",
-        "ja": "めそっどしぐにちゃのけいやく",
+        "ja": "メソッドシグネチャの契約",
         "ja_typings": [
           "mesoddoshigunichanokeiyaku"
         ]
       },
       {
         "en": "a concrete class",
-        "ja": "きゅうしょうてきなくらす",
+        "ja": "具象的なクラス",
         "ja_typings": [
           "kyuushotekinakurasu",
           "kyuushoutekinakurasu"
@@ -2519,14 +2519,14 @@
       },
       {
         "en": "a data container",
-        "ja": "でーたこんてな",
+        "ja": "データコンテナ",
         "ja_typings": [
           "detakontena"
         ]
       },
       {
         "en": "a static method",
-        "ja": "すたてぃっくめそっど",
+        "ja": "スタティックメソッド",
         "ja_typings": [
           "sutatikkumesoddo"
         ]
@@ -2538,7 +2538,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is an interface in OOP?",
-      "ja": "OOPにおけるインターフェースとは何ですか？"
+      "ja": "OOPのインターフェースとは？"
     },
     "question_text_reading": {
       "en": "What is an interface in OOP?",
@@ -2549,28 +2549,28 @@
     "choices": [
       {
         "en": "Singleton",
-        "ja": "Singleton",
+        "ja": "シングルトン",
         "ja_typings": [
           "singleton"
         ]
       },
       {
         "en": "Factory",
-        "ja": "Factory",
+        "ja": "ファクトリー",
         "ja_typings": [
           "factory"
         ]
       },
       {
         "en": "Observer",
-        "ja": "Observer",
+        "ja": "オブザーバー",
         "ja_typings": [
           "observer"
         ]
       },
       {
         "en": "Strategy",
-        "ja": "Strategy",
+        "ja": "ストラテジー",
         "ja_typings": [
           "strategy"
         ]
@@ -2582,7 +2582,7 @@
     "image_path": null,
     "question_text": {
       "en": "What pattern ensures a class has only one instance?",
-      "ja": "クラスにインスタンスが一つしか存在しないことを保証するパターンは何ですか？"
+      "ja": "クラスのインスタンスをひとつにするパターンは？"
     },
     "question_text_reading": {
       "en": "What pattern ensures a class has only one instance?",
@@ -2593,28 +2593,28 @@
     "choices": [
       {
         "en": "Strategy",
-        "ja": "Strategy",
+        "ja": "ストラテジー",
         "ja_typings": [
           "strategy"
         ]
       },
       {
         "en": "Singleton",
-        "ja": "Singleton",
+        "ja": "シングルトン",
         "ja_typings": [
           "singleton"
         ]
       },
       {
         "en": "Decorator",
-        "ja": "Decorator",
+        "ja": "デコレーター",
         "ja_typings": [
           "decorator"
         ]
       },
       {
         "en": "Command",
-        "ja": "Command",
+        "ja": "コマンド",
         "ja_typings": [
           "command"
         ]
@@ -2626,7 +2626,7 @@
     "image_path": null,
     "question_text": {
       "en": "What pattern defines a family of algorithms?",
-      "ja": "アルゴリズムの「ファミリー」を定義するパターンとは何ですか？"
+      "ja": "アルゴリズムの家族を定義するパターンは？"
     },
     "question_text_reading": {
       "en": "What pattern defines a family of algorithms?",
@@ -2637,7 +2637,7 @@
     "choices": [
       {
         "en": "notifies subscribers of changes",
-        "ja": "こうどくしゃにへんかをつうち",
+        "ja": "購読者に変化を通知",
         "ja_typings": [
           "kodokushanihenkaotsuuchi",
           "koudokushanihenkaotsuuchi"
@@ -2645,7 +2645,7 @@
       },
       {
         "en": "creates objects",
-        "ja": "おぶじぇくとをさくせい",
+        "ja": "オブジェクトを作成",
         "ja_typings": [
           "obujekutosakusei",
           "obujekutoosakusei"
@@ -2653,7 +2653,7 @@
       },
       {
         "en": "wraps objects",
-        "ja": "おぶじぇくとをらっぷ",
+        "ja": "オブジェクトをラップ",
         "ja_typings": [
           "obujekutorappu",
           "obujekutoorappu"
@@ -2661,7 +2661,7 @@
       },
       {
         "en": "restricts instances",
-        "ja": "いんすたんすをせいげん",
+        "ja": "インスタンスを制限",
         "ja_typings": [
           "insutansuoseigen"
         ]
@@ -2673,7 +2673,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does the Observer pattern do?",
-      "ja": "Observerパターンはどのような役割を果たしますか？"
+      "ja": "Observerパターンは何をするか？"
     },
     "question_text_reading": {
       "en": "What does the Observer pattern do?",
@@ -2684,14 +2684,14 @@
     "choices": [
       {
         "en": "creates objects without specifying class",
-        "ja": "くらすをしていせずおぶじぇくとさくせい",
+        "ja": "クラスをしていせずオブジェクト作成",
         "ja_typings": [
           "kurasuoshiteisezuobujekutosakusei"
         ]
       },
       {
         "en": "observes state changes",
-        "ja": "じょうたいへんかをかんさつ",
+        "ja": "状態変化を観察",
         "ja_typings": [
           "jotaihenkaokansatsu",
           "joutaihenkaokansatsu"
@@ -2699,7 +2699,7 @@
       },
       {
         "en": "adds behavior dynamically",
-        "ja": "どうてきにどうさをついか",
+        "ja": "動的に動作を追加",
         "ja_typings": [
           "dotekinidosaotsuika",
           "doutekinidousaotsuika"
@@ -2707,7 +2707,7 @@
       },
       {
         "en": "reduces coupling",
-        "ja": "けつごうをへらす",
+        "ja": "結合を減らす",
         "ja_typings": [
           "ketsugooherasu",
           "ketsugouoherasu"
@@ -2720,7 +2720,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the Factory pattern?",
-      "ja": "ファクトリーパターンとは、どのような設計パターンですか？"
+      "ja": "ファクトリーパターンとは？"
     },
     "question_text_reading": {
       "en": "What is the Factory pattern?",
@@ -2731,28 +2731,28 @@
     "choices": [
       {
         "en": "Decorator",
-        "ja": "Decorator",
+        "ja": "デコレーター",
         "ja_typings": [
           "decorator"
         ]
       },
       {
         "en": "Singleton",
-        "ja": "Singleton",
+        "ja": "シングルトン",
         "ja_typings": [
           "singleton"
         ]
       },
       {
         "en": "Facade",
-        "ja": "Facade",
+        "ja": "ファサード",
         "ja_typings": [
           "facade"
         ]
       },
       {
         "en": "Template",
-        "ja": "Template",
+        "ja": "テンプレート",
         "ja_typings": [
           "template"
         ]
@@ -2764,7 +2764,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which pattern adds behavior without modifying class?",
-      "ja": "クラスのコードを変更せずに振る舞いを追加するパターンはどれ？"
+      "ja": "クラスを変更せずに動作を追加するパターンは？"
     },
     "question_text_reading": {
       "en": "Which pattern adds behavior without modifying class?",
@@ -2775,7 +2775,7 @@
     "choices": [
       {
         "en": "saves work temporarily",
-        "ja": "さぎょうをいじてきほぞん",
+        "ja": "作業を一時保存",
         "ja_typings": [
           "sagyooijitekihozon",
           "sagyouoijitekihozon"
@@ -2783,21 +2783,21 @@
       },
       {
         "en": "deletes branch",
-        "ja": "ぶらんちをさくじょ",
+        "ja": "ブランチを削除",
         "ja_typings": [
           "buranchiosakujo"
         ]
       },
       {
         "en": "merges branches",
-        "ja": "ぶらんちをがったい",
+        "ja": "ブランチを合体",
         "ja_typings": [
           "buranchiogattai"
         ]
       },
       {
         "en": "creates tag",
-        "ja": "たぐをさくせい",
+        "ja": "タグを作成",
         "ja_typings": [
           "taguosakusei"
         ]
@@ -2820,7 +2820,7 @@
     "choices": [
       {
         "en": "personal copy of a repo",
-        "ja": "りぽのこじんようこぴー",
+        "ja": "リポの個人用コピー",
         "ja_typings": [
           "riponokojinyokopi",
           "riponokojinyoukopi"
@@ -2828,21 +2828,21 @@
       },
       {
         "en": "a branch name",
-        "ja": "ぶらんちめい",
+        "ja": "ブランチ名",
         "ja_typings": [
           "buranchimei"
         ]
       },
       {
         "en": "a commit hash",
-        "ja": "こみっとはっしゅ",
+        "ja": "コミットハッシュ",
         "ja_typings": [
           "komittohasshu"
         ]
       },
       {
         "en": "a merge strategy",
-        "ja": "がったいせんりゃく",
+        "ja": "合体戦略",
         "ja_typings": [
           "gattaisenryaku"
         ]
@@ -2865,7 +2865,7 @@
     "choices": [
       {
         "en": "applies a specific commit",
-        "ja": "とくていのこみっとをてきよう",
+        "ja": "特定のコミットを適用",
         "ja_typings": [
           "tokuteinokomittotekiyo",
           "tokuteinokomittootekiyou"
@@ -2873,7 +2873,7 @@
       },
       {
         "en": "removes a commit",
-        "ja": "こみっとをさくじょ",
+        "ja": "コミットを削除",
         "ja_typings": [
           "komittosakujo",
           "komittoosakujo"
@@ -2881,7 +2881,7 @@
       },
       {
         "en": "lists all commits",
-        "ja": "こみっとをいちらん",
+        "ja": "コミットを一覧",
         "ja_typings": [
           "komittoichiran",
           "komittooichiran"
@@ -2889,7 +2889,7 @@
       },
       {
         "en": "creates a branch",
-        "ja": "ぶらんちをさくせい",
+        "ja": "ブランチを作成",
         "ja_typings": [
           "buranchiosakusei"
         ]
@@ -2912,7 +2912,7 @@
     "choices": [
       {
         "en": "named reference to a commit",
-        "ja": "こみっとへのなまえつきさんしょう",
+        "ja": "コミットへの名前付き参照",
         "ja_typings": [
           "komittohenonamaetsukisansho",
           "komittohenonamaetsukisanshou"
@@ -2920,21 +2920,21 @@
       },
       {
         "en": "a branch alias",
-        "ja": "ぶらんちのべつめい",
+        "ja": "ブランチの別名",
         "ja_typings": [
           "buranchinobetsumei"
         ]
       },
       {
         "en": "a merge request",
-        "ja": "まーじりくえすと",
+        "ja": "マージリクエスト",
         "ja_typings": [
           "majirikuesuto"
         ]
       },
       {
         "en": "a remote name",
-        "ja": "りもーとめい",
+        "ja": "リモートネーム",
         "ja_typings": [
           "rimotomei"
         ]
@@ -2957,7 +2957,7 @@
     "choices": [
       {
         "en": "reapplies commits on new base",
-        "ja": "こみっとをあたらしいきていにてきよう",
+        "ja": "コミットを新しい基底条件に適用",
         "ja_typings": [
           "komittoatarashiikiteinitekiyo",
           "komittooatarashiikiteinitekiyou"
@@ -2965,7 +2965,7 @@
       },
       {
         "en": "reverts all changes",
-        "ja": "すべてのへんこうをもとにもどす",
+        "ja": "すべての変更を元に戻す",
         "ja_typings": [
           "subetenohenkoomotonimodosu",
           "subetenohenkouomotonimodosu"
@@ -2973,14 +2973,14 @@
       },
       {
         "en": "creates a new branch",
-        "ja": "あたらしいぶらんちをさくせい",
+        "ja": "新しいブランチを作成",
         "ja_typings": [
           "atarashiiburanchiosakusei"
         ]
       },
       {
         "en": "pushes to remote",
-        "ja": "りもーとにぷっしゅ",
+        "ja": "リモートにプッシュ",
         "ja_typings": [
           "rimotonipusshu"
         ]
@@ -3003,28 +3003,28 @@
     "choices": [
       {
         "en": "testing individual components",
-        "ja": "こぶひんのてすと",
+        "ja": "個部品のテスト",
         "ja_typings": [
           "kobuhinnotesuto"
         ]
       },
       {
         "en": "testing entire system",
-        "ja": "しすてむぜんたいのてすと",
+        "ja": "システム全体のテスト",
         "ja_typings": [
           "shisutemuzentainotesuto"
         ]
       },
       {
         "en": "testing user interface",
-        "ja": "ゆーざーいんたーふぇーすのてすと",
+        "ja": "ユーザーインターフェースのテスト",
         "ja_typings": [
           "yuzaintafesunotesuto"
         ]
       },
       {
         "en": "testing performance",
-        "ja": "ぱふぉーまんすのてすと",
+        "ja": "パフォーマンスのテスト",
         "ja_typings": [
           "pafomansunotesuto"
         ]
@@ -3036,7 +3036,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is unit testing?",
-      "ja": "ユニットテストとは何ですか？"
+      "ja": "ユニットテストとは何か？"
     },
     "question_text_reading": {
       "en": "What is unit testing?",
@@ -3047,7 +3047,7 @@
     "choices": [
       {
         "en": "Test Driven Development",
-        "ja": "てすときどうかいはつ",
+        "ja": "テスト駆動開発",
         "ja_typings": [
           "tesutokidokaihatsu",
           "tesutokidoukaihatsu"
@@ -3055,21 +3055,21 @@
       },
       {
         "en": "Type Definition Document",
-        "ja": "かたていぎどきゅめんと",
+        "ja": "型定義ドキュメント",
         "ja_typings": [
           "katateigidokyumento"
         ]
       },
       {
         "en": "Tool Deployment Design",
-        "ja": "つーるはいひせっけい",
+        "ja": "ツールデプロイメントデザイン",
         "ja_typings": [
           "tsuruhaihisekkei"
         ]
       },
       {
         "en": "Total Data Delivery",
-        "ja": "そうでーたはいそう",
+        "ja": "データ配信",
         "ja_typings": [
           "sodetahaiso",
           "soudetahaisou"
@@ -3093,21 +3093,21 @@
     "choices": [
       {
         "en": "simulated dependency",
-        "ja": "ぎそのいぞんかんけい",
+        "ja": "基底依存関係",
         "ja_typings": [
           "gisonoizonkankei"
         ]
       },
       {
         "en": "real database",
-        "ja": "じっさいのでーたべーす",
+        "ja": "実際のデータベース",
         "ja_typings": [
           "jissainodetabesu"
         ]
       },
       {
         "en": "test runner",
-        "ja": "てすとじっこうき",
+        "ja": "テスト実行機",
         "ja_typings": [
           "tesutojikkoki",
           "tesutojikkouki"
@@ -3115,7 +3115,7 @@
       },
       {
         "en": "assertion library",
-        "ja": "あさーしょんらいぶらり",
+        "ja": "アサーションライブラリ",
         "ja_typings": [
           "asashonraiburari"
         ]
@@ -3127,7 +3127,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a mock in testing?",
-      "ja": "テストにおける「mock」とは何ですか？"
+      "ja": "テストのモックとは何か？"
     },
     "question_text_reading": {
       "en": "What is a mock in testing?",
@@ -3138,28 +3138,28 @@
     "choices": [
       {
         "en": "testing component interactions",
-        "ja": "こんぽーねんとのれんけいをてすと",
+        "ja": "コンポーネントの連携をテスト",
         "ja_typings": [
           "konponentonorenkeiotesuto"
         ]
       },
       {
         "en": "testing one function",
-        "ja": "ひとつのかんすうをてすと",
+        "ja": "一つの関数をテスト",
         "ja_typings": [
           "hitotsunokansuuotesuto"
         ]
       },
       {
         "en": "testing UI only",
-        "ja": "UIのみてすと",
+        "ja": "UIのみテスト",
         "ja_typings": [
           "uinomitesuto"
         ]
       },
       {
         "en": "testing code style",
-        "ja": "こーどすたいるをてすと",
+        "ja": "コードスタイルをテスト",
         "ja_typings": [
           "kodosutairuotesuto"
         ]
@@ -3171,7 +3171,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is integration testing?",
-      "ja": "統合テストとは何ですか？"
+      "ja": "統合テストとは何か？"
     },
     "question_text_reading": {
       "en": "What is integration testing?",
@@ -3182,7 +3182,7 @@
     "choices": [
       {
         "en": "checks expected condition",
-        "ja": "きたいするじょうけんをかくにん",
+        "ja": "期待する条件を確認",
         "ja_typings": [
           "kitaisurujokenokakunin",
           "kitaisurujoukenokakunin"
@@ -3190,7 +3190,7 @@
       },
       {
         "en": "runs the test",
-        "ja": "てすとをじっこう",
+        "ja": "テストを実行",
         "ja_typings": [
           "tesutojikko",
           "tesutoojikkou"
@@ -3198,14 +3198,14 @@
       },
       {
         "en": "logs a message",
-        "ja": "めっせーじをきろく",
+        "ja": "メッセージを記録",
         "ja_typings": [
           "messejiokiroku"
         ]
       },
       {
         "en": "skips the test",
-        "ja": "てすとをすきっぷ",
+        "ja": "テストをスキップ",
         "ja_typings": [
           "tesutosukippu",
           "tesutoosukippu"
@@ -3229,7 +3229,7 @@
     "choices": [
       {
         "en": "no side effects, same input = same output",
-        "ja": "ふくさよううなし、どうにゅうりょく=どうしゅつりょく",
+        "ja": "副作用なし、同一入力=同一出力",
         "ja_typings": [
           "fukusayounashi donyuuryokudoshutsuryoku",
           "fukusayouunashi dounyuuryokudoushutsuryoku"
@@ -3237,7 +3237,7 @@
       },
       {
         "en": "modifies global state",
-        "ja": "ぐろーばるじょうたいをへんこう",
+        "ja": "グローバルステートを変更",
         "ja_typings": [
           "gurobarujotaiohenko",
           "gurobarujoutaiohenkou"
@@ -3245,7 +3245,7 @@
       },
       {
         "en": "uses external variables",
-        "ja": "がいぶへんすうをしよう",
+        "ja": "外部変数をしよう",
         "ja_typings": [
           "gaibuhensuuoshiyo",
           "gaibuhensuuoshiyou"
@@ -3253,7 +3253,7 @@
       },
       {
         "en": "called only once",
-        "ja": "いちどしかよびだせない",
+        "ja": "一度しか呼び出せない",
         "ja_typings": [
           "ichidoshikayobidasenai"
         ]
@@ -3265,7 +3265,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a pure function?",
-      "ja": "純粋関数（pure function）とはどのようなものですか？"
+      "ja": "純粋関数とは何か？"
     },
     "question_text_reading": {
       "en": "What is a pure function?",
@@ -3276,7 +3276,7 @@
     "choices": [
       {
         "en": "takes or returns a function",
-        "ja": "かんすうをうけとるかかえす",
+        "ja": "関数を受け取るか返す",
         "ja_typings": [
           "kansuuoketorukakaesu",
           "kansuuouketorukakaesu"
@@ -3284,7 +3284,7 @@
       },
       {
         "en": "runs faster than normal",
-        "ja": "ふつうよりはやくじっこう",
+        "ja": "普通より速く実行",
         "ja_typings": [
           "futsuuyorihayakujikko",
           "futsuuyorihayakujikkou"
@@ -3292,7 +3292,7 @@
       },
       {
         "en": "has more parameters",
-        "ja": "よりおおくのぱらめーたをもつ",
+        "ja": "より多くのパラメーターを持つ",
         "ja_typings": [
           "yoriokunoparametaomotsu",
           "yoriookunoparametaomotsu"
@@ -3300,7 +3300,7 @@
       },
       {
         "en": "is recursive",
-        "ja": "さいきてき",
+        "ja": "再帰的",
         "ja_typings": [
           "saikiteki"
         ]
@@ -3312,7 +3312,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a higher-order function?",
-      "ja": "高階関数（higher-order function）とはどのようなものですか？"
+      "ja": "高階関数とは何か？"
     },
     "question_text_reading": {
       "en": "What is a higher-order function?",
@@ -3323,7 +3323,7 @@
     "choices": [
       {
         "en": "combining elements into one value",
-        "ja": "ようそをひとつのちにまとめる",
+        "ja": "要素を一つの値にまとめる",
         "ja_typings": [
           "yosohitotsunochinimatomeru",
           "yousoohitotsunochinimatomeru"
@@ -3331,7 +3331,7 @@
       },
       {
         "en": "filtering elements",
-        "ja": "ようそをふぃるたりんぐ",
+        "ja": "要素をフィルタリング",
         "ja_typings": [
           "yosofirutaringu",
           "yousoofirutaringu"
@@ -3339,7 +3339,7 @@
       },
       {
         "en": "sorting elements",
-        "ja": "ようそをせいれつ",
+        "ja": "要素を整列",
         "ja_typings": [
           "yososeiretsu",
           "yousooseiretsu"
@@ -3347,7 +3347,7 @@
       },
       {
         "en": "mapping elements",
-        "ja": "ようそをまっぴんぐ",
+        "ja": "要素をマッピング",
         "ja_typings": [
           "yosomappingu",
           "yousoomappingu"
@@ -3371,28 +3371,28 @@
     "choices": [
       {
         "en": "data cannot be changed after creation",
-        "ja": "さくせいごにでーたをかえられない",
+        "ja": "作成後にデータを変えられない",
         "ja_typings": [
           "sakuseigonidetaokaerarenai"
         ]
       },
       {
         "en": "data is always null",
-        "ja": "でーたはつねにnull",
+        "ja": "データは常にnull",
         "ja_typings": [
           "detahatsuneninull"
         ]
       },
       {
         "en": "variables are global",
-        "ja": "へんすうはぐろーばる",
+        "ja": "変数はグローバル",
         "ja_typings": [
           "hensuuhagurobaru"
         ]
       },
       {
         "en": "functions have no return",
-        "ja": "かんすうはもどらない",
+        "ja": "関数は戻らない",
         "ja_typings": [
           "kansuuhamodoranai"
         ]
@@ -3404,7 +3404,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is immutability?",
-      "ja": "不変性（immutability）とは、どのような概念ですか？"
+      "ja": "不変性とは何か？"
     },
     "question_text_reading": {
       "en": "What is immutability?",
@@ -3415,28 +3415,28 @@
     "choices": [
       {
         "en": "combining functions to build new ones",
-        "ja": "かんすうをくみあわせてあたらしいかんすうをつくる",
+        "ja": "関数を組み合わせて新しい関数を作る",
         "ja_typings": [
           "kansuuokumiawaseteatarashiikansuuotsukuru"
         ]
       },
       {
         "en": "calling all functions at once",
-        "ja": "すべてのかんすうをいちどによびだす",
+        "ja": "すべての関数を一度に呼び出す",
         "ja_typings": [
           "subetenokansuuoichidoniyobidasu"
         ]
       },
       {
         "en": "defining functions inside loops",
-        "ja": "るーぷないにかんすうをていぎ",
+        "ja": "ループ内に関数を定義",
         "ja_typings": [
           "rupunainikansuuoteigi"
         ]
       },
       {
         "en": "converting functions to strings",
-        "ja": "かんすうをもじれつにへんかん",
+        "ja": "関数を文字列に変換",
         "ja_typings": [
           "kansuuomojiretsunihenkan"
         ]
@@ -3448,7 +3448,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is function composition?",
-      "ja": "関数合成とは何ですか？"
+      "ja": "関数合成とは何か？"
     },
     "question_text_reading": {
       "en": "What is function composition?",
@@ -3459,14 +3459,14 @@
     "choices": [
       {
         "en": "types checked at compile time",
-        "ja": "かんぱいるじにがたをかくにん",
+        "ja": "コンパイル時に型を確認",
         "ja_typings": [
           "kanpairujinigataokakunin"
         ]
       },
       {
         "en": "types checked at runtime",
-        "ja": "じっこうじにがたをかくにん",
+        "ja": "実行時に型を確認",
         "ja_typings": [
           "jikkojinigataokakunin",
           "jikkoujinigataokakunin"
@@ -3474,14 +3474,14 @@
       },
       {
         "en": "no type checking",
-        "ja": "がたかくにんなし",
+        "ja": "型確認なし",
         "ja_typings": [
           "gatakakuninnashi"
         ]
       },
       {
         "en": "types inferred by AI",
-        "ja": "AIがたをすいろん",
+        "ja": "AIが型を推論",
         "ja_typings": [
           "aigataosuiron"
         ]
@@ -3493,7 +3493,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is static typing?",
-      "ja": "静的型付けとは、どのようなものですか？"
+      "ja": "静的型付けとは何か？"
     },
     "question_text_reading": {
       "en": "What is static typing?",
@@ -3504,21 +3504,21 @@
     "choices": [
       {
         "en": "compiler deduces type from context",
-        "ja": "こんぱいらがぶんみゃくからがたをすいてい",
+        "ja": "コンパイラが文脈から型を推定",
         "ja_typings": [
           "konpairagabunmyakukaragataosuitei"
         ]
       },
       {
         "en": "developer declares every type",
-        "ja": "かいはつしゃがすべてのがたをせんげん",
+        "ja": "開発者がすべての型を宣言",
         "ja_typings": [
           "kaihatsushagasubetenogataosengen"
         ]
       },
       {
         "en": "runtime assigns types",
-        "ja": "じっこうじにがたをわりあて",
+        "ja": "実行時に型を割り当て",
         "ja_typings": [
           "jikkojinigataowariate",
           "jikkoujinigataowariate"
@@ -3526,7 +3526,7 @@
       },
       {
         "en": "types are always strings",
-        "ja": "がたはつねにもじれつ",
+        "ja": "型は常に文字列",
         "ja_typings": [
           "gatahatsunenimojiretsu"
         ]
@@ -3538,7 +3538,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is type inference?",
-      "ja": "型推論とは何ですか？"
+      "ja": "ガタスシロンとは何か？"
     },
     "question_text_reading": {
       "en": "What is type inference?",
@@ -3549,7 +3549,7 @@
     "choices": [
       {
         "en": "type that works with many types",
-        "ja": "おおくのがたにたいおうするがた",
+        "ja": "多くの型に対応する型",
         "ja_typings": [
           "okunogatanitaiosurugata",
           "ookunogatanitaiousurugata"
@@ -3557,21 +3557,21 @@
       },
       {
         "en": "always integer type",
-        "ja": "つねにせいすうがた",
+        "ja": "常に整数型",
         "ja_typings": [
           "tsuneniseisuugata"
         ]
       },
       {
         "en": "a string template",
-        "ja": "もじれつてんぷれーと",
+        "ja": "文字列テンプレート",
         "ja_typings": [
           "mojiretsutenpureto"
         ]
       },
       {
         "en": "a null type",
-        "ja": "nullがた",
+        "ja": "null型",
         "ja_typings": [
           "nullgata"
         ]
@@ -3583,7 +3583,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a generic type?",
-      "ja": "ジェネリック型とは何ですか？"
+      "ja": "ジェネリック型とは何か？"
     },
     "question_text_reading": {
       "en": "What is a generic type?",
@@ -3594,14 +3594,14 @@
     "choices": [
       {
         "en": "two processes wait for each other",
-        "ja": "ふたつのぷろせすがたがいにまちつづける",
+        "ja": "二つのプロセスが互いに待ち続ける",
         "ja_typings": [
           "futatsunopurosesugatagainimachitsuzukeru"
         ]
       },
       {
         "en": "process running too fast",
-        "ja": "ぷろせすがはやすぎるじっこう",
+        "ja": "プロセスが速すぎる実行",
         "ja_typings": [
           "purosesugahayasugirujikko",
           "purosesugahayasugirujikkou"
@@ -3609,14 +3609,14 @@
       },
       {
         "en": "memory overflow",
-        "ja": "めもりおーばーふろー",
+        "ja": "メモリオーバーフロー",
         "ja_typings": [
           "memoriobafuro"
         ]
       },
       {
         "en": "CPU overload",
-        "ja": "CPUかふか",
+        "ja": "CPU過負荷",
         "ja_typings": [
           "cpukafuka"
         ]
@@ -3628,7 +3628,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a deadlock?",
-      "ja": "デッドロックとは何ですか？"
+      "ja": "デッドロックとは何か？"
     },
     "question_text_reading": {
       "en": "What is a deadlock?",
@@ -3639,7 +3639,7 @@
     "choices": [
       {
         "en": "mutual exclusion lock",
-        "ja": "そうごはいたじょきょのろっく",
+        "ja": "相互排他除のロック",
         "ja_typings": [
           "sogohaitajokyonorokku",
           "sougohaitajokyonorokku"
@@ -3647,7 +3647,7 @@
       },
       {
         "en": "multiple threads running",
-        "ja": "ふくすうすれっどじっこう",
+        "ja": "複数スレッド実行",
         "ja_typings": [
           "fukusuusureddojikko",
           "fukusuusureddojikkou"
@@ -3655,14 +3655,14 @@
       },
       {
         "en": "memory allocation unit",
-        "ja": "めもりかくほたんい",
+        "ja": "メモリ割り当てユニット",
         "ja_typings": [
           "memorikakuhotani"
         ]
       },
       {
         "en": "message queue",
-        "ja": "めっせーじきゅー",
+        "ja": "メッセージキュー",
         "ja_typings": [
           "messejikyu"
         ]
@@ -3674,7 +3674,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a mutex?",
-      "ja": "mutexとは何ですか？"
+      "ja": "ミューテックスとは何か？"
     },
     "question_text_reading": {
       "en": "What is a mutex?",
@@ -3685,14 +3685,14 @@
     "choices": [
       {
         "en": "outcome depends on thread timing",
-        "ja": "けっかがすれっどのたいみんぐによる",
+        "ja": "結果がスレッドのタイミングによる",
         "ja_typings": [
           "kekkagasureddonotaiminguniyoru"
         ]
       },
       {
         "en": "two threads with same speed",
-        "ja": "どうじそくどのふたつのすれっど",
+        "ja": "同時速度の二つのスレッド",
         "ja_typings": [
           "dojisokudonofutatsunosureddo",
           "doujisokudonofutatsunosureddo"
@@ -3700,14 +3700,14 @@
       },
       {
         "en": "process priority conflict",
-        "ja": "ぷろせすゆうせんどのこんぐりくと",
+        "ja": "プロセス優先度のコンフリクト",
         "ja_typings": [
           "purosesuyuusendonokongurikuto"
         ]
       },
       {
         "en": "infinite loop",
-        "ja": "むげんるーぷ",
+        "ja": "無限ループ",
         "ja_typings": [
           "mugenrupu"
         ]
@@ -3719,7 +3719,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a race condition?",
-      "ja": "競合状態とは何ですか？"
+      "ja": "レースコンディションとは何か？"
     },
     "question_text_reading": {
       "en": "What is a race condition?",
@@ -3730,7 +3730,7 @@
     "choices": [
       {
         "en": "non-blocking asynchronous code",
-        "ja": "ふぶろっきんぐのひどうきこーど",
+        "ja": "ノンブロッキングの非同期コード",
         "ja_typings": [
           "fuburokkingunohidokikodo",
           "fuburokkingunohidoukikodo"
@@ -3738,7 +3738,7 @@
       },
       {
         "en": "parallel computing",
-        "ja": "へいこうけいさん",
+        "ja": "並行計算",
         "ja_typings": [
           "heikokeisan",
           "heikoukeisan"
@@ -3746,7 +3746,7 @@
       },
       {
         "en": "synchronous locking",
-        "ja": "どうきてきろっく",
+        "ja": "同期ロック",
         "ja_typings": [
           "dokitekirokku",
           "doukitekirokku"
@@ -3754,7 +3754,7 @@
       },
       {
         "en": "error catching",
-        "ja": "えらーきゃっち",
+        "ja": "エラーキャッチ",
         "ja_typings": [
           "erakyatchi"
         ]
@@ -3777,7 +3777,7 @@
     "choices": [
       {
         "en": "smallest unit of execution",
-        "ja": "さいしょうのじっこうたんい",
+        "ja": "最小の実行単位",
         "ja_typings": [
           "saishonojikkotani",
           "saishounojikkoutani"
@@ -3785,21 +3785,21 @@
       },
       {
         "en": "a type of variable",
-        "ja": "へんすうのしゅるい",
+        "ja": "変数の種類",
         "ja_typings": [
           "hensuunoshurui"
         ]
       },
       {
         "en": "a network connection",
-        "ja": "ねっとわーくせつぞく",
+        "ja": "ネットワーク接続",
         "ja_typings": [
           "nettowakusetsuzoku"
         ]
       },
       {
         "en": "a file handle",
-        "ja": "ふぁいるはんどる",
+        "ja": "ファイルハンドル",
         "ja_typings": [
           "fairuhandoru"
         ]
@@ -3811,7 +3811,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a thread?",
-      "ja": "スレッドとは何ですか？"
+      "ja": "スレッドとは何か？"
     },
     "question_text_reading": {
       "en": "What is a thread?",
@@ -3822,7 +3822,7 @@
     "choices": [
       {
         "en": "memory not freed after use",
-        "ja": "しようごにかいほうされないめもり",
+        "ja": "使用後に解放されないメモリ",
         "ja_typings": [
           "shiyogonikaihosarenaimemori",
           "shiyougonikaihousarenaimemori"
@@ -3830,21 +3830,21 @@
       },
       {
         "en": "reading wrong memory",
-        "ja": "まちがっためもりをよむ",
+        "ja": "間違ったメモリを読む",
         "ja_typings": [
           "machigattamemorioyomu"
         ]
       },
       {
         "en": "writing beyond array bounds",
-        "ja": "はいれつはんいがいへきおく",
+        "ja": "配列範囲外記憶",
         "ja_typings": [
           "hairetsuhanigaihekioku"
         ]
       },
       {
         "en": "accessing null pointer",
-        "ja": "nullぽいんたーにあくせす",
+        "ja": "nullポインターにアクセス",
         "ja_typings": [
           "nullpointaniakusesu"
         ]
@@ -3856,7 +3856,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a memory leak?",
-      "ja": "メモリリークとはどのような現象ですか？"
+      "ja": "メモリリークとは何か？"
     },
     "question_text_reading": {
       "en": "What is a memory leak?",
@@ -3867,7 +3867,7 @@
     "choices": [
       {
         "en": "automatic memory management",
-        "ja": "じどうめもりかんり",
+        "ja": "自動メモリ管理",
         "ja_typings": [
           "jidomemorikanri",
           "jidoumemorikanri"
@@ -3875,7 +3875,7 @@
       },
       {
         "en": "manual memory freeing",
-        "ja": "てどうめもりかいほう",
+        "ja": "手動メモリ解放",
         "ja_typings": [
           "tedomemorikaiho",
           "tedoumemorikaihou"
@@ -3883,7 +3883,7 @@
       },
       {
         "en": "disk cleanup",
-        "ja": "でぃすくせいそう",
+        "ja": "ディスククリーンアップ",
         "ja_typings": [
           "disukuseiso",
           "disukuseisou"
@@ -3891,7 +3891,7 @@
       },
       {
         "en": "removing dead code",
-        "ja": "でっどこーどさくじょ",
+        "ja": "デッドコード削除",
         "ja_typings": [
           "deddokodosakujo"
         ]
@@ -3903,7 +3903,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is garbage collection?",
-      "ja": "ガベージコレクションとは何ですか？"
+      "ja": "ガービッジコレクションとは何か？"
     },
     "question_text_reading": {
       "en": "What is garbage collection?",
@@ -3914,28 +3914,28 @@
     "choices": [
       {
         "en": "call stack exceeds its limit",
-        "ja": "こーるすたっくがかぎりをこえる",
+        "ja": "コールスタックが限りをこえる",
         "ja_typings": [
           "korusutakkugakagiriokoeru"
         ]
       },
       {
         "en": "array index out of bounds",
-        "ja": "はいれつのいんでくすがはんいがい",
+        "ja": "配列インデックスが範囲外",
         "ja_typings": [
           "hairetsunoindekusugahanigai"
         ]
       },
       {
         "en": "heap memory full",
-        "ja": "ひーぷめもりまんぱい",
+        "ja": "ヒープメモリ満杯",
         "ja_typings": [
           "hipumemorimanpai"
         ]
       },
       {
         "en": "too many variables",
-        "ja": "へんすうがおおすぎる",
+        "ja": "変数がおおすぎる",
         "ja_typings": [
           "hensuugaosugiru",
           "hensuugaoosugiru"
@@ -3948,7 +3948,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a stack overflow?",
-      "ja": "スタックオーバーフローとは何ですか？"
+      "ja": "スタックオーバーフローとは何か？"
     },
     "question_text_reading": {
       "en": "What is a stack overflow?",
@@ -3959,7 +3959,7 @@
     "choices": [
       {
         "en": "dynamic memory allocation area",
-        "ja": "どうてきめもりかくほりょういき",
+        "ja": "動的メモリ確保領域",
         "ja_typings": [
           "dotekimemorikakuhoryoiki",
           "doutekimemorikakuhoryouiki"
@@ -3967,14 +3967,14 @@
       },
       {
         "en": "function call memory",
-        "ja": "かんすうよびだしめもり",
+        "ja": "関数呼び出しメモリ",
         "ja_typings": [
           "kansuuyobidashimemori"
         ]
       },
       {
         "en": "code storage area",
-        "ja": "こーどほぞんりょういき",
+        "ja": "コードストレージエリア",
         "ja_typings": [
           "kodohozonryoiki",
           "kodohozonryouiki"
@@ -3982,7 +3982,7 @@
       },
       {
         "en": "CPU register",
-        "ja": "CPUれじすた",
+        "ja": "CPUレジスタ",
         "ja_typings": [
           "cpurejisuta"
         ]
@@ -3994,7 +3994,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the heap in memory?",
-      "ja": "メモリにおけるヒープとは何ですか？"
+      "ja": "メモリのヒープとは何か？"
     },
     "question_text_reading": {
       "en": "What is the heap in memory?",
@@ -4005,7 +4005,7 @@
     "choices": [
       {
         "en": "HyperText Transfer Protocol",
-        "ja": "はいぱーてきすとてんそうぷろとこる",
+        "ja": "ハイパーテキスト転送プロトコル",
         "ja_typings": [
           "haipatekisutotensopurotokoru",
           "haipatekisutotensoupurotokoru"
@@ -4013,7 +4013,7 @@
       },
       {
         "en": "High Traffic TCP Protocol",
-        "ja": "こうとらふぃっくTCPぷろとこる",
+        "ja": "高トラフィックTCPプロトコル",
         "ja_typings": [
           "kotorafikkutcppurotokoru",
           "koutorafikkutcppurotokoru"
@@ -4021,7 +4021,7 @@
       },
       {
         "en": "Hosted Text Transfer Process",
-        "ja": "ほすてっどてきすとてんそうぷろせす",
+        "ja": "ホステッドテキスト転送プロセス",
         "ja_typings": [
           "hosuteddotekisutotensopurosesu",
           "hosuteddotekisutotensoupurosesu"
@@ -4029,7 +4029,7 @@
       },
       {
         "en": "HyperText Transport Process",
-        "ja": "はいぱーてきすとてんそうぷろせす",
+        "ja": "ハイパーテキストトランスポートプロトコル",
         "ja_typings": [
           "haipatekisutotensopurosesu",
           "haipatekisutotensoupurosesu"
@@ -4053,7 +4053,7 @@
     "choices": [
       {
         "en": "unique device identifier on network",
-        "ja": "ねっとわーくじょうのゆにーくなそうちしきべつし",
+        "ja": "ネットワーク上のユニークな装置識別子",
         "ja_typings": [
           "nettowakujonoyunikunasochishikibetsushi",
           "nettowakujounoyunikunasouchishikibetsushi"
@@ -4061,21 +4061,21 @@
       },
       {
         "en": "website domain name",
-        "ja": "うぇぶさいとどめいんめい",
+        "ja": "ウェブサイトドメイン名",
         "ja_typings": [
           "webusaitodomeinmei"
         ]
       },
       {
         "en": "MAC address alias",
-        "ja": "MACあどれすのべつめい",
+        "ja": "MACアドレスの別名",
         "ja_typings": [
           "macadoresunobetsumei"
         ]
       },
       {
         "en": "user login name",
-        "ja": "ゆーざーろぐいんめい",
+        "ja": "ユーザーログイン名",
         "ja_typings": [
           "yuzaroguinmei"
         ]
@@ -4087,7 +4087,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is an IP address?",
-      "ja": "IPアドレスとは何ですか？"
+      "ja": "IPアドレスとは何か？"
     },
     "question_text_reading": {
       "en": "What is an IP address?",
@@ -4098,21 +4098,21 @@
     "choices": [
       {
         "en": "translates domain to IP",
-        "ja": "どめいんをIPにへんかん",
+        "ja": "ドメインをIPに変換",
         "ja_typings": [
           "domeinoipnihenkan"
         ]
       },
       {
         "en": "stores web pages",
-        "ja": "うぇぶぺーじをほぞん",
+        "ja": "ウェブページを保存",
         "ja_typings": [
           "webupejiohozon"
         ]
       },
       {
         "en": "encrypts traffic",
-        "ja": "つうしんをあんごうか",
+        "ja": "通信を暗号化",
         "ja_typings": [
           "tsuushinoangoka",
           "tsuushinoangouka"
@@ -4120,7 +4120,7 @@
       },
       {
         "en": "assigns MAC addresses",
-        "ja": "MACあどれすをわりあて",
+        "ja": "MACアドレスを割り当て",
         "ja_typings": [
           "macadoresuowariate"
         ]
@@ -4143,7 +4143,7 @@
     "choices": [
       {
         "en": "stateless web API standard",
-        "ja": "むじょうたいのうぇぶAPIきじゅん",
+        "ja": "無状態のウェブAPI標準",
         "ja_typings": [
           "mujotainowebuapikijun",
           "mujoutainowebuapikijun"
@@ -4151,21 +4151,21 @@
       },
       {
         "en": "database query language",
-        "ja": "でーたべーすくえりげんご",
+        "ja": "データベースクエリ言語",
         "ja_typings": [
           "detabesukuerigengo"
         ]
       },
       {
         "en": "frontend framework",
-        "ja": "ふろんとえんどふれーむわーく",
+        "ja": "フロントエンドフレームワーク",
         "ja_typings": [
           "furontoendofuremuwaku"
         ]
       },
       {
         "en": "server-side rendering",
-        "ja": "さーばーさいどれんだりんぐ",
+        "ja": "サーバーサイドレンダリング",
         "ja_typings": [
           "sabasaidorendaringu"
         ]
@@ -4221,7 +4221,7 @@
     "image_path": null,
     "question_text": {
       "en": "What HTTP method is used to update a resource?",
-      "ja": "リソースを更新するために使用されるHTTPメソッドはどれですか？"
+      "ja": "リソースを更新するHTTPメソッドは？"
     },
     "question_text_reading": {
       "en": "What HTTP method is used to update a resource?",
@@ -4246,14 +4246,14 @@
       },
       {
         "en": "list",
-        "ja": "list",
+        "ja": "リスト",
         "ja_typings": [
           "list"
         ]
       },
       {
         "en": "show",
-        "ja": "show",
+        "ja": "ショー",
         "ja_typings": [
           "show"
         ]
@@ -4265,7 +4265,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which command lists files in Linux?",
-      "ja": "Linuxでファイル一覧を表示するコマンドは何ですか？"
+      "ja": "Linuxでファイルを一覧するコマンドは？"
     },
     "question_text_reading": {
       "en": "Which command lists files in Linux?",
@@ -4276,14 +4276,14 @@
     "choices": [
       {
         "en": "sets file permissions",
-        "ja": "ふぁいるのけんげんをせってい",
+        "ja": "ファイルの権限を設定",
         "ja_typings": [
           "fairunokengenosettei"
         ]
       },
       {
         "en": "changes file owner",
-        "ja": "ふぁいるのおーなーをへんこう",
+        "ja": "ファイルのオーナーを変更",
         "ja_typings": [
           "fairunonaohenko",
           "fairunoonaohenkou"
@@ -4291,14 +4291,14 @@
       },
       {
         "en": "creates directory",
-        "ja": "でぃれくとりをさくせい",
+        "ja": "ディレクトリを作成",
         "ja_typings": [
           "direkutoriosakusei"
         ]
       },
       {
         "en": "deletes file",
-        "ja": "ふぁいるをさくじょ",
+        "ja": "ファイルを削除",
         "ja_typings": [
           "fairuosakujo"
         ]
@@ -4321,7 +4321,7 @@
     "choices": [
       {
         "en": "first line specifying interpreter",
-        "ja": "いんたーぷりたをしていするさいしょのぎょう",
+        "ja": "インタープリタを指定する最初の行",
         "ja_typings": [
           "intapuritaoshiteisurusaishonogyo",
           "intapuritaoshiteisurusaishonogyou"
@@ -4329,21 +4329,21 @@
       },
       {
         "en": "comment in shell script",
-        "ja": "しぇるすくりぷとのこめんと",
+        "ja": "シェルスクリプトのコメント",
         "ja_typings": [
           "sherusukuriputonokomento"
         ]
       },
       {
         "en": "variable declaration",
-        "ja": "へんすうせんげん",
+        "ja": "変数宣言",
         "ja_typings": [
           "hensuusengen"
         ]
       },
       {
         "en": "function definition",
-        "ja": "かんすうていぎ",
+        "ja": "関数定義",
         "ja_typings": [
           "kansuuteigi"
         ]
@@ -4355,7 +4355,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a shebang line?",
-      "ja": "shebang lineとは何ですか？"
+      "ja": "Shebang lineとは何か？"
     },
     "question_text_reading": {
       "en": "What is a shebang line?",
@@ -4366,28 +4366,28 @@
     "choices": [
       {
         "en": "searches text patterns",
-        "ja": "てきすとぱたーんをけんさく",
+        "ja": "テキストパターンを検索",
         "ja_typings": [
           "tekisutopatanokensaku"
         ]
       },
       {
         "en": "copies files",
-        "ja": "ふぁいるをこぴー",
+        "ja": "ファイルをコピー",
         "ja_typings": [
           "fairuokopi"
         ]
       },
       {
         "en": "compresses files",
-        "ja": "ふぁいるをあっしゅく",
+        "ja": "ファイルを圧縮",
         "ja_typings": [
           "fairuoasshuku"
         ]
       },
       {
         "en": "monitors processes",
-        "ja": "ぷろせすをかんし",
+        "ja": "プロセスを監視",
         "ja_typings": [
           "purosesuokanshi"
         ]
@@ -4410,14 +4410,14 @@
     "choices": [
       {
         "en": "sends output to next command",
-        "ja": "しゅつりょくをつぎのこまんどにおくる",
+        "ja": "出力を次のコマンドへ送る",
         "ja_typings": [
           "shutsuryokuotsuginokomandoniokuru"
         ]
       },
       {
         "en": "runs commands in background",
-        "ja": "こまんどをばっくぐらうんどでじっこう",
+        "ja": "コマンドをバックグラウンドで実行",
         "ja_typings": [
           "komandobakkuguraundodejikko",
           "komandoobakkuguraundodejikkou"
@@ -4425,14 +4425,14 @@
       },
       {
         "en": "redirects to file",
-        "ja": "ふぁいるにりだいれくと",
+        "ja": "ファイルにリダイレクト",
         "ja_typings": [
           "fairuniridairekuto"
         ]
       },
       {
         "en": "separates arguments",
-        "ja": "ひきすうをくぎる",
+        "ja": "引数を区切る",
         "ja_typings": [
           "hikisuuokugiru"
         ]
@@ -4444,7 +4444,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does `|` (pipe) do in shell?",
-      "ja": "シェルにおけるパイプ記号「|」は何の役割を果たしますか？"
+      "ja": "シェル の `|`（パイプ）は何をするか？"
     },
     "question_text_reading": {
       "en": "What does `|` (pipe) do in shell?",
@@ -4455,7 +4455,7 @@
     "choices": [
       {
         "en": "Structured Query Language",
-        "ja": "こうぞうかくえりげんご",
+        "ja": "構造化クエリ言語",
         "ja_typings": [
           "kozokakuerigengo",
           "kouzoukakuerigengo"
@@ -4463,14 +4463,14 @@
       },
       {
         "en": "Simple Query Logic",
-        "ja": "かんたんくえりろじっく",
+        "ja": "シンプルクエリロジック",
         "ja_typings": [
           "kantankuerirojikku"
         ]
       },
       {
         "en": "Server Query Layer",
-        "ja": "さーばーくえりそう",
+        "ja": "サーバークエリレイヤー",
         "ja_typings": [
           "sabakueriso",
           "sabakuerisou"
@@ -4478,7 +4478,7 @@
       },
       {
         "en": "Stored Query Library",
-        "ja": "ほぞんずみくえりらいぶらり",
+        "ja": "保存済みクエリライブラリ",
         "ja_typings": [
           "hozonzumikueriraiburari"
         ]
@@ -4501,7 +4501,7 @@
     "choices": [
       {
         "en": "unique identifier for each row",
-        "ja": "かくぎょうのゆにーくしきべつし",
+        "ja": "各行のユニーク識別子",
         "ja_typings": [
           "kakugyonoyunikushikibetsushi",
           "kakugyounoyunikushikibetsushi"
@@ -4509,14 +4509,14 @@
       },
       {
         "en": "first column in table",
-        "ja": "てーぶるのさいしょのれつ",
+        "ja": "テーブルの最初の列",
         "ja_typings": [
           "teburunosaishonoretsu"
         ]
       },
       {
         "en": "encrypted field",
-        "ja": "あんごうかふぃーるど",
+        "ja": "暗号化フィールド",
         "ja_typings": [
           "angokafirudo",
           "angoukafirudo"
@@ -4524,7 +4524,7 @@
       },
       {
         "en": "foreign reference",
-        "ja": "がいぶさんしょう",
+        "ja": "外部参照",
         "ja_typings": [
           "gaibusansho",
           "gaibusanshou"
@@ -4537,7 +4537,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a primary key?",
-      "ja": "プライマリキーとは何ですか？"
+      "ja": "主キーとは何か？"
     },
     "question_text_reading": {
       "en": "What is a primary key?",
@@ -4548,7 +4548,7 @@
     "choices": [
       {
         "en": "combines rows from multiple tables",
-        "ja": "ふくすうてーぶるのぎょうをけつごう",
+        "ja": "複数テーブルの行を結合",
         "ja_typings": [
           "fukusuuteburunogyooketsugo",
           "fukusuuteburunogyouoketsugou"
@@ -4556,14 +4556,14 @@
       },
       {
         "en": "creates a new table",
-        "ja": "あたらしいてーぶるをさくせい",
+        "ja": "新しいテーブルを作成",
         "ja_typings": [
           "atarashiiteburuosakusei"
         ]
       },
       {
         "en": "deletes duplicate rows",
-        "ja": "じゅうふくぎょうをさくじょ",
+        "ja": "重複行を削除",
         "ja_typings": [
           "juufukugyoosakujo",
           "juufukugyouosakujo"
@@ -4571,7 +4571,7 @@
       },
       {
         "en": "sorts table data",
-        "ja": "てーぶるでーたをせいれつ",
+        "ja": "テーブルデータを整列",
         "ja_typings": [
           "teburudetaoseiretsu"
         ]
@@ -4594,7 +4594,7 @@
     "choices": [
       {
         "en": "speeds up data retrieval",
-        "ja": "でーたけんさくをこうそくか",
+        "ja": "データ検索を高速化",
         "ja_typings": [
           "detakensakuokosokuka",
           "detakensakuokousokuka"
@@ -4602,7 +4602,7 @@
       },
       {
         "en": "ensures data integrity",
-        "ja": "でーたのせいごうせいをほしょう",
+        "ja": "データの整合性を保証",
         "ja_typings": [
           "detanoseigoseiohosho",
           "detanoseigouseiohoshou"
@@ -4610,14 +4610,14 @@
       },
       {
         "en": "compresses table data",
-        "ja": "てーぶるでーたをあっしゅく",
+        "ja": "テーブルデータを圧縮",
         "ja_typings": [
           "teburudetaoasshuku"
         ]
       },
       {
         "en": "backs up the database",
-        "ja": "でーたべーすをばっくあっぷ",
+        "ja": "データベースをバックアップ",
         "ja_typings": [
           "detabesuobakkuappu"
         ]
@@ -4629,7 +4629,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is indexing in databases?",
-      "ja": "データベースにおけるインデックスとは何ですか？"
+      "ja": "データベースのインデックスとは何か？"
     },
     "question_text_reading": {
       "en": "What is indexing in databases?",
@@ -4640,7 +4640,7 @@
     "choices": [
       {
         "en": "atomic set of operations",
-        "ja": "げんしてきなそうさのあつまり",
+        "ja": "原子的な操作の集まり",
         "ja_typings": [
           "genshitekinasosanoatsumari",
           "genshitekinasousanoatsumari"
@@ -4648,21 +4648,21 @@
       },
       {
         "en": "a single SQL query",
-        "ja": "ひとつのSQLくえり",
+        "ja": "一つのSQLクエリ",
         "ja_typings": [
           "hitotsunosqlkueri"
         ]
       },
       {
         "en": "database backup process",
-        "ja": "でーたべーすばっくあっぷぷろせす",
+        "ja": "データベースバックアッププロセス",
         "ja_typings": [
           "detabesubakkuappupurosesu"
         ]
       },
       {
         "en": "user authentication",
-        "ja": "ゆーざーにんしょう",
+        "ja": "ユーザー認証",
         "ja_typings": [
           "yuzaninsho",
           "yuzaninshou"
@@ -4675,7 +4675,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a transaction in databases?",
-      "ja": "データベースにおけるトランザクションとは何ですか？"
+      "ja": "データベースのトランザクションとは何か？"
     },
     "question_text_reading": {
       "en": "What is a transaction in databases?",
@@ -4686,14 +4686,14 @@
     "choices": [
       {
         "en": "Atomicity Consistency Isolation Durability",
-        "ja": "げんしせいいっかんせいどくりつせいもちぞくせい",
+        "ja": "原子性一貫性独立性持続性",
         "ja_typings": [
           "genshiseiikkanseidokuritsuseimochizokusei"
         ]
       },
       {
         "en": "All Conditions In Database",
-        "ja": "でーたべーすのすべてのじょうけん",
+        "ja": "データベースのすべての条件",
         "ja_typings": [
           "detabesunosubetenojoken",
           "detabesunosubetenojouken"
@@ -4701,7 +4701,7 @@
       },
       {
         "en": "Automatic Cache Index Design",
-        "ja": "じどうきゃっしゅいんでくすせっけい",
+        "ja": "自動キャッシュインデックス設計",
         "ja_typings": [
           "jidokyasshuindekususekkei",
           "jidoukyasshuindekususekkei"
@@ -4709,7 +4709,7 @@
       },
       {
         "en": "Access Control Identity Domain",
-        "ja": "あくせすせいぎょしきべつどめいん",
+        "ja": "アクセス制御識別ドメイン",
         "ja_typings": [
           "akusesuseigyoshikibetsudomein"
         ]
@@ -4732,7 +4732,7 @@
     "choices": [
       {
         "en": "injecting malicious SQL into queries",
-        "ja": "くえりにあくいのあるSQLをそうにゅう",
+        "ja": "クエリに悪意のあるSQLを挿入",
         "ja_typings": [
           "kueriniakuinoarusqlosonyuu",
           "kueriniakuinoarusqlosounyuu"
@@ -4740,21 +4740,21 @@
       },
       {
         "en": "optimizing SQL queries",
-        "ja": "SQLくえりをさいてきか",
+        "ja": "SQLクエリを最適化",
         "ja_typings": [
           "sqlkueriosaitekika"
         ]
       },
       {
         "en": "importing SQL data",
-        "ja": "SQLでーたをいんぽーと",
+        "ja": "SQLデータをインポート",
         "ja_typings": [
           "sqldetaoinpoto"
         ]
       },
       {
         "en": "encrypting SQL data",
-        "ja": "SQLでーたをあんごうか",
+        "ja": "SQLデータを暗号化",
         "ja_typings": [
           "sqldetaoangoka",
           "sqldetaoangouka"
@@ -4767,7 +4767,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is SQL injection?",
-      "ja": "SQL injectionとは、どのようなものですか？"
+      "ja": "SQLインジェクションとは何か？"
     },
     "question_text_reading": {
       "en": "What is SQL injection?",
@@ -4778,7 +4778,7 @@
     "choices": [
       {
         "en": "Cross-Site Scripting attack",
-        "ja": "くろすさいとすくりぷてぃんぐこうげき",
+        "ja": "クロスサイトスクリプティング攻撃",
         "ja_typings": [
           "kurosusaitosukuriputingukogeki",
           "kurosusaitosukuriputingukougeki"
@@ -4786,7 +4786,7 @@
       },
       {
         "en": "Extra Security System",
-        "ja": "きょうかせきゅりてぃしすてむ",
+        "ja": "強化セキュリティシステム",
         "ja_typings": [
           "kyokasekyuritishisutemu",
           "kyoukasekyuritishisutemu"
@@ -4794,14 +4794,14 @@
       },
       {
         "en": "XML Style Sheet",
-        "ja": "XMLすたいるしーと",
+        "ja": "XMLスタイルシート",
         "ja_typings": [
           "xmlsutairushito"
         ]
       },
       {
         "en": "External Source Server",
-        "ja": "がいぶそーすさーばー",
+        "ja": "外部ソースサーバー",
         "ja_typings": [
           "gaibusosusaba"
         ]
@@ -4824,7 +4824,7 @@
     "choices": [
       {
         "en": "HTTP over TLS/SSL",
-        "ja": "TLS/SSLによるあんごうかHTTP",
+        "ja": "TLS/SSLによる暗号化HTTP",
         "ja_typings": [
           "tls/sslniyoruangokahttp",
           "tls/sslniyoruangoukahttp"
@@ -4832,7 +4832,7 @@
       },
       {
         "en": "HTTP with speed boost",
-        "ja": "そくどこうかHTTP",
+        "ja": "速度向上HTTP",
         "ja_typings": [
           "sokudokokahttp",
           "sokudokoukahttp"
@@ -4840,7 +4840,7 @@
       },
       {
         "en": "HTTP for servers only",
-        "ja": "さーばーせんようHTTP",
+        "ja": "サーバー専用HTTP",
         "ja_typings": [
           "sabasenyohttp",
           "sabasenyouhttp"
@@ -4848,7 +4848,7 @@
       },
       {
         "en": "HTTP with caching",
-        "ja": "きゃっしゅつきHTTP",
+        "ja": "キャッシュ付きHTTP",
         "ja_typings": [
           "kyasshutsukihttp"
         ]
@@ -4871,7 +4871,7 @@
     "choices": [
       {
         "en": "forcing user to make unintended request",
-        "ja": "ゆーざーにひとしらずのりくえすとをさせる",
+        "ja": "ユーザーに意図しないリクエストをさせる",
         "ja_typings": [
           "yuzanihitoshirazunorikuesutosaseru",
           "yuzanihitoshirazunorikuesutoosaseru"
@@ -4879,7 +4879,7 @@
       },
       {
         "en": "stealing database credentials",
-        "ja": "でーたべーすのにんしょうじょうほうをぬすむ",
+        "ja": "データベースの認証情報を盗む",
         "ja_typings": [
           "detabesunoninshojohoonusumu",
           "detabesunoninshoujouhouonusumu"
@@ -4887,7 +4887,7 @@
       },
       {
         "en": "injecting scripts into pages",
-        "ja": "ぺーじにすくりぷとをそうにゅう",
+        "ja": "ページにスクリプトを注入",
         "ja_typings": [
           "pejinisukuriputosonyuu",
           "pejinisukuriputoosounyuu"
@@ -4895,7 +4895,7 @@
       },
       {
         "en": "overloading server with traffic",
-        "ja": "さーばーにとらふぃっくをかける",
+        "ja": "サーバーにトラフィックをかける",
         "ja_typings": [
           "sabanitorafikkuokakeru"
         ]
@@ -4918,7 +4918,7 @@
     "choices": [
       {
         "en": "one-way transformation of data",
-        "ja": "でーたのいっぽうこうへんかん",
+        "ja": "データの一方方向変換",
         "ja_typings": [
           "detanoippokohenkan",
           "detanoippoukouhenkan"
@@ -4926,7 +4926,7 @@
       },
       {
         "en": "two-way encryption",
-        "ja": "そうほうこうあんごうか",
+        "ja": "双方向暗号化",
         "ja_typings": [
           "sohokoangoka",
           "souhoukouangouka"
@@ -4934,14 +4934,14 @@
       },
       {
         "en": "data compression",
-        "ja": "でーたあっしゅく",
+        "ja": "データ圧縮",
         "ja_typings": [
           "detaasshuku"
         ]
       },
       {
         "en": "data storage",
-        "ja": "でーたほぞん",
+        "ja": "データストレージ",
         "ja_typings": [
           "detahozon"
         ]
@@ -4953,7 +4953,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is hashing in security?",
-      "ja": "セキュリティにおけるハッシュとは何ですか？"
+      "ja": "セキュリティのハッシュとは何か？"
     },
     "question_text_reading": {
       "en": "What is hashing in security?",
@@ -4964,14 +4964,14 @@
     "choices": [
       {
         "en": "containerization platform",
-        "ja": "こんてなかぷらっとふぉーむ",
+        "ja": "コンテナ化プラットフォーム",
         "ja_typings": [
           "kontenakapurattofomu"
         ]
       },
       {
         "en": "virtual machine software",
-        "ja": "かそうましんそふとうぇあ",
+        "ja": "仮想マシンソフトウェア",
         "ja_typings": [
           "kasomashinsofutowea",
           "kasoumashinsofutowea"
@@ -4979,14 +4979,14 @@
       },
       {
         "en": "cloud storage service",
-        "ja": "くらうどすとれーじさーびす",
+        "ja": "クラウドストレージサービス",
         "ja_typings": [
           "kuraudosutorejisabisu"
         ]
       },
       {
         "en": "CI/CD pipeline tool",
-        "ja": "CI/CDぱいぷらいんつーる",
+        "ja": "CI/CDパイプラインツール",
         "ja_typings": [
           "ci/cdpaipuraintsuru"
         ]
@@ -5009,28 +5009,28 @@
     "choices": [
       {
         "en": "container orchestration system",
-        "ja": "こんてなおーけすとれーしょんしすてむ",
+        "ja": "コンテナオーケストレーションシステム",
         "ja_typings": [
           "kontenaokesutoreshonshisutemu"
         ]
       },
       {
         "en": "database management system",
-        "ja": "でーたべーすかんりしすてむ",
+        "ja": "データベース管理システム",
         "ja_typings": [
           "detabesukanrishisutemu"
         ]
       },
       {
         "en": "code review tool",
-        "ja": "こーどれびゅーつーる",
+        "ja": "コードレビューツール",
         "ja_typings": [
           "kodorebyutsuru"
         ]
       },
       {
         "en": "monitoring platform",
-        "ja": "もにたりんぐぷらっとふぉーむ",
+        "ja": "モニタリングプラットフォーム",
         "ja_typings": [
           "monitaringupurattofomu"
         ]
@@ -5053,7 +5053,7 @@
     "choices": [
       {
         "en": "Continuous Integration/Delivery",
-        "ja": "けいぞくてきとうごう/はいそう",
+        "ja": "継続的統合/配信",
         "ja_typings": [
           "keizokutekitogo/haiso",
           "keizokutekitougou/haisou"
@@ -5061,7 +5061,7 @@
       },
       {
         "en": "Code Inspection/Change Deploy",
-        "ja": "こーどけんさ/へんこうはいひ",
+        "ja": "コード検査/変更配備",
         "ja_typings": [
           "kodokensa/henkohaihi",
           "kodokensa/henkouhaihi"
@@ -5069,7 +5069,7 @@
       },
       {
         "en": "Container Integration/Distribution",
-        "ja": "こんてなとうごう/はいふ",
+        "ja": "コンテナ統合/ディストリビューション",
         "ja_typings": [
           "kontenatogo/haifu",
           "kontenatougou/haifu"
@@ -5077,7 +5077,7 @@
       },
       {
         "en": "Cloud Infrastructure/Design",
-        "ja": "くらうどきばんせっけい",
+        "ja": "クラウド基盤設計",
         "ja_typings": [
           "kuraudokibansekkei"
         ]
@@ -5100,7 +5100,7 @@
     "choices": [
       {
         "en": "managing infra through code",
-        "ja": "こーどをつうじてきばんをかんり",
+        "ja": "コードを通じて基盤を管理",
         "ja_typings": [
           "kodotsuujitekibanokanri",
           "kodootsuujitekibanokanri"
@@ -5108,7 +5108,7 @@
       },
       {
         "en": "writing code on servers",
-        "ja": "さーばーでこーどをかく",
+        "ja": "サーバーでコードを書く",
         "ja_typings": [
           "sabadekodokaku",
           "sabadekodookaku"
@@ -5116,7 +5116,7 @@
       },
       {
         "en": "converting code to hardware",
-        "ja": "こーどをはーどうぇあにへんかん",
+        "ja": "コードをハードウェアに変換",
         "ja_typings": [
           "kodohadoweanihenkan",
           "kodoohadoweanihenkan"
@@ -5124,7 +5124,7 @@
       },
       {
         "en": "hosting code in cloud",
-        "ja": "くらうどでこーどをほすと",
+        "ja": "クラウドでコードをホスト",
         "ja_typings": [
           "kuraudodekodohosuto",
           "kuraudodekodoohosuto"
@@ -5148,7 +5148,7 @@
     "choices": [
       {
         "en": "small independently deployable service",
-        "ja": "しょうきぼのどくりつはいひかのうなさーびす",
+        "ja": "小型の独立配備可能サービス",
         "ja_typings": [
           "shokibonodokuritsuhaihikanonasabisu",
           "shoukibonodokuritsuhaihikanounasabisu"
@@ -5156,7 +5156,7 @@
       },
       {
         "en": "a small VM",
-        "ja": "しょうきぼかそうましん",
+        "ja": "小型仮想マシン",
         "ja_typings": [
           "shokibokasomashin",
           "shoukibokasoumashin"
@@ -5164,7 +5164,7 @@
       },
       {
         "en": "a lightweight database",
-        "ja": "けいりょうでーたべーす",
+        "ja": "軽量データベース",
         "ja_typings": [
           "keiryodetabesu",
           "keiryoudetabesu"
@@ -5172,7 +5172,7 @@
       },
       {
         "en": "a frontend component",
-        "ja": "ふろんとえんどこんぽーねんと",
+        "ja": "フロントエンドコンポーネント",
         "ja_typings": [
           "furontoendokonponento"
         ]
@@ -5184,7 +5184,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a microservice?",
-      "ja": "マイクロサービスとはどのようなものですか？"
+      "ja": "マイクロサービスとは何か？"
     },
     "question_text_reading": {
       "en": "What is a microservice?",
@@ -5195,28 +5195,28 @@
     "choices": [
       {
         "en": "interface for software to communicate",
-        "ja": "そふとうぇあがつうしんするためのいんたーふぇーす",
+        "ja": "ソフトウェアが通信するためのインターフェース",
         "ja_typings": [
           "sofutoweagatsuushinsurutamenointafesu"
         ]
       },
       {
         "en": "a programming language",
-        "ja": "ぷろぐらみんぐげんご",
+        "ja": "プログラミング言語",
         "ja_typings": [
           "puroguramingugengo"
         ]
       },
       {
         "en": "a database type",
-        "ja": "でーたべーすのしゅるい",
+        "ja": "データベースの種類",
         "ja_typings": [
           "detabesunoshurui"
         ]
       },
       {
         "en": "a design pattern",
-        "ja": "せっけいぱたーん",
+        "ja": "設計パターン",
         "ja_typings": [
           "sekkeipatan"
         ]
@@ -5239,7 +5239,7 @@
     "choices": [
       {
         "en": "software with public source code",
-        "ja": "そーすこーどがこうかいされているそふとうぇあ",
+        "ja": "ソースコードが公開されているソフトウェア",
         "ja_typings": [
           "sosukodogakokaisareteirusofutowea",
           "sosukodogakoukaisareteirusofutowea"
@@ -5247,7 +5247,7 @@
       },
       {
         "en": "free commercial software",
-        "ja": "むりょうしょうようそふとうぇあ",
+        "ja": "無料商用ソフトウェア",
         "ja_typings": [
           "muryoshoyosofutowea",
           "muryoushouyousofutowea"
@@ -5255,7 +5255,7 @@
       },
       {
         "en": "software without license",
-        "ja": "らいせんすなしそふとうぶ",
+        "ja": "ライセンスなしソフトウェア",
         "ja_typings": [
           "raisensunashisofutobu",
           "raisensunashisofutoubu"
@@ -5263,7 +5263,7 @@
       },
       {
         "en": "browser-based software",
-        "ja": "ぶらうざーべーすそふとうぇあ",
+        "ja": "ブラウザベースソフトウェア",
         "ja_typings": [
           "burauzabesusofutowea"
         ]
@@ -5275,7 +5275,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is open source software?",
-      "ja": "オープンソースソフトウェアとは何ですか？"
+      "ja": "オープンソースソフトウェアとは何か？"
     },
     "question_text_reading": {
       "en": "What is open source software?",
@@ -5286,7 +5286,7 @@
     "choices": [
       {
         "en": "MAJOR.MINOR.PATCH version numbering",
-        "ja": "MAJOR.MINOR.PATCHばんごうつけ",
+        "ja": "MAJOR.MINOR.PATCH番号付け",
         "ja_typings": [
           "major.minor.patchbangotsuke",
           "major.minor.patchbangoutsuke"
@@ -5294,7 +5294,7 @@
       },
       {
         "en": "random version numbers",
-        "ja": "らんだむなばーじょんばんごう",
+        "ja": "ランダムなバージョン番号",
         "ja_typings": [
           "randamunabajonbango",
           "randamunabajonbangou"
@@ -5302,14 +5302,14 @@
       },
       {
         "en": "date-based versioning",
-        "ja": "にちつきばーじょにんぐ",
+        "ja": "日付バージョン管理",
         "ja_typings": [
           "nichitsukibajoningu"
         ]
       },
       {
         "en": "letter-based versioning",
-        "ja": "もじつきばーじょにんぐ",
+        "ja": "文字付きバージョンニング",
         "ja_typings": [
           "mojitsukibajoningu"
         ]
@@ -5321,7 +5321,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is semantic versioning?",
-      "ja": "セマンティックバージョニングとは何ですか？"
+      "ja": "セマンティックバージョニングとは何か？"
     },
     "question_text_reading": {
       "en": "What is semantic versioning?",
@@ -5332,14 +5332,14 @@
     "choices": [
       {
         "en": "tool that checks code style",
-        "ja": "こーどすたいるをかくにんするつーる",
+        "ja": "コードスタイルをかくにんするツール",
         "ja_typings": [
           "kodosutairuokakuninsurutsuru"
         ]
       },
       {
         "en": "tool that runs tests",
-        "ja": "てすとをじっこうするつーる",
+        "ja": "テストを実行するツール",
         "ja_typings": [
           "tesutojikkosurutsuru",
           "tesutoojikkousurutsuru"
@@ -5347,7 +5347,7 @@
       },
       {
         "en": "tool that compiles code",
-        "ja": "こーどをこんぱいるするつーる",
+        "ja": "コードをコンパイルするツール",
         "ja_typings": [
           "kodokonpairusurutsuru",
           "kodookonpairusurutsuru"
@@ -5355,7 +5355,7 @@
       },
       {
         "en": "tool that deploys code",
-        "ja": "こーどをはいひするつーる",
+        "ja": "コードを配備するツール",
         "ja_typings": [
           "kodohaihisurutsuru",
           "kodoohaihisurutsuru"
@@ -5368,7 +5368,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a linter?",
-      "ja": "リンターとは何ですか？"
+      "ja": "リンターとは何か？"
     },
     "question_text_reading": {
       "en": "What is a linter?",
@@ -5379,7 +5379,7 @@
     "choices": [
       {
         "en": "improving code without changing behavior",
-        "ja": "どうさをかえずにこーどをかいぜん",
+        "ja": "動作を変えずにコードを改善",
         "ja_typings": [
           "dosaokaezunikodokaizen",
           "dousaokaezunikodookaizen"
@@ -5387,7 +5387,7 @@
       },
       {
         "en": "adding new features",
-        "ja": "あたらしいきのうをついか",
+        "ja": "新しい機能を追加",
         "ja_typings": [
           "atarashiikinootsuika",
           "atarashiikinouotsuika"
@@ -5395,14 +5395,14 @@
       },
       {
         "en": "fixing bugs",
-        "ja": "ばぐをしゅうせい",
+        "ja": "バグを修正",
         "ja_typings": [
           "baguoshuusei"
         ]
       },
       {
         "en": "rewriting from scratch",
-        "ja": "さいしょからかきなおす",
+        "ja": "最初から書き直す",
         "ja_typings": [
           "saishokarakakinaosu"
         ]
@@ -5414,7 +5414,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is refactoring?",
-      "ja": "リファクタリングとは、どのようなものですか？"
+      "ja": "リファクタリングとは何か？"
     },
     "question_text_reading": {
       "en": "What is refactoring?",
@@ -5425,21 +5425,21 @@
     "choices": [
       {
         "en": "future cost of shortcuts taken now",
-        "ja": "いまとったちかみちのみらいのこすと",
+        "ja": "今取った近道(ちかみち)の未来のコスト",
         "ja_typings": [
           "imatottachikamichinomirainokosuto"
         ]
       },
       {
         "en": "money owed for software licenses",
-        "ja": "そふとうぇあらいせんすのさいむ",
+        "ja": "ソフトウェアライセンスの債務",
         "ja_typings": [
           "sofutowearaisensunosaimu"
         ]
       },
       {
         "en": "bugs introduced by new features",
-        "ja": "あたらしいきのうによるばぐ",
+        "ja": "新しい機能によるバグ",
         "ja_typings": [
           "atarashiikinoniyorubagu",
           "atarashiikinouniyorubagu"
@@ -5447,7 +5447,7 @@
       },
       {
         "en": "outdated documentation",
-        "ja": "ふるいどきゅめんとしょ",
+        "ja": "古いドキュメント書",
         "ja_typings": [
           "furuidokyumentosho"
         ]
@@ -5459,7 +5459,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is technical debt?",
-      "ja": "技術的負債とは何ですか？"
+      "ja": "技術的負債とは何か？"
     },
     "question_text_reading": {
       "en": "What is technical debt?",
@@ -5470,7 +5470,7 @@
     "choices": [
       {
         "en": "examining code for quality",
-        "ja": "ひんしつのためにこーどをけんとう",
+        "ja": "品質のためにコードを検討",
         "ja_typings": [
           "hinshitsunotamenikodokento",
           "hinshitsunotamenikodookentou"
@@ -5478,7 +5478,7 @@
       },
       {
         "en": "running automated tests",
-        "ja": "じどうてすとをじっこう",
+        "ja": "自動テストを実行",
         "ja_typings": [
           "jidotesutojikko",
           "jidoutesutoojikkou"
@@ -5486,7 +5486,7 @@
       },
       {
         "en": "deploying code to production",
-        "ja": "こーどをほんばんにはいひ",
+        "ja": "コードを本番に入力",
         "ja_typings": [
           "kodohonbannihaihi",
           "kodoohonbannihaihi"
@@ -5494,7 +5494,7 @@
       },
       {
         "en": "deleting unused code",
-        "ja": "つかわないこーどをさくじょ",
+        "ja": "使わないコードを削除",
         "ja_typings": [
           "tsukawanaikodosakujo",
           "tsukawanaikodoosakujo"
@@ -5507,7 +5507,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is code review?",
-      "ja": "コードレビューとは、どのようなものですか？"
+      "ja": "コードレビューとは何か？"
     },
     "question_text_reading": {
       "en": "What is code review?",
@@ -5518,7 +5518,7 @@
     "choices": [
       {
         "en": "automates compilation and packaging",
-        "ja": "こんぱいるとぱっけーじをじどうか",
+        "ja": "コンパイルとパッケージを自動化",
         "ja_typings": [
           "konpairutopakkejiojidoka",
           "konpairutopakkejiojidouka"
@@ -5526,7 +5526,7 @@
       },
       {
         "en": "stores source code",
-        "ja": "そーすこーどをほぞん",
+        "ja": "ソースコードを保存",
         "ja_typings": [
           "sosukodohozon",
           "sosukodoohozon"
@@ -5534,7 +5534,7 @@
       },
       {
         "en": "monitors application health",
-        "ja": "あぷりのけんこうをかんし",
+        "ja": "アプリの健康を監視",
         "ja_typings": [
           "apurinokenkookanshi",
           "apurinokenkouokanshi"
@@ -5542,7 +5542,7 @@
       },
       {
         "en": "manages user accounts",
-        "ja": "ゆーざーあかうんとをかんり",
+        "ja": "ユーザーアカウントを管理",
         "ja_typings": [
           "yuzaakauntokanri",
           "yuzaakauntookanri"
@@ -5555,7 +5555,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a build system?",
-      "ja": "ビルドシステムとは、どのようなものですか？"
+      "ja": "ビルドシステムとは何か？"
     },
     "question_text_reading": {
       "en": "What is a build system?",
@@ -5566,7 +5566,7 @@
     "choices": [
       {
         "en": "providing dependencies from outside",
-        "ja": "がいぶからいぞんかんけいをていきょう",
+        "ja": "外部から依存関係を提供",
         "ja_typings": [
           "gaibukaraizonkankeioteikyo",
           "gaibukaraizonkankeioteikyou"
@@ -5574,14 +5574,14 @@
       },
       {
         "en": "installing npm packages",
-        "ja": "npmぱっけーじをいんすとーる",
+        "ja": "npmパッケージをインストール",
         "ja_typings": [
           "npmpakkejioinsutoru"
         ]
       },
       {
         "en": "injecting code at runtime",
-        "ja": "じっこうじにこーどをそうにゅう",
+        "ja": "実行時にコードを挿入",
         "ja_typings": [
           "jikkojinikodosonyuu",
           "jikkoujinikodoosounyuu"
@@ -5589,7 +5589,7 @@
       },
       {
         "en": "caching function results",
-        "ja": "かんすうけっかをきゃっしゅ",
+        "ja": "関数結果をキャッシュ",
         "ja_typings": [
           "kansuukekkaokyasshu"
         ]
@@ -5601,7 +5601,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is dependency injection?",
-      "ja": "依存性の注入とは何ですか？"
+      "ja": "依存性の注入とは何か？"
     },
     "question_text_reading": {
       "en": "What is dependency injection?",
@@ -5612,7 +5612,7 @@
     "choices": [
       {
         "en": "mechanism for handling async events",
-        "ja": "ひどうきいべんとをしょりするしくみ",
+        "ja": "非同期イベントを処理する仕組み",
         "ja_typings": [
           "hidokiibentoshorisurushikumi",
           "hidoukiibentooshorisurushikumi"
@@ -5620,21 +5620,21 @@
       },
       {
         "en": "a type of loop statement",
-        "ja": "るーぷぶんのしゅるい",
+        "ja": "ループ文の種類",
         "ja_typings": [
           "rupubunnoshurui"
         ]
       },
       {
         "en": "error handling mechanism",
-        "ja": "えらーしょりのしくみ",
+        "ja": "エラーハンドリングメカニズム",
         "ja_typings": [
           "erashorinoshikumi"
         ]
       },
       {
         "en": "UI rendering cycle",
-        "ja": "UIれんだりんぐのしゅき",
+        "ja": "UIレンダリングのサイクル",
         "ja_typings": [
           "uirendaringunoshuki"
         ]
@@ -5646,7 +5646,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is an event loop?",
-      "ja": "イベントループとは何ですか？"
+      "ja": "イベントループとは何か？"
     },
     "question_text_reading": {
       "en": "What is an event loop?",
@@ -5657,7 +5657,7 @@
     "choices": [
       {
         "en": "Document Object Model",
-        "ja": "どきゅめんとおぶじぇくともでる",
+        "ja": "ドキュメント・オブ・ドキュメント・モデル",
         "ja_typings": [
           "dokyumentobujekutomoderu",
           "dokyumentoobujekutomoderu"
@@ -5665,14 +5665,14 @@
       },
       {
         "en": "Data Object Management",
-        "ja": "でーたおぶじぇくとかんり",
+        "ja": "データオブジェクト管理",
         "ja_typings": [
           "detaobujekutokanri"
         ]
       },
       {
         "en": "Dynamic Output Module",
-        "ja": "どうてきしゅつりょくもじゅーる",
+        "ja": "動的出力モジュール",
         "ja_typings": [
           "dotekishutsuryokumojuru",
           "doutekishutsuryokumojuru"
@@ -5680,7 +5680,7 @@
       },
       {
         "en": "Distributed Object Method",
-        "ja": "ぶんさんおぶじぇくとめそっど",
+        "ja": "分散オブジェクトメソッド",
         "ja_typings": [
           "bunsanobujekutomesoddo"
         ]
@@ -5703,28 +5703,28 @@
     "choices": [
       {
         "en": "event propagates up the DOM tree",
-        "ja": "いべんとがDOMツリーをのぼる",
+        "ja": "イベントがDOMツリーを登る",
         "ja_typings": [
           "ibentogadomtsurionoboru"
         ]
       },
       {
         "en": "events are queued",
-        "ja": "いべんとがきゅーにはいる",
+        "ja": "イベントがキューに入る",
         "ja_typings": [
           "ibentogakyunihairu"
         ]
       },
       {
         "en": "events are cancelled",
-        "ja": "いべんとがキャンセルされる",
+        "ja": "イベントがキャンセルされる",
         "ja_typings": [
           "ibentogakyanserusareru"
         ]
       },
       {
         "en": "events repeat in loop",
-        "ja": "いべんとがるーぷでくりかえす",
+        "ja": "イベントがループで繰り返す",
         "ja_typings": [
           "ibentogarupudekurikaesu"
         ]
@@ -5736,7 +5736,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is event bubbling?",
-      "ja": "イベントバブリングとは何ですか？"
+      "ja": "イベントバブリングとは何か？"
     },
     "question_text_reading": {
       "en": "What is event bubbling?",
@@ -5747,7 +5747,7 @@
     "choices": [
       {
         "en": "loading resources only when needed",
-        "ja": "ひつようなときだけりそーすをろーど",
+        "ja": "必要なときだけリソースをロード",
         "ja_typings": [
           "hitsuyonatokidakerisosuorodo",
           "hitsuyounatokidakerisosuorodo"
@@ -5755,7 +5755,7 @@
       },
       {
         "en": "loading all resources at start",
-        "ja": "きどうじにすべてのりそーすをろーど",
+        "ja": "起動時にすべてのリソースをロード",
         "ja_typings": [
           "kidojinisubetenorisosuorodo",
           "kidoujinisubetenorisosuorodo"
@@ -5763,14 +5763,14 @@
       },
       {
         "en": "loading in random order",
-        "ja": "らんだむなじゅんでろーど",
+        "ja": "ランダムな順でロード",
         "ja_typings": [
           "randamunajunderodo"
         ]
       },
       {
         "en": "loading from local cache only",
-        "ja": "ろーかるきゃっしゅからのみろーど",
+        "ja": "ローカルキャッシュからのみロード",
         "ja_typings": [
           "rokarukyasshukaranomirodo"
         ]
@@ -5782,7 +5782,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is lazy loading?",
-      "ja": "遅延読み込みとは何ですか？"
+      "ja": "Lazy loadingとは何か？"
     },
     "question_text_reading": {
       "en": "What is lazy loading?",
@@ -5793,7 +5793,7 @@
     "choices": [
       {
         "en": "removing unused code from bundles",
-        "ja": "ばんどるからつかわないこーどをさくじょ",
+        "ja": "バンドルから使わないコードを削除",
         "ja_typings": [
           "bandorukaratsukawanaikodosakujo",
           "bandorukaratsukawanaikodoosakujo"
@@ -5801,21 +5801,21 @@
       },
       {
         "en": "optimizing recursive algorithms",
-        "ja": "さいきあるごりずむのさいてきか",
+        "ja": "再帰アルゴリズムの最適化",
         "ja_typings": [
           "saikiarugorizumunosaitekika"
         ]
       },
       {
         "en": "sorting import statements",
-        "ja": "いんぽーとのせいれつ",
+        "ja": "importのせいれつ",
         "ja_typings": [
           "inpotonoseiretsu"
         ]
       },
       {
         "en": "caching dependency trees",
-        "ja": "いぞんかんけいつりーのきゃっしゅ",
+        "ja": "依存関係ツリーのキャッシュ",
         "ja_typings": [
           "izonkankeitsurinokyasshu"
         ]
@@ -5827,7 +5827,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is tree shaking?",
-      "ja": "ツリーシェイキングとは何ですか？"
+      "ja": "Tree shakingとは何か？"
     },
     "question_text_reading": {
       "en": "What is tree shaking?",
@@ -5838,7 +5838,7 @@
     "choices": [
       {
         "en": "indication of deeper problem in code",
-        "ja": "こーどのふかいもんだいのしょうこう",
+        "ja": "コードの深い問題の兆候",
         "ja_typings": [
           "kodonofukaimondainoshoko",
           "kodonofukaimondainoshoukou"
@@ -5846,7 +5846,7 @@
       },
       {
         "en": "runtime error message",
-        "ja": "じっこうじえらーめっせーじ",
+        "ja": "実行時エラーメッセージ",
         "ja_typings": [
           "jikkojieramesseji",
           "jikkoujieramesseji"
@@ -5854,14 +5854,14 @@
       },
       {
         "en": "compiler warning",
-        "ja": "こんぱいらけいこく",
+        "ja": "コンパイラ警告",
         "ja_typings": [
           "konpairakeikoku"
         ]
       },
       {
         "en": "style guide violation",
-        "ja": "すたいるがいどのいはん",
+        "ja": "スタイルガイド違反",
         "ja_typings": [
           "sutairugaidonoihan"
         ]
@@ -5873,7 +5873,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a code smell?",
-      "ja": "コードスメルとは何ですか？"
+      "ja": "コードスメルとは何か？"
     },
     "question_text_reading": {
       "en": "What is a code smell?",
@@ -5884,7 +5884,7 @@
     "choices": [
       {
         "en": "two developers working on same code",
-        "ja": "ふたりがどうじにどうじこーどをさぎょう",
+        "ja": "二人が同時に同じコードを作業",
         "ja_typings": [
           "futarigadojinidojikodosagyo",
           "futarigadoujinidoujikodoosagyou"
@@ -5892,14 +5892,14 @@
       },
       {
         "en": "programming in two languages",
-        "ja": "ふたつのげんごでぷろぐらみんぐ",
+        "ja": "二つの言語でプログラミング",
         "ja_typings": [
           "futatsunogengodepuroguramingu"
         ]
       },
       {
         "en": "using two machines",
-        "ja": "ふたつのましんをしよう",
+        "ja": "二つのマシンをしよう",
         "ja_typings": [
           "futatsunomashinoshiyo",
           "futatsunomashinoshiyou"
@@ -5907,7 +5907,7 @@
       },
       {
         "en": "writing code twice for safety",
-        "ja": "あんぜんのためこーどをにかいかく",
+        "ja": "安全のためコードを書きかく",
         "ja_typings": [
           "anzennotamekodonikaikaku",
           "anzennotamekodoonikaikaku"
@@ -5920,7 +5920,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is pair programming?",
-      "ja": "ペアプログラミングとはどのようなものですか？"
+      "ja": "ペアプログラミングとは何か？"
     },
     "question_text_reading": {
       "en": "What is pair programming?",
@@ -5931,7 +5931,7 @@
     "choices": [
       {
         "en": "Integrated Development Environment",
-        "ja": "とうごうかいはつかんきょう",
+        "ja": "統合開発環境",
         "ja_typings": [
           "togokaihatsukankyo",
           "tougoukaihatsukankyou"
@@ -5939,7 +5939,7 @@
       },
       {
         "en": "Internet Data Exchange",
-        "ja": "いんたーねっとでーたこうかん",
+        "ja": "インターネットデータ交換",
         "ja_typings": [
           "intanettodetakokan",
           "intanettodetakoukan"
@@ -5947,14 +5947,14 @@
       },
       {
         "en": "Internal Deploy Engine",
-        "ja": "ないぶはいひえんじん",
+        "ja": "内部デプロイエンジン",
         "ja_typings": [
           "naibuhaihienjin"
         ]
       },
       {
         "en": "Interface Design Element",
-        "ja": "いんたーふぇーすせっけいようそ",
+        "ja": "インターフェース設計要素",
         "ja_typings": [
           "intafesusekkeiyoso",
           "intafesusekkeiyouso"
@@ -5978,28 +5978,28 @@
     "choices": [
       {
         "en": "type determined by interface not class",
-        "ja": "くらすでなくいんたーふぇーすでがたをはんてい",
+        "ja": "クラスでなくインターフェースで型を判定",
         "ja_typings": [
           "kurasudenakuintafesudegataohantei"
         ]
       },
       {
         "en": "converting string to number",
-        "ja": "もじれつをすうちにへんかん",
+        "ja": "文字列を数値へ変換",
         "ja_typings": [
           "mojiretsuosuuchinihenkan"
         ]
       },
       {
         "en": "strict type checking",
-        "ja": "きびしいがたかくにん",
+        "ja": "厳しい型確認",
         "ja_typings": [
           "kibishiigatakakunin"
         ]
       },
       {
         "en": "defining types at compile time",
-        "ja": "かんぱいるじにがたをていぎ",
+        "ja": "コンパイル時に型を定義",
         "ja_typings": [
           "kanpairujinigataoteigi"
         ]
@@ -6011,7 +6011,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is duck typing?",
-      "ja": "ダックタイピングとは何ですか？"
+      "ja": "ダックタイピングとは何か？"
     },
     "question_text_reading": {
       "en": "What is duck typing?",
@@ -6022,7 +6022,7 @@
     "choices": [
       {
         "en": "function with its captured environment",
-        "ja": "かんきょうをほじしたかんすう",
+        "ja": "環境を保持した関数",
         "ja_typings": [
           "kankyoohojishitakansuu",
           "kankyouohojishitakansuu"
@@ -6030,14 +6030,14 @@
       },
       {
         "en": "a sealed class",
-        "ja": "ふいんされたくらす",
+        "ja": "封印されたクラス",
         "ja_typings": [
           "fuinsaretakurasu"
         ]
       },
       {
         "en": "end of function scope",
-        "ja": "かんすうのすこーぷのおわり",
+        "ja": "関数のスコープの終わり",
         "ja_typings": [
           "kansuunosukopunowari",
           "kansuunosukopunoowari"
@@ -6045,7 +6045,7 @@
       },
       {
         "en": "an anonymous object",
-        "ja": "むめいおぶじぇくと",
+        "ja": "無名オブジェクト",
         "ja_typings": [
           "mumeiobujekuto"
         ]
@@ -6057,7 +6057,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a closure?",
-      "ja": "クローズ（closure）とは何ですか？"
+      "ja": "クロージャとは何か？"
     },
     "question_text_reading": {
       "en": "What is a closure?",
@@ -6068,28 +6068,28 @@
     "choices": [
       {
         "en": "transforming f(a,b) into f(a)(b)",
-        "ja": "f(a,b)をf(a)(b)にへんかん",
+        "ja": "f(a,b)をf(a)(b)に変換",
         "ja_typings": [
           "f a b of a b nihenkan"
         ]
       },
       {
         "en": "adding curry to code",
-        "ja": "こーどにかりーをついか",
+        "ja": "コードにカレーを追加",
         "ja_typings": [
           "kodonikariotsuika"
         ]
       },
       {
         "en": "memoizing function results",
-        "ja": "かんすうけっかをきおく",
+        "ja": "関数結果を記憶",
         "ja_typings": [
           "kansuukekkaokioku"
         ]
       },
       {
         "en": "defining variadic functions",
-        "ja": "かへいすうかんすうをていぎ",
+        "ja": "可変数関数を定義",
         "ja_typings": [
           "kaheisuukansuuoteigi"
         ]
@@ -6101,7 +6101,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is currying?",
-      "ja": "カリー化とは何ですか？"
+      "ja": "Curryingとは何か？"
     },
     "question_text_reading": {
       "en": "What is currying?",
@@ -6112,7 +6112,7 @@
     "choices": [
       {
         "en": "binary instruction format for browsers",
-        "ja": "ぶらうざーようのばいなりめいれいけいしき",
+        "ja": "ブラウザ用のバイナリ命令形式",
         "ja_typings": [
           "burauzayonobainarimeireikeishiki",
           "burauzayounobainarimeireikeishiki"
@@ -6120,21 +6120,21 @@
       },
       {
         "en": "a JavaScript framework",
-        "ja": "JavaScriptふれーむわーく",
+        "ja": "JavaScriptフレームワーク",
         "ja_typings": [
           "javascriptfuremuwaku"
         ]
       },
       {
         "en": "a CSS preprocessor",
-        "ja": "CSSぷりぷろせっさ",
+        "ja": "CSSプリプロセッサ",
         "ja_typings": [
           "csspuripurosessa"
         ]
       },
       {
         "en": "a server runtime",
-        "ja": "さーばーじっこうかんきょう",
+        "ja": "サーバー実行環境",
         "ja_typings": [
           "sabajikkokankyo",
           "sabajikkoukankyou"
@@ -6158,7 +6158,7 @@
     "choices": [
       {
         "en": "object from which others inherit",
-        "ja": "ほかのおぶじぇくとがけいしょうするおぶじぇくと",
+        "ja": "他のオブジェクトが継承するオブジェクト",
         "ja_typings": [
           "hokanobujekutogakeishosuruobujekuto",
           "hokanoobujekutogakeishousuruobujekuto"
@@ -6166,21 +6166,21 @@
       },
       {
         "en": "first version of software",
-        "ja": "そふとうぇあのさいしょのばーじょん",
+        "ja": "ソフトウェアの最初のバージョン",
         "ja_typings": [
           "sofutoweanosaishonobajon"
         ]
       },
       {
         "en": "a constructor function",
-        "ja": "こんすとらくたかんすう",
+        "ja": "コンストラクタ関数",
         "ja_typings": [
           "konsutorakutakansuu"
         ]
       },
       {
         "en": "a static method",
-        "ja": "すたてぃっくめそっど",
+        "ja": "スタティックメソッド",
         "ja_typings": [
           "sutatikkumesoddo"
         ]
@@ -6192,7 +6192,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a prototype in JavaScript?",
-      "ja": "JavaScriptのぷろとたいぷとは何か？"
+      "ja": "JavaScriptのプロトタイプとは何か？"
     },
     "question_text_reading": {
       "en": "What is a prototype in JavaScript?",
@@ -6203,7 +6203,7 @@
     "choices": [
       {
         "en": "calling multiple methods in sequence",
-        "ja": "めそっどをれんけつしてよびだす",
+        "ja": "メソッドを連結して呼び出す",
         "ja_typings": [
           "mesoddorenketsushiteyobidasu",
           "mesoddoorenketsushiteyobidasu"
@@ -6211,7 +6211,7 @@
       },
       {
         "en": "inheriting methods from parent",
-        "ja": "おやからめそっどをけいしょう",
+        "ja": "親からメソッドを継承",
         "ja_typings": [
           "oyakaramesoddokeisho",
           "oyakaramesoddookeishou"
@@ -6219,7 +6219,7 @@
       },
       {
         "en": "linking two objects",
-        "ja": "ふたつのおぶじぇくとをれんけつ",
+        "ja": "二つのオブジェクトを連結",
         "ja_typings": [
           "futatsunobujekutorenketsu",
           "futatsunoobujekutoorenketsu"
@@ -6227,7 +6227,7 @@
       },
       {
         "en": "calling same method twice",
-        "ja": "どうじめそっどをにかいよびだす",
+        "ja": "同じソッドを二回呼び出す",
         "ja_typings": [
           "dojimesoddonikaiyobidasu",
           "doujimesoddoonikaiyobidasu"
@@ -6240,7 +6240,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is method chaining?",
-      "ja": "メソッドチェーンとは、どのようなものですか？"
+      "ja": "メソッドチェイニングとは何か？"
     },
     "question_text_reading": {
       "en": "What is method chaining?",
@@ -6251,7 +6251,7 @@
     "choices": [
       {
         "en": "five OOP design principles",
-        "ja": "ごつのOOPせっけいげんそく",
+        "ja": "五つのOOP設計原則",
         "ja_typings": [
           "gotsunoopsekkeigensoku",
           "gotsunooopsekkeigensoku"
@@ -6259,21 +6259,21 @@
       },
       {
         "en": "a security standard",
-        "ja": "せきゅりてぃきじゅん",
+        "ja": "セキュリティ基準",
         "ja_typings": [
           "sekyuritikijun"
         ]
       },
       {
         "en": "a testing framework",
-        "ja": "てすとふれーむわーく",
+        "ja": "テストフレームワーク",
         "ja_typings": [
           "tesutofuremuwaku"
         ]
       },
       {
         "en": "a data format",
-        "ja": "でーたけいしき",
+        "ja": "データ形式",
         "ja_typings": [
           "detakeishiki"
         ]
@@ -6285,7 +6285,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the SOLID principle?",
-      "ja": "SOLIDげんそくとは何か？"
+      "ja": "SOLID原則とは何か？"
     },
     "question_text_reading": {
       "en": "What is the SOLID principle?",
@@ -6296,14 +6296,14 @@
     "choices": [
       {
         "en": "Don't Repeat Yourself",
-        "ja": "じぶんじしんをくりかえさない",
+        "ja": "自分自身を繰り返さない",
         "ja_typings": [
           "jibunjishinokurikaesanai"
         ]
       },
       {
         "en": "Design Reusable Years",
-        "ja": "さいりようかのうなねんのせっけい",
+        "ja": "再利用可能な年の設計",
         "ja_typings": [
           "sairiyokanonanennosekkei",
           "sairiyoukanounanennosekkei"
@@ -6311,14 +6311,14 @@
       },
       {
         "en": "Deploy Rapidly Yearly",
-        "ja": "まいとしはやくはいひ",
+        "ja": "毎年速く配備",
         "ja_typings": [
           "maitoshihayakuhaihi"
         ]
       },
       {
         "en": "Define Register Yield",
-        "ja": "さいじぇいきゅうをていぎ",
+        "ja": "最次級を定義",
         "ja_typings": [
           "saijeikyuuoteigi"
         ]
@@ -6330,7 +6330,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is DRY principle?",
-      "ja": "DRY原則とは、どのような考え方ですか？"
+      "ja": "DRY原則とは何か？"
     },
     "question_text_reading": {
       "en": "What is DRY principle?",
@@ -6341,28 +6341,28 @@
     "choices": [
       {
         "en": "Keep It Simple Stupid",
-        "ja": "かんたんにしておけ",
+        "ja": "簡単にしておけ",
         "ja_typings": [
           "kantannishiteoke"
         ]
       },
       {
         "en": "Keys In Secure Storage",
-        "ja": "かぎをあんぜんにほぞん",
+        "ja": "鍵を安全に保存",
         "ja_typings": [
           "kagioanzennihozon"
         ]
       },
       {
         "en": "Keep Iterations Short Strong",
-        "ja": "いてれーしょんをみじかくつよく",
+        "ja": "イテレーションを短く強く",
         "ja_typings": [
           "itereshonomijikakutsuyoku"
         ]
       },
       {
         "en": "Kill Invalid Session States",
-        "ja": "ふせいせっしょんをさくじょ",
+        "ja": "不正セッションを削除",
         "ja_typings": [
           "fuseisesshonosakujo"
         ]
@@ -6374,7 +6374,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is KISS principle?",
-      "ja": "KISSげんそくとは何か？"
+      "ja": "KISS原則とは何か？"
     },
     "question_text_reading": {
       "en": "What is KISS principle?",
@@ -6385,28 +6385,28 @@
     "choices": [
       {
         "en": "HTTP callback when event occurs",
-        "ja": "いべんとはっせいじのHTTPこーるばっく",
+        "ja": "イベント発生時のHTTPコールバック",
         "ja_typings": [
           "ibentohasseijinohttpkorubakku"
         ]
       },
       {
         "en": "a browser plugin",
-        "ja": "ぶらうざーぷらぐいん",
+        "ja": "ブラウザプラグイン",
         "ja_typings": [
           "burauzapuraguin"
         ]
       },
       {
         "en": "a type of API key",
-        "ja": "APIきーのしゅるい",
+        "ja": "APIキーの種類",
         "ja_typings": [
           "apikinoshurui"
         ]
       },
       {
         "en": "a frontend hook",
-        "ja": "ふろんとえんどふっく",
+        "ja": "フロントエンドフック",
         "ja_typings": [
           "furontoendofukku"
         ]
@@ -6418,7 +6418,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a webhook?",
-      "ja": "webhookとはどのような仕組みですか？"
+      "ja": "Webhookとは何か？"
     },
     "question_text_reading": {
       "en": "What is a webhook?",
@@ -6429,28 +6429,28 @@
     "choices": [
       {
         "en": "query language for APIs",
-        "ja": "APIのためのくえりげんご",
+        "ja": "APIのためのクエリ言語",
         "ja_typings": [
           "apinotamenokuerigengo"
         ]
       },
       {
         "en": "graph database query",
-        "ja": "ぐらふでーたべーすくえり",
+        "ja": "グラフデータベースクエリ",
         "ja_typings": [
           "gurafudetabesukueri"
         ]
       },
       {
         "en": "frontend rendering library",
-        "ja": "ふろんとえんどれんだりんぐらいぶらり",
+        "ja": "フロントエンドレンダリングライブラリ",
         "ja_typings": [
           "furontoendorendaringuraiburari"
         ]
       },
       {
         "en": "CSS animation library",
-        "ja": "CSSあにめーしょんらいぶらり",
+        "ja": "CSSアニメーションライブラリ",
         "ja_typings": [
           "cssanimeshonraiburari"
         ]
@@ -6473,28 +6473,28 @@
     "choices": [
       {
         "en": "rendering HTML on server",
-        "ja": "さーばーでHTMLをせいせい",
+        "ja": "サーバーでHTMLを生成",
         "ja_typings": [
           "sabadehtmloseisei"
         ]
       },
       {
         "en": "rendering CSS on server",
-        "ja": "さーばーでCSSをせいせい",
+        "ja": "サーバーでCSSを生成",
         "ja_typings": [
           "sabadecssoseisei"
         ]
       },
       {
         "en": "processing data on client",
-        "ja": "くらいあんとでもにょりをしょり",
+        "ja": "クライアントでデータを処理",
         "ja_typings": [
           "kuraiantodemonyorioshori"
         ]
       },
       {
         "en": "caching on server",
-        "ja": "さーばーできゃっしゅ",
+        "ja": "サーバーキャッシュ",
         "ja_typings": [
           "sabadekyasshu"
         ]
@@ -6506,7 +6506,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is server-side rendering?",
-      "ja": "サーバーサイドレンダリングとは、どのような仕組みのことですか？"
+      "ja": "サーバーサイドレンダリングとは何か？"
     },
     "question_text_reading": {
       "en": "What is server-side rendering?",
@@ -6517,21 +6517,21 @@
     "choices": [
       {
         "en": "attaching JS to server-rendered HTML",
-        "ja": "さーばーせいせいHTMLにJSをてんぷ",
+        "ja": "サーバー生成HTMLにJSを添付",
         "ja_typings": [
           "sabaseiseihtmlnijsotenpu"
         ]
       },
       {
         "en": "loading CSS styles",
-        "ja": "CSSすたいるのろーど",
+        "ja": "CSSスタイルのロード",
         "ja_typings": [
           "csssutairunorodo"
         ]
       },
       {
         "en": "compressing images",
-        "ja": "がぞうのあっしゅく",
+        "ja": "画像の圧縮",
         "ja_typings": [
           "gazonoasshuku",
           "gazounoasshuku"
@@ -6539,7 +6539,7 @@
       },
       {
         "en": "managing cookies",
-        "ja": "くっきーのかんり",
+        "ja": "クッキーの管理",
         "ja_typings": [
           "kukkinokanri"
         ]
@@ -6551,7 +6551,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is hydration in web development?",
-      "ja": "Web開発における「hydration」とは何ですか？"
+      "ja": "Web開発のhydrationとは何か？"
     },
     "question_text_reading": {
       "en": "What is hydration in web development?",
@@ -6562,28 +6562,28 @@
     "choices": [
       {
         "en": "self-contained unit of code",
-        "ja": "どくりつしたこーどのたんい",
+        "ja": "独立したコードの単位",
         "ja_typings": [
           "dokuritsushitakodonotani"
         ]
       },
       {
         "en": "a hardware component",
-        "ja": "はーどうぇあこんぽーねんと",
+        "ja": "ハードウェアコンポーネント",
         "ja_typings": [
           "hadoweakonponento"
         ]
       },
       {
         "en": "a CSS class",
-        "ja": "CSSくらす",
+        "ja": "CSSクラス",
         "ja_typings": [
           "csskurasu"
         ]
       },
       {
         "en": "a database table",
-        "ja": "でーたべーすてーぶる",
+        "ja": "データベーステーブル",
         "ja_typings": [
           "detabesuteburu"
         ]
@@ -6595,7 +6595,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a module in programming?",
-      "ja": "プログラミングにおける「モジュール」とは何ですか？"
+      "ja": "プログラミングのモジュールとは何か？"
     },
     "question_text_reading": {
       "en": "What is a module in programming?",
@@ -6606,28 +6606,28 @@
     "choices": [
       {
         "en": "installing and managing libraries",
-        "ja": "らいぶらりのいんすとーるとかんり",
+        "ja": "ライブラリのインストールと管理",
         "ja_typings": [
           "raiburarinoinsutorutokanri"
         ]
       },
       {
         "en": "organizing files in folders",
-        "ja": "ふぁいるをふぉるだでせいり",
+        "ja": "ファイルをフォルダーで整理",
         "ja_typings": [
           "fairuoforudadeseiri"
         ]
       },
       {
         "en": "managing server packages",
-        "ja": "さーばーぱっけーじのかんり",
+        "ja": "サーバーパッケージの管理",
         "ja_typings": [
           "sabapakkejinokanri"
         ]
       },
       {
         "en": "shipping software updates",
-        "ja": "そふとうぇあこうしんのはいそう",
+        "ja": "ソフトウェア更新の配信",
         "ja_typings": [
           "sofutoweakoshinnohaiso",
           "sofutoweakoushinnohaisou"
@@ -6640,7 +6640,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is package management?",
-      "ja": "パッケージ管理とは、どのようなものですか？"
+      "ja": "パッケージ管理とは何か？"
     },
     "question_text_reading": {
       "en": "What is package management?",
@@ -6651,21 +6651,21 @@
     "choices": [
       {
         "en": "OS-level configuration value",
-        "ja": "OSれべるのせってちち",
+        "ja": "OSレベルの設定値",
         "ja_typings": [
           "osreberunosettechichi"
         ]
       },
       {
         "en": "local variable in function",
-        "ja": "かんすうのろーかるへんすう",
+        "ja": "関数のローカル変数",
         "ja_typings": [
           "kansuunorokaruhensuu"
         ]
       },
       {
         "en": "global JS variable",
-        "ja": "ぐろーばるJS変数",
+        "ja": "グローバルJS変数",
         "ja_typings": [
           "gurobarujs"
         ]
@@ -6684,7 +6684,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is environment variable?",
-      "ja": "環境変数とは何ですか？"
+      "ja": "環境変数とは何か？"
     },
     "question_text_reading": {
       "en": "What is environment variable?",
@@ -6695,7 +6695,7 @@
     "choices": [
       {
         "en": "inconsistency from concurrent access",
-        "ja": "どうじあくせすによるふせいごうせい",
+        "ja": "同時アクセスによる不整合性",
         "ja_typings": [
           "dojiakusesuniyorufuseigosei",
           "doujiakusesuniyorufuseigousei"
@@ -6703,7 +6703,7 @@
       },
       {
         "en": "slow query execution",
-        "ja": "くえりのおそいじっこう",
+        "ja": "クエリの遅い実行",
         "ja_typings": [
           "kuerinosoijikko",
           "kuerinoosoijikkou"
@@ -6711,7 +6711,7 @@
       },
       {
         "en": "index corruption",
-        "ja": "いんでくすのそんしょう",
+        "ja": "インデックスの損傷",
         "ja_typings": [
           "indekusunosonsho",
           "indekusunosonshou"
@@ -6719,7 +6719,7 @@
       },
       {
         "en": "data type mismatch",
-        "ja": "でーたがたのふいっち",
+        "ja": "データ型のミスマッチ",
         "ja_typings": [
           "detagatanofuitchi"
         ]
@@ -6731,7 +6731,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a race condition in databases?",
-      "ja": "データベースにおける「race condition」とは何ですか？"
+      "ja": "データベースのレースコンディションとは何か？"
     },
     "question_text_reading": {
       "en": "What is a race condition in databases?",
@@ -6742,7 +6742,7 @@
     "choices": [
       {
         "en": "organizing data to reduce redundancy",
-        "ja": "じょうちょうをへらすでーたのせいり",
+        "ja": "冗長性を減らすデータの整理",
         "ja_typings": [
           "jochooherasudetanoseiri",
           "jouchouoherasudetanoseiri"
@@ -6750,7 +6750,7 @@
       },
       {
         "en": "sorting table rows",
-        "ja": "てーぶるぎょうのせいれつ",
+        "ja": "テーブル行の整列",
         "ja_typings": [
           "teburugyonoseiretsu",
           "teburugyounoseiretsu"
@@ -6758,7 +6758,7 @@
       },
       {
         "en": "encrypting sensitive data",
-        "ja": "きみつでーたのあんごうか",
+        "ja": "機密データの暗号化",
         "ja_typings": [
           "kimitsudetanoangoka",
           "kimitsudetanoangouka"
@@ -6766,7 +6766,7 @@
       },
       {
         "en": "compressing table data",
-        "ja": "てーぶるでーたのあっしゅく",
+        "ja": "テーブルデータの圧縮",
         "ja_typings": [
           "teburudetanoasshuku"
         ]
@@ -6778,7 +6778,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is normalization in databases?",
-      "ja": "データベースにおける正規化（normalization）とは何ですか？"
+      "ja": "データベースの正規化とは何か？"
     },
     "question_text_reading": {
       "en": "What is normalization in databases?",
@@ -6789,28 +6789,28 @@
     "choices": [
       {
         "en": "Cascading Style Sheets",
-        "ja": "かすけーでぃんぐすたいるしーと",
+        "ja": "カスケード・スタイル・シート",
         "ja_typings": [
           "kasukedingusutairushito"
         ]
       },
       {
         "en": "Computer Style System",
-        "ja": "こんぴゅーたすたいるしすてむ",
+        "ja": "コンピュータスタイルシステム",
         "ja_typings": [
           "konpyutasutairushisutemu"
         ]
       },
       {
         "en": "Content Style Standard",
-        "ja": "こんてんつすたいるきじゅん",
+        "ja": "コンテンツスタイルスタンダード",
         "ja_typings": [
           "kontentsusutairukijun"
         ]
       },
       {
         "en": "Creative Style Syntax",
-        "ja": "くりえいてぃぶすたいるこうもん",
+        "ja": "クリエイティブスタイルシンタックス",
         "ja_typings": [
           "kurieitibusutairukomon",
           "kurieitibusutairukoumon"
@@ -6834,7 +6834,7 @@
     "choices": [
       {
         "en": "<a>",
-        "ja": "<a>",
+        "ja": "ひらがな読み正本: げんきなひと",
         "ja_typings": [
           "<a>"
         ]
@@ -6848,14 +6848,14 @@
       },
       {
         "en": "<href>",
-        "ja": "<href>",
+        "ja": "きていじょうけん",
         "ja_typings": [
           "<href>"
         ]
       },
       {
         "en": "<url>",
-        "ja": "<url>",
+        "ja": "きていじょうけん",
         "ja_typings": [
           "<url>"
         ]
@@ -6867,7 +6867,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which HTML tag creates a hyperlink?",
-      "ja": "ハイパーリンクをつくるHTMLたぐは？"
+      "ja": "ハイパーリンクをつくるHTMLタグは？"
     },
     "question_text_reading": {
       "en": "Which HTML tag creates a hyperlink?",
@@ -6878,21 +6878,21 @@
     "choices": [
       {
         "en": "content, padding, border, margin",
-        "ja": "こんてんつぱでぃんぐぼーだーまーじん",
+        "ja": "コンテンツパディングボーダーマージン",
         "ja_typings": [
           "kontentsupadingubodamajin"
         ]
       },
       {
         "en": "width, height, color, font",
-        "ja": "はばたかさいろふぉんと",
+        "ja": "幅高さ色フォント",
         "ja_typings": [
           "habatakasairofonto"
         ]
       },
       {
         "en": "display, position, float, clear",
-        "ja": "ひょうじいちふろーとくりあ",
+        "ja": "表示位置フロートクリア",
         "ja_typings": [
           "hyojiichifurotokuria",
           "hyoujiichifurotokuria"
@@ -6900,7 +6900,7 @@
       },
       {
         "en": "flex, grid, block, inline",
-        "ja": "ふれっくすぐりっどぶろっくいんらいん",
+        "ja": "フレックスグリッドブロックインライン",
         "ja_typings": [
           "furekkusuguriddoburokkuinrain"
         ]
@@ -6912,7 +6912,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the CSS box model?",
-      "ja": "CSSのボックスモデルとは何ですか？"
+      "ja": "CSSのボックスモデルとは？"
     },
     "question_text_reading": {
       "en": "What is the CSS box model?",
@@ -6923,28 +6923,28 @@
     "choices": [
       {
         "en": "flexible layout model",
-        "ja": "ふれきしぶるれいあうともでる",
+        "ja": "フレキシブルレイアウトモデル",
         "ja_typings": [
           "furekishiburureiautomoderu"
         ]
       },
       {
         "en": "fixed grid layout",
-        "ja": "こていぐりっどれいあうと",
+        "ja": "固定グリッドレイアウト",
         "ja_typings": [
           "koteiguriddoreiauto"
         ]
       },
       {
         "en": "absolute positioning",
-        "ja": "ぜったいいちしてい",
+        "ja": "絶対位置指定",
         "ja_typings": [
           "zettaiichishitei"
         ]
       },
       {
         "en": "full-screen mode",
-        "ja": "ふるすくりーんもーど",
+        "ja": "フルスクリーンモード",
         "ja_typings": [
           "furusukurinmodo"
         ]
@@ -6967,7 +6967,7 @@
     "choices": [
       {
         "en": "rules applied at specific screen sizes",
-        "ja": "とくていがめんさいずにてきようするるーる",
+        "ja": "特定画面サイズに適用するルール",
         "ja_typings": [
           "tokuteigamensaizunitekiyosurururu",
           "tokuteigamensaizunitekiyousurururu"
@@ -6975,21 +6975,21 @@
       },
       {
         "en": "querying a database",
-        "ja": "でーたべーすをくえり",
+        "ja": "データベースをクエリ",
         "ja_typings": [
           "detabesuokueri"
         ]
       },
       {
         "en": "fetching media files",
-        "ja": "めでぃあふぁいるをとりこむ",
+        "ja": "メディアファイルを取り込む",
         "ja_typings": [
           "mediafairuotorikomu"
         ]
       },
       {
         "en": "importing stylesheets",
-        "ja": "すたいるしーとをいんぽーと",
+        "ja": "スタイルシートをインポート",
         "ja_typings": [
           "sutairushitoinpoto",
           "sutairushitooinpoto"
@@ -7002,7 +7002,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is media query in CSS?",
-      "ja": "CSSにおけるメディアクエリとは何ですか？"
+      "ja": "CSSのメディアクエリとは？"
     },
     "question_text_reading": {
       "en": "What is media query in CSS?",
@@ -7013,7 +7013,7 @@
     "choices": [
       {
         "en": "JavaScript UI library",
-        "ja": "JavaScriptのUIらいぶらり",
+        "ja": "JavaScriptのUIライブラリ",
         "ja_typings": [
           "javascriptnoiraiburari",
           "javascriptnouiraiburari"
@@ -7021,21 +7021,21 @@
       },
       {
         "en": "CSS framework",
-        "ja": "CSSふれーむわーく",
+        "ja": "CSSフレームワーク",
         "ja_typings": [
           "cssfuremuwaku"
         ]
       },
       {
         "en": "database ORM",
-        "ja": "でーたべーすORM",
+        "ja": "データベースORM",
         "ja_typings": [
           "detabesuorm"
         ]
       },
       {
         "en": "backend framework",
-        "ja": "ばっくえんどふれーむわーく",
+        "ja": "バックエンドフレームワーク",
         "ja_typings": [
           "bakkuendofuremuwaku"
         ]
@@ -7058,7 +7058,7 @@
     "choices": [
       {
         "en": "reusable UI building block",
-        "ja": "さいりようかのうなUIのたんい",
+        "ja": "再利用可能なUIの単位",
         "ja_typings": [
           "sairiyokanonauinotani",
           "sairiyoukanounauinotani"
@@ -7066,21 +7066,21 @@
       },
       {
         "en": "CSS animation",
-        "ja": "CSSあにめーしょん",
+        "ja": "CSSアニメーション",
         "ja_typings": [
           "cssanimeshon"
         ]
       },
       {
         "en": "database model",
-        "ja": "でーたべーすもでる",
+        "ja": "データベースモデル",
         "ja_typings": [
           "detabesumoderu"
         ]
       },
       {
         "en": "server endpoint",
-        "ja": "さーばーえんどぽいんと",
+        "ja": "サーバーエンドポイント",
         "ja_typings": [
           "sabaendopointo"
         ]
@@ -7092,7 +7092,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a React component?",
-      "ja": "Reactこんぽーねんととは何か？"
+      "ja": "Reactコンポーネントとは何か？"
     },
     "question_text_reading": {
       "en": "What is a React component?",
@@ -7103,7 +7103,7 @@
     "choices": [
       {
         "en": "JavaScript XML syntax extension",
-        "ja": "JavaScript XMLこうもんかくちょう",
+        "ja": "JavaScript XML構文拡張",
         "ja_typings": [
           "javascript xmlkomonkakucho",
           "javascript xmlkoumonkakuchou"
@@ -7111,7 +7111,7 @@
       },
       {
         "en": "Java Scripting Extension",
-        "ja": "Javaすくりぷとかくちょう",
+        "ja": "JavaScript Extension",
         "ja_typings": [
           "javasukuriputokakucho",
           "javasukuriputokakuchou"
@@ -7119,7 +7119,7 @@
       },
       {
         "en": "JSON Exchange Format",
-        "ja": "JSONこうかんけいしき",
+        "ja": "JSON交換形式",
         "ja_typings": [
           "jsonkokankeishiki",
           "jsonkoukankeishiki"
@@ -7127,7 +7127,7 @@
       },
       {
         "en": "JavaScript Index",
-        "ja": "JavaScriptいんでくす",
+        "ja": "JavaScriptインデックス",
         "ja_typings": [
           "javascriptindekusu"
         ]
@@ -7150,28 +7150,28 @@
     "choices": [
       {
         "en": "lightweight copy of real DOM",
-        "ja": "じっさいDOMのかるいこぴー",
+        "ja": "実DOMの軽いコピー",
         "ja_typings": [
           "jissaidomnokaruikopi"
         ]
       },
       {
         "en": "server-side DOM rendering",
-        "ja": "さーばーさいどDOMれんだりんぐ",
+        "ja": "サーバーサイドDOMレンダリング",
         "ja_typings": [
           "sabasaidodomrendaringu"
         ]
       },
       {
         "en": "DOM created by CSS",
-        "ja": "CSSがさくせいしたDOM",
+        "ja": "CSSが作成したDOM",
         "ja_typings": [
           "cssgasakuseishitadom"
         ]
       },
       {
         "en": "cached DOM snapshot",
-        "ja": "DOMのきゃっしゅすなっぷしょっと",
+        "ja": "DOMのキャッシュスナップショット",
         "ja_typings": [
           "domnokyasshusunappushotto"
         ]
@@ -7183,7 +7183,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the virtual DOM in React?",
-      "ja": "Reactにおける仮想DOMとは何ですか？"
+      "ja": "ReactのVirtual DOMとは？"
     },
     "question_text_reading": {
       "en": "What is the virtual DOM in React?",
@@ -7194,7 +7194,7 @@
     "choices": [
       {
         "en": "manages component local state",
-        "ja": "こんぽーねんとのろーかるじょうたいをかんり",
+        "ja": "コンポーネントのローカルステートを管理",
         "ja_typings": [
           "konponentonorokarujotaiokanri",
           "konponentonorokarujoutaiokanri"
@@ -7202,14 +7202,14 @@
       },
       {
         "en": "fetches API data",
-        "ja": "APIでーたをとりこむ",
+        "ja": "APIでデータを取り込む",
         "ja_typings": [
           "apidetaotorikomu"
         ]
       },
       {
         "en": "creates new component",
-        "ja": "あたらしいこんぽーねんとをさくせい",
+        "ja": "新しいコンポーネントを作成",
         "ja_typings": [
           "atarashiikonponentosakusei",
           "atarashiikonponentoosakusei"
@@ -7217,7 +7217,7 @@
       },
       {
         "en": "handles routing",
-        "ja": "るーてぃんぐをしょり",
+        "ja": "ルーティングを処理",
         "ja_typings": [
           "rutinguoshori"
         ]
@@ -7240,7 +7240,7 @@
     "choices": [
       {
         "en": "runs side effects after render",
-        "ja": "れんだーごにふくさようをじっこう",
+        "ja": "レンダー後に副作用を実行",
         "ja_typings": [
           "rendagonifukusayoojikko",
           "rendagonifukusayouojikkou"
@@ -7248,7 +7248,7 @@
       },
       {
         "en": "updates component styles",
-        "ja": "こんぽーねんとのすたいるをこうしん",
+        "ja": "コンポーネントのスタイルを更新",
         "ja_typings": [
           "konponentonosutairuokoshin",
           "konponentonosutairuokoushin"
@@ -7256,7 +7256,7 @@
       },
       {
         "en": "creates global state",
-        "ja": "ぐろーばるじょうたいをさくせい",
+        "ja": "グローバルステートを作成",
         "ja_typings": [
           "gurobarujotaiosakusei",
           "gurobarujoutaiosakusei"
@@ -7264,7 +7264,7 @@
       },
       {
         "en": "handles form input",
-        "ja": "ふぉーむにゅうりょくをしょり",
+        "ja": "フォーム入力を処理",
         "ja_typings": [
           "fomunyuuryokuoshori"
         ]
@@ -7287,28 +7287,28 @@
     "choices": [
       {
         "en": "progressive JavaScript framework",
-        "ja": "ぷろぐれっしぶJavaScriptふれーむわーく",
+        "ja": "プログレッシブJavaScriptフレームワーク",
         "ja_typings": [
           "puroguresshibujavascriptfuremuwaku"
         ]
       },
       {
         "en": "backend Node.js framework",
-        "ja": "ばっくえんどNode.jsふれーむわーく",
+        "ja": "バックエンドNode.jsフレームワーク",
         "ja_typings": [
           "bakkuendonode.jsfuremuwaku"
         ]
       },
       {
         "en": "CSS preprocessor",
-        "ja": "CSSぷりぷろせっさ",
+        "ja": "CSSプリプロセッサ",
         "ja_typings": [
           "csspuripurosessa"
         ]
       },
       {
         "en": "database query builder",
-        "ja": "でーたべーすくえりびるだー",
+        "ja": "データベースクエリビルダー",
         "ja_typings": [
           "detabesukueribiruda"
         ]
@@ -7331,14 +7331,14 @@
     "choices": [
       {
         "en": "typed superset of JavaScript",
-        "ja": "がたつきJavaScriptのすーぱーせっと",
+        "ja": "型付きJavaScriptのスーパーセット",
         "ja_typings": [
           "gatatsukijavascriptnosupasetto"
         ]
       },
       {
         "en": "JavaScript backend runtime",
-        "ja": "JavaScriptばっくえんどじっこうかんきょう",
+        "ja": "JavaScriptバックエンド実行環境",
         "ja_typings": [
           "javascriptbakkuendojikkokankyo",
           "javascriptbakkuendojikkoukankyou"
@@ -7346,14 +7346,14 @@
       },
       {
         "en": "CSS framework",
-        "ja": "CSSふれーむわーく",
+        "ja": "CSSフレームワーク",
         "ja_typings": [
           "cssfuremuwaku"
         ]
       },
       {
         "en": "HTML template engine",
-        "ja": "HTMLてんぷれーとえんじん",
+        "ja": "HTMLテンプレートエンジン",
         "ja_typings": [
           "htmltenpuretoenjin"
         ]
@@ -7376,28 +7376,28 @@
     "choices": [
       {
         "en": "Node.js package manager",
-        "ja": "Node.jsぱっけーじまねーじゃ",
+        "ja": "Node.jsパッケージマネージャー",
         "ja_typings": [
           "node.jspakkejimaneja"
         ]
       },
       {
         "en": "network protocol manager",
-        "ja": "ねっとわーくぷろとこるまねーじゃ",
+        "ja": "ネットワークプロトコルマネージャー",
         "ja_typings": [
           "nettowakupurotokorumaneja"
         ]
       },
       {
         "en": "new project module",
-        "ja": "あたらしいぷろじぇくとのもじゅーる",
+        "ja": "新しいプロジェクトのモジュール",
         "ja_typings": [
           "atarashiipurojekutonomojuru"
         ]
       },
       {
         "en": "null pointer method",
-        "ja": "nullぽいんたーめそっど",
+        "ja": "nullポインターメソッド",
         "ja_typings": [
           "nullpointamesoddo"
         ]
@@ -7420,7 +7420,7 @@
     "choices": [
       {
         "en": "JavaScript server-side runtime",
-        "ja": "JavaScriptのさーばーがわじっこうかんきょう",
+        "ja": "JavaScriptのサーバーサイドランタイム",
         "ja_typings": [
           "javascriptnosabagawajikkokankyo",
           "javascriptnosabagawajikkoukankyou"
@@ -7428,21 +7428,21 @@
       },
       {
         "en": "browser JavaScript engine",
-        "ja": "ぶらうざーJavaScriptえんじん",
+        "ja": "ブラウザJavaScriptエンジン",
         "ja_typings": [
           "burauzajavascriptenjin"
         ]
       },
       {
         "en": "database for JSON",
-        "ja": "JSONのでーたべーす",
+        "ja": "JSONのデータベース",
         "ja_typings": [
           "jsonnodetabesu"
         ]
       },
       {
         "en": "CSS compiler",
-        "ja": "CSSこんぱいら",
+        "ja": "CSSコンパイラ",
         "ja_typings": [
           "csskonpaira"
         ]
@@ -7465,28 +7465,28 @@
     "choices": [
       {
         "en": "module bundler for JavaScript",
-        "ja": "JavaScriptのもじゅーるばんどらー",
+        "ja": "JavaScriptのモジュールバンドラー",
         "ja_typings": [
           "javascriptnomojurubandora"
         ]
       },
       {
         "en": "web server software",
-        "ja": "うぇぶさーばーそふとうぇあ",
+        "ja": "ウェブサーバーソフトウェア",
         "ja_typings": [
           "webusabasofutowea"
         ]
       },
       {
         "en": "CSS framework",
-        "ja": "CSSふれーむわーく",
+        "ja": "CSSフレームワーク",
         "ja_typings": [
           "cssfuremuwaku"
         ]
       },
       {
         "en": "backend framework",
-        "ja": "ばっくえんどふれーむわーく",
+        "ja": "バックエンドフレームワーク",
         "ja_typings": [
           "bakkuendofuremuwaku"
         ]
@@ -7509,28 +7509,28 @@
     "choices": [
       {
         "en": "Single Page Application",
-        "ja": "しんぐるぺーじあぷりけーしょん",
+        "ja": "シングルページアプリケーション",
         "ja_typings": [
           "shingurupejiapurikeshon"
         ]
       },
       {
         "en": "Server-side PHP Application",
-        "ja": "さーばーがわPHPあぷり",
+        "ja": "サーバーサイドPHPアプリケーション",
         "ja_typings": [
           "sabagawaphpapuri"
         ]
       },
       {
         "en": "Secure Protocol API",
-        "ja": "あんぜんぷろとこるAPI",
+        "ja": "安全プロトコルAPI",
         "ja_typings": [
           "anzenpurotokoruapi"
         ]
       },
       {
         "en": "Static Page Archive",
-        "ja": "せいてきぺーじあーかいぶ",
+        "ja": "静的ページアーカイブ",
         "ja_typings": [
           "seitekipejiakaibu"
         ]
@@ -7553,21 +7553,21 @@
     "choices": [
       {
         "en": "Server-Side Rendering",
-        "ja": "さーばーさいどれんだりんぐ",
+        "ja": "サーバーサイドレンダリング",
         "ja_typings": [
           "sabasaidorendaringu"
         ]
       },
       {
         "en": "Static Style Rules",
-        "ja": "せいてきすたいるるーる",
+        "ja": "静的スタイルルール",
         "ja_typings": [
           "seitekisutairururu"
         ]
       },
       {
         "en": "Shared Script Resources",
-        "ja": "きょうゆうすくりぷとりそーす",
+        "ja": "共有スクリプトリソース",
         "ja_typings": [
           "kyoyuusukuriputorisosu",
           "kyouyuusukuriputorisosu"
@@ -7575,7 +7575,7 @@
       },
       {
         "en": "Secure Session Registry",
-        "ja": "あんぜんせっしょんとうろく",
+        "ja": "セキュアセッションレジストリ",
         "ja_typings": [
           "anzensesshontoroku",
           "anzensesshontouroku"
@@ -7588,7 +7588,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is SSR in web?",
-      "ja": "WebにおけるSSRとは何ですか？"
+      "ja": "ウェブのSSRとは？"
     },
     "question_text_reading": {
       "en": "What is SSR in web?",
@@ -7599,7 +7599,7 @@
     "choices": [
       {
         "en": "small data stored in browser",
-        "ja": "ぶらうざーにほぞんされるしょうさなでーた",
+        "ja": "ブラウザに保存される少なデータ",
         "ja_typings": [
           "burauzanihozonsarerushosanadeta",
           "burauzanihozonsarerushousanadeta"
@@ -7607,14 +7607,14 @@
       },
       {
         "en": "server-side session",
-        "ja": "さーばーがわせっしょん",
+        "ja": "サーバーサイドセッション",
         "ja_typings": [
           "sabagawasesshon"
         ]
       },
       {
         "en": "encrypted token",
-        "ja": "あんごうかされたとーくん",
+        "ja": "暗号化されたトークン",
         "ja_typings": [
           "angokasaretatokun",
           "angoukasaretatokun"
@@ -7622,7 +7622,7 @@
       },
       {
         "en": "database record",
-        "ja": "でーたべーすのれこーど",
+        "ja": "データベースレコード",
         "ja_typings": [
           "detabesunorekodo"
         ]
@@ -7634,7 +7634,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a cookie?",
-      "ja": "クッキーとは何ですか？"
+      "ja": "クッキーとは何か？"
     },
     "question_text_reading": {
       "en": "What is a cookie?",
@@ -7645,28 +7645,28 @@
     "choices": [
       {
         "en": "browser-based persistent key-value store",
-        "ja": "ぶらうざーのきーちストレージ",
+        "ja": "ブラウザのキー値ストア",
         "ja_typings": [
           "burauzanokichisutoreji"
         ]
       },
       {
         "en": "local database server",
-        "ja": "ろーかるでーたべーすさーばー",
+        "ja": "ローカルデータベースサーバー",
         "ja_typings": [
           "rokarudetabesusaba"
         ]
       },
       {
         "en": "server-side cache",
-        "ja": "さーばーがわきゃっしゅ",
+        "ja": "サーバーサイドキャッシュ",
         "ja_typings": [
           "sabagawakyasshu"
         ]
       },
       {
         "en": "file system API",
-        "ja": "ふぁいるしすてむAPI",
+        "ja": "ファイルシステムAPI",
         "ja_typings": [
           "fairushisutemuapi"
         ]
@@ -7689,7 +7689,7 @@
     "choices": [
       {
         "en": "makes HTTP requests",
-        "ja": "HTTPりくえすとをおこなう",
+        "ja": "HTTPリクエストをおこなう",
         "ja_typings": [
           "httprikuesutookonau",
           "httprikuesutoookonau"
@@ -7697,21 +7697,21 @@
       },
       {
         "en": "reads local files",
-        "ja": "ろーかるふぁいるをよむ",
+        "ja": "ローカルファイルを読む",
         "ja_typings": [
           "rokarufairuoyomu"
         ]
       },
       {
         "en": "queries database",
-        "ja": "でーたべーすをくえり",
+        "ja": "データベースをクエリ",
         "ja_typings": [
           "detabesuokueri"
         ]
       },
       {
         "en": "renders HTML",
-        "ja": "HTMLをれんだー",
+        "ja": "HTMLをレンダー",
         "ja_typings": [
           "htmlorenda"
         ]
@@ -7734,7 +7734,7 @@
     "choices": [
       {
         "en": "Cross-Origin Resource Sharing",
-        "ja": "くろすおりじんりそーすきょうゆう",
+        "ja": "クロスオリジンリソースシャリング",
         "ja_typings": [
           "kurosuorijinrisosukyoyuu",
           "kurosuorijinrisosukyouyuu"
@@ -7742,7 +7742,7 @@
       },
       {
         "en": "Content Oriented Rendering System",
-        "ja": "こんてんつしこうれんだりんぐしすてむ",
+        "ja": "コンテンツ指向レンダリングシステム",
         "ja_typings": [
           "kontentsushikorendaringushisutemu",
           "kontentsushikourendaringushisutemu"
@@ -7750,14 +7750,14 @@
       },
       {
         "en": "Cache Override Request Scheme",
-        "ja": "きゃっしゅおーばーらいどりくえすとけいしき",
+        "ja": "キャッシュオーバーライドリクエストスキーム",
         "ja_typings": [
           "kyasshuobaraidorikuesutokeishiki"
         ]
       },
       {
         "en": "Client Origin Response Standard",
-        "ja": "くらいあんとおりじんおうとうきじゅん",
+        "ja": "クライアントオリジンレスポンススタンダード",
         "ja_typings": [
           "kuraiantorijinotokijun",
           "kuraiantoorijinoutoukijun"
@@ -7781,14 +7781,14 @@
     "choices": [
       {
         "en": "Content Delivery Network",
-        "ja": "こんてんつはいしんねっとわーく",
+        "ja": "コンテンツ配信ネットワーク",
         "ja_typings": [
           "kontentsuhaishinnettowaku"
         ]
       },
       {
         "en": "Centralized Data Node",
-        "ja": "ちゅうおうかでーたのーど",
+        "ja": "中央データノード",
         "ja_typings": [
           "chuuokadetanodo",
           "chuuoukadetanodo"
@@ -7796,14 +7796,14 @@
       },
       {
         "en": "Cloud Database Network",
-        "ja": "くらうどでーたべーすねっとわーく",
+        "ja": "クラウドデータベースネットワーク",
         "ja_typings": [
           "kuraudodetabesunettowaku"
         ]
       },
       {
         "en": "Client Domain Name",
-        "ja": "くらいあんとどめいんめい",
+        "ja": "クライアントドメイン名",
         "ja_typings": [
           "kuraiantodomeinmei"
         ]
@@ -7826,14 +7826,14 @@
     "choices": [
       {
         "en": "HTML that conveys meaning",
-        "ja": "いみをつたえるHTML",
+        "ja": "意味を伝えるHTML",
         "ja_typings": [
           "imiotsutaeruhtml"
         ]
       },
       {
         "en": "HTML with inline styles",
-        "ja": "いんらいんすたいるつきHTML",
+        "ja": "インラインスタイル付きHTML",
         "ja_typings": [
           "inrainsutairutsukihtml"
         ]
@@ -7847,7 +7847,7 @@
       },
       {
         "en": "compressed HTML",
-        "ja": "あっしゅくされたHTML",
+        "ja": "圧縮されたHTML",
         "ja_typings": [
           "asshukusaretahtml"
         ]
@@ -7859,7 +7859,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is semantic HTML?",
-      "ja": "セマンティックHTMLとは、どのようなものですか？"
+      "ja": "セマンティックHTMLとは何か？"
     },
     "question_text_reading": {
       "en": "What is semantic HTML?",
@@ -7870,28 +7870,28 @@
     "choices": [
       {
         "en": "declares character encoding",
-        "ja": "もじぶんにょくをせんげん",
+        "ja": "文字種にょくをせんげん",
         "ja_typings": [
           "mojibunnyokuosengen"
         ]
       },
       {
         "en": "sets page title",
-        "ja": "ぺーじのたいとるをせってい",
+        "ja": "ページのタイトルを設定",
         "ja_typings": [
           "pejinotaitoruosettei"
         ]
       },
       {
         "en": "defines CSS styles",
-        "ja": "CSSすたいるをていぎ",
+        "ja": "CSSスタイルを定義",
         "ja_typings": [
           "csssutairuoteigi"
         ]
       },
       {
         "en": "links JavaScript file",
-        "ja": "JavaScriptふぁいるをりんく",
+        "ja": "JavaScriptファイルをリンク",
         "ja_typings": [
           "javascriptfairuorinku"
         ]
@@ -7914,7 +7914,7 @@
     "choices": [
       {
         "en": "loads content only when needed",
-        "ja": "ひつようなときだけこんてんつをろーど",
+        "ja": "必要なときだけコンテンツをロード",
         "ja_typings": [
           "hitsuyonatokidakekontentsuorodo",
           "hitsuyounatokidakekontentsuorodo"
@@ -7922,14 +7922,14 @@
       },
       {
         "en": "caches all content",
-        "ja": "すべてのこんてんつをきゃっしゅ",
+        "ja": "すべてのコンテンツをキャッシュ",
         "ja_typings": [
           "subetenokontentsuokyasshu"
         ]
       },
       {
         "en": "preloads all images",
-        "ja": "すべてのがぞうをじぜんろーど",
+        "ja": "すべての画像をプリロード",
         "ja_typings": [
           "subetenogazoojizenrodo",
           "subetenogazouojizenrodo"
@@ -7937,7 +7937,7 @@
       },
       {
         "en": "loads on first visit only",
-        "ja": "さいしょのほうもんのみろーど",
+        "ja": "最初の訪問のみロード",
         "ja_typings": [
           "saishonohomonnomirodo",
           "saishonohoumonnomirodo"
@@ -7950,7 +7950,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is lazy loading in web?",
-      "ja": "Webにおける「lazy loading」とは、どのような仕組みのことですか？"
+      "ja": "Webのlazy loadingとは？"
     },
     "question_text_reading": {
       "en": "What is lazy loading in web?",
@@ -7961,7 +7961,7 @@
     "choices": [
       {
         "en": "build from basic to enhanced",
-        "ja": "きほんからこうきのうへきちく",
+        "ja": "基本から高機能へ構築",
         "ja_typings": [
           "kihonkarakokinohekichiku",
           "kihonkarakoukinouhekichiku"
@@ -7969,7 +7969,7 @@
       },
       {
         "en": "add features progressively over time",
-        "ja": "じかんとともにきのうをついか",
+        "ja": "時間とともに機能を追加",
         "ja_typings": [
           "jikantotomonikinootsuika",
           "jikantotomonikinouotsuika"
@@ -7977,7 +7977,7 @@
       },
       {
         "en": "enhance CSS over HTML",
-        "ja": "HTMLよりCSSをきょうか",
+        "ja": "HTMLよりCSSを強化",
         "ja_typings": [
           "htmlyoricssokyoka",
           "htmlyoricssokyouka"
@@ -7985,7 +7985,7 @@
       },
       {
         "en": "upgrade to latest browser only",
-        "ja": "さいしんぶらうざーのみたいおう",
+        "ja": "最新ブラウザのみ対応",
         "ja_typings": [
           "saishinburauzanomitaio",
           "saishinburauzanomitaiou"
@@ -7998,7 +7998,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is progressive enhancement?",
-      "ja": "プログレッシブエンハンスメントとは何ですか？"
+      "ja": "Progressive Enhancementとは？"
     },
     "question_text_reading": {
       "en": "What is progressive enhancement?",
@@ -8009,7 +8009,7 @@
     "choices": [
       {
         "en": "extends CSS with variables and nesting",
-        "ja": "へんすうとねすとでCSSをかくちょう",
+        "ja": "変数とネストでCSSを拡張",
         "ja_typings": [
           "hensuutonesutodecssokakucho",
           "hensuutonesutodecssokakuchou"
@@ -8017,21 +8017,21 @@
       },
       {
         "en": "compresses CSS files",
-        "ja": "CSSふぁいるをあっしゅく",
+        "ja": "CSSファイルを圧縮",
         "ja_typings": [
           "cssfairuoasshuku"
         ]
       },
       {
         "en": "converts CSS to JavaScript",
-        "ja": "CSSをJavaScriptにへんかん",
+        "ja": "CSSをJavaScriptに変換",
         "ja_typings": [
           "cssojavascriptnihenkan"
         ]
       },
       {
         "en": "generates CSS from images",
-        "ja": "がぞうからCSSをせいせい",
+        "ja": "画像からCSSを生成",
         "ja_typings": [
           "gazokaracssoseisei",
           "gazoukaracssoseisei"
@@ -8044,7 +8044,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a CSS preprocessor?",
-      "ja": "CSSプリプロセッサとは何ですか？"
+      "ja": "CSSプリプロセッサとは何か？"
     },
     "question_text_reading": {
       "en": "What is a CSS preprocessor?",
@@ -8055,14 +8055,14 @@
     "choices": [
       {
         "en": "utility-first CSS framework",
-        "ja": "ゆーてぃりてぃおしのCSSふれーむわーく",
+        "ja": "ユーティリティファーストのCSSフレームワーク",
         "ja_typings": [
           "yutiritioshinocssfuremuwaku"
         ]
       },
       {
         "en": "component-based UI library",
-        "ja": "こんぽーねんとべーすのUIらいぶらり",
+        "ja": "コンポーネントベースのUIライブラリ",
         "ja_typings": [
           "konponentobesunoiraiburari",
           "konponentobesunouiraiburari"
@@ -8070,14 +8070,14 @@
       },
       {
         "en": "CSS-in-JS solution",
-        "ja": "CSS-in-JSそりゅーしょん",
+        "ja": "CSS-in-JSソリューション",
         "ja_typings": [
           "cssinjssoryushon"
         ]
       },
       {
         "en": "CSS animation library",
-        "ja": "CSSあにめーしょんらいぶらり",
+        "ja": "CSSアニメーションライブラリ",
         "ja_typings": [
           "cssanimeshonraiburari"
         ]
@@ -8100,21 +8100,21 @@
     "choices": [
       {
         "en": "removing unused JS from bundle",
-        "ja": "つかわないJSをばんどるからのぞく",
+        "ja": "使わないJSをバンドルから除く",
         "ja_typings": [
           "tsukawanaijsobandorukaranozoku"
         ]
       },
       {
         "en": "optimizing CSS selectors",
-        "ja": "CSSせれくたをさいてきか",
+        "ja": "CSSセレクタを最適化",
         "ja_typings": [
           "cssserekutaosaitekika"
         ]
       },
       {
         "en": "caching static assets",
-        "ja": "せいてきあせっとをきゃっしゅ",
+        "ja": "静的アセットをキャッシュ",
         "ja_typings": [
           "seitekiasettokyasshu",
           "seitekiasettookyasshu"
@@ -8122,7 +8122,7 @@
       },
       {
         "en": "sorting DOM elements",
-        "ja": "DOMようそをせいれつ",
+        "ja": "DOM要素を整列",
         "ja_typings": [
           "domyososeiretsu",
           "domyousooseiretsu"
@@ -8135,7 +8135,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is tree shaking in frontend?",
-      "ja": "フロントエンドにおけるツリーシェイキングとは何ですか？"
+      "ja": "フロントエンドのツリーシェイキングとは？"
     },
     "question_text_reading": {
       "en": "What is tree shaking in frontend?",
@@ -8146,14 +8146,14 @@
     "choices": [
       {
         "en": "metadata and resource links",
-        "ja": "めたでーたとりそーすりんく",
+        "ja": "メタデータとリソースリンク",
         "ja_typings": [
           "metadetatorisosurinku"
         ]
       },
       {
         "en": "visible page content",
-        "ja": "ひょうじされるぺーじこんてんつ",
+        "ja": "表示されるページコンテンツ",
         "ja_typings": [
           "hyojisarerupejikontentsu",
           "hyoujisarerupejikontentsu"
@@ -8161,14 +8161,14 @@
       },
       {
         "en": "JavaScript functions",
-        "ja": "JavaScriptかんすう",
+        "ja": "JavaScript関数",
         "ja_typings": [
           "javascriptkansuu"
         ]
       },
       {
         "en": "CSS styles",
-        "ja": "CSSすたいる",
+        "ja": "CSSスタイル",
         "ja_typings": [
           "csssutairu"
         ]
@@ -8191,7 +8191,7 @@
     "choices": [
       {
         "en": "positions relative to nearest positioned ancestor",
-        "ja": "もっともちかいいちしていそせんへのそうたいいち",
+        "ja": "もっとも近い位置指定の祖先への相対位置",
         "ja_typings": [
           "mottomochikaiichishiteisosenhenosotaiichi",
           "mottomochikaiichishiteisosenhenosoutaiichi"
@@ -8199,7 +8199,7 @@
       },
       {
         "en": "positions relative to viewport",
-        "ja": "びゅーぽーとへのそうたいいち",
+        "ja": "ビューポートへの相対位置",
         "ja_typings": [
           "byupotohenosotaiichi",
           "byupotohenosoutaiichi"
@@ -8207,7 +8207,7 @@
       },
       {
         "en": "stacks with other elements",
-        "ja": "ほかのようそとかさなる",
+        "ja": "他の要素と積層する",
         "ja_typings": [
           "hokanoyosotokasanaru",
           "hokanoyousotokasanaru"
@@ -8215,7 +8215,7 @@
       },
       {
         "en": "removes from document flow",
-        "ja": "ぶんしょうのふろーからとりのぞく",
+        "ja": "文書のフローから取り除く",
         "ja_typings": [
           "bunshonofurokaratorinozoku",
           "bunshounofurokaratorinozoku"
@@ -8239,7 +8239,7 @@
     "choices": [
       {
         "en": "controls stacking order of elements",
-        "ja": "ようそのかさなりじゅんをせいぎょ",
+        "ja": "要素の重ね順を制御",
         "ja_typings": [
           "yosonokasanarijunoseigyo",
           "yousonokasanarijunoseigyo"
@@ -8247,7 +8247,7 @@
       },
       {
         "en": "sets element zoom level",
-        "ja": "ようそのずーむをせってい",
+        "ja": "要素のズームを設定",
         "ja_typings": [
           "yosonozumuosettei",
           "yousonozumuosettei"
@@ -8255,14 +8255,14 @@
       },
       {
         "en": "defines CSS grid zones",
-        "ja": "CSSぐりっどのぞーんをていぎ",
+        "ja": "CSSグリッドのゾーンを定義",
         "ja_typings": [
           "cssguriddonozonoteigi"
         ]
       },
       {
         "en": "sets animation delay",
-        "ja": "あにめーしょんのおくれをせってい",
+        "ja": "アニメーションの遅れを設定",
         "ja_typings": [
           "animeshonnokureosettei",
           "animeshonnookureosettei"
@@ -8286,7 +8286,7 @@
     "choices": [
       {
         "en": "Block Element Modifier naming convention",
-        "ja": "ぶろっくようそもでぃふぁいやめいめいきやく",
+        "ja": "ブロック要素の修飾語命名規則",
         "ja_typings": [
           "burokkuyosomodifaiyameimeikiyaku",
           "burokkuyousomodifaiyameimeikiyaku"
@@ -8294,14 +8294,14 @@
       },
       {
         "en": "Browser Event Model",
-        "ja": "ぶらうざーいべんともでる",
+        "ja": "ブラウザイベントモデル",
         "ja_typings": [
           "burauzaibentomoderu"
         ]
       },
       {
         "en": "Built-in Extension Method",
-        "ja": "そなわったかくちょうめそっど",
+        "ja": "備わった拡張メソッド",
         "ja_typings": [
           "sonawattakakuchomesoddo",
           "sonawattakakuchoumesoddo"
@@ -8309,7 +8309,7 @@
       },
       {
         "en": "Background Effect Mode",
-        "ja": "はいけいこうかもーど",
+        "ja": "背景効果モード",
         "ja_typings": [
           "haikeikokamodo",
           "haikeikoukamodo"
@@ -8333,28 +8333,28 @@
     "choices": [
       {
         "en": "custom property storing a value",
-        "ja": "ちをほぞんするかすたむぷろぱてぃ",
+        "ja": "値を保存するカスタムプロパティ",
         "ja_typings": [
           "chiohozonsurukasutamupuropati"
         ]
       },
       {
         "en": "JavaScript variable in CSS",
-        "ja": "CSSのJavaScriptへんすう",
+        "ja": "CSSのJavaScript変数",
         "ja_typings": [
           "cssnojavascripthensuu"
         ]
       },
       {
         "en": "random CSS value",
-        "ja": "らんだむCSSち",
+        "ja": "ランダムCSS値",
         "ja_typings": [
           "randamucsschi"
         ]
       },
       {
         "en": "inherited CSS property",
-        "ja": "けいしょうするCSSぷろぱてぃ",
+        "ja": "継承するCSSプロパティ",
         "ja_typings": [
           "keishosurucsspuropati",
           "keishousurucsspuropati"
@@ -8386,21 +8386,21 @@
       },
       {
         "en": "URL shortening",
-        "ja": "URLたんしゅく",
+        "ja": "URL短縮",
         "ja_typings": [
           "urltanshuku"
         ]
       },
       {
         "en": "caching strategy",
-        "ja": "きゃっしゅせんりゃく",
+        "ja": "キャッシングストラテジー",
         "ja_typings": [
           "kyasshusenryaku"
         ]
       },
       {
         "en": "server-side security",
-        "ja": "さーばーがわせきゅりてぃ",
+        "ja": "サーバーサイドセキュリティ",
         "ja_typings": [
           "sabagawasekyuriti"
         ]
@@ -8412,7 +8412,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is accessibility (a11y) in web?",
-      "ja": "うぇぶのアクセシビリティとは？"
+      "ja": "ウェブのアクセシビリティとは？"
     },
     "question_text_reading": {
       "en": "What is accessibility (a11y) in web?",
@@ -8423,14 +8423,14 @@
     "choices": [
       {
         "en": "Accessible Rich Internet Applications",
-        "ja": "アクセスしやすいりちなインターネットアプリ",
+        "ja": "アクセシブルリッチインターネットアプリケーション",
         "ja_typings": [
           "akusesushiyasuirichinaintanettoapuri"
         ]
       },
       {
         "en": "Automated Rendering Index API",
-        "ja": "じどうれんだりんぐしすう",
+        "ja": "自動レンダリング指数",
         "ja_typings": [
           "jidorendaringushisuu",
           "jidourendaringushisuu"
@@ -8438,7 +8438,7 @@
       },
       {
         "en": "Advanced Resource Integration Architecture",
-        "ja": "こうきゅうりそーすとうごうあーきてくちゃ",
+        "ja": "高度リソース統合アーキテクチャ",
         "ja_typings": [
           "kokyuurisosutogoakitekucha",
           "koukyuurisosutougouakitekucha"
@@ -8446,7 +8446,7 @@
       },
       {
         "en": "Application Route Inspection Agent",
-        "ja": "あぷりるーとけんさえーじぇんと",
+        "ja": "アプリケーションルートインスペクションエージェント",
         "ja_typings": [
           "apurirutokensaejento"
         ]
@@ -8458,7 +8458,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is ARIA in web accessibility?",
-      "ja": "ウェブアクセシビリティにおけるARIAとは何ですか？"
+      "ja": "ウェブのARIAとは？"
     },
     "question_text_reading": {
       "en": "What is ARIA in web accessibility?",
@@ -8469,21 +8469,21 @@
     "choices": [
       {
         "en": "Progressive Web App",
-        "ja": "ぷろぐれっしぶうぇぶあぷり",
+        "ja": "プログレッシブウェブアプリ",
         "ja_typings": [
           "puroguresshibuwebuapuri"
         ]
       },
       {
         "en": "Private Web Archive",
-        "ja": "ぷらいべーとうぇぶあーかいぶ",
+        "ja": "プライベートウェブアーカイブ",
         "ja_typings": [
           "puraibetowebuakaibu"
         ]
       },
       {
         "en": "Public Webpack Agent",
-        "ja": "こうかいWebpackえーじぇんと",
+        "ja": "公開Webpackエージェント",
         "ja_typings": [
           "kokaiwebpackejento",
           "koukaiwebpackejento"
@@ -8491,7 +8491,7 @@
       },
       {
         "en": "Preloaded Web Asset",
-        "ja": "じぜんろーどされたうぇぶあせっと",
+        "ja": "事前ロードされたウェブアセット",
         "ja_typings": [
           "jizenrodosaretawebuasetto"
         ]
@@ -8514,7 +8514,7 @@
     "choices": [
       {
         "en": "background script for offline support",
-        "ja": "おふらいんたいおうのばっくぐらうんどすくりぷと",
+        "ja": "オフライン対応のバックグラウンドスクリプト",
         "ja_typings": [
           "ofuraintaionobakkuguraundosukuriputo",
           "ofuraintaiounobakkuguraundosukuriputo"
@@ -8522,21 +8522,21 @@
       },
       {
         "en": "server-side worker process",
-        "ja": "さーばーがわわーかーぷろせす",
+        "ja": "サーバーサイドワーカープロセス",
         "ja_typings": [
           "sabagawawakapurosesu"
         ]
       },
       {
         "en": "CSS animation worker",
-        "ja": "CSSあにめーしょんわーかー",
+        "ja": "CSSアニメーションワーカー",
         "ja_typings": [
           "cssanimeshonwaka"
         ]
       },
       {
         "en": "database connection pool",
-        "ja": "でーたべーすせつぞくぷーる",
+        "ja": "データベース接続プール",
         "ja_typings": [
           "detabesusetsuzokupuru"
         ]
@@ -8548,7 +8548,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a service worker?",
-      "ja": "サービスワーカーとは何ですか？"
+      "ja": "Service Workerとは何か？"
     },
     "question_text_reading": {
       "en": "What is a service worker?",
@@ -8559,28 +8559,28 @@
     "choices": [
       {
         "en": "React framework with SSR and SSG",
-        "ja": "SSRとSSGのReactふれーむわーく",
+        "ja": "SSRとSSGのReactフレームワーク",
         "ja_typings": [
           "ssrtossgnoreactfuremuwaku"
         ]
       },
       {
         "en": "Node.js web server",
-        "ja": "Node.jsうぇぶさーばー",
+        "ja": "Node.jsウェブサーバー",
         "ja_typings": [
           "node.jswebusaba"
         ]
       },
       {
         "en": "CSS framework",
-        "ja": "CSSふれーむわーく",
+        "ja": "CSSフレームワーク",
         "ja_typings": [
           "cssfuremuwaku"
         ]
       },
       {
         "en": "JavaScript test runner",
-        "ja": "JavaScriptてすとじっこうき",
+        "ja": "JavaScriptテスト実行機",
         "ja_typings": [
           "javascripttesutojikkoki",
           "javascripttesutojikkouki"
@@ -8604,28 +8604,28 @@
     "choices": [
       {
         "en": "full-stack Svelte framework",
-        "ja": "ふるすたっくSvelteふれーむわーく",
+        "ja": "フルスタックSvelteフレームワーク",
         "ja_typings": [
           "furusutakkusveltefuremuwaku"
         ]
       },
       {
         "en": "CSS animation toolkit",
-        "ja": "CSSあにめーしょんつーるきっと",
+        "ja": "CSSアニメーションツールキット",
         "ja_typings": [
           "cssanimeshontsurukitto"
         ]
       },
       {
         "en": "JavaScript bundler",
-        "ja": "JavaScriptばんどらー",
+        "ja": "JavaScriptバンドラー",
         "ja_typings": [
           "javascriptbandora"
         ]
       },
       {
         "en": "headless CMS",
-        "ja": "へっどれすCMS",
+        "ja": "ヘッドレスCMS",
         "ja_typings": [
           "heddoresucms"
         ]
@@ -8648,7 +8648,7 @@
     "choices": [
       {
         "en": "describes image for accessibility",
-        "ja": "アクセシビリティのためにがぞうをせつめい",
+        "ja": "アクセシビリティのために画像を説明",
         "ja_typings": [
           "akuseshibiritinotamenigazoosetsumei",
           "akuseshibiritinotamenigazouosetsumei"
@@ -8656,7 +8656,7 @@
       },
       {
         "en": "sets image alignment",
-        "ja": "がぞうのいちをせってい",
+        "ja": "画像の位置を設定",
         "ja_typings": [
           "gazonoichiosettei",
           "gazounoichiosettei"
@@ -8664,7 +8664,7 @@
       },
       {
         "en": "defines image source",
-        "ja": "がぞうのそーすをていぎ",
+        "ja": "画像のソースを定義",
         "ja_typings": [
           "gazonososuoteigi",
           "gazounososuoteigi"
@@ -8672,7 +8672,7 @@
       },
       {
         "en": "sets image size",
-        "ja": "がぞうのさいずをせってい",
+        "ja": "画像のサイズを設定",
         "ja_typings": [
           "gazonosaizuosettei",
           "gazounosaizuosettei"
@@ -8696,7 +8696,7 @@
     "choices": [
       {
         "en": "multiplexing multiple requests",
-        "ja": "ふくすうりくえすとをたじゅうか",
+        "ja": "複数リクエストを多重化",
         "ja_typings": [
           "fukusuurikuesutotajuuka",
           "fukusuurikuesutootajuuka"
@@ -8704,14 +8704,14 @@
       },
       {
         "en": "removing all headers",
-        "ja": "すべてのへっだーをさくじょ",
+        "ja": "すべてのヘッダーを削除",
         "ja_typings": [
           "subetenoheddaosakujo"
         ]
       },
       {
         "en": "using UDP instead of TCP",
-        "ja": "TCPのかわりにUDPをしよう",
+        "ja": "TCPの代わりにUDPをしよう",
         "ja_typings": [
           "tcpnokawariniudposhiyo",
           "tcpnokawariniudposhiyou"
@@ -8719,7 +8719,7 @@
       },
       {
         "en": "encrypting by default",
-        "ja": "きほんであんごうか",
+        "ja": "基本で暗号化",
         "ja_typings": [
           "kihondeangoka",
           "kihondeangouka"
@@ -8743,7 +8743,7 @@
     "choices": [
       {
         "en": "full-duplex communication protocol",
-        "ja": "ぜんにほうこうつうしんぷろとこる",
+        "ja": "全二重通信プロトコル",
         "ja_typings": [
           "zennihokotsuushinpurotokoru",
           "zennihoukoutsuushinpurotokoru"
@@ -8751,7 +8751,7 @@
       },
       {
         "en": "unidirectional HTTP streaming",
-        "ja": "いっぽうこうHTTPすとりーみんぐ",
+        "ja": "一方通行HTTPストリーミング",
         "ja_typings": [
           "ippokohttpsutorimingu",
           "ippoukouhttpsutorimingu"
@@ -8759,14 +8759,14 @@
       },
       {
         "en": "REST API standard",
-        "ja": "REST APIきじゅん",
+        "ja": "REST API基準",
         "ja_typings": [
           "rest apikijun"
         ]
       },
       {
         "en": "WebAssembly socket",
-        "ja": "WebAssemblyそけっと",
+        "ja": "WebAssemblyソケット",
         "ja_typings": [
           "webassemblysoketto"
         ]
@@ -8789,14 +8789,14 @@
     "choices": [
       {
         "en": "encapsulated DOM sub-tree",
-        "ja": "かぷせるかされたDOMのさぶつりー",
+        "ja": "カプセル化されたDOMのサブツリー",
         "ja_typings": [
           "kapuserukasaretadomnosabutsuri"
         ]
       },
       {
         "en": "invisible DOM elements",
-        "ja": "みえないDOMようそ",
+        "ja": "見えないDOM要素",
         "ja_typings": [
           "mienaidomyoso",
           "mienaidomyouso"
@@ -8804,14 +8804,14 @@
       },
       {
         "en": "server-side DOM",
-        "ja": "さーばーがわDOM",
+        "ja": "サーバーサイドDOM",
         "ja_typings": [
           "sabagawadom"
         ]
       },
       {
         "en": "cached DOM snapshot",
-        "ja": "きゃっしゅされたDOMすなっぷしょっと",
+        "ja": "キャッシュされたDOMスナップショット",
         "ja_typings": [
           "kyasshusaretadomsunappushotto"
         ]
@@ -8834,14 +8834,14 @@
     "choices": [
       {
         "en": "user-defined HTML tag",
-        "ja": "ゆーざーていぎのHTMLたぐ",
+        "ja": "ユーザー定義のHTMLタグ",
         "ja_typings": [
           "yuzateiginohtmltagu"
         ]
       },
       {
         "en": "styled HTML element",
-        "ja": "すたいるつきHTMLようそ",
+        "ja": "スタイルのHTML要素",
         "ja_typings": [
           "sutairutsukihtmlyoso",
           "sutairutsukihtmlyouso"
@@ -8849,7 +8849,7 @@
       },
       {
         "en": "hidden HTML element",
-        "ja": "かくされたHTMLようそ",
+        "ja": "隠されたHTML要素",
         "ja_typings": [
           "kakusaretahtmlyoso",
           "kakusaretahtmlyouso"
@@ -8857,7 +8857,7 @@
       },
       {
         "en": "dynamic HTML element",
-        "ja": "どうてきHTMLようそ",
+        "ja": "動的HTML要素",
         "ja_typings": [
           "dotekihtmlyoso",
           "doutekihtmlyouso"
@@ -8870,7 +8870,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a custom HTML element?",
-      "ja": "カスタムHTML要素とは何ですか？"
+      "ja": "カスタムHTML要素とは何か？"
     },
     "question_text_reading": {
       "en": "What is a custom HTML element?",
@@ -8881,7 +8881,7 @@
     "choices": [
       {
         "en": "loads script after HTML parsing",
-        "ja": "HTMLかいせきごにすくりぷとをろーど",
+        "ja": "HTML解析後にスクリプトをロード",
         "ja_typings": [
           "htmlkaisekigonisukuriputorodo",
           "htmlkaisekigonisukuriputoorodo"
@@ -8889,7 +8889,7 @@
       },
       {
         "en": "disables script execution",
-        "ja": "すくりぷとじっこうをむこうか",
+        "ja": "スクリプト実行を無効化",
         "ja_typings": [
           "sukuriputojikkoomukoka",
           "sukuriputojikkouomukouka"
@@ -8897,7 +8897,7 @@
       },
       {
         "en": "loads script before HTML",
-        "ja": "HTMLのまえにすくりぷとをろーど",
+        "ja": "HTMLの前にスクリプトをロード",
         "ja_typings": [
           "htmlnomaenisukuriputorodo",
           "htmlnomaenisukuriputoorodo"
@@ -8905,7 +8905,7 @@
       },
       {
         "en": "compresses script file",
-        "ja": "すくりぷとふぁいるをあっしゅく",
+        "ja": "スクリプトファイルを圧縮",
         "ja_typings": [
           "sukuriputofairuoasshuku"
         ]
@@ -8928,7 +8928,7 @@
     "choices": [
       {
         "en": "em is parent-relative, rem is root-relative",
-        "ja": "emはおや、remはるーとからそうたい",
+        "ja": "emは親、remはルートから相対",
         "ja_typings": [
           "emhaoya remharutokarasotai",
           "emhaoya remharutokarasoutai"
@@ -8936,21 +8936,21 @@
       },
       {
         "en": "em is pixels, rem is percentages",
-        "ja": "emはぴくせる、remはぱーせんと",
+        "ja": "emはピクセル、remはパーセント",
         "ja_typings": [
           "emhapikuseru remhapasento"
         ]
       },
       {
         "en": "em is for fonts, rem is for margins",
-        "ja": "emはふぉんと、remはまーじん",
+        "ja": "emはフォントと、remはマージン",
         "ja_typings": [
           "emhafonto remhamajin"
         ]
       },
       {
         "en": "em is absolute, rem is relative",
-        "ja": "emはぜったい、remはそうたい",
+        "ja": "emは絶対、remは相対",
         "ja_typings": [
           "emhazettai remhasotai",
           "emhazettai remhasoutai"
@@ -8974,28 +8974,28 @@
     "choices": [
       {
         "en": "two-dimensional layout system",
-        "ja": "にじげんれいあうとしすてむ",
+        "ja": "二次元レイアウトシステム",
         "ja_typings": [
           "nijigenreiautoshisutemu"
         ]
       },
       {
         "en": "one-dimensional flex layout",
-        "ja": "いちじげんふれっくすれいあうと",
+        "ja": "一次元フレックスレイアウト",
         "ja_typings": [
           "ichijigenfurekkusureiauto"
         ]
       },
       {
         "en": "table-based layout",
-        "ja": "てーぶるべーすれいあうと",
+        "ja": "テーブルベースレイアウト",
         "ja_typings": [
           "teburubesureiauto"
         ]
       },
       {
         "en": "fixed-position system",
-        "ja": "こていいちしすてむ",
+        "ja": "固定位置システム",
         "ja_typings": [
           "koteiichishisutemu"
         ]
@@ -9007,7 +9007,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a CSS grid?",
-      "ja": "CSS gridとはどのようなものですか？"
+      "ja": "CSSグリッドとは何か？"
     },
     "question_text_reading": {
       "en": "What is a CSS grid?",
@@ -9018,7 +9018,7 @@
     "choices": [
       {
         "en": "visible area of browser window",
-        "ja": "ぶらうざーうぃんどうのひょうじりょういき",
+        "ja": "ブラウザウィンドウの表示領域",
         "ja_typings": [
           "burauzawindonohyojiryoiki",
           "burauzawindounohyoujiryouiki"
@@ -9026,7 +9026,7 @@
       },
       {
         "en": "screen resolution setting",
-        "ja": "がめんかいぞうどせってい",
+        "ja": "画面解像度設定",
         "ja_typings": [
           "gamenkaizodosettei",
           "gamenkaizoudosettei"
@@ -9034,14 +9034,14 @@
       },
       {
         "en": "full page width",
-        "ja": "ぺーじのぜんはば",
+        "ja": "ページの全幅",
         "ja_typings": [
           "pejinozenhaba"
         ]
       },
       {
         "en": "CSS container unit",
-        "ja": "CSSこんてなたんい",
+        "ja": "CSSコンテナ単位",
         "ja_typings": [
           "csskontenatani"
         ]
@@ -9053,7 +9053,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is viewport in CSS?",
-      "ja": "CSSのびゅーぽーととは何か？"
+      "ja": "CSSのビューポートとは何か？"
     },
     "question_text_reading": {
       "en": "What is viewport in CSS?",
@@ -9064,14 +9064,14 @@
     "choices": [
       {
         "en": "removing unnecessary characters from code",
-        "ja": "こーどから不要文字をとりのぞく",
+        "ja": "コードから不要文字を取り除く",
         "ja_typings": [
           "kodokaraotorinozoku"
         ]
       },
       {
         "en": "compressing images",
-        "ja": "がぞうをあっしゅく",
+        "ja": "画像を圧縮",
         "ja_typings": [
           "gazooasshuku",
           "gazouoasshuku"
@@ -9079,14 +9079,14 @@
       },
       {
         "en": "caching static files",
-        "ja": "せいてきふぁいるをきゃっしゅ",
+        "ja": "静的ファイルをキャッシュ",
         "ja_typings": [
           "seitekifairuokyasshu"
         ]
       },
       {
         "en": "splitting code into chunks",
-        "ja": "こーどをちゃんくにぶんかつ",
+        "ja": "コードをチャンクに分割",
         "ja_typings": [
           "kodochankunibunkatsu",
           "kodoochankunibunkatsu"
@@ -9099,7 +9099,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is minification in web?",
-      "ja": "ウェブにおける「minification」とは何ですか？"
+      "ja": "ウェブのミニファイは何か？"
     },
     "question_text_reading": {
       "en": "What is minification in web?",
@@ -9110,7 +9110,7 @@
     "choices": [
       {
         "en": "dividing bundle into smaller chunks",
-        "ja": "ばんどるをしょうさなちゃんくにぶんかつ",
+        "ja": "バンドルを小さなチャンクに分割",
         "ja_typings": [
           "bandoruoshosanachankunibunkatsu",
           "bandoruoshousanachankunibunkatsu"
@@ -9118,14 +9118,14 @@
       },
       {
         "en": "splitting CSS from JS",
-        "ja": "JSからCSSをわける",
+        "ja": "JSからCSSを分ける",
         "ja_typings": [
           "jskaracssowakeru"
         ]
       },
       {
         "en": "separating test code",
-        "ja": "てすとこーどをきりはなす",
+        "ja": "テストコードを切り離す",
         "ja_typings": [
           "tesutokodokirihanasu",
           "tesutokodookirihanasu"
@@ -9133,7 +9133,7 @@
       },
       {
         "en": "dividing HTML sections",
-        "ja": "HTMLせくしょんをぶんかつ",
+        "ja": "HTMLセクションを分割",
         "ja_typings": [
           "htmlsekushonobunkatsu"
         ]
@@ -9145,7 +9145,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is code splitting?",
-      "ja": "コードスプリッティングとは、どのようなものですか？"
+      "ja": "コードスプリッティングとは何か？"
     },
     "question_text_reading": {
       "en": "What is code splitting?",
@@ -9156,7 +9156,7 @@
     "choices": [
       {
         "en": "loads and executes script asynchronously",
-        "ja": "すくりぷとをひどうきにろーどじっこう",
+        "ja": "スクリプトを非同期にロード実行",
         "ja_typings": [
           "sukuriputohidokinirodojikko",
           "sukuriputoohidoukinirodojikkou"
@@ -9164,7 +9164,7 @@
       },
       {
         "en": "prevents script execution",
-        "ja": "すくりぷとじっこうをぼうし",
+        "ja": "スクリプト実行を防止",
         "ja_typings": [
           "sukuriputojikkooboshi",
           "sukuriputojikkouoboushi"
@@ -9172,7 +9172,7 @@
       },
       {
         "en": "caches the script",
-        "ja": "すくりぷとをきゃっしゅ",
+        "ja": "スクリプトをキャッシュ",
         "ja_typings": [
           "sukuriputokyasshu",
           "sukuriputookyasshu"
@@ -9180,7 +9180,7 @@
       },
       {
         "en": "loads script synchronously",
-        "ja": "どうきにすくりぷとをろーど",
+        "ja": "同期にスクリプトをロード",
         "ja_typings": [
           "dokinisukuriputorodo",
           "doukinisukuriputoorodo"
@@ -9204,7 +9204,7 @@
     "choices": [
       {
         "en": "open standard for authorization",
-        "ja": "にんかのおーぷんきじゅん",
+        "ja": "認可のオープン標準",
         "ja_typings": [
           "ninkanopunkijun",
           "ninkanoopunkijun"
@@ -9212,7 +9212,7 @@
       },
       {
         "en": "password encryption method",
-        "ja": "ぱすわーどあんごうかほうほう",
+        "ja": "パスワード暗号化方法",
         "ja_typings": [
           "pasuwadoangokahoho",
           "pasuwadoangoukahouhou"
@@ -9220,7 +9220,7 @@
       },
       {
         "en": "object authentication",
-        "ja": "おぶじぇくとにんしょう",
+        "ja": "オブジェクト認証",
         "ja_typings": [
           "obujekutoninsho",
           "obujekutoninshou"
@@ -9228,7 +9228,7 @@
       },
       {
         "en": "online API handler",
-        "ja": "おんらいんAPIはんどらー",
+        "ja": "オンラインAPIハンドラー",
         "ja_typings": [
           "onrainapihandora"
         ]
@@ -9251,7 +9251,7 @@
     "choices": [
       {
         "en": "JSON Web Token for auth",
-        "ja": "にんしょうようのJSONうぇぶとーくん",
+        "ja": "認証用のJSON Web Token",
         "ja_typings": [
           "ninshoyonojsonwebutokun",
           "ninshouyounojsonwebutokun"
@@ -9259,21 +9259,21 @@
       },
       {
         "en": "JavaScript Web Tool",
-        "ja": "JavaScriptうぶえぶつーる",
+        "ja": "JavaScriptウェブツール",
         "ja_typings": [
           "javascriptubuebutsuru"
         ]
       },
       {
         "en": "JSON Writer Template",
-        "ja": "JSONきじゅつてんぷれーと",
+        "ja": "JSON記述テンプレート",
         "ja_typings": [
           "jsonkijutsutenpureto"
         ]
       },
       {
         "en": "Java Web Transaction",
-        "ja": "Javaうぇぶとらんざくしょん",
+        "ja": "Javaウェブトランザクション",
         "ja_typings": [
           "javawebutoranzakushon"
         ]
@@ -9296,28 +9296,28 @@
     "choices": [
       {
         "en": "backend content management without frontend",
-        "ja": "ふろんとえんどなしのCMS",
+        "ja": "フロントエンドなしのCMS",
         "ja_typings": [
           "furontoendonashinocms"
         ]
       },
       {
         "en": "CMS without user interface",
-        "ja": "ゆーざーいんたーふぇーすなしCMS",
+        "ja": "ユーザーインターフェースなしCMS",
         "ja_typings": [
           "yuzaintafesunashicms"
         ]
       },
       {
         "en": "CMS stored in cloud",
-        "ja": "くらうどほぞんのCMS",
+        "ja": "クラウド保存のCMS",
         "ja_typings": [
           "kuraudohozonnocms"
         ]
       },
       {
         "en": "CMS for static sites only",
-        "ja": "せいてきさいとのみのCMS",
+        "ja": "静的サイトのみのCMS",
         "ja_typings": [
           "seitekisaitonominocms"
         ]
@@ -9329,7 +9329,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a headless CMS?",
-      "ja": "ヘッドレスCMSとは何ですか？"
+      "ja": "ヘッドレスCMSとは何か？"
     },
     "question_text_reading": {
       "en": "What is a headless CMS?",
@@ -9340,28 +9340,28 @@
     "choices": [
       {
         "en": "XML file listing site pages",
-        "ja": "さいとのぺーじをいちらんするXMLふぁいる",
+        "ja": "サイトのページを一覧するXMLファイル",
         "ja_typings": [
           "saitonopejioichiransuruxmlfairu"
         ]
       },
       {
         "en": "visual site design",
-        "ja": "びじゅあるなさいとせっけい",
+        "ja": "ビジュアルサイトデザイン",
         "ja_typings": [
           "bijuarunasaitosekkei"
         ]
       },
       {
         "en": "HTML navigation menu",
-        "ja": "HTMLなびげーしょんめにゅー",
+        "ja": "HTMLナビゲーションメニュー",
         "ja_typings": [
           "htmlnabigeshonmenyu"
         ]
       },
       {
         "en": "Google Analytics report",
-        "ja": "Googleアナリティクスレポート",
+        "ja": "Google Analytics report",
         "ja_typings": [
           "gogleanaritikusurepoto",
           "googleanaritikusurepoto"
@@ -9374,7 +9374,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a sitemap?",
-      "ja": "sitemapとは何ですか？"
+      "ja": "サイトマップとは何か？"
     },
     "question_text_reading": {
       "en": "What is a sitemap?",
@@ -9385,21 +9385,21 @@
     "choices": [
       {
         "en": "Search Engine Optimization",
-        "ja": "けんさくえんじんさいてきか",
+        "ja": "検索エンジン最適化",
         "ja_typings": [
           "kensakuenjinsaitekika"
         ]
       },
       {
         "en": "Secure Encoded Output",
-        "ja": "あんぜんなえんこーどしゅつりょく",
+        "ja": "安全なエンコード出力",
         "ja_typings": [
           "anzennaenkodoshutsuryoku"
         ]
       },
       {
         "en": "Server Environment Options",
-        "ja": "さーばーかんきょうせってい",
+        "ja": "サーバー環境設定",
         "ja_typings": [
           "sabakankyosettei",
           "sabakankyousettei"
@@ -9407,7 +9407,7 @@
       },
       {
         "en": "Static Element Object",
-        "ja": "せいてきようそおぶじぇくと",
+        "ja": "静的要素オブジェクト",
         "ja_typings": [
           "seitekiyosobujekuto",
           "seitekiyousoobujekuto"
@@ -9431,7 +9431,7 @@
     "choices": [
       {
         "en": "Google's page experience metrics",
-        "ja": "Googleのぺーじたいけんしひょう",
+        "ja": "Googleのページ体験指標",
         "ja_typings": [
           "goglenopejitaikenshihyo",
           "googlenopejitaikenshihyou"
@@ -9439,21 +9439,21 @@
       },
       {
         "en": "browser security standards",
-        "ja": "ぶらうざーせきゅりてぃきじゅん",
+        "ja": "ブラウザセキュリティスタンダード",
         "ja_typings": [
           "burauzasekyuritikijun"
         ]
       },
       {
         "en": "web development checklist",
-        "ja": "うぇぶかいはつちぇっくりすと",
+        "ja": "ウェブ開発チェックリスト",
         "ja_typings": [
           "webukaihatsuchekkurisuto"
         ]
       },
       {
         "en": "CSS performance metrics",
-        "ja": "CSSぱふぉーまんすしひょう",
+        "ja": "CSSパフォーマンス指標",
         "ja_typings": [
           "csspafomansushihyo",
           "csspafomansushihyou"
@@ -9466,7 +9466,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is Core Web Vitals?",
-      "ja": "Core Web Vitalsとは、どのような指標のことですか？"
+      "ja": "Core Web Vitalsとは何か？"
     },
     "question_text_reading": {
       "en": "What is Core Web Vitals?",
@@ -9477,7 +9477,7 @@
     "choices": [
       {
         "en": "Largest Contentful Paint",
-        "ja": "さいだいこんてんつのびょうが",
+        "ja": "最大コンテンツの描画",
         "ja_typings": [
           "saidaikontentsunobyoga",
           "saidaikontentsunobyouga"
@@ -9485,14 +9485,14 @@
       },
       {
         "en": "Lowest CPU Processing",
-        "ja": "さいていCPUしょり",
+        "ja": "最低CPU処理",
         "ja_typings": [
           "saiteicpushori"
         ]
       },
       {
         "en": "Longest Cache Period",
-        "ja": "さいちょうきゃっしゅきかん",
+        "ja": "最長キャッシュ期間",
         "ja_typings": [
           "saichokyasshukikan",
           "saichoukyasshukikan"
@@ -9500,7 +9500,7 @@
       },
       {
         "en": "Last Click Position",
-        "ja": "さいごのくりっくいち",
+        "ja": "最後のクリック位置",
         "ja_typings": [
           "saigonokurikkuichi"
         ]
@@ -9512,7 +9512,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does LCP stand for in web performance?",
-      "ja": "ウェブパフォーマンスにおけるLCPとは何の略ですか？"
+      "ja": "ウェブパフォーマンスのLCPとは？"
     },
     "question_text_reading": {
       "en": "What does LCP stand for in web performance?",
@@ -9523,28 +9523,28 @@
     "choices": [
       {
         "en": "JSON file describing PWA app",
-        "ja": "PWAを説明するJSONふぁいる",
+        "ja": "PWAを説明するJSONファイル",
         "ja_typings": [
           "pwaosurujsonfairu"
         ]
       },
       {
         "en": "CSS configuration file",
-        "ja": "CSS設定ふぁいる",
+        "ja": "CSS設定ファイル",
         "ja_typings": [
           "cssfairu"
         ]
       },
       {
         "en": "server routing config",
-        "ja": "さーばーるーてぃんぐせってい",
+        "ja": "サーバールーティング設定",
         "ja_typings": [
           "sabarutingusettei"
         ]
       },
       {
         "en": "list of site dependencies",
-        "ja": "さいとのいぞんかんけいいちらん",
+        "ja": "サイトの依存関係一覧",
         "ja_typings": [
           "saitonoizonkankeiichiran"
         ]
@@ -9556,7 +9556,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a web manifest file?",
-      "ja": "ウェブマニフェストファイルとは何ですか？"
+      "ja": "ウェブマニフェストファイルとは？"
     },
     "question_text_reading": {
       "en": "What is a web manifest file?",
@@ -9567,7 +9567,7 @@
     "choices": [
       {
         "en": "same code renders on server and client",
-        "ja": "どうじこーどをさーばーとくらいあんとでれんだー",
+        "ja": "同時コードをサーバーとクライアントでレンダリング",
         "ja_typings": [
           "dojikodosabatokuraiantoderenda",
           "doujikodoosabatokuraiantoderenda"
@@ -9575,21 +9575,21 @@
       },
       {
         "en": "rendering only on client",
-        "ja": "くらいあんとのみれんだー",
+        "ja": "クライアントのみレンダリング",
         "ja_typings": [
           "kuraiantonomirenda"
         ]
       },
       {
         "en": "rendering only on server",
-        "ja": "さーばーのみれんだー",
+        "ja": "サーバーのみレンダリング",
         "ja_typings": [
           "sabanomirenda"
         ]
       },
       {
         "en": "rendering in parallel",
-        "ja": "へいこうれんだー",
+        "ja": "並列レンダリング",
         "ja_typings": [
           "heikorenda",
           "heikourenda"
@@ -9602,7 +9602,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is isomorphic rendering?",
-      "ja": "isomorphic renderingとはどのようなものですか？"
+      "ja": "Isomorphic renderingとは？"
     },
     "question_text_reading": {
       "en": "What is isomorphic rendering?",
@@ -9613,7 +9613,7 @@
     "choices": [
       {
         "en": "fast frontend build tool",
-        "ja": "こうそくふろんとえんどびるどつーる",
+        "ja": "高速フロントエンドビルドツール",
         "ja_typings": [
           "kosokufurontoendobirudotsuru",
           "kousokufurontoendobirudotsuru"
@@ -9621,7 +9621,7 @@
       },
       {
         "en": "Vue.js only bundler",
-        "ja": "Vue.jsせんようばんどらー",
+        "ja": "Vue.js専用バンドラー",
         "ja_typings": [
           "vue.jssenyobandora",
           "vue.jssenyoubandora"
@@ -9629,14 +9629,14 @@
       },
       {
         "en": "CSS preprocessor",
-        "ja": "CSSぷりぷろせっさ",
+        "ja": "CSSプリプロセッサ",
         "ja_typings": [
           "csspuripurosessa"
         ]
       },
       {
         "en": "backend web server",
-        "ja": "ばっくえんどうぇぶさーばー",
+        "ja": "バックエンドウェブサーバー",
         "ja_typings": [
           "bakkuendowebusaba"
         ]
@@ -9659,28 +9659,28 @@
     "choices": [
       {
         "en": "JavaScript linting tool",
-        "ja": "JavaScriptのりんたー",
+        "ja": "JavaScriptのリンター",
         "ja_typings": [
           "javascriptnorinta"
         ]
       },
       {
         "en": "ES6 compiler",
-        "ja": "ES6こんぱいら",
+        "ja": "ES6コンパイラ",
         "ja_typings": [
           "es6konpaira"
         ]
       },
       {
         "en": "JavaScript bundler",
-        "ja": "JavaScriptばんどらー",
+        "ja": "JavaScriptバンドラー",
         "ja_typings": [
           "javascriptbandora"
         ]
       },
       {
         "en": "Express server middleware",
-        "ja": "Expressさーばーみどるうぇあ",
+        "ja": "Expressサーバーミドルウェア",
         "ja_typings": [
           "expresssabamidoruwea"
         ]
@@ -9703,28 +9703,28 @@
     "choices": [
       {
         "en": "opinionated code formatter",
-        "ja": "独自方針のこーどふぉーまったー",
+        "ja": "独自方針のコードフォーマッター",
         "ja_typings": [
           "nokodofomatta"
         ]
       },
       {
         "en": "CSS preprocessor",
-        "ja": "CSSぷりぷろせっさ",
+        "ja": "CSSプリプロセッサ",
         "ja_typings": [
           "csspuripurosessa"
         ]
       },
       {
         "en": "JavaScript linter",
-        "ja": "JavaScriptりんたー",
+        "ja": "JavaScriptリンター",
         "ja_typings": [
           "javascriptrinta"
         ]
       },
       {
         "en": "package manager",
-        "ja": "ぱっけーじまねーじゃ",
+        "ja": "パッケージマネージャー",
         "ja_typings": [
           "pakkejimaneja"
         ]
@@ -9747,7 +9747,7 @@
     "choices": [
       {
         "en": "metadata sent with request/response",
-        "ja": "りくえすと/おうとうとともにおくるめたでーた",
+        "ja": "リクエスト/レスポンスとともに送るメタデータ",
         "ja_typings": [
           "rikuesuto/otototomoniokurumetadeta",
           "rikuesuto/outoutotomoniokurumetadeta"
@@ -9755,21 +9755,21 @@
       },
       {
         "en": "page title in HTML",
-        "ja": "HTMLのぺーじたいとる",
+        "ja": "HTMLのページタイトル",
         "ja_typings": [
           "htmlnopejitaitoru"
         ]
       },
       {
         "en": "CSS heading style",
-        "ja": "CSSのみだしすたいる",
+        "ja": "CSS見出しスタイル",
         "ja_typings": [
           "cssnomidashisutairu"
         ]
       },
       {
         "en": "database column header",
-        "ja": "でーたべーすれつみだし",
+        "ja": "データベース列見出し",
         "ja_typings": [
           "detabesuretsumidashi"
         ]
@@ -9781,7 +9781,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is an HTTP header?",
-      "ja": "HTTPへっだーとは何か？"
+      "ja": "HTTPヘッダーとは何か？"
     },
     "question_text_reading": {
       "en": "What is an HTTP header?",
@@ -9792,28 +9792,28 @@
     "choices": [
       {
         "en": "resource not found",
-        "ja": "りそーすがみつからない",
+        "ja": "リソースが見つからない",
         "ja_typings": [
           "risosugamitsukaranai"
         ]
       },
       {
         "en": "server internal error",
-        "ja": "さーばーないぶえらー",
+        "ja": "サーバー内部エラー",
         "ja_typings": [
           "sabanaibuera"
         ]
       },
       {
         "en": "access forbidden",
-        "ja": "アクセスきんし",
+        "ja": "アクセス禁止",
         "ja_typings": [
           "akusesukinshi"
         ]
       },
       {
         "en": "connection timeout",
-        "ja": "せつぞくたいむあうと",
+        "ja": "接続タイムアウト",
         "ja_typings": [
           "setsuzokutaimuauto"
         ]
@@ -9825,7 +9825,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a 404 error?",
-      "ja": "404えらーとは何か？"
+      "ja": "404 errorとは何か？"
     },
     "question_text_reading": {
       "en": "What is a 404 error?",
@@ -9836,28 +9836,28 @@
     "choices": [
       {
         "en": "internal server error",
-        "ja": "さーばーないぶえらー",
+        "ja": "サーバー内部エラー",
         "ja_typings": [
           "sabanaibuera"
         ]
       },
       {
         "en": "resource not found",
-        "ja": "りそーすがみつからない",
+        "ja": "リソースが見つからない",
         "ja_typings": [
           "risosugamitsukaranai"
         ]
       },
       {
         "en": "access forbidden",
-        "ja": "アクセスきんし",
+        "ja": "アクセス禁止",
         "ja_typings": [
           "akusesukinshi"
         ]
       },
       {
         "en": "redirect response",
-        "ja": "りだいれくとおうとう",
+        "ja": "リダイレクトレスポンス",
         "ja_typings": [
           "ridairekutouto",
           "ridairekutooutou"
@@ -9870,7 +9870,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a 500 error?",
-      "ja": "500えらーとは何か？"
+      "ja": "500 errorとは何か？"
     },
     "question_text_reading": {
       "en": "What is a 500 error?",
@@ -9881,7 +9881,7 @@
     "choices": [
       {
         "en": "response telling client to go to new URL",
-        "ja": "あたらしいURLへいどうするおうとう",
+        "ja": "新しいURLへ移動する応答",
         "ja_typings": [
           "atarashiiurlheidosuruoto",
           "atarashiiurlheidousuruoutou"
@@ -9889,7 +9889,7 @@
       },
       {
         "en": "caching server response",
-        "ja": "さーばーおうとうをきゃっしゅ",
+        "ja": "サーバー応答をキャッシュ",
         "ja_typings": [
           "sabaotookyasshu",
           "sabaoutouokyasshu"
@@ -9897,7 +9897,7 @@
       },
       {
         "en": "compressing response body",
-        "ja": "おうとうぼでぃをあっしゅく",
+        "ja": "応答ボディを圧縮",
         "ja_typings": [
           "otobodioasshuku",
           "outoubodioasshuku"
@@ -9905,7 +9905,7 @@
       },
       {
         "en": "blocking client request",
-        "ja": "くらいあんとりくえすとをそしょ",
+        "ja": "ブロッキングクライアントリクエストを阻止",
         "ja_typings": [
           "kuraiantorikuesutososho",
           "kuraiantorikuesutoososho"
@@ -9918,7 +9918,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a redirect in HTTP?",
-      "ja": "HTTPにおけるリダイレクトとは何ですか？"
+      "ja": "HTTPのリダイレクトとは何か？"
     },
     "question_text_reading": {
       "en": "What is a redirect in HTTP?",
@@ -9929,14 +9929,14 @@
     "choices": [
       {
         "en": "escaping user input",
-        "ja": "ゆーざーにゅうりょくをえすけーぷ",
+        "ja": "ユーザー入力をエスケープ",
         "ja_typings": [
           "yuzanyuuryokuoesukepu"
         ]
       },
       {
         "en": "encrypting all data",
-        "ja": "すべてのでーたをあんごうか",
+        "ja": "すべてのデータを暗号化",
         "ja_typings": [
           "subetenodetaoangoka",
           "subetenodetaoangouka"
@@ -9944,14 +9944,14 @@
       },
       {
         "en": "using HTTPS",
-        "ja": "HTTPSをつかう",
+        "ja": "HTTPSを使う",
         "ja_typings": [
           "httpsotsukau"
         ]
       },
       {
         "en": "disabling JavaScript",
-        "ja": "JavaScriptをむこうか",
+        "ja": "JavaScriptを無効化",
         "ja_typings": [
           "javascriptomukoka",
           "javascriptomukouka"
@@ -9975,7 +9975,7 @@
     "choices": [
       {
         "en": "HTTP header controlling resource loading",
-        "ja": "りそーすろーどをせいぎょするHTTPへっだー",
+        "ja": "リソースロードを制御するHTTPヘッダー",
         "ja_typings": [
           "risosurodoseigyosuruhttphedda",
           "risosurodooseigyosuruhttphedda"
@@ -9983,21 +9983,21 @@
       },
       {
         "en": "cookie security setting",
-        "ja": "くっきーのせきゅりてぃせってい",
+        "ja": "クッキーのセキュリティ設定",
         "ja_typings": [
           "kukkinosekyuritisettei"
         ]
       },
       {
         "en": "CORS configuration",
-        "ja": "CORSのせってい",
+        "ja": "CORSの設定",
         "ja_typings": [
           "corsnosettei"
         ]
       },
       {
         "en": "SSL certificate policy",
-        "ja": "SSLしょうめいしょのぽりしー",
+        "ja": "SSL証明書のポリシー",
         "ja_typings": [
           "sslshomeishonoporishi",
           "sslshoumeishonoporishi"
@@ -10010,7 +10010,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is Content Security Policy?",
-      "ja": "Content Security Policy（CSP）とは、どのようなものですか？"
+      "ja": "コンテンツセキュリティポリシーとは何か？"
     },
     "question_text_reading": {
       "en": "What is Content Security Policy?",
@@ -10021,7 +10021,7 @@
     "choices": [
       {
         "en": "URL that accepts API requests",
-        "ja": "APIりくえすとをうけつけるURL",
+        "ja": "APIリクエストを受け付けるURL",
         "ja_typings": [
           "apirikuesutouketsukeruurl",
           "apirikuesutoouketsukeruurl"
@@ -10029,21 +10029,21 @@
       },
       {
         "en": "server hostname",
-        "ja": "さーばーのほすとめい",
+        "ja": "サーバーのホスト名",
         "ja_typings": [
           "sabanohosutomei"
         ]
       },
       {
         "en": "database connection string",
-        "ja": "でーたべーすせつぞくもじれつ",
+        "ja": "データベース接続文字列",
         "ja_typings": [
           "detabesusetsuzokumojiretsu"
         ]
       },
       {
         "en": "frontend route",
-        "ja": "ふろんとえんどるーと",
+        "ja": "フロントエンドルート",
         "ja_typings": [
           "furontoendoruto"
         ]
@@ -10055,7 +10055,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a REST endpoint?",
-      "ja": "RESTエンドポイントとは何ですか？"
+      "ja": "RESTエンドポイントとは何か？"
     },
     "question_text_reading": {
       "en": "What is a REST endpoint?",
@@ -10066,7 +10066,7 @@
     "choices": [
       {
         "en": "handling events on parent for children",
-        "ja": "おやがこどもののいべんとをしょり",
+        "ja": "親が子どものイベントを処理",
         "ja_typings": [
           "oyagakodomononoibentoshori",
           "oyagakodomononoibentooshori"
@@ -10074,7 +10074,7 @@
       },
       {
         "en": "delegating events to server",
-        "ja": "いべんとをさーばーにいにん",
+        "ja": "イベントをサーバーに委任",
         "ja_typings": [
           "ibentosabaniinin",
           "ibentoosabaniinin"
@@ -10082,7 +10082,7 @@
       },
       {
         "en": "preventing event bubbling",
-        "ja": "いべんとばぶりんぐをぼうし",
+        "ja": "イベントバブリングを防止",
         "ja_typings": [
           "ibentobaburinguoboshi",
           "ibentobaburinguoboushi"
@@ -10090,7 +10090,7 @@
       },
       {
         "en": "creating custom events",
-        "ja": "かすたむいべんとをさくせい",
+        "ja": "カスタムイベントを作成",
         "ja_typings": [
           "kasutamuibentosakusei",
           "kasutamuibentoosakusei"
@@ -10103,7 +10103,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is event delegation in JS?",
-      "ja": "JSにおけるイベントデリゲーションとは何ですか？"
+      "ja": "JSのイベントデリゲーションとは？"
     },
     "question_text_reading": {
       "en": "What is event delegation in JS?",
@@ -10114,7 +10114,7 @@
     "choices": [
       {
         "en": "delaying function until input stops",
-        "ja": "にゅうりょくがとまるまでかんすうをおくらす",
+        "ja": "入力が止まるまで関数を遅らす",
         "ja_typings": [
           "nyuuryokugatomarumadekansuuokurasu",
           "nyuuryokugatomarumadekansuuookurasu"
@@ -10122,14 +10122,14 @@
       },
       {
         "en": "cancelling previous function call",
-        "ja": "まえのかんすうよびだしをキャンセル",
+        "ja": "前の関数呼び出しをキャンセル",
         "ja_typings": [
           "maenokansuuyobidashiokyanseru"
         ]
       },
       {
         "en": "batching multiple events",
-        "ja": "ふくすうのいべんとをまとめる",
+        "ja": "複数のイベントをまとめる",
         "ja_typings": [
           "fukusuunoibentomatomeru",
           "fukusuunoibentoomatomeru"
@@ -10137,7 +10137,7 @@
       },
       {
         "en": "filtering duplicate events",
-        "ja": "じゅうふくいべんとをふぃるたー",
+        "ja": "重複イベントをフィルタリング",
         "ja_typings": [
           "juufukuibentofiruta",
           "juufukuibentoofiruta"
@@ -10150,7 +10150,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is debouncing in JS?",
-      "ja": "JSにおける「デバウンス（debouncing）」とは何ですか？"
+      "ja": "JSのデバウンスとは何か？"
     },
     "question_text_reading": {
       "en": "What is debouncing in JS?",
@@ -10161,7 +10161,7 @@
     "choices": [
       {
         "en": "limiting function call frequency",
-        "ja": "かんすうよびだしのひんどをせいげん",
+        "ja": "関数呼び出しの頻度を制限",
         "ja_typings": [
           "kansuuyobidashinohindoseigen",
           "kansuuyobidashinohindooseigen"
@@ -10169,7 +10169,7 @@
       },
       {
         "en": "slowing network speed",
-        "ja": "ねっとわーくそくどをおとす",
+        "ja": "ネットワーク速度を落とす",
         "ja_typings": [
           "nettowakusokudootosu",
           "nettowakusokudoootosu"
@@ -10177,7 +10177,7 @@
       },
       {
         "en": "compressing data transfer",
-        "ja": "でーたてんそうをあっしゅく",
+        "ja": "データ転送を圧縮",
         "ja_typings": [
           "detatensooasshuku",
           "detatensouoasshuku"
@@ -10185,7 +10185,7 @@
       },
       {
         "en": "delaying API response",
-        "ja": "APIおうとうをおくらす",
+        "ja": "API応答を流す",
         "ja_typings": [
           "apiotookurasu",
           "apioutouookurasu"
@@ -10198,7 +10198,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is throttling in JS?",
-      "ja": "JSにおける「throttling」とは何ですか？"
+      "ja": "JSのスロットリングとは何か？"
     },
     "question_text_reading": {
       "en": "What is throttling in JS?",
@@ -10209,7 +10209,7 @@
     "choices": [
       {
         "en": "reusable custom HTML element",
-        "ja": "さいりようかのうなかすたむHTMLようそ",
+        "ja": "再利用可能なカスタムHTML要素",
         "ja_typings": [
           "sairiyokanonakasutamuhtmlyoso",
           "sairiyoukanounakasutamuhtmlyouso"
@@ -10217,21 +10217,21 @@
       },
       {
         "en": "React component",
-        "ja": "Reactこんぽーねんと",
+        "ja": "Reactコンポーネント",
         "ja_typings": [
           "reactkonponento"
         ]
       },
       {
         "en": "server-side component",
-        "ja": "さーばーがわこんぽーねんと",
+        "ja": "サーバーサイドコンポーネント",
         "ja_typings": [
           "sabagawakonponento"
         ]
       },
       {
         "en": "CSS design component",
-        "ja": "CSSせっけいこんぽーねんと",
+        "ja": "CSS設計コンポーネント",
         "ja_typings": [
           "csssekkeikonponento"
         ]
@@ -10243,7 +10243,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a web component?",
-      "ja": "Web Componentとはどのようなものですか？"
+      "ja": "Web componentとは何か？"
     },
     "question_text_reading": {
       "en": "What is a web component?",
@@ -10254,7 +10254,7 @@
     "choices": [
       {
         "en": "storing responses to avoid refetching",
-        "ja": "さいとりこみをさけるおうとうのほぞん",
+        "ja": "再取得を避ける応答の保存",
         "ja_typings": [
           "saitorikomiosakeruotonohozon",
           "saitorikomiosakeruoutounohozon"
@@ -10262,21 +10262,21 @@
       },
       {
         "en": "server-side database cache",
-        "ja": "さーばーがわでーたべーすきゃっしゅ",
+        "ja": "サーバーサイドデータベースキャッシュ",
         "ja_typings": [
           "sabagawadetabesukyasshu"
         ]
       },
       {
         "en": "browser memory allocation",
-        "ja": "ぶらうざーめもりかくほ",
+        "ja": "ブラウザメモリ割り当て",
         "ja_typings": [
           "burauzamemorikakuho"
         ]
       },
       {
         "en": "CDN configuration",
-        "ja": "CDNのせってい",
+        "ja": "CDNの設定",
         "ja_typings": [
           "cdnnosettei"
         ]
@@ -10288,7 +10288,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is an HTTP cache?",
-      "ja": "HTTPキャッシュとは何ですか？"
+      "ja": "HTTPキャッシュとは何か？"
     },
     "question_text_reading": {
       "en": "What is an HTTP cache?",
@@ -10299,7 +10299,7 @@
     "choices": [
       {
         "en": "stateless authentication",
-        "ja": "むじょうたいにんしょう",
+        "ja": "無状態認証",
         "ja_typings": [
           "mujotaininsho",
           "mujoutaininshou"
@@ -10307,7 +10307,7 @@
       },
       {
         "en": "data encryption",
-        "ja": "でーたあんごうか",
+        "ja": "データ暗号化",
         "ja_typings": [
           "detaangoka",
           "detaangouka"
@@ -10315,14 +10315,14 @@
       },
       {
         "en": "database connection",
-        "ja": "でーたべーすせつぞく",
+        "ja": "データベース接続",
         "ja_typings": [
           "detabesusetsuzoku"
         ]
       },
       {
         "en": "HTML template rendering",
-        "ja": "HTMLてんぷれーとれんだー",
+        "ja": "HTMLテンプレートレンダリング",
         "ja_typings": [
           "htmltenpuretorenda"
         ]
@@ -10345,28 +10345,28 @@
     "choices": [
       {
         "en": "Vue.js full-stack framework",
-        "ja": "Vue.jsふるすたっくふれーむわーく",
+        "ja": "Vue.jsフルスタックフレームワーク",
         "ja_typings": [
           "vue.jsfurusutakkufuremuwaku"
         ]
       },
       {
         "en": "Node.js web server",
-        "ja": "Node.jsうぇぶさーばー",
+        "ja": "Node.jsウェブサーバー",
         "ja_typings": [
           "node.jswebusaba"
         ]
       },
       {
         "en": "React SSR framework",
-        "ja": "ReactSSRふれーむわーく",
+        "ja": "React SSRフレームワーク",
         "ja_typings": [
           "reactssrfuremuwaku"
         ]
       },
       {
         "en": "JavaScript bundler",
-        "ja": "JavaScriptばんどらー",
+        "ja": "JavaScriptバンドラー",
         "ja_typings": [
           "javascriptbandora"
         ]
@@ -10389,14 +10389,14 @@
     "choices": [
       {
         "en": "static site builder with islands",
-        "ja": "あいらんどあーきてくちゃのせいてきさいとびるだー",
+        "ja": "アイランドアーキテクチャの静的サイトビルダー",
         "ja_typings": [
           "airandoakitekuchanoseitekisaitobiruda"
         ]
       },
       {
         "en": "JavaScript runtime",
-        "ja": "JavaScriptじっこうかんきょう",
+        "ja": "JavaScript実行環境",
         "ja_typings": [
           "javascriptjikkokankyo",
           "javascriptjikkoukankyou"
@@ -10404,14 +10404,14 @@
       },
       {
         "en": "CSS framework",
-        "ja": "CSSふれーむわーく",
+        "ja": "CSSフレームワーク",
         "ja_typings": [
           "cssfuremuwaku"
         ]
       },
       {
         "en": "database ORM",
-        "ja": "でーたべーすORM",
+        "ja": "データベースORM",
         "ja_typings": [
           "detabesuorm"
         ]
@@ -10434,7 +10434,7 @@
     "choices": [
       {
         "en": "single repo containing multiple projects",
-        "ja": "ふくすうぷろじぇくトをふくむひとつのりぽ",
+        "ja": "複数のプロジェクトを含む一つのリポジトリ",
         "ja_typings": [
           "fukusuupurojekutofukumuhitotsunoripo",
           "fukusuupurojekutoofukumuhitotsunoripo"
@@ -10442,21 +10442,21 @@
       },
       {
         "en": "read-only repository",
-        "ja": "どくとりのりぽじとり",
+        "ja": "ドクトリのリポジトリ",
         "ja_typings": [
           "dokutorinoripojitori"
         ]
       },
       {
         "en": "monolithic backend app",
-        "ja": "ものりしっくばっくえんどあぷり",
+        "ja": "モノリシックバックエンドアプリ",
         "ja_typings": [
           "monorishikkubakkuendoapuri"
         ]
       },
       {
         "en": "private fork repository",
-        "ja": "ぷらいべーとふぉーくりぽ",
+        "ja": "プライベートフォークリポジトリ",
         "ja_typings": [
           "puraibetofokuripo"
         ]
@@ -10468,7 +10468,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a monorepo?",
-      "ja": "モノレポとは何ですか？"
+      "ja": "モノレポとは何か？"
     },
     "question_text_reading": {
       "en": "What is a monorepo?",
@@ -10479,28 +10479,28 @@
     "choices": [
       {
         "en": "tool for developing UI components in isolation",
-        "ja": "こんぽーねんたをとくりつかいはつするつーる",
+        "ja": "コンポーネントを独立して開発するためのツール",
         "ja_typings": [
           "konponentaotokuritsukaihatsusurutsuru"
         ]
       },
       {
         "en": "documentation generator",
-        "ja": "どきゅめんとせいせいき",
+        "ja": "ドキュメントジェネレーター",
         "ja_typings": [
           "dokyumentoseiseiki"
         ]
       },
       {
         "en": "e2e testing framework",
-        "ja": "e2eてすとふれーむわーく",
+        "ja": "e2eテストフレームワーク",
         "ja_typings": [
           "e2etesutofuremuwaku"
         ]
       },
       {
         "en": "CSS component library",
-        "ja": "CSSこんぽーねんとらいぶらり",
+        "ja": "CSSコンポーネントライブラリ",
         "ja_typings": [
           "csskonponentoraiburari"
         ]
@@ -10523,7 +10523,7 @@
     "choices": [
       {
         "en": "browser automation and e2e testing tool",
-        "ja": "ぶらうざーじどうかとe2eてすとつーる",
+        "ja": "ブラウザ自動化とE2Eテストツール",
         "ja_typings": [
           "burauzajidokatoe2etesutotsuru",
           "burauzajidoukatoe2etesutotsuru"
@@ -10531,21 +10531,21 @@
       },
       {
         "en": "React component library",
-        "ja": "Reactこんぽーねんとらいぶらり",
+        "ja": "Reactコンポーネントライブラリ",
         "ja_typings": [
           "reactkonponentoraiburari"
         ]
       },
       {
         "en": "JavaScript bundler",
-        "ja": "JavaScriptばんどらー",
+        "ja": "JavaScriptバンドラー",
         "ja_typings": [
           "javascriptbandora"
         ]
       },
       {
         "en": "CSS animation framework",
-        "ja": "CSSあにめーしょんふれーむわーく",
+        "ja": "CSSアニメーションフレームワーク",
         "ja_typings": [
           "cssanimeshonfuremuwaku"
         ]
@@ -10568,28 +10568,28 @@
     "choices": [
       {
         "en": "end-to-end type-safe API",
-        "ja": "えんどつーえんどがたあんぜんAPI",
+        "ja": "エンドツーエンド型安全API",
         "ja_typings": [
           "endotsuendogataanzenapi"
         ]
       },
       {
         "en": "TypeScript RPC library",
-        "ja": "TypeScriptRPCらいぶらり",
+        "ja": "TypeScript RPCライブラリ",
         "ja_typings": [
           "typescriptrpcraiburari"
         ]
       },
       {
         "en": "remote database client",
-        "ja": "りもーとでーたべーすくらいあんと",
+        "ja": "リモートデータベースクライアント",
         "ja_typings": [
           "rimotodetabesukuraianto"
         ]
       },
       {
         "en": "React state manager",
-        "ja": "Reactじょうたいかんり",
+        "ja": "React状態管理",
         "ja_typings": [
           "reactjotaikanri",
           "reactjoutaikanri"
@@ -10613,28 +10613,28 @@
     "choices": [
       {
         "en": "serverless compute at edge",
-        "ja": "えっじのさーばーれすけいさん",
+        "ja": "エッジのサーバーレスコンピューティング",
         "ja_typings": [
           "ejjinosabaresukeisan"
         ]
       },
       {
         "en": "cloud storage service",
-        "ja": "くらうどすとれーじさーびす",
+        "ja": "クラウドストレージサービス",
         "ja_typings": [
           "kuraudosutorejisabisu"
         ]
       },
       {
         "en": "DNS management tool",
-        "ja": "DNSかんりつーる",
+        "ja": "DNS管理ツール",
         "ja_typings": [
           "dnskanritsuru"
         ]
       },
       {
         "en": "CDN only service",
-        "ja": "CDNのみのさーびす",
+        "ja": "CDNのみのサービス",
         "ja_typings": [
           "cdnnominosabisu"
         ]
@@ -10657,28 +10657,28 @@
     "choices": [
       {
         "en": "frontend cloud deployment platform",
-        "ja": "ふろんとえんどくらうどはいひぷらっとふぉーむ",
+        "ja": "フロントエンドクラウドデプロイメントプラットフォーム",
         "ja_typings": [
           "furontoendokuraudohaihipurattofomu"
         ]
       },
       {
         "en": "backend server framework",
-        "ja": "ばっくえんどさーばーふれーむわーく",
+        "ja": "バックエンドサーバーフレームワーク",
         "ja_typings": [
           "bakkuendosabafuremuwaku"
         ]
       },
       {
         "en": "containerization service",
-        "ja": "こんてなかさーびす",
+        "ja": "コンテナ化サービス",
         "ja_typings": [
           "kontenakasabisu"
         ]
       },
       {
         "en": "database hosting",
-        "ja": "でーたべーすほすてぃんぐ",
+        "ja": "データベースホスティング",
         "ja_typings": [
           "detabesuhosutingu"
         ]
@@ -10701,28 +10701,28 @@
     "choices": [
       {
         "en": "tells crawlers which pages to skip",
-        "ja": "くろーらーにどのぺーじをとばすかつたえる",
+        "ja": "クローラーにどのページを飛ばすか伝える",
         "ja_typings": [
           "kuroranidonopejiotobasukatsutaeru"
         ]
       },
       {
         "en": "defines site security rules",
-        "ja": "さいとのせきゅりてぃるーるをていぎ",
+        "ja": "サイトのセキュリティルールを定義",
         "ja_typings": [
           "saitonosekyuritiruruoteigi"
         ]
       },
       {
         "en": "configures web server",
-        "ja": "うぇぶさーばーをせってい",
+        "ja": "ウェブサーバーを設定",
         "ja_typings": [
           "webusabaosettei"
         ]
       },
       {
         "en": "lists all site pages",
-        "ja": "すべてのさいとぺーじをいちらん",
+        "ja": "すべてのサイトページを一覧",
         "ja_typings": [
           "subetenosaitopejioichiran"
         ]
@@ -10734,7 +10734,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the purpose of `robots.txt`?",
-      "ja": "`robots.txt`の目的は？"
+      "ja": "robots.txtの目的は？"
     },
     "question_text_reading": {
       "en": "What is the purpose of `robots.txt`?",
@@ -10745,28 +10745,28 @@
     "choices": [
       {
         "en": "metadata for social sharing previews",
-        "ja": "SNSしぇあのぷれびゅーめたでーた",
+        "ja": "SNSシェアのプレビューデータ",
         "ja_typings": [
           "snssheanopurebyumetadeta"
         ]
       },
       {
         "en": "graph database protocol",
-        "ja": "ぐらふでーたべーすぷろとこる",
+        "ja": "グラフデータベースプロトコル",
         "ja_typings": [
           "gurafudetabesupurotokoru"
         ]
       },
       {
         "en": "open source API standard",
-        "ja": "おーぷんそーすAPIきじゅん",
+        "ja": "オープンソースAPI標準",
         "ja_typings": [
           "opunsosuapikijun"
         ]
       },
       {
         "en": "network graph routing",
-        "ja": "ねっとわーくぐらふるーてぃんぐ",
+        "ja": "ネットワークグラフルーティング",
         "ja_typings": [
           "nettowakugurafurutingu"
         ]
@@ -10778,7 +10778,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is open graph protocol?",
-      "ja": "open graph protocolとはどのようなものですか？"
+      "ja": "Open Graph Protocolとは？"
     },
     "question_text_reading": {
       "en": "What is open graph protocol?",
@@ -10789,7 +10789,7 @@
     "choices": [
       {
         "en": "software managing hardware and software",
-        "ja": "はーどとそふとをかんりするそふとうぇあ",
+        "ja": "ハードとソフトを管理するソフトウェア",
         "ja_typings": [
           "hadotosofutokanrisurusofutowea",
           "hadotosofutookanrisurusofutowea"
@@ -10797,21 +10797,21 @@
       },
       {
         "en": "programming language",
-        "ja": "ぷろぐらみんぐげんご",
+        "ja": "プログラミング言語",
         "ja_typings": [
           "puroguramingugengo"
         ]
       },
       {
         "en": "database management system",
-        "ja": "でーたべーすかんりしすてむ",
+        "ja": "データベース管理システム",
         "ja_typings": [
           "detabesukanrishisutemu"
         ]
       },
       {
         "en": "network protocol",
-        "ja": "ねっとわーくぷろとこる",
+        "ja": "ネットワークプロトコル",
         "ja_typings": [
           "nettowakupurotokoru"
         ]
@@ -10823,7 +10823,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is an operating system?",
-      "ja": "オペレーティングシステム（OS）とは、どのようなものですか？"
+      "ja": "オペレーティングシステムとは何か？"
     },
     "question_text_reading": {
       "en": "What is an operating system?",
@@ -10834,7 +10834,7 @@
     "choices": [
       {
         "en": "running multiple OS on one hardware",
-        "ja": "いちはーどでふくすうOSをじっこう",
+        "ja": "一ハードで複数OSを実行",
         "ja_typings": [
           "ichihadodefukusuuosojikko",
           "ichihadodefukusuuosojikkou"
@@ -10842,7 +10842,7 @@
       },
       {
         "en": "increasing CPU speed",
-        "ja": "CPUそくどをあげる",
+        "ja": "CPU速度を上げる",
         "ja_typings": [
           "cpusokudoageru",
           "cpusokudooageru"
@@ -10850,14 +10850,14 @@
       },
       {
         "en": "compressing disk data",
-        "ja": "でぃすくでーたをあっしゅく",
+        "ja": "ディスクデータを圧縮",
         "ja_typings": [
           "disukudetaoasshuku"
         ]
       },
       {
         "en": "networking two computers",
-        "ja": "にたいのPCをつなぐ",
+        "ja": "二台のPCをつなぐ",
         "ja_typings": [
           "nitainopcotsunagu"
         ]
@@ -10869,7 +10869,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is virtualization?",
-      "ja": "仮想化とはどのようなものですか？"
+      "ja": "仮想化とは何か？"
     },
     "question_text_reading": {
       "en": "What is virtualization?",
@@ -10880,28 +10880,28 @@
     "choices": [
       {
         "en": "core of operating system",
-        "ja": "OSのかくしん",
+        "ja": "OSの核心",
         "ja_typings": [
           "osnokakushin"
         ]
       },
       {
         "en": "user application",
-        "ja": "ゆーざーあぷりけーしょん",
+        "ja": "ユーザーアプリケーション",
         "ja_typings": [
           "yuzaapurikeshon"
         ]
       },
       {
         "en": "network driver",
-        "ja": "ねっとわーくどらいばー",
+        "ja": "ネットワークドライバー",
         "ja_typings": [
           "nettowakudoraiba"
         ]
       },
       {
         "en": "file system type",
-        "ja": "ふぁいるしすてむのしゅるい",
+        "ja": "ファイルシステムの種類",
         "ja_typings": [
           "fairushisutemunoshurui"
         ]
@@ -10913,7 +10913,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a kernel?",
-      "ja": "カーネルとは何ですか？"
+      "ja": "カーネルとは何か？"
     },
     "question_text_reading": {
       "en": "What is a kernel?",
@@ -10924,7 +10924,7 @@
     "choices": [
       {
         "en": "firmware initializing hardware at boot",
-        "ja": "きどうじにはーどをしょきかするふぁーむうぇあ",
+        "ja": "起動時にハードを初期化するファームウェア",
         "ja_typings": [
           "kidojinihadoshokikasurufamuwea",
           "kidoujinihadooshokikasurufamuwea"
@@ -10932,21 +10932,21 @@
       },
       {
         "en": "operating system kernel",
-        "ja": "OSかーねる",
+        "ja": "OSカーネル",
         "ja_typings": [
           "oskaneru"
         ]
       },
       {
         "en": "disk partition tool",
-        "ja": "でぃすくぱーてぃしょんつーる",
+        "ja": "ディスクパーティションツール",
         "ja_typings": [
           "disukupatishontsuru"
         ]
       },
       {
         "en": "network configuration",
-        "ja": "ねっとわーくせってい",
+        "ja": "ネットワーク設定",
         "ja_typings": [
           "nettowakusettei"
         ]
@@ -10969,28 +10969,28 @@
     "choices": [
       {
         "en": "Solid State Drive",
-        "ja": "そりっどすてーとどらいぶ",
+        "ja": "ソリッドステートドライブ",
         "ja_typings": [
           "soriddosutetodoraibu"
         ]
       },
       {
         "en": "Secure Storage Device",
-        "ja": "あんぜんすとれーじでばいす",
+        "ja": "安全ストレージデバイス",
         "ja_typings": [
           "anzensutorejidebaisu"
         ]
       },
       {
         "en": "Software Simulation Disk",
-        "ja": "そふとうぇあしみゅれーしょんでぃすく",
+        "ja": "ソフトウェアシミュレーションディスク",
         "ja_typings": [
           "sofutoweashimyureshondisuku"
         ]
       },
       {
         "en": "System Status Drive",
-        "ja": "しすてむじょうたいどらいぶ",
+        "ja": "システム状態ドライブ",
         "ja_typings": [
           "shisutemujotaidoraibu",
           "shisutemujoutaidoraibu"
@@ -11014,21 +11014,21 @@
     "choices": [
       {
         "en": "Random Access Memory",
-        "ja": "らんだむあくせすめもり",
+        "ja": "ランダムアクセスメモリ",
         "ja_typings": [
           "randamuakusesumemori"
         ]
       },
       {
         "en": "Read-only Archive Memory",
-        "ja": "どくとりあーかいぶめもり",
+        "ja": "ドキュアカイブメモリ",
         "ja_typings": [
           "dokutoriakaibumemori"
         ]
       },
       {
         "en": "Rapid Application Module",
-        "ja": "こうそくあぷりけーしょんもじゅーる",
+        "ja": "高速アプリケーションモジュール",
         "ja_typings": [
           "kosokuapurikeshonmojuru",
           "kousokuapurikeshonmojuru"
@@ -11036,7 +11036,7 @@
       },
       {
         "en": "Remote Access Machine",
-        "ja": "りもーとあくせすましん",
+        "ja": "リモートアクセスマシン",
         "ja_typings": [
           "rimotoakusesumashin"
         ]
@@ -11059,7 +11059,7 @@
     "choices": [
       {
         "en": "Central Processing Unit",
-        "ja": "ちゅうおうしょりそうち",
+        "ja": "中央処理装置",
         "ja_typings": [
           "chuuoshorisochi",
           "chuuoushorisouchi"
@@ -11067,21 +11067,21 @@
       },
       {
         "en": "Core Processing Utility",
-        "ja": "かーしょりゆーてぃりてぃ",
+        "ja": "コアプロセッシングユーティリティ",
         "ja_typings": [
           "kashoriyutiriti"
         ]
       },
       {
         "en": "Computer Power Unit",
-        "ja": "こんぴゅーたでんりょくたんい",
+        "ja": "コンピュータ電力単位",
         "ja_typings": [
           "konpyutadenryokutani"
         ]
       },
       {
         "en": "Cache Processing Unit",
-        "ja": "きゃっしゅしょりそうち",
+        "ja": "キャッシュ処理装置",
         "ja_typings": [
           "kyasshushorisochi",
           "kyasshushorisouchi"
@@ -11105,7 +11105,7 @@
     "choices": [
       {
         "en": "Graphics Processing Unit",
-        "ja": "ぐらふぃっくすしょりそうち",
+        "ja": "グラフィックスプロセッシングユニット",
         "ja_typings": [
           "gurafikkusushorisochi",
           "gurafikkusushorisouchi"
@@ -11113,7 +11113,7 @@
       },
       {
         "en": "General Program Utility",
-        "ja": "はんようぷろぐらむゆーてぃりてぃ",
+        "ja": "汎用プログラムユーティリティ",
         "ja_typings": [
           "hanyopuroguramuyutiriti",
           "hanyoupuroguramuyutiriti"
@@ -11121,14 +11121,14 @@
       },
       {
         "en": "Global Power Unit",
-        "ja": "ぐろーばるでんりょくたんい",
+        "ja": "グローバルパワーユニット",
         "ja_typings": [
           "gurobarudenryokutani"
         ]
       },
       {
         "en": "Grid Processing Unit",
-        "ja": "ぐりっどしょりそうち",
+        "ja": "グリッド処理装置",
         "ja_typings": [
           "guriddoshorisochi",
           "guriddoshorisouchi"
@@ -11152,21 +11152,21 @@
     "choices": [
       {
         "en": "internet communication protocol suite",
-        "ja": "いんたーねっとつうしんぷろとこるぐん",
+        "ja": "インターネット通信プロトコルスイート",
         "ja_typings": [
           "intanettotsuushinpurotokorugun"
         ]
       },
       {
         "en": "type of CPU instruction",
-        "ja": "CPUめいれいのしゅるい",
+        "ja": "CPU命令の種類",
         "ja_typings": [
           "cpumeireinoshurui"
         ]
       },
       {
         "en": "file transfer standard",
-        "ja": "ふぁいるてんそうきじゅん",
+        "ja": "ファイル転送標準",
         "ja_typings": [
           "fairutensokijun",
           "fairutensoukijun"
@@ -11174,7 +11174,7 @@
       },
       {
         "en": "terminal control protocol",
-        "ja": "たーみなるせいぎょぷろとこる",
+        "ja": "ターミナルコントロールプロトコル",
         "ja_typings": [
           "taminaruseigyopurotokoru"
         ]
@@ -11197,28 +11197,28 @@
     "choices": [
       {
         "en": "network security barrier",
-        "ja": "ねっとわーくせきゅりてぃのかべ",
+        "ja": "ネットワークセキュリティバリア",
         "ja_typings": [
           "nettowakusekyuritinokabe"
         ]
       },
       {
         "en": "database access control",
-        "ja": "でーたべーすあくせすせいぎょ",
+        "ja": "データベースアクセス制御",
         "ja_typings": [
           "detabesuakusesuseigyo"
         ]
       },
       {
         "en": "antivirus software",
-        "ja": "あんちういるすそふとうぇあ",
+        "ja": "アンチウイルスソフトウェア",
         "ja_typings": [
           "anchiuirususofutowea"
         ]
       },
       {
         "en": "CPU heat protection",
-        "ja": "CPUねつほご",
+        "ja": "CPU熱保護",
         "ja_typings": [
           "cpunetsuhogo"
         ]
@@ -11230,7 +11230,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a firewall?",
-      "ja": "ファイアウォールとはどのようなものですか？"
+      "ja": "ファイアウォールとは何か？"
     },
     "question_text_reading": {
       "en": "What is a firewall?",
@@ -11241,7 +11241,7 @@
     "choices": [
       {
         "en": "automatically assigns IP addresses",
-        "ja": "IPあどれすをじどうわりあて",
+        "ja": "IPアドレスを自動割り当て",
         "ja_typings": [
           "ipadoresuojidowariate",
           "ipadoresuojidouwariate"
@@ -11249,7 +11249,7 @@
       },
       {
         "en": "encrypts network traffic",
-        "ja": "ねっとわーくつうしんをあんごうか",
+        "ja": "ネットワーク通信を暗号化",
         "ja_typings": [
           "nettowakutsuushinoangoka",
           "nettowakutsuushinoangouka"
@@ -11257,14 +11257,14 @@
       },
       {
         "en": "resolves domain names",
-        "ja": "どめいんめいをかいけつ",
+        "ja": "ドメイン名を解決",
         "ja_typings": [
           "domeinmeiokaiketsu"
         ]
       },
       {
         "en": "manages user accounts",
-        "ja": "ゆーざーあかうんとをかんり",
+        "ja": "ユーザーアカウントを管理",
         "ja_typings": [
           "yuzaakauntokanri",
           "yuzaakauntookanri"
@@ -11288,28 +11288,28 @@
     "choices": [
       {
         "en": "unique hardware network identifier",
-        "ja": "はーどのゆにーくなねっとわーくしきべつし",
+        "ja": "ハードのユニークなネットワーク識別子",
         "ja_typings": [
           "hadonoyunikunanettowakushikibetsushi"
         ]
       },
       {
         "en": "IP address alias",
-        "ja": "IPあどれすのべつめい",
+        "ja": "IPアドレスの別名",
         "ja_typings": [
           "ipadoresunobetsumei"
         ]
       },
       {
         "en": "domain name record",
-        "ja": "どめいんめいのれこーど",
+        "ja": "ドメイン名のレコード",
         "ja_typings": [
           "domeinmeinorekodo"
         ]
       },
       {
         "en": "router configuration",
-        "ja": "るーたーのせってい",
+        "ja": "ルーターの設定",
         "ja_typings": [
           "rutanosettei"
         ]
@@ -11321,7 +11321,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a MAC address?",
-      "ja": "MACアドレスとは何ですか？"
+      "ja": "MACアドレスとは何か？"
     },
     "question_text_reading": {
       "en": "What is a MAC address?",
@@ -11332,7 +11332,7 @@
     "choices": [
       {
         "en": "Virtual Private Network",
-        "ja": "かそうぷらいべーとねっとわーく",
+        "ja": "仮想プライベートネットワーク",
         "ja_typings": [
           "kasopuraibetonettowaku",
           "kasoupuraibetonettowaku"
@@ -11340,7 +11340,7 @@
       },
       {
         "en": "Verified Protocol Node",
-        "ja": "けんしょうずみぷろとこるのーど",
+        "ja": "検証済みプロトコルノード",
         "ja_typings": [
           "kenshozumipurotokorunodo",
           "kenshouzumipurotokorunodo"
@@ -11348,7 +11348,7 @@
       },
       {
         "en": "Variable Port Number",
-        "ja": "かへんぽーとばんごう",
+        "ja": "可変ポート番号",
         "ja_typings": [
           "kahenpotobango",
           "kahenpotobangou"
@@ -11356,7 +11356,7 @@
       },
       {
         "en": "Visual Page Navigator",
-        "ja": "びじゅあるぺーじなびげーたー",
+        "ja": "ビジュアルページナビゲーター",
         "ja_typings": [
           "bijuarupejinabigeta"
         ]
@@ -11379,7 +11379,7 @@
     "choices": [
       {
         "en": "translates private to public IP",
-        "ja": "しにゅうりょくIPをこうかいIPにへんかん",
+        "ja": "侵入力IPを公開IPに変換",
         "ja_typings": [
           "shinyuuryokuipokokaiipnihenkan",
           "shinyuuryokuipokoukaiipnihenkan"
@@ -11387,14 +11387,14 @@
       },
       {
         "en": "assigns domain names",
-        "ja": "どめいんめいをわりあて",
+        "ja": "ドメイン名を割り当て",
         "ja_typings": [
           "domeinmeiowariate"
         ]
       },
       {
         "en": "encrypts network packets",
-        "ja": "ねっとわーくぱけっとをあんごうか",
+        "ja": "ネットワークパケットを暗号化",
         "ja_typings": [
           "nettowakupakettoangoka",
           "nettowakupakettooangouka"
@@ -11402,7 +11402,7 @@
       },
       {
         "en": "monitors network traffic",
-        "ja": "ねっとわーくつうしんをかんし",
+        "ja": "ネットワーク通信を監視",
         "ja_typings": [
           "nettowakutsuushinokanshi"
         ]
@@ -11414,7 +11414,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is NAT in networking?",
-      "ja": "ネットワークにおけるNATとは何ですか？"
+      "ja": "ネットワークのNATとは何か？"
     },
     "question_text_reading": {
       "en": "What is NAT in networking?",
@@ -11425,28 +11425,28 @@
     "choices": [
       {
         "en": "logical subdivision of a network",
-        "ja": "ねっとわーくの論理的な細分",
+        "ja": "ネットワークの論理的な細分",
         "ja_typings": [
           "nettowakunona"
         ]
       },
       {
         "en": "type of network cable",
-        "ja": "ねっとわーくけーぶるのしゅるい",
+        "ja": "ネットワークケーブルの種類",
         "ja_typings": [
           "nettowakukeburunoshurui"
         ]
       },
       {
         "en": "wireless network protocol",
-        "ja": "むせんねっとわーくぷろとこる",
+        "ja": "ワイヤレスネットワークプロトコル",
         "ja_typings": [
           "musennettowakupurotokoru"
         ]
       },
       {
         "en": "network security zone",
-        "ja": "ねっとわーくせきゅりてぃぞーん",
+        "ja": "ネットワークセキュリティゾーン",
         "ja_typings": [
           "nettowakusekyuritizon"
         ]
@@ -11458,7 +11458,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a subnet?",
-      "ja": "サブネットとは何ですか？"
+      "ja": "サブネットとは何か？"
     },
     "question_text_reading": {
       "en": "What is a subnet?",
@@ -11469,7 +11469,7 @@
     "choices": [
       {
         "en": "redundant array of independent disks",
-        "ja": "どくりつでぃすくのじょうちょうはいれつ",
+        "ja": "独立ディスクの冗長配列",
         "ja_typings": [
           "dokuritsudisukunojochohairetsu",
           "dokuritsudisukunojouchouhairetsu"
@@ -11477,21 +11477,21 @@
       },
       {
         "en": "random access index drive",
-        "ja": "らんだむあくせすいんでくすどらいぶ",
+        "ja": "ランダムアクセスインデックスドライブ",
         "ja_typings": [
           "randamuakusesuindekusudoraibu"
         ]
       },
       {
         "en": "remote access interface device",
-        "ja": "りもーとあくせすいんたーふぇーすでばいす",
+        "ja": "リモートアクセスインターフェースデバイス",
         "ja_typings": [
           "rimotoakusesuintafesudebaisu"
         ]
       },
       {
         "en": "real-time AI data",
-        "ja": "りあるたいむAIでーた",
+        "ja": "リアルタイムAIデータ",
         "ja_typings": [
           "riarutaimuaideta"
         ]
@@ -11503,7 +11503,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is RAID in storage?",
-      "ja": "すとれーじのRAIDとは何か？"
+      "ja": "ストレージのRAIDとは何か？"
     },
     "question_text_reading": {
       "en": "What is RAID in storage?",
@@ -11514,21 +11514,21 @@
     "choices": [
       {
         "en": "distributes traffic across servers",
-        "ja": "さーばーにつうしんをぶんさん",
+        "ja": "サーバーに通信を分散",
         "ja_typings": [
           "sabanitsuushinobunsan"
         ]
       },
       {
         "en": "monitors CPU load",
-        "ja": "CPUふかをかんし",
+        "ja": "CPU負荷を監視",
         "ja_typings": [
           "cpufukaokanshi"
         ]
       },
       {
         "en": "balances database queries",
-        "ja": "でーたべーすくえりをちょうせい",
+        "ja": "データベースクエリを調整",
         "ja_typings": [
           "detabesukueriochosei",
           "detabesukueriochousei"
@@ -11536,7 +11536,7 @@
       },
       {
         "en": "manages server power",
-        "ja": "さーばーでんりょくをかんり",
+        "ja": "サーバー電力を管理",
         "ja_typings": [
           "sabadenryokuokanri"
         ]
@@ -11548,7 +11548,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a load balancer?",
-      "ja": "ロードバランサーとはどのようなものですか？"
+      "ja": "ロードバランサーとは何か？"
     },
     "question_text_reading": {
       "en": "What is a load balancer?",
@@ -11559,28 +11559,28 @@
     "choices": [
       {
         "en": "intermediary between client and server",
-        "ja": "くらいあんととさーばーのちゅうかい",
+        "ja": "クライアントとサーバーの仲介",
         "ja_typings": [
           "kuraiantotosabanochuukai"
         ]
       },
       {
         "en": "backup server",
-        "ja": "ばっくあっぷさーばー",
+        "ja": "バックアップサーバー",
         "ja_typings": [
           "bakkuappusaba"
         ]
       },
       {
         "en": "DNS server",
-        "ja": "DNSさーばー",
+        "ja": "DNSサーバー",
         "ja_typings": [
           "dnssaba"
         ]
       },
       {
         "en": "mail server",
-        "ja": "めーるさーばー",
+        "ja": "メールサーバー",
         "ja_typings": [
           "merusaba"
         ]
@@ -11592,7 +11592,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a proxy server?",
-      "ja": "プロキシサーバーとは、どのようなものですか？"
+      "ja": "プロキシサーバーとは何か？"
     },
     "question_text_reading": {
       "en": "What is a proxy server?",
@@ -11603,28 +11603,28 @@
     "choices": [
       {
         "en": "sits in front of servers",
-        "ja": "さーばーのまえにいちする",
+        "ja": "サーバーの前に位置する",
         "ja_typings": [
           "sabanomaeniichisuru"
         ]
       },
       {
         "en": "sits in front of clients",
-        "ja": "くらいあんとのまえにいちする",
+        "ja": "クライアントの前に座る",
         "ja_typings": [
           "kuraiantonomaeniichisuru"
         ]
       },
       {
         "en": "caches client data",
-        "ja": "くらいあんとでーたをきゃっしゅ",
+        "ja": "クライアントデータをキャッシュ",
         "ja_typings": [
           "kuraiantodetaokyasshu"
         ]
       },
       {
         "en": "monitors server logs",
-        "ja": "さーばーろぐをかんし",
+        "ja": "サーバーログを監視",
         "ja_typings": [
           "sabaroguokanshi"
         ]
@@ -11636,7 +11636,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a reverse proxy?",
-      "ja": "リバースプロキシとは何ですか？"
+      "ja": "リバースプロキシとは何か？"
     },
     "question_text_reading": {
       "en": "What is a reverse proxy?",
@@ -11647,28 +11647,28 @@
     "choices": [
       {
         "en": "Secure Shell remote protocol",
-        "ja": "あんぜんなしぇるりもーとぷろとこる",
+        "ja": "セキュアシェルリモートプロトコル",
         "ja_typings": [
           "anzennasherurimotopurotokoru"
         ]
       },
       {
         "en": "Simple Service Handler",
-        "ja": "かんたんなさーびすはんどらー",
+        "ja": "シンプルなサービスハンドラー",
         "ja_typings": [
           "kantannasabisuhandora"
         ]
       },
       {
         "en": "Secure Script Host",
-        "ja": "あんぜんなすくりぷとほすと",
+        "ja": "セキュアスクリプトホスト",
         "ja_typings": [
           "anzennasukuriputohosuto"
         ]
       },
       {
         "en": "Shared Server Hub",
-        "ja": "きょうゆうさーばーはぶ",
+        "ja": "共有サーバーハブ",
         "ja_typings": [
           "kyoyuusabahabu",
           "kyouyuusabahabu"
@@ -11692,14 +11692,14 @@
     "choices": [
       {
         "en": "software creating and managing VMs",
-        "ja": "VMをさくせいかんりするそふとうぇあ",
+        "ja": "VMを作成管理するソフトウェア",
         "ja_typings": [
           "vmosakuseikanrisurusofutowea"
         ]
       },
       {
         "en": "high-speed processor",
-        "ja": "こうそくしょりそうち",
+        "ja": "高速処理装置",
         "ja_typings": [
           "kosokushorisochi",
           "kousokushorisouchi"
@@ -11707,14 +11707,14 @@
       },
       {
         "en": "network monitoring tool",
-        "ja": "ねっとわーくかんしつーる",
+        "ja": "ネットワークモニタリングツール",
         "ja_typings": [
           "nettowakukanshitsuru"
         ]
       },
       {
         "en": "database indexer",
-        "ja": "でーたべーすいんでくさー",
+        "ja": "データベースインデクサー",
         "ja_typings": [
           "detabesuindekusa"
         ]
@@ -11726,7 +11726,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a hypervisor?",
-      "ja": "ハイパーバイザーとは何ですか？"
+      "ja": "ハイパーバイザーとは何か？"
     },
     "question_text_reading": {
       "en": "What is a hypervisor?",
@@ -11737,14 +11737,14 @@
     "choices": [
       {
         "en": "immutable snapshot of container filesystem",
-        "ja": "こんてなふぁいるしすてむのふへんすなっぷ",
+        "ja": "コンテナファイルシステムの不変スナップショット",
         "ja_typings": [
           "kontenafairushisutemunofuhensunappu"
         ]
       },
       {
         "en": "virtual machine backup",
-        "ja": "かそうましんばっくあっぷ",
+        "ja": "仮想マシンバックアップ",
         "ja_typings": [
           "kasomashinbakkuappu",
           "kasoumashinbakkuappu"
@@ -11752,14 +11752,14 @@
       },
       {
         "en": "disk partition image",
-        "ja": "でぃすくぱーてぃしょんいめーじ",
+        "ja": "ディスクパーティションイメージ",
         "ja_typings": [
           "disukupatishonimeji"
         ]
       },
       {
         "en": "OS installation disk",
-        "ja": "OSいんすとーるでぃすく",
+        "ja": "OSインストールディスク",
         "ja_typings": [
           "osinsutorudisuku"
         ]
@@ -11771,7 +11771,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a container image?",
-      "ja": "コンテナイメージとは何ですか？"
+      "ja": "コンテナイメージとは何か？"
     },
     "question_text_reading": {
       "en": "What is a container image?",
@@ -11782,7 +11782,7 @@
     "choices": [
       {
         "en": "running code without managing servers",
-        "ja": "さーばーかんりなしでこーどをじっこう",
+        "ja": "サーバー管理なしでコードを実行",
         "ja_typings": [
           "sabakanrinashidekodojikko",
           "sabakanrinashidekodoojikkou"
@@ -11790,21 +11790,21 @@
       },
       {
         "en": "computing with no power",
-        "ja": "でんりょくなしのけいさん",
+        "ja": "電力なしの計算",
         "ja_typings": [
           "denryokunashinokeisan"
         ]
       },
       {
         "en": "computing on local machine only",
-        "ja": "ろーかるましんのみけいさん",
+        "ja": "ローカルマシンのみ計算",
         "ja_typings": [
           "rokarumashinnomikeisan"
         ]
       },
       {
         "en": "computing without internet",
-        "ja": "いんたーねっとなしけいさん",
+        "ja": "インターネットなし計算",
         "ja_typings": [
           "intanettonashikeisan"
         ]
@@ -11816,7 +11816,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is serverless computing?",
-      "ja": "サーバーレスコンピューティングとは何ですか？"
+      "ja": "サーバーレスコンピューティングとは何か？"
     },
     "question_text_reading": {
       "en": "What is serverless computing?",
@@ -11827,28 +11827,28 @@
     "choices": [
       {
         "en": "processing data near the source",
-        "ja": "でーたそーすのちかくでしょり",
+        "ja": "データソースの近くで処理",
         "ja_typings": [
           "detasosunochikakudeshori"
         ]
       },
       {
         "en": "computing on blockchain",
-        "ja": "ぶろっくちぇーんでけいさん",
+        "ja": "ブロックチェーンで計算",
         "ja_typings": [
           "burokkuchendekeisan"
         ]
       },
       {
         "en": "computing on GPU only",
-        "ja": "GPUのみけいさん",
+        "ja": "GPUのみ計算",
         "ja_typings": [
           "gpunomikeisan"
         ]
       },
       {
         "en": "computing at data center",
-        "ja": "でーたせんたーでけいさん",
+        "ja": "データセンターで計算",
         "ja_typings": [
           "detasentadekeisan"
         ]
@@ -11860,7 +11860,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is edge computing?",
-      "ja": "エッジコンピューティングとは何ですか？"
+      "ja": "エッジコンピューティングとは何か？"
     },
     "question_text_reading": {
       "en": "What is edge computing?",
@@ -11871,28 +11871,28 @@
     "choices": [
       {
         "en": "delivering content with low latency",
-        "ja": "ていれいてんしーでこんてんつはいしん",
+        "ja": "低遅延でコンテンツ配信",
         "ja_typings": [
           "teireitenshidekontentsuhaishin"
         ]
       },
       {
         "en": "storing large databases",
-        "ja": "だいきぼでーたべーすのほぞん",
+        "ja": "大規模データベースの保存",
         "ja_typings": [
           "daikibodetabesunohozon"
         ]
       },
       {
         "en": "processing complex queries",
-        "ja": "ふくざつくえりのしょり",
+        "ja": "複雑なクエリの処理",
         "ja_typings": [
           "fukuzatsukuerinoshori"
         ]
       },
       {
         "en": "running server-side code",
-        "ja": "さーばーがわこーどのじっこう",
+        "ja": "サーバー側コードの実行",
         "ja_typings": [
           "sabagawakodonojikko",
           "sabagawakodonojikkou"
@@ -11916,7 +11916,7 @@
     "choices": [
       {
         "en": "storing frequently accessed data for speed",
-        "ja": "こうひんどでーたをほぞんして高速化",
+        "ja": "高頻度データを保存して高速化",
         "ja_typings": [
           "kohindodetaohozonshite",
           "kouhindodetaohozonshite"
@@ -11924,7 +11924,7 @@
       },
       {
         "en": "encrypting stored data",
-        "ja": "ほぞんでーたをあんごうか",
+        "ja": "保存データを暗号化",
         "ja_typings": [
           "hozondetaoangoka",
           "hozondetaoangouka"
@@ -11932,14 +11932,14 @@
       },
       {
         "en": "compressing stored data",
-        "ja": "ほぞんでーたをあっしゅく",
+        "ja": "保存データを圧縮",
         "ja_typings": [
           "hozondetaoasshuku"
         ]
       },
       {
         "en": "backing up stored data",
-        "ja": "ほぞんでーたをばっくあっぷ",
+        "ja": "保存データをバックアップ",
         "ja_typings": [
           "hozondetaobakkuappu"
         ]
@@ -11951,7 +11951,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is caching in computing?",
-      "ja": "コンピューティングにおけるキャッシングとは何ですか？"
+      "ja": "計算機のキャッシュとは何か？"
     },
     "question_text_reading": {
       "en": "What is caching in computing?",
@@ -11962,28 +11962,28 @@
     "choices": [
       {
         "en": "async communication buffer between services",
-        "ja": "さーびす間の非同期通信バッファ",
+        "ja": "サービス間の非同期通信バッファ",
         "ja_typings": [
           "sabisunobaffa"
         ]
       },
       {
         "en": "user notification queue",
-        "ja": "ゆーざーつうちきゅー",
+        "ja": "ユーザー通知キュー",
         "ja_typings": [
           "yuzatsuuchikyu"
         ]
       },
       {
         "en": "database write buffer",
-        "ja": "でーたべーすきおみこみばっふぁ",
+        "ja": "データベース書き込みバッファ",
         "ja_typings": [
           "detabesukiomikomibaffa"
         ]
       },
       {
         "en": "email sending queue",
-        "ja": "めーるそうしんきゅー",
+        "ja": "メール送信キュー",
         "ja_typings": [
           "merusoshinkyu",
           "merusoushinkyu"
@@ -11996,7 +11996,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a message queue?",
-      "ja": "メッセージキューとはどのようなものですか？"
+      "ja": "メッセージキューとは何か？"
     },
     "question_text_reading": {
       "en": "What is a message queue?",
@@ -12007,7 +12007,7 @@
     "choices": [
       {
         "en": "publishers send to topics, subscribers receive",
-        "ja": "しゅっぱんしゃがそうしん、こうどくしゃがじゅしん",
+        "ja": "出版社が送信、購読者が受信",
         "ja_typings": [
           "shuppanshagasoshin kodokushagajushin",
           "shuppanshagasoushin koudokushagajushin"
@@ -12015,14 +12015,14 @@
       },
       {
         "en": "point-to-point messaging",
-        "ja": "いちたいいちめっせーじんぐ",
+        "ja": "点対点メッセージング",
         "ja_typings": [
           "ichitaiichimessejingu"
         ]
       },
       {
         "en": "broadcast to all users",
-        "ja": "ぜんゆーざーにほうそう",
+        "ja": "全ユーザーにブロードキャスト",
         "ja_typings": [
           "zenyuzanihoso",
           "zenyuzanihousou"
@@ -12030,7 +12030,7 @@
       },
       {
         "en": "encrypted direct messaging",
-        "ja": "あんごうかちょくせつめっせーじ",
+        "ja": "暗号化直接メッセージ",
         "ja_typings": [
           "angokachokusetsumesseji",
           "angoukachokusetsumesseji"
@@ -12043,7 +12043,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is pub/sub messaging?",
-      "ja": "pub/subめっせーじんぐとは何か？"
+      "ja": "pub/subメッセージングとは何か？"
     },
     "question_text_reading": {
       "en": "What is pub/sub messaging?",
@@ -12054,28 +12054,28 @@
     "choices": [
       {
         "en": "server located close to users",
-        "ja": "ゆーざーのちかくにあるさーばー",
+        "ja": "ユーザーの近くにあるサーバー",
         "ja_typings": [
           "yuzanochikakuniarusaba"
         ]
       },
       {
         "en": "cloud data node",
-        "ja": "くらうどでーたのーど",
+        "ja": "クラウドデータノード",
         "ja_typings": [
           "kuraudodetanodo"
         ]
       },
       {
         "en": "database replica",
-        "ja": "でーたべーすのれぷりか",
+        "ja": "データベースのレプリカ",
         "ja_typings": [
           "detabesunorepurika"
         ]
       },
       {
         "en": "network router",
-        "ja": "ねっとわーくるーたー",
+        "ja": "ネットワークルーター",
         "ja_typings": [
           "nettowakuruta"
         ]
@@ -12087,7 +12087,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a CDN edge node?",
-      "ja": "CDNの「エッジノード」とはどのようなものですか？"
+      "ja": "CDNのエッジノードとは何か？"
     },
     "question_text_reading": {
       "en": "What is a CDN edge node?",
@@ -12098,14 +12098,14 @@
     "choices": [
       {
         "en": "adding more servers",
-        "ja": "さーばーをふやす",
+        "ja": "サーバーを増やす",
         "ja_typings": [
           "sabaofuyasu"
         ]
       },
       {
         "en": "upgrading existing server",
-        "ja": "きそんさーばーをきょうか",
+        "ja": "既存サーバーを強化",
         "ja_typings": [
           "kisonsabaokyoka",
           "kisonsabaokyouka"
@@ -12113,14 +12113,14 @@
       },
       {
         "en": "compressing server data",
-        "ja": "さーばーでーたをあっしゅく",
+        "ja": "サーバーデータを圧縮",
         "ja_typings": [
           "sabadetaoasshuku"
         ]
       },
       {
         "en": "adding more CPU cores",
-        "ja": "CPUこあをふやす",
+        "ja": "CPUコアを増やす",
         "ja_typings": [
           "cpukoaofuyasu"
         ]
@@ -12132,7 +12132,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is horizontal scaling?",
-      "ja": "水平スケーリングとは何ですか？"
+      "ja": "水平スケーリングとは何か？"
     },
     "question_text_reading": {
       "en": "What is horizontal scaling?",
@@ -12143,7 +12143,7 @@
     "choices": [
       {
         "en": "upgrading existing server resources",
-        "ja": "きそんさーばーのりそーすをきょうか",
+        "ja": "既存サーバーのリソースを強化",
         "ja_typings": [
           "kisonsabanorisosuokyoka",
           "kisonsabanorisosuokyouka"
@@ -12151,21 +12151,21 @@
       },
       {
         "en": "adding more servers",
-        "ja": "さーばーをふやす",
+        "ja": "サーバーを増やす",
         "ja_typings": [
           "sabaofuyasu"
         ]
       },
       {
         "en": "adding more data centers",
-        "ja": "でーたせんたーをふやす",
+        "ja": "データセンターを増やす",
         "ja_typings": [
           "detasentaofuyasu"
         ]
       },
       {
         "en": "upgrading network speed",
-        "ja": "ねっとわーくそくどをきょうか",
+        "ja": "ネットワーク速度を強化",
         "ja_typings": [
           "nettowakusokudokyoka",
           "nettowakusokudookyouka"
@@ -12178,7 +12178,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is vertical scaling?",
-      "ja": "すいちょくすけーりんぐとは何か？"
+      "ja": "垂直スケーリングとは何か？"
     },
     "question_text_reading": {
       "en": "What is vertical scaling?",
@@ -12189,7 +12189,7 @@
     "choices": [
       {
         "en": "facility housing computing infrastructure",
-        "ja": "けいさんきばんをほうじょするしせつ",
+        "ja": "計算基盤を補助する施設",
         "ja_typings": [
           "keisankibanohojosurushisetsu",
           "keisankibanohoujosurushisetsu"
@@ -12197,21 +12197,21 @@
       },
       {
         "en": "company headquarters",
-        "ja": "かいしゃのほんしゃ",
+        "ja": "会社の本社",
         "ja_typings": [
           "kaishanohonsha"
         ]
       },
       {
         "en": "cloud storage account",
-        "ja": "くらうどすとれーじあかうんと",
+        "ja": "クラウドストレージアカウント",
         "ja_typings": [
           "kuraudosutorejiakaunto"
         ]
       },
       {
         "en": "network operations center",
-        "ja": "ねっとわーくうんようせんたー",
+        "ja": "ネットワークオペレーションセンター",
         "ja_typings": [
           "nettowakuunyosenta",
           "nettowakuunyousenta"
@@ -12224,7 +12224,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a data center?",
-      "ja": "データセンターとはどのような施設ですか？"
+      "ja": "データセンターとは何か？"
     },
     "question_text_reading": {
       "en": "What is a data center?",
@@ -12235,7 +12235,7 @@
     "choices": [
       {
         "en": "time system runs without failure",
-        "ja": "しすてむがふぐなくどうさしているじかん",
+        "ja": "システムが不具合なく動作している時間",
         "ja_typings": [
           "shisutemugafugunakudosashiteirujikan",
           "shisutemugafugunakudousashiteirujikan"
@@ -12243,7 +12243,7 @@
       },
       {
         "en": "time to complete an update",
-        "ja": "こうしんにかかるじかん",
+        "ja": "更新にかかる時間",
         "ja_typings": [
           "koshinnikakarujikan",
           "koushinnikakarujikan"
@@ -12251,14 +12251,14 @@
       },
       {
         "en": "CPU processing time",
-        "ja": "CPUしょりじかん",
+        "ja": "CPU処理時間",
         "ja_typings": [
           "cpushorijikan"
         ]
       },
       {
         "en": "network connection time",
-        "ja": "ねっとわーくせつぞくじかん",
+        "ja": "ネットワーク接続時間",
         "ja_typings": [
           "nettowakusetsuzokujikan"
         ]
@@ -12270,7 +12270,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is uptime in computing?",
-      "ja": "コンピューティングにおける「uptime」とは何ですか？"
+      "ja": "計算機のuptimeとは何か？"
     },
     "question_text_reading": {
       "en": "What is uptime in computing?",
@@ -12281,28 +12281,28 @@
     "choices": [
       {
         "en": "Service Level Agreement",
-        "ja": "さーびすすいじゅんのけいやく",
+        "ja": "サービスレベルアグリーメント",
         "ja_typings": [
           "sabisusuijunnokeiyaku"
         ]
       },
       {
         "en": "System Load Average",
-        "ja": "しすてむふかへいきん",
+        "ja": "システム負荷平均",
         "ja_typings": [
           "shisutemufukaheikin"
         ]
       },
       {
         "en": "Secure Login API",
-        "ja": "あんぜんなろぐいんAPI",
+        "ja": "安全なログインAPI",
         "ja_typings": [
           "anzennaroguinapi"
         ]
       },
       {
         "en": "Software License Archive",
-        "ja": "そふとうぇあらいせんすあーかいぶ",
+        "ja": "ソフトウェアライセンスアーカイブ",
         "ja_typings": [
           "sofutowearaisensuakaibu"
         ]
@@ -12325,7 +12325,7 @@
     "choices": [
       {
         "en": "tracking system health and performance",
-        "ja": "しすてむのけんこうとぱふぉーまんすをついせき",
+        "ja": "システムの健康とパフォーマンスを追跡",
         "ja_typings": [
           "shisutemunokenkotopafomansuotsuiseki",
           "shisutemunokenkoutopafomansuotsuiseki"
@@ -12333,14 +12333,14 @@
       },
       {
         "en": "monitoring code quality",
-        "ja": "こーどひんしつをかんし",
+        "ja": "コード品質を監視",
         "ja_typings": [
           "kodohinshitsuokanshi"
         ]
       },
       {
         "en": "watching user behavior",
-        "ja": "ゆーざーこうどうをかんし",
+        "ja": "ユーザー行動を監視",
         "ja_typings": [
           "yuzakodookanshi",
           "yuzakoudouokanshi"
@@ -12348,7 +12348,7 @@
       },
       {
         "en": "checking database integrity",
-        "ja": "でーたべーすせいごうせいをかくにん",
+        "ja": "データベース整合性を確認",
         "ja_typings": [
           "detabesuseigoseiokakunin",
           "detabesuseigouseiokakunin"
@@ -12361,7 +12361,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is monitoring in DevOps?",
-      "ja": "DevOpsのもにたりんぐとは何か？"
+      "ja": "DevOpsのモニタリングとは何か？"
     },
     "question_text_reading": {
       "en": "What is monitoring in DevOps?",
@@ -12372,7 +12372,7 @@
     "choices": [
       {
         "en": "running two identical environments",
-        "ja": "ふたつのどうじかんきょうをじっこう",
+        "ja": "二つの同時環境を実行",
         "ja_typings": [
           "futatsunodojikankyoojikko",
           "futatsunodoujikankyouojikkou"
@@ -12380,21 +12380,21 @@
       },
       {
         "en": "gradual traffic rollout",
-        "ja": "だんかいてきなつうしんきりかえ",
+        "ja": "段階的な通信切り替え",
         "ja_typings": [
           "dankaitekinatsuushinkirikae"
         ]
       },
       {
         "en": "color-coded code deployment",
-        "ja": "いろわけのこーどはいひ",
+        "ja": "色分けのコード配備",
         "ja_typings": [
           "irowakenokodohaihi"
         ]
       },
       {
         "en": "server room color system",
-        "ja": "さーばールームのいろわけ",
+        "ja": "サーバーールームの色分け",
         "ja_typings": [
           "sabarumunoirowake"
         ]
@@ -12406,7 +12406,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is blue-green deployment?",
-      "ja": "ブルーグリーンデプロイメントとは何ですか？"
+      "ja": "Blue-green deploymentとは何か？"
     },
     "question_text_reading": {
       "en": "What is blue-green deployment?",
@@ -12417,7 +12417,7 @@
     "choices": [
       {
         "en": "releasing to small user subset first",
-        "ja": "さきにしょうすうのゆーざーにリリース",
+        "ja": "先に少数のユーザーにリリース",
         "ja_typings": [
           "sakinishosuunoyuzaniririsu",
           "sakinishousuunoyuzaniririsu"
@@ -12425,21 +12425,21 @@
       },
       {
         "en": "deploying to all users at once",
-        "ja": "いちどにぜんゆーざーにはいひ",
+        "ja": "一度に全ユーザーに配備",
         "ja_typings": [
           "ichidonizenyuzanihaihi"
         ]
       },
       {
         "en": "deploying without testing",
-        "ja": "てすとなしにはいひ",
+        "ja": "テストなしにはいひ",
         "ja_typings": [
           "tesutonashinihaihi"
         ]
       },
       {
         "en": "automated rollback deployment",
-        "ja": "じどうろーるばっくはいひ",
+        "ja": "自動ロールバックデプロイ",
         "ja_typings": [
           "jidororubakkuhaihi",
           "jidourorubakkuhaihi"
@@ -12452,7 +12452,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is canary deployment?",
-      "ja": "カナリアデプロイメントとは何ですか？"
+      "ja": "カナリアはひとは何か？"
     },
     "question_text_reading": {
       "en": "What is canary deployment?",
@@ -12463,21 +12463,21 @@
     "choices": [
       {
         "en": "storage for container images",
-        "ja": "こんてないめーじのほぞんばしょ",
+        "ja": "コンテナイメージの保存場所",
         "ja_typings": [
           "kontenaimejinohozonbasho"
         ]
       },
       {
         "en": "database for containers",
-        "ja": "こんてなのでーたべーす",
+        "ja": "コンテナのデータベース",
         "ja_typings": [
           "kontenanodetabesu"
         ]
       },
       {
         "en": "OS registry for apps",
-        "ja": "OSのあぷりとうろく",
+        "ja": "OSのアプリ登録",
         "ja_typings": [
           "osnoapuritoroku",
           "osnoapuritouroku"
@@ -12485,7 +12485,7 @@
       },
       {
         "en": "network DNS registry",
-        "ja": "ネットワークDNSとうろく",
+        "ja": "ネットワークDNS登録",
         "ja_typings": [
           "nettowakudnstoroku",
           "nettowakudnstouroku"
@@ -12498,7 +12498,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a container registry?",
-      "ja": "コンテナレジストリとは何ですか？"
+      "ja": "コンテナレジストリとは何か？"
     },
     "question_text_reading": {
       "en": "What is a container registry?",
@@ -12516,7 +12516,7 @@
       },
       {
         "en": "container runtime",
-        "ja": "こんてなじっこうかんきょう",
+        "ja": "コンテナ実行環境",
         "ja_typings": [
           "kontenajikkokankyo",
           "kontenajikkoukankyou"
@@ -12524,14 +12524,14 @@
       },
       {
         "en": "CI/CD pipeline tool",
-        "ja": "CI/CDぱいぷらいんつーる",
+        "ja": "CI/CDパイプラインツール",
         "ja_typings": [
           "ci/cdpaipuraintsuru"
         ]
       },
       {
         "en": "monitoring platform",
-        "ja": "もにたりんぐぷらっとふぉーむ",
+        "ja": "モニタリングプラットフォーム",
         "ja_typings": [
           "monitaringupurattofomu"
         ]
@@ -12554,7 +12554,7 @@
     "choices": [
       {
         "en": "IT automation and config management tool",
-        "ja": "ITじどうかとせってかんりつーる",
+        "ja": "IT自動化と設定管理ツール",
         "ja_typings": [
           "itjidokatosettekanritsuru",
           "itjidoukatosettekanritsuru"
@@ -12562,21 +12562,21 @@
       },
       {
         "en": "container orchestration tool",
-        "ja": "こんてなおーけすとれーしょんつーる",
+        "ja": "コンテナオーケストレーションツール",
         "ja_typings": [
           "kontenaokesutoreshontsuru"
         ]
       },
       {
         "en": "log analysis platform",
-        "ja": "ろぐぶんせきぷらっとふぉーむ",
+        "ja": "ログ分析プラットフォーム",
         "ja_typings": [
           "rogubunsekipurattofomu"
         ]
       },
       {
         "en": "network packet analyzer",
-        "ja": "ねっとわーくぱけっとかいせき",
+        "ja": "ネットワークパケットアナライザ",
         "ja_typings": [
           "nettowakupakettokaiseki"
         ]
@@ -12599,28 +12599,28 @@
     "choices": [
       {
         "en": "monitoring and alerting toolkit",
-        "ja": "もにたりんぐとあらーとのつーるきっと",
+        "ja": "モニタリングとアラートのツールキット",
         "ja_typings": [
           "monitaringutoaratonotsurukitto"
         ]
       },
       {
         "en": "container platform",
-        "ja": "こんてなぷらっとふぉーむ",
+        "ja": "コンテナプラットフォーム",
         "ja_typings": [
           "kontenapurattofomu"
         ]
       },
       {
         "en": "log management system",
-        "ja": "ろぐかんりしすてむ",
+        "ja": "ログ管理システム",
         "ja_typings": [
           "rogukanrishisutemu"
         ]
       },
       {
         "en": "infrastructure provisioner",
-        "ja": "きばんぷろびじょにんぐ",
+        "ja": "基盤プロビジョニング",
         "ja_typings": [
           "kibanpurobijoningu"
         ]
@@ -12643,28 +12643,28 @@
     "choices": [
       {
         "en": "visualization and dashboard tool",
-        "ja": "びじゅあらいぜーしょんとだっしゅぼーどつーる",
+        "ja": "ビジュアライゼーションとダッシュボードツール",
         "ja_typings": [
           "bijuaraizeshontodasshubodotsuru"
         ]
       },
       {
         "en": "database backup tool",
-        "ja": "でーたべーすばっくあっぷつーる",
+        "ja": "データベースバックアップツール",
         "ja_typings": [
           "detabesubakkuapputsuru"
         ]
       },
       {
         "en": "code quality analyzer",
-        "ja": "こーどひんしつかいせきつーる",
+        "ja": "コード品質解析ツール",
         "ja_typings": [
           "kodohinshitsukaisekitsuru"
         ]
       },
       {
         "en": "network configuration tool",
-        "ja": "ねっとわーくせってつーる",
+        "ja": "ネットワーク設定ツール",
         "ja_typings": [
           "nettowakusettetsuru"
         ]
@@ -12687,28 +12687,28 @@
     "choices": [
       {
         "en": "Elasticsearch Logstash Kibana",
-        "ja": "Elasticsearchろぐすたっしゅきばな",
+        "ja": "Elasticsearchログスタッシュキバナ",
         "ja_typings": [
           "elasticsearchrogusutasshukibana"
         ]
       },
       {
         "en": "Edge Load Kubernetes",
-        "ja": "えっじろーどくーばねてぃす",
+        "ja": "エッジロードクーバネティス",
         "ja_typings": [
           "ejjirodokubanetisu"
         ]
       },
       {
         "en": "Event Log Kernel",
-        "ja": "いべんとろぐかーねる",
+        "ja": "イベントログカーネル",
         "ja_typings": [
           "ibentorogukaneru"
         ]
       },
       {
         "en": "Elastic Linux Kernel",
-        "ja": "えらすてぃっくLinuxかーねる",
+        "ja": "エラスティックLinuxカーネル",
         "ja_typings": [
           "erasutikkulinuxkaneru"
         ]
@@ -12720,7 +12720,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is ELK stack?",
-      "ja": "ELKスタックとはどのようなものですか？"
+      "ja": "ELKスタックとは何か？"
     },
     "question_text_reading": {
       "en": "What is ELK stack?",
@@ -12731,7 +12731,7 @@
     "choices": [
       {
         "en": "ability to understand system state from outputs",
-        "ja": "しゅつりょくからじょうたいをりかいできること",
+        "ja": "出力から状態を理解できること",
         "ja_typings": [
           "shutsuryokukarajotaiorikaidekirukoto",
           "shutsuryokukarajoutaiorikaidekirukoto"
@@ -12739,14 +12739,14 @@
       },
       {
         "en": "ability to monitor CPU usage",
-        "ja": "CPU使用率をかんしできること",
+        "ja": "CPU使用率を監視できること",
         "ja_typings": [
           "cpuokanshidekirukoto"
         ]
       },
       {
         "en": "ability to view source code",
-        "ja": "そーすこーどをみられること",
+        "ja": "ソースコードを見られること",
         "ja_typings": [
           "sosukodomirarerukoto",
           "sosukodoomirarerukoto"
@@ -12754,7 +12754,7 @@
       },
       {
         "en": "ability to access logs",
-        "ja": "ろぐにアクセスできること",
+        "ja": "ログにアクセスできること",
         "ja_typings": [
           "roguniakusesudekirukoto"
         ]
@@ -12766,7 +12766,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is observability in systems?",
-      "ja": "システムにおける「observability」とは何でしょうか？"
+      "ja": "システム の 観測可能性 とは 何か？"
     },
     "question_text_reading": {
       "en": "What is observability in systems?",
@@ -12777,7 +12777,7 @@
     "choices": [
       {
         "en": "smallest deployable unit in K8s",
-        "ja": "K8sのさいしょうはいひたんい",
+        "ja": "K8sの最小配備単位",
         "ja_typings": [
           "k8snosaishohaihitani",
           "k8snosaishouhaihitani"
@@ -12785,21 +12785,21 @@
       },
       {
         "en": "K8s database unit",
-        "ja": "K8sのでーたべーすたんい",
+        "ja": "K8sのデータベースユニット",
         "ja_typings": [
           "k8snodetabesutani"
         ]
       },
       {
         "en": "K8s network unit",
-        "ja": "K8sのねっとわーくたんい",
+        "ja": "K8sのネットワーク単位",
         "ja_typings": [
           "k8snonettowakutani"
         ]
       },
       {
         "en": "K8s storage unit",
-        "ja": "K8sのすとれーじたんい",
+        "ja": "K8sのストレージユニット",
         "ja_typings": [
           "k8snosutorejitani"
         ]
@@ -12811,7 +12811,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a container pod in Kubernetes?",
-      "ja": "Kubernetesのぽっどとは何か？"
+      "ja": "KubernetesのPodとは何か？"
     },
     "question_text_reading": {
       "en": "What is a container pod in Kubernetes?",
@@ -12822,28 +12822,28 @@
     "choices": [
       {
         "en": "script defining container image",
-        "ja": "こんてないめーじをていぎするすくりぷと",
+        "ja": "コンテナイメージを定義するスクリプト",
         "ja_typings": [
           "kontenaimejioteigisurusukuriputo"
         ]
       },
       {
         "en": "Docker network config",
-        "ja": "Dockerねっとわーくせってい",
+        "ja": "Dockerネットワーク設定",
         "ja_typings": [
           "dockernettowakusettei"
         ]
       },
       {
         "en": "Docker volume config",
-        "ja": "Dockerぼりゅーむせってい",
+        "ja": "Dockerボリューム設定",
         "ja_typings": [
           "dockerboryumusettei"
         ]
       },
       {
         "en": "Docker compose file",
-        "ja": "Dockerこんぽーずふぁいる",
+        "ja": "Docker compose file",
         "ja_typings": [
           "dockerkonpozufairu"
         ]
@@ -12866,28 +12866,28 @@
     "choices": [
       {
         "en": "tool for multi-container applications",
-        "ja": "ふくすうこんてなあぷりのつーる",
+        "ja": "複数コンテナアプリケーションのツール",
         "ja_typings": [
           "fukusuukontenaapurinotsuru"
         ]
       },
       {
         "en": "Docker installation script",
-        "ja": "Dockerいんすとーるすくりぷと",
+        "ja": "Dockerインストールスクリプト",
         "ja_typings": [
           "dockerinsutorusukuriputo"
         ]
       },
       {
         "en": "Docker image builder",
-        "ja": "Dockerいめーじびるだー",
+        "ja": "Dockerイメージビルダー",
         "ja_typings": [
           "dockerimejibiruda"
         ]
       },
       {
         "en": "Docker networking tool",
-        "ja": "Dockerねっとわーくつーる",
+        "ja": "Dockerネットワークツール",
         "ja_typings": [
           "dockernettowakutsuru"
         ]
@@ -12910,28 +12910,28 @@
     "choices": [
       {
         "en": "logical isolation within cluster",
-        "ja": "くらすたないのろんりてきかくり",
+        "ja": "クラスター内の論理的隔離",
         "ja_typings": [
           "kurasutanainoronritekikakuri"
         ]
       },
       {
         "en": "global cluster name",
-        "ja": "くらすたのぐろーばるめい",
+        "ja": "クラスターのグローバル名",
         "ja_typings": [
           "kurasutanogurobarumei"
         ]
       },
       {
         "en": "network isolation zone",
-        "ja": "ねっとわーくかくりぞーん",
+        "ja": "ネットワーク隔離ゾーン",
         "ja_typings": [
           "nettowakukakurizon"
         ]
       },
       {
         "en": "storage partition",
-        "ja": "すとれーじぱーてぃしょん",
+        "ja": "ストレージパーティション",
         "ja_typings": [
           "sutorejipatishon"
         ]
@@ -12943,7 +12943,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a Kubernetes namespace?",
-      "ja": "Kubernetesのなめすぺーすとは何か？"
+      "ja": "Kubernetesのnamespaceとは何か？"
     },
     "question_text_reading": {
       "en": "What is a Kubernetes namespace?",
@@ -12954,28 +12954,28 @@
     "choices": [
       {
         "en": "Kubernetes application package",
-        "ja": "Kubernetesあぷりぱっけーじ",
+        "ja": "Kubernetesアプリケーションパッケージ",
         "ja_typings": [
           "kubernetesapuripakkeji"
         ]
       },
       {
         "en": "monitoring dashboard",
-        "ja": "もにたりんぐだっしゅぼーど",
+        "ja": "モニタリングダッシュボード",
         "ja_typings": [
           "monitaringudasshubodo"
         ]
       },
       {
         "en": "Docker image format",
-        "ja": "Dockerいめーじけいしき",
+        "ja": "Dockerイメージ形式",
         "ja_typings": [
           "dockerimejikeishiki"
         ]
       },
       {
         "en": "CI pipeline config",
-        "ja": "CIぱいぷらいんせってい",
+        "ja": "CIパイプライン設定",
         "ja_typings": [
           "cipaipurainsettei"
         ]
@@ -12987,7 +12987,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a Helm chart?",
-      "ja": "Helmちゃーととは何か？"
+      "ja": "Helmチャートとは何か？"
     },
     "question_text_reading": {
       "en": "What is a Helm chart?",
@@ -12998,21 +12998,21 @@
     "choices": [
       {
         "en": "using Git as source of truth for infra",
-        "ja": "きばんのせいしんとしてGitをつかう",
+        "ja": "基盤の真実としてGitを使う",
         "ja_typings": [
           "kibannoseishintoshitegitotsukau"
         ]
       },
       {
         "en": "Git-based CI/CD only",
-        "ja": "GitべースのCI/CDのみ",
+        "ja": "GitベースのCI/CDのみ",
         "ja_typings": [
           "gitbesunoci/cdnomi"
         ]
       },
       {
         "en": "GitLab operations",
-        "ja": "GitLabのうんよう",
+        "ja": "GitLabの運用",
         "ja_typings": [
           "gitlabnonyo",
           "gitlabnounyou"
@@ -13020,7 +13020,7 @@
       },
       {
         "en": "Git security operations",
-        "ja": "Gitのせきゅりてぃうんよう",
+        "ja": "Gitのセキュリティ運用",
         "ja_typings": [
           "gitnosekyuritiunyo",
           "gitnosekyuritiunyou"
@@ -13044,7 +13044,7 @@
     "choices": [
       {
         "en": "intentionally injecting failures to test resilience",
-        "ja": "たいきゅうせいをためすためにいとてきにしょうがいそうにゅう",
+        "ja": "耐久性をためすために意図的に障害を注入",
         "ja_typings": [
           "taikyuuseiotamesutameniitotekinishogaisonyuu",
           "taikyuuseiotamesutameniitotekinishougaisounyuu"
@@ -13052,7 +13052,7 @@
       },
       {
         "en": "random code changes",
-        "ja": "らんだむなこーどへんこう",
+        "ja": "ランダムなコード変更",
         "ja_typings": [
           "randamunakodohenko",
           "randamunakodohenkou"
@@ -13060,14 +13060,14 @@
       },
       {
         "en": "disorganized development process",
-        "ja": "ふせいりなかいはつぷろせす",
+        "ja": "不整な開発プロセス",
         "ja_typings": [
           "fuseirinakaihatsupurosesu"
         ]
       },
       {
         "en": "testing on production only",
-        "ja": "ほんばんのみでてすと",
+        "ja": "本番のみでテスト",
         "ja_typings": [
           "honbannomidetesuto"
         ]
@@ -13079,7 +13079,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is chaos engineering?",
-      "ja": "カオスエンジニアリングとは、具体的にどのようなものですか？"
+      "ja": "Chaos Engineeringとは何か？"
     },
     "question_text_reading": {
       "en": "What is chaos engineering?",
@@ -13090,28 +13090,28 @@
     "choices": [
       {
         "en": "HTTP callback triggered by events",
-        "ja": "いべんとにトリガーされるHTTPこーるばっく",
+        "ja": "イベントにトリガーされるHTTPコールバック",
         "ja_typings": [
           "ibentonitorigasareruhttpkorubakku"
         ]
       },
       {
         "en": "frontend JavaScript hook",
-        "ja": "ふろんとえんどJavaScriptふっく",
+        "ja": "フロントエンドJavaScriptフック",
         "ja_typings": [
           "furontoendojavascriptfukku"
         ]
       },
       {
         "en": "backend API endpoint",
-        "ja": "ばっくえんどAPIえんどぽいんと",
+        "ja": "バックエンドAPIエンドポイント",
         "ja_typings": [
           "bakkuendoapiendopointo"
         ]
       },
       {
         "en": "browser event listener",
-        "ja": "ぶらうざーいべんとりすなー",
+        "ja": "ブラウザイベントリスナー",
         "ja_typings": [
           "burauzaibentorisuna"
         ]
@@ -13123,7 +13123,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a webhook?",
-      "ja": "webhookとはどのような仕組みのことですか？"
+      "ja": "Webhookとは何か？"
     },
     "question_text_reading": {
       "en": "What is a webhook?",
@@ -13134,7 +13134,7 @@
     "choices": [
       {
         "en": "time delay before transfer begins",
-        "ja": "てんそうが始まるまでの時間遅延",
+        "ja": "転送が始まるまでの時間遅延",
         "ja_typings": [
           "tensogamarumadeno",
           "tensougamarumadeno"
@@ -13142,7 +13142,7 @@
       },
       {
         "en": "network throughput",
-        "ja": "ねっとわーくすいといっぷりょう",
+        "ja": "ネットワークスループット",
         "ja_typings": [
           "nettowakusuitoippuryo",
           "nettowakusuitoippuryou"
@@ -13150,14 +13150,14 @@
       },
       {
         "en": "CPU processing speed",
-        "ja": "CPUしょりそくど",
+        "ja": "CPU処理速度",
         "ja_typings": [
           "cpushorisokudo"
         ]
       },
       {
         "en": "disk read speed",
-        "ja": "でぃすくよみとりそくど",
+        "ja": "ディスクリードスピード",
         "ja_typings": [
           "disukuyomitorisokudo"
         ]
@@ -13169,7 +13169,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is latency in computing?",
-      "ja": "コンピューティングにおけるレイテンシとは何ですか？"
+      "ja": "計算機のレイテンシーとは何か？"
     },
     "question_text_reading": {
       "en": "What is latency in computing?",
@@ -13180,7 +13180,7 @@
     "choices": [
       {
         "en": "amount of work done per unit time",
-        "ja": "たんいじかんあたりのさぎょうりょう",
+        "ja": "単位時間あたりの作業量",
         "ja_typings": [
           "tanijikanatarinosagyoryo",
           "tanijikanatarinosagyouryou"
@@ -13188,7 +13188,7 @@
       },
       {
         "en": "time to process one task",
-        "ja": "いちさぎょうのしょりじかん",
+        "ja": "一作業の処理時間",
         "ja_typings": [
           "ichisagyonoshorijikan",
           "ichisagyounoshorijikan"
@@ -13196,14 +13196,14 @@
       },
       {
         "en": "memory bandwidth",
-        "ja": "めもりたいいき",
+        "ja": "メモリ帯域",
         "ja_typings": [
           "memoritaiiki"
         ]
       },
       {
         "en": "disk capacity",
-        "ja": "でぃすくようりょう",
+        "ja": "ディスク容量",
         "ja_typings": [
           "disukuyoryo",
           "disukuyouryou"
@@ -13216,7 +13216,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is throughput in computing?",
-      "ja": "コンピューティングにおける「throughput」とは何ですか？"
+      "ja": "計算機のスループットとは何か？"
     },
     "question_text_reading": {
       "en": "What is throughput in computing?",
@@ -13227,14 +13227,14 @@
     "choices": [
       {
         "en": "Application Programming Interface",
-        "ja": "あぷりけーしょんぷろぐらみんぐいんたーふぇーす",
+        "ja": "アプリケーションプログラミングインターフェース",
         "ja_typings": [
           "apurikeshonpuroguraminguintafesu"
         ]
       },
       {
         "en": "Advanced Protocol Integration",
-        "ja": "こうきゅうぷろとこるとうごう",
+        "ja": "高度プロトコル統合",
         "ja_typings": [
           "kokyuupurotokorutogo",
           "koukyuupurotokorutougou"
@@ -13242,7 +13242,7 @@
       },
       {
         "en": "Automated Process Interface",
-        "ja": "じどうぷろせすいんたーふぇーす",
+        "ja": "自動プロセスインターフェース",
         "ja_typings": [
           "jidopurosesuintafesu",
           "jidoupurosesuintafesu"
@@ -13250,7 +13250,7 @@
       },
       {
         "en": "Application Protocol Index",
-        "ja": "あぷりけーしょんぷろとこるいんでくす",
+        "ja": "アプリケーションプロトコルインデックス",
         "ja_typings": [
           "apurikeshonpurotokoruindekusu"
         ]
@@ -13262,7 +13262,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does API stand for?",
-      "ja": "APIとは何の略語ですか？"
+      "ja": "APIの略語の意味は？"
     },
     "question_text_reading": {
       "en": "What does API stand for?",
@@ -13273,7 +13273,7 @@
     "choices": [
       {
         "en": "Uniform Resource Locator",
-        "ja": "とういつりそーすいちしかし",
+        "ja": "統一資源ロケータ",
         "ja_typings": [
           "toitsurisosuichishikashi",
           "touitsurisosuichishikashi"
@@ -13281,7 +13281,7 @@
       },
       {
         "en": "Universal Request Link",
-        "ja": "はんようりくえすとりんく",
+        "ja": "万用リクエストリンク",
         "ja_typings": [
           "hanyorikuesutorinku",
           "hanyourikuesutorinku"
@@ -13289,7 +13289,7 @@
       },
       {
         "en": "Unified Route Label",
-        "ja": "とういつるーとらべる",
+        "ja": "統一ルートラベル",
         "ja_typings": [
           "toitsurutoraberu",
           "touitsurutoraberu"
@@ -13297,7 +13297,7 @@
       },
       {
         "en": "User Resource Library",
-        "ja": "ゆーざーりそーすらいぶらり",
+        "ja": "ユーザーリソースライブラリ",
         "ja_typings": [
           "yuzarisosuraiburari"
         ]
@@ -13309,7 +13309,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does URL stand for?",
-      "ja": "URLは何の略語ですか？"
+      "ja": "URLの略語の意味は？"
     },
     "question_text_reading": {
       "en": "What does URL stand for?",
@@ -13320,7 +13320,7 @@
     "choices": [
       {
         "en": "Integrated Development Environment",
-        "ja": "とうごうかいはつかんきょう",
+        "ja": "統合開発環境",
         "ja_typings": [
           "togokaihatsukankyo",
           "tougoukaihatsukankyou"
@@ -13328,14 +13328,14 @@
       },
       {
         "en": "Internal Debug Engine",
-        "ja": "ないぶでばっぐえんじん",
+        "ja": "内部デバッグエンジン",
         "ja_typings": [
           "naibudebagguenjin"
         ]
       },
       {
         "en": "Interface Design Element",
-        "ja": "いんたーふぇーすせっけいようそ",
+        "ja": "インターフェース設計要素",
         "ja_typings": [
           "intafesusekkeiyoso",
           "intafesusekkeiyouso"
@@ -13343,7 +13343,7 @@
       },
       {
         "en": "Iterative Deployment Engine",
-        "ja": "はんぷくはいひえんじん",
+        "ja": "反復配備エンジン",
         "ja_typings": [
           "hanpukuhaihienjin"
         ]
@@ -13355,7 +13355,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does IDE stand for?",
-      "ja": "IDEとは何の略語ですか？"
+      "ja": "IDEの略語の意味は？"
     },
     "question_text_reading": {
       "en": "What does IDE stand for?",
@@ -13366,7 +13366,7 @@
     "choices": [
       {
         "en": "Object-Relational Mapping",
-        "ja": "おぶじぇくとかんけいしゃぞう",
+        "ja": "オブジェクトリレーショナルマッピング",
         "ja_typings": [
           "obujekutokankeishazo",
           "obujekutokankeishazou"
@@ -13374,21 +13374,21 @@
       },
       {
         "en": "Open Resource Management",
-        "ja": "おーぷんりそーすかんり",
+        "ja": "オープンリソースマネジメント",
         "ja_typings": [
           "opunrisosukanri"
         ]
       },
       {
         "en": "Optimized Request Module",
-        "ja": "さいてきかりくえすともじゅーる",
+        "ja": "最適要求モジュール",
         "ja_typings": [
           "saitekikarikuesutomojuru"
         ]
       },
       {
         "en": "Output Response Model",
-        "ja": "しゅつりょくおうとうもでる",
+        "ja": "出力応答モデル",
         "ja_typings": [
           "shutsuryokuotomoderu",
           "shutsuryokuoutoumoderu"
@@ -13401,7 +13401,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does ORM stand for?",
-      "ja": "ORMとは何の略語ですか？"
+      "ja": "ORMの略語の意味は？"
     },
     "question_text_reading": {
       "en": "What does ORM stand for?",
@@ -13412,28 +13412,28 @@
     "choices": [
       {
         "en": "Model View Controller",
-        "ja": "もでるびゅーこんとろーらー",
+        "ja": "モデルビューコントローラー",
         "ja_typings": [
           "moderubyukontorora"
         ]
       },
       {
         "en": "Main Version Code",
-        "ja": "めいんばーじょんこーど",
+        "ja": "メインバージョンコード",
         "ja_typings": [
           "meinbajonkodo"
         ]
       },
       {
         "en": "Mobile View Component",
-        "ja": "もばいるびゅーこんぽーねんと",
+        "ja": "モバイルビューコンポーネント",
         "ja_typings": [
           "mobairubyukonponento"
         ]
       },
       {
         "en": "Multi Value Cache",
-        "ja": "たちかんりきゃっしゅ",
+        "ja": "多値管理キャッシュ",
         "ja_typings": [
           "tachikanrikyasshu"
         ]
@@ -13445,7 +13445,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does MVC stand for?",
-      "ja": "MVCは何の略語ですか？"
+      "ja": "MVCの略語の意味は？"
     },
     "question_text_reading": {
       "en": "What does MVC stand for?",
@@ -13456,28 +13456,28 @@
     "choices": [
       {
         "en": "Software as a Service",
-        "ja": "さーびすとしてのそふとうぇあ",
+        "ja": "サービスとしてのソフトウェア",
         "ja_typings": [
           "sabisutoshitenosofutowea"
         ]
       },
       {
         "en": "Security as a System",
-        "ja": "しすてむとしてのせきゅりてぃ",
+        "ja": "システムとしてのセキュリティ",
         "ja_typings": [
           "shisutemutoshitenosekyuriti"
         ]
       },
       {
         "en": "Storage and a Server",
-        "ja": "すとれーじとさーばー",
+        "ja": "ストレージとサーバー",
         "ja_typings": [
           "sutorejitosaba"
         ]
       },
       {
         "en": "Scalable API Service",
-        "ja": "すけーらぶるAPIさーびす",
+        "ja": "スケーラブルAPIサービス",
         "ja_typings": [
           "sukeraburuapisabisu"
         ]
@@ -13489,7 +13489,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does SaaS stand for?",
-      "ja": "SaaSとは何の略語ですか？"
+      "ja": "SaaSの略語の意味は？"
     },
     "question_text_reading": {
       "en": "What does SaaS stand for?",
@@ -13500,14 +13500,14 @@
     "choices": [
       {
         "en": "Infrastructure as a Service",
-        "ja": "さーびすとしてのきばん",
+        "ja": "サービスとしての基盤",
         "ja_typings": [
           "sabisutoshitenokiban"
         ]
       },
       {
         "en": "Integration and a System",
-        "ja": "とうごうとしすてむ",
+        "ja": "統合とシステム",
         "ja_typings": [
           "togotoshisutemu",
           "tougoutoshisutemu"
@@ -13515,14 +13515,14 @@
       },
       {
         "en": "Interface as a Standard",
-        "ja": "きじゅんとしてのいんたーふぇーす",
+        "ja": "基準としてのインターフェース",
         "ja_typings": [
           "kijuntoshitenointafesu"
         ]
       },
       {
         "en": "Identity and a Server",
-        "ja": "しきべつとさーばー",
+        "ja": "識別とサーバー",
         "ja_typings": [
           "shikibetsutosaba"
         ]
@@ -13534,7 +13534,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does IaaS stand for?",
-      "ja": "IaaSとは何の略語ですか？"
+      "ja": "IaaSの略語の意味は？"
     },
     "question_text_reading": {
       "en": "What does IaaS stand for?",
@@ -13545,28 +13545,28 @@
     "choices": [
       {
         "en": "Platform as a Service",
-        "ja": "さーびすとしてのぷらっとふぉーむ",
+        "ja": "サービスとしてのプラットフォーム",
         "ja_typings": [
           "sabisutoshitenopurattofomu"
         ]
       },
       {
         "en": "Privacy and a System",
-        "ja": "ぷらいばしーとしすてむ",
+        "ja": "プライバシーとシステム",
         "ja_typings": [
           "puraibashitoshisutemu"
         ]
       },
       {
         "en": "Process as a Service",
-        "ja": "さーびすとしてのぷろせす",
+        "ja": "サービスとしてのプロセス",
         "ja_typings": [
           "sabisutoshitenopurosesu"
         ]
       },
       {
         "en": "Package as a Server",
-        "ja": "さーばーとしてのぱっけーじ",
+        "ja": "サーバーとしてのパッケージ",
         "ja_typings": [
           "sabatoshitenopakkeji"
         ]
@@ -13578,7 +13578,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does PaaS stand for?",
-      "ja": "PaaSとは何の略語ですか？"
+      "ja": "PaaSの略語の意味は？"
     },
     "question_text_reading": {
       "en": "What does PaaS stand for?",
@@ -13589,7 +13589,7 @@
     "choices": [
       {
         "en": "Create Read Update Delete",
-        "ja": "さくせいよみこうしんさくじょ",
+        "ja": "作成読み更新削除",
         "ja_typings": [
           "sakuseiyomikoshinsakujo",
           "sakuseiyomikoushinsakujo"
@@ -13597,7 +13597,7 @@
       },
       {
         "en": "Copy Refresh Update Deploy",
-        "ja": "こぴーこうしんはいひ",
+        "ja": "コピー更新配備",
         "ja_typings": [
           "kopikoshinhaihi",
           "kopikoushinhaihi"
@@ -13605,7 +13605,7 @@
       },
       {
         "en": "Cache Read Update Delete",
-        "ja": "きゃっしゅよみこうしんさくじょ",
+        "ja": "キャッシュ読み更新削除",
         "ja_typings": [
           "kyasshuyomikoshinsakujo",
           "kyasshuyomikoushinsakujo"
@@ -13613,7 +13613,7 @@
       },
       {
         "en": "Create Run Update Dump",
-        "ja": "さくせいじっこうこうしんだんぷ",
+        "ja": "作成実行更新ダンプ",
         "ja_typings": [
           "sakuseijikkokoshindanpu",
           "sakuseijikkoukoushindanpu"
@@ -13626,7 +13626,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does CRUD stand for?",
-      "ja": "CRUDは何の頭文字ですか？"
+      "ja": "CRUDの略語の意味は？"
     },
     "question_text_reading": {
       "en": "What does CRUD stand for?",
@@ -13637,7 +13637,7 @@
     "choices": [
       {
         "en": "Object-Oriented Programming",
-        "ja": "おぶじぇくとしこうぷろぐらみんぐ",
+        "ja": "オブジェクト指向プログラミング",
         "ja_typings": [
           "obujekutoshikopuroguramingu",
           "obujekutoshikoupuroguramingu"
@@ -13645,7 +13645,7 @@
       },
       {
         "en": "Open Operation Protocol",
-        "ja": "おーぷんそうさぷろとこる",
+        "ja": "オープンオペレーションプロトコル",
         "ja_typings": [
           "opunsosapurotokoru",
           "opunsousapurotokoru"
@@ -13653,14 +13653,14 @@
       },
       {
         "en": "Ordered Output Process",
-        "ja": "じゅんじょつきしゅつりょくぷろせす",
+        "ja": "順序出力プロセス",
         "ja_typings": [
           "junjotsukishutsuryokupurosesu"
         ]
       },
       {
         "en": "Object Output Port",
-        "ja": "おぶじぇくとしゅつりょくぽーと",
+        "ja": "オブジェクト出力ポート",
         "ja_typings": [
           "obujekutoshutsuryokupoto"
         ]
@@ -13672,7 +13672,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does OOP stand for?",
-      "ja": "OOPは何の略語ですか？"
+      "ja": "OOPの略語の意味は？"
     },
     "question_text_reading": {
       "en": "What does OOP stand for?",
@@ -13683,14 +13683,14 @@
     "choices": [
       {
         "en": "Command Line Interface",
-        "ja": "こまんどらいんいんたーふぇーす",
+        "ja": "コマンドラインインターフェース",
         "ja_typings": [
           "komandorainintafesu"
         ]
       },
       {
         "en": "Client Logic Integration",
-        "ja": "くらいあんとろじっくとうごう",
+        "ja": "クライアントロジックインテグレーション",
         "ja_typings": [
           "kuraiantorojikkutogo",
           "kuraiantorojikkutougou"
@@ -13698,14 +13698,14 @@
       },
       {
         "en": "Core Library Index",
-        "ja": "こあらいぶらりいんでくす",
+        "ja": "コアライブラリインデックス",
         "ja_typings": [
           "koaraiburariindekusu"
         ]
       },
       {
         "en": "Compiled Language Input",
-        "ja": "こんぱいるでごにゅうりょく",
+        "ja": "コンパイル言語入力",
         "ja_typings": [
           "konpairudegonyuuryoku"
         ]
@@ -13717,7 +13717,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does CLI stand for?",
-      "ja": "CLIとは何の略語ですか？"
+      "ja": "CLIの略語の意味は？"
     },
     "question_text_reading": {
       "en": "What does CLI stand for?",
@@ -13728,14 +13728,14 @@
     "choices": [
       {
         "en": "Graphical User Interface",
-        "ja": "ぐらふぃかるゆーざーいんたーふぇーす",
+        "ja": "グラフィカルユーザーインターフェース",
         "ja_typings": [
           "gurafikaruyuzaintafesu"
         ]
       },
       {
         "en": "General Utility Index",
-        "ja": "はんようゆーてぃりてぃいんでくす",
+        "ja": "汎用ユーティリティインデックス",
         "ja_typings": [
           "hanyoyutiritiindekusu",
           "hanyouyutiritiindekusu"
@@ -13743,7 +13743,7 @@
       },
       {
         "en": "Global Update Interface",
-        "ja": "ぐろーばるこうしんいんたーふぇーす",
+        "ja": "グローバル更新インターフェース",
         "ja_typings": [
           "gurobarukoshinintafesu",
           "gurobarukoushinintafesu"
@@ -13751,7 +13751,7 @@
       },
       {
         "en": "Grid UI Integration",
-        "ja": "ぐりっどUIとうごう",
+        "ja": "グリッドUI統合",
         "ja_typings": [
           "guriddoitogo",
           "guriddouitougou"
@@ -13764,7 +13764,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does GUI stand for?",
-      "ja": "GUIは何の略語ですか？"
+      "ja": "GUIの略語の意味は？"
     },
     "question_text_reading": {
       "en": "What does GUI stand for?",
@@ -13775,28 +13775,28 @@
     "choices": [
       {
         "en": "Software Development Kit",
-        "ja": "そふとうぇあかいはつきっと",
+        "ja": "ソフトウェア開発キット",
         "ja_typings": [
           "sofutoweakaihatsukitto"
         ]
       },
       {
         "en": "Secure Data Key",
-        "ja": "あんぜんなでーたきー",
+        "ja": "安全なデータキー",
         "ja_typings": [
           "anzennadetaki"
         ]
       },
       {
         "en": "System Deployment Kit",
-        "ja": "しすてむはいひきっと",
+        "ja": "システムデプロイメントキット",
         "ja_typings": [
           "shisutemuhaihikitto"
         ]
       },
       {
         "en": "Service Discovery Key",
-        "ja": "さーびすはっけんきー",
+        "ja": "サービスディスカバリーキー",
         "ja_typings": [
           "sabisuhakkenki"
         ]
@@ -13808,7 +13808,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does SDK stand for?",
-      "ja": "SDKとは何の略語ですか？"
+      "ja": "SDKの略語の意味は？"
     },
     "question_text_reading": {
       "en": "What does SDK stand for?",
@@ -13819,7 +13819,7 @@
     "choices": [
       {
         "en": "End of File",
-        "ja": "ふぁいるのおわり",
+        "ja": "ファイルの終わり",
         "ja_typings": [
           "fairunowari",
           "fairunoowari"
@@ -13827,14 +13827,14 @@
       },
       {
         "en": "Error on Function",
-        "ja": "かんすうのえらー",
+        "ja": "関数のエラー",
         "ja_typings": [
           "kansuunoera"
         ]
       },
       {
         "en": "Execute Other Function",
-        "ja": "べつのかんすうをじっこう",
+        "ja": "別関数を実行",
         "ja_typings": [
           "betsunokansuuojikko",
           "betsunokansuuojikkou"
@@ -13842,7 +13842,7 @@
       },
       {
         "en": "Event on Failure",
-        "ja": "しっぱいのいべんと",
+        "ja": "失敗のイベント",
         "ja_typings": [
           "shippainoibento"
         ]
@@ -13854,7 +13854,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does EOF stand for in programming?",
-      "ja": "プログラミングにおける「EOF」は何の略語ですか？"
+      "ja": "プログラミングのEOFの略語の意味は？"
     },
     "question_text_reading": {
       "en": "What does EOF stand for in programming?",
@@ -13865,28 +13865,28 @@
     "choices": [
       {
         "en": "true/false data type",
-        "ja": "しんぎゃくのでーたがた",
+        "ja": "真偽データ型",
         "ja_typings": [
           "shingyakunodetagata"
         ]
       },
       {
         "en": "integer type",
-        "ja": "せいすうがた",
+        "ja": "整数型",
         "ja_typings": [
           "seisuugata"
         ]
       },
       {
         "en": "string type",
-        "ja": "もじれつがた",
+        "ja": "文字列型",
         "ja_typings": [
           "mojiretsugata"
         ]
       },
       {
         "en": "array type",
-        "ja": "はいれつがた",
+        "ja": "配列型",
         "ja_typings": [
           "hairetsugata"
         ]
@@ -13898,7 +13898,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a boolean?",
-      "ja": "ブーリアンとは何ですか？"
+      "ja": "ブーリアンとは何か？"
     },
     "question_text_reading": {
       "en": "What is a boolean?",
@@ -13909,28 +13909,28 @@
     "choices": [
       {
         "en": "absence of a value",
-        "ja": "ちが存在しないこと",
+        "ja": "値の不在",
         "ja_typings": [
           "chigashinaikoto"
         ]
       },
       {
         "en": "zero integer",
-        "ja": "ゼロのせいすう",
+        "ja": "ゼロの整数",
         "ja_typings": [
           "zeronoseisuu"
         ]
       },
       {
         "en": "empty string",
-        "ja": "くうのもじれつ",
+        "ja": "空の文字列",
         "ja_typings": [
           "kuunomojiretsu"
         ]
       },
       {
         "en": "false boolean",
-        "ja": "falseのぶーりあん",
+        "ja": "falseのブーリアン",
         "ja_typings": [
           "falsenoburian"
         ]
@@ -13953,7 +13953,7 @@
     "choices": [
       {
         "en": "variable declared but not assigned",
-        "ja": "せんげんされたがだいにゅうされていないへんすう",
+        "ja": "宣言されたが代入されていない変数",
         "ja_typings": [
           "sengensaretagadainyuusareteinaihensuu"
         ]
@@ -13974,7 +13974,7 @@
       },
       {
         "en": "zero value",
-        "ja": "ぜろのち",
+        "ja": "ゼロの地",
         "ja_typings": [
           "zeronochi"
         ]
@@ -13997,28 +13997,28 @@
     "choices": [
       {
         "en": "converting a value to another type",
-        "ja": "ちをべつのかたにへんかん",
+        "ja": "値を別の型へ変換",
         "ja_typings": [
           "chiobetsunokatanihenkan"
         ]
       },
       {
         "en": "checking if types match",
-        "ja": "かたがいっちするかかくにん",
+        "ja": "型が一致するか確認",
         "ja_typings": [
           "katagaitchisurukakakunin"
         ]
       },
       {
         "en": "declaring a new type",
-        "ja": "あたらしいかたをせんげん",
+        "ja": "新しい型を宣言",
         "ja_typings": [
           "atarashiikataosengen"
         ]
       },
       {
         "en": "deleting a variable type",
-        "ja": "へんすうのかたをさくじょ",
+        "ja": "変数の型を削除",
         "ja_typings": [
           "hensuunokataosakujo"
         ]
@@ -14030,7 +14030,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is type casting?",
-      "ja": "型キャストとは、どのようなものですか？"
+      "ja": "型変換とは何か？"
     },
     "question_text_reading": {
       "en": "What is type casting?",
@@ -14041,7 +14041,7 @@
     "choices": [
       {
         "en": "container preventing name conflicts",
-        "ja": "なまえのしょうとつをふせぐこんてな",
+        "ja": "名前の衝突を防ぐコンテナ",
         "ja_typings": [
           "namaenoshototsuofusegukontena",
           "namaenoshoutotsuofusegukontena"
@@ -14049,21 +14049,21 @@
       },
       {
         "en": "network address space",
-        "ja": "ねっとわーくあどれすくうかん",
+        "ja": "ネットワークアドレス空間",
         "ja_typings": [
           "nettowakuadoresukuukan"
         ]
       },
       {
         "en": "database schema",
-        "ja": "でーたべーすすきーま",
+        "ja": "データベーススキーマ",
         "ja_typings": [
           "detabesusukima"
         ]
       },
       {
         "en": "variable scope",
-        "ja": "へんすうのすこーぷ",
+        "ja": "変数のスコープ",
         "ja_typings": [
           "hensuunosukopu"
         ]
@@ -14075,7 +14075,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a namespace?",
-      "ja": "名前空間とは何ですか？"
+      "ja": "ネームスペースとは何か？"
     },
     "question_text_reading": {
       "en": "What is a namespace?",
@@ -14086,14 +14086,14 @@
     "choices": [
       {
         "en": "set of named constants",
-        "ja": "なまえつきていすうのあつまり",
+        "ja": "名前付き定数の集まり",
         "ja_typings": [
           "namaetsukiteisuunoatsumari"
         ]
       },
       {
         "en": "dynamic array",
-        "ja": "どうてきはいれつ",
+        "ja": "動的配列",
         "ja_typings": [
           "dotekihairetsu",
           "doutekihairetsu"
@@ -14101,7 +14101,7 @@
       },
       {
         "en": "error number type",
-        "ja": "えらーばんごうがた",
+        "ja": "エラー番号型",
         "ja_typings": [
           "erabangogata",
           "erabangougata"
@@ -14109,7 +14109,7 @@
       },
       {
         "en": "network enumeration",
-        "ja": "ねっとわーくれっきょ",
+        "ja": "ネットワーク列挙",
         "ja_typings": [
           "nettowakurekkyo"
         ]
@@ -14121,7 +14121,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is an enum?",
-      "ja": "enumとはどのようなものですか？"
+      "ja": "Enumとは何か？"
     },
     "question_text_reading": {
       "en": "What is an enum?",
@@ -14132,7 +14132,7 @@
     "choices": [
       {
         "en": "custom data type grouping fields",
-        "ja": "ふぃーるどをまとめたかすたむでーたがた",
+        "ja": "フィールドをまとめたカスタムデータ型",
         "ja_typings": [
           "firudomatometakasutamudetagata",
           "firudoomatometakasutamudetagata"
@@ -14140,21 +14140,21 @@
       },
       {
         "en": "built-in array type",
-        "ja": "そなわったはいれつがた",
+        "ja": "備わった配列型",
         "ja_typings": [
           "sonawattahairetsugata"
         ]
       },
       {
         "en": "function signature",
-        "ja": "かんすうのしぐにちゃ",
+        "ja": "関数のシグネチャ",
         "ja_typings": [
           "kansuunoshigunicha"
         ]
       },
       {
         "en": "class without methods",
-        "ja": "めそっどなしのくらす",
+        "ja": "メソッドなしのクラス",
         "ja_typings": [
           "mesoddonashinokurasu"
         ]
@@ -14166,7 +14166,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a struct?",
-      "ja": "structとはどのようなものですか？"
+      "ja": "structとは何か？"
     },
     "question_text_reading": {
       "en": "What is a struct?",
@@ -14177,28 +14177,28 @@
     "choices": [
       {
         "en": "prints formatted output",
-        "ja": "しょしきつきしゅつりょく",
+        "ja": "書式付き出力",
         "ja_typings": [
           "shoshikitsukishutsuryoku"
         ]
       },
       {
         "en": "reads formatted input",
-        "ja": "しょしきつきにゅうりょくよみこみ",
+        "ja": "書式指定入力読み込み",
         "ja_typings": [
           "shoshikitsukinyuuryokuyomikomi"
         ]
       },
       {
         "en": "allocates memory",
-        "ja": "めもりをかくほ",
+        "ja": "メモリを確保",
         "ja_typings": [
           "memoriokakuho"
         ]
       },
       {
         "en": "defines format string",
-        "ja": "しょしきもじれつをていぎ",
+        "ja": "書式文字列を定義",
         "ja_typings": [
           "shoshikimojiretsuoteigi"
         ]
@@ -14221,21 +14221,21 @@
     "choices": [
       {
         "en": "variable storing memory address",
-        "ja": "めもりあどれすをほぞんするへんすう",
+        "ja": "メモリアドレスを保存する変数",
         "ja_typings": [
           "memoriadoresuohozonsuruhensuu"
         ]
       },
       {
         "en": "index into an array",
-        "ja": "はいれつのいんでくす",
+        "ja": "配列のインデックス",
         "ja_typings": [
           "hairetsunoindekusu"
         ]
       },
       {
         "en": "reference to a function",
-        "ja": "かんすうのさんしょう",
+        "ja": "関数の参照",
         "ja_typings": [
           "kansuunosansho",
           "kansuunosanshou"
@@ -14255,7 +14255,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a pointer in C?",
-      "ja": "C言語におけるポインターとは何ですか？"
+      "ja": "Cのポインターとは何か？"
     },
     "question_text_reading": {
       "en": "What is a pointer in C?",
@@ -14266,14 +14266,14 @@
     "choices": [
       {
         "en": "includes a header file",
-        "ja": "へっだーふぁいるをとりこむ",
+        "ja": "ヘッダーファイルを取り込む",
         "ja_typings": [
           "heddafairuotorikomu"
         ]
       },
       {
         "en": "defines a macro",
-        "ja": "まくろをていぎ",
+        "ja": "マクロを定義",
         "ja_typings": [
           "makuroteigi",
           "makurooteigi"
@@ -14281,7 +14281,7 @@
       },
       {
         "en": "starts a comment",
-        "ja": "こめんとをかいし",
+        "ja": "コメントを開始",
         "ja_typings": [
           "komentokaishi",
           "komentookaishi"
@@ -14289,7 +14289,7 @@
       },
       {
         "en": "imports a library",
-        "ja": "らいぶらりをいんぽーと",
+        "ja": "ライブラリをインポート",
         "ja_typings": [
           "raiburarioinpoto"
         ]
@@ -14312,7 +14312,7 @@
     "choices": [
       {
         "en": "error before program runs",
-        "ja": "ぷろぐらむじっこうまえのえらー",
+        "ja": "プログラム実行前のエラー",
         "ja_typings": [
           "puroguramujikkomaenoera",
           "puroguramujikkoumaenoera"
@@ -14320,7 +14320,7 @@
       },
       {
         "en": "error during execution",
-        "ja": "じっこうちゅうのえらー",
+        "ja": "実行中のエラー",
         "ja_typings": [
           "jikkochuunoera",
           "jikkouchuunoera"
@@ -14328,14 +14328,14 @@
       },
       {
         "en": "error in test code",
-        "ja": "てすとこーどのえらー",
+        "ja": "テストコードのエラー",
         "ja_typings": [
           "tesutokodonoera"
         ]
       },
       {
         "en": "error in database",
-        "ja": "でーたべーすのえらー",
+        "ja": "データベースのエラー",
         "ja_typings": [
           "detabesunoera"
         ]
@@ -14347,7 +14347,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a compile error?",
-      "ja": "compile errorとはどのようなものですか？"
+      "ja": "Compile errorとは何か？"
     },
     "question_text_reading": {
       "en": "What is a compile error?",
@@ -14358,7 +14358,7 @@
     "choices": [
       {
         "en": "error during program execution",
-        "ja": "ぷろぐらむじっこうちゅうのえらー",
+        "ja": "プログラム実行中のエラー",
         "ja_typings": [
           "puroguramujikkochuunoera",
           "puroguramujikkouchuunoera"
@@ -14366,21 +14366,21 @@
       },
       {
         "en": "error before compilation",
-        "ja": "かんぱいるまえのえらー",
+        "ja": "コンパイル前のエラー",
         "ja_typings": [
           "kanpairumaenoera"
         ]
       },
       {
         "en": "error in source code format",
-        "ja": "そーすこーどけいしきのえらー",
+        "ja": "ソースコード形式のエラー",
         "ja_typings": [
           "sosukodokeishikinoera"
         ]
       },
       {
         "en": "error in test output",
-        "ja": "てすとしゅつりょくのえらー",
+        "ja": "テスト出力のエラー",
         "ja_typings": [
           "tesutoshutsuryokunoera"
         ]
@@ -14392,7 +14392,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a runtime error?",
-      "ja": "ランタイムエラーとは、どのようなものですか？"
+      "ja": "実行時エラーとは何か？"
     },
     "question_text_reading": {
       "en": "What is a runtime error?",
@@ -14403,7 +14403,7 @@
     "choices": [
       {
         "en": "program runs but produces wrong results",
-        "ja": "じっこうはするが結果がまちがい",
+        "ja": "実行はするが結果が間違い",
         "ja_typings": [
           "jikkohasurugagamachigai",
           "jikkouhasurugagamachigai"
@@ -14411,14 +14411,14 @@
       },
       {
         "en": "program fails to compile",
-        "ja": "かんぱいるに失敗",
+        "ja": "コンパイルに失敗",
         "ja_typings": [
           "kanpairuni"
         ]
       },
       {
         "en": "program crashes at runtime",
-        "ja": "じっこうちゅうにくらっしゅ",
+        "ja": "実行中にクラッシュ",
         "ja_typings": [
           "jikkochuunikurasshu",
           "jikkouchuunikurasshu"
@@ -14426,7 +14426,7 @@
       },
       {
         "en": "program has syntax error",
-        "ja": "こうもんえらーがある",
+        "ja": "構文エラーがある",
         "ja_typings": [
           "komoneragaaru",
           "koumoneragaaru"
@@ -14439,7 +14439,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a logic error?",
-      "ja": "ロジックエラーとは、どのようなものですか？"
+      "ja": "ロジックエラーとは何か？"
     },
     "question_text_reading": {
       "en": "What is a logic error?",
@@ -14450,7 +14450,7 @@
     "choices": [
       {
         "en": "standard input stream",
-        "ja": "ひょうじゅんにゅうりょくすとりーむ",
+        "ja": "標準入力ストリーム",
         "ja_typings": [
           "hyojunnyuuryokusutorimu",
           "hyoujunnyuuryokusutorimu"
@@ -14458,21 +14458,21 @@
       },
       {
         "en": "static input definition",
-        "ja": "せいてきにゅうりょくていぎ",
+        "ja": "静的入力定義",
         "ja_typings": [
           "seitekinyuuryokuteigi"
         ]
       },
       {
         "en": "string input module",
-        "ja": "もじれつにゅうりょくもじゅーる",
+        "ja": "文字列入力モジュール",
         "ja_typings": [
           "mojiretsunyuuryokumojuru"
         ]
       },
       {
         "en": "system info node",
-        "ja": "しすてむじょうほうのーど",
+        "ja": "システム情報ノード",
         "ja_typings": [
           "shisutemujohonodo",
           "shisutemujouhounodo"
@@ -14496,7 +14496,7 @@
     "choices": [
       {
         "en": "standard output stream",
-        "ja": "ひょうじゅんしゅつりょくすとりーむ",
+        "ja": "標準出力ストリーム",
         "ja_typings": [
           "hyojunshutsuryokusutorimu",
           "hyoujunshutsuryokusutorimu"
@@ -14504,21 +14504,21 @@
       },
       {
         "en": "static output definition",
-        "ja": "せいてきしゅつりょくていぎ",
+        "ja": "静的出力定義",
         "ja_typings": [
           "seitekishutsuryokuteigi"
         ]
       },
       {
         "en": "string output module",
-        "ja": "もじれつしゅつりょくもじゅーる",
+        "ja": "文字列出力モジュール",
         "ja_typings": [
           "mojiretsushutsuryokumojuru"
         ]
       },
       {
         "en": "system traffic output",
-        "ja": "しすてむつうしんしゅつりょく",
+        "ja": "システム通信出力",
         "ja_typings": [
           "shisutemutsuushinshutsuryoku"
         ]
@@ -14541,7 +14541,7 @@
     "choices": [
       {
         "en": "standard error stream",
-        "ja": "ひょうじゅんえらーすとりーむ",
+        "ja": "標準エラーストリーム",
         "ja_typings": [
           "hyojunerasutorimu",
           "hyoujunerasutorimu"
@@ -14549,7 +14549,7 @@
       },
       {
         "en": "static error report",
-        "ja": "せいてきえらーほうこく",
+        "ja": "静的エラーレポート",
         "ja_typings": [
           "seitekierahokoku",
           "seitekierahoukoku"
@@ -14557,14 +14557,14 @@
       },
       {
         "en": "string error module",
-        "ja": "もじれつえらーもじゅーる",
+        "ja": "文字列エラーモジュール",
         "ja_typings": [
           "mojiretsueramojuru"
         ]
       },
       {
         "en": "system task error",
-        "ja": "しすてむたすくえらー",
+        "ja": "システムタスクエラー",
         "ja_typings": [
           "shisutemutasukuera"
         ]
@@ -14587,28 +14587,28 @@
     "choices": [
       {
         "en": "named storage location for data",
-        "ja": "でーたのなまえつきほぞんばしょ",
+        "ja": "データの名前付き保存場所",
         "ja_typings": [
           "detanonamaetsukihozonbasho"
         ]
       },
       {
         "en": "fixed constant value",
-        "ja": "こていのていすうち",
+        "ja": "固定定数値",
         "ja_typings": [
           "koteinoteisuuchi"
         ]
       },
       {
         "en": "function parameter",
-        "ja": "かんすうぱらめーた",
+        "ja": "関数パラメータ",
         "ja_typings": [
           "kansuuparameta"
         ]
       },
       {
         "en": "loop counter",
-        "ja": "るーぷかうんたー",
+        "ja": "ループカウンター",
         "ja_typings": [
           "rupukaunta"
         ]
@@ -14620,7 +14620,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a variable?",
-      "ja": "変数（variable）とは何ですか？"
+      "ja": "変数とは何か？"
     },
     "question_text_reading": {
       "en": "What is a variable?",
@@ -14631,28 +14631,28 @@
     "choices": [
       {
         "en": "value that cannot change",
-        "ja": "かえられないち",
+        "ja": "不変値",
         "ja_typings": [
           "kaerarenaichi"
         ]
       },
       {
         "en": "variable with fixed type",
-        "ja": "かたこていのへんすう",
+        "ja": "固定型の変数",
         "ja_typings": [
           "katakoteinohensuu"
         ]
       },
       {
         "en": "loop limit value",
-        "ja": "るーぷのかぎりち",
+        "ja": "ループの限り値",
         "ja_typings": [
           "rupunokagirichi"
         ]
       },
       {
         "en": "function return value",
-        "ja": "かんすうのもどりち",
+        "ja": "関数の戻り値",
         "ja_typings": [
           "kansuunomodorichi"
         ]
@@ -14664,7 +14664,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a constant?",
-      "ja": "定数とは何ですか？"
+      "ja": "定数とは何か？"
     },
     "question_text_reading": {
       "en": "What is a constant?",
@@ -14675,7 +14675,7 @@
     "choices": [
       {
         "en": "order in which operators are evaluated",
-        "ja": "えんざんしがひょうかされるじゅん",
+        "ja": "演算子が評価される順",
         "ja_typings": [
           "enzanshigahyokasarerujun",
           "enzanshigahyoukasarerujun"
@@ -14683,14 +14683,14 @@
       },
       {
         "en": "strength of an operator",
-        "ja": "えんざんしのちから",
+        "ja": "演算子の力",
         "ja_typings": [
           "enzanshinochikara"
         ]
       },
       {
         "en": "number of operands required",
-        "ja": "ひつようなオペランドのかず",
+        "ja": "必要なオペランドの数",
         "ja_typings": [
           "hitsuyonaoperandonokazu",
           "hitsuyounaoperandonokazu"
@@ -14698,7 +14698,7 @@
       },
       {
         "en": "speed of operator execution",
-        "ja": "えんざんしじっこうのそくど",
+        "ja": "演算子実行の速度",
         "ja_typings": [
           "enzanshijikkonosokudo",
           "enzanshijikkounosokudo"
@@ -14711,7 +14711,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is operator precedence?",
-      "ja": "演算子の優先順位とは何ですか？"
+      "ja": "演算子の優先順位とは何か？"
     },
     "question_text_reading": {
       "en": "What is operator precedence?",
@@ -14722,7 +14722,7 @@
     "choices": [
       {
         "en": "stopping evaluation when result is determined",
-        "ja": "けっかがきまるとひょうかをとめる",
+        "ja": "結果が決まると評価を止める",
         "ja_typings": [
           "kekkagakimarutohyokaotomeru",
           "kekkagakimarutohyoukaotomeru"
@@ -14730,7 +14730,7 @@
       },
       {
         "en": "fast execution optimization",
-        "ja": "こうそくじっこうのさいてきか",
+        "ja": "高速実行の最適化",
         "ja_typings": [
           "kosokujikkonosaitekika",
           "kousokujikkounosaitekika"
@@ -14738,7 +14738,7 @@
       },
       {
         "en": "evaluating only one operand",
-        "ja": "いちオペランドのみひょうか",
+        "ja": "一オペランドのみ評価",
         "ja_typings": [
           "ichioperandonomihyoka",
           "ichioperandonomihyouka"
@@ -14746,7 +14746,7 @@
       },
       {
         "en": "ignoring second operand always",
-        "ja": "つねにだいにオペランドをむし",
+        "ja": "常に第二オペランドを無視",
         "ja_typings": [
           "tsunenidainioperandomushi",
           "tsunenidainioperandoomushi"
@@ -14759,7 +14759,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is short-circuit evaluation?",
-      "ja": "ショートサーキット評価とは何ですか？"
+      "ja": "短絡評価とは何か？"
     },
     "question_text_reading": {
       "en": "What is short-circuit evaluation?",
@@ -14770,7 +14770,7 @@
     "choices": [
       {
         "en": "condition ? value_if_true : value_if_false",
-        "ja": "じょうけん?しんのち:ぎのち",
+        "ja": "条件?真の値:偽の値",
         "ja_typings": [
           "joken shinnochi ginochi",
           "jouken shinnochi ginochi"
@@ -14778,7 +14778,7 @@
       },
       {
         "en": "operator with three operands only",
-        "ja": "さんつのオペランドのみのえんざんし",
+        "ja": "三つのオペランドのみの演算子",
         "ja_typings": [
           "santsunoperandonominoenzanshi",
           "santsunooperandonominoenzanshi"
@@ -14786,14 +14786,14 @@
       },
       {
         "en": "third operator in expression",
-        "ja": "しきのさんばんめのえんざんし",
+        "ja": "式の三番目の演算子",
         "ja_typings": [
           "shikinosanbanmenoenzanshi"
         ]
       },
       {
         "en": "triple assignment operator",
-        "ja": "みっつだいにゅうえんざんし",
+        "ja": "三重代入演算子",
         "ja_typings": [
           "mittsudainyuuenzanshi"
         ]
@@ -14805,7 +14805,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a ternary operator?",
-      "ja": "三項演算子とは何ですか？"
+      "ja": "三項演算子とは何か？"
     },
     "question_text_reading": {
       "en": "What is a ternary operator?",
@@ -14816,28 +14816,28 @@
     "choices": [
       {
         "en": "Death Note",
-        "ja": "でーすのーと",
+        "ja": "デスノート",
         "ja_typings": [
           "desunoto"
         ]
       },
       {
         "en": "Bleach",
-        "ja": "ぶりーち",
+        "ja": "ブリーチ",
         "ja_typings": [
           "burichi"
         ]
       },
       {
         "en": "Naruto",
-        "ja": "なると",
+        "ja": "ナルト",
         "ja_typings": [
           "naruto"
         ]
       },
       {
         "en": "One Piece",
-        "ja": "わんぴーす",
+        "ja": "ワンピース",
         "ja_typings": [
           "wanpisu"
         ]
@@ -14849,7 +14849,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime features a boy who gains power from a Death Note?",
-      "ja": "しのちょうからちからをえる少年のアニメは？"
+      "ja": "死の帳から力を得る少年のアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime features a boy who gains power from a Death Note?",
@@ -14874,14 +14874,14 @@
       },
       {
         "en": "Sakura Haruno",
-        "ja": "はるのさくら",
+        "ja": "春野さくら",
         "ja_typings": [
           "harunosakura"
         ]
       },
       {
         "en": "Kakashi Hatake",
-        "ja": "はたけかかし",
+        "ja": "畑ヶ樫",
         "ja_typings": [
           "hatakekakashi"
         ]
@@ -14893,7 +14893,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the name of the protagonist in Naruto?",
-      "ja": "『NARUTO -ナルト-』の主人公の名前は何ですか？"
+      "ja": "Narutoの主人公の名前は？"
     },
     "question_text_reading": {
       "en": "What is the name of the protagonist in Naruto?",
@@ -14904,28 +14904,28 @@
     "choices": [
       {
         "en": "Attack on Titan",
-        "ja": "しんげきのきょじん",
+        "ja": "進撃の巨人",
         "ja_typings": [
           "shingekinokyojin"
         ]
       },
       {
         "en": "Fullmetal Alchemist",
-        "ja": "はがねのれんきんじゅつし",
+        "ja": "鋼の錬金術師",
         "ja_typings": [
           "haganenorenkinjutsushi"
         ]
       },
       {
         "en": "Dragon Ball Z",
-        "ja": "どらごんぼーるぜっと",
+        "ja": "ドラゴンボールZ",
         "ja_typings": [
           "doragonboruzetto"
         ]
       },
       {
         "en": "Sword Art Online",
-        "ja": "そーどあーとおんらいん",
+        "ja": "ソードアート・オンライン",
         "ja_typings": [
           "sodoatonrain",
           "sodoatoonrain"
@@ -14938,7 +14938,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime is set in a world where humans live inside walls to avoid Titans?",
-      "ja": "タイタンから身を守るため、人類が壁の中に暮らす世界を舞台にしたアニメはどれ？"
+      "ja": "巨人の逃れるために壁の中で暮らす世界のアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime is set in a world where humans live inside walls to avoid Titans?",
@@ -14949,7 +14949,7 @@
     "choices": [
       {
         "en": "Spirited Away",
-        "ja": "せんとちひろのかみかくし",
+        "ja": "千と千尋の神隠し",
         "ja_typings": [
           "sentochihironokamikakushi"
         ]
@@ -14963,14 +14963,14 @@
       },
       {
         "en": "Princess Mononoke",
-        "ja": "もののけひめ",
+        "ja": "もののけ姫",
         "ja_typings": [
           "mononokehime"
         ]
       },
       {
         "en": "Howl's Moving Castle",
-        "ja": "ハウルのうごくしろ",
+        "ja": "ハウルの動く城",
         "ja_typings": [
           "haurunogokushiro",
           "haurunougokushiro"
@@ -14983,7 +14983,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which Studio Ghibli film features a girl who works in a bathhouse for spirits?",
-      "ja": "精霊の湯屋で働く少女が登場するスタジオジブリの作品はどれ？"
+      "ja": "精霊の湯屋で働く少女のスタジオジブリ映画は？"
     },
     "question_text_reading": {
       "en": "Which Studio Ghibli film features a girl who works in a bathhouse for spirits?",
@@ -14994,14 +14994,14 @@
     "choices": [
       {
         "en": "one punch defeats any enemy",
-        "ja": "いちげきですべてのてきをたおす",
+        "ja": "一撃ですべての敵を倒す",
         "ja_typings": [
           "ichigekidesubetenotekiotaosu"
         ]
       },
       {
         "en": "super speed",
-        "ja": "ちょうそくど",
+        "ja": "超速度",
         "ja_typings": [
           "chosokudo",
           "chousokudo"
@@ -15009,7 +15009,7 @@
       },
       {
         "en": "flight",
-        "ja": "ひこう",
+        "ja": "飛行",
         "ja_typings": [
           "hiko",
           "hikou"
@@ -15017,7 +15017,7 @@
       },
       {
         "en": "telepathy",
-        "ja": "てれぱしー",
+        "ja": "テレパシー",
         "ja_typings": [
           "terepashi"
         ]
@@ -15029,7 +15029,7 @@
     "image_path": null,
     "question_text": {
       "en": "What power does Saitama from One Punch Man have?",
-      "ja": "『ワンパンマン』の埼玉が持つ力は何ですか？"
+      "ja": "ワンパンマンのサイタマの力は？"
     },
     "question_text_reading": {
       "en": "What power does Saitama from One Punch Man have?",
@@ -15040,28 +15040,28 @@
     "choices": [
       {
         "en": "One Piece",
-        "ja": "わんぴーす",
+        "ja": "ワンピース",
         "ja_typings": [
           "wanpisu"
         ]
       },
       {
         "en": "Fairy Tail",
-        "ja": "ふぇありーている",
+        "ja": "フェアリーテイル",
         "ja_typings": [
           "feariteiru"
         ]
       },
       {
         "en": "Bleach",
-        "ja": "ぶりーち",
+        "ja": "ブリーチ",
         "ja_typings": [
           "burichi"
         ]
       },
       {
         "en": "Dragon Ball",
-        "ja": "どらごんぼーる",
+        "ja": "ドラゴンボール",
         "ja_typings": [
           "doragonboru"
         ]
@@ -15073,7 +15073,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime features the Straw Hat Pirates?",
-      "ja": "ストローハットの海賊が登場するアニメはどれ？"
+      "ja": "麦わらの一族のアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime features the Straw Hat Pirates?",
@@ -15084,14 +15084,14 @@
     "choices": [
       {
         "en": "Akira Toriyama",
-        "ja": "とりやまあきら",
+        "ja": "鳥山明",
         "ja_typings": [
           "toriyamaakira"
         ]
       },
       {
         "en": "Eiichiro Oda",
-        "ja": "おだえいいちろう",
+        "ja": "織田栄一郎",
         "ja_typings": [
           "odaeiichiro",
           "odaeiichirou"
@@ -15099,14 +15099,14 @@
       },
       {
         "en": "Masashi Kishimoto",
-        "ja": "きしもとまさし",
+        "ja": "岸本正史",
         "ja_typings": [
           "kishimotomasashi"
         ]
       },
       {
         "en": "Tite Kubo",
-        "ja": "くぼたいと",
+        "ja": "久保帯人",
         "ja_typings": [
           "kubotaito"
         ]
@@ -15118,7 +15118,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who is the author of Dragon Ball?",
-      "ja": "ドラゴンボールのさくしゃは？"
+      "ja": "ドラゴンボールの作者は？"
     },
     "question_text_reading": {
       "en": "Who is the author of Dragon Ball?",
@@ -15129,28 +15129,28 @@
     "choices": [
       {
         "en": "Demon Slayer",
-        "ja": "きめつのやいば",
+        "ja": "鬼滅の刃",
         "ja_typings": [
           "kimetsunoyaiba"
         ]
       },
       {
         "en": "Jujutsu Kaisen",
-        "ja": "じゅじゅつかいせん",
+        "ja": "呪術廻戦",
         "ja_typings": [
           "jujutsukaisen"
         ]
       },
       {
         "en": "Bleach",
-        "ja": "ぶりーち",
+        "ja": "ブリーチ",
         "ja_typings": [
           "burichi"
         ]
       },
       {
         "en": "Naruto",
-        "ja": "なると",
+        "ja": "ナルト",
         "ja_typings": [
           "naruto"
         ]
@@ -15162,7 +15162,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime is about a boy named Tanjiro fighting demons?",
-      "ja": "炭治郎という少年が鬼と戦うアニメはどれ？"
+      "ja": "炭治郎という少年がお鬼と戦うアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime is about a boy named Tanjiro fighting demons?",
@@ -15173,28 +15173,28 @@
     "choices": [
       {
         "en": "virtual reality MMORPG",
-        "ja": "ばーちゃるりありてぃMMORPG",
+        "ja": "バーチャルリアリティMMORPG",
         "ja_typings": [
           "bacharuriaritimmorpg"
         ]
       },
       {
         "en": "feudal Japan",
-        "ja": "えどじだいのにほん",
+        "ja": "江戸時代のにほん",
         "ja_typings": [
           "edojidainonihon"
         ]
       },
       {
         "en": "outer space",
-        "ja": "うちゅう",
+        "ja": "宇宙",
         "ja_typings": [
           "uchuu"
         ]
       },
       {
         "en": "post-apocalyptic earth",
-        "ja": "ぶんめいほうかいごのちきゅう",
+        "ja": "文明崩壊後の地球",
         "ja_typings": [
           "bunmeihokaigonochikyuu",
           "bunmeihoukaigonochikyuu"
@@ -15207,7 +15207,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the setting of Sword Art Online?",
-      "ja": "ソードアートオンラインのぶたいは？"
+      "ja": "ソードアートオンラインの舞台は？"
     },
     "question_text_reading": {
       "en": "What is the setting of Sword Art Online?",
@@ -15218,28 +15218,28 @@
     "choices": [
       {
         "en": "Pokemon",
-        "ja": "ぽけもん",
+        "ja": "ポケモン",
         "ja_typings": [
           "pokemon"
         ]
       },
       {
         "en": "Digimon",
-        "ja": "でじもん",
+        "ja": "デジモン",
         "ja_typings": [
           "dejimon"
         ]
       },
       {
         "en": "Beyblade",
-        "ja": "べいぶれーど",
+        "ja": "ベイブレード",
         "ja_typings": [
           "beiburedo"
         ]
       },
       {
         "en": "Yu-Gi-Oh",
-        "ja": "ゆうぎおー",
+        "ja": "遊戯王",
         "ja_typings": [
           "yuugio"
         ]
@@ -15251,7 +15251,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime follows a boy who wants to be the best Pokemon trainer?",
-      "ja": "最強のポケモントレーナーを目指す少年を描いたアニメはどれ？"
+      "ja": "最強のポケモン トレーナーをめざす少年のアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime follows a boy who wants to be the best Pokemon trainer?",
@@ -15262,28 +15262,28 @@
     "choices": [
       {
         "en": "Hideaki Anno",
-        "ja": "あんのひであき",
+        "ja": "庵野ひであき",
         "ja_typings": [
           "annohideaki"
         ]
       },
       {
         "en": "Hayao Miyazaki",
-        "ja": "みやざきはやお",
+        "ja": "宮崎駿",
         "ja_typings": [
           "miyazakihayao"
         ]
       },
       {
         "en": "Satoshi Kon",
-        "ja": "こんさとし",
+        "ja": "根里俊",
         "ja_typings": [
           "konsatoshi"
         ]
       },
       {
         "en": "Osamu Tezuka",
-        "ja": "てづかおさむ",
+        "ja": "手塚治虫",
         "ja_typings": [
           "tezukaosamu"
         ]
@@ -15295,7 +15295,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who created the Evangelion series?",
-      "ja": "エヴァンゲリオンシリーズを制作したのは誰ですか？"
+      "ja": "エヴァンゲリオンシリーズを作ったのは？"
     },
     "question_text_reading": {
       "en": "Who created the Evangelion series?",
@@ -15306,28 +15306,28 @@
     "choices": [
       {
         "en": "Attack on Titan",
-        "ja": "しんげきのきょじん",
+        "ja": "進撃の巨人",
         "ja_typings": [
           "shingekinokyojin"
         ]
       },
       {
         "en": "Fullmetal Alchemist",
-        "ja": "はがねのれんきんじゅつし",
+        "ja": "鋼の錬金術師",
         "ja_typings": [
           "haganenorenkinjutsushi"
         ]
       },
       {
         "en": "My Hero Academia",
-        "ja": "ぼくのひーろーあかでみあ",
+        "ja": "僕のヒーローアカデミア",
         "ja_typings": [
           "bokunohiroakademia"
         ]
       },
       {
         "en": "Black Clover",
-        "ja": "ぶらっくくろーばー",
+        "ja": "ブラッククローバー",
         "ja_typings": [
           "burakkukuroba"
         ]
@@ -15339,7 +15339,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime features the Survey Corps?",
-      "ja": "ちょうさへいだんがとうじょうするアニメは？"
+      "ja": "調査兵団が登場するアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime features the Survey Corps?",
@@ -15350,14 +15350,14 @@
     "choices": [
       {
         "en": "Izuku Midoriya",
-        "ja": "みどりやいずく",
+        "ja": "緑谷出久",
         "ja_typings": [
           "midoriyaizuku"
         ]
       },
       {
         "en": "Katsuki Bakugo",
-        "ja": "ばくごうかつき",
+        "ja": "爆豪勝己",
         "ja_typings": [
           "bakugokatsuki",
           "bakugoukatsuki"
@@ -15365,7 +15365,7 @@
       },
       {
         "en": "Shouto Todoroki",
-        "ja": "とどろきしょうと",
+        "ja": "轟焦凍",
         "ja_typings": [
           "todorokishoto",
           "todorokishouto"
@@ -15373,7 +15373,7 @@
       },
       {
         "en": "Tenya Iida",
-        "ja": "いいだてんや",
+        "ja": "飯田天弥",
         "ja_typings": [
           "iidatenya"
         ]
@@ -15385,7 +15385,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the full name of the protagonist in My Hero Academia?",
-      "ja": "『僕のヒーローアカデミア』の主人公のフルネームは何ですか？"
+      "ja": "僕のヒーローアカデミアの主人公のフルネームは？"
     },
     "question_text_reading": {
       "en": "What is the full name of the protagonist in My Hero Academia?",
@@ -15396,28 +15396,28 @@
     "choices": [
       {
         "en": "Naruto",
-        "ja": "なると",
+        "ja": "ナルト",
         "ja_typings": [
           "naruto"
         ]
       },
       {
         "en": "Bleach",
-        "ja": "ぶりーち",
+        "ja": "ブリーチ",
         "ja_typings": [
           "burichi"
         ]
       },
       {
         "en": "Dragon Ball",
-        "ja": "どらごんぼーる",
+        "ja": "ドラゴンボール",
         "ja_typings": [
           "doragonboru"
         ]
       },
       {
         "en": "One Piece",
-        "ja": "わんぴーす",
+        "ja": "ワンピース",
         "ja_typings": [
           "wanpisu"
         ]
@@ -15429,7 +15429,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime features ninjas with special chakra abilities?",
-      "ja": "特殊なチャクラの能力を持つ忍者が登場するアニメはどれ？"
+      "ja": "特別なチャクラの能力を持つ忍者のアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime features ninjas with special chakra abilities?",
@@ -15440,14 +15440,14 @@
     "choices": [
       {
         "en": "Gainax",
-        "ja": "がいなっくす",
+        "ja": "ゲインアクス",
         "ja_typings": [
           "gainakkusu"
         ]
       },
       {
         "en": "Toei Animation",
-        "ja": "とうえいあにめーしょん",
+        "ja": "東映アニメーション",
         "ja_typings": [
           "toeianimeshon",
           "toueianimeshon"
@@ -15455,14 +15455,14 @@
       },
       {
         "en": "Madhouse",
-        "ja": "まっどはうす",
+        "ja": "マッドハウス",
         "ja_typings": [
           "maddohausu"
         ]
       },
       {
         "en": "Kyoto Animation",
-        "ja": "きょーとあにめーしょん",
+        "ja": "京都アニメーション",
         "ja_typings": [
           "kyotoanimeshon"
         ]
@@ -15474,7 +15474,7 @@
     "image_path": null,
     "question_text": {
       "en": "What studio produced Neon Genesis Evangelion?",
-      "ja": "『新世紀エヴァンゲリオン』を制作したスタジオはどこ？"
+      "ja": "新世紀エヴァンゲリオンを製作したスタジオは？"
     },
     "question_text_reading": {
       "en": "What studio produced Neon Genesis Evangelion?",
@@ -15485,28 +15485,28 @@
     "choices": [
       {
         "en": "Dragon Ball",
-        "ja": "どらごんぼーる",
+        "ja": "ドラゴンボール",
         "ja_typings": [
           "doragonboru"
         ]
       },
       {
         "en": "Naruto",
-        "ja": "なると",
+        "ja": "ナルト",
         "ja_typings": [
           "naruto"
         ]
       },
       {
         "en": "One Piece",
-        "ja": "わんぴーす",
+        "ja": "ワンピース",
         "ja_typings": [
           "wanpisu"
         ]
       },
       {
         "en": "Bleach",
-        "ja": "ぶりーち",
+        "ja": "ブリーチ",
         "ja_typings": [
           "burichi"
         ]
@@ -15518,7 +15518,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime series is known for the 'Kamehameha' attack?",
-      "ja": "かめはめはの技で知られるアニメシリーズはどれですか？"
+      "ja": "かめはめはこうげきでゆうめいなアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime series is known for the 'Kamehameha' attack?",
@@ -15529,7 +15529,7 @@
     "choices": [
       {
         "en": "magical girl",
-        "ja": "まほうしょうじょ",
+        "ja": "魔法少女",
         "ja_typings": [
           "mahoshojo",
           "mahoushoujo"
@@ -15537,21 +15537,21 @@
       },
       {
         "en": "mecha",
-        "ja": "めか",
+        "ja": "メカ",
         "ja_typings": [
           "meka"
         ]
       },
       {
         "en": "isekai",
-        "ja": "いせかい",
+        "ja": "異世界",
         "ja_typings": [
           "isekai"
         ]
       },
       {
         "en": "sports",
-        "ja": "すぽーつ",
+        "ja": "スポーツ",
         "ja_typings": [
           "supotsu"
         ]
@@ -15563,7 +15563,7 @@
     "image_path": null,
     "question_text": {
       "en": "What genre is Sailor Moon?",
-      "ja": "せーらーむーんのジャンルは？"
+      "ja": "セーラーミーンのジャンルは？"
     },
     "question_text_reading": {
       "en": "What genre is Sailor Moon?",
@@ -15581,21 +15581,21 @@
       },
       {
         "en": "Misty",
-        "ja": "かすみ",
+        "ja": "霞",
         "ja_typings": [
           "kasumi"
         ]
       },
       {
         "en": "Brock",
-        "ja": "たけし",
+        "ja": "武志",
         "ja_typings": [
           "takeshi"
         ]
       },
       {
         "en": "Gary",
-        "ja": "しげる",
+        "ja": "茂",
         "ja_typings": [
           "shigeru"
         ]
@@ -15607,7 +15607,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who is Pikachu's trainer in Pokemon anime?",
-      "ja": "ポケモンアニメでぴかちゅうのとれーなーは？"
+      "ja": "ポケモンアニメでピカチュウのトレーナーは？"
     },
     "question_text_reading": {
       "en": "Who is Pikachu's trainer in Pokemon anime?",
@@ -15618,28 +15618,28 @@
     "choices": [
       {
         "en": "Haikyuu!!",
-        "ja": "はいきゅー!!",
+        "ja": "ハイキュー",
         "ja_typings": [
           "haikyu"
         ]
       },
       {
         "en": "Slam Dunk",
-        "ja": "すらむだんく",
+        "ja": "スラムダンク",
         "ja_typings": [
           "suramudanku"
         ]
       },
       {
         "en": "Kuroko's Basketball",
-        "ja": "くろこのバスケ",
+        "ja": "黒子のバスケ",
         "ja_typings": [
           "kurokonobasuke"
         ]
       },
       {
         "en": "Captain Tsubasa",
-        "ja": "きゃぷてんつばさ",
+        "ja": "キャプテン翼",
         "ja_typings": [
           "kyaputentsubasa"
         ]
@@ -15651,7 +15651,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime is set in a sports high school for volleyball?",
-      "ja": "バレーボールをテーマにしたスポーツ高校を舞台にしているアニメはどれ？"
+      "ja": "バレーボールの高校のアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime is set in a sports high school for volleyball?",
@@ -15662,28 +15662,28 @@
     "choices": [
       {
         "en": "genre where character is transported to another world",
-        "ja": "べつのせかいにうつされるジャンル",
+        "ja": "別の世界に移されるジャンル",
         "ja_typings": [
           "betsunosekainiutsusarerujanru"
         ]
       },
       {
         "en": "genre about samurai",
-        "ja": "さむらいのジャンル",
+        "ja": "侍のジャンル",
         "ja_typings": [
           "samurainojanru"
         ]
       },
       {
         "en": "genre about sports",
-        "ja": "すぽーつのジャンル",
+        "ja": "スポーツのジャンル",
         "ja_typings": [
           "supotsunojanru"
         ]
       },
       {
         "en": "genre about mecha robots",
-        "ja": "めかろぼっとのジャンル",
+        "ja": "メカロボットのジャンル",
         "ja_typings": [
           "mekarobottonojanru"
         ]
@@ -15695,7 +15695,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is isekai?",
-      "ja": "異世界（いせかい）とは、どのようなジャンルを指すのでしょうか？"
+      "ja": "異世界とは何か？"
     },
     "question_text_reading": {
       "en": "What is isekai?",
@@ -15706,28 +15706,28 @@
     "choices": [
       {
         "en": "One Piece",
-        "ja": "わんぴーす",
+        "ja": "ワンピース",
         "ja_typings": [
           "wanpisu"
         ]
       },
       {
         "en": "Naruto",
-        "ja": "なると",
+        "ja": "ナルト",
         "ja_typings": [
           "naruto"
         ]
       },
       {
         "en": "Dragon Ball",
-        "ja": "どらごんぼーる",
+        "ja": "ドラゴンボール",
         "ja_typings": [
           "doragonboru"
         ]
       },
       {
         "en": "Fairy Tail",
-        "ja": "ふぇありーている",
+        "ja": "フェアリーテイル",
         "ja_typings": [
           "feariteiru"
         ]
@@ -15739,7 +15739,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime features Monkey D. Luffy?",
-      "ja": "モンキー・D・ルフィが登場するアニメはどれ？"
+      "ja": "Monkey D. Luffyが登場するアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime features Monkey D. Luffy?",
@@ -15750,7 +15750,7 @@
     "choices": [
       {
         "en": "U.A. High School",
-        "ja": "ゆーえいこうこう",
+        "ja": "U.A.高校",
         "ja_typings": [
           "yueikoko",
           "yueikoukou"
@@ -15758,7 +15758,7 @@
       },
       {
         "en": "Shiketsu High",
-        "ja": "しけつこうこう",
+        "ja": "式鉄高校",
         "ja_typings": [
           "shiketsukoko",
           "shiketsukoukou"
@@ -15766,14 +15766,14 @@
       },
       {
         "en": "Ketsubutsu Academy",
-        "ja": "けつぶつがくえん",
+        "ja": "結仏学園",
         "ja_typings": [
           "ketsubutsugakuen"
         ]
       },
       {
         "en": "Seiai Academy",
-        "ja": "せいあいがくえん",
+        "ja": "精愛学園",
         "ja_typings": [
           "seiaigakuen"
         ]
@@ -15785,7 +15785,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the name of the school in My Hero Academia?",
-      "ja": "僕のヒーローアカデミアに登場する学校の名前は何ですか？"
+      "ja": "僕のヒーローアカデミアの学校の名前は？"
     },
     "question_text_reading": {
       "en": "What is the name of the school in My Hero Academia?",
@@ -15796,28 +15796,28 @@
     "choices": [
       {
         "en": "Death Note",
-        "ja": "でーすのーと",
+        "ja": "デスノート",
         "ja_typings": [
           "desunoto"
         ]
       },
       {
         "en": "Monster",
-        "ja": "もんすたー",
+        "ja": "モンスター",
         "ja_typings": [
           "monsuta"
         ]
       },
       {
         "en": "Psycho-Pass",
-        "ja": "さいこぱす",
+        "ja": "サイコパス",
         "ja_typings": [
           "saikopasu"
         ]
       },
       {
         "en": "Detective Conan",
-        "ja": "めいたんていこなん",
+        "ja": "名探偵コナン",
         "ja_typings": [
           "meitanteikonan"
         ]
@@ -15829,7 +15829,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime follows L and Light's cat-and-mouse detective game?",
-      "ja": "Lとライトの猫とネズミのような推理ゲームを描いたアニメはどれ？"
+      "ja": "Lとライトの隠れんぼのような推理のアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime follows L and Light's cat-and-mouse detective game?",
@@ -15840,28 +15840,28 @@
     "choices": [
       {
         "en": "Naruto",
-        "ja": "なると",
+        "ja": "ナルト",
         "ja_typings": [
           "naruto"
         ]
       },
       {
         "en": "Bleach",
-        "ja": "ぶりーち",
+        "ja": "ブリーチ",
         "ja_typings": [
           "burichi"
         ]
       },
       {
         "en": "Fairy Tail",
-        "ja": "ふぇありーている",
+        "ja": "フェアリーテイル",
         "ja_typings": [
           "feariteiru"
         ]
       },
       {
         "en": "Attack on Titan",
-        "ja": "しんげきのきょじん",
+        "ja": "進撃の巨人",
         "ja_typings": [
           "shingekinokyojin"
         ]
@@ -15873,7 +15873,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime is set in the fictional Konoha village?",
-      "ja": "かそうのこのははのむらが舞台のアニメは？"
+      "ja": "仮想の木葉の村が舞台のアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime is set in the fictional Konoha village?",
@@ -15884,28 +15884,28 @@
     "choices": [
       {
         "en": "Naruto, Bleach, One Piece",
-        "ja": "なるとぶりーちわんぴーす",
+        "ja": "ナルト・ブリーチ・ワンピース",
         "ja_typings": [
           "narutoburichiwanpisu"
         ]
       },
       {
         "en": "Dragon Ball, Naruto, One Piece",
-        "ja": "どらごんぼーるなるとわんぴーす",
+        "ja": "ドラゴンボールナルトワンピース",
         "ja_typings": [
           "doragonborunarutowanpisu"
         ]
       },
       {
         "en": "Bleach, Dragon Ball, Fairy Tail",
-        "ja": "ぶりーちどらごんぼーるふぇありーている",
+        "ja": "ブリーチ・ドラゴンボール・フェアリーテイル",
         "ja_typings": [
           "burichidoragonborufeariteiru"
         ]
       },
       {
         "en": "One Piece, My Hero, Attack on Titan",
-        "ja": "わんぴーすひーろーきょじん",
+        "ja": "ワンピースヒーローキョジン",
         "ja_typings": [
           "wanpisuhirokyojin"
         ]
@@ -15917,7 +15917,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the 'Big Three' of older Shonen Jump anime?",
-      "ja": "むかしのじゃんぷのさんだいアニメは？"
+      "ja": "昔のジャンプの三大アニメは？"
     },
     "question_text_reading": {
       "en": "What is the 'Big Three' of older Shonen Jump anime?",
@@ -15928,7 +15928,7 @@
     "choices": [
       {
         "en": "anime featuring giant robots",
-        "ja": "きょだいろぼっとがとうじょうするアニメ",
+        "ja": "巨大ロボットが登場するアニメ",
         "ja_typings": [
           "kyodairobottogatojosuruanime",
           "kyodairobottogatoujousuruanime"
@@ -15936,7 +15936,7 @@
       },
       {
         "en": "anime about magic users",
-        "ja": "まほうつかいのアニメ",
+        "ja": "魔法使いのアニメ",
         "ja_typings": [
           "mahotsukainoanime",
           "mahoutsukainoanime"
@@ -15944,14 +15944,14 @@
       },
       {
         "en": "anime set in feudal Japan",
-        "ja": "えどじだいのアニメ",
+        "ja": "江戸時代のアニメ",
         "ja_typings": [
           "edojidainoanime"
         ]
       },
       {
         "en": "anime about cooking",
-        "ja": "りょうりのアニメ",
+        "ja": "料理のアニメ",
         "ja_typings": [
           "ryorinoanime",
           "ryourinoanime"
@@ -15964,7 +15964,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a mecha anime?",
-      "ja": "めかアニメとは何か？"
+      "ja": "メカアニメとは何か？"
     },
     "question_text_reading": {
       "en": "What is a mecha anime?",
@@ -15975,28 +15975,28 @@
     "choices": [
       {
         "en": "Kiki's Delivery Service",
-        "ja": "まじょのたっきゅうびん",
+        "ja": "魔女の宅急便",
         "ja_typings": [
           "majonotakkyuubin"
         ]
       },
       {
         "en": "Spirited Away",
-        "ja": "せんとちひろのかみかくし",
+        "ja": "千と千尋の神隠し",
         "ja_typings": [
           "sentochihironokamikakushi"
         ]
       },
       {
         "en": "Nausicaa",
-        "ja": "なうしか",
+        "ja": "ナウシカ",
         "ja_typings": [
           "naushika"
         ]
       },
       {
         "en": "Castle in the Sky",
-        "ja": "てんくうのしろらぴゅた",
+        "ja": "天空の城ラピュタ",
         "ja_typings": [
           "tenkuunoshirorapyuta"
         ]
@@ -16008,7 +16008,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which Ghibli film features a young witch who delivers by broomstick?",
-      "ja": "ほうきで飛ぶ若い魔女が登場するジブリ映画はどれでしょう？"
+      "ja": "ほうきでいたつするわかいまじょのジブリえいがは？"
     },
     "question_text_reading": {
       "en": "Which Ghibli film features a young witch who delivers by broomstick?",
@@ -16019,28 +16019,28 @@
     "choices": [
       {
         "en": "Bleach",
-        "ja": "ぶりーち",
+        "ja": "ブリーチ",
         "ja_typings": [
           "burichi"
         ]
       },
       {
         "en": "Naruto",
-        "ja": "なると",
+        "ja": "ナルト",
         "ja_typings": [
           "naruto"
         ]
       },
       {
         "en": "Dragon Ball",
-        "ja": "どらごんぼーる",
+        "ja": "ドラゴンボール",
         "ja_typings": [
           "doragonboru"
         ]
       },
       {
         "en": "One Piece",
-        "ja": "わんぴーす",
+        "ja": "ワンピース",
         "ja_typings": [
           "wanpisu"
         ]
@@ -16052,7 +16052,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime follows Ichigo Kurosaki, a Soul Reaper?",
-      "ja": "主人公が死神（Soul Reaper）であるイチゴ・クロサキを追うアニメはどれ？"
+      "ja": "一護（いちご）黒崎（くろさき）という死神（しにがみ）のアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime follows Ichigo Kurosaki, a Soul Reaper?",
@@ -16063,28 +16063,28 @@
     "choices": [
       {
         "en": "anime targeted at young male audience",
-        "ja": "わかいだんせいむけアニメ",
+        "ja": "若い男性向けアニメ",
         "ja_typings": [
           "wakaidanseimukeanime"
         ]
       },
       {
         "en": "anime targeted at young female audience",
-        "ja": "わかいじょせいむけアニメ",
+        "ja": "若い女性向けアニメ",
         "ja_typings": [
           "wakaijoseimukeanime"
         ]
       },
       {
         "en": "anime for adult men",
-        "ja": "おとなのだんせいむけアニメ",
+        "ja": "大人男性向けアニメ",
         "ja_typings": [
           "otonanodanseimukeanime"
         ]
       },
       {
         "en": "anime for children",
-        "ja": "こどもむけアニメ",
+        "ja": "子供向けアニメ",
         "ja_typings": [
           "kodomomukeanime"
         ]
@@ -16096,7 +16096,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a 'shonen' anime?",
-      "ja": "少年（shonen）アニメとはどのようなジャンルですか？"
+      "ja": "少年アニメとは何か？"
     },
     "question_text_reading": {
       "en": "What is a 'shonen' anime?",
@@ -16107,28 +16107,28 @@
     "choices": [
       {
         "en": "anime targeted at young female audience",
-        "ja": "わかいじょせいむけアニメ",
+        "ja": "若い女性向けアニメ",
         "ja_typings": [
           "wakaijoseimukeanime"
         ]
       },
       {
         "en": "anime targeted at young male audience",
-        "ja": "わかいだんせいむけアニメ",
+        "ja": "若男性向けアニメ",
         "ja_typings": [
           "wakaidanseimukeanime"
         ]
       },
       {
         "en": "anime about romance only",
-        "ja": "れんあいのみのアニメ",
+        "ja": "恋愛のみのアニメ",
         "ja_typings": [
           "renainominoanime"
         ]
       },
       {
         "en": "anime with female protagonists only",
-        "ja": "じょしゅじんこうのみのアニメ",
+        "ja": "女子主人公のみのアニメ",
         "ja_typings": [
           "joshujinkonominoanime",
           "joshujinkounominoanime"
@@ -16141,7 +16141,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a 'shoujo' anime?",
-      "ja": "shoujoアニメとは、どのようなジャンルを指すものですか？"
+      "ja": "少女アニメとは何か？"
     },
     "question_text_reading": {
       "en": "What is a 'shoujo' anime?",
@@ -16152,28 +16152,28 @@
     "choices": [
       {
         "en": "Dragon Ball",
-        "ja": "どらごんぼーる",
+        "ja": "ドラゴンボール",
         "ja_typings": [
           "doragonboru"
         ]
       },
       {
         "en": "Naruto",
-        "ja": "なると",
+        "ja": "ナルト",
         "ja_typings": [
           "naruto"
         ]
       },
       {
         "en": "One Piece",
-        "ja": "わんぴーす",
+        "ja": "ワンピース",
         "ja_typings": [
           "wanpisu"
         ]
       },
       {
         "en": "Baki",
-        "ja": "ばき",
+        "ja": "バキ",
         "ja_typings": [
           "baki"
         ]
@@ -16185,7 +16185,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime is about a boy named Goku who trains in martial arts?",
-      "ja": "武術を極める少年、孫悟空（Goku）を主人公としたアニメはどれ？"
+      "ja": "悟空という少年が武道を極めるアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime is about a boy named Goku who trains in martial arts?",
@@ -16196,14 +16196,14 @@
     "choices": [
       {
         "en": "Original Video Animation",
-        "ja": "おりじなるびでおあにめーしょん",
+        "ja": "オリジナルビデオアニメーション",
         "ja_typings": [
           "orijinarubideoanimeshon"
         ]
       },
       {
         "en": "Official Voice Acting",
-        "ja": "こうしきせいゆうえんぎ",
+        "ja": "公式ボイスアクト",
         "ja_typings": [
           "koshikiseiyuuengi",
           "koushikiseiyuuengi"
@@ -16211,14 +16211,14 @@
       },
       {
         "en": "Online Visual Archive",
-        "ja": "おんらいんびじゅあるあーかいぶ",
+        "ja": "オンラインビジュアルアーカイブ",
         "ja_typings": [
           "onrainbijuaruakaibu"
         ]
       },
       {
         "en": "Overseas Video Animation",
-        "ja": "かいがいびでおあにめーしょん",
+        "ja": "海外ビデオアニメーション",
         "ja_typings": [
           "kaigaibideoanimeshon"
         ]
@@ -16230,7 +16230,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does 'OVA' stand for in anime?",
-      "ja": "アニメにおける「OVA」は何の略語ですか？"
+      "ja": "アニメのOVAの略語の意味は？"
     },
     "question_text_reading": {
       "en": "What does 'OVA' stand for in anime?",
@@ -16241,28 +16241,28 @@
     "choices": [
       {
         "en": "One Piece",
-        "ja": "わんぴーす",
+        "ja": "ワンピース",
         "ja_typings": [
           "wanpisu"
         ]
       },
       {
         "en": "Fairy Tail",
-        "ja": "ふぇありーている",
+        "ja": "フェアリーテイル",
         "ja_typings": [
           "feariteiru"
         ]
       },
       {
         "en": "Naruto",
-        "ja": "なると",
+        "ja": "ナルト",
         "ja_typings": [
           "naruto"
         ]
       },
       {
         "en": "Black Clover",
-        "ja": "ぶらっくくろーばー",
+        "ja": "ブラッククローバー",
         "ja_typings": [
           "burakkukuroba"
         ]
@@ -16274,7 +16274,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime is famous for the 'Thousand Sunny' ship?",
-      "ja": "サン・サニー号で有名なアニメはどれ？"
+      "ja": "サウザンドサニー号で有名なアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime is famous for the 'Thousand Sunny' ship?",
@@ -16285,7 +16285,7 @@
     "choices": [
       {
         "en": "JoJo's Bizarre Adventure",
-        "ja": "じょじょのきみょうなぼうけん",
+        "ja": "ジョジョの奇妙な冒険",
         "ja_typings": [
           "jojonokimyonaboken",
           "jojonokimyounabouken"
@@ -16293,21 +16293,21 @@
       },
       {
         "en": "Fullmetal Alchemist",
-        "ja": "はがねのれんきんじゅつし",
+        "ja": "鋼の錬金術師",
         "ja_typings": [
           "haganenorenkinjutsushi"
         ]
       },
       {
         "en": "Noragami",
-        "ja": "のらがみ",
+        "ja": "神奈満",
         "ja_typings": [
           "noragami"
         ]
       },
       {
         "en": "Blue Exorcist",
-        "ja": "あおのえくそしすと",
+        "ja": "青の祓魔師",
         "ja_typings": [
           "aonoekusoshisuto"
         ]
@@ -16319,7 +16319,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime series has 'Stand' abilities as its main power system?",
-      "ja": "すたんどのうりょくがメインのアニメシリーズは？"
+      "ja": "スタンドの能力がメインのアニメシリーズは？"
     },
     "question_text_reading": {
       "en": "Which anime series has 'Stand' abilities as its main power system?",
@@ -16330,14 +16330,14 @@
     "choices": [
       {
         "en": "a quirk that can be passed to others",
-        "ja": "ひとにわたせるこせい",
+        "ja": "人に渡せる個性",
         "ja_typings": [
           "hitoniwataserukosei"
         ]
       },
       {
         "en": "a villain's ultimate power",
-        "ja": "ヴィランのさいきょうのちから",
+        "ja": "ヴィランの最強の力",
         "ja_typings": [
           "virannosaikyonochikara",
           "virannosaikyounochikara"
@@ -16345,7 +16345,7 @@
       },
       {
         "en": "a hero association rank",
-        "ja": "ひーろーきょうかいのくらす",
+        "ja": "ヒーロー協会 の クラス",
         "ja_typings": [
           "hirokyokainokurasu",
           "hirokyoukainokurasu"
@@ -16353,7 +16353,7 @@
       },
       {
         "en": "a special move name",
-        "ja": "とくしゅわざのなまえ",
+        "ja": "特殊技の名前",
         "ja_typings": [
           "tokushuwazanonamae"
         ]
@@ -16365,7 +16365,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'One For All' in My Hero Academia?",
-      "ja": "『僕のヒーローアカデミア』における「One For All」とは何ですか？"
+      "ja": "僕のヒーローアカデミアのOne For Allとは？"
     },
     "question_text_reading": {
       "en": "What is 'One For All' in My Hero Academia?",
@@ -16376,7 +16376,7 @@
     "choices": [
       {
         "en": "Food Wars",
-        "ja": "しょくげきのそうま",
+        "ja": "食戟のソーマ",
         "ja_typings": [
           "shokugekinosoma",
           "shokugekinosouma"
@@ -16384,21 +16384,21 @@
       },
       {
         "en": "Silver Spoon",
-        "ja": "ぎんのさじ",
+        "ja": "銀の匙",
         "ja_typings": [
           "ginnosaji"
         ]
       },
       {
         "en": "Sweetness and Lightning",
-        "ja": "あまあまといなずま",
+        "ja": "甘藷と稲妻",
         "ja_typings": [
           "amaamatoinazuma"
         ]
       },
       {
         "en": "Cooking Master Boy",
-        "ja": "ちゅうかいちばん",
+        "ja": "中華一番",
         "ja_typings": [
           "chuukaichiban"
         ]
@@ -16410,7 +16410,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime is set in a cooking high school?",
-      "ja": "料理をテーマにした高校を舞台とするアニメはどれですか？"
+      "ja": "料理の高校のアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime is set in a cooking high school?",
@@ -16421,28 +16421,28 @@
     "choices": [
       {
         "en": "Raditz",
-        "ja": "らでぃっつ",
+        "ja": "ラディッツ",
         "ja_typings": [
           "radittsu"
         ]
       },
       {
         "en": "Frieza",
-        "ja": "ふりーざ",
+        "ja": "フリーザ",
         "ja_typings": [
           "furiza"
         ]
       },
       {
         "en": "Cell",
-        "ja": "せる",
+        "ja": "セル",
         "ja_typings": [
           "seru"
         ]
       },
       {
         "en": "Beerus",
-        "ja": "びーるす",
+        "ja": "ビールス",
         "ja_typings": [
           "birusu"
         ]
@@ -16454,7 +16454,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who is the villain in the first arc of Dragon Ball Z?",
-      "ja": "ドラゴンボールZさいしょのあーくのヴィランは？"
+      "ja": "ドラゴンボールZ最初のアークのヴィランは？"
     },
     "question_text_reading": {
       "en": "Who is the villain in the first arc of Dragon Ball Z?",
@@ -16465,14 +16465,14 @@
     "choices": [
       {
         "en": "science of transmuting matter",
-        "ja": "ぶっしつへんかんのかがく",
+        "ja": "物質変換の科学",
         "ja_typings": [
           "busshitsuhenkannokagaku"
         ]
       },
       {
         "en": "magic spells",
-        "ja": "まほうのじゅもん",
+        "ja": "魔法の呪文",
         "ja_typings": [
           "mahonojumon",
           "mahounojumon"
@@ -16480,7 +16480,7 @@
       },
       {
         "en": "martial arts style",
-        "ja": "ぶどうのりゅうは",
+        "ja": "葡萄流派",
         "ja_typings": [
           "budonoryuuha",
           "budounoryuuha"
@@ -16488,7 +16488,7 @@
       },
       {
         "en": "alchemy potions",
-        "ja": "れんきんやく",
+        "ja": "錬金薬",
         "ja_typings": [
           "renkinyaku"
         ]
@@ -16500,7 +16500,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'Alchemy' in Fullmetal Alchemist?",
-      "ja": "『鋼の錬金術師』における「錬金術（Alchemy）」とは何ですか？"
+      "ja": "鋼の錬金術の錬金術とは？"
     },
     "question_text_reading": {
       "en": "What is 'Alchemy' in Fullmetal Alchemist?",
@@ -16511,28 +16511,28 @@
     "choices": [
       {
         "en": "Attack on Titan",
-        "ja": "しんげきのきょじん",
+        "ja": "進撃の巨人",
         "ja_typings": [
           "shingekinokyojin"
         ]
       },
       {
         "en": "Jujutsu Kaisen",
-        "ja": "じゅじゅつかいせん",
+        "ja": "呪術廻戦",
         "ja_typings": [
           "jujutsukaisen"
         ]
       },
       {
         "en": "Black Clover",
-        "ja": "ぶらっくくろーばー",
+        "ja": "ブラッククローバー",
         "ja_typings": [
           "burakkukuroba"
         ]
       },
       {
         "en": "Fairy Tail",
-        "ja": "ふぇありーている",
+        "ja": "フェアリーテイル",
         "ja_typings": [
           "feariteiru"
         ]
@@ -16544,7 +16544,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime features the 'Survey Corps' fighting Titans?",
-      "ja": "タイタンと戦う「調査兵団（Survey Corps）」が登場するアニメはどれ？"
+      "ja": "調査兵団が巨人と戦うアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime features the 'Survey Corps' fighting Titans?",
@@ -16555,14 +16555,14 @@
     "choices": [
       {
         "en": "romantic fantasy",
-        "ja": "ろまんてぃっくふぁんたじー",
+        "ja": "ロマンティックファンタジー",
         "ja_typings": [
           "romantikkufantaji"
         ]
       },
       {
         "en": "action shonen",
-        "ja": "あくしょんしょうねん",
+        "ja": "アクション少年",
         "ja_typings": [
           "akushonshonen",
           "akushonshounen"
@@ -16570,14 +16570,14 @@
       },
       {
         "en": "mecha",
-        "ja": "めか",
+        "ja": "メカ",
         "ja_typings": [
           "meka"
         ]
       },
       {
         "en": "horror",
-        "ja": "ほらー",
+        "ja": "ホラー",
         "ja_typings": [
           "hora"
         ]
@@ -16589,7 +16589,7 @@
     "image_path": null,
     "question_text": {
       "en": "What genre is 'Your Name (Kimi no Na wa)'?",
-      "ja": "君の名ははどのジャンルの作品ですか？"
+      "ja": "君の名はのジャンルは？"
     },
     "question_text_reading": {
       "en": "What genre is 'Your Name (Kimi no Na wa)'?",
@@ -16600,28 +16600,28 @@
     "choices": [
       {
         "en": "Hayao Miyazaki",
-        "ja": "みやざきはやお",
+        "ja": "宮崎駿",
         "ja_typings": [
           "miyazakihayao"
         ]
       },
       {
         "en": "Isao Takahata",
-        "ja": "たかはたいさお",
+        "ja": "高畑清",
         "ja_typings": [
           "takahataisao"
         ]
       },
       {
         "en": "Satoshi Kon",
-        "ja": "こんさとし",
+        "ja": "根里俊",
         "ja_typings": [
           "konsatoshi"
         ]
       },
       {
         "en": "Mamoru Oshii",
-        "ja": "おしいまもる",
+        "ja": "押井修",
         "ja_typings": [
           "oshiimamoru"
         ]
@@ -16633,7 +16633,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who directed Spirited Away?",
-      "ja": "もののけ姫を監督したのは誰ですか？"
+      "ja": "もののけ姫を監督したのは？"
     },
     "question_text_reading": {
       "en": "Who directed Spirited Away?",
@@ -16644,7 +16644,7 @@
     "choices": [
       {
         "en": "Catbus",
-        "ja": "ねこばす",
+        "ja": "猫バス",
         "ja_typings": [
           "nekobasu"
         ]
@@ -16665,7 +16665,7 @@
       },
       {
         "en": "Nyanko Express",
-        "ja": "にゃんこえくすぷれす",
+        "ja": "にゃんこエクスプレス",
         "ja_typings": [
           "nyankoekusupuresu"
         ]
@@ -16677,7 +16677,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the name of the cat bus in My Neighbor Totoro?",
-      "ja": "となりのトトロに登場するねこバスの名前は何ですか？"
+      "ja": "となりのトトロのねこバスのなまえは？"
     },
     "question_text_reading": {
       "en": "What is the name of the cat bus in My Neighbor Totoro?",
@@ -16688,28 +16688,28 @@
     "choices": [
       {
         "en": "Demon Slayer",
-        "ja": "きめつのやいば",
+        "ja": "鬼滅の刃",
         "ja_typings": [
           "kimetsunoyaiba"
         ]
       },
       {
         "en": "My Hero Academia",
-        "ja": "ぼくのひーろーあかでみあ",
+        "ja": "僕のヒーローアカデミア",
         "ja_typings": [
           "bokunohiroakademia"
         ]
       },
       {
         "en": "Naruto",
-        "ja": "なると",
+        "ja": "ナルト",
         "ja_typings": [
           "naruto"
         ]
       },
       {
         "en": "Bleach",
-        "ja": "ぶりーち",
+        "ja": "ブリーチ",
         "ja_typings": [
           "burichi"
         ]
@@ -16721,7 +16721,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime features heroes called 'Hashira'?",
-      "ja": "柱（Hashira）と呼ばれるヒーローが登場するアニメはどれ？"
+      "ja": "柱と呼ばれるヒーローたちのアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime features heroes called 'Hashira'?",
@@ -16732,28 +16732,28 @@
     "choices": [
       {
         "en": "Shadow Clone Jutsu",
-        "ja": "かげぶんしんのじゅつ",
+        "ja": "影分身の術",
         "ja_typings": [
           "kagebunshinnojutsu"
         ]
       },
       {
         "en": "Rasengan",
-        "ja": "らせんがん",
+        "ja": "螺旋眼",
         "ja_typings": [
           "rasengan"
         ]
       },
       {
         "en": "Chidori",
-        "ja": "ちどり",
+        "ja": "千鳥",
         "ja_typings": [
           "chidori"
         ]
       },
       {
         "en": "Fire Style",
-        "ja": "かとん",
+        "ja": "火遁",
         "ja_typings": [
           "katon"
         ]
@@ -16765,7 +16765,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the name of Naruto's signature technique?",
-      "ja": "ナルトの代名詞的な術の名前は何ですか？"
+      "ja": "ナルトの得意技の名前は？"
     },
     "question_text_reading": {
       "en": "What is the name of Naruto's signature technique?",
@@ -16776,7 +16776,7 @@
     "choices": [
       {
         "en": "Sword Art Online",
-        "ja": "そーどあーとおんらいん",
+        "ja": "ソードアート・オンライン",
         "ja_typings": [
           "sodoatonrain",
           "sodoatoonrain"
@@ -16784,7 +16784,7 @@
       },
       {
         "en": "Log Horizon",
-        "ja": "ろぐほらいずん",
+        "ja": "ログホライズン",
         "ja_typings": [
           "roguhoraizun"
         ]
@@ -16798,7 +16798,7 @@
       },
       {
         "en": "No Game No Life",
-        "ja": "のーげーむのーらいふ",
+        "ja": "ノーゲーム・ノーライフ",
         "ja_typings": [
           "nogemunoraifu"
         ]
@@ -16810,7 +16810,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime is about a virtual game where dying in-game means death in real life?",
-      "ja": "げーむないしすると現実でもしぬアニメは？"
+      "ja": "ゲーム内で死ぬと現実でもしぬアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime is about a virtual game where dying in-game means death in real life?",
@@ -16821,7 +16821,7 @@
     "choices": [
       {
         "en": "writing names to kill people",
-        "ja": "なまえをかいてひとをころす",
+        "ja": "名前を書いて人を殺す",
         "ja_typings": [
           "namaeokaitehitokorosu",
           "namaeokaitehitookorosu"
@@ -16829,14 +16829,14 @@
       },
       {
         "en": "seeing the future",
-        "ja": "みらいをみる",
+        "ja": "未来を見る",
         "ja_typings": [
           "miraiomiru"
         ]
       },
       {
         "en": "mind control",
-        "ja": "せんのうする",
+        "ja": "専能する",
         "ja_typings": [
           "sennosuru",
           "sennousuru"
@@ -16844,7 +16844,7 @@
       },
       {
         "en": "time travel",
-        "ja": "じかんりょこう",
+        "ja": "時間旅行",
         "ja_typings": [
           "jikanryoko",
           "jikanryokou"
@@ -16857,7 +16857,7 @@
     "image_path": null,
     "question_text": {
       "en": "What power does Light Yagami use in Death Note?",
-      "ja": "デスノートで夜神月が使用する力は何ですか？"
+      "ja": "デスノートでやがみらいとが使う力は？"
     },
     "question_text_reading": {
       "en": "What power does Light Yagami use in Death Note?",
@@ -16868,28 +16868,28 @@
     "choices": [
       {
         "en": "Naruto",
-        "ja": "なると",
+        "ja": "ナルト",
         "ja_typings": [
           "naruto"
         ]
       },
       {
         "en": "Boruto",
-        "ja": "ぼると",
+        "ja": "ボルト",
         "ja_typings": [
           "boruto"
         ]
       },
       {
         "en": "Dragon Ball",
-        "ja": "どらごんぼーる",
+        "ja": "ドラゴンボール",
         "ja_typings": [
           "doragonboru"
         ]
       },
       {
         "en": "Fairy Tail",
-        "ja": "ふぇありーている",
+        "ja": "フェアリーテイル",
         "ja_typings": [
           "feariteiru"
         ]
@@ -16901,7 +16901,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime is set in the Hidden Leaf Village?",
-      "ja": "隠された葉の里を舞台にしているアニメはどれですか？"
+      "ja": "隠れ小葉の里を舞台にしたアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime is set in the Hidden Leaf Village?",
@@ -16912,7 +16912,7 @@
     "choices": [
       {
         "en": "a superpower",
-        "ja": "ちょうのうりょく",
+        "ja": "超能力力",
         "ja_typings": [
           "chonoryoku",
           "chounouryoku"
@@ -16920,7 +16920,7 @@
       },
       {
         "en": "a school rule",
-        "ja": "がっこうのきまり",
+        "ja": "学校の規まり",
         "ja_typings": [
           "gakkonokimari",
           "gakkounokimari"
@@ -16928,7 +16928,7 @@
       },
       {
         "en": "a villain title",
-        "ja": "ヴィランのしょうごう",
+        "ja": "ヴィランの称号",
         "ja_typings": [
           "virannoshogo",
           "virannoshougou"
@@ -16936,7 +16936,7 @@
       },
       {
         "en": "a fighting technique",
-        "ja": "ぶとうのわざ",
+        "ja": "闘うの技",
         "ja_typings": [
           "butonowaza",
           "butounowaza"
@@ -16949,7 +16949,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the 'Quirk' in My Hero Academia?",
-      "ja": "『僕のヒーローアカデミア』における「個性（Quirk）」とは何ですか？"
+      "ja": "僕のヒーローアカデミアの個性とは？"
     },
     "question_text_reading": {
       "en": "What is the 'Quirk' in My Hero Academia?",
@@ -16960,28 +16960,28 @@
     "choices": [
       {
         "en": "Death Note",
-        "ja": "でーすのーと",
+        "ja": "デスノート",
         "ja_typings": [
           "desunoto"
         ]
       },
       {
         "en": "Bleach",
-        "ja": "ぶりーち",
+        "ja": "ブリーチ",
         "ja_typings": [
           "burichi"
         ]
       },
       {
         "en": "Noragami",
-        "ja": "のらがみ",
+        "ja": "神束",
         "ja_typings": [
           "noragami"
         ]
       },
       {
         "en": "Soul Eater",
-        "ja": "そうるいーたー",
+        "ja": "ソウルイーター",
         "ja_typings": [
           "soruita",
           "souruita"
@@ -16994,7 +16994,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime features Ryuk, a death god?",
-      "ja": "りゅーくというしにがみがとうじょうするアニメは？"
+      "ja": "Ryukという死神が出現するアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime features Ryuk, a death god?",
@@ -17005,21 +17005,21 @@
     "choices": [
       {
         "en": "giant humanoid creature",
-        "ja": "きょだいなにんげんがたいきもの",
+        "ja": "巨大な人間型生物",
         "ja_typings": [
           "kyodainaningengataikimono"
         ]
       },
       {
         "en": "large robot",
-        "ja": "きょだいなろぼっと",
+        "ja": "巨大なロボット",
         "ja_typings": [
           "kyodainarobotto"
         ]
       },
       {
         "en": "supernatural spirit",
-        "ja": "ちょうしぜんのれい",
+        "ja": "超自然の霊",
         "ja_typings": [
           "choshizennorei",
           "choushizennorei"
@@ -17027,7 +17027,7 @@
       },
       {
         "en": "ancient warrior",
-        "ja": "こだいのせんし",
+        "ja": "古代の戦士",
         "ja_typings": [
           "kodainosenshi"
         ]
@@ -17039,7 +17039,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'Titan' in Attack on Titan?",
-      "ja": "進撃の巨人における「タイタン」とは何ですか？"
+      "ja": "進撃の巨人の巨人は？"
     },
     "question_text_reading": {
       "en": "What is 'Titan' in Attack on Titan?",
@@ -17050,28 +17050,28 @@
     "choices": [
       {
         "en": "Yu-Gi-Oh",
-        "ja": "ゆうぎおー",
+        "ja": "遊戯王",
         "ja_typings": [
           "yuugio"
         ]
       },
       {
         "en": "Pokemon",
-        "ja": "ぽけもん",
+        "ja": "ポケモン",
         "ja_typings": [
           "pokemon"
         ]
       },
       {
         "en": "Beyblade",
-        "ja": "べいぶれーど",
+        "ja": "ベイブレード",
         "ja_typings": [
           "beiburedo"
         ]
       },
       {
         "en": "Digimon",
-        "ja": "でじもん",
+        "ja": "デジモン",
         "ja_typings": [
           "dejimon"
         ]
@@ -17083,7 +17083,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime is based on a card game?",
-      "ja": "カードゲームを原作としたアニメはどれですか？"
+      "ja": "カードゲームをもとにしたアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime is based on a card game?",
@@ -17094,28 +17094,28 @@
     "choices": [
       {
         "en": "Frieza",
-        "ja": "ふりーざ",
+        "ja": "フリーザ",
         "ja_typings": [
           "furiza"
         ]
       },
       {
         "en": "Cell",
-        "ja": "せる",
+        "ja": "セル",
         "ja_typings": [
           "seru"
         ]
       },
       {
         "en": "Buu",
-        "ja": "ぶう",
+        "ja": "ブー",
         "ja_typings": [
           "buu"
         ]
       },
       {
         "en": "Vegeta",
-        "ja": "べじーた",
+        "ja": "ベジータ",
         "ja_typings": [
           "bejita"
         ]
@@ -17127,7 +17127,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who is the main antagonist of the Frieza arc in Dragon Ball Z?",
-      "ja": "ドラゴンボールZのふりーざへんのしゅてきは？"
+      "ja": "ドラゴンボールZのフリーザ編の主敵は？"
     },
     "question_text_reading": {
       "en": "Who is the main antagonist of the Frieza arc in Dragon Ball Z?",
@@ -17138,28 +17138,28 @@
     "choices": [
       {
         "en": "world where everything is decided by games",
-        "ja": "ゲームですべてがきめられるせかい",
+        "ja": "ゲームですべてがきめられる世界",
         "ja_typings": [
           "gemudesubetegakimerarerusekai"
         ]
       },
       {
         "en": "virtual MMORPG",
-        "ja": "ばーちゃるMMORPG",
+        "ja": "バーチャルMMORPG",
         "ja_typings": [
           "bacharummorpg"
         ]
       },
       {
         "en": "feudal Japan",
-        "ja": "えどじだいのにほん",
+        "ja": "江戸時代のにほん",
         "ja_typings": [
           "edojidainonihon"
         ]
       },
       {
         "en": "post-apocalyptic earth",
-        "ja": "ぶんめいほうかいごのちきゅう",
+        "ja": "文明崩壊後の地球",
         "ja_typings": [
           "bunmeihokaigonochikyuu",
           "bunmeihoukaigonochikyuu"
@@ -17172,7 +17172,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the setting of 'No Game No Life'?",
-      "ja": "のーげーむのーらいふの舞台は？"
+      "ja": "ノーゲーム・ノーライフの舞台は？"
     },
     "question_text_reading": {
       "en": "What is the setting of 'No Game No Life'?",
@@ -17183,28 +17183,28 @@
     "choices": [
       {
         "en": "Hiromu Arakawa",
-        "ja": "あらかわひろむ",
+        "ja": "荒川広務",
         "ja_typings": [
           "arakawahiromu"
         ]
       },
       {
         "en": "Masashi Kishimoto",
-        "ja": "きしもとまさし",
+        "ja": "岸本正史",
         "ja_typings": [
           "kishimotomasashi"
         ]
       },
       {
         "en": "Tite Kubo",
-        "ja": "くぼたいと",
+        "ja": "久保帯人",
         "ja_typings": [
           "kubotaito"
         ]
       },
       {
         "en": "Akira Toriyama",
-        "ja": "とりやまあきら",
+        "ja": "鳥山明",
         "ja_typings": [
           "toriyamaakira"
         ]
@@ -17216,7 +17216,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who wrote the manga 'Fullmetal Alchemist'?",
-      "ja": "『鋼の錬金術師』の漫画を書いたのは誰？"
+      "ja": "鋼の錬金術師をかいたのは？"
     },
     "question_text_reading": {
       "en": "Who wrote the manga 'Fullmetal Alchemist'?",
@@ -17227,28 +17227,28 @@
     "choices": [
       {
         "en": "voice actor",
-        "ja": "せいゆう",
+        "ja": "声優",
         "ja_typings": [
           "seiyuu"
         ]
       },
       {
         "en": "anime director",
-        "ja": "かんとく",
+        "ja": "監督",
         "ja_typings": [
           "kantoku"
         ]
       },
       {
         "en": "character designer",
-        "ja": "きゃらくたーでざいなー",
+        "ja": "キャラクターデザイナー",
         "ja_typings": [
           "kyarakutadezaina"
         ]
       },
       {
         "en": "soundtrack composer",
-        "ja": "おんがくさっきょくか",
+        "ja": "音楽作曲家",
         "ja_typings": [
           "ongakusakkyokuka"
         ]
@@ -17260,7 +17260,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a 'seiyuu' in anime?",
-      "ja": "アニメにおける「seiyuu」とは何ですか？"
+      "ja": "アニメの声優とは何か？"
     },
     "question_text_reading": {
       "en": "What is a 'seiyuu' in anime?",
@@ -17271,21 +17271,21 @@
     "choices": [
       {
         "en": "dubbed has translated voice, subbed has subtitles",
-        "ja": "だぶどはほんやくおんせい、さぶどはじまく",
+        "ja": "ダブドは翻訳音声、サブドは字幕",
         "ja_typings": [
           "dabudohahonyakuonsei sabudohajimaku"
         ]
       },
       {
         "en": "dubbed is the original, subbed is translated",
-        "ja": "だぶどはげんさく、さぶどはほんやく",
+        "ja": "ダブドは原作、サブドは翻訳",
         "ja_typings": [
           "dabudohagensaku sabudohahonyaku"
         ]
       },
       {
         "en": "dubbed is higher quality",
-        "ja": "だぶどのほうがこうひん",
+        "ja": "ダブドの方が高品質",
         "ja_typings": [
           "dabudonohogakohin",
           "dabudonohougakouhin"
@@ -17293,7 +17293,7 @@
       },
       {
         "en": "subbed has no audio",
-        "ja": "さぶどにはおとがない",
+        "ja": "サブドには音がない",
         "ja_typings": [
           "sabudonihaotoganai"
         ]
@@ -17305,7 +17305,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the difference between dubbed and subbed anime?",
-      "ja": "吹替版と字幕版のアニメの違いは何ですか？"
+      "ja": "ダブドとサブドのアニメの違いは？"
     },
     "question_text_reading": {
       "en": "What is the difference between dubbed and subbed anime?",
@@ -17316,21 +17316,21 @@
     "choices": [
       {
         "en": "Black Butler",
-        "ja": "くろしつじ",
+        "ja": "黒執事",
         "ja_typings": [
           "kuroshitsuji"
         ]
       },
       {
         "en": "Overlord",
-        "ja": "おーばーろーど",
+        "ja": "オーバーロード",
         "ja_typings": [
           "obarodo"
         ]
       },
       {
         "en": "Moriarty the Patriot",
-        "ja": "ゆうこくのもりあーてぃ",
+        "ja": "誘刻のモリアーティ",
         "ja_typings": [
           "yuukokunomoriati"
         ]
@@ -17349,7 +17349,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime series is set in 19th century England with a demon butler?",
-      "ja": "19世紀のイングランドを舞台に、悪魔の執事が登場するアニメシリーズはどれ？"
+      "ja": "悪魔の執事がいる19世紀英国のアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime series is set in 19th century England with a demon butler?",
@@ -17360,28 +17360,28 @@
     "choices": [
       {
         "en": "popular manga magazine",
-        "ja": "にんきまんがざっし",
+        "ja": "人気漫画雑誌",
         "ja_typings": [
           "ninkimangazasshi"
         ]
       },
       {
         "en": "anime streaming service",
-        "ja": "アニメはいしんさーびす",
+        "ja": "アニメ配信サービス",
         "ja_typings": [
           "animehaishinsabisu"
         ]
       },
       {
         "en": "anime convention",
-        "ja": "アニメのいべんと",
+        "ja": "アニメのイベント",
         "ja_typings": [
           "animenoibento"
         ]
       },
       {
         "en": "anime film studio",
-        "ja": "アニメえいがすたじお",
+        "ja": "アニメ映画スタジオ",
         "ja_typings": [
           "animeeigasutajio"
         ]
@@ -17393,7 +17393,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'Shounen Jump'?",
-      "ja": "少年ジャンプとは何ですか？"
+      "ja": "少年ジャンプとは何か？"
     },
     "question_text_reading": {
       "en": "What is 'Shounen Jump'?",
@@ -17404,28 +17404,28 @@
     "choices": [
       {
         "en": "Jujutsu Kaisen",
-        "ja": "じゅじゅつかいせん",
+        "ja": "呪術廻戦",
         "ja_typings": [
           "jujutsukaisen"
         ]
       },
       {
         "en": "Noragami",
-        "ja": "のらがみ",
+        "ja": "神束",
         "ja_typings": [
           "noragami"
         ]
       },
       {
         "en": "Blue Exorcist",
-        "ja": "あおのえくそしすと",
+        "ja": "青の祓魔師",
         "ja_typings": [
           "aonoekusoshisuto"
         ]
       },
       {
         "en": "Soul Eater",
-        "ja": "そうるいーたー",
+        "ja": "ソウルイーター",
         "ja_typings": [
           "soruita",
           "souruita"
@@ -17438,7 +17438,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime follows a group of exorcists called 'jujutsu sorcerers'?",
-      "ja": "呪術師（jujutsu sorcerers）と呼ばれる祓魔師のグループを追うアニメはどれですか？"
+      "ja": "呪術師のようしゃたちのアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime follows a group of exorcists called 'jujutsu sorcerers'?",
@@ -17449,21 +17449,21 @@
     "choices": [
       {
         "en": "Nezuko",
-        "ja": "ねずこ",
+        "ja": "禰豆子",
         "ja_typings": [
           "nezuko"
         ]
       },
       {
         "en": "Aoi",
-        "ja": "あおい",
+        "ja": "青井",
         "ja_typings": [
           "aoi"
         ]
       },
       {
         "en": "Shinobu",
-        "ja": "しのぶ",
+        "ja": "忍ぶ",
         "ja_typings": [
           "shinobu"
         ]
@@ -17482,7 +17482,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the name of Tanjiro's sister in Demon Slayer?",
-      "ja": "鬼滅の刃に登場する炭治郎の妹の名前は何ですか？"
+      "ja": "鬼滅の刃で炭治郎の妹の名前は？"
     },
     "question_text_reading": {
       "en": "What is the name of Tanjiro's sister in Demon Slayer?",
@@ -17493,28 +17493,28 @@
     "choices": [
       {
         "en": "Naruto",
-        "ja": "なると",
+        "ja": "ナルト",
         "ja_typings": [
           "naruto"
         ]
       },
       {
         "en": "Fairy Tail",
-        "ja": "ふぇありーている",
+        "ja": "フェアリーテイル",
         "ja_typings": [
           "feariteiru"
         ]
       },
       {
         "en": "Inuyasha",
-        "ja": "いぬやしゃ",
+        "ja": "犬夜叉",
         "ja_typings": [
           "inuyasha"
         ]
       },
       {
         "en": "Bleach",
-        "ja": "ぶりーち",
+        "ja": "ブリーチ",
         "ja_typings": [
           "burichi"
         ]
@@ -17526,7 +17526,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime features the 'Nine-Tails Fox' sealed inside a character?",
-      "ja": "九尾の狐がキャラクターの内部に封印されているアニメはどれ？"
+      "ja": "九尾が封印されたキャラのアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime features the 'Nine-Tails Fox' sealed inside a character?",
@@ -17537,7 +17537,7 @@
     "choices": [
       {
         "en": "depicting everyday life",
-        "ja": "にちじょうせいかつをえがく",
+        "ja": "日常生活を描く",
         "ja_typings": [
           "nichijoseikatsuoegaku",
           "nichijouseikatsuoegaku"
@@ -17545,21 +17545,21 @@
       },
       {
         "en": "depicting extreme action",
-        "ja": "きょくたんなあくしょんをえがく",
+        "ja": "極端なアクションを描く",
         "ja_typings": [
           "kyokutannaakushonoegaku"
         ]
       },
       {
         "en": "depicting fantasy worlds",
-        "ja": "ふぁんたじーのせかいをえがく",
+        "ja": "ファンタジーの世界を描く",
         "ja_typings": [
           "fantajinosekaioegaku"
         ]
       },
       {
         "en": "depicting sports tournaments",
-        "ja": "すぽーつたいかいをえがく",
+        "ja": "スポーツ大会を描く",
         "ja_typings": [
           "supotsutaikaioegaku"
         ]
@@ -17571,7 +17571,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the anime genre 'slice of life'?",
-      "ja": "アニメのジャンルである「slice of life」とはどのようなものですか？"
+      "ja": "アニメのslice of lifeジャンルとは？"
     },
     "question_text_reading": {
       "en": "What is the anime genre 'slice of life'?",
@@ -17582,7 +17582,7 @@
     "choices": [
       {
         "en": "seasonal broadcast unit (~13 episodes)",
-        "ja": "きせつほうそうのたんい（やく13わ）",
+        "ja": "季節放送の単位（約13話）",
         "ja_typings": [
           "kisetsuhosonotani yaku13wa",
           "kisetsuhousounotani yaku13wa"
@@ -17597,14 +17597,14 @@
       },
       {
         "en": "anime film format",
-        "ja": "アニメえいがけいしき",
+        "ja": "アニメ映画形式",
         "ja_typings": [
           "animeeigakeishiki"
         ]
       },
       {
         "en": "streaming season format",
-        "ja": "はいしんきせつけいしき",
+        "ja": "配信シーズンフォーマット",
         "ja_typings": [
           "haishinkisetsukeishiki"
         ]
@@ -17616,7 +17616,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'cour' in anime terminology?",
-      "ja": "アニメの専門用語における「cour」とは何ですか？"
+      "ja": "アニメ用語の「クール」とは何か？"
     },
     "question_text_reading": {
       "en": "What is 'cour' in anime terminology?",
@@ -17627,28 +17627,28 @@
     "choices": [
       {
         "en": "Jujutsu Kaisen",
-        "ja": "じゅじゅつかいせん",
+        "ja": "呪術廻戦",
         "ja_typings": [
           "jujutsukaisen"
         ]
       },
       {
         "en": "Demon Slayer",
-        "ja": "きめつのやいば",
+        "ja": "鬼滅の刃",
         "ja_typings": [
           "kimetsunoyaiba"
         ]
       },
       {
         "en": "My Hero Academia",
-        "ja": "ぼくのひーろーあかでみあ",
+        "ja": "僕のヒーローアカデミア",
         "ja_typings": [
           "bokunohiroakademia"
         ]
       },
       {
         "en": "One Piece",
-        "ja": "わんぴーす",
+        "ja": "ワンピース",
         "ja_typings": [
           "wanpisu"
         ]
@@ -17660,7 +17660,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime is produced by MAPPA?",
-      "ja": "MAPPAがせいさくしたアニメは？"
+      "ja": "MAPPAが制作したアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime is produced by MAPPA?",
@@ -17671,7 +17671,7 @@
     "choices": [
       {
         "en": "high-quality animation and emotional stories",
-        "ja": "こうひんなあにめーしょんとかんどうてきなはなし",
+        "ja": "高品質なアニメーションと感動的な物語",
         "ja_typings": [
           "kohinnaanimeshontokandotekinahanashi",
           "kouhinnaanimeshontokandoutekinahanashi"
@@ -17679,14 +17679,14 @@
       },
       {
         "en": "mecha anime",
-        "ja": "めかアニメ",
+        "ja": "メカアニメ",
         "ja_typings": [
           "mekaanime"
         ]
       },
       {
         "en": "action-heavy shonen",
-        "ja": "あくしょんしょうねん",
+        "ja": "アクション少年",
         "ja_typings": [
           "akushonshonen",
           "akushonshounen"
@@ -17694,7 +17694,7 @@
       },
       {
         "en": "violent horror anime",
-        "ja": "はきょくてきなほらーアニメ",
+        "ja": "暴力的なホラーアニメ",
         "ja_typings": [
           "hakyokutekinahoraanime"
         ]
@@ -17706,7 +17706,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is Kyoto Animation known for?",
-      "ja": "京都アニメーションはどのようなことで知られているでしょうか？"
+      "ja": "京都アニメは何で有名か？"
     },
     "question_text_reading": {
       "en": "What is Kyoto Animation known for?",
@@ -17717,28 +17717,28 @@
     "choices": [
       {
         "en": "Jujutsu Kaisen",
-        "ja": "じゅじゅつかいせん",
+        "ja": "呪術廻戦",
         "ja_typings": [
           "jujutsukaisen"
         ]
       },
       {
         "en": "Bleach",
-        "ja": "ぶりーち",
+        "ja": "ブリーチ",
         "ja_typings": [
           "burichi"
         ]
       },
       {
         "en": "Naruto",
-        "ja": "なると",
+        "ja": "ナルト",
         "ja_typings": [
           "naruto"
         ]
       },
       {
         "en": "My Hero Academia",
-        "ja": "ぼくのひーろーあかでみあ",
+        "ja": "僕のヒーローアカデミア",
         "ja_typings": [
           "bokunohiroakademia"
         ]
@@ -17750,7 +17750,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime features Satoru Gojo?",
-      "ja": "サトル・ゴジョが登場するアニメはどれ？"
+      "ja": "五条悟が登場するアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime features Satoru Gojo?",
@@ -17761,7 +17761,7 @@
     "choices": [
       {
         "en": "Eiichiro Oda",
-        "ja": "おだえいいちろう",
+        "ja": "織田栄一郎",
         "ja_typings": [
           "odaeiichiro",
           "odaeiichirou"
@@ -17769,21 +17769,21 @@
       },
       {
         "en": "Masashi Kishimoto",
-        "ja": "きしもとまさし",
+        "ja": "岸本正史",
         "ja_typings": [
           "kishimotomasashi"
         ]
       },
       {
         "en": "Akira Toriyama",
-        "ja": "とりやまあきら",
+        "ja": "鳥山明",
         "ja_typings": [
           "toriyamaakira"
         ]
       },
       {
         "en": "Hiromu Arakawa",
-        "ja": "あらかわひろむ",
+        "ja": "荒川広務",
         "ja_typings": [
           "arakawahiromu"
         ]
@@ -17795,7 +17795,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who is the creator of One Piece?",
-      "ja": "ワンピースのさくしゃは？"
+      "ja": "ワンピースの作者は？"
     },
     "question_text_reading": {
       "en": "Who is the creator of One Piece?",
@@ -17806,28 +17806,28 @@
     "choices": [
       {
         "en": "Naruto's signature phrase",
-        "ja": "ナルトのくちぐせ",
+        "ja": "ナルトの口癖",
         "ja_typings": [
           "narutonokuchiguse"
         ]
       },
       {
         "en": "a jutsu name",
-        "ja": "じゅつのなまえ",
+        "ja": "術の名前",
         "ja_typings": [
           "jutsunonamae"
         ]
       },
       {
         "en": "a village name",
-        "ja": "むらのなまえ",
+        "ja": "村の名前",
         "ja_typings": [
           "muranonamae"
         ]
       },
       {
         "en": "a character title",
-        "ja": "きゃらのしょうごう",
+        "ja": "キャラの称号",
         "ja_typings": [
           "kyaranoshogo",
           "kyaranoshougou"
@@ -17851,28 +17851,28 @@
     "choices": [
       {
         "en": "Castle in the Sky",
-        "ja": "てんくうのしろらぴゅた",
+        "ja": "天空の城ラピュタ",
         "ja_typings": [
           "tenkuunoshirorapyuta"
         ]
       },
       {
         "en": "Nausicaa",
-        "ja": "かぜのたにのなうしか",
+        "ja": "風の谷のナウシカア",
         "ja_typings": [
           "kazenotaninonaushika"
         ]
       },
       {
         "en": "Princess Mononoke",
-        "ja": "もののけひめ",
+        "ja": "もののけ姫",
         "ja_typings": [
           "mononokehime"
         ]
       },
       {
         "en": "The Wind Rises",
-        "ja": "かぜたちぬ",
+        "ja": "風立ちぬ",
         "ja_typings": [
           "kazetachinu"
         ]
@@ -17884,7 +17884,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which Ghibli film features a flying island called Laputa?",
-      "ja": "ラピュタという空飛ぶ島が登場するジブリ映画はどれ？"
+      "ja": "ラピュタという飛ぶ島のジブリ映画は？"
     },
     "question_text_reading": {
       "en": "Which Ghibli film features a flying island called Laputa?",
@@ -17895,7 +17895,7 @@
     "choices": [
       {
         "en": "Doraemon",
-        "ja": "どらえもん",
+        "ja": "ドラえもん",
         "ja_typings": [
           "doraemon"
         ]
@@ -17909,14 +17909,14 @@
       },
       {
         "en": "Shizuka",
-        "ja": "しずか",
+        "ja": "静か",
         "ja_typings": [
           "shizuka"
         ]
       },
       {
         "en": "Gian",
-        "ja": "じゃいあん",
+        "ja": "ジャイアン",
         "ja_typings": [
           "jaian"
         ]
@@ -17928,7 +17928,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the name of the robot in Doraemon?",
-      "ja": "ドラえもんという漫画に登場するロボットの名前は何ですか？"
+      "ja": "ドラえもんのロボットの名前は？"
     },
     "question_text_reading": {
       "en": "What is the name of the robot in Doraemon?",
@@ -17939,28 +17939,28 @@
     "choices": [
       {
         "en": "Attack on Titan",
-        "ja": "しんげきのきょじん",
+        "ja": "進撃の巨人",
         "ja_typings": [
           "shingekinokyojin"
         ]
       },
       {
         "en": "Code Geass",
-        "ja": "こーどぎあす",
+        "ja": "コードギアス",
         "ja_typings": [
           "kodogiasu"
         ]
       },
       {
         "en": "Gurren Lagann",
-        "ja": "てんげんとっぱぐれんらがん",
+        "ja": "天元突破グレンラガン",
         "ja_typings": [
           "tengentoppagurenragan"
         ]
       },
       {
         "en": "Neon Genesis Evangelion",
-        "ja": "しんせいきえんがえりおん",
+        "ja": "新世紀エヴァンゲリオン",
         "ja_typings": [
           "shinseikiengaerion"
         ]
@@ -17972,7 +17972,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime is set in a world with 'Titans' and 3D Maneuver Gear?",
-      "ja": "きょじんと立体機動装置のせかいのアニメは？"
+      "ja": "巨人と立体機動装置の世界のanimeは？"
     },
     "question_text_reading": {
       "en": "Which anime is set in a world with 'Titans' and 3D Maneuver Gear?",
@@ -17983,28 +17983,28 @@
     "choices": [
       {
         "en": "fantasy isekai world",
-        "ja": "ふぁんたじーのいせかい",
+        "ja": "ファンタジーの異世界",
         "ja_typings": [
           "fantajinoisekai"
         ]
       },
       {
         "en": "virtual MMORPG",
-        "ja": "ばーちゃるMMORPG",
+        "ja": "バーチャルMMORPG",
         "ja_typings": [
           "bacharummorpg"
         ]
       },
       {
         "en": "futuristic Japan",
-        "ja": "みらいのにほん",
+        "ja": "未来の日本",
         "ja_typings": [
           "mirainonihon"
         ]
       },
       {
         "en": "post-apocalyptic world",
-        "ja": "ぶんめいほうかいごのせかい",
+        "ja": "文明崩壊後の世界",
         "ja_typings": [
           "bunmeihokaigonosekai",
           "bunmeihoukaigonosekai"
@@ -18017,7 +18017,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the setting of 'Re:Zero'?",
-      "ja": "りぜろの舞台は？"
+      "ja": "リゼロの舞台は？"
     },
     "question_text_reading": {
       "en": "What is the setting of 'Re:Zero'?",
@@ -18028,28 +18028,28 @@
     "choices": [
       {
         "en": "Naruto",
-        "ja": "なると",
+        "ja": "ナルト",
         "ja_typings": [
           "naruto"
         ]
       },
       {
         "en": "Bleach",
-        "ja": "ぶりーち",
+        "ja": "ブリーチ",
         "ja_typings": [
           "burichi"
         ]
       },
       {
         "en": "Fairy Tail",
-        "ja": "ふぇありーている",
+        "ja": "フェアリーテイル",
         "ja_typings": [
           "feariteiru"
         ]
       },
       {
         "en": "Black Clover",
-        "ja": "ぶらっくくろーばー",
+        "ja": "ブラッククローバー",
         "ja_typings": [
           "burakkukuroba"
         ]
@@ -18061,7 +18061,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime features the 'Akatsuki' organization?",
-      "ja": "暁（あかつき）という組織が登場するアニメはどれ？"
+      "ja": "暁という組織が登場するアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime features the 'Akatsuki' organization?",
@@ -18072,28 +18072,28 @@
     "choices": [
       {
         "en": "exhibits about Studio Ghibli films",
-        "ja": "スタジオジブリさくひんのてんじ",
+        "ja": "スタジオジブリ作品の展示",
         "ja_typings": [
           "sutajiojiburisakuhinnotenji"
         ]
       },
       {
         "en": "live anime performances",
-        "ja": "アニメのらいぶぱふぉーまんす",
+        "ja": "アニメのライブパフォーマンス",
         "ja_typings": [
           "animenoraibupafomansu"
         ]
       },
       {
         "en": "anime figure collection",
-        "ja": "アニメのふぃぎゅあこれくしょん",
+        "ja": "アニメのフィギュアコレクション",
         "ja_typings": [
           "animenofigyuakorekushon"
         ]
       },
       {
         "en": "anime film production",
-        "ja": "アニメえいがせいさく",
+        "ja": "アニメ映画制作",
         "ja_typings": [
           "animeeigaseisaku"
         ]
@@ -18105,7 +18105,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'Ghibli Museum' famous for?",
-      "ja": "ジブリ美術館は、何で有名なのでしょうか？"
+      "ja": "ジブリ美術館は何で有名か？"
     },
     "question_text_reading": {
       "en": "What is 'Ghibli Museum' famous for?",
@@ -18116,28 +18116,28 @@
     "choices": [
       {
         "en": "Bleach",
-        "ja": "ぶりーち",
+        "ja": "ブリーチ",
         "ja_typings": [
           "burichi"
         ]
       },
       {
         "en": "Naruto",
-        "ja": "なると",
+        "ja": "ナルト",
         "ja_typings": [
           "naruto"
         ]
       },
       {
         "en": "Fairy Tail",
-        "ja": "ふぇありーている",
+        "ja": "フェアリーテイル",
         "ja_typings": [
           "feariteiru"
         ]
       },
       {
         "en": "One Piece",
-        "ja": "わんぴーす",
+        "ja": "ワンピース",
         "ja_typings": [
           "wanpisu"
         ]
@@ -18149,7 +18149,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime has 'Zanpakuto' as spirit swords?",
-      "ja": "斬魄刀（ざんぱくとう）という名の霊剣が登場するアニメはどれ？"
+      "ja": "斬魄刀という精霊剣のアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime has 'Zanpakuto' as spirit swords?",
@@ -18160,28 +18160,28 @@
     "choices": [
       {
         "en": "1997",
-        "ja": "1997ねん",
+        "ja": "1997年",
         "ja_typings": [
           "1997nen"
         ]
       },
       {
         "en": "1995",
-        "ja": "1995ねん",
+        "ja": "1995年",
         "ja_typings": [
           "1995nen"
         ]
       },
       {
         "en": "1999",
-        "ja": "1999ねん",
+        "ja": "1999年",
         "ja_typings": [
           "1999nen"
         ]
       },
       {
         "en": "2001",
-        "ja": "2001ねん",
+        "ja": "2001年",
         "ja_typings": [
           "2001nen"
         ]
@@ -18193,7 +18193,7 @@
     "image_path": null,
     "question_text": {
       "en": "What year did the original Pokemon anime first air in Japan?",
-      "ja": "オリジナルのポケモンアニメが日本で初めて放送されたのは何年ですか？"
+      "ja": "ポケモンアニメが日本で初めて放送されたのは何年か？"
     },
     "question_text_reading": {
       "en": "What year did the original Pokemon anime first air in Japan?",
@@ -18204,28 +18204,28 @@
     "choices": [
       {
         "en": "Hunter x Hunter",
-        "ja": "はんたーはんたー",
+        "ja": "ハンター×ハンター",
         "ja_typings": [
           "hantahanta"
         ]
       },
       {
         "en": "Yu Yu Hakusho",
-        "ja": "ゆゆはくしょ",
+        "ja": "幽遊白書",
         "ja_typings": [
           "yuyuhakusho"
         ]
       },
       {
         "en": "Fairy Tail",
-        "ja": "ふぇありーている",
+        "ja": "フェアリーテイル",
         "ja_typings": [
           "feariteiru"
         ]
       },
       {
         "en": "Black Clover",
-        "ja": "ぶらっくくろーばー",
+        "ja": "ブラッククローバー",
         "ja_typings": [
           "burakkukuroba"
         ]
@@ -18237,7 +18237,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime features characters fighting with 'Nen' energy?",
-      "ja": "Nenというエネルギーを使って戦うキャラクターが登場するアニメはどれ？"
+      "ja": "練（ねん）を使って戦うアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime features characters fighting with 'Nen' energy?",
@@ -18248,28 +18248,28 @@
     "choices": [
       {
         "en": "Edward's automail limbs",
-        "ja": "えどわーどのぎそくしし",
+        "ja": "エドワードの自動メール肢",
         "ja_typings": [
           "edowadonogisokushishi"
         ]
       },
       {
         "en": "a type of alchemy",
-        "ja": "れんきんじゅつのしゅるい",
+        "ja": "錬金術の種類",
         "ja_typings": [
           "renkinjutsunoshurui"
         ]
       },
       {
         "en": "a city name",
-        "ja": "まちのなまえ",
+        "ja": "街の名前",
         "ja_typings": [
           "machinonamae"
         ]
       },
       {
         "en": "a villain's title",
-        "ja": "ヴィランのしょうごう",
+        "ja": "ヴィランの称号",
         "ja_typings": [
           "virannoshogo",
           "virannoshougou"
@@ -18282,7 +18282,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'Fullmetal' referring to in Fullmetal Alchemist?",
-      "ja": "『鋼の錬金術師』における「Fullmetal」は、何を指しているのでしょうか？"
+      "ja": "鋼の錬金術の「鋼の」は何をさすか？"
     },
     "question_text_reading": {
       "en": "What is 'Fullmetal' referring to in Fullmetal Alchemist?",
@@ -18293,28 +18293,28 @@
     "choices": [
       {
         "en": "Re:Zero",
-        "ja": "りぜろ",
+        "ja": "Re:Zero",
         "ja_typings": [
           "rizero"
         ]
       },
       {
         "en": "Overlord",
-        "ja": "おーばーろーど",
+        "ja": "オーバーロード",
         "ja_typings": [
           "obarodo"
         ]
       },
       {
         "en": "That Time I Got Reincarnated as a Slime",
-        "ja": "てんせいしたらスライムだったけん",
+        "ja": "転生したらスライムだった件",
         "ja_typings": [
           "tenseishitarasuraimudattaken"
         ]
       },
       {
         "en": "KonoSuba",
-        "ja": "このすばー",
+        "ja": "このすば",
         "ja_typings": [
           "konosuba"
         ]
@@ -18326,7 +18326,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime features the character Rem?",
-      "ja": "キャラクター「レム」が登場するアニメはどれ？"
+      "ja": "レムが登場するアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime features the character Rem?",
@@ -18344,21 +18344,21 @@
       },
       {
         "en": "only Japanese animation",
-        "ja": "にほんのアニメのみ",
+        "ja": "日本のアニメのみ",
         "ja_typings": [
           "nihonnoanimenomi"
         ]
       },
       {
         "en": "cartoon characters",
-        "ja": "まんがのキャラクター",
+        "ja": "漫画のキャラクター",
         "ja_typings": [
           "manganokyarakuta"
         ]
       },
       {
         "en": "motion pictures",
-        "ja": "えいが",
+        "ja": "映画",
         "ja_typings": [
           "eiga"
         ]
@@ -18370,7 +18370,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'Anime' literally referring to in Japanese?",
-      "ja": "日本語で「Anime」という言葉は、文字通り何を指しているのでしょうか？"
+      "ja": "日本語で「アニメ」はもともと何をさすか？"
     },
     "question_text_reading": {
       "en": "What is 'Anime' literally referring to in Japanese?",
@@ -18381,28 +18381,28 @@
     "choices": [
       {
         "en": "My Hero Academia",
-        "ja": "ぼくのひーろーあかでみあ",
+        "ja": "僕のヒーローアカデミア",
         "ja_typings": [
           "bokunohiroakademia"
         ]
       },
       {
         "en": "Naruto",
-        "ja": "なると",
+        "ja": "ナルト",
         "ja_typings": [
           "naruto"
         ]
       },
       {
         "en": "Dragon Ball Z",
-        "ja": "どらごんぼーるZ",
+        "ja": "ドラゴンボールZ",
         "ja_typings": [
           "doragonboruz"
         ]
       },
       {
         "en": "One Piece",
-        "ja": "わんぴーす",
+        "ja": "ワンピース",
         "ja_typings": [
           "wanpisu"
         ]
@@ -18414,7 +18414,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime is famous for the phrase 'Plus Ultra'?",
-      "ja": "Plus Ultraというフレーズで有名なアニメはどれ？"
+      "ja": "Plus Ultraというフレーズで有名なアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime is famous for the phrase 'Plus Ultra'?",
@@ -18425,28 +18425,28 @@
     "choices": [
       {
         "en": "My Hero Academia",
-        "ja": "ぼくのひーろーあかでみあ",
+        "ja": "僕のヒーローアカデミア",
         "ja_typings": [
           "bokunohiroakademia"
         ]
       },
       {
         "en": "Naruto",
-        "ja": "なると",
+        "ja": "ナルト",
         "ja_typings": [
           "naruto"
         ]
       },
       {
         "en": "Dragon Ball",
-        "ja": "どらごんぼーる",
+        "ja": "ドラゴンボール",
         "ja_typings": [
           "doragonboru"
         ]
       },
       {
         "en": "Black Clover",
-        "ja": "ぶらっくくろーばー",
+        "ja": "ブラッククローバー",
         "ja_typings": [
           "burakkukuroba"
         ]
@@ -18458,7 +18458,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime is about a boy who discovers he can become a hero by training hard?",
-      "ja": "一生懸命トレーニングを積むことでヒーローになれることを知った少年を描いたアニメはどれ？"
+      "ja": "懸念練習でヒーローになれることを知った少年のアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime is about a boy who discovers he can become a hero by training hard?",
@@ -18469,28 +18469,28 @@
     "choices": [
       {
         "en": "Attack on Titan",
-        "ja": "あたっくおんたいたん",
+        "ja": "アタック・オン・タイタン",
         "ja_typings": [
           "atakkuontaitan"
         ]
       },
       {
         "en": "Titan Attack",
-        "ja": "たいたんあたっく",
+        "ja": "タイタンアタック",
         "ja_typings": [
           "taitanatakku"
         ]
       },
       {
         "en": "Rumbling Titans",
-        "ja": "らんぶりんぐたいたんず",
+        "ja": "ランブリングタイタンズ",
         "ja_typings": [
           "ranburingutaitanzu"
         ]
       },
       {
         "en": "Rising Titans",
-        "ja": "らいじんぐたいたんず",
+        "ja": "ライジングタイタンズ",
         "ja_typings": [
           "raijingutaitanzu"
         ]
@@ -18502,7 +18502,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'Shingeki no Kyojin' in English?",
-      "ja": "しんげきのきょじんの英語タイトルは？"
+      "ja": "進撃の巨人の英語タイトルは？"
     },
     "question_text_reading": {
       "en": "What is 'Shingeki no Kyojin' in English?",
@@ -18513,28 +18513,28 @@
     "choices": [
       {
         "en": "Infinity",
-        "ja": "むげん",
+        "ja": "無限",
         "ja_typings": [
           "mugen"
         ]
       },
       {
         "en": "Six Eyes",
-        "ja": "ろくがん",
+        "ja": "六眼",
         "ja_typings": [
           "rokugan"
         ]
       },
       {
         "en": "Reverse Cursed Technique",
-        "ja": "はんてんじゅつしき",
+        "ja": "反転呪術式",
         "ja_typings": [
           "hantenjutsushiki"
         ]
       },
       {
         "en": "Domain Expansion",
-        "ja": "りょういきてんかい",
+        "ja": "領位展開",
         "ja_typings": [
           "ryoikitenkai",
           "ryouikitenkai"
@@ -18547,7 +18547,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the name of Satoru Gojo's special ability?",
-      "ja": "ごじょうさとるの特殊能力のなまえは？"
+      "ja": "五条悟の特殊能力の名前は？"
     },
     "question_text_reading": {
       "en": "What is the name of Satoru Gojo's special ability?",
@@ -18558,14 +18558,14 @@
     "choices": [
       {
         "en": "psychological thriller",
-        "ja": "しんりさすぺんす",
+        "ja": "心理スリラー",
         "ja_typings": [
           "shinrisasupensu"
         ]
       },
       {
         "en": "action shonen",
-        "ja": "あくしょんしょうねん",
+        "ja": "アクション少年",
         "ja_typings": [
           "akushonshonen",
           "akushonshounen"
@@ -18573,14 +18573,14 @@
       },
       {
         "en": "romance",
-        "ja": "れんあい",
+        "ja": "恋愛",
         "ja_typings": [
           "renai"
         ]
       },
       {
         "en": "fantasy adventure",
-        "ja": "ふぁんたじーぼうけん",
+        "ja": "ファンタジーアドベンチャー",
         "ja_typings": [
           "fantajiboken",
           "fantajibouken"
@@ -18604,7 +18604,7 @@
     "choices": [
       {
         "en": "Nintendo 64",
-        "ja": "にんてんどうろくじゅうよん",
+        "ja": "任天堂64",
         "ja_typings": [
           "nintendorokujuuyon",
           "nintendourokujuuyon"
@@ -18612,21 +18612,21 @@
       },
       {
         "en": "Super Famicom",
-        "ja": "すーぱーふぁみこん",
+        "ja": "スーパーファミコン",
         "ja_typings": [
           "supafamikon"
         ]
       },
       {
         "en": "Sega Saturn",
-        "ja": "せがさたーん",
+        "ja": "セガサターン",
         "ja_typings": [
           "segasatan"
         ]
       },
       {
         "en": "Atari 2600",
-        "ja": "あたりにせんろっぴゃく",
+        "ja": "アタリ2600",
         "ja_typings": [
           "atarinisenroppyaku"
         ]
@@ -18638,7 +18638,7 @@
     "image_path": null,
     "question_text": {
       "en": "What console launched the modern era of 3D gaming?",
-      "ja": "3Dゲームの現代的な時代を切り開いたゲーム機は何ですか？"
+      "ja": "3Dゲームの新時代を開いた手は？"
     },
     "question_text_reading": {
       "en": "What console launched the modern era of 3D gaming?",
@@ -18649,28 +18649,28 @@
     "choices": [
       {
         "en": "The Legend of Zelda",
-        "ja": "ぜるだのでんせつ",
+        "ja": "ゼルダの伝説",
         "ja_typings": [
           "zerudanodensetsu"
         ]
       },
       {
         "en": "Metroid",
-        "ja": "めとろいど",
+        "ja": "メトロイド",
         "ja_typings": [
           "metoroido"
         ]
       },
       {
         "en": "Kirby",
-        "ja": "かーびぃ",
+        "ja": "カービー",
         "ja_typings": [
           "kabii"
         ]
       },
       {
         "en": "Star Fox",
-        "ja": "すたーふぉっくす",
+        "ja": "スターフォックス",
         "ja_typings": [
           "sutafokkusu"
         ]
@@ -18682,7 +18682,7 @@
     "image_path": null,
     "question_text": {
       "en": "What game features Link as the protagonist?",
-      "ja": "リンクが主人公のゲームはどれ？"
+      "ja": "リンクが主人公のゲームは？"
     },
     "question_text_reading": {
       "en": "What game features Link as the protagonist?",
@@ -18693,28 +18693,28 @@
     "choices": [
       {
         "en": "Minecraft",
-        "ja": "まいんくらふと",
+        "ja": "マインクラフト",
         "ja_typings": [
           "mainkurafuto"
         ]
       },
       {
         "en": "Tetris",
-        "ja": "てとりす",
+        "ja": "テトリス",
         "ja_typings": [
           "tetorisu"
         ]
       },
       {
         "en": "GTA V",
-        "ja": "GTA5",
+        "ja": "GTA V",
         "ja_typings": [
           "gta5"
         ]
       },
       {
         "en": "Wii Sports",
-        "ja": "wiiすぽーつ",
+        "ja": "Wii Sports",
         "ja_typings": [
           "wiisupotsu"
         ]
@@ -18726,7 +18726,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the best-selling video game of all time (as of 2024)?",
-      "ja": "2024ねんじてんでもっともうれたびでおげーむは？"
+      "ja": "2024年で最も売れたビデオゲームは？"
     },
     "question_text_reading": {
       "en": "What is the best-selling video game of all time (as of 2024)?",
@@ -18737,21 +18737,21 @@
     "choices": [
       {
         "en": "Sony",
-        "ja": "そにー",
+        "ja": "ソニー",
         "ja_typings": [
           "soni"
         ]
       },
       {
         "en": "Microsoft",
-        "ja": "まいくろそふと",
+        "ja": "マイクロソフト",
         "ja_typings": [
           "maikurosofuto"
         ]
       },
       {
         "en": "Nintendo",
-        "ja": "にんてんどう",
+        "ja": "任天堂",
         "ja_typings": [
           "nintendo",
           "nintendou"
@@ -18759,7 +18759,7 @@
       },
       {
         "en": "Sega",
-        "ja": "せが",
+        "ja": "セガ",
         "ja_typings": [
           "sega"
         ]
@@ -18771,7 +18771,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which company makes the PlayStation?",
-      "ja": "PlayStationを製造している会社はどこですか？"
+      "ja": "PlayStationを作っている会社は？"
     },
     "question_text_reading": {
       "en": "Which company makes the PlayStation?",
@@ -18782,28 +18782,28 @@
     "choices": [
       {
         "en": "Super Mario",
-        "ja": "すーぱーまりお",
+        "ja": "スーパーマリオ",
         "ja_typings": [
           "supamario"
         ]
       },
       {
         "en": "Donkey Kong",
-        "ja": "どんきーこんぐ",
+        "ja": "ドンキーコング",
         "ja_typings": [
           "donkikongu"
         ]
       },
       {
         "en": "Sonic",
-        "ja": "そにっく",
+        "ja": "ソニック",
         "ja_typings": [
           "sonikku"
         ]
       },
       {
         "en": "Mega Man",
-        "ja": "ろっくまん",
+        "ja": "ロックマン",
         "ja_typings": [
           "rokkuman"
         ]
@@ -18815,7 +18815,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which game features Mario and Luigi?",
-      "ja": "マリオとルイージが登場するゲームはどれですか？"
+      "ja": "マリオとルイージが登場するゲームは？"
     },
     "question_text_reading": {
       "en": "Which game features Mario and Luigi?",
@@ -18826,28 +18826,28 @@
     "choices": [
       {
         "en": "Pac-Man",
-        "ja": "ぱっくまん",
+        "ja": "パックマン",
         "ja_typings": [
           "pakkuman"
         ]
       },
       {
         "en": "Kirby",
-        "ja": "かーびぃ",
+        "ja": "カービィ",
         "ja_typings": [
           "kabii"
         ]
       },
       {
         "en": "Pikachu",
-        "ja": "ぴかちゅう",
+        "ja": "ピカチュウ",
         "ja_typings": [
           "pikachuu"
         ]
       },
       {
         "en": "Chocobo",
-        "ja": "ちょこぼ",
+        "ja": "チョコボ",
         "ja_typings": [
           "chokobo"
         ]
@@ -18859,7 +18859,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the iconic yellow ghost-eating character?",
-      "ja": "象徴的な黄色い、お化けを食べるキャラクターは何でしょう？"
+      "ja": "お化けをたべる黄色いキャラクターは？"
     },
     "question_text_reading": {
       "en": "What is the iconic yellow ghost-eating character?",
@@ -18870,28 +18870,28 @@
     "choices": [
       {
         "en": "Halo",
-        "ja": "へいろー",
+        "ja": "ヘイロー",
         "ja_typings": [
           "heiro"
         ]
       },
       {
         "en": "Doom",
-        "ja": "どぅーむ",
+        "ja": "ドゥーム",
         "ja_typings": [
           "dumu"
         ]
       },
       {
         "en": "Call of Duty",
-        "ja": "こーるおぶでゅーてぃ",
+        "ja": "コールオブデューティー",
         "ja_typings": [
           "koruobudeyuti"
         ]
       },
       {
         "en": "Battlefield",
-        "ja": "ばとるふぃーるど",
+        "ja": "バトルフィールド",
         "ja_typings": [
           "batorufirudo"
         ]
@@ -18903,7 +18903,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which game series features Master Chief?",
-      "ja": "マスターチーフが登場するゲームシリーズはどれですか？"
+      "ja": "マスターチーフが登場するゲームシリーズは？"
     },
     "question_text_reading": {
       "en": "Which game series features Master Chief?",
@@ -18914,28 +18914,28 @@
     "choices": [
       {
         "en": "PUBG",
-        "ja": "ぱぶじー",
+        "ja": "PUBG",
         "ja_typings": [
           "pabuji"
         ]
       },
       {
         "en": "Fortnite",
-        "ja": "ふぉーとないと",
+        "ja": "フォートナイト",
         "ja_typings": [
           "fotonaito"
         ]
       },
       {
         "en": "Warzone",
-        "ja": "うぉーぞーん",
+        "ja": "Warzone",
         "ja_typings": [
           "wozon"
         ]
       },
       {
         "en": "Apex Legends",
-        "ja": "えいぺっくすれじぇんず",
+        "ja": "Apex Legends",
         "ja_typings": [
           "eipekkusurejenzu"
         ]
@@ -18947,7 +18947,7 @@
     "image_path": null,
     "question_text": {
       "en": "What game popularized the battle royale genre?",
-      "ja": "バトルロイヤルというジャンルを広めたゲームは何でしょう？"
+      "ja": "バトルロイヤルジャンルを広めたゲームは？"
     },
     "question_text_reading": {
       "en": "What game popularized the battle royale genre?",
@@ -18958,14 +18958,14 @@
     "choices": [
       {
         "en": "Sega",
-        "ja": "せが",
+        "ja": "セガ",
         "ja_typings": [
           "sega"
         ]
       },
       {
         "en": "Nintendo",
-        "ja": "にんてんどう",
+        "ja": "任天堂",
         "ja_typings": [
           "nintendo",
           "nintendou"
@@ -18973,14 +18973,14 @@
       },
       {
         "en": "Capcom",
-        "ja": "かぷこむ",
+        "ja": "カプコン",
         "ja_typings": [
           "kapukomu"
         ]
       },
       {
         "en": "Konami",
-        "ja": "こなみ",
+        "ja": "コナミ",
         "ja_typings": [
           "konami"
         ]
@@ -18992,7 +18992,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which company made Sonic the Hedgehog?",
-      "ja": "ソニック・ザ・ヘッジホッグを制作した会社はどこですか？"
+      "ja": "ソニック・ザ・ヘッジホッグを作った会社は？"
     },
     "question_text_reading": {
       "en": "Which company made Sonic the Hedgehog?",
@@ -19003,28 +19003,28 @@
     "choices": [
       {
         "en": "Halo",
-        "ja": "へいろー",
+        "ja": "ヘイロー",
         "ja_typings": [
           "heiro"
         ]
       },
       {
         "en": "Gears of War",
-        "ja": "ぎあすおぶうぉー",
+        "ja": "ギアズオブウォー",
         "ja_typings": [
           "giasuobuwo"
         ]
       },
       {
         "en": "Mass Effect",
-        "ja": "ますえふぇくと",
+        "ja": "マスエフェクト",
         "ja_typings": [
           "masuefekuto"
         ]
       },
       {
         "en": "Destiny",
-        "ja": "ですてぃにー",
+        "ja": "デスティニー",
         "ja_typings": [
           "desutini"
         ]
@@ -19036,7 +19036,7 @@
     "image_path": null,
     "question_text": {
       "en": "What game series features the Covenant as enemies?",
-      "ja": "コヴェナントという敵が登場するゲームシリーズはどれ？"
+      "ja": "Covenantが敵として登場するゲームシリーズは？"
     },
     "question_text_reading": {
       "en": "What game series features the Covenant as enemies?",
@@ -19047,28 +19047,28 @@
     "choices": [
       {
         "en": "Portal",
-        "ja": "ぽーたる",
+        "ja": "ポータル",
         "ja_typings": [
           "potaru"
         ]
       },
       {
         "en": "Half-Life",
-        "ja": "はーふらいふ",
+        "ja": "ハーフライフ",
         "ja_typings": [
           "hafuraifu"
         ]
       },
       {
         "en": "Mirror's Edge",
-        "ja": "みらーずえっじ",
+        "ja": "ミラーズエッジ",
         "ja_typings": [
           "mirazuejji"
         ]
       },
       {
         "en": "Bioshock",
-        "ja": "ばいおしょっく",
+        "ja": "バイオショック",
         "ja_typings": [
           "baioshokku"
         ]
@@ -19080,7 +19080,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which game is famous for the phrase 'The Cake is a Lie'?",
-      "ja": "The Cake is a Lieというフレーズで有名なゲームはどれですか？"
+      "ja": "「ケーキは嘘だ」というフレーズで有名なゲームは？"
     },
     "question_text_reading": {
       "en": "Which game is famous for the phrase 'The Cake is a Lie'?",
@@ -19091,14 +19091,14 @@
     "choices": [
       {
         "en": "dark fantasy medieval world",
-        "ja": "くらいちゅうせいふぁんたじーのせかい",
+        "ja": "暗い中世ファンタジーの世界",
         "ja_typings": [
           "kuraichuuseifantajinosekai"
         ]
       },
       {
         "en": "futuristic space",
-        "ja": "みらいのうちゅう",
+        "ja": "未来の宇宙",
         "ja_typings": [
           "mirainochuu",
           "mirainouchuu"
@@ -19106,14 +19106,14 @@
       },
       {
         "en": "modern day city",
-        "ja": "げんだいのとし",
+        "ja": "現代の都市",
         "ja_typings": [
           "gendainotoshi"
         ]
       },
       {
         "en": "post-apocalyptic wasteland",
-        "ja": "ぶんめいほうかいごのこうやー",
+        "ja": "文明崩壊後の荒野",
         "ja_typings": [
           "bunmeihokaigonokoya",
           "bunmeihoukaigonokouya"
@@ -19137,28 +19137,28 @@
     "choices": [
       {
         "en": "Resident Evil",
-        "ja": "ばいおはざーど",
+        "ja": "バイオハザード",
         "ja_typings": [
           "baiohazado"
         ]
       },
       {
         "en": "Silent Hill",
-        "ja": "さいれんとひる",
+        "ja": "サイレントヒル",
         "ja_typings": [
           "sairentohiru"
         ]
       },
       {
         "en": "Alone in the Dark",
-        "ja": "あろーんいんざだーく",
+        "ja": "アローン・イン・ザ・ダーク",
         "ja_typings": [
           "aroninzadaku"
         ]
       },
       {
         "en": "Fatal Frame",
-        "ja": "ぜろ",
+        "ja": "ゼロ",
         "ja_typings": [
           "zero"
         ]
@@ -19170,7 +19170,7 @@
     "image_path": null,
     "question_text": {
       "en": "What game created the 'survival horror' genre?",
-      "ja": "サバイバルホラーというジャンルを確立したゲームはどれでしょう？"
+      "ja": "サバイバルホラーというジャンルを作ったゲームは？"
     },
     "question_text_reading": {
       "en": "What game created the 'survival horror' genre?",
@@ -19181,28 +19181,28 @@
     "choices": [
       {
         "en": "2011",
-        "ja": "2011ねん",
+        "ja": "2011年",
         "ja_typings": [
           "2011nen"
         ]
       },
       {
         "en": "2009",
-        "ja": "2009ねん",
+        "ja": "2009年",
         "ja_typings": [
           "2009nen"
         ]
       },
       {
         "en": "2013",
-        "ja": "2013ねん",
+        "ja": "2013年",
         "ja_typings": [
           "2013nen"
         ]
       },
       {
         "en": "2015",
-        "ja": "2015ねん",
+        "ja": "2015年",
         "ja_typings": [
           "2015nen"
         ]
@@ -19214,7 +19214,7 @@
     "image_path": null,
     "question_text": {
       "en": "What year was the original Minecraft released to the public?",
-      "ja": "オリジナルのMinecraftが一般に公開されたのは何年ですか？"
+      "ja": "オリジナルマインクラフトが公開されたのは何年か？"
     },
     "question_text_reading": {
       "en": "What year was the original Minecraft released to the public?",
@@ -19225,7 +19225,7 @@
     "choices": [
       {
         "en": "clear lines by filling them",
-        "ja": "れつをうめてきえす",
+        "ja": "列を埋めて消す",
         "ja_typings": [
           "retsuometekiesu",
           "retsuoumetekiesu"
@@ -19233,21 +19233,21 @@
       },
       {
         "en": "defeat enemies",
-        "ja": "てきをたおす",
+        "ja": "敵を倒す",
         "ja_typings": [
           "tekiotaosu"
         ]
       },
       {
         "en": "collect all pieces",
-        "ja": "すべてのぴーすをあつめる",
+        "ja": "すべてのピースを集める",
         "ja_typings": [
           "subetenopisuoatsumeru"
         ]
       },
       {
         "en": "build the tallest tower",
-        "ja": "いちばんたかいとうをたてる",
+        "ja": "一番高い塔を立てる",
         "ja_typings": [
           "ichibantakaitootateru",
           "ichibantakaitouotateru"
@@ -19260,7 +19260,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the objective in Tetris?",
-      "ja": "テトリスのもくてきは何か？"
+      "ja": "テトリスの目的は何か？"
     },
     "question_text_reading": {
       "en": "What is the objective in Tetris?",
@@ -19271,14 +19271,14 @@
     "choices": [
       {
         "en": "Red Dead Redemption",
-        "ja": "れっどでっどりでんぷしょん",
+        "ja": "レッドデッドレッドンプション",
         "ja_typings": [
           "reddodeddoridenpushon"
         ]
       },
       {
         "en": "GTA",
-        "ja": "グランドせふとおーと",
+        "ja": "グランドセフトオート",
         "ja_typings": [
           "gurandosefutoto",
           "gurandosefutooto"
@@ -19286,14 +19286,14 @@
       },
       {
         "en": "Outlaws of the West",
-        "ja": "あうとろーずおぶざうぇすと",
+        "ja": "アウトローズオブザウェスト",
         "ja_typings": [
           "autorozuobuzawesuto"
         ]
       },
       {
         "en": "Wild West Online",
-        "ja": "わいるどうぇすとおんらいん",
+        "ja": "ワイルドウェストオンライン",
         "ja_typings": [
           "wairudowesutonrain",
           "wairudowesutoonrain"
@@ -19306,7 +19306,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which game series features Arthur Morgan or John Marston?",
-      "ja": "アーサー・モルガンやジョン・マストンが登場するゲームシリーズはどれ？"
+      "ja": "アーサー・モルガンまたはジョン・マストンが登場するシリーズは？"
     },
     "question_text_reading": {
       "en": "Which game series features Arthur Morgan or John Marston?",
@@ -19317,28 +19317,28 @@
     "choices": [
       {
         "en": "life simulation",
-        "ja": "せいかつしみゅれーしょん",
+        "ja": "生活シミュレーション",
         "ja_typings": [
           "seikatsushimyureshon"
         ]
       },
       {
         "en": "action RPG",
-        "ja": "あくしょんRPG",
+        "ja": "アクションRPG",
         "ja_typings": [
           "akushonrpg"
         ]
       },
       {
         "en": "survival horror",
-        "ja": "さばいばるほらー",
+        "ja": "サバイバルホラー",
         "ja_typings": [
           "sabaibaruhora"
         ]
       },
       {
         "en": "strategy",
-        "ja": "すとらてじー",
+        "ja": "ストラテジー",
         "ja_typings": [
           "sutorateji"
         ]
@@ -19350,7 +19350,7 @@
     "image_path": null,
     "question_text": {
       "en": "What genre is 'The Sims'?",
-      "ja": "『The Sims』はどのようなジャンルのゲームですか？"
+      "ja": "The Simsのジャンルは？"
     },
     "question_text_reading": {
       "en": "What genre is 'The Sims'?",
@@ -19361,28 +19361,28 @@
     "choices": [
       {
         "en": "The Legend of Zelda",
-        "ja": "ぜるだのでんせつ",
+        "ja": "ゼルダの伝説",
         "ja_typings": [
           "zerudanodensetsu"
         ]
       },
       {
         "en": "Fire Emblem",
-        "ja": "ふぁいあーえんぶれむ",
+        "ja": "ファイアーエムブレム",
         "ja_typings": [
           "faiaenburemu"
         ]
       },
       {
         "en": "Xenoblade",
-        "ja": "ぜのぶれーど",
+        "ja": "ゼノブレイド",
         "ja_typings": [
           "zenoburedo"
         ]
       },
       {
         "en": "Metroid",
-        "ja": "めとろいど",
+        "ja": "メトロイド",
         "ja_typings": [
           "metoroido"
         ]
@@ -19394,7 +19394,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which Nintendo franchise features Link and Zelda?",
-      "ja": "リンクとゼルダが登場する任天堂のフランチャイズはどれですか？"
+      "ja": "リンクとゼルダの任天堂フランチャイズは？"
     },
     "question_text_reading": {
       "en": "Which Nintendo franchise features Link and Zelda?",
@@ -19405,21 +19405,21 @@
     "choices": [
       {
         "en": "social deduction",
-        "ja": "しゃかいてきすいろん",
+        "ja": "社会的推論",
         "ja_typings": [
           "shakaitekisuiron"
         ]
       },
       {
         "en": "battle royale",
-        "ja": "ばとるろわいやる",
+        "ja": "バトルロイヤル",
         "ja_typings": [
           "batorurowaiyaru"
         ]
       },
       {
         "en": "real-time strategy",
-        "ja": "りあるたいむすとらてじー",
+        "ja": "リアルタイムストラテジー",
         "ja_typings": [
           "riarutaimusutorateji"
         ]
@@ -19438,7 +19438,7 @@
     "image_path": null,
     "question_text": {
       "en": "What type of game is 'Among Us'?",
-      "ja": "あまんぐあすのゲームジャンルは？"
+      "ja": "Among Usのゲームジャンルは？"
     },
     "question_text_reading": {
       "en": "What type of game is 'Among Us'?",
@@ -19449,28 +19449,28 @@
     "choices": [
       {
         "en": "Color TV-Game",
-        "ja": "からーTVゲーム",
+        "ja": "カラーTVゲーム",
         "ja_typings": [
           "karatvgemu"
         ]
       },
       {
         "en": "Famicom",
-        "ja": "ふぁみこん",
+        "ja": "ファミコン",
         "ja_typings": [
           "famikon"
         ]
       },
       {
         "en": "Game & Watch",
-        "ja": "ゲームあんどうぉっち",
+        "ja": "ゲームアンドウォッチ",
         "ja_typings": [
           "gemuandowotchi"
         ]
       },
       {
         "en": "Game Boy",
-        "ja": "ゲームぼーい",
+        "ja": "ゲームボーイ",
         "ja_typings": [
           "gemuboi"
         ]
@@ -19482,7 +19482,7 @@
     "image_path": null,
     "question_text": {
       "en": "What was Nintendo's first game console?",
-      "ja": "任天堂が発売した最初のゲーム機は何ですか？"
+      "ja": "任天堂の初めてのゲーム機は？"
     },
     "question_text_reading": {
       "en": "What was Nintendo's first game console?",
@@ -19493,28 +19493,28 @@
     "choices": [
       {
         "en": "Mass Effect",
-        "ja": "ますえふぇくと",
+        "ja": "マスエフェクト",
         "ja_typings": [
           "masuefekuto"
         ]
       },
       {
         "en": "Halo",
-        "ja": "へいろー",
+        "ja": "ヘイロー",
         "ja_typings": [
           "heiro"
         ]
       },
       {
         "en": "Destiny",
-        "ja": "ですてぃにー",
+        "ja": "デスティニー",
         "ja_typings": [
           "desutini"
         ]
       },
       {
         "en": "Gears of War",
-        "ja": "ぎあすおぶうぉー",
+        "ja": "ギアズオブウォー",
         "ja_typings": [
           "giasuobuwo"
         ]
@@ -19526,7 +19526,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which game series features Commander Shepard?",
-      "ja": "コマンドー・シェパードが登場するゲームシリーズはどれ？"
+      "ja": "シェパードが主なシリーズは？"
     },
     "question_text_reading": {
       "en": "Which game series features Commander Shepard?",
@@ -19537,28 +19537,28 @@
     "choices": [
       {
         "en": "Navi",
-        "ja": "なび",
+        "ja": "ナビ",
         "ja_typings": [
           "nabi"
         ]
       },
       {
         "en": "Tatl",
-        "ja": "たとる",
+        "ja": "タトル",
         "ja_typings": [
           "tatoru"
         ]
       },
       {
         "en": "Midna",
-        "ja": "みどな",
+        "ja": "ミドナ",
         "ja_typings": [
           "midona"
         ]
       },
       {
         "en": "Fi",
-        "ja": "ふぁい",
+        "ja": "Fi",
         "ja_typings": [
           "fai"
         ]
@@ -19570,7 +19570,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the name of Link's fairy companion in Ocarina of Time?",
-      "ja": "時のオカリナに登場するリンクの妖精の名前は何ですか？"
+      "ja": "時のオカリナでリンクの妖精の名前は？"
     },
     "question_text_reading": {
       "en": "What is the name of Link's fairy companion in Ocarina of Time?",
@@ -19581,28 +19581,28 @@
     "choices": [
       {
         "en": "Japanese-style role-playing game",
-        "ja": "にほんしきのRPG",
+        "ja": "日本式のRPG",
         "ja_typings": [
           "nihonshikinorpg"
         ]
       },
       {
         "en": "Java-based RPG engine",
-        "ja": "JavaべーすのRPGえんじん",
+        "ja": "JavaベースのRPGエンジン",
         "ja_typings": [
           "javabesunorpgenjin"
         ]
       },
       {
         "en": "Junior RPG for kids",
-        "ja": "こどもむけのRPG",
+        "ja": "子供向けのRPG",
         "ja_typings": [
           "kodomomukenorpg"
         ]
       },
       {
         "en": "jungle role-playing game",
-        "ja": "じゃんぐるRPG",
+        "ja": "ジャングルRPG",
         "ja_typings": [
           "jangururpg"
         ]
@@ -19625,28 +19625,28 @@
     "choices": [
       {
         "en": "Square Enix",
-        "ja": "すくえあえにっくす",
+        "ja": "スクウェア・エニックス",
         "ja_typings": [
           "sukueaenikkusu"
         ]
       },
       {
         "en": "Capcom",
-        "ja": "かぷこむ",
+        "ja": "カプコン",
         "ja_typings": [
           "kapukomu"
         ]
       },
       {
         "en": "Konami",
-        "ja": "こなみ",
+        "ja": "コナミ",
         "ja_typings": [
           "konami"
         ]
       },
       {
         "en": "Bandai Namco",
-        "ja": "ばんだいなむこ",
+        "ja": "バンダイナムコ",
         "ja_typings": [
           "bandainamuko"
         ]
@@ -19658,7 +19658,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which game company made Final Fantasy?",
-      "ja": "ファイナルファンタジーを制作したゲーム会社はどこですか？"
+      "ja": "ファイナルファンタジーを作った会社は？"
     },
     "question_text_reading": {
       "en": "Which game company made Final Fantasy?",
@@ -19669,21 +19669,21 @@
     "choices": [
       {
         "en": "character dies permanently when killed",
-        "ja": "しぬとキャラがえいきゅうにきえる",
+        "ja": "死ぬとキャラが永久に消える",
         "ja_typings": [
           "shinutokyaragaeikyuunikieru"
         ]
       },
       {
         "en": "infinite lives system",
-        "ja": "むげんのいのちのしすてむ",
+        "ja": "無限の命のシステム",
         "ja_typings": [
           "mugennoinochinoshisutemu"
         ]
       },
       {
         "en": "auto-save after death",
-        "ja": "しごとじどうほぞん",
+        "ja": "仕事自動保存",
         "ja_typings": [
           "shigotojidohozon",
           "shigotojidouhozon"
@@ -19691,7 +19691,7 @@
       },
       {
         "en": "death animation system",
-        "ja": "しのあにめーしょんしすてむ",
+        "ja": "死のアニメーションシステム",
         "ja_typings": [
           "shinoanimeshonshisutemu"
         ]
@@ -19703,7 +19703,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'permadeath' in games?",
-      "ja": "ゲームにおける「permadeath」とは何ですか？"
+      "ja": "ゲームのパーマデスとは何か？"
     },
     "question_text_reading": {
       "en": "What is 'permadeath' in games?",
@@ -19714,7 +19714,7 @@
     "choices": [
       {
         "en": "procedural generation with permadeath",
-        "ja": "じどうせいせいとぱーまです",
+        "ja": "自動生成とパーマデス",
         "ja_typings": [
           "jidoseiseitopamadesu",
           "jidouseiseitopamadesu"
@@ -19722,7 +19722,7 @@
       },
       {
         "en": "game about thieves",
-        "ja": "どろぼうのゲーム",
+        "ja": "泥棒のゲーム",
         "ja_typings": [
           "dorobonogemu",
           "dorobounogemu"
@@ -19730,14 +19730,14 @@
       },
       {
         "en": "classic 8-bit game",
-        "ja": "クラシックはちびっとゲーム",
+        "ja": "クラシック八ビットゲーム",
         "ja_typings": [
           "kurashikkuhachibittogemu"
         ]
       },
       {
         "en": "linear adventure game",
-        "ja": "いちじゅんのぼうけんゲーム",
+        "ja": "一次純の冒険ゲーム",
         "ja_typings": [
           "ichijunnobokengemu",
           "ichijunnoboukengemu"
@@ -19750,7 +19750,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a roguelike game?",
-      "ja": "ローグライクゲームとはどのようなジャンルのゲームですか？"
+      "ja": "ローグライクゲームとは何か？"
     },
     "question_text_reading": {
       "en": "What is a roguelike game?",
@@ -19761,14 +19761,14 @@
     "choices": [
       {
         "en": "checkmate opponent's king",
-        "ja": "あいてのきんぐをちぇっくめーと",
+        "ja": "相手のキングをチェックメイト",
         "ja_typings": [
           "aitenokinguochekkumeto"
         ]
       },
       {
         "en": "capture all pieces",
-        "ja": "ぜんてはつきょうする",
+        "ja": "全手つきょうする",
         "ja_typings": [
           "zentehatsukyosuru",
           "zentehatsukyousuru"
@@ -19776,7 +19776,7 @@
       },
       {
         "en": "reach the other side",
-        "ja": "はんたいがわにとうたつ",
+        "ja": "反対側に到達する",
         "ja_typings": [
           "hantaigawanitotatsu",
           "hantaigawanitoutatsu"
@@ -19784,7 +19784,7 @@
       },
       {
         "en": "collect most points",
-        "ja": "もっともてんすうをとる",
+        "ja": "最も点数を取る",
         "ja_typings": [
           "mottomotensuuotoru"
         ]
@@ -19796,7 +19796,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the objective in chess (video game version)?",
-      "ja": "チェス（ビデオゲーム版）における目的は何ですか？"
+      "ja": "チェスの目的は何か？"
     },
     "question_text_reading": {
       "en": "What is the objective in chess (video game version)?",
@@ -19807,28 +19807,28 @@
     "choices": [
       {
         "en": "1985",
-        "ja": "1985ねん",
+        "ja": "1985年",
         "ja_typings": [
           "1985nen"
         ]
       },
       {
         "en": "1983",
-        "ja": "1983ねん",
+        "ja": "1983年",
         "ja_typings": [
           "1983nen"
         ]
       },
       {
         "en": "1987",
-        "ja": "1987ねん",
+        "ja": "1987年",
         "ja_typings": [
           "1987nen"
         ]
       },
       {
         "en": "1989",
-        "ja": "1989ねん",
+        "ja": "1989年",
         "ja_typings": [
           "1989nen"
         ]
@@ -19840,7 +19840,7 @@
     "image_path": null,
     "question_text": {
       "en": "What year was the first Super Mario Bros released?",
-      "ja": "スーパーマリオブラザーズが最初に発売されたのは何年ですか？"
+      "ja": "初のスーパーマリオブラザーズはいつ発売されたか？"
     },
     "question_text_reading": {
       "en": "What year was the first Super Mario Bros released?",
@@ -19851,28 +19851,28 @@
     "choices": [
       {
         "en": "Halo",
-        "ja": "へいろー",
+        "ja": "ヘイロー",
         "ja_typings": [
           "heiro"
         ]
       },
       {
         "en": "Star Wars Battlefront",
-        "ja": "すたーうぉーずばとるふろんと",
+        "ja": "スター・ウォーズ・バトルフロント",
         "ja_typings": [
           "sutawozubatorufuronto"
         ]
       },
       {
         "en": "Destiny",
-        "ja": "ですてぃにー",
+        "ja": "デスティニー",
         "ja_typings": [
           "desutini"
         ]
       },
       {
         "en": "Anthem",
-        "ja": "あんせむ",
+        "ja": "アンセム",
         "ja_typings": [
           "ansemu"
         ]
@@ -19884,7 +19884,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which game features the Covenant, Flood, and Forerunners?",
-      "ja": "コベナント、フラッド、フォレナーナーが登場するゲームはどれですか？"
+      "ja": "Covenant、Flood、Forerunnersが登場するゲームは？"
     },
     "question_text_reading": {
       "en": "Which game features the Covenant, Flood, and Forerunners?",
@@ -19895,28 +19895,28 @@
     "choices": [
       {
         "en": "city building simulation",
-        "ja": "まちづくりしみゅれーしょん",
+        "ja": "街づくりシミュレーション",
         "ja_typings": [
           "machizukurishimyureshon"
         ]
       },
       {
         "en": "action platformer",
-        "ja": "あくしょんぷらっとふぉーまー",
+        "ja": "アクションプラットフォーマー",
         "ja_typings": [
           "akushonpurattofoma"
         ]
       },
       {
         "en": "racing game",
-        "ja": "れーすゲーム",
+        "ja": "レーシングゲーム",
         "ja_typings": [
           "resugemu"
         ]
       },
       {
         "en": "horror survival",
-        "ja": "ほらーさばいばる",
+        "ja": "ホラーサバイバル",
         "ja_typings": [
           "horasabaibaru"
         ]
@@ -19928,7 +19928,7 @@
     "image_path": null,
     "question_text": {
       "en": "What type of game is 'SimCity'?",
-      "ja": "しむしてぃのゲームジャンルは？"
+      "ja": "SimCityのゲームジャンルは？"
     },
     "question_text_reading": {
       "en": "What type of game is 'SimCity'?",
@@ -19946,21 +19946,21 @@
       },
       {
         "en": "Gold Coins",
-        "ja": "きんか",
+        "ja": "金貨",
         "ja_typings": [
           "kinka"
         ]
       },
       {
         "en": "Nook Miles",
-        "ja": "ぬっきーまいる",
+        "ja": "ヌッキーマイル",
         "ja_typings": [
           "nukkimairu"
         ]
       },
       {
         "en": "Rupees",
-        "ja": "るぴー",
+        "ja": "ルピー",
         "ja_typings": [
           "rupi"
         ]
@@ -19972,7 +19972,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the main currency in Animal Crossing?",
-      "ja": "あつまれどうぶつのもりの主な通貨は何ですか？"
+      "ja": "あつまれどうぶつのもりの通貨は？"
     },
     "question_text_reading": {
       "en": "What is the main currency in Animal Crossing?",
@@ -19983,21 +19983,21 @@
     "choices": [
       {
         "en": "Pokemon",
-        "ja": "ぽけもん",
+        "ja": "ポケモン",
         "ja_typings": [
           "pokemon"
         ]
       },
       {
         "en": "Monster Hunter",
-        "ja": "もんすたーはんたー",
+        "ja": "モンスターハンター",
         "ja_typings": [
           "monsutahanta"
         ]
       },
       {
         "en": "Digimon",
-        "ja": "でじもん",
+        "ja": "デジモン",
         "ja_typings": [
           "dejimon"
         ]
@@ -20027,21 +20027,21 @@
     "choices": [
       {
         "en": "Microsoft",
-        "ja": "まいくろそふと",
+        "ja": "マイクロソフト",
         "ja_typings": [
           "maikurosofuto"
         ]
       },
       {
         "en": "Sony",
-        "ja": "そにー",
+        "ja": "ソニー",
         "ja_typings": [
           "soni"
         ]
       },
       {
         "en": "Nintendo",
-        "ja": "にんてんどう",
+        "ja": "任天堂",
         "ja_typings": [
           "nintendo",
           "nintendou"
@@ -20049,7 +20049,7 @@
       },
       {
         "en": "Valve",
-        "ja": "ばるぶ",
+        "ja": "バルブ",
         "ja_typings": [
           "barubu"
         ]
@@ -20061,7 +20061,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which company makes the Xbox?",
-      "ja": "Xboxを製造しているのはどの会社ですか？"
+      "ja": "Xboxを作っている会社は？"
     },
     "question_text_reading": {
       "en": "Which company makes the Xbox?",
@@ -20105,7 +20105,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'health points' abbreviated as in games?",
-      "ja": "ゲームでヘルスポイントのりゃくごは？"
+      "ja": "ゲームでヘルスポイントの略語は？"
     },
     "question_text_reading": {
       "en": "What is 'health points' abbreviated as in games?",
@@ -20149,7 +20149,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'magic points' abbreviated as in games?",
-      "ja": "ゲームで「magic points」は略して何と呼ぶ？"
+      "ja": "ゲームで魔法ポイントの略語は？"
     },
     "question_text_reading": {
       "en": "What is 'magic points' abbreviated as in games?",
@@ -20160,28 +20160,28 @@
     "choices": [
       {
         "en": "Non-Player Character",
-        "ja": "のんぷれいやーキャラクター",
+        "ja": "ノンプレイヤーキャラクター",
         "ja_typings": [
           "nonpureiyakyarakuta"
         ]
       },
       {
         "en": "New Player Content",
-        "ja": "にゅーぷれいやーこんてんつ",
+        "ja": "ニュープレイヤーコンテンツ",
         "ja_typings": [
           "nyupureiyakontentsu"
         ]
       },
       {
         "en": "Next Play Control",
-        "ja": "ねくすとぷれいこんとろーる",
+        "ja": "ネクストプレイコントロール",
         "ja_typings": [
           "nekusutopureikontororu"
         ]
       },
       {
         "en": "Network Play Connection",
-        "ja": "ねっとわーくぷれいせつぞく",
+        "ja": "ネットワークプレイ接続",
         "ja_typings": [
           "nettowakupureisetsuzoku"
         ]
@@ -20193,7 +20193,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does 'NPC' mean in video games?",
-      "ja": "ビデオゲームのNPCのいみは？"
+      "ja": "ビデオゲームのNPCの意味は？"
     },
     "question_text_reading": {
       "en": "What does 'NPC' mean in video games?",
@@ -20204,7 +20204,7 @@
     "choices": [
       {
         "en": "Downloadable Content",
-        "ja": "だうんろーどかのうなこんてんつ",
+        "ja": "ダウンロード可能コンテンツ",
         "ja_typings": [
           "daunrodokanonakontentsu",
           "daunrodokanounakontentsu"
@@ -20212,7 +20212,7 @@
       },
       {
         "en": "Dynamic Level Content",
-        "ja": "どうてきれべるこんてんつ",
+        "ja": "動的レベルコンテンツ",
         "ja_typings": [
           "dotekireberukontentsu",
           "doutekireberukontentsu"
@@ -20220,14 +20220,14 @@
       },
       {
         "en": "Direct Link Connection",
-        "ja": "ちょくせつりんくせつぞく",
+        "ja": "直接リンク接続",
         "ja_typings": [
           "chokusetsurinkusetsuzoku"
         ]
       },
       {
         "en": "Dual-Layer Cartridge",
-        "ja": "だぶるれいやーかーとりっじ",
+        "ja": "デュアルレイヤーカートリッジ",
         "ja_typings": [
           "daburureiyakatorijji"
         ]
@@ -20239,7 +20239,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'DLC' in gaming?",
-      "ja": "ゲームのDLCのいみは？"
+      "ja": "ゲームのDLCの意味は？"
     },
     "question_text_reading": {
       "en": "What is 'DLC' in gaming?",
@@ -20250,14 +20250,14 @@
     "choices": [
       {
         "en": "repeatedly fighting to gain levels",
-        "ja": "くりかえしたたかってれべるあげ",
+        "ja": "繰り返し戦ってレベル上げ",
         "ja_typings": [
           "kurikaeshitatakattereberuage"
         ]
       },
       {
         "en": "crafting items",
-        "ja": "どうぐをつくる",
+        "ja": "道具を作る",
         "ja_typings": [
           "doguotsukuru",
           "douguotsukuru"
@@ -20265,7 +20265,7 @@
       },
       {
         "en": "exploring new areas",
-        "ja": "あたらしいりょいきをたんさく",
+        "ja": "新しい領域を探索",
         "ja_typings": [
           "atarashiiryoikiotansaku"
         ]
@@ -20285,7 +20285,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'grinding' in RPGs?",
-      "ja": "RPGにおける「grinding」とはどのような行為ですか？"
+      "ja": "RPGの「grinding」とは何か？"
     },
     "question_text_reading": {
       "en": "What is 'grinding' in RPGs?",
@@ -20296,7 +20296,7 @@
     "choices": [
       {
         "en": "random in-game reward container",
-        "ja": "らんだむなゲームないほうしゅうコンテナ",
+        "ja": "ランダムなゲーム内報酬コンテナ",
         "ja_typings": [
           "randamunagemunaihoshuukontena",
           "randamunagemunaihoushuukontena"
@@ -20304,14 +20304,14 @@
       },
       {
         "en": "storage for items",
-        "ja": "アイテムのほぞんぼっくす",
+        "ja": "アイテムの保存ボックス",
         "ja_typings": [
           "aitemunohozonbokkusu"
         ]
       },
       {
         "en": "chest with guaranteed rewards",
-        "ja": "ほしょうりわーどのはこ",
+        "ja": "保証リワードの箱",
         "ja_typings": [
           "hoshoriwadonohako",
           "hoshouriwadonohako"
@@ -20319,7 +20319,7 @@
       },
       {
         "en": "enemy drop container",
-        "ja": "てきのどろっぷコンテナ",
+        "ja": "敵のドロップコンテナ",
         "ja_typings": [
           "tekinodoroppukontena"
         ]
@@ -20331,7 +20331,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a 'loot box'?",
-      "ja": "loot boxとは何ですか？"
+      "ja": "ルートボックスとは何か？"
     },
     "question_text_reading": {
       "en": "What is a 'loot box'?",
@@ -20342,28 +20342,28 @@
     "choices": [
       {
         "en": "hidden joke or secret by developers",
-        "ja": "かいはつしゃのかくされたじょーくやひみつ",
+        "ja": "開発者の隠されたジョークや秘密",
         "ja_typings": [
           "kaihatsushanokakusaretajokuyahimitsu"
         ]
       },
       {
         "en": "seasonal event content",
-        "ja": "きせつイベントコンテンツ",
+        "ja": "季節イベントコンテンツ",
         "ja_typings": [
           "kisetsuibentokontentsu"
         ]
       },
       {
         "en": "bonus stage at the end",
-        "ja": "さいごのぼーなすすてーじ",
+        "ja": "最後のボーナスステージ",
         "ja_typings": [
           "saigonobonasusuteji"
         ]
       },
       {
         "en": "collectible egg item",
-        "ja": "しゅうしゅうひんのたまご",
+        "ja": "収集品の卵",
         "ja_typings": [
           "shuushuuhinnotamago"
         ]
@@ -20375,7 +20375,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is an 'Easter egg' in games?",
-      "ja": "ゲームのイースターたまごとは何か？"
+      "ja": "ゲームのイースターエッグとは何か？"
     },
     "question_text_reading": {
       "en": "What is an 'Easter egg' in games?",
@@ -20386,14 +20386,14 @@
     "choices": [
       {
         "en": "completing a game as fast as possible",
-        "ja": "できるだけはやくゲームをクリア",
+        "ja": "できるだけ早くゲームをクリア",
         "ja_typings": [
           "dekirudakehayakugemuokuria"
         ]
       },
       {
         "en": "racing mini-game mode",
-        "ja": "れーすのみにゲームもーど",
+        "ja": "レースミニゲームモード",
         "ja_typings": [
           "resunominigemumodo"
         ]
@@ -20407,7 +20407,7 @@
       },
       {
         "en": "playing on highest difficulty",
-        "ja": "さいこうなんどでぷれい",
+        "ja": "最高難度でプレイ",
         "ja_typings": [
           "saikonandodepurei",
           "saikounandodepurei"
@@ -20420,7 +20420,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'speedrunning'?",
-      "ja": "speedrunningとはどのようなものですか？"
+      "ja": "スピードランとは何か？"
     },
     "question_text_reading": {
       "en": "What is 'speedrunning'?",
@@ -20431,7 +20431,7 @@
     "choices": [
       {
         "en": "First-Person Shooter",
-        "ja": "いちにんしょうシューター",
+        "ja": "一人称シューター",
         "ja_typings": [
           "ichininshoshuta",
           "ichininshoushuta"
@@ -20439,7 +20439,7 @@
       },
       {
         "en": "Fast Pacing System",
-        "ja": "こうそくぺーすしすてむ",
+        "ja": "高速ペースシステム",
         "ja_typings": [
           "kosokupesushisutemu",
           "kousokupesushisutemu"
@@ -20447,14 +20447,14 @@
       },
       {
         "en": "Full Player Score",
-        "ja": "ふるぷれいやーすこあ",
+        "ja": "フルプレイヤー・スコア",
         "ja_typings": [
           "furupureiyasukoa"
         ]
       },
       {
         "en": "Frames Per Second gaming",
-        "ja": "ふれーむぱーせかんどゲーム",
+        "ja": "フレームパーセカンドゲーミング",
         "ja_typings": [
           "furemupasekandogemu"
         ]
@@ -20477,28 +20477,28 @@
     "choices": [
       {
         "en": "Multiplayer Online Battle Arena",
-        "ja": "たにんぷれいおんらいんばとるあれな",
+        "ja": "他人プレイオンラインバトルアリーナ",
         "ja_typings": [
           "taninpureionrainbatoruarena"
         ]
       },
       {
         "en": "Mobile Online Battle App",
-        "ja": "もばいるおんらいんばとるあぷ",
+        "ja": "モバイルオンラインバトルアプリ",
         "ja_typings": [
           "mobairuonrainbatoruapu"
         ]
       },
       {
         "en": "Modern Open Battle Action",
-        "ja": "もだんおーぷんばとるあくしょん",
+        "ja": "モダンオープンバトルアクション",
         "ja_typings": [
           "modanopunbatoruakushon"
         ]
       },
       {
         "en": "Multi-Object Battle Assignment",
-        "ja": "ふくすうもくひょうばとるかだい",
+        "ja": "複数目標バトルアサインメント",
         "ja_typings": [
           "fukusuumokuhyobatorukadai",
           "fukusuumokuhyoubatorukadai"
@@ -20522,28 +20522,28 @@
     "choices": [
       {
         "en": "Minecraft",
-        "ja": "まいんくらふと",
+        "ja": "マインクラフト",
         "ja_typings": [
           "mainkurafuto"
         ]
       },
       {
         "en": "Terraria",
-        "ja": "てらりあ",
+        "ja": "テラリア",
         "ja_typings": [
           "teraria"
         ]
       },
       {
         "en": "Fortnite",
-        "ja": "ふぉーとないと",
+        "ja": "フォートナイト",
         "ja_typings": [
           "fotonaito"
         ]
       },
       {
         "en": "Roblox",
-        "ja": "ろぶろっくす",
+        "ja": "Roblox",
         "ja_typings": [
           "roburokkusu"
         ]
@@ -20555,7 +20555,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which game has 'Creepers' as enemies?",
-      "ja": "敵として「Creepers」が登場するゲームはどれ？"
+      "ja": "クリーパーが敵として登場するゲームは？"
     },
     "question_text_reading": {
       "en": "Which game has 'Creepers' as enemies?",
@@ -20566,21 +20566,21 @@
     "choices": [
       {
         "en": "the classic overworld theme",
-        "ja": "クラシックなマップテーマ",
+        "ja": "クラシックなワールドテーマ",
         "ja_typings": [
           "kurashikkunamapputema"
         ]
       },
       {
         "en": "a pop song",
-        "ja": "ぽっぷそんぐ",
+        "ja": "ポップソング",
         "ja_typings": [
           "poppusongu"
         ]
       },
       {
         "en": "a battle anthem",
-        "ja": "せんとうのひめい",
+        "ja": "戦闘の主題",
         "ja_typings": [
           "sentonohimei",
           "sentounohimei"
@@ -20588,7 +20588,7 @@
       },
       {
         "en": "the Zelda lullaby",
-        "ja": "ぜるだのこもりうた",
+        "ja": "ゼルダの子守唄",
         "ja_typings": [
           "zerudanokomoriuta"
         ]
@@ -20600,7 +20600,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the iconic opening music of the original Legend of Zelda?",
-      "ja": "ゼルダのでんせつのアイコニックなオープニング音楽は？"
+      "ja": "ゼルダの伝説のアイコニックなオープニング音楽は？"
     },
     "question_text_reading": {
       "en": "What is the iconic opening music of the original Legend of Zelda?",
@@ -20611,7 +20611,7 @@
     "choices": [
       {
         "en": "defeat a boss without taking damage",
-        "ja": "ダメージをうけずにボスをたおす",
+        "ja": "ダメージをうけずにボスを倒す",
         "ja_typings": [
           "damejiokezunibosuotaosu",
           "damejioukezunibosuotaosu"
@@ -20619,21 +20619,21 @@
       },
       {
         "en": "defeat a boss in one hit",
-        "ja": "いちげきでボスをたおす",
+        "ja": "一撃でボスを倒す",
         "ja_typings": [
           "ichigekidebosuotaosu"
         ]
       },
       {
         "en": "fight boss with no weapons",
-        "ja": "ぶきなしでボスとたたかう",
+        "ja": "武器なしでボスと戦う",
         "ja_typings": [
           "bukinashidebosutotatakau"
         ]
       },
       {
         "en": "kill boss before it attacks",
-        "ja": "ボスがこうげきするまえにたおす",
+        "ja": "ボスが攻撃する前に倒す",
         "ja_typings": [
           "bosugakogekisurumaenitaosu",
           "bosugakougekisurumaenitaosu"
@@ -20646,7 +20646,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does it mean to 'no-hit' a boss?",
-      "ja": "ボスを「no-hit」するとは、具体的にどのような状態を指すのでしょうか？"
+      "ja": "ボスを「no-hit」するとは？"
     },
     "question_text_reading": {
       "en": "What does it mean to 'no-hit' a boss?",
@@ -20657,7 +20657,7 @@
     "choices": [
       {
         "en": "player has failed and must restart",
-        "ja": "プレイヤーがしっぱいしてやりなおし",
+        "ja": "プレイヤーが失敗してやり直し",
         "ja_typings": [
           "pureiyagashippaishiteyarinaoshi"
         ]
@@ -20671,14 +20671,14 @@
       },
       {
         "en": "a multiplayer session ends",
-        "ja": "たにんぷれいのせっしょんが終わった",
+        "ja": "他人プレイのセッションが終わった",
         "ja_typings": [
           "taninpureinosesshongawatta"
         ]
       },
       {
         "en": "a loading screen appears",
-        "ja": "ろーどがめんがひょうじ",
+        "ja": "ローディング画面が表示",
         "ja_typings": [
           "rodogamengahyoji",
           "rodogamengahyouji"
@@ -20691,7 +20691,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'Game Over' traditionally?",
-      "ja": "「ゲームオーバー」はどういいみか？"
+      "ja": "「ゲームオーバー」はどういう意味か？"
     },
     "question_text_reading": {
       "en": "What is 'Game Over' traditionally?",
@@ -20702,7 +20702,7 @@
     "choices": [
       {
         "en": "cooperative multiplayer gameplay",
-        "ja": "きょうりょくたにんぷれい",
+        "ja": "協力多人プレイ",
         "ja_typings": [
           "kyoryokutaninpurei",
           "kyouryokutaninpurei"
@@ -20710,7 +20710,7 @@
       },
       {
         "en": "competitive multiplayer",
-        "ja": "きょうそうたにんぷれい",
+        "ja": "競争多人プレイ",
         "ja_typings": [
           "kyosotaninpurei",
           "kyousoutaninpurei"
@@ -20718,14 +20718,14 @@
       },
       {
         "en": "single player with AI partner",
-        "ja": "AIぱーとなーとのたんどく",
+        "ja": "AIパートナーとの単独",
         "ja_typings": [
           "aipatonatonotandoku"
         ]
       },
       {
         "en": "online ranking system",
-        "ja": "おんらいんらんきんぐしすてむ",
+        "ja": "オンラインランキングシステム",
         "ja_typings": [
           "onrainrankingushisutemu"
         ]
@@ -20737,7 +20737,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'co-op' gaming?",
-      "ja": "こおぷゲームとは？"
+      "ja": "Co-opゲームとは？"
     },
     "question_text_reading": {
       "en": "What is 'co-op' gaming?",
@@ -20748,28 +20748,28 @@
     "choices": [
       {
         "en": "open-world with player freedom",
-        "ja": "プレイヤーのじゆうなおーぷんわーるど",
+        "ja": "プレイヤーの自由なオープンワールド",
         "ja_typings": [
           "pureiyanojiyuunaopunwarudo"
         ]
       },
       {
         "en": "game played in physical sandbox",
-        "ja": "ぶつりてきなすなばでのゲーム",
+        "ja": "物理的な砂場でのゲーム",
         "ja_typings": [
           "butsuritekinasunabadenogemu"
         ]
       },
       {
         "en": "game with no objectives",
-        "ja": "もくてきのないゲーム",
+        "ja": "目的のないゲーム",
         "ja_typings": [
           "mokutekinonaigemu"
         ]
       },
       {
         "en": "children's educational game",
-        "ja": "こどものきょういくゲーム",
+        "ja": "子供の教育ゲーム",
         "ja_typings": [
           "kodomonokyoikugemu",
           "kodomonokyouikugemu"
@@ -20782,7 +20782,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a 'sandbox' game?",
-      "ja": "サンドボックスゲームとはどのようなものですか？"
+      "ja": "サンドボックスゲームとは？"
     },
     "question_text_reading": {
       "en": "What is a 'sandbox' game?",
@@ -20793,28 +20793,28 @@
     "choices": [
       {
         "en": "Resident Evil",
-        "ja": "ばいおはざーど",
+        "ja": "バイオハザード",
         "ja_typings": [
           "baiohazado"
         ]
       },
       {
         "en": "Devil May Cry",
-        "ja": "でびるめいくらい",
+        "ja": "デビルメイクライ",
         "ja_typings": [
           "debirumeikurai"
         ]
       },
       {
         "en": "Street Fighter",
-        "ja": "すとりーとふぁいたー",
+        "ja": "ストリートファイター",
         "ja_typings": [
           "sutoritofaita"
         ]
       },
       {
         "en": "Monster Hunter",
-        "ja": "もんすたーはんたー",
+        "ja": "モンスターハンター",
         "ja_typings": [
           "monsutahanta"
         ]
@@ -20826,7 +20826,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which Capcom game series features Leon Kennedy and Chris Redfield?",
-      "ja": "カプコンのゲームシリーズで、リーオン・ケネディとクリス・レッドフィールドが登場するのはどれですか？"
+      "ja": "レオン・ケネディとクリス・レッドフィールドのカプコンシリーズは？"
     },
     "question_text_reading": {
       "en": "Which Capcom game series features Leon Kennedy and Chris Redfield?",
@@ -20837,7 +20837,7 @@
     "choices": [
       {
         "en": "instant hit detection along line of sight",
-        "ja": "しやのびょうしょくにそくじあたりはんてい",
+        "ja": "視野の秒速当たり判定",
         "ja_typings": [
           "shiyanobyoshokunisokujiatarihantei",
           "shiyanobyoushokunisokujiatarihantei"
@@ -20845,7 +20845,7 @@
       },
       {
         "en": "projectile with travel time",
-        "ja": "ひこうじかんのあるだんがん",
+        "ja": "飛行時間のある弾丸",
         "ja_typings": [
           "hikojikannoarudangan",
           "hikoujikannoarudangan"
@@ -20853,7 +20853,7 @@
       },
       {
         "en": "melee hit detection",
-        "ja": "きんせんこうげきはんてい",
+        "ja": "近戦攻撃判定",
         "ja_typings": [
           "kinsenkogekihantei",
           "kinsenkougekihantei"
@@ -20861,7 +20861,7 @@
       },
       {
         "en": "player detection system",
-        "ja": "プレイヤーはんていしすてむ",
+        "ja": "プレイヤー判定システム",
         "ja_typings": [
           "pureiyahanteishisutemu"
         ]
@@ -20873,7 +20873,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a 'hit scan' in FPS games?",
-      "ja": "FPSゲームにおける「hit scan」とは何ですか？"
+      "ja": "FPSのヒットスキャンとは何か？"
     },
     "question_text_reading": {
       "en": "What is a 'hit scan' in FPS games?",
@@ -20884,7 +20884,7 @@
     "choices": [
       {
         "en": "high latency causing delay",
-        "ja": "こうれいてんしーによるおくれ",
+        "ja": "高レイテンシーによる遅れ",
         "ja_typings": [
           "koreitenshiniyoruokure",
           "koureitenshiniyoruokure"
@@ -20892,21 +20892,21 @@
       },
       {
         "en": "slow frame rate",
-        "ja": "ていふれーむれーと",
+        "ja": "定フレームレート",
         "ja_typings": [
           "teifuremureto"
         ]
       },
       {
         "en": "server maintenance window",
-        "ja": "さーばーめんてなんすのじかん",
+        "ja": "サーバーメンテナンスウィンドウの時間",
         "ja_typings": [
           "sabamentenansunojikan"
         ]
       },
       {
         "en": "game crash event",
-        "ja": "ゲームのくらっしゅ",
+        "ja": "ゲームのクラッシュ",
         "ja_typings": [
           "gemunokurasshu"
         ]
@@ -20918,7 +20918,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'lag' in online gaming?",
-      "ja": "オンラインゲームにおける「lag」とは何ですか？"
+      "ja": "オンラインゲームのラグとは何か？"
     },
     "question_text_reading": {
       "en": "What is 'lag' in online gaming?",
@@ -20929,7 +20929,7 @@
     "choices": [
       {
         "en": "open-world action-adventure",
-        "ja": "おーぷんわーるどアクションぼうけん",
+        "ja": "オープンワールドアクションアドベンチャー",
         "ja_typings": [
           "opunwarudoakushonboken",
           "opunwarudoakushonbouken"
@@ -20937,21 +20937,21 @@
       },
       {
         "en": "linear JRPG",
-        "ja": "いちじゅんのJRPG",
+        "ja": "一純のJRPG",
         "ja_typings": [
           "ichijunnojrpg"
         ]
       },
       {
         "en": "turn-based strategy",
-        "ja": "ターンせいすとらてじー",
+        "ja": "ターン制ストラテジー",
         "ja_typings": [
           "tanseisutorateji"
         ]
       },
       {
         "en": "racing game",
-        "ja": "れーすゲーム",
+        "ja": "レーシングゲーム",
         "ja_typings": [
           "resugemu"
         ]
@@ -20963,7 +20963,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which game is famous for 'The Legend of Zelda: Breath of the Wild'?",
-      "ja": "ゼルダのでんせつ ブレスオブザワイルドはどんなゲームか？"
+      "ja": "ゼルダの伝説 ブレス オブ ザ ワイルドはどんなゲームか？"
     },
     "question_text_reading": {
       "en": "Which game is famous for 'The Legend of Zelda: Breath of the Wild'?",
@@ -20974,7 +20974,7 @@
     "choices": [
       {
         "en": "Nintendo Switch",
-        "ja": "にんてんどうスイッチ",
+        "ja": "ニンテンドースイッチ",
         "ja_typings": [
           "nintendosuitchi",
           "nintendousuitchi"
@@ -20982,21 +20982,21 @@
       },
       {
         "en": "Sony Switch",
-        "ja": "そにースイッチ",
+        "ja": "ソニー スイッチ",
         "ja_typings": [
           "sonisuitchi"
         ]
       },
       {
         "en": "Xbox Switch",
-        "ja": "えっくすぼっくすスイッチ",
+        "ja": "Xbox Switch",
         "ja_typings": [
           "ekkusubokkususuitchi"
         ]
       },
       {
         "en": "Sega Switch",
-        "ja": "せがスイッチ",
+        "ja": "セガ スイッチ",
         "ja_typings": [
           "segasuitchi"
         ]
@@ -21008,7 +21008,7 @@
     "image_path": null,
     "question_text": {
       "en": "What console is the Switch?",
-      "ja": "スイッチはどのゲームきか？"
+      "ja": "Switchはどのゲーム機か？"
     },
     "question_text_reading": {
       "en": "What console is the Switch?",
@@ -21019,21 +21019,21 @@
     "choices": [
       {
         "en": "capture opponent's king",
-        "ja": "あいてのきんぐをつかまえる",
+        "ja": "相手のキングを捕まえる",
         "ja_typings": [
           "aitenokinguotsukamaeru"
         ]
       },
       {
         "en": "collect all opponent pieces",
-        "ja": "あいてのこまをすべてとる",
+        "ja": "相手の駒をすべて取る",
         "ja_typings": [
           "aitenokomaosubetetoru"
         ]
       },
       {
         "en": "reach opponent's back row",
-        "ja": "あいてのうしろのれつにとどく",
+        "ja": "相手の後ろの列に届く",
         "ja_typings": [
           "aitenoshironoretsunitodoku",
           "aitenoushironoretsunitodoku"
@@ -21041,7 +21041,7 @@
       },
       {
         "en": "earn the most points",
-        "ja": "もっともてんすうをかくとく",
+        "ja": "もっとも点数を獲得",
         "ja_typings": [
           "mottomotensuuokakutoku"
         ]
@@ -21053,7 +21053,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the objective in chess?",
-      "ja": "チェスにおける目的は何ですか？"
+      "ja": "チェスの目的は何か？"
     },
     "question_text_reading": {
       "en": "What is the objective in chess?",
@@ -21071,21 +21071,21 @@
       },
       {
         "en": "Platform versus Platform",
-        "ja": "ぷらっとふぉーむたいぷらっとふぉーむ",
+        "ja": "プラットフォーム対プラットフォーム",
         "ja_typings": [
           "purattofomutaipurattofomu"
         ]
       },
       {
         "en": "Points versus Progress",
-        "ja": "てんすうたいしんちょく",
+        "ja": "点数対進捗",
         "ja_typings": [
           "tensuutaishinchoku"
         ]
       },
       {
         "en": "Procedural versus Pre-made",
-        "ja": "じどうたいてづくり",
+        "ja": "自動体づくり",
         "ja_typings": [
           "jidotaitezukuri",
           "jidoutaitezukuri"
@@ -21109,7 +21109,7 @@
     "choices": [
       {
         "en": "Player versus Environment",
-        "ja": "プレイヤー対かんきょう",
+        "ja": "プレイヤー対環境",
         "ja_typings": [
           "pureiyakankyo",
           "pureiyakankyou"
@@ -21117,7 +21117,7 @@
       },
       {
         "en": "Player versus Enemy",
-        "ja": "プレイヤー対てき",
+        "ja": "プレイヤー対敵",
         "ja_typings": [
           "pureiyateki"
         ]
@@ -21131,7 +21131,7 @@
       },
       {
         "en": "Points versus Experience",
-        "ja": "てんすうたいたいけんち",
+        "ja": "点数対体験値",
         "ja_typings": [
           "tensuutaitaikenchi"
         ]
@@ -21154,7 +21154,7 @@
     "choices": [
       {
         "en": "temporary enhancement to character stats",
-        "ja": "キャラのすたーつのいちじてきこうじょう",
+        "ja": "キャラのステータスの一時的向上",
         "ja_typings": [
           "kyaranosutatsunoichijitekikojo",
           "kyaranosutatsunoichijitekikoujou"
@@ -21162,7 +21162,7 @@
       },
       {
         "en": "attack that hits multiple enemies",
-        "ja": "ふくすうのてきにあたるこうげき",
+        "ja": "複数の敵に当たる攻撃",
         "ja_typings": [
           "fukusuunotekiniatarukogeki",
           "fukusuunotekiniatarukougeki"
@@ -21170,14 +21170,14 @@
       },
       {
         "en": "item that restores health",
-        "ja": "HPをかいふくするアイテム",
+        "ja": "HPを回復するアイテム",
         "ja_typings": [
           "hpokaifukusuruaitemu"
         ]
       },
       {
         "en": "armor ability upgrade",
-        "ja": "よろいののうりょくきょうか",
+        "ja": "鎧の能力強化",
         "ja_typings": [
           "yoroinonoryokukyoka",
           "yoroinonouryokukyouka"
@@ -21190,7 +21190,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a 'buff' in games?",
-      "ja": "ゲームにおける「buff」とは何ですか？"
+      "ja": "ゲームのバフとは何か？"
     },
     "question_text_reading": {
       "en": "What is a 'buff' in games?",
@@ -21201,7 +21201,7 @@
     "choices": [
       {
         "en": "weakening something overpowered",
-        "ja": "つよすぎるものをよわくする",
+        "ja": "強すぎるものを弱くする",
         "ja_typings": [
           "tsuyosugirumonoyowakusuru",
           "tsuyosugirumonooyowakusuru"
@@ -21209,7 +21209,7 @@
       },
       {
         "en": "strengthening something weak",
-        "ja": "よわいものをつよくする",
+        "ja": "弱いものを強くする",
         "ja_typings": [
           "yowaimonotsuyokusuru",
           "yowaimonootsuyokusuru"
@@ -21217,14 +21217,14 @@
       },
       {
         "en": "removing a character",
-        "ja": "キャラをさくじょ",
+        "ja": "文字を削除",
         "ja_typings": [
           "kyaraosakujo"
         ]
       },
       {
         "en": "adding new content",
-        "ja": "あたらしいこんてんつをついか",
+        "ja": "新しいコンテンツを追加",
         "ja_typings": [
           "atarashiikontentsuotsuika"
         ]
@@ -21236,7 +21236,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a 'nerf' in game balance?",
-      "ja": "ゲームバランスのなーふとは何か？"
+      "ja": "ゲームバランスのナーフとは何か？"
     },
     "question_text_reading": {
       "en": "What is a 'nerf' in game balance?",
@@ -21247,28 +21247,28 @@
     "choices": [
       {
         "en": "Capcom",
-        "ja": "かぷこむ",
+        "ja": "カプコン",
         "ja_typings": [
           "kapukomu"
         ]
       },
       {
         "en": "SNK",
-        "ja": "えすえぬけー",
+        "ja": "SNK",
         "ja_typings": [
           "esuenuke"
         ]
       },
       {
         "en": "Namco",
-        "ja": "なむこ",
+        "ja": "ナムコ",
         "ja_typings": [
           "namuko"
         ]
       },
       {
         "en": "Midway",
-        "ja": "みっどうぇい",
+        "ja": "ミッドウェイ",
         "ja_typings": [
           "middowei"
         ]
@@ -21280,7 +21280,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which company made Street Fighter?",
-      "ja": "ストリートファイターを開発した会社はどこですか？"
+      "ja": "ストリートファイターを作った会社は？"
     },
     "question_text_reading": {
       "en": "Which company made Street Fighter?",
@@ -21291,28 +21291,28 @@
     "choices": [
       {
         "en": "Breakout",
-        "ja": "ぶれいくあうと",
+        "ja": "ブレイクアウト",
         "ja_typings": [
           "bureikuauto"
         ]
       },
       {
         "en": "Pong",
-        "ja": "ぽんぐ",
+        "ja": "ポング",
         "ja_typings": [
           "pongu"
         ]
       },
       {
         "en": "Space Invaders",
-        "ja": "すぺーすいんべーだーず",
+        "ja": "スペースインベーダーズ",
         "ja_typings": [
           "supesuinbedazu"
         ]
       },
       {
         "en": "Galaga",
-        "ja": "ぎゃらが",
+        "ja": "ギャラガ",
         "ja_typings": [
           "gyaraga"
         ]
@@ -21324,7 +21324,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the classic arcade game where you break bricks with a ball?",
-      "ja": "ぼーるでれんがをこわすクラシックアーケードゲームは？"
+      "ja": "ボールでレンガをこわすクラシックアーケードゲームは？"
     },
     "question_text_reading": {
       "en": "What is the classic arcade game where you break bricks with a ball?",
@@ -21335,28 +21335,28 @@
     "choices": [
       {
         "en": "League of Legends",
-        "ja": "りーぐおぶれじぇんず",
+        "ja": "リーグ・オブ・レジェンド",
         "ja_typings": [
           "riguoburejenzu"
         ]
       },
       {
         "en": "Dota 2",
-        "ja": "どーたつー",
+        "ja": "Dota 2",
         "ja_typings": [
           "dotatsu"
         ]
       },
       {
         "en": "Smite",
-        "ja": "すまいと",
+        "ja": "スマイト",
         "ja_typings": [
           "sumaito"
         ]
       },
       {
         "en": "Heroes of the Storm",
-        "ja": "ひーろーずおぶざすとーむ",
+        "ja": "ヒーローズオブザストーム",
         "ja_typings": [
           "hirozuobuzasutomu"
         ]
@@ -21379,28 +21379,28 @@
     "choices": [
       {
         "en": "dark fantasy medieval world",
-        "ja": "くらいふぁんたじーのちゅうせいせかい",
+        "ja": "ダークファンタジーの中世世界",
         "ja_typings": [
           "kuraifantajinochuuseisekai"
         ]
       },
       {
         "en": "futuristic cyberpunk city",
-        "ja": "みらいのさいばーぱんくとし",
+        "ja": "未来のサイバーパンク都市",
         "ja_typings": [
           "mirainosaibapankutoshi"
         ]
       },
       {
         "en": "ancient Japan",
-        "ja": "こだいのにほん",
+        "ja": "古代日本",
         "ja_typings": [
           "kodainonihon"
         ]
       },
       {
         "en": "post-apocalyptic USA",
-        "ja": "ぶんめいほうかいごのアメリカ",
+        "ja": "文明崩壊後のアメリカ",
         "ja_typings": [
           "bunmeihokaigonoamerika",
           "bunmeihoukaigonoamerika"
@@ -21424,28 +21424,28 @@
     "choices": [
       {
         "en": "reviving after death to continue play",
-        "ja": "しんでもふっかつしてぷれいをつづける",
+        "ja": "死んでも復活してプレイを続ける",
         "ja_typings": [
           "shindemofukkatsushitepureiotsuzukeru"
         ]
       },
       {
         "en": "loading a save file",
-        "ja": "さらにゅうのろーど",
+        "ja": "さらにゅうのロード",
         "ja_typings": [
           "saranyuunorodo"
         ]
       },
       {
         "en": "starting the game over",
-        "ja": "ゲームをさいしょからやりなおす",
+        "ja": "ゲームを最初からやり直す",
         "ja_typings": [
           "gemuosaishokarayarinaosu"
         ]
       },
       {
         "en": "switching to a new character",
-        "ja": "あたらしいキャラにきりかえる",
+        "ja": "新しいキャラに切り替える",
         "ja_typings": [
           "atarashiikyaranikirikaeru"
         ]
@@ -21457,7 +21457,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'respawning' in games?",
-      "ja": "ゲームにおける「respawning」とはどういう意味ですか？"
+      "ja": "ゲームのrespawningとは何か？"
     },
     "question_text_reading": {
       "en": "What is 'respawning' in games?",
@@ -21468,21 +21468,21 @@
     "choices": [
       {
         "en": "Wood, Stone, Metal",
-        "ja": "もく、いし、きんぞく",
+        "ja": "木、石、金属",
         "ja_typings": [
           "moku ishi kinzoku"
         ]
       },
       {
         "en": "Gold Coins",
-        "ja": "きんか",
+        "ja": "金貨",
         "ja_typings": [
           "kinka"
         ]
       },
       {
         "en": "Bricks",
-        "ja": "れんが",
+        "ja": "レンガ",
         "ja_typings": [
           "renga"
         ]
@@ -21501,7 +21501,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the main resource in Fortnite for building?",
-      "ja": "フォートナイトで建築に使う主な資源は何ですか？"
+      "ja": "フォートナイトで建築に使うメインリソースは？"
     },
     "question_text_reading": {
       "en": "What is the main resource in Fortnite for building?",
@@ -21512,7 +21512,7 @@
     "choices": [
       {
         "en": "in-game award for completing a challenge",
-        "ja": "ちゃれんじクリアのゲームないほうしょう",
+        "ja": "チャレンジクリアのゲーム内報酬",
         "ja_typings": [
           "charenjikurianogemunaihosho",
           "charenjikurianogemunaihoushou"
@@ -21520,21 +21520,21 @@
       },
       {
         "en": "final game completion screen",
-        "ja": "ゲームのさいしゅうクリアがめん",
+        "ja": "ゲームの最終クリア画面",
         "ja_typings": [
           "gemunosaishuukuriagamen"
         ]
       },
       {
         "en": "high score record",
-        "ja": "ハイスコアきろく",
+        "ja": "ハイスコア記録",
         "ja_typings": [
           "haisukoakiroku"
         ]
       },
       {
         "en": "unlocked weapon or item",
-        "ja": "かいじょされたぶきやアイテム",
+        "ja": "解除された武器やアイテム",
         "ja_typings": [
           "kaijosaretabukiyaaitemu"
         ]
@@ -21546,7 +21546,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is an 'achievement' in games?",
-      "ja": "ゲームにおける「achievement」とは何ですか？"
+      "ja": "ゲームのアチーブメントとは何か？"
     },
     "question_text_reading": {
       "en": "What is an 'achievement' in games?",
@@ -21557,7 +21557,7 @@
     "choices": [
       {
         "en": "number of frames rendered per second",
-        "ja": "いちびょうあたりのふれーむすう",
+        "ja": "一秒あたりのフレーム数",
         "ja_typings": [
           "ichibyoatarinofuremusuu",
           "ichibyouatarinofuremusuu"
@@ -21565,21 +21565,21 @@
       },
       {
         "en": "game difficulty level",
-        "ja": "ゲームのなんいどれべる",
+        "ja": "ゲームの難易度レベル",
         "ja_typings": [
           "gemunonanidoreberu"
         ]
       },
       {
         "en": "internet connection speed",
-        "ja": "いんたーねっとせつぞくそくど",
+        "ja": "インターネット接続速度",
         "ja_typings": [
           "intanettosetsuzokusokudo"
         ]
       },
       {
         "en": "animation smoothness setting",
-        "ja": "あにめーしょんなめらかさのせってい",
+        "ja": "アニメーションの滑らかさの設定",
         "ja_typings": [
           "animeshonnamerakasanosettei"
         ]
@@ -21591,7 +21591,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'frame rate' in games?",
-      "ja": "ゲームにおける「frame rate」とは何ですか？"
+      "ja": "ゲームのフレームレートとは何か？"
     },
     "question_text_reading": {
       "en": "What is 'frame rate' in games?",
@@ -21602,7 +21602,7 @@
     "choices": [
       {
         "en": "synchronizing frame rate with display refresh",
-        "ja": "ふれーむれーとをてぃすぷれいのりふれっしゅにどうき",
+        "ja": "フレームレートをディスプレイのリフレッシュに同期",
         "ja_typings": [
           "furemuretotisupureinorifuresshunidoki",
           "furemuretootisupureinorifuresshunidouki"
@@ -21610,14 +21610,14 @@
       },
       {
         "en": "vertical screen split mode",
-        "ja": "すいちょくがめんぶんかつもーど",
+        "ja": "垂直画面分割モード",
         "ja_typings": [
           "suichokugamenbunkatsumodo"
         ]
       },
       {
         "en": "voice sync for multiplayer",
-        "ja": "たにんぷれいのおんせいどうき",
+        "ja": "他人プレイの音声同期",
         "ja_typings": [
           "taninpureinonseidoki",
           "taninpureinoonseidouki"
@@ -21625,7 +21625,7 @@
       },
       {
         "en": "video quality setting",
-        "ja": "どうがひんしつのせってい",
+        "ja": "動画品質設定",
         "ja_typings": [
           "dogahinshitsunosettei",
           "dougahinshitsunosettei"
@@ -21638,7 +21638,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'V-sync' in gaming?",
-      "ja": "ゲームのVsyncとは何か？"
+      "ja": "ゲームのV-syncとは何か？"
     },
     "question_text_reading": {
       "en": "What is 'V-sync' in gaming?",
@@ -21649,21 +21649,21 @@
     "choices": [
       {
         "en": "one of the first arcade video games",
-        "ja": "さいしょきのアーケードビデオゲーム",
+        "ja": "最初のアーケードビデオゲーム",
         "ja_typings": [
           "saishokinoakedobideogemu"
         ]
       },
       {
         "en": "a pinball machine",
-        "ja": "ぴんぼーるましん",
+        "ja": "ピンボールマシン",
         "ja_typings": [
           "pinborumashin"
         ]
       },
       {
         "en": "a Nintendo handheld game",
-        "ja": "にんてんどうけいたいゲーム",
+        "ja": "任天堂携帯ゲーム",
         "ja_typings": [
           "nintendokeitaigemu",
           "nintendoukeitaigemu"
@@ -21671,7 +21671,7 @@
       },
       {
         "en": "an Atari driving game",
-        "ja": "あたりのどらいびんぐゲーム",
+        "ja": "アタリのドライビングゲーム",
         "ja_typings": [
           "atarinodoraibingugemu"
         ]
@@ -21683,7 +21683,7 @@
     "image_path": null,
     "question_text": {
       "en": "What was Pong?",
-      "ja": "Pongとはどのようなゲームでしたか？"
+      "ja": "Pongとは何か？"
     },
     "question_text_reading": {
       "en": "What was Pong?",
@@ -21694,14 +21694,14 @@
     "choices": [
       {
         "en": "shooter genre with extremely dense projectiles",
-        "ja": "だんがんびっしりのシューターゲーム",
+        "ja": "弾がん密度のシューターゲーム",
         "ja_typings": [
           "danganbisshirinoshutagemu"
         ]
       },
       {
         "en": "shooter with single large bullet",
-        "ja": "おおきなたまひとつのシューター",
+        "ja": "大きな玉ひとつのシューター",
         "ja_typings": [
           "okinatamahitotsunoshuta",
           "ookinatamahitotsunoshuta"
@@ -21709,14 +21709,14 @@
       },
       {
         "en": "physical shooting game",
-        "ja": "ぶつりてきしゃげきゲーム",
+        "ja": "物理的シューティングゲーム",
         "ja_typings": [
           "butsuritekishagekigemu"
         ]
       },
       {
         "en": "sword-fighting game",
-        "ja": "けんとうゲーム",
+        "ja": "剣闘ゲーム",
         "ja_typings": [
           "kentogemu",
           "kentougemu"
@@ -21729,7 +21729,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'bullet hell' in games?",
-      "ja": "ゲームにおける「bullet hell」とはどのようなものですか？"
+      "ja": "ゲームの弾幕とは何か？"
     },
     "question_text_reading": {
       "en": "What is 'bullet hell' in games?",
@@ -21740,28 +21740,28 @@
     "choices": [
       {
         "en": "location where game progress is saved",
-        "ja": "ゲームのしんちょくをほぞんするばしょ",
+        "ja": "ゲームの進捗を保存する場所",
         "ja_typings": [
           "gemunoshinchokuohozonsurubasho"
         ]
       },
       {
         "en": "checkpoint that restores health",
-        "ja": "HPをかいふくするチェックポイント",
+        "ja": "HPを回復するチェックポイント",
         "ja_typings": [
           "hpokaifukusuruchekkupointo"
         ]
       },
       {
         "en": "item for saving inventory",
-        "ja": "インベントリほぞんアイテム",
+        "ja": "インベントリ保存アイテム",
         "ja_typings": [
           "inbentorihozonaitemu"
         ]
       },
       {
         "en": "the game's final destination",
-        "ja": "ゲームのさいしゅうもくてき",
+        "ja": "ゲームの最終目的地",
         "ja_typings": [
           "gemunosaishuumokuteki"
         ]
@@ -21773,7 +21773,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a 'save point'?",
-      "ja": "save pointとは何ですか？"
+      "ja": "セーブポイントとは何か？"
     },
     "question_text_reading": {
       "en": "What is a 'save point'?",
@@ -21784,7 +21784,7 @@
     "choices": [
       {
         "en": "large freely explorable environment",
-        "ja": "おおきくじゆうにたんさくできるかんきょう",
+        "ja": "大きく自由に探索できる環境",
         "ja_typings": [
           "okikujiyuunitansakudekirukankyo",
           "ookikujiyuunitansakudekirukankyou"
@@ -21792,21 +21792,21 @@
       },
       {
         "en": "game with no story",
-        "ja": "ものがたりのないゲーム",
+        "ja": "物語のないゲーム",
         "ja_typings": [
           "monogatarinonaigemu"
         ]
       },
       {
         "en": "multiplayer game world",
-        "ja": "たにんぷれいのゲームせかい",
+        "ja": "他人プレイのゲーム世界",
         "ja_typings": [
           "taninpureinogemusekai"
         ]
       },
       {
         "en": "game with random world generation",
-        "ja": "らんだむせいせいのゲームせかい",
+        "ja": "ランダム生成のゲーム世界",
         "ja_typings": [
           "randamuseiseinogemusekai"
         ]
@@ -21818,7 +21818,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'open world' in games?",
-      "ja": "ゲームにおける「open world」とはどのようなものですか？"
+      "ja": "ゲームのオープンワールドとは何か？"
     },
     "question_text_reading": {
       "en": "What is 'open world' in games?",
@@ -21829,7 +21829,7 @@
     "choices": [
       {
         "en": "players take turns to act",
-        "ja": "プレイヤーがじゅんばんにこうどう",
+        "ja": "プレイヤーが順番に行動",
         "ja_typings": [
           "pureiyagajunbannikodo",
           "pureiyagajunbannikoudou"
@@ -21837,7 +21837,7 @@
       },
       {
         "en": "real-time combat",
-        "ja": "りあるたいむせんとう",
+        "ja": "リアルタイムコンバット",
         "ja_typings": [
           "riarutaimusento",
           "riarutaimusentou"
@@ -21845,7 +21845,7 @@
       },
       {
         "en": "automatic combat system",
-        "ja": "じどうせんとうしすてむ",
+        "ja": "自動戦闘システム",
         "ja_typings": [
           "jidosentoshisutemu",
           "jidousentoushisutemu"
@@ -21853,7 +21853,7 @@
       },
       {
         "en": "time-limited battle mode",
-        "ja": "じかんせいのバトルもーど",
+        "ja": "時間制限バトルモード",
         "ja_typings": [
           "jikanseinobatorumodo"
         ]
@@ -21865,7 +21865,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'turn-based' combat?",
-      "ja": "ターン制の戦闘とはどのようなものですか？"
+      "ja": "ターン制戦闘とは何か？"
     },
     "question_text_reading": {
       "en": "What is 'turn-based' combat?",
@@ -21876,28 +21876,28 @@
     "choices": [
       {
         "en": "strategy game with real-time gameplay",
-        "ja": "りあるたいむのすとらてじーゲーム",
+        "ja": "リアルタイムのストラテジーゲーム",
         "ja_typings": [
           "riarutaimunosutoratejigemu"
         ]
       },
       {
         "en": "racing strategy game",
-        "ja": "れーすすとらてじーゲーム",
+        "ja": "レーシングストラテジーゲーム",
         "ja_typings": [
           "resusutoratejigemu"
         ]
       },
       {
         "en": "real-world problem simulation",
-        "ja": "げんじつもんだいのしみゅれーしょん",
+        "ja": "現実問題のシミュレーション",
         "ja_typings": [
           "genjitsumondainoshimyureshon"
         ]
       },
       {
         "en": "online team strategy game",
-        "ja": "おんらいんちーむすとらてじー",
+        "ja": "オンラインチームストラテジー",
         "ja_typings": [
           "onrainchimusutorateji"
         ]
@@ -21909,7 +21909,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'real-time strategy' (RTS)?",
-      "ja": "リアルタイムストラテジー（RTS）とは、どのようなジャンルのゲームのことですか？"
+      "ja": "リアルタイムストラテジーとは何か？"
     },
     "question_text_reading": {
       "en": "What is 'real-time strategy' (RTS)?",
@@ -21920,7 +21920,7 @@
     "choices": [
       {
         "en": "update fixing bugs or balancing",
-        "ja": "ばぐのしゅうせいやバランスのこうしん",
+        "ja": "バグの修正やバランスの更新",
         "ja_typings": [
           "bagunoshuuseiyabaransunokoshin",
           "bagunoshuuseiyabaransunokoushin"
@@ -21928,21 +21928,21 @@
       },
       {
         "en": "new game level",
-        "ja": "あたらしいゲームれべる",
+        "ja": "新しいゲームレベル",
         "ja_typings": [
           "atarashiigemureberu"
         ]
       },
       {
         "en": "skin or appearance pack",
-        "ja": "スキンやがいかんぱっく",
+        "ja": "スキンや外観パック",
         "ja_typings": [
           "sukinyagaikanpakku"
         ]
       },
       {
         "en": "seasonal game event",
-        "ja": "きせつゲームイベント",
+        "ja": "季節ゲームイベント",
         "ja_typings": [
           "kisetsugemuibento"
         ]
@@ -21954,7 +21954,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a 'patch' in gaming?",
-      "ja": "ゲームにおける「patch」とは何ですか？"
+      "ja": "ゲームのパッチとは何か？"
     },
     "question_text_reading": {
       "en": "What is a 'patch' in gaming?",
@@ -21965,28 +21965,28 @@
     "choices": [
       {
         "en": "multiplatform",
-        "ja": "まるちぷらっとふぉーむ",
+        "ja": "マルチプラットフォーム",
         "ja_typings": [
           "maruchipurattofomu"
         ]
       },
       {
         "en": "cross-play",
-        "ja": "くろすぷれい",
+        "ja": "クロスプレイ",
         "ja_typings": [
           "kurosupurei"
         ]
       },
       {
         "en": "universal",
-        "ja": "ゆにばーさる",
+        "ja": "ユニバーサル",
         "ja_typings": [
           "yunibasaru"
         ]
       },
       {
         "en": "platform-agnostic",
-        "ja": "ぷらっとふぉーむぎょうとく",
+        "ja": "プラットフォーム非依存",
         "ja_typings": [
           "purattofomugyotoku",
           "purattofomugyoutoku"
@@ -21999,7 +21999,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the term for games released on multiple platforms?",
-      "ja": "複数のプラットフォームでリリースされるゲームの総称は何ですか？"
+      "ja": "複数プラットフォームでリリースされるゲームの用語は？"
     },
     "question_text_reading": {
       "en": "What is the term for games released on multiple platforms?",
@@ -22010,28 +22010,28 @@
     "choices": [
       {
         "en": "game where player jumps between platforms",
-        "ja": "プレイヤーがぷらっとふぉーむをとびわたるゲーム",
+        "ja": "プレイヤーがプラットフォームを飛びわたるゲーム",
         "ja_typings": [
           "pureiyagapurattofomuotobiwatarugemu"
         ]
       },
       {
         "en": "game played on game console platform",
-        "ja": "ゲームきぷらっとふぉームで遊ぶゲーム",
+        "ja": "ゲームプラットフォームで遊ぶゲーム",
         "ja_typings": [
           "gemukipurattofomudebugemu"
         ]
       },
       {
         "en": "game about building platforms",
-        "ja": "ぷらっとふぉームをけんちくするゲーム",
+        "ja": "プラットフォームを建築するゲーム",
         "ja_typings": [
           "purattofomuokenchikusurugemu"
         ]
       },
       {
         "en": "game with online platform features",
-        "ja": "おんらいんぷらっとふぁむきのうつきゲーム",
+        "ja": "オンラインプラットフォーム機能付きゲーム",
         "ja_typings": [
           "onrainpurattofamukinotsukigemu",
           "onrainpurattofamukinoutsukigemu"
@@ -22044,7 +22044,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a 'platformer' game?",
-      "ja": "プラットフォーマーゲームとはどのようなジャンルですか？"
+      "ja": "プラットフォーマーゲームとは何か？"
     },
     "question_text_reading": {
       "en": "What is a 'platformer' game?",
@@ -22055,7 +22055,7 @@
     "choices": [
       {
         "en": "exploration game with abilities unlocking new areas",
-        "ja": "のうりょくかいじょで新エリアを探索",
+        "ja": "能力解除で新エリアを探索",
         "ja_typings": [
           "noryokukaijodeeriao",
           "nouryokukaijodeeriao"
@@ -22063,21 +22063,21 @@
       },
       {
         "en": "space exploration game",
-        "ja": "うちゅうたんさくゲーム",
+        "ja": "宇宙探査ゲーム",
         "ja_typings": [
           "uchuutansakugemu"
         ]
       },
       {
         "en": "game combining Metroid and Castlevania mechanics",
-        "ja": "めとろいどとかすとるばにあのゲームシステムを合わせたゲーム",
+        "ja": "メトロイドとキャスティーヴァニアのゲームシステムを合わせたゲーム",
         "ja_typings": [
           "metoroidotokasutorubanianogemushisutemuowasetagemu"
         ]
       },
       {
         "en": "horror survival platformer",
-        "ja": "ほらーさばいばるぷらっとふぁーまー",
+        "ja": "ホラーサバイバルプラットフォーマー",
         "ja_typings": [
           "horasabaibarupurattofama"
         ]
@@ -22089,7 +22089,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'Metroidvania' genre?",
-      "ja": "めとろいどばにあジャンルとは何か？"
+      "ja": "メトロイドヴァニアジャンルとは何か？"
     },
     "question_text_reading": {
       "en": "What is 'Metroidvania' genre?",
@@ -22100,28 +22100,28 @@
     "choices": [
       {
         "en": "9th generation",
-        "ja": "きゅうせだい",
+        "ja": "九世代",
         "ja_typings": [
           "kyuusedai"
         ]
       },
       {
         "en": "8th generation",
-        "ja": "はちせだい",
+        "ja": "八世代",
         "ja_typings": [
           "hachisedai"
         ]
       },
       {
         "en": "10th generation",
-        "ja": "じゅっせだい",
+        "ja": "十世代",
         "ja_typings": [
           "jussedai"
         ]
       },
       {
         "en": "7th generation",
-        "ja": "ななせだい",
+        "ja": "七世代",
         "ja_typings": [
           "nanasedai"
         ]
@@ -22133,7 +22133,7 @@
     "image_path": null,
     "question_text": {
       "en": "What console generation is the PlayStation 5?",
-      "ja": "プレイステーション5は何世代目のゲームきか？"
+      "ja": "プレイステーション5は何世代目のゲーム機？"
     },
     "question_text_reading": {
       "en": "What console generation is the PlayStation 5?",
@@ -22144,7 +22144,7 @@
     "choices": [
       {
         "en": "game made without major publisher",
-        "ja": "大手ぱぶりっしゃーなしのゲーム",
+        "ja": "大手パブリッシャーなしのゲーム",
         "ja_typings": [
           "paburisshanashinogemu"
         ]
@@ -22158,14 +22158,14 @@
       },
       {
         "en": "foreign import game",
-        "ja": "がいこくゆにゅうゲーム",
+        "ja": "外国輸入ゲーム",
         "ja_typings": [
           "gaikokuyunyuugemu"
         ]
       },
       {
         "en": "in-development unreleased game",
-        "ja": "かいはつちゅうのみリリースゲーム",
+        "ja": "開発中の未リリースゲーム",
         "ja_typings": [
           "kaihatsuchuunomiririsugemu"
         ]
@@ -22177,7 +22177,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is an 'indie game'?",
-      "ja": "indie gameとはどのようなものですか？"
+      "ja": "インディーゲームとは何か？"
     },
     "question_text_reading": {
       "en": "What is an 'indie game'?",
@@ -22188,7 +22188,7 @@
     "choices": [
       {
         "en": "PC game distribution platform",
-        "ja": "PCゲームはいしんぷらっとふぁーむ",
+        "ja": "PCゲーム配信プラットフォーム",
         "ja_typings": [
           "pcgemuhaishinpurattofamu"
         ]
@@ -22202,14 +22202,14 @@
       },
       {
         "en": "console by Valve",
-        "ja": "Valveのゲームき",
+        "ja": "Valveのゲーム機",
         "ja_typings": [
           "valvenogemuki"
         ]
       },
       {
         "en": "game streaming service",
-        "ja": "ゲームはいしんさーびす",
+        "ja": "ゲーム配信サービス",
         "ja_typings": [
           "gemuhaishinsabisu"
         ]
@@ -22232,21 +22232,21 @@
     "choices": [
       {
         "en": "Japanese comic book style",
-        "ja": "にほんのまんがスタイル",
+        "ja": "日本の漫画スタイル",
         "ja_typings": [
           "nihonnomangasutairu"
         ]
       },
       {
         "en": "Japanese animation",
-        "ja": "にほんのアニメーション",
+        "ja": "日本のアニメーション",
         "ja_typings": [
           "nihonnoanimeshon"
         ]
       },
       {
         "en": "Japanese novel",
-        "ja": "にほんのしょうせつ",
+        "ja": "日本の小説",
         "ja_typings": [
           "nihonnoshosetsu",
           "nihonnoshousetsu"
@@ -22254,7 +22254,7 @@
       },
       {
         "en": "Japanese film",
-        "ja": "にほんのえいが",
+        "ja": "日本の映画",
         "ja_typings": [
           "nihonnoeiga"
         ]
@@ -22266,7 +22266,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is manga?",
-      "ja": "マンガとは何ですか？"
+      "ja": "漫画とは何か？"
     },
     "question_text_reading": {
       "en": "What is manga?",
@@ -22277,14 +22277,14 @@
     "choices": [
       {
         "en": "Akira Toriyama",
-        "ja": "とりやまあきら",
+        "ja": "鳥山明",
         "ja_typings": [
           "toriyamaakira"
         ]
       },
       {
         "en": "Eiichiro Oda",
-        "ja": "おだえいいちろう",
+        "ja": "織田栄一郎",
         "ja_typings": [
           "odaeiichiro",
           "odaeiichirou"
@@ -22292,14 +22292,14 @@
       },
       {
         "en": "Masashi Kishimoto",
-        "ja": "きしもとまさし",
+        "ja": "岸本正史",
         "ja_typings": [
           "kishimotomasashi"
         ]
       },
       {
         "en": "Tite Kubo",
-        "ja": "くぼたいと",
+        "ja": "久保帯人",
         "ja_typings": [
           "kubotaito"
         ]
@@ -22311,7 +22311,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who created Dragon Ball manga?",
-      "ja": "ドラゴンボールのまんがをかいたのは？"
+      "ja": "ドラゴンボールの漫画をかいたのは？"
     },
     "question_text_reading": {
       "en": "Who created Dragon Ball manga?",
@@ -22322,28 +22322,28 @@
     "choices": [
       {
         "en": "One Piece",
-        "ja": "わんぴーす",
+        "ja": "ワンピース",
         "ja_typings": [
           "wanpisu"
         ]
       },
       {
         "en": "Dragon Ball",
-        "ja": "どらごんぼーる",
+        "ja": "ドラゴンボール",
         "ja_typings": [
           "doragonboru"
         ]
       },
       {
         "en": "Naruto",
-        "ja": "なると",
+        "ja": "ナルト",
         "ja_typings": [
           "naruto"
         ]
       },
       {
         "en": "Demon Slayer",
-        "ja": "きめつのやいば",
+        "ja": "鬼滅の刃",
         "ja_typings": [
           "kimetsunoyaiba"
         ]
@@ -22355,7 +22355,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the best-selling manga of all time?",
-      "ja": "史上最も売れた漫画は何ですか？"
+      "ja": "もっともうれたまんがは？"
     },
     "question_text_reading": {
       "en": "What is the best-selling manga of all time?",
@@ -22366,7 +22366,7 @@
     "choices": [
       {
         "en": "Weekly Shonen Jump",
-        "ja": "しゅうかんしょうねんじゃんぷ",
+        "ja": "週間少年ジャンプ",
         "ja_typings": [
           "shuukanshonenjanpu",
           "shuukanshounenjanpu"
@@ -22374,7 +22374,7 @@
       },
       {
         "en": "Weekly Shonen Magazine",
-        "ja": "しゅうかんしょうねんまがじん",
+        "ja": "週間少年マガジン",
         "ja_typings": [
           "shuukanshonenmagajin",
           "shuukanshounenmagajin"
@@ -22382,14 +22382,14 @@
       },
       {
         "en": "Big Comic Spirits",
-        "ja": "びっぐこみっくすぴりっつ",
+        "ja": "ビッグコミックスピリッツ",
         "ja_typings": [
           "biggukomikkusupirittsu"
         ]
       },
       {
         "en": "Shonen Sunday",
-        "ja": "しょうねんさんでー",
+        "ja": "少年サンデー",
         "ja_typings": [
           "shonensande",
           "shounensande"
@@ -22402,7 +22402,7 @@
     "image_path": null,
     "question_text": {
       "en": "What magazine did Naruto run in?",
-      "ja": "ナルトが掲載されていたざっしは？"
+      "ja": "ナルトが掲載されていた雑誌は？"
     },
     "question_text_reading": {
       "en": "What magazine did Naruto run in?",
@@ -22413,7 +22413,7 @@
     "choices": [
       {
         "en": "collected manga volume",
-        "ja": "まんがのたんこうぼん",
+        "ja": "漫画の単行本",
         "ja_typings": [
           "manganotankobon",
           "manganotankoubon"
@@ -22421,14 +22421,14 @@
       },
       {
         "en": "chapter running in magazine",
-        "ja": "ざっしけいさいのかい",
+        "ja": "雑誌掲載の回",
         "ja_typings": [
           "zasshikeisainokai"
         ]
       },
       {
         "en": "limited edition release",
-        "ja": "かいていばんのはっぴょう",
+        "ja": "書いて版の発表",
         "ja_typings": [
           "kaiteibannohappyo",
           "kaiteibannohappyou"
@@ -22436,7 +22436,7 @@
       },
       {
         "en": "manga digital format",
-        "ja": "まんがのでじたるけいしき",
+        "ja": "漫画のデジタル形式",
         "ja_typings": [
           "manganodejitarukeishiki"
         ]
@@ -22448,7 +22448,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'tankoubon'?",
-      "ja": "たんこうぼんとは何ですか？"
+      "ja": "単行本とは何か？"
     },
     "question_text_reading": {
       "en": "What is 'tankoubon'?",
@@ -22459,14 +22459,14 @@
     "choices": [
       {
         "en": "adult men",
-        "ja": "せいじんだんせい",
+        "ja": "成人男性",
         "ja_typings": [
           "seijindansei"
         ]
       },
       {
         "en": "young boys",
-        "ja": "しょうねん",
+        "ja": "少年",
         "ja_typings": [
           "shonen",
           "shounen"
@@ -22474,7 +22474,7 @@
       },
       {
         "en": "young girls",
-        "ja": "しょうじょ",
+        "ja": "少女",
         "ja_typings": [
           "shojo",
           "shoujo"
@@ -22482,7 +22482,7 @@
       },
       {
         "en": "adult women",
-        "ja": "せいじんじょせい",
+        "ja": "成人女性",
         "ja_typings": [
           "seijinjosei"
         ]
@@ -22494,7 +22494,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'seinen' manga targeted at?",
-      "ja": "seinen漫画は、どのような読者を主なターゲットとしているのでしょうか？"
+      "ja": "青年漫画は何を対象としているか？"
     },
     "question_text_reading": {
       "en": "What is 'seinen' manga targeted at?",
@@ -22505,14 +22505,14 @@
     "choices": [
       {
         "en": "adult women",
-        "ja": "せいじんじょせい",
+        "ja": "成人女性",
         "ja_typings": [
           "seijinjosei"
         ]
       },
       {
         "en": "young girls",
-        "ja": "しょうじょ",
+        "ja": "少女",
         "ja_typings": [
           "shojo",
           "shoujo"
@@ -22520,14 +22520,14 @@
       },
       {
         "en": "adult men",
-        "ja": "せいじんだんせい",
+        "ja": "成人男性",
         "ja_typings": [
           "seijindansei"
         ]
       },
       {
         "en": "young boys",
-        "ja": "しょうねん",
+        "ja": "少年",
         "ja_typings": [
           "shonen",
           "shounen"
@@ -22540,7 +22540,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'josei' manga targeted at?",
-      "ja": "joseiマンガは、どのような読者を主なターゲットとしているのでしょうか？"
+      "ja": "女性漫画は何を対象としているか？"
     },
     "question_text_reading": {
       "en": "What is 'josei' manga targeted at?",
@@ -22551,28 +22551,28 @@
     "choices": [
       {
         "en": "manga artist",
-        "ja": "まんがか",
+        "ja": "漫画家",
         "ja_typings": [
           "mangaka"
         ]
       },
       {
         "en": "manga publisher",
-        "ja": "まんがのしゅっぱんしゃ",
+        "ja": "漫画の出版社",
         "ja_typings": [
           "manganoshuppansha"
         ]
       },
       {
         "en": "manga reader",
-        "ja": "まんがのどくしゃ",
+        "ja": "漫画の読者",
         "ja_typings": [
           "manganodokusha"
         ]
       },
       {
         "en": "manga editor",
-        "ja": "まんがのへんしゅうしゃ",
+        "ja": "漫画の編集者",
         "ja_typings": [
           "manganohenshuusha"
         ]
@@ -22584,7 +22584,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does 'manga-ka' mean?",
-      "ja": "manga-kaとは、どのような意味ですか？"
+      "ja": "漫画家とは何か？"
     },
     "question_text_reading": {
       "en": "What does 'manga-ka' mean?",
@@ -22595,14 +22595,14 @@
     "choices": [
       {
         "en": "reading guide for kanji",
-        "ja": "かんじのよみがたのてびき",
+        "ja": "漢字の読み方の手引き",
         "ja_typings": [
           "kanjinoyomigatanotebiki"
         ]
       },
       {
         "en": "sound effect text",
-        "ja": "おんさようのてきすと",
+        "ja": "音響効果テキスト",
         "ja_typings": [
           "onsayonotekisuto",
           "onsayounotekisuto"
@@ -22610,14 +22610,14 @@
       },
       {
         "en": "speech bubble text",
-        "ja": "ふきだしのてきすと",
+        "ja": "吹き出しのテキスト",
         "ja_typings": [
           "fukidashinotekisuto"
         ]
       },
       {
         "en": "character name label",
-        "ja": "キャラのなまえのらべる",
+        "ja": "キャラの名のラベル",
         "ja_typings": [
           "kyaranonamaenoraberu"
         ]
@@ -22629,7 +22629,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'furigana' in manga?",
-      "ja": "漫画における「ふりがな」とは何ですか？"
+      "ja": "漫画のふりがなとは何か？"
     },
     "question_text_reading": {
       "en": "What is 'furigana' in manga?",
@@ -22640,7 +22640,7 @@
     "choices": [
       {
         "en": "Kentaro Miura",
-        "ja": "みうらけんたろう",
+        "ja": "三浦建太郎",
         "ja_typings": [
           "miurakentaro",
           "miurakentarou"
@@ -22648,21 +22648,21 @@
       },
       {
         "en": "Hajime Isayama",
-        "ja": "いさやまはじめ",
+        "ja": "諫山創",
         "ja_typings": [
           "isayamahajime"
         ]
       },
       {
         "en": "Hirohiko Araki",
-        "ja": "あらきひろひこ",
+        "ja": "荒木広彦",
         "ja_typings": [
           "arakihirohiko"
         ]
       },
       {
         "en": "Rumiko Takahashi",
-        "ja": "たかはしるみこ",
+        "ja": "高橋留美子",
         "ja_typings": [
           "takahashirumiko"
         ]
@@ -22674,7 +22674,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who created the manga 'Berserk'?",
-      "ja": "漫画『ベルセルク』の作者は誰ですか？"
+      "ja": "漫画「ベルセルク」をかいたのは？"
     },
     "question_text_reading": {
       "en": "Who created the manga 'Berserk'?",
@@ -22685,21 +22685,21 @@
     "choices": [
       {
         "en": "a hero so powerful he defeats enemies in one punch",
-        "ja": "いちげきでてきをたおすひーろー",
+        "ja": "一撃で敵を倒すヒーロー",
         "ja_typings": [
           "ichigekidetekiotaosuhiro"
         ]
       },
       {
         "en": "a boxing champion",
-        "ja": "ぼくしんぐのチャンピオン",
+        "ja": "ボクシングのチャンピオン",
         "ja_typings": [
           "bokushingunochanpion"
         ]
       },
       {
         "en": "a cook who fights with food",
-        "ja": "たべもので戦うりょうりにん",
+        "ja": "食べ物で戦う料理人",
         "ja_typings": [
           "tabemonodeuryorinin",
           "tabemonodeuryourinin"
@@ -22707,7 +22707,7 @@
       },
       {
         "en": "a school delinquent",
-        "ja": "こうこうのふりょう",
+        "ja": "高校の不良",
         "ja_typings": [
           "kokonofuryo",
           "koukounofuryou"
@@ -22720,7 +22720,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the manga 'One Punch Man' about?",
-      "ja": "漫画『ワンパンマン』は、どのような物語を描いているのでしょうか？"
+      "ja": "漫画「ワンパンマン」は何についてか？"
     },
     "question_text_reading": {
       "en": "What is the manga 'One Punch Man' about?",
@@ -22731,28 +22731,28 @@
     "choices": [
       {
         "en": "Berserk",
-        "ja": "べるせるく",
+        "ja": "Berserk",
         "ja_typings": [
           "beruseruku"
         ]
       },
       {
         "en": "Doraemon",
-        "ja": "どらえもん",
+        "ja": "ドラえもん",
         "ja_typings": [
           "doraemon"
         ]
       },
       {
         "en": "Crayon Shin-chan",
-        "ja": "くれよんしんちゃん",
+        "ja": "クレヨンしんちゃん",
         "ja_typings": [
           "kureyonshinchan"
         ]
       },
       {
         "en": "Yotsuba",
-        "ja": "よつばと",
+        "ja": "四つ葉と",
         "ja_typings": [
           "yotsubato"
         ]
@@ -22764,7 +22764,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which manga is known for its intricate artwork style?",
-      "ja": "緻密な作画スタイルで知られる漫画はどれですか？"
+      "ja": "複雑な絵の漫画で知られるのは？"
     },
     "question_text_reading": {
       "en": "Which manga is known for its intricate artwork style?",
@@ -22775,28 +22775,28 @@
     "choices": [
       {
         "en": "Astro Boy",
-        "ja": "てつわんあとむ",
+        "ja": "鉄腕アトム",
         "ja_typings": [
           "tetsuwanatomu"
         ]
       },
       {
         "en": "Doraemon",
-        "ja": "どらえもん",
+        "ja": "ドラえもん",
         "ja_typings": [
           "doraemon"
         ]
       },
       {
         "en": "Sailor Moon",
-        "ja": "せーらーむーん",
+        "ja": "セーラー・ムーン",
         "ja_typings": [
           "seramun"
         ]
       },
       {
         "en": "Dragon Ball",
-        "ja": "どらごんぼーる",
+        "ja": "ドラゴンボール",
         "ja_typings": [
           "doragonboru"
         ]
@@ -22808,7 +22808,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the most famous work of Osamu Tezuka?",
-      "ja": "手塚治虫の最も有名な作品は何ですか？"
+      "ja": "手塚治虫の最も有名な作品は？"
     },
     "question_text_reading": {
       "en": "What is the most famous work of Osamu Tezuka?",
@@ -22819,7 +22819,7 @@
     "choices": [
       {
         "en": "action and adventure for young boys",
-        "ja": "しょうねんのアクションとぼうけん",
+        "ja": "少年のアクションと冒険",
         "ja_typings": [
           "shonennoakushontoboken",
           "shounennoakushontobouken"
@@ -22827,7 +22827,7 @@
       },
       {
         "en": "romance for young girls",
-        "ja": "しょうじょのれんあい",
+        "ja": "少女の恋愛",
         "ja_typings": [
           "shojonorenai",
           "shoujonorenai"
@@ -22835,7 +22835,7 @@
       },
       {
         "en": "everyday life stories",
-        "ja": "にちじょうせいかつのはなし",
+        "ja": "日常生活の話",
         "ja_typings": [
           "nichijoseikatsunohanashi",
           "nichijouseikatsunohanashi"
@@ -22843,7 +22843,7 @@
       },
       {
         "en": "historical drama",
-        "ja": "れきしのどらま",
+        "ja": "歴史のドラマ",
         "ja_typings": [
           "rekishinodorama"
         ]
@@ -22855,7 +22855,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'Shonen' manga primarily about?",
-      "ja": "しょうねんまんがのおもなないようは？"
+      "ja": "少年漫画の主な内容は？"
     },
     "question_text_reading": {
       "en": "What is 'Shonen' manga primarily about?",
@@ -22866,7 +22866,7 @@
     "choices": [
       {
         "en": "JoJo's Bizarre Adventure",
-        "ja": "じょじょのきみょうなぼうけん",
+        "ja": "ジョジョの奇妙な冒険",
         "ja_typings": [
           "jojonokimyonaboken",
           "jojonokimyounabouken"
@@ -22874,21 +22874,21 @@
       },
       {
         "en": "Fist of the North Star",
-        "ja": "ほくとのけん",
+        "ja": "北斗の拳",
         "ja_typings": [
           "hokutonoken"
         ]
       },
       {
         "en": "Vinland Saga",
-        "ja": "ゔぃんらんどさが",
+        "ja": "ヴィンランド・サガ",
         "ja_typings": [
           "vinrandosaga"
         ]
       },
       {
         "en": "Kingdom",
-        "ja": "きんぐだむ",
+        "ja": "キングダム",
         "ja_typings": [
           "kingudamu"
         ]
@@ -22900,7 +22900,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which manga follows the Joestars across multiple generations?",
-      "ja": "ジョースター家の物語を、何世代にもわたって追う漫画はどれだろう？"
+      "ja": "ジョースター家の物語の漫画は？"
     },
     "question_text_reading": {
       "en": "Which manga follows the Joestars across multiple generations?",
@@ -22911,28 +22911,28 @@
     "choices": [
       {
         "en": "Korean-style digital vertical scroll comic",
-        "ja": "かんこくしきのたてなが電子まんが",
+        "ja": "韓国式の縦長電子漫画",
         "ja_typings": [
           "kankokushikinotatenagamanga"
         ]
       },
       {
         "en": "animated manga episode",
-        "ja": "アニメかされたまんがのわ",
+        "ja": "アニメ化された漫画の輪",
         "ja_typings": [
           "animekasaretamanganowa"
         ]
       },
       {
         "en": "Japanese manga on web",
-        "ja": "ウェブのにほんまんが",
+        "ja": "ウェブの日本漫画",
         "ja_typings": [
           "webunonihonmanga"
         ]
       },
       {
         "en": "manga with animated panels",
-        "ja": "うごくコマのまんが",
+        "ja": "動くコマの漫画",
         "ja_typings": [
           "ugokukomanomanga"
         ]
@@ -22944,7 +22944,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'webtoon'?",
-      "ja": "うぇぶとぅーんとは何か？"
+      "ja": "Webtoonとは何か？"
     },
     "question_text_reading": {
       "en": "What is 'webtoon'?",
@@ -22955,28 +22955,28 @@
     "choices": [
       {
         "en": "Tite Kubo",
-        "ja": "くぼたいと",
+        "ja": "久保帯人",
         "ja_typings": [
           "kubotaito"
         ]
       },
       {
         "en": "Masashi Kishimoto",
-        "ja": "きしもとまさし",
+        "ja": "岸本正史",
         "ja_typings": [
           "kishimotomasashi"
         ]
       },
       {
         "en": "Akira Toriyama",
-        "ja": "とりやまあきら",
+        "ja": "鳥山明",
         "ja_typings": [
           "toriyamaakira"
         ]
       },
       {
         "en": "Eiichiro Oda",
-        "ja": "おだえいいちろう",
+        "ja": "織田栄一郎",
         "ja_typings": [
           "odaeiichiro",
           "odaeiichirou"
@@ -22989,7 +22989,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who created Bleach?",
-      "ja": "Bleach（ブリーチ）を創造したのは誰ですか？"
+      "ja": "ブリーチをかいたのは？"
     },
     "question_text_reading": {
       "en": "Who created Bleach?",
@@ -23000,28 +23000,28 @@
     "choices": [
       {
         "en": "psychological thriller manga",
-        "ja": "しんりすりらーまんが",
+        "ja": "サイコロジカルスリラーマンガ",
         "ja_typings": [
           "shinrisuriramanga"
         ]
       },
       {
         "en": "sports manga",
-        "ja": "すぽーつまんが",
+        "ja": "スポーツマンガ",
         "ja_typings": [
           "supotsumanga"
         ]
       },
       {
         "en": "romantic comedy manga",
-        "ja": "ろまんてぃっくこめでぃまんが",
+        "ja": "ロマンティックコメディマンガ",
         "ja_typings": [
           "romantikkukomedimanga"
         ]
       },
       {
         "en": "sci-fi adventure manga",
-        "ja": "さいえんすふぃくしょんぼうけんまんが",
+        "ja": "サイエンス・フィクション・アドベンチャー・マンガ",
         "ja_typings": [
           "saiensufikushonbokenmanga",
           "saiensufikushonboukenmanga"
@@ -23034,7 +23034,7 @@
     "image_path": null,
     "question_text": {
       "en": "What type of story is 'Monster' by Naoki Urasawa?",
-      "ja": "浦沢直樹の『MONSTER』は、どのようなジャンルの物語ですか？"
+      "ja": "浦沢直樹の『MONSTER』はどんな物語か？"
     },
     "question_text_reading": {
       "en": "What type of story is 'Monster' by Naoki Urasawa?",
@@ -23045,14 +23045,14 @@
     "choices": [
       {
         "en": "self-published fan comic",
-        "ja": "じがんのファンまんが",
+        "ja": "自販のファン漫画",
         "ja_typings": [
           "jigannofanmanga"
         ]
       },
       {
         "en": "official manga chapter",
-        "ja": "こうしきのまんがかい",
+        "ja": "公式の漫画回",
         "ja_typings": [
           "koshikinomangakai",
           "koushikinomangakai"
@@ -23060,14 +23060,14 @@
       },
       {
         "en": "licensed manga reprint",
-        "ja": "きょかずみのまんがさいはん",
+        "ja": "極蔵の漫画再版",
         "ja_typings": [
           "kyokazuminomangasaihan"
         ]
       },
       {
         "en": "manga award winner",
-        "ja": "まんがしょうじゅしょうさく",
+        "ja": "漫画賞受賞作",
         "ja_typings": [
           "mangashojushosaku",
           "mangashoujushousaku"
@@ -23080,7 +23080,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'doujinshi'?",
-      "ja": "どうじんしとは何か？"
+      "ja": "同人誌とは何か？"
     },
     "question_text_reading": {
       "en": "What is 'doujinshi'?",
@@ -23091,7 +23091,7 @@
     "choices": [
       {
         "en": "Inuyasha",
-        "ja": "いぬやしゃ",
+        "ja": "犬夜叉",
         "ja_typings": [
           "inuyasha"
         ]
@@ -23113,7 +23113,7 @@
       },
       {
         "en": "Blade of the Immortal",
-        "ja": "むげんのじゅうにん",
+        "ja": "無限の住人",
         "ja_typings": [
           "mugennojuunin"
         ]
@@ -23125,7 +23125,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which manga is about a time-traveling story in feudal Japan?",
-      "ja": "戦国時代を舞台に、タイムトラベルする漫画はどれ？"
+      "ja": "戦国時代のにほんにタイムトラベルする漫画は？"
     },
     "question_text_reading": {
       "en": "Which manga is about a time-traveling story in feudal Japan?",
@@ -23136,7 +23136,7 @@
     "choices": [
       {
         "en": "a curious 5-year-old girl's daily life",
-        "ja": "ごさいのしょうじょのにちじょう",
+        "ja": "五歳の少女の日常生活",
         "ja_typings": [
           "gosainoshojononichijo",
           "gosainoshoujononichijou"
@@ -23144,7 +23144,7 @@
       },
       {
         "en": "a fantasy adventure",
-        "ja": "ふぁんたじーぼうけん",
+        "ja": "ファンタジーアドベンチャー",
         "ja_typings": [
           "fantajiboken",
           "fantajibouken"
@@ -23152,7 +23152,7 @@
       },
       {
         "en": "a high school romance",
-        "ja": "こうこうのれんあい",
+        "ja": "高校の恋愛",
         "ja_typings": [
           "kokonorenai",
           "koukounorenai"
@@ -23160,7 +23160,7 @@
       },
       {
         "en": "a sports tournament",
-        "ja": "すぽーつたいかい",
+        "ja": "スポーツ大会",
         "ja_typings": [
           "supotsutaikai"
         ]
@@ -23172,7 +23172,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the manga 'Yotsubato!' about?",
-      "ja": "漫画『よつばと!』は、どのような物語を描いているの？"
+      "ja": "漫画「よつばと!」は何についてか？"
     },
     "question_text_reading": {
       "en": "What is the manga 'Yotsubato!' about?",
@@ -23183,7 +23183,7 @@
     "choices": [
       {
         "en": "Kingdom",
-        "ja": "きんぐだむ",
+        "ja": "キングダム",
         "ja_typings": [
           "kingudamu"
         ]
@@ -23197,7 +23197,7 @@
       },
       {
         "en": "Lone Wolf and Cub",
-        "ja": "こかみのおおかみ",
+        "ja": "骨喰いの狼",
         "ja_typings": [
           "kokaminookami",
           "kokaminoookami"
@@ -23205,7 +23205,7 @@
       },
       {
         "en": "Vinland Saga",
-        "ja": "ゔぃんらんどさが",
+        "ja": "ヴィンランド・サガ",
         "ja_typings": [
           "vinrandosaga"
         ]
@@ -23217,7 +23217,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which manga series is set in ancient China?",
-      "ja": "古代中国を舞台にしている漫画シリーズはどれですか？"
+      "ja": "古代中国を舞台にしたマンガシリーズは？"
     },
     "question_text_reading": {
       "en": "Which manga series is set in ancient China?",
@@ -23228,7 +23228,7 @@
     "choices": [
       {
         "en": "Eiichiro Oda",
-        "ja": "おだえいいちろう",
+        "ja": "織田栄一郎",
         "ja_typings": [
           "odaeiichiro",
           "odaeiichirou"
@@ -23236,21 +23236,21 @@
       },
       {
         "en": "Masashi Kishimoto",
-        "ja": "きしもとまさし",
+        "ja": "岸本正史",
         "ja_typings": [
           "kishimotomasashi"
         ]
       },
       {
         "en": "Akira Toriyama",
-        "ja": "とりやまあきら",
+        "ja": "鳥山明",
         "ja_typings": [
           "toriyamaakira"
         ]
       },
       {
         "en": "Rumiko Takahashi",
-        "ja": "たかはしるみこ",
+        "ja": "高橋留美子",
         "ja_typings": [
           "takahashirumiko"
         ]
@@ -23262,7 +23262,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who draws One Piece?",
-      "ja": "ワンピースの作者は誰ですか？"
+      "ja": "ワンピースをかいているのは誰か？"
     },
     "question_text_reading": {
       "en": "Who draws One Piece?",
@@ -23273,28 +23273,28 @@
     "choices": [
       {
         "en": "Vikings in medieval Europe",
-        "ja": "ちゅうせいヨーロッパのバイキング",
+        "ja": "中世ヨーロッパのバイキング",
         "ja_typings": [
           "chuuseiyoroppanobaikingu"
         ]
       },
       {
         "en": "Vikings in ancient Japan",
-        "ja": "こだいにほんのバイキング",
+        "ja": "古代日本のバイキング",
         "ja_typings": [
           "kodainihonnobaikingu"
         ]
       },
       {
         "en": "Samurai in medieval Japan",
-        "ja": "ちゅうせいにほんのさむらい",
+        "ja": "中世日本のサムライ",
         "ja_typings": [
           "chuuseinihonnosamurai"
         ]
       },
       {
         "en": "Warriors in ancient Greece",
-        "ja": "こだいギリシャのせんし",
+        "ja": "古代ギリシャの戦士",
         "ja_typings": [
           "kodaigirishanosenshi"
         ]
@@ -23306,7 +23306,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the premise of Vinland Saga?",
-      "ja": "『ヴィンランド・サガ』の物語の前提となるものは何ですか？"
+      "ja": "Vinland Sagaの設定は？"
     },
     "question_text_reading": {
       "en": "What is the premise of Vinland Saga?",
@@ -23317,14 +23317,14 @@
     "choices": [
       {
         "en": "dramatic realist manga for adults",
-        "ja": "おとなのためのしじつてきなまんが",
+        "ja": "大人のための写実的な漫画",
         "ja_typings": [
           "otonanotamenoshijitsutekinamanga"
         ]
       },
       {
         "en": "funny children's manga",
-        "ja": "こどものためのおもしろまんが",
+        "ja": "子供のための面白い漫画",
         "ja_typings": [
           "kodomonotamenomoshiromanga",
           "kodomonotamenoomoshiromanga"
@@ -23332,14 +23332,14 @@
       },
       {
         "en": "newspaper political cartoon",
-        "ja": "しんぶんのせいじまんが",
+        "ja": "新聞の政治漫画",
         "ja_typings": [
           "shinbunnoseijimanga"
         ]
       },
       {
         "en": "animated manga format",
-        "ja": "アニメかけいしき",
+        "ja": "アニメ形式",
         "ja_typings": [
           "animekakeishiki"
         ]
@@ -23351,7 +23351,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'gekiga'?",
-      "ja": "げきがとは何か？"
+      "ja": "劇画とは何か？"
     },
     "question_text_reading": {
       "en": "What is 'gekiga'?",
@@ -23362,28 +23362,28 @@
     "choices": [
       {
         "en": "Fullmetal Alchemist",
-        "ja": "はがねのれんきんじゅつし",
+        "ja": "鋼の錬金術師",
         "ja_typings": [
           "haganenorenkinjutsushi"
         ]
       },
       {
         "en": "Noragami",
-        "ja": "のらがみ",
+        "ja": "神奈満",
         "ja_typings": [
           "noragami"
         ]
       },
       {
         "en": "Blue Exorcist",
-        "ja": "あおのえくそしすと",
+        "ja": "青の祓魔師",
         "ja_typings": [
           "aonoekusoshisuto"
         ]
       },
       {
         "en": "Soul Eater",
-        "ja": "そうるいーたー",
+        "ja": "ソウルイーター",
         "ja_typings": [
           "soruita",
           "souruita"
@@ -23396,7 +23396,7 @@
     "image_path": null,
     "question_text": {
       "en": "What manga features Edward and Alphonse Elric?",
-      "ja": "エドワードとアルフォンス・エルリックが登場する漫画は何ですか？"
+      "ja": "エドワードとアルフォンス・エルリックのマンガは？"
     },
     "question_text_reading": {
       "en": "What manga features Edward and Alphonse Elric?",
@@ -23407,14 +23407,14 @@
     "choices": [
       {
         "en": "Demon Slayer",
-        "ja": "でーもんすれいやー",
+        "ja": "デモン・スレイヤー",
         "ja_typings": [
           "demonsureiya"
         ]
       },
       {
         "en": "Blade of Demons",
-        "ja": "ぶれいどおぶでーもんず",
+        "ja": "ブレイドオブデーモンズ",
         "ja_typings": [
           "bureidobudemonzu",
           "bureidoobudemonzu"
@@ -23422,14 +23422,14 @@
       },
       {
         "en": "Demon Sword",
-        "ja": "でーもんそーど",
+        "ja": "デーモンソード",
         "ja_typings": [
           "demonsodo"
         ]
       },
       {
         "en": "Night of Demons",
-        "ja": "ないとおぶでーもんず",
+        "ja": "ナイトオブデーモンズ",
         "ja_typings": [
           "naitobudemonzu",
           "naitoobudemonzu"
@@ -23442,7 +23442,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is Kimetsu no Yaiba known as in English?",
-      "ja": "きめつのやいばの英語タイトルは？"
+      "ja": "鬼滅の刃の英語タイトルは？"
     },
     "question_text_reading": {
       "en": "What is Kimetsu no Yaiba known as in English?",
@@ -23453,21 +23453,21 @@
     "choices": [
       {
         "en": "Attack on Titan",
-        "ja": "しんげきのきょじん",
+        "ja": "進撃の巨人",
         "ja_typings": [
           "shingekinokyojin"
         ]
       },
       {
         "en": "Fairy Tail",
-        "ja": "ふぇありーている",
+        "ja": "フェアリーテイル",
         "ja_typings": [
           "feariteiru"
         ]
       },
       {
         "en": "Sword Art Online",
-        "ja": "そーどあーとおんらいん",
+        "ja": "ソードアート・オンライン",
         "ja_typings": [
           "sodoatonrain",
           "sodoatoonrain"
@@ -23475,7 +23475,7 @@
       },
       {
         "en": "That Time I Got Reincarnated as a Slime",
-        "ja": "てんせいスライム",
+        "ja": "転生スライム",
         "ja_typings": [
           "tenseisuraimu"
         ]
@@ -23487,7 +23487,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which manga is drawn by Hajime Isayama?",
-      "ja": "ハジメ・イサヤマが描いた漫画はどれですか？"
+      "ja": "諫山創が描いた漫画は？"
     },
     "question_text_reading": {
       "en": "Which manga is drawn by Hajime Isayama?",
@@ -23498,14 +23498,14 @@
     "choices": [
       {
         "en": "adult women",
-        "ja": "せいじんじょせい",
+        "ja": "成人女性",
         "ja_typings": [
           "seijinjosei"
         ]
       },
       {
         "en": "young girls",
-        "ja": "しょうじょ",
+        "ja": "少女",
         "ja_typings": [
           "shojo",
           "shoujo"
@@ -23513,7 +23513,7 @@
       },
       {
         "en": "young boys",
-        "ja": "しょうねん",
+        "ja": "少年",
         "ja_typings": [
           "shonen",
           "shounen"
@@ -23521,7 +23521,7 @@
       },
       {
         "en": "adult men",
-        "ja": "せいじんだんせい",
+        "ja": "成人男性",
         "ja_typings": [
           "seijindansei"
         ]
@@ -23533,7 +23533,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'Josei' manga magazine aimed at?",
-      "ja": "女性向けの漫画雑誌は、どのような層を対象としているのでしょうか？"
+      "ja": "女性漫画雑誌の対象は？"
     },
     "question_text_reading": {
       "en": "What is 'Josei' manga magazine aimed at?",
@@ -23544,28 +23544,28 @@
     "choices": [
       {
         "en": "manga adaptation of light novel",
-        "ja": "らいとのべるのまんがか",
+        "ja": "ライトノベルの漫画化",
         "ja_typings": [
           "raitonoberunomangaka"
         ]
       },
       {
         "en": "short manga chapter",
-        "ja": "みじかいまんがかい",
+        "ja": "短い漫画回",
         "ja_typings": [
           "mijikaimangakai"
         ]
       },
       {
         "en": "manga with simple art",
-        "ja": "かんたんなえのまんが",
+        "ja": "簡単な絵の漫画",
         "ja_typings": [
           "kantannaenomanga"
         ]
       },
       {
         "en": "manga for young children",
-        "ja": "ようじむけまんが",
+        "ja": "幼児向けマンガ",
         "ja_typings": [
           "yojimukemanga",
           "youjimukemanga"
@@ -23578,7 +23578,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the manga equivalent of a light novel?",
-      "ja": "ライトノベルに相当する漫画は何ですか？"
+      "ja": "ライトノベルの漫画相当は？"
     },
     "question_text_reading": {
       "en": "What is the manga equivalent of a light novel?",
@@ -23589,28 +23589,28 @@
     "choices": [
       {
         "en": "Fullmetal Alchemist",
-        "ja": "はがねのれんきんじゅつし",
+        "ja": "鋼の錬金術師",
         "ja_typings": [
           "haganenorenkinjutsushi"
         ]
       },
       {
         "en": "Black Clover",
-        "ja": "ぶらっくくろーばー",
+        "ja": "ブラッククローバー",
         "ja_typings": [
           "burakkukuroba"
         ]
       },
       {
         "en": "Magi",
-        "ja": "まぎ",
+        "ja": "マギ",
         "ja_typings": [
           "magi"
         ]
       },
       {
         "en": "Fairy Tail",
-        "ja": "ふぇありーている",
+        "ja": "フェアリーテイル",
         "ja_typings": [
           "feariteiru"
         ]
@@ -23622,7 +23622,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which manga features the Elric brothers searching for the Philosopher's Stone?",
-      "ja": "けんじゃのいしをさがすえるりっくきょうだいのまんがは？"
+      "ja": "賢者の石をさがすエルリック兄弟の漫画は？"
     },
     "question_text_reading": {
       "en": "Which manga features the Elric brothers searching for the Philosopher's Stone?",
@@ -23633,21 +23633,21 @@
     "choices": [
       {
         "en": "Fujiko F. Fujio",
-        "ja": "ふじこえふふじお",
+        "ja": "藤子エフ・フジオ",
         "ja_typings": [
           "fujikoefufujio"
         ]
       },
       {
         "en": "Osamu Tezuka",
-        "ja": "てづかおさむ",
+        "ja": "手塚治虫",
         "ja_typings": [
           "tezukaosamu"
         ]
       },
       {
         "en": "Shotaro Ishinomori",
-        "ja": "いしのもりしょうたろう",
+        "ja": "石ノ森章太郎",
         "ja_typings": [
           "ishinomorishotaro",
           "ishinomorishoutarou"
@@ -23655,7 +23655,7 @@
       },
       {
         "en": "Go Nagai",
-        "ja": "ながいごう",
+        "ja": "永井豪",
         "ja_typings": [
           "nagaigo",
           "nagaigou"
@@ -23668,7 +23668,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who created Doraemon?",
-      "ja": "ドラえもんを創造したのは誰ですか？"
+      "ja": "ドラえもんをかいたのは？"
     },
     "question_text_reading": {
       "en": "Who created Doraemon?",
@@ -23679,21 +23679,21 @@
     "choices": [
       {
         "en": "historical samurai drama",
-        "ja": "れきしのさむらいどらま",
+        "ja": "歴史のサムライドラマ",
         "ja_typings": [
           "rekishinosamuraidorama"
         ]
       },
       {
         "en": "sci-fi thriller",
-        "ja": "SF/すりらー",
+        "ja": "sci-fi thriller",
         "ja_typings": [
           "sf/surira"
         ]
       },
       {
         "en": "supernatural romance",
-        "ja": "ちょうしぜんれんあい",
+        "ja": "超自然恋愛",
         "ja_typings": [
           "choshizenrenai",
           "choushizenrenai"
@@ -23701,7 +23701,7 @@
       },
       {
         "en": "sports manga",
-        "ja": "すぽーつまんが",
+        "ja": "スポーツマンガ",
         "ja_typings": [
           "supotsumanga"
         ]
@@ -23724,28 +23724,28 @@
     "choices": [
       {
         "en": "story derived from main series featuring side characters",
-        "ja": "メインシリーズのサブキャラのはなし",
+        "ja": "メインシリーズのサブキャラの話",
         "ja_typings": [
           "meinshirizunosabukyaranohanashi"
         ]
       },
       {
         "en": "sequel to original manga",
-        "ja": "オリジナルまんがのぞくへん",
+        "ja": "オリジナル漫画の続編",
         "ja_typings": [
           "orijinarumanganozokuhen"
         ]
       },
       {
         "en": "remix version of original",
-        "ja": "オリジナルのりみっくすばん",
+        "ja": "オリジナルのリミックス版",
         "ja_typings": [
           "orijinarunorimikkusuban"
         ]
       },
       {
         "en": "overseas licensed version",
-        "ja": "かいがいきょかばん",
+        "ja": "海外許可版",
         "ja_typings": [
           "kaigaikyokaban"
         ]
@@ -23757,7 +23757,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a 'spin-off' manga?",
-      "ja": "スピンオフまんがとは何か？"
+      "ja": "スピンオフ漫画とは何か？"
     },
     "question_text_reading": {
       "en": "What is a 'spin-off' manga?",
@@ -23768,28 +23768,28 @@
     "choices": [
       {
         "en": "right to left reading direction",
-        "ja": "みぎからひだりによむ",
+        "ja": "右から左に読む",
         "ja_typings": [
           "migikarahidariniyomu"
         ]
       },
       {
         "en": "bottom to top reading",
-        "ja": "したからうえによむ",
+        "ja": "下から上によむ",
         "ja_typings": [
           "shitakaraueniyomu"
         ]
       },
       {
         "en": "left to right reading",
-        "ja": "ひだりからみぎによむ",
+        "ja": "左から右に読む",
         "ja_typings": [
           "hidarikaramiginiyomu"
         ]
       },
       {
         "en": "diagonal reading",
-        "ja": "ななめによむ",
+        "ja": "斜めに読む",
         "ja_typings": [
           "nanameniyomu"
         ]
@@ -23801,7 +23801,7 @@
     "image_path": null,
     "question_text": {
       "en": "What makes manga read differently from Western comics?",
-      "ja": "まんがが西洋まんがとちがうよみかたは？"
+      "ja": "漫画が西洋漫画と違う読み方は？"
     },
     "question_text_reading": {
       "en": "What makes manga read differently from Western comics?",
@@ -23812,28 +23812,28 @@
     "choices": [
       {
         "en": "One Piece",
-        "ja": "わんぴーす",
+        "ja": "ワンピース",
         "ja_typings": [
           "wanpisu"
         ]
       },
       {
         "en": "Dragon Ball",
-        "ja": "どらごんぼーる",
+        "ja": "ドラゴンボール",
         "ja_typings": [
           "doragonboru"
         ]
       },
       {
         "en": "Golgo 13",
-        "ja": "ごるごじゅうさん",
+        "ja": "ゴルゴ13",
         "ja_typings": [
           "gorugojuusan"
         ]
       },
       {
         "en": "Naruto",
-        "ja": "なると",
+        "ja": "ナルト",
         "ja_typings": [
           "naruto"
         ]
@@ -23845,7 +23845,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which manga has the longest running story?",
-      "ja": "最も連載期間が長い漫画はどれですか？"
+      "ja": "もっともちょうへんの漫画は？"
     },
     "question_text_reading": {
       "en": "Which manga has the longest running story?",
@@ -23856,7 +23856,7 @@
     "choices": [
       {
         "en": "romance and emotional stories",
-        "ja": "れんあいとかんじょうのはなし",
+        "ja": "恋愛と感情の話",
         "ja_typings": [
           "renaitokanjonohanashi",
           "renaitokanjounohanashi"
@@ -23864,21 +23864,21 @@
       },
       {
         "en": "intense action battles",
-        "ja": "げきれつなアクションバトル",
+        "ja": "激烈なアクションバトル",
         "ja_typings": [
           "gekiretsunaakushonbatoru"
         ]
       },
       {
         "en": "historical epics",
-        "ja": "れきしのたいさく",
+        "ja": "歴史の対作",
         "ja_typings": [
           "rekishinotaisaku"
         ]
       },
       {
         "en": "sports competitions",
-        "ja": "すぽーつたいかい",
+        "ja": "スポーツ大会",
         "ja_typings": [
           "supotsutaikai"
         ]
@@ -23890,7 +23890,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'shojo manga' famous for?",
-      "ja": "少女漫画は、どのような点で有名なのでしょうか？"
+      "ja": "少女漫画は何で有名か？"
     },
     "question_text_reading": {
       "en": "What is 'shojo manga' famous for?",
@@ -23901,28 +23901,28 @@
     "choices": [
       {
         "en": "Naoko Takeuchi",
-        "ja": "たけうちなおこ",
+        "ja": "竹内直子",
         "ja_typings": [
           "takeuchinaoko"
         ]
       },
       {
         "en": "Rumiko Takahashi",
-        "ja": "たかはしるみこ",
+        "ja": "高橋留美子",
         "ja_typings": [
           "takahashirumiko"
         ]
       },
       {
         "en": "CLAMP",
-        "ja": "くらんぷ",
+        "ja": "クランプ",
         "ja_typings": [
           "kuranpu"
         ]
       },
       {
         "en": "Yoshihiro Togashi",
-        "ja": "とがしよしひろ",
+        "ja": "渡辺義弘",
         "ja_typings": [
           "togashiyoshihiro"
         ]
@@ -23934,7 +23934,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who is the creator of Sailor Moon manga?",
-      "ja": "セーラームーンまんがのさくしゃは？"
+      "ja": "セーラームーン漫画の作者は？"
     },
     "question_text_reading": {
       "en": "Who is the creator of Sailor Moon manga?",
@@ -23945,14 +23945,14 @@
     "choices": [
       {
         "en": "horror involving spirals",
-        "ja": "らせんをもとにしたほらー",
+        "ja": "らせんをもとにしたホラー",
         "ja_typings": [
           "rasenomotonishitahora"
         ]
       },
       {
         "en": "comedy about cooking",
-        "ja": "りょうりのこめでぃ",
+        "ja": "料理のコメディ",
         "ja_typings": [
           "ryorinokomedi",
           "ryourinokomedi"
@@ -23960,7 +23960,7 @@
       },
       {
         "en": "romance in high school",
-        "ja": "こうこうのれんあい",
+        "ja": "高校の恋愛",
         "ja_typings": [
           "kokonorenai",
           "koukounorenai"
@@ -23968,7 +23968,7 @@
       },
       {
         "en": "historical action",
-        "ja": "れきしのアクション",
+        "ja": "歴史のアクション",
         "ja_typings": [
           "rekishinoakushon"
         ]
@@ -23980,7 +23980,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the manga 'Uzumaki' known for?",
-      "ja": "漫画『うずまき』は、何で知られているのでしょうか？"
+      "ja": "漫画「うずまき」は何で有名か？"
     },
     "question_text_reading": {
       "en": "What is the manga 'Uzumaki' known for?",
@@ -23991,28 +23991,28 @@
     "choices": [
       {
         "en": "Fist of the North Star",
-        "ja": "ほくとのけん",
+        "ja": "北斗の拳",
         "ja_typings": [
           "hokutonoken"
         ]
       },
       {
         "en": "Berserk",
-        "ja": "べるせるく",
+        "ja": "Berserk",
         "ja_typings": [
           "beruseruku"
         ]
       },
       {
         "en": "Vinland Saga",
-        "ja": "ゔぃんらんどさが",
+        "ja": "ヴィンランド・サガ",
         "ja_typings": [
           "vinrandosaga"
         ]
       },
       {
         "en": "Kingdom",
-        "ja": "きんぐだむ",
+        "ja": "キングダム",
         "ja_typings": [
           "kingudamu"
         ]
@@ -24024,7 +24024,7 @@
     "image_path": null,
     "question_text": {
       "en": "What manga features Kenshiro as the main character?",
-      "ja": "ケンシロウが主人公の漫画はどれ？"
+      "ja": "拳四郎が主人公の漫画は？"
     },
     "question_text_reading": {
       "en": "What manga features Kenshiro as the main character?",
@@ -24035,28 +24035,28 @@
     "choices": [
       {
         "en": "1997",
-        "ja": "1997ねん",
+        "ja": "1997年",
         "ja_typings": [
           "1997nen"
         ]
       },
       {
         "en": "1995",
-        "ja": "1995ねん",
+        "ja": "1995年",
         "ja_typings": [
           "1995nen"
         ]
       },
       {
         "en": "1999",
-        "ja": "1999ねん",
+        "ja": "1999年",
         "ja_typings": [
           "1999nen"
         ]
       },
       {
         "en": "2001",
-        "ja": "2001ねん",
+        "ja": "2001年",
         "ja_typings": [
           "2001nen"
         ]
@@ -24068,7 +24068,7 @@
     "image_path": null,
     "question_text": {
       "en": "What year was the first chapter of One Piece published?",
-      "ja": "ワンピースの最初の章が刊行されたのは何年ですか？"
+      "ja": "ワンピースの最初の回がしゅっぱんされたのはなんねんか？"
     },
     "question_text_reading": {
       "en": "What year was the first chapter of One Piece published?",
@@ -24079,28 +24079,28 @@
     "choices": [
       {
         "en": "Jujutsu Kaisen",
-        "ja": "じゅじゅつかいせん",
+        "ja": "呪術廻戦",
         "ja_typings": [
           "jujutsukaisen"
         ]
       },
       {
         "en": "Bleach",
-        "ja": "ぶりーち",
+        "ja": "ブリーチ",
         "ja_typings": [
           "burichi"
         ]
       },
       {
         "en": "Black Clover",
-        "ja": "ぶらっくくろーばー",
+        "ja": "ブラッククローバー",
         "ja_typings": [
           "burakkukuroba"
         ]
       },
       {
         "en": "Soul Eater",
-        "ja": "そうるいーたー",
+        "ja": "ソウルイーター",
         "ja_typings": [
           "soruita",
           "souruita"
@@ -24113,7 +24113,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the manga about Yuji Itadori eating a cursed finger?",
-      "ja": "呪いの指を食べる虎杖悠仁（ゆうじ・いたどり）に関する漫画は何ですか？"
+      "ja": "雄二虎杖が呪いの指を食べる漫画は？"
     },
     "question_text_reading": {
       "en": "What is the manga about Yuji Itadori eating a cursed finger?",
@@ -24124,28 +24124,28 @@
     "choices": [
       {
         "en": "basketball",
-        "ja": "ばすけっとぼーる",
+        "ja": "バスケットボール",
         "ja_typings": [
           "basukettoboru"
         ]
       },
       {
         "en": "baseball",
-        "ja": "やきゅう",
+        "ja": "野球",
         "ja_typings": [
           "yakyuu"
         ]
       },
       {
         "en": "soccer",
-        "ja": "さっかー",
+        "ja": "サッカー",
         "ja_typings": [
           "sakka"
         ]
       },
       {
         "en": "volleyball",
-        "ja": "ばれーぼーる",
+        "ja": "バレーボール",
         "ja_typings": [
           "bareboru"
         ]
@@ -24168,28 +24168,28 @@
     "choices": [
       {
         "en": "Erased (Boku dake ga Inai Machi)",
-        "ja": "ぼくだけがいないまち",
+        "ja": "僕だけがいない街",
         "ja_typings": [
           "bokudakegainaimachi"
         ]
       },
       {
         "en": "Monster",
-        "ja": "もんすたー",
+        "ja": "モンスター",
         "ja_typings": [
           "monsuta"
         ]
       },
       {
         "en": "Death Note",
-        "ja": "でーすのーと",
+        "ja": "デスノート",
         "ja_typings": [
           "desunoto"
         ]
       },
       {
         "en": "20th Century Boys",
-        "ja": "20せいきしょうねん",
+        "ja": "20世紀少年",
         "ja_typings": [
           "20seikishonen",
           "20seikishounen"
@@ -24202,7 +24202,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which manga features time-travel murder mystery?",
-      "ja": "タイムトラベルのさつじんミステリーのまんがは？"
+      "ja": "タイムトラベルの殺人ミステリーの漫画は？"
     },
     "question_text_reading": {
       "en": "Which manga features time-travel murder mystery?",
@@ -24213,28 +24213,28 @@
     "choices": [
       {
         "en": "complex psychological thriller manga",
-        "ja": "ふくざつなしんりすりらーまんが",
+        "ja": "複雑心理スリラーマンガ",
         "ja_typings": [
           "fukuzatsunashinrisuriramanga"
         ]
       },
       {
         "en": "simple action manga",
-        "ja": "かんたんなアクションまんが",
+        "ja": "簡単なアクション漫画",
         "ja_typings": [
           "kantannaakushonmanga"
         ]
       },
       {
         "en": "children's manga",
-        "ja": "こどものまんが",
+        "ja": "子供の漫画",
         "ja_typings": [
           "kodomonomanga"
         ]
       },
       {
         "en": "romantic comedy manga",
-        "ja": "ろまんてぃっくこめでぃまんが",
+        "ja": "ロマンティックコメディマンガ",
         "ja_typings": [
           "romantikkukomedimanga"
         ]
@@ -24246,7 +24246,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is Naoki Urasawa known for?",
-      "ja": "浦沢直樹はどのような作品で知られているだろうか？"
+      "ja": "浦沢直樹は何で有名か？"
     },
     "question_text_reading": {
       "en": "What is Naoki Urasawa known for?",
@@ -24257,7 +24257,7 @@
     "choices": [
       {
         "en": "Weekly Shonen Jump",
-        "ja": "しゅうかんしょうねんじゃんぷ",
+        "ja": "週間少年ジャンプ",
         "ja_typings": [
           "shuukanshonenjanpu",
           "shuukanshounenjanpu"
@@ -24265,7 +24265,7 @@
       },
       {
         "en": "Monthly Shonen Jump",
-        "ja": "げっかんしょうねんじゃんぷ",
+        "ja": "月刊少年ジャンプ",
         "ja_typings": [
           "gekkanshonenjanpu",
           "gekkanshounenjanpu"
@@ -24273,7 +24273,7 @@
       },
       {
         "en": "Shonen Magazine",
-        "ja": "しょうねんまがじん",
+        "ja": "少年マガジン",
         "ja_typings": [
           "shonenmagajin",
           "shounenmagajin"
@@ -24281,7 +24281,7 @@
       },
       {
         "en": "Young Jump",
-        "ja": "ようじゃんぷ",
+        "ja": "ヨングジャンプ",
         "ja_typings": [
           "yojanpu",
           "youjanpu"
@@ -24294,7 +24294,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the manga that Chainsaw Man is serialized in?",
-      "ja": "『チェンソーマン』が連載されている漫画のタイトルは何ですか？"
+      "ja": "チェンソーマンが掲載されている漫画は？"
     },
     "question_text_reading": {
       "en": "What is the manga that Chainsaw Man is serialized in?",
@@ -24305,28 +24305,28 @@
     "choices": [
       {
         "en": "Yoshihiro Togashi",
-        "ja": "とがしよしひろ",
+        "ja": "渡辺義弘",
         "ja_typings": [
           "togashiyoshihiro"
         ]
       },
       {
         "en": "Masashi Kishimoto",
-        "ja": "きしもとまさし",
+        "ja": "岸本正史",
         "ja_typings": [
           "kishimotomasashi"
         ]
       },
       {
         "en": "Tite Kubo",
-        "ja": "くぼたいと",
+        "ja": "久保帯人",
         "ja_typings": [
           "kubotaito"
         ]
       },
       {
         "en": "Akira Toriyama",
-        "ja": "とりやまあきら",
+        "ja": "鳥山明",
         "ja_typings": [
           "toriyamaakira"
         ]
@@ -24338,7 +24338,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who created 'Hunter x Hunter'?",
-      "ja": "ハンターハンターをかいたのは？"
+      "ja": "ハンター×ハンターをかいたのは？"
     },
     "question_text_reading": {
       "en": "Who created 'Hunter x Hunter'?",
@@ -24349,7 +24349,7 @@
     "choices": [
       {
         "en": "a boy who secretly draws shojo manga",
-        "ja": "ひそかにしょうじょまんがをかくしょうねん",
+        "ja": "密かに少女漫画を書く少年",
         "ja_typings": [
           "hisokanishojomangaokakushonen",
           "hisokanishoujomangaokakushounen"
@@ -24357,14 +24357,14 @@
       },
       {
         "en": "a monthly manga magazine",
-        "ja": "げっかんのまんがざっし",
+        "ja": "月刊の漫画雑誌",
         "ja_typings": [
           "gekkannomangazasshi"
         ]
       },
       {
         "en": "a shonen manga artist's life",
-        "ja": "しょうねんまんがかのせいかつ",
+        "ja": "少年漫画家の生活",
         "ja_typings": [
           "shonenmangakanoseikatsu",
           "shounenmangakanoseikatsu"
@@ -24372,7 +24372,7 @@
       },
       {
         "en": "a manga club in school",
-        "ja": "がっこうのまんがぶ",
+        "ja": "学校の漫画部",
         "ja_typings": [
           "gakkonomangabu",
           "gakkounomangabu"
@@ -24385,7 +24385,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'Gekkan Shounen Nozaki-kun' about?",
-      "ja": "『月刊少年ノ崎くん』は、どのような物語ですか？"
+      "ja": "「月刊少年の崎くん」は何についてか？"
     },
     "question_text_reading": {
       "en": "What is 'Gekkan Shounen Nozaki-kun' about?",
@@ -24396,28 +24396,28 @@
     "choices": [
       {
         "en": "Hunter x Hunter",
-        "ja": "はんたーはんたー",
+        "ja": "ハンター×ハンター",
         "ja_typings": [
           "hantahanta"
         ]
       },
       {
         "en": "Yu Yu Hakusho",
-        "ja": "ゆゆはくしょ",
+        "ja": "幽遊白書",
         "ja_typings": [
           "yuyuhakusho"
         ]
       },
       {
         "en": "Fairy Tail",
-        "ja": "ふぇありーている",
+        "ja": "フェアリーテイル",
         "ja_typings": [
           "feariteiru"
         ]
       },
       {
         "en": "Magi",
-        "ja": "まぎ",
+        "ja": "マギ",
         "ja_typings": [
           "magi"
         ]
@@ -24429,7 +24429,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which manga ran from 1999 and features Gon Freecss as protagonist?",
-      "ja": "1999年から連載され、主人公がGon Freecssの漫画はどれ？"
+      "ja": "1999年から連載のゴン・フリークスが主人公の漫画は？"
     },
     "question_text_reading": {
       "en": "Which manga ran from 1999 and features Gon Freecss as protagonist?",
@@ -24440,28 +24440,28 @@
     "choices": [
       {
         "en": "four-panel comic strip",
-        "ja": "よんコマのまんが",
+        "ja": "四コマの漫画",
         "ja_typings": [
           "yonkomanomanga"
         ]
       },
       {
         "en": "manga with four main characters",
-        "ja": "しにんのメインキャラのまんが",
+        "ja": "死人のメインキャラの漫画",
         "ja_typings": [
           "shininnomeinkyaranomanga"
         ]
       },
       {
         "en": "manga spanning four volumes",
-        "ja": "よんかんのまんが",
+        "ja": "四巻の漫画",
         "ja_typings": [
           "yonkannomanga"
         ]
       },
       {
         "en": "manga about four seasons",
-        "ja": "しきのまんが",
+        "ja": "四季のマンガ",
         "ja_typings": [
           "shikinomanga"
         ]
@@ -24473,7 +24473,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'yonkoma' manga?",
-      "ja": "よんコマ漫画とは、どのようなものですか？"
+      "ja": "四コマ漫画とは何か？"
     },
     "question_text_reading": {
       "en": "What is 'yonkoma' manga?",
@@ -24484,14 +24484,14 @@
     "choices": [
       {
         "en": "iyashikei (healing/soothing) manga",
-        "ja": "いやしけい（ほっこり）まんが",
+        "ja": "癒し系（ほっこり）マンガ",
         "ja_typings": [
           "iyashikei hokkori manga"
         ]
       },
       {
         "en": "action shonen",
-        "ja": "あくしょんしょうねん",
+        "ja": "アクション少年",
         "ja_typings": [
           "akushonshonen",
           "akushonshounen"
@@ -24499,14 +24499,14 @@
       },
       {
         "en": "sports manga",
-        "ja": "すぽーつまんが",
+        "ja": "スポーツマンガ",
         "ja_typings": [
           "supotsumanga"
         ]
       },
       {
         "en": "horror manga",
-        "ja": "ほらーまんが",
+        "ja": "ホラーマンガ",
         "ja_typings": [
           "horamanga"
         ]
@@ -24518,7 +24518,7 @@
     "image_path": null,
     "question_text": {
       "en": "What type of manga is 'Yuru Camp'?",
-      "ja": "『ゆるキャン△』はどのようなジャンルの漫画ですか？"
+      "ja": "ゆるキャンの漫画の種類は？"
     },
     "question_text_reading": {
       "en": "What type of manga is 'Yuru Camp'?",
@@ -24529,14 +24529,14 @@
     "choices": [
       {
         "en": "Hiro Mashima",
-        "ja": "ましまひろ",
+        "ja": "真島広",
         "ja_typings": [
           "mashimahiro"
         ]
       },
       {
         "en": "Eiichiro Oda",
-        "ja": "おだえいいちろう",
+        "ja": "織田栄一郎",
         "ja_typings": [
           "odaeiichiro",
           "odaeiichirou"
@@ -24544,14 +24544,14 @@
       },
       {
         "en": "Masashi Kishimoto",
-        "ja": "きしもとまさし",
+        "ja": "岸本正史",
         "ja_typings": [
           "kishimotomasashi"
         ]
       },
       {
         "en": "Yoshihiro Togashi",
-        "ja": "とがしよしひろ",
+        "ja": "東城義弘",
         "ja_typings": [
           "togashiyoshihiro"
         ]
@@ -24581,14 +24581,14 @@
       },
       {
         "en": "Sailor Moon",
-        "ja": "せーらーむーん",
+        "ja": "セーラー・ムーン",
         "ja_typings": [
           "seramun"
         ]
       },
       {
         "en": "Ouran High School Host Club",
-        "ja": "おうらんこうこうホストクラブ",
+        "ja": "桜蘭高校ホストクラブ",
         "ja_typings": [
           "orankokohosutokurabu",
           "ourankoukouhosutokurabu"
@@ -24596,7 +24596,7 @@
       },
       {
         "en": "Fruits Basket",
-        "ja": "ふるーつばすけっと",
+        "ja": "フルーツバスケット",
         "ja_typings": [
           "furutsubasuketto"
         ]
@@ -24608,7 +24608,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the famous manga by CLAMP?",
-      "ja": "CLAMPによる有名な漫画作品は何ですか？"
+      "ja": "CLAMPの有名な漫画は？"
     },
     "question_text_reading": {
       "en": "What is the famous manga by CLAMP?",
@@ -24619,7 +24619,7 @@
     "choices": [
       {
         "en": "mature themes for adult men",
-        "ja": "せいじんだんせいのためのおとなのテーマ",
+        "ja": "成人男性のためのテーマ",
         "ja_typings": [
           "seijindanseinotamenotonanotema",
           "seijindanseinotamenootonanotema"
@@ -24627,7 +24627,7 @@
       },
       {
         "en": "school romance stories",
-        "ja": "がっこうのれんあいはなし",
+        "ja": "学校の恋愛話",
         "ja_typings": [
           "gakkonorenaihanashi",
           "gakkounorenaihanashi"
@@ -24635,7 +24635,7 @@
       },
       {
         "en": "magical girl themes",
-        "ja": "まほうしょうじょテーマ",
+        "ja": "魔法少女テーマ",
         "ja_typings": [
           "mahoshojotema",
           "mahoushoujotema"
@@ -24643,7 +24643,7 @@
       },
       {
         "en": "tournament battle arcs",
-        "ja": "たいかいばとるへん",
+        "ja": "大会バトルアークス",
         "ja_typings": [
           "taikaibatoruhen"
         ]
@@ -24655,7 +24655,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'Seinen' manga known for?",
-      "ja": "青年（せいねん）向け漫画は、どのようなジャンルで知られているだろうか？"
+      "ja": "青年漫画は何で有名か？"
     },
     "question_text_reading": {
       "en": "What is 'Seinen' manga known for?",
@@ -24666,21 +24666,21 @@
     "choices": [
       {
         "en": "distinctive flamboyant art style",
-        "ja": "どくとくのはなやかなえのスタイル",
+        "ja": "独特な華やかな絵のスタイル",
         "ja_typings": [
           "dokutokunohanayakanaenosutairu"
         ]
       },
       {
         "en": "simple minimalist drawing",
-        "ja": "かんたんなミニマリストのえ",
+        "ja": "簡単なミニマリストの絵",
         "ja_typings": [
           "kantannaminimarisutonoe"
         ]
       },
       {
         "en": "realistic photo-like art",
-        "ja": "しゃしんのようなリアルなえ",
+        "ja": "写真のようなリアルな絵",
         "ja_typings": [
           "shashinnoyonariarunae",
           "shashinnoyounariarunae"
@@ -24688,7 +24688,7 @@
       },
       {
         "en": "abstract expressionist style",
-        "ja": "ちゅうしょうひょうげんしゅぎのスタイル",
+        "ja": "抽象表現主義のスタイル",
         "ja_typings": [
           "chuushohyogenshuginosutairu",
           "chuushouhyougenshuginosutairu"
@@ -24701,7 +24701,7 @@
     "image_path": null,
     "question_text": {
       "en": "What makes Hirohiko Araki unique as a manga artist?",
-      "ja": "漫画家として荒木飛呂彦の独自性はどこにあるだろうか？"
+      "ja": "漫画家としての荒木飛呂彦の特長は？"
     },
     "question_text_reading": {
       "en": "What makes Hirohiko Araki unique as a manga artist?",
@@ -24712,28 +24712,28 @@
     "choices": [
       {
         "en": "Paris",
-        "ja": "ぱり",
+        "ja": "パリ",
         "ja_typings": [
           "pari"
         ]
       },
       {
         "en": "Lyon",
-        "ja": "りよん",
+        "ja": "リヨン",
         "ja_typings": [
           "riyon"
         ]
       },
       {
         "en": "Marseille",
-        "ja": "まるせいゆ",
+        "ja": "マルセイユ",
         "ja_typings": [
           "maruseiyu"
         ]
       },
       {
         "en": "Nice",
-        "ja": "にーす",
+        "ja": "ニース",
         "ja_typings": [
           "nisu"
         ]
@@ -24745,7 +24745,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of France?",
-      "ja": "フランスの首都はどこですか？"
+      "ja": "フランスの首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of France?",
@@ -24756,7 +24756,7 @@
     "choices": [
       {
         "en": "Tokyo",
-        "ja": "とうきょう",
+        "ja": "東京",
         "ja_typings": [
           "tokyo",
           "toukyou"
@@ -24764,7 +24764,7 @@
       },
       {
         "en": "Osaka",
-        "ja": "おおさか",
+        "ja": "大阪",
         "ja_typings": [
           "osaka",
           "oosaka"
@@ -24772,7 +24772,7 @@
       },
       {
         "en": "Kyoto",
-        "ja": "きょうと",
+        "ja": "京都",
         "ja_typings": [
           "kyoto",
           "kyouto"
@@ -24780,7 +24780,7 @@
       },
       {
         "en": "Nagoya",
-        "ja": "なごや",
+        "ja": "名古屋",
         "ja_typings": [
           "nagoya"
         ]
@@ -24792,7 +24792,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Japan?",
-      "ja": "日本の首都はどこですか？"
+      "ja": "日本の首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of Japan?",
@@ -24803,28 +24803,28 @@
     "choices": [
       {
         "en": "Russia",
-        "ja": "ろしあ",
+        "ja": "ロシア",
         "ja_typings": [
           "roshia"
         ]
       },
       {
         "en": "Canada",
-        "ja": "かなだ",
+        "ja": "カナダ",
         "ja_typings": [
           "kanada"
         ]
       },
       {
         "en": "China",
-        "ja": "ちゅうごく",
+        "ja": "中国",
         "ja_typings": [
           "chuugoku"
         ]
       },
       {
         "en": "United States",
-        "ja": "あめりか",
+        "ja": "アメリカ",
         "ja_typings": [
           "amerika"
         ]
@@ -24836,7 +24836,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the largest country by area?",
-      "ja": "面積が最も大きい国はどこですか？"
+      "ja": "面積がもっともおおきい国は？"
     },
     "question_text_reading": {
       "en": "What is the largest country by area?",
@@ -24847,21 +24847,21 @@
     "choices": [
       {
         "en": "Nile",
-        "ja": "ないる",
+        "ja": "ナイル",
         "ja_typings": [
           "nairu"
         ]
       },
       {
         "en": "Amazon",
-        "ja": "あまぞん",
+        "ja": "Amazon",
         "ja_typings": [
           "amazon"
         ]
       },
       {
         "en": "Yangtze",
-        "ja": "ようすこう",
+        "ja": "揚子江",
         "ja_typings": [
           "yosuko",
           "yousukou"
@@ -24869,7 +24869,7 @@
       },
       {
         "en": "Mississippi",
-        "ja": "みししっぴ",
+        "ja": "ミシシッピ",
         "ja_typings": [
           "mishishippi"
         ]
@@ -24881,7 +24881,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the longest river in the world?",
-      "ja": "世界で最も長い川は何ですか？"
+      "ja": "世界で最も長い川は？"
     },
     "question_text_reading": {
       "en": "What is the longest river in the world?",
@@ -24892,28 +24892,28 @@
     "choices": [
       {
         "en": "Mount Everest",
-        "ja": "えべれすとさん",
+        "ja": "エベレスト山",
         "ja_typings": [
           "eberesutosan"
         ]
       },
       {
         "en": "K2",
-        "ja": "けーつー",
+        "ja": "K2",
         "ja_typings": [
           "ketsu"
         ]
       },
       {
         "en": "Kangchenjunga",
-        "ja": "かんちぇんじゅんがさん",
+        "ja": "カンチェンジュンガ",
         "ja_typings": [
           "kanchenjungasan"
         ]
       },
       {
         "en": "Mont Blanc",
-        "ja": "もんぶらん",
+        "ja": "モンブラン",
         "ja_typings": [
           "monburan"
         ]
@@ -24925,7 +24925,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the highest mountain in the world?",
-      "ja": "世界で最も高い山は何ですか？"
+      "ja": "世界で最も高い山は？"
     },
     "question_text_reading": {
       "en": "What is the highest mountain in the world?",
@@ -24936,21 +24936,21 @@
     "choices": [
       {
         "en": "Africa",
-        "ja": "あふりか",
+        "ja": "アフリカ",
         "ja_typings": [
           "afurika"
         ]
       },
       {
         "en": "Asia",
-        "ja": "あじあ",
+        "ja": "アジア",
         "ja_typings": [
           "ajia"
         ]
       },
       {
         "en": "Middle East",
-        "ja": "ちゅうとう",
+        "ja": "中東",
         "ja_typings": [
           "chuuto",
           "chuutou"
@@ -24958,7 +24958,7 @@
       },
       {
         "en": "Europe",
-        "ja": "えーろっぱ",
+        "ja": "ヨーロッパ",
         "ja_typings": [
           "eroppa"
         ]
@@ -24970,7 +24970,7 @@
     "image_path": null,
     "question_text": {
       "en": "What continent is Egypt in?",
-      "ja": "エジプトはどの大陸に位置していますか？"
+      "ja": "エジプトはどの大陸にあるか？"
     },
     "question_text_reading": {
       "en": "What continent is Egypt in?",
@@ -24981,28 +24981,28 @@
     "choices": [
       {
         "en": "Berlin",
-        "ja": "べるりん",
+        "ja": "ベルリン",
         "ja_typings": [
           "berurin"
         ]
       },
       {
         "en": "Munich",
-        "ja": "みゅんへん",
+        "ja": "ミュンヘン",
         "ja_typings": [
           "myunhen"
         ]
       },
       {
         "en": "Hamburg",
-        "ja": "はんぶるく",
+        "ja": "ハンブルク",
         "ja_typings": [
           "hanburuku"
         ]
       },
       {
         "en": "Frankfurt",
-        "ja": "ふらんくふると",
+        "ja": "フランクフルト",
         "ja_typings": [
           "furankufuruto"
         ]
@@ -25014,7 +25014,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Germany?",
-      "ja": "ドイツの首都はどこですか？"
+      "ja": "ドイツの首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of Germany?",
@@ -25025,7 +25025,7 @@
     "choices": [
       {
         "en": "Atlantic Ocean",
-        "ja": "たいせいよう",
+        "ja": "大西洋",
         "ja_typings": [
           "taiseiyo",
           "taiseiyou"
@@ -25033,7 +25033,7 @@
       },
       {
         "en": "Pacific Ocean",
-        "ja": "たいへいよう",
+        "ja": "太平洋",
         "ja_typings": [
           "taiheiyo",
           "taiheiyou"
@@ -25041,7 +25041,7 @@
       },
       {
         "en": "Indian Ocean",
-        "ja": "いんどよう",
+        "ja": "インド洋",
         "ja_typings": [
           "indoyo",
           "indoyou"
@@ -25049,7 +25049,7 @@
       },
       {
         "en": "Southern Ocean",
-        "ja": "なんきょくかい",
+        "ja": "南極海",
         "ja_typings": [
           "nankyokukai"
         ]
@@ -25061,7 +25061,7 @@
     "image_path": null,
     "question_text": {
       "en": "What ocean separates Africa from South America?",
-      "ja": "アフリカ大陸と南米大陸を隔てている海はどこですか？"
+      "ja": "アフリカと南アメリカを隔てる海は？"
     },
     "question_text_reading": {
       "en": "What ocean separates Africa from South America?",
@@ -25072,28 +25072,28 @@
     "choices": [
       {
         "en": "Canberra",
-        "ja": "きゃんべら",
+        "ja": "キャンベラ",
         "ja_typings": [
           "kyanbera"
         ]
       },
       {
         "en": "Sydney",
-        "ja": "しどにー",
+        "ja": "シドニー",
         "ja_typings": [
           "shidoni"
         ]
       },
       {
         "en": "Melbourne",
-        "ja": "めるぼるん",
+        "ja": "メルボルン",
         "ja_typings": [
           "meruborun"
         ]
       },
       {
         "en": "Brisbane",
-        "ja": "ぶりずべん",
+        "ja": "ブリスベン",
         "ja_typings": [
           "burizuben"
         ]
@@ -25105,7 +25105,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Australia?",
-      "ja": "オーストラリアの首都はどこですか？"
+      "ja": "オーストラリアの首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of Australia?",
@@ -25116,28 +25116,28 @@
     "choices": [
       {
         "en": "Vatican City",
-        "ja": "ばちかんし",
+        "ja": "バチカン市国",
         "ja_typings": [
           "bachikanshi"
         ]
       },
       {
         "en": "Monaco",
-        "ja": "もなこ",
+        "ja": "モナコ",
         "ja_typings": [
           "monako"
         ]
       },
       {
         "en": "San Marino",
-        "ja": "さんまりの",
+        "ja": "サンマリノ",
         "ja_typings": [
           "sanmarino"
         ]
       },
       {
         "en": "Liechtenstein",
-        "ja": "りひてんしゅたいん",
+        "ja": "リヒテンシュタイン",
         "ja_typings": [
           "rihitenshutain"
         ]
@@ -25149,7 +25149,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the smallest country in the world?",
-      "ja": "世界で最も面積が小さい国はどこですか？"
+      "ja": "世界で最も小さい国は？"
     },
     "question_text_reading": {
       "en": "What is the smallest country in the world?",
@@ -25160,28 +25160,28 @@
     "choices": [
       {
         "en": "Brasilia",
-        "ja": "ぶらじりあ",
+        "ja": "ブラジリア",
         "ja_typings": [
           "burajiria"
         ]
       },
       {
         "en": "Rio de Janeiro",
-        "ja": "りおでじゃねいろ",
+        "ja": "リオデジャネイロ",
         "ja_typings": [
           "riodejaneiro"
         ]
       },
       {
         "en": "São Paulo",
-        "ja": "さんぱうろ",
+        "ja": "サンパウロ",
         "ja_typings": [
           "sanpauro"
         ]
       },
       {
         "en": "Salvador",
-        "ja": "さるばどーる",
+        "ja": "サルバドール",
         "ja_typings": [
           "sarubadoru"
         ]
@@ -25193,7 +25193,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Brazil?",
-      "ja": "ブラジルの首都はどこですか？"
+      "ja": "ブラジルの首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of Brazil?",
@@ -25204,28 +25204,28 @@
     "choices": [
       {
         "en": "Beijing",
-        "ja": "ぺきん",
+        "ja": "北京",
         "ja_typings": [
           "pekin"
         ]
       },
       {
         "en": "Shanghai",
-        "ja": "しゃんはい",
+        "ja": "上海",
         "ja_typings": [
           "shanhai"
         ]
       },
       {
         "en": "Hong Kong",
-        "ja": "ほんこん",
+        "ja": "香港",
         "ja_typings": [
           "honkon"
         ]
       },
       {
         "en": "Guangzhou",
-        "ja": "こうしゅう",
+        "ja": "広州",
         "ja_typings": [
           "koshuu",
           "koushuu"
@@ -25238,7 +25238,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of China?",
-      "ja": "中国の首都はどこですか？"
+      "ja": "中国の首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of China?",
@@ -25249,28 +25249,28 @@
     "choices": [
       {
         "en": "Sahara",
-        "ja": "さはら",
+        "ja": "サハラ",
         "ja_typings": [
           "sahara"
         ]
       },
       {
         "en": "Arabian",
-        "ja": "あらびあ",
+        "ja": "アラビア",
         "ja_typings": [
           "arabia"
         ]
       },
       {
         "en": "Gobi",
-        "ja": "ごび",
+        "ja": "ゴビ",
         "ja_typings": [
           "gobi"
         ]
       },
       {
         "en": "Antarctic",
-        "ja": "なんきょく",
+        "ja": "南極",
         "ja_typings": [
           "nankyoku"
         ]
@@ -25282,7 +25282,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the largest desert in the world?",
-      "ja": "世界で最も広い砂漠はどこですか？"
+      "ja": "世界で最も大きい砂漠は？"
     },
     "question_text_reading": {
       "en": "What is the largest desert in the world?",
@@ -25293,28 +25293,28 @@
     "choices": [
       {
         "en": "7",
-        "ja": "なな",
+        "ja": "七",
         "ja_typings": [
           "nana"
         ]
       },
       {
         "en": "5",
-        "ja": "ご",
+        "ja": "五",
         "ja_typings": [
           "go"
         ]
       },
       {
         "en": "6",
-        "ja": "ろく",
+        "ja": "六",
         "ja_typings": [
           "roku"
         ]
       },
       {
         "en": "8",
-        "ja": "はち",
+        "ja": "八",
         "ja_typings": [
           "hachi"
         ]
@@ -25326,7 +25326,7 @@
     "image_path": null,
     "question_text": {
       "en": "How many continents are there?",
-      "ja": "地球上には何大陸ありますか？"
+      "ja": "大陸はいくつあるか？"
     },
     "question_text_reading": {
       "en": "How many continents are there?",
@@ -25337,28 +25337,28 @@
     "choices": [
       {
         "en": "Washington D.C.",
-        "ja": "わしんとんでぃーしー",
+        "ja": "ワシントンD.C",
         "ja_typings": [
           "washintondishi"
         ]
       },
       {
         "en": "New York",
-        "ja": "にゅーよーく",
+        "ja": "ニューヨーク",
         "ja_typings": [
           "nyuyoku"
         ]
       },
       {
         "en": "Los Angeles",
-        "ja": "ろさんぜるす",
+        "ja": "ロサンゼルス",
         "ja_typings": [
           "rosanzerusu"
         ]
       },
       {
         "en": "Chicago",
-        "ja": "しかご",
+        "ja": "シカゴ",
         "ja_typings": [
           "shikago"
         ]
@@ -25370,7 +25370,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of the USA?",
-      "ja": "アメリカのしゅとは？"
+      "ja": "アメリカの首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of the USA?",
@@ -25381,28 +25381,28 @@
     "choices": [
       {
         "en": "Rome",
-        "ja": "ろーま",
+        "ja": "ローマ",
         "ja_typings": [
           "roma"
         ]
       },
       {
         "en": "Milan",
-        "ja": "みらの",
+        "ja": "ミラノ",
         "ja_typings": [
           "mirano"
         ]
       },
       {
         "en": "Naples",
-        "ja": "なぽり",
+        "ja": "ナポリ",
         "ja_typings": [
           "napori"
         ]
       },
       {
         "en": "Florence",
-        "ja": "ふぃれんつぇ",
+        "ja": "フィレンツェ",
         "ja_typings": [
           "firentse"
         ]
@@ -25414,7 +25414,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Italy?",
-      "ja": "イタリアの首都はどこですか？"
+      "ja": "イタリアの首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of Italy?",
@@ -25425,28 +25425,28 @@
     "choices": [
       {
         "en": "Madrid",
-        "ja": "まどりーど",
+        "ja": "マドリード",
         "ja_typings": [
           "madorido"
         ]
       },
       {
         "en": "Barcelona",
-        "ja": "ばるせろな",
+        "ja": "バルセロナ",
         "ja_typings": [
           "baruserona"
         ]
       },
       {
         "en": "Seville",
-        "ja": "せびりあ",
+        "ja": "セビリア",
         "ja_typings": [
           "sebiria"
         ]
       },
       {
         "en": "Valencia",
-        "ja": "ばれんしあ",
+        "ja": "バレンシア",
         "ja_typings": [
           "barenshia"
         ]
@@ -25458,7 +25458,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Spain?",
-      "ja": "スペインの首都はどこですか？"
+      "ja": "スペインの首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of Spain?",
@@ -25469,28 +25469,28 @@
     "choices": [
       {
         "en": "Ottawa",
-        "ja": "おたわ",
+        "ja": "オタワ",
         "ja_typings": [
           "otawa"
         ]
       },
       {
         "en": "Toronto",
-        "ja": "とろんと",
+        "ja": "トロント",
         "ja_typings": [
           "toronto"
         ]
       },
       {
         "en": "Vancouver",
-        "ja": "ばんくーばー",
+        "ja": "バンクーバー",
         "ja_typings": [
           "bankuba"
         ]
       },
       {
         "en": "Montreal",
-        "ja": "もんとりおーる",
+        "ja": "モントリオール",
         "ja_typings": [
           "montorioru"
         ]
@@ -25502,7 +25502,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Canada?",
-      "ja": "カナダの首都はどこですか？"
+      "ja": "カナダの首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of Canada?",
@@ -25513,28 +25513,28 @@
     "choices": [
       {
         "en": "Moscow",
-        "ja": "もすくわ",
+        "ja": "モスクワ",
         "ja_typings": [
           "mosukuwa"
         ]
       },
       {
         "en": "Saint Petersburg",
-        "ja": "さんくとぺてるぶるく",
+        "ja": "サンクトペテルブルク",
         "ja_typings": [
           "sankutopeteruburuku"
         ]
       },
       {
         "en": "Novosibirsk",
-        "ja": "のぼしびるすく",
+        "ja": "ノボシビルスク",
         "ja_typings": [
           "noboshibirusuku"
         ]
       },
       {
         "en": "Vladivostok",
-        "ja": "うらじおすとく",
+        "ja": "Владивосток",
         "ja_typings": [
           "urajiosutoku"
         ]
@@ -25546,7 +25546,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Russia?",
-      "ja": "ロシアの首都はどこですか？"
+      "ja": "ロシアの首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of Russia?",
@@ -25557,7 +25557,7 @@
     "choices": [
       {
         "en": "Seoul",
-        "ja": "そうる",
+        "ja": "ソウル",
         "ja_typings": [
           "soru",
           "souru"
@@ -25565,21 +25565,21 @@
       },
       {
         "en": "Busan",
-        "ja": "ぷさん",
+        "ja": "釜山",
         "ja_typings": [
           "pusan"
         ]
       },
       {
         "en": "Incheon",
-        "ja": "いんちぇおん",
+        "ja": "仁川",
         "ja_typings": [
           "incheon"
         ]
       },
       {
         "en": "Daegu",
-        "ja": "てぐ",
+        "ja": "大邱",
         "ja_typings": [
           "tegu"
         ]
@@ -25591,7 +25591,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of South Korea?",
-      "ja": "韓国の首都はどこですか？"
+      "ja": "韓国の首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of South Korea?",
@@ -25602,28 +25602,28 @@
     "choices": [
       {
         "en": "New Delhi",
-        "ja": "にゅーでりー",
+        "ja": "ニューデリー",
         "ja_typings": [
           "nyuderi"
         ]
       },
       {
         "en": "Mumbai",
-        "ja": "むんばい",
+        "ja": "ムンバイ",
         "ja_typings": [
           "munbai"
         ]
       },
       {
         "en": "Kolkata",
-        "ja": "こるかた",
+        "ja": "コルカタ",
         "ja_typings": [
           "korukata"
         ]
       },
       {
         "en": "Chennai",
-        "ja": "ちぇんない",
+        "ja": "チェンナイ",
         "ja_typings": [
           "chennai"
         ]
@@ -25635,7 +25635,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of India?",
-      "ja": "インドの首都はどこですか？"
+      "ja": "インドの首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of India?",
@@ -25646,28 +25646,28 @@
     "choices": [
       {
         "en": "Mexico City",
-        "ja": "めきしこしてぃー",
+        "ja": "メキシコシティ",
         "ja_typings": [
           "mekishikoshiti"
         ]
       },
       {
         "en": "Guadalajara",
-        "ja": "ぐあだらはら",
+        "ja": "グアダラハラ",
         "ja_typings": [
           "guadarahara"
         ]
       },
       {
         "en": "Monterrey",
-        "ja": "もんてれー",
+        "ja": "モンテレイ",
         "ja_typings": [
           "montere"
         ]
       },
       {
         "en": "Tijuana",
-        "ja": "てぃふあな",
+        "ja": "ティフアナ",
         "ja_typings": [
           "tifuana"
         ]
@@ -25679,7 +25679,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Mexico?",
-      "ja": "メキシコの首都はどこですか？"
+      "ja": "メキシコの首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of Mexico?",
@@ -25690,28 +25690,28 @@
     "choices": [
       {
         "en": "France",
-        "ja": "ふらんす",
+        "ja": "フランス",
         "ja_typings": [
           "furansu"
         ]
       },
       {
         "en": "Germany",
-        "ja": "どいつ",
+        "ja": "ドイツ",
         "ja_typings": [
           "doitsu"
         ]
       },
       {
         "en": "Italy",
-        "ja": "いたりあ",
+        "ja": "イタリア",
         "ja_typings": [
           "itaria"
         ]
       },
       {
         "en": "Belgium",
-        "ja": "べるぎー",
+        "ja": "ベルギー",
         "ja_typings": [
           "berugi"
         ]
@@ -25723,7 +25723,7 @@
     "image_path": null,
     "question_text": {
       "en": "What country has the Eiffel Tower?",
-      "ja": "エッフェル塔がある国はどこでしょう？"
+      "ja": "エッフェル塔はどの国にあるか？"
     },
     "question_text_reading": {
       "en": "What country has the Eiffel Tower?",
@@ -25734,28 +25734,28 @@
     "choices": [
       {
         "en": "Italy",
-        "ja": "いたりあ",
+        "ja": "イタリア",
         "ja_typings": [
           "itaria"
         ]
       },
       {
         "en": "Greece",
-        "ja": "ぎりしあ",
+        "ja": "ギリシャ",
         "ja_typings": [
           "girishia"
         ]
       },
       {
         "en": "Spain",
-        "ja": "すぺいん",
+        "ja": "スペイン",
         "ja_typings": [
           "supein"
         ]
       },
       {
         "en": "Turkey",
-        "ja": "とるこ",
+        "ja": "トルコ",
         "ja_typings": [
           "toruko"
         ]
@@ -25767,7 +25767,7 @@
     "image_path": null,
     "question_text": {
       "en": "What country has the Colosseum?",
-      "ja": "コロッセオがある国はどこですか？"
+      "ja": "コロッセオはどの国にあるか？"
     },
     "question_text_reading": {
       "en": "What country has the Colosseum?",
@@ -25778,28 +25778,28 @@
     "choices": [
       {
         "en": "Brazil",
-        "ja": "ぶらじる",
+        "ja": "ブラジル",
         "ja_typings": [
           "burajiru"
         ]
       },
       {
         "en": "Peru",
-        "ja": "ぺるー",
+        "ja": "ペルー",
         "ja_typings": [
           "peru"
         ]
       },
       {
         "en": "Colombia",
-        "ja": "ころんびあ",
+        "ja": "コロンビア",
         "ja_typings": [
           "koronbia"
         ]
       },
       {
         "en": "Venezuela",
-        "ja": "べねずえら",
+        "ja": "ベネズエラ",
         "ja_typings": [
           "benezuera"
         ]
@@ -25811,7 +25811,7 @@
     "image_path": null,
     "question_text": {
       "en": "What country is the Amazon rainforest mostly in?",
-      "ja": "アマゾン熱帯雨林は、主にどの国に位置していますか？"
+      "ja": "アマゾン熱帯雨林は主にどの国にあるか？"
     },
     "question_text_reading": {
       "en": "What country is the Amazon rainforest mostly in?",
@@ -25822,14 +25822,14 @@
     "choices": [
       {
         "en": "Mediterranean Sea",
-        "ja": "ちちゅうかい",
+        "ja": "地中海",
         "ja_typings": [
           "chichuukai"
         ]
       },
       {
         "en": "Red Sea",
-        "ja": "こうかい",
+        "ja": "紅海",
         "ja_typings": [
           "kokai",
           "koukai"
@@ -25837,14 +25837,14 @@
       },
       {
         "en": "Black Sea",
-        "ja": "こっかい",
+        "ja": "黒海",
         "ja_typings": [
           "kokkai"
         ]
       },
       {
         "en": "Caspian Sea",
-        "ja": "かすぴかい",
+        "ja": "カスピ海",
         "ja_typings": [
           "kasupikai"
         ]
@@ -25856,7 +25856,7 @@
     "image_path": null,
     "question_text": {
       "en": "What sea is between Europe and Africa?",
-      "ja": "ヨーロッパとアフリカの間にある海はどこですか？"
+      "ja": "ヨーロッパとアフリカの間の海は？"
     },
     "question_text_reading": {
       "en": "What sea is between Europe and Africa?",
@@ -25867,28 +25867,28 @@
     "choices": [
       {
         "en": "Ecuador",
-        "ja": "えくあどる",
+        "ja": "エクアドル",
         "ja_typings": [
           "ekuadoru"
         ]
       },
       {
         "en": "Peru",
-        "ja": "ぺるー",
+        "ja": "ペルー",
         "ja_typings": [
           "peru"
         ]
       },
       {
         "en": "Colombia",
-        "ja": "ころんびあ",
+        "ja": "コロンビア",
         "ja_typings": [
           "koronbia"
         ]
       },
       {
         "en": "Chile",
-        "ja": "ちり",
+        "ja": "チリ",
         "ja_typings": [
           "chiri"
         ]
@@ -25900,7 +25900,7 @@
     "image_path": null,
     "question_text": {
       "en": "What country owns the Galapagos Islands?",
-      "ja": "ガラパゴス諸島はどの国の領土ですか？"
+      "ja": "ガラパゴス諸島はどの国の領土か？"
     },
     "question_text_reading": {
       "en": "What country owns the Galapagos Islands?",
@@ -25911,28 +25911,28 @@
     "choices": [
       {
         "en": "Andes",
-        "ja": "あんです",
+        "ja": "アンデス",
         "ja_typings": [
           "andesu"
         ]
       },
       {
         "en": "Himalayas",
-        "ja": "ひまらや",
+        "ja": "ヒマラヤ",
         "ja_typings": [
           "himaraya"
         ]
       },
       {
         "en": "Rockies",
-        "ja": "ろっきー",
+        "ja": "ロッキー",
         "ja_typings": [
           "rokki"
         ]
       },
       {
         "en": "Alps",
-        "ja": "あるぷす",
+        "ja": "アルプス",
         "ja_typings": [
           "arupusu"
         ]
@@ -25944,7 +25944,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the longest mountain range?",
-      "ja": "世界で最も長い山脈は何ですか？"
+      "ja": "世界で最も長い山脈は？"
     },
     "question_text_reading": {
       "en": "What is the longest mountain range?",
@@ -25955,28 +25955,28 @@
     "choices": [
       {
         "en": "Lake Baikal",
-        "ja": "ばいかるこ",
+        "ja": "バイカル湖",
         "ja_typings": [
           "baikaruko"
         ]
       },
       {
         "en": "Lake Superior",
-        "ja": "すぺりおるこ",
+        "ja": "レイク・スピリオル",
         "ja_typings": [
           "superioruko"
         ]
       },
       {
         "en": "Caspian Sea",
-        "ja": "かすぴかい",
+        "ja": "カスピ海",
         "ja_typings": [
           "kasupikai"
         ]
       },
       {
         "en": "Crater Lake",
-        "ja": "くれーたーれいく",
+        "ja": "クレーターレイク",
         "ja_typings": [
           "kuretareiku"
         ]
@@ -25988,7 +25988,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the deepest lake in the world?",
-      "ja": "世界で最も深い湖の名前は何ですか？"
+      "ja": "世界で最も深い湖は？"
     },
     "question_text_reading": {
       "en": "What is the deepest lake in the world?",
@@ -25999,28 +25999,28 @@
     "choices": [
       {
         "en": "China",
-        "ja": "ちゅうごく",
+        "ja": "中国",
         "ja_typings": [
           "chuugoku"
         ]
       },
       {
         "en": "Australia",
-        "ja": "おーすとらりあ",
+        "ja": "オーストラリア",
         "ja_typings": [
           "osutoraria"
         ]
       },
       {
         "en": "Brazil",
-        "ja": "ぶらじる",
+        "ja": "ブラジル",
         "ja_typings": [
           "burajiru"
         ]
       },
       {
         "en": "Russia",
-        "ja": "ろしあ",
+        "ja": "ロシア",
         "ja_typings": [
           "roshia"
         ]
@@ -26032,7 +26032,7 @@
     "image_path": null,
     "question_text": {
       "en": "What country has the most natural UNESCO World Heritage Sites?",
-      "ja": "自然のUNESCO世界遺産が最も多い国はどこでしょう？"
+      "ja": "自然のユネスコ世界遺産がもっとも多い国は？"
     },
     "question_text_reading": {
       "en": "What country has the most natural UNESCO World Heritage Sites?",
@@ -26043,7 +26043,7 @@
     "choices": [
       {
         "en": "Pacific Ocean",
-        "ja": "たいへいよう",
+        "ja": "太平洋",
         "ja_typings": [
           "taiheiyo",
           "taiheiyou"
@@ -26051,7 +26051,7 @@
       },
       {
         "en": "Atlantic Ocean",
-        "ja": "たいせいよう",
+        "ja": "大西洋",
         "ja_typings": [
           "taiseiyo",
           "taiseiyou"
@@ -26059,7 +26059,7 @@
       },
       {
         "en": "Indian Ocean",
-        "ja": "いんどよう",
+        "ja": "インド洋",
         "ja_typings": [
           "indoyo",
           "indoyou"
@@ -26067,7 +26067,7 @@
       },
       {
         "en": "Arctic Ocean",
-        "ja": "ほっきょくかい",
+        "ja": "北極海",
         "ja_typings": [
           "hokkyokukai"
         ]
@@ -26079,7 +26079,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the largest ocean?",
-      "ja": "世界で一番大きな海はどれでしょう？"
+      "ja": "最も大きい海は？"
     },
     "question_text_reading": {
       "en": "What is the largest ocean?",
@@ -26090,14 +26090,14 @@
     "choices": [
       {
         "en": "South America",
-        "ja": "みなみあめりか",
+        "ja": "南アメリカ",
         "ja_typings": [
           "minamiamerika"
         ]
       },
       {
         "en": "Central America",
-        "ja": "ちゅうおうあめりか",
+        "ja": "中央アメリカ",
         "ja_typings": [
           "chuuoamerika",
           "chuuouamerika"
@@ -26105,14 +26105,14 @@
       },
       {
         "en": "North America",
-        "ja": "きたあめりか",
+        "ja": "北アメリカ",
         "ja_typings": [
           "kitaamerika"
         ]
       },
       {
         "en": "Europe",
-        "ja": "えーろっぱ",
+        "ja": "ヨーロッパ",
         "ja_typings": [
           "eroppa"
         ]
@@ -26124,7 +26124,7 @@
     "image_path": null,
     "question_text": {
       "en": "What continent is Argentina in?",
-      "ja": "アルゼンチンはどの大陸に位置していますか？"
+      "ja": "アルゼンチンはどの大陸にあるか？"
     },
     "question_text_reading": {
       "en": "What continent is Argentina in?",
@@ -26135,28 +26135,28 @@
     "choices": [
       {
         "en": "Japan",
-        "ja": "にほん",
+        "ja": "日本",
         "ja_typings": [
           "nihon"
         ]
       },
       {
         "en": "China",
-        "ja": "ちゅうごく",
+        "ja": "中国",
         "ja_typings": [
           "chuugoku"
         ]
       },
       {
         "en": "South Korea",
-        "ja": "かんこく",
+        "ja": "韓国",
         "ja_typings": [
           "kankoku"
         ]
       },
       {
         "en": "Thailand",
-        "ja": "たいらんど",
+        "ja": "タイランド",
         "ja_typings": [
           "tairando"
         ]
@@ -26168,7 +26168,7 @@
     "image_path": null,
     "question_text": {
       "en": "What country is known as the Land of the Rising Sun?",
-      "ja": "日の出の国として知られる国はどこですか？"
+      "ja": "日の出の国といわれるのはどの国か？"
     },
     "question_text_reading": {
       "en": "What country is known as the Land of the Rising Sun?",
@@ -26179,28 +26179,28 @@
     "choices": [
       {
         "en": "Cairo",
-        "ja": "かいろ",
+        "ja": "カイロ",
         "ja_typings": [
           "kairo"
         ]
       },
       {
         "en": "Alexandria",
-        "ja": "あれくさんどりあ",
+        "ja": "アレクサンドリア",
         "ja_typings": [
           "arekusandoria"
         ]
       },
       {
         "en": "Luxor",
-        "ja": "るくそーる",
+        "ja": "ルクソール",
         "ja_typings": [
           "rukusoru"
         ]
       },
       {
         "en": "Aswan",
-        "ja": "あすわん",
+        "ja": "アスワン",
         "ja_typings": [
           "asuwan"
         ]
@@ -26212,7 +26212,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Egypt?",
-      "ja": "エジプトの首都はどこですか？"
+      "ja": "エジプトの首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of Egypt?",
@@ -26223,28 +26223,28 @@
     "choices": [
       {
         "en": "Ural Mountains",
-        "ja": "うらるさんみゃく",
+        "ja": "ウラル山脈",
         "ja_typings": [
           "urarusanmyaku"
         ]
       },
       {
         "en": "Himalayas",
-        "ja": "ひまらや",
+        "ja": "ヒマラヤ",
         "ja_typings": [
           "himaraya"
         ]
       },
       {
         "en": "Caucasus",
-        "ja": "こーかさすさんみゃく",
+        "ja": "コーカサス山脈",
         "ja_typings": [
           "kokasasusanmyaku"
         ]
       },
       {
         "en": "Alps",
-        "ja": "あるぷす",
+        "ja": "アルプス",
         "ja_typings": [
           "arupusu"
         ]
@@ -26256,7 +26256,7 @@
     "image_path": null,
     "question_text": {
       "en": "What mountain range separates Europe and Asia?",
-      "ja": "ヨーロッパとアジアを隔てている山脈はどれでしょう？"
+      "ja": "ヨーロッパとアジアを隔てる山脈は？"
     },
     "question_text_reading": {
       "en": "What mountain range separates Europe and Asia?",
@@ -26267,28 +26267,28 @@
     "choices": [
       {
         "en": "Australia",
-        "ja": "おーすとらりあ",
+        "ja": "オーストラリア",
         "ja_typings": [
           "osutoraria"
         ]
       },
       {
         "en": "Indonesia",
-        "ja": "いんどねしあ",
+        "ja": "インドネシア",
         "ja_typings": [
           "indoneshia"
         ]
       },
       {
         "en": "Philippines",
-        "ja": "ふぃりぴん",
+        "ja": "フィリピン",
         "ja_typings": [
           "firipin"
         ]
       },
       {
         "en": "Papua New Guinea",
-        "ja": "ぱぷあにゅーぎにあ",
+        "ja": "パプアニューギニア",
         "ja_typings": [
           "papuanyuginia"
         ]
@@ -26300,7 +26300,7 @@
     "image_path": null,
     "question_text": {
       "en": "What country has the Great Barrier Reef?",
-      "ja": "グレートバリアリーフはどのくににあるか？"
+      "ja": "グレートバリアリーフはどの国にあるか？"
     },
     "question_text_reading": {
       "en": "What country has the Great Barrier Reef?",
@@ -26311,28 +26311,28 @@
     "choices": [
       {
         "en": "Ankara",
-        "ja": "あんから",
+        "ja": "アンカラ",
         "ja_typings": [
           "ankara"
         ]
       },
       {
         "en": "Istanbul",
-        "ja": "いすたんぶーる",
+        "ja": "イスタンブール",
         "ja_typings": [
           "isutanburu"
         ]
       },
       {
         "en": "Izmir",
-        "ja": "いずみる",
+        "ja": "イズミル",
         "ja_typings": [
           "izumiru"
         ]
       },
       {
         "en": "Bursa",
-        "ja": "ぶるさ",
+        "ja": "ブルサ",
         "ja_typings": [
           "burusa"
         ]
@@ -26344,7 +26344,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Turkey?",
-      "ja": "トルコの首都はどこですか？"
+      "ja": "トルコのしゅとは？"
     },
     "question_text_reading": {
       "en": "What is the capital of Turkey?",
@@ -26355,28 +26355,28 @@
     "choices": [
       {
         "en": "Pretoria",
-        "ja": "ぷれとりあ",
+        "ja": "プレトリア",
         "ja_typings": [
           "puretoria"
         ]
       },
       {
         "en": "Cape Town",
-        "ja": "けいぷたうん",
+        "ja": "ケープタウン",
         "ja_typings": [
           "keiputaun"
         ]
       },
       {
         "en": "Johannesburg",
-        "ja": "よはねすばーぐ",
+        "ja": "ヨハネスブルグ",
         "ja_typings": [
           "yohanesubagu"
         ]
       },
       {
         "en": "Durban",
-        "ja": "だーばん",
+        "ja": "ダーバン",
         "ja_typings": [
           "daban"
         ]
@@ -26388,7 +26388,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of South Africa?",
-      "ja": "南アフリカの首都はどこですか？"
+      "ja": "南アフリカの首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of South Africa?",
@@ -26399,28 +26399,28 @@
     "choices": [
       {
         "en": "Multiple countries in North Africa",
-        "ja": "きたあふりかのふくすうのくに",
+        "ja": "北アフリカの複数の国",
         "ja_typings": [
           "kitaafurikanofukusuunokuni"
         ]
       },
       {
         "en": "Egypt only",
-        "ja": "えじぷとのみ",
+        "ja": "エジプトのみ",
         "ja_typings": [
           "ejiputonomi"
         ]
       },
       {
         "en": "Libya only",
-        "ja": "りびあのみ",
+        "ja": "リビアのみ",
         "ja_typings": [
           "ribianomi"
         ]
       },
       {
         "en": "Algeria only",
-        "ja": "あるじぇりあのみ",
+        "ja": "アルジェリアのみ",
         "ja_typings": [
           "arujerianomi"
         ]
@@ -26432,7 +26432,7 @@
     "image_path": null,
     "question_text": {
       "en": "What country is the Sahara Desert mostly in?",
-      "ja": "サハラ砂漠は、主にどの国に位置していますか？"
+      "ja": "サハラ砂漠は主にどの国にあるか？"
     },
     "question_text_reading": {
       "en": "What country is the Sahara Desert mostly in?",
@@ -26443,28 +26443,28 @@
     "choices": [
       {
         "en": "Buenos Aires",
-        "ja": "ぶえのすあいれす",
+        "ja": "ブエノスアイレス",
         "ja_typings": [
           "buenosuairesu"
         ]
       },
       {
         "en": "Córdoba",
-        "ja": "こるどば",
+        "ja": "コルドバ",
         "ja_typings": [
           "korudoba"
         ]
       },
       {
         "en": "Rosario",
-        "ja": "ろさりお",
+        "ja": "ロサリオ",
         "ja_typings": [
           "rosario"
         ]
       },
       {
         "en": "Mendoza",
-        "ja": "めんどさ",
+        "ja": "メンドーサ",
         "ja_typings": [
           "mendosa"
         ]
@@ -26476,7 +26476,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Argentina?",
-      "ja": "アルゼンチンの首都はどこですか？"
+      "ja": "アルゼンチンのしゅとは？"
     },
     "question_text_reading": {
       "en": "What is the capital of Argentina?",
@@ -26487,28 +26487,28 @@
     "choices": [
       {
         "en": "Stockholm",
-        "ja": "すとっくほるむ",
+        "ja": "ストックホルム",
         "ja_typings": [
           "sutokkuhorumu"
         ]
       },
       {
         "en": "Oslo",
-        "ja": "おすろ",
+        "ja": "オスロ",
         "ja_typings": [
           "osuro"
         ]
       },
       {
         "en": "Copenhagen",
-        "ja": "こぺんはーげん",
+        "ja": "コペンハーゲン",
         "ja_typings": [
           "kopenhagen"
         ]
       },
       {
         "en": "Helsinki",
-        "ja": "へるしんき",
+        "ja": "ヘルシンキ",
         "ja_typings": [
           "herushinki"
         ]
@@ -26520,7 +26520,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Sweden?",
-      "ja": "スウェーデンの首都はどこですか？"
+      "ja": "スウェーデンの首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of Sweden?",
@@ -26531,28 +26531,28 @@
     "choices": [
       {
         "en": "Athens",
-        "ja": "あてね",
+        "ja": "アテネ",
         "ja_typings": [
           "atene"
         ]
       },
       {
         "en": "Thessaloniki",
-        "ja": "てっさろにき",
+        "ja": "テッサロニキ",
         "ja_typings": [
           "tessaroniki"
         ]
       },
       {
         "en": "Crete",
-        "ja": "くれーた",
+        "ja": "クレータ",
         "ja_typings": [
           "kureta"
         ]
       },
       {
         "en": "Sparta",
-        "ja": "すぱるた",
+        "ja": "スパルタ",
         "ja_typings": [
           "suparuta"
         ]
@@ -26564,7 +26564,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Greece?",
-      "ja": "ギリシャの首都はどこですか？"
+      "ja": "ギリシャの首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of Greece?",
@@ -26575,28 +26575,28 @@
     "choices": [
       {
         "en": "Amsterdam",
-        "ja": "あむすてるだむ",
+        "ja": "アムステルダム",
         "ja_typings": [
           "amusuterudamu"
         ]
       },
       {
         "en": "The Hague",
-        "ja": "でんはーぐ",
+        "ja": "デンハーグ",
         "ja_typings": [
           "denhagu"
         ]
       },
       {
         "en": "Rotterdam",
-        "ja": "ろってるだむ",
+        "ja": "ロッテルダム",
         "ja_typings": [
           "rotterudamu"
         ]
       },
       {
         "en": "Utrecht",
-        "ja": "うとれひと",
+        "ja": "ユトレヒト",
         "ja_typings": [
           "utorehito"
         ]
@@ -26608,7 +26608,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Netherlands?",
-      "ja": "オランダの首都はどこですか？"
+      "ja": "オランダの首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of Netherlands?",
@@ -26619,14 +26619,14 @@
     "choices": [
       {
         "en": "Warsaw",
-        "ja": "わるしゃわ",
+        "ja": "ワルシャワ",
         "ja_typings": [
           "warushawa"
         ]
       },
       {
         "en": "Krakow",
-        "ja": "くらこふ",
+        "ja": "クラクフ",
         "ja_typings": [
           "kurakofu"
         ]
@@ -26640,7 +26640,7 @@
       },
       {
         "en": "Wroclaw",
-        "ja": "ぶろつわふ",
+        "ja": "ヴロツワフ",
         "ja_typings": [
           "burotsuwafu"
         ]
@@ -26652,7 +26652,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Poland?",
-      "ja": "ポーランドの首都はどこですか？"
+      "ja": "ポーランドの首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of Poland?",
@@ -26663,28 +26663,28 @@
     "choices": [
       {
         "en": "Sweden",
-        "ja": "すうぇーでん",
+        "ja": "スウェーデン",
         "ja_typings": [
           "suweden"
         ]
       },
       {
         "en": "Indonesia",
-        "ja": "いんどねしあ",
+        "ja": "インドネシア",
         "ja_typings": [
           "indoneshia"
         ]
       },
       {
         "en": "Philippines",
-        "ja": "ふぃりぴん",
+        "ja": "フィリピン",
         "ja_typings": [
           "firipin"
         ]
       },
       {
         "en": "Japan",
-        "ja": "にほん",
+        "ja": "日本",
         "ja_typings": [
           "nihon"
         ]
@@ -26696,7 +26696,7 @@
     "image_path": null,
     "question_text": {
       "en": "What country has the most islands?",
-      "ja": "最も多くの島を持つ国はどこでしょう？"
+      "ja": "最も多い島のある国は？"
     },
     "question_text_reading": {
       "en": "What country has the most islands?",
@@ -26707,28 +26707,28 @@
     "choices": [
       {
         "en": "Wellington",
-        "ja": "うぇりんとん",
+        "ja": "ウェリントン",
         "ja_typings": [
           "werinton"
         ]
       },
       {
         "en": "Auckland",
-        "ja": "おーくらんど",
+        "ja": "オークランド",
         "ja_typings": [
           "okurando"
         ]
       },
       {
         "en": "Christchurch",
-        "ja": "くらいすとちゃーち",
+        "ja": "クライストチャーチ",
         "ja_typings": [
           "kuraisutochachi"
         ]
       },
       {
         "en": "Dunedin",
-        "ja": "だにーでぃん",
+        "ja": "ダニーディン",
         "ja_typings": [
           "danidin"
         ]
@@ -26740,7 +26740,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of New Zealand?",
-      "ja": "ニュージーランドの首都はどこですか？"
+      "ja": "ニュージーランドの首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of New Zealand?",
@@ -26751,28 +26751,28 @@
     "choices": [
       {
         "en": "Abuja",
-        "ja": "あぶじゃ",
+        "ja": "アブジャ",
         "ja_typings": [
           "abuja"
         ]
       },
       {
         "en": "Lagos",
-        "ja": "らごす",
+        "ja": "ラゴス",
         "ja_typings": [
           "ragosu"
         ]
       },
       {
         "en": "Kano",
-        "ja": "かの",
+        "ja": "カーノ",
         "ja_typings": [
           "kano"
         ]
       },
       {
         "en": "Ibadan",
-        "ja": "いばだん",
+        "ja": "イバダン",
         "ja_typings": [
           "ibadan"
         ]
@@ -26784,7 +26784,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Nigeria?",
-      "ja": "ナイジェリアの首都はどこですか？"
+      "ja": "ナイジェリアのしゅとは？"
     },
     "question_text_reading": {
       "en": "What is the capital of Nigeria?",
@@ -26795,28 +26795,28 @@
     "choices": [
       {
         "en": "Bangkok",
-        "ja": "ばんこく",
+        "ja": "バンコク",
         "ja_typings": [
           "bankoku"
         ]
       },
       {
         "en": "Chiang Mai",
-        "ja": "ちぇんまい",
+        "ja": "チェンマイ",
         "ja_typings": [
           "chenmai"
         ]
       },
       {
         "en": "Pattaya",
-        "ja": "ぱたや",
+        "ja": "パタヤ",
         "ja_typings": [
           "pataya"
         ]
       },
       {
         "en": "Phuket",
-        "ja": "ぷーけっと",
+        "ja": "プーケット",
         "ja_typings": [
           "puketto"
         ]
@@ -26828,7 +26828,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Thailand?",
-      "ja": "タイの首都はどこですか？"
+      "ja": "タイランドの首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of Thailand?",
@@ -26839,28 +26839,28 @@
     "choices": [
       {
         "en": "India",
-        "ja": "いんど",
+        "ja": "インド",
         "ja_typings": [
           "indo"
         ]
       },
       {
         "en": "Pakistan",
-        "ja": "ぱきすたん",
+        "ja": "パキスタン",
         "ja_typings": [
           "pakisutan"
         ]
       },
       {
         "en": "Bangladesh",
-        "ja": "ばんぐらでしゅ",
+        "ja": "バングラデシュ",
         "ja_typings": [
           "banguradeshu"
         ]
       },
       {
         "en": "Nepal",
-        "ja": "ねぱーる",
+        "ja": "ネパール",
         "ja_typings": [
           "neparu"
         ]
@@ -26872,7 +26872,7 @@
     "image_path": null,
     "question_text": {
       "en": "What country is the Taj Mahal in?",
-      "ja": "タージ・マハルはどの国にありますか？"
+      "ja": "タージ・マハルはどの国にあるか？"
     },
     "question_text_reading": {
       "en": "What country is the Taj Mahal in?",
@@ -26883,28 +26883,28 @@
     "choices": [
       {
         "en": "Riyadh",
-        "ja": "りやど",
+        "ja": "リヤド",
         "ja_typings": [
           "riyado"
         ]
       },
       {
         "en": "Mecca",
-        "ja": "めっか",
+        "ja": "メッカ",
         "ja_typings": [
           "mekka"
         ]
       },
       {
         "en": "Jeddah",
-        "ja": "じぇっだ",
+        "ja": "ジェッダ",
         "ja_typings": [
           "jedda"
         ]
       },
       {
         "en": "Medina",
-        "ja": "めでぃな",
+        "ja": "メディナ",
         "ja_typings": [
           "medina"
         ]
@@ -26916,7 +26916,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Saudi Arabia?",
-      "ja": "サウジアラビアの首都はどこですか？"
+      "ja": "サウジアラビアの首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of Saudi Arabia?",
@@ -26927,28 +26927,28 @@
     "choices": [
       {
         "en": "Nairobi",
-        "ja": "ないろびー",
+        "ja": "ナイロビー",
         "ja_typings": [
           "nairobi"
         ]
       },
       {
         "en": "Mombasa",
-        "ja": "もんばさ",
+        "ja": "モンバサ",
         "ja_typings": [
           "monbasa"
         ]
       },
       {
         "en": "Kisumu",
-        "ja": "きすむ",
+        "ja": "キスム",
         "ja_typings": [
           "kisumu"
         ]
       },
       {
         "en": "Nakuru",
-        "ja": "なくる",
+        "ja": "ナクル",
         "ja_typings": [
           "nakuru"
         ]
@@ -26960,7 +26960,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Kenya?",
-      "ja": "ケニアの首都はどこですか？"
+      "ja": "ケニアのしゅとは？"
     },
     "question_text_reading": {
       "en": "What is the capital of Kenya?",
@@ -26971,28 +26971,28 @@
     "choices": [
       {
         "en": "Lagos",
-        "ja": "らごす",
+        "ja": "ラゴス",
         "ja_typings": [
           "ragosu"
         ]
       },
       {
         "en": "Cairo",
-        "ja": "かいろ",
+        "ja": "カイロ",
         "ja_typings": [
           "kairo"
         ]
       },
       {
         "en": "Kinshasa",
-        "ja": "きんしゃさ",
+        "ja": "キンシャサ",
         "ja_typings": [
           "kinshasa"
         ]
       },
       {
         "en": "Johannesburg",
-        "ja": "よはねすばーぐ",
+        "ja": "ヨハネスブルグ",
         "ja_typings": [
           "yohanesubagu"
         ]
@@ -27004,7 +27004,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the largest city in Africa by population?",
-      "ja": "アフリカで人口が最も多い都市はどこですか？"
+      "ja": "人口がもっともおおいアフリカの都市は？"
     },
     "question_text_reading": {
       "en": "What is the largest city in Africa by population?",
@@ -27015,28 +27015,28 @@
     "choices": [
       {
         "en": "USA and Canada",
-        "ja": "あめりかとかなだ",
+        "ja": "アメリカとカナダ",
         "ja_typings": [
           "amerikatokanada"
         ]
       },
       {
         "en": "USA and Mexico",
-        "ja": "あめりかとめきしこ",
+        "ja": "アメリカとメキシコ",
         "ja_typings": [
           "amerikatomekishiko"
         ]
       },
       {
         "en": "Canada and UK",
-        "ja": "かなだとえいこく",
+        "ja": "カナダと英国",
         "ja_typings": [
           "kanadatoeikoku"
         ]
       },
       {
         "en": "USA and UK",
-        "ja": "あめりかとえいこく",
+        "ja": "アメリカと英国",
         "ja_typings": [
           "amerikatoeikoku"
         ]
@@ -27048,7 +27048,7 @@
     "image_path": null,
     "question_text": {
       "en": "What two countries share Niagara Falls?",
-      "ja": "ナイアガラ滝を共有している二つの国はどこでしょう？"
+      "ja": "ナイアガラ滝を共有する二つの国は？"
     },
     "question_text_reading": {
       "en": "What two countries share Niagara Falls?",
@@ -27059,28 +27059,28 @@
     "choices": [
       {
         "en": "Lisbon",
-        "ja": "りずぼん",
+        "ja": "リスボン",
         "ja_typings": [
           "rizubon"
         ]
       },
       {
         "en": "Porto",
-        "ja": "ぽると",
+        "ja": "ポルト",
         "ja_typings": [
           "poruto"
         ]
       },
       {
         "en": "Faro",
-        "ja": "ふぁろ",
+        "ja": "ファロ",
         "ja_typings": [
           "faro"
         ]
       },
       {
         "en": "Braga",
-        "ja": "ぶらが",
+        "ja": "ブラガ",
         "ja_typings": [
           "buraga"
         ]
@@ -27092,7 +27092,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Portugal?",
-      "ja": "ポルトガルの首都はどこですか？"
+      "ja": "ポルトガルの首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of Portugal?",
@@ -27103,28 +27103,28 @@
     "choices": [
       {
         "en": "Vienna",
-        "ja": "うぃーん",
+        "ja": "ウィーン",
         "ja_typings": [
           "win"
         ]
       },
       {
         "en": "Salzburg",
-        "ja": "ざるつぶるく",
+        "ja": "ザルツブルク",
         "ja_typings": [
           "zarutsuburuku"
         ]
       },
       {
         "en": "Graz",
-        "ja": "ぐらーつ",
+        "ja": "グラフ",
         "ja_typings": [
           "guratsu"
         ]
       },
       {
         "en": "Innsbruck",
-        "ja": "いんすぶるっく",
+        "ja": "インスブルック",
         "ja_typings": [
           "insuburukku"
         ]
@@ -27136,7 +27136,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Austria?",
-      "ja": "オーストリアの首都はどこですか？"
+      "ja": "オーストリアの首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of Austria?",
@@ -27147,28 +27147,28 @@
     "choices": [
       {
         "en": "1945",
-        "ja": "1945ねん",
+        "ja": "1945年",
         "ja_typings": [
           "1945nen"
         ]
       },
       {
         "en": "1943",
-        "ja": "1943ねん",
+        "ja": "1943年",
         "ja_typings": [
           "1943nen"
         ]
       },
       {
         "en": "1947",
-        "ja": "1947ねん",
+        "ja": "1947年",
         "ja_typings": [
           "1947nen"
         ]
       },
       {
         "en": "1940",
-        "ja": "1940ねん",
+        "ja": "1940年",
         "ja_typings": [
           "1940nen"
         ]
@@ -27180,7 +27180,7 @@
     "image_path": null,
     "question_text": {
       "en": "In what year did World War II end?",
-      "ja": "第二次世界大戦は、何年に終結したのでしょうか？"
+      "ja": "第二次世界大戦は何年終わったか？"
     },
     "question_text_reading": {
       "en": "In what year did World War II end?",
@@ -27191,28 +27191,28 @@
     "choices": [
       {
         "en": "George Washington",
-        "ja": "じょーじわしんとん",
+        "ja": "ジョージ・ワシントン",
         "ja_typings": [
           "jojiwashinton"
         ]
       },
       {
         "en": "Abraham Lincoln",
-        "ja": "えいぶらはむりんかーん",
+        "ja": "エイブラハム・リンカーン",
         "ja_typings": [
           "eiburahamurinkan"
         ]
       },
       {
         "en": "Thomas Jefferson",
-        "ja": "とーますじぇふぁーそん",
+        "ja": "トーマス・ジェファーソン",
         "ja_typings": [
           "tomasujefason"
         ]
       },
       {
         "en": "John Adams",
-        "ja": "じょんあだむず",
+        "ja": "ジョン・アダムズ",
         "ja_typings": [
           "jonadamuzu"
         ]
@@ -27224,7 +27224,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who was the first President of the United States?",
-      "ja": "アメリカ合衆国初の大統領は誰ですか？"
+      "ja": "アメリカの初代大統領は誰か？"
     },
     "question_text_reading": {
       "en": "Who was the first President of the United States?",
@@ -27235,28 +27235,28 @@
     "choices": [
       {
         "en": "1789",
-        "ja": "1789ねん",
+        "ja": "1789年",
         "ja_typings": [
           "1789nen"
         ]
       },
       {
         "en": "1776",
-        "ja": "1776ねん",
+        "ja": "1776年",
         "ja_typings": [
           "1776nen"
         ]
       },
       {
         "en": "1804",
-        "ja": "1804ねん",
+        "ja": "1804年",
         "ja_typings": [
           "1804nen"
         ]
       },
       {
         "en": "1815",
-        "ja": "1815ねん",
+        "ja": "1815年",
         "ja_typings": [
           "1815nen"
         ]
@@ -27268,7 +27268,7 @@
     "image_path": null,
     "question_text": {
       "en": "What year did the French Revolution begin?",
-      "ja": "フランス革命は何年頃に始まったのでしょうか？"
+      "ja": "フランス革命は何年始まったか？"
     },
     "question_text_reading": {
       "en": "What year did the French Revolution begin?",
@@ -27279,7 +27279,7 @@
     "choices": [
       {
         "en": "Various Chinese emperors",
-        "ja": "れきだいのちゅうごくこうてい",
+        "ja": "歴代の中国皇帝",
         "ja_typings": [
           "rekidainochuugokukotei",
           "rekidainochuugokukoutei"
@@ -27287,21 +27287,21 @@
       },
       {
         "en": "Genghis Khan",
-        "ja": "ちんぎすかん",
+        "ja": "チンギス・ハン",
         "ja_typings": [
           "chingisukan"
         ]
       },
       {
         "en": "Kublai Khan",
-        "ja": "くびらいかん",
+        "ja": "クビライ・ハン",
         "ja_typings": [
           "kubiraikan"
         ]
       },
       {
         "en": "Emperor Qin Shi Huang alone",
-        "ja": "しこうていだけ",
+        "ja": "秦始皇帝だけ",
         "ja_typings": [
           "shikoteidake",
           "shikouteidake"
@@ -27314,7 +27314,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who built the Great Wall of China?",
-      "ja": "万里の長城を築いたのは誰ですか？"
+      "ja": "中国の万里の長城を築いたのは誰か？"
     },
     "question_text_reading": {
       "en": "Who built the Great Wall of China?",
@@ -27325,28 +27325,28 @@
     "choices": [
       {
         "en": "Ancient Egyptians",
-        "ja": "こだいえじぷとじん",
+        "ja": "古代エジプト人",
         "ja_typings": [
           "kodaiejiputojin"
         ]
       },
       {
         "en": "Ancient Romans",
-        "ja": "こだいろーまじん",
+        "ja": "古代ローマ人",
         "ja_typings": [
           "kodairomajin"
         ]
       },
       {
         "en": "Ancient Greeks",
-        "ja": "こだいぎりしあじん",
+        "ja": "古代ギリシャ人",
         "ja_typings": [
           "kodaigirishiajin"
         ]
       },
       {
         "en": "Ancient Mesopotamians",
-        "ja": "こだいめそぽたみあじん",
+        "ja": "古代メソポタミア人",
         "ja_typings": [
           "kodaimesopotamiajin"
         ]
@@ -27358,7 +27358,7 @@
     "image_path": null,
     "question_text": {
       "en": "What civilization built the pyramids of Giza?",
-      "ja": "ギザのピラミッドを建設したのはどの文明ですか？"
+      "ja": "ギザのピラミッドを築いた文明は？"
     },
     "question_text_reading": {
       "en": "What civilization built the pyramids of Giza?",
@@ -27369,28 +27369,28 @@
     "choices": [
       {
         "en": "476 AD",
-        "ja": "476ねん",
+        "ja": "476年",
         "ja_typings": [
           "476nen"
         ]
       },
       {
         "en": "410 AD",
-        "ja": "410ねん",
+        "ja": "410年",
         "ja_typings": [
           "410nen"
         ]
       },
       {
         "en": "565 AD",
-        "ja": "565ねん",
+        "ja": "565年",
         "ja_typings": [
           "565nen"
         ]
       },
       {
         "en": "395 AD",
-        "ja": "395ねん",
+        "ja": "395年",
         "ja_typings": [
           "395nen"
         ]
@@ -27402,7 +27402,7 @@
     "image_path": null,
     "question_text": {
       "en": "When did the Roman Empire fall?",
-      "ja": "ローマ帝国はいつ滅亡したのでしょうか？"
+      "ja": "ローマ帝国はいつ滅んだか？"
     },
     "question_text_reading": {
       "en": "When did the Roman Empire fall?",
@@ -27413,7 +27413,7 @@
     "choices": [
       {
         "en": "French military leader and emperor",
-        "ja": "ふらんすのぐんじどうしゃとこうてい",
+        "ja": "フランスの軍指導者と皇帝",
         "ja_typings": [
           "furansunogunjidoshatokotei",
           "furansunogunjidoushatokoutei"
@@ -27421,21 +27421,21 @@
       },
       {
         "en": "British admiral",
-        "ja": "えいこくのかいぐんていとく",
+        "ja": "英国の海軍提督",
         "ja_typings": [
           "eikokunokaigunteitoku"
         ]
       },
       {
         "en": "Russian tsar",
-        "ja": "ろしあのツァーリ",
+        "ja": "ロシアのツァーリ",
         "ja_typings": [
           "roshianotsari"
         ]
       },
       {
         "en": "Prussian king",
-        "ja": "ぷろいせんのおう",
+        "ja": "プロイセンの王",
         "ja_typings": [
           "puroisennou",
           "puroisennoou"
@@ -27448,7 +27448,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who was Napoleon Bonaparte?",
-      "ja": "ナポレオン・ボナパルトとはどのような人物ですか？"
+      "ja": "ナポレオン・ボナパルトとは誰か？"
     },
     "question_text_reading": {
       "en": "Who was Napoleon Bonaparte?",
@@ -27459,28 +27459,28 @@
     "choices": [
       {
         "en": "1492",
-        "ja": "1492ねん",
+        "ja": "1492年",
         "ja_typings": [
           "1492nen"
         ]
       },
       {
         "en": "1498",
-        "ja": "1498ねん",
+        "ja": "1498年",
         "ja_typings": [
           "1498nen"
         ]
       },
       {
         "en": "1488",
-        "ja": "1488ねん",
+        "ja": "1488年",
         "ja_typings": [
           "1488nen"
         ]
       },
       {
         "en": "1510",
-        "ja": "1510ねん",
+        "ja": "1510年",
         "ja_typings": [
           "1510nen"
         ]
@@ -27492,7 +27492,7 @@
     "image_path": null,
     "question_text": {
       "en": "What year did Columbus reach the Americas?",
-      "ja": "コロンブスがアメリカ大陸に到達したのは何年ですか？"
+      "ja": "コロンブスがアメリカにたっしたのはなんねんか？"
     },
     "question_text_reading": {
       "en": "What year did Columbus reach the Americas?",
@@ -27510,7 +27510,7 @@
       },
       {
         "en": "war fought in cold climates",
-        "ja": "さむいきこうでのせんそう",
+        "ja": "寒冷気候での戦争",
         "ja_typings": [
           "samuikikodenosenso",
           "samuikikoudenosensou"
@@ -27518,7 +27518,7 @@
       },
       {
         "en": "war between Northern and Southern states",
-        "ja": "ほくぶとなんぶのせんそう",
+        "ja": "北部と南部の戦争",
         "ja_typings": [
           "hokubutonanbunosenso",
           "hokubutonanbunosensou"
@@ -27526,7 +27526,7 @@
       },
       {
         "en": "war without weapons",
-        "ja": "ぶきなしのせんそう",
+        "ja": "武器なき戦争",
         "ja_typings": [
           "bukinashinosenso",
           "bukinashinosensou"
@@ -27539,7 +27539,7 @@
     "image_path": null,
     "question_text": {
       "en": "What was the Cold War?",
-      "ja": "冷戦とは、どのような時代のことだったのでしょうか？"
+      "ja": "冷戦とは何か？"
     },
     "question_text_reading": {
       "en": "What was the Cold War?",
@@ -27550,28 +27550,28 @@
     "choices": [
       {
         "en": "Cleopatra VII",
-        "ja": "くれおぱとら7せい",
+        "ja": "クレオパトラ7世",
         "ja_typings": [
           "kureopatora7sei"
         ]
       },
       {
         "en": "Ramesses II",
-        "ja": "らめせす2せい",
+        "ja": "ラメセス2世",
         "ja_typings": [
           "ramesesu2sei"
         ]
       },
       {
         "en": "Tutankhamun",
-        "ja": "つたんかーめん",
+        "ja": "ツタンカーメン",
         "ja_typings": [
           "tsutankamen"
         ]
       },
       {
         "en": "Nefertiti",
-        "ja": "ねふぇるてぃてぃ",
+        "ja": "ネフェルティティ",
         "ja_typings": [
           "neferutiti"
         ]
@@ -27583,7 +27583,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who was the last Pharaoh of ancient Egypt?",
-      "ja": "古代エジプトの最後のファラオは誰ですか？"
+      "ja": "古代エジプトの最後のファラオは誰か？"
     },
     "question_text_reading": {
       "en": "Who was the last Pharaoh of ancient Egypt?",
@@ -27594,28 +27594,28 @@
     "choices": [
       {
         "en": "1868",
-        "ja": "1868ねん",
+        "ja": "1868年",
         "ja_typings": [
           "1868nen"
         ]
       },
       {
         "en": "1853",
-        "ja": "1853ねん",
+        "ja": "1853年",
         "ja_typings": [
           "1853nen"
         ]
       },
       {
         "en": "1889",
-        "ja": "1889ねん",
+        "ja": "1889年",
         "ja_typings": [
           "1889nen"
         ]
       },
       {
         "en": "1912",
-        "ja": "1912ねん",
+        "ja": "1912年",
         "ja_typings": [
           "1912nen"
         ]
@@ -27627,7 +27627,7 @@
     "image_path": null,
     "question_text": {
       "en": "In what year did Japan's Meiji Restoration begin?",
-      "ja": "日本の明治維新は何年頃に始まったのでしょうか？"
+      "ja": "日本の明治維新は始まったのは何年か？"
     },
     "question_text_reading": {
       "en": "In what year did Japan's Meiji Restoration begin?",
@@ -27638,7 +27638,7 @@
     "choices": [
       {
         "en": "English charter limiting royal power",
-        "ja": "おうけんをせいげんするえいこくのけんしょう",
+        "ja": "王権を制限する英国の憲章",
         "ja_typings": [
           "okenoseigensurueikokunokensho",
           "oukenoseigensurueikokunokenshou"
@@ -27646,7 +27646,7 @@
       },
       {
         "en": "Roman law code",
-        "ja": "ろーまのほうてん",
+        "ja": "ローマの法典",
         "ja_typings": [
           "romanohoten",
           "romanohouten"
@@ -27654,14 +27654,14 @@
       },
       {
         "en": "French revolutionary document",
-        "ja": "ふらんすかくめいのぶんしょ",
+        "ja": "フランス革命の文書",
         "ja_typings": [
           "furansukakumeinobunsho"
         ]
       },
       {
         "en": "Church constitution",
-        "ja": "きょうかいのけんぽう",
+        "ja": "教会の憲法",
         "ja_typings": [
           "kyokainokenpo",
           "kyoukainokenpou"
@@ -27674,7 +27674,7 @@
     "image_path": null,
     "question_text": {
       "en": "What was the Magna Carta?",
-      "ja": "マグナ・カルタとは何ですか？"
+      "ja": "マグナ・カルタとは何か？"
     },
     "question_text_reading": {
       "en": "What was the Magna Carta?",
@@ -27685,28 +27685,28 @@
     "choices": [
       {
         "en": "Mahatma Gandhi",
-        "ja": "まはとまがんじー",
+        "ja": "マハトマ・ガンディー",
         "ja_typings": [
           "mahatomaganji"
         ]
       },
       {
         "en": "Jawaharlal Nehru",
-        "ja": "じゃわはるらーるねるー",
+        "ja": "ジャワハルラールネルー",
         "ja_typings": [
           "jawaharuraruneru"
         ]
       },
       {
         "en": "Subhas Chandra Bose",
-        "ja": "すばーすちゃんどらぼーす",
+        "ja": "サブハス・チャンドラ・ボース",
         "ja_typings": [
           "subasuchandorabosu"
         ]
       },
       {
         "en": "Bhagat Singh",
-        "ja": "ばがとしん",
+        "ja": "バガット・シン",
         "ja_typings": [
           "bagatoshin"
         ]
@@ -27718,7 +27718,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who led the Indian independence movement against Britain?",
-      "ja": "イギリスに対するインドの独立運動を主導したのは誰ですか？"
+      "ja": "英国に対するインド独立運動を率いたのは誰か？"
     },
     "question_text_reading": {
       "en": "Who led the Indian independence movement against Britain?",
@@ -27729,7 +27729,7 @@
     "choices": [
       {
         "en": "European cultural revival 14th-17th century",
-        "ja": "14-17せいきのおうしゅうぶんかのふっこう",
+        "ja": "14-17世紀の欧州文化の復興",
         "ja_typings": [
           "1417seikinoushuubunkanofukko",
           "1417seikinooushuubunkanofukkou"
@@ -27737,7 +27737,7 @@
       },
       {
         "en": "Roman Empire's golden age",
-        "ja": "ろーまていこくのおうごんじだい",
+        "ja": "ローマ帝国の黄金時代",
         "ja_typings": [
           "romateikokunougonjidai",
           "romateikokunoougonjidai"
@@ -27745,14 +27745,14 @@
       },
       {
         "en": "Medieval crusade period",
-        "ja": "ちゅうせいじゅうじぐんのじだい",
+        "ja": "中世十字軍の時代",
         "ja_typings": [
           "chuuseijuujigunnojidai"
         ]
       },
       {
         "en": "Age of Exploration",
-        "ja": "だいこうかいじだい",
+        "ja": "大航海時代",
         "ja_typings": [
           "daikokaijidai",
           "daikoukaijidai"
@@ -27765,7 +27765,7 @@
     "image_path": null,
     "question_text": {
       "en": "What was the Renaissance?",
-      "ja": "ルネサンスとは、どのような時代のことですか？"
+      "ja": "ルネサンスとは何か？"
     },
     "question_text_reading": {
       "en": "What was the Renaissance?",
@@ -27776,28 +27776,28 @@
     "choices": [
       {
         "en": "1989",
-        "ja": "1989ねん",
+        "ja": "1989年",
         "ja_typings": [
           "1989nen"
         ]
       },
       {
         "en": "1991",
-        "ja": "1991ねん",
+        "ja": "1991年",
         "ja_typings": [
           "1991nen"
         ]
       },
       {
         "en": "1985",
-        "ja": "1985ねん",
+        "ja": "1985年",
         "ja_typings": [
           "1985nen"
         ]
       },
       {
         "en": "1993",
-        "ja": "1993ねん",
+        "ja": "1993年",
         "ja_typings": [
           "1993nen"
         ]
@@ -27809,7 +27809,7 @@
     "image_path": null,
     "question_text": {
       "en": "When did the Berlin Wall fall?",
-      "ja": "ベルリンの壁はいつ崩壊したのでしょうか？"
+      "ja": "ベルリンの壁はいつ倒れたか？"
     },
     "question_text_reading": {
       "en": "When did the Berlin Wall fall?",
@@ -27820,7 +27820,7 @@
     "choices": [
       {
         "en": "colonial protest against British taxation",
-        "ja": "えいこくかぜいへのしょくみんちのこうぎ",
+        "ja": "英国税への植民地の抗議",
         "ja_typings": [
           "eikokukazeihenoshokuminchinokogi",
           "eikokukazeihenoshokuminchinokougi"
@@ -27828,14 +27828,14 @@
       },
       {
         "en": "tea festival in Boston",
-        "ja": "ぼすとんのちゃのさいてん",
+        "ja": "ボストン の ティー フェスティバル",
         "ja_typings": [
           "bosutonnochanosaiten"
         ]
       },
       {
         "en": "British tea trade event",
-        "ja": "えいこくのちゃのぼうえきいべんと",
+        "ja": "英国の茶の貿易イベント",
         "ja_typings": [
           "eikokunochanoboekiibento",
           "eikokunochanobouekiibento"
@@ -27843,7 +27843,7 @@
       },
       {
         "en": "American tea company celebration",
-        "ja": "アメリカのちゃかいしゃのさいてん",
+        "ja": "アメリカの茶会社のお祝い",
         "ja_typings": [
           "amerikanochakaishanosaiten"
         ]
@@ -27855,7 +27855,7 @@
     "image_path": null,
     "question_text": {
       "en": "What was the Boston Tea Party?",
-      "ja": "ボストン茶会事件とは、どのような出来事だったのでしょうか？"
+      "ja": "ボストン・ティー・パーティーとは何か？"
     },
     "question_text_reading": {
       "en": "What was the Boston Tea Party?",
@@ -27866,28 +27866,28 @@
     "choices": [
       {
         "en": "Karl Marx and Friedrich Engels",
-        "ja": "かーるまるくすとふりーどりひえんげるす",
+        "ja": "カール・マルクスとフリードリヒ・エンゲルス",
         "ja_typings": [
           "karumarukusutofuridorihiengerusu"
         ]
       },
       {
         "en": "Vladimir Lenin",
-        "ja": "うらじーみるれーにん",
+        "ja": "ウラジーミル・レーニン",
         "ja_typings": [
           "urajimirurenin"
         ]
       },
       {
         "en": "Leon Trotsky",
-        "ja": "れおんとろつきー",
+        "ja": "レオン・トロツキー",
         "ja_typings": [
           "reontorotsuki"
         ]
       },
       {
         "en": "Joseph Stalin",
-        "ja": "じょせふすたーりん",
+        "ja": "ジョセフ・スターリン",
         "ja_typings": [
           "josefusutarin"
         ]
@@ -27899,7 +27899,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who wrote the Communist Manifesto?",
-      "ja": "『共産党宣言』を著したのは誰ですか？"
+      "ja": "共産党宣言を書いたのは誰か？"
     },
     "question_text_reading": {
       "en": "Who wrote the Communist Manifesto?",
@@ -27910,7 +27910,7 @@
     "choices": [
       {
         "en": "ancient trade routes connecting East and West",
-        "ja": "ひがしとにしをつなぐこだいのぼうえきろ",
+        "ja": "東と西をつなぐ古代の貿易路",
         "ja_typings": [
           "higashitonishiotsunagukodainoboekiro",
           "higashitonishiotsunagukodainobouekiro"
@@ -27918,7 +27918,7 @@
       },
       {
         "en": "Chinese imperial road",
-        "ja": "ちゅうごくこうていのどうろ",
+        "ja": "中国皇帝の道路",
         "ja_typings": [
           "chuugokukoteinodoro",
           "chuugokukouteinodouro"
@@ -27926,7 +27926,7 @@
       },
       {
         "en": "road built of silk material",
-        "ja": "きぬでつくられたどうろ",
+        "ja": "絹でつくられた道路",
         "ja_typings": [
           "kinudetsukuraretadoro",
           "kinudetsukuraretadouro"
@@ -27934,7 +27934,7 @@
       },
       {
         "en": "Indian spice trade route",
-        "ja": "いんどのこうしんりょうぼうえきろ",
+        "ja": "インドの香辛料貿易路",
         "ja_typings": [
           "indonokoshinryoboekiro",
           "indonokoushinryoubouekiro"
@@ -27947,7 +27947,7 @@
     "image_path": null,
     "question_text": {
       "en": "What was the Silk Road?",
-      "ja": "シルクロードとは、どのようなものだったのでしょうか？"
+      "ja": "シルクロードとは何か？"
     },
     "question_text_reading": {
       "en": "What was the Silk Road?",
@@ -27958,7 +27958,7 @@
     "choices": [
       {
         "en": "Roman general and dictator",
-        "ja": "ろーまのしょうぐんとどくさいしゃ",
+        "ja": "ローマの将軍と独裁者",
         "ja_typings": [
           "romanoshoguntodokusaisha",
           "romanoshouguntodokusaisha"
@@ -27966,21 +27966,21 @@
       },
       {
         "en": "Greek philosopher",
-        "ja": "ぎりしあのてつがくしゃ",
+        "ja": "ギリシャの哲学者",
         "ja_typings": [
           "girishianotetsugakusha"
         ]
       },
       {
         "en": "Egyptian pharaoh",
-        "ja": "えじぷとのふぁらお",
+        "ja": "エジプトのファラオ",
         "ja_typings": [
           "ejiputonofarao"
         ]
       },
       {
         "en": "Persian king",
-        "ja": "ぺるしあのおう",
+        "ja": "ペルシャの王",
         "ja_typings": [
           "perushianou",
           "perushianoou"
@@ -27993,7 +27993,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who was Julius Caesar?",
-      "ja": "ジュリアス・カエサルとはどのような人物ですか？"
+      "ja": "ジュリアス・シーザーとは誰か？"
     },
     "question_text_reading": {
       "en": "Who was Julius Caesar?",
@@ -28004,28 +28004,28 @@
     "choices": [
       {
         "en": "1914",
-        "ja": "1914ねん",
+        "ja": "1914年",
         "ja_typings": [
           "1914nen"
         ]
       },
       {
         "en": "1916",
-        "ja": "1916ねん",
+        "ja": "1916年",
         "ja_typings": [
           "1916nen"
         ]
       },
       {
         "en": "1912",
-        "ja": "1912ねん",
+        "ja": "1912年",
         "ja_typings": [
           "1912nen"
         ]
       },
       {
         "en": "1918",
-        "ja": "1918ねん",
+        "ja": "1918年",
         "ja_typings": [
           "1918nen"
         ]
@@ -28037,7 +28037,7 @@
     "image_path": null,
     "question_text": {
       "en": "What year did the first World War begin?",
-      "ja": "第一次世界大戦は何年に始まったの？"
+      "ja": "第一次世界大戦は何年始まったか？"
     },
     "question_text_reading": {
       "en": "What year did the first World War begin?",
@@ -28048,14 +28048,14 @@
     "choices": [
       {
         "en": "founder of Mongol Empire",
-        "ja": "もんごるていこくのきそしゃ",
+        "ja": "モンゴル帝国の基礎者",
         "ja_typings": [
           "mongoruteikokunokisosha"
         ]
       },
       {
         "en": "Chinese emperor",
-        "ja": "ちゅうごくのこうてい",
+        "ja": "中国の皇帝",
         "ja_typings": [
           "chuugokunokotei",
           "chuugokunokoutei"
@@ -28063,7 +28063,7 @@
       },
       {
         "en": "Japanese shogun",
-        "ja": "にほんのしょうぐん",
+        "ja": "日本の将軍",
         "ja_typings": [
           "nihonnoshogun",
           "nihonnoshougun"
@@ -28071,7 +28071,7 @@
       },
       {
         "en": "Persian conqueror",
-        "ja": "ぺるしあのせいふくしゃ",
+        "ja": "ペルシャの征服者",
         "ja_typings": [
           "perushianoseifukusha"
         ]
@@ -28083,7 +28083,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who was Genghis Khan?",
-      "ja": "チンギス・ハンとはどのような人物ですか？"
+      "ja": "チンギス・ハンとは誰か？"
     },
     "question_text_reading": {
       "en": "Who was Genghis Khan?",
@@ -28094,21 +28094,21 @@
     "choices": [
       {
         "en": "Meiji Restoration",
-        "ja": "めいじいしん",
+        "ja": "明治維新",
         "ja_typings": [
           "meijiishin"
         ]
       },
       {
         "en": "Mongol invasion",
-        "ja": "もんごるのしんにゅう",
+        "ja": "モンゴルの侵入",
         "ja_typings": [
           "mongorunoshinnyuu"
         ]
       },
       {
         "en": "Perry's arrival",
-        "ja": "ぺりーのらいこう",
+        "ja": "ペリーの来航",
         "ja_typings": [
           "perinoraiko",
           "perinoraikou"
@@ -28116,7 +28116,7 @@
       },
       {
         "en": "Edo Period end",
-        "ja": "えどじだいのおわり",
+        "ja": "江戸時代のおわり",
         "ja_typings": [
           "edojidainowari",
           "edojidainoowari"
@@ -28129,7 +28129,7 @@
     "image_path": null,
     "question_text": {
       "en": "What ended the feudal period in Japan?",
-      "ja": "日本の封建時代を終わらせたのは何ですか？"
+      "ja": "日本の封建時代を終わらせたのは何か？"
     },
     "question_text_reading": {
       "en": "What ended the feudal period in Japan?",
@@ -28140,14 +28140,14 @@
     "choices": [
       {
         "en": "racial segregation in South Africa",
-        "ja": "みなみあふりかのじんしゅぶんり",
+        "ja": "南アフリカの人種分離",
         "ja_typings": [
           "minamiafurikanojinshubunri"
         ]
       },
       {
         "en": "South African independence movement",
-        "ja": "みなみあふりかのどくりつうんどう",
+        "ja": "南アフリカの独立運動",
         "ja_typings": [
           "minamiafurikanodokuritsuundo",
           "minamiafurikanodokuritsuundou"
@@ -28155,7 +28155,7 @@
       },
       {
         "en": "African traditional religion",
-        "ja": "アフリカのでんとうてきしゅうきょう",
+        "ja": "アフリカの伝統的宗教",
         "ja_typings": [
           "afurikanodentotekishuukyo",
           "afurikanodentoutekishuukyou"
@@ -28163,7 +28163,7 @@
       },
       {
         "en": "South African economic policy",
-        "ja": "みなみあふりかのけいざいせいさく",
+        "ja": "南アフリカの経済政策",
         "ja_typings": [
           "minamiafurikanokeizaiseisaku"
         ]
@@ -28175,7 +28175,7 @@
     "image_path": null,
     "question_text": {
       "en": "What was apartheid?",
-      "ja": "アパルトヘイトとはどのような制度だったのでしょうか？"
+      "ja": "アパルトヘイトとは何か？"
     },
     "question_text_reading": {
       "en": "What was apartheid?",
@@ -28186,28 +28186,28 @@
     "choices": [
       {
         "en": "1865",
-        "ja": "1865ねん",
+        "ja": "1865年",
         "ja_typings": [
           "1865nen"
         ]
       },
       {
         "en": "1863",
-        "ja": "1863ねん",
+        "ja": "1863年",
         "ja_typings": [
           "1863nen"
         ]
       },
       {
         "en": "1867",
-        "ja": "1867ねん",
+        "ja": "一八六七年",
         "ja_typings": [
           "1867nen"
         ]
       },
       {
         "en": "1861",
-        "ja": "1861ねん",
+        "ja": "1861年",
         "ja_typings": [
           "1861nen"
         ]
@@ -28219,7 +28219,7 @@
     "image_path": null,
     "question_text": {
       "en": "When did the American Civil War end?",
-      "ja": "アメリカ南北戦争はいつ終わったの？"
+      "ja": "アメリカ南北戦争は何年におわったか？"
     },
     "question_text_reading": {
       "en": "When did the American Civil War end?",
@@ -28230,28 +28230,28 @@
     "choices": [
       {
         "en": "Johannes Gutenberg",
-        "ja": "よはねすぐーてんべるく",
+        "ja": "ヨハネス・グーテンベルク",
         "ja_typings": [
           "yohanesugutenberuku"
         ]
       },
       {
         "en": "Leonardo da Vinci",
-        "ja": "れおなるどだびんち",
+        "ja": "レオナルド・ダ・ヴィンチ",
         "ja_typings": [
           "reonarudodabinchi"
         ]
       },
       {
         "en": "Isaac Newton",
-        "ja": "あいざっくにゅーとん",
+        "ja": "アイザック・ニュートン",
         "ja_typings": [
           "aizakkunyuton"
         ]
       },
       {
         "en": "Nikola Tesla",
-        "ja": "にこらてすら",
+        "ja": "ニコラ・テスラ",
         "ja_typings": [
           "nikoratesura"
         ]
@@ -28263,7 +28263,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who invented the printing press?",
-      "ja": "印刷機（printing press）を発明したのは誰ですか？"
+      "ja": "印刷機を発明したのは誰か？"
     },
     "question_text_reading": {
       "en": "Who invented the printing press?",
@@ -28274,14 +28274,14 @@
     "choices": [
       {
         "en": "14th century pandemic plague",
-        "ja": "14せいきのぺすとのぱんでみっく",
+        "ja": "14世紀のペストのパンデミック",
         "ja_typings": [
           "14seikinopesutonopandemikku"
         ]
       },
       {
         "en": "World War I battle",
-        "ja": "だいいちじたいせんのせんとう",
+        "ja": "第一次世界大戦の戦闘",
         "ja_typings": [
           "daiichijitaisennosento",
           "daiichijitaisennosentou"
@@ -28289,14 +28289,14 @@
       },
       {
         "en": "Medieval famine",
-        "ja": "ちゅうせいのききん",
+        "ja": "中世の飢饉",
         "ja_typings": [
           "chuuseinokikin"
         ]
       },
       {
         "en": "African drought event",
-        "ja": "あふりかのかんばつ",
+        "ja": "アフリカの干ばつ",
         "ja_typings": [
           "afurikanokanbatsu"
         ]
@@ -28308,7 +28308,7 @@
     "image_path": null,
     "question_text": {
       "en": "What was the Black Death?",
-      "ja": "黒死病とは、どのような病気でしたか？"
+      "ja": "ペストとは何か？"
     },
     "question_text_reading": {
       "en": "What was the Black Death?",
@@ -28319,7 +28319,7 @@
     "choices": [
       {
         "en": "American civil rights leader",
-        "ja": "アメリカのこうみんけんうんどうのしどうしゃ",
+        "ja": "アメリカの公民権運動の指導者",
         "ja_typings": [
           "amerikanokominkenundonoshidosha",
           "amerikanokouminkenundounoshidousha"
@@ -28327,7 +28327,7 @@
       },
       {
         "en": "British prime minister",
-        "ja": "えいこくのしゅしょう",
+        "ja": "英国の首相",
         "ja_typings": [
           "eikokunoshusho",
           "eikokunoshushou"
@@ -28335,14 +28335,14 @@
       },
       {
         "en": "German reformer",
-        "ja": "どいつのかいかくしゃ",
+        "ja": "ドイツの改革者",
         "ja_typings": [
           "doitsunokaikakusha"
         ]
       },
       {
         "en": "South African president",
-        "ja": "みなみあふりかのだいとうりょう",
+        "ja": "南アフリカの大統領",
         "ja_typings": [
           "minamiafurikanodaitoryo",
           "minamiafurikanodaitouryou"
@@ -28355,7 +28355,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who was Martin Luther King Jr.?",
-      "ja": "マーティン・ルーサー・キング・ジュニアとはどのような人物ですか？"
+      "ja": "マーティン・ルーサー・キング・ジュニアとは誰か？"
     },
     "question_text_reading": {
       "en": "Who was Martin Luther King Jr.?",
@@ -28366,28 +28366,28 @@
     "choices": [
       {
         "en": "1991",
-        "ja": "1991ねん",
+        "ja": "1991年",
         "ja_typings": [
           "1991nen"
         ]
       },
       {
         "en": "1989",
-        "ja": "1989ねん",
+        "ja": "1989年",
         "ja_typings": [
           "1989nen"
         ]
       },
       {
         "en": "1993",
-        "ja": "1993ねん",
+        "ja": "1993年",
         "ja_typings": [
           "1993nen"
         ]
       },
       {
         "en": "1985",
-        "ja": "1985ねん",
+        "ja": "1985年",
         "ja_typings": [
           "1985nen"
         ]
@@ -28399,7 +28399,7 @@
     "image_path": null,
     "question_text": {
       "en": "What year did the Soviet Union collapse?",
-      "ja": "ソビエト連邦が崩壊したのは何年ですか？"
+      "ja": "ソビエト連邦は何年に崩壊したか？"
     },
     "question_text_reading": {
       "en": "What year did the Soviet Union collapse?",
@@ -28410,28 +28410,28 @@
     "choices": [
       {
         "en": "Fidel Castro",
-        "ja": "ふぃでるかすとろ",
+        "ja": "フィデル・カストロ",
         "ja_typings": [
           "fiderukasutoro"
         ]
       },
       {
         "en": "Che Guevara",
-        "ja": "ちぇげばら",
+        "ja": "チエゲラ",
         "ja_typings": [
           "chegebara"
         ]
       },
       {
         "en": "Raul Castro",
-        "ja": "らうるかすとろ",
+        "ja": "ラウル・カストロ",
         "ja_typings": [
           "raurukasutoro"
         ]
       },
       {
         "en": "Fulgencio Batista",
-        "ja": "ふるへんしおばてぃすた",
+        "ja": "フルヘンシオ・バティスタ",
         "ja_typings": [
           "furuhenshiobatisuta"
         ]
@@ -28443,7 +28443,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who led the Cuban Revolution?",
-      "ja": "キューバ革命を主導したのは誰ですか？"
+      "ja": "キューバ革命を率いたのは誰か？"
     },
     "question_text_reading": {
       "en": "Who led the Cuban Revolution?",
@@ -28454,7 +28454,7 @@
     "choices": [
       {
         "en": "Allied invasion of Normandy in 1944",
-        "ja": "1944ねんのどーるのだんせんじょうりくさくせん",
+        "ja": "1944年のノルマンディー上陸作戦",
         "ja_typings": [
           "1944nennodorunodansenjorikusakusen",
           "1944nennodorunodansenjourikusakusen"
@@ -28462,7 +28462,7 @@
       },
       {
         "en": "Japanese attack on Pearl Harbor",
-        "ja": "にほんのぱーるはーばーこうげき",
+        "ja": "日本のパールハーバー攻撃",
         "ja_typings": [
           "nihonnoparuhabakogeki",
           "nihonnoparuhabakougeki"
@@ -28470,7 +28470,7 @@
       },
       {
         "en": "Germany's invasion of France",
-        "ja": "どいつのふらんすしんこう",
+        "ja": "ドイツのフランス侵攻",
         "ja_typings": [
           "doitsunofuransushinko",
           "doitsunofuransushinkou"
@@ -28478,7 +28478,7 @@
       },
       {
         "en": "End of World War II",
-        "ja": "だいにじたいせんのおわり",
+        "ja": "第二次世界大戦の終わり",
         "ja_typings": [
           "dainijitaisennowari",
           "dainijitaisennoowari"
@@ -28491,7 +28491,7 @@
     "image_path": null,
     "question_text": {
       "en": "What was D-Day?",
-      "ja": "D-Dayとは、どのような出来事だったのでしょうか？"
+      "ja": "D-Dayとは何か？"
     },
     "question_text_reading": {
       "en": "What was D-Day?",
@@ -28502,28 +28502,28 @@
     "choices": [
       {
         "en": "1912",
-        "ja": "1912ねん",
+        "ja": "1912年",
         "ja_typings": [
           "1912nen"
         ]
       },
       {
         "en": "1914",
-        "ja": "1914ねん",
+        "ja": "1914年",
         "ja_typings": [
           "1914nen"
         ]
       },
       {
         "en": "1910",
-        "ja": "1910ねん",
+        "ja": "1910年",
         "ja_typings": [
           "1910nen"
         ]
       },
       {
         "en": "1915",
-        "ja": "1915ねん",
+        "ja": "1915年",
         "ja_typings": [
           "1915nen"
         ]
@@ -28535,7 +28535,7 @@
     "image_path": null,
     "question_text": {
       "en": "When did the Titanic sink?",
-      "ja": "タイタニック号はいつ沈没したの？"
+      "ja": "タイタニックは何年に沈んだか？"
     },
     "question_text_reading": {
       "en": "When did the Titanic sink?",
@@ -28546,14 +28546,14 @@
     "choices": [
       {
         "en": "founder of modern nursing",
-        "ja": "きんだいかんごのそしゃ",
+        "ja": "近代看護の創始者",
         "ja_typings": [
           "kindaikangonososha"
         ]
       },
       {
         "en": "British queen",
-        "ja": "えいこくのじょおう",
+        "ja": "英国の女王",
         "ja_typings": [
           "eikokunojou",
           "eikokunojoou"
@@ -28561,14 +28561,14 @@
       },
       {
         "en": "American scientist",
-        "ja": "アメリカのかがくしゃ",
+        "ja": "アメリカの科学者",
         "ja_typings": [
           "amerikanokagakusha"
         ]
       },
       {
         "en": "French artist",
-        "ja": "ふらんすのがか",
+        "ja": "フランスの画家",
         "ja_typings": [
           "furansunogaka"
         ]
@@ -28580,7 +28580,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who was Florence Nightingale?",
-      "ja": "フローレンス・ナイチンゲールとはどのような人物ですか？"
+      "ja": "フローレンス・ナイチンゲールとは誰か？"
     },
     "question_text_reading": {
       "en": "Who was Florence Nightingale?",
@@ -28591,28 +28591,28 @@
     "choices": [
       {
         "en": "vast empire from Greece to India",
-        "ja": "ぎりしあからいんどまでのきょだいなていこく",
+        "ja": "ギリシャからインドまでの巨大な帝国",
         "ja_typings": [
           "girishiakaraindomadenokyodainateikoku"
         ]
       },
       {
         "en": "Roman Empire",
-        "ja": "ろーまていこく",
+        "ja": "ローマ帝国",
         "ja_typings": [
           "romateikoku"
         ]
       },
       {
         "en": "Persian Empire",
-        "ja": "ぺるしあていこく",
+        "ja": "ペルシャ帝国",
         "ja_typings": [
           "perushiateikoku"
         ]
       },
       {
         "en": "Macedonian city-states only",
-        "ja": "まけどにあのとしこっかのみ",
+        "ja": "マケドニアの都市国家のみ",
         "ja_typings": [
           "makedonianotoshikokkanomi"
         ]
@@ -28624,7 +28624,7 @@
     "image_path": null,
     "question_text": {
       "en": "What empire did Alexander the Great build?",
-      "ja": "アレクサンドロス大王が築いた帝国はどれでしょう？"
+      "ja": "アレクサンドロス大王はどのような帝国を築いたか？"
     },
     "question_text_reading": {
       "en": "What empire did Alexander the Great build?",
@@ -28635,28 +28635,28 @@
     "choices": [
       {
         "en": "1941",
-        "ja": "1941ねん",
+        "ja": "1941年",
         "ja_typings": [
           "1941nen"
         ]
       },
       {
         "en": "1939",
-        "ja": "1939ねん",
+        "ja": "1939年",
         "ja_typings": [
           "1939nen"
         ]
       },
       {
         "en": "1943",
-        "ja": "1943ねん",
+        "ja": "1943年",
         "ja_typings": [
           "1943nen"
         ]
       },
       {
         "en": "1945",
-        "ja": "1945ねん",
+        "ja": "1945年",
         "ja_typings": [
           "1945nen"
         ]
@@ -28668,7 +28668,7 @@
     "image_path": null,
     "question_text": {
       "en": "When did Japan attack Pearl Harbor?",
-      "ja": "日本がパールハーバーを攻撃したのはいつですか？"
+      "ja": "日本は何年にパールハーバーを攻撃したか？"
     },
     "question_text_reading": {
       "en": "When did Japan attack Pearl Harbor?",
@@ -28679,28 +28679,28 @@
     "choices": [
       {
         "en": "Neil Armstrong",
-        "ja": "にーるあーむすとろんぐ",
+        "ja": "ニール・アームストロング",
         "ja_typings": [
           "niruamusutorongu"
         ]
       },
       {
         "en": "Buzz Aldrin",
-        "ja": "ばずおるどりん",
+        "ja": "バズ・オールドリン",
         "ja_typings": [
           "bazuorudorin"
         ]
       },
       {
         "en": "Yuri Gagarin",
-        "ja": "ゆーりががーりん",
+        "ja": "ユーリ・ガガーリン",
         "ja_typings": [
           "yurigagarin"
         ]
       },
       {
         "en": "John Glenn",
-        "ja": "じょんぐれん",
+        "ja": "ジョン・グレン",
         "ja_typings": [
           "jonguren"
         ]
@@ -28712,7 +28712,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who was the first man on the moon?",
-      "ja": "はじめて月にたったのは誰か？"
+      "ja": "初めて月にたったのは誰か？"
     },
     "question_text_reading": {
       "en": "Who was the first man on the moon?",
@@ -28723,7 +28723,7 @@
     "choices": [
       {
         "en": "Medieval European religious military campaigns",
-        "ja": "ちゅうせいおうしゅうのしゅうきょうてきぐんじえんせい",
+        "ja": "中世ヨーロッパの宗教的軍事遠征",
         "ja_typings": [
           "chuuseioshuunoshuukyotekigunjiensei",
           "chuuseioushuunoshuukyoutekigunjiensei"
@@ -28731,7 +28731,7 @@
       },
       {
         "en": "Ancient Greek military alliance",
-        "ja": "こだいぎりしあのぐんじどうめい",
+        "ja": "古代ギリシャの軍事同盟",
         "ja_typings": [
           "kodaigirishianogunjidomei",
           "kodaigirishianogunjidoumei"
@@ -28739,7 +28739,7 @@
       },
       {
         "en": "Roman expansion campaigns",
-        "ja": "ろーまのかくちょうえんせい",
+        "ja": "ローマの拡張遠征",
         "ja_typings": [
           "romanokakuchoensei",
           "romanokakuchouensei"
@@ -28747,7 +28747,7 @@
       },
       {
         "en": "Viking raids on Europe",
-        "ja": "えいこくへのばいきんぐのしゅうげき",
+        "ja": "ヨーロッパへのヴァイキングの襲撃",
         "ja_typings": [
           "eikokuhenobaikingunoshuugeki"
         ]
@@ -28759,7 +28759,7 @@
     "image_path": null,
     "question_text": {
       "en": "What was the Crusades?",
-      "ja": "十字軍とはどのようなものですか？"
+      "ja": "十字軍とは何か？"
     },
     "question_text_reading": {
       "en": "What was the Crusades?",
@@ -28770,7 +28770,7 @@
     "choices": [
       {
         "en": "18th century philosophical movement emphasizing reason",
-        "ja": "18せいきのりせいをじゅうしするてつがくうんどう",
+        "ja": "18世紀の理性を重視する哲学運動",
         "ja_typings": [
           "18seikinoriseiojuushisurutetsugakuundo",
           "18seikinoriseiojuushisurutetsugakuundou"
@@ -28778,14 +28778,14 @@
       },
       {
         "en": "Ancient Greek philosophy era",
-        "ja": "こだいぎりしあてつがくのじだい",
+        "ja": "古代ギリシア哲学の時代",
         "ja_typings": [
           "kodaigirishiatetsugakunojidai"
         ]
       },
       {
         "en": "Medieval church domination",
-        "ja": "ちゅうせいのきょうかいしはい",
+        "ja": "中世の教会支配",
         "ja_typings": [
           "chuuseinokyokaishihai",
           "chuuseinokyoukaishihai"
@@ -28793,7 +28793,7 @@
       },
       {
         "en": "Renaissance art movement",
-        "ja": "るねさんすのびじゅつうんどう",
+        "ja": "ルネサンスの美術運動",
         "ja_typings": [
           "runesansunobijutsuundo",
           "runesansunobijutsuundou"
@@ -28806,7 +28806,7 @@
     "image_path": null,
     "question_text": {
       "en": "What was the Enlightenment?",
-      "ja": "啓蒙時代とは、どのようなものだったのでしょうか？"
+      "ja": "啓蒙時代とは何か？"
     },
     "question_text_reading": {
       "en": "What was the Enlightenment?",
@@ -28817,7 +28817,7 @@
     "choices": [
       {
         "en": "South African anti-apartheid leader and president",
-        "ja": "みなみあふりかのはんあぱるとへいとうどうしゃとだいとうりょう",
+        "ja": "南アフリカの反アパルトヘイト指導者と大統領",
         "ja_typings": [
           "minamiafurikanohanaparutoheitodoshatodaitoryo",
           "minamiafurikanohanaparutoheitoudoushatodaitouryou"
@@ -28825,7 +28825,7 @@
       },
       {
         "en": "Kenyan independence leader",
-        "ja": "けにあのどくりつうんどうのしどうしゃ",
+        "ja": "ケニアの独立運動の指導者",
         "ja_typings": [
           "kenianodokuritsuundonoshidosha",
           "kenianodokuritsuundounoshidousha"
@@ -28833,7 +28833,7 @@
       },
       {
         "en": "Nigerian president",
-        "ja": "ないじぇりあのだいとうりょう",
+        "ja": "ナイジェリアの大統領",
         "ja_typings": [
           "naijerianodaitoryo",
           "naijerianodaitouryou"
@@ -28841,7 +28841,7 @@
       },
       {
         "en": "Egyptian revolutionary",
-        "ja": "えじぷとのかくめいか",
+        "ja": "エジプトの革命家",
         "ja_typings": [
           "ejiputonokakumeika"
         ]
@@ -28853,7 +28853,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who was Nelson Mandela?",
-      "ja": "ネルソン・マンデラとはどのような人物ですか？"
+      "ja": "ネルソン・マンデラとは誰か？"
     },
     "question_text_reading": {
       "en": "Who was Nelson Mandela?",
@@ -28864,28 +28864,28 @@
     "choices": [
       {
         "en": "1945",
-        "ja": "1945ねん",
+        "ja": "1945年",
         "ja_typings": [
           "1945nen"
         ]
       },
       {
         "en": "1919",
-        "ja": "1919ねん",
+        "ja": "1919年",
         "ja_typings": [
           "1919nen"
         ]
       },
       {
         "en": "1950",
-        "ja": "1950ねん",
+        "ja": "1950年",
         "ja_typings": [
           "1950nen"
         ]
       },
       {
         "en": "1941",
-        "ja": "1941ねん",
+        "ja": "1941年",
         "ja_typings": [
           "1941nen"
         ]
@@ -28897,7 +28897,7 @@
     "image_path": null,
     "question_text": {
       "en": "When was the United Nations founded?",
-      "ja": "国連はいつ設立されたのでしょうか？"
+      "ja": "国際連合は何年に設立されたか？"
     },
     "question_text_reading": {
       "en": "When was the United Nations founded?",
@@ -28908,7 +28908,7 @@
     "choices": [
       {
         "en": "shift from agricultural to industrial economy",
-        "ja": "のうぎょうからこうぎょうけいざいへのてんかん",
+        "ja": "農業から工業経済への転換",
         "ja_typings": [
           "nogyokarakogyokeizaihenotenkan",
           "nougyoukarakougyoukeizaihenotenkan"
@@ -28916,21 +28916,21 @@
       },
       {
         "en": "political revolution in France",
-        "ja": "ふらんすのせいじかくめい",
+        "ja": "フランスの政治革命",
         "ja_typings": [
           "furansunoseijikakumei"
         ]
       },
       {
         "en": "technology revolution in 20th century",
-        "ja": "20せいきのぎじゅつかくめい",
+        "ja": "20世紀の技術革命",
         "ja_typings": [
           "20seikinogijutsukakumei"
         ]
       },
       {
         "en": "industrial nations forming alliance",
-        "ja": "こうぎょうこくのどうめいけっせい",
+        "ja": "工業国の同盟形成",
         "ja_typings": [
           "kogyokokunodomeikessei",
           "kougyoukokunodoumeikessei"
@@ -28943,7 +28943,7 @@
     "image_path": null,
     "question_text": {
       "en": "What was the Industrial Revolution?",
-      "ja": "産業革命とは何ですか？"
+      "ja": "産業革命とは何か？"
     },
     "question_text_reading": {
       "en": "What was the Industrial Revolution?",
@@ -28954,7 +28954,7 @@
     "choices": [
       {
         "en": "founder of People's Republic of China",
-        "ja": "ちゅうかじんみんきょうわこくのきそしゃ",
+        "ja": "中国人民共和国の基礎者",
         "ja_typings": [
           "chuukajinminkyowakokunokisosha",
           "chuukajinminkyouwakokunokisosha"
@@ -28962,7 +28962,7 @@
       },
       {
         "en": "Japanese emperor",
-        "ja": "にほんのてんのう",
+        "ja": "日本の天皇",
         "ja_typings": [
           "nihonnotenno",
           "nihonnotennou"
@@ -28970,7 +28970,7 @@
       },
       {
         "en": "Vietnamese communist leader",
-        "ja": "べとなむのきょうさんしゅぎしどうしゃ",
+        "ja": "ベトナムの共産主義指導者",
         "ja_typings": [
           "betonamunokyosanshugishidosha",
           "betonamunokyousanshugishidousha"
@@ -28978,7 +28978,7 @@
       },
       {
         "en": "Korean war hero",
-        "ja": "ちょうせんせんそうのえいゆう",
+        "ja": "朝鮮戦争の英雄",
         "ja_typings": [
           "chosensensonoeiyuu",
           "chousensensounoeiyuu"
@@ -28991,7 +28991,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who was Mao Zedong?",
-      "ja": "毛沢東とはどのような人物ですか？"
+      "ja": "毛沢東とは誰か？"
     },
     "question_text_reading": {
       "en": "Who was Mao Zedong?",
@@ -29002,28 +29002,28 @@
     "choices": [
       {
         "en": "1953",
-        "ja": "1953ねん",
+        "ja": "1953年",
         "ja_typings": [
           "1953nen"
         ]
       },
       {
         "en": "1950",
-        "ja": "1950ねん",
+        "ja": "1950年",
         "ja_typings": [
           "1950nen"
         ]
       },
       {
         "en": "1955",
-        "ja": "1955ねん",
+        "ja": "1955年",
         "ja_typings": [
           "1955nen"
         ]
       },
       {
         "en": "1945",
-        "ja": "1945ねん",
+        "ja": "1945年",
         "ja_typings": [
           "1945nen"
         ]
@@ -29035,7 +29035,7 @@
     "image_path": null,
     "question_text": {
       "en": "When did the Korean War end?",
-      "ja": "朝鮮戦争はいつ終わったの？"
+      "ja": "朝鮮戦争は何年終わったか？"
     },
     "question_text_reading": {
       "en": "When did the Korean War end?",
@@ -29046,14 +29046,14 @@
     "choices": [
       {
         "en": "last active pharaoh of ancient Egypt",
-        "ja": "こだいえじぷとのさいごのふぁらお",
+        "ja": "古代エジプトの最後のファラオ",
         "ja_typings": [
           "kodaiejiputonosaigonofarao"
         ]
       },
       {
         "en": "Roman empress",
-        "ja": "ろーまのこうごう",
+        "ja": "ローマの皇后",
         "ja_typings": [
           "romanokogo",
           "romanokougou"
@@ -29061,14 +29061,14 @@
       },
       {
         "en": "Greek goddess",
-        "ja": "ぎりしあのめがみ",
+        "ja": "ギリシャの女神",
         "ja_typings": [
           "girishianomegami"
         ]
       },
       {
         "en": "Persian queen",
-        "ja": "ぺるしあのじょおう",
+        "ja": "ペルシャの女王",
         "ja_typings": [
           "perushianojou",
           "perushianojoou"
@@ -29081,7 +29081,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who was Cleopatra?",
-      "ja": "クレオパトラとは、いったいどんな人物だったのでしょうか？"
+      "ja": "クレオパトラとは誰か？"
     },
     "question_text_reading": {
       "en": "Who was Cleopatra?",
@@ -29092,7 +29092,7 @@
     "choices": [
       {
         "en": "war between Britain and China over trade",
-        "ja": "えいこくとちゅうごくのぼうえきせんそう",
+        "ja": "英国と中国の貿易戦争",
         "ja_typings": [
           "eikokutochuugokunoboekisenso",
           "eikokutochuugokunobouekisensou"
@@ -29100,7 +29100,7 @@
       },
       {
         "en": "war over drug prohibition",
-        "ja": "やくぶつきんしのせんそう",
+        "ja": "薬物禁しの戦争",
         "ja_typings": [
           "yakubutsukinshinosenso",
           "yakubutsukinshinosensou"
@@ -29108,7 +29108,7 @@
       },
       {
         "en": "war between China and Japan",
-        "ja": "ちゅうにちせんそう",
+        "ja": "中国日戦争",
         "ja_typings": [
           "chuunichisenso",
           "chuunichisensou"
@@ -29116,7 +29116,7 @@
       },
       {
         "en": "war in British India",
-        "ja": "えいりょういんどのせんそう",
+        "ja": "イギリス領インドの戦争",
         "ja_typings": [
           "eiryoindonosenso",
           "eiryouindonosensou"
@@ -29129,7 +29129,7 @@
     "image_path": null,
     "question_text": {
       "en": "What was the Opium War?",
-      "ja": "アヘン戦争とは、どのような戦争だったのでしょうか？"
+      "ja": "アヘン戦争とは何か？"
     },
     "question_text_reading": {
       "en": "What was the Opium War?",
@@ -29140,7 +29140,7 @@
     "choices": [
       {
         "en": "16th US president who abolished slavery",
-        "ja": "どれいせいをはいしした16だいアメリカだいとうりょう",
+        "ja": "奴隷制を廃止した第16代アメリカ大統領",
         "ja_typings": [
           "doreiseiohaishishita16daiamerikadaitoryo",
           "doreiseiohaishishita16daiamerikadaitouryou"
@@ -29148,7 +29148,7 @@
       },
       {
         "en": "1st US president",
-        "ja": "アメリカしょだいだいとうりょう",
+        "ja": "アメリカ初代大統領",
         "ja_typings": [
           "amerikashodaidaitoryo",
           "amerikashodaidaitouryou"
@@ -29156,7 +29156,7 @@
       },
       {
         "en": "US president in WWI era",
-        "ja": "だいいちじたいせんきのあめりかだいとうりょう",
+        "ja": "第一次世界線のアメリカ大統領",
         "ja_typings": [
           "daiichijitaisenkinoamerikadaitoryo",
           "daiichijitaisenkinoamerikadaitouryou"
@@ -29164,7 +29164,7 @@
       },
       {
         "en": "US president in WWII era",
-        "ja": "だいにじたいせんきのあめりかだいとうりょう",
+        "ja": "第二次世界線のアメリカ大統領",
         "ja_typings": [
           "dainijitaisenkinoamerikadaitoryo",
           "dainijitaisenkinoamerikadaitouryou"
@@ -29177,7 +29177,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who was Abraham Lincoln?",
-      "ja": "エイブラハム・リンカーンとはどのような人物ですか？"
+      "ja": "エイブラハム・リンカーンとは誰か？"
     },
     "question_text_reading": {
       "en": "Who was Abraham Lincoln?",
@@ -29188,28 +29188,28 @@
     "choices": [
       {
         "en": "1969",
-        "ja": "1969ねん",
+        "ja": "1969年",
         "ja_typings": [
           "1969nen"
         ]
       },
       {
         "en": "1967",
-        "ja": "1967ねん",
+        "ja": "1967年",
         "ja_typings": [
           "1967nen"
         ]
       },
       {
         "en": "1971",
-        "ja": "1971ねん",
+        "ja": "1971年",
         "ja_typings": [
           "1971nen"
         ]
       },
       {
         "en": "1965",
-        "ja": "1965ねん",
+        "ja": "1965年",
         "ja_typings": [
           "1965nen"
         ]
@@ -29221,7 +29221,7 @@
     "image_path": null,
     "question_text": {
       "en": "What year did the Moon landing occur?",
-      "ja": "月面着陸は何年でしたか？"
+      "ja": "月に人が降りたのは何年か？"
     },
     "question_text_reading": {
       "en": "What year did the Moon landing occur?",
@@ -29232,14 +29232,14 @@
     "choices": [
       {
         "en": "WWII US program to develop atomic bomb",
-        "ja": "だいにじたいせんのアメリカのげんしばくだんかいはつ",
+        "ja": "第二次大戦のアメリカの原爆開発",
         "ja_typings": [
           "dainijitaisennoamerikanogenshibakudankaihatsu"
         ]
       },
       {
         "en": "construction of Manhattan island",
-        "ja": "まんはったんとうのけんせつ",
+        "ja": "マンハッタン島の建設",
         "ja_typings": [
           "manhattantonokensetsu",
           "manhattantounokensetsu"
@@ -29247,14 +29247,14 @@
       },
       {
         "en": "Cold War spy program",
-        "ja": "れいせんのすぱいけいかく",
+        "ja": "冷戦のスパイ計画",
         "ja_typings": [
           "reisennosupaikeikaku"
         ]
       },
       {
         "en": "space exploration program",
-        "ja": "うちゅうたんさくけいかく",
+        "ja": "宇宙探査計画",
         "ja_typings": [
           "uchuutansakukeikaku"
         ]
@@ -29266,7 +29266,7 @@
     "image_path": null,
     "question_text": {
       "en": "What was the Manhattan Project?",
-      "ja": "マンハッタン計画とは何ですか？"
+      "ja": "マンハッタン・プロジェクトとは何か？"
     },
     "question_text_reading": {
       "en": "What was the Manhattan Project?",
@@ -29277,7 +29277,7 @@
     "choices": [
       {
         "en": "inventor of AC electrical system",
-        "ja": "こうりゅうでんきのはつめいか",
+        "ja": "交流電気の発明家",
         "ja_typings": [
           "koryuudenkinohatsumeika",
           "kouryuudenkinohatsumeika"
@@ -29285,14 +29285,14 @@
       },
       {
         "en": "inventor of the telephone",
-        "ja": "でんわのはつめいか",
+        "ja": "電話の発明家",
         "ja_typings": [
           "denwanohatsumeika"
         ]
       },
       {
         "en": "founder of Tesla Motors",
-        "ja": "てすらもーたーずのそうぎょうしゃ",
+        "ja": "テスラモーターズの創業者",
         "ja_typings": [
           "tesuramotazunosogyosha",
           "tesuramotazunosougyousha"
@@ -29300,7 +29300,7 @@
       },
       {
         "en": "inventor of the light bulb",
-        "ja": "でんきゅうのはつめいか",
+        "ja": "電球の発明家",
         "ja_typings": [
           "denkyuunohatsumeika"
         ]
@@ -29312,7 +29312,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who was Nikola Tesla?",
-      "ja": "ニコラ・テスラとはどのような人物ですか？"
+      "ja": "ニコラ・テスラとは誰か？"
     },
     "question_text_reading": {
       "en": "Who was Nikola Tesla?",
@@ -29323,7 +29323,7 @@
     "choices": [
       {
         "en": "military government led by a shogun",
-        "ja": "しょうぐんにひきいられたぶがてくせいけん",
+        "ja": "将軍に引きいられた武家政権",
         "ja_typings": [
           "shogunnihikiiraretabugatekuseiken",
           "shougunnihikiiraretabugatekuseiken"
@@ -29331,7 +29331,7 @@
       },
       {
         "en": "imperial government system",
-        "ja": "こうしつのせいふしすてむ",
+        "ja": "公室の政府システム",
         "ja_typings": [
           "koshitsunoseifushisutemu",
           "koushitsunoseifushisutemu"
@@ -29339,7 +29339,7 @@
       },
       {
         "en": "samurai martial arts school",
-        "ja": "さむらいのぶどうがっこう",
+        "ja": "侍の武道学校",
         "ja_typings": [
           "samurainobudogakko",
           "samurainobudougakkou"
@@ -29347,7 +29347,7 @@
       },
       {
         "en": "Buddhist temple organization",
-        "ja": "ぶっきょうじのそしき",
+        "ja": "仏教寺の組織",
         "ja_typings": [
           "bukkyojinososhiki",
           "bukkyoujinososhiki"
@@ -29360,7 +29360,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the Shogunate in Japanese history?",
-      "ja": "日本の歴史における「幕府（Shogunate）」とはどのようなものですか？"
+      "ja": "日本の将軍とはどのようなものか？"
     },
     "question_text_reading": {
       "en": "What is the Shogunate in Japanese history?",
@@ -29371,7 +29371,7 @@
     "choices": [
       {
         "en": "series of conflicts between England and France",
-        "ja": "えいふらんかんのいちれんのぶんそう",
+        "ja": "イングランドとフランスの一連の紛争",
         "ja_typings": [
           "eifurankannoichirennobunso",
           "eifurankannoichirennobunsou"
@@ -29379,7 +29379,7 @@
       },
       {
         "en": "war lasting exactly 100 years",
-        "ja": "ちょうど100ねんつづいたせんそう",
+        "ja": "ちょうど百年間続いた戦争",
         "ja_typings": [
           "chodo100nentsuzuitasenso",
           "choudo100nentsuzuitasensou"
@@ -29387,7 +29387,7 @@
       },
       {
         "en": "war between 100 nations",
-        "ja": "100のくにのせんそう",
+        "ja": "百の国の戦争",
         "ja_typings": [
           "100nokuninosenso",
           "100nokuninosensou"
@@ -29395,7 +29395,7 @@
       },
       {
         "en": "Medieval plague lasting 100 years",
-        "ja": "100ねんつづいたちゅうせいのえきびょう",
+        "ja": "百年続いた中世の疫病",
         "ja_typings": [
           "100nentsuzuitachuuseinoekibyo",
           "100nentsuzuitachuuseinoekibyou"
@@ -29408,7 +29408,7 @@
     "image_path": null,
     "question_text": {
       "en": "What was the Hundred Years' War?",
-      "ja": "百年戦争とは、どのような戦いだったのでしょうか？"
+      "ja": "百年戦争とは何か？"
     },
     "question_text_reading": {
       "en": "What was the Hundred Years' War?",
@@ -29419,14 +29419,14 @@
     "choices": [
       {
         "en": "founder of the Edo shogunate",
-        "ja": "えどばくふのきそしゃ",
+        "ja": "江戸幕府の基礎者",
         "ja_typings": [
           "edobakufunokisosha"
         ]
       },
       {
         "en": "first emperor of Japan",
-        "ja": "にほんのしょだいてんのう",
+        "ja": "日本の初代天皇",
         "ja_typings": [
           "nihonnoshodaitenno",
           "nihonnoshodaitennou"
@@ -29434,7 +29434,7 @@
       },
       {
         "en": "samurai who unified Japan alone",
-        "ja": "にほんをたんどくでとういつしたさむらい",
+        "ja": "日本を単独で統一した侍",
         "ja_typings": [
           "nihonotandokudetoitsushitasamurai",
           "nihonotandokudetouitsushitasamurai"
@@ -29442,7 +29442,7 @@
       },
       {
         "en": "reformer of the Meiji era",
-        "ja": "めいじじだいのかいかくしゃ",
+        "ja": "明治時代の改革者",
         "ja_typings": [
           "meijijidainokaikakusha"
         ]
@@ -29454,7 +29454,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who was Tokugawa Ieyasu?",
-      "ja": "徳川家康とはどのような人物ですか？"
+      "ja": "徳川家康とは誰か？"
     },
     "question_text_reading": {
       "en": "Who was Tokugawa Ieyasu?",
@@ -29465,7 +29465,7 @@
     "choices": [
       {
         "en": "peace treaty ending the first World War",
-        "ja": "だいいちじせかいたいせんをおわらせたへいわじょうやく",
+        "ja": "第一次世界大戦を終わらせた平和条約",
         "ja_typings": [
           "daiichijisekaitaisenowarasetaheiwajoyaku",
           "daiichijisekaitaisenoowarasetaheiwajouyaku"
@@ -29473,7 +29473,7 @@
       },
       {
         "en": "peace treaty ending the second World War",
-        "ja": "だいにじせかいたいせんをおわらせたへいわじょうやく",
+        "ja": "第二次世界大戦を終わらせた平和条約",
         "ja_typings": [
           "dainijisekaitaisenowarasetaheiwajoyaku",
           "dainijisekaitaisenoowarasetaheiwajouyaku"
@@ -29481,7 +29481,7 @@
       },
       {
         "en": "treaty dividing Europe in Cold War",
-        "ja": "れいせんでのおうしゅうのぶんかつじょうやく",
+        "ja": "冷戦での欧州の分割条約",
         "ja_typings": [
           "reisendenoushuunobunkatsujoyaku",
           "reisendenooushuunobunkatsujouyaku"
@@ -29489,7 +29489,7 @@
       },
       {
         "en": "trade treaty between France and Germany",
-        "ja": "ふらんすとどいつのぼうえきじょうやく",
+        "ja": "フランスとドイツの貿易条約",
         "ja_typings": [
           "furansutodoitsunoboekijoyaku",
           "furansutodoitsunobouekijouyaku"
@@ -29502,7 +29502,7 @@
     "image_path": null,
     "question_text": {
       "en": "What was the Treaty of Versailles?",
-      "ja": "ヴェルサイユ条約とはどのようなものですか？"
+      "ja": "ヴェルサイユ条約とは何か？"
     },
     "question_text_reading": {
       "en": "What was the Treaty of Versailles?",
@@ -29513,7 +29513,7 @@
     "choices": [
       {
         "en": "British PM in the second World War",
-        "ja": "だいにじせかいたいせんのえいこくしゅしょう",
+        "ja": "第二次世界大戦の英国首相",
         "ja_typings": [
           "dainijisekaitaisennoeikokushusho",
           "dainijisekaitaisennoeikokushushou"
@@ -29521,7 +29521,7 @@
       },
       {
         "en": "British PM in the first World War",
-        "ja": "だいいちじせかいたいせんのえいこくしゅしょう",
+        "ja": "第一次世界大戦の英国首相",
         "ja_typings": [
           "daiichijisekaitaisennoeikokushusho",
           "daiichijisekaitaisennoeikokushushou"
@@ -29529,7 +29529,7 @@
       },
       {
         "en": "British king during WWII",
-        "ja": "だいにじたいせんのえいこくおう",
+        "ja": "第二次大戦の英国王",
         "ja_typings": [
           "dainijitaisennoeikokuo",
           "dainijitaisennoeikokuou"
@@ -29537,7 +29537,7 @@
       },
       {
         "en": "American president during WWII",
-        "ja": "だいにじたいせんのアメリカだいとうりょう",
+        "ja": "第二次世界のアメリカ大統領",
         "ja_typings": [
           "dainijitaisennoamerikadaitoryo",
           "dainijitaisennoamerikadaitouryou"
@@ -29550,7 +29550,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who was Winston Churchill?",
-      "ja": "ウィンストン・チャーチルとはどのような人物ですか？"
+      "ja": "ウィンストン・チャーチルとは誰か？"
     },
     "question_text_reading": {
       "en": "Who was Winston Churchill?",
@@ -29561,28 +29561,28 @@
     "choices": [
       {
         "en": "1918",
-        "ja": "1918ねん",
+        "ja": "1918年",
         "ja_typings": [
           "1918nen"
         ]
       },
       {
         "en": "1916",
-        "ja": "1916ねん",
+        "ja": "1916年",
         "ja_typings": [
           "1916nen"
         ]
       },
       {
         "en": "1920",
-        "ja": "1920ねん",
+        "ja": "1920年",
         "ja_typings": [
           "1920nen"
         ]
       },
       {
         "en": "1919",
-        "ja": "1919ねん",
+        "ja": "1919年",
         "ja_typings": [
           "1919nen"
         ]
@@ -29594,7 +29594,7 @@
     "image_path": null,
     "question_text": {
       "en": "When did World War I end?",
-      "ja": "第一次世界大戦はいつ終わったの？"
+      "ja": "第一次世界大戦は何年におわったか？"
     },
     "question_text_reading": {
       "en": "When did World War I end?",
@@ -29605,7 +29605,7 @@
     "choices": [
       {
         "en": "water (H2O)",
-        "ja": "みずえいちにおー",
+        "ja": "水H2O",
         "ja_typings": [
           "mizueichinio"
         ]
@@ -29619,7 +29619,7 @@
       },
       {
         "en": "hydrogen peroxide (H2O2)",
-        "ja": "かさんかすいそえいちにおーに",
+        "ja": "過酸化水素H2O2",
         "ja_typings": [
           "kasankasuisoeichinioni"
         ]
@@ -29638,7 +29638,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the chemical symbol for water?",
-      "ja": "水は何の化学記号ですか？"
+      "ja": "水の化学式は？"
     },
     "question_text_reading": {
       "en": "What is the chemical symbol for water?",
@@ -29649,7 +29649,7 @@
     "choices": [
       {
         "en": "object at rest stays at rest unless acted upon",
-        "ja": "がいりょくなしにせいしのぶったいはせいしをたもつ",
+        "ja": "外力なしに静止の物体は静止を保つ",
         "ja_typings": [
           "gairyokunashiniseishinobuttaihaseishiotamotsu"
         ]
@@ -29663,7 +29663,7 @@
       },
       {
         "en": "equal and opposite reactions",
-        "ja": "さようとはんさようがひとしい",
+        "ja": "作用とはん作用が等しい",
         "ja_typings": [
           "sayotohansayogahitoshii",
           "sayoutohansayougahitoshii"
@@ -29671,7 +29671,7 @@
       },
       {
         "en": "energy cannot be created or destroyed",
-        "ja": "えねるぎーはそうせいもしょうめつもしない",
+        "ja": "エネルギーは創成も消滅もしない",
         "ja_typings": [
           "enerugihasoseimoshometsumoshinai",
           "enerugihasouseimoshoumetsumoshinai"
@@ -29684,7 +29684,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is Newton's first law of motion?",
-      "ja": "ニュートンの運動の第1法則とは何ですか？"
+      "ja": "ニュートンの運動の第一法則は？"
     },
     "question_text_reading": {
       "en": "What is Newton's first law of motion?",
@@ -29695,28 +29695,28 @@
     "choices": [
       {
         "en": "Mars",
-        "ja": "かせい",
+        "ja": "火星",
         "ja_typings": [
           "kasei"
         ]
       },
       {
         "en": "Jupiter",
-        "ja": "もくせい",
+        "ja": "木星",
         "ja_typings": [
           "mokusei"
         ]
       },
       {
         "en": "Saturn",
-        "ja": "どせい",
+        "ja": "土星",
         "ja_typings": [
           "dosei"
         ]
       },
       {
         "en": "Venus",
-        "ja": "きんせい",
+        "ja": "金星",
         "ja_typings": [
           "kinsei"
         ]
@@ -29728,7 +29728,7 @@
     "image_path": null,
     "question_text": {
       "en": "What planet is known as the Red Planet?",
-      "ja": "赤い惑星として知られているのはどの惑星ですか？"
+      "ja": "赤い惑星と呼ばれるのは？"
     },
     "question_text_reading": {
       "en": "What planet is known as the Red Planet?",
@@ -29739,14 +29739,14 @@
     "choices": [
       {
         "en": "plants converting light to energy",
-        "ja": "しょくぶつがひかりをえねるぎーにへんかん",
+        "ja": "植物が光をエネルギーに変換",
         "ja_typings": [
           "shokubutsugahikarioeneruginihenkan"
         ]
       },
       {
         "en": "animal digestion process",
-        "ja": "どうぶつのしょうかぷろせす",
+        "ja": "動物の消化プロセス",
         "ja_typings": [
           "dobutsunoshokapurosesu",
           "doubutsunoshoukapurosesu"
@@ -29754,14 +29754,14 @@
       },
       {
         "en": "water cycle process",
-        "ja": "みずのじゅんかんぷろせす",
+        "ja": "水の循環プロセス",
         "ja_typings": [
           "mizunojunkanpurosesu"
         ]
       },
       {
         "en": "cellular respiration",
-        "ja": "さいぼうこきゅう",
+        "ja": "細胞呼吸",
         "ja_typings": [
           "saibokokyuu",
           "saiboukokyuu"
@@ -29774,7 +29774,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is photosynthesis?",
-      "ja": "光合成とは何ですか？"
+      "ja": "光合成とは何か？"
     },
     "question_text_reading": {
       "en": "What is photosynthesis?",
@@ -29785,28 +29785,28 @@
     "choices": [
       {
         "en": "about 300,000 km/s",
-        "ja": "やく30まんkm/s",
+        "ja": "約30万km/s",
         "ja_typings": [
           "yaku30mankm/s"
         ]
       },
       {
         "en": "about 30,000 km/s",
-        "ja": "やく3まんkm/s",
+        "ja": "約3万km/s",
         "ja_typings": [
           "yaku3mankm/s"
         ]
       },
       {
         "en": "about 3,000 km/s",
-        "ja": "やく3せんkm/s",
+        "ja": "約3千km/s",
         "ja_typings": [
           "yaku3senkm/s"
         ]
       },
       {
         "en": "about 3,000,000 km/s",
-        "ja": "やく300まんkm/s",
+        "ja": "約300万km/s",
         "ja_typings": [
           "yaku300mankm/s"
         ]
@@ -29818,7 +29818,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the speed of light?",
-      "ja": "光の速さはどれくらいですか？"
+      "ja": "光の速度は？"
     },
     "question_text_reading": {
       "en": "What is the speed of light?",
@@ -29829,7 +29829,7 @@
     "choices": [
       {
         "en": "molecule storing genetic information",
-        "ja": "いでんじょうほうをほぞんするぶんし",
+        "ja": "遺伝情報を保存する分子",
         "ja_typings": [
           "idenjohoohozonsurubunshi",
           "idenjouhouohozonsurubunshi"
@@ -29837,21 +29837,21 @@
       },
       {
         "en": "protein in muscles",
-        "ja": "きんにくのたんぱくしつ",
+        "ja": "筋肉のタンパク質",
         "ja_typings": [
           "kinnikunotanpakushitsu"
         ]
       },
       {
         "en": "type of RNA",
-        "ja": "RNAのしゅるい",
+        "ja": "RNAの種類",
         "ja_typings": [
           "rnanoshurui"
         ]
       },
       {
         "en": "cell membrane component",
-        "ja": "さいぼうまくのせいぶん",
+        "ja": "細胞膜の成分",
         "ja_typings": [
           "saibomakunoseibun",
           "saiboumakunoseibun"
@@ -29875,7 +29875,7 @@
     "choices": [
       {
         "en": "table organizing chemical elements",
-        "ja": "かがくげんそをせいりしたひょう",
+        "ja": "化学元素を整理した表",
         "ja_typings": [
           "kagakugensoseirishitahyo",
           "kagakugensooseirishitahyou"
@@ -29883,7 +29883,7 @@
       },
       {
         "en": "table of chemical reactions",
-        "ja": "かがくはんのうのひょう",
+        "ja": "化学反応の表",
         "ja_typings": [
           "kagakuhannonohyo",
           "kagakuhannounohyou"
@@ -29891,7 +29891,7 @@
       },
       {
         "en": "table of atomic weights only",
-        "ja": "げんしりょうのみのひょう",
+        "ja": "原子量のみの表",
         "ja_typings": [
           "genshiryonominohyo",
           "genshiryounominohyou"
@@ -29899,7 +29899,7 @@
       },
       {
         "en": "table of natural compounds",
-        "ja": "しぜんかごうぶつのひょう",
+        "ja": "天然化合物の表",
         "ja_typings": [
           "shizenkagobutsunohyo",
           "shizenkagoubutsunohyou"
@@ -29912,7 +29912,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the periodic table?",
-      "ja": "周期表とは何ですか？"
+      "ja": "元素周期表とは何か？"
     },
     "question_text_reading": {
       "en": "What is the periodic table?",
@@ -29923,14 +29923,14 @@
     "choices": [
       {
         "en": "rapid air expansion from lightning heat",
-        "ja": "いなびかりの熱による急速な空気膨張",
+        "ja": "稲光の熱による急速な空気膨張",
         "ja_typings": [
           "inabikarinoniyoruna"
         ]
       },
       {
         "en": "clouds colliding",
-        "ja": "くものしょうとつ",
+        "ja": "雲の衝突",
         "ja_typings": [
           "kumonoshototsu",
           "kumonoshoutotsu"
@@ -29938,7 +29938,7 @@
       },
       {
         "en": "electric discharge from clouds",
-        "ja": "くもからのほうでん",
+        "ja": "雲からの放電",
         "ja_typings": [
           "kumokaranohoden",
           "kumokaranohouden"
@@ -29946,7 +29946,7 @@
       },
       {
         "en": "sonic boom from rain",
-        "ja": "あめのそにっくぶーむ",
+        "ja": "雨のソニックブーム",
         "ja_typings": [
           "amenosonikkubumu"
         ]
@@ -29958,7 +29958,7 @@
     "image_path": null,
     "question_text": {
       "en": "What causes thunder?",
-      "ja": "雷はなぜ鳴るのでしょうか？"
+      "ja": "雷が鳴る理由は？"
     },
     "question_text_reading": {
       "en": "What causes thunder?",
@@ -29976,21 +29976,21 @@
       },
       {
         "en": "dark star that produces no light",
-        "ja": "ひかりをだしていないくらいほし",
+        "ja": "光をだしていないくらいほし",
         "ja_typings": [
           "hikariodashiteinaikuraihoshi"
         ]
       },
       {
         "en": "empty space in galaxy",
-        "ja": "ぎゃらくしーのそらのくうかん",
+        "ja": "銀河の空の空間",
         "ja_typings": [
           "gyarakushinosoranokuukan"
         ]
       },
       {
         "en": "remnant of a supernova",
-        "ja": "ちょうしんせいのなごり",
+        "ja": "超新星の残り",
         "ja_typings": [
           "choshinseinonagori",
           "choushinseinonagori"
@@ -30003,7 +30003,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a black hole?",
-      "ja": "ブラックホールとは何ですか？"
+      "ja": "ブラックホールとは何か？"
     },
     "question_text_reading": {
       "en": "What is a black hole?",
@@ -30014,14 +30014,14 @@
     "choices": [
       {
         "en": "change in heritable traits over generations",
-        "ja": "せだいをこえてかわるいでんてきとくせい",
+        "ja": "世代を越えて変わる遺伝的特性",
         "ja_typings": [
           "sedaiokoetekawaruidentekitokusei"
         ]
       },
       {
         "en": "transformation within one organism's lifetime",
-        "ja": "いのちのあいだにそのどうぶつがかわること",
+        "ja": "一生の間にその動物が変わること",
         "ja_typings": [
           "inochinoaidanisonodobutsugakawarukoto",
           "inochinoaidanisonodoubutsugakawarukoto"
@@ -30029,7 +30029,7 @@
       },
       {
         "en": "adaptation to daily environment",
-        "ja": "にちじょうかんきょうへのてきおう",
+        "ja": "日常生活への適応",
         "ja_typings": [
           "nichijokankyohenotekio",
           "nichijoukankyouhenotekiou"
@@ -30037,7 +30037,7 @@
       },
       {
         "en": "growth and development of individual",
-        "ja": "こたいのせいちょうとはったつ",
+        "ja": "個体の成長と発達",
         "ja_typings": [
           "kotainoseichotohattatsu",
           "kotainoseichoutohattatsu"
@@ -30050,7 +30050,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is evolution?",
-      "ja": "進化とは、どのような現象ですか？"
+      "ja": "進化とは何か？"
     },
     "question_text_reading": {
       "en": "What is evolution?",
@@ -30094,7 +30094,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the atomic number of Carbon?",
-      "ja": "炭素の原子番号は何ですか？"
+      "ja": "炭素の原子番号は？"
     },
     "question_text_reading": {
       "en": "What is the atomic number of Carbon?",
@@ -30105,7 +30105,7 @@
     "choices": [
       {
         "en": "attraction between masses",
-        "ja": "しつりょうかんのひきつけあい",
+        "ja": "質量間の引力",
         "ja_typings": [
           "shitsuryokannohikitsukeai",
           "shitsuryoukannohikitsukeai"
@@ -30113,21 +30113,21 @@
       },
       {
         "en": "repulsion between charges",
-        "ja": "でんかのはんぱつりょく",
+        "ja": "電荷の反発力",
         "ja_typings": [
           "denkanohanpatsuryoku"
         ]
       },
       {
         "en": "electromagnetic force",
-        "ja": "でんじりょく",
+        "ja": "電磁力",
         "ja_typings": [
           "denjiryoku"
         ]
       },
       {
         "en": "nuclear binding force",
-        "ja": "かくりょく",
+        "ja": "核力",
         "ja_typings": [
           "kakuryoku"
         ]
@@ -30139,7 +30139,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is gravity?",
-      "ja": "重力とは、どのようなものですか？"
+      "ja": "重力とは何か？"
     },
     "question_text_reading": {
       "en": "What is gravity?",
@@ -30150,21 +30150,21 @@
     "choices": [
       {
         "en": "Einstein's theory of space, time, and gravity",
-        "ja": "アインシュタインのくうかんじかんじゅうりょくのりろん",
+        "ja": "アインシュタインの空間時間重力のリ論",
         "ja_typings": [
           "ainshutainnokuukanjikanjuuryokunoriron"
         ]
       },
       {
         "en": "theory of evolution",
-        "ja": "しんかろん",
+        "ja": "進化論",
         "ja_typings": [
           "shinkaron"
         ]
       },
       {
         "en": "theory of quantum mechanics",
-        "ja": "りょうしりきがく",
+        "ja": "量子力学",
         "ja_typings": [
           "ryoshirikigaku",
           "ryoushirikigaku"
@@ -30172,7 +30172,7 @@
       },
       {
         "en": "Newton's laws of motion",
-        "ja": "にゅーとんのうんどうほうそく",
+        "ja": "ニュートンの運動法則",
         "ja_typings": [
           "nyutonnondohosoku",
           "nyutonnoundouhousoku"
@@ -30185,7 +30185,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the theory of relativity?",
-      "ja": "相対性理論とはどのようなものですか？"
+      "ja": "相対性理論とは何か？"
     },
     "question_text_reading": {
       "en": "What is the theory of relativity?",
@@ -30196,28 +30196,28 @@
     "choices": [
       {
         "en": "Nitrogen",
-        "ja": "ちっそ",
+        "ja": "窒素",
         "ja_typings": [
           "chisso"
         ]
       },
       {
         "en": "Oxygen",
-        "ja": "さんそ",
+        "ja": "酸素",
         "ja_typings": [
           "sanso"
         ]
       },
       {
         "en": "Carbon Dioxide",
-        "ja": "にさんかたんそ",
+        "ja": "二酸化炭素",
         "ja_typings": [
           "nisankatanso"
         ]
       },
       {
         "en": "Argon",
-        "ja": "あるごん",
+        "ja": "アルゴン",
         "ja_typings": [
           "arugon"
         ]
@@ -30229,7 +30229,7 @@
     "image_path": null,
     "question_text": {
       "en": "What gas is most abundant in Earth's atmosphere?",
-      "ja": "地球の大気中に最も豊富に存在する気体は何ですか？"
+      "ja": "地球の大気にもっともおおい気体は？"
     },
     "question_text_reading": {
       "en": "What gas is most abundant in Earth's atmosphere?",
@@ -30240,7 +30240,7 @@
     "choices": [
       {
         "en": "nerve cell",
-        "ja": "しんけいさいぼう",
+        "ja": "神経細胞",
         "ja_typings": [
           "shinkeisaibo",
           "shinkeisaibou"
@@ -30248,7 +30248,7 @@
       },
       {
         "en": "muscle cell",
-        "ja": "きんにくさいぼう",
+        "ja": "筋細胞",
         "ja_typings": [
           "kinnikusaibo",
           "kinnikusaibou"
@@ -30256,14 +30256,14 @@
       },
       {
         "en": "blood cell",
-        "ja": "けっきゅう",
+        "ja": "血液",
         "ja_typings": [
           "kekkyuu"
         ]
       },
       {
         "en": "skin cell",
-        "ja": "ひふさいぼう",
+        "ja": "皮膚細胞",
         "ja_typings": [
           "hifusaibo",
           "hifusaibou"
@@ -30276,7 +30276,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a neuron?",
-      "ja": "ニューロンとは何ですか？"
+      "ja": "ニューロンとは何か？"
     },
     "question_text_reading": {
       "en": "What is a neuron?",
@@ -30287,7 +30287,7 @@
     "choices": [
       {
         "en": "universe began from a hot dense state",
-        "ja": "うちゅうはこうおんこうみつじょうたいからはじまった",
+        "ja": "宇宙は高温高密度状態から始まった",
         "ja_typings": [
           "uchuuhakoonkomitsujotaikarahajimatta",
           "uchuuhakouonkoumitsujoutaikarahajimatta"
@@ -30295,21 +30295,21 @@
       },
       {
         "en": "universe has always existed",
-        "ja": "うちゅうはつねにそんざいしていた",
+        "ja": "宇宙は常に存在していた",
         "ja_typings": [
           "uchuuhatsunenisonzaishiteita"
         ]
       },
       {
         "en": "universe is contracting",
-        "ja": "うちゅうはしゅうしゅくしている",
+        "ja": "宇宙は収縮している",
         "ja_typings": [
           "uchuuhashuushukushiteiru"
         ]
       },
       {
         "en": "stars created the universe",
-        "ja": "ほしがうちゅうをつくった",
+        "ja": "星が宇宙を創った",
         "ja_typings": [
           "hoshigauchuuotsukutta"
         ]
@@ -30321,7 +30321,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the Big Bang theory?",
-      "ja": "ビッグバン理論とは、どのようなものですか？"
+      "ja": "ビッグバン理論とは何か？"
     },
     "question_text_reading": {
       "en": "What is the Big Bang theory?",
@@ -30332,7 +30332,7 @@
     "choices": [
       {
         "en": "cell's powerhouse producing ATP",
-        "ja": "さいぼうのATPせいさんそうち",
+        "ja": "細胞のATP生産装置",
         "ja_typings": [
           "saibonoatpseisansochi",
           "saibounoatpseisansouchi"
@@ -30340,7 +30340,7 @@
       },
       {
         "en": "protein synthesis organelle",
-        "ja": "たんぱくしつごうせいのきかん",
+        "ja": "タンパク質合成の器官",
         "ja_typings": [
           "tanpakushitsugoseinokikan",
           "tanpakushitsugouseinokikan"
@@ -30348,7 +30348,7 @@
       },
       {
         "en": "cell's genetic material storage",
-        "ja": "さいぼうのいでんじかんり",
+        "ja": "細胞の遺伝子環理",
         "ja_typings": [
           "saibonoidenjikanri",
           "saibounoidenjikanri"
@@ -30356,7 +30356,7 @@
       },
       {
         "en": "cell membrane pump",
-        "ja": "さいぼうまくのぽんぷ",
+        "ja": "細胞膜ポンプ",
         "ja_typings": [
           "saibomakunoponpu",
           "saiboumakunoponpu"
@@ -30369,7 +30369,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the mitochondria?",
-      "ja": "ミトコンドリアとは何ですか？"
+      "ja": "ミトコンドリアは何か？"
     },
     "question_text_reading": {
       "en": "What is the mitochondria?",
@@ -30380,7 +30380,7 @@
     "choices": [
       {
         "en": "water moving through semipermeable membrane",
-        "ja": "はんとうまくをこしてみずがいどうする",
+        "ja": "半透膜をこして水が移動する",
         "ja_typings": [
           "hantomakuokoshitemizugaidosuru",
           "hantoumakuokoshitemizugaidousuru"
@@ -30388,7 +30388,7 @@
       },
       {
         "en": "nutrient absorption in cells",
-        "ja": "さいぼうでのえいようきゅうしゅう",
+        "ja": "細胞での栄養吸収",
         "ja_typings": [
           "saibodenoeiyokyuushuu",
           "saiboudenoeiyoukyuushuu"
@@ -30396,7 +30396,7 @@
       },
       {
         "en": "gas exchange in lungs",
-        "ja": "はいでのがすこうかん",
+        "ja": "肺でのガス交換",
         "ja_typings": [
           "haidenogasukokan",
           "haidenogasukoukan"
@@ -30404,7 +30404,7 @@
       },
       {
         "en": "salt dissolving in water",
-        "ja": "しおがみずにとけること",
+        "ja": "塩が水に溶けること",
         "ja_typings": [
           "shiogamizunitokerukoto"
         ]
@@ -30416,7 +30416,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is osmosis?",
-      "ja": "浸透圧とは何ですか？"
+      "ja": "浸透とは何か？"
     },
     "question_text_reading": {
       "en": "What is osmosis?",
@@ -30427,14 +30427,14 @@
     "choices": [
       {
         "en": "atmosphere trapping heat",
-        "ja": "たいきがねつをとじこめる",
+        "ja": "大気が熱を閉じ込める",
         "ja_typings": [
           "taikiganetsuotojikomeru"
         ]
       },
       {
         "en": "plants using sunlight",
-        "ja": "しょくぶつがたいようこうをりようする",
+        "ja": "植物が太陽光を利用する",
         "ja_typings": [
           "shokubutsugataiyokooriyosuru",
           "shokubutsugataiyoukouoriyousuru"
@@ -30442,7 +30442,7 @@
       },
       {
         "en": "ocean warming by sun",
-        "ja": "たいようにようる海のあたたまり",
+        "ja": "太陽による海のあたたまり",
         "ja_typings": [
           "taiyoniyorunoatatamari",
           "taiyouniyourunoatatamari"
@@ -30450,7 +30450,7 @@
       },
       {
         "en": "volcanoes releasing CO2",
-        "ja": "かざんがCO₂をほうしゅつする",
+        "ja": "火山がCO₂を放出する",
         "ja_typings": [
           "kazangacohoshutsusuru",
           "kazangacoohoushutsusuru"
@@ -30463,7 +30463,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the greenhouse effect?",
-      "ja": "温室効果とは何ですか？"
+      "ja": "温室効果とは何か？"
     },
     "question_text_reading": {
       "en": "What is the greenhouse effect?",
@@ -30474,28 +30474,28 @@
     "choices": [
       {
         "en": "gravity",
-        "ja": "じゅうりょく",
+        "ja": "重力",
         "ja_typings": [
           "juuryoku"
         ]
       },
       {
         "en": "magnetic force",
-        "ja": "じりょく",
+        "ja": "磁力",
         "ja_typings": [
           "jiryoku"
         ]
       },
       {
         "en": "nuclear force",
-        "ja": "かくりょく",
+        "ja": "核力",
         "ja_typings": [
           "kakuryoku"
         ]
       },
       {
         "en": "centrifugal force",
-        "ja": "えんしんりょく",
+        "ja": "遠心力",
         "ja_typings": [
           "enshinryoku"
         ]
@@ -30507,7 +30507,7 @@
     "image_path": null,
     "question_text": {
       "en": "What force keeps planets in orbit?",
-      "ja": "惑星を軌道に留めている力は何ですか？"
+      "ja": "惑星を軌道に留める力は？"
     },
     "question_text_reading": {
       "en": "What force keeps planets in orbit?",
@@ -30518,7 +30518,7 @@
     "choices": [
       {
         "en": "contains DNA and controls cell activities",
-        "ja": "DNAをもちさいぼうかつどうをせいぎょ",
+        "ja": "DNAを持ち細胞活動を制御",
         "ja_typings": [
           "dnaomochisaibokatsudooseigyo",
           "dnaomochisaiboukatsudouoseigyo"
@@ -30526,7 +30526,7 @@
       },
       {
         "en": "produces energy for the cell",
-        "ja": "さいぼうのためにえねるぎーをせいさん",
+        "ja": "細胞のためにエネルギーを生産",
         "ja_typings": [
           "saibonotamenienerugioseisan",
           "saibounotamenienerugioseisan"
@@ -30534,7 +30534,7 @@
       },
       {
         "en": "creates proteins for the cell",
-        "ja": "さいぼうのためにたんぱくしつをつくる",
+        "ja": "細胞のためにタンパク質をつくる",
         "ja_typings": [
           "saibonotamenitanpakushitsuotsukuru",
           "saibounotamenitanpakushitsuotsukuru"
@@ -30542,7 +30542,7 @@
       },
       {
         "en": "controls cell movement",
-        "ja": "さいぼうのうごきをせいぎょ",
+        "ja": "細胞の動きを制御",
         "ja_typings": [
           "saibonogokioseigyo",
           "saibounougokioseigyo"
@@ -30555,7 +30555,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the function of the nucleus in a cell?",
-      "ja": "細胞の核はどのような役割を果たしているのでしょうか？"
+      "ja": "細胞の核の役割は？"
     },
     "question_text_reading": {
       "en": "What is the function of the nucleus in a cell?",
@@ -30566,7 +30566,7 @@
     "choices": [
       {
         "en": "smallest unit of an element",
-        "ja": "げんそのさいしょうたんい",
+        "ja": "原子の最小単位",
         "ja_typings": [
           "gensonosaishotani",
           "gensonosaishoutani"
@@ -30574,7 +30574,7 @@
       },
       {
         "en": "smallest particle of matter",
-        "ja": "ぶっしつのさいしょうりゅうし",
+        "ja": "物質の最小粒子",
         "ja_typings": [
           "busshitsunosaishoryuushi",
           "busshitsunosaishouryuushi"
@@ -30582,7 +30582,7 @@
       },
       {
         "en": "subatomic particle",
-        "ja": "そうあとみっくりゅうし",
+        "ja": "素粒子",
         "ja_typings": [
           "soatomikkuryuushi",
           "souatomikkuryuushi"
@@ -30590,7 +30590,7 @@
       },
       {
         "en": "molecule of two atoms",
-        "ja": "ふたつのげんしのぶんし",
+        "ja": "二つの原子の分子",
         "ja_typings": [
           "futatsunogenshinobunshi"
         ]
@@ -30602,7 +30602,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is an atom?",
-      "ja": "原子とは何ですか？"
+      "ja": "原子とは何か？"
     },
     "question_text_reading": {
       "en": "What is an atom?",
@@ -30613,28 +30613,28 @@
     "choices": [
       {
         "en": "positively charged particle in nucleus",
-        "ja": "かくのなかのせいのでんかりゅうし",
+        "ja": "核のなかの正の電荷粒子",
         "ja_typings": [
           "kakunonakanoseinodenkaryuushi"
         ]
       },
       {
         "en": "negatively charged particle",
-        "ja": "ふのでんかりゅうし",
+        "ja": "負電荷粒子",
         "ja_typings": [
           "funodenkaryuushi"
         ]
       },
       {
         "en": "neutral particle in nucleus",
-        "ja": "かくのなかのちゅうせいりゅうし",
+        "ja": "核のなかの中性粒子",
         "ja_typings": [
           "kakunonakanochuuseiryuushi"
         ]
       },
       {
         "en": "particle outside nucleus",
-        "ja": "かくのそとのりゅうし",
+        "ja": "核のそとのりゅうし",
         "ja_typings": [
           "kakunosotonoryuushi"
         ]
@@ -30646,7 +30646,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a proton?",
-      "ja": "陽子とは何ですか？"
+      "ja": "陽子とは何か？"
     },
     "question_text_reading": {
       "en": "What is a proton?",
@@ -30657,7 +30657,7 @@
     "choices": [
       {
         "en": "negatively charged particle orbiting nucleus",
-        "ja": "かくをこうかいするふのでんかりゅうし",
+        "ja": "核を崩壊する負の電粒子",
         "ja_typings": [
           "kakuokokaisurufunodenkaryuushi",
           "kakuokoukaisurufunodenkaryuushi"
@@ -30665,21 +30665,21 @@
       },
       {
         "en": "positively charged particle",
-        "ja": "せいのでんかりゅうし",
+        "ja": "正電粒子",
         "ja_typings": [
           "seinodenkaryuushi"
         ]
       },
       {
         "en": "particle in nucleus",
-        "ja": "かくのなかのりゅうし",
+        "ja": "核のなかの粒子",
         "ja_typings": [
           "kakunonakanoryuushi"
         ]
       },
       {
         "en": "neutral particle",
-        "ja": "ちゅうせいりゅうし",
+        "ja": "中性粒子",
         "ja_typings": [
           "chuuseiryuushi"
         ]
@@ -30691,7 +30691,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is an electron?",
-      "ja": "電子とは何ですか？"
+      "ja": "電子とは何か？"
     },
     "question_text_reading": {
       "en": "What is an electron?",
@@ -30702,21 +30702,21 @@
     "choices": [
       {
         "en": "neutral particle in the nucleus",
-        "ja": "かくのなかのちゅうせいりゅうし",
+        "ja": "核のなかの中性粒子",
         "ja_typings": [
           "kakunonakanochuuseiryuushi"
         ]
       },
       {
         "en": "positively charged nuclear particle",
-        "ja": "かくのせいでんかりゅうし",
+        "ja": "陽子",
         "ja_typings": [
           "kakunoseidenkaryuushi"
         ]
       },
       {
         "en": "negatively charged orbital particle",
-        "ja": "ふのでんかこうかいりゅうし",
+        "ja": "負電荷軌道粒子",
         "ja_typings": [
           "funodenkakokairyuushi",
           "funodenkakoukairyuushi"
@@ -30724,7 +30724,7 @@
       },
       {
         "en": "particle outside the atom",
-        "ja": "げんしのそとのりゅうし",
+        "ja": "原子の外の粒子",
         "ja_typings": [
           "genshinosotonoryuushi"
         ]
@@ -30736,7 +30736,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a neutron?",
-      "ja": "中性子とは何ですか？"
+      "ja": "中性子とは何か？"
     },
     "question_text_reading": {
       "en": "What is a neutron?",
@@ -30747,7 +30747,7 @@
     "choices": [
       {
         "en": "galaxy containing our solar system",
-        "ja": "たいようけいをふくむぎゃらくしー",
+        "ja": "太陽系を含む銀河系",
         "ja_typings": [
           "taiyokeiofukumugyarakushi",
           "taiyoukeiofukumugyarakushi"
@@ -30755,21 +30755,21 @@
       },
       {
         "en": "visible path of the moon",
-        "ja": "つきのみちすじ",
+        "ja": "月の道筋",
         "ja_typings": [
           "tsukinomichisuji"
         ]
       },
       {
         "en": "meteor shower event",
-        "ja": "りゅうせいうのできごと",
+        "ja": "流星雨のできごと",
         "ja_typings": [
           "ryuuseiunodekigoto"
         ]
       },
       {
         "en": "region of dense stars near Sun",
-        "ja": "たいようきんくのこうみつほしいき",
+        "ja": "太陽近傍の恒星域",
         "ja_typings": [
           "taiyokinkunokomitsuhoshiiki",
           "taiyoukinkunokoumitsuhoshiiki"
@@ -30782,7 +30782,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the Milky Way?",
-      "ja": "天の川銀河とはどのようなものですか？"
+      "ja": "天の川とは何か？"
     },
     "question_text_reading": {
       "en": "What is the Milky Way?",
@@ -30793,14 +30793,14 @@
     "choices": [
       {
         "en": "waves of electric and magnetic fields",
-        "ja": "でんきとじきのは",
+        "ja": "電磁の波",
         "ja_typings": [
           "denkitojikinoha"
         ]
       },
       {
         "en": "radiation from radioactive materials",
-        "ja": "ほうしゃせいぶっしつからのほうしゃ",
+        "ja": "放射性物質からの放射",
         "ja_typings": [
           "hoshaseibusshitsukaranohosha",
           "houshaseibusshitsukaranohousha"
@@ -30808,7 +30808,7 @@
       },
       {
         "en": "radiation from the sun only",
-        "ja": "たいようからのみのほうしゃ",
+        "ja": "太陽からののみの放射",
         "ja_typings": [
           "taiyokaranominohosha",
           "taiyoukaranominohousha"
@@ -30816,7 +30816,7 @@
       },
       {
         "en": "radiation in Earth's core",
-        "ja": "ちきゅうのかくのほうしゃ",
+        "ja": "地球の核の放射",
         "ja_typings": [
           "chikyuunokakunohosha",
           "chikyuunokakunohousha"
@@ -30829,7 +30829,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is electromagnetic radiation?",
-      "ja": "電磁放射とは何ですか？"
+      "ja": "電磁放射とは何か？"
     },
     "question_text_reading": {
       "en": "What is electromagnetic radiation?",
@@ -30840,14 +30840,14 @@
     "choices": [
       {
         "en": "forces holding atoms together in molecules",
-        "ja": "ぶんしのなかでげんしをつなぐちから",
+        "ja": "分子の中で原子をつなぐ力",
         "ja_typings": [
           "bunshinonakadegenshiotsunaguchikara"
         ]
       },
       {
         "en": "chemical reaction rate",
-        "ja": "かがくはんのうのそくど",
+        "ja": "化学反応の速度",
         "ja_typings": [
           "kagakuhannonosokudo",
           "kagakuhannounosokudo"
@@ -30855,7 +30855,7 @@
       },
       {
         "en": "process of dissolving substances",
-        "ja": "ぶっしつのようかいぷろせす",
+        "ja": "物質の溶解プロセス",
         "ja_typings": [
           "busshitsunoyokaipurosesu",
           "busshitsunoyoukaipurosesu"
@@ -30863,7 +30863,7 @@
       },
       {
         "en": "separation of compounds",
-        "ja": "かごうぶつのぶんりかい",
+        "ja": "化合物の分離解離",
         "ja_typings": [
           "kagobutsunobunrikai",
           "kagoubutsunobunrikai"
@@ -30876,7 +30876,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is chemical bonding?",
-      "ja": "化学結合とは何ですか？"
+      "ja": "化学結合とは何か？"
     },
     "question_text_reading": {
       "en": "What is chemical bonding?",
@@ -30887,7 +30887,7 @@
     "choices": [
       {
         "en": "testable proposed explanation",
-        "ja": "けんしょう可能なかていの説明",
+        "ja": "検証可能な過程の説明",
         "ja_typings": [
           "kenshonakateino",
           "kenshounakateino"
@@ -30895,7 +30895,7 @@
       },
       {
         "en": "proven scientific fact",
-        "ja": "しょうめいされたかがくてきじじつ",
+        "ja": "証明された科学的事実",
         "ja_typings": [
           "shomeisaretakagakutekijijitsu",
           "shoumeisaretakagakutekijijitsu"
@@ -30903,14 +30903,14 @@
       },
       {
         "en": "experimental result",
-        "ja": "じっけんけっか",
+        "ja": "実験結果",
         "ja_typings": [
           "jikkenkekka"
         ]
       },
       {
         "en": "scientific law",
-        "ja": "かがくてきほうそく",
+        "ja": "科学的法則",
         "ja_typings": [
           "kagakutekihosoku",
           "kagakutekihousoku"
@@ -30923,7 +30923,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a hypothesis?",
-      "ja": "仮説とは何ですか？"
+      "ja": "仮説とは何か？"
     },
     "question_text_reading": {
       "en": "What is a hypothesis?",
@@ -30934,7 +30934,7 @@
     "choices": [
       {
         "en": "systematic approach to testing hypotheses",
-        "ja": "かせつをけんしょうするけいとうてきなほうほう",
+        "ja": "仮説を検証する系統的な方法",
         "ja_typings": [
           "kasetsuokenshosurukeitotekinahoho",
           "kasetsuokenshousurukeitoutekinahouhou"
@@ -30942,14 +30942,14 @@
       },
       {
         "en": "collection of scientific facts",
-        "ja": "かがくてきじじつのしゅうしゅう",
+        "ja": "科学的事実の収集",
         "ja_typings": [
           "kagakutekijijitsunoshuushuu"
         ]
       },
       {
         "en": "laboratory equipment usage",
-        "ja": "じっけんきぐのしよう",
+        "ja": "実験器具の使用",
         "ja_typings": [
           "jikkenkigunoshiyo",
           "jikkenkigunoshiyou"
@@ -30957,7 +30957,7 @@
       },
       {
         "en": "publishing research papers",
-        "ja": "けんきゅうろんぶんのこうかい",
+        "ja": "研究論文の公開",
         "ja_typings": [
           "kenkyuuronbunnokokai",
           "kenkyuuronbunnokoukai"
@@ -30970,7 +30970,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the scientific method?",
-      "ja": "科学的な手法とは何ですか？"
+      "ja": "科学的諸法とは何か？"
     },
     "question_text_reading": {
       "en": "What is the scientific method?",
@@ -30981,7 +30981,7 @@
     "choices": [
       {
         "en": "unit of heredity on DNA",
-        "ja": "DNAじょうのいでんのたんい",
+        "ja": "DNA上の遺伝の単位",
         "ja_typings": [
           "dnajonoidennotani",
           "dnajounoidennotani"
@@ -30989,14 +30989,14 @@
       },
       {
         "en": "type of protein",
-        "ja": "たんぱくしつのしゅるい",
+        "ja": "タンパク質の種類",
         "ja_typings": [
           "tanpakushitsunoshurui"
         ]
       },
       {
         "en": "cell membrane component",
-        "ja": "さいぼうまくのせいぶん",
+        "ja": "細胞膜の成分",
         "ja_typings": [
           "saibomakunoseibun",
           "saiboumakunoseibun"
@@ -31004,7 +31004,7 @@
       },
       {
         "en": "RNA molecule",
-        "ja": "RNAぶんし",
+        "ja": "RNA分子",
         "ja_typings": [
           "rnabunshi"
         ]
@@ -31016,7 +31016,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a gene?",
-      "ja": "遺伝子とは何ですか？"
+      "ja": "遺伝子とは何か？"
     },
     "question_text_reading": {
       "en": "What is a gene?",
@@ -31027,14 +31027,14 @@
     "choices": [
       {
         "en": "feeding relationships in ecosystem",
-        "ja": "せいたいけいのしょくじかんけい",
+        "ja": "生態系の食物間関係",
         "ja_typings": [
           "seitaikeinoshokujikankei"
         ]
       },
       {
         "en": "path food takes in digestion",
-        "ja": "しょうかのなかのしょくひんのみち",
+        "ja": "消化のなかの食の道",
         "ja_typings": [
           "shokanonakanoshokuhinnomichi",
           "shoukanonakanoshokuhinnomichi"
@@ -31042,7 +31042,7 @@
       },
       {
         "en": "supply chain for food industry",
-        "ja": "しょくひんさんぎょうのさぷらいちぇーん",
+        "ja": "食品産業のサプライチェーン",
         "ja_typings": [
           "shokuhinsangyonosapuraichen",
           "shokuhinsangyounosapuraichen"
@@ -31050,7 +31050,7 @@
       },
       {
         "en": "chain of supermarkets",
-        "ja": "すーぱーのれんさ",
+        "ja": "スーパーの連鎖",
         "ja_typings": [
           "supanorensa"
         ]
@@ -31062,7 +31062,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the food chain?",
-      "ja": "食物連鎖とは、どのようなものですか？"
+      "ja": "食物連鎖とは何か？"
     },
     "question_text_reading": {
       "en": "What is the food chain?",
@@ -31073,28 +31073,28 @@
     "choices": [
       {
         "en": "100°C",
-        "ja": "100ど",
+        "ja": "100°C",
         "ja_typings": [
           "100do"
         ]
       },
       {
         "en": "90°C",
-        "ja": "90ど",
+        "ja": "90°C",
         "ja_typings": [
           "90do"
         ]
       },
       {
         "en": "110°C",
-        "ja": "110ど",
+        "ja": "110°C",
         "ja_typings": [
           "110do"
         ]
       },
       {
         "en": "80°C",
-        "ja": "80ど",
+        "ja": "80°C",
         "ja_typings": [
           "80do"
         ]
@@ -31106,7 +31106,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the boiling point of water at sea level?",
-      "ja": "海面における水の沸点は何度ですか？"
+      "ja": "海面での水の沸点は？"
     },
     "question_text_reading": {
       "en": "What is the boiling point of water at sea level?",
@@ -31117,28 +31117,28 @@
     "choices": [
       {
         "en": "substances transform into new substances",
-        "ja": "ぶっしつがあたらしいぶっしつにへんかん",
+        "ja": "物質が新しい物質に変換",
         "ja_typings": [
           "busshitsugaatarashiibusshitsunihenkan"
         ]
       },
       {
         "en": "physical change in matter",
-        "ja": "ぶっしつのぶつりてきへんか",
+        "ja": "物質の物理的変化",
         "ja_typings": [
           "busshitsunobutsuritekihenka"
         ]
       },
       {
         "en": "mixing two liquids",
-        "ja": "ふたつのえきたいをまぜる",
+        "ja": "二つの液体を混ぜる",
         "ja_typings": [
           "futatsunoekitaiomazeru"
         ]
       },
       {
         "en": "dissolving a solid",
-        "ja": "こたいをようかいする",
+        "ja": "固体を溶解する",
         "ja_typings": [
           "kotaioyokaisuru",
           "kotaioyoukaisuru"
@@ -31151,7 +31151,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a chemical reaction?",
-      "ja": "化学反応とは、どのようなものですか？"
+      "ja": "化学反応とは何か？"
     },
     "question_text_reading": {
       "en": "What is a chemical reaction?",
@@ -31162,7 +31162,7 @@
     "choices": [
       {
         "en": "time for half of atoms to decay",
-        "ja": "げんしのはんぶんがほうかいするまでのじかん",
+        "ja": "原子の半分が崩壊するまでの時間",
         "ja_typings": [
           "genshinohanbungahokaisurumadenojikan",
           "genshinohanbungahoukaisurumadenojikan"
@@ -31170,7 +31170,7 @@
       },
       {
         "en": "half the element's lifespan",
-        "ja": "げんそのじゅみょうのはんぶん",
+        "ja": "元素の寿命の半分",
         "ja_typings": [
           "gensonojumyonohanbun",
           "gensonojumyounohanbun"
@@ -31178,14 +31178,14 @@
       },
       {
         "en": "time for element to double",
-        "ja": "げんそが2ばいになるじかん",
+        "ja": "元素が2倍になる時間",
         "ja_typings": [
           "gensoga2baininarujikan"
         ]
       },
       {
         "en": "half the atomic weight",
-        "ja": "げんしりょうのはんぶん",
+        "ja": "原子量の半分",
         "ja_typings": [
           "genshiryonohanbun",
           "genshiryounohanbun"
@@ -31198,7 +31198,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the half-life of a radioactive element?",
-      "ja": "放射性元素の半減期とは何ですか？"
+      "ja": "放射性元素の半減期とは何か？"
     },
     "question_text_reading": {
       "en": "What is the half-life of a radioactive element?",
@@ -31209,7 +31209,7 @@
     "choices": [
       {
         "en": "substance that speeds up reaction without being consumed",
-        "ja": "じぶんはへらずにはんのうをはやめるぶっしつ",
+        "ja": "自分は減らずに反応を速める物質",
         "ja_typings": [
           "jibunhaherazunihannoohayamerubusshitsu",
           "jibunhaherazunihannouohayamerubusshitsu"
@@ -31217,7 +31217,7 @@
       },
       {
         "en": "substance consumed in reaction",
-        "ja": "はんのうでしょうひされるぶっしつ",
+        "ja": "反応で消費される物質",
         "ja_typings": [
           "hannodeshohisarerubusshitsu",
           "hannoudeshouhisarerubusshitsu"
@@ -31225,7 +31225,7 @@
       },
       {
         "en": "substance that stops reaction",
-        "ja": "はんのうをとめるぶっしつ",
+        "ja": "反応を止める物質",
         "ja_typings": [
           "hannootomerubusshitsu",
           "hannouotomerubusshitsu"
@@ -31233,7 +31233,7 @@
       },
       {
         "en": "substance produced by reaction",
-        "ja": "はんのうでせいせいされるぶっしつ",
+        "ja": "反応で生成される物質",
         "ja_typings": [
           "hannodeseiseisarerubusshitsu",
           "hannoudeseiseisarerubusshitsu"
@@ -31246,7 +31246,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a catalyst?",
-      "ja": "触媒とは何ですか？"
+      "ja": "触媒とは何か？"
     },
     "question_text_reading": {
       "en": "What is a catalyst?",
@@ -31257,7 +31257,7 @@
     "choices": [
       {
         "en": "energy of motion",
-        "ja": "うんどうのえねるぎー",
+        "ja": "運動のエネルギー",
         "ja_typings": [
           "undonoenerugi",
           "undounoenerugi"
@@ -31265,21 +31265,21 @@
       },
       {
         "en": "stored potential energy",
-        "ja": "たくわえられたいねるぎー",
+        "ja": "蓄えられたエネルギー",
         "ja_typings": [
           "takuwaeraretainerugi"
         ]
       },
       {
         "en": "thermal energy",
-        "ja": "ねつえねるぎー",
+        "ja": "熱エネルギー",
         "ja_typings": [
           "netsuenerugi"
         ]
       },
       {
         "en": "chemical energy",
-        "ja": "かがくえねるぎー",
+        "ja": "化学エネルギー",
         "ja_typings": [
           "kagakuenerugi"
         ]
@@ -31291,7 +31291,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is kinetic energy?",
-      "ja": "運動エネルギーとは何ですか？"
+      "ja": "運動エネルギーとは何か？"
     },
     "question_text_reading": {
       "en": "What is kinetic energy?",
@@ -31302,7 +31302,7 @@
     "choices": [
       {
         "en": "stored energy due to position or state",
-        "ja": "いちやじょうたいによるたくわえられたえねるぎー",
+        "ja": "位置や状態による蓄えられたエネルギー",
         "ja_typings": [
           "ichiyajotainiyorutakuwaeraretaenerugi",
           "ichiyajoutainiyorutakuwaeraretaenerugi"
@@ -31310,7 +31310,7 @@
       },
       {
         "en": "energy of motion",
-        "ja": "うんどうのえねるぎー",
+        "ja": "運動のエネルギー",
         "ja_typings": [
           "undonoenerugi",
           "undounoenerugi"
@@ -31318,14 +31318,14 @@
       },
       {
         "en": "electrical energy",
-        "ja": "でんきえねるぎー",
+        "ja": "電気エネルギー",
         "ja_typings": [
           "denkienerugi"
         ]
       },
       {
         "en": "nuclear energy",
-        "ja": "かくえねるぎー",
+        "ja": "核エネルギー",
         "ja_typings": [
           "kakuenerugi"
         ]
@@ -31337,7 +31337,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is potential energy?",
-      "ja": "ポテンシャルエネルギーとは何ですか？"
+      "ja": "エネルギーとは何か？"
     },
     "question_text_reading": {
       "en": "What is potential energy?",
@@ -31348,7 +31348,7 @@
     "choices": [
       {
         "en": "energy cannot be created or destroyed",
-        "ja": "えねるぎーはそうせいもしょうめつもしない",
+        "ja": "エネルギーは創成も消滅もしない",
         "ja_typings": [
           "enerugihasoseimoshometsumoshinai",
           "enerugihasouseimoshoumetsumoshinai"
@@ -31356,21 +31356,21 @@
       },
       {
         "en": "energy increases in closed systems",
-        "ja": "へいさいけいでえねるぎーはふえる",
+        "ja": "閉鎖系でエネルギーは増える",
         "ja_typings": [
           "heisaikeideenerugihafueru"
         ]
       },
       {
         "en": "energy is always converted to heat",
-        "ja": "えねるぎーはつねにねつにへんかん",
+        "ja": "エネルギーは常に熱に変換",
         "ja_typings": [
           "enerugihatsuneninetsunihenkan"
         ]
       },
       {
         "en": "energy is constant only in space",
-        "ja": "えねるぎーはうちゅうでのみいってい",
+        "ja": "エネルギーは宇宙でのみ一定",
         "ja_typings": [
           "enerugihauchuudenomiittei"
         ]
@@ -31382,7 +31382,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the law of conservation of energy?",
-      "ja": "エネルギー保存の法則とは、どのようなものですか？"
+      "ja": "エネルギー保存の法則とは何か？"
     },
     "question_text_reading": {
       "en": "What is the law of conservation of energy?",
@@ -31393,7 +31393,7 @@
     "choices": [
       {
         "en": "carry oxygen through the body",
-        "ja": "さんそをからだにはこぶ",
+        "ja": "酸素を体にはこぶ",
         "ja_typings": [
           "sansokaradanihakobu",
           "sansookaradanihakobu"
@@ -31401,7 +31401,7 @@
       },
       {
         "en": "fight infections",
-        "ja": "かんせんしょうとたたかう",
+        "ja": "感染症と戦う",
         "ja_typings": [
           "kansenshototatakau",
           "kansenshoutotatakau"
@@ -31409,14 +31409,14 @@
       },
       {
         "en": "form blood clots",
-        "ja": "けっせんをつくる",
+        "ja": "血栓を作る",
         "ja_typings": [
           "kessenotsukuru"
         ]
       },
       {
         "en": "produce hormones",
-        "ja": "ほるもんをせいさん",
+        "ja": "ホルモンを生産",
         "ja_typings": [
           "horumonoseisan"
         ]
@@ -31428,7 +31428,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the role of red blood cells?",
-      "ja": "赤血球の役割は何ですか？"
+      "ja": "赤血球の役割は？"
     },
     "question_text_reading": {
       "en": "What is the role of red blood cells?",
@@ -31439,7 +31439,7 @@
     "choices": [
       {
         "en": "fight infections and foreign bodies",
-        "ja": "かんせんしょうとがいぶしんたいとたたかう",
+        "ja": "感染症と異物体と戦う",
         "ja_typings": [
           "kansenshotogaibushintaitotatakau",
           "kansenshoutogaibushintaitotatakau"
@@ -31447,7 +31447,7 @@
       },
       {
         "en": "carry oxygen",
-        "ja": "さんそをはこぶ",
+        "ja": "酸素を運ぶ",
         "ja_typings": [
           "sansohakobu",
           "sansoohakobu"
@@ -31455,14 +31455,14 @@
       },
       {
         "en": "clot blood",
-        "ja": "ちをかたまらせる",
+        "ja": "血をかたまる",
         "ja_typings": [
           "chiokatamaraseru"
         ]
       },
       {
         "en": "store nutrients",
-        "ja": "えいようをちょくせつほぞん",
+        "ja": "栄養を直接保存",
         "ja_typings": [
           "eiyoochokusetsuhozon",
           "eiyouochokusetsuhozon"
@@ -31475,7 +31475,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the function of white blood cells?",
-      "ja": "白血球の主な役割は何ですか？"
+      "ja": "白血球の役割は？"
     },
     "question_text_reading": {
       "en": "What is the function of white blood cells?",
@@ -31486,7 +31486,7 @@
     "choices": [
       {
         "en": "pancreas",
-        "ja": "すいぞう",
+        "ja": "膵臓",
         "ja_typings": [
           "suizo",
           "suizou"
@@ -31494,7 +31494,7 @@
       },
       {
         "en": "liver",
-        "ja": "かんぞう",
+        "ja": "肝臓",
         "ja_typings": [
           "kanzo",
           "kanzou"
@@ -31502,7 +31502,7 @@
       },
       {
         "en": "kidney",
-        "ja": "じんぞう",
+        "ja": "腎臓",
         "ja_typings": [
           "jinzo",
           "jinzou"
@@ -31510,7 +31510,7 @@
       },
       {
         "en": "spleen",
-        "ja": "ひぞう",
+        "ja": "脾臓",
         "ja_typings": [
           "hizo",
           "hizou"
@@ -31523,7 +31523,7 @@
     "image_path": null,
     "question_text": {
       "en": "What organ produces insulin?",
-      "ja": "インスリンを分泌する臓器はどれですか？"
+      "ja": "インスリンを生産する器官は？"
     },
     "question_text_reading": {
       "en": "What organ produces insulin?",
@@ -31534,7 +31534,7 @@
     "choices": [
       {
         "en": "filter blood and produce urine",
-        "ja": "けつえきをこしてにょうをつくる",
+        "ja": "血液を濾して尿をつくる",
         "ja_typings": [
           "ketsuekiokoshitenyootsukuru",
           "ketsuekiokoshitenyouotsukuru"
@@ -31542,7 +31542,7 @@
       },
       {
         "en": "digest food",
-        "ja": "しょくぶつをしょうか",
+        "ja": "植物を消化",
         "ja_typings": [
           "shokubutsuoshoka",
           "shokubutsuoshouka"
@@ -31550,7 +31550,7 @@
       },
       {
         "en": "produce oxygen",
-        "ja": "さんそをせいさん",
+        "ja": "酸素を生産",
         "ja_typings": [
           "sansoseisan",
           "sansooseisan"
@@ -31558,7 +31558,7 @@
       },
       {
         "en": "control heartbeat",
-        "ja": "しんぱくをせいぎょ",
+        "ja": "心拍を制御",
         "ja_typings": [
           "shinpakuoseigyo"
         ]
@@ -31570,7 +31570,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the function of the kidney?",
-      "ja": "腎臓の主な機能は何ですか？"
+      "ja": "腎臓の役割は？"
     },
     "question_text_reading": {
       "en": "What is the function of the kidney?",
@@ -31581,7 +31581,7 @@
     "choices": [
       {
         "en": "substance stimulating immune response",
-        "ja": "めんえきはんのうをうながすぶっしつ",
+        "ja": "免疫反応を促す物質",
         "ja_typings": [
           "menekihannoonagasubusshitsu",
           "menekihannouounagasubusshitsu"
@@ -31589,21 +31589,21 @@
       },
       {
         "en": "medicine killing bacteria directly",
-        "ja": "さいきんをちょくせつころすやくざい",
+        "ja": "細菌を直接殺す薬剤",
         "ja_typings": [
           "saikinochokusetsukorosuyakuzai"
         ]
       },
       {
         "en": "medicine reducing fever",
-        "ja": "ねつをさげるやくざい",
+        "ja": "熱を下げる薬剤",
         "ja_typings": [
           "netsuosageruyakuzai"
         ]
       },
       {
         "en": "medicine for pain relief",
-        "ja": "いたみどめのやくざい",
+        "ja": "痛み止めの薬剤",
         "ja_typings": [
           "itamidomenoyakuzai"
         ]
@@ -31626,28 +31626,28 @@
     "choices": [
       {
         "en": "measure of acidity or alkalinity",
-        "ja": "さんせいやアルカリせいのはかりかた",
+        "ja": "酸性やアルカリ性のはかりかた",
         "ja_typings": [
           "sanseiyaarukariseinohakarikata"
         ]
       },
       {
         "en": "measure of chemical purity",
-        "ja": "かがくじゅんすいどのはかりかた",
+        "ja": "化学純度の測定方法",
         "ja_typings": [
           "kagakujunsuidonohakarikata"
         ]
       },
       {
         "en": "measure of temperature",
-        "ja": "おんどのはかりかた",
+        "ja": "温度の測り方",
         "ja_typings": [
           "ondonohakarikata"
         ]
       },
       {
         "en": "measure of pressure",
-        "ja": "あつりょくのはかりかた",
+        "ja": "圧力の測り方",
         "ja_typings": [
           "atsuryokunohakarikata"
         ]
@@ -31659,7 +31659,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the pH scale?",
-      "ja": "pHスケールとは何ですか？"
+      "ja": "pHスケールとは何か？"
     },
     "question_text_reading": {
       "en": "What is the pH scale?",
@@ -31670,14 +31670,14 @@
     "choices": [
       {
         "en": "rain with high acidity from pollution",
-        "ja": "おせんによるさんせいのつよいあめ",
+        "ja": "汚染による酸性の強い雨",
         "ja_typings": [
           "osenniyorusanseinotsuyoiame"
         ]
       },
       {
         "en": "rain in tropical areas",
-        "ja": "ねったいちほうのあめ",
+        "ja": "熱帯地方の雨",
         "ja_typings": [
           "nettaichihonoame",
           "nettaichihounoame"
@@ -31685,14 +31685,14 @@
       },
       {
         "en": "rain with heavy metal content",
-        "ja": "じゅうきんぞくをふくむあめ",
+        "ja": "重金属を含む雨",
         "ja_typings": [
           "juukinzokuofukumuame"
         ]
       },
       {
         "en": "rain during volcanic eruption",
-        "ja": "かざんふんかちゅうのあめ",
+        "ja": "火山噴火中の雨",
         "ja_typings": [
           "kazanfunkachuunoame"
         ]
@@ -31704,7 +31704,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is acid rain?",
-      "ja": "酸性雨とは何ですか？"
+      "ja": "酸性雨とは何か？"
     },
     "question_text_reading": {
       "en": "What is acid rain?",
@@ -31715,7 +31715,7 @@
     "choices": [
       {
         "en": "splitting an atom releasing energy",
-        "ja": "げんしをわってえねるぎーをかいほう",
+        "ja": "原子を割ってエネルギーを解放",
         "ja_typings": [
           "genshiowatteenerugiokaiho",
           "genshiowatteenerugiokaihou"
@@ -31723,7 +31723,7 @@
       },
       {
         "en": "combining atoms to release energy",
-        "ja": "げんしをあわせてえねるぎーをかいほう",
+        "ja": "原子をあわせてエネルギーを解放",
         "ja_typings": [
           "genshioawaseteenerugiokaiho",
           "genshioawaseteenerugiokaihou"
@@ -31731,7 +31731,7 @@
       },
       {
         "en": "radioactive decay of atoms",
-        "ja": "げんしのほうしゃせいほうかい",
+        "ja": "原子の放射性崩壊",
         "ja_typings": [
           "genshinohoshaseihokai",
           "genshinohoushaseihoukai"
@@ -31739,7 +31739,7 @@
       },
       {
         "en": "chemical breakdown of molecules",
-        "ja": "ぶんしのかがくてきぶんかい",
+        "ja": "分子の化学的分解",
         "ja_typings": [
           "bunshinokagakutekibunkai"
         ]
@@ -31751,7 +31751,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is nuclear fission?",
-      "ja": "核分裂とは何ですか？"
+      "ja": "核分裂とは何か？"
     },
     "question_text_reading": {
       "en": "What is nuclear fission?",
@@ -31762,7 +31762,7 @@
     "choices": [
       {
         "en": "combining nuclei to release energy",
-        "ja": "かくをあわせてえねるぎーをかいほう",
+        "ja": "核をあわせてエネルギーを解放",
         "ja_typings": [
           "kakuoawaseteenerugiokaiho",
           "kakuoawaseteenerugiokaihou"
@@ -31770,7 +31770,7 @@
       },
       {
         "en": "splitting nucleus to release energy",
-        "ja": "かくをわってえねるぎーをかいほう",
+        "ja": "核を割ってエネルギーを解放",
         "ja_typings": [
           "kakuowatteenerugiokaiho",
           "kakuowatteenerugiokaihou"
@@ -31778,7 +31778,7 @@
       },
       {
         "en": "radioactive emission from nucleus",
-        "ja": "かくからのほうしゃせいはっしゃ",
+        "ja": "核からの放射性崩壊",
         "ja_typings": [
           "kakukaranohoshaseihassha",
           "kakukaranohoushaseihassha"
@@ -31786,7 +31786,7 @@
       },
       {
         "en": "nuclear chain reaction",
-        "ja": "かくれんさはんのう",
+        "ja": "核連鎖反応",
         "ja_typings": [
           "kakurensahanno",
           "kakurensahannou"
@@ -31799,7 +31799,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is nuclear fusion?",
-      "ja": "核融合とは何ですか？"
+      "ja": "核融合とは何か？"
     },
     "question_text_reading": {
       "en": "What is nuclear fusion?",
@@ -31810,14 +31810,14 @@
     "choices": [
       {
         "en": "massive sections of Earth's crust",
-        "ja": "ちきゅうのちかくのきょだいなぶぶん",
+        "ja": "地球の近くの巨大な部分",
         "ja_typings": [
           "chikyuunochikakunokyodainabubun"
         ]
       },
       {
         "en": "layers of the atmosphere",
-        "ja": "たいきのそう",
+        "ja": "大気の層",
         "ja_typings": [
           "taikinoso",
           "taikinosou"
@@ -31825,14 +31825,14 @@
       },
       {
         "en": "ocean floor sections",
-        "ja": "かいていのぶぶん",
+        "ja": "海底の部分",
         "ja_typings": [
           "kaiteinobubun"
         ]
       },
       {
         "en": "continental shelf regions",
-        "ja": "たいりくだなのりょういき",
+        "ja": "大陸棚地域",
         "ja_typings": [
           "tairikudananoryoiki",
           "tairikudananoryouiki"
@@ -31856,7 +31856,7 @@
     "choices": [
       {
         "en": "movement of tectonic plates",
-        "ja": "プレートのうごき",
+        "ja": "プレートの動き",
         "ja_typings": [
           "puretonogoki",
           "puretonougoki"
@@ -31864,14 +31864,14 @@
       },
       {
         "en": "underground explosions",
-        "ja": "ちかのばくはつ",
+        "ja": "地下爆発",
         "ja_typings": [
           "chikanobakuhatsu"
         ]
       },
       {
         "en": "volcanic activity",
-        "ja": "かざんかつどう",
+        "ja": "火山活動",
         "ja_typings": [
           "kazankatsudo",
           "kazankatsudou"
@@ -31879,7 +31879,7 @@
       },
       {
         "en": "ocean tides",
-        "ja": "うみのしおか",
+        "ja": "海の潮か",
         "ja_typings": [
           "uminoshioka"
         ]
@@ -31891,7 +31891,7 @@
     "image_path": null,
     "question_text": {
       "en": "What causes an earthquake?",
-      "ja": "地震の原因は何ですか？"
+      "ja": "地震の原因は？"
     },
     "question_text_reading": {
       "en": "What causes an earthquake?",
@@ -31902,7 +31902,7 @@
     "choices": [
       {
         "en": "layer absorbing UV radiation",
-        "ja": "しがいせんをきゅうしゅうするそう",
+        "ja": "紫外線を吸収する層",
         "ja_typings": [
           "shigaisenokyuushuusuruso",
           "shigaisenokyuushuusurusou"
@@ -31910,7 +31910,7 @@
       },
       {
         "en": "layer containing most oxygen",
-        "ja": "さんそをもっともふくむそう",
+        "ja": "酸素をもっとも含む層",
         "ja_typings": [
           "sansomottomofukumuso",
           "sansoomottomofukumusou"
@@ -31918,7 +31918,7 @@
       },
       {
         "en": "layer reflecting radio waves",
-        "ja": "でんぱをはんしゃするそう",
+        "ja": "電波を反射する層",
         "ja_typings": [
           "denpaohanshasuruso",
           "denpaohanshasurusou"
@@ -31926,7 +31926,7 @@
       },
       {
         "en": "layer containing greenhouse gases",
-        "ja": "おんしつこうかがすをふくむそう",
+        "ja": "温室効果ガスを含む層",
         "ja_typings": [
           "onshitsukokagasuofukumuso",
           "onshitsukoukagasuofukumusou"
@@ -31939,7 +31939,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the ozone layer?",
-      "ja": "オゾン層とは何ですか？"
+      "ja": "オゾン層とは何か？"
     },
     "question_text_reading": {
       "en": "What is the ozone layer?",
@@ -31950,28 +31950,28 @@
     "choices": [
       {
         "en": "energy from naturally replenishing sources",
-        "ja": "しぜんにおぎなわれるみなもとのえねるぎー",
+        "ja": "自然に補給されるみなもとのエネルギー",
         "ja_typings": [
           "shizennioginawareruminamotonoenerugi"
         ]
       },
       {
         "en": "energy from oil and gas",
-        "ja": "せきゆとがすのえねるぎー",
+        "ja": "石油とガスのエネルギー",
         "ja_typings": [
           "sekiyutogasunoenerugi"
         ]
       },
       {
         "en": "energy from nuclear fission",
-        "ja": "かくぶんれつのえねるぎー",
+        "ja": "核分裂のエネルギー",
         "ja_typings": [
           "kakubunretsunoenerugi"
         ]
       },
       {
         "en": "energy from coal",
-        "ja": "せきたんのえねるぎー",
+        "ja": "石炭のエネルギー",
         "ja_typings": [
           "sekitannoenerugi"
         ]
@@ -31983,7 +31983,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a renewable energy source?",
-      "ja": "再生可能エネルギー源とは何ですか？"
+      "ja": "再生可能なエネルギーとは何か？"
     },
     "question_text_reading": {
       "en": "What is a renewable energy source?",
@@ -31994,28 +31994,28 @@
     "choices": [
       {
         "en": "4",
-        "ja": "よん",
+        "ja": "四",
         "ja_typings": [
           "yon"
         ]
       },
       {
         "en": "3",
-        "ja": "さん",
+        "ja": "三",
         "ja_typings": [
           "san"
         ]
       },
       {
         "en": "5",
-        "ja": "ご",
+        "ja": "五",
         "ja_typings": [
           "go"
         ]
       },
       {
         "en": "6",
-        "ja": "ろく",
+        "ja": "六",
         "ja_typings": [
           "roku"
         ]
@@ -32027,7 +32027,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 2 + 2?",
-      "ja": "2足す2はいくつですか？"
+      "ja": "2たす2はいくつ？"
     },
     "question_text_reading": {
       "en": "What is 2 + 2?",
@@ -32038,28 +32038,28 @@
     "choices": [
       {
         "en": "12",
-        "ja": "じゅうに",
+        "ja": "十二",
         "ja_typings": [
           "juuni"
         ]
       },
       {
         "en": "11",
-        "ja": "じゅういち",
+        "ja": "11",
         "ja_typings": [
           "juuichi"
         ]
       },
       {
         "en": "13",
-        "ja": "じゅうさん",
+        "ja": "十三",
         "ja_typings": [
           "juusan"
         ]
       },
       {
         "en": "14",
-        "ja": "じゅうし",
+        "ja": "十四",
         "ja_typings": [
           "juushi"
         ]
@@ -32071,7 +32071,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the square root of 144?",
-      "ja": "144の平方根は何ですか？"
+      "ja": "144の平方根は？"
     },
     "question_text_reading": {
       "en": "What is the square root of 144?",
@@ -32082,28 +32082,28 @@
     "choices": [
       {
         "en": "3.14159",
-        "ja": "さんてんいちよんいちごきゅう",
+        "ja": "3.14159",
         "ja_typings": [
           "santenichiyonichigokyuu"
         ]
       },
       {
         "en": "2.71828",
-        "ja": "にてんなないちはちにはち",
+        "ja": "2.71828",
         "ja_typings": [
           "nitennanaichihachinihachi"
         ]
       },
       {
         "en": "1.41421",
-        "ja": "いちてんよんいちよんにいち",
+        "ja": "1.41421",
         "ja_typings": [
           "ichitenyonichiyonniichi"
         ]
       },
       {
         "en": "1.73205",
-        "ja": "いちてんななさんにれい",
+        "ja": "1.73205",
         "ja_typings": [
           "ichitennanasannirei"
         ]
@@ -32115,7 +32115,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is pi approximately equal to?",
-      "ja": "円周率 pi はおよそいくつですか？"
+      "ja": "円周率πはおよそいくつ？"
     },
     "question_text_reading": {
       "en": "What is pi approximately equal to?",
@@ -32126,7 +32126,7 @@
     "choices": [
       {
         "en": "a²+b²=c²",
-        "ja": "えーじじょうたすびーじじょうはしーじじょう",
+        "ja": "a²+b²=c²",
         "ja_typings": [
           "ejijotasubijijohashijijo",
           "ejijoutasubijijouhashijijou"
@@ -32134,21 +32134,21 @@
       },
       {
         "en": "a+b=c",
-        "ja": "えーたすびーはしー",
+        "ja": "a+b=c",
         "ja_typings": [
           "etasubihashi"
         ]
       },
       {
         "en": "a×b=c",
-        "ja": "えーかけるびーはしー",
+        "ja": "A×B=C",
         "ja_typings": [
           "ekakerubihashi"
         ]
       },
       {
         "en": "a²-b²=c",
-        "ja": "えーじじょうひくびーじじょうはしー",
+        "ja": "a²-b²=c",
         "ja_typings": [
           "ejijohikubijijohashi",
           "ejijouhikubijijouhashi"
@@ -32161,7 +32161,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the Pythagorean theorem?",
-      "ja": "ピタゴラスの定理とは何ですか？"
+      "ja": "ピタゴラスの定理とは？"
     },
     "question_text_reading": {
       "en": "What is the Pythagorean theorem?",
@@ -32172,21 +32172,21 @@
     "choices": [
       {
         "en": "a number divisible only by 1 and itself",
-        "ja": "1とじぶんじしんでのみわりきれるかず",
+        "ja": "1と自分自身でのみ割り切れる数",
         "ja_typings": [
           "1tojibunjishindenomiwarikirerukazu"
         ]
       },
       {
         "en": "a number divisible by 2",
-        "ja": "2でわりきれるかず",
+        "ja": "2で割り切れる数",
         "ja_typings": [
           "2dewarikirerukazu"
         ]
       },
       {
         "en": "a number greater than 100",
-        "ja": "100よりおおきいかず",
+        "ja": "百より大きい数",
         "ja_typings": [
           "100yoriokiikazu",
           "100yoriookiikazu"
@@ -32194,7 +32194,7 @@
       },
       {
         "en": "a negative number",
-        "ja": "ふのかず",
+        "ja": "負の数",
         "ja_typings": [
           "funokazu"
         ]
@@ -32206,7 +32206,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a prime number?",
-      "ja": "素数とは何ですか？"
+      "ja": "素数は何か？"
     },
     "question_text_reading": {
       "en": "What is a prime number?",
@@ -32217,28 +32217,28 @@
     "choices": [
       {
         "en": "three million six hundred twenty-eight thousand eight hundred",
-        "ja": "さんびゃくろくじゅうにまんはっせん",
+        "ja": "三百六十二万八千",
         "ja_typings": [
           "sanbyakurokujuunimanhassen"
         ]
       },
       {
         "en": "3628000",
-        "ja": "さんびゃくろくじゅうにまんぜろ",
+        "ja": "3628000",
         "ja_typings": [
           "sanbyakurokujuunimanzero"
         ]
       },
       {
         "en": "thirty-six million two hundred eighty-eight thousand",
-        "ja": "さんぜんろっぴゃくにじゅうはちまん",
+        "ja": "三十六百万二八万八千",
         "ja_typings": [
           "sanzenroppyakunijuuhachiman"
         ]
       },
       {
         "en": "three hundred sixty-two thousand eight hundred eighty",
-        "ja": "さんじゅうろくまんにせんはっぴゃくはちじゅう",
+        "ja": "三百六万十二千八百八十",
         "ja_typings": [
           "sanjuurokumannisenhappyakuhachijuu"
         ]
@@ -32250,7 +32250,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 10 factorial (10!)?",
-      "ja": "10の階乗（10!）はいくつですか？"
+      "ja": "10の階乗(10!)はいくつ？"
     },
     "question_text_reading": {
       "en": "What is 10 factorial (10!)?",
@@ -32261,28 +32261,28 @@
     "choices": [
       {
         "en": "180 degrees",
-        "ja": "ひゃくはちじゅうど",
+        "ja": "180度",
         "ja_typings": [
           "hyakuhachijuudo"
         ]
       },
       {
         "en": "90 degrees",
-        "ja": "きゅうじゅうど",
+        "ja": "九十度",
         "ja_typings": [
           "kyuujuudo"
         ]
       },
       {
         "en": "270 degrees",
-        "ja": "にひゃくななじゅうど",
+        "ja": "270度",
         "ja_typings": [
           "nihyakunanajuudo"
         ]
       },
       {
         "en": "360 degrees",
-        "ja": "さんびゃくろくじゅうど",
+        "ja": "360度",
         "ja_typings": [
           "sanbyakurokujuudo"
         ]
@@ -32294,7 +32294,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the sum of angles in a triangle?",
-      "ja": "三角形の内角の和は何度ですか？"
+      "ja": "三角形の内角の和は？"
     },
     "question_text_reading": {
       "en": "What is the sum of angles in a triangle?",
@@ -32305,7 +32305,7 @@
     "choices": [
       {
         "en": "πr squared",
-        "ja": "ぱいあーるじじょう",
+        "ja": "πr²",
         "ja_typings": [
           "paiarujijo",
           "paiarujijou"
@@ -32313,21 +32313,21 @@
       },
       {
         "en": "two pi r",
-        "ja": "にぱいあーる",
+        "ja": "2πr",
         "ja_typings": [
           "nipaiaru"
         ]
       },
       {
         "en": "πr (no square)",
-        "ja": "ぱいかけるあーる",
+        "ja": "πr",
         "ja_typings": [
           "paikakeruaru"
         ]
       },
       {
         "en": "pi times d",
-        "ja": "ぱいかけるでぃー",
+        "ja": "π×d",
         "ja_typings": [
           "paikakerudi"
         ]
@@ -32339,7 +32339,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the area of a circle?",
-      "ja": "円の面積を求める公式は何ですか？"
+      "ja": "円の面積は？"
     },
     "question_text_reading": {
       "en": "What is the area of a circle?",
@@ -32350,14 +32350,14 @@
     "choices": [
       {
         "en": "two pi r",
-        "ja": "にぱいあーる",
+        "ja": "2πr",
         "ja_typings": [
           "nipaiaru"
         ]
       },
       {
         "en": "πr squared",
-        "ja": "ぱいあーるじじょう",
+        "ja": "πr²",
         "ja_typings": [
           "paiarujijo",
           "paiarujijou"
@@ -32365,14 +32365,14 @@
       },
       {
         "en": "πr (no square)",
-        "ja": "ぱいかけるあーる",
+        "ja": "πr",
         "ja_typings": [
           "paikakeruaru"
         ]
       },
       {
         "en": "four pi r",
-        "ja": "よんぱいあーる",
+        "ja": "4πr",
         "ja_typings": [
           "yonpaiaru"
         ]
@@ -32384,7 +32384,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the circumference of a circle?",
-      "ja": "円の円周（circumference）とは何ですか？"
+      "ja": "円の周長は？"
     },
     "question_text_reading": {
       "en": "What is the circumference of a circle?",
@@ -32395,28 +32395,28 @@
     "choices": [
       {
         "en": "0, 1, 1, 2, 3, 5",
-        "ja": "れい いち いち に さん ご",
+        "ja": "例 一 一 二 三 五",
         "ja_typings": [
           "rei ichi ichi ni san go"
         ]
       },
       {
         "en": "1, 2, 3, 5, 8",
-        "ja": "いち に さん ご はち",
+        "ja": "一二三五八",
         "ja_typings": [
           "ichi ni san go hachi"
         ]
       },
       {
         "en": "0, 1, 2, 3, 5",
-        "ja": "れい いち に さん ご",
+        "ja": "零 一 二 三 五",
         "ja_typings": [
           "rei ichi ni san go"
         ]
       },
       {
         "en": "1, 1, 2, 4, 8",
-        "ja": "いち いち に よん はち",
+        "ja": "1 1 2 4 8",
         "ja_typings": [
           "ichi ichi ni yon hachi"
         ]
@@ -32428,7 +32428,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the Fibonacci sequence starting with?",
-      "ja": "フィボナッチ数列は、何から始まるでしょうか？"
+      "ja": "フィボナッチ数列のはじまりは？"
     },
     "question_text_reading": {
       "en": "What is the Fibonacci sequence starting with?",
@@ -32439,28 +32439,28 @@
     "choices": [
       {
         "en": "average of values",
-        "ja": "あたいのへいきん",
+        "ja": "値の平均",
         "ja_typings": [
           "atainoheikin"
         ]
       },
       {
         "en": "middle value",
-        "ja": "まんなかのあたい",
+        "ja": "真ん中の値",
         "ja_typings": [
           "mannakanoatai"
         ]
       },
       {
         "en": "most frequent value",
-        "ja": "もっともひんぱんなあたい",
+        "ja": "最も頻繁な値",
         "ja_typings": [
           "mottomohinpannaatai"
         ]
       },
       {
         "en": "range of values",
-        "ja": "あたいのはんい",
+        "ja": "値の範囲",
         "ja_typings": [
           "atainohani"
         ]
@@ -32472,7 +32472,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does 'mean' refer to in statistics?",
-      "ja": "統計学における「mean」とは何を指すのでしょうか？"
+      "ja": "統計での平均とは？"
     },
     "question_text_reading": {
       "en": "What does 'mean' refer to in statistics?",
@@ -32483,28 +32483,28 @@
     "choices": [
       {
         "en": "middle value in sorted data",
-        "ja": "せいれつされたでーたのまんなかのあたい",
+        "ja": "ソートされたデータの真ん中の値",
         "ja_typings": [
           "seiretsusaretadetanomannakanoatai"
         ]
       },
       {
         "en": "average of all values",
-        "ja": "すべてのあたいのへいきん",
+        "ja": "すべての値の平均",
         "ja_typings": [
           "subetenoatainoheikin"
         ]
       },
       {
         "en": "most common value",
-        "ja": "もっともよくでるあたい",
+        "ja": "最もよく出る値",
         "ja_typings": [
           "mottomoyokuderuatai"
         ]
       },
       {
         "en": "difference between max and min",
-        "ja": "さいだいとさいしょうのさ",
+        "ja": "最大と最小の差",
         "ja_typings": [
           "saidaitosaishonosa",
           "saidaitosaishounosa"
@@ -32517,7 +32517,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the median?",
-      "ja": "中央値とは何ですか？"
+      "ja": "中央値とは何か？"
     },
     "question_text_reading": {
       "en": "What is the median?",
@@ -32528,28 +32528,28 @@
     "choices": [
       {
         "en": "most frequently occurring value",
-        "ja": "もっともひんぱんにでるあたい",
+        "ja": "最も頻繁に出る値",
         "ja_typings": [
           "mottomohinpannideruatai"
         ]
       },
       {
         "en": "average value",
-        "ja": "へいきんち",
+        "ja": "平均値",
         "ja_typings": [
           "heikinchi"
         ]
       },
       {
         "en": "middle value",
-        "ja": "なかまのち",
+        "ja": "中間の地",
         "ja_typings": [
           "nakamanochi"
         ]
       },
       {
         "en": "range of values",
-        "ja": "はんい",
+        "ja": "範囲",
         "ja_typings": [
           "hani"
         ]
@@ -32561,7 +32561,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the mode in statistics?",
-      "ja": "統計学における「mode」とは何ですか？"
+      "ja": "統計での最頻値とは？"
     },
     "question_text_reading": {
       "en": "What is the mode in statistics?",
@@ -32572,7 +32572,7 @@
     "choices": [
       {
         "en": "equation with x²",
-        "ja": "えっくすじじょうをふくむほうていしき",
+        "ja": "x²を含む方程式",
         "ja_typings": [
           "ekkusujijoofukumuhoteishiki",
           "ekkusujijouofukumuhouteishiki"
@@ -32580,7 +32580,7 @@
       },
       {
         "en": "equation with x³",
-        "ja": "えっくすさんじょうをふくむほうていしき",
+        "ja": "x³を含む方程式",
         "ja_typings": [
           "ekkususanjoofukumuhoteishiki",
           "ekkususanjouofukumuhouteishiki"
@@ -32588,7 +32588,7 @@
       },
       {
         "en": "equation with no variables",
-        "ja": "へんすうのないほうていしき",
+        "ja": "変数のない方程式",
         "ja_typings": [
           "hensuunonaihoteishiki",
           "hensuunonaihouteishiki"
@@ -32596,7 +32596,7 @@
       },
       {
         "en": "equation with only addition",
-        "ja": "たしざんだけのほうていしき",
+        "ja": "加算だけの方程式",
         "ja_typings": [
           "tashizandakenohoteishiki",
           "tashizandakenohouteishiki"
@@ -32609,7 +32609,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a quadratic equation?",
-      "ja": "二次方程式とはどのようなものですか？"
+      "ja": "二次方程式とは何か？"
     },
     "question_text_reading": {
       "en": "What is a quadratic equation?",
@@ -32620,7 +32620,7 @@
     "choices": [
       {
         "en": "x = (-b ± √(b²-4ac)) / 2a",
-        "ja": "えっくすはまいなすびーぷらすまいなするーとびーじじょうひくよんえーしーわるにえー",
+        "ja": "xは(-b ± √(b²-4ac)) / 2a",
         "ja_typings": [
           "ekkusuhamainasubipurasumainasurutobijijohikuyoneshiwarunie",
           "ekkusuhamainasubipurasumainasurutobijijouhikuyoneshiwarunie"
@@ -32628,21 +32628,21 @@
       },
       {
         "en": "x = -b/a",
-        "ja": "えっくすはまいなすびーわるえー",
+        "ja": "xは-b/a",
         "ja_typings": [
           "ekkusuhamainasubiwarue"
         ]
       },
       {
         "en": "x = b/2a",
-        "ja": "えっくすはびーわるにえー",
+        "ja": "xはb/2a",
         "ja_typings": [
           "ekkusuhabiwarunie"
         ]
       },
       {
         "en": "x = √b/a",
-        "ja": "えっくすはるーとびーわるえー",
+        "ja": "xは√b/a",
         "ja_typings": [
           "ekkusuharutobiwarue"
         ]
@@ -32654,7 +32654,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the quadratic formula?",
-      "ja": "二次方程式の解の公式とは何ですか？"
+      "ja": "二次方程式の解の公式は？"
     },
     "question_text_reading": {
       "en": "What is the quadratic formula?",
@@ -32665,7 +32665,7 @@
     "choices": [
       {
         "en": "inverse of exponentiation",
-        "ja": "べきじょうのぎゃくさん",
+        "ja": "べき乗の逆関数",
         "ja_typings": [
           "bekijonogyakusan",
           "bekijounogyakusan"
@@ -32673,7 +32673,7 @@
       },
       {
         "en": "square root operation",
-        "ja": "へいほうこんのけいさん",
+        "ja": "平方根の計算",
         "ja_typings": [
           "heihokonnokeisan",
           "heihoukonnokeisan"
@@ -32681,14 +32681,14 @@
       },
       {
         "en": "sum of a series",
-        "ja": "すうれつのわ",
+        "ja": "数列の和",
         "ja_typings": [
           "suuretsunowa"
         ]
       },
       {
         "en": "ratio of two numbers",
-        "ja": "にすうのひ",
+        "ja": "二数の比",
         "ja_typings": [
           "nisuunohi"
         ]
@@ -32700,7 +32700,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a logarithm?",
-      "ja": "対数（logarithm）とは何ですか？"
+      "ja": "対数とは何か？"
     },
     "question_text_reading": {
       "en": "What is a logarithm?",
@@ -32711,28 +32711,28 @@
     "choices": [
       {
         "en": "rate of change of a function",
-        "ja": "かんすうのへんかのわりあい",
+        "ja": "関数の変化の割合",
         "ja_typings": [
           "kansuunohenkanowariai"
         ]
       },
       {
         "en": "area under a curve",
-        "ja": "きょくせんのしたのめんせき",
+        "ja": "曲線の下の面積",
         "ja_typings": [
           "kyokusennoshitanomenseki"
         ]
       },
       {
         "en": "sum of a function",
-        "ja": "かんすうのわ",
+        "ja": "関数の和",
         "ja_typings": [
           "kansuunowa"
         ]
       },
       {
         "en": "inverse of a function",
-        "ja": "かんすうのぎゃく",
+        "ja": "関数の逆",
         "ja_typings": [
           "kansuunogyaku"
         ]
@@ -32744,7 +32744,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the derivative in calculus?",
-      "ja": "微積分学における「微分」とは何ですか？"
+      "ja": "微分とは何か？"
     },
     "question_text_reading": {
       "en": "What is the derivative in calculus?",
@@ -32755,28 +32755,28 @@
     "choices": [
       {
         "en": "area under a curve",
-        "ja": "きょくせんのしたのめんせき",
+        "ja": "曲線の下の面積",
         "ja_typings": [
           "kyokusennoshitanomenseki"
         ]
       },
       {
         "en": "rate of change",
-        "ja": "へんかのわりあい",
+        "ja": "変化の割合",
         "ja_typings": [
           "henkanowariai"
         ]
       },
       {
         "en": "slope of a function",
-        "ja": "かんすうのかたむき",
+        "ja": "関数の傾き",
         "ja_typings": [
           "kansuunokatamuki"
         ]
       },
       {
         "en": "maximum of a function",
-        "ja": "かんすうのさいだいち",
+        "ja": "関数の最大値",
         "ja_typings": [
           "kansuunosaidaichi"
         ]
@@ -32788,7 +32788,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is integration in calculus?",
-      "ja": "微積分学における「integration」とは何ですか？"
+      "ja": "積分とは何か？"
     },
     "question_text_reading": {
       "en": "What is integration in calculus?",
@@ -32799,7 +32799,7 @@
     "choices": [
       {
         "en": "quantity with magnitude and direction",
-        "ja": "おおきさとむきをもつりょう",
+        "ja": "大きさと向きをもつりょう",
         "ja_typings": [
           "okisatomukiomotsuryo",
           "ookisatomukiomotsuryou"
@@ -32807,7 +32807,7 @@
       },
       {
         "en": "quantity with magnitude only",
-        "ja": "おおきさだけをもつりょう",
+        "ja": "大きさだけを持つ量",
         "ja_typings": [
           "okisadakeomotsuryo",
           "ookisadakeomotsuryou"
@@ -32815,7 +32815,7 @@
       },
       {
         "en": "a type of matrix",
-        "ja": "ぎょうれつのいっしゅ",
+        "ja": "行列の一次種",
         "ja_typings": [
           "gyoretsunoisshu",
           "gyouretsunoisshu"
@@ -32823,7 +32823,7 @@
       },
       {
         "en": "a scalar value",
-        "ja": "すからーのあたい",
+        "ja": "スカラーの値",
         "ja_typings": [
           "sukaranoatai"
         ]
@@ -32835,7 +32835,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a vector?",
-      "ja": "ベクトルとは何ですか？"
+      "ja": "ベクトルとは何か？"
     },
     "question_text_reading": {
       "en": "What is a vector?",
@@ -32846,7 +32846,7 @@
     "choices": [
       {
         "en": "rectangular array of numbers",
-        "ja": "すうのちょうほうけいのはいれつ",
+        "ja": "数値の長方形の配列",
         "ja_typings": [
           "suunochohokeinohairetsu",
           "suunochouhoukeinohairetsu"
@@ -32854,7 +32854,7 @@
       },
       {
         "en": "single row of numbers",
-        "ja": "すうのいちぎょう",
+        "ja": "数の一行",
         "ja_typings": [
           "suunoichigyo",
           "suunoichigyou"
@@ -32862,7 +32862,7 @@
       },
       {
         "en": "a polynomial",
-        "ja": "たこうしき",
+        "ja": "多項式",
         "ja_typings": [
           "takoshiki",
           "takoushiki"
@@ -32870,7 +32870,7 @@
       },
       {
         "en": "a prime number set",
-        "ja": "そすうのしゅうごう",
+        "ja": "素数の集合",
         "ja_typings": [
           "sosuunoshuugo",
           "sosuunoshuugou"
@@ -32883,7 +32883,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a matrix in mathematics?",
-      "ja": "数学における行列とは何ですか？"
+      "ja": "数学での行列とは何か？"
     },
     "question_text_reading": {
       "en": "What is a matrix in mathematics?",
@@ -32894,7 +32894,7 @@
     "choices": [
       {
         "en": "likelihood of an event",
-        "ja": "できごとのおこりやすさ",
+        "ja": "事象の起こりやすさ",
         "ja_typings": [
           "dekigotonokoriyasusa",
           "dekigotonookoriyasusa"
@@ -32902,21 +32902,21 @@
       },
       {
         "en": "frequency of an event",
-        "ja": "できごとのひんど",
+        "ja": "事象の頻度",
         "ja_typings": [
           "dekigotonohindo"
         ]
       },
       {
         "en": "certainty of an event",
-        "ja": "できごとのかくじつせい",
+        "ja": "出来事の確実性",
         "ja_typings": [
           "dekigotonokakujitsusei"
         ]
       },
       {
         "en": "range of outcomes",
-        "ja": "けっかのはんい",
+        "ja": "結果の範囲",
         "ja_typings": [
           "kekkanohani"
         ]
@@ -32928,7 +32928,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is probability?",
-      "ja": "確率とは何ですか？"
+      "ja": "確率とは何か？"
     },
     "question_text_reading": {
       "en": "What is probability?",
@@ -32939,28 +32939,28 @@
     "choices": [
       {
         "en": "1/6",
-        "ja": "ろくぶんのいち",
+        "ja": "六分のいち",
         "ja_typings": [
           "rokubunnoichi"
         ]
       },
       {
         "en": "1/2",
-        "ja": "にぶんのいち",
+        "ja": "二分のいち",
         "ja_typings": [
           "nibunnoichi"
         ]
       },
       {
         "en": "1/3",
-        "ja": "さんぶんのいち",
+        "ja": "三分のいち",
         "ja_typings": [
           "sanbunnoichi"
         ]
       },
       {
         "en": "1/4",
-        "ja": "よんぶんのいち",
+        "ja": "四分のいち",
         "ja_typings": [
           "yonbunnoichi"
         ]
@@ -32972,7 +32972,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the probability of rolling a 6 on a die?",
-      "ja": "サイコロを振って6が出る確率はどれくらいですか？"
+      "ja": "サイコロで6が出る確率は？"
     },
     "question_text_reading": {
       "en": "What is the probability of rolling a 6 on a die?",
@@ -32983,28 +32983,28 @@
     "choices": [
       {
         "en": "collection of distinct objects",
-        "ja": "ことなるものの あつまり",
+        "ja": "異なるものの集まり",
         "ja_typings": [
           "kotonarumonono atsumari"
         ]
       },
       {
         "en": "ordered sequence",
-        "ja": "じゅんじょのあるならび",
+        "ja": "順序のある並び",
         "ja_typings": [
           "junjonoarunarabi"
         ]
       },
       {
         "en": "mathematical function",
-        "ja": "すうがくてきかんすう",
+        "ja": "数学的関数",
         "ja_typings": [
           "suugakutekikansuu"
         ]
       },
       {
         "en": "pair of numbers",
-        "ja": "すうのくみ",
+        "ja": "数の組",
         "ja_typings": [
           "suunokumi"
         ]
@@ -33016,7 +33016,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a set in mathematics?",
-      "ja": "数学における「set」とはどのようなものですか？"
+      "ja": "数学での集合とは何か？"
     },
     "question_text_reading": {
       "en": "What is a set in mathematics?",
@@ -33027,7 +33027,7 @@
     "choices": [
       {
         "en": "all elements in either set",
-        "ja": "どちらかのしゅうごうにあるすべての要素",
+        "ja": "どちらかの集合にあるすべての要素",
         "ja_typings": [
           "dochirakanoshuugoniarusubeteno",
           "dochirakanoshuugouniarusubeteno"
@@ -33035,7 +33035,7 @@
       },
       {
         "en": "elements in both sets",
-        "ja": "りょうほうにあるようそ",
+        "ja": "両方にある要素",
         "ja_typings": [
           "ryohoniaruyoso",
           "ryouhouniaruyouso"
@@ -33043,7 +33043,7 @@
       },
       {
         "en": "elements in only one set",
-        "ja": "いっぽうにしかないようそ",
+        "ja": "一方にしかない要素",
         "ja_typings": [
           "ipponishikanaiyoso",
           "ippounishikanaiyouso"
@@ -33051,7 +33051,7 @@
       },
       {
         "en": "the empty set",
-        "ja": "くうしゅうごう",
+        "ja": "空集合",
         "ja_typings": [
           "kuushuugo",
           "kuushuugou"
@@ -33064,7 +33064,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the union of two sets?",
-      "ja": "二つの集合の和集合とは何ですか？"
+      "ja": "二つの集合の和集合とは何か？"
     },
     "question_text_reading": {
       "en": "What is the union of two sets?",
@@ -33075,7 +33075,7 @@
     "choices": [
       {
         "en": "elements common to both sets",
-        "ja": "りょうほうのしゅうごうにふくまれるようそ",
+        "ja": "両方の集合に含まれる要素",
         "ja_typings": [
           "ryohonoshuugonifukumareruyoso",
           "ryouhounoshuugounifukumareruyouso"
@@ -33083,7 +33083,7 @@
       },
       {
         "en": "all elements in either set",
-        "ja": "どちらかにあるすべてのようそ",
+        "ja": "どちらかにあるすべての要素",
         "ja_typings": [
           "dochirakaniarusubetenoyoso",
           "dochirakaniarusubetenoyouso"
@@ -33091,7 +33091,7 @@
       },
       {
         "en": "elements in only one set",
-        "ja": "いっぽうにしかないようそ",
+        "ja": "一方にしかない要素",
         "ja_typings": [
           "ipponishikanaiyoso",
           "ippounishikanaiyouso"
@@ -33099,7 +33099,7 @@
       },
       {
         "en": "the complement set",
-        "ja": "ほごしゅうごう",
+        "ja": "保護集合",
         "ja_typings": [
           "hogoshuugo",
           "hogoshuugou"
@@ -33112,7 +33112,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the intersection of two sets?",
-      "ja": "二つの集合の共通部分とは何ですか？"
+      "ja": "二つの集合の積集合とは何か？"
     },
     "question_text_reading": {
       "en": "What is the intersection of two sets?",
@@ -33123,7 +33123,7 @@
     "choices": [
       {
         "en": "relation mapping input to output",
-        "ja": "にゅうりょくをしゅつりょくにたいおうさせるかんけい",
+        "ja": "入力を出力に対応させる関係",
         "ja_typings": [
           "nyuuryokuoshutsuryokunitaiosaserukankei",
           "nyuuryokuoshutsuryokunitaiousaserukankei"
@@ -33131,7 +33131,7 @@
       },
       {
         "en": "a type of matrix",
-        "ja": "ぎょうれつのいっしゅ",
+        "ja": "行列の一種",
         "ja_typings": [
           "gyoretsunoisshu",
           "gyouretsunoisshu"
@@ -33139,7 +33139,7 @@
       },
       {
         "en": "a polynomial expression",
-        "ja": "たこうしきひょうげん",
+        "ja": "多項式表現",
         "ja_typings": [
           "takoshikihyogen",
           "takoushikihyougen"
@@ -33147,7 +33147,7 @@
       },
       {
         "en": "a geometric shape",
-        "ja": "きかがくてきけいじょう",
+        "ja": "幾何学的形状",
         "ja_typings": [
           "kikagakutekikeijo",
           "kikagakutekikeijou"
@@ -33160,7 +33160,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a function in math?",
-      "ja": "数学における「関数（function）」とは何ですか？"
+      "ja": "数学での関数とは何か？"
     },
     "question_text_reading": {
       "en": "What is a function in math?",
@@ -33171,14 +33171,14 @@
     "choices": [
       {
         "en": "number with real and imaginary parts",
-        "ja": "じつぶぶんときょぶぶんをもつかず",
+        "ja": "実部と虚部をもつ数",
         "ja_typings": [
           "jitsububuntokyobubunomotsukazu"
         ]
       },
       {
         "en": "number greater than 1000",
-        "ja": "1000よりおおきいかず",
+        "ja": "1000より大きい数",
         "ja_typings": [
           "1000yoriokiikazu",
           "1000yoriookiikazu"
@@ -33186,14 +33186,14 @@
       },
       {
         "en": "negative integer",
-        "ja": "ふのせいすう",
+        "ja": "負の整数",
         "ja_typings": [
           "funoseisuu"
         ]
       },
       {
         "en": "irrational number",
-        "ja": "むりすう",
+        "ja": "無理数",
         "ja_typings": [
           "murisuu"
         ]
@@ -33205,7 +33205,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a complex number?",
-      "ja": "複素数とは何ですか？"
+      "ja": "複素数とは何か？"
     },
     "question_text_reading": {
       "en": "What is a complex number?",
@@ -33216,7 +33216,7 @@
     "choices": [
       {
         "en": "number that cannot be expressed as fraction",
-        "ja": "ぶんすうでひょうせないかず",
+        "ja": "無理数",
         "ja_typings": [
           "bunsuudehyosenaikazu",
           "bunsuudehyousenaikazu"
@@ -33224,14 +33224,14 @@
       },
       {
         "en": "negative number",
-        "ja": "ふのかず",
+        "ja": "負の数",
         "ja_typings": [
           "funokazu"
         ]
       },
       {
         "en": "very large number",
-        "ja": "とてもおおきいかず",
+        "ja": "とても大きい数",
         "ja_typings": [
           "totemookiikazu",
           "totemoookiikazu"
@@ -33239,7 +33239,7 @@
       },
       {
         "en": "number divisible by prime",
-        "ja": "そすうでわれるかず",
+        "ja": "素数で割れる数",
         "ja_typings": [
           "sosuudewarerukazu"
         ]
@@ -33251,7 +33251,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is an irrational number?",
-      "ja": "無理数とはどのような数ですか？"
+      "ja": "無理数とは何か？"
     },
     "question_text_reading": {
       "en": "What is an irrational number?",
@@ -33262,28 +33262,28 @@
     "choices": [
       {
         "en": "7",
-        "ja": "なな",
+        "ja": "七",
         "ja_typings": [
           "nana"
         ]
       },
       {
         "en": "-7",
-        "ja": "まいなすなな",
+        "ja": "-7",
         "ja_typings": [
           "mainasunana"
         ]
       },
       {
         "en": "0",
-        "ja": "れい",
+        "ja": "例",
         "ja_typings": [
           "rei"
         ]
       },
       {
         "en": "49",
-        "ja": "よんじゅうきゅう",
+        "ja": "49",
         "ja_typings": [
           "yonjuukyuu"
         ]
@@ -33295,7 +33295,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the absolute value of -7?",
-      "ja": "-7の絶対値はいくつですか？"
+      "ja": "-7の絶対値は？"
     },
     "question_text_reading": {
       "en": "What is the absolute value of -7?",
@@ -33306,28 +33306,28 @@
     "choices": [
       {
         "en": "0",
-        "ja": "れい",
+        "ja": "例",
         "ja_typings": [
           "rei"
         ]
       },
       {
         "en": "1",
-        "ja": "いち",
+        "ja": "一",
         "ja_typings": [
           "ichi"
         ]
       },
       {
         "en": "-1",
-        "ja": "まいなすいち",
+        "ja": "-1",
         "ja_typings": [
           "mainasuichi"
         ]
       },
       {
         "en": "undefined",
-        "ja": "ていぎされていない",
+        "ja": "定義されていない",
         "ja_typings": [
           "teigisareteinai"
         ]
@@ -33339,7 +33339,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the slope of a horizontal line?",
-      "ja": "水平な直線の傾きはいくつですか？"
+      "ja": "水平線の傾きは？"
     },
     "question_text_reading": {
       "en": "What is the slope of a horizontal line?",
@@ -33350,28 +33350,28 @@
     "choices": [
       {
         "en": "undefined",
-        "ja": "ていぎされていない",
+        "ja": "定義されていない",
         "ja_typings": [
           "teigisareteinai"
         ]
       },
       {
         "en": "0",
-        "ja": "れい",
+        "ja": "例",
         "ja_typings": [
           "rei"
         ]
       },
       {
         "en": "1",
-        "ja": "いち",
+        "ja": "一",
         "ja_typings": [
           "ichi"
         ]
       },
       {
         "en": "-1",
-        "ja": "まいなすいち",
+        "ja": "-1",
         "ja_typings": [
           "mainasuichi"
         ]
@@ -33383,7 +33383,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the slope of a vertical line?",
-      "ja": "垂直な直線の傾きはいくつですか？"
+      "ja": "垂直線の傾きは？"
     },
     "question_text_reading": {
       "en": "What is the slope of a vertical line?",
@@ -33394,7 +33394,7 @@
     "choices": [
       {
         "en": "sequence where each term is multiplied by a constant",
-        "ja": "かくこうをていすうでかけるすうれつ",
+        "ja": "各項を定数でかける数列",
         "ja_typings": [
           "kakukooteisuudekakerusuuretsu",
           "kakukouoteisuudekakerusuuretsu"
@@ -33402,7 +33402,7 @@
       },
       {
         "en": "sequence where each term adds a constant",
-        "ja": "かくこうにていすうをたすすうれつ",
+        "ja": "各項一定数を足す数列",
         "ja_typings": [
           "kakukoniteisuuotasusuuretsu",
           "kakukouniteisuuotasusuuretsu"
@@ -33410,14 +33410,14 @@
       },
       {
         "en": "sequence of prime numbers",
-        "ja": "そすうのすうれつ",
+        "ja": "素数の数列",
         "ja_typings": [
           "sosuunosuuretsu"
         ]
       },
       {
         "en": "sequence of squares",
-        "ja": "じじょうのすうれつ",
+        "ja": "自上の数列",
         "ja_typings": [
           "jijonosuuretsu",
           "jijounosuuretsu"
@@ -33430,7 +33430,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a geometric progression?",
-      "ja": "幾何数列とはどのようなものですか？"
+      "ja": "等比数列とは何か？"
     },
     "question_text_reading": {
       "en": "What is a geometric progression?",
@@ -33441,7 +33441,7 @@
     "choices": [
       {
         "en": "sequence where each term adds a constant",
-        "ja": "かくこうにていすうをたすすうれつ",
+        "ja": "各項一定数とする数列",
         "ja_typings": [
           "kakukoniteisuuotasusuuretsu",
           "kakukouniteisuuotasusuuretsu"
@@ -33449,7 +33449,7 @@
       },
       {
         "en": "sequence where each term is multiplied",
-        "ja": "かくこうをかけるすうれつ",
+        "ja": "各項をかける数列",
         "ja_typings": [
           "kakukookakerusuuretsu",
           "kakukouokakerusuuretsu"
@@ -33457,7 +33457,7 @@
       },
       {
         "en": "decreasing sequence",
-        "ja": "げんしょうするすうれつ",
+        "ja": "減少する数列",
         "ja_typings": [
           "genshosurusuuretsu",
           "genshousurusuuretsu"
@@ -33465,7 +33465,7 @@
       },
       {
         "en": "random number sequence",
-        "ja": "らんすうのすうれつ",
+        "ja": "乱数の数列",
         "ja_typings": [
           "ransuunosuuretsu"
         ]
@@ -33477,7 +33477,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is an arithmetic progression?",
-      "ja": "等差数列とは、どのようなものですか？"
+      "ja": "等差数列とは何か？"
     },
     "question_text_reading": {
       "en": "What is an arithmetic progression?",
@@ -33488,7 +33488,7 @@
     "choices": [
       {
         "en": "(4/3)πr³",
-        "ja": "よんさんぶんのぱいあーるさんじょう",
+        "ja": "(4/3)πr³",
         "ja_typings": [
           "yonsanbunnopaiarusanjo",
           "yonsanbunnopaiarusanjou"
@@ -33496,7 +33496,7 @@
       },
       {
         "en": "πr²",
-        "ja": "ぱいあーるじじょう",
+        "ja": "πr²",
         "ja_typings": [
           "paiarujijo",
           "paiarujijou"
@@ -33504,7 +33504,7 @@
       },
       {
         "en": "(4/3)πr²",
-        "ja": "よんさんぶんのぱいあーるじじょう",
+        "ja": "(4/3)πr²",
         "ja_typings": [
           "yonsanbunnopaiarujijo",
           "yonsanbunnopaiarujijou"
@@ -33512,7 +33512,7 @@
       },
       {
         "en": "πr³",
-        "ja": "ぱいあーるさんじょう",
+        "ja": "πr³",
         "ja_typings": [
           "paiarusanjo",
           "paiarusanjou"
@@ -33525,7 +33525,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the formula for the volume of a sphere?",
-      "ja": "球の体積を求める公式は何ですか？"
+      "ja": "球の体積の公式は？"
     },
     "question_text_reading": {
       "en": "What is the formula for the volume of a sphere?",
@@ -33536,28 +33536,28 @@
     "choices": [
       {
         "en": "2.71828",
-        "ja": "にてんなないちはちにはち",
+        "ja": "ネイピア数",
         "ja_typings": [
           "nitennanaichihachinihachi"
         ]
       },
       {
         "en": "3.14159",
-        "ja": "さんてんいちよんいちごきゅう",
+        "ja": "3.14159",
         "ja_typings": [
           "santenichiyonichigokyuu"
         ]
       },
       {
         "en": "1.41421",
-        "ja": "いちてんよんいちよんにいち",
+        "ja": "1.41421",
         "ja_typings": [
           "ichitenyonichiyonniichi"
         ]
       },
       {
         "en": "1.61803",
-        "ja": "いちてんろくいちはちれいさん",
+        "ja": "1.61803",
         "ja_typings": [
           "ichitenrokuichihachireisan"
         ]
@@ -33569,7 +33569,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is Euler's number 'e'?",
-      "ja": "オイラー数「e」とは、どのような値ですか？"
+      "ja": "オイラーの数eはおよそいくつ？"
     },
     "question_text_reading": {
       "en": "What is Euler's number 'e'?",
@@ -33580,7 +33580,7 @@
     "choices": [
       {
         "en": "triangular array of binomial coefficients",
-        "ja": "にこうけいすうのさんかっけいはいれつ",
+        "ja": "二項係数の三角配列",
         "ja_typings": [
           "nikokeisuunosankakkeihairetsu",
           "nikoukeisuunosankakkeihairetsu"
@@ -33588,14 +33588,14 @@
       },
       {
         "en": "triangle with all sides equal",
-        "ja": "すべてのへんがひとしいさんかっけい",
+        "ja": "すべての辺が等しい三角形",
         "ja_typings": [
           "subetenohengahitoshiisankakkei"
         ]
       },
       {
         "en": "triangle used in geometry proofs",
-        "ja": "きかがくのしょうめいにつかうさんかっけい",
+        "ja": "幾何学の証明に使う三角形",
         "ja_typings": [
           "kikagakunoshomeinitsukausankakkei",
           "kikagakunoshoumeinitsukausankakkei"
@@ -33603,7 +33603,7 @@
       },
       {
         "en": "a graph type in statistics",
-        "ja": "とうけいのぐらふのいっしゅ",
+        "ja": "統計のグラフの一種",
         "ja_typings": [
           "tokeinogurafunoisshu",
           "toukeinogurafunoisshu"
@@ -33616,7 +33616,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is Pascal's triangle?",
-      "ja": "パスカルの三角形とは何ですか？"
+      "ja": "パスカルの三角形とは何か？"
     },
     "question_text_reading": {
       "en": "What is Pascal's triangle?",
@@ -33627,7 +33627,7 @@
     "choices": [
       {
         "en": "arrangement of items in order",
-        "ja": "こうもくをじゅんじょよくならべたもの",
+        "ja": "項目を順序よく並べたもの",
         "ja_typings": [
           "komokuojunjoyokunarabetamono",
           "koumokuojunjoyokunarabetamono"
@@ -33635,7 +33635,7 @@
       },
       {
         "en": "selection without order",
-        "ja": "じゅんじょをきにしないせんたく",
+        "ja": "順序を気にしない選択",
         "ja_typings": [
           "junjokinishinaisentaku",
           "junjookinishinaisentaku"
@@ -33643,14 +33643,14 @@
       },
       {
         "en": "multiplication of all integers to n",
-        "ja": "nまでのせいすうのせき",
+        "ja": "nまでの整数積",
         "ja_typings": [
           "nmadenoseisuunoseki"
         ]
       },
       {
         "en": "sum of a series",
-        "ja": "すうれつのわ",
+        "ja": "数列和",
         "ja_typings": [
           "suuretsunowa"
         ]
@@ -33662,7 +33662,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a permutation?",
-      "ja": "順列（permutation）とは何ですか？"
+      "ja": "順列とは何か？"
     },
     "question_text_reading": {
       "en": "What is a permutation?",
@@ -33673,7 +33673,7 @@
     "choices": [
       {
         "en": "selection without regard to order",
-        "ja": "じゅんじょをきにしないせんたく",
+        "ja": "順序を気にしない選択",
         "ja_typings": [
           "junjokinishinaisentaku",
           "junjookinishinaisentaku"
@@ -33681,14 +33681,14 @@
       },
       {
         "en": "arrangement in specific order",
-        "ja": "とくていのじゅんじょによるならべかた",
+        "ja": "特定の順序による並べ方",
         "ja_typings": [
           "tokuteinojunjoniyorunarabekata"
         ]
       },
       {
         "en": "sum of elements",
-        "ja": "ようそのわ",
+        "ja": "要素の和",
         "ja_typings": [
           "yosonowa",
           "yousonowa"
@@ -33696,7 +33696,7 @@
       },
       {
         "en": "product of elements",
-        "ja": "ようそのせき",
+        "ja": "要素の積",
         "ja_typings": [
           "yosonoseki",
           "yousonoseki"
@@ -33709,7 +33709,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a combination?",
-      "ja": "組み合わせとは何ですか？"
+      "ja": "組み合わせとは何か？"
     },
     "question_text_reading": {
       "en": "What is a combination?",
@@ -33720,28 +33720,28 @@
     "choices": [
       {
         "en": "Mandarin Chinese",
-        "ja": "まんだりんちゃいにーず",
+        "ja": "マンダリンチャイニーズ",
         "ja_typings": [
           "mandarinchainizu"
         ]
       },
       {
         "en": "English",
-        "ja": "えいご",
+        "ja": "英語",
         "ja_typings": [
           "eigo"
         ]
       },
       {
         "en": "Spanish",
-        "ja": "すぺいんご",
+        "ja": "スペイン語",
         "ja_typings": [
           "supeingo"
         ]
       },
       {
         "en": "Hindi",
-        "ja": "ひんでぃーご",
+        "ja": "ヒンディー語",
         "ja_typings": [
           "hindigo"
         ]
@@ -33753,7 +33753,7 @@
     "image_path": null,
     "question_text": {
       "en": "What language has the most native speakers?",
-      "ja": "最も多くのネイティブスピーカーを持つ言語はどれでしょう？"
+      "ja": "最も多くの母語話者を持つ言語は？"
     },
     "question_text_reading": {
       "en": "What language has the most native speakers?",
@@ -33764,28 +33764,28 @@
     "choices": [
       {
         "en": "26",
-        "ja": "にじゅうろく",
+        "ja": "二十六",
         "ja_typings": [
           "nijuuroku"
         ]
       },
       {
         "en": "24",
-        "ja": "にじゅうし",
+        "ja": "二十四",
         "ja_typings": [
           "nijuushi"
         ]
       },
       {
         "en": "28",
-        "ja": "にじゅうはち",
+        "ja": "二十八",
         "ja_typings": [
           "nijuuhachi"
         ]
       },
       {
         "en": "30",
-        "ja": "さんじゅう",
+        "ja": "三十",
         "ja_typings": [
           "sanjuu"
         ]
@@ -33797,7 +33797,7 @@
     "image_path": null,
     "question_text": {
       "en": "How many letters are in the English alphabet?",
-      "ja": "英語のアルファベットには、いくつ文字がありますか？"
+      "ja": "英語のアルファベットは何文字？"
     },
     "question_text_reading": {
       "en": "How many letters are in the English alphabet?",
@@ -33808,28 +33808,28 @@
     "choices": [
       {
         "en": "Portuguese",
-        "ja": "ぽるとがるご",
+        "ja": "ポルトガル語",
         "ja_typings": [
           "porutogarugo"
         ]
       },
       {
         "en": "Spanish",
-        "ja": "すぺいんご",
+        "ja": "スペイン語",
         "ja_typings": [
           "supeingo"
         ]
       },
       {
         "en": "English",
-        "ja": "えいご",
+        "ja": "英語",
         "ja_typings": [
           "eigo"
         ]
       },
       {
         "en": "French",
-        "ja": "ふらんすご",
+        "ja": "フランス語",
         "ja_typings": [
           "furansugo"
         ]
@@ -33841,7 +33841,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the official language of Brazil?",
-      "ja": "ブラジルの公用語は何ですか？"
+      "ja": "ブラジルの公用語は？"
     },
     "question_text_reading": {
       "en": "What is the official language of Brazil?",
@@ -33852,28 +33852,28 @@
     "choices": [
       {
         "en": "Arabic",
-        "ja": "あらびあご",
+        "ja": "アラビア語",
         "ja_typings": [
           "arabiago"
         ]
       },
       {
         "en": "Hebrew",
-        "ja": "へぶらいご",
+        "ja": "ヘブライ語",
         "ja_typings": [
           "heburaigo"
         ]
       },
       {
         "en": "Turkish",
-        "ja": "とるこご",
+        "ja": "トルコ語",
         "ja_typings": [
           "torukogo"
         ]
       },
       {
         "en": "Persian",
-        "ja": "ぺるしあご",
+        "ja": "ペルシャ語",
         "ja_typings": [
           "perushiago"
         ]
@@ -33885,7 +33885,7 @@
     "image_path": null,
     "question_text": {
       "en": "What language is spoken in Egypt?",
-      "ja": "エジプトで話されている言語は何ですか？"
+      "ja": "エジプトで使われる言語は？"
     },
     "question_text_reading": {
       "en": "What language is spoken in Egypt?",
@@ -33896,28 +33896,28 @@
     "choices": [
       {
         "en": "Kanji, Hiragana, Katakana",
-        "ja": "かんじ、ひらがな、かたかな",
+        "ja": "漢字、ひらがな、カタカナ",
         "ja_typings": [
           "kanji hiragana katakana"
         ]
       },
       {
         "en": "Latin alphabet only",
-        "ja": "らてんもじのみ",
+        "ja": "ラテン文字のみ",
         "ja_typings": [
           "ratenmojinomi"
         ]
       },
       {
         "en": "Arabic script",
-        "ja": "あらびあもじ",
+        "ja": "アラビア文字",
         "ja_typings": [
           "arabiamoji"
         ]
       },
       {
         "en": "Cyrillic script",
-        "ja": "きりるもじ",
+        "ja": "キリル文字",
         "ja_typings": [
           "kirirumoji"
         ]
@@ -33929,7 +33929,7 @@
     "image_path": null,
     "question_text": {
       "en": "What script is used for Japanese?",
-      "ja": "日本語の文字を扱うのに使われるスクリプトはどれですか？"
+      "ja": "日本語ではどの文字を使うか？"
     },
     "question_text_reading": {
       "en": "What script is used for Japanese?",
@@ -33940,28 +33940,28 @@
     "choices": [
       {
         "en": "word with similar meaning",
-        "ja": "にたいみのことば",
+        "ja": "類義語",
         "ja_typings": [
           "nitaiminokotoba"
         ]
       },
       {
         "en": "word with opposite meaning",
-        "ja": "はんたいのいみのことば",
+        "ja": "反対の意味の言葉",
         "ja_typings": [
           "hantainoiminokotoba"
         ]
       },
       {
         "en": "word that sounds the same",
-        "ja": "おなじおとのことば",
+        "ja": "同じ音の単語",
         "ja_typings": [
           "onajiotonokotoba"
         ]
       },
       {
         "en": "word from another language",
-        "ja": "べつのげんごからのことば",
+        "ja": "別の言語からの言葉",
         "ja_typings": [
           "betsunogengokaranokotoba"
         ]
@@ -33973,7 +33973,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a synonym?",
-      "ja": "同義語とは何ですか？"
+      "ja": "同義語とは何か？"
     },
     "question_text_reading": {
       "en": "What is a synonym?",
@@ -33984,28 +33984,28 @@
     "choices": [
       {
         "en": "word with opposite meaning",
-        "ja": "はんたいのいみのことば",
+        "ja": "反対の意味の言葉",
         "ja_typings": [
           "hantainoiminokotoba"
         ]
       },
       {
         "en": "word with similar meaning",
-        "ja": "にたいみのことば",
+        "ja": "類義語",
         "ja_typings": [
           "nitaiminokotoba"
         ]
       },
       {
         "en": "word from another language",
-        "ja": "べつのげんごからのことば",
+        "ja": "別の言語からの言葉",
         "ja_typings": [
           "betsunogengokaranokotoba"
         ]
       },
       {
         "en": "a foreign word",
-        "ja": "がいこくご",
+        "ja": "外国語",
         "ja_typings": [
           "gaikokugo"
         ]
@@ -34017,7 +34017,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is an antonym?",
-      "ja": "類義語の対義語とは何ですか？"
+      "ja": "反対語とは何か？"
     },
     "question_text_reading": {
       "en": "What is an antonym?",
@@ -34028,7 +34028,7 @@
     "choices": [
       {
         "en": "Japanese poem with 5-7-5 syllables",
-        "ja": "ごしちごのおんのにほんのし",
+        "ja": "五七五の音のにほんのし",
         "ja_typings": [
           "goshichigononnonihonnoshi",
           "goshichigonoonnonihonnoshi"
@@ -34036,21 +34036,21 @@
       },
       {
         "en": "Chinese poem form",
-        "ja": "ちゅうごくのしのけいしき",
+        "ja": "中国の詩の形式",
         "ja_typings": [
           "chuugokunoshinokeishiki"
         ]
       },
       {
         "en": "free verse poem",
-        "ja": "じゆうし",
+        "ja": "自由詩",
         "ja_typings": [
           "jiyuushi"
         ]
       },
       {
         "en": "rhyming couplet",
-        "ja": "ぐいんをそろえたにれんく",
+        "ja": "韻をそろえた二連句",
         "ja_typings": [
           "guinosoroetanirenku"
         ]
@@ -34062,7 +34062,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a haiku?",
-      "ja": "俳句とはどのようなものですか？"
+      "ja": "俳句とは何か？"
     },
     "question_text_reading": {
       "en": "What is a haiku?",
@@ -34073,14 +34073,14 @@
     "choices": [
       {
         "en": "word borrowed from another language",
-        "ja": "べつのげんごからかりたことば",
+        "ja": "別の言語から借りた言葉",
         "ja_typings": [
           "betsunogengokarakaritakotoba"
         ]
       },
       {
         "en": "word used in legal documents",
-        "ja": "ほうりつぶんしょにつかうことば",
+        "ja": "法律文書に使う言葉",
         "ja_typings": [
           "horitsubunshonitsukaukotoba",
           "houritsubunshonitsukaukotoba"
@@ -34088,14 +34088,14 @@
       },
       {
         "en": "made-up word",
-        "ja": "つくりことば",
+        "ja": "作り言葉",
         "ja_typings": [
           "tsukurikotoba"
         ]
       },
       {
         "en": "archaic word",
-        "ja": "ふるいことば",
+        "ja": "古語",
         "ja_typings": [
           "furuikotoba"
         ]
@@ -34107,7 +34107,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does 'loanword' mean?",
-      "ja": "がいらいごとは何か？"
+      "ja": "外来語とは何か？"
     },
     "question_text_reading": {
       "en": "What does 'loanword' mean?",
@@ -34118,7 +34118,7 @@
     "choices": [
       {
         "en": "word that imitates a sound",
-        "ja": "おとをまねることば",
+        "ja": "音を真似る言葉",
         "ja_typings": [
           "otomanerukotoba",
           "otoomanerukotoba"
@@ -34126,21 +34126,21 @@
       },
       {
         "en": "very long word",
-        "ja": "とてもながいことば",
+        "ja": "とても長い言葉",
         "ja_typings": [
           "totemonagaikotoba"
         ]
       },
       {
         "en": "a silent letter",
-        "ja": "さいれんとれたー",
+        "ja": "サイレントレター",
         "ja_typings": [
           "sairentoreta"
         ]
       },
       {
         "en": "compound word",
-        "ja": "ふくごうご",
+        "ja": "複合語",
         "ja_typings": [
           "fukugogo",
           "fukugougo"
@@ -34153,7 +34153,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is onomatopoeia?",
-      "ja": "擬音語（おのまとご）とは何ですか？"
+      "ja": "オノマトペとは何か？"
     },
     "question_text_reading": {
       "en": "What is onomatopoeia?",
@@ -34164,28 +34164,28 @@
     "choices": [
       {
         "en": "aqua",
-        "ja": "あくあ",
+        "ja": "アクア",
         "ja_typings": [
           "akua"
         ]
       },
       {
         "en": "terra",
-        "ja": "てら",
+        "ja": "テラ",
         "ja_typings": [
           "tera"
         ]
       },
       {
         "en": "ignis",
-        "ja": "いぐにす",
+        "ja": "イグニス",
         "ja_typings": [
           "igunisu"
         ]
       },
       {
         "en": "aer",
-        "ja": "あえる",
+        "ja": "エア",
         "ja_typings": [
           "aeru"
         ]
@@ -34197,7 +34197,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the Latin word for water?",
-      "ja": "水を表すラテン語は何ですか？"
+      "ja": "水のラテン語は？"
     },
     "question_text_reading": {
       "en": "What is the Latin word for water?",
@@ -34208,28 +34208,28 @@
     "choices": [
       {
         "en": "Indo-European",
-        "ja": "いんどーよーろっぱごぞく",
+        "ja": "インド・ヨーロッパ語族",
         "ja_typings": [
           "indoyoroppagozoku"
         ]
       },
       {
         "en": "Afro-Asiatic",
-        "ja": "あふろあじあごぞく",
+        "ja": "アフロアジア諸族",
         "ja_typings": [
           "afuroajiagozoku"
         ]
       },
       {
         "en": "Sino-Tibetan",
-        "ja": "ちゅうごくちべっとごぞく",
+        "ja": "中国チベット諸族",
         "ja_typings": [
           "chuugokuchibettogozoku"
         ]
       },
       {
         "en": "Austronesian",
-        "ja": "おーすとろねしあごぞく",
+        "ja": "オストロネシアン語族",
         "ja_typings": [
           "osutoroneshiagozoku"
         ]
@@ -34241,7 +34241,7 @@
     "image_path": null,
     "question_text": {
       "en": "What language family does English belong to?",
-      "ja": "英語はどの言語族に属しますか？"
+      "ja": "英語はどの語族か？"
     },
     "question_text_reading": {
       "en": "What language family does English belong to?",
@@ -34252,7 +34252,7 @@
     "choices": [
       {
         "en": "word that reads same forwards and backwards",
-        "ja": "まえからもうしろからもよめることば",
+        "ja": "前から後ろからも読める言葉",
         "ja_typings": [
           "maekaramoshirokaramoyomerukotoba",
           "maekaramoushirokaramoyomerukotoba"
@@ -34260,14 +34260,14 @@
       },
       {
         "en": "word with silent letters",
-        "ja": "さいれんとれたーのあることば",
+        "ja": "サイレントレターのある言葉",
         "ja_typings": [
           "sairentoretanoarukotoba"
         ]
       },
       {
         "en": "compound word",
-        "ja": "ふくごうご",
+        "ja": "複合語",
         "ja_typings": [
           "fukugogo",
           "fukugougo"
@@ -34275,7 +34275,7 @@
       },
       {
         "en": "a very short word",
-        "ja": "とてもみじかいことば",
+        "ja": "とても短い言葉",
         "ja_typings": [
           "totemomijikaikotoba"
         ]
@@ -34287,7 +34287,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a palindrome?",
-      "ja": "回文（palindrome）とは何ですか？"
+      "ja": "回文とは何か？"
     },
     "question_text_reading": {
       "en": "What is a palindrome?",
@@ -34298,7 +34298,7 @@
     "choices": [
       {
         "en": "Early Modern English",
-        "ja": "そうききんだいえいご",
+        "ja": "早期近代英語",
         "ja_typings": [
           "sokikindaieigo",
           "soukikindaieigo"
@@ -34306,21 +34306,21 @@
       },
       {
         "en": "Old English",
-        "ja": "こえいご",
+        "ja": "古英語",
         "ja_typings": [
           "koeigo"
         ]
       },
       {
         "en": "Middle English",
-        "ja": "ちゅうえいご",
+        "ja": "中英語",
         "ja_typings": [
           "chuueigo"
         ]
       },
       {
         "en": "Latin",
-        "ja": "らてんご",
+        "ja": "ラテン語",
         "ja_typings": [
           "ratengo"
         ]
@@ -34332,7 +34332,7 @@
     "image_path": null,
     "question_text": {
       "en": "What language did Shakespeare write in?",
-      "ja": "シェイクスピアはどの言語で作品を書いたのでしょうか？"
+      "ja": "シェイクスピアは何語で書いたか？"
     },
     "question_text_reading": {
       "en": "What language did Shakespeare write in?",
@@ -34343,28 +34343,28 @@
     "choices": [
       {
         "en": "English",
-        "ja": "えいご",
+        "ja": "英語",
         "ja_typings": [
           "eigo"
         ]
       },
       {
         "en": "Spanish",
-        "ja": "すぺいんご",
+        "ja": "スペイン語",
         "ja_typings": [
           "supeingo"
         ]
       },
       {
         "en": "Mandarin",
-        "ja": "まんだりん",
+        "ja": "マンダリン",
         "ja_typings": [
           "mandarin"
         ]
       },
       {
         "en": "French",
-        "ja": "ふらんすご",
+        "ja": "フランス語",
         "ja_typings": [
           "furansugo"
         ]
@@ -34376,7 +34376,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the most studied second language globally?",
-      "ja": "世界で最も学習されている第二言語は何でしょう？"
+      "ja": "世界で最も学ばれている第二言語は？"
     },
     "question_text_reading": {
       "en": "What is the most studied second language globally?",
@@ -34387,7 +34387,7 @@
     "choices": [
       {
         "en": "study of word origins",
-        "ja": "ことばのおこりのがくもん",
+        "ja": "言葉の起源の学問",
         "ja_typings": [
           "kotobanokorinogakumon",
           "kotobanookorinogakumon"
@@ -34395,7 +34395,7 @@
       },
       {
         "en": "study of grammar",
-        "ja": "ぶんぽうのがくもん",
+        "ja": "文法学",
         "ja_typings": [
           "bunponogakumon",
           "bunpounogakumon"
@@ -34403,7 +34403,7 @@
       },
       {
         "en": "study of dialects",
-        "ja": "ほうげんのがくもん",
+        "ja": "方言学",
         "ja_typings": [
           "hogennogakumon",
           "hougennogakumon"
@@ -34411,7 +34411,7 @@
       },
       {
         "en": "study of pronunciation",
-        "ja": "はつおんのがくもん",
+        "ja": "発音の学問",
         "ja_typings": [
           "hatsuonnogakumon"
         ]
@@ -34423,7 +34423,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does 'etymology' mean?",
-      "ja": "etymologyとは、どのような意味ですか？"
+      "ja": "語源学とは何か？"
     },
     "question_text_reading": {
       "en": "What does 'etymology' mean?",
@@ -34434,7 +34434,7 @@
     "choices": [
       {
         "en": "rules for structure of language",
-        "ja": "げんごのこうぞうのきそく",
+        "ja": "言語の構造の規則",
         "ja_typings": [
           "gengonokozonokisoku",
           "gengonokouzounokisoku"
@@ -34442,21 +34442,21 @@
       },
       {
         "en": "vocabulary of a language",
-        "ja": "げんごのごい",
+        "ja": "言語の語彙",
         "ja_typings": [
           "gengonogoi"
         ]
       },
       {
         "en": "pronunciation system",
-        "ja": "はつおんのしすてむ",
+        "ja": "発音のシステム",
         "ja_typings": [
           "hatsuonnoshisutemu"
         ]
       },
       {
         "en": "writing system",
-        "ja": "ひょうきほう",
+        "ja": "表記法",
         "ja_typings": [
           "hyokiho",
           "hyoukihou"
@@ -34469,7 +34469,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is grammar?",
-      "ja": "文法とは一体何でしょうか？"
+      "ja": "文法とは何か？"
     },
     "question_text_reading": {
       "en": "What is grammar?",
@@ -34480,7 +34480,7 @@
     "choices": [
       {
         "en": "rules about sentence structure",
-        "ja": "ぶんのこうぞうにかんするきそく",
+        "ja": "文の構造に関する規則",
         "ja_typings": [
           "bunnokozonikansurukisoku",
           "bunnokouzounikansurukisoku"
@@ -34488,21 +34488,21 @@
       },
       {
         "en": "study of word meaning",
-        "ja": "ことばのいみのけんきゅう",
+        "ja": "言葉の意味の研究",
         "ja_typings": [
           "kotobanoiminokenkyuu"
         ]
       },
       {
         "en": "pronunciation rules",
-        "ja": "はつおんのきそく",
+        "ja": "発音の規則",
         "ja_typings": [
           "hatsuonnokisoku"
         ]
       },
       {
         "en": "origin of words",
-        "ja": "ことばのおこり",
+        "ja": "言葉の起源",
         "ja_typings": [
           "kotobanokori",
           "kotobanookori"
@@ -34515,7 +34515,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is syntax?",
-      "ja": "構文とは何ですか？"
+      "ja": "構文とは何か？"
     },
     "question_text_reading": {
       "en": "What is syntax?",
@@ -34526,14 +34526,14 @@
     "choices": [
       {
         "en": "study of meaning in language",
-        "ja": "げんごのいみのけんきゅう",
+        "ja": "言語の意味の研究",
         "ja_typings": [
           "gengonoiminokenkyuu"
         ]
       },
       {
         "en": "study of sentence structure",
-        "ja": "ぶんのこうぞうのけんきゅう",
+        "ja": "文の構造の研究",
         "ja_typings": [
           "bunnokozonokenkyuu",
           "bunnokouzounokenkyuu"
@@ -34541,14 +34541,14 @@
       },
       {
         "en": "study of sounds",
-        "ja": "おとのけんきゅう",
+        "ja": "音の研究",
         "ja_typings": [
           "otonokenkyuu"
         ]
       },
       {
         "en": "study of dialects",
-        "ja": "ほうげんのけんきゅう",
+        "ja": "方言の研究",
         "ja_typings": [
           "hogennokenkyuu",
           "hougennokenkyuu"
@@ -34561,7 +34561,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is semantics?",
-      "ja": "意味論（semantics）とは、どのようなものですか？"
+      "ja": "意味論とは何か？"
     },
     "question_text_reading": {
       "en": "What is semantics?",
@@ -34572,28 +34572,28 @@
     "choices": [
       {
         "en": "regional variation of a language",
-        "ja": "げんごのちいきてきへんたい",
+        "ja": "言語の地域的変体",
         "ja_typings": [
           "gengonochiikitekihentai"
         ]
       },
       {
         "en": "simplified form of language",
-        "ja": "げんごのかんりゃくけい",
+        "ja": "言語の簡略形",
         "ja_typings": [
           "gengonokanryakukei"
         ]
       },
       {
         "en": "foreign language",
-        "ja": "がいこくご",
+        "ja": "外国語",
         "ja_typings": [
           "gaikokugo"
         ]
       },
       {
         "en": "written form of language",
-        "ja": "ごのきじゅつけい",
+        "ja": "語の記述体系",
         "ja_typings": [
           "gonokijutsukei"
         ]
@@ -34605,7 +34605,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a dialect?",
-      "ja": "方言とは、どのようなものですか？"
+      "ja": "方言とは何か？"
     },
     "question_text_reading": {
       "en": "What is a dialect?",
@@ -34616,7 +34616,7 @@
     "choices": [
       {
         "en": "constructed international language",
-        "ja": "じんこうてきなこくさいきょうつうご",
+        "ja": "人工的な国際共通語",
         "ja_typings": [
           "jinkotekinakokusaikyotsuugo",
           "jinkoutekinakokusaikyoutsuugo"
@@ -34624,7 +34624,7 @@
       },
       {
         "en": "ancient Latin dialect",
-        "ja": "こだいらてんのほうげん",
+        "ja": "古代ラテンの方言",
         "ja_typings": [
           "kodairatennohogen",
           "kodairatennohougen"
@@ -34632,7 +34632,7 @@
       },
       {
         "en": "Spanish dialect",
-        "ja": "すぺいんごのほうげん",
+        "ja": "スペイン語の方言",
         "ja_typings": [
           "supeingonohogen",
           "supeingonohougen"
@@ -34640,7 +34640,7 @@
       },
       {
         "en": "mix of French and Italian",
-        "ja": "ふらんすごとイタリアごのまぜ",
+        "ja": "フランス語とイタリア語の混ぜ",
         "ja_typings": [
           "furansugotoitariagonomaze"
         ]
@@ -34652,7 +34652,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is Esperanto?",
-      "ja": "エスペラントとは、どのような言語ですか？"
+      "ja": "エスペラントとは何か？"
     },
     "question_text_reading": {
       "en": "What is Esperanto?",
@@ -34663,28 +34663,28 @@
     "choices": [
       {
         "en": "smallest unit of sound in language",
-        "ja": "げんごでもっともちいさなおとのたんい",
+        "ja": "言語でもっとも小さい音の単位",
         "ja_typings": [
           "gengodemottomochiisanaotonotani"
         ]
       },
       {
         "en": "written letter",
-        "ja": "きじゅつもじ",
+        "ja": "記述文字",
         "ja_typings": [
           "kijutsumoji"
         ]
       },
       {
         "en": "unit of meaning",
-        "ja": "いみのたんい",
+        "ja": "意味の単位",
         "ja_typings": [
           "iminotani"
         ]
       },
       {
         "en": "sentence structure unit",
-        "ja": "ぶんこうぞうのたんい",
+        "ja": "文構造の単位",
         "ja_typings": [
           "bunkozonotani",
           "bunkouzounotani"
@@ -34697,7 +34697,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a phoneme?",
-      "ja": "音素（phoneme）とは何ですか？"
+      "ja": "音素とは何か？"
     },
     "question_text_reading": {
       "en": "What is a phoneme?",
@@ -34708,28 +34708,28 @@
     "choices": [
       {
         "en": "Russian",
-        "ja": "ろしあご",
+        "ja": "ロシア語",
         "ja_typings": [
           "roshiago"
         ]
       },
       {
         "en": "Greek",
-        "ja": "ぎりしあご",
+        "ja": "ギリシャ語",
         "ja_typings": [
           "girishiago"
         ]
       },
       {
         "en": "Arabic",
-        "ja": "あらびあご",
+        "ja": "アラビア語",
         "ja_typings": [
           "arabiago"
         ]
       },
       {
         "en": "Hebrew",
-        "ja": "へぶらいご",
+        "ja": "ヘブライ語",
         "ja_typings": [
           "heburaigo"
         ]
@@ -34741,7 +34741,7 @@
     "image_path": null,
     "question_text": {
       "en": "What language uses the Cyrillic alphabet?",
-      "ja": "キリル文字を使う言語は何ですか？"
+      "ja": "キリル文字を使う言語は？"
     },
     "question_text_reading": {
       "en": "What language uses the Cyrillic alphabet?",
@@ -34752,7 +34752,7 @@
     "choices": [
       {
         "en": "word describing an action or state",
-        "ja": "こうどうやじょうたいをあらわすことば",
+        "ja": "行動や状態を表す言葉",
         "ja_typings": [
           "kodoyajotaioarawasukotoba",
           "koudouyajoutaioarawasukotoba"
@@ -34760,21 +34760,21 @@
       },
       {
         "en": "word describing a noun",
-        "ja": "めいしをせつめいすることば",
+        "ja": "名詞を説明することば",
         "ja_typings": [
           "meishiosetsumeisurukotoba"
         ]
       },
       {
         "en": "name of a person or thing",
-        "ja": "ひとやものの なまえ",
+        "ja": "人やものの名前",
         "ja_typings": [
           "hitoyamonono namae"
         ]
       },
       {
         "en": "connecting word",
-        "ja": "つなぎことば",
+        "ja": "接続語",
         "ja_typings": [
           "tsunagikotoba"
         ]
@@ -34786,7 +34786,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a verb?",
-      "ja": "動詞（verb）とは、どのようなものですか？"
+      "ja": "動詞とは何か？"
     },
     "question_text_reading": {
       "en": "What is a verb?",
@@ -34797,14 +34797,14 @@
     "choices": [
       {
         "en": "word that describes a noun",
-        "ja": "めいしをしゅうしょくすることば",
+        "ja": "名詞を修飾する言葉",
         "ja_typings": [
           "meishioshuushokusurukotoba"
         ]
       },
       {
         "en": "word describing an action",
-        "ja": "こうどうをあらわすことば",
+        "ja": "行動を表す言葉",
         "ja_typings": [
           "kodooarawasukotoba",
           "koudouoarawasukotoba"
@@ -34812,14 +34812,14 @@
       },
       {
         "en": "a type of pronoun",
-        "ja": "だいめいしのいっしゅ",
+        "ja": "代名詞の一種",
         "ja_typings": [
           "daimeishinoisshu"
         ]
       },
       {
         "en": "word connecting clauses",
-        "ja": "せつをつなぐことば",
+        "ja": "接続する言葉",
         "ja_typings": [
           "setsuotsunagukotoba"
         ]
@@ -34831,7 +34831,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is an adjective?",
-      "ja": "形容詞とは、どのようなものですか？"
+      "ja": "形容詞とは何か？"
     },
     "question_text_reading": {
       "en": "What is an adjective?",
@@ -34842,7 +34842,7 @@
     "choices": [
       {
         "en": "word naming a person, place, or thing",
-        "ja": "ひとやばしょやものをなまえづけることば",
+        "ja": "人や場所やものを名づける言葉",
         "ja_typings": [
           "hitoyabashoyamononamaezukerukotoba",
           "hitoyabashoyamonoonamaezukerukotoba"
@@ -34850,7 +34850,7 @@
       },
       {
         "en": "word describing an action",
-        "ja": "こうどうをあらわすことば",
+        "ja": "行動を表す言葉",
         "ja_typings": [
           "kodooarawasukotoba",
           "koudouoarawasukotoba"
@@ -34858,7 +34858,7 @@
       },
       {
         "en": "word modifying verbs",
-        "ja": "どうしをしゅうしょくすることば",
+        "ja": "動詞を修飾する言葉",
         "ja_typings": [
           "doshioshuushokusurukotoba",
           "doushioshuushokusurukotoba"
@@ -34866,7 +34866,7 @@
       },
       {
         "en": "connecting word",
-        "ja": "つなぐことば",
+        "ja": "繋ぐ言葉",
         "ja_typings": [
           "tsunagukotoba"
         ]
@@ -34878,7 +34878,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a noun?",
-      "ja": "名詞とはどのようなものですか？"
+      "ja": "名詞とは何か？"
     },
     "question_text_reading": {
       "en": "What is a noun?",
@@ -34889,14 +34889,14 @@
     "choices": [
       {
         "en": "word showing relationship between nouns",
-        "ja": "めいしかんのかんけいをしめすことば",
+        "ja": "名詞間の関係を示す言葉",
         "ja_typings": [
           "meishikannokankeioshimesukotoba"
         ]
       },
       {
         "en": "word describing action",
-        "ja": "こうどうをあらわすことば",
+        "ja": "行動を表す言葉",
         "ja_typings": [
           "kodooarawasukotoba",
           "koudouoarawasukotoba"
@@ -34904,14 +34904,14 @@
       },
       {
         "en": "plural noun form",
-        "ja": "めいしのふくすうけい",
+        "ja": "名の複数形",
         "ja_typings": [
           "meishinofukusuukei"
         ]
       },
       {
         "en": "type of adjective",
-        "ja": "けいようしのいっしゅ",
+        "ja": "形容詞の一種",
         "ja_typings": [
           "keiyoshinoisshu",
           "keiyoushinoisshu"
@@ -34924,7 +34924,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a preposition?",
-      "ja": "前置詞（preposition）とは何ですか？"
+      "ja": "前置詞とは何か？"
     },
     "question_text_reading": {
       "en": "What is a preposition?",
@@ -34935,28 +34935,28 @@
     "choices": [
       {
         "en": "direct comparison without 'like' or 'as'",
-        "ja": "likeやasをつかわないちょくせつのひかく",
+        "ja": "likeやasを使わない直接的な比較",
         "ja_typings": [
           "likeyaasotsukawanaichokusetsunohikaku"
         ]
       },
       {
         "en": "comparison using 'like' or 'as'",
-        "ja": "likeやasをつかったひかく",
+        "ja": "likeやasを使った比較",
         "ja_typings": [
           "likeyaasotsukattahikaku"
         ]
       },
       {
         "en": "giving human traits to non-humans",
-        "ja": "にんげんいがいのものにじんかくをもたせること",
+        "ja": "人間以外のものに人格を持たせること",
         "ja_typings": [
           "ningenigainomononijinkakuomotaserukoto"
         ]
       },
       {
         "en": "exaggeration for effect",
-        "ja": "こうかのためのこちょう",
+        "ja": "効果のための誇張",
         "ja_typings": [
           "kokanotamenokocho",
           "koukanotamenokochou"
@@ -34969,7 +34969,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is metaphor?",
-      "ja": "メタファーとは何ですか？"
+      "ja": "比喩とは何か？"
     },
     "question_text_reading": {
       "en": "What is metaphor?",
@@ -34980,28 +34980,28 @@
     "choices": [
       {
         "en": "comparison using 'like' or 'as'",
-        "ja": "likeやasをつかったひかく",
+        "ja": "likeやasを使った比較",
         "ja_typings": [
           "likeyaasotsukattahikaku"
         ]
       },
       {
         "en": "direct comparison without 'like' or 'as'",
-        "ja": "likeやasをつかわないひかく",
+        "ja": "likeやasを使わない比較",
         "ja_typings": [
           "likeyaasotsukawanaihikaku"
         ]
       },
       {
         "en": "repetition of initial sounds",
-        "ja": "しょきおんのくりかえし",
+        "ja": "初期音の繰り返し",
         "ja_typings": [
           "shokionnokurikaeshi"
         ]
       },
       {
         "en": "word imitating sound",
-        "ja": "おとをまねることば",
+        "ja": "音をまねることば",
         "ja_typings": [
           "otomanerukotoba",
           "otoomanerukotoba"
@@ -35014,7 +35014,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a simile?",
-      "ja": "simileとはどのようなものですか？"
+      "ja": "simileとは何か？"
     },
     "question_text_reading": {
       "en": "What is a simile?",
@@ -35025,28 +35025,28 @@
     "choices": [
       {
         "en": "repetition of initial consonant sounds",
-        "ja": "しょきしいんのくりかえし",
+        "ja": "初期音の繰り返し",
         "ja_typings": [
           "shokishiinnokurikaeshi"
         ]
       },
       {
         "en": "comparison using 'like'",
-        "ja": "likeをつかったひかく",
+        "ja": "likeを使った比較",
         "ja_typings": [
           "likeotsukattahikaku"
         ]
       },
       {
         "en": "word with same spelling, different meaning",
-        "ja": "つづりがおなじでいみがちがうことば",
+        "ja": "綴りが同じで意味が違う言葉",
         "ja_typings": [
           "tsuzurigaonajideimigachigaukotoba"
         ]
       },
       {
         "en": "giving objects human traits",
-        "ja": "ものにじんかくをもたせること",
+        "ja": "ものに人格をもたせること",
         "ja_typings": [
           "mononijinkakuomotaserukoto"
         ]
@@ -35058,7 +35058,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is alliteration?",
-      "ja": "頭韻（alliteration）とは、どのような現象ですか？"
+      "ja": "どうじしゅんぷうとは何か？"
     },
     "question_text_reading": {
       "en": "What is alliteration?",
@@ -35069,28 +35069,28 @@
     "choices": [
       {
         "en": "Japan",
-        "ja": "にほん",
+        "ja": "日本",
         "ja_typings": [
           "nihon"
         ]
       },
       {
         "en": "China",
-        "ja": "ちゅうごく",
+        "ja": "中国",
         "ja_typings": [
           "chuugoku"
         ]
       },
       {
         "en": "Korea",
-        "ja": "かんこく",
+        "ja": "韓国",
         "ja_typings": [
           "kankoku"
         ]
       },
       {
         "en": "Thailand",
-        "ja": "たいらんど",
+        "ja": "タイランド",
         "ja_typings": [
           "tairando"
         ]
@@ -35102,7 +35102,7 @@
     "image_path": null,
     "question_text": {
       "en": "What country is sushi originally from?",
-      "ja": "寿司はどの国が発祥ですか？"
+      "ja": "寿司の原産地はどこ？"
     },
     "question_text_reading": {
       "en": "What country is sushi originally from?",
@@ -35113,28 +35113,28 @@
     "choices": [
       {
         "en": "sitar",
-        "ja": "したーる",
+        "ja": "シタール",
         "ja_typings": [
           "shitaru"
         ]
       },
       {
         "en": "shamisen",
-        "ja": "しゃみせん",
+        "ja": "三味線",
         "ja_typings": [
           "shamisen"
         ]
       },
       {
         "en": "erhu",
-        "ja": "にこ",
+        "ja": "二子",
         "ja_typings": [
           "niko"
         ]
       },
       {
         "en": "didgeridoo",
-        "ja": "でぃじゅりどぅー",
+        "ja": "ディジュリドゥー",
         "ja_typings": [
           "dijuridu"
         ]
@@ -35146,7 +35146,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the traditional instrument of India?",
-      "ja": "インドの伝統的な楽器は何ですか？"
+      "ja": "インドの伝統楽器は？"
     },
     "question_text_reading": {
       "en": "What is the traditional instrument of India?",
@@ -35157,7 +35157,7 @@
     "choices": [
       {
         "en": "Spanish dance and music style",
-        "ja": "すぺいんのぶようとおんがくのすたいる",
+        "ja": "スペインの舞踊と音楽のスタイル",
         "ja_typings": [
           "supeinnobuyotongakunosutairu",
           "supeinnobuyoutoongakunosutairu"
@@ -35165,7 +35165,7 @@
       },
       {
         "en": "Italian opera style",
-        "ja": "いたりあのおぺらすたいる",
+        "ja": "イタリアのオペラスタイル",
         "ja_typings": [
           "itarianoperasutairu",
           "itarianooperasutairu"
@@ -35173,7 +35173,7 @@
       },
       {
         "en": "Brazilian dance",
-        "ja": "ぶらじるのぶよう",
+        "ja": "ブラジルの舞踊",
         "ja_typings": [
           "burajirunobuyo",
           "burajirunobuyou"
@@ -35181,7 +35181,7 @@
       },
       {
         "en": "Mexican folk music",
-        "ja": "めきしこのみんぞくおんがく",
+        "ja": "メキシコの民俗音楽",
         "ja_typings": [
           "mekishikonominzokuongaku"
         ]
@@ -35193,7 +35193,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is flamenco?",
-      "ja": "フラメンコとはどのようなものですか？"
+      "ja": "フラメンコとは何か？"
     },
     "question_text_reading": {
       "en": "What is flamenco?",
@@ -35204,28 +35204,28 @@
     "choices": [
       {
         "en": "annual festival with samba parades",
-        "ja": "さんばぱれーどのねんかんまつり",
+        "ja": "サンバパレードの年間祭り",
         "ja_typings": [
           "sanbaparedononenkanmatsuri"
         ]
       },
       {
         "en": "Christmas celebration",
-        "ja": "くりすますのいわい",
+        "ja": "クリスマスのお祝い",
         "ja_typings": [
           "kurisumasunoiwai"
         ]
       },
       {
         "en": "harvest festival",
-        "ja": "しゅうかくまつり",
+        "ja": "収穫祭",
         "ja_typings": [
           "shuukakumatsuri"
         ]
       },
       {
         "en": "water festival",
-        "ja": "みずまつり",
+        "ja": "水祭り",
         "ja_typings": [
           "mizumatsuri"
         ]
@@ -35237,7 +35237,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is Carnival in Brazil?",
-      "ja": "ブラジルのカーニバルとはどのようなものですか？"
+      "ja": "ブラジルのカーニバルとは何か？"
     },
     "question_text_reading": {
       "en": "What is Carnival in Brazil?",
@@ -35248,7 +35248,7 @@
     "choices": [
       {
         "en": "ancient Roman amphitheater",
-        "ja": "こだいろーまのえんけいきょうぎじょう",
+        "ja": "古ローマの円形競技場",
         "ja_typings": [
           "kodairomanoenkeikyogijo",
           "kodairomanoenkeikyougijou"
@@ -35256,21 +35256,21 @@
       },
       {
         "en": "Egyptian pyramid",
-        "ja": "えじぷとのぴらみっど",
+        "ja": "エジプトのピラミッド",
         "ja_typings": [
           "ejiputonopiramiddo"
         ]
       },
       {
         "en": "Greek temple",
-        "ja": "ぎりしあのしんでん",
+        "ja": "ギリシャの神殿",
         "ja_typings": [
           "girishianoshinden"
         ]
       },
       {
         "en": "Medieval castle",
-        "ja": "ちゅうせいのしろ",
+        "ja": "中世の城",
         "ja_typings": [
           "chuuseinoshiro"
         ]
@@ -35282,7 +35282,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the Colosseum?",
-      "ja": "コロッセオとは何ですか？"
+      "ja": "コロッセオムとは何か？"
     },
     "question_text_reading": {
       "en": "What is the Colosseum?",
@@ -35293,7 +35293,7 @@
     "choices": [
       {
         "en": "Japanese art of flower arranging",
-        "ja": "にほんのかどう",
+        "ja": "日本のかどう",
         "ja_typings": [
           "nihonnokado",
           "nihonnokadou"
@@ -35301,14 +35301,14 @@
       },
       {
         "en": "Japanese sword art",
-        "ja": "にほんのけんじゅつ",
+        "ja": "日本の剣術",
         "ja_typings": [
           "nihonnokenjutsu"
         ]
       },
       {
         "en": "Korean paper folding",
-        "ja": "かんこくのおりがみ",
+        "ja": "韓国の折り紙",
         "ja_typings": [
           "kankokunorigami",
           "kankokunoorigami"
@@ -35316,7 +35316,7 @@
       },
       {
         "en": "Chinese tea ceremony",
-        "ja": "ちゅうごくのちゃのゆ",
+        "ja": "中国の茶の湯",
         "ja_typings": [
           "chuugokunochanoyu"
         ]
@@ -35328,7 +35328,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is ikebana?",
-      "ja": "生け花とは何ですか？"
+      "ja": "生け花とは何か？"
     },
     "question_text_reading": {
       "en": "What is ikebana?",
@@ -35339,28 +35339,28 @@
     "choices": [
       {
         "en": "Scotland",
-        "ja": "すこっとらんど",
+        "ja": "スコットランド",
         "ja_typings": [
           "sukottorando"
         ]
       },
       {
         "en": "Ireland",
-        "ja": "あいるらんど",
+        "ja": "アイルランド",
         "ja_typings": [
           "airurando"
         ]
       },
       {
         "en": "Wales",
-        "ja": "うぇーるず",
+        "ja": "ウェールズ",
         "ja_typings": [
           "weruzu"
         ]
       },
       {
         "en": "England",
-        "ja": "いんぐらんど",
+        "ja": "イングランド",
         "ja_typings": [
           "ingurando"
         ]
@@ -35372,7 +35372,7 @@
     "image_path": null,
     "question_text": {
       "en": "What country does the kilt come from?",
-      "ja": "キルトはどの国発祥のものですか？"
+      "ja": "キルトはどこの国のもの？"
     },
     "question_text_reading": {
       "en": "What country does the kilt come from?",
@@ -35383,7 +35383,7 @@
     "choices": [
       {
         "en": "chado",
-        "ja": "ちゃどう",
+        "ja": "茶道",
         "ja_typings": [
           "chado",
           "chadou"
@@ -35391,14 +35391,14 @@
       },
       {
         "en": "kabuki",
-        "ja": "かぶき",
+        "ja": "歌舞伎",
         "ja_typings": [
           "kabuki"
         ]
       },
       {
         "en": "noh",
-        "ja": "のう",
+        "ja": "ノウ",
         "ja_typings": [
           "no",
           "nou"
@@ -35406,7 +35406,7 @@
       },
       {
         "en": "sumo",
-        "ja": "すもう",
+        "ja": "相撲",
         "ja_typings": [
           "sumo",
           "sumou"
@@ -35419,7 +35419,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the traditional Japanese tea ceremony called?",
-      "ja": "日本の伝統的なお茶の儀式は何と呼ばれますか？"
+      "ja": "日本の茶道の正式名称は？"
     },
     "question_text_reading": {
       "en": "What is the traditional Japanese tea ceremony called?",
@@ -35430,28 +35430,28 @@
     "choices": [
       {
         "en": "Halloween",
-        "ja": "はろうぃん",
+        "ja": "ハロウィン",
         "ja_typings": [
           "harowin"
         ]
       },
       {
         "en": "Thanksgiving",
-        "ja": "さんくすぎびんぐ",
+        "ja": "サンクスギビング",
         "ja_typings": [
           "sankusugibingu"
         ]
       },
       {
         "en": "Christmas",
-        "ja": "くりすます",
+        "ja": "クリスマス",
         "ja_typings": [
           "kurisumasu"
         ]
       },
       {
         "en": "Easter",
-        "ja": "いーすたー",
+        "ja": "イースター",
         "ja_typings": [
           "isuta"
         ]
@@ -35463,7 +35463,7 @@
     "image_path": null,
     "question_text": {
       "en": "What festival is celebrated on October 31?",
-      "ja": "10月31日に祝われる祭りは何ですか？"
+      "ja": "10月31日にいわわれる祭りは？"
     },
     "question_text_reading": {
       "en": "What festival is celebrated on October 31?",
@@ -35474,7 +35474,7 @@
     "choices": [
       {
         "en": "Hindu festival of lights",
-        "ja": "ひんどうきょうのひかりのまつり",
+        "ja": "ヒンドゥーの光の祭り",
         "ja_typings": [
           "hindokyonohikarinomatsuri",
           "hindoukyounohikarinomatsuri"
@@ -35482,14 +35482,14 @@
       },
       {
         "en": "Muslim new year",
-        "ja": "いすらむのしんねん",
+        "ja": "イスラムの新年",
         "ja_typings": [
           "isuramunoshinnen"
         ]
       },
       {
         "en": "Buddhist harvest festival",
-        "ja": "ぶっきょうのしゅうかくまつり",
+        "ja": "仏教の収穫祭り",
         "ja_typings": [
           "bukkyonoshuukakumatsuri",
           "bukkyounoshuukakumatsuri"
@@ -35497,7 +35497,7 @@
       },
       {
         "en": "Sikh water festival",
-        "ja": "しっきょうのみずまつり",
+        "ja": "シク教の水祭り",
         "ja_typings": [
           "shikkyonomizumatsuri",
           "shikkyounomizumatsuri"
@@ -35510,7 +35510,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is Diwali?",
-      "ja": "ディワリとは、どのようなお祭りですか？"
+      "ja": "ディワリとは何か？"
     },
     "question_text_reading": {
       "en": "What is Diwali?",
@@ -35521,7 +35521,7 @@
     "choices": [
       {
         "en": "Mexican holiday honoring deceased",
-        "ja": "しにょにけいいをひょうするめきしこのしゅくじつ",
+        "ja": "死者記念日を表すメキシコの祝日",
         "ja_typings": [
           "shinyonikeiiohyosurumekishikonoshukujitsu",
           "shinyonikeiiohyousurumekishikonoshukujitsu"
@@ -35529,7 +35529,7 @@
       },
       {
         "en": "Spanish funeral rite",
-        "ja": "すぺいんのそうぎのぎしき",
+        "ja": "スペインの葬儀の儀式",
         "ja_typings": [
           "supeinnosoginogishiki",
           "supeinnosouginogishiki"
@@ -35537,14 +35537,14 @@
       },
       {
         "en": "Halloween-inspired festival",
-        "ja": "はろうぃんにもとづくまつり",
+        "ja": "ハロウィンに基づく祭り",
         "ja_typings": [
           "harowinnimotozukumatsuri"
         ]
       },
       {
         "en": "South American harvest day",
-        "ja": "なんべいのしゅうかくのひ",
+        "ja": "南米の収穫の日",
         "ja_typings": [
           "nanbeinoshuukakunohi"
         ]
@@ -35556,7 +35556,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the Day of the Dead (Día de los Muertos)?",
-      "ja": "Day of the Dead（ディア・デ・ロス・ムエルトス）とは、どのようなものですか？"
+      "ja": "シャのひ（Día de los Muertos）とは何か？"
     },
     "question_text_reading": {
       "en": "What is the Day of the Dead (Día de los Muertos)?",
@@ -35567,7 +35567,7 @@
     "choices": [
       {
         "en": "Japanese art of paper folding",
-        "ja": "かみをおるにほんのげいじゅつ",
+        "ja": "紙を折る日本の芸術",
         "ja_typings": [
           "kamiorunihonnogeijutsu",
           "kamioorunihonnogeijutsu"
@@ -35575,14 +35575,14 @@
       },
       {
         "en": "Chinese ink painting",
-        "ja": "ちゅうごくのすみえ",
+        "ja": "中国の墨絵",
         "ja_typings": [
           "chuugokunosumie"
         ]
       },
       {
         "en": "Korean pottery art",
-        "ja": "かんこくのとうじ",
+        "ja": "韓国の陶磁器",
         "ja_typings": [
           "kankokunotoji",
           "kankokunotouji"
@@ -35590,7 +35590,7 @@
       },
       {
         "en": "Japanese wood carving",
-        "ja": "にほんのもくちょう",
+        "ja": "日本のもくちょう",
         "ja_typings": [
           "nihonnomokucho",
           "nihonnomokuchou"
@@ -35603,7 +35603,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is origami?",
-      "ja": "折り紙とは何ですか？"
+      "ja": "折り紙とは何か？"
     },
     "question_text_reading": {
       "en": "What is origami?",
@@ -35614,28 +35614,28 @@
     "choices": [
       {
         "en": "Spring Festival",
-        "ja": "しゅんせつ",
+        "ja": "春節",
         "ja_typings": [
           "shunsetsu"
         ]
       },
       {
         "en": "Moon Festival",
-        "ja": "つきまつり",
+        "ja": "月祭",
         "ja_typings": [
           "tsukimatsuri"
         ]
       },
       {
         "en": "Dragon Festival",
-        "ja": "りゅうまつり",
+        "ja": "竜馬祭り",
         "ja_typings": [
           "ryuumatsuri"
         ]
       },
       {
         "en": "Harvest Festival",
-        "ja": "しゅうかくまつり",
+        "ja": "収穫祭",
         "ja_typings": [
           "shuukakumatsuri"
         ]
@@ -35647,7 +35647,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the Chinese New Year also called?",
-      "ja": "中国の正月は他に何というのでしょうか？"
+      "ja": "中国の春節は何ともいわれるか？"
     },
     "question_text_reading": {
       "en": "What is the Chinese New Year also called?",
@@ -35658,28 +35658,28 @@
     "choices": [
       {
         "en": "soccer (football)",
-        "ja": "さっかーふっとぼーる",
+        "ja": "サッカーボール",
         "ja_typings": [
           "sakkafuttoboru"
         ]
       },
       {
         "en": "basketball",
-        "ja": "ばすけっとぼーる",
+        "ja": "バスケットボール",
         "ja_typings": [
           "basukettoboru"
         ]
       },
       {
         "en": "cricket",
-        "ja": "くりけっと",
+        "ja": "クリケット",
         "ja_typings": [
           "kuriketto"
         ]
       },
       {
         "en": "baseball",
-        "ja": "やきゅう",
+        "ja": "野球",
         "ja_typings": [
           "yakyuu"
         ]
@@ -35691,7 +35691,7 @@
     "image_path": null,
     "question_text": {
       "en": "What sport is most popular globally?",
-      "ja": "世界で最も人気のあるスポーツは何でしょう？"
+      "ja": "世界で最も人気なスポーツは？"
     },
     "question_text_reading": {
       "en": "What sport is most popular globally?",
@@ -35702,28 +35702,28 @@
     "choices": [
       {
         "en": "kimono",
-        "ja": "きもの",
+        "ja": "着物",
         "ja_typings": [
           "kimono"
         ]
       },
       {
         "en": "hanbok",
-        "ja": "はんぼく",
+        "ja": "韓服",
         "ja_typings": [
           "hanboku"
         ]
       },
       {
         "en": "cheongsam",
-        "ja": "ちょんさむ",
+        "ja": "チョンサン",
         "ja_typings": [
           "chonsamu"
         ]
       },
       {
         "en": "sari",
-        "ja": "さりー",
+        "ja": "サリ",
         "ja_typings": [
           "sari"
         ]
@@ -35735,7 +35735,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the traditional clothing of Japan?",
-      "ja": "日本の伝統的な衣装は何ですか？"
+      "ja": "日本で伝統的な着物は？"
     },
     "question_text_reading": {
       "en": "What is the traditional clothing of Japan?",
@@ -35746,7 +35746,7 @@
     "choices": [
       {
         "en": "ancient Indian practice of mind and body",
-        "ja": "こだいいんどのこころとからだのしょう",
+        "ja": "古代インドの心と体のショー",
         "ja_typings": [
           "kodaiindonokokorotokaradanosho",
           "kodaiindonokokorotokaradanoshou"
@@ -35754,7 +35754,7 @@
       },
       {
         "en": "Chinese martial art",
-        "ja": "ちゅうごくのぶどう",
+        "ja": "中国の武道",
         "ja_typings": [
           "chuugokunobudo",
           "chuugokunobudou"
@@ -35762,7 +35762,7 @@
       },
       {
         "en": "Japanese meditation technique",
-        "ja": "にほんのめでぃてーしょんぎほう",
+        "ja": "日本のメディテーション技法",
         "ja_typings": [
           "nihonnomediteshongiho",
           "nihonnomediteshongihou"
@@ -35770,7 +35770,7 @@
       },
       {
         "en": "Korean breathing exercise",
-        "ja": "かんこくのこきゅうたいそう",
+        "ja": "韓国の呼吸体操",
         "ja_typings": [
           "kankokunokokyuutaiso",
           "kankokunokokyuutaisou"
@@ -35783,7 +35783,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is yoga?",
-      "ja": "ヨガとは、どのようなものですか？"
+      "ja": "ヨガとは何か？"
     },
     "question_text_reading": {
       "en": "What is yoga?",
@@ -35794,7 +35794,7 @@
     "choices": [
       {
         "en": "Korean fermented vegetable dish",
-        "ja": "かんこくのはっこうやさいりょうり",
+        "ja": "韓国の発酵野菜料理",
         "ja_typings": [
           "kankokunohakkoyasairyori",
           "kankokunohakkouyasairyouri"
@@ -35802,14 +35802,14 @@
       },
       {
         "en": "Japanese pickled vegetables",
-        "ja": "にほんのつけもの",
+        "ja": "日本の漬物",
         "ja_typings": [
           "nihonnotsukemono"
         ]
       },
       {
         "en": "Chinese noodle dish",
-        "ja": "ちゅうごくのめんりょうり",
+        "ja": "中国の麺料理",
         "ja_typings": [
           "chuugokunomenryori",
           "chuugokunomenryouri"
@@ -35817,7 +35817,7 @@
       },
       {
         "en": "Thai spicy soup",
-        "ja": "たいのからいすーぷ",
+        "ja": "タイの辛いスープ",
         "ja_typings": [
           "tainokaraisupu"
         ]
@@ -35829,7 +35829,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is kimchi?",
-      "ja": "キムチとは何ですか？"
+      "ja": "キムチとは何か？"
     },
     "question_text_reading": {
       "en": "What is kimchi?",
@@ -35840,14 +35840,14 @@
     "choices": [
       {
         "en": "respectful greeting in Hindu culture",
-        "ja": "ひんどぅーぶんかのそんけいのあいさつ",
+        "ja": "ヒンドゥー文化の尊敬の挨拶",
         "ja_typings": [
           "hindubunkanosonkeinoaisatsu"
         ]
       },
       {
         "en": "goodbye in Japanese",
-        "ja": "にほんごのさようなら",
+        "ja": "日本語のさようなら",
         "ja_typings": [
           "nihongonosayonara",
           "nihongonosayounara"
@@ -35855,7 +35855,7 @@
       },
       {
         "en": "thank you in Arabic",
-        "ja": "あらびあごのありがとう",
+        "ja": "アラビア語のありがとう",
         "ja_typings": [
           "arabiagonoarigato",
           "arabiagonoarigatou"
@@ -35863,7 +35863,7 @@
       },
       {
         "en": "good morning in Swahili",
-        "ja": "すわひりごのおはよう",
+        "ja": "スワヒリ語のおはよう",
         "ja_typings": [
           "suwahirigonohayo",
           "suwahirigonoohayou"
@@ -35876,7 +35876,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the meaning of 'namaste'?",
-      "ja": "namasteはどのような意味ですか？"
+      "ja": "ナマステの意味は？"
     },
     "question_text_reading": {
       "en": "What is the meaning of 'namaste'?",
@@ -35887,28 +35887,28 @@
     "choices": [
       {
         "en": "Italy",
-        "ja": "いたりあ",
+        "ja": "イタリア",
         "ja_typings": [
           "itaria"
         ]
       },
       {
         "en": "China",
-        "ja": "ちゅうごく",
+        "ja": "中国",
         "ja_typings": [
           "chuugoku"
         ]
       },
       {
         "en": "France",
-        "ja": "ふらんす",
+        "ja": "フランス",
         "ja_typings": [
           "furansu"
         ]
       },
       {
         "en": "Spain",
-        "ja": "すぺいん",
+        "ja": "スペイン",
         "ja_typings": [
           "supein"
         ]
@@ -35920,7 +35920,7 @@
     "image_path": null,
     "question_text": {
       "en": "What country did pasta originally come from?",
-      "ja": "パスタは、元々どの国で食べられていたのでしょうか？"
+      "ja": "パスタの原産地はどこ？"
     },
     "question_text_reading": {
       "en": "What country did pasta originally come from?",
@@ -35931,14 +35931,14 @@
     "choices": [
       {
         "en": "famous painting by Leonardo da Vinci",
-        "ja": "れおなるど・だ・ゔぃんちのゆうめいなえ",
+        "ja": "レオナルド・ダ・ヴィンチの有名な絵",
         "ja_typings": [
           "reonarudo da vinchinoyuumeinae"
         ]
       },
       {
         "en": "ancient Greek sculpture",
-        "ja": "こだいぎりしあのちょうこく",
+        "ja": "古代ギリシャの彫刻",
         "ja_typings": [
           "kodaigirishianochokoku",
           "kodaigirishianochoukoku"
@@ -35946,14 +35946,14 @@
       },
       {
         "en": "Renaissance building",
-        "ja": "るねっさんすけんちく",
+        "ja": "ルネサンス建築",
         "ja_typings": [
           "runessansukenchiku"
         ]
       },
       {
         "en": "Egyptian artifact",
-        "ja": "えじぷとのこうぶつ",
+        "ja": "エジプトの工物",
         "ja_typings": [
           "ejiputonokobutsu",
           "ejiputonokoubutsu"
@@ -35966,7 +35966,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the Mona Lisa?",
-      "ja": "モナ・リザとは何ですか？"
+      "ja": "モナ・リザとは何か？"
     },
     "question_text_reading": {
       "en": "What is the Mona Lisa?",
@@ -35977,7 +35977,7 @@
     "choices": [
       {
         "en": "mausoleum in India",
-        "ja": "いんどのびょうびょう",
+        "ja": "インドの廟堂",
         "ja_typings": [
           "indonobyobyo",
           "indonobyoubyou"
@@ -35985,21 +35985,21 @@
       },
       {
         "en": "temple in Thailand",
-        "ja": "たいのしんでん",
+        "ja": "タイのシンデン",
         "ja_typings": [
           "tainoshinden"
         ]
       },
       {
         "en": "palace in China",
-        "ja": "ちゅうごくのきゅうでん",
+        "ja": "中国の宮殿",
         "ja_typings": [
           "chuugokunokyuuden"
         ]
       },
       {
         "en": "fortress in Pakistan",
-        "ja": "ぱきすたんのとりで",
+        "ja": "パキスタンの砦",
         "ja_typings": [
           "pakisutannotoride"
         ]
@@ -36011,7 +36011,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the Taj Mahal?",
-      "ja": "タージ・マハルとは何ですか？"
+      "ja": "タージ・マハルとは何か？"
     },
     "question_text_reading": {
       "en": "What is the Taj Mahal?",
@@ -36022,7 +36022,7 @@
     "choices": [
       {
         "en": "Russian nesting doll",
-        "ja": "ろしあのだるまにんぎょう",
+        "ja": "ロシアのダッルマ人形",
         "ja_typings": [
           "roshianodarumaningyo",
           "roshianodarumaningyou"
@@ -36030,14 +36030,14 @@
       },
       {
         "en": "Japanese puzzle box",
-        "ja": "にほんのひみつはこ",
+        "ja": "日本の秘密箱",
         "ja_typings": [
           "nihonnohimitsuhako"
         ]
       },
       {
         "en": "Chinese porcelain figure",
-        "ja": "ちゅうごくのとうじにんぎょう",
+        "ja": "中国の陶磁人形",
         "ja_typings": [
           "chuugokunotojiningyo",
           "chuugokunotoujiningyou"
@@ -36045,7 +36045,7 @@
       },
       {
         "en": "German wooden toy",
-        "ja": "どいつのもくせいおもちゃ",
+        "ja": "ドイツの木製おもちゃ",
         "ja_typings": [
           "doitsunomokuseiomocha"
         ]
@@ -36057,7 +36057,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a matryoshka?",
-      "ja": "マトリョーシカとは何ですか？"
+      "ja": "マトリョーシカとは何か？"
     },
     "question_text_reading": {
       "en": "What is a matryoshka?",
@@ -36068,28 +36068,28 @@
     "choices": [
       {
         "en": "China",
-        "ja": "ちゅうごく",
+        "ja": "中国",
         "ja_typings": [
           "chuugoku"
         ]
       },
       {
         "en": "India",
-        "ja": "いんど",
+        "ja": "インド",
         "ja_typings": [
           "indo"
         ]
       },
       {
         "en": "Europe",
-        "ja": "ゆーろっぱ",
+        "ja": "ヨーロッパ",
         "ja_typings": [
           "yuroppa"
         ]
       },
       {
         "en": "Middle East",
-        "ja": "ちゅうとう",
+        "ja": "中東",
         "ja_typings": [
           "chuuto",
           "chuutou"
@@ -36102,7 +36102,7 @@
     "image_path": null,
     "question_text": {
       "en": "What country is known for inventing gunpowder?",
-      "ja": "火薬を発明したとされる国はどこですか？"
+      "ja": "火薬を発明したとされる国は？"
     },
     "question_text_reading": {
       "en": "What country is known for inventing gunpowder?",
@@ -36113,28 +36113,28 @@
     "choices": [
       {
         "en": "decorative handwriting or lettering",
-        "ja": "かざりもじのてがき",
+        "ja": "飾り文字の手書き",
         "ja_typings": [
           "kazarimojinotegaki"
         ]
       },
       {
         "en": "painted silk art",
-        "ja": "ぬのにえをかくげいじゅつ",
+        "ja": "塗り絵を描く芸術",
         "ja_typings": [
           "nunonieokakugeijutsu"
         ]
       },
       {
         "en": "stone carving art",
-        "ja": "いしぼりのげいじゅつ",
+        "ja": "石彫りの芸術",
         "ja_typings": [
           "ishiborinogeijutsu"
         ]
       },
       {
         "en": "weaving pattern art",
-        "ja": "おりものもようのげいじゅつ",
+        "ja": "織物模様の芸術",
         "ja_typings": [
           "orimonomoyonogeijutsu",
           "orimonomoyounogeijutsu"
@@ -36147,7 +36147,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the art of calligraphy?",
-      "ja": "書道とは、どのような芸術なのでしょうか？"
+      "ja": "書道とは何か？"
     },
     "question_text_reading": {
       "en": "What is the art of calligraphy?",
@@ -36158,28 +36158,28 @@
     "choices": [
       {
         "en": "Japanese warrior class",
-        "ja": "にほんのぶし",
+        "ja": "日本の武士",
         "ja_typings": [
           "nihonnobushi"
         ]
       },
       {
         "en": "Chinese noble class",
-        "ja": "ちゅうごくのきぞく",
+        "ja": "中国の貴族",
         "ja_typings": [
           "chuugokunokizoku"
         ]
       },
       {
         "en": "Korean royal guard",
-        "ja": "かんこくのきんえいたい",
+        "ja": "韓国の禁衛隊",
         "ja_typings": [
           "kankokunokineitai"
         ]
       },
       {
         "en": "Mongolian cavalry soldier",
-        "ja": "もうこのきへいへいし",
+        "ja": "モンゴル騎兵兵士",
         "ja_typings": [
           "mokonokiheiheishi",
           "moukonokiheiheishi"
@@ -36192,7 +36192,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a samurai?",
-      "ja": "侍とはどのような存在ですか？"
+      "ja": "侍とは何か？"
     },
     "question_text_reading": {
       "en": "What is a samurai?",
@@ -36203,7 +36203,7 @@
     "choices": [
       {
         "en": "symbol of Olympic games",
-        "ja": "おりんぴっくのしょうちょう",
+        "ja": "オリンピックの象徴",
         "ja_typings": [
           "orinpikkunoshocho",
           "orinpikkunoshouchou"
@@ -36211,7 +36211,7 @@
       },
       {
         "en": "torch used to signal race start",
-        "ja": "れーすのすたーとのしんごうたいまつ",
+        "ja": "レースのスタートの信号対物",
         "ja_typings": [
           "resunosutatonoshingotaimatsu",
           "resunosutatonoshingoutaimatsu"
@@ -36219,14 +36219,14 @@
       },
       {
         "en": "fire kept in ancient Rome",
-        "ja": "こだいろーまでともされたひ",
+        "ja": "古代ローマとされた日",
         "ja_typings": [
           "kodairomadetomosaretahi"
         ]
       },
       {
         "en": "eternal flame of peace",
-        "ja": "えいきゅうへいわのほのお",
+        "ja": "永遠平和の炎",
         "ja_typings": [
           "eikyuuheiwanohono",
           "eikyuuheiwanohonoo"
@@ -36239,7 +36239,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the Olympic flame?",
-      "ja": "オリンピックの炎とは何ですか？"
+      "ja": "オリンピックの炎とは何か？"
     },
     "question_text_reading": {
       "en": "What is the Olympic flame?",
@@ -36250,21 +36250,21 @@
     "choices": [
       {
         "en": "Japanese style comics",
-        "ja": "にほんすたいるのまんが",
+        "ja": "日本スタイルの漫画",
         "ja_typings": [
           "nihonsutairunomanga"
         ]
       },
       {
         "en": "Korean animation",
-        "ja": "かんこくのあにめ",
+        "ja": "韓国のアニメ",
         "ja_typings": [
           "kankokunoanime"
         ]
       },
       {
         "en": "Chinese illustrated novel",
-        "ja": "ちゅうごくのさしえしょうせつ",
+        "ja": "中国の挿絵小説",
         "ja_typings": [
           "chuugokunosashieshosetsu",
           "chuugokunosashieshousetsu"
@@ -36272,7 +36272,7 @@
       },
       {
         "en": "Japanese film genre",
-        "ja": "にほんのえいがじゃんる",
+        "ja": "日本の映画ジャンル",
         "ja_typings": [
           "nihonnoeigajanru"
         ]
@@ -36284,7 +36284,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is manga?",
-      "ja": "漫画とは何ですか？"
+      "ja": "漫画とは何か？"
     },
     "question_text_reading": {
       "en": "What is manga?",
@@ -36295,21 +36295,21 @@
     "choices": [
       {
         "en": "urban culture with rap, DJing, breakdancing",
-        "ja": "らっぷ、でぃーじぇい、ぶれいくだんすのあーばんぶんか",
+        "ja": "ラップ、DJ、ブレイクダンスのアバンカルチャー",
         "ja_typings": [
           "rappu dijei bureikudansunoabanbunka"
         ]
       },
       {
         "en": "Japanese street fashion",
-        "ja": "にほんのすとりーとふぁっしょん",
+        "ja": "日本のストリートファッション",
         "ja_typings": [
           "nihonnosutoritofasshon"
         ]
       },
       {
         "en": "Latin music movement",
-        "ja": "らてんおんがくのうんどう",
+        "ja": "ラテン音楽の運動",
         "ja_typings": [
           "ratenongakunondo",
           "ratenongakunoundou"
@@ -36317,7 +36317,7 @@
       },
       {
         "en": "European folk culture revival",
-        "ja": "ゆーろっぱのみんぞくぶんかのふっかつ",
+        "ja": "ヨーロッパの民族文化の復興",
         "ja_typings": [
           "yuroppanominzokubunkanofukkatsu"
         ]
@@ -36329,7 +36329,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is hip-hop culture?",
-      "ja": "ヒップホップカルチャーとは、どのようなものですか？"
+      "ja": "ヒップホップ文化とは何か？"
     },
     "question_text_reading": {
       "en": "What is hip-hop culture?",
@@ -36340,28 +36340,28 @@
     "choices": [
       {
         "en": "7",
-        "ja": "なな",
+        "ja": "七",
         "ja_typings": [
           "nana"
         ]
       },
       {
         "en": "6",
-        "ja": "ろく",
+        "ja": "六",
         "ja_typings": [
           "roku"
         ]
       },
       {
         "en": "5",
-        "ja": "ご",
+        "ja": "五",
         "ja_typings": [
           "go"
         ]
       },
       {
         "en": "8",
-        "ja": "はち",
+        "ja": "八",
         "ja_typings": [
           "hachi"
         ]
@@ -36373,7 +36373,7 @@
     "image_path": null,
     "question_text": {
       "en": "How many continents are there on Earth?",
-      "ja": "地球上には何大陸ありますか？"
+      "ja": "地球にはいくつの大陸があるか？"
     },
     "question_text_reading": {
       "en": "How many continents are there on Earth?",
@@ -36384,7 +36384,7 @@
     "choices": [
       {
         "en": "Pacific Ocean",
-        "ja": "たいへいよう",
+        "ja": "太平洋",
         "ja_typings": [
           "taiheiyo",
           "taiheiyou"
@@ -36392,7 +36392,7 @@
       },
       {
         "en": "Atlantic Ocean",
-        "ja": "たいせいよう",
+        "ja": "大西洋",
         "ja_typings": [
           "taiseiyo",
           "taiseiyou"
@@ -36400,7 +36400,7 @@
       },
       {
         "en": "Indian Ocean",
-        "ja": "いんどよう",
+        "ja": "インド洋",
         "ja_typings": [
           "indoyo",
           "indoyou"
@@ -36408,7 +36408,7 @@
       },
       {
         "en": "Arctic Ocean",
-        "ja": "ほっきょくかい",
+        "ja": "北極海",
         "ja_typings": [
           "hokkyokukai"
         ]
@@ -36420,7 +36420,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the largest ocean?",
-      "ja": "世界で一番大きな海はどれでしょう？"
+      "ja": "最も大きな海は？"
     },
     "question_text_reading": {
       "en": "What is the largest ocean?",
@@ -36431,28 +36431,28 @@
     "choices": [
       {
         "en": "366",
-        "ja": "さんびゃくろくじゅうろく",
+        "ja": "366",
         "ja_typings": [
           "sanbyakurokujuuroku"
         ]
       },
       {
         "en": "365",
-        "ja": "さんびゃくろくじゅうご",
+        "ja": "365",
         "ja_typings": [
           "sanbyakurokujuugo"
         ]
       },
       {
         "en": "367",
-        "ja": "さんびゃくろくじゅうなな",
+        "ja": "三百六十七",
         "ja_typings": [
           "sanbyakurokujuunana"
         ]
       },
       {
         "en": "364",
-        "ja": "さんびゃくろくじゅうし",
+        "ja": "三百六十四",
         "ja_typings": [
           "sanbyakurokujuushi"
         ]
@@ -36464,7 +36464,7 @@
     "image_path": null,
     "question_text": {
       "en": "How many days are in a leap year?",
-      "ja": "うるうどしには何日ありますか？"
+      "ja": "うるうどしはなんにち？"
     },
     "question_text_reading": {
       "en": "How many days are in a leap year?",
@@ -36475,28 +36475,28 @@
     "choices": [
       {
         "en": "Au",
-        "ja": "おーゆー",
+        "ja": "Au",
         "ja_typings": [
           "oyu"
         ]
       },
       {
         "en": "Go",
-        "ja": "じーおー",
+        "ja": "G O",
         "ja_typings": [
           "jio"
         ]
       },
       {
         "en": "Gd",
-        "ja": "じーでぃー",
+        "ja": "ジーディー",
         "ja_typings": [
           "jidi"
         ]
       },
       {
         "en": "Ag",
-        "ja": "えーじー",
+        "ja": "Ag",
         "ja_typings": [
           "eji"
         ]
@@ -36508,7 +36508,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the chemical symbol for gold?",
-      "ja": "金（ゴールド）の化学記号は何ですか？"
+      "ja": "金の化学記号は？"
     },
     "question_text_reading": {
       "en": "What is the chemical symbol for gold?",
@@ -36519,28 +36519,28 @@
     "choices": [
       {
         "en": "Mount Everest",
-        "ja": "えべれすとさん",
+        "ja": "エベレスト山",
         "ja_typings": [
           "eberesutosan"
         ]
       },
       {
         "en": "K2",
-        "ja": "けーつー",
+        "ja": "K2",
         "ja_typings": [
           "ketsu"
         ]
       },
       {
         "en": "Kilimanjaro",
-        "ja": "きりまんじゃろ",
+        "ja": "キリマンジャロ",
         "ja_typings": [
           "kirimanjaro"
         ]
       },
       {
         "en": "Mont Blanc",
-        "ja": "もんぶらん",
+        "ja": "モンブラン",
         "ja_typings": [
           "monburan"
         ]
@@ -36552,7 +36552,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the tallest mountain in the world?",
-      "ja": "世界で最も高い山は何ですか？"
+      "ja": "世界で最も高い山は？"
     },
     "question_text_reading": {
       "en": "What is the tallest mountain in the world?",
@@ -36563,28 +36563,28 @@
     "choices": [
       {
         "en": "206",
-        "ja": "にひゃくろく",
+        "ja": "206",
         "ja_typings": [
           "nihyakuroku"
         ]
       },
       {
         "en": "206",
-        "ja": "にひゃくろく",
+        "ja": "206",
         "ja_typings": [
           "nihyakuroku"
         ]
       },
       {
         "en": "198",
-        "ja": "ひゃくきゅうじゅうはち",
+        "ja": "198",
         "ja_typings": [
           "hyakukyuujuuhachi"
         ]
       },
       {
         "en": "213",
-        "ja": "にひゃくじゅうさん",
+        "ja": "213",
         "ja_typings": [
           "nihyakujuusan"
         ]
@@ -36596,7 +36596,7 @@
     "image_path": null,
     "question_text": {
       "en": "How many bones are in the adult human body?",
-      "ja": "成人の人体には、骨がいくつあるでしょうか？"
+      "ja": "成人の人間の骨はいくつ？"
     },
     "question_text_reading": {
       "en": "How many bones are in the adult human body?",
@@ -36607,7 +36607,7 @@
     "choices": [
       {
         "en": "about 300,000 km/s",
-        "ja": "やく30まんきろ/びょう",
+        "ja": "約30万km/秒",
         "ja_typings": [
           "yaku30mankiro/byo",
           "yaku30mankiro/byou"
@@ -36615,7 +36615,7 @@
       },
       {
         "en": "about 150,000 km/s",
-        "ja": "やく15まんきろ/びょう",
+        "ja": "約15万km/秒",
         "ja_typings": [
           "yaku15mankiro/byo",
           "yaku15mankiro/byou"
@@ -36623,7 +36623,7 @@
       },
       {
         "en": "about 600,000 km/s",
-        "ja": "やく60まんきろ/びょう",
+        "ja": "約60万km/秒",
         "ja_typings": [
           "yaku60mankiro/byo",
           "yaku60mankiro/byou"
@@ -36631,7 +36631,7 @@
       },
       {
         "en": "about 100,000 km/s",
-        "ja": "やく10まんきろ/びょう",
+        "ja": "約10万km/s",
         "ja_typings": [
           "yaku10mankiro/byo",
           "yaku10mankiro/byou"
@@ -36644,7 +36644,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the speed of light?",
-      "ja": "光の速さはどれくらいですか？"
+      "ja": "光の速度は？"
     },
     "question_text_reading": {
       "en": "What is the speed of light?",
@@ -36655,28 +36655,28 @@
     "choices": [
       {
         "en": "8",
-        "ja": "はち",
+        "ja": "八",
         "ja_typings": [
           "hachi"
         ]
       },
       {
         "en": "9",
-        "ja": "きゅう",
+        "ja": "九",
         "ja_typings": [
           "kyuu"
         ]
       },
       {
         "en": "7",
-        "ja": "なな",
+        "ja": "七",
         "ja_typings": [
           "nana"
         ]
       },
       {
         "en": "10",
-        "ja": "じゅう",
+        "ja": "十",
         "ja_typings": [
           "juu"
         ]
@@ -36688,7 +36688,7 @@
     "image_path": null,
     "question_text": {
       "en": "How many planets are in our solar system?",
-      "ja": "太陽系には何個の惑星がありますか？"
+      "ja": "太陽系には何個の惑星があるか？"
     },
     "question_text_reading": {
       "en": "How many planets are in our solar system?",
@@ -36699,28 +36699,28 @@
     "choices": [
       {
         "en": "carbon dioxide",
-        "ja": "にさんかたんそ",
+        "ja": "二酸化炭素",
         "ja_typings": [
           "nisankatanso"
         ]
       },
       {
         "en": "oxygen",
-        "ja": "さんそ",
+        "ja": "酸素",
         "ja_typings": [
           "sanso"
         ]
       },
       {
         "en": "nitrogen",
-        "ja": "ちっそ",
+        "ja": "窒素",
         "ja_typings": [
           "chisso"
         ]
       },
       {
         "en": "hydrogen",
-        "ja": "すいそ",
+        "ja": "水素",
         "ja_typings": [
           "suiso"
         ]
@@ -36732,7 +36732,7 @@
     "image_path": null,
     "question_text": {
       "en": "What gas do plants absorb from the air?",
-      "ja": "植物は空気中からどのようなガスを吸収するのでしょうか？"
+      "ja": "植物は空気から何を吸収するか？"
     },
     "question_text_reading": {
       "en": "What gas do plants absorb from the air?",
@@ -36743,28 +36743,28 @@
     "choices": [
       {
         "en": "Russia",
-        "ja": "ろしあ",
+        "ja": "ロシア",
         "ja_typings": [
           "roshia"
         ]
       },
       {
         "en": "Canada",
-        "ja": "かなだ",
+        "ja": "カナダ",
         "ja_typings": [
           "kanada"
         ]
       },
       {
         "en": "USA",
-        "ja": "あめりか",
+        "ja": "アメリカ",
         "ja_typings": [
           "amerika"
         ]
       },
       {
         "en": "China",
-        "ja": "ちゅうごく",
+        "ja": "中国",
         "ja_typings": [
           "chuugoku"
         ]
@@ -36776,7 +36776,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the largest country by area?",
-      "ja": "面積が一番大きい国はどこですか？"
+      "ja": "面積で最も大きな国は？"
     },
     "question_text_reading": {
       "en": "What is the largest country by area?",
@@ -36787,28 +36787,28 @@
     "choices": [
       {
         "en": "Canberra",
-        "ja": "きゃんべら",
+        "ja": "キャンベラ",
         "ja_typings": [
           "kyanbera"
         ]
       },
       {
         "en": "Sydney",
-        "ja": "しどにー",
+        "ja": "シドニー",
         "ja_typings": [
           "shidoni"
         ]
       },
       {
         "en": "Melbourne",
-        "ja": "めるぼるん",
+        "ja": "メルボルン",
         "ja_typings": [
           "meruborun"
         ]
       },
       {
         "en": "Brisbane",
-        "ja": "ぶりすべん",
+        "ja": "ブリスベン",
         "ja_typings": [
           "burisuben"
         ]
@@ -36820,7 +36820,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Australia?",
-      "ja": "オーストラリアの首都はどこですか？"
+      "ja": "オーストラリアの首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of Australia?",
@@ -36831,7 +36831,7 @@
     "choices": [
       {
         "en": "largest river by discharge volume",
-        "ja": "りゅうりょうせかいさいだいのかわ",
+        "ja": "流量世界最大(の)川",
         "ja_typings": [
           "ryuuryosekaisaidainokawa",
           "ryuuryousekaisaidainokawa"
@@ -36839,7 +36839,7 @@
       },
       {
         "en": "longest river in the world",
-        "ja": "せかいさいちょうのかわ",
+        "ja": "世界最長の川",
         "ja_typings": [
           "sekaisaichonokawa",
           "sekaisaichounokawa"
@@ -36847,14 +36847,14 @@
       },
       {
         "en": "deepest river",
-        "ja": "もっともふかいかわ",
+        "ja": "最も深い川",
         "ja_typings": [
           "mottomofukaikawa"
         ]
       },
       {
         "en": "fastest flowing river",
-        "ja": "もっともながれのはやいかわ",
+        "ja": "最も流れの速い川",
         "ja_typings": [
           "mottomonagarenohayaikawa"
         ]
@@ -36866,7 +36866,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the Amazon River known for?",
-      "ja": "アマゾン川は、何で有名でしょうか？"
+      "ja": "アマゾン川は何で有名？"
     },
     "question_text_reading": {
       "en": "What is the Amazon River known for?",
@@ -36877,14 +36877,14 @@
     "choices": [
       {
         "en": "diamond",
-        "ja": "だいやもんど",
+        "ja": "ダイヤモンド",
         "ja_typings": [
           "daiyamondo"
         ]
       },
       {
         "en": "quartz",
-        "ja": "すいしょう",
+        "ja": "水晶",
         "ja_typings": [
           "suisho",
           "suishou"
@@ -36892,14 +36892,14 @@
       },
       {
         "en": "corundum",
-        "ja": "こらんだむ",
+        "ja": "コランダム",
         "ja_typings": [
           "korandamu"
         ]
       },
       {
         "en": "topaz",
-        "ja": "とぱーず",
+        "ja": "トパーズ",
         "ja_typings": [
           "topazu"
         ]
@@ -36911,7 +36911,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the hardest natural substance?",
-      "ja": "自然界で最も硬い物質は何ですか？"
+      "ja": "自然界で最も硬い物質は？"
     },
     "question_text_reading": {
       "en": "What is the hardest natural substance?",
@@ -36922,28 +36922,28 @@
     "choices": [
       {
         "en": "4",
-        "ja": "よん",
+        "ja": "四",
         "ja_typings": [
           "yon"
         ]
       },
       {
         "en": "2",
-        "ja": "に",
+        "ja": "二",
         "ja_typings": [
           "ni"
         ]
       },
       {
         "en": "3",
-        "ja": "さん",
+        "ja": "三",
         "ja_typings": [
           "san"
         ]
       },
       {
         "en": "6",
-        "ja": "ろく",
+        "ja": "六",
         "ja_typings": [
           "roku"
         ]
@@ -36955,7 +36955,7 @@
     "image_path": null,
     "question_text": {
       "en": "How many chambers does a human heart have?",
-      "ja": "人間の心臓は、何つの部屋に分かれていますか？"
+      "ja": "人間の心臓はいくつ部屋に分かれているか？"
     },
     "question_text_reading": {
       "en": "How many chambers does a human heart have?",
@@ -36966,28 +36966,28 @@
     "choices": [
       {
         "en": "yen",
-        "ja": "えん",
+        "ja": "円",
         "ja_typings": [
           "en"
         ]
       },
       {
         "en": "won",
-        "ja": "うぉん",
+        "ja": "won",
         "ja_typings": [
           "won"
         ]
       },
       {
         "en": "yuan",
-        "ja": "げん",
+        "ja": "元",
         "ja_typings": [
           "gen"
         ]
       },
       {
         "en": "baht",
-        "ja": "ばーつ",
+        "ja": "バート",
         "ja_typings": [
           "batsu"
         ]
@@ -36999,7 +36999,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the currency of Japan?",
-      "ja": "日本の通貨は何ですか？"
+      "ja": "日本の通貨は？"
     },
     "question_text_reading": {
       "en": "What is the currency of Japan?",
@@ -37010,28 +37010,28 @@
     "choices": [
       {
         "en": "Sahara",
-        "ja": "さはら",
+        "ja": "サハラ",
         "ja_typings": [
           "sahara"
         ]
       },
       {
         "en": "Gobi",
-        "ja": "ごびさばく",
+        "ja": "ゴビ砂漠",
         "ja_typings": [
           "gobisabaku"
         ]
       },
       {
         "en": "Arabian",
-        "ja": "あらびあさばく",
+        "ja": "アラビア砂漠",
         "ja_typings": [
           "arabiasabaku"
         ]
       },
       {
         "en": "Antarctica",
-        "ja": "なんきょく",
+        "ja": "南極",
         "ja_typings": [
           "nankyoku"
         ]
@@ -37043,7 +37043,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the largest desert in the world?",
-      "ja": "世界で最も広い砂漠はどこですか？"
+      "ja": "世界最大の砂漠は？"
     },
     "question_text_reading": {
       "en": "What is the largest desert in the world?",
@@ -37054,28 +37054,28 @@
     "choices": [
       {
         "en": "1945",
-        "ja": "せんきゅうひゃくよんじゅうご",
+        "ja": "1945",
         "ja_typings": [
           "senkyuuhyakuyonjuugo"
         ]
       },
       {
         "en": "1944",
-        "ja": "せんきゅうひゃくよんじゅうし",
+        "ja": "1944",
         "ja_typings": [
           "senkyuuhyakuyonjuushi"
         ]
       },
       {
         "en": "1946",
-        "ja": "せんきゅうひゃくよんじゅうろく",
+        "ja": "1946",
         "ja_typings": [
           "senkyuuhyakuyonjuuroku"
         ]
       },
       {
         "en": "1943",
-        "ja": "せんきゅうひゃくよんじゅうさん",
+        "ja": "1943",
         "ja_typings": [
           "senkyuuhyakuyonjuusan"
         ]
@@ -37087,7 +37087,7 @@
     "image_path": null,
     "question_text": {
       "en": "What year did World War II end?",
-      "ja": "第二次世界大戦は、何年終わったのでしょうか？"
+      "ja": "第二次世界大戦は何年終わったか？"
     },
     "question_text_reading": {
       "en": "What year did World War II end?",
@@ -37098,28 +37098,28 @@
     "choices": [
       {
         "en": "100°C",
-        "ja": "ひゃくど",
+        "ja": "100°C",
         "ja_typings": [
           "hyakudo"
         ]
       },
       {
         "en": "90°C",
-        "ja": "きゅうじゅうど",
+        "ja": "90°C",
         "ja_typings": [
           "kyuujuudo"
         ]
       },
       {
         "en": "110°C",
-        "ja": "ひゃくじゅうど",
+        "ja": "110°C",
         "ja_typings": [
           "hyakujuudo"
         ]
       },
       {
         "en": "80°C",
-        "ja": "はちじゅうど",
+        "ja": "80°C",
         "ja_typings": [
           "hachijuudo"
         ]
@@ -37131,7 +37131,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the boiling point of water at sea level?",
-      "ja": "海面における水の沸点は何度ですか？"
+      "ja": "海面での水の沸点は？"
     },
     "question_text_reading": {
       "en": "What is the boiling point of water at sea level?",
@@ -37142,28 +37142,28 @@
     "choices": [
       {
         "en": "0°C",
-        "ja": "れいど",
+        "ja": "0°C",
         "ja_typings": [
           "reido"
         ]
       },
       {
         "en": "-10°C",
-        "ja": "まいなすじゅうど",
+        "ja": "-10°C",
         "ja_typings": [
           "mainasujuudo"
         ]
       },
       {
         "en": "4°C",
-        "ja": "よんど",
+        "ja": "4°C",
         "ja_typings": [
           "yondo"
         ]
       },
       {
         "en": "10°C",
-        "ja": "じゅうど",
+        "ja": "10°C",
         "ja_typings": [
           "juudo"
         ]
@@ -37175,7 +37175,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the freezing point of water?",
-      "ja": "水の凝固点は何度ですか？"
+      "ja": "水の氷始める温度は？"
     },
     "question_text_reading": {
       "en": "What is the freezing point of water?",
@@ -37186,28 +37186,28 @@
     "choices": [
       {
         "en": "Hydrogen",
-        "ja": "すいそ",
+        "ja": "水素",
         "ja_typings": [
           "suiso"
         ]
       },
       {
         "en": "Helium",
-        "ja": "へりうむ",
+        "ja": "ヘリウム",
         "ja_typings": [
           "heriumu"
         ]
       },
       {
         "en": "Lithium",
-        "ja": "りちうむ",
+        "ja": "リチウム",
         "ja_typings": [
           "richiumu"
         ]
       },
       {
         "en": "Carbon",
-        "ja": "たんそ",
+        "ja": "炭素",
         "ja_typings": [
           "tanso"
         ]
@@ -37219,7 +37219,7 @@
     "image_path": null,
     "question_text": {
       "en": "What element has the atomic number 1?",
-      "ja": "原子番号が1の元素は何ですか？"
+      "ja": "原子番号1の元素は？"
     },
     "question_text_reading": {
       "en": "What element has the atomic number 1?",
@@ -37230,7 +37230,7 @@
     "choices": [
       {
         "en": "process by which plants make food from sunlight",
-        "ja": "しょくぶつがたいようのひかりからしょくもつをつくるかてい",
+        "ja": "植物が太陽の光から食物をつくる過程",
         "ja_typings": [
           "shokubutsugataiyonohikarikarashokumotsuotsukurukatei",
           "shokubutsugataiyounohikarikarashokumotsuotsukurukatei"
@@ -37238,21 +37238,21 @@
       },
       {
         "en": "process of plant respiration",
-        "ja": "しょくぶつのこきゅうのかてい",
+        "ja": "植物の呼吸の過程",
         "ja_typings": [
           "shokubutsunokokyuunokatei"
         ]
       },
       {
         "en": "process of plant reproduction",
-        "ja": "しょくぶつのはんしょくのかてい",
+        "ja": "植物の繁殖の過程",
         "ja_typings": [
           "shokubutsunohanshokunokatei"
         ]
       },
       {
         "en": "process of nutrient absorption",
-        "ja": "えいようきゅうしゅうのかてい",
+        "ja": "栄養吸収の過程",
         "ja_typings": [
           "eiyokyuushuunokatei",
           "eiyoukyuushuunokatei"
@@ -37265,7 +37265,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is photosynthesis?",
-      "ja": "光合成とは何ですか？"
+      "ja": "光合成とは何か？"
     },
     "question_text_reading": {
       "en": "What is photosynthesis?",
@@ -37276,28 +37276,28 @@
     "choices": [
       {
         "en": "Spanish",
-        "ja": "すぺいんご",
+        "ja": "スペイン語",
         "ja_typings": [
           "supeingo"
         ]
       },
       {
         "en": "Portuguese",
-        "ja": "ぽるとがるご",
+        "ja": "ポルトガル語",
         "ja_typings": [
           "porutogarugo"
         ]
       },
       {
         "en": "Italian",
-        "ja": "いたりあご",
+        "ja": "イタリア語",
         "ja_typings": [
           "itariago"
         ]
       },
       {
         "en": "French",
-        "ja": "ふらんすご",
+        "ja": "フランス語",
         "ja_typings": [
           "furansugo"
         ]
@@ -37309,7 +37309,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the main language spoken in Argentina?",
-      "ja": "アルゼンチンで主に話されている言語は何ですか？"
+      "ja": "あるぜんちんでつかわれるしゅのことばは？"
     },
     "question_text_reading": {
       "en": "What is the main language spoken in Argentina?",
@@ -37320,21 +37320,21 @@
     "choices": [
       {
         "en": "femur (thigh bone)",
-        "ja": "だいたいこつ",
+        "ja": "大腿骨",
         "ja_typings": [
           "daitaikotsu"
         ]
       },
       {
         "en": "tibia (shin bone)",
-        "ja": "けいこつ",
+        "ja": "脛骨",
         "ja_typings": [
           "keikotsu"
         ]
       },
       {
         "en": "humerus (upper arm)",
-        "ja": "じょうわんこつ",
+        "ja": "上腕骨",
         "ja_typings": [
           "jowankotsu",
           "jouwankotsu"
@@ -37342,7 +37342,7 @@
       },
       {
         "en": "spine",
-        "ja": "せきちゅう",
+        "ja": "脊柱",
         "ja_typings": [
           "sekichuu"
         ]
@@ -37354,7 +37354,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the longest bone in the human body?",
-      "ja": "人体で最も長い骨は何ですか？"
+      "ja": "人間の体で最も長い骨は？"
     },
     "question_text_reading": {
       "en": "What is the longest bone in the human body?",
@@ -37365,28 +37365,28 @@
     "choices": [
       {
         "en": "Alexander Graham Bell",
-        "ja": "あれくさんだー・ぐらはむ・べる",
+        "ja": "アレクサンダー・グラハム・ベル",
         "ja_typings": [
           "arekusanda gurahamu beru"
         ]
       },
       {
         "en": "Thomas Edison",
-        "ja": "とーます・えじそん",
+        "ja": "トーマス・エジソン",
         "ja_typings": [
           "tomasu ejison"
         ]
       },
       {
         "en": "Nikola Tesla",
-        "ja": "にこら・てすら",
+        "ja": "ニコラ・テスラ",
         "ja_typings": [
           "nikora tesura"
         ]
       },
       {
         "en": "Guglielmo Marconi",
-        "ja": "ぐりえるも・まるこーに",
+        "ja": "グリエルモ・マルコーニ",
         "ja_typings": [
           "gurierumo marukoni"
         ]
@@ -37398,7 +37398,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who invented the telephone?",
-      "ja": "電話を最初に発明したのは誰でしょう？"
+      "ja": "電話を発明したのは誰？"
     },
     "question_text_reading": {
       "en": "Who invented the telephone?",
@@ -37409,28 +37409,28 @@
     "choices": [
       {
         "en": "nitrogen",
-        "ja": "ちっそ",
+        "ja": "窒素",
         "ja_typings": [
           "chisso"
         ]
       },
       {
         "en": "oxygen",
-        "ja": "さんそ",
+        "ja": "酸素",
         "ja_typings": [
           "sanso"
         ]
       },
       {
         "en": "carbon dioxide",
-        "ja": "にさんかたんそ",
+        "ja": "二酸化炭素",
         "ja_typings": [
           "nisankatanso"
         ]
       },
       {
         "en": "argon",
-        "ja": "あるごん",
+        "ja": "アルゴン",
         "ja_typings": [
           "arugon"
         ]
@@ -37442,7 +37442,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the most abundant gas in Earth's atmosphere?",
-      "ja": "地球の大気中で最も豊富に存在する気体は何ですか？"
+      "ja": "地球の大気で最も多い気体は？"
     },
     "question_text_reading": {
       "en": "What is the most abundant gas in Earth's atmosphere?",
@@ -37453,28 +37453,28 @@
     "choices": [
       {
         "en": "16",
-        "ja": "じゅうろく",
+        "ja": "十六",
         "ja_typings": [
           "juuroku"
         ]
       },
       {
         "en": "14",
-        "ja": "じゅうし",
+        "ja": "十五",
         "ja_typings": [
           "juushi"
         ]
       },
       {
         "en": "18",
-        "ja": "じゅうはち",
+        "ja": "十八",
         "ja_typings": [
           "juuhachi"
         ]
       },
       {
         "en": "12",
-        "ja": "じゅうに",
+        "ja": "十二",
         "ja_typings": [
           "juuni"
         ]
@@ -37486,7 +37486,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the square root of 256?",
-      "ja": "256の平方根は何ですか？"
+      "ja": "256の平方根は？"
     },
     "question_text_reading": {
       "en": "What is the square root of 256?",
@@ -37497,28 +37497,28 @@
     "choices": [
       {
         "en": "32",
-        "ja": "さんじゅうほんに",
+        "ja": "三十本に",
         "ja_typings": [
           "sanjuuhonni"
         ]
       },
       {
         "en": "28",
-        "ja": "にじゅうはっぽん",
+        "ja": "二十八本",
         "ja_typings": [
           "nijuuhappon"
         ]
       },
       {
         "en": "30",
-        "ja": "さんじゅっぽん",
+        "ja": "三十本",
         "ja_typings": [
           "sanjuppon"
         ]
       },
       {
         "en": "34",
-        "ja": "さんじゅうよんほん",
+        "ja": "三十四本",
         "ja_typings": [
           "sanjuuyonhon"
         ]
@@ -37530,7 +37530,7 @@
     "image_path": null,
     "question_text": {
       "en": "How many teeth does an adult human have?",
-      "ja": "おとなのにんげんのはは何本？"
+      "ja": "成人の人間の歯は何本？"
     },
     "question_text_reading": {
       "en": "How many teeth does an adult human have?",
@@ -37541,21 +37541,21 @@
     "choices": [
       {
         "en": "Jupiter",
-        "ja": "もくせい",
+        "ja": "木星",
         "ja_typings": [
           "mokusei"
         ]
       },
       {
         "en": "Saturn",
-        "ja": "どせい",
+        "ja": "土星",
         "ja_typings": [
           "dosei"
         ]
       },
       {
         "en": "Neptune",
-        "ja": "かいおうせい",
+        "ja": "海洋性",
         "ja_typings": [
           "kaiosei",
           "kaiousei"
@@ -37563,7 +37563,7 @@
       },
       {
         "en": "Uranus",
-        "ja": "てんのうせい",
+        "ja": "天王星",
         "ja_typings": [
           "tennosei",
           "tennousei"
@@ -37576,7 +37576,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the largest planet in our solar system?",
-      "ja": "太陽系の中で最も大きな惑星は何ですか？"
+      "ja": "太陽系で最も大きい惑星は？"
     },
     "question_text_reading": {
       "en": "What is the largest planet in our solar system?",
@@ -37587,28 +37587,28 @@
     "choices": [
       {
         "en": "O (oxygen)",
-        "ja": "おーさんそ",
+        "ja": "酸素",
         "ja_typings": [
           "osanso"
         ]
       },
       {
         "en": "Ox",
-        "ja": "おっくす",
+        "ja": "オックス",
         "ja_typings": [
           "okkusu"
         ]
       },
       {
         "en": "Og",
-        "ja": "おーじー",
+        "ja": "OG",
         "ja_typings": [
           "oji"
         ]
       },
       {
         "en": "On",
-        "ja": "おーえぬ",
+        "ja": "On",
         "ja_typings": [
           "oenu"
         ]
@@ -37620,7 +37620,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the symbol for the element oxygen?",
-      "ja": "酸素の元素記号は何ですか？"
+      "ja": "酸素の元素記号は？"
     },
     "question_text_reading": {
       "en": "What is the symbol for the element oxygen?",
@@ -37631,28 +37631,28 @@
     "choices": [
       {
         "en": "Mercury",
-        "ja": "すいせい",
+        "ja": "水星",
         "ja_typings": [
           "suisei"
         ]
       },
       {
         "en": "Venus",
-        "ja": "きんせい",
+        "ja": "金星",
         "ja_typings": [
           "kinsei"
         ]
       },
       {
         "en": "Earth",
-        "ja": "ちきゅう",
+        "ja": "地球",
         "ja_typings": [
           "chikyuu"
         ]
       },
       {
         "en": "Mars",
-        "ja": "かせい",
+        "ja": "火星",
         "ja_typings": [
           "kasei"
         ]
@@ -37664,7 +37664,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which planet is closest to the sun?",
-      "ja": "太陽に最も近い惑星はどれですか？"
+      "ja": "最も太陽に近い惑星は？"
     },
     "question_text_reading": {
       "en": "Which planet is closest to the sun?",
@@ -37675,28 +37675,28 @@
     "choices": [
       {
         "en": "Vatican City",
-        "ja": "ばちかんしこっか",
+        "ja": "バチカン市国",
         "ja_typings": [
           "bachikanshikokka"
         ]
       },
       {
         "en": "Monaco",
-        "ja": "もなこ",
+        "ja": "モナコ",
         "ja_typings": [
           "monako"
         ]
       },
       {
         "en": "Liechtenstein",
-        "ja": "りひてんしゅたいん",
+        "ja": "リヒテンシュタイン",
         "ja_typings": [
           "rihitenshutain"
         ]
       },
       {
         "en": "San Marino",
-        "ja": "さんまりの",
+        "ja": "サンマリノ",
         "ja_typings": [
           "sanmarino"
         ]
@@ -37708,7 +37708,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the smallest country in the world?",
-      "ja": "世界で最も小さい国はどこですか？"
+      "ja": "世界で最も小さい国は？"
     },
     "question_text_reading": {
       "en": "What is the smallest country in the world?",
@@ -37719,28 +37719,28 @@
     "choices": [
       {
         "en": "6",
-        "ja": "ろく",
+        "ja": "六",
         "ja_typings": [
           "roku"
         ]
       },
       {
         "en": "4",
-        "ja": "よん",
+        "ja": "四",
         "ja_typings": [
           "yon"
         ]
       },
       {
         "en": "8",
-        "ja": "はち",
+        "ja": "八",
         "ja_typings": [
           "hachi"
         ]
       },
       {
         "en": "12",
-        "ja": "じゅうに",
+        "ja": "十二",
         "ja_typings": [
           "juuni"
         ]
@@ -37752,7 +37752,7 @@
     "image_path": null,
     "question_text": {
       "en": "How many strings does a standard guitar have?",
-      "ja": "標準的なギターは、何本の弦を持っていますか？"
+      "ja": "普通のギターは何本の弦を持つか？"
     },
     "question_text_reading": {
       "en": "How many strings does a standard guitar have?",
@@ -37763,28 +37763,28 @@
     "choices": [
       {
         "en": "Deoxyribonucleic Acid",
-        "ja": "でおきしりぼかくさん",
+        "ja": "デオキシリボ核酸",
         "ja_typings": [
           "deokishiribokakusan"
         ]
       },
       {
         "en": "Dynamic Nucleic Acid",
-        "ja": "だいなみっくかくさん",
+        "ja": "ダイナミック核酸",
         "ja_typings": [
           "dainamikkukakusan"
         ]
       },
       {
         "en": "Deoxyribose Nuclease Acid",
-        "ja": "でおきしりぼーすかくさん",
+        "ja": "デオキシリボースヌクレオ酸",
         "ja_typings": [
           "deokishiribosukakusan"
         ]
       },
       {
         "en": "Double Nucleic Array",
-        "ja": "だぶるかくさんのはいれつ",
+        "ja": "ダブルナクリアレイ",
         "ja_typings": [
           "daburukakusannohairetsu"
         ]
@@ -37796,7 +37796,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does DNA stand for?",
-      "ja": "DNAは何の略語ですか？"
+      "ja": "DNAの略称の正式名は？"
     },
     "question_text_reading": {
       "en": "What does DNA stand for?",
@@ -37807,28 +37807,28 @@
     "choices": [
       {
         "en": "NaCl",
-        "ja": "えぬえーしーえる",
+        "ja": "エヌエーシーエル",
         "ja_typings": [
           "enueshieru"
         ]
       },
       {
         "en": "NaF",
-        "ja": "えぬえーえふ",
+        "ja": "エヌエーエフ",
         "ja_typings": [
           "enueefu"
         ]
       },
       {
         "en": "KCl",
-        "ja": "けーしーえる",
+        "ja": "text{KCl}",
         "ja_typings": [
           "keshieru"
         ]
       },
       {
         "en": "CaCl₂",
-        "ja": "しーえーしーえるに",
+        "ja": "text{CaCl}_2",
         "ja_typings": [
           "shieshieruni"
         ]
@@ -37840,7 +37840,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the chemical formula for table salt?",
-      "ja": "食塩の化学式は何ですか？"
+      "ja": "食塩の化学式は？"
     },
     "question_text_reading": {
       "en": "What is the chemical formula for table salt?",
@@ -37851,7 +37851,7 @@
     "choices": [
       {
         "en": "sumo",
-        "ja": "すもう",
+        "ja": "相撲",
         "ja_typings": [
           "sumo",
           "sumou"
@@ -37859,14 +37859,14 @@
       },
       {
         "en": "baseball",
-        "ja": "やきゅう",
+        "ja": "野球",
         "ja_typings": [
           "yakyuu"
         ]
       },
       {
         "en": "judo",
-        "ja": "じゅうどう",
+        "ja": "柔道",
         "ja_typings": [
           "juudo",
           "juudou"
@@ -37874,7 +37874,7 @@
       },
       {
         "en": "kendo",
-        "ja": "けんどう",
+        "ja": "剣道",
         "ja_typings": [
           "kendo",
           "kendou"
@@ -37887,7 +37887,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the national sport of Japan?",
-      "ja": "日本の国技は何ですか？"
+      "ja": "日本の国技は？"
     },
     "question_text_reading": {
       "en": "What is the national sport of Japan?",
@@ -37898,21 +37898,21 @@
     "choices": [
       {
         "en": "earthquake magnitude",
-        "ja": "じしんのきぼ",
+        "ja": "地震の規模",
         "ja_typings": [
           "jishinnokibo"
         ]
       },
       {
         "en": "wind speed",
-        "ja": "ふうそく",
+        "ja": "風速",
         "ja_typings": [
           "fuusoku"
         ]
       },
       {
         "en": "rainfall amount",
-        "ja": "こうすいりょう",
+        "ja": "降水量",
         "ja_typings": [
           "kosuiryo",
           "kousuiryou"
@@ -37920,7 +37920,7 @@
       },
       {
         "en": "temperature",
-        "ja": "きおん",
+        "ja": "温度",
         "ja_typings": [
           "kion"
         ]
@@ -37932,7 +37932,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does the Richter scale measure?",
-      "ja": "リヒタースケールは、何を示すものですか？"
+      "ja": "リヒタースケールは何をはかるか？"
     },
     "question_text_reading": {
       "en": "What does the Richter scale measure?",
@@ -37943,28 +37943,28 @@
     "choices": [
       {
         "en": "1969",
-        "ja": "せんきゅうひゃくろくじゅうきゅう",
+        "ja": "1969",
         "ja_typings": [
           "senkyuuhyakurokujuukyuu"
         ]
       },
       {
         "en": "1967",
-        "ja": "せんきゅうひゃくろくじゅうなな",
+        "ja": "1967",
         "ja_typings": [
           "senkyuuhyakurokujuunana"
         ]
       },
       {
         "en": "1971",
-        "ja": "せんきゅうひゃくななじゅういち",
+        "ja": "1971",
         "ja_typings": [
           "senkyuuhyakunanajuuichi"
         ]
       },
       {
         "en": "1965",
-        "ja": "せんきゅうひゃくろくじゅうご",
+        "ja": "1965",
         "ja_typings": [
           "senkyuuhyakurokujuugo"
         ]
@@ -37976,7 +37976,7 @@
     "image_path": null,
     "question_text": {
       "en": "What year did the first moon landing occur?",
-      "ja": "初めて月面に着陸したのは何年ですか？"
+      "ja": "初の月への着陸は何年？"
     },
     "question_text_reading": {
       "en": "What year did the first moon landing occur?",
@@ -37987,28 +37987,28 @@
     "choices": [
       {
         "en": "Fe",
-        "ja": "えふいー",
+        "ja": "エフアイ",
         "ja_typings": [
           "efui"
         ]
       },
       {
         "en": "Ir",
-        "ja": "あいあーる",
+        "ja": "IR",
         "ja_typings": [
           "aiaru"
         ]
       },
       {
         "en": "In",
-        "ja": "あいえぬ",
+        "ja": "In",
         "ja_typings": [
           "aienu"
         ]
       },
       {
         "en": "Ie",
-        "ja": "あいいー",
+        "ja": "アイー",
         "ja_typings": [
           "aii"
         ]
@@ -38020,7 +38020,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the symbol for the element iron?",
-      "ja": "鉄の元素記号は何ですか？"
+      "ja": "鉄の元素記号は？"
     },
     "question_text_reading": {
       "en": "What is the symbol for the element iron?",
@@ -38031,7 +38031,7 @@
     "choices": [
       {
         "en": "sperm whale",
-        "ja": "まっこうくじら",
+        "ja": "抹香クジラ",
         "ja_typings": [
           "makkokujira",
           "makkoukujira"
@@ -38039,14 +38039,14 @@
       },
       {
         "en": "blue whale",
-        "ja": "しろながすくじら",
+        "ja": "白鼻クジラ",
         "ja_typings": [
           "shironagasukujira"
         ]
       },
       {
         "en": "elephant",
-        "ja": "ぞう",
+        "ja": "象",
         "ja_typings": [
           "zo",
           "zou"
@@ -38054,7 +38054,7 @@
       },
       {
         "en": "howler monkey",
-        "ja": "ほえざる",
+        "ja": "ホエザルモンキー",
         "ja_typings": [
           "hoezaru"
         ]
@@ -38066,7 +38066,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the loudest animal on Earth?",
-      "ja": "地球上で最も大きな音を出す動物は何でしょう？"
+      "ja": "地球で最も大きな声を出す動物は？"
     },
     "question_text_reading": {
       "en": "What is the loudest animal on Earth?",
@@ -38077,28 +38077,28 @@
     "choices": [
       {
         "en": "ampere",
-        "ja": "あんぺあ",
+        "ja": "アンペア",
         "ja_typings": [
           "anpea"
         ]
       },
       {
         "en": "volt",
-        "ja": "ぼると",
+        "ja": "ボルト",
         "ja_typings": [
           "boruto"
         ]
       },
       {
         "en": "watt",
-        "ja": "わっと",
+        "ja": "ワット",
         "ja_typings": [
           "watto"
         ]
       },
       {
         "en": "ohm",
-        "ja": "おーむ",
+        "ja": "オーム",
         "ja_typings": [
           "omu"
         ]
@@ -38110,7 +38110,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the unit of electric current?",
-      "ja": "電気電流の単位は何ですか？"
+      "ja": "電流の単位は？"
     },
     "question_text_reading": {
       "en": "What is the unit of electric current?",
@@ -38121,28 +38121,28 @@
     "choices": [
       {
         "en": "virtual YouTuber using avatar",
-        "ja": "あばたーをつかうばーちゃるゆーちゅーばー",
+        "ja": "アバターを使うバーチャルYouTuber",
         "ja_typings": [
           "abataotsukaubacharuyuchuba"
         ]
       },
       {
         "en": "video game streamer",
-        "ja": "びでおげーむすとりーまー",
+        "ja": "ビデオゲームストリーマー",
         "ja_typings": [
           "bideogemusutorima"
         ]
       },
       {
         "en": "virtual reality developer",
-        "ja": "ばーちゃるりありてぃかいはつしゃ",
+        "ja": "バーチャルリアリティデベロッパー",
         "ja_typings": [
           "bacharuriaritikaihatsusha"
         ]
       },
       {
         "en": "music video creator",
-        "ja": "みゅーじっくびでおくりえいたー",
+        "ja": "ミュージックビデオクリエイター",
         "ja_typings": [
           "myujikkubideokurieita"
         ]
@@ -38154,7 +38154,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a VTuber?",
-      "ja": "VTuberとはどのような存在ですか？"
+      "ja": "VTuberとは何か？"
     },
     "question_text_reading": {
       "en": "What is a VTuber?",
@@ -38165,7 +38165,7 @@
     "choices": [
       {
         "en": "Cover Corp",
-        "ja": "かばーこーぽれーしょん",
+        "ja": "カバーコーポレーション",
         "ja_typings": [
           "kabakoporeshon"
         ]
@@ -38179,14 +38179,14 @@
       },
       {
         "en": "Sony Music",
-        "ja": "そにーみゅーじっく",
+        "ja": "ソニーミュージック",
         "ja_typings": [
           "sonimyujikku"
         ]
       },
       {
         "en": "Kadokawa",
-        "ja": "かどかわ",
+        "ja": "角川",
         "ja_typings": [
           "kadokawa"
         ]
@@ -38198,7 +38198,7 @@
     "image_path": null,
     "question_text": {
       "en": "What company is Hololive associated with?",
-      "ja": "Hololiveはどの会社と関連していますか？"
+      "ja": "ホロライブはどの会社？"
     },
     "question_text_reading": {
       "en": "What company is Hololive associated with?",
@@ -38209,28 +38209,28 @@
     "choices": [
       {
         "en": "VTuber agency by Anycolor",
-        "ja": "えにーからーのぶいちゅーばーじむしょ",
+        "ja": "AnycolorのVTuber事務所",
         "ja_typings": [
           "enikaranobuichubajimusho"
         ]
       },
       {
         "en": "anime production studio",
-        "ja": "あにめせいさくすたじお",
+        "ja": "アニメ制作スタジオ",
         "ja_typings": [
           "animeseisakusutajio"
         ]
       },
       {
         "en": "game development company",
-        "ja": "げーむかいはつかいしゃ",
+        "ja": "ゲーム開発会社",
         "ja_typings": [
           "gemukaihatsukaisha"
         ]
       },
       {
         "en": "music label",
-        "ja": "おんがくれーべる",
+        "ja": "音楽レーベル",
         "ja_typings": [
           "ongakureberu"
         ]
@@ -38242,7 +38242,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is Nijisanji?",
-      "ja": "Nijisanjiとはどのような存在ですか？"
+      "ja": "にじさんじとは何か？"
     },
     "question_text_reading": {
       "en": "What is Nijisanji?",
@@ -38253,21 +38253,21 @@
     "choices": [
       {
         "en": "overseas fans",
-        "ja": "かいがいのふぁん",
+        "ja": "海外のファン",
         "ja_typings": [
           "kaigainofan"
         ]
       },
       {
         "en": "Japanese idol fans",
-        "ja": "にほんのあいどるふぁん",
+        "ja": "日本のアイドルファン",
         "ja_typings": [
           "nihonnoaidorufan"
         ]
       },
       {
         "en": "anime reviewers",
-        "ja": "あにめひょうろんか",
+        "ja": "アニメレビューア",
         "ja_typings": [
           "animehyoronka",
           "animehyouronka"
@@ -38275,7 +38275,7 @@
       },
       {
         "en": "foreign critics",
-        "ja": "がいこくのひひょうか",
+        "ja": "外国の批評家",
         "ja_typings": [
           "gaikokunohihyoka",
           "gaikokunohihyouka"
@@ -38288,7 +38288,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does 'kaigai niki' mean?",
-      "ja": "かいがいにきとは何か？"
+      "ja": "海外日記とは何か？"
     },
     "question_text_reading": {
       "en": "What does 'kaigai niki' mean?",
@@ -38299,7 +38299,7 @@
     "choices": [
       {
         "en": "paid donation message on YouTube",
-        "ja": "ゆーちゅーぶでのゆうりょうきふめっせーじ",
+        "ja": "YouTubeでの有料寄付メッセージ",
         "ja_typings": [
           "yuchubudenoyuuryokifumesseji",
           "yuchubudenoyuuryoukifumesseji"
@@ -38307,14 +38307,14 @@
       },
       {
         "en": "premium subscription plan",
-        "ja": "ぷれみあむさぶすくりぷしょん",
+        "ja": "プレミアムサブスクリプション",
         "ja_typings": [
           "puremiamusabusukuripushon"
         ]
       },
       {
         "en": "exclusive fan club",
-        "ja": "せんようふぁんくらぶ",
+        "ja": "専用ファンクラブ",
         "ja_typings": [
           "senyofankurabu",
           "senyoufankurabu"
@@ -38322,7 +38322,7 @@
       },
       {
         "en": "live concert ticket",
-        "ja": "らいぶこんさーとちけっと",
+        "ja": "ライブコンサートチケット",
         "ja_typings": [
           "raibukonsatochiketto"
         ]
@@ -38334,7 +38334,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'superchat'?",
-      "ja": "すーぱーちゃっととは何か？"
+      "ja": "スーパーチャットとは何か？"
     },
     "question_text_reading": {
       "en": "What is 'superchat'?",
@@ -38345,7 +38345,7 @@
     "choices": [
       {
         "en": "revealing someone's private info online",
-        "ja": "ひとのしんじょうをねっとにばらすこと",
+        "ja": "人の心情をネットにばらすこと",
         "ja_typings": [
           "hitonoshinjoonettonibarasukoto",
           "hitonoshinjouonettonibarasukoto"
@@ -38353,14 +38353,14 @@
       },
       {
         "en": "deleting account data",
-        "ja": "あかうんとでーたのさくじょ",
+        "ja": "アカウントデータの削除",
         "ja_typings": [
           "akauntodetanosakujo"
         ]
       },
       {
         "en": "sending spam messages",
-        "ja": "すぱむめっせーじのそうしん",
+        "ja": "スパムメッセージの送信",
         "ja_typings": [
           "supamumessejinososhin",
           "supamumessejinosoushin"
@@ -38368,7 +38368,7 @@
       },
       {
         "en": "mass following on social media",
-        "ja": "すーしゃるめでぃあでたいりょうふぉろー",
+        "ja": "ソーシャルメディアで大量フォロー",
         "ja_typings": [
           "susharumediadetairyoforo",
           "susharumediadetairyouforo"
@@ -38381,7 +38381,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'doxxing'?",
-      "ja": "ドクシングとは何ですか？"
+      "ja": "Doxxingとは何か？"
     },
     "question_text_reading": {
       "en": "What is 'doxxing'?",
@@ -38392,28 +38392,28 @@
     "choices": [
       {
         "en": "Good Game",
-        "ja": "ぐっどげーむ",
+        "ja": "グッドゲーム",
         "ja_typings": [
           "guddogemu"
         ]
       },
       {
         "en": "Get Good",
-        "ja": "げっとぐっど",
+        "ja": "ゲットグッド",
         "ja_typings": [
           "gettoguddo"
         ]
       },
       {
         "en": "Game Goal",
-        "ja": "げーむごーる",
+        "ja": "ゲームゴール",
         "ja_typings": [
           "gemugoru"
         ]
       },
       {
         "en": "Gear Group",
-        "ja": "ぎあぐるーぷ",
+        "ja": "ギアグループ",
         "ja_typings": [
           "giagurupu"
         ]
@@ -38425,7 +38425,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does 'GG' stand for in gaming?",
-      "ja": "ゲーミングにおける「GG」は、何の略語ですか？"
+      "ja": "ゲーミングでGGとはどういう意味？"
     },
     "question_text_reading": {
       "en": "What does 'GG' stand for in gaming?",
@@ -38436,7 +38436,7 @@
     "choices": [
       {
         "en": "broadcasting live content online",
-        "ja": "おんらいんでらいぶこんてんつをほうそうすること",
+        "ja": "オンラインでライブコンテンツを放送すること",
         "ja_typings": [
           "onrainderaibukontentsuohososurukoto",
           "onrainderaibukontentsuohousousurukoto"
@@ -38444,21 +38444,21 @@
       },
       {
         "en": "downloading large files",
-        "ja": "だいきなふぁいるのだうんろーど",
+        "ja": "大きなファイルのダウンロード",
         "ja_typings": [
           "daikinafairunodaunrodo"
         ]
       },
       {
         "en": "editing video content",
-        "ja": "びでおこんてんつのへんしゅう",
+        "ja": "ビデオコンテンツの編集",
         "ja_typings": [
           "bideokontentsunohenshuu"
         ]
       },
       {
         "en": "uploading to video archive",
-        "ja": "びでおあーかいぶへのあっぷろーど",
+        "ja": "ビデオアーカイブへのアップロード",
         "ja_typings": [
           "bideoakaibuhenoappurodo"
         ]
@@ -38470,7 +38470,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'streaming'?",
-      "ja": "ストリーミングとは、どのような概念ですか？"
+      "ja": "ストリーミングとは何か？"
     },
     "question_text_reading": {
       "en": "What is 'streaming'?",
@@ -38481,21 +38481,21 @@
     "choices": [
       {
         "en": "short edited portion of a stream",
-        "ja": "すとりーむのみじかくへんしゅうしたぶぶん",
+        "ja": "ストリームの短く編集した部分",
         "ja_typings": [
           "sutorimunomijikakuhenshuushitabubun"
         ]
       },
       {
         "en": "full archive recording",
-        "ja": "かんぜんなあーかいぶろくが",
+        "ja": "完全なアーカイブ録画",
         "ja_typings": [
           "kanzennaakaiburokuga"
         ]
       },
       {
         "en": "official music video",
-        "ja": "こうしきみゅーじっくびでお",
+        "ja": "公式ミュージックビデオ",
         "ja_typings": [
           "koshikimyujikkubideo",
           "koushikimyujikkubideo"
@@ -38503,7 +38503,7 @@
       },
       {
         "en": "original game soundtrack",
-        "ja": "げーむのおりじなるさうんどとらっく",
+        "ja": "ゲームのオリジナルサウンドトラック",
         "ja_typings": [
           "gemunorijinarusaundotorakku",
           "gemunoorijinarusaundotorakku"
@@ -38516,7 +38516,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a 'clip' in VTuber culture?",
-      "ja": "VTuber文化における「clip」とは何ですか？"
+      "ja": "VTuber文化でのクリップとは？"
     },
     "question_text_reading": {
       "en": "What is a 'clip' in VTuber culture?",
@@ -38527,14 +38527,14 @@
     "choices": [
       {
         "en": "artwork created by fans of a character",
-        "ja": "きゃらくたーのふぁんがつくったえ",
+        "ja": "キャラクターのファンが作った絵",
         "ja_typings": [
           "kyarakutanofangatsukuttae"
         ]
       },
       {
         "en": "official promotional art",
-        "ja": "こうしきぷろもーしょんあーと",
+        "ja": "公式プロモーションアート",
         "ja_typings": [
           "koshikipuromoshonato",
           "koushikipuromoshonato"
@@ -38542,7 +38542,7 @@
       },
       {
         "en": "AI-generated images",
-        "ja": "えーあいがせいせいしたがぞう",
+        "ja": "AI生成画像",
         "ja_typings": [
           "eaigaseiseishitagazo",
           "eaigaseiseishitagazou"
@@ -38550,7 +38550,7 @@
       },
       {
         "en": "commercial illustration",
-        "ja": "しょうぎょうてきいらすと",
+        "ja": "商業的イラスト",
         "ja_typings": [
           "shogyotekiirasuto",
           "shougyoutekiirasuto"
@@ -38563,7 +38563,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'fan art'?",
-      "ja": "ファンアートとはどのようなものですか？"
+      "ja": "ファンアートとは何か？"
     },
     "question_text_reading": {
       "en": "What is 'fan art'?",
@@ -38574,21 +38574,21 @@
     "choices": [
       {
         "en": "live streaming platform",
-        "ja": "らいぶすとりーみんぐぷらっとふぉーむ",
+        "ja": "ライブストリーミングプラットフォーム",
         "ja_typings": [
           "raibusutorimingupurattofomu"
         ]
       },
       {
         "en": "social media platform",
-        "ja": "そーしゃるめでぃあぷらっとふぉーむ",
+        "ja": "ソーシャルメディアプラットフォーム",
         "ja_typings": [
           "sosharumediapurattofomu"
         ]
       },
       {
         "en": "video sharing site",
-        "ja": "どうがきょうゆうさいと",
+        "ja": "動画共有サイト",
         "ja_typings": [
           "dogakyoyuusaito",
           "dougakyouyuusaito"
@@ -38596,7 +38596,7 @@
       },
       {
         "en": "messaging app",
-        "ja": "めっせーじんぐあぷり",
+        "ja": "メッセージングアプリ",
         "ja_typings": [
           "messejinguapuri"
         ]
@@ -38608,7 +38608,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is Twitch?",
-      "ja": "Twitchとはどのようなサービスですか？"
+      "ja": "Twitchとは何か？"
     },
     "question_text_reading": {
       "en": "What is Twitch?",
@@ -38619,28 +38619,28 @@
     "choices": [
       {
         "en": "chat and voice platform for communities",
-        "ja": "こみゅにてぃのちゃっととぼいすぷらっとふぉーむ",
+        "ja": "コミュニティのチャットとボイスプラットフォーム",
         "ja_typings": [
           "komyunitinochattotoboisupurattofomu"
         ]
       },
       {
         "en": "streaming platform",
-        "ja": "すとりーみんぐぷらっとふぉーむ",
+        "ja": "ストリーミングプラットフォーム",
         "ja_typings": [
           "sutorimingupurattofomu"
         ]
       },
       {
         "en": "game development tool",
-        "ja": "げーむかいはつつーる",
+        "ja": "ゲーム開発ツール",
         "ja_typings": [
           "gemukaihatsutsuru"
         ]
       },
       {
         "en": "video editing software",
-        "ja": "びでおへんしゅうそふと",
+        "ja": "ビデオ編集ソフト",
         "ja_typings": [
           "bideohenshuusofuto"
         ]
@@ -38652,7 +38652,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is Discord?",
-      "ja": "Discordとはどのようなものですか？"
+      "ja": "Discordとは何か？"
     },
     "question_text_reading": {
       "en": "What is Discord?",
@@ -38663,28 +38663,28 @@
     "choices": [
       {
         "en": "something controversial or embarrassing",
-        "ja": "こんとろばーしゃるまたははずかしいこと",
+        "ja": "コントロバーシャルまたははずかしいこと",
         "ja_typings": [
           "kontorobasharumatahahazukashiikoto"
         ]
       },
       {
         "en": "a great performance",
-        "ja": "すばらしいぱふぉーまんす",
+        "ja": "素晴らしいパフォーマンス",
         "ja_typings": [
           "subarashiipafomansu"
         ]
       },
       {
         "en": "a new debut",
-        "ja": "しんきでびゅー",
+        "ja": "新デビュー",
         "ja_typings": [
           "shinkidebyu"
         ]
       },
       {
         "en": "a popular song",
-        "ja": "にんきのうた",
+        "ja": "人気歌",
         "ja_typings": [
           "ninkinota",
           "ninkinouta"
@@ -38697,7 +38697,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'yab' in VTuber slang?",
-      "ja": "VTuberのスラングにおける「yab」とはどういう意味ですか？"
+      "ja": "VTuber slangでやばいとは？"
     },
     "question_text_reading": {
       "en": "What is 'yab' in VTuber slang?",
@@ -38708,7 +38708,7 @@
     "choices": [
       {
         "en": "first public stream",
-        "ja": "はじめてのこうかいすとりーむ",
+        "ja": "初めての公開ストリーム",
         "ja_typings": [
           "hajimetenokokaisutorimu",
           "hajimetenokoukaisutorimu"
@@ -38716,21 +38716,21 @@
       },
       {
         "en": "first solo concert",
-        "ja": "はじめてのそろこんさーと",
+        "ja": "初めてのソロコンサート",
         "ja_typings": [
           "hajimetenosorokonsato"
         ]
       },
       {
         "en": "first merchandise release",
-        "ja": "はじめてのぐっずはんばい",
+        "ja": "初めてのグッズ販売",
         "ja_typings": [
           "hajimetenoguzzuhanbai"
         ]
       },
       {
         "en": "first collaboration",
-        "ja": "はじめてのこらぼれーしょん",
+        "ja": "初めてのコラボレーション",
         "ja_typings": [
           "hajimetenokoraboreshon"
         ]
@@ -38742,7 +38742,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a 'debut' for a VTuber?",
-      "ja": "VTuberにおける「デビュー」とは、どのような意味を持つのでしょうか？"
+      "ja": "VTuberのdebutとは？"
     },
     "question_text_reading": {
       "en": "What is a 'debut' for a VTuber?",
@@ -38753,7 +38753,7 @@
     "choices": [
       {
         "en": "dedicated superfan in Japanese internet culture",
-        "ja": "にほんのねっとぶんかでのねっしんなちょうふぁん",
+        "ja": "日本のネット文化での熱心な超ファン",
         "ja_typings": [
           "nihonnonettobunkadenonesshinnachofan",
           "nihonnonettobunkadenonesshinnachoufan"
@@ -38761,14 +38761,14 @@
       },
       {
         "en": "aggressive trolling",
-        "ja": "あぐれっしぶなとろーりんぐ",
+        "ja": "アグレッシブなトローリング",
         "ja_typings": [
           "aguresshibunatororingu"
         ]
       },
       {
         "en": "popular music genre",
-        "ja": "にんきのおんがくじゃんる",
+        "ja": "人気音楽ジャンル",
         "ja_typings": [
           "ninkinongakujanru",
           "ninkinoongakujanru"
@@ -38776,7 +38776,7 @@
       },
       {
         "en": "gaming achievement",
-        "ja": "げーみんぐのじつせき",
+        "ja": "ゲーミングのアチーブメント",
         "ja_typings": [
           "gemingunojitsuseki"
         ]
@@ -38788,7 +38788,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does 'GachiBASS' mean?",
-      "ja": "GachiBASSとはどういう意味ですか？"
+      "ja": "GachiBASSとはどんな意味？"
     },
     "question_text_reading": {
       "en": "What does 'GachiBASS' mean?",
@@ -38799,28 +38799,28 @@
     "choices": [
       {
         "en": "software for animating 2D characters",
-        "ja": "2Dきゃらくたーをあにめーとするそふとうぇあ",
+        "ja": "2Dキャラクターをアニメーするソフトウェア",
         "ja_typings": [
           "2dkyarakutaoanimetosurusofutowea"
         ]
       },
       {
         "en": "2D game engine",
-        "ja": "2Dげーむえんじん",
+        "ja": "2Dゲームエンジン",
         "ja_typings": [
           "2dgemuenjin"
         ]
       },
       {
         "en": "video editing tool",
-        "ja": "びでおへんしゅうつーる",
+        "ja": "ビデオ編集ツール",
         "ja_typings": [
           "bideohenshuutsuru"
         ]
       },
       {
         "en": "streaming plugin",
-        "ja": "すとりーみんぐぷらぐいん",
+        "ja": "ストリーミングプラグイン",
         "ja_typings": [
           "sutorimingupuraguin"
         ]
@@ -38832,7 +38832,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'live2D'?",
-      "ja": "らいぶつーでぃーとは何か？"
+      "ja": "live2Dとは何か？"
     },
     "question_text_reading": {
       "en": "What is 'live2D'?",
@@ -38843,7 +38843,7 @@
     "choices": [
       {
         "en": "paid subscription to a channel",
-        "ja": "ちゃんねるへのゆうりょうさぶすくりぷしょん",
+        "ja": "チャンネルへの有料サブスクリプション",
         "ja_typings": [
           "channeruhenoyuuryosabusukuripushon",
           "channeruhenoyuuryousabusukuripushon"
@@ -38851,7 +38851,7 @@
       },
       {
         "en": "free follower account",
-        "ja": "むりょうのふぉろわーあかうんと",
+        "ja": "無料のフォロワーアカウント",
         "ja_typings": [
           "muryonoforowaakaunto",
           "muryounoforowaakaunto"
@@ -38859,7 +38859,7 @@
       },
       {
         "en": "official partner status",
-        "ja": "こうしきぱーとなーのすてーたす",
+        "ja": "公式パートナーのステータス",
         "ja_typings": [
           "koshikipatonanosutetasu",
           "koushikipatonanosutetasu"
@@ -38867,7 +38867,7 @@
       },
       {
         "en": "staff role",
-        "ja": "すたっふのやくわり",
+        "ja": "スタッフの役割",
         "ja_typings": [
           "sutaffunoyakuwari"
         ]
@@ -38879,7 +38879,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a 'membership' on YouTube?",
-      "ja": "YouTubeにおける「membership」とは何ですか？"
+      "ja": "YouTubeでのmembershipとは？"
     },
     "question_text_reading": {
       "en": "What is a 'membership' on YouTube?",
@@ -38890,28 +38890,28 @@
     "choices": [
       {
         "en": "favorite VTuber or idol",
-        "ja": "おきにいりのぶいちゅーばーやあいどる",
+        "ja": "お気に入りのVTuberやアイドル",
         "ja_typings": [
           "okiniirinobuichubayaaidoru"
         ]
       },
       {
         "en": "Japanese greeting",
-        "ja": "にほんごのあいさつ",
+        "ja": "日本語の挨拶",
         "ja_typings": [
           "nihongonoaisatsu"
         ]
       },
       {
         "en": "gift item",
-        "ja": "ぷれぜんとひん",
+        "ja": "プレゼント品",
         "ja_typings": [
           "purezentohin"
         ]
       },
       {
         "en": "streaming schedule",
-        "ja": "すとりーみんぐすけじゅーる",
+        "ja": "ストリーミングスケジュール",
         "ja_typings": [
           "sutorimingusukejuru"
         ]
@@ -38923,7 +38923,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'oshi'?",
-      "ja": "推しとは、具体的にどのようなものを指すのでしょうか？"
+      "ja": "推しとは何か？"
     },
     "question_text_reading": {
       "en": "What is 'oshi'?",
@@ -38934,28 +38934,28 @@
     "choices": [
       {
         "en": "TL",
-        "ja": "てぃーえる",
+        "ja": "TL",
         "ja_typings": [
           "tieru"
         ]
       },
       {
         "en": "Sub",
-        "ja": "さぶ",
+        "ja": "サブ",
         "ja_typings": [
           "sabu"
         ]
       },
       {
         "en": "Clip",
-        "ja": "くりっぷ",
+        "ja": "クリップ",
         "ja_typings": [
           "kurippu"
         ]
       },
       {
         "en": "EN",
-        "ja": "いーえぬ",
+        "ja": "EN",
         "ja_typings": [
           "ienu"
         ]
@@ -38967,7 +38967,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the term for simultaneous translator in VTuber culture?",
-      "ja": "VTuber文化における同時通訳者を何と呼ぶのでしょうか？"
+      "ja": "VTuber文化で同時通訳者を何といいますか？"
     },
     "question_text_reading": {
       "en": "What is the term for simultaneous translator in VTuber culture?",
@@ -38978,28 +38978,28 @@
     "choices": [
       {
         "en": "casual talk stream with no specific topic",
-        "ja": "とくていのわだいのないかいわすとりーむ",
+        "ja": "特定の話題のない会話ストリーム",
         "ja_typings": [
           "tokuteinowadainonaikaiwasutorimu"
         ]
       },
       {
         "en": "game stream",
-        "ja": "げーむすとりーむ",
+        "ja": "ゲームストリーム",
         "ja_typings": [
           "gemusutorimu"
         ]
       },
       {
         "en": "singing concert",
-        "ja": "うたこんさーと",
+        "ja": "歌コンサート",
         "ja_typings": [
           "utakonsato"
         ]
       },
       {
         "en": "drawing stream",
-        "ja": "おえかきすとりーむ",
+        "ja": "絵描きストリーム",
         "ja_typings": [
           "oekakisutorimu"
         ]
@@ -39011,7 +39011,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'zatsudan'?",
-      "ja": "ざつだんとは何か？"
+      "ja": "雑談とは何か？"
     },
     "question_text_reading": {
       "en": "What is 'zatsudan'?",
@@ -39022,7 +39022,7 @@
     "choices": [
       {
         "en": "expression of excitement or amazement",
-        "ja": "こうふんやおどろきのひょうげん",
+        "ja": "興奮やおどろきの表現",
         "ja_typings": [
           "kofunyaodorokinohyogen",
           "koufunyaodorokinohyougen"
@@ -39030,14 +39030,14 @@
       },
       {
         "en": "greeting",
-        "ja": "あいさつ",
+        "ja": "挨拶",
         "ja_typings": [
           "aisatsu"
         ]
       },
       {
         "en": "expression of sadness",
-        "ja": "かなしみのひょうげん",
+        "ja": "悲しみの表現",
         "ja_typings": [
           "kanashiminohyogen",
           "kanashiminohyougen"
@@ -39045,7 +39045,7 @@
       },
       {
         "en": "request to repeat",
-        "ja": "くりかえしのようきゅう",
+        "ja": "繰り返しの要求",
         "ja_typings": [
           "kurikaeshinoyokyuu",
           "kurikaeshinoyoukyuu"
@@ -39058,7 +39058,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does 'pog' or 'poggers' mean in chat?",
-      "ja": "チャットで「pog」や「poggers」はどのような意味ですか？"
+      "ja": "チャットでpogやpoggersとはどういう意味？"
     },
     "question_text_reading": {
       "en": "What does 'pog' or 'poggers' mean in chat?",
@@ -39069,28 +39069,28 @@
     "choices": [
       {
         "en": "laughing emote on Twitch",
-        "ja": "ついっちでのわらいのえもーと",
+        "ja": "Twitchでの笑いのエモート",
         "ja_typings": [
           "tsuitchidenowarainoemoto"
         ]
       },
       {
         "en": "crying emote",
-        "ja": "なきのえもーと",
+        "ja": "泣きのエモート",
         "ja_typings": [
           "nakinoemoto"
         ]
       },
       {
         "en": "angry emote",
-        "ja": "おこりのえもーと",
+        "ja": "怒りのエモート",
         "ja_typings": [
           "okorinoemoto"
         ]
       },
       {
         "en": "love emote",
-        "ja": "あいのえもーと",
+        "ja": "愛のエモート",
         "ja_typings": [
           "ainoemoto"
         ]
@@ -39102,7 +39102,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'KEKW'?",
-      "ja": "KEKWとは何ですか？"
+      "ja": "けくわとは何か？"
     },
     "question_text_reading": {
       "en": "What is 'KEKW'?",
@@ -39113,14 +39113,14 @@
     "choices": [
       {
         "en": "sending your audience to another streamer",
-        "ja": "かんきゃくをほかのすとりーまーにおくること",
+        "ja": "観客を他のストリーマーに送ること",
         "ja_typings": [
           "kankyakuohokanosutorimaniokurukoto"
         ]
       },
       {
         "en": "attacking another streamer's chat",
-        "ja": "ほかのすとりーまーのちゃっとをこうげき",
+        "ja": "他のストリーマーのチャットを攻撃",
         "ja_typings": [
           "hokanosutorimanochattokogeki",
           "hokanosutorimanochattookougeki"
@@ -39128,14 +39128,14 @@
       },
       {
         "en": "copyright striking content",
-        "ja": "ちょさくけんしんこく",
+        "ja": "著作権侵害コンテンツ",
         "ja_typings": [
           "chosakukenshinkoku"
         ]
       },
       {
         "en": "banning viewers",
-        "ja": "びゅわーのばん",
+        "ja": "ビューワーのバン",
         "ja_typings": [
           "byuwanoban"
         ]
@@ -39147,7 +39147,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is a 'raid' on Twitch?",
-      "ja": "Twitchにおける「raid」とはどのようなものですか？"
+      "ja": "Twitchでのraidとは何か？"
     },
     "question_text_reading": {
       "en": "What is a 'raid' on Twitch?",
@@ -39158,28 +39158,28 @@
     "choices": [
       {
         "en": "character's backstory and world-building",
-        "ja": "きゃらくたーのばっくすとーりーとせかいかん",
+        "ja": "キャラクターのバックストーリーと世界観",
         "ja_typings": [
           "kyarakutanobakkusutoritosekaikan"
         ]
       },
       {
         "en": "stream schedule",
-        "ja": "すとりーむすけじゅーる",
+        "ja": "ストリームスケジュール",
         "ja_typings": [
           "sutorimusukejuru"
         ]
       },
       {
         "en": "fan community rules",
-        "ja": "ふぁんこみゅにてぃのるーる",
+        "ja": "ファンコミュニティのルール",
         "ja_typings": [
           "fankomyunitinoruru"
         ]
       },
       {
         "en": "merchandise collection",
-        "ja": "ぐっずのこれくしょん",
+        "ja": "グッズのコレクション",
         "ja_typings": [
           "guzzunokorekushon"
         ]
@@ -39191,7 +39191,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'lore' in VTuber context?",
-      "ja": "VTuberにおける「lore」とは、どのようなものですか？"
+      "ja": "VTuber文脈でのloreとは何か？"
     },
     "question_text_reading": {
       "en": "What is 'lore' in VTuber context?",
@@ -39202,28 +39202,28 @@
     "choices": [
       {
         "en": "first stream with a 3D model",
-        "ja": "さんじげんもでるではじめてすとりーむ",
+        "ja": "三次元モデルではじめてストリーム",
         "ja_typings": [
           "sanjigenmoderudehajimetesutorimu"
         ]
       },
       {
         "en": "first collaboration in 3D space",
-        "ja": "さんじげんくうかんではじめてのこらぼ",
+        "ja": "三次元空間ではじめてのコラボ",
         "ja_typings": [
           "sanjigenkuukandehajimetenokorabo"
         ]
       },
       {
         "en": "debut in 3D VR world",
-        "ja": "3Dぶいあーるせかいにでびゅー",
+        "ja": "3D VR世界にデビュー",
         "ja_typings": [
           "3dbuiarusekainidebyu"
         ]
       },
       {
         "en": "first IRL stream",
-        "ja": "はじめてのりあるいちじょうすとりーむ",
+        "ja": "初めてのIRLストリーム",
         "ja_typings": [
           "hajimetenoriaruichijosutorimu",
           "hajimetenoriaruichijousutorimu"
@@ -39236,7 +39236,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is '3D debut' for a VTuber?",
-      "ja": "VTuberにとっての「3D debut」とは何ですか？"
+      "ja": "VTuberの3D debutとは？"
     },
     "question_text_reading": {
       "en": "What is '3D debut' for a VTuber?",
@@ -39247,21 +39247,21 @@
     "choices": [
       {
         "en": "In Real Life",
-        "ja": "げんじつせかい",
+        "ja": "現実世界",
         "ja_typings": [
           "genjitsusekai"
         ]
       },
       {
         "en": "Internet Relay Link",
-        "ja": "いんたーねっとりれーりんく",
+        "ja": "インターネットリレーリンク",
         "ja_typings": [
           "intanettorirerinku"
         ]
       },
       {
         "en": "In Reference Level",
-        "ja": "さんしょうのれべる",
+        "ja": "参照レベル",
         "ja_typings": [
           "sanshonoreberu",
           "sanshounoreberu"
@@ -39269,7 +39269,7 @@
       },
       {
         "en": "Interactive Reality Layer",
-        "ja": "そうほうてきりある",
+        "ja": "方法的リアレイヤー",
         "ja_typings": [
           "sohotekiriaru",
           "souhoutekiriaru"
@@ -39282,7 +39282,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does 'IRL' stand for?",
-      "ja": "IRLとは何の略語ですか？"
+      "ja": "IRLとは何の略？"
     },
     "question_text_reading": {
       "en": "What does 'IRL' stand for?",
@@ -39293,7 +39293,7 @@
     "choices": [
       {
         "en": "Japanese video sharing website",
-        "ja": "にほんのどうがきょうゆうさいと",
+        "ja": "日本の動画共有サイト",
         "ja_typings": [
           "nihonnodogakyoyuusaito",
           "nihonnodougakyouyuusaito"
@@ -39301,21 +39301,21 @@
       },
       {
         "en": "Japanese social media",
-        "ja": "にほんのそーしゃるめでぃあ",
+        "ja": "日本のソーシャルメディア",
         "ja_typings": [
           "nihonnososharumedia"
         ]
       },
       {
         "en": "Japanese streaming platform",
-        "ja": "にほんのすとりーみんぐぷらっとふぉーむ",
+        "ja": "日本のストリーミングプラットフォーム",
         "ja_typings": [
           "nihonnosutorimingupurattofomu"
         ]
       },
       {
         "en": "Japanese music platform",
-        "ja": "にほんのおんがくぷらっとふぉーむ",
+        "ja": "日本の音楽プラットフォーム",
         "ja_typings": [
           "nihonnongakupurattofomu",
           "nihonnoongakupurattofomu"
@@ -39328,7 +39328,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'NicoNico Douga'?",
-      "ja": "NicoNico Dougaとはどのようなものですか？"
+      "ja": "ニコニコ動画とは何か？"
     },
     "question_text_reading": {
       "en": "What is 'NicoNico Douga'?",
@@ -39339,7 +39339,7 @@
     "choices": [
       {
         "en": "voice synthesizer software featuring virtual singers",
-        "ja": "かそうかしゅとくみあわせたこえごうせいそふと",
+        "ja": "仮想歌手と組み合わせた音声合成ソフト",
         "ja_typings": [
           "kasokashutokumiawasetakoegoseisofuto",
           "kasoukashutokumiawasetakoegouseisofuto"
@@ -39347,21 +39347,21 @@
       },
       {
         "en": "virtual idol group",
-        "ja": "ばーちゃるあいどるぐるーぷ",
+        "ja": "バーチャルアイドルグループ",
         "ja_typings": [
           "bacharuaidorugurupu"
         ]
       },
       {
         "en": "VTuber agency",
-        "ja": "ぶいちゅーばーじむしょ",
+        "ja": "VTuber agency",
         "ja_typings": [
           "buichubajimusho"
         ]
       },
       {
         "en": "music streaming app",
-        "ja": "おんがくすとりーみんぐあぷり",
+        "ja": "音楽ストリーミングアプリ",
         "ja_typings": [
           "ongakusutoriminguapuri"
         ]
@@ -39373,7 +39373,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'Vocaloid'?",
-      "ja": "ぼーかろいどとは何か？"
+      "ja": "ボーカロイドとは何か？"
     },
     "question_text_reading": {
       "en": "What is 'Vocaloid'?",
@@ -39384,28 +39384,28 @@
     "choices": [
       {
         "en": "Hatsune Miku",
-        "ja": "はつねみく",
+        "ja": "初音ミク",
         "ja_typings": [
           "hatsunemiku"
         ]
       },
       {
         "en": "Kagamine Rin",
-        "ja": "かがみねりん",
+        "ja": "鏡音リン",
         "ja_typings": [
           "kagaminerin"
         ]
       },
       {
         "en": "Megurine Luka",
-        "ja": "めぐりんるか",
+        "ja": "巡林ルカ",
         "ja_typings": [
           "megurinruka"
         ]
       },
       {
         "en": "Kaito",
-        "ja": "かいと",
+        "ja": "海斗",
         "ja_typings": [
           "kaito"
         ]
@@ -39417,7 +39417,7 @@
     "image_path": null,
     "question_text": {
       "en": "What character is the most famous Vocaloid?",
-      "ja": "最も有名なボーカロイドのキャラクターは誰でしょう？"
+      "ja": "最も有名なボーカロイドのキャラクターは？"
     },
     "question_text_reading": {
       "en": "What character is the most famous Vocaloid?",
@@ -39428,7 +39428,7 @@
     "choices": [
       {
         "en": "humorous image or idea spread online",
-        "ja": "おんらいんでひろがるゆーもらすがぞうやかんがえ",
+        "ja": "オンラインで広がるユーモラスな画像や考え",
         "ja_typings": [
           "onraindehirogaruyumorasugazoyakangae",
           "onraindehirogaruyumorasugazouyakangae"
@@ -39436,7 +39436,7 @@
       },
       {
         "en": "official advertisement",
-        "ja": "こうしきこうこく",
+        "ja": "公式広告",
         "ja_typings": [
           "koshikikokoku",
           "koushikikoukoku"
@@ -39444,14 +39444,14 @@
       },
       {
         "en": "news article",
-        "ja": "にゅーすきじ",
+        "ja": "ニュース記事",
         "ja_typings": [
           "nyusukiji"
         ]
       },
       {
         "en": "computer virus",
-        "ja": "こんぴゅーたういるす",
+        "ja": "コンピュータウイルス",
         "ja_typings": [
           "konpyutauirusu"
         ]
@@ -39463,7 +39463,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'meme' on the internet?",
-      "ja": "インターネットにおける「meme」とは何ですか？"
+      "ja": "インターネットでミームとは何か？"
     },
     "question_text_reading": {
       "en": "What is 'meme' on the internet?",
@@ -39474,7 +39474,7 @@
     "choices": [
       {
         "en": "deliberately provoking others online",
-        "ja": "おんらいんでいとてきにひとをちょはつすること",
+        "ja": "オンラインで意図的に人を挑発すること",
         "ja_typings": [
           "onraindeitotekinihitochohatsusurukoto",
           "onraindeitotekinihitoochohatsusurukoto"
@@ -39482,7 +39482,7 @@
       },
       {
         "en": "sharing positive content",
-        "ja": "ぽじてぃぶなこんてんつをきょうゆう",
+        "ja": "ポジティブなコンテンツを共有",
         "ja_typings": [
           "pojitibunakontentsuokyoyuu",
           "pojitibunakontentsuokyouyuu"
@@ -39490,14 +39490,14 @@
       },
       {
         "en": "promoting products",
-        "ja": "せいひんのぷろもーしょん",
+        "ja": "製品のプロモーション",
         "ja_typings": [
           "seihinnopuromoshon"
         ]
       },
       {
         "en": "building online communities",
-        "ja": "おんらいんこみゅにてぃのけいせい",
+        "ja": "オンラインコミュニティの形成",
         "ja_typings": [
           "onrainkomyunitinokeisei"
         ]
@@ -39509,7 +39509,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'trolling' online?",
-      "ja": "オンラインで「trolling」とはどういう行為ですか？"
+      "ja": "オンラインでtrollingとは何か？"
     },
     "question_text_reading": {
       "en": "What is 'trolling' online?",
@@ -39520,7 +39520,7 @@
     "choices": [
       {
         "en": "Away From Keyboard",
-        "ja": "きーぼーどをはなれている",
+        "ja": "キーボードを離れている",
         "ja_typings": [
           "kibodohanareteiru",
           "kibodoohanareteiru"
@@ -39528,21 +39528,21 @@
       },
       {
         "en": "Active For Killers",
-        "ja": "あくてぃぶふぉーきらーず",
+        "ja": "アクティブフォーキラーズ",
         "ja_typings": [
           "akutibufokirazu"
         ]
       },
       {
         "en": "Awaiting Feedback Kindly",
-        "ja": "へんじまちのれいきんもーど",
+        "ja": "返事待ちの領域モード",
         "ja_typings": [
           "henjimachinoreikinmodo"
         ]
       },
       {
         "en": "All Friends Known",
-        "ja": "すべてのともだちはいどく",
+        "ja": "全ての友達は一同",
         "ja_typings": [
           "subetenotomodachihaidoku"
         ]
@@ -39554,7 +39554,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does AFK stand for?",
-      "ja": "AFKとは何の略語ですか？"
+      "ja": "AFKとは何の略？"
     },
     "question_text_reading": {
       "en": "What does AFK stand for?",
@@ -39565,7 +39565,7 @@
     "choices": [
       {
         "en": "randomized loot mechanic inspired by capsule toys",
-        "ja": "かぷせるがちゃからのらんだむほうしゅうしすてむ",
+        "ja": "カプセルガチャからのランダム報酬システム",
         "ja_typings": [
           "kapuserugachakaranorandamuhoshuushisutemu",
           "kapuserugachakaranorandamuhoushuushisutemu"
@@ -39573,21 +39573,21 @@
       },
       {
         "en": "guaranteed rare item drop",
-        "ja": "かならずレアあいてむがでるじすてむ",
+        "ja": "必ずレアアイテムが出るシステム",
         "ja_typings": [
           "kanarazureaaitemugaderujisutemu"
         ]
       },
       {
         "en": "battle pass system",
-        "ja": "ばとるぱすしすてむ",
+        "ja": "バトルパスシステム",
         "ja_typings": [
           "batorupasushisutemu"
         ]
       },
       {
         "en": "game difficulty system",
-        "ja": "むずかしさのしすてむ",
+        "ja": "難しさのシステム",
         "ja_typings": [
           "muzukashisanoshisutemu"
         ]
@@ -39599,7 +39599,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'gacha' in gaming?",
-      "ja": "ゲームにおける「ガチャ」とは何ですか？"
+      "ja": "ゲーミングでガチャとは何か？"
     },
     "question_text_reading": {
       "en": "What is 'gacha' in gaming?",
@@ -39610,28 +39610,28 @@
     "choices": [
       {
         "en": "Massively Multiplayer Online (game)",
-        "ja": "まっしぶりーまるちぷれいやーおんらいんげーむ",
+        "ja": "マッシブリーマルチプレイヤーオンラインゲーム",
         "ja_typings": [
           "masshiburimaruchipureiyaonraingemu"
         ]
       },
       {
         "en": "Mobile Multiplayer Online",
-        "ja": "もばいるまるちぷれいやーおんらいん",
+        "ja": "モバイルマルチプレイヤーオンライン",
         "ja_typings": [
           "mobairumaruchipureiyaonrain"
         ]
       },
       {
         "en": "Managed Multiplayer Offline",
-        "ja": "かんりされたおふらいんたいせん",
+        "ja": "管理されたオフライン対戦",
         "ja_typings": [
           "kanrisaretaofuraintaisen"
         ]
       },
       {
         "en": "Modern Multiplayer Option",
-        "ja": "もだんなたいせんのおぷしょん",
+        "ja": "モダンマルチプレイヤーオプション",
         "ja_typings": [
           "modannataisennopushon",
           "modannataisennoopushon"
@@ -39644,7 +39644,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'MMO'?",
-      "ja": "えむえむおーとはなに？"
+      "ja": "MMOとはなに？"
     },
     "question_text_reading": {
       "en": "What is 'MMO'?",
@@ -39655,28 +39655,28 @@
     "choices": [
       {
         "en": "latency between player and server",
-        "ja": "ぷれいやーとさーばーかんのちえん",
+        "ja": "プレイヤーとサーバー間の遅延",
         "ja_typings": [
           "pureiyatosabakannochien"
         ]
       },
       {
         "en": "number of players online",
-        "ja": "おんらいんのぷれいやーすう",
+        "ja": "オンラインのプレイヤー数",
         "ja_typings": [
           "onrainnopureiyasuu"
         ]
       },
       {
         "en": "player ranking score",
-        "ja": "ぷれいやーのらんきんぐすこあ",
+        "ja": "プレイヤーのランキングスコア",
         "ja_typings": [
           "pureiyanorankingusukoa"
         ]
       },
       {
         "en": "message notification",
-        "ja": "めっせーじのつうち",
+        "ja": "メッセージの通知",
         "ja_typings": [
           "messejinotsuuchi"
         ]
@@ -39688,7 +39688,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'ping' in online gaming?",
-      "ja": "オンラインゲームにおける「ping」とは何ですか？"
+      "ja": "オンラインゲーミングでpingとは？"
     },
     "question_text_reading": {
       "en": "What is 'ping' in online gaming?",
@@ -39699,7 +39699,7 @@
     "choices": [
       {
         "en": "competitive video gaming",
-        "ja": "きょうぎてきびでおげーみんぐ",
+        "ja": "競技的ビデオゲーミング",
         "ja_typings": [
           "kyogitekibideogemingu",
           "kyougitekibideogemingu"
@@ -39707,7 +39707,7 @@
       },
       {
         "en": "electronic exercise equipment",
-        "ja": "でんしてきうんどうきぐ",
+        "ja": "電子運動器具",
         "ja_typings": [
           "denshitekiundokigu",
           "denshitekiundoukigu"
@@ -39715,14 +39715,14 @@
       },
       {
         "en": "electric motor racing",
-        "ja": "でんきもーたーれーす",
+        "ja": "電気モーターレーシング",
         "ja_typings": [
           "denkimotaresu"
         ]
       },
       {
         "en": "online sports betting",
-        "ja": "おんらいんすぽーつとうひょう",
+        "ja": "オンラインスポーツベッティング",
         "ja_typings": [
           "onrainsupotsutohyo",
           "onrainsupotsutouhyou"
@@ -39735,7 +39735,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'esports'?",
-      "ja": "esportsとは、具体的にどのようなものを指すのでしょうか？"
+      "ja": "eスポーツとは何か？"
     },
     "question_text_reading": {
       "en": "What is 'esports'?",
@@ -39746,28 +39746,28 @@
     "choices": [
       {
         "en": "First Person Shooter",
-        "ja": "ふぁーすとぱーそんしゅーたー",
+        "ja": "ファーストパーソンシューター",
         "ja_typings": [
           "fasutopasonshuta"
         ]
       },
       {
         "en": "Frames Per Second",
-        "ja": "ふれーむぱーせかんど",
+        "ja": "フレームパーセカンド",
         "ja_typings": [
           "furemupasekando"
         ]
       },
       {
         "en": "Fantasy Player System",
-        "ja": "ふぁんたじーぷれいやーしすてむ",
+        "ja": "ファンタジープレイヤーシステム",
         "ja_typings": [
           "fantajipureiyashisutemu"
         ]
       },
       {
         "en": "Final Player Score",
-        "ja": "ふぁいなるぷれいやーすこあ",
+        "ja": "ファイナルプレイヤー スコア",
         "ja_typings": [
           "fainarupureiyasukoa"
         ]
@@ -39779,7 +39779,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does FPS stand for in gaming?",
-      "ja": "ゲームにおける「FPS」は何の略語ですか？"
+      "ja": "ゲーミングでFPSとは何の略？"
     },
     "question_text_reading": {
       "en": "What does FPS stand for in gaming?",
@@ -39790,28 +39790,28 @@
     "choices": [
       {
         "en": "Hit Points / Health Points",
-        "ja": "ひっとぽいんつ・へるすぽいんつ",
+        "ja": "ヒットポイント・ヘルスポイント",
         "ja_typings": [
           "hittopointsu herusupointsu"
         ]
       },
       {
         "en": "Hero Power",
-        "ja": "ひーろーぱわー",
+        "ja": "ヒーローパワー",
         "ja_typings": [
           "hiropawa"
         ]
       },
       {
         "en": "High Power",
-        "ja": "はいぱわー",
+        "ja": "ハイパワー",
         "ja_typings": [
           "haipawa"
         ]
       },
       {
         "en": "Healing Potion",
-        "ja": "ひーりんぐぽーしょん",
+        "ja": "ヒーリングポーション",
         "ja_typings": [
           "hiringuposhon"
         ]
@@ -39823,7 +39823,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does HP stand for in games?",
-      "ja": "ゲームにおけるHPとは何の略語ですか？"
+      "ja": "ゲームでHPとは何の略？"
     },
     "question_text_reading": {
       "en": "What does HP stand for in games?",
@@ -39834,14 +39834,14 @@
     "choices": [
       {
         "en": "completing a game as fast as possible",
-        "ja": "できるだけはやくげーむをクリアすること",
+        "ja": "できるだけ早くゲームをクリアすること",
         "ja_typings": [
           "dekirudakehayakugemuokuriasurukoto"
         ]
       },
       {
         "en": "reviewing games quickly",
-        "ja": "はやくげーむをひょうかすること",
+        "ja": "早くゲームを評価すること",
         "ja_typings": [
           "hayakugemuohyokasurukoto",
           "hayakugemuohyoukasurukoto"
@@ -39849,7 +39849,7 @@
       },
       {
         "en": "streaming at high frame rate",
-        "ja": "こうふれーむれーとですとりーむ",
+        "ja": "高フレームレートでストリーミング",
         "ja_typings": [
           "kofuremuretodesutorimu",
           "koufuremuretodesutorimu"
@@ -39857,7 +39857,7 @@
       },
       {
         "en": "running in virtual reality games",
-        "ja": "ぶぁーちゃるりありてぃげーむでのらんにんぐ",
+        "ja": "バーチャルリアリティゲームでのランニング",
         "ja_typings": [
           "buacharuriaritigemudenoranningu"
         ]
@@ -39869,7 +39869,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'speedrunning'?",
-      "ja": "すぴーどらんにんぐとは何か？"
+      "ja": "スピードランニングとは何か？"
     },
     "question_text_reading": {
       "en": "What is 'speedrunning'?",

--- a/data/questions_ja.json
+++ b/data/questions_ja.json
@@ -329,14 +329,14 @@
       },
       {
         "en": "%",
-        "ja": "きていじょうけん",
+        "ja": "%",
         "ja_typings": [
           "%"
         ]
       },
       {
         "en": "**",
-        "ja": "きていじょうけん",
+        "ja": "**",
         "ja_typings": [
           "**"
         ]
@@ -632,7 +632,7 @@
       },
       {
         "en": "*",
-        "ja": "きていじょうけん",
+        "ja": "*",
         "ja_typings": [
           "*"
         ]
@@ -646,7 +646,7 @@
       },
       {
         "en": "#",
-        "ja": "きていじょうけん",
+        "ja": "#",
         "ja_typings": [
           "#"
         ]
@@ -1036,14 +1036,14 @@
       },
       {
         "en": "assignment",
-        "ja": "第２入",
+        "ja": "代入",
         "ja_typings": [
           "dainyuu"
         ]
       },
       {
         "en": "loose equality",
-        "ja": "緩やかななどうち",
+        "ja": "緩やかな等値",
         "ja_typings": [
           "yuruyakanadochi",
           "yuruyakanadouchi"
@@ -1074,7 +1074,7 @@
     "choices": [
       {
         "en": "() => {}",
-        "ja": "きていじょうけん() => {}",
+        "ja": "() => {}",
         "ja_typings": [
           "() => {}"
         ]
@@ -2043,7 +2043,7 @@
     "image_path": null,
     "question_text": {
       "en": "What does Dijkstra's algorithm find?",
-      "ja": "ダイクストラのあるごりずむはなにをもとめるか？"
+      "ja": "ダイクストラのアルゴリズムは何を求めるか？"
     },
     "question_text_reading": {
       "en": "What does Dijkstra's algorithm find?",
@@ -6834,7 +6834,7 @@
     "choices": [
       {
         "en": "<a>",
-        "ja": "ひらがな読み正本: げんきなひと",
+        "ja": "<a>",
         "ja_typings": [
           "<a>"
         ]
@@ -6848,14 +6848,14 @@
       },
       {
         "en": "<href>",
-        "ja": "きていじょうけん",
+        "ja": "<href>",
         "ja_typings": [
           "<href>"
         ]
       },
       {
         "en": "<url>",
-        "ja": "きていじょうけん",
+        "ja": "<url>",
         "ja_typings": [
           "<url>"
         ]
@@ -10185,7 +10185,7 @@
       },
       {
         "en": "delaying API response",
-        "ja": "API応答を流す",
+        "ja": "API応答を遅らす",
         "ja_typings": [
           "apiotookurasu",
           "apioutouookurasu"
@@ -12452,7 +12452,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is canary deployment?",
-      "ja": "カナリアはひとは何か？"
+      "ja": "カナリア配備とは何か？"
     },
     "question_text_reading": {
       "en": "What is canary deployment?",
@@ -14140,7 +14140,7 @@
       },
       {
         "en": "built-in array type",
-        "ja": "備わった配列型",
+        "ja": "組み込み配列型",
         "ja_typings": [
           "sonawattahairetsugata"
         ]
@@ -14860,14 +14860,14 @@
     "choices": [
       {
         "en": "Naruto Uzumaki",
-        "ja": "うずまきなると",
+        "ja": "うずまきナルト",
         "ja_typings": [
           "uzumakinaruto"
         ]
       },
       {
         "en": "Sasuke Uchiha",
-        "ja": "うちはさすけ",
+        "ja": "うちはサスケ",
         "ja_typings": [
           "uchihasasuke"
         ]
@@ -15518,7 +15518,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which anime series is known for the 'Kamehameha' attack?",
-      "ja": "かめはめはこうげきでゆうめいなアニメは？"
+      "ja": "かめはめ波攻撃で有名なアニメは？"
     },
     "question_text_reading": {
       "en": "Which anime series is known for the 'Kamehameha' attack?",
@@ -16008,7 +16008,7 @@
     "image_path": null,
     "question_text": {
       "en": "Which Ghibli film features a young witch who delivers by broomstick?",
-      "ja": "ほうきでいたつするわかいまじょのジブリえいがは？"
+      "ja": "ほうきで配達する若い魔女のジブリ映画は？"
     },
     "question_text_reading": {
       "en": "Which Ghibli film features a young witch who delivers by broomstick?",
@@ -16658,7 +16658,7 @@
       },
       {
         "en": "Meow Train",
-        "ja": "にゃーれっしゃ",
+        "ja": "ニャー列車",
         "ja_typings": [
           "nyaressha"
         ]
@@ -16677,7 +16677,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the name of the cat bus in My Neighbor Totoro?",
-      "ja": "となりのトトロのねこバスのなまえは？"
+      "ja": "となりのトトロの猫バスの名前は？"
     },
     "question_text_reading": {
       "en": "What is the name of the cat bus in My Neighbor Totoro?",
@@ -16912,7 +16912,7 @@
     "choices": [
       {
         "en": "a superpower",
-        "ja": "超能力力",
+        "ja": "超能力",
         "ja_typings": [
           "chonoryoku",
           "chounouryoku"
@@ -16936,7 +16936,7 @@
       },
       {
         "en": "a fighting technique",
-        "ja": "闘うの技",
+        "ja": "戦う技",
         "ja_typings": [
           "butonowaza",
           "butounowaza"
@@ -22355,7 +22355,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the best-selling manga of all time?",
-      "ja": "もっともうれたまんがは？"
+      "ja": "最も売れた漫画は？"
     },
     "question_text_reading": {
       "en": "What is the best-selling manga of all time?",
@@ -22989,7 +22989,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who created Bleach?",
-      "ja": "ブリーチをかいたのは？"
+      "ja": "ブリーチを描いたのは？"
     },
     "question_text_reading": {
       "en": "Who created Bleach?",
@@ -23098,7 +23098,7 @@
       },
       {
         "en": "Rurouni Kenshin",
-        "ja": "るろうにけんしん",
+        "ja": "るろうに剣心",
         "ja_typings": [
           "ruronikenshin",
           "rurounikenshin"
@@ -23262,7 +23262,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who draws One Piece?",
-      "ja": "ワンピースをかいているのは誰か？"
+      "ja": "ワンピースを描いているのは誰か？"
     },
     "question_text_reading": {
       "en": "Who draws One Piece?",
@@ -23668,7 +23668,7 @@
     "image_path": null,
     "question_text": {
       "en": "Who created Doraemon?",
-      "ja": "ドラえもんをかいたのは？"
+      "ja": "ドラえもんを描いたのは？"
     },
     "question_text_reading": {
       "en": "Who created Doraemon?",
@@ -24220,7 +24220,7 @@
       },
       {
         "en": "simple action manga",
-        "ja": "簡単なアクション漫画",
+        "ja": "単純なアクション漫画",
         "ja_typings": [
           "kantannaakushonmanga"
         ]
@@ -26344,7 +26344,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Turkey?",
-      "ja": "トルコのしゅとは？"
+      "ja": "トルコの首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of Turkey?",
@@ -26960,7 +26960,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the capital of Kenya?",
-      "ja": "ケニアのしゅとは？"
+      "ja": "ケニアの首都は？"
     },
     "question_text_reading": {
       "en": "What is the capital of Kenya?",
@@ -29976,7 +29976,7 @@
       },
       {
         "en": "dark star that produces no light",
-        "ja": "光をだしていないくらいほし",
+        "ja": "光を出していない暗い星",
         "ja_typings": [
           "hikariodashiteinaikuraihoshi"
         ]
@@ -30634,7 +30634,7 @@
       },
       {
         "en": "particle outside nucleus",
-        "ja": "核のそとのりゅうし",
+        "ja": "核の外の粒子",
         "ja_typings": [
           "kakunosotonoryuushi"
         ]
@@ -31455,7 +31455,7 @@
       },
       {
         "en": "clot blood",
-        "ja": "血をかたまる",
+        "ja": "血を固まらせる",
         "ja_typings": [
           "chiokatamaraseru"
         ]
@@ -32027,7 +32027,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 2 + 2?",
-      "ja": "2たす2はいくつ？"
+      "ja": "2足す2はいくつ？"
     },
     "question_text_reading": {
       "en": "What is 2 + 2?",
@@ -35001,7 +35001,7 @@
       },
       {
         "en": "word imitating sound",
-        "ja": "音をまねることば",
+        "ja": "音をまねる言葉",
         "ja_typings": [
           "otomanerukotoba",
           "otoomanerukotoba"
@@ -35058,7 +35058,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is alliteration?",
-      "ja": "どうじしゅんぷうとは何か？"
+      "ja": "頭韻とは何か？"
     },
     "question_text_reading": {
       "en": "What is alliteration?",
@@ -36464,7 +36464,7 @@
     "image_path": null,
     "question_text": {
       "en": "How many days are in a leap year?",
-      "ja": "うるうどしはなんにち？"
+      "ja": "うるう年は何日？"
     },
     "question_text_reading": {
       "en": "How many days are in a leap year?",
@@ -37309,7 +37309,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is the main language spoken in Argentina?",
-      "ja": "あるぜんちんでつかわれるしゅのことばは？"
+      "ja": "アルゼンチンで使われる主な言葉は？"
     },
     "question_text_reading": {
       "en": "What is the main language spoken in Argentina?",
@@ -39102,7 +39102,7 @@
     "image_path": null,
     "question_text": {
       "en": "What is 'KEKW'?",
-      "ja": "けくわとは何か？"
+      "ja": "KEKWとは何か？"
     },
     "question_text_reading": {
       "en": "What is 'KEKW'?",

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -174,13 +174,13 @@ Field roles:
 |---|---|
 | `question_text.<lang>` | **display** form. Quiz UI shows this. JA aims for natural kanji-kana mixed text. |
 | `question_text_reading.<lang>` | **reading** form. Hiragana for JA. Used by TTS / future RPG audio paths and as a safety net for the migration that rewrites `question_text.ja`. Optional (defaults to display when absent). |
-| `choices[].<lang>` | per-language choice label. JA stays hiragana / katakana / ASCII because it doubles as the typing target. |
-| `choices[].ja_typings` | extra accepted JA typings (Hepburn variants, official spellings). |
+| `choices[].<lang>` | per-language choice display label. JA should be natural kanji-kana mixed text where appropriate. |
+| `choices[].ja_typings` | accepted JA typing forms (Hepburn variants, official spellings). This is the typing target when the JA display label contains kanji. |
 
 Migration recipe (`scripts/`, see README for full chain):
 
 1. `backfill_question_text_reading.py` — copies current `question_text` into `question_text_reading` (idempotent).
-2. `restore_ja_question_texts_with_ollama.py` — rewrites only `question_text.ja` for hiragana-heavy entries via local Gemma. Reading is preserved.
+2. `restore_ja_question_texts_with_ollama.py` — rewrites `question_text.ja` for hiragana-heavy entries via local Gemma. With `--all --include-choices`, refreshes every JA question display and answer label through the same model path. Reading / `ja_typings` are preserved.
 3. `question_text_stats.py` / `list_suspect_question_texts.py` — diagnostics.
 4. `cargo run --bin lint-questions -- data/questions_ja.json data/questions_en.json` — final lint.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -141,38 +141,48 @@ Within one 10-prompt run:
 
 Quiz-side runs are not bound by this layout — quiz questions may freely mix kinds.
 
-### Quiz question (`data/questions_<lang>.yaml`)
+### Quiz question (`data/questions_<lang>.json`)
 
-```yaml
-- id: q001
-  genre: programming
-  question: Which keyword moves ownership in Rust?
-  choices: [borrow, move, ref, clone]
-  correct: 1                # 0-indexed
-  kind: word
+Bilingual quiz banks live in JSON (one file per language, but each entry carries every language). The schema:
 
-- id: q050
-  genre: history
-  question: Who was the first president of the United States?
-  choices:
-    - George Washington
-    - Abraham Lincoln
-    - Thomas Jefferson
-    - John Adams
-  correct: 0
-  kind: phrase
-
-- id: q099
-  genre: literature
-  question: How does Descartes' famous proposition begin in English?
-  choices:
-    - I think therefore I am
-    - I drink therefore I sleep
-    - I see therefore I know
-    - I am therefore I think
-  correct: 0
-  kind: sentence
+```json
+{
+  "id": "q001",
+  "genre": "science",
+  "question_text": {
+    "en": "What is the chemical formula for water?",
+    "ja": "水の化学式は？"
+  },
+  "question_text_reading": {
+    "en": "What is the chemical formula for water?",
+    "ja": "みずのかがくしきは？"
+  },
+  "choices": [
+    { "en": "CO2", "ja": "CO2", "ja_typings": ["co2"] },
+    { "en": "H2O", "ja": "H2O", "ja_typings": ["h2o"] },
+    { "en": "O2",  "ja": "O2",  "ja_typings": ["o2"] },
+    { "en": "N2",  "ja": "N2",  "ja_typings": ["n2"] }
+  ],
+  "correct_answer_index": 1,
+  "image_path": null
+}
 ```
+
+Field roles:
+
+| field | role |
+|---|---|
+| `question_text.<lang>` | **display** form. Quiz UI shows this. JA aims for natural kanji-kana mixed text. |
+| `question_text_reading.<lang>` | **reading** form. Hiragana for JA. Used by TTS / future RPG audio paths and as a safety net for the migration that rewrites `question_text.ja`. Optional (defaults to display when absent). |
+| `choices[].<lang>` | per-language choice label. JA stays hiragana / katakana / ASCII because it doubles as the typing target. |
+| `choices[].ja_typings` | extra accepted JA typings (Hepburn variants, official spellings). |
+
+Migration recipe (`scripts/`, see README for full chain):
+
+1. `backfill_question_text_reading.py` — copies current `question_text` into `question_text_reading` (idempotent).
+2. `restore_ja_question_texts_with_ollama.py` — rewrites only `question_text.ja` for hiragana-heavy entries via local Gemma. Reading is preserved.
+3. `question_text_stats.py` / `list_suspect_question_texts.py` — diagnostics.
+4. `cargo run --bin lint-questions -- data/questions_ja.json data/questions_en.json` — final lint.
 
 Validation: no two choices in a question may share a prefix that would make an auto-confirm ambiguous. Enforced by `cargo run --bin lint-questions -- <files>` (CI job `lint-data`) and by the unit tests `shipped_question_data_is_clean_{ja,en}` in `src/io/validator.rs`.
 

--- a/scripts/backfill_question_text_reading.py
+++ b/scripts/backfill_question_text_reading.py
@@ -1,0 +1,60 @@
+"""
+question_text_reading をバックフィルする。
+
+各 Question の question_text に登録されているすべての言語について、
+question_text_reading にエントリが無ければ question_text の値をそのまま
+コピーする。これにより:
+
+- ja の現状ひらがな表記を「読み」として安全に退避できる
+- restore_ja_question_texts_with_ollama.py で question_text.ja を漢字
+  かな交じりへ書き換えても、読みは失われない
+
+何度実行しても安全 (idempotent)。
+
+usage:
+    uv run python3 scripts/backfill_question_text_reading.py data/questions_ja.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def backfill(path: Path) -> tuple[int, int]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    added = 0
+    touched = 0
+    for q in data:
+        qt = q.get("question_text") or {}
+        qtr = q.get("question_text_reading") or {}
+        any_added = False
+        for lang, text in qt.items():
+            if lang not in qtr:
+                qtr[lang] = text
+                added += 1
+                any_added = True
+        if any_added:
+            q["question_text_reading"] = qtr
+            touched += 1
+    path.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return added, touched
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("path", type=Path, nargs="+", help="questions_*.json files")
+    args = ap.parse_args()
+    for p in args.path:
+        added, touched = backfill(p)
+        print(f"{p}: added {added} reading entries across {touched} questions")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/list_suspect_question_texts.py
+++ b/scripts/list_suspect_question_texts.py
@@ -1,0 +1,59 @@
+"""
+変換後にまだ「ひらがな寄りで漢字がほぼ無い」 question_text.ja を列挙する。
+
+usage:
+    uv run python3 scripts/list_suspect_question_texts.py data/questions_ja.json
+    uv run python3 scripts/list_suspect_question_texts.py data/questions_ja.json --limit 100 --min-hiragana-ratio 0.7 --max-kanji 0
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+KANJI_RE = re.compile(r"[一-鿿]")
+
+
+def is_hiragana(c: str) -> bool:
+    return "ぁ" <= c <= "ゟ"
+
+
+def is_katakana(c: str) -> bool:
+    return "ァ" <= c <= "ヿ"
+
+
+def hira_ratio(s: str) -> float:
+    h = sum(1 for c in s if is_hiragana(c))
+    t = sum(1 for c in s if c.isalnum() or is_hiragana(c) or is_katakana(c) or KANJI_RE.match(c))
+    return h / t if t else 0.0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("path", type=Path)
+    ap.add_argument("--limit", type=int, default=50)
+    ap.add_argument("--min-hiragana-ratio", type=float, default=0.6)
+    ap.add_argument("--max-kanji", type=int, default=1)
+    args = ap.parse_args()
+
+    data = json.loads(args.path.read_text(encoding="utf-8"))
+    suspects = []
+    for q in data:
+        ja = (q.get("question_text") or {}).get("ja", "")
+        en = (q.get("question_text") or {}).get("en", "")
+        kanji = len(KANJI_RE.findall(ja))
+        ratio = hira_ratio(ja)
+        if ratio >= args.min_hiragana_ratio and kanji <= args.max_kanji:
+            suspects.append((q.get("id", "?"), ratio, kanji, ja, en))
+
+    print(f"# suspect: {len(suspects)} (showing up to {args.limit})")
+    for qid, ratio, kanji, ja, en in suspects[: args.limit]:
+        print(f"{qid}\thira={ratio:.2f}\tkanji={kanji}\tja={ja!r}\ten={en!r}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/question_text_stats.py
+++ b/scripts/question_text_stats.py
@@ -1,0 +1,83 @@
+"""
+questions_*.json の question_text の状態を集計する。
+
+主な指標:
+- total: 問題数
+- has_reading: question_text_reading.ja が入っている問題数
+- no_kanji: question_text.ja に漢字が一文字も無い
+- hira_heavy: ひらがな比率 (>= --min-hiragana-ratio) かつ 漢字数 <= --max-kanji
+- equal_to_reading: question_text.ja と question_text_reading.ja が一致
+
+usage:
+    uv run python3 scripts/question_text_stats.py data/questions_ja.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+KANJI_RE = re.compile(r"[一-鿿]")
+
+
+def is_hiragana(c: str) -> bool:
+    return "ぁ" <= c <= "ゟ"
+
+
+def is_katakana(c: str) -> bool:
+    return "ァ" <= c <= "ヿ"
+
+
+def hira_ratio(s: str) -> float:
+    h = sum(1 for c in s if is_hiragana(c))
+    t = sum(1 for c in s if c.isalnum() or is_hiragana(c) or is_katakana(c) or KANJI_RE.match(c))
+    return h / t if t else 0.0
+
+
+def kanji_count(s: str) -> int:
+    return len(KANJI_RE.findall(s))
+
+
+def stats(path: Path, min_hira: float, max_kanji: int) -> None:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    total = len(data)
+    has_reading = 0
+    no_kanji = 0
+    hira_heavy = 0
+    equal_to_reading = 0
+    for q in data:
+        ja = (q.get("question_text") or {}).get("ja", "")
+        ja_reading = (q.get("question_text_reading") or {}).get("ja", "")
+        if ja_reading:
+            has_reading += 1
+        if kanji_count(ja) == 0:
+            no_kanji += 1
+        if hira_ratio(ja) >= min_hira and kanji_count(ja) <= max_kanji:
+            hira_heavy += 1
+        if ja and ja == ja_reading:
+            equal_to_reading += 1
+
+    print(f"file: {path}")
+    print(f"  total: {total}")
+    print(f"  question_text_reading.ja present: {has_reading}")
+    print(f"  no kanji in question_text.ja: {no_kanji}")
+    print(f"  hira_ratio>={min_hira} & kanji<={max_kanji}: {hira_heavy}")
+    print(f"  display == reading (ja): {equal_to_reading}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("path", type=Path, nargs="+")
+    ap.add_argument("--min-hiragana-ratio", type=float, default=0.6)
+    ap.add_argument("--max-kanji", type=int, default=1)
+    args = ap.parse_args()
+    for p in args.path:
+        stats(p, args.min_hiragana_ratio, args.max_kanji)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/restore_ja_question_texts_with_ollama.py
+++ b/scripts/restore_ja_question_texts_with_ollama.py
@@ -1,0 +1,242 @@
+"""
+question_text.ja を漢字かな交じりへ書き換える。
+
+入力: question_text.en (主) + question_text_reading.ja (補助ヒント)
+出力: question_text.ja のみ書き換え。choices や reading は触らない。
+
+事前に backfill_question_text_reading.py を必ず実行しておくこと。
+読みが question_text_reading.ja に退避されている前提で動く。
+
+ローカル LLM (デフォルト: Ollama gemma4:e4b) に問い合わせて自然な
+日本語のクイズ問題文を生成する。フィルタ条件:
+
+- ひらがな比率 >= --min-hiragana-ratio (デフォ 0.6)
+- かつ 漢字数 <= --max-kanji (デフォ 1)
+- 既に question_text_reading.ja が空の場合はスキップ (バックフィル未実行)
+
+usage:
+    uv run python3 scripts/restore_ja_question_texts_with_ollama.py data/questions_ja.json --dry-run
+    uv run python3 scripts/restore_ja_question_texts_with_ollama.py data/questions_ja.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+KANJI_RE = re.compile(r"[一-鿿]")
+
+PROMPT = """\
+英語のクイズ問題文を、自然で読みやすい日本語のクイズ問題文に翻訳してください。
+
+ルール:
+- 漢字とかなをバランスよく使う (現代の自然な書き言葉)
+- 文末は「？」で終える
+- 出力は問題文一行のみ。説明・引用符・注釈・前置きは出力しない
+- 専門用語や英語のキーワードはそのまま英字で残してよい (例: Python, lambda, NaN)
+- 既存のひらがな読みは参考にしてよいが、表記は読みやすく整えること
+- LaTeX 記法 ($...$ や \\log など) は使わず、プレーンテキストで書くこと
+- 余計な丸括弧の英訳併記 (例:「ハッシュ衝突（hash collision）」) は付けないこと
+
+英語: {en}
+ひらがな読み参考: {reading}
+日本語:"""
+
+PROMPT_FALLBACK = """\
+Translate this English quiz question to natural Japanese (mix kanji and kana, modern written style).
+Output only the Japanese question, ending with ？. No explanation, no quotes, single line.
+Keep technical English keywords as-is (e.g. Python, lambda, NaN). No LaTeX, no parenthetical English glosses.
+
+English: {en}
+Japanese:"""
+
+
+def is_hiragana(c: str) -> bool:
+    return "ぁ" <= c <= "ゟ"
+
+
+def is_katakana(c: str) -> bool:
+    return "ァ" <= c <= "ヿ"
+
+
+def hira_ratio(s: str) -> float:
+    h = sum(1 for c in s if is_hiragana(c))
+    t = sum(1 for c in s if c.isalnum() or is_hiragana(c) or is_katakana(c) or KANJI_RE.match(c))
+    return h / t if t else 0.0
+
+
+def kanji_count(s: str) -> int:
+    return len(KANJI_RE.findall(s))
+
+
+def call_ollama(host: str, model: str, prompt: str, timeout: int) -> str:
+    body = json.dumps(
+        {
+            "model": model,
+            "stream": False,
+            "options": {
+                "temperature": 0.2,
+                "num_predict": 120,
+                "num_ctx": 1024,
+            },
+            "prompt": prompt,
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        f"{host.rstrip('/')}/api/generate",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        payload = json.loads(resp.read())
+    return payload.get("response", "").strip()
+
+
+def clean_response(s: str) -> str:
+    # Take only the first line (model sometimes adds explanations after).
+    s = s.strip()
+    s = s.splitlines()[0].strip() if s else s
+    if not s:
+        return s
+    # Strip outer wrappers only when balanced — avoids leaving a stray
+    # closing bracket like "たんこうぼん」とは何？" when the model emits
+    # only one side.
+    for opener, closer in (("「", "」"), ('"', '"'), ("'", "'"), ("`", "`")):
+        if s.startswith(opener) and s.endswith(closer) and len(s) >= 2:
+            s = s[1:-1].strip()
+    # Strip LaTeX inline math wrappers ($...$) but keep the inner text.
+    s = re.sub(r"\$([^$]+)\$", r"\1", s)
+    # Strip residual LaTeX command backslashes (e.g. \log -> log).
+    s = re.sub(r"\\([A-Za-z]+)", r"\1", s)
+    # Normalise terminal punctuation to a full-width question mark.
+    s = re.sub(r"[?？。．\.!！]+\s*$", "", s).rstrip()
+    s = s + "？"
+    return s
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("path", type=Path)
+    ap.add_argument("--ollama-host", default="http://127.0.0.1:11434")
+    ap.add_argument("--model", default="gemma4:e4b")
+    ap.add_argument("--min-hiragana-ratio", type=float, default=0.6)
+    ap.add_argument("--max-kanji", type=int, default=1)
+    ap.add_argument("--limit", type=int, default=0, help="0 = no limit")
+    ap.add_argument("--start-id", default=None, help="resume from this question id")
+    ap.add_argument("--timeout", type=int, default=120)
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--verbose", action="store_true")
+    args = ap.parse_args()
+
+    data = json.loads(args.path.read_text(encoding="utf-8"))
+
+    targets: list[dict] = []
+    for q in data:
+        qt = q.get("question_text") or {}
+        qtr = q.get("question_text_reading") or {}
+        ja = qt.get("ja", "")
+        en = qt.get("en", "")
+        ja_reading = qtr.get("ja", "")
+        if not ja_reading:
+            # backfill 未済 → 触らない (安全策)
+            continue
+        if not en:
+            continue
+        if hira_ratio(ja) < args.min_hiragana_ratio:
+            continue
+        if kanji_count(ja) > args.max_kanji:
+            continue
+        targets.append(q)
+
+    if args.start_id is not None:
+        skip = True
+        new_targets = []
+        for q in targets:
+            if skip and q.get("id") == args.start_id:
+                skip = False
+            if not skip:
+                new_targets.append(q)
+        targets = new_targets
+
+    if args.limit > 0:
+        targets = targets[: args.limit]
+
+    print(f"target: {len(targets)} questions")
+    if args.dry_run:
+        for q in targets[:20]:
+            print(f"  {q.get('id')}: {q['question_text']['ja']!r} <- {q['question_text']['en']!r}")
+        if len(targets) > 20:
+            print(f"  ... and {len(targets) - 20} more")
+        return 0
+
+    converted = 0
+    failed = 0
+    started = time.monotonic()
+    save_every = 25
+    max_retries = 2
+    for i, q in enumerate(targets, 1):
+        en = q["question_text"]["en"]
+        reading = q["question_text_reading"]["ja"]
+        new_ja = ""
+        raw = ""
+        dt = 0.0
+        ok = False
+        last_err = None
+        # Two prompt variants: primary Japanese-led, fallback English-led
+        # (Gemma occasionally returns whitespace-only output for the JP prompt
+        # on certain inputs — the EN-led prompt rescues those cases).
+        for attempt in range(max_retries + 1):
+            prompt = (PROMPT if attempt == 0 else PROMPT_FALLBACK).format(en=en, reading=reading)
+            try:
+                t0 = time.monotonic()
+                raw = call_ollama(args.ollama_host, args.model, prompt, args.timeout)
+                dt = time.monotonic() - t0
+                new_ja = clean_response(raw)
+                if new_ja and len(new_ja) >= 3:
+                    ok = True
+                    break
+            except (urllib.error.URLError, TimeoutError, OSError) as e:
+                last_err = e
+                time.sleep(0.5)
+                continue
+            time.sleep(0.3)
+        if not ok:
+            failed += 1
+            if last_err is not None:
+                print(f"  [{i}/{len(targets)}] {q.get('id')} ERROR after retries: {last_err}", file=sys.stderr)
+            else:
+                print(f"  [{i}/{len(targets)}] {q.get('id')} EMPTY after retries: {raw!r}", file=sys.stderr)
+            continue
+        old_ja = q["question_text"]["ja"]
+        q["question_text"]["ja"] = new_ja
+        converted += 1
+        if args.verbose or i <= 3 or i % 25 == 0:
+            print(f"  [{i}/{len(targets)}] {q.get('id')} {dt:.1f}s  {old_ja!r} -> {new_ja!r}")
+        if i % save_every == 0:
+            args.path.write_text(
+                json.dumps(data, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            elapsed = time.monotonic() - started
+            rate = i / elapsed
+            eta = (len(targets) - i) / rate if rate else 0
+            print(f"    -- checkpoint saved ({i}/{len(targets)}, {rate:.2f} q/s, ETA {eta/60:.1f} min)")
+
+    args.path.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    elapsed = time.monotonic() - started
+    print(f"converted: {converted}  failed: {failed}  elapsed: {elapsed/60:.1f} min")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/restore_ja_question_texts_with_ollama.py
+++ b/scripts/restore_ja_question_texts_with_ollama.py
@@ -2,7 +2,8 @@
 question_text.ja を漢字かな交じりへ書き換える。
 
 入力: question_text.en (主) + question_text_reading.ja (補助ヒント)
-出力: question_text.ja のみ書き換え。choices や reading は触らない。
+出力: question_text.ja を書き換え。--include-choices 指定時は choices[].ja
+も表示用の自然な日本語へ書き換える。reading / ja_typings は触らない。
 
 事前に backfill_question_text_reading.py を必ず実行しておくこと。
 読みが question_text_reading.ja に退避されている前提で動く。
@@ -10,13 +11,16 @@ question_text.ja を漢字かな交じりへ書き換える。
 ローカル LLM (デフォルト: Ollama gemma4:e4b) に問い合わせて自然な
 日本語のクイズ問題文を生成する。フィルタ条件:
 
-- ひらがな比率 >= --min-hiragana-ratio (デフォ 0.6)
-- かつ 漢字数 <= --max-kanji (デフォ 1)
+- デフォルトでは以下の疑わしい項目だけを対象にする
+  - ひらがな比率 >= --min-hiragana-ratio (デフォ 0.6)
+  - かつ 漢字数 <= --max-kanji (デフォ 1)
+- --all 指定時はフィルタせず全件を対象にする
 - 既に question_text_reading.ja が空の場合はスキップ (バックフィル未実行)
 
 usage:
     uv run python3 scripts/restore_ja_question_texts_with_ollama.py data/questions_ja.json --dry-run
     uv run python3 scripts/restore_ja_question_texts_with_ollama.py data/questions_ja.json
+    uv run python3 scripts/restore_ja_question_texts_with_ollama.py data/questions_ja.json --all --include-choices
 """
 
 from __future__ import annotations
@@ -33,27 +37,71 @@ from pathlib import Path
 KANJI_RE = re.compile(r"[一-鿿]")
 
 PROMPT = """\
-英語のクイズ問題文を、自然で読みやすい日本語のクイズ問題文に翻訳してください。
+ひらがな読みのクイズ問題文を、読みを変えずに自然な漢字かな交じり表記へ直してください。
 
 ルール:
-- 漢字とかなをバランスよく使う (現代の自然な書き言葉)
-- 文末は「？」で終える
+- ひらがな読み参考の語順・助詞・文末を変えない
+- 「何ですか」「どれですか」など、読み参考に無い語を追加しない
+- 読み参考に無い説明や言い換えをしない
+- 漢字・カタカナ・英字への表記変換だけを行う
+- 英語は曖昧な固有名詞・専門用語の表記判断にだけ使う
+- 読み参考が「？」で終わるなら、出力も「？」で終える
 - 出力は問題文一行のみ。説明・引用符・注釈・前置きは出力しない
-- 専門用語や英語のキーワードはそのまま英字で残してよい (例: Python, lambda, NaN)
-- 既存のひらがな読みは参考にしてよいが、表記は読みやすく整えること
+- 専門用語や英語のキーワードは英字で残してよい (例: Python, lambda, NaN)
 - LaTeX 記法 ($...$ や \\log など) は使わず、プレーンテキストで書くこと
 - 余計な丸括弧の英訳併記 (例:「ハッシュ衝突（hash collision）」) は付けないこと
 
+専門用語の例:
+- きていじょうけん + base case -> 基底条件 (「規定以上条件」ではない)
+- とれーと + trait -> トレイト
+- れんけつりすと + linked list -> 連結リスト
+- はばゆうせんたんさく + BFS -> 幅優先探索
+- すいちょくすけーりんぐ + vertical scaling -> 垂直スケーリング
+
 英語: {en}
-ひらがな読み参考: {reading}
+ひらがな読み正本: {reading}
 日本語:"""
 
 PROMPT_FALLBACK = """\
-Translate this English quiz question to natural Japanese (mix kanji and kana, modern written style).
-Output only the Japanese question, ending with ？. No explanation, no quotes, single line.
-Keep technical English keywords as-is (e.g. Python, lambda, NaN). No LaTeX, no parenthetical English glosses.
+Convert this Japanese hiragana reading into natural kanji-kana display text without changing its wording.
+Do not add words, do not paraphrase, and do not translate freely.
+Use the English only to disambiguate terms. Output one Japanese question line only.
 
 English: {en}
+Hiragana reading to preserve: {reading}
+Japanese:"""
+
+CHOICE_PROMPT = """\
+ひらがな読みのクイズ回答候補を、読みを変えずに自然な漢字かな交じり表記へ直してください。
+
+ルール:
+- 読み参考の語順・助詞・意味を変えない
+- 読み参考に無い語を追加しない
+- 説明や言い換えをしない
+- 漢字・カタカナ・英字への表記変換だけを行う
+- 英語は曖昧な固有名詞・専門用語の表記判断にだけ使う
+- 文末の句点や疑問符は付けない
+- 出力は回答候補一つだけ。説明・引用符・前置きは出力しない
+- コード、コマンド、HTMLタグ、数式、化学式、略語、固有の英字表記はそのまま残してよい
+- 余計な英訳併記は付けないこと
+
+専門用語の例:
+- きていじょうけん + base case -> 基底条件
+- とれーと + trait -> トレイト
+- れんけつりすと + linked list -> 連結リスト
+- はばゆうせんたんさく + BFS -> 幅優先探索
+
+英語: {en}
+ひらがな読み正本: {reading}
+日本語:"""
+
+CHOICE_PROMPT_FALLBACK = """\
+Convert this Japanese hiragana answer reading into a natural kanji-kana display label without changing its wording.
+Do not add words, do not paraphrase, and do not translate freely.
+Use the English only to disambiguate terms. Output one answer label only.
+
+English: {en}
+Hiragana reading to preserve: {reading}
 Japanese:"""
 
 
@@ -76,13 +124,20 @@ def kanji_count(s: str) -> int:
 
 
 def call_ollama(host: str, model: str, prompt: str, timeout: int) -> str:
+    return call_ollama_with_options(host, model, prompt, timeout, num_predict=120)
+
+
+def call_ollama_with_options(
+    host: str, model: str, prompt: str, timeout: int, *, num_predict: int
+) -> str:
     body = json.dumps(
         {
             "model": model,
             "stream": False,
+            "think": False,
             "options": {
                 "temperature": 0.2,
-                "num_predict": 120,
+                "num_predict": num_predict,
                 "num_ctx": 1024,
             },
             "prompt": prompt,
@@ -96,6 +151,10 @@ def call_ollama(host: str, model: str, prompt: str, timeout: int) -> str:
     )
     with urllib.request.urlopen(req, timeout=timeout) as resp:
         payload = json.loads(resp.read())
+    if payload.get("error"):
+        raise RuntimeError(payload["error"])
+    if not payload.get("response") and payload.get("done_reason") == "length":
+        raise RuntimeError(f"empty response before visible output; increase --num-predict (eval_count={payload.get('eval_count')})")
     return payload.get("response", "").strip()
 
 
@@ -121,6 +180,54 @@ def clean_response(s: str) -> str:
     return s
 
 
+def clean_choice_response(s: str) -> str:
+    s = s.strip()
+    s = s.splitlines()[0].strip() if s else s
+    if not s:
+        return s
+    for opener, closer in (("「", "」"), ('"', '"'), ("'", "'"), ("`", "`")):
+        if s.startswith(opener) and s.endswith(closer) and len(s) >= 2:
+            s = s[1:-1].strip()
+    s = re.sub(r"\$([^$]+)\$", r"\1", s)
+    s = re.sub(r"\\([A-Za-z]+)", r"\1", s)
+    s = re.sub(r"[?？。．\.!！]+\s*$", "", s).strip()
+    return s
+
+
+def should_rewrite_display(s: str, min_hira: float, max_kanji: int, rewrite_all: bool) -> bool:
+    if rewrite_all:
+        return True
+    return hira_ratio(s) >= min_hira and kanji_count(s) <= max_kanji
+
+
+def generate_with_retries(
+    *,
+    host: str,
+    model: str,
+    prompts: list[str],
+    timeout: int,
+    num_predict: int,
+    cleaner,
+) -> tuple[str, str, float, object | None]:
+    raw = ""
+    dt = 0.0
+    last_err = None
+    for prompt in prompts:
+        try:
+            t0 = time.monotonic()
+            raw = call_ollama_with_options(host, model, prompt, timeout, num_predict=num_predict)
+            dt = time.monotonic() - t0
+            cleaned = cleaner(raw)
+            if cleaned and len(cleaned) >= 1:
+                return cleaned, raw, dt, None
+        except (urllib.error.URLError, TimeoutError, OSError, RuntimeError) as e:
+            last_err = e
+            time.sleep(0.5)
+            continue
+        time.sleep(0.3)
+    return "", raw, dt, last_err
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("path", type=Path)
@@ -128,16 +235,24 @@ def main() -> int:
     ap.add_argument("--model", default="gemma4:e4b")
     ap.add_argument("--min-hiragana-ratio", type=float, default=0.6)
     ap.add_argument("--max-kanji", type=int, default=1)
-    ap.add_argument("--limit", type=int, default=0, help="0 = no limit")
+    ap.add_argument("--all", action="store_true", help="rewrite all question_text.ja entries")
+    ap.add_argument(
+        "--include-choices",
+        action="store_true",
+        help="also rewrite choices[].ja display labels; ja_typings are preserved",
+    )
+    ap.add_argument("--limit", type=int, default=0, help="total item limit; 0 = no limit")
     ap.add_argument("--start-id", default=None, help="resume from this question id")
     ap.add_argument("--timeout", type=int, default=120)
+    ap.add_argument("--num-predict", type=int, default=160)
     ap.add_argument("--dry-run", action="store_true")
     ap.add_argument("--verbose", action="store_true")
     args = ap.parse_args()
 
     data = json.loads(args.path.read_text(encoding="utf-8"))
 
-    targets: list[dict] = []
+    question_targets: list[dict] = []
+    choice_targets: list[tuple[dict, int, dict]] = []
     for q in data:
         qt = q.get("question_text") or {}
         qtr = q.get("question_text_reading") or {}
@@ -149,85 +264,151 @@ def main() -> int:
             continue
         if not en:
             continue
-        if hira_ratio(ja) < args.min_hiragana_ratio:
-            continue
-        if kanji_count(ja) > args.max_kanji:
-            continue
-        targets.append(q)
+        if should_rewrite_display(ja, args.min_hiragana_ratio, args.max_kanji, args.all):
+            question_targets.append(q)
+        if args.include_choices:
+            for choice_idx, choice in enumerate(q.get("choices", [])):
+                choice_ja = choice.get("ja", "")
+                choice_en = choice.get("en", "")
+                if not choice_ja or not choice_en:
+                    continue
+                if should_rewrite_display(choice_ja, args.min_hiragana_ratio, args.max_kanji, args.all):
+                    choice_targets.append((q, choice_idx, choice))
 
     if args.start_id is not None:
         skip = True
-        new_targets = []
-        for q in targets:
+        new_question_targets = []
+        for q in question_targets:
             if skip and q.get("id") == args.start_id:
                 skip = False
             if not skip:
-                new_targets.append(q)
-        targets = new_targets
+                new_question_targets.append(q)
+        question_targets = new_question_targets
+
+        skip = True
+        new_choice_targets = []
+        for q, choice_idx, choice in choice_targets:
+            if skip and q.get("id") == args.start_id:
+                skip = False
+            if not skip:
+                new_choice_targets.append((q, choice_idx, choice))
+        choice_targets = new_choice_targets
 
     if args.limit > 0:
-        targets = targets[: args.limit]
+        question_targets = question_targets[: args.limit]
+        remaining = args.limit - len(question_targets)
+        choice_targets = choice_targets[: max(0, remaining)]
 
-    print(f"target: {len(targets)} questions")
+    total_targets = len(question_targets) + len(choice_targets)
+    print(f"target: {len(question_targets)} questions, {len(choice_targets)} choices")
     if args.dry_run:
-        for q in targets[:20]:
+        for q in question_targets[:20]:
             print(f"  {q.get('id')}: {q['question_text']['ja']!r} <- {q['question_text']['en']!r}")
-        if len(targets) > 20:
-            print(f"  ... and {len(targets) - 20} more")
+        if len(question_targets) > 20:
+            print(f"  ... and {len(question_targets) - 20} more questions")
+        for q, choice_idx, choice in choice_targets[:20]:
+            print(f"  {q.get('id')} choice#{choice_idx}: {choice['ja']!r} <- {choice['en']!r}")
+        if len(choice_targets) > 20:
+            print(f"  ... and {len(choice_targets) - 20} more choices")
         return 0
 
     converted = 0
     failed = 0
     started = time.monotonic()
     save_every = 25
-    max_retries = 2
-    for i, q in enumerate(targets, 1):
+    for i, q in enumerate(question_targets, 1):
         en = q["question_text"]["en"]
         reading = q["question_text_reading"]["ja"]
-        new_ja = ""
-        raw = ""
-        dt = 0.0
-        ok = False
-        last_err = None
         # Two prompt variants: primary Japanese-led, fallback English-led
         # (Gemma occasionally returns whitespace-only output for the JP prompt
         # on certain inputs — the EN-led prompt rescues those cases).
-        for attempt in range(max_retries + 1):
-            prompt = (PROMPT if attempt == 0 else PROMPT_FALLBACK).format(en=en, reading=reading)
-            try:
-                t0 = time.monotonic()
-                raw = call_ollama(args.ollama_host, args.model, prompt, args.timeout)
-                dt = time.monotonic() - t0
-                new_ja = clean_response(raw)
-                if new_ja and len(new_ja) >= 3:
-                    ok = True
-                    break
-            except (urllib.error.URLError, TimeoutError, OSError) as e:
-                last_err = e
-                time.sleep(0.5)
-                continue
-            time.sleep(0.3)
-        if not ok:
+        prompts = [
+            PROMPT.format(en=en, reading=reading),
+            PROMPT_FALLBACK.format(en=en, reading=reading),
+            PROMPT_FALLBACK.format(en=en, reading=reading),
+        ]
+        new_ja, raw, dt, last_err = generate_with_retries(
+            host=args.ollama_host,
+            model=args.model,
+            prompts=prompts,
+            timeout=args.timeout,
+            num_predict=args.num_predict,
+            cleaner=clean_response,
+        )
+        if not new_ja or len(new_ja) < 3:
             failed += 1
             if last_err is not None:
-                print(f"  [{i}/{len(targets)}] {q.get('id')} ERROR after retries: {last_err}", file=sys.stderr)
+                print(
+                    f"  [question {i}/{len(question_targets)}] {q.get('id')} ERROR after retries: {last_err}",
+                    file=sys.stderr,
+                )
             else:
-                print(f"  [{i}/{len(targets)}] {q.get('id')} EMPTY after retries: {raw!r}", file=sys.stderr)
+                print(
+                    f"  [question {i}/{len(question_targets)}] {q.get('id')} EMPTY after retries: {raw!r}",
+                    file=sys.stderr,
+                )
             continue
         old_ja = q["question_text"]["ja"]
         q["question_text"]["ja"] = new_ja
         converted += 1
         if args.verbose or i <= 3 or i % 25 == 0:
-            print(f"  [{i}/{len(targets)}] {q.get('id')} {dt:.1f}s  {old_ja!r} -> {new_ja!r}")
+            print(f"  [question {i}/{len(question_targets)}] {q.get('id')} {dt:.1f}s  {old_ja!r} -> {new_ja!r}")
         if i % save_every == 0:
             args.path.write_text(
                 json.dumps(data, ensure_ascii=False, indent=2) + "\n",
                 encoding="utf-8",
             )
             elapsed = time.monotonic() - started
-            rate = i / elapsed
-            eta = (len(targets) - i) / rate if rate else 0
-            print(f"    -- checkpoint saved ({i}/{len(targets)}, {rate:.2f} q/s, ETA {eta/60:.1f} min)")
+            done = i
+            rate = done / elapsed
+            eta = (total_targets - done) / rate if rate else 0
+            print(f"    -- checkpoint saved ({done}/{total_targets}, {rate:.2f} item/s, ETA {eta/60:.1f} min)")
+
+    offset = len(question_targets)
+    for j, (q, choice_idx, choice) in enumerate(choice_targets, 1):
+        en = choice["en"]
+        reading = choice["ja"]
+        prompts = [
+            CHOICE_PROMPT.format(en=en, reading=reading),
+            CHOICE_PROMPT_FALLBACK.format(en=en, reading=reading),
+            CHOICE_PROMPT_FALLBACK.format(en=en, reading=reading),
+        ]
+        new_ja, raw, dt, last_err = generate_with_retries(
+            host=args.ollama_host,
+            model=args.model,
+            prompts=prompts,
+            timeout=args.timeout,
+            num_predict=args.num_predict,
+            cleaner=clean_choice_response,
+        )
+        if not new_ja:
+            failed += 1
+            if last_err is not None:
+                print(
+                    f"  [choice {j}/{len(choice_targets)}] {q.get('id')}#{choice_idx} ERROR after retries: {last_err}",
+                    file=sys.stderr,
+                )
+            else:
+                print(
+                    f"  [choice {j}/{len(choice_targets)}] {q.get('id')}#{choice_idx} EMPTY after retries: {raw!r}",
+                    file=sys.stderr,
+                )
+            continue
+        old_ja = choice["ja"]
+        choice["ja"] = new_ja
+        converted += 1
+        if args.verbose or j <= 3 or j % 50 == 0:
+            print(f"  [choice {j}/{len(choice_targets)}] {q.get('id')}#{choice_idx} {dt:.1f}s  {old_ja!r} -> {new_ja!r}")
+        done = offset + j
+        if done % save_every == 0:
+            args.path.write_text(
+                json.dumps(data, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            elapsed = time.monotonic() - started
+            rate = done / elapsed
+            eta = (total_targets - done) / rate if rate else 0
+            print(f"    -- checkpoint saved ({done}/{total_targets}, {rate:.2f} item/s, ETA {eta/60:.1f} min)")
 
     args.path.write_text(
         json.dumps(data, ensure_ascii=False, indent=2) + "\n",

--- a/src/bin/lint-questions.rs
+++ b/src/bin/lint-questions.rs
@@ -90,7 +90,7 @@ fn find_ja_typing_errors(path: &str, questions: &[Question]) -> Vec<String> {
             let Some(ja) = choice.labels.get("ja") else {
                 continue;
             };
-            if contains_han(ja) && choice.ja_typings.is_empty() {
+            if choice.ja_typings.is_empty() && contains_han(ja) {
                 errors.push(format!(
                     "[ja_typings missing] question {} choice #{} has non-kana ja={:?}",
                     question.id, choice_idx, ja
@@ -114,7 +114,7 @@ fn find_ja_typing_errors(path: &str, questions: &[Question]) -> Vec<String> {
                 ));
             }
 
-            if !contains_han(ja) {
+            if choice.ja_typings.is_empty() && !contains_han(ja) {
                 let expected = expected_ja_typings(ja);
                 if let Some(reason) = ja_typing_mismatch_reason(choice, &actual, &expected) {
                     errors.push(format!(

--- a/src/game/quiz.rs
+++ b/src/game/quiz.rs
@@ -304,6 +304,7 @@ mod tests {
             id: "q-test".into(),
             genre: "test".into(),
             question_text,
+            question_text_reading: HashMap::new(),
             choices,
             correct_answer_index: correct,
             image_path: None,

--- a/src/io/data_loader.rs
+++ b/src/io/data_loader.rs
@@ -109,6 +109,18 @@ impl DataLoader {
             })
     }
 
+    /// Phonetic reading form (hiragana for ja). Falls back to display text when
+    /// the reading field is absent so older question files keep working.
+    /// Used by TTS / RPG audio paths.
+    #[allow(dead_code)]
+    pub fn get_question_reading_text(question: &Question, language: &Language) -> String {
+        question
+            .question_text_reading
+            .get(language.code())
+            .cloned()
+            .unwrap_or_else(|| Self::get_question_text(question, language))
+    }
+
     pub fn get_choice_text(choice: &Choice, language: &Language) -> String {
         choice
             .labels

--- a/src/io/data_loader.rs
+++ b/src/io/data_loader.rs
@@ -136,6 +136,11 @@ impl DataLoader {
                 for typing in &choice.ja_typings {
                     variants.push(typing.to_lowercase());
                 }
+                if !variants.is_empty() {
+                    variants.sort();
+                    variants.dedup();
+                    return variants;
+                }
                 let displayed = Self::get_choice_text(choice, language);
                 if displayed.is_ascii() {
                     variants.push(displayed.to_lowercase());
@@ -216,7 +221,7 @@ mod tests {
                 ("ja".to_string(), "とうきょう".to_string()),
                 ("en".to_string(), "Tokyo".to_string()),
             ]),
-            ja_typings: vec!["tokyo".to_string()],
+            ja_typings: vec!["tokyo".to_string(), "toukyou".to_string()],
         };
         assert_eq!(
             DataLoader::get_choice_typing_texts(&choice, &Language::Japanese),

--- a/src/io/validator.rs
+++ b/src/io/validator.rs
@@ -171,6 +171,7 @@ mod tests {
             id: id.into(),
             genre: "test".into(),
             question_text,
+            question_text_reading: HashMap::new(),
             choices,
             correct_answer_index: 0,
             image_path: None,
@@ -297,6 +298,7 @@ mod tests {
                 m.insert("ja".to_string(), "ダミー".to_string());
                 m
             },
+            question_text_reading: HashMap::new(),
             choices: vec![
                 {
                     let mut labels = HashMap::new();
@@ -338,6 +340,7 @@ mod tests {
                 m.insert("ja".to_string(), "ダミー".to_string());
                 m
             },
+            question_text_reading: HashMap::new(),
             choices: vec![
                 {
                     let mut labels = HashMap::new();

--- a/src/io/validator.rs
+++ b/src/io/validator.rs
@@ -80,6 +80,11 @@ fn typing_texts(choice: &Choice, language: &str) -> Vec<String> {
                 .iter()
                 .map(|typing| typing.to_lowercase())
                 .collect();
+            if !variants.is_empty() {
+                variants.sort();
+                variants.dedup();
+                return variants;
+            }
             let Some(displayed) = choice.labels.get(language) else {
                 return variants;
             };

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,6 +6,12 @@ pub struct Question {
     pub id: String,
     pub genre: String,
     pub question_text: HashMap<String, String>,
+    /// Per-language reading form (hiragana for ja, identical to display for en).
+    /// Used by TTS / future RPG audio paths and as a safety net if `question_text`
+    /// gets rewritten by a migration. Optional for backwards compatibility with
+    /// older question files.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub question_text_reading: HashMap<String, String>,
     pub choices: Vec<Choice>,
     pub correct_answer_index: usize,
     pub image_path: Option<String>,


### PR DESCRIPTION
## 概要

Issue #92「JAクイズの問題文・選択肢が全てひらがな表示」への対応。実態は表示ロジックではなくマスターデータ側で `question_text.ja` がひらがな主体だったため、データ側を直す方針で対応。

## 変更点

### コード

- `Question` に `question_text_reading: HashMap<String, String>` 追加。読み (TTS / RPG 音声系) と表示を分離する。`#[serde(default)]` で旧データ互換
- `DataLoader::get_question_reading_text()` 追加。reading が無ければ display にフォールバック

### Migration スクリプト (`scripts/`)

- `backfill_question_text_reading.py` — 既存 `question_text` を reading に複製 (idempotent)
- `restore_ja_question_texts_with_ollama.py` — ローカル Gemma で `question_text.ja` のみ書き換え。reading は触らない
- `question_text_stats.py` / `list_suspect_question_texts.py` — 診断

### データ

`data/questions_ja.json` の 564 問を Gemma 4 (gemma4:e4b on kako-rog Windows Ollama) で書き換え。

| 指標 | before | after |
|---|---|---|
| ひらがな主体 (>=0.6 ratio かつ kanji<=1) | 658 | 49 |
| 漢字ゼロ | 380 | 97 |

残り 49 (~5.5%) の suspect は: カタカナ語が主の問題で漢字が必要ない (e.g. `マイクロサービスとはどのようなものですか？`)、または変換に失敗した anime/manga 系の少数。`scripts/list_suspect_question_texts.py` で再列挙可能。

### docs

- `docs/spec.md` の Quiz schema を JSON ベースで更新、新フィールド明記、migration recipe 追記
- `README.md` に `## Maintenance scripts` セクション追加

## Test plan

- [x] `cargo test` (148 + 33 + 7 = 188 件) 全 pass
- [x] `cargo run --bin lint-questions -- data/questions_ja.json data/questions_en.json` クリーン
- [ ] `cargo install --path .` で実機 JA Quiz を回し、表示が漢字かな混じりになっていることを目視
- [ ] suspect 49 問を順次手動修正 (別タスク)

Closes #92