### PR TITLE
chore: clippy --all-targets の警告7件を解消

### DIFF
--- a/src/game/quiz.rs
+++ b/src/game/quiz.rs
@@ -37,11 +37,11 @@ pub struct QuizGame {
 pub struct QuizResult {
     #[cfg_attr(not(test), allow(dead_code))]
     pub is_correct: bool,
-    #[cfg_attr(not(test), allow(dead_code))]
+    #[allow(dead_code)]
     pub correct_answer_index: usize,
     #[cfg_attr(not(test), allow(dead_code))]
     pub selected_answer_index: usize,
-    #[cfg_attr(not(test), allow(dead_code))]
+    #[allow(dead_code)]
     pub time_taken: Duration,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -389,7 +389,7 @@ mod tests {
             Some(Commands::Quiz { seed, .. }) => {
                 assert_eq!(seed, Some(u64::MAX));
             }
-            other => panic!("expected Quiz subcommand, got {:?}", other),
+            other => panic!("expected Quiz subcommand, got {other:?}"),
         }
     }
 
@@ -402,7 +402,7 @@ mod tests {
             Some(Commands::Rpg { floor, .. }) => {
                 assert_eq!(floor, Some(u32::MAX));
             }
-            other => panic!("expected Rpg subcommand, got {:?}", other),
+            other => panic!("expected Rpg subcommand, got {other:?}"),
         }
     }
 

--- a/src/ui/input_loop.rs
+++ b/src/ui/input_loop.rs
@@ -152,7 +152,7 @@ mod tests {
         tx.send(key).unwrap();
         match input.recv_until(Duration::from_millis(100)) {
             RecvOutcome::Key(k) => assert_eq!(k.code, KeyCode::Char('x')),
-            other => panic!("expected Key, got {:?}", other),
+            other => panic!("expected Key, got {other:?}"),
         }
     }
 
@@ -173,7 +173,7 @@ mod tests {
         drop(tx);
         match input.recv_until(Duration::from_millis(100)) {
             RecvOutcome::Disconnected => {}
-            other => panic!("expected Disconnected, got {:?}", other),
+            other => panic!("expected Disconnected, got {other:?}"),
         }
     }
 

--- a/src/ui/listen.rs
+++ b/src/ui/listen.rs
@@ -478,6 +478,17 @@ impl ListenUI {
     }
 }
 
+/// Build a one-line message for callers that want to surface a TTS
+/// init failure to the player without crashing the run. Shared so the
+/// menu and any future entry points format it consistently.
+pub fn tts_unavailable_message(err: &dyn std::error::Error) -> String {
+    format!(
+        "Listening mode is unavailable on this system: {err}\n\
+         (On Linux, install and start `speech-dispatcher`.)\n\
+         Press Enter to return to the menu."
+    )
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -544,15 +555,4 @@ mod tests {
         ui.replay();
         assert_eq!(ui.plays, 2, "plays should be +2 after second replay()");
     }
-}
-
-/// Build a one-line message for callers that want to surface a TTS
-/// init failure to the player without crashing the run. Shared so the
-/// menu and any future entry points format it consistently.
-pub fn tts_unavailable_message(err: &dyn std::error::Error) -> String {
-    format!(
-        "Listening mode is unavailable on this system: {err}\n\
-         (On Linux, install and start `speech-dispatcher`.)\n\
-         Press Enter to return to the menu."
-    )
 }

--- a/src/ui/records.rs
+++ b/src/ui/records.rs
@@ -291,7 +291,7 @@ mod tests {
             score,
             cpm: 0,
             wpm: 0,
-            ts: format!("1970-01-01T{:02}:00:00Z", ts),
+            ts: format!("1970-01-01T{ts:02}:00:00Z"),
         }
     }
 


### PR DESCRIPTION
## 変更内容

`cargo clippy --all-targets -- -D warnings` がクリーンに通るように:

- **uninlined_format_args** (5箇所): `panic!("... {:?}", x)` → `panic!("... {x:?}")` 等
  - src/main.rs, src/ui/input_loop.rs, src/ui/records.rs
- **items_after_test_module**: `src/ui/listen.rs` の `tts_unavailable_message` を test mod の前に移動
- **dead_code**: `src/game/quiz.rs` の `QuizResult.correct_answer_index` / `time_taken` を test 限定 allow から無条件 `#[allow(dead_code)]` へ（テストでも実利用していないため）

#97 セルフレビューで指摘された別件の hygiene 系警告をまとめて対応。挙動への変更なし。

## テスト
- `cargo clippy --all-targets -- -D warnings` → クリーン
- `cargo test` → 180 passed