### PR TITLE
feat: 問題数を735から1768に拡充 (+1033問)

### DIFF
--- a/data/questions_en.json
+++ b/data/questions_en.json
@@ -30136,5 +30136,2757 @@
     "correct_answer_index": 1,
     "image_path": null,
     "ja_reviewed": true
+  },
+  {
+    "choices": [
+      {
+        "en": "merge --no-ff",
+        "ja": "マージノーエフエフ",
+        "ja_typings": []
+      },
+      {
+        "en": "rebase",
+        "ja": "リベース",
+        "ja_typings": []
+      },
+      {
+        "en": "cherry-pick",
+        "ja": "チェリーピック",
+        "ja_typings": []
+      },
+      {
+        "en": "squash",
+        "ja": "スカッシュ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00736",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Git command merges by creating a new commit that combines branch histories without fast-forward?",
+      "ja": "ファストフォワードなしで新しいコミットを作ってブランチ履歴をマージする Git コマンドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "301",
+        "ja": "サンマルイチ",
+        "ja_typings": []
+      },
+      {
+        "en": "302",
+        "ja": "サンマルニ",
+        "ja_typings": []
+      },
+      {
+        "en": "307",
+        "ja": "サンマルナナ",
+        "ja_typings": []
+      },
+      {
+        "en": "308",
+        "ja": "サンマルハチ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00737",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status code indicates that the requested resource was permanently moved?",
+      "ja": "リクエストされたリソースが恒久的に移動したことを示す HTTP ステータスコードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Singleton",
+        "ja": "シングルトン",
+        "ja_typings": []
+      },
+      {
+        "en": "Factory",
+        "ja": "ファクトリー",
+        "ja_typings": []
+      },
+      {
+        "en": "Builder",
+        "ja": "ビルダー",
+        "ja_typings": []
+      },
+      {
+        "en": "Prototype",
+        "ja": "プロトタイプ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00738",
+    "image_path": null,
+    "question_text": {
+      "en": "Which design pattern ensures a class has only one instance?",
+      "ja": "クラスがただ一つのインスタンスしか持たないことを保証するデザインパターンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SFTP",
+        "ja": "エスエフティーピー",
+        "ja_typings": []
+      },
+      {
+        "en": "FTPS",
+        "ja": "エフティーピーエス",
+        "ja_typings": []
+      },
+      {
+        "en": "FTP",
+        "ja": "エフティーピー",
+        "ja_typings": []
+      },
+      {
+        "en": "TFTP",
+        "ja": "ティーエフティーピー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00739",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol is used to securely transfer files over SSH?",
+      "ja": "SSH 経由で安全にファイルを転送するプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ReplicaSet",
+        "ja": "レプリカセット",
+        "ja_typings": []
+      },
+      {
+        "en": "DaemonSet",
+        "ja": "デーモンセット",
+        "ja_typings": []
+      },
+      {
+        "en": "StatefulSet",
+        "ja": "ステートフルセット",
+        "ja_typings": []
+      },
+      {
+        "en": "Job",
+        "ja": "ジョブ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00740",
+    "image_path": null,
+    "question_text": {
+      "en": "In Kubernetes, what controller maintains a stable set of replica Pods?",
+      "ja": "Kubernetes でレプリカ Pod の安定集合を維持するコントローラーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aurora",
+        "ja": "オーロラ",
+        "ja_typings": []
+      },
+      {
+        "en": "DynamoDB",
+        "ja": "ダイナモディービー",
+        "ja_typings": []
+      },
+      {
+        "en": "Redshift",
+        "ja": "レッドシフト",
+        "ja_typings": []
+      },
+      {
+        "en": "Neptune",
+        "ja": "ネプチューン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00741",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS service provides a fully managed relational database for PostgreSQL with Aurora compatibility?",
+      "ja": "Aurora 互換のマネージドリレーショナル DB を提供する AWS サービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Consistency",
+        "ja": "コンシステンシー",
+        "ja_typings": []
+      },
+      {
+        "en": "Availability",
+        "ja": "アベイラビリティ",
+        "ja_typings": []
+      },
+      {
+        "en": "Partition tolerance",
+        "ja": "パーティショントレランス",
+        "ja_typings": []
+      },
+      {
+        "en": "Durability",
+        "ja": "デュラビリティ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00742",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CAP theorem property guarantees every read returns the most recent write?",
+      "ja": "CAP 定理で、すべての読み出しが最新の書き込みを返すことを保証する性質は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Integration test",
+        "ja": "インテグレーションテスト",
+        "ja_typings": []
+      },
+      {
+        "en": "Unit test",
+        "ja": "ユニットテスト",
+        "ja_typings": []
+      },
+      {
+        "en": "End-to-end test",
+        "ja": "エンドトゥーエンドテスト",
+        "ja_typings": []
+      },
+      {
+        "en": "Smoke test",
+        "ja": "スモークテスト",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00743",
+    "image_path": null,
+    "question_text": {
+      "en": "Which test type checks the integration of multiple modules working together?",
+      "ja": "複数のモジュールが連携して動作することを検証するテストの種類は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Transport layer",
+        "ja": "トランスポート層",
+        "ja_typings": []
+      },
+      {
+        "en": "Network layer",
+        "ja": "ネットワーク層",
+        "ja_typings": []
+      },
+      {
+        "en": "Session layer",
+        "ja": "セッション層",
+        "ja_typings": []
+      },
+      {
+        "en": "Data link layer",
+        "ja": "データリンク層",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00744",
+    "image_path": null,
+    "question_text": {
+      "en": "Which OSI model layer is responsible for end-to-end communication and reliability?",
+      "ja": "OSI 参照モデルでエンドツーエンドの通信と信頼性を担う層は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Durability",
+        "ja": "デュラビリティ",
+        "ja_typings": []
+      },
+      {
+        "en": "Isolation",
+        "ja": "アイソレーション",
+        "ja_typings": []
+      },
+      {
+        "en": "Consistency",
+        "ja": "コンシステンシー",
+        "ja_typings": []
+      },
+      {
+        "en": "Atomicity",
+        "ja": "アトミシティ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00745",
+    "image_path": null,
+    "question_text": {
+      "en": "Which database concept ensures that committed data survives system failures?",
+      "ja": "コミット済みのデータがシステム障害後も残ることを保証する DB の概念は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ip route",
+        "ja": "アイピールート",
+        "ja_typings": []
+      },
+      {
+        "en": "netstat",
+        "ja": "ネットスタット",
+        "ja_typings": []
+      },
+      {
+        "en": "traceroute",
+        "ja": "トレースルート",
+        "ja_typings": []
+      },
+      {
+        "en": "ifconfig",
+        "ja": "アイエフコンフィグ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00746",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Linux command shows the routing table?",
+      "ja": "Linux でルーティングテーブルを表示するコマンドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Retrospective",
+        "ja": "レトロスペクティブ",
+        "ja_typings": []
+      },
+      {
+        "en": "Sprint Review",
+        "ja": "スプリントレビュー",
+        "ja_typings": []
+      },
+      {
+        "en": "Daily Stand-up",
+        "ja": "デイリースタンドアップ",
+        "ja_typings": []
+      },
+      {
+        "en": "Sprint Planning",
+        "ja": "スプリントプランニング",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00747",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Agile ceremony reviews what the team learned during the sprint to improve processes?",
+      "ja": "プロセス改善のためスプリント中の学びを振り返るアジャイルのセレモニーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SQS",
+        "ja": "エスキューエス",
+        "ja_typings": []
+      },
+      {
+        "en": "SNS",
+        "ja": "エスエヌエス",
+        "ja_typings": []
+      },
+      {
+        "en": "Kinesis",
+        "ja": "キネシス",
+        "ja_typings": []
+      },
+      {
+        "en": "EventBridge",
+        "ja": "イベントブリッジ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00748",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS service provides a managed message queue?",
+      "ja": "マネージドメッセージキューを提供する AWS サービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Functional programming",
+        "ja": "関数型プログラミング",
+        "ja_typings": []
+      },
+      {
+        "en": "Object-oriented programming",
+        "ja": "オブジェクト指向プログラミング",
+        "ja_typings": []
+      },
+      {
+        "en": "Procedural programming",
+        "ja": "手続き型プログラミング",
+        "ja_typings": []
+      },
+      {
+        "en": "Logic programming",
+        "ja": "論理型プログラミング",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00749",
+    "image_path": null,
+    "question_text": {
+      "en": "Which programming paradigm treats computation as evaluation of mathematical functions?",
+      "ja": "計算を数学的関数の評価として扱うプログラミングパラダイムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SAML",
+        "ja": "サムル",
+        "ja_typings": []
+      },
+      {
+        "en": "OAuth",
+        "ja": "オーオース",
+        "ja_typings": []
+      },
+      {
+        "en": "OpenID Connect",
+        "ja": "オープンアイディーコネクト",
+        "ja_typings": []
+      },
+      {
+        "en": "Kerberos",
+        "ja": "ケルベロス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00750",
+    "image_path": null,
+    "question_text": {
+      "en": "Which authentication standard is widely used for federated single sign-on with XML assertions?",
+      "ja": "XML アサーションでフェデレーテッド SSO に広く使われる認証規格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lead Time for Changes",
+        "ja": "リードタイムフォーチェンジズ",
+        "ja_typings": []
+      },
+      {
+        "en": "Mean Time to Recover",
+        "ja": "ミーンタイムトゥーリカバー",
+        "ja_typings": []
+      },
+      {
+        "en": "Change Failure Rate",
+        "ja": "チェンジフェイリャーレート",
+        "ja_typings": []
+      },
+      {
+        "en": "Deployment Frequency",
+        "ja": "デプロイメントフリークエンシー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00751",
+    "image_path": null,
+    "question_text": {
+      "en": "Which DevOps metric measures the time from code commit to production deployment?",
+      "ja": "コミットから本番デプロイまでの時間を計測する DevOps メトリクスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SaaS",
+        "ja": "サース",
+        "ja_typings": []
+      },
+      {
+        "en": "PaaS",
+        "ja": "パース",
+        "ja_typings": []
+      },
+      {
+        "en": "IaaS",
+        "ja": "アイアース",
+        "ja_typings": []
+      },
+      {
+        "en": "FaaS",
+        "ja": "ファース",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00752",
+    "image_path": null,
+    "question_text": {
+      "en": "Which type of cloud computing service provides ready-to-use applications over the internet?",
+      "ja": "利用可能なアプリケーションをインターネット経由で提供するクラウドサービス種別は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "wa",
+        "ja": "は",
+        "ja_typings": []
+      },
+      {
+        "en": "ga",
+        "ja": "が",
+        "ja_typings": []
+      },
+      {
+        "en": "wo",
+        "ja": "を",
+        "ja_typings": []
+      },
+      {
+        "en": "ni",
+        "ja": "に",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00753",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese particle marks the topic of a sentence?",
+      "ja": "日本語で文の主題を示す助詞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Uralic",
+        "ja": "ウラル語族",
+        "ja_typings": []
+      },
+      {
+        "en": "Indo-European",
+        "ja": "インドヨーロッパ語族",
+        "ja_typings": []
+      },
+      {
+        "en": "Turkic",
+        "ja": "テュルク語族",
+        "ja_typings": []
+      },
+      {
+        "en": "Altaic",
+        "ja": "アルタイ語族",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00754",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language family does Finnish belong to?",
+      "ja": "フィンランド語が属する語族は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Homophone",
+        "ja": "同音異義語",
+        "ja_typings": []
+      },
+      {
+        "en": "Synonym",
+        "ja": "類義語",
+        "ja_typings": []
+      },
+      {
+        "en": "Antonym",
+        "ja": "対義語",
+        "ja_typings": []
+      },
+      {
+        "en": "Hyponym",
+        "ja": "下位語",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00755",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the linguistic term for words that sound the same but have different meanings?",
+      "ja": "音は同じだが意味が異なる単語を指す言語学用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cuneiform",
+        "ja": "楔形文字",
+        "ja_typings": []
+      },
+      {
+        "en": "Hieroglyphs",
+        "ja": "ヒエログリフ",
+        "ja_typings": []
+      },
+      {
+        "en": "Linear A",
+        "ja": "線文字A",
+        "ja_typings": []
+      },
+      {
+        "en": "Phoenician",
+        "ja": "フェニキア文字",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00756",
+    "image_path": null,
+    "question_text": {
+      "en": "Which writing system was used in ancient Mesopotamia?",
+      "ja": "古代メソポタミアで使われた文字体系は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Humble language",
+        "ja": "謙譲語",
+        "ja_typings": []
+      },
+      {
+        "en": "Respectful language",
+        "ja": "尊敬語",
+        "ja_typings": []
+      },
+      {
+        "en": "Polite language",
+        "ja": "丁寧語",
+        "ja_typings": []
+      },
+      {
+        "en": "Beautified language",
+        "ja": "美化語",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00757",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese honorific form lowers the speaker to elevate the listener?",
+      "ja": "話者を低めて聴者を高める日本語の敬語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Accusative",
+        "ja": "対格",
+        "ja_typings": []
+      },
+      {
+        "en": "Nominative",
+        "ja": "主格",
+        "ja_typings": []
+      },
+      {
+        "en": "Genitive",
+        "ja": "属格",
+        "ja_typings": []
+      },
+      {
+        "en": "Dative",
+        "ja": "与格",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00758",
+    "image_path": null,
+    "question_text": {
+      "en": "Which grammatical case marks the direct object in Latin?",
+      "ja": "ラテン語で直接目的語を示す格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fourth tone",
+        "ja": "第四声",
+        "ja_typings": []
+      },
+      {
+        "en": "First tone",
+        "ja": "第一声",
+        "ja_typings": []
+      },
+      {
+        "en": "Second tone",
+        "ja": "第二声",
+        "ja_typings": []
+      },
+      {
+        "en": "Third tone",
+        "ja": "第三声",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00759",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Chinese tone is described as a sharp falling tone?",
+      "ja": "中国語で鋭く下がる調子とされる四声は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Loanword",
+        "ja": "借用語",
+        "ja_typings": []
+      },
+      {
+        "en": "Calque",
+        "ja": "翻訳借用",
+        "ja_typings": []
+      },
+      {
+        "en": "Cognate",
+        "ja": "同源語",
+        "ja_typings": []
+      },
+      {
+        "en": "Neologism",
+        "ja": "新造語",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00760",
+    "image_path": null,
+    "question_text": {
+      "en": "Which term refers to the borrowing of a word from another language with adaptation?",
+      "ja": "他言語からの適応付き単語借用を指す用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Past perfect",
+        "ja": "過去完了",
+        "ja_typings": []
+      },
+      {
+        "en": "Present perfect",
+        "ja": "現在完了",
+        "ja_typings": []
+      },
+      {
+        "en": "Future perfect",
+        "ja": "未来完了",
+        "ja_typings": []
+      },
+      {
+        "en": "Simple past",
+        "ja": "過去",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00761",
+    "image_path": null,
+    "question_text": {
+      "en": "In English grammar, which tense expresses an action completed before another past action?",
+      "ja": "英文法で、別の過去の行為より前に完了した行為を表す時制は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Romanian",
+        "ja": "ルーマニア語",
+        "ja_typings": []
+      },
+      {
+        "en": "Italian",
+        "ja": "イタリア語",
+        "ja_typings": []
+      },
+      {
+        "en": "Spanish",
+        "ja": "スペイン語",
+        "ja_typings": []
+      },
+      {
+        "en": "Catalan",
+        "ja": "カタルーニャ語",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00762",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Romance language is the official language of Romania?",
+      "ja": "ルーマニアの公用語であるロマンス諸語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hangul",
+        "ja": "ハングル",
+        "ja_typings": []
+      },
+      {
+        "en": "Hanja",
+        "ja": "ハンジャ",
+        "ja_typings": []
+      },
+      {
+        "en": "Katakana",
+        "ja": "カタカナ",
+        "ja_typings": []
+      },
+      {
+        "en": "Cyrillic",
+        "ja": "キリル文字",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00763",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the official script used to write Korean?",
+      "ja": "朝鮮語の表記に使われる公式文字は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Verb",
+        "ja": "動詞",
+        "ja_typings": []
+      },
+      {
+        "en": "i-adjective",
+        "ja": "イ形容詞",
+        "ja_typings": []
+      },
+      {
+        "en": "na-adjective",
+        "ja": "ナ形容詞",
+        "ja_typings": []
+      },
+      {
+        "en": "Adverb",
+        "ja": "副詞",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00764",
+    "image_path": null,
+    "question_text": {
+      "en": "Which kind of word in Japanese conjugates and ends in u?",
+      "ja": "日本語でウ段で終わり活用する品詞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Simile",
+        "ja": "直喩",
+        "ja_typings": []
+      },
+      {
+        "en": "Metaphor",
+        "ja": "隠喩",
+        "ja_typings": []
+      },
+      {
+        "en": "Personification",
+        "ja": "擬人法",
+        "ja_typings": []
+      },
+      {
+        "en": "Hyperbole",
+        "ja": "誇張法",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00765",
+    "image_path": null,
+    "question_text": {
+      "en": "Which figure of speech compares two things using like or as?",
+      "ja": "「ようだ」「みたいに」を使って似たものを喩える修辞法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Serbian",
+        "ja": "セルビア語",
+        "ja_typings": []
+      },
+      {
+        "en": "Russian",
+        "ja": "ロシア語",
+        "ja_typings": []
+      },
+      {
+        "en": "Polish",
+        "ja": "ポーランド語",
+        "ja_typings": []
+      },
+      {
+        "en": "Czech",
+        "ja": "チェコ語",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00766",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Slavic language is written with both Latin and Cyrillic scripts officially?",
+      "ja": "ラテン文字とキリル文字の両方が公式に使われるスラブ語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Niger-Congo",
+        "ja": "ニジェールコンゴ語族",
+        "ja_typings": []
+      },
+      {
+        "en": "Indo-European",
+        "ja": "インドヨーロッパ語族",
+        "ja_typings": []
+      },
+      {
+        "en": "Sino-Tibetan",
+        "ja": "シナチベット語族",
+        "ja_typings": []
+      },
+      {
+        "en": "Austronesian",
+        "ja": "オーストロネシア語族",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00767",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the largest language family in the world by number of languages?",
+      "ja": "言語数で世界最大の語族は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "To-on",
+        "ja": "唐音",
+        "ja_typings": []
+      },
+      {
+        "en": "Go-on",
+        "ja": "呉音",
+        "ja_typings": []
+      },
+      {
+        "en": "Kan-on",
+        "ja": "漢音",
+        "ja_typings": []
+      },
+      {
+        "en": "Kun-yomi",
+        "ja": "訓読み",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00768",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese kanji reading was brought from Tang-dynasty China?",
+      "ja": "唐代中国から伝わった漢字の読みは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sumerian cuneiform",
+        "ja": "シュメール楔形文字",
+        "ja_typings": []
+      },
+      {
+        "en": "Egyptian hieroglyphs",
+        "ja": "エジプトヒエログリフ",
+        "ja_typings": []
+      },
+      {
+        "en": "Chinese oracle bone script",
+        "ja": "中国甲骨文字",
+        "ja_typings": []
+      },
+      {
+        "en": "Indus script",
+        "ja": "インダス文字",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00769",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the oldest known fully deciphered writing system?",
+      "ja": "完全に解読された最古の文字体系は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kimchi",
+        "ja": "キムチ",
+        "ja_typings": []
+      },
+      {
+        "en": "Bibimbap",
+        "ja": "ビビンバ",
+        "ja_typings": []
+      },
+      {
+        "en": "Bulgogi",
+        "ja": "プルコギ",
+        "ja_typings": []
+      },
+      {
+        "en": "Japchae",
+        "ja": "チャプチェ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00770",
+    "image_path": null,
+    "question_text": {
+      "en": "Which traditional Korean dish consists of fermented vegetables, typically cabbage?",
+      "ja": "発酵野菜、特に白菜を使った韓国の伝統料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Galette",
+        "ja": "ガレット",
+        "ja_typings": []
+      },
+      {
+        "en": "Crepe",
+        "ja": "クレープ",
+        "ja_typings": []
+      },
+      {
+        "en": "Frittata",
+        "ja": "フリッタータ",
+        "ja_typings": []
+      },
+      {
+        "en": "Quiche",
+        "ja": "キッシュ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00771",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French dish is a thin pancake filled with savory ingredients, originally from Brittany?",
+      "ja": "ブルターニュ地方発祥の塩味の薄焼き菓子料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Obon",
+        "ja": "お盆",
+        "ja_typings": []
+      },
+      {
+        "en": "Tanabata",
+        "ja": "七夕",
+        "ja_typings": []
+      },
+      {
+        "en": "Hanami",
+        "ja": "花見",
+        "ja_typings": []
+      },
+      {
+        "en": "Shichigosan",
+        "ja": "七五三",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00772",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese summer festival features paper lanterns and is held in mid-August to honor ancestors?",
+      "ja": "8月中旬に先祖供養のため灯籠を掲げる日本の夏祭りは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Paella",
+        "ja": "パエリア",
+        "ja_typings": []
+      },
+      {
+        "en": "Risotto",
+        "ja": "リゾット",
+        "ja_typings": []
+      },
+      {
+        "en": "Jambalaya",
+        "ja": "ジャンバラヤ",
+        "ja_typings": []
+      },
+      {
+        "en": "Biryani",
+        "ja": "ビリヤニ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00773",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Spanish dish features saffron-flavored rice with seafood or meat?",
+      "ja": "サフラン風味の米にシーフードや肉を入れたスペイン料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Day of the Dead",
+        "ja": "死者の日",
+        "ja_typings": []
+      },
+      {
+        "en": "Cinco de Mayo",
+        "ja": "シンコデマヨ",
+        "ja_typings": []
+      },
+      {
+        "en": "Las Posadas",
+        "ja": "ラスポサダス",
+        "ja_typings": []
+      },
+      {
+        "en": "Carnival",
+        "ja": "カーニバル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00774",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mexican festival on November 1-2 honors deceased relatives?",
+      "ja": "11月1日から2日に故人を讃えるメキシコの祭りは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Karesansui",
+        "ja": "枯山水",
+        "ja_typings": []
+      },
+      {
+        "en": "Tsukiyama",
+        "ja": "築山",
+        "ja_typings": []
+      },
+      {
+        "en": "Chaniwa",
+        "ja": "茶庭",
+        "ja_typings": []
+      },
+      {
+        "en": "Kaiyu-shiki",
+        "ja": "回遊式",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00775",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese garden style uses raked gravel and rocks to represent landscapes?",
+      "ja": "砂利や岩で景色を表現する日本庭園の様式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sari",
+        "ja": "サリー",
+        "ja_typings": []
+      },
+      {
+        "en": "Dhoti",
+        "ja": "ドーティ",
+        "ja_typings": []
+      },
+      {
+        "en": "Lehenga",
+        "ja": "レヘンガ",
+        "ja_typings": []
+      },
+      {
+        "en": "Salwar",
+        "ja": "サルワール",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00776",
+    "image_path": null,
+    "question_text": {
+      "en": "Which traditional Indian garment is a long unstitched cloth wrapped around the body?",
+      "ja": "長く縫っていない布を体に巻くインドの伝統衣装は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Opera cake",
+        "ja": "オペラ",
+        "ja_typings": []
+      },
+      {
+        "en": "Mille-feuille",
+        "ja": "ミルフィーユ",
+        "ja_typings": []
+      },
+      {
+        "en": "Eclair",
+        "ja": "エクレア",
+        "ja_typings": []
+      },
+      {
+        "en": "Macaron",
+        "ja": "マカロン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00777",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French dessert is a layered cake with coffee buttercream and chocolate?",
+      "ja": "コーヒーバタークリームとチョコレートの層状ケーキはフランスの何という菓子?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cezve",
+        "ja": "ジェズベ",
+        "ja_typings": []
+      },
+      {
+        "en": "Drip",
+        "ja": "ドリップ",
+        "ja_typings": []
+      },
+      {
+        "en": "French press",
+        "ja": "フレンチプレス",
+        "ja_typings": []
+      },
+      {
+        "en": "Espresso",
+        "ja": "エスプレッソ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00778",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Turkish coffee preparation involves boiling finely ground coffee in a small pot?",
+      "ja": "小さな鍋で細かく挽いたコーヒーを煮詰めるトルコのコーヒー抽出法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Piobaireachd",
+        "ja": "ピーブロック",
+        "ja_typings": []
+      },
+      {
+        "en": "Reel",
+        "ja": "リール",
+        "ja_typings": []
+      },
+      {
+        "en": "Jig",
+        "ja": "ジグ",
+        "ja_typings": []
+      },
+      {
+        "en": "Strathspey",
+        "ja": "ストラススペイ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00779",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Scottish bagpipe music style features ornate variations on a theme?",
+      "ja": "主題への装飾的変奏が特徴のスコットランドのバグパイプ曲は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tango",
+        "ja": "タンゴ",
+        "ja_typings": []
+      },
+      {
+        "en": "Samba",
+        "ja": "サンバ",
+        "ja_typings": []
+      },
+      {
+        "en": "Salsa",
+        "ja": "サルサ",
+        "ja_typings": []
+      },
+      {
+        "en": "Bachata",
+        "ja": "バチャータ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00780",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Argentine dance originated in Buenos Aires and Montevideo in the late 19th century?",
+      "ja": "19世紀後半にブエノスアイレスとモンテビデオで生まれたアルゼンチンの舞踊は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Borscht",
+        "ja": "ボルシチ",
+        "ja_typings": []
+      },
+      {
+        "en": "Solyanka",
+        "ja": "ソリャンカ",
+        "ja_typings": []
+      },
+      {
+        "en": "Shchi",
+        "ja": "シチー",
+        "ja_typings": []
+      },
+      {
+        "en": "Okroshka",
+        "ja": "オクローシカ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00781",
+    "image_path": null,
+    "question_text": {
+      "en": "Which traditional Russian soup is made with beetroot?",
+      "ja": "ビーツを使ったロシアの伝統スープは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "La Scala",
+        "ja": "ラ・スカラ",
+        "ja_typings": []
+      },
+      {
+        "en": "Teatro Massimo",
+        "ja": "テアトロマッシモ",
+        "ja_typings": []
+      },
+      {
+        "en": "La Fenice",
+        "ja": "ラ・フェニーチェ",
+        "ja_typings": []
+      },
+      {
+        "en": "San Carlo",
+        "ja": "サンカルロ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00782",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian opera house in Milan opened in 1778?",
+      "ja": "1778年に開館したミラノのオペラ劇場は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Capoeira",
+        "ja": "カポエイラ",
+        "ja_typings": []
+      },
+      {
+        "en": "Vale tudo",
+        "ja": "バーリトゥード",
+        "ja_typings": []
+      },
+      {
+        "en": "Luta livre",
+        "ja": "ルタリーブリ",
+        "ja_typings": []
+      },
+      {
+        "en": "Jiu-jitsu",
+        "ja": "ジュージツ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00783",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Brazilian martial art combines dance, acrobatics, and music?",
+      "ja": "ダンス、アクロバット、音楽を組み合わせたブラジルの武術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Symposium",
+        "ja": "シンポシウム",
+        "ja_typings": []
+      },
+      {
+        "en": "Agora",
+        "ja": "アゴラ",
+        "ja_typings": []
+      },
+      {
+        "en": "Hetairia",
+        "ja": "ヘタイリア",
+        "ja_typings": []
+      },
+      {
+        "en": "Andron",
+        "ja": "アンドロン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00784",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Greek philosophical drinking party was the subject of works by Plato and Xenophon?",
+      "ja": "プラトンとクセノフォンの著作の主題となったギリシャの哲学的宴会は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Daiginjo",
+        "ja": "大吟醸",
+        "ja_typings": []
+      },
+      {
+        "en": "Ginjo",
+        "ja": "吟醸",
+        "ja_typings": []
+      },
+      {
+        "en": "Junmai",
+        "ja": "純米",
+        "ja_typings": []
+      },
+      {
+        "en": "Honjozo",
+        "ja": "本醸造",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00785",
+    "image_path": null,
+    "question_text": {
+      "en": "Which type of Japanese sake brewing requires polishing rice to at least 50% of its original size?",
+      "ja": "米を原料の50%以下まで精米する日本酒の種類は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Samba",
+        "ja": "サンバ",
+        "ja_typings": []
+      },
+      {
+        "en": "Tango",
+        "ja": "タンゴ",
+        "ja_typings": []
+      },
+      {
+        "en": "Bachata",
+        "ja": "バチャータ",
+        "ja_typings": []
+      },
+      {
+        "en": "Salsa",
+        "ja": "サルサ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00786",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Brazilian dance is the signature of the Rio Carnival?",
+      "ja": "リオのカーニバルを代表するブラジルのダンスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cheongsam",
+        "ja": "チャイナドレス",
+        "ja_typings": []
+      },
+      {
+        "en": "Hanfu",
+        "ja": "漢服",
+        "ja_typings": []
+      },
+      {
+        "en": "Tangzhuang",
+        "ja": "唐装",
+        "ja_typings": []
+      },
+      {
+        "en": "Ao Dai",
+        "ja": "アオザイ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00787",
+    "image_path": null,
+    "question_text": {
+      "en": "Which traditional Chinese dress for women features a high collar and side slits?",
+      "ja": "高い襟とサイドスリットが特徴の中国伝統衣装(女性用)は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cinco de Mayo",
+        "ja": "シンコデマヨ",
+        "ja_typings": []
+      },
+      {
+        "en": "Day of the Dead",
+        "ja": "死者の日",
+        "ja_typings": []
+      },
+      {
+        "en": "Las Posadas",
+        "ja": "ラスポサダス",
+        "ja_typings": []
+      },
+      {
+        "en": "Independence Day",
+        "ja": "独立記念日",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00788",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mexican holiday on May 5 commemorates the 1862 victory over the French at Puebla?",
+      "ja": "1862年のプエブラでの対仏勝利を讃える5月5日のメキシコの祝日は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "San Fermin",
+        "ja": "サンフェルミン",
+        "ja_typings": []
+      },
+      {
+        "en": "La Tomatina",
+        "ja": "ラ・トマティーナ",
+        "ja_typings": []
+      },
+      {
+        "en": "Las Fallas",
+        "ja": "ラスファジャス",
+        "ja_typings": []
+      },
+      {
+        "en": "Feria de Abril",
+        "ja": "フェリアデアブリル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00789",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Spanish festival is famous for the running of the bulls in Pamplona?",
+      "ja": "パンプローナでの牛追いで有名なスペインの祭りは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Salsa",
+        "ja": "サルサ",
+        "ja_typings": []
+      },
+      {
+        "en": "Tango",
+        "ja": "タンゴ",
+        "ja_typings": []
+      },
+      {
+        "en": "Samba",
+        "ja": "サンバ",
+        "ja_typings": []
+      },
+      {
+        "en": "Flamenco",
+        "ja": "フラメンコ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00790",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Cuban-origin dance is known for its quick step patterns and is popular worldwide?",
+      "ja": "キューバ発祥で速いステップで世界的に普及している舞踊は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Diwali",
+        "ja": "ディワリ",
+        "ja_typings": []
+      },
+      {
+        "en": "Holi",
+        "ja": "ホーリー",
+        "ja_typings": []
+      },
+      {
+        "en": "Navratri",
+        "ja": "ナヴラトリ",
+        "ja_typings": []
+      },
+      {
+        "en": "Pongal",
+        "ja": "ポンガル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00791",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hindu festival of lights is celebrated in autumn?",
+      "ja": "秋に祝われるヒンドゥー教の光の祭りは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Semantics",
+        "ja": "意味論",
+        "ja_typings": []
+      },
+      {
+        "en": "Syntax",
+        "ja": "統語論",
+        "ja_typings": []
+      },
+      {
+        "en": "Phonology",
+        "ja": "音韻論",
+        "ja_typings": []
+      },
+      {
+        "en": "Pragmatics",
+        "ja": "語用論",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00792",
+    "image_path": null,
+    "question_text": {
+      "en": "Which field of linguistics studies meaning in language?",
+      "ja": "言語の意味を研究する言語学の分野は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kanji",
+        "ja": "漢字",
+        "ja_typings": []
+      },
+      {
+        "en": "Hiragana",
+        "ja": "ひらがな",
+        "ja_typings": []
+      },
+      {
+        "en": "Katakana",
+        "ja": "カタカナ",
+        "ja_typings": []
+      },
+      {
+        "en": "Romaji",
+        "ja": "ローマ字",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00793",
+    "image_path": null,
+    "question_text": {
+      "en": "Which kind of Japanese characters represent meaning rather than sound?",
+      "ja": "音ではなく意味を表現する日本語の文字は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Active voice",
+        "ja": "能動態",
+        "ja_typings": []
+      },
+      {
+        "en": "Passive voice",
+        "ja": "受動態",
+        "ja_typings": []
+      },
+      {
+        "en": "Middle voice",
+        "ja": "中動態",
+        "ja_typings": []
+      },
+      {
+        "en": "Causative voice",
+        "ja": "使役態",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00794",
+    "image_path": null,
+    "question_text": {
+      "en": "In English grammar, which voice has the subject performing the action?",
+      "ja": "主語が動作を行う英文法の態は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Adverb",
+        "ja": "副詞",
+        "ja_typings": []
+      },
+      {
+        "en": "Noun",
+        "ja": "名詞",
+        "ja_typings": []
+      },
+      {
+        "en": "Particle",
+        "ja": "助詞",
+        "ja_typings": []
+      },
+      {
+        "en": "Conjunction",
+        "ja": "接続詞",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00795",
+    "image_path": null,
+    "question_text": {
+      "en": "Which part of speech modifies verbs, adjectives, or other adverbs?",
+      "ja": "動詞、形容詞、または他の副詞を修飾する品詞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sino-Tibetan",
+        "ja": "シナチベット語族",
+        "ja_typings": []
+      },
+      {
+        "en": "Indo-European",
+        "ja": "インドヨーロッパ語族",
+        "ja_typings": []
+      },
+      {
+        "en": "Austroasiatic",
+        "ja": "オーストロアジア語族",
+        "ja_typings": []
+      },
+      {
+        "en": "Altaic",
+        "ja": "アルタイ語族",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00796",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language family includes Mandarin Chinese and Tibetan?",
+      "ja": "中国語とチベット語を含む語族は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Austronesian",
+        "ja": "オーストロネシア語族",
+        "ja_typings": []
+      },
+      {
+        "en": "Sino-Tibetan",
+        "ja": "シナチベット語族",
+        "ja_typings": []
+      },
+      {
+        "en": "Dravidian",
+        "ja": "ドラビダ語族",
+        "ja_typings": []
+      },
+      {
+        "en": "Niger-Congo",
+        "ja": "ニジェールコンゴ語族",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00797",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language family includes Indonesian, Tagalog, and Malagasy?",
+      "ja": "インドネシア語、タガログ語、マダガスカル語を含む語族は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hyperbole",
+        "ja": "誇張法",
+        "ja_typings": []
+      },
+      {
+        "en": "Metaphor",
+        "ja": "隠喩",
+        "ja_typings": []
+      },
+      {
+        "en": "Litotes",
+        "ja": "緩叙法",
+        "ja_typings": []
+      },
+      {
+        "en": "Irony",
+        "ja": "皮肉",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00798",
+    "image_path": null,
+    "question_text": {
+      "en": "Which figure of speech exaggerates for emphasis or effect?",
+      "ja": "強調や効果のため誇張する修辞法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bopomofo",
+        "ja": "ボポモフォ",
+        "ja_typings": []
+      },
+      {
+        "en": "Pinyin",
+        "ja": "ピンイン",
+        "ja_typings": []
+      },
+      {
+        "en": "Wade-Giles",
+        "ja": "ウェード式",
+        "ja_typings": []
+      },
+      {
+        "en": "Zhuyin Fuhao",
+        "ja": "注音符号",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00799",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mandarin phonetic system uses zhuyin symbols and is used in Taiwan?",
+      "ja": "台湾で使われる注音符号のマンダリン発音表記は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fargate",
+        "ja": "ファーゲート",
+        "ja_typings": []
+      },
+      {
+        "en": "ECS",
+        "ja": "イーシーエス",
+        "ja_typings": []
+      },
+      {
+        "en": "EKS",
+        "ja": "イーケーエス",
+        "ja_typings": []
+      },
+      {
+        "en": "Lambda",
+        "ja": "ラムダ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00800",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS service provides serverless container compute that runs without managing servers?",
+      "ja": "サーバー管理不要でコンテナ実行環境を提供する AWS サービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "IaaS",
+        "ja": "アイアース",
+        "ja_typings": []
+      },
+      {
+        "en": "PaaS",
+        "ja": "パース",
+        "ja_typings": []
+      },
+      {
+        "en": "SaaS",
+        "ja": "サース",
+        "ja_typings": []
+      },
+      {
+        "en": "FaaS",
+        "ja": "ファース",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00801",
+    "image_path": null,
+    "question_text": {
+      "en": "Which type of cloud computing provides raw virtualized hardware resources?",
+      "ja": "生の仮想化ハードウェアリソースを提供するクラウドの種類は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FaaS",
+        "ja": "ファース",
+        "ja_typings": []
+      },
+      {
+        "en": "PaaS",
+        "ja": "パース",
+        "ja_typings": []
+      },
+      {
+        "en": "IaaS",
+        "ja": "アイアース",
+        "ja_typings": []
+      },
+      {
+        "en": "SaaS",
+        "ja": "サース",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00802",
+    "image_path": null,
+    "question_text": {
+      "en": "Which cloud computing model executes code in response to events without managing infrastructure?",
+      "ja": "インフラ管理不要でイベント応答コード実行をするクラウドモデルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DynamoDB",
+        "ja": "ダイナモディービー",
+        "ja_typings": []
+      },
+      {
+        "en": "RDS",
+        "ja": "アールディーエス",
+        "ja_typings": []
+      },
+      {
+        "en": "Aurora",
+        "ja": "オーロラ",
+        "ja_typings": []
+      },
+      {
+        "en": "Redshift",
+        "ja": "レッドシフト",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00803",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS service is a fully managed NoSQL key-value database?",
+      "ja": "マネージドな NoSQL キーバリュー DB である AWS サービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Redshift",
+        "ja": "レッドシフト",
+        "ja_typings": []
+      },
+      {
+        "en": "RDS",
+        "ja": "アールディーエス",
+        "ja_typings": []
+      },
+      {
+        "en": "Athena",
+        "ja": "アテナ",
+        "ja_typings": []
+      },
+      {
+        "en": "Aurora",
+        "ja": "オーロラ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00804",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS service is a petabyte-scale data warehouse?",
+      "ja": "ペタバイト規模のデータウェアハウスである AWS サービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Terraform",
+        "ja": "テラフォーム",
+        "ja_typings": []
+      },
+      {
+        "en": "Pulumi",
+        "ja": "プルミ",
+        "ja_typings": []
+      },
+      {
+        "en": "Ansible",
+        "ja": "アンシブル",
+        "ja_typings": []
+      },
+      {
+        "en": "CloudFormation",
+        "ja": "クラウドフォーメーション",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00805",
+    "image_path": null,
+    "question_text": {
+      "en": "Which open-source IaC tool by HashiCorp uses HCL to define cloud infrastructure?",
+      "ja": "HashiCorp 製で HCL でクラウドインフラを定義する IaC ツールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ansible",
+        "ja": "アンシブル",
+        "ja_typings": []
+      },
+      {
+        "en": "Chef",
+        "ja": "シェフ",
+        "ja_typings": []
+      },
+      {
+        "en": "Puppet",
+        "ja": "パペット",
+        "ja_typings": []
+      },
+      {
+        "en": "Salt",
+        "ja": "ソルト",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00806",
+    "image_path": null,
+    "question_text": {
+      "en": "Which open-source configuration management tool uses YAML playbooks?",
+      "ja": "YAML プレイブックを使う構成管理ツールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sprint Review",
+        "ja": "スプリントレビュー",
+        "ja_typings": []
+      },
+      {
+        "en": "Retrospective",
+        "ja": "レトロスペクティブ",
+        "ja_typings": []
+      },
+      {
+        "en": "Daily Stand-up",
+        "ja": "デイリースタンドアップ",
+        "ja_typings": []
+      },
+      {
+        "en": "Sprint Planning",
+        "ja": "スプリントプランニング",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00807",
+    "image_path": null,
+    "question_text": {
+      "en": "In Scrum, which ceremony lets the team demo completed work to stakeholders?",
+      "ja": "Scrum でステークホルダーに完了作業をデモするセレモニーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kepler",
+        "ja": "ケプラー",
+        "ja_typings": []
+      },
+      {
+        "en": "Galileo",
+        "ja": "ガリレオ",
+        "ja_typings": []
+      },
+      {
+        "en": "Copernicus",
+        "ja": "コペルニクス",
+        "ja_typings": []
+      },
+      {
+        "en": "Brahe",
+        "ja": "ブラーエ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00808",
+    "image_path": null,
+    "question_text": {
+      "en": "Which German astronomer formulated the laws of planetary motion?",
+      "ja": "惑星運動の法則を定式化したドイツの天文学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Koch",
+        "ja": "コッホ",
+        "ja_typings": []
+      },
+      {
+        "en": "Pasteur",
+        "ja": "パスツール",
+        "ja_typings": []
+      },
+      {
+        "en": "Lister",
+        "ja": "リスター",
+        "ja_typings": []
+      },
+      {
+        "en": "Jenner",
+        "ja": "ジェンナー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00809",
+    "image_path": null,
+    "question_text": {
+      "en": "Which German physician proved that specific microorganisms cause specific diseases?",
+      "ja": "特定の微生物が特定の病気を引き起こすことを証明したドイツの医師は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Helium",
+        "ja": "ヘリウム",
+        "ja_typings": []
+      },
+      {
+        "en": "Neon",
+        "ja": "ネオン",
+        "ja_typings": []
+      },
+      {
+        "en": "Argon",
+        "ja": "アルゴン",
+        "ja_typings": []
+      },
+      {
+        "en": "Hydrogen",
+        "ja": "水素",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00810",
+    "image_path": null,
+    "question_text": {
+      "en": "Which noble gas is used to inflate party balloons and is the second lightest element?",
+      "ja": "パーティー用風船に使われ、2番目に軽い気体元素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Liver",
+        "ja": "肝臓",
+        "ja_typings": []
+      },
+      {
+        "en": "Pancreas",
+        "ja": "膵臓",
+        "ja_typings": []
+      },
+      {
+        "en": "Kidney",
+        "ja": "腎臓",
+        "ja_typings": []
+      },
+      {
+        "en": "Spleen",
+        "ja": "脾臓",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00811",
+    "image_path": null,
+    "question_text": {
+      "en": "Which human organ produces bile and detoxifies the blood?",
+      "ja": "胆汁を分泌し血液を解毒するヒトの臓器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Volt",
+        "ja": "ボルト",
+        "ja_typings": []
+      },
+      {
+        "en": "Watt",
+        "ja": "ワット",
+        "ja_typings": []
+      },
+      {
+        "en": "Ohm",
+        "ja": "オーム",
+        "ja_typings": []
+      },
+      {
+        "en": "Ampere",
+        "ja": "アンペア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00812",
+    "image_path": null,
+    "question_text": {
+      "en": "Which unit of electric potential difference is named after an Italian physicist?",
+      "ja": "イタリア人物理学者にちなんだ電位差の単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Watt",
+        "ja": "ワット",
+        "ja_typings": []
+      },
+      {
+        "en": "Volt",
+        "ja": "ボルト",
+        "ja_typings": []
+      },
+      {
+        "en": "Joule",
+        "ja": "ジュール",
+        "ja_typings": []
+      },
+      {
+        "en": "Newton",
+        "ja": "ニュートン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00813",
+    "image_path": null,
+    "question_text": {
+      "en": "Which SI unit of power equals one joule per second?",
+      "ja": "毎秒1ジュールに相当する SI 単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rutherford",
+        "ja": "ラザフォード",
+        "ja_typings": []
+      },
+      {
+        "en": "Bohr",
+        "ja": "ボーア",
+        "ja_typings": []
+      },
+      {
+        "en": "Thomson",
+        "ja": "トムソン",
+        "ja_typings": []
+      },
+      {
+        "en": "Curie",
+        "ja": "キュリー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00814",
+    "image_path": null,
+    "question_text": {
+      "en": "Which physicist discovered the atomic nucleus through the gold foil experiment?",
+      "ja": "金箔実験で原子核を発見した物理学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pascal",
+        "ja": "パスカル",
+        "ja_typings": []
+      },
+      {
+        "en": "Bar",
+        "ja": "バール",
+        "ja_typings": []
+      },
+      {
+        "en": "Torr",
+        "ja": "トール",
+        "ja_typings": []
+      },
+      {
+        "en": "Atmosphere",
+        "ja": "アトモスフィア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00815",
+    "image_path": null,
+    "question_text": {
+      "en": "Which unit of pressure equals one newton per square meter?",
+      "ja": "平方メートルあたり1ニュートンの圧力単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nero",
+        "ja": "ネロ",
+        "ja_typings": []
+      },
+      {
+        "en": "Caligula",
+        "ja": "カリグラ",
+        "ja_typings": []
+      },
+      {
+        "en": "Domitian",
+        "ja": "ドミティアヌス",
+        "ja_typings": []
+      },
+      {
+        "en": "Commodus",
+        "ja": "コンモドゥス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00816",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Roman emperor is infamous for allegedly playing music while Rome burned?",
+      "ja": "ローマ市街炎上中に演奏したと言われる悪名高いローマ皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hadrian",
+        "ja": "ハドリアヌス",
+        "ja_typings": []
+      },
+      {
+        "en": "Trajan",
+        "ja": "トラヤヌス",
+        "ja_typings": []
+      },
+      {
+        "en": "Antoninus Pius",
+        "ja": "アントニヌスピウス",
+        "ja_typings": []
+      },
+      {
+        "en": "Marcus Aurelius",
+        "ja": "マルクスアウレリウス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00817",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Roman emperor built a famous wall across northern Britain?",
+      "ja": "北ブリテンに有名な城壁を築いたローマ皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Battle of Waterloo",
+        "ja": "ワーテルローの戦い",
+        "ja_typings": []
+      },
+      {
+        "en": "Battle of Leipzig",
+        "ja": "ライプツィヒの戦い",
+        "ja_typings": []
+      },
+      {
+        "en": "Battle of Valmy",
+        "ja": "バルミーの戦い",
+        "ja_typings": []
+      },
+      {
+        "en": "Battle of Borodino",
+        "ja": "ボロジノの戦い",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00818",
+    "image_path": null,
+    "question_text": {
+      "en": "In which 1815 battle was Napoleon finally defeated?",
+      "ja": "1815年にナポレオンが最終的に敗北した戦闘は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vasco da Gama",
+        "ja": "ヴァスコ・ダ・ガマ",
+        "ja_typings": []
+      },
+      {
+        "en": "Magellan",
+        "ja": "マゼラン",
+        "ja_typings": []
+      },
+      {
+        "en": "Columbus",
+        "ja": "コロンブス",
+        "ja_typings": []
+      },
+      {
+        "en": "Henry the Navigator",
+        "ja": "エンリケ航海王子",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00819",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Portuguese explorer was the first European to reach India by sea?",
+      "ja": "海路で初めてインドに到達したポルトガル人探検家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Amerigo Vespucci",
+        "ja": "アメリゴ・ヴェスプッチ",
+        "ja_typings": []
+      },
+      {
+        "en": "Magellan",
+        "ja": "マゼラン",
+        "ja_typings": []
+      },
+      {
+        "en": "Columbus",
+        "ja": "コロンブス",
+        "ja_typings": []
+      },
+      {
+        "en": "Marco Polo",
+        "ja": "マルコ・ポーロ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00820",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian explorer's first name became the basis for the name 'America'?",
+      "ja": "「アメリカ」の語源となったイタリア人探検家の名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Magellan",
+        "ja": "マゼラン",
+        "ja_typings": []
+      },
+      {
+        "en": "Vasco da Gama",
+        "ja": "ヴァスコ・ダ・ガマ",
+        "ja_typings": []
+      },
+      {
+        "en": "Cabral",
+        "ja": "カブラル",
+        "ja_typings": []
+      },
+      {
+        "en": "Dias",
+        "ja": "ディアス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00821",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Portuguese-born explorer led the first expedition to circumnavigate the globe?",
+      "ja": "世界一周航海の最初の遠征を率いたポルトガル出身の探検家は?"
+    }
   }
 ]

--- a/data/questions_en.json
+++ b/data/questions_en.json
@@ -1583,7 +1583,7 @@
         "ja": "核反応",
         "en": "Nuclear reaction",
         "ja_typings": [
-          "kakuhannou"
+          "kakuhannnou"
         ]
       },
       {
@@ -1836,7 +1836,7 @@
         "ja": "天然ガス",
         "en": "Natural gas",
         "ja_typings": [
-          "tennengasu"
+          "tennnengasu"
         ]
       }
     ],
@@ -2430,7 +2430,8 @@
         "ja": "ソウル",
         "en": "Seoul",
         "ja_typings": [
-          "souru"
+          "souru",
+          "soru"
         ]
       },
       {
@@ -2642,7 +2643,7 @@
         "ja": "エディンバラ",
         "en": "Edinburgh",
         "ja_typings": [
-          "edhinbara"
+          "edinbara"
         ]
       },
       {
@@ -3168,7 +3169,8 @@
         "ja": "メキシコシティ",
         "en": "Mexico City",
         "ja_typings": [
-          "mekishikoshithi"
+          "mekishikoshithi",
+          "mekishikoshiti"
         ]
       },
       {
@@ -3640,7 +3642,7 @@
         "ja": "メディナ",
         "en": "Medina",
         "ja_typings": [
-          "medhina"
+          "medina"
         ]
       }
     ],
@@ -3872,7 +3874,8 @@
         "ja": "サンティアゴ",
         "en": "Santiago",
         "ja_typings": [
-          "santhiago"
+          "santhiago",
+          "santiago"
         ]
       },
       {
@@ -5888,7 +5891,8 @@
         "ja": "ティム・バーナーズ＝リー",
         "en": "Tim Berners-Lee",
         "ja_typings": [
-          "thimu/ba-na-zuri-"
+          "thimu/ba-na-zuri-",
+          "timu/ba-na-zuri-"
         ]
       },
       {
@@ -7014,8 +7018,8 @@
     "id": "q0172",
     "genre": "programming",
     "question_text": {
-      "ja": "1 バイトは何ビット？",
-      "en": "How many bits are in one byte?"
+      "ja": "現代のコンピューティングで 1 バイトを構成するビット数は?",
+      "en": "How many bits make up one byte in modern computing?"
     },
     "choices": [
       {
@@ -12318,7 +12322,8 @@
         "ja": "プロダクトオーナー",
         "en": "Product Owner",
         "ja_typings": [
-          "purodakutoo-na-"
+          "purodakutoo-na-",
+          "purodakuto-na-"
         ]
       },
       {
@@ -12851,7 +12856,8 @@
         "ja": "レトロスペクティブ",
         "en": "Retrospective",
         "ja_typings": [
-          "retorosupekuthibu"
+          "retorosupekuthibu",
+          "retorosupekutibu"
         ]
       },
       {
@@ -13869,7 +13875,7 @@
         "ja": "庵野秀明",
         "en": "Hideaki Anno",
         "ja_typings": [
-          "annohideaki"
+          "annnohideaki"
         ]
       },
       {
@@ -13917,7 +13923,7 @@
         "ja": "庵野秀明",
         "en": "Hideaki Anno",
         "ja_typings": [
-          "annohideaki"
+          "annnohideaki"
         ]
       },
       {
@@ -14163,7 +14169,7 @@
         "ja": "庵野秀明",
         "en": "Hideaki Anno",
         "ja_typings": [
-          "annohideaki"
+          "annnohideaki"
         ]
       },
       {
@@ -15981,7 +15987,8 @@
         "ja": "サガフロンティア",
         "en": "SaGa Frontier",
         "ja_typings": [
-          "sagafuronthia"
+          "sagafuronthia",
+          "sagafurontia"
         ]
       }
     ],
@@ -16992,7 +16999,7 @@
         "ja": "ディグダグ",
         "en": "Dig Dug",
         "ja_typings": [
-          "dhigudagu"
+          "digudagu"
         ]
       },
       {
@@ -17108,7 +17115,8 @@
         "ja": "コール オブ デューティ",
         "en": "Call of Duty",
         "ja_typings": [
-          "ko-ru obu deyu-thi"
+          "ko-ru obu deyu-thi",
+          "ko-ru obu deyu-ti"
         ]
       },
       {
@@ -17156,7 +17164,8 @@
         "ja": "コール オブ デューティ",
         "en": "Call of Duty",
         "ja_typings": [
-          "ko-ru obu deyu-thi"
+          "ko-ru obu deyu-thi",
+          "ko-ru obu deyu-ti"
         ]
       },
       {
@@ -17286,7 +17295,7 @@
         "ja": "パラディンズ",
         "en": "Paladins",
         "ja_typings": [
-          "paradhinzu"
+          "paradinzu"
         ]
       },
       {
@@ -17484,7 +17493,8 @@
         "ja": "ダークソウル",
         "en": "Dark Souls",
         "ja_typings": [
-          "da-kusouru"
+          "da-kusouru",
+          "da-kusoru"
         ]
       },
       {
@@ -17607,7 +17617,8 @@
         "ja": "トゥームレイダー",
         "en": "Tomb Raider",
         "ja_typings": [
-          "twu-mureida-"
+          "twu-mureida-",
+          "tu-mureida-"
         ]
       },
       {
@@ -17744,7 +17755,8 @@
         "ja": "シャドウバース",
         "en": "Shadowverse",
         "ja_typings": [
-          "shadouba-su"
+          "shadouba-su",
+          "shadoba-su"
         ]
       }
     ],
@@ -17894,7 +17906,8 @@
         "ja": "マリオパーティ",
         "en": "Mario Party",
         "ja_typings": [
-          "mariopa-thi"
+          "mariopa-thi",
+          "mariopa-ti"
         ]
       },
       {
@@ -17908,7 +17921,8 @@
         "ja": "スプラトゥーン",
         "en": "Splatoon",
         "ja_typings": [
-          "supuratwu-n"
+          "supuratwu-n",
+          "supuratu-n"
         ]
       }
     ],
@@ -17928,7 +17942,8 @@
         "ja": "スプラトゥーン",
         "en": "Splatoon",
         "ja_typings": [
-          "supuratwu-n"
+          "supuratwu-n",
+          "supuratu-n"
         ]
       },
       {
@@ -20348,7 +20363,8 @@
         "ja": "アウグストゥス",
         "en": "Augustus",
         "ja_typings": [
-          "augusutwusu"
+          "augusutwusu",
+          "augusutusu"
         ]
       },
       {
@@ -20861,7 +20877,8 @@
         "ja": "ボッティチェリ",
         "en": "Botticelli",
         "ja_typings": [
-          "botthicheri"
+          "botthicheri",
+          "botticheri"
         ]
       }
     ],
@@ -20881,7 +20898,8 @@
         "ja": "マルティン・ルター",
         "en": "Martin Luther",
         "ja_typings": [
-          "maruthin/ruta-"
+          "maruthin/ruta-",
+          "marutin/ruta-"
         ]
       },
       {
@@ -21298,7 +21316,8 @@
         "ja": "マーティン・ルーサー・キング",
         "en": "Martin Luther King Jr.",
         "ja_typings": [
-          "ma-thin/ru-sa-/kingu"
+          "ma-thin/ru-sa-/kingu",
+          "ma-tin/ru-sa-/kingu"
         ]
       },
       {
@@ -21373,7 +21392,7 @@
         "ja": "ガンディー",
         "en": "Mahatma Gandhi",
         "ja_typings": [
-          "gandhi-"
+          "gandi-"
         ]
       },
       {
@@ -21517,7 +21536,8 @@
         "ja": "ティムール",
         "en": "Timur",
         "ja_typings": [
-          "thimu-ru"
+          "thimu-ru",
+          "timu-ru"
         ]
       }
     ],
@@ -21619,7 +21639,7 @@
         "ja": "ケネディとフルシチョフ",
         "en": "Kennedy and Khrushchev",
         "ja_typings": [
-          "kenedhitofurushichofu"
+          "keneditofurushichofu"
         ]
       },
       {
@@ -21749,7 +21769,8 @@
         "ja": "トゥキディデス",
         "en": "Thucydides",
         "ja_typings": [
-          "twukidhidesu"
+          "twukidhidesu",
+          "tukididesu"
         ]
       },
       {
@@ -22208,7 +22229,7 @@
         "ja": "カトリーヌ・ド・メディシス",
         "en": "Catherine de' Medici",
         "ja_typings": [
-          "katori-nu/do/medhishisu"
+          "katori-nu/do/medishisu"
         ]
       },
       {
@@ -23800,7 +23821,7 @@
         "ja": "ハーディ",
         "en": "Hardy",
         "ja_typings": [
-          "ha-dhi"
+          "ha-di"
         ]
       },
       {
@@ -25433,7 +25454,7 @@
         "ja": "千利休",
         "en": "Sen no Rikyu",
         "ja_typings": [
-          "sennorikyuu"
+          "sennnorikyuu"
         ]
       },
       {
@@ -25522,7 +25543,7 @@
         "ja": "ディワリ",
         "en": "Diwali",
         "ja_typings": [
-          "dhiwari"
+          "diwari"
         ]
       },
       {
@@ -25782,7 +25803,8 @@
         "ja": "ラ・トマティーナ",
         "en": "La Tomatina",
         "ja_typings": [
-          "ra/tomathi-na"
+          "ra/tomathi-na",
+          "ra/tomati-na"
         ]
       }
     ],
@@ -25802,7 +25824,8 @@
         "ja": "ラ・トマティーナ",
         "en": "La Tomatina",
         "ja_typings": [
-          "ra/tomathi-na"
+          "ra/tomathi-na",
+          "ra/tomati-na"
         ]
       },
       {
@@ -25884,7 +25907,8 @@
         "ja": "ラタトゥイユ",
         "en": "Ratatouille",
         "ja_typings": [
-          "ratatwuiyu"
+          "ratatwuiyu",
+          "ratatuiyu"
         ]
       },
       {
@@ -25932,7 +25956,8 @@
         "ja": "ドーティ",
         "en": "Dhoti",
         "ja_typings": [
-          "do-thi"
+          "do-thi",
+          "do-ti"
         ]
       },
       {
@@ -26356,7 +26381,7 @@
         "ja": "ピアディーナ",
         "en": "Piadina",
         "ja_typings": [
-          "piadhi-na"
+          "piadi-na"
         ]
       }
     ],
@@ -26663,7 +26688,7 @@
         "ja": "アントニ・ガウディ",
         "en": "Antoni Gaudi",
         "ja_typings": [
-          "antoni/gaudhi"
+          "antoni/gaudi"
         ]
       },
       {
@@ -26684,7 +26709,7 @@
         "ja": "ザハ・ハディド",
         "en": "Zaha Hadid",
         "ja_typings": [
-          "zaha/hadhido"
+          "zaha/hadido"
         ]
       }
     ],
@@ -26704,7 +26729,8 @@
         "ja": "トルティーヤ",
         "en": "Tortilla",
         "ja_typings": [
-          "toruthi-ya"
+          "toruthi-ya",
+          "toruti-ya"
         ]
       },
       {
@@ -27299,7 +27325,8 @@
         "ja": "ヒョウ",
         "en": "leopard",
         "ja_typings": [
-          "hyou"
+          "hyou",
+          "hyo"
         ]
       }
     ],
@@ -27415,7 +27442,8 @@
         "ja": "スティーブンソン",
         "en": "George Stephenson",
         "ja_typings": [
-          "suthi-bunson"
+          "suthi-bunson",
+          "suti-bunson"
         ]
       },
       {
@@ -28235,7 +28263,7 @@
         "ja": "ディケンズ",
         "en": "Charles Dickens",
         "ja_typings": [
-          "dhikenzu"
+          "dikenzu"
         ]
       },
       {
@@ -28467,7 +28495,8 @@
         "ja": "スティーブ・ジョブズ",
         "en": "Steve Jobs",
         "ja_typings": [
-          "suthi-bu/jobuzu"
+          "suthi-bu/jobuzu",
+          "suti-bu/jobuzu"
         ]
       },
       {
@@ -28481,7 +28510,8 @@
         "ja": "ティム・クック",
         "en": "Tim Cook",
         "ja_typings": [
-          "thimu/kukku"
+          "thimu/kukku",
+          "timu/kukku"
         ]
       },
       {
@@ -29951,14 +29981,16 @@
         "ja": "ありがとう",
         "en": "Thanks",
         "ja_typings": [
-          "arigatou"
+          "arigatou",
+          "arigato"
         ]
       },
       {
         "ja": "おはよう",
         "en": "Good morning",
         "ja_typings": [
-          "ohayou"
+          "ohayou",
+          "ohayo"
         ]
       },
       {
@@ -30142,22 +30174,30 @@
       {
         "en": "merge --no-ff",
         "ja": "マージノーエフエフ",
-        "ja_typings": []
+        "ja_typings": [
+          "ma-jino-efuefu"
+        ]
       },
       {
         "en": "rebase",
         "ja": "リベース",
-        "ja_typings": []
+        "ja_typings": [
+          "ribe-su"
+        ]
       },
       {
         "en": "cherry-pick",
         "ja": "チェリーピック",
-        "ja_typings": []
+        "ja_typings": [
+          "cheri-pikku"
+        ]
       },
       {
         "en": "squash",
         "ja": "スカッシュ",
-        "ja_typings": []
+        "ja_typings": [
+          "sukasshu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -30174,22 +30214,30 @@
       {
         "en": "301",
         "ja": "サンマルイチ",
-        "ja_typings": []
+        "ja_typings": [
+          "sanmaruichi"
+        ]
       },
       {
         "en": "302",
         "ja": "サンマルニ",
-        "ja_typings": []
+        "ja_typings": [
+          "sanmaruni"
+        ]
       },
       {
         "en": "307",
         "ja": "サンマルナナ",
-        "ja_typings": []
+        "ja_typings": [
+          "sanmarunana"
+        ]
       },
       {
         "en": "308",
         "ja": "サンマルハチ",
-        "ja_typings": []
+        "ja_typings": [
+          "sanmaruhachi"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -30206,22 +30254,30 @@
       {
         "en": "Singleton",
         "ja": "シングルトン",
-        "ja_typings": []
+        "ja_typings": [
+          "shinguruton"
+        ]
       },
       {
         "en": "Factory",
         "ja": "ファクトリー",
-        "ja_typings": []
+        "ja_typings": [
+          "fakutori-"
+        ]
       },
       {
         "en": "Builder",
         "ja": "ビルダー",
-        "ja_typings": []
+        "ja_typings": [
+          "biruda-"
+        ]
       },
       {
         "en": "Prototype",
         "ja": "プロトタイプ",
-        "ja_typings": []
+        "ja_typings": [
+          "purototaipu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -30238,22 +30294,30 @@
       {
         "en": "SFTP",
         "ja": "エスエフティーピー",
-        "ja_typings": []
+        "ja_typings": [
+          "esuefuti-pi-"
+        ]
       },
       {
         "en": "FTPS",
         "ja": "エフティーピーエス",
-        "ja_typings": []
+        "ja_typings": [
+          "efuti-pi-esu"
+        ]
       },
       {
         "en": "FTP",
         "ja": "エフティーピー",
-        "ja_typings": []
+        "ja_typings": [
+          "efuti-pi-"
+        ]
       },
       {
         "en": "TFTP",
         "ja": "ティーエフティーピー",
-        "ja_typings": []
+        "ja_typings": [
+          "ti-efuti-pi-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -30270,22 +30334,30 @@
       {
         "en": "ReplicaSet",
         "ja": "レプリカセット",
-        "ja_typings": []
+        "ja_typings": [
+          "repurikasetto"
+        ]
       },
       {
         "en": "DaemonSet",
         "ja": "デーモンセット",
-        "ja_typings": []
+        "ja_typings": [
+          "de-monsetto"
+        ]
       },
       {
         "en": "StatefulSet",
         "ja": "ステートフルセット",
-        "ja_typings": []
+        "ja_typings": [
+          "sute-tofurusetto"
+        ]
       },
       {
         "en": "Job",
         "ja": "ジョブ",
-        "ja_typings": []
+        "ja_typings": [
+          "jobu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -30302,22 +30374,30 @@
       {
         "en": "Aurora",
         "ja": "オーロラ",
-        "ja_typings": []
+        "ja_typings": [
+          "o-rora"
+        ]
       },
       {
         "en": "DynamoDB",
         "ja": "ダイナモディービー",
-        "ja_typings": []
+        "ja_typings": [
+          "dainamodi-bi-"
+        ]
       },
       {
         "en": "Redshift",
         "ja": "レッドシフト",
-        "ja_typings": []
+        "ja_typings": [
+          "reddoshifuto"
+        ]
       },
       {
         "en": "Neptune",
         "ja": "ネプチューン",
-        "ja_typings": []
+        "ja_typings": [
+          "nepuchu-n"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -30334,22 +30414,30 @@
       {
         "en": "Consistency",
         "ja": "コンシステンシー",
-        "ja_typings": []
+        "ja_typings": [
+          "konshisutenshi-"
+        ]
       },
       {
         "en": "Availability",
         "ja": "アベイラビリティ",
-        "ja_typings": []
+        "ja_typings": [
+          "abeirabiriti"
+        ]
       },
       {
         "en": "Partition tolerance",
         "ja": "パーティショントレランス",
-        "ja_typings": []
+        "ja_typings": [
+          "pa-tishontoreransu"
+        ]
       },
       {
         "en": "Durability",
         "ja": "デュラビリティ",
-        "ja_typings": []
+        "ja_typings": [
+          "deyurabiriti"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -30366,22 +30454,30 @@
       {
         "en": "Integration test",
         "ja": "インテグレーションテスト",
-        "ja_typings": []
+        "ja_typings": [
+          "integure-shontesuto"
+        ]
       },
       {
         "en": "Unit test",
         "ja": "ユニットテスト",
-        "ja_typings": []
+        "ja_typings": [
+          "yunittotesuto"
+        ]
       },
       {
         "en": "End-to-end test",
         "ja": "エンドトゥーエンドテスト",
-        "ja_typings": []
+        "ja_typings": [
+          "endotu-endotesuto"
+        ]
       },
       {
         "en": "Smoke test",
         "ja": "スモークテスト",
-        "ja_typings": []
+        "ja_typings": [
+          "sumo-kutesuto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -30398,22 +30494,30 @@
       {
         "en": "Transport layer",
         "ja": "トランスポート層",
-        "ja_typings": []
+        "ja_typings": [
+          "toransupo-tosou"
+        ]
       },
       {
         "en": "Network layer",
         "ja": "ネットワーク層",
-        "ja_typings": []
+        "ja_typings": [
+          "nettowa-kusou"
+        ]
       },
       {
         "en": "Session layer",
         "ja": "セッション層",
-        "ja_typings": []
+        "ja_typings": [
+          "sesshonsou"
+        ]
       },
       {
         "en": "Data link layer",
         "ja": "データリンク層",
-        "ja_typings": []
+        "ja_typings": [
+          "de-tarinkusou"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -30430,22 +30534,30 @@
       {
         "en": "Durability",
         "ja": "デュラビリティ",
-        "ja_typings": []
+        "ja_typings": [
+          "deyurabiriti"
+        ]
       },
       {
         "en": "Isolation",
         "ja": "アイソレーション",
-        "ja_typings": []
+        "ja_typings": [
+          "aisore-shon"
+        ]
       },
       {
         "en": "Consistency",
         "ja": "コンシステンシー",
-        "ja_typings": []
+        "ja_typings": [
+          "konshisutenshi-"
+        ]
       },
       {
         "en": "Atomicity",
         "ja": "アトミシティ",
-        "ja_typings": []
+        "ja_typings": [
+          "atomishiti"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -30462,22 +30574,30 @@
       {
         "en": "ip route",
         "ja": "アイピールート",
-        "ja_typings": []
+        "ja_typings": [
+          "aipi-ru-to"
+        ]
       },
       {
         "en": "netstat",
         "ja": "ネットスタット",
-        "ja_typings": []
+        "ja_typings": [
+          "nettosutatto"
+        ]
       },
       {
         "en": "traceroute",
         "ja": "トレースルート",
-        "ja_typings": []
+        "ja_typings": [
+          "tore-suru-to"
+        ]
       },
       {
         "en": "ifconfig",
         "ja": "アイエフコンフィグ",
-        "ja_typings": []
+        "ja_typings": [
+          "aiefukonfigu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -30494,22 +30614,30 @@
       {
         "en": "Retrospective",
         "ja": "レトロスペクティブ",
-        "ja_typings": []
+        "ja_typings": [
+          "retorosupekutibu"
+        ]
       },
       {
         "en": "Sprint Review",
         "ja": "スプリントレビュー",
-        "ja_typings": []
+        "ja_typings": [
+          "supurintorebyu-"
+        ]
       },
       {
         "en": "Daily Stand-up",
         "ja": "デイリースタンドアップ",
-        "ja_typings": []
+        "ja_typings": [
+          "deiri-sutandoappu"
+        ]
       },
       {
         "en": "Sprint Planning",
         "ja": "スプリントプランニング",
-        "ja_typings": []
+        "ja_typings": [
+          "supurintopurannningu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -30526,22 +30654,30 @@
       {
         "en": "SQS",
         "ja": "エスキューエス",
-        "ja_typings": []
+        "ja_typings": [
+          "esukyu-esu"
+        ]
       },
       {
         "en": "SNS",
         "ja": "エスエヌエス",
-        "ja_typings": []
+        "ja_typings": [
+          "esuenuesu"
+        ]
       },
       {
         "en": "Kinesis",
         "ja": "キネシス",
-        "ja_typings": []
+        "ja_typings": [
+          "kineshisu"
+        ]
       },
       {
         "en": "EventBridge",
         "ja": "イベントブリッジ",
-        "ja_typings": []
+        "ja_typings": [
+          "ibentoburijji"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -30558,22 +30694,30 @@
       {
         "en": "Functional programming",
         "ja": "関数型プログラミング",
-        "ja_typings": []
+        "ja_typings": [
+          "kansuugatapuroguramingu"
+        ]
       },
       {
         "en": "Object-oriented programming",
         "ja": "オブジェクト指向プログラミング",
-        "ja_typings": []
+        "ja_typings": [
+          "obujekutoshikoupuroguramingu"
+        ]
       },
       {
         "en": "Procedural programming",
         "ja": "手続き型プログラミング",
-        "ja_typings": []
+        "ja_typings": [
+          "tetsudukigatapuroguramingu"
+        ]
       },
       {
         "en": "Logic programming",
         "ja": "論理型プログラミング",
-        "ja_typings": []
+        "ja_typings": [
+          "ronrigatapuroguramingu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -30590,22 +30734,30 @@
       {
         "en": "SAML",
         "ja": "サムル",
-        "ja_typings": []
+        "ja_typings": [
+          "samuru"
+        ]
       },
       {
         "en": "OAuth",
         "ja": "オーオース",
-        "ja_typings": []
+        "ja_typings": [
+          "o-o-su"
+        ]
       },
       {
         "en": "OpenID Connect",
         "ja": "オープンアイディーコネクト",
-        "ja_typings": []
+        "ja_typings": [
+          "o-punnaidi-konekuto"
+        ]
       },
       {
         "en": "Kerberos",
         "ja": "ケルベロス",
-        "ja_typings": []
+        "ja_typings": [
+          "keruberosu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -30622,22 +30774,30 @@
       {
         "en": "Lead Time for Changes",
         "ja": "リードタイムフォーチェンジズ",
-        "ja_typings": []
+        "ja_typings": [
+          "ri-dotaimufo-chenjizu"
+        ]
       },
       {
         "en": "Mean Time to Recover",
         "ja": "ミーンタイムトゥーリカバー",
-        "ja_typings": []
+        "ja_typings": [
+          "mi-ntaimutu-rikaba-"
+        ]
       },
       {
         "en": "Change Failure Rate",
         "ja": "チェンジフェイリャーレート",
-        "ja_typings": []
+        "ja_typings": [
+          "chenjifeirya-re-to"
+        ]
       },
       {
         "en": "Deployment Frequency",
         "ja": "デプロイメントフリークエンシー",
-        "ja_typings": []
+        "ja_typings": [
+          "depuroimentofuri-kuenshi-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -30654,22 +30814,30 @@
       {
         "en": "SaaS",
         "ja": "サース",
-        "ja_typings": []
+        "ja_typings": [
+          "sa-su"
+        ]
       },
       {
         "en": "PaaS",
         "ja": "パース",
-        "ja_typings": []
+        "ja_typings": [
+          "pa-su"
+        ]
       },
       {
         "en": "IaaS",
         "ja": "アイアース",
-        "ja_typings": []
+        "ja_typings": [
+          "aia-su"
+        ]
       },
       {
         "en": "FaaS",
         "ja": "ファース",
-        "ja_typings": []
+        "ja_typings": [
+          "fa-su"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -30686,22 +30854,30 @@
       {
         "en": "wa",
         "ja": "は",
-        "ja_typings": []
+        "ja_typings": [
+          "ha"
+        ]
       },
       {
         "en": "ga",
         "ja": "が",
-        "ja_typings": []
+        "ja_typings": [
+          "ga"
+        ]
       },
       {
         "en": "wo",
         "ja": "を",
-        "ja_typings": []
+        "ja_typings": [
+          "o"
+        ]
       },
       {
         "en": "ni",
         "ja": "に",
-        "ja_typings": []
+        "ja_typings": [
+          "ni"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -30718,22 +30894,30 @@
       {
         "en": "Uralic",
         "ja": "ウラル語族",
-        "ja_typings": []
+        "ja_typings": [
+          "urarugozoku"
+        ]
       },
       {
         "en": "Indo-European",
         "ja": "インドヨーロッパ語族",
-        "ja_typings": []
+        "ja_typings": [
+          "indoyo-roppagozoku"
+        ]
       },
       {
         "en": "Turkic",
         "ja": "テュルク語族",
-        "ja_typings": []
+        "ja_typings": [
+          "tyurukugozoku"
+        ]
       },
       {
         "en": "Altaic",
         "ja": "アルタイ語族",
-        "ja_typings": []
+        "ja_typings": [
+          "arutaigozoku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -30750,22 +30934,30 @@
       {
         "en": "Homophone",
         "ja": "同音異義語",
-        "ja_typings": []
+        "ja_typings": [
+          "douonigigo"
+        ]
       },
       {
         "en": "Synonym",
         "ja": "類義語",
-        "ja_typings": []
+        "ja_typings": [
+          "ruigigo"
+        ]
       },
       {
         "en": "Antonym",
         "ja": "対義語",
-        "ja_typings": []
+        "ja_typings": [
+          "taigigo"
+        ]
       },
       {
         "en": "Hyponym",
         "ja": "下位語",
-        "ja_typings": []
+        "ja_typings": [
+          "kaigo"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -30782,22 +30974,30 @@
       {
         "en": "Cuneiform",
         "ja": "楔形文字",
-        "ja_typings": []
+        "ja_typings": [
+          "kusabigatamoji"
+        ]
       },
       {
         "en": "Hieroglyphs",
         "ja": "ヒエログリフ",
-        "ja_typings": []
+        "ja_typings": [
+          "hierogurifu"
+        ]
       },
       {
         "en": "Linear A",
         "ja": "線文字A",
-        "ja_typings": []
+        "ja_typings": [
+          "senmojiA"
+        ]
       },
       {
         "en": "Phoenician",
         "ja": "フェニキア文字",
-        "ja_typings": []
+        "ja_typings": [
+          "fenikiamoji"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -30814,22 +31014,30 @@
       {
         "en": "Humble language",
         "ja": "謙譲語",
-        "ja_typings": []
+        "ja_typings": [
+          "kenjougo"
+        ]
       },
       {
         "en": "Respectful language",
         "ja": "尊敬語",
-        "ja_typings": []
+        "ja_typings": [
+          "sonkeigo"
+        ]
       },
       {
         "en": "Polite language",
         "ja": "丁寧語",
-        "ja_typings": []
+        "ja_typings": [
+          "teineigo"
+        ]
       },
       {
         "en": "Beautified language",
         "ja": "美化語",
-        "ja_typings": []
+        "ja_typings": [
+          "bikago"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -30846,22 +31054,30 @@
       {
         "en": "Accusative",
         "ja": "対格",
-        "ja_typings": []
+        "ja_typings": [
+          "taikaku"
+        ]
       },
       {
         "en": "Nominative",
         "ja": "主格",
-        "ja_typings": []
+        "ja_typings": [
+          "shukaku"
+        ]
       },
       {
         "en": "Genitive",
         "ja": "属格",
-        "ja_typings": []
+        "ja_typings": [
+          "zokkaku"
+        ]
       },
       {
         "en": "Dative",
         "ja": "与格",
-        "ja_typings": []
+        "ja_typings": [
+          "yokaku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -30878,22 +31094,30 @@
       {
         "en": "Fourth tone",
         "ja": "第四声",
-        "ja_typings": []
+        "ja_typings": [
+          "daiyonsei"
+        ]
       },
       {
         "en": "First tone",
         "ja": "第一声",
-        "ja_typings": []
+        "ja_typings": [
+          "daiissei"
+        ]
       },
       {
         "en": "Second tone",
         "ja": "第二声",
-        "ja_typings": []
+        "ja_typings": [
+          "dainisei"
+        ]
       },
       {
         "en": "Third tone",
         "ja": "第三声",
-        "ja_typings": []
+        "ja_typings": [
+          "daisansei"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -30910,22 +31134,30 @@
       {
         "en": "Loanword",
         "ja": "借用語",
-        "ja_typings": []
+        "ja_typings": [
+          "shakuyougo"
+        ]
       },
       {
         "en": "Calque",
         "ja": "翻訳借用",
-        "ja_typings": []
+        "ja_typings": [
+          "honyakushakuyou"
+        ]
       },
       {
         "en": "Cognate",
         "ja": "同源語",
-        "ja_typings": []
+        "ja_typings": [
+          "dougengo"
+        ]
       },
       {
         "en": "Neologism",
         "ja": "新造語",
-        "ja_typings": []
+        "ja_typings": [
+          "shinzougo"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -30942,22 +31174,30 @@
       {
         "en": "Past perfect",
         "ja": "過去完了",
-        "ja_typings": []
+        "ja_typings": [
+          "kakokanryou"
+        ]
       },
       {
         "en": "Present perfect",
         "ja": "現在完了",
-        "ja_typings": []
+        "ja_typings": [
+          "genzaikanryou"
+        ]
       },
       {
         "en": "Future perfect",
         "ja": "未来完了",
-        "ja_typings": []
+        "ja_typings": [
+          "miraikanryou"
+        ]
       },
       {
         "en": "Simple past",
         "ja": "過去",
-        "ja_typings": []
+        "ja_typings": [
+          "kako"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -30974,22 +31214,30 @@
       {
         "en": "Romanian",
         "ja": "ルーマニア語",
-        "ja_typings": []
+        "ja_typings": [
+          "ru-maniago"
+        ]
       },
       {
         "en": "Italian",
         "ja": "イタリア語",
-        "ja_typings": []
+        "ja_typings": [
+          "itariago"
+        ]
       },
       {
         "en": "Spanish",
         "ja": "スペイン語",
-        "ja_typings": []
+        "ja_typings": [
+          "supeingo"
+        ]
       },
       {
         "en": "Catalan",
         "ja": "カタルーニャ語",
-        "ja_typings": []
+        "ja_typings": [
+          "kataru-nyago"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31006,22 +31254,30 @@
       {
         "en": "Hangul",
         "ja": "ハングル",
-        "ja_typings": []
+        "ja_typings": [
+          "hanguru"
+        ]
       },
       {
         "en": "Hanja",
         "ja": "ハンジャ",
-        "ja_typings": []
+        "ja_typings": [
+          "hanja"
+        ]
       },
       {
         "en": "Katakana",
         "ja": "カタカナ",
-        "ja_typings": []
+        "ja_typings": [
+          "katakana"
+        ]
       },
       {
         "en": "Cyrillic",
         "ja": "キリル文字",
-        "ja_typings": []
+        "ja_typings": [
+          "kirirumoji"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31038,22 +31294,30 @@
       {
         "en": "Verb",
         "ja": "動詞",
-        "ja_typings": []
+        "ja_typings": [
+          "doushi"
+        ]
       },
       {
         "en": "i-adjective",
         "ja": "イ形容詞",
-        "ja_typings": []
+        "ja_typings": [
+          "ikeiyoushi"
+        ]
       },
       {
         "en": "na-adjective",
         "ja": "ナ形容詞",
-        "ja_typings": []
+        "ja_typings": [
+          "nakeiyoushi"
+        ]
       },
       {
         "en": "Adverb",
         "ja": "副詞",
-        "ja_typings": []
+        "ja_typings": [
+          "fukushi"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31070,22 +31334,30 @@
       {
         "en": "Simile",
         "ja": "直喩",
-        "ja_typings": []
+        "ja_typings": [
+          "chokuyu"
+        ]
       },
       {
         "en": "Metaphor",
         "ja": "隠喩",
-        "ja_typings": []
+        "ja_typings": [
+          "inyu"
+        ]
       },
       {
         "en": "Personification",
         "ja": "擬人法",
-        "ja_typings": []
+        "ja_typings": [
+          "gijinhou"
+        ]
       },
       {
         "en": "Hyperbole",
         "ja": "誇張法",
-        "ja_typings": []
+        "ja_typings": [
+          "kochouhou"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31102,22 +31374,30 @@
       {
         "en": "Serbian",
         "ja": "セルビア語",
-        "ja_typings": []
+        "ja_typings": [
+          "serubiago"
+        ]
       },
       {
         "en": "Russian",
         "ja": "ロシア語",
-        "ja_typings": []
+        "ja_typings": [
+          "roshiago"
+        ]
       },
       {
         "en": "Polish",
         "ja": "ポーランド語",
-        "ja_typings": []
+        "ja_typings": [
+          "po-randogo"
+        ]
       },
       {
         "en": "Czech",
         "ja": "チェコ語",
-        "ja_typings": []
+        "ja_typings": [
+          "chekogo"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31134,22 +31414,30 @@
       {
         "en": "Niger-Congo",
         "ja": "ニジェールコンゴ語族",
-        "ja_typings": []
+        "ja_typings": [
+          "nije-rukongogozoku"
+        ]
       },
       {
         "en": "Indo-European",
         "ja": "インドヨーロッパ語族",
-        "ja_typings": []
+        "ja_typings": [
+          "indoyo-roppagozoku"
+        ]
       },
       {
         "en": "Sino-Tibetan",
         "ja": "シナチベット語族",
-        "ja_typings": []
+        "ja_typings": [
+          "shinachibettogozoku"
+        ]
       },
       {
         "en": "Austronesian",
         "ja": "オーストロネシア語族",
-        "ja_typings": []
+        "ja_typings": [
+          "o-sutoroneshiagozoku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31166,22 +31454,30 @@
       {
         "en": "To-on",
         "ja": "唐音",
-        "ja_typings": []
+        "ja_typings": [
+          "touon"
+        ]
       },
       {
         "en": "Go-on",
         "ja": "呉音",
-        "ja_typings": []
+        "ja_typings": [
+          "goon"
+        ]
       },
       {
         "en": "Kan-on",
         "ja": "漢音",
-        "ja_typings": []
+        "ja_typings": [
+          "kanon"
+        ]
       },
       {
         "en": "Kun-yomi",
         "ja": "訓読み",
-        "ja_typings": []
+        "ja_typings": [
+          "kunyomi"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31198,22 +31494,30 @@
       {
         "en": "Sumerian cuneiform",
         "ja": "シュメール楔形文字",
-        "ja_typings": []
+        "ja_typings": [
+          "shume-rukusabigatamoji"
+        ]
       },
       {
         "en": "Egyptian hieroglyphs",
         "ja": "エジプトヒエログリフ",
-        "ja_typings": []
+        "ja_typings": [
+          "ejiputohierogurifu"
+        ]
       },
       {
         "en": "Chinese oracle bone script",
         "ja": "中国甲骨文字",
-        "ja_typings": []
+        "ja_typings": [
+          "chuugokukoukotsumoji"
+        ]
       },
       {
         "en": "Indus script",
         "ja": "インダス文字",
-        "ja_typings": []
+        "ja_typings": [
+          "indasumoji"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31230,22 +31534,30 @@
       {
         "en": "Kimchi",
         "ja": "キムチ",
-        "ja_typings": []
+        "ja_typings": [
+          "kimuchi"
+        ]
       },
       {
         "en": "Bibimbap",
         "ja": "ビビンバ",
-        "ja_typings": []
+        "ja_typings": [
+          "bibinba"
+        ]
       },
       {
         "en": "Bulgogi",
         "ja": "プルコギ",
-        "ja_typings": []
+        "ja_typings": [
+          "purukogi"
+        ]
       },
       {
         "en": "Japchae",
         "ja": "チャプチェ",
-        "ja_typings": []
+        "ja_typings": [
+          "chapuche"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31262,22 +31574,30 @@
       {
         "en": "Galette",
         "ja": "ガレット",
-        "ja_typings": []
+        "ja_typings": [
+          "garetto"
+        ]
       },
       {
         "en": "Crepe",
         "ja": "クレープ",
-        "ja_typings": []
+        "ja_typings": [
+          "kure-pu"
+        ]
       },
       {
         "en": "Frittata",
         "ja": "フリッタータ",
-        "ja_typings": []
+        "ja_typings": [
+          "furitta-ta"
+        ]
       },
       {
         "en": "Quiche",
         "ja": "キッシュ",
-        "ja_typings": []
+        "ja_typings": [
+          "kisshu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31294,22 +31614,30 @@
       {
         "en": "Obon",
         "ja": "お盆",
-        "ja_typings": []
+        "ja_typings": [
+          "obon"
+        ]
       },
       {
         "en": "Tanabata",
         "ja": "七夕",
-        "ja_typings": []
+        "ja_typings": [
+          "tanabata"
+        ]
       },
       {
         "en": "Hanami",
         "ja": "花見",
-        "ja_typings": []
+        "ja_typings": [
+          "hanami"
+        ]
       },
       {
         "en": "Shichigosan",
         "ja": "七五三",
-        "ja_typings": []
+        "ja_typings": [
+          "shichigosan"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31326,22 +31654,30 @@
       {
         "en": "Paella",
         "ja": "パエリア",
-        "ja_typings": []
+        "ja_typings": [
+          "paeria"
+        ]
       },
       {
         "en": "Risotto",
         "ja": "リゾット",
-        "ja_typings": []
+        "ja_typings": [
+          "rizotto"
+        ]
       },
       {
         "en": "Jambalaya",
         "ja": "ジャンバラヤ",
-        "ja_typings": []
+        "ja_typings": [
+          "janbaraya"
+        ]
       },
       {
         "en": "Biryani",
         "ja": "ビリヤニ",
-        "ja_typings": []
+        "ja_typings": [
+          "biriyani"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31358,22 +31694,30 @@
       {
         "en": "Day of the Dead",
         "ja": "死者の日",
-        "ja_typings": []
+        "ja_typings": [
+          "shishanohi"
+        ]
       },
       {
         "en": "Cinco de Mayo",
         "ja": "シンコデマヨ",
-        "ja_typings": []
+        "ja_typings": [
+          "shinkodemayo"
+        ]
       },
       {
         "en": "Las Posadas",
         "ja": "ラスポサダス",
-        "ja_typings": []
+        "ja_typings": [
+          "rasuposadasu"
+        ]
       },
       {
         "en": "Carnival",
         "ja": "カーニバル",
-        "ja_typings": []
+        "ja_typings": [
+          "ka-nibaru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31390,22 +31734,30 @@
       {
         "en": "Karesansui",
         "ja": "枯山水",
-        "ja_typings": []
+        "ja_typings": [
+          "karesansui"
+        ]
       },
       {
         "en": "Tsukiyama",
         "ja": "築山",
-        "ja_typings": []
+        "ja_typings": [
+          "tsukiyama"
+        ]
       },
       {
         "en": "Chaniwa",
         "ja": "茶庭",
-        "ja_typings": []
+        "ja_typings": [
+          "chaniwa"
+        ]
       },
       {
         "en": "Kaiyu-shiki",
         "ja": "回遊式",
-        "ja_typings": []
+        "ja_typings": [
+          "kaiyuushiki"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31422,22 +31774,30 @@
       {
         "en": "Sari",
         "ja": "サリー",
-        "ja_typings": []
+        "ja_typings": [
+          "sari-"
+        ]
       },
       {
         "en": "Dhoti",
         "ja": "ドーティ",
-        "ja_typings": []
+        "ja_typings": [
+          "do-ti"
+        ]
       },
       {
         "en": "Lehenga",
         "ja": "レヘンガ",
-        "ja_typings": []
+        "ja_typings": [
+          "rehenga"
+        ]
       },
       {
         "en": "Salwar",
         "ja": "サルワール",
-        "ja_typings": []
+        "ja_typings": [
+          "saruwa-ru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31454,22 +31814,30 @@
       {
         "en": "Opera cake",
         "ja": "オペラ",
-        "ja_typings": []
+        "ja_typings": [
+          "opera"
+        ]
       },
       {
         "en": "Mille-feuille",
         "ja": "ミルフィーユ",
-        "ja_typings": []
+        "ja_typings": [
+          "mirufi-yu"
+        ]
       },
       {
         "en": "Eclair",
         "ja": "エクレア",
-        "ja_typings": []
+        "ja_typings": [
+          "ekurea"
+        ]
       },
       {
         "en": "Macaron",
         "ja": "マカロン",
-        "ja_typings": []
+        "ja_typings": [
+          "makaron"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31486,22 +31854,30 @@
       {
         "en": "Cezve",
         "ja": "ジェズベ",
-        "ja_typings": []
+        "ja_typings": [
+          "jezube"
+        ]
       },
       {
         "en": "Drip",
         "ja": "ドリップ",
-        "ja_typings": []
+        "ja_typings": [
+          "dorippu"
+        ]
       },
       {
         "en": "French press",
         "ja": "フレンチプレス",
-        "ja_typings": []
+        "ja_typings": [
+          "furenchipuresu"
+        ]
       },
       {
         "en": "Espresso",
         "ja": "エスプレッソ",
-        "ja_typings": []
+        "ja_typings": [
+          "esupuresso"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31518,22 +31894,30 @@
       {
         "en": "Piobaireachd",
         "ja": "ピーブロック",
-        "ja_typings": []
+        "ja_typings": [
+          "pi-burokku"
+        ]
       },
       {
         "en": "Reel",
         "ja": "リール",
-        "ja_typings": []
+        "ja_typings": [
+          "ri-ru"
+        ]
       },
       {
         "en": "Jig",
         "ja": "ジグ",
-        "ja_typings": []
+        "ja_typings": [
+          "jigu"
+        ]
       },
       {
         "en": "Strathspey",
         "ja": "ストラススペイ",
-        "ja_typings": []
+        "ja_typings": [
+          "sutorasusupei"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31550,22 +31934,30 @@
       {
         "en": "Tango",
         "ja": "タンゴ",
-        "ja_typings": []
+        "ja_typings": [
+          "tango"
+        ]
       },
       {
         "en": "Samba",
         "ja": "サンバ",
-        "ja_typings": []
+        "ja_typings": [
+          "sanba"
+        ]
       },
       {
         "en": "Salsa",
         "ja": "サルサ",
-        "ja_typings": []
+        "ja_typings": [
+          "sarusa"
+        ]
       },
       {
         "en": "Bachata",
         "ja": "バチャータ",
-        "ja_typings": []
+        "ja_typings": [
+          "bacha-ta"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31582,22 +31974,30 @@
       {
         "en": "Borscht",
         "ja": "ボルシチ",
-        "ja_typings": []
+        "ja_typings": [
+          "borushichi"
+        ]
       },
       {
         "en": "Solyanka",
         "ja": "ソリャンカ",
-        "ja_typings": []
+        "ja_typings": [
+          "soryanka"
+        ]
       },
       {
         "en": "Shchi",
         "ja": "シチー",
-        "ja_typings": []
+        "ja_typings": [
+          "shichi-"
+        ]
       },
       {
         "en": "Okroshka",
         "ja": "オクローシカ",
-        "ja_typings": []
+        "ja_typings": [
+          "okuro-shika"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31614,22 +32014,30 @@
       {
         "en": "La Scala",
         "ja": "ラ・スカラ",
-        "ja_typings": []
+        "ja_typings": [
+          "ra/sukara"
+        ]
       },
       {
         "en": "Teatro Massimo",
         "ja": "テアトロマッシモ",
-        "ja_typings": []
+        "ja_typings": [
+          "teatoromasshimo"
+        ]
       },
       {
         "en": "La Fenice",
         "ja": "ラ・フェニーチェ",
-        "ja_typings": []
+        "ja_typings": [
+          "ra/feni-che"
+        ]
       },
       {
         "en": "San Carlo",
         "ja": "サンカルロ",
-        "ja_typings": []
+        "ja_typings": [
+          "sankaruro"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31646,22 +32054,30 @@
       {
         "en": "Capoeira",
         "ja": "カポエイラ",
-        "ja_typings": []
+        "ja_typings": [
+          "kapoeira"
+        ]
       },
       {
         "en": "Vale tudo",
         "ja": "バーリトゥード",
-        "ja_typings": []
+        "ja_typings": [
+          "ba-ritu-do"
+        ]
       },
       {
         "en": "Luta livre",
         "ja": "ルタリーブリ",
-        "ja_typings": []
+        "ja_typings": [
+          "rutari-buri"
+        ]
       },
       {
         "en": "Jiu-jitsu",
         "ja": "ジュージツ",
-        "ja_typings": []
+        "ja_typings": [
+          "ju-jitsu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31678,22 +32094,30 @@
       {
         "en": "Symposium",
         "ja": "シンポシウム",
-        "ja_typings": []
+        "ja_typings": [
+          "shinposhiumu"
+        ]
       },
       {
         "en": "Agora",
         "ja": "アゴラ",
-        "ja_typings": []
+        "ja_typings": [
+          "agora"
+        ]
       },
       {
         "en": "Hetairia",
         "ja": "ヘタイリア",
-        "ja_typings": []
+        "ja_typings": [
+          "hetairia"
+        ]
       },
       {
         "en": "Andron",
         "ja": "アンドロン",
-        "ja_typings": []
+        "ja_typings": [
+          "andoron"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31710,22 +32134,30 @@
       {
         "en": "Daiginjo",
         "ja": "大吟醸",
-        "ja_typings": []
+        "ja_typings": [
+          "daiginjou"
+        ]
       },
       {
         "en": "Ginjo",
         "ja": "吟醸",
-        "ja_typings": []
+        "ja_typings": [
+          "ginjou"
+        ]
       },
       {
         "en": "Junmai",
         "ja": "純米",
-        "ja_typings": []
+        "ja_typings": [
+          "junmai"
+        ]
       },
       {
         "en": "Honjozo",
         "ja": "本醸造",
-        "ja_typings": []
+        "ja_typings": [
+          "honjouzou"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31742,22 +32174,30 @@
       {
         "en": "Samba",
         "ja": "サンバ",
-        "ja_typings": []
+        "ja_typings": [
+          "sanba"
+        ]
       },
       {
         "en": "Tango",
         "ja": "タンゴ",
-        "ja_typings": []
+        "ja_typings": [
+          "tango"
+        ]
       },
       {
         "en": "Bachata",
         "ja": "バチャータ",
-        "ja_typings": []
+        "ja_typings": [
+          "bacha-ta"
+        ]
       },
       {
         "en": "Salsa",
         "ja": "サルサ",
-        "ja_typings": []
+        "ja_typings": [
+          "sarusa"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31774,22 +32214,30 @@
       {
         "en": "Cheongsam",
         "ja": "チャイナドレス",
-        "ja_typings": []
+        "ja_typings": [
+          "chainadoresu"
+        ]
       },
       {
         "en": "Hanfu",
         "ja": "漢服",
-        "ja_typings": []
+        "ja_typings": [
+          "kanfuku"
+        ]
       },
       {
         "en": "Tangzhuang",
         "ja": "唐装",
-        "ja_typings": []
+        "ja_typings": [
+          "tousou"
+        ]
       },
       {
         "en": "Ao Dai",
         "ja": "アオザイ",
-        "ja_typings": []
+        "ja_typings": [
+          "aozai"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31806,22 +32254,30 @@
       {
         "en": "Cinco de Mayo",
         "ja": "シンコデマヨ",
-        "ja_typings": []
+        "ja_typings": [
+          "shinkodemayo"
+        ]
       },
       {
         "en": "Day of the Dead",
         "ja": "死者の日",
-        "ja_typings": []
+        "ja_typings": [
+          "shishanohi"
+        ]
       },
       {
         "en": "Las Posadas",
         "ja": "ラスポサダス",
-        "ja_typings": []
+        "ja_typings": [
+          "rasuposadasu"
+        ]
       },
       {
         "en": "Independence Day",
         "ja": "独立記念日",
-        "ja_typings": []
+        "ja_typings": [
+          "dokuritsukinenbi"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31838,22 +32294,30 @@
       {
         "en": "San Fermin",
         "ja": "サンフェルミン",
-        "ja_typings": []
+        "ja_typings": [
+          "sanferumin"
+        ]
       },
       {
         "en": "La Tomatina",
         "ja": "ラ・トマティーナ",
-        "ja_typings": []
+        "ja_typings": [
+          "ra/tomati-na"
+        ]
       },
       {
         "en": "Las Fallas",
         "ja": "ラスファジャス",
-        "ja_typings": []
+        "ja_typings": [
+          "rasufajasu"
+        ]
       },
       {
         "en": "Feria de Abril",
         "ja": "フェリアデアブリル",
-        "ja_typings": []
+        "ja_typings": [
+          "feriadeaburiru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31870,22 +32334,30 @@
       {
         "en": "Salsa",
         "ja": "サルサ",
-        "ja_typings": []
+        "ja_typings": [
+          "sarusa"
+        ]
       },
       {
         "en": "Tango",
         "ja": "タンゴ",
-        "ja_typings": []
+        "ja_typings": [
+          "tango"
+        ]
       },
       {
         "en": "Samba",
         "ja": "サンバ",
-        "ja_typings": []
+        "ja_typings": [
+          "sanba"
+        ]
       },
       {
         "en": "Flamenco",
         "ja": "フラメンコ",
-        "ja_typings": []
+        "ja_typings": [
+          "furamenko"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31902,22 +32374,30 @@
       {
         "en": "Diwali",
         "ja": "ディワリ",
-        "ja_typings": []
+        "ja_typings": [
+          "diwari"
+        ]
       },
       {
         "en": "Holi",
         "ja": "ホーリー",
-        "ja_typings": []
+        "ja_typings": [
+          "ho-ri-"
+        ]
       },
       {
         "en": "Navratri",
         "ja": "ナヴラトリ",
-        "ja_typings": []
+        "ja_typings": [
+          "navuratori"
+        ]
       },
       {
         "en": "Pongal",
         "ja": "ポンガル",
-        "ja_typings": []
+        "ja_typings": [
+          "pongaru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31934,22 +32414,30 @@
       {
         "en": "Semantics",
         "ja": "意味論",
-        "ja_typings": []
+        "ja_typings": [
+          "imiron"
+        ]
       },
       {
         "en": "Syntax",
         "ja": "統語論",
-        "ja_typings": []
+        "ja_typings": [
+          "tougoron"
+        ]
       },
       {
         "en": "Phonology",
         "ja": "音韻論",
-        "ja_typings": []
+        "ja_typings": [
+          "onninron"
+        ]
       },
       {
         "en": "Pragmatics",
         "ja": "語用論",
-        "ja_typings": []
+        "ja_typings": [
+          "goyouron"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31966,22 +32454,30 @@
       {
         "en": "Kanji",
         "ja": "漢字",
-        "ja_typings": []
+        "ja_typings": [
+          "kanji"
+        ]
       },
       {
         "en": "Hiragana",
         "ja": "ひらがな",
-        "ja_typings": []
+        "ja_typings": [
+          "hiragana"
+        ]
       },
       {
         "en": "Katakana",
         "ja": "カタカナ",
-        "ja_typings": []
+        "ja_typings": [
+          "katakana"
+        ]
       },
       {
         "en": "Romaji",
         "ja": "ローマ字",
-        "ja_typings": []
+        "ja_typings": [
+          "ro-maji"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -31998,22 +32494,30 @@
       {
         "en": "Active voice",
         "ja": "能動態",
-        "ja_typings": []
+        "ja_typings": [
+          "noudoutai"
+        ]
       },
       {
         "en": "Passive voice",
         "ja": "受動態",
-        "ja_typings": []
+        "ja_typings": [
+          "judoutai"
+        ]
       },
       {
         "en": "Middle voice",
         "ja": "中動態",
-        "ja_typings": []
+        "ja_typings": [
+          "chuudoutai"
+        ]
       },
       {
         "en": "Causative voice",
         "ja": "使役態",
-        "ja_typings": []
+        "ja_typings": [
+          "shiekitai"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32030,22 +32534,30 @@
       {
         "en": "Adverb",
         "ja": "副詞",
-        "ja_typings": []
+        "ja_typings": [
+          "fukushi"
+        ]
       },
       {
         "en": "Noun",
         "ja": "名詞",
-        "ja_typings": []
+        "ja_typings": [
+          "meishi"
+        ]
       },
       {
         "en": "Particle",
         "ja": "助詞",
-        "ja_typings": []
+        "ja_typings": [
+          "joshi"
+        ]
       },
       {
         "en": "Conjunction",
         "ja": "接続詞",
-        "ja_typings": []
+        "ja_typings": [
+          "setsuzokushi"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32062,22 +32574,30 @@
       {
         "en": "Sino-Tibetan",
         "ja": "シナチベット語族",
-        "ja_typings": []
+        "ja_typings": [
+          "shinachibettogozoku"
+        ]
       },
       {
         "en": "Indo-European",
         "ja": "インドヨーロッパ語族",
-        "ja_typings": []
+        "ja_typings": [
+          "indoyo-roppagozoku"
+        ]
       },
       {
         "en": "Austroasiatic",
         "ja": "オーストロアジア語族",
-        "ja_typings": []
+        "ja_typings": [
+          "o-sutoroajiagozoku"
+        ]
       },
       {
         "en": "Altaic",
         "ja": "アルタイ語族",
-        "ja_typings": []
+        "ja_typings": [
+          "arutaigozoku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32094,22 +32614,30 @@
       {
         "en": "Austronesian",
         "ja": "オーストロネシア語族",
-        "ja_typings": []
+        "ja_typings": [
+          "o-sutoroneshiagozoku"
+        ]
       },
       {
         "en": "Sino-Tibetan",
         "ja": "シナチベット語族",
-        "ja_typings": []
+        "ja_typings": [
+          "shinachibettogozoku"
+        ]
       },
       {
         "en": "Dravidian",
         "ja": "ドラビダ語族",
-        "ja_typings": []
+        "ja_typings": [
+          "dorabidagozoku"
+        ]
       },
       {
         "en": "Niger-Congo",
         "ja": "ニジェールコンゴ語族",
-        "ja_typings": []
+        "ja_typings": [
+          "nije-rukongogozoku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32126,22 +32654,30 @@
       {
         "en": "Hyperbole",
         "ja": "誇張法",
-        "ja_typings": []
+        "ja_typings": [
+          "kochouhou"
+        ]
       },
       {
         "en": "Metaphor",
         "ja": "隠喩",
-        "ja_typings": []
+        "ja_typings": [
+          "inyu"
+        ]
       },
       {
         "en": "Litotes",
         "ja": "緩叙法",
-        "ja_typings": []
+        "ja_typings": [
+          "kankyokuhou"
+        ]
       },
       {
         "en": "Irony",
         "ja": "皮肉",
-        "ja_typings": []
+        "ja_typings": [
+          "hiniku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32158,22 +32694,30 @@
       {
         "en": "Bopomofo",
         "ja": "ボポモフォ",
-        "ja_typings": []
+        "ja_typings": [
+          "bopomofo"
+        ]
       },
       {
         "en": "Pinyin",
         "ja": "ピンイン",
-        "ja_typings": []
+        "ja_typings": [
+          "pinnin"
+        ]
       },
       {
         "en": "Wade-Giles",
         "ja": "ウェード式",
-        "ja_typings": []
+        "ja_typings": [
+          "we-doshiki"
+        ]
       },
       {
         "en": "Zhuyin Fuhao",
         "ja": "注音符号",
-        "ja_typings": []
+        "ja_typings": [
+          "chuuonfugou"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32190,22 +32734,30 @@
       {
         "en": "Fargate",
         "ja": "ファーゲート",
-        "ja_typings": []
+        "ja_typings": [
+          "fa-ge-to"
+        ]
       },
       {
         "en": "ECS",
         "ja": "イーシーエス",
-        "ja_typings": []
+        "ja_typings": [
+          "i-shi-esu"
+        ]
       },
       {
         "en": "EKS",
         "ja": "イーケーエス",
-        "ja_typings": []
+        "ja_typings": [
+          "i-ke-esu"
+        ]
       },
       {
         "en": "Lambda",
         "ja": "ラムダ",
-        "ja_typings": []
+        "ja_typings": [
+          "ramuda"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32222,22 +32774,30 @@
       {
         "en": "IaaS",
         "ja": "アイアース",
-        "ja_typings": []
+        "ja_typings": [
+          "aia-su"
+        ]
       },
       {
         "en": "PaaS",
         "ja": "パース",
-        "ja_typings": []
+        "ja_typings": [
+          "pa-su"
+        ]
       },
       {
         "en": "SaaS",
         "ja": "サース",
-        "ja_typings": []
+        "ja_typings": [
+          "sa-su"
+        ]
       },
       {
         "en": "FaaS",
         "ja": "ファース",
-        "ja_typings": []
+        "ja_typings": [
+          "fa-su"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32254,22 +32814,30 @@
       {
         "en": "FaaS",
         "ja": "ファース",
-        "ja_typings": []
+        "ja_typings": [
+          "fa-su"
+        ]
       },
       {
         "en": "PaaS",
         "ja": "パース",
-        "ja_typings": []
+        "ja_typings": [
+          "pa-su"
+        ]
       },
       {
         "en": "IaaS",
         "ja": "アイアース",
-        "ja_typings": []
+        "ja_typings": [
+          "aia-su"
+        ]
       },
       {
         "en": "SaaS",
         "ja": "サース",
-        "ja_typings": []
+        "ja_typings": [
+          "sa-su"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32286,22 +32854,30 @@
       {
         "en": "DynamoDB",
         "ja": "ダイナモディービー",
-        "ja_typings": []
+        "ja_typings": [
+          "dainamodi-bi-"
+        ]
       },
       {
         "en": "RDS",
         "ja": "アールディーエス",
-        "ja_typings": []
+        "ja_typings": [
+          "a-rudi-esu"
+        ]
       },
       {
         "en": "Aurora",
         "ja": "オーロラ",
-        "ja_typings": []
+        "ja_typings": [
+          "o-rora"
+        ]
       },
       {
         "en": "Redshift",
         "ja": "レッドシフト",
-        "ja_typings": []
+        "ja_typings": [
+          "reddoshifuto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32318,22 +32894,30 @@
       {
         "en": "Redshift",
         "ja": "レッドシフト",
-        "ja_typings": []
+        "ja_typings": [
+          "reddoshifuto"
+        ]
       },
       {
         "en": "RDS",
         "ja": "アールディーエス",
-        "ja_typings": []
+        "ja_typings": [
+          "a-rudi-esu"
+        ]
       },
       {
         "en": "Athena",
         "ja": "アテナ",
-        "ja_typings": []
+        "ja_typings": [
+          "atena"
+        ]
       },
       {
         "en": "Aurora",
         "ja": "オーロラ",
-        "ja_typings": []
+        "ja_typings": [
+          "o-rora"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32350,22 +32934,30 @@
       {
         "en": "Terraform",
         "ja": "テラフォーム",
-        "ja_typings": []
+        "ja_typings": [
+          "terafo-mu"
+        ]
       },
       {
         "en": "Pulumi",
         "ja": "プルミ",
-        "ja_typings": []
+        "ja_typings": [
+          "purumi"
+        ]
       },
       {
         "en": "Ansible",
         "ja": "アンシブル",
-        "ja_typings": []
+        "ja_typings": [
+          "anshiburu"
+        ]
       },
       {
         "en": "CloudFormation",
         "ja": "クラウドフォーメーション",
-        "ja_typings": []
+        "ja_typings": [
+          "kuraudofo-me-shon"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32382,22 +32974,30 @@
       {
         "en": "Ansible",
         "ja": "アンシブル",
-        "ja_typings": []
+        "ja_typings": [
+          "anshiburu"
+        ]
       },
       {
         "en": "Chef",
         "ja": "シェフ",
-        "ja_typings": []
+        "ja_typings": [
+          "shefu"
+        ]
       },
       {
         "en": "Puppet",
         "ja": "パペット",
-        "ja_typings": []
+        "ja_typings": [
+          "papetto"
+        ]
       },
       {
         "en": "Salt",
         "ja": "ソルト",
-        "ja_typings": []
+        "ja_typings": [
+          "soruto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32414,22 +33014,30 @@
       {
         "en": "Sprint Review",
         "ja": "スプリントレビュー",
-        "ja_typings": []
+        "ja_typings": [
+          "supurintorebyu-"
+        ]
       },
       {
         "en": "Retrospective",
         "ja": "レトロスペクティブ",
-        "ja_typings": []
+        "ja_typings": [
+          "retorosupekutibu"
+        ]
       },
       {
         "en": "Daily Stand-up",
         "ja": "デイリースタンドアップ",
-        "ja_typings": []
+        "ja_typings": [
+          "deiri-sutandoappu"
+        ]
       },
       {
         "en": "Sprint Planning",
         "ja": "スプリントプランニング",
-        "ja_typings": []
+        "ja_typings": [
+          "supurintopurannningu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32446,22 +33054,30 @@
       {
         "en": "Kepler",
         "ja": "ケプラー",
-        "ja_typings": []
+        "ja_typings": [
+          "kepura-"
+        ]
       },
       {
         "en": "Galileo",
         "ja": "ガリレオ",
-        "ja_typings": []
+        "ja_typings": [
+          "garireo"
+        ]
       },
       {
         "en": "Copernicus",
         "ja": "コペルニクス",
-        "ja_typings": []
+        "ja_typings": [
+          "koperunikusu"
+        ]
       },
       {
         "en": "Brahe",
         "ja": "ブラーエ",
-        "ja_typings": []
+        "ja_typings": [
+          "bura-e"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32478,22 +33094,30 @@
       {
         "en": "Koch",
         "ja": "コッホ",
-        "ja_typings": []
+        "ja_typings": [
+          "kohho"
+        ]
       },
       {
         "en": "Pasteur",
         "ja": "パスツール",
-        "ja_typings": []
+        "ja_typings": [
+          "pasutsu-ru"
+        ]
       },
       {
         "en": "Lister",
         "ja": "リスター",
-        "ja_typings": []
+        "ja_typings": [
+          "risuta-"
+        ]
       },
       {
         "en": "Jenner",
         "ja": "ジェンナー",
-        "ja_typings": []
+        "ja_typings": [
+          "jennna-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32510,22 +33134,30 @@
       {
         "en": "Helium",
         "ja": "ヘリウム",
-        "ja_typings": []
+        "ja_typings": [
+          "heriumu"
+        ]
       },
       {
         "en": "Neon",
         "ja": "ネオン",
-        "ja_typings": []
+        "ja_typings": [
+          "neon"
+        ]
       },
       {
         "en": "Argon",
         "ja": "アルゴン",
-        "ja_typings": []
+        "ja_typings": [
+          "arugon"
+        ]
       },
       {
         "en": "Hydrogen",
         "ja": "水素",
-        "ja_typings": []
+        "ja_typings": [
+          "suiso"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32542,22 +33174,30 @@
       {
         "en": "Liver",
         "ja": "肝臓",
-        "ja_typings": []
+        "ja_typings": [
+          "kanzou"
+        ]
       },
       {
         "en": "Pancreas",
         "ja": "膵臓",
-        "ja_typings": []
+        "ja_typings": [
+          "suizou"
+        ]
       },
       {
         "en": "Kidney",
         "ja": "腎臓",
-        "ja_typings": []
+        "ja_typings": [
+          "jinzou"
+        ]
       },
       {
         "en": "Spleen",
         "ja": "脾臓",
-        "ja_typings": []
+        "ja_typings": [
+          "hizou"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32574,22 +33214,30 @@
       {
         "en": "Volt",
         "ja": "ボルト",
-        "ja_typings": []
+        "ja_typings": [
+          "boruto"
+        ]
       },
       {
         "en": "Watt",
         "ja": "ワット",
-        "ja_typings": []
+        "ja_typings": [
+          "watto"
+        ]
       },
       {
         "en": "Ohm",
         "ja": "オーム",
-        "ja_typings": []
+        "ja_typings": [
+          "o-mu"
+        ]
       },
       {
         "en": "Ampere",
         "ja": "アンペア",
-        "ja_typings": []
+        "ja_typings": [
+          "anpea"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32606,22 +33254,30 @@
       {
         "en": "Watt",
         "ja": "ワット",
-        "ja_typings": []
+        "ja_typings": [
+          "watto"
+        ]
       },
       {
         "en": "Volt",
         "ja": "ボルト",
-        "ja_typings": []
+        "ja_typings": [
+          "boruto"
+        ]
       },
       {
         "en": "Joule",
         "ja": "ジュール",
-        "ja_typings": []
+        "ja_typings": [
+          "ju-ru"
+        ]
       },
       {
         "en": "Newton",
         "ja": "ニュートン",
-        "ja_typings": []
+        "ja_typings": [
+          "nyu-ton"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32638,22 +33294,30 @@
       {
         "en": "Rutherford",
         "ja": "ラザフォード",
-        "ja_typings": []
+        "ja_typings": [
+          "razafo-do"
+        ]
       },
       {
         "en": "Bohr",
         "ja": "ボーア",
-        "ja_typings": []
+        "ja_typings": [
+          "bo-a"
+        ]
       },
       {
         "en": "Thomson",
         "ja": "トムソン",
-        "ja_typings": []
+        "ja_typings": [
+          "tomuson"
+        ]
       },
       {
         "en": "Curie",
         "ja": "キュリー",
-        "ja_typings": []
+        "ja_typings": [
+          "kyuri-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32670,22 +33334,30 @@
       {
         "en": "Pascal",
         "ja": "パスカル",
-        "ja_typings": []
+        "ja_typings": [
+          "pasukaru"
+        ]
       },
       {
         "en": "Bar",
         "ja": "バール",
-        "ja_typings": []
+        "ja_typings": [
+          "ba-ru"
+        ]
       },
       {
         "en": "Torr",
         "ja": "トール",
-        "ja_typings": []
+        "ja_typings": [
+          "to-ru"
+        ]
       },
       {
         "en": "Atmosphere",
         "ja": "アトモスフィア",
-        "ja_typings": []
+        "ja_typings": [
+          "atomosufia"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32702,22 +33374,30 @@
       {
         "en": "Nero",
         "ja": "ネロ",
-        "ja_typings": []
+        "ja_typings": [
+          "nero"
+        ]
       },
       {
         "en": "Caligula",
         "ja": "カリグラ",
-        "ja_typings": []
+        "ja_typings": [
+          "karigura"
+        ]
       },
       {
         "en": "Domitian",
         "ja": "ドミティアヌス",
-        "ja_typings": []
+        "ja_typings": [
+          "domitianusu"
+        ]
       },
       {
         "en": "Commodus",
         "ja": "コンモドゥス",
-        "ja_typings": []
+        "ja_typings": [
+          "konmodusu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32734,22 +33414,30 @@
       {
         "en": "Hadrian",
         "ja": "ハドリアヌス",
-        "ja_typings": []
+        "ja_typings": [
+          "hadorianusu"
+        ]
       },
       {
         "en": "Trajan",
         "ja": "トラヤヌス",
-        "ja_typings": []
+        "ja_typings": [
+          "torayanusu"
+        ]
       },
       {
         "en": "Antoninus Pius",
         "ja": "アントニヌスピウス",
-        "ja_typings": []
+        "ja_typings": [
+          "antoninusupiusu"
+        ]
       },
       {
         "en": "Marcus Aurelius",
         "ja": "マルクスアウレリウス",
-        "ja_typings": []
+        "ja_typings": [
+          "marukusuaureriusu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32766,22 +33454,30 @@
       {
         "en": "Battle of Waterloo",
         "ja": "ワーテルローの戦い",
-        "ja_typings": []
+        "ja_typings": [
+          "wa-teru-notatakai"
+        ]
       },
       {
         "en": "Battle of Leipzig",
         "ja": "ライプツィヒの戦い",
-        "ja_typings": []
+        "ja_typings": [
+          "raiputsihinotatakai"
+        ]
       },
       {
         "en": "Battle of Valmy",
         "ja": "バルミーの戦い",
-        "ja_typings": []
+        "ja_typings": [
+          "barumi-notatakai"
+        ]
       },
       {
         "en": "Battle of Borodino",
         "ja": "ボロジノの戦い",
-        "ja_typings": []
+        "ja_typings": [
+          "borojinonotatakai"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32798,22 +33494,30 @@
       {
         "en": "Vasco da Gama",
         "ja": "ヴァスコ・ダ・ガマ",
-        "ja_typings": []
+        "ja_typings": [
+          "vasuko/da/gama"
+        ]
       },
       {
         "en": "Magellan",
         "ja": "マゼラン",
-        "ja_typings": []
+        "ja_typings": [
+          "mazeran"
+        ]
       },
       {
         "en": "Columbus",
         "ja": "コロンブス",
-        "ja_typings": []
+        "ja_typings": [
+          "koronbusu"
+        ]
       },
       {
         "en": "Henry the Navigator",
         "ja": "エンリケ航海王子",
-        "ja_typings": []
+        "ja_typings": [
+          "enrikekoukaiouji"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32830,22 +33534,30 @@
       {
         "en": "Amerigo Vespucci",
         "ja": "アメリゴ・ヴェスプッチ",
-        "ja_typings": []
+        "ja_typings": [
+          "amerigo/vesuputchi"
+        ]
       },
       {
         "en": "Magellan",
         "ja": "マゼラン",
-        "ja_typings": []
+        "ja_typings": [
+          "mazeran"
+        ]
       },
       {
         "en": "Columbus",
         "ja": "コロンブス",
-        "ja_typings": []
+        "ja_typings": [
+          "koronbusu"
+        ]
       },
       {
         "en": "Marco Polo",
         "ja": "マルコ・ポーロ",
-        "ja_typings": []
+        "ja_typings": [
+          "maruko/po-ro"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32862,22 +33574,30 @@
       {
         "en": "Magellan",
         "ja": "マゼラン",
-        "ja_typings": []
+        "ja_typings": [
+          "mazeran"
+        ]
       },
       {
         "en": "Vasco da Gama",
         "ja": "ヴァスコ・ダ・ガマ",
-        "ja_typings": []
+        "ja_typings": [
+          "vasuko/da/gama"
+        ]
       },
       {
         "en": "Cabral",
         "ja": "カブラル",
-        "ja_typings": []
+        "ja_typings": [
+          "kaburaru"
+        ]
       },
       {
         "en": "Dias",
         "ja": "ディアス",
-        "ja_typings": []
+        "ja_typings": [
+          "diasu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32894,22 +33614,30 @@
       {
         "en": "Vietnam",
         "ja": "ベトナム",
-        "ja_typings": []
+        "ja_typings": [
+          "betonamu"
+        ]
       },
       {
         "en": "Laos",
         "ja": "ラオス",
-        "ja_typings": []
+        "ja_typings": [
+          "raosu"
+        ]
       },
       {
         "en": "Cambodia",
         "ja": "カンボジア",
-        "ja_typings": []
+        "ja_typings": [
+          "kanbojia"
+        ]
       },
       {
         "en": "Myanmar",
         "ja": "ミャンマー",
-        "ja_typings": []
+        "ja_typings": [
+          "myanma-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32926,22 +33654,30 @@
       {
         "en": "Indonesia",
         "ja": "インドネシア",
-        "ja_typings": []
+        "ja_typings": [
+          "indoneshia"
+        ]
       },
       {
         "en": "Malaysia",
         "ja": "マレーシア",
-        "ja_typings": []
+        "ja_typings": [
+          "mare-shia"
+        ]
       },
       {
         "en": "Philippines",
         "ja": "フィリピン",
-        "ja_typings": []
+        "ja_typings": [
+          "firipin"
+        ]
       },
       {
         "en": "Singapore",
         "ja": "シンガポール",
-        "ja_typings": []
+        "ja_typings": [
+          "shingapo-ru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32958,22 +33694,30 @@
       {
         "en": "Turkey",
         "ja": "トルコ",
-        "ja_typings": []
+        "ja_typings": [
+          "toruko"
+        ]
       },
       {
         "en": "Greece",
         "ja": "ギリシャ",
-        "ja_typings": []
+        "ja_typings": [
+          "girisha"
+        ]
       },
       {
         "en": "Bulgaria",
         "ja": "ブルガリア",
-        "ja_typings": []
+        "ja_typings": [
+          "burugaria"
+        ]
       },
       {
         "en": "Romania",
         "ja": "ルーマニア",
-        "ja_typings": []
+        "ja_typings": [
+          "ru-mania"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -32990,22 +33734,30 @@
       {
         "en": "Portugal",
         "ja": "ポルトガル",
-        "ja_typings": []
+        "ja_typings": [
+          "porutogaru"
+        ]
       },
       {
         "en": "Spain",
         "ja": "スペイン",
-        "ja_typings": []
+        "ja_typings": [
+          "supein"
+        ]
       },
       {
         "en": "Italy",
         "ja": "イタリア",
-        "ja_typings": []
+        "ja_typings": [
+          "itaria"
+        ]
       },
       {
         "en": "Greece",
         "ja": "ギリシャ",
-        "ja_typings": []
+        "ja_typings": [
+          "girisha"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -33022,22 +33774,30 @@
       {
         "en": "Finland",
         "ja": "フィンランド",
-        "ja_typings": []
+        "ja_typings": [
+          "finrando"
+        ]
       },
       {
         "en": "Sweden",
         "ja": "スウェーデン",
-        "ja_typings": []
+        "ja_typings": [
+          "suwe-den"
+        ]
       },
       {
         "en": "Norway",
         "ja": "ノルウェー",
-        "ja_typings": []
+        "ja_typings": [
+          "noruwe-"
+        ]
       },
       {
         "en": "Denmark",
         "ja": "デンマーク",
-        "ja_typings": []
+        "ja_typings": [
+          "denma-ku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -33054,22 +33814,30 @@
       {
         "en": "Norway",
         "ja": "ノルウェー",
-        "ja_typings": []
+        "ja_typings": [
+          "noruwe-"
+        ]
       },
       {
         "en": "Sweden",
         "ja": "スウェーデン",
-        "ja_typings": []
+        "ja_typings": [
+          "suwe-den"
+        ]
       },
       {
         "en": "Iceland",
         "ja": "アイスランド",
-        "ja_typings": []
+        "ja_typings": [
+          "aisurando"
+        ]
       },
       {
         "en": "Finland",
         "ja": "フィンランド",
-        "ja_typings": []
+        "ja_typings": [
+          "finrando"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -33086,22 +33854,30 @@
       {
         "en": "Austria",
         "ja": "オーストリア",
-        "ja_typings": []
+        "ja_typings": [
+          "o-sutoria"
+        ]
       },
       {
         "en": "Switzerland",
         "ja": "スイス",
-        "ja_typings": []
+        "ja_typings": [
+          "suisu"
+        ]
       },
       {
         "en": "Hungary",
         "ja": "ハンガリー",
-        "ja_typings": []
+        "ja_typings": [
+          "hangari-"
+        ]
       },
       {
         "en": "Czech Republic",
         "ja": "チェコ",
-        "ja_typings": []
+        "ja_typings": [
+          "cheko"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -33118,22 +33894,30 @@
       {
         "en": "Czech Republic",
         "ja": "チェコ",
-        "ja_typings": []
+        "ja_typings": [
+          "cheko"
+        ]
       },
       {
         "en": "Slovakia",
         "ja": "スロバキア",
-        "ja_typings": []
+        "ja_typings": [
+          "surobakia"
+        ]
       },
       {
         "en": "Poland",
         "ja": "ポーランド",
-        "ja_typings": []
+        "ja_typings": [
+          "po-rando"
+        ]
       },
       {
         "en": "Hungary",
         "ja": "ハンガリー",
-        "ja_typings": []
+        "ja_typings": [
+          "hangari-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -33150,22 +33934,30 @@
       {
         "en": "Poland",
         "ja": "ポーランド",
-        "ja_typings": []
+        "ja_typings": [
+          "po-rando"
+        ]
       },
       {
         "en": "Czech Republic",
         "ja": "チェコ",
-        "ja_typings": []
+        "ja_typings": [
+          "cheko"
+        ]
       },
       {
         "en": "Lithuania",
         "ja": "リトアニア",
-        "ja_typings": []
+        "ja_typings": [
+          "ritoania"
+        ]
       },
       {
         "en": "Belarus",
         "ja": "ベラルーシ",
-        "ja_typings": []
+        "ja_typings": [
+          "beraru-shi"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -33182,22 +33974,30 @@
       {
         "en": "Argentina",
         "ja": "アルゼンチン",
-        "ja_typings": []
+        "ja_typings": [
+          "aruzenchin"
+        ]
       },
       {
         "en": "Chile",
         "ja": "チリ",
-        "ja_typings": []
+        "ja_typings": [
+          "chiri"
+        ]
       },
       {
         "en": "Uruguay",
         "ja": "ウルグアイ",
-        "ja_typings": []
+        "ja_typings": [
+          "uruguai"
+        ]
       },
       {
         "en": "Paraguay",
         "ja": "パラグアイ",
-        "ja_typings": []
+        "ja_typings": [
+          "paraguai"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -33214,22 +34014,30 @@
       {
         "en": "Peru",
         "ja": "ペルー",
-        "ja_typings": []
+        "ja_typings": [
+          "peru-"
+        ]
       },
       {
         "en": "Ecuador",
         "ja": "エクアドル",
-        "ja_typings": []
+        "ja_typings": [
+          "ekuadoru"
+        ]
       },
       {
         "en": "Bolivia",
         "ja": "ボリビア",
-        "ja_typings": []
+        "ja_typings": [
+          "boribia"
+        ]
       },
       {
         "en": "Colombia",
         "ja": "コロンビア",
-        "ja_typings": []
+        "ja_typings": [
+          "koronbia"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -33246,22 +34054,30 @@
       {
         "en": "Kenya",
         "ja": "ケニア",
-        "ja_typings": []
+        "ja_typings": [
+          "kenia"
+        ]
       },
       {
         "en": "Tanzania",
         "ja": "タンザニア",
-        "ja_typings": []
+        "ja_typings": [
+          "tanzania"
+        ]
       },
       {
         "en": "Uganda",
         "ja": "ウガンダ",
-        "ja_typings": []
+        "ja_typings": [
+          "uganda"
+        ]
       },
       {
         "en": "Ethiopia",
         "ja": "エチオピア",
-        "ja_typings": []
+        "ja_typings": [
+          "echiopia"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -33278,22 +34094,30 @@
       {
         "en": "Egypt",
         "ja": "エジプト",
-        "ja_typings": []
+        "ja_typings": [
+          "ejiputo"
+        ]
       },
       {
         "en": "Libya",
         "ja": "リビア",
-        "ja_typings": []
+        "ja_typings": [
+          "ribia"
+        ]
       },
       {
         "en": "Sudan",
         "ja": "スーダン",
-        "ja_typings": []
+        "ja_typings": [
+          "su-dan"
+        ]
       },
       {
         "en": "Algeria",
         "ja": "アルジェリア",
-        "ja_typings": []
+        "ja_typings": [
+          "arujeria"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -33310,22 +34134,30 @@
       {
         "en": "New Zealand",
         "ja": "ニュージーランド",
-        "ja_typings": []
+        "ja_typings": [
+          "nyu-ji-rando"
+        ]
       },
       {
         "en": "Australia",
         "ja": "オーストラリア",
-        "ja_typings": []
+        "ja_typings": [
+          "o-sutoraria"
+        ]
       },
       {
         "en": "Fiji",
         "ja": "フィジー",
-        "ja_typings": []
+        "ja_typings": [
+          "fiji-"
+        ]
       },
       {
         "en": "Samoa",
         "ja": "サモア",
-        "ja_typings": []
+        "ja_typings": [
+          "samoa"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -33342,22 +34174,30 @@
       {
         "en": "Australia",
         "ja": "オーストラリア",
-        "ja_typings": []
+        "ja_typings": [
+          "o-sutoraria"
+        ]
       },
       {
         "en": "New Zealand",
         "ja": "ニュージーランド",
-        "ja_typings": []
+        "ja_typings": [
+          "nyu-ji-rando"
+        ]
       },
       {
         "en": "Papua New Guinea",
         "ja": "パプアニューギニア",
-        "ja_typings": []
+        "ja_typings": [
+          "papuanyu-ginia"
+        ]
       },
       {
         "en": "Fiji",
         "ja": "フィジー",
-        "ja_typings": []
+        "ja_typings": [
+          "fiji-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -33374,22 +34214,30 @@
       {
         "en": "Canada",
         "ja": "カナダ",
-        "ja_typings": []
+        "ja_typings": [
+          "kanada"
+        ]
       },
       {
         "en": "United States",
         "ja": "アメリカ",
-        "ja_typings": []
+        "ja_typings": [
+          "amerika"
+        ]
       },
       {
         "en": "Mexico",
         "ja": "メキシコ",
-        "ja_typings": []
+        "ja_typings": [
+          "mekishiko"
+        ]
       },
       {
         "en": "Cuba",
         "ja": "キューバ",
-        "ja_typings": []
+        "ja_typings": [
+          "kyu-ba"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -33766,12 +34614,16 @@
       {
         "en": "Russia",
         "ja": "ロシア",
-        "ja_typings": []
+        "ja_typings": [
+          "roshia"
+        ]
       },
       {
         "en": "Canada",
         "ja": "カナダ",
-        "ja_typings": []
+        "ja_typings": [
+          "kanada"
+        ]
       },
       {
         "en": "China",
@@ -33783,7 +34635,9 @@
       {
         "en": "Brazil",
         "ja": "ブラジル",
-        "ja_typings": []
+        "ja_typings": [
+          "burajiru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -33807,17 +34661,23 @@
       {
         "en": "Monaco",
         "ja": "モナコ",
-        "ja_typings": []
+        "ja_typings": [
+          "monako"
+        ]
       },
       {
         "en": "San Marino",
         "ja": "サンマリノ",
-        "ja_typings": []
+        "ja_typings": [
+          "sanmarino"
+        ]
       },
       {
         "en": "Liechtenstein",
         "ja": "リヒテンシュタイン",
-        "ja_typings": []
+        "ja_typings": [
+          "rihitenshutain"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -33994,22 +34854,30 @@
       {
         "en": "Africa",
         "ja": "アフリカ",
-        "ja_typings": []
+        "ja_typings": [
+          "afurika"
+        ]
       },
       {
         "en": "Asia",
         "ja": "アジア",
-        "ja_typings": []
+        "ja_typings": [
+          "ajia"
+        ]
       },
       {
         "en": "Europe",
         "ja": "ヨーロッパ",
-        "ja_typings": []
+        "ja_typings": [
+          "yo-roppa"
+        ]
       },
       {
         "en": "Oceania",
         "ja": "オセアニア",
-        "ja_typings": []
+        "ja_typings": [
+          "oseania"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -34026,17 +34894,23 @@
       {
         "en": "Africa",
         "ja": "アフリカ",
-        "ja_typings": []
+        "ja_typings": [
+          "afurika"
+        ]
       },
       {
         "en": "Asia",
         "ja": "アジア",
-        "ja_typings": []
+        "ja_typings": [
+          "ajia"
+        ]
       },
       {
         "en": "Europe",
         "ja": "ヨーロッパ",
-        "ja_typings": []
+        "ja_typings": [
+          "yo-roppa"
+        ]
       },
       {
         "en": "South America",
@@ -34060,7 +34934,9 @@
       {
         "en": "Kilimanjaro",
         "ja": "キリマンジャロ",
-        "ja_typings": []
+        "ja_typings": [
+          "kirimanjaro"
+        ]
       },
       {
         "en": "Mount Kenya",
@@ -34098,22 +34974,30 @@
       {
         "en": "Rome",
         "ja": "ローマ",
-        "ja_typings": []
+        "ja_typings": [
+          "ro-ma"
+        ]
       },
       {
         "en": "Athens",
         "ja": "アテネ",
-        "ja_typings": []
+        "ja_typings": [
+          "atene"
+        ]
       },
       {
         "en": "Istanbul",
         "ja": "イスタンブール",
-        "ja_typings": []
+        "ja_typings": [
+          "isutanbu-ru"
+        ]
       },
       {
         "en": "Jerusalem",
         "ja": "エルサレム",
-        "ja_typings": []
+        "ja_typings": [
+          "erusaremu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -34151,7 +35035,9 @@
       {
         "en": "Kublai Khan",
         "ja": "フビライハン",
-        "ja_typings": []
+        "ja_typings": [
+          "fubiraihan"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -34168,22 +35054,30 @@
       {
         "en": "Genghis Khan",
         "ja": "チンギスハン",
-        "ja_typings": []
+        "ja_typings": [
+          "chingisuhan"
+        ]
       },
       {
         "en": "Kublai Khan",
         "ja": "フビライハン",
-        "ja_typings": []
+        "ja_typings": [
+          "fubiraihan"
+        ]
       },
       {
         "en": "Tamerlane",
         "ja": "ティムール",
-        "ja_typings": []
+        "ja_typings": [
+          "timu-ru"
+        ]
       },
       {
         "en": "Attila",
         "ja": "アッティラ",
-        "ja_typings": []
+        "ja_typings": [
+          "attira"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -34200,22 +35094,30 @@
       {
         "en": "Cleopatra",
         "ja": "クレオパトラ",
-        "ja_typings": []
+        "ja_typings": [
+          "kureopatora"
+        ]
       },
       {
         "en": "Nefertiti",
         "ja": "ネフェルティティ",
-        "ja_typings": []
+        "ja_typings": [
+          "neferutiti"
+        ]
       },
       {
         "en": "Hatshepsut",
         "ja": "ハトシェプスト",
-        "ja_typings": []
+        "ja_typings": [
+          "hatoshepusuto"
+        ]
       },
       {
         "en": "Isis",
         "ja": "イシス",
-        "ja_typings": []
+        "ja_typings": [
+          "ishisu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -34232,22 +35134,30 @@
       {
         "en": "Rajendra Prasad",
         "ja": "ラジェンドラプラサド",
-        "ja_typings": []
+        "ja_typings": [
+          "rajendorapurasado"
+        ]
       },
       {
         "en": "Jawaharlal Nehru",
         "ja": "ネルー",
-        "ja_typings": []
+        "ja_typings": [
+          "neru-"
+        ]
       },
       {
         "en": "Mahatma Gandhi",
         "ja": "ガンディー",
-        "ja_typings": []
+        "ja_typings": [
+          "gandi-"
+        ]
       },
       {
         "en": "Indira Gandhi",
         "ja": "インディラガンディー",
-        "ja_typings": []
+        "ja_typings": [
+          "indiragandi-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -34264,22 +35174,30 @@
       {
         "en": "Gandhi",
         "ja": "ガンディー",
-        "ja_typings": []
+        "ja_typings": [
+          "gandi-"
+        ]
       },
       {
         "en": "Nehru",
         "ja": "ネルー",
-        "ja_typings": []
+        "ja_typings": [
+          "neru-"
+        ]
       },
       {
         "en": "Bose",
         "ja": "ボース",
-        "ja_typings": []
+        "ja_typings": [
+          "bo-su"
+        ]
       },
       {
         "en": "Tagore",
         "ja": "タゴール",
-        "ja_typings": []
+        "ja_typings": [
+          "tago-ru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -34296,22 +35214,30 @@
       {
         "en": "Churchill",
         "ja": "チャーチル",
-        "ja_typings": []
+        "ja_typings": [
+          "cha-chiru"
+        ]
       },
       {
         "en": "Chamberlain",
         "ja": "チェンバレン",
-        "ja_typings": []
+        "ja_typings": [
+          "chenbaren"
+        ]
       },
       {
         "en": "Attlee",
         "ja": "アトリー",
-        "ja_typings": []
+        "ja_typings": [
+          "atori-"
+        ]
       },
       {
         "en": "Eden",
         "ja": "イーデン",
-        "ja_typings": []
+        "ja_typings": [
+          "i-den"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -34328,22 +35254,30 @@
       {
         "en": "Hitler",
         "ja": "ヒトラー",
-        "ja_typings": []
+        "ja_typings": [
+          "hitora-"
+        ]
       },
       {
         "en": "Himmler",
         "ja": "ヒムラー",
-        "ja_typings": []
+        "ja_typings": [
+          "himura-"
+        ]
       },
       {
         "en": "Goebbels",
         "ja": "ゲッベルス",
-        "ja_typings": []
+        "ja_typings": [
+          "gebberusu"
+        ]
       },
       {
         "en": "Goering",
         "ja": "ゲーリング",
-        "ja_typings": []
+        "ja_typings": [
+          "ge-ringu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -34360,22 +35294,30 @@
       {
         "en": "Stalin",
         "ja": "スターリン",
-        "ja_typings": []
+        "ja_typings": [
+          "suta-rin"
+        ]
       },
       {
         "en": "Lenin",
         "ja": "レーニン",
-        "ja_typings": []
+        "ja_typings": [
+          "re-nin"
+        ]
       },
       {
         "en": "Khrushchev",
         "ja": "フルシチョフ",
-        "ja_typings": []
+        "ja_typings": [
+          "furushichofu"
+        ]
       },
       {
         "en": "Trotsky",
         "ja": "トロツキー",
-        "ja_typings": []
+        "ja_typings": [
+          "torotsuki-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -34392,22 +35334,30 @@
       {
         "en": "Lenin",
         "ja": "レーニン",
-        "ja_typings": []
+        "ja_typings": [
+          "re-nin"
+        ]
       },
       {
         "en": "Stalin",
         "ja": "スターリン",
-        "ja_typings": []
+        "ja_typings": [
+          "suta-rin"
+        ]
       },
       {
         "en": "Trotsky",
         "ja": "トロツキー",
-        "ja_typings": []
+        "ja_typings": [
+          "torotsuki-"
+        ]
       },
       {
         "en": "Marx",
         "ja": "マルクス",
-        "ja_typings": []
+        "ja_typings": [
+          "marukusu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -34424,22 +35374,30 @@
       {
         "en": "Marx",
         "ja": "マルクス",
-        "ja_typings": []
+        "ja_typings": [
+          "marukusu"
+        ]
       },
       {
         "en": "Lenin",
         "ja": "レーニン",
-        "ja_typings": []
+        "ja_typings": [
+          "re-nin"
+        ]
       },
       {
         "en": "Bakunin",
         "ja": "バクーニン",
-        "ja_typings": []
+        "ja_typings": [
+          "baku-nin"
+        ]
       },
       {
         "en": "Proudhon",
         "ja": "プルードン",
-        "ja_typings": []
+        "ja_typings": [
+          "puru-don"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -34456,22 +35414,30 @@
       {
         "en": "Lincoln",
         "ja": "リンカーン",
-        "ja_typings": []
+        "ja_typings": [
+          "rinka-n"
+        ]
       },
       {
         "en": "Garfield",
         "ja": "ガーフィールド",
-        "ja_typings": []
+        "ja_typings": [
+          "ga-fi-rudo"
+        ]
       },
       {
         "en": "McKinley",
         "ja": "マッキンリー",
-        "ja_typings": []
+        "ja_typings": [
+          "makkinri-"
+        ]
       },
       {
         "en": "Kennedy",
         "ja": "ケネディ",
-        "ja_typings": []
+        "ja_typings": [
+          "kenedi"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -34488,22 +35454,30 @@
       {
         "en": "Kennedy",
         "ja": "ケネディ",
-        "ja_typings": []
+        "ja_typings": [
+          "kenedi"
+        ]
       },
       {
         "en": "Eisenhower",
         "ja": "アイゼンハワー",
-        "ja_typings": []
+        "ja_typings": [
+          "aizenhawa-"
+        ]
       },
       {
         "en": "Johnson",
         "ja": "ジョンソン",
-        "ja_typings": []
+        "ja_typings": [
+          "jonson"
+        ]
       },
       {
         "en": "Nixon",
         "ja": "ニクソン",
-        "ja_typings": []
+        "ja_typings": [
+          "nikuson"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -34520,22 +35494,30 @@
       {
         "en": "Columbus",
         "ja": "コロンブス",
-        "ja_typings": []
+        "ja_typings": [
+          "koronbusu"
+        ]
       },
       {
         "en": "Magellan",
         "ja": "マゼラン",
-        "ja_typings": []
+        "ja_typings": [
+          "mazeran"
+        ]
       },
       {
         "en": "Vespucci",
         "ja": "ベスプッチ",
-        "ja_typings": []
+        "ja_typings": [
+          "besuputchi"
+        ]
       },
       {
         "en": "Cabot",
         "ja": "カボット",
-        "ja_typings": []
+        "ja_typings": [
+          "kabotto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -34559,17 +35541,23 @@
       {
         "en": "Columbus",
         "ja": "コロンブス",
-        "ja_typings": []
+        "ja_typings": [
+          "koronbusu"
+        ]
       },
       {
         "en": "Vasco da Gama",
         "ja": "バスコダガマ",
-        "ja_typings": []
+        "ja_typings": [
+          "basukodagama"
+        ]
       },
       {
         "en": "Drake",
         "ja": "ドレーク",
-        "ja_typings": []
+        "ja_typings": [
+          "dore-ku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -34586,22 +35574,30 @@
       {
         "en": "Leonardo da Vinci",
         "ja": "ダヴィンチ",
-        "ja_typings": []
+        "ja_typings": [
+          "davinchi"
+        ]
       },
       {
         "en": "Michelangelo",
         "ja": "ミケランジェロ",
-        "ja_typings": []
+        "ja_typings": [
+          "mikeranjero"
+        ]
       },
       {
         "en": "Raphael",
         "ja": "ラファエロ",
-        "ja_typings": []
+        "ja_typings": [
+          "rafaero"
+        ]
       },
       {
         "en": "Botticelli",
         "ja": "ボッティチェリ",
-        "ja_typings": []
+        "ja_typings": [
+          "botticheri"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -34618,22 +35614,30 @@
       {
         "en": "Copernicus",
         "ja": "コペルニクス",
-        "ja_typings": []
+        "ja_typings": [
+          "koperunikusu"
+        ]
       },
       {
         "en": "Galileo",
         "ja": "ガリレオ",
-        "ja_typings": []
+        "ja_typings": [
+          "garireo"
+        ]
       },
       {
         "en": "Kepler",
         "ja": "ケプラー",
-        "ja_typings": []
+        "ja_typings": [
+          "kepura-"
+        ]
       },
       {
         "en": "Brahe",
         "ja": "ブラーエ",
-        "ja_typings": []
+        "ja_typings": [
+          "bura-e"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -34650,22 +35654,30 @@
       {
         "en": "Babur",
         "ja": "バーブル",
-        "ja_typings": []
+        "ja_typings": [
+          "ba-buru"
+        ]
       },
       {
         "en": "Akbar",
         "ja": "アクバル",
-        "ja_typings": []
+        "ja_typings": [
+          "akubaru"
+        ]
       },
       {
         "en": "Aurangzeb",
         "ja": "アウラングゼーブ",
-        "ja_typings": []
+        "ja_typings": [
+          "auranguze-bu"
+        ]
       },
       {
         "en": "Shah Jahan",
         "ja": "シャージャハン",
-        "ja_typings": []
+        "ja_typings": [
+          "sha-jahan"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -34682,22 +35694,30 @@
       {
         "en": "Shah Jahan",
         "ja": "シャージャハン",
-        "ja_typings": []
+        "ja_typings": [
+          "sha-jahan"
+        ]
       },
       {
         "en": "Akbar",
         "ja": "アクバル",
-        "ja_typings": []
+        "ja_typings": [
+          "akubaru"
+        ]
       },
       {
         "en": "Babur",
         "ja": "バーブル",
-        "ja_typings": []
+        "ja_typings": [
+          "ba-buru"
+        ]
       },
       {
         "en": "Aurangzeb",
         "ja": "アウラングゼーブ",
-        "ja_typings": []
+        "ja_typings": [
+          "auranguze-bu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -34994,22 +36014,30 @@
       {
         "en": "Inca",
         "ja": "インカ",
-        "ja_typings": []
+        "ja_typings": [
+          "inka"
+        ]
       },
       {
         "en": "Maya",
         "ja": "マヤ",
-        "ja_typings": []
+        "ja_typings": [
+          "maya"
+        ]
       },
       {
         "en": "Aztec",
         "ja": "アステカ",
-        "ja_typings": []
+        "ja_typings": [
+          "asuteka"
+        ]
       },
       {
         "en": "Olmec",
         "ja": "オルメカ",
-        "ja_typings": []
+        "ja_typings": [
+          "orumeka"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -35026,22 +36054,30 @@
       {
         "en": "Maya",
         "ja": "マヤ",
-        "ja_typings": []
+        "ja_typings": [
+          "maya"
+        ]
       },
       {
         "en": "Aztec",
         "ja": "アステカ",
-        "ja_typings": []
+        "ja_typings": [
+          "asuteka"
+        ]
       },
       {
         "en": "Inca",
         "ja": "インカ",
-        "ja_typings": []
+        "ja_typings": [
+          "inka"
+        ]
       },
       {
         "en": "Toltec",
         "ja": "トルテカ",
-        "ja_typings": []
+        "ja_typings": [
+          "toruteka"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -35058,22 +36094,30 @@
       {
         "en": "Aztec",
         "ja": "アステカ",
-        "ja_typings": []
+        "ja_typings": [
+          "asuteka"
+        ]
       },
       {
         "en": "Maya",
         "ja": "マヤ",
-        "ja_typings": []
+        "ja_typings": [
+          "maya"
+        ]
       },
       {
         "en": "Inca",
         "ja": "インカ",
-        "ja_typings": []
+        "ja_typings": [
+          "inka"
+        ]
       },
       {
         "en": "Olmec",
         "ja": "オルメカ",
-        "ja_typings": []
+        "ja_typings": [
+          "orumeka"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -35130,22 +36174,30 @@
       {
         "en": "Ataturk",
         "ja": "アタチュルク",
-        "ja_typings": []
+        "ja_typings": [
+          "atachuruku"
+        ]
       },
       {
         "en": "Erdogan",
         "ja": "エルドアン",
-        "ja_typings": []
+        "ja_typings": [
+          "erudoan"
+        ]
       },
       {
         "en": "Inonu",
         "ja": "イノニュ",
-        "ja_typings": []
+        "ja_typings": [
+          "inonyu"
+        ]
       },
       {
         "en": "Ozal",
         "ja": "オザル",
-        "ja_typings": []
+        "ja_typings": [
+          "ozaru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -35362,22 +36414,30 @@
       {
         "en": "Ag",
         "ja": "Ag",
-        "ja_typings": []
+        "ja_typings": [
+          "ag"
+        ]
       },
       {
         "en": "Au",
         "ja": "Au",
-        "ja_typings": []
+        "ja_typings": [
+          "au"
+        ]
       },
       {
         "en": "Al",
         "ja": "Al",
-        "ja_typings": []
+        "ja_typings": [
+          "al"
+        ]
       },
       {
         "en": "As",
         "ja": "As",
-        "ja_typings": []
+        "ja_typings": [
+          "as"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -35394,22 +36454,30 @@
       {
         "en": "Na",
         "ja": "Na",
-        "ja_typings": []
+        "ja_typings": [
+          "na"
+        ]
       },
       {
         "en": "So",
         "ja": "So",
-        "ja_typings": []
+        "ja_typings": [
+          "so"
+        ]
       },
       {
         "en": "Sn",
         "ja": "Sn",
-        "ja_typings": []
+        "ja_typings": [
+          "sn"
+        ]
       },
       {
         "en": "Ni",
         "ja": "Ni",
-        "ja_typings": []
+        "ja_typings": [
+          "ni"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -35426,22 +36494,30 @@
       {
         "en": "K",
         "ja": "K",
-        "ja_typings": []
+        "ja_typings": [
+          "k"
+        ]
       },
       {
         "en": "P",
         "ja": "P",
-        "ja_typings": []
+        "ja_typings": [
+          "p"
+        ]
       },
       {
         "en": "Ca",
         "ja": "Ca",
-        "ja_typings": []
+        "ja_typings": [
+          "ca"
+        ]
       },
       {
         "en": "Po",
         "ja": "Po",
-        "ja_typings": []
+        "ja_typings": [
+          "po"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -35472,7 +36548,9 @@
       {
         "en": "Argon",
         "ja": "アルゴン",
-        "ja_typings": []
+        "ja_typings": [
+          "arugon"
+        ]
       },
       {
         "en": "Carbon dioxide",
@@ -35503,17 +36581,23 @@
       {
         "en": "Methane",
         "ja": "メタン",
-        "ja_typings": []
+        "ja_typings": [
+          "metan"
+        ]
       },
       {
         "en": "Ozone",
         "ja": "オゾン",
-        "ja_typings": []
+        "ja_typings": [
+          "ozon"
+        ]
       },
       {
         "en": "Argon",
         "ja": "アルゴン",
-        "ja_typings": []
+        "ja_typings": [
+          "arugon"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -35650,12 +36734,16 @@
       {
         "en": "Mitochondria",
         "ja": "ミトコンドリア",
-        "ja_typings": []
+        "ja_typings": [
+          "mitokondoria"
+        ]
       },
       {
         "en": "Ribosome",
         "ja": "リボソーム",
-        "ja_typings": []
+        "ja_typings": [
+          "riboso-mu"
+        ]
       },
       {
         "en": "Nucleus",
@@ -35667,7 +36755,9 @@
       {
         "en": "Lysosome",
         "ja": "リソソーム",
-        "ja_typings": []
+        "ja_typings": [
+          "risoso-mu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -35724,22 +36814,30 @@
       {
         "en": "Newton",
         "ja": "ニュートン",
-        "ja_typings": []
+        "ja_typings": [
+          "nyu-ton"
+        ]
       },
       {
         "en": "Galileo",
         "ja": "ガリレオ",
-        "ja_typings": []
+        "ja_typings": [
+          "garireo"
+        ]
       },
       {
         "en": "Kepler",
         "ja": "ケプラー",
-        "ja_typings": []
+        "ja_typings": [
+          "kepura-"
+        ]
       },
       {
         "en": "Einstein",
         "ja": "アインシュタイン",
-        "ja_typings": []
+        "ja_typings": [
+          "ainshutain"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -35756,22 +36854,30 @@
       {
         "en": "Darwin",
         "ja": "ダーウィン",
-        "ja_typings": []
+        "ja_typings": [
+          "da-win"
+        ]
       },
       {
         "en": "Mendel",
         "ja": "メンデル",
-        "ja_typings": []
+        "ja_typings": [
+          "menderu"
+        ]
       },
       {
         "en": "Lamarck",
         "ja": "ラマルク",
-        "ja_typings": []
+        "ja_typings": [
+          "ramaruku"
+        ]
       },
       {
         "en": "Wallace",
         "ja": "ウォレス",
-        "ja_typings": []
+        "ja_typings": [
+          "woresu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -35788,22 +36894,30 @@
       {
         "en": "Mendel",
         "ja": "メンデル",
-        "ja_typings": []
+        "ja_typings": [
+          "menderu"
+        ]
       },
       {
         "en": "Darwin",
         "ja": "ダーウィン",
-        "ja_typings": []
+        "ja_typings": [
+          "da-win"
+        ]
       },
       {
         "en": "Watson",
         "ja": "ワトソン",
-        "ja_typings": []
+        "ja_typings": [
+          "watoson"
+        ]
       },
       {
         "en": "Crick",
         "ja": "クリック",
-        "ja_typings": []
+        "ja_typings": [
+          "kurikku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -35820,22 +36934,30 @@
       {
         "en": "Marie Curie",
         "ja": "マリーキュリー",
-        "ja_typings": []
+        "ja_typings": [
+          "mari-kyuri-"
+        ]
       },
       {
         "en": "Lise Meitner",
         "ja": "リーゼマイトナー",
-        "ja_typings": []
+        "ja_typings": [
+          "ri-zemaitona-"
+        ]
       },
       {
         "en": "Rosalind Franklin",
         "ja": "フランクリン",
-        "ja_typings": []
+        "ja_typings": [
+          "furankurin"
+        ]
       },
       {
         "en": "Irene Joliot-Curie",
         "ja": "ジョリオキュリー",
-        "ja_typings": []
+        "ja_typings": [
+          "joriokyuri-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -35972,7 +37094,9 @@
       {
         "en": "Diamond",
         "ja": "ダイヤモンド",
-        "ja_typings": []
+        "ja_typings": [
+          "daiyamondo"
+        ]
       },
       {
         "en": "Quartz",
@@ -35984,12 +37108,16 @@
       {
         "en": "Corundum",
         "ja": "コランダム",
-        "ja_typings": []
+        "ja_typings": [
+          "korandamu"
+        ]
       },
       {
         "en": "Topaz",
         "ja": "トパーズ",
-        "ja_typings": []
+        "ja_typings": [
+          "topa-zu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -36126,22 +37254,30 @@
       {
         "en": "Watt",
         "ja": "ワット",
-        "ja_typings": []
+        "ja_typings": [
+          "watto"
+        ]
       },
       {
         "en": "Joule",
         "ja": "ジュール",
-        "ja_typings": []
+        "ja_typings": [
+          "ju-ru"
+        ]
       },
       {
         "en": "Pascal",
         "ja": "パスカル",
-        "ja_typings": []
+        "ja_typings": [
+          "pasukaru"
+        ]
       },
       {
         "en": "Newton",
         "ja": "ニュートン",
-        "ja_typings": []
+        "ja_typings": [
+          "nyu-ton"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -36198,7 +37334,9 @@
       {
         "en": "Richter scale",
         "ja": "リヒタースケール",
-        "ja_typings": []
+        "ja_typings": [
+          "rihita-suke-ru"
+        ]
       },
       {
         "en": "Mohs scale",
@@ -36236,22 +37374,30 @@
       {
         "en": "Flask",
         "ja": "フラスク",
-        "ja_typings": []
+        "ja_typings": [
+          "furasuku"
+        ]
       },
       {
         "en": "Django",
         "ja": "ジャンゴ",
-        "ja_typings": []
+        "ja_typings": [
+          "jango"
+        ]
       },
       {
         "en": "FastAPI",
         "ja": "ファストエーピーアイ",
-        "ja_typings": []
+        "ja_typings": [
+          "fasutoe-pi-ai"
+        ]
       },
       {
         "en": "Tornado",
         "ja": "トルネード",
-        "ja_typings": []
+        "ja_typings": [
+          "torune-do"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -36268,22 +37414,30 @@
       {
         "en": "FastAPI",
         "ja": "ファストエーピーアイ",
-        "ja_typings": []
+        "ja_typings": [
+          "fasutoe-pi-ai"
+        ]
       },
       {
         "en": "Flask",
         "ja": "フラスク",
-        "ja_typings": []
+        "ja_typings": [
+          "furasuku"
+        ]
       },
       {
         "en": "Django",
         "ja": "ジャンゴ",
-        "ja_typings": []
+        "ja_typings": [
+          "jango"
+        ]
       },
       {
         "en": "Pyramid",
         "ja": "ピラミッド",
-        "ja_typings": []
+        "ja_typings": [
+          "piramiddo"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -36300,22 +37454,30 @@
       {
         "en": "NumPy",
         "ja": "ナンパイ",
-        "ja_typings": []
+        "ja_typings": [
+          "nanpai"
+        ]
       },
       {
         "en": "SciPy",
         "ja": "サイパイ",
-        "ja_typings": []
+        "ja_typings": [
+          "saipai"
+        ]
       },
       {
         "en": "SymPy",
         "ja": "シンパイ",
-        "ja_typings": []
+        "ja_typings": [
+          "shinpai"
+        ]
       },
       {
         "en": "Numba",
         "ja": "ナンバ",
-        "ja_typings": []
+        "ja_typings": [
+          "nanba"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -36332,22 +37494,30 @@
       {
         "en": "pandas",
         "ja": "パンダス",
-        "ja_typings": []
+        "ja_typings": [
+          "pandasu"
+        ]
       },
       {
         "en": "polars",
         "ja": "ポーラーズ",
-        "ja_typings": []
+        "ja_typings": [
+          "po-ra-zu"
+        ]
       },
       {
         "en": "dask",
         "ja": "ダスク",
-        "ja_typings": []
+        "ja_typings": [
+          "dasuku"
+        ]
       },
       {
         "en": "modin",
         "ja": "モディン",
-        "ja_typings": []
+        "ja_typings": [
+          "modin"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -36364,22 +37534,30 @@
       {
         "en": "PyTorch",
         "ja": "パイトーチ",
-        "ja_typings": []
+        "ja_typings": [
+          "paito-chi"
+        ]
       },
       {
         "en": "TensorFlow",
         "ja": "テンソルフロー",
-        "ja_typings": []
+        "ja_typings": [
+          "tensorufuro-"
+        ]
       },
       {
         "en": "JAX",
         "ja": "ジャックス",
-        "ja_typings": []
+        "ja_typings": [
+          "jakkusu"
+        ]
       },
       {
         "en": "MXNet",
         "ja": "エムエックスネット",
-        "ja_typings": []
+        "ja_typings": [
+          "emuekkusunetto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -36396,22 +37574,30 @@
       {
         "en": "Django",
         "ja": "ジャンゴ",
-        "ja_typings": []
+        "ja_typings": [
+          "jango"
+        ]
       },
       {
         "en": "Flask",
         "ja": "フラスク",
-        "ja_typings": []
+        "ja_typings": [
+          "furasuku"
+        ]
       },
       {
         "en": "Bottle",
         "ja": "ボトル",
-        "ja_typings": []
+        "ja_typings": [
+          "botoru"
+        ]
       },
       {
         "en": "CherryPy",
         "ja": "チェリーパイ",
-        "ja_typings": []
+        "ja_typings": [
+          "cheri-pai"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -36428,22 +37614,30 @@
       {
         "en": "uv",
         "ja": "ユーブイ",
-        "ja_typings": []
+        "ja_typings": [
+          "yu-bui"
+        ]
       },
       {
         "en": "poetry",
         "ja": "ポエトリー",
-        "ja_typings": []
+        "ja_typings": [
+          "poetori-"
+        ]
       },
       {
         "en": "pipenv",
         "ja": "ピップエンブ",
-        "ja_typings": []
+        "ja_typings": [
+          "pippuenbu"
+        ]
       },
       {
         "en": "conda",
         "ja": "コンダ",
-        "ja_typings": []
+        "ja_typings": [
+          "konda"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -36460,22 +37654,30 @@
       {
         "en": "Ruff",
         "ja": "ラフ",
-        "ja_typings": []
+        "ja_typings": [
+          "rafu"
+        ]
       },
       {
         "en": "Black",
         "ja": "ブラック",
-        "ja_typings": []
+        "ja_typings": [
+          "burakku"
+        ]
       },
       {
         "en": "Flake8",
         "ja": "フレイクエイト",
-        "ja_typings": []
+        "ja_typings": [
+          "fureikueito"
+        ]
       },
       {
         "en": "Pylint",
         "ja": "パイリント",
-        "ja_typings": []
+        "ja_typings": [
+          "pairinto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -36492,22 +37694,30 @@
       {
         "en": "Clone",
         "ja": "クローン",
-        "ja_typings": []
+        "ja_typings": [
+          "kuro-n"
+        ]
       },
       {
         "en": "Copy",
         "ja": "コピー",
-        "ja_typings": []
+        "ja_typings": [
+          "kopi-"
+        ]
       },
       {
         "en": "Drop",
         "ja": "ドロップ",
-        "ja_typings": []
+        "ja_typings": [
+          "doroppu"
+        ]
       },
       {
         "en": "Move",
         "ja": "ムーブ",
-        "ja_typings": []
+        "ja_typings": [
+          "mu-bu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -36524,22 +37734,30 @@
       {
         "en": "Copy",
         "ja": "コピー",
-        "ja_typings": []
+        "ja_typings": [
+          "kopi-"
+        ]
       },
       {
         "en": "Clone",
         "ja": "クローン",
-        "ja_typings": []
+        "ja_typings": [
+          "kuro-n"
+        ]
       },
       {
         "en": "Sized",
         "ja": "サイズド",
-        "ja_typings": []
+        "ja_typings": [
+          "saizudo"
+        ]
       },
       {
         "en": "Send",
         "ja": "センド",
-        "ja_typings": []
+        "ja_typings": [
+          "sendo"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -36556,22 +37774,30 @@
       {
         "en": "format!",
         "ja": "フォーマット",
-        "ja_typings": []
+        "ja_typings": [
+          "fo-matto"
+        ]
       },
       {
         "en": "println!",
         "ja": "プリントエルエヌ",
-        "ja_typings": []
+        "ja_typings": [
+          "purintoeruenu"
+        ]
       },
       {
         "en": "write!",
         "ja": "ライト",
-        "ja_typings": []
+        "ja_typings": [
+          "raito"
+        ]
       },
       {
         "en": "eprintln!",
         "ja": "イープリントエルエヌ",
-        "ja_typings": []
+        "ja_typings": [
+          "i-purintoeruenu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -36588,22 +37814,30 @@
       {
         "en": "derive",
         "ja": "デライブ",
-        "ja_typings": []
+        "ja_typings": [
+          "deraibu"
+        ]
       },
       {
         "en": "inline",
         "ja": "インライン",
-        "ja_typings": []
+        "ja_typings": [
+          "inrain"
+        ]
       },
       {
         "en": "repr",
         "ja": "リプル",
-        "ja_typings": []
+        "ja_typings": [
+          "ripuru"
+        ]
       },
       {
         "en": "cfg",
         "ja": "シーエフジー",
-        "ja_typings": []
+        "ja_typings": [
+          "shi-efuji-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -36620,22 +37854,30 @@
       {
         "en": "tokio",
         "ja": "トーキオ",
-        "ja_typings": []
+        "ja_typings": [
+          "to-kio"
+        ]
       },
       {
         "en": "smol",
         "ja": "スモル",
-        "ja_typings": []
+        "ja_typings": [
+          "sumoru"
+        ]
       },
       {
         "en": "async-std",
         "ja": "エイシンクエスティーディー",
-        "ja_typings": []
+        "ja_typings": [
+          "eishinkuesuti-di-"
+        ]
       },
       {
         "en": "glommio",
         "ja": "グロミオ",
-        "ja_typings": []
+        "ja_typings": [
+          "guromio"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -36652,22 +37894,30 @@
       {
         "en": "axum",
         "ja": "アクサム",
-        "ja_typings": []
+        "ja_typings": [
+          "akusamu"
+        ]
       },
       {
         "en": "actix-web",
         "ja": "アクティクスウェブ",
-        "ja_typings": []
+        "ja_typings": [
+          "akutikusuwebu"
+        ]
       },
       {
         "en": "rocket",
         "ja": "ロケット",
-        "ja_typings": []
+        "ja_typings": [
+          "roketto"
+        ]
       },
       {
         "en": "warp",
         "ja": "ワープ",
-        "ja_typings": []
+        "ja_typings": [
+          "wa-pu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -36684,22 +37934,30 @@
       {
         "en": "Deno",
         "ja": "デノ",
-        "ja_typings": []
+        "ja_typings": [
+          "deno"
+        ]
       },
       {
         "en": "Bun",
         "ja": "バン",
-        "ja_typings": []
+        "ja_typings": [
+          "ban"
+        ]
       },
       {
         "en": "Node.js",
         "ja": "ノードジェイエス",
-        "ja_typings": []
+        "ja_typings": [
+          "no-dojeiesu"
+        ]
       },
       {
         "en": "Workers",
         "ja": "ワーカーズ",
-        "ja_typings": []
+        "ja_typings": [
+          "wa-ka-zu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -36716,22 +37974,30 @@
       {
         "en": "Bun",
         "ja": "バン",
-        "ja_typings": []
+        "ja_typings": [
+          "ban"
+        ]
       },
       {
         "en": "Deno",
         "ja": "デノ",
-        "ja_typings": []
+        "ja_typings": [
+          "deno"
+        ]
       },
       {
         "en": "Node.js",
         "ja": "ノードジェイエス",
-        "ja_typings": []
+        "ja_typings": [
+          "no-dojeiesu"
+        ]
       },
       {
         "en": "QuickJS",
         "ja": "クイックジェイエス",
-        "ja_typings": []
+        "ja_typings": [
+          "kuikkujeiesu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -36748,22 +38014,30 @@
       {
         "en": "Microsoft",
         "ja": "マイクロソフト",
-        "ja_typings": []
+        "ja_typings": [
+          "maikurosofuto"
+        ]
       },
       {
         "en": "Google",
         "ja": "グーグル",
-        "ja_typings": []
+        "ja_typings": [
+          "gu-guru"
+        ]
       },
       {
         "en": "Meta",
         "ja": "メタ",
-        "ja_typings": []
+        "ja_typings": [
+          "meta"
+        ]
       },
       {
         "en": "Apple",
         "ja": "アップル",
-        "ja_typings": []
+        "ja_typings": [
+          "appuru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -36780,22 +38054,30 @@
       {
         "en": "esbuild",
         "ja": "イーエスビルド",
-        "ja_typings": []
+        "ja_typings": [
+          "i-esubirudo"
+        ]
       },
       {
         "en": "Webpack",
         "ja": "ウェブパック",
-        "ja_typings": []
+        "ja_typings": [
+          "webupakku"
+        ]
       },
       {
         "en": "Rollup",
         "ja": "ロールアップ",
-        "ja_typings": []
+        "ja_typings": [
+          "ro-ruappu"
+        ]
       },
       {
         "en": "Parcel",
         "ja": "パーセル",
-        "ja_typings": []
+        "ja_typings": [
+          "pa-seru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -36812,22 +38094,30 @@
       {
         "en": "Vite",
         "ja": "ヴィート",
-        "ja_typings": []
+        "ja_typings": [
+          "vi-to"
+        ]
       },
       {
         "en": "Snowpack",
         "ja": "スノーパック",
-        "ja_typings": []
+        "ja_typings": [
+          "suno-pakku"
+        ]
       },
       {
         "en": "Webpack",
         "ja": "ウェブパック",
-        "ja_typings": []
+        "ja_typings": [
+          "webupakku"
+        ]
       },
       {
         "en": "Browserify",
         "ja": "ブラウザリファイ",
-        "ja_typings": []
+        "ja_typings": [
+          "burauzarifai"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -36844,22 +38134,30 @@
       {
         "en": "Vitest",
         "ja": "ヴァイテスト",
-        "ja_typings": []
+        "ja_typings": [
+          "vaitesuto"
+        ]
       },
       {
         "en": "Mocha",
         "ja": "モカ",
-        "ja_typings": []
+        "ja_typings": [
+          "moka"
+        ]
       },
       {
         "en": "Jasmine",
         "ja": "ジャスミン",
-        "ja_typings": []
+        "ja_typings": [
+          "jasumin"
+        ]
       },
       {
         "en": "AVA",
         "ja": "エイバ",
-        "ja_typings": []
+        "ja_typings": [
+          "eiba"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -36876,22 +38174,30 @@
       {
         "en": "Elixir",
         "ja": "エリクサー",
-        "ja_typings": []
+        "ja_typings": [
+          "erikusa-"
+        ]
       },
       {
         "en": "Clojure",
         "ja": "クロージャ",
-        "ja_typings": []
+        "ja_typings": [
+          "kuro-ja"
+        ]
       },
       {
         "en": "Scala",
         "ja": "スカラ",
-        "ja_typings": []
+        "ja_typings": [
+          "sukara"
+        ]
       },
       {
         "en": "F#",
         "ja": "エフシャープ",
-        "ja_typings": []
+        "ja_typings": [
+          "efusha-pu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -36908,22 +38214,30 @@
       {
         "en": "Clojure",
         "ja": "クロージャ",
-        "ja_typings": []
+        "ja_typings": [
+          "kuro-ja"
+        ]
       },
       {
         "en": "Scala",
         "ja": "スカラ",
-        "ja_typings": []
+        "ja_typings": [
+          "sukara"
+        ]
       },
       {
         "en": "Groovy",
         "ja": "グルービー",
-        "ja_typings": []
+        "ja_typings": [
+          "guru-bi-"
+        ]
       },
       {
         "en": "Kotlin",
         "ja": "コトリン",
-        "ja_typings": []
+        "ja_typings": [
+          "kotorin"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -36940,22 +38254,30 @@
       {
         "en": "Kotlin",
         "ja": "コトリン",
-        "ja_typings": []
+        "ja_typings": [
+          "kotorin"
+        ]
       },
       {
         "en": "Java",
         "ja": "ジャバ",
-        "ja_typings": []
+        "ja_typings": [
+          "jaba"
+        ]
       },
       {
         "en": "Dart",
         "ja": "ダート",
-        "ja_typings": []
+        "ja_typings": [
+          "da-to"
+        ]
       },
       {
         "en": "Swift",
         "ja": "スウィフト",
-        "ja_typings": []
+        "ja_typings": [
+          "suwifuto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -36972,22 +38294,30 @@
       {
         "en": "Dart",
         "ja": "ダート",
-        "ja_typings": []
+        "ja_typings": [
+          "da-to"
+        ]
       },
       {
         "en": "Kotlin",
         "ja": "コトリン",
-        "ja_typings": []
+        "ja_typings": [
+          "kotorin"
+        ]
       },
       {
         "en": "Swift",
         "ja": "スウィフト",
-        "ja_typings": []
+        "ja_typings": [
+          "suwifuto"
+        ]
       },
       {
         "en": "TypeScript",
         "ja": "タイプスクリプト",
-        "ja_typings": []
+        "ja_typings": [
+          "taipusukuriputo"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -37004,22 +38334,30 @@
       {
         "en": "Lua",
         "ja": "ルア",
-        "ja_typings": []
+        "ja_typings": [
+          "rua"
+        ]
       },
       {
         "en": "Tcl",
         "ja": "ティーシーエル",
-        "ja_typings": []
+        "ja_typings": [
+          "ti-shi-eru"
+        ]
       },
       {
         "en": "Squirrel",
         "ja": "スクィレル",
-        "ja_typings": []
+        "ja_typings": [
+          "sukuireru"
+        ]
       },
       {
         "en": "AngelScript",
         "ja": "エンジェルスクリプト",
-        "ja_typings": []
+        "ja_typings": [
+          "enjerusukuriputo"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -37036,22 +38374,30 @@
       {
         "en": "F#",
         "ja": "エフシャープ",
-        "ja_typings": []
+        "ja_typings": [
+          "efusha-pu"
+        ]
       },
       {
         "en": "OCaml",
         "ja": "オーキャムル",
-        "ja_typings": []
+        "ja_typings": [
+          "o-kyamuru"
+        ]
       },
       {
         "en": "Haskell",
         "ja": "ハスケル",
-        "ja_typings": []
+        "ja_typings": [
+          "hasukeru"
+        ]
       },
       {
         "en": "Elm",
         "ja": "エルム",
-        "ja_typings": []
+        "ja_typings": [
+          "erumu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -37068,22 +38414,30 @@
       {
         "en": "Swift",
         "ja": "スウィフト",
-        "ja_typings": []
+        "ja_typings": [
+          "suwifuto"
+        ]
       },
       {
         "en": "Kotlin",
         "ja": "コトリン",
-        "ja_typings": []
+        "ja_typings": [
+          "kotorin"
+        ]
       },
       {
         "en": "Rust",
         "ja": "ラスト",
-        "ja_typings": []
+        "ja_typings": [
+          "rasuto"
+        ]
       },
       {
         "en": "Go",
         "ja": "ゴー",
-        "ja_typings": []
+        "ja_typings": [
+          "go-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -37100,22 +38454,30 @@
       {
         "en": "Rust",
         "ja": "ラスト",
-        "ja_typings": []
+        "ja_typings": [
+          "rasuto"
+        ]
       },
       {
         "en": "Go",
         "ja": "ゴー",
-        "ja_typings": []
+        "ja_typings": [
+          "go-"
+        ]
       },
       {
         "en": "Zig",
         "ja": "ジグ",
-        "ja_typings": []
+        "ja_typings": [
+          "jigu"
+        ]
       },
       {
         "en": "Nim",
         "ja": "ニム",
-        "ja_typings": []
+        "ja_typings": [
+          "nimu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -37132,22 +38494,30 @@
       {
         "en": "Zig",
         "ja": "ジグ",
-        "ja_typings": []
+        "ja_typings": [
+          "jigu"
+        ]
       },
       {
         "en": "Rust",
         "ja": "ラスト",
-        "ja_typings": []
+        "ja_typings": [
+          "rasuto"
+        ]
       },
       {
         "en": "D",
         "ja": "ディー",
-        "ja_typings": []
+        "ja_typings": [
+          "di-"
+        ]
       },
       {
         "en": "Nim",
         "ja": "ニム",
-        "ja_typings": []
+        "ja_typings": [
+          "nimu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -37164,22 +38534,30 @@
       {
         "en": "Merge sort",
         "ja": "マージソート",
-        "ja_typings": []
+        "ja_typings": [
+          "ma-jiso-to"
+        ]
       },
       {
         "en": "Quicksort",
         "ja": "クイックソート",
-        "ja_typings": []
+        "ja_typings": [
+          "kuikkuso-to"
+        ]
       },
       {
         "en": "Heapsort",
         "ja": "ヒープソート",
-        "ja_typings": []
+        "ja_typings": [
+          "hi-puso-to"
+        ]
       },
       {
         "en": "Bubble sort",
         "ja": "バブルソート",
-        "ja_typings": []
+        "ja_typings": [
+          "baburuso-to"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -37196,12 +38574,16 @@
       {
         "en": "Heap",
         "ja": "ヒープ",
-        "ja_typings": []
+        "ja_typings": [
+          "hi-pu"
+        ]
       },
       {
         "en": "Stack",
         "ja": "スタック",
-        "ja_typings": []
+        "ja_typings": [
+          "sutakku"
+        ]
       },
       {
         "en": "Linked list",
@@ -37213,7 +38595,9 @@
       {
         "en": "Hash table",
         "ja": "ハッシュテーブル",
-        "ja_typings": []
+        "ja_typings": [
+          "hasshute-buru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -37230,22 +38614,30 @@
       {
         "en": "Trie",
         "ja": "トライ",
-        "ja_typings": []
+        "ja_typings": [
+          "torai"
+        ]
       },
       {
         "en": "Heap",
         "ja": "ヒープ",
-        "ja_typings": []
+        "ja_typings": [
+          "hi-pu"
+        ]
       },
       {
         "en": "B-tree",
         "ja": "ビーツリー",
-        "ja_typings": []
+        "ja_typings": [
+          "bi-tsuri-"
+        ]
       },
       {
         "en": "Skip list",
         "ja": "スキップリスト",
-        "ja_typings": []
+        "ja_typings": [
+          "sukippurisuto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -37262,22 +38654,31 @@
       {
         "en": "In-order",
         "ja": "インオーダー",
-        "ja_typings": []
+        "ja_typings": [
+          "inno-da-"
+        ]
       },
       {
         "en": "Pre-order",
         "ja": "プリオーダー",
-        "ja_typings": []
+        "ja_typings": [
+          "purio-da-"
+        ]
       },
       {
         "en": "Post-order",
         "ja": "ポストオーダー",
-        "ja_typings": []
+        "ja_typings": [
+          "posuto-da-",
+          "posutoo-da-"
+        ]
       },
       {
         "en": "Level-order",
         "ja": "レベルオーダー",
-        "ja_typings": []
+        "ja_typings": [
+          "reberuo-da-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -37294,22 +38695,30 @@
       {
         "en": "Floyd-Warshall",
         "ja": "フロイドワーシャル",
-        "ja_typings": []
+        "ja_typings": [
+          "furoidowa-sharu"
+        ]
       },
       {
         "en": "Dijkstra",
         "ja": "ダイクストラ",
-        "ja_typings": []
+        "ja_typings": [
+          "daikusutora"
+        ]
       },
       {
         "en": "Bellman-Ford",
         "ja": "ベルマンフォード",
-        "ja_typings": []
+        "ja_typings": [
+          "berumanfo-do"
+        ]
       },
       {
         "en": "A-star",
         "ja": "エースター",
-        "ja_typings": []
+        "ja_typings": [
+          "e-suta-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -37340,7 +38749,9 @@
       {
         "en": "Backtracking",
         "ja": "バックトラッキング",
-        "ja_typings": []
+        "ja_typings": [
+          "bakkutorakkingu"
+        ]
       },
       {
         "en": "Brute force",
@@ -37404,22 +38815,30 @@
       {
         "en": "Docker image",
         "ja": "ドッカーイメージ",
-        "ja_typings": []
+        "ja_typings": [
+          "dokka-ime-ji"
+        ]
       },
       {
         "en": "Vagrant box",
         "ja": "ベイグラントボックス",
-        "ja_typings": []
+        "ja_typings": [
+          "beigurantobokkusu"
+        ]
       },
       {
         "en": "AMI",
         "ja": "エーエムアイ",
-        "ja_typings": []
+        "ja_typings": [
+          "e-emuai"
+        ]
       },
       {
         "en": "LXD image",
         "ja": "エルエックスディーイメージ",
-        "ja_typings": []
+        "ja_typings": [
+          "eruekkusudi-ime-ji"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -37436,22 +38855,30 @@
       {
         "en": "curl",
         "ja": "カール",
-        "ja_typings": []
+        "ja_typings": [
+          "ka-ru"
+        ]
       },
       {
         "en": "wget",
         "ja": "ダブルゲット",
-        "ja_typings": []
+        "ja_typings": [
+          "daburugetto"
+        ]
       },
       {
         "en": "httpie",
         "ja": "エイチティーティーピーアイイー",
-        "ja_typings": []
+        "ja_typings": [
+          "eichiti-ti-pi-aii-"
+        ]
       },
       {
         "en": "aria2",
         "ja": "アリアツー",
-        "ja_typings": []
+        "ja_typings": [
+          "ariatsu-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -37468,22 +38895,30 @@
       {
         "en": "Subversion",
         "ja": "サブバージョン",
-        "ja_typings": []
+        "ja_typings": [
+          "sabuba-jon"
+        ]
       },
       {
         "en": "Git",
         "ja": "ギット",
-        "ja_typings": []
+        "ja_typings": [
+          "gitto"
+        ]
       },
       {
         "en": "Mercurial",
         "ja": "マーキュリアル",
-        "ja_typings": []
+        "ja_typings": [
+          "ma-kyuriaru"
+        ]
       },
       {
         "en": "Bazaar",
         "ja": "バザール",
-        "ja_typings": []
+        "ja_typings": [
+          "baza-ru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -37500,22 +38935,30 @@
       {
         "en": "GitHub Actions",
         "ja": "ギットハブアクションズ",
-        "ja_typings": []
+        "ja_typings": [
+          "gittohabuakushonzu"
+        ]
       },
       {
         "en": "CircleCI",
         "ja": "サークルシーアイ",
-        "ja_typings": []
+        "ja_typings": [
+          "sa-kurushi-ai"
+        ]
       },
       {
         "en": "Travis CI",
         "ja": "トラビスシーアイ",
-        "ja_typings": []
+        "ja_typings": [
+          "torabisushi-ai"
+        ]
       },
       {
         "en": "Jenkins",
         "ja": "ジェンキンス",
-        "ja_typings": []
+        "ja_typings": [
+          "jenkinsu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -37532,22 +38975,30 @@
       {
         "en": "Markdown",
         "ja": "マークダウン",
-        "ja_typings": []
+        "ja_typings": [
+          "ma-kudaun"
+        ]
       },
       {
         "en": "reStructuredText",
         "ja": "アールエスティー",
-        "ja_typings": []
+        "ja_typings": [
+          "a-ruesuti-"
+        ]
       },
       {
         "en": "AsciiDoc",
         "ja": "アスキードック",
-        "ja_typings": []
+        "ja_typings": [
+          "asuki-dokku"
+        ]
       },
       {
         "en": "Textile",
         "ja": "テクスタイル",
-        "ja_typings": []
+        "ja_typings": [
+          "tekusutairu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -37564,22 +39015,30 @@
       {
         "en": "TOML",
         "ja": "トムル",
-        "ja_typings": []
+        "ja_typings": [
+          "tomuru"
+        ]
       },
       {
         "en": "YAML",
         "ja": "ヤムル",
-        "ja_typings": []
+        "ja_typings": [
+          "yamuru"
+        ]
       },
       {
         "en": "XML",
         "ja": "エックスエムエル",
-        "ja_typings": []
+        "ja_typings": [
+          "ekkusuemueru"
+        ]
       },
       {
         "en": "INI",
         "ja": "アイエヌアイ",
-        "ja_typings": []
+        "ja_typings": [
+          "aienuai"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -37596,22 +39055,30 @@
       {
         "en": "YAML",
         "ja": "ヤムル",
-        "ja_typings": []
+        "ja_typings": [
+          "yamuru"
+        ]
       },
       {
         "en": "TOML",
         "ja": "トムル",
-        "ja_typings": []
+        "ja_typings": [
+          "tomuru"
+        ]
       },
       {
         "en": "JSON",
         "ja": "ジェイソン",
-        "ja_typings": []
+        "ja_typings": [
+          "jeison"
+        ]
       },
       {
         "en": "XML",
         "ja": "エックスエムエル",
-        "ja_typings": []
+        "ja_typings": [
+          "ekkusuemueru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -37628,22 +39095,30 @@
       {
         "en": "Niklaus Wirth",
         "ja": "ニクラウス・ヴィルト",
-        "ja_typings": []
+        "ja_typings": [
+          "nikurausu/viruto"
+        ]
       },
       {
         "en": "Anders Hejlsberg",
         "ja": "アンダース・ヘルスバーグ",
-        "ja_typings": []
+        "ja_typings": [
+          "anda-su/herusuba-gu"
+        ]
       },
       {
         "en": "Donald Knuth",
         "ja": "ドナルド・クヌース",
-        "ja_typings": []
+        "ja_typings": [
+          "donarudo/kunu-su"
+        ]
       },
       {
         "en": "Edsger Dijkstra",
         "ja": "エドガー・ダイクストラ",
-        "ja_typings": []
+        "ja_typings": [
+          "edoga-/daikusutora"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -37660,22 +39135,30 @@
       {
         "en": "Anders Hejlsberg",
         "ja": "アンダース・ヘルスバーグ",
-        "ja_typings": []
+        "ja_typings": [
+          "anda-su/herusuba-gu"
+        ]
       },
       {
         "en": "Brendan Eich",
         "ja": "ブレンダン・アイク",
-        "ja_typings": []
+        "ja_typings": [
+          "burendan/aiku"
+        ]
       },
       {
         "en": "Bjarne Stroustrup",
         "ja": "ビャーネ・ストロヴストルップ",
-        "ja_typings": []
+        "ja_typings": [
+          "bya-ne/sutorovusutoruppu"
+        ]
       },
       {
         "en": "James Gosling",
         "ja": "ジェームズ・ゴスリン",
-        "ja_typings": []
+        "ja_typings": [
+          "je-muzu/gosurin"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -37692,22 +39175,30 @@
       {
         "en": "James Gosling",
         "ja": "ジェームズ・ゴスリン",
-        "ja_typings": []
+        "ja_typings": [
+          "je-muzu/gosurin"
+        ]
       },
       {
         "en": "Guido van Rossum",
         "ja": "グイド・ヴァン・ロッサム",
-        "ja_typings": []
+        "ja_typings": [
+          "guido/van/rossamu"
+        ]
       },
       {
         "en": "Bjarne Stroustrup",
         "ja": "ビャーネ・ストロヴストルップ",
-        "ja_typings": []
+        "ja_typings": [
+          "bya-ne/sutorovusutoruppu"
+        ]
       },
       {
         "en": "Ken Thompson",
         "ja": "ケン・トンプソン",
-        "ja_typings": []
+        "ja_typings": [
+          "ken/tonpuson"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -37724,22 +39215,30 @@
       {
         "en": "Donald Knuth",
         "ja": "ドナルド・クヌース",
-        "ja_typings": []
+        "ja_typings": [
+          "donarudo/kunu-su"
+        ]
       },
       {
         "en": "Edsger Dijkstra",
         "ja": "エドガー・ダイクストラ",
-        "ja_typings": []
+        "ja_typings": [
+          "edoga-/daikusutora"
+        ]
       },
       {
         "en": "Tony Hoare",
         "ja": "トニー・ホーア",
-        "ja_typings": []
+        "ja_typings": [
+          "toni-/ho-a"
+        ]
       },
       {
         "en": "John McCarthy",
         "ja": "ジョン・マッカーシー",
-        "ja_typings": []
+        "ja_typings": [
+          "jon/makka-shi-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -37756,22 +39255,30 @@
       {
         "en": "John McCarthy",
         "ja": "ジョン・マッカーシー",
-        "ja_typings": []
+        "ja_typings": [
+          "jon/makka-shi-"
+        ]
       },
       {
         "en": "Alan Kay",
         "ja": "アラン・ケイ",
-        "ja_typings": []
+        "ja_typings": [
+          "aran/kei"
+        ]
       },
       {
         "en": "Grace Hopper",
         "ja": "グレース・ホッパー",
-        "ja_typings": []
+        "ja_typings": [
+          "gure-su/hoppa-"
+        ]
       },
       {
         "en": "Niklaus Wirth",
         "ja": "ニクラウス・ヴィルト",
-        "ja_typings": []
+        "ja_typings": [
+          "nikurausu/viruto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -37788,22 +39295,30 @@
       {
         "en": "Alan Kay",
         "ja": "アラン・ケイ",
-        "ja_typings": []
+        "ja_typings": [
+          "aran/kei"
+        ]
       },
       {
         "en": "Bjarne Stroustrup",
         "ja": "ビャーネ・ストロヴストルップ",
-        "ja_typings": []
+        "ja_typings": [
+          "bya-ne/sutorovusutoruppu"
+        ]
       },
       {
         "en": "Grady Booch",
         "ja": "グラディ・ブーチ",
-        "ja_typings": []
+        "ja_typings": [
+          "guradi/bu-chi"
+        ]
       },
       {
         "en": "James Gosling",
         "ja": "ジェームズ・ゴスリン",
-        "ja_typings": []
+        "ja_typings": [
+          "je-muzu/gosurin"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -37914,7 +39429,9 @@
       {
         "en": "Pair programming",
         "ja": "ペアプログラミング",
-        "ja_typings": []
+        "ja_typings": [
+          "peapuroguramingu"
+        ]
       },
       {
         "en": "Continuous integration",
@@ -37938,22 +39455,30 @@
       {
         "en": "`<article>`",
         "ja": "アーティクル",
-        "ja_typings": []
+        "ja_typings": [
+          "a-tikuru"
+        ]
       },
       {
         "en": "`<section>`",
         "ja": "セクション",
-        "ja_typings": []
+        "ja_typings": [
+          "sekushon"
+        ]
       },
       {
         "en": "`<aside>`",
         "ja": "アサイド",
-        "ja_typings": []
+        "ja_typings": [
+          "asaido"
+        ]
       },
       {
         "en": "`<main>`",
         "ja": "メイン",
-        "ja_typings": []
+        "ja_typings": [
+          "mein"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -37970,22 +39495,30 @@
       {
         "en": "`<section>`",
         "ja": "セクション",
-        "ja_typings": []
+        "ja_typings": [
+          "sekushon"
+        ]
       },
       {
         "en": "`<article>`",
         "ja": "アーティクル",
-        "ja_typings": []
+        "ja_typings": [
+          "a-tikuru"
+        ]
       },
       {
         "en": "`<div>`",
         "ja": "ディブ",
-        "ja_typings": []
+        "ja_typings": [
+          "dibu"
+        ]
       },
       {
         "en": "`<aside>`",
         "ja": "アサイド",
-        "ja_typings": []
+        "ja_typings": [
+          "asaido"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38002,22 +39535,30 @@
       {
         "en": "`<aside>`",
         "ja": "アサイド",
-        "ja_typings": []
+        "ja_typings": [
+          "asaido"
+        ]
       },
       {
         "en": "`<footer>`",
         "ja": "フッター",
-        "ja_typings": []
+        "ja_typings": [
+          "futta-"
+        ]
       },
       {
         "en": "`<header>`",
         "ja": "ヘッダー",
-        "ja_typings": []
+        "ja_typings": [
+          "hedda-"
+        ]
       },
       {
         "en": "`<nav>`",
         "ja": "ナブ",
-        "ja_typings": []
+        "ja_typings": [
+          "nabu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38034,22 +39575,30 @@
       {
         "en": "`<svg>`",
         "ja": "エスブイジー",
-        "ja_typings": []
+        "ja_typings": [
+          "esubuiji-"
+        ]
       },
       {
         "en": "`<canvas>`",
         "ja": "キャンバス",
-        "ja_typings": []
+        "ja_typings": [
+          "kyanbasu"
+        ]
       },
       {
         "en": "`<picture>`",
         "ja": "ピクチャー",
-        "ja_typings": []
+        "ja_typings": [
+          "pikucha-"
+        ]
       },
       {
         "en": "`<object>`",
         "ja": "オブジェクト",
-        "ja_typings": []
+        "ja_typings": [
+          "obujekuto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38066,22 +39615,30 @@
       {
         "en": "`<canvas>`",
         "ja": "キャンバス",
-        "ja_typings": []
+        "ja_typings": [
+          "kyanbasu"
+        ]
       },
       {
         "en": "`<svg>`",
         "ja": "エスブイジー",
-        "ja_typings": []
+        "ja_typings": [
+          "esubuiji-"
+        ]
       },
       {
         "en": "`<picture>`",
         "ja": "ピクチャー",
-        "ja_typings": []
+        "ja_typings": [
+          "pikucha-"
+        ]
       },
       {
         "en": "`<figure>`",
         "ja": "フィギュア",
-        "ja_typings": []
+        "ja_typings": [
+          "figyua"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38098,22 +39655,30 @@
       {
         "en": "`list`",
         "ja": "リスト",
-        "ja_typings": []
+        "ja_typings": [
+          "risuto"
+        ]
       },
       {
         "en": "`select`",
         "ja": "セレクト",
-        "ja_typings": []
+        "ja_typings": [
+          "serekuto"
+        ]
       },
       {
         "en": "`options`",
         "ja": "オプションズ",
-        "ja_typings": []
+        "ja_typings": [
+          "opushonzu"
+        ]
       },
       {
         "en": "`combo`",
         "ja": "コンボ",
-        "ja_typings": []
+        "ja_typings": [
+          "konbo"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38130,22 +39695,30 @@
       {
         "en": "`color`",
         "ja": "カラー",
-        "ja_typings": []
+        "ja_typings": [
+          "kara-"
+        ]
       },
       {
         "en": "`picker`",
         "ja": "ピッカー",
-        "ja_typings": []
+        "ja_typings": [
+          "pikka-"
+        ]
       },
       {
         "en": "`hex`",
         "ja": "ヘックス",
-        "ja_typings": []
+        "ja_typings": [
+          "hekkusu"
+        ]
       },
       {
         "en": "`palette`",
         "ja": "パレット",
-        "ja_typings": []
+        "ja_typings": [
+          "paretto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38162,22 +39735,31 @@
       {
         "en": "`:first-child`",
         "ja": "ファーストチャイルド",
-        "ja_typings": []
+        "ja_typings": [
+          "fa-sutochairudo"
+        ]
       },
       {
         "en": "`:nth-child(1)`",
         "ja": "エヌスチャイルド",
-        "ja_typings": []
+        "ja_typings": [
+          "enusuchairudo"
+        ]
       },
       {
         "en": "`:first-of-type`",
         "ja": "ファーストオブタイプ",
-        "ja_typings": []
+        "ja_typings": [
+          "fa-sutobutaipu",
+          "fa-sutoobutaipu"
+        ]
       },
       {
         "en": "`:root`",
         "ja": "ルート",
-        "ja_typings": []
+        "ja_typings": [
+          "ru-to"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38194,22 +39776,30 @@
       {
         "en": "`rem`",
         "ja": "レム",
-        "ja_typings": []
+        "ja_typings": [
+          "remu"
+        ]
       },
       {
         "en": "`em`",
         "ja": "エム",
-        "ja_typings": []
+        "ja_typings": [
+          "emu"
+        ]
       },
       {
         "en": "`px`",
         "ja": "ピクセル",
-        "ja_typings": []
+        "ja_typings": [
+          "pikuseru"
+        ]
       },
       {
         "en": "`pt`",
         "ja": "ポイント",
-        "ja_typings": []
+        "ja_typings": [
+          "pointo"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38226,22 +39816,30 @@
       {
         "en": "`vw`",
         "ja": "ブイダブリュ",
-        "ja_typings": []
+        "ja_typings": [
+          "buidaburyu"
+        ]
       },
       {
         "en": "`vh`",
         "ja": "ブイエイチ",
-        "ja_typings": []
+        "ja_typings": [
+          "buieichi"
+        ]
       },
       {
         "en": "`vmin`",
         "ja": "ブイミン",
-        "ja_typings": []
+        "ja_typings": [
+          "buimin"
+        ]
       },
       {
         "en": "`vmax`",
         "ja": "ブイマックス",
-        "ja_typings": []
+        "ja_typings": [
+          "buimakkusu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38258,22 +39856,30 @@
       {
         "en": "`z-index`",
         "ja": "ゼットインデックス",
-        "ja_typings": []
+        "ja_typings": [
+          "zettoindekkusu"
+        ]
       },
       {
         "en": "`order`",
         "ja": "オーダー",
-        "ja_typings": []
+        "ja_typings": [
+          "o-da-"
+        ]
       },
       {
         "en": "`stack`",
         "ja": "スタック",
-        "ja_typings": []
+        "ja_typings": [
+          "sutakku"
+        ]
       },
       {
         "en": "`layer`",
         "ja": "レイヤー",
-        "ja_typings": []
+        "ja_typings": [
+          "reiya-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38290,22 +39896,30 @@
       {
         "en": "`calc()`",
         "ja": "カルク",
-        "ja_typings": []
+        "ja_typings": [
+          "karuku"
+        ]
       },
       {
         "en": "`min()`",
         "ja": "ミン",
-        "ja_typings": []
+        "ja_typings": [
+          "min"
+        ]
       },
       {
         "en": "`max()`",
         "ja": "マックス",
-        "ja_typings": []
+        "ja_typings": [
+          "makkusu"
+        ]
       },
       {
         "en": "`clamp()`",
         "ja": "クランプ",
-        "ja_typings": []
+        "ja_typings": [
+          "kuranpu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38322,22 +39936,30 @@
       {
         "en": "`@media`",
         "ja": "アットメディア",
-        "ja_typings": []
+        "ja_typings": [
+          "attomedia"
+        ]
       },
       {
         "en": "`@supports`",
         "ja": "アットサポーツ",
-        "ja_typings": []
+        "ja_typings": [
+          "attosapo-tsu"
+        ]
       },
       {
         "en": "`@container`",
         "ja": "アットコンテナ",
-        "ja_typings": []
+        "ja_typings": [
+          "attokontena"
+        ]
       },
       {
         "en": "`@layer`",
         "ja": "アットレイヤー",
-        "ja_typings": []
+        "ja_typings": [
+          "attoreiya-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38354,22 +39976,30 @@
       {
         "en": "`@container`",
         "ja": "アットコンテナ",
-        "ja_typings": []
+        "ja_typings": [
+          "attokontena"
+        ]
       },
       {
         "en": "`@media`",
         "ja": "アットメディア",
-        "ja_typings": []
+        "ja_typings": [
+          "attomedia"
+        ]
       },
       {
         "en": "`@scope`",
         "ja": "アットスコープ",
-        "ja_typings": []
+        "ja_typings": [
+          "attosuko-pu"
+        ]
       },
       {
         "en": "`@supports`",
         "ja": "アットサポーツ",
-        "ja_typings": []
+        "ja_typings": [
+          "attosapo-tsu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38386,22 +40016,30 @@
       {
         "en": "`transition`",
         "ja": "トランジション",
-        "ja_typings": []
+        "ja_typings": [
+          "toranjishon"
+        ]
       },
       {
         "en": "`animation`",
         "ja": "アニメーション",
-        "ja_typings": []
+        "ja_typings": [
+          "anime-shon"
+        ]
       },
       {
         "en": "`transform`",
         "ja": "トランスフォーム",
-        "ja_typings": []
+        "ja_typings": [
+          "toransufo-mu"
+        ]
       },
       {
         "en": "`filter`",
         "ja": "フィルター",
-        "ja_typings": []
+        "ja_typings": [
+          "firuta-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38418,22 +40056,30 @@
       {
         "en": "`filter`",
         "ja": "フィルター",
-        "ja_typings": []
+        "ja_typings": [
+          "firuta-"
+        ]
       },
       {
         "en": "`opacity`",
         "ja": "オパシティ",
-        "ja_typings": []
+        "ja_typings": [
+          "opashiti"
+        ]
       },
       {
         "en": "`mix-blend-mode`",
         "ja": "ミックスブレンドモード",
-        "ja_typings": []
+        "ja_typings": [
+          "mikkusuburendomo-do"
+        ]
       },
       {
         "en": "`backdrop`",
         "ja": "バックドロップ",
-        "ja_typings": []
+        "ja_typings": [
+          "bakkudoroppu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38450,22 +40096,30 @@
       {
         "en": "`querySelector`",
         "ja": "クエリセレクタ",
-        "ja_typings": []
+        "ja_typings": [
+          "kueriserekuta"
+        ]
       },
       {
         "en": "`getElementById`",
         "ja": "ゲットエレメントバイアイディー",
-        "ja_typings": []
+        "ja_typings": [
+          "gettoerementobaiaidi-"
+        ]
       },
       {
         "en": "`getElementsByTagName`",
         "ja": "ゲットエレメンツバイタグネーム",
-        "ja_typings": []
+        "ja_typings": [
+          "gettoerementsubaitagune-mu"
+        ]
       },
       {
         "en": "`find`",
         "ja": "ファインド",
-        "ja_typings": []
+        "ja_typings": [
+          "faindo"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38482,22 +40136,30 @@
       {
         "en": "`fetch`",
         "ja": "フェッチ",
-        "ja_typings": []
+        "ja_typings": [
+          "fetchi"
+        ]
       },
       {
         "en": "`axios`",
         "ja": "アクシオス",
-        "ja_typings": []
+        "ja_typings": [
+          "akushiosu"
+        ]
       },
       {
         "en": "`ajax`",
         "ja": "エイジャックス",
-        "ja_typings": []
+        "ja_typings": [
+          "eijakkusu"
+        ]
       },
       {
         "en": "`request`",
         "ja": "リクエスト",
-        "ja_typings": []
+        "ja_typings": [
+          "rikuesuto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38514,22 +40176,30 @@
       {
         "en": "IntersectionObserver",
         "ja": "インターセクションオブザーバー",
-        "ja_typings": []
+        "ja_typings": [
+          "inta-sekushonnobuza-ba-"
+        ]
       },
       {
         "en": "MutationObserver",
         "ja": "ミューテーションオブザーバー",
-        "ja_typings": []
+        "ja_typings": [
+          "myu-te-shonnobuza-ba-"
+        ]
       },
       {
         "en": "ResizeObserver",
         "ja": "リサイズオブザーバー",
-        "ja_typings": []
+        "ja_typings": [
+          "risaizuobuza-ba-"
+        ]
       },
       {
         "en": "PerformanceObserver",
         "ja": "パフォーマンスオブザーバー",
-        "ja_typings": []
+        "ja_typings": [
+          "pafo-mansuobuza-ba-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38546,22 +40216,30 @@
       {
         "en": "MutationObserver",
         "ja": "ミューテーションオブザーバー",
-        "ja_typings": []
+        "ja_typings": [
+          "myu-te-shonnobuza-ba-"
+        ]
       },
       {
         "en": "IntersectionObserver",
         "ja": "インターセクションオブザーバー",
-        "ja_typings": []
+        "ja_typings": [
+          "inta-sekushonnobuza-ba-"
+        ]
       },
       {
         "en": "ResizeObserver",
         "ja": "リサイズオブザーバー",
-        "ja_typings": []
+        "ja_typings": [
+          "risaizuobuza-ba-"
+        ]
       },
       {
         "en": "PerformanceObserver",
         "ja": "パフォーマンスオブザーバー",
-        "ja_typings": []
+        "ja_typings": [
+          "pafo-mansuobuza-ba-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38578,22 +40256,30 @@
       {
         "en": "ResizeObserver",
         "ja": "リサイズオブザーバー",
-        "ja_typings": []
+        "ja_typings": [
+          "risaizuobuza-ba-"
+        ]
       },
       {
         "en": "MutationObserver",
         "ja": "ミューテーションオブザーバー",
-        "ja_typings": []
+        "ja_typings": [
+          "myu-te-shonnobuza-ba-"
+        ]
       },
       {
         "en": "IntersectionObserver",
         "ja": "インターセクションオブザーバー",
-        "ja_typings": []
+        "ja_typings": [
+          "inta-sekushonnobuza-ba-"
+        ]
       },
       {
         "en": "Layout API",
         "ja": "レイアウトエーピーアイ",
-        "ja_typings": []
+        "ja_typings": [
+          "reiautoe-pi-ai"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38610,22 +40296,30 @@
       {
         "en": "`requestAnimationFrame`",
         "ja": "リクエストアニメーションフレーム",
-        "ja_typings": []
+        "ja_typings": [
+          "rikuesutoanime-shonfure-mu"
+        ]
       },
       {
         "en": "`setTimeout`",
         "ja": "セットタイムアウト",
-        "ja_typings": []
+        "ja_typings": [
+          "settotaimuauto"
+        ]
       },
       {
         "en": "`setInterval`",
         "ja": "セットインターバル",
-        "ja_typings": []
+        "ja_typings": [
+          "settointa-baru"
+        ]
       },
       {
         "en": "`queueMicrotask`",
         "ja": "キューマイクロタスク",
-        "ja_typings": []
+        "ja_typings": [
+          "kyu-maikurotasuku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38642,22 +40336,30 @@
       {
         "en": "Promise",
         "ja": "プロミス",
-        "ja_typings": []
+        "ja_typings": [
+          "puromisu"
+        ]
       },
       {
         "en": "Observable",
         "ja": "オブザーバブル",
-        "ja_typings": []
+        "ja_typings": [
+          "obuza-baburu"
+        ]
       },
       {
         "en": "Stream",
         "ja": "ストリーム",
-        "ja_typings": []
+        "ja_typings": [
+          "sutori-mu"
+        ]
       },
       {
         "en": "Channel",
         "ja": "チャネル",
-        "ja_typings": []
+        "ja_typings": [
+          "chaneru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38674,22 +40376,30 @@
       {
         "en": "302",
         "ja": "サンマルニ",
-        "ja_typings": []
+        "ja_typings": [
+          "sanmaruni"
+        ]
       },
       {
         "en": "301",
         "ja": "サンマルイチ",
-        "ja_typings": []
+        "ja_typings": [
+          "sanmaruichi"
+        ]
       },
       {
         "en": "303",
         "ja": "サンマルサン",
-        "ja_typings": []
+        "ja_typings": [
+          "sanmarusan"
+        ]
       },
       {
         "en": "307",
         "ja": "サンマルナナ",
-        "ja_typings": []
+        "ja_typings": [
+          "sanmarunana"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38706,22 +40416,30 @@
       {
         "en": "503",
         "ja": "ゴーマルサン",
-        "ja_typings": []
+        "ja_typings": [
+          "go-marusan"
+        ]
       },
       {
         "en": "502",
         "ja": "ゴーマルニ",
-        "ja_typings": []
+        "ja_typings": [
+          "go-maruni"
+        ]
       },
       {
         "en": "504",
         "ja": "ゴーマルヨン",
-        "ja_typings": []
+        "ja_typings": [
+          "go-maruyon"
+        ]
       },
       {
         "en": "500",
         "ja": "ゴヒャク",
-        "ja_typings": []
+        "ja_typings": [
+          "gohyaku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38738,22 +40456,30 @@
       {
         "en": "413",
         "ja": "ヨンイチサン",
-        "ja_typings": []
+        "ja_typings": [
+          "yonnichisan"
+        ]
       },
       {
         "en": "414",
         "ja": "ヨンイチヨン",
-        "ja_typings": []
+        "ja_typings": [
+          "yonnichiyon"
+        ]
       },
       {
         "en": "400",
         "ja": "ヨンヒャク",
-        "ja_typings": []
+        "ja_typings": [
+          "yonhyaku"
+        ]
       },
       {
         "en": "411",
         "ja": "ヨンイチイチ",
-        "ja_typings": []
+        "ja_typings": [
+          "yonnichiichi"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38770,22 +40496,30 @@
       {
         "en": "304",
         "ja": "サンマルヨン",
-        "ja_typings": []
+        "ja_typings": [
+          "sanmaruyon"
+        ]
       },
       {
         "en": "305",
         "ja": "サンマルゴ",
-        "ja_typings": []
+        "ja_typings": [
+          "sanmarugo"
+        ]
       },
       {
         "en": "306",
         "ja": "サンマルロク",
-        "ja_typings": []
+        "ja_typings": [
+          "sanmaruroku"
+        ]
       },
       {
         "en": "302",
         "ja": "サンマルニ",
-        "ja_typings": []
+        "ja_typings": [
+          "sanmaruni"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38802,22 +40536,30 @@
       {
         "en": "Authorization",
         "ja": "オーソライゼーション",
-        "ja_typings": []
+        "ja_typings": [
+          "o-soraize-shon"
+        ]
       },
       {
         "en": "Authentication",
         "ja": "オーセンティケーション",
-        "ja_typings": []
+        "ja_typings": [
+          "o-sentike-shon"
+        ]
       },
       {
         "en": "Credentials",
         "ja": "クレデンシャルズ",
-        "ja_typings": []
+        "ja_typings": [
+          "kuredensharuzu"
+        ]
       },
       {
         "en": "X-Token",
         "ja": "エックストークン",
-        "ja_typings": []
+        "ja_typings": [
+          "ekkusuto-kun"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38834,22 +40576,30 @@
       {
         "en": "Content-Type",
         "ja": "コンテントタイプ",
-        "ja_typings": []
+        "ja_typings": [
+          "kontentotaipu"
+        ]
       },
       {
         "en": "Accept",
         "ja": "アクセプト",
-        "ja_typings": []
+        "ja_typings": [
+          "akuseputo"
+        ]
       },
       {
         "en": "Content-Length",
         "ja": "コンテントレングス",
-        "ja_typings": []
+        "ja_typings": [
+          "kontentorengusu"
+        ]
       },
       {
         "en": "Content-Encoding",
         "ja": "コンテントエンコーディング",
-        "ja_typings": []
+        "ja_typings": [
+          "kontentoenko-dingu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38866,22 +40616,30 @@
       {
         "en": "Accept",
         "ja": "アクセプト",
-        "ja_typings": []
+        "ja_typings": [
+          "akuseputo"
+        ]
       },
       {
         "en": "Content-Type",
         "ja": "コンテントタイプ",
-        "ja_typings": []
+        "ja_typings": [
+          "kontentotaipu"
+        ]
       },
       {
         "en": "Vary",
         "ja": "ベアリー",
-        "ja_typings": []
+        "ja_typings": [
+          "beari-"
+        ]
       },
       {
         "en": "Allow",
         "ja": "アロー",
-        "ja_typings": []
+        "ja_typings": [
+          "aro-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38898,22 +40656,30 @@
       {
         "en": "User-Agent",
         "ja": "ユーザーエージェント",
-        "ja_typings": []
+        "ja_typings": [
+          "yu-za-e-jento"
+        ]
       },
       {
         "en": "Referer",
         "ja": "リファラー",
-        "ja_typings": []
+        "ja_typings": [
+          "rifara-"
+        ]
       },
       {
         "en": "From",
         "ja": "フロム",
-        "ja_typings": []
+        "ja_typings": [
+          "furomu"
+        ]
       },
       {
         "en": "Host",
         "ja": "ホスト",
-        "ja_typings": []
+        "ja_typings": [
+          "hosuto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38930,22 +40696,30 @@
       {
         "en": "SQL injection",
         "ja": "エスキューエルインジェクション",
-        "ja_typings": []
+        "ja_typings": [
+          "esukyu-eruinjekushon"
+        ]
       },
       {
         "en": "XSS",
         "ja": "クロスサイトスクリプティング",
-        "ja_typings": []
+        "ja_typings": [
+          "kurosusaitosukuriputingu"
+        ]
       },
       {
         "en": "CSRF",
         "ja": "クロスサイトリクエストフォージェリ",
-        "ja_typings": []
+        "ja_typings": [
+          "kurosusaitorikuesutofo-jeri"
+        ]
       },
       {
         "en": "Path traversal",
         "ja": "パストラバーサル",
-        "ja_typings": []
+        "ja_typings": [
+          "pasutoraba-saru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38962,22 +40736,30 @@
       {
         "en": "Path traversal",
         "ja": "パストラバーサル",
-        "ja_typings": []
+        "ja_typings": [
+          "pasutoraba-saru"
+        ]
       },
       {
         "en": "SQL injection",
         "ja": "エスキューエルインジェクション",
-        "ja_typings": []
+        "ja_typings": [
+          "esukyu-eruinjekushon"
+        ]
       },
       {
         "en": "XSS",
         "ja": "クロスサイトスクリプティング",
-        "ja_typings": []
+        "ja_typings": [
+          "kurosusaitosukuriputingu"
+        ]
       },
       {
         "en": "Clickjacking",
         "ja": "クリックジャッキング",
-        "ja_typings": []
+        "ja_typings": [
+          "kurikkujakkingu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -38994,22 +40776,30 @@
       {
         "en": "Clickjacking",
         "ja": "クリックジャッキング",
-        "ja_typings": []
+        "ja_typings": [
+          "kurikkujakkingu"
+        ]
       },
       {
         "en": "Phishing",
         "ja": "フィッシング",
-        "ja_typings": []
+        "ja_typings": [
+          "fisshingu"
+        ]
       },
       {
         "en": "CSRF",
         "ja": "クロスサイトリクエストフォージェリ",
-        "ja_typings": []
+        "ja_typings": [
+          "kurosusaitorikuesutofo-jeri"
+        ]
       },
       {
         "en": "XSS",
         "ja": "クロスサイトスクリプティング",
-        "ja_typings": []
+        "ja_typings": [
+          "kurosusaitosukuriputingu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -39026,22 +40816,30 @@
       {
         "en": "X-Frame-Options",
         "ja": "エックスフレームオプションズ",
-        "ja_typings": []
+        "ja_typings": [
+          "ekkusufure-muopushonzu"
+        ]
       },
       {
         "en": "Content-Security-Policy",
         "ja": "コンテンツセキュリティポリシー",
-        "ja_typings": []
+        "ja_typings": [
+          "kontentsusekyuritiporishi-"
+        ]
       },
       {
         "en": "X-Content-Type-Options",
         "ja": "エックスコンテンツタイプオプションズ",
-        "ja_typings": []
+        "ja_typings": [
+          "ekkusukontentsutaipuopushonzu"
+        ]
       },
       {
         "en": "Referrer-Policy",
         "ja": "リファラーポリシー",
-        "ja_typings": []
+        "ja_typings": [
+          "rifara-porishi-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -39058,22 +40856,30 @@
       {
         "en": "Strict-Transport-Security",
         "ja": "ストリクトトランスポートセキュリティ",
-        "ja_typings": []
+        "ja_typings": [
+          "sutorikutotoransupo-tosekyuriti"
+        ]
       },
       {
         "en": "Content-Security-Policy",
         "ja": "コンテンツセキュリティポリシー",
-        "ja_typings": []
+        "ja_typings": [
+          "kontentsusekyuritiporishi-"
+        ]
       },
       {
         "en": "X-Frame-Options",
         "ja": "エックスフレームオプションズ",
-        "ja_typings": []
+        "ja_typings": [
+          "ekkusufure-muopushonzu"
+        ]
       },
       {
         "en": "Permissions-Policy",
         "ja": "パーミッションズポリシー",
-        "ja_typings": []
+        "ja_typings": [
+          "pa-misshonzuporishi-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -39090,22 +40896,30 @@
       {
         "en": "Redux",
         "ja": "リダックス",
-        "ja_typings": []
+        "ja_typings": [
+          "ridakkusu"
+        ]
       },
       {
         "en": "MobX",
         "ja": "モブエックス",
-        "ja_typings": []
+        "ja_typings": [
+          "mobuekkusu"
+        ]
       },
       {
         "en": "Recoil",
         "ja": "リコイル",
-        "ja_typings": []
+        "ja_typings": [
+          "rikoiru"
+        ]
       },
       {
         "en": "Zustand",
         "ja": "ズスタンド",
-        "ja_typings": []
+        "ja_typings": [
+          "zusutando"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -39122,22 +40936,30 @@
       {
         "en": "styled-components",
         "ja": "スタイルドコンポーネンツ",
-        "ja_typings": []
+        "ja_typings": [
+          "sutairudokonpo-nentsu"
+        ]
       },
       {
         "en": "Emotion",
         "ja": "エモーション",
-        "ja_typings": []
+        "ja_typings": [
+          "emo-shon"
+        ]
       },
       {
         "en": "JSS",
         "ja": "ジェイエスエス",
-        "ja_typings": []
+        "ja_typings": [
+          "jeiesuesu"
+        ]
       },
       {
         "en": "Linaria",
         "ja": "リナリア",
-        "ja_typings": []
+        "ja_typings": [
+          "rinaria"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -39154,22 +40976,30 @@
       {
         "en": "Astro",
         "ja": "アストロ",
-        "ja_typings": []
+        "ja_typings": [
+          "asutoro"
+        ]
       },
       {
         "en": "Remix",
         "ja": "リミックス",
-        "ja_typings": []
+        "ja_typings": [
+          "rimikkusu"
+        ]
       },
       {
         "en": "SolidStart",
         "ja": "ソリッドスタート",
-        "ja_typings": []
+        "ja_typings": [
+          "soriddosuta-to"
+        ]
       },
       {
         "en": "Qwik",
         "ja": "クィック",
-        "ja_typings": []
+        "ja_typings": [
+          "kuikku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -39186,22 +41016,30 @@
       {
         "en": "SolidJS",
         "ja": "ソリッドジェイエス",
-        "ja_typings": []
+        "ja_typings": [
+          "soriddojeiesu"
+        ]
       },
       {
         "en": "Svelte",
         "ja": "スベルト",
-        "ja_typings": []
+        "ja_typings": [
+          "suberuto"
+        ]
       },
       {
         "en": "Vue",
         "ja": "ビュー",
-        "ja_typings": []
+        "ja_typings": [
+          "byu-"
+        ]
       },
       {
         "en": "Preact",
         "ja": "プリアクト",
-        "ja_typings": []
+        "ja_typings": [
+          "puriakuto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -39218,22 +41056,30 @@
       {
         "en": "Qwik",
         "ja": "クィック",
-        "ja_typings": []
+        "ja_typings": [
+          "kuikku"
+        ]
       },
       {
         "en": "Astro",
         "ja": "アストロ",
-        "ja_typings": []
+        "ja_typings": [
+          "asutoro"
+        ]
       },
       {
         "en": "Remix",
         "ja": "リミックス",
-        "ja_typings": []
+        "ja_typings": [
+          "rimikkusu"
+        ]
       },
       {
         "en": "SolidJS",
         "ja": "ソリッドジェイエス",
-        "ja_typings": []
+        "ja_typings": [
+          "soriddojeiesu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -39250,22 +41096,31 @@
       {
         "en": "Remix",
         "ja": "リミックス",
-        "ja_typings": []
+        "ja_typings": [
+          "rimikkusu"
+        ]
       },
       {
         "en": "Next.js",
         "ja": "ネクストジェイエス",
-        "ja_typings": []
+        "ja_typings": [
+          "nekusutojeiesu"
+        ]
       },
       {
         "en": "Gatsby",
         "ja": "ギャツビー",
-        "ja_typings": []
+        "ja_typings": [
+          "gyatsubi-"
+        ]
       },
       {
         "en": "Redwood",
         "ja": "レッドウッド",
-        "ja_typings": []
+        "ja_typings": [
+          "reddoddo",
+          "reddouddo"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -39282,22 +41137,30 @@
       {
         "en": "WHATWG",
         "ja": "ワットダブリュージー",
-        "ja_typings": []
+        "ja_typings": [
+          "wattodaburyu-ji-"
+        ]
       },
       {
         "en": "W3C",
         "ja": "ダブリュースリーシー",
-        "ja_typings": []
+        "ja_typings": [
+          "daburyu-suri-shi-"
+        ]
       },
       {
         "en": "ECMA",
         "ja": "エクマ",
-        "ja_typings": []
+        "ja_typings": [
+          "ekuma"
+        ]
       },
       {
         "en": "IETF",
         "ja": "アイイーティーエフ",
-        "ja_typings": []
+        "ja_typings": [
+          "aii-ti-efu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -39314,22 +41177,30 @@
       {
         "en": "ECMA International",
         "ja": "エクマインターナショナル",
-        "ja_typings": []
+        "ja_typings": [
+          "ekumainta-nashonaru"
+        ]
       },
       {
         "en": "WHATWG",
         "ja": "ワットダブリュージー",
-        "ja_typings": []
+        "ja_typings": [
+          "wattodaburyu-ji-"
+        ]
       },
       {
         "en": "W3C",
         "ja": "ダブリュースリーシー",
-        "ja_typings": []
+        "ja_typings": [
+          "daburyu-suri-shi-"
+        ]
       },
       {
         "en": "IETF",
         "ja": "アイイーティーエフ",
-        "ja_typings": []
+        "ja_typings": [
+          "aii-ti-efu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -39346,22 +41217,30 @@
       {
         "en": "WebKit",
         "ja": "ウェブキット",
-        "ja_typings": []
+        "ja_typings": [
+          "webukitto"
+        ]
       },
       {
         "en": "Blink",
         "ja": "ブリンク",
-        "ja_typings": []
+        "ja_typings": [
+          "burinku"
+        ]
       },
       {
         "en": "Gecko",
         "ja": "ゲッコー",
-        "ja_typings": []
+        "ja_typings": [
+          "gekko-"
+        ]
       },
       {
         "en": "Servo",
         "ja": "サーボ",
-        "ja_typings": []
+        "ja_typings": [
+          "sa-bo"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -39378,22 +41257,30 @@
       {
         "en": "Gecko",
         "ja": "ゲッコー",
-        "ja_typings": []
+        "ja_typings": [
+          "gekko-"
+        ]
       },
       {
         "en": "WebKit",
         "ja": "ウェブキット",
-        "ja_typings": []
+        "ja_typings": [
+          "webukitto"
+        ]
       },
       {
         "en": "Blink",
         "ja": "ブリンク",
-        "ja_typings": []
+        "ja_typings": [
+          "burinku"
+        ]
       },
       {
         "en": "Trident",
         "ja": "トライデント",
-        "ja_typings": []
+        "ja_typings": [
+          "toraidento"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -39410,22 +41297,30 @@
       {
         "en": "Blink",
         "ja": "ブリンク",
-        "ja_typings": []
+        "ja_typings": [
+          "burinku"
+        ]
       },
       {
         "en": "WebKit",
         "ja": "ウェブキット",
-        "ja_typings": []
+        "ja_typings": [
+          "webukitto"
+        ]
       },
       {
         "en": "Gecko",
         "ja": "ゲッコー",
-        "ja_typings": []
+        "ja_typings": [
+          "gekko-"
+        ]
       },
       {
         "en": "EdgeHTML",
         "ja": "エッジエイチティーエムエル",
-        "ja_typings": []
+        "ja_typings": [
+          "ejjieichiti-emueru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -39442,22 +41337,30 @@
       {
         "en": "WebAssembly",
         "ja": "ウェブアセンブリ",
-        "ja_typings": []
+        "ja_typings": [
+          "webuasenburi"
+        ]
       },
       {
         "en": "asm.js",
         "ja": "エイエスエムジェイエス",
-        "ja_typings": []
+        "ja_typings": [
+          "eiesuemujeiesu"
+        ]
       },
       {
         "en": "NaCl",
         "ja": "ネイティブクライアント",
-        "ja_typings": []
+        "ja_typings": [
+          "neitibukuraianto"
+        ]
       },
       {
         "en": "PNaCl",
         "ja": "ピーネイティブクライアント",
-        "ja_typings": []
+        "ja_typings": [
+          "pi-neitibukuraianto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -39474,22 +41377,30 @@
       {
         "en": "Web App Manifest",
         "ja": "ウェブアプリマニフェスト",
-        "ja_typings": []
+        "ja_typings": [
+          "webuapurimanifesuto"
+        ]
       },
       {
         "en": "robots.txt",
         "ja": "ロボッツテキスト",
-        "ja_typings": []
+        "ja_typings": [
+          "robottsutekisuto"
+        ]
       },
       {
         "en": "sitemap.xml",
         "ja": "サイトマップエックスエムエル",
-        "ja_typings": []
+        "ja_typings": [
+          "saitomappuekkusuemueru"
+        ]
       },
       {
         "en": "favicon.ico",
         "ja": "ファビコン",
-        "ja_typings": []
+        "ja_typings": [
+          "fabikon"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -39506,22 +41417,30 @@
       {
         "en": "robots.txt",
         "ja": "ロボッツテキスト",
-        "ja_typings": []
+        "ja_typings": [
+          "robottsutekisuto"
+        ]
       },
       {
         "en": "sitemap.xml",
         "ja": "サイトマップエックスエムエル",
-        "ja_typings": []
+        "ja_typings": [
+          "saitomappuekkusuemueru"
+        ]
       },
       {
         "en": "humans.txt",
         "ja": "ヒューマンズテキスト",
-        "ja_typings": []
+        "ja_typings": [
+          "hyu-manzutekisuto"
+        ]
       },
       {
         "en": "ads.txt",
         "ja": "アドステキスト",
-        "ja_typings": []
+        "ja_typings": [
+          "adosutekisuto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -39538,22 +41457,30 @@
       {
         "en": "sitemap.xml",
         "ja": "サイトマップエックスエムエル",
-        "ja_typings": []
+        "ja_typings": [
+          "saitomappuekkusuemueru"
+        ]
       },
       {
         "en": "robots.txt",
         "ja": "ロボッツテキスト",
-        "ja_typings": []
+        "ja_typings": [
+          "robottsutekisuto"
+        ]
       },
       {
         "en": "manifest.json",
         "ja": "マニフェストジェイソン",
-        "ja_typings": []
+        "ja_typings": [
+          "manifesutojeison"
+        ]
       },
       {
         "en": "feed.xml",
         "ja": "フィードエックスエムエル",
-        "ja_typings": []
+        "ja_typings": [
+          "fi-doekkusuemueru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -39570,22 +41497,30 @@
       {
         "en": "WebRTC",
         "ja": "ウェブアールティーシー",
-        "ja_typings": []
+        "ja_typings": [
+          "webua-ruti-shi-"
+        ]
       },
       {
         "en": "WebSocket",
         "ja": "ウェブソケット",
-        "ja_typings": []
+        "ja_typings": [
+          "webusoketto"
+        ]
       },
       {
         "en": "WebTransport",
         "ja": "ウェブトランスポート",
-        "ja_typings": []
+        "ja_typings": [
+          "webutoransupo-to"
+        ]
       },
       {
         "en": "SSE",
         "ja": "エスエスイー",
-        "ja_typings": []
+        "ja_typings": [
+          "esuesui-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -39602,22 +41537,30 @@
       {
         "en": "Server-Sent Events",
         "ja": "サーバーセントイベンツ",
-        "ja_typings": []
+        "ja_typings": [
+          "sa-ba-sentoibentsu"
+        ]
       },
       {
         "en": "WebSocket",
         "ja": "ウェブソケット",
-        "ja_typings": []
+        "ja_typings": [
+          "webusoketto"
+        ]
       },
       {
         "en": "Long polling",
         "ja": "ロングポーリング",
-        "ja_typings": []
+        "ja_typings": [
+          "rongupo-ringu"
+        ]
       },
       {
         "en": "Webhook",
         "ja": "ウェブフック",
-        "ja_typings": []
+        "ja_typings": [
+          "webufukku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -39635,7 +41578,8 @@
         "en": "1024",
         "ja": "センニジュウヨン",
         "ja_typings": [
-          "sennijuuyon"
+          "sennijuuyon",
+          "sennnijuuyon"
         ]
       },
       {
@@ -39649,7 +41593,8 @@
         "en": "2048",
         "ja": "ニセンヨンジュウハチ",
         "ja_typings": [
-          "nisenyonjuuhachi"
+          "nisenyonjuuhachi",
+          "nisennyonjuuhachi"
         ]
       },
       {
@@ -39754,22 +41699,30 @@
       {
         "en": "2.7",
         "ja": "ニテンナナ",
-        "ja_typings": []
+        "ja_typings": [
+          "nitennnana"
+        ]
       },
       {
         "en": "3.1",
         "ja": "サンテンイチ",
-        "ja_typings": []
+        "ja_typings": [
+          "santennichi"
+        ]
       },
       {
         "en": "1.6",
         "ja": "イッテンロク",
-        "ja_typings": []
+        "ja_typings": [
+          "ittenroku"
+        ]
       },
       {
         "en": "2.3",
         "ja": "ニテンサン",
-        "ja_typings": []
+        "ja_typings": [
+          "nitensan"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -39828,7 +41781,9 @@
         "ja": "パイアールジジョウ",
         "ja_typings": [
           "paiaaru jijou",
-          "pai a-ru jijou"
+          "pai a-ru jijou",
+          "paia-rujijo",
+          "paia-rujijou"
         ]
       },
       {
@@ -39836,7 +41791,8 @@
         "ja": "ニパイアール",
         "ja_typings": [
           "nipaiaaru",
-          "ni pai a-ru"
+          "ni pai a-ru",
+          "nipaia-ru"
         ]
       },
       {
@@ -39850,7 +41806,9 @@
         "en": "four pi r squared",
         "ja": "ヨンパイアールジジョウ",
         "ja_typings": [
-          "yonpaiaaru jijou"
+          "yonpaiaaru jijou",
+          "yonpaia-rujijo",
+          "yonpaia-rujijou"
         ]
       }
     ],
@@ -39949,28 +41907,32 @@
         "en": "1/6",
         "ja": "ロクブンノイチ",
         "ja_typings": [
-          "rokubunnoichi"
+          "rokubunnoichi",
+          "rokubunnnoichi"
         ]
       },
       {
         "en": "1/3",
         "ja": "サンブンノイチ",
         "ja_typings": [
-          "sanbunnoichi"
+          "sanbunnoichi",
+          "sanbunnnoichi"
         ]
       },
       {
         "en": "1/2",
         "ja": "ニブンノイチ",
         "ja_typings": [
-          "nibunnoichi"
+          "nibunnoichi",
+          "nibunnnoichi"
         ]
       },
       {
         "en": "1/12",
         "ja": "ジュウニブンノイチ",
         "ja_typings": [
-          "juunibunnoichi"
+          "juunibunnoichi",
+          "juunibunnnoichi"
         ]
       }
     ],
@@ -40069,7 +42031,8 @@
         "en": "middle value",
         "ja": "マンナカノアタイ",
         "ja_typings": [
-          "mannakanoatai"
+          "mannakanoatai",
+          "mannnakanoatai"
         ]
       },
       {
@@ -40090,7 +42053,8 @@
         "en": "total sum",
         "ja": "ゴウケイ",
         "ja_typings": [
-          "goukei"
+          "goukei",
+          "gokei"
         ]
       }
     ],
@@ -40109,7 +42073,8 @@
         "en": "cube",
         "ja": "リッポウタイ",
         "ja_typings": [
-          "rippoutai"
+          "rippoutai",
+          "rippotai"
         ]
       },
       {
@@ -40210,7 +42175,8 @@
         "en": "squared sum",
         "ja": "ジジョウワ",
         "ja_typings": [
-          "jijouwa"
+          "jijouwa",
+          "jijowa"
         ]
       }
     ],
@@ -40389,21 +42355,24 @@
         "en": "1/2",
         "ja": "ニブンノイチ",
         "ja_typings": [
-          "nibunnoichi"
+          "nibunnoichi",
+          "nibunnnoichi"
         ]
       },
       {
         "en": "root 3 over 2",
         "ja": "ルートサンブンノニ",
         "ja_typings": [
-          "ru-tosanbunnoni"
+          "ru-tosanbunnoni",
+          "ru-tosanbunnnoni"
         ]
       },
       {
         "en": "root 2 over 2",
         "ja": "ルートニブンノニ",
         "ja_typings": [
-          "ru-tonibunnoni"
+          "ru-tonibunnoni",
+          "ru-tonibunnnoni"
         ]
       },
       {
@@ -40443,7 +42412,8 @@
         "en": "x cubed",
         "ja": "エックスサンジョウ",
         "ja_typings": [
-          "ekkususanjou"
+          "ekkususanjou",
+          "ekkususanjo"
         ]
       },
       {
@@ -40476,14 +42446,16 @@
         "en": "x squared",
         "ja": "エックスニジョウ",
         "ja_typings": [
-          "ekkusunijou"
+          "ekkusunijou",
+          "ekkusunijo"
         ]
       },
       {
         "en": "e to the x",
         "ja": "イーノエックスジョウ",
         "ja_typings": [
-          "i-noekkusujou"
+          "i-noekkusujou",
+          "i-noekkusujo"
         ]
       },
       {
@@ -40588,22 +42560,30 @@
       {
         "en": "Automated Teller Machine",
         "ja": "オートメイテッドテラーマシン",
-        "ja_typings": []
+        "ja_typings": [
+          "o-tomeiteddotera-mashin"
+        ]
       },
       {
         "en": "Auto Transfer Money",
         "ja": "オートトランスファーマネー",
-        "ja_typings": []
+        "ja_typings": [
+          "o-totoransufa-mane-"
+        ]
       },
       {
         "en": "Account Transfer Method",
         "ja": "アカウントトランスファーメソッド",
-        "ja_typings": []
+        "ja_typings": [
+          "akauntotoransufa-mesoddo"
+        ]
       },
       {
         "en": "Active Time Manager",
         "ja": "アクティブタイムマネージャー",
-        "ja_typings": []
+        "ja_typings": [
+          "akutibutaimumane-ja-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -40661,28 +42641,33 @@
         "en": "3600 seconds",
         "ja": "サンゼンロッピャクビョウ",
         "ja_typings": [
-          "sanzenroppyakubyou"
+          "sanzenroppyakubyou",
+          "sanzenroppyakubyo"
         ]
       },
       {
         "en": "60 seconds",
         "ja": "ロクジュウビョウ",
         "ja_typings": [
-          "rokujuubyou"
+          "rokujuubyou",
+          "rokujuubyo"
         ]
       },
       {
         "en": "7200 seconds",
         "ja": "ナナセンニヒャクビョウ",
         "ja_typings": [
-          "nanasennihyakubyou"
+          "nanasennihyakubyou",
+          "nanasennnihyakubyo",
+          "nanasennnihyakubyou"
         ]
       },
       {
         "en": "1800 seconds",
         "ja": "センハッピャクビョウ",
         "ja_typings": [
-          "senhappyakubyou"
+          "senhappyakubyou",
+          "senhappyakubyo"
         ]
       }
     ],
@@ -40701,28 +42686,36 @@
         "en": "300000 km per second",
         "ja": "サンジュウマンキロメートルマイビョウ",
         "ja_typings": [
-          "sanjuumankiromeetorumaibyou"
+          "sanjuumankiromeetorumaibyou",
+          "sanjuumankirome-torumaibyo",
+          "sanjuumankirome-torumaibyou"
         ]
       },
       {
         "en": "30000 km per second",
         "ja": "サンマンキロメートルマイビョウ",
         "ja_typings": [
-          "sanmankiromeetorumaibyou"
+          "sanmankiromeetorumaibyou",
+          "sanmankirome-torumaibyo",
+          "sanmankirome-torumaibyou"
         ]
       },
       {
         "en": "3 million km per second",
         "ja": "サンビャクマンキロメートルマイビョウ",
         "ja_typings": [
-          "sanbyakumankiromeetorumaibyou"
+          "sanbyakumankiromeetorumaibyou",
+          "sanbyakumankirome-torumaibyo",
+          "sanbyakumankirome-torumaibyou"
         ]
       },
       {
         "en": "3000 km per second",
         "ja": "サンゼンキロメートルマイビョウ",
         "ja_typings": [
-          "sanzenkiromeetorumaibyou"
+          "sanzenkiromeetorumaibyou",
+          "sanzenkirome-torumaibyo",
+          "sanzenkirome-torumaibyou"
         ]
       }
     ],
@@ -40740,22 +42733,30 @@
       {
         "en": "Chief Executive Officer",
         "ja": "チーフエグゼクティブオフィサー",
-        "ja_typings": []
+        "ja_typings": [
+          "chi-fueguzekutibuofisa-"
+        ]
       },
       {
         "en": "Central Executive Order",
         "ja": "セントラルエグゼクティブオーダー",
-        "ja_typings": []
+        "ja_typings": [
+          "sentorarueguzekutibuo-da-"
+        ]
       },
       {
         "en": "Corporate Engineer Officer",
         "ja": "コーポレートエンジニアオフィサー",
-        "ja_typings": []
+        "ja_typings": [
+          "ko-pore-toenjiniaofisa-"
+        ]
       },
       {
         "en": "Chief Engineering Operator",
         "ja": "チーフエンジニアリングオペレーター",
-        "ja_typings": []
+        "ja_typings": [
+          "chi-fuenjiniaringuopere-ta-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -40813,21 +42814,24 @@
         "en": "Pacific Ocean",
         "ja": "タイヘイヨウ",
         "ja_typings": [
-          "taiheiyou"
+          "taiheiyou",
+          "taiheiyo"
         ]
       },
       {
         "en": "Atlantic Ocean",
         "ja": "タイセイヨウ",
         "ja_typings": [
-          "taiseiyou"
+          "taiseiyou",
+          "taiseiyo"
         ]
       },
       {
         "en": "Indian Ocean",
         "ja": "インドヨウ",
         "ja_typings": [
-          "indoyou"
+          "indoyou",
+          "indoyo"
         ]
       },
       {
@@ -40852,7 +42856,9 @@
       {
         "en": "Mount Everest",
         "ja": "エベレスト",
-        "ja_typings": []
+        "ja_typings": [
+          "eberesuto"
+        ]
       },
       {
         "en": "K2",
@@ -40871,7 +42877,9 @@
       {
         "en": "Mont Blanc",
         "ja": "モンブラン",
-        "ja_typings": []
+        "ja_typings": [
+          "monburan"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -40888,22 +42896,30 @@
       {
         "en": "Canada",
         "ja": "カナダ",
-        "ja_typings": []
+        "ja_typings": [
+          "kanada"
+        ]
       },
       {
         "en": "Russia",
         "ja": "ロシア",
-        "ja_typings": []
+        "ja_typings": [
+          "roshia"
+        ]
       },
       {
         "en": "Australia",
         "ja": "オーストラリア",
-        "ja_typings": []
+        "ja_typings": [
+          "o-sutoraria"
+        ]
       },
       {
         "en": "Indonesia",
         "ja": "インドネシア",
-        "ja_typings": []
+        "ja_typings": [
+          "indoneshia"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -40920,22 +42936,30 @@
       {
         "en": "Global Positioning System",
         "ja": "グローバルポジショニングシステム",
-        "ja_typings": []
+        "ja_typings": [
+          "guro-barupojishoningushisutemu"
+        ]
       },
       {
         "en": "General Position Service",
         "ja": "ジェネラルポジションサービス",
-        "ja_typings": []
+        "ja_typings": [
+          "jenerarupojishonsa-bisu"
+        ]
       },
       {
         "en": "Geographic Plot Standard",
         "ja": "ジオグラフィックプロットスタンダード",
-        "ja_typings": []
+        "ja_typings": [
+          "jiogurafikkupurottosutanda-do"
+        ]
       },
       {
         "en": "Ground Path Sensor",
         "ja": "グラウンドパスセンサー",
-        "ja_typings": []
+        "ja_typings": [
+          "guraundopasusensa-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -40992,22 +43016,30 @@
       {
         "en": "pascal",
         "ja": "パスカル",
-        "ja_typings": []
+        "ja_typings": [
+          "pasukaru"
+        ]
       },
       {
         "en": "hertz",
         "ja": "ヘルツ",
-        "ja_typings": []
+        "ja_typings": [
+          "herutsu"
+        ]
       },
       {
         "en": "joule",
         "ja": "ジュール",
-        "ja_typings": []
+        "ja_typings": [
+          "ju-ru"
+        ]
       },
       {
         "en": "newton",
         "ja": "ニュートン",
-        "ja_typings": []
+        "ja_typings": [
+          "nyu-ton"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -41065,23 +43097,31 @@
         "en": "distress signal",
         "ja": "ソウナンシンゴウ",
         "ja_typings": [
-          "sounanshingou"
+          "sounanshingou",
+          "sonanshingo"
         ]
       },
       {
         "en": "save our ship",
         "ja": "セーブアワーシップ",
-        "ja_typings": []
+        "ja_typings": [
+          "se-buawa-shippu"
+        ]
       },
       {
         "en": "ship out signal",
         "ja": "シップアウトシグナル",
-        "ja_typings": []
+        "ja_typings": [
+          "shippuautoshigunaru"
+        ]
       },
       {
         "en": "standard order set",
         "ja": "スタンダードオーダーセット",
-        "ja_typings": []
+        "ja_typings": [
+          "sutanda-do-da-setto",
+          "sutanda-doo-da-setto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -41098,22 +43138,30 @@
       {
         "en": "Very Important Person",
         "ja": "ベリーインポータントパーソン",
-        "ja_typings": []
+        "ja_typings": [
+          "beri-inpo-tantopa-son"
+        ]
       },
       {
         "en": "Vital Information Pass",
         "ja": "バイタルインフォメーションパス",
-        "ja_typings": []
+        "ja_typings": [
+          "baitaruinfome-shonpasu"
+        ]
       },
       {
         "en": "Visual Identity Profile",
         "ja": "ビジュアルアイデンティティプロファイル",
-        "ja_typings": []
+        "ja_typings": [
+          "bijuaruaidentitipurofairu"
+        ]
       },
       {
         "en": "Verified Internal Pass",
         "ja": "ベリファイドインターナルパス",
-        "ja_typings": []
+        "ja_typings": [
+          "berifaidointa-narupasu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -41177,17 +43225,23 @@
       {
         "en": "Monaco",
         "ja": "モナコ",
-        "ja_typings": []
+        "ja_typings": [
+          "monako"
+        ]
       },
       {
         "en": "San Marino",
         "ja": "サンマリノ",
-        "ja_typings": []
+        "ja_typings": [
+          "sanmarino"
+        ]
       },
       {
         "en": "Liechtenstein",
         "ja": "リヒテンシュタイン",
-        "ja_typings": []
+        "ja_typings": [
+          "rihitenshutain"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -41204,22 +43258,30 @@
       {
         "en": "Portable Document Format",
         "ja": "ポータブルドキュメントフォーマット",
-        "ja_typings": []
+        "ja_typings": [
+          "po-taburudokyumentofo-matto"
+        ]
       },
       {
         "en": "Personal Data File",
         "ja": "パーソナルデータファイル",
-        "ja_typings": []
+        "ja_typings": [
+          "pa-sonarude-tafairu"
+        ]
       },
       {
         "en": "Public Document Folder",
         "ja": "パブリックドキュメントフォルダ",
-        "ja_typings": []
+        "ja_typings": [
+          "paburikkudokyumentoforuda"
+        ]
       },
       {
         "en": "Print Direct Form",
         "ja": "プリントダイレクトフォーム",
-        "ja_typings": []
+        "ja_typings": [
+          "purintodairekutofo-mu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -41316,22 +43378,30 @@
       {
         "en": "good game",
         "ja": "グッドゲーム",
-        "ja_typings": []
+        "ja_typings": [
+          "guddoge-mu"
+        ]
       },
       {
         "en": "get going",
         "ja": "ゲットゴーイング",
-        "ja_typings": []
+        "ja_typings": [
+          "gettogo-ingu"
+        ]
       },
       {
         "en": "great gain",
         "ja": "グレートゲイン",
-        "ja_typings": []
+        "ja_typings": [
+          "gure-togein"
+        ]
       },
       {
         "en": "game guide",
         "ja": "ゲームガイド",
-        "ja_typings": []
+        "ja_typings": [
+          "ge-mugaido"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -41348,22 +43418,30 @@
       {
         "en": "Away From Keyboard",
         "ja": "アウェイフロムキーボード",
-        "ja_typings": []
+        "ja_typings": [
+          "aweifuromuki-bo-do"
+        ]
       },
       {
         "en": "All For Kicks",
         "ja": "オールフォーキックス",
-        "ja_typings": []
+        "ja_typings": [
+          "o-rufo-kikkusu"
+        ]
       },
       {
         "en": "Asking For Knowledge",
         "ja": "アスキングフォーナレッジ",
-        "ja_typings": []
+        "ja_typings": [
+          "asukingufo-narejji"
+        ]
       },
       {
         "en": "Active Friend Killer",
         "ja": "アクティブフレンドキラー",
-        "ja_typings": []
+        "ja_typings": [
+          "akutibufurendokira-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -41420,22 +43498,30 @@
       {
         "en": "Live2D model",
         "ja": "ライブツーディーモデル",
-        "ja_typings": []
+        "ja_typings": [
+          "raibutsu-di-moderu"
+        ]
       },
       {
         "en": "flat avatar",
         "ja": "フラットアバター",
-        "ja_typings": []
+        "ja_typings": [
+          "furattoabata-"
+        ]
       },
       {
         "en": "paper avatar",
         "ja": "ペーパーアバター",
-        "ja_typings": []
+        "ja_typings": [
+          "pe-pa-abata-"
+        ]
       },
       {
         "en": "static icon",
         "ja": "スタティックアイコン",
-        "ja_typings": []
+        "ja_typings": [
+          "sutatikkuaikon"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -41453,20 +43539,24 @@
         "en": "paid comment",
         "ja": "ユウリョウコメント",
         "ja_typings": [
-          "yuuryoukomento"
+          "yuuryoukomento",
+          "yuuryokomento"
         ]
       },
       {
         "en": "free comment",
         "ja": "ムリョウコメント",
         "ja_typings": [
-          "muryoukomento"
+          "muryoukomento",
+          "muryokomento"
         ]
       },
       {
         "en": "system message",
         "ja": "システムメッセージ",
-        "ja_typings": []
+        "ja_typings": [
+          "shisutemumesse-ji"
+        ]
       },
       {
         "en": "auto reply",
@@ -41490,22 +43580,30 @@
       {
         "en": "good luck have fun",
         "ja": "グッドラックハブファン",
-        "ja_typings": []
+        "ja_typings": [
+          "guddorakkuhabufan"
+        ]
       },
       {
         "en": "get level high first",
         "ja": "ゲットレベルハイファースト",
-        "ja_typings": []
+        "ja_typings": [
+          "gettoreberuhaifa-suto"
+        ]
       },
       {
         "en": "go left hit fast",
         "ja": "ゴーレフトヒットファスト",
-        "ja_typings": []
+        "ja_typings": [
+          "go-refutohittofasuto"
+        ]
       },
       {
         "en": "great loss huge fight",
         "ja": "グレートロスヒュージファイト",
-        "ja_typings": []
+        "ja_typings": [
+          "gure-torosuhyu-jifaito"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -41530,7 +43628,8 @@
         "en": "expert",
         "ja": "ジョウキュウシャ",
         "ja_typings": [
-          "joukyuusha"
+          "joukyuusha",
+          "jokyuusha"
         ]
       },
       {
@@ -41569,17 +43668,23 @@
       {
         "en": "casual player",
         "ja": "ライトプレイヤー",
-        "ja_typings": []
+        "ja_typings": [
+          "raitopureiya-"
+        ]
       },
       {
         "en": "cheating player",
         "ja": "チートプレイヤー",
-        "ja_typings": []
+        "ja_typings": [
+          "chi-topureiya-"
+        ]
       },
       {
         "en": "new player",
         "ja": "ニュープレイヤー",
-        "ja_typings": []
+        "ja_typings": [
+          "nyu-pureiya-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -41597,7 +43702,8 @@
         "en": "excitement",
         "ja": "コウフン",
         "ja_typings": [
-          "koufun"
+          "koufun",
+          "kofun"
         ]
       },
       {
@@ -41618,7 +43724,8 @@
         "en": "regret",
         "ja": "コウカイ",
         "ja_typings": [
-          "koukai"
+          "koukai",
+          "kokai"
         ]
       }
     ],
@@ -41637,23 +43744,30 @@
         "en": "most effective tactic",
         "ja": "サイコウセンリャク",
         "ja_typings": [
-          "saikousenryaku"
+          "saikousenryaku",
+          "saikosenryaku"
         ]
       },
       {
         "en": "mini event",
         "ja": "ミニイベント",
-        "ja_typings": []
+        "ja_typings": [
+          "miniibento"
+        ]
       },
       {
         "en": "modder area",
         "ja": "モッダーエリア",
-        "ja_typings": []
+        "ja_typings": [
+          "modda-eria"
+        ]
       },
       {
         "en": "main enemy target",
         "ja": "メインエネミーターゲット",
-        "ja_typings": []
+        "ja_typings": [
+          "meinnenemi-ta-getto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -41711,7 +43825,8 @@
         "en": "low quality post",
         "ja": "ヒンシツノヒクイトウコウ",
         "ja_typings": [
-          "hinshitsunohikuitoukou"
+          "hinshitsunohikuitoukou",
+          "hinshitsunohikuitoko"
         ]
       },
       {
@@ -41725,14 +43840,16 @@
         "en": "paid sponsorship",
         "ja": "ユウリョウスポンサー",
         "ja_typings": [
-          "yuuryousuponsa-"
+          "yuuryousuponsa-",
+          "yuuryosuponsa-"
         ]
       },
       {
         "en": "legal notice",
         "ja": "ホウテキツウチ",
         "ja_typings": [
-          "houtekitsuuchi"
+          "houtekitsuuchi",
+          "hotekitsuuchi"
         ]
       }
     ],
@@ -41751,7 +43868,8 @@
         "en": "silent viewer",
         "ja": "ムゲンシチョウシャ",
         "ja_typings": [
-          "mugenshichousha"
+          "mugenshichousha",
+          "mugenshichosha"
         ]
       },
       {
@@ -41765,14 +43883,16 @@
         "en": "paid member",
         "ja": "ユウリョウメンバー",
         "ja_typings": [
-          "yuuryoumenba-"
+          "yuuryoumenba-",
+          "yuuryomenba-"
         ]
       },
       {
         "en": "auto bot",
         "ja": "ジドウボット",
         "ja_typings": [
-          "jidoubotto"
+          "jidoubotto",
+          "jidobotto"
         ]
       }
     ],
@@ -41791,14 +43911,16 @@
         "en": "leaking personal info",
         "ja": "コジンジョウホウバクロ",
         "ja_typings": [
-          "kojinjouhoubakuro"
+          "kojinjouhoubakuro",
+          "kojinjohobakuro"
         ]
       },
       {
         "en": "sharing memes",
         "ja": "ミームキョウユウ",
         "ja_typings": [
-          "mi-mukyouyuu"
+          "mi-mukyouyuu",
+          "mi-mukyoyuu"
         ]
       },
       {
@@ -41812,7 +43934,8 @@
         "en": "posting reviews",
         "ja": "レビュートウコウ",
         "ja_typings": [
-          "rebyu-toukou"
+          "rebyu-toukou",
+          "rebyu-toko"
         ]
       }
     ],
@@ -41830,22 +43953,30 @@
       {
         "en": "First Person Shooter",
         "ja": "ファーストパーソンシューター",
-        "ja_typings": []
+        "ja_typings": [
+          "fa-sutopa-sonshu-ta-"
+        ]
       },
       {
         "en": "Fast Paced Style",
         "ja": "ファストペーストスタイル",
-        "ja_typings": []
+        "ja_typings": [
+          "fasutope-sutosutairu"
+        ]
       },
       {
         "en": "Final Play Set",
         "ja": "ファイナルプレイセット",
-        "ja_typings": []
+        "ja_typings": [
+          "fainarupureisetto"
+        ]
       },
       {
         "en": "Front Page Score",
         "ja": "フロントページスコア",
-        "ja_typings": []
+        "ja_typings": [
+          "furontope-jisukoa"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -41863,7 +43994,8 @@
         "en": "clearing a game as fast as possible",
         "ja": "ゲームサイソクコウリャク",
         "ja_typings": [
-          "ge-musaisokukouryaku"
+          "ge-musaisokukouryaku",
+          "ge-musaisokukoryaku"
         ]
       },
       {
@@ -41883,7 +44015,9 @@
       {
         "en": "multiplayer raid",
         "ja": "マルチレイド",
-        "ja_typings": []
+        "ja_typings": [
+          "maruchireido"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -41901,14 +44035,17 @@
         "en": "sending viewers to another channel",
         "ja": "ベツチャンネルニシチョウシャヲオクル",
         "ja_typings": [
-          "betsuchannnerunishichoushawookuru"
+          "betsuchannnerunishichoushawookuru",
+          "betsuchannnerunishichoshaokuru",
+          "betsuchannnerunishichoushaookuru"
         ]
       },
       {
         "en": "hacking attack",
         "ja": "ハッキングコウゲキ",
         "ja_typings": [
-          "hakkingukougeki"
+          "hakkingukougeki",
+          "hakkingukogeki"
         ]
       },
       {
@@ -41921,7 +44058,9 @@
       {
         "en": "login bonus",
         "ja": "ログインボーナス",
-        "ja_typings": []
+        "ja_typings": [
+          "roguinbo-nasu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -41960,7 +44099,8 @@
         "en": "ad song",
         "ja": "コウコクキョク",
         "ja_typings": [
-          "koukokukyoku"
+          "koukokukyoku",
+          "kokokukyoku"
         ]
       }
     ],
@@ -42033,14 +44173,16 @@
         "en": "calm goodbye",
         "ja": "オダヤカナサヨウナラ",
         "ja_typings": [
-          "odayakanasayounara"
+          "odayakanasayounara",
+          "odayakanasayonara"
         ]
       },
       {
         "en": "auto save",
         "ja": "ジドウホゾン",
         "ja_typings": [
-          "jidouhozon"
+          "jidouhozon",
+          "jidohozon"
         ]
       }
     ],
@@ -42072,7 +44214,9 @@
       {
         "en": "Public versus Private",
         "ja": "パブリックタイプライベート",
-        "ja_typings": []
+        "ja_typings": [
+          "paburikkutaipuraibe-to"
+        ]
       },
       {
         "en": "Pick versus Pull",
@@ -42097,7 +44241,8 @@
         "en": "embarrassment",
         "ja": "キョウシュク",
         "ja_typings": [
-          "kyoushuku"
+          "kyoushuku",
+          "kyoshuku"
         ]
       },
       {
@@ -42137,14 +44282,16 @@
         "en": "indecent content",
         "ja": "セイテキナナイヨウ",
         "ja_typings": [
-          "seitekinanaiyou"
+          "seitekinanaiyou",
+          "seitekinanaiyo"
         ]
       },
       {
         "en": "educational topic",
         "ja": "キョウイクテーマ",
         "ja_typings": [
-          "kyouikute-ma"
+          "kyouikute-ma",
+          "kyoikute-ma"
         ]
       },
       {
@@ -42177,28 +44324,32 @@
         "en": "very funny",
         "ja": "オオワライ",
         "ja_typings": [
-          "oowarai"
+          "oowarai",
+          "owarai"
         ]
       },
       {
         "en": "very sad",
         "ja": "オオナキ",
         "ja_typings": [
-          "oonaki"
+          "oonaki",
+          "onaki"
         ]
       },
       {
         "en": "very angry",
         "ja": "オオイカリ",
         "ja_typings": [
-          "ooikari"
+          "ooikari",
+          "oikari"
         ]
       },
       {
         "en": "very scared",
         "ja": "オオオビエ",
         "ja_typings": [
-          "ooobie"
+          "ooobie",
+          "oobie"
         ]
       }
     ],
@@ -42217,28 +44368,32 @@
         "en": "clip video",
         "ja": "クリップドウガ",
         "ja_typings": [
-          "kurippudouga"
+          "kurippudouga",
+          "kurippudoga"
         ]
       },
       {
         "en": "trim video",
         "ja": "トリムドウガ",
         "ja_typings": [
-          "torimudouga"
+          "torimudouga",
+          "torimudoga"
         ]
       },
       {
         "en": "snippet video",
         "ja": "スニペットドウガ",
         "ja_typings": [
-          "sunipettodouga"
+          "sunipettodouga",
+          "sunipettodoga"
         ]
       },
       {
         "en": "flash video",
         "ja": "フラッシュドウガ",
         "ja_typings": [
-          "furasshudouga"
+          "furasshudouga",
+          "furasshudoga"
         ]
       }
     ],
@@ -42256,22 +44411,30 @@
       {
         "en": "Central Processing Unit",
         "ja": "セントラルプロセッシングユニット",
-        "ja_typings": []
+        "ja_typings": [
+          "sentorarupurosesshinguyunitto"
+        ]
       },
       {
         "en": "Computer Program Utility",
         "ja": "コンピュータプログラムユーティリティ",
-        "ja_typings": []
+        "ja_typings": [
+          "konpyu-tapuroguramuyu-tiriti"
+        ]
       },
       {
         "en": "Cache Processing Update",
         "ja": "キャッシュプロセッシングアップデート",
-        "ja_typings": []
+        "ja_typings": [
+          "kyasshupurosesshinguappude-to"
+        ]
       },
       {
         "en": "Code Pipeline Unit",
         "ja": "コードパイプラインユニット",
-        "ja_typings": []
+        "ja_typings": [
+          "ko-dopaipurainnyunitto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -42288,22 +44451,30 @@
       {
         "en": "Random Access Memory",
         "ja": "ランダムアクセスメモリ",
-        "ja_typings": []
+        "ja_typings": [
+          "randamuakusesumemori"
+        ]
       },
       {
         "en": "Read Access Mode",
         "ja": "リードアクセスモード",
-        "ja_typings": []
+        "ja_typings": [
+          "ri-doakusesumo-do"
+        ]
       },
       {
         "en": "Rapid Address Manager",
         "ja": "ラピッドアドレスマネージャー",
-        "ja_typings": []
+        "ja_typings": [
+          "rapiddoadoresumane-ja-"
+        ]
       },
       {
         "en": "Recursive Allocation Method",
         "ja": "リカーシブアロケーションメソッド",
-        "ja_typings": []
+        "ja_typings": [
+          "rika-shibuaroke-shonmesoddo"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -42321,8 +44492,6 @@
         "en": "port 22",
         "ja": "ニジュウニバン",
         "ja_typings": [
-          "nijuunipan",
-          "nijuunipan",
           "nijuuniban"
         ]
       },
@@ -42362,22 +44531,30 @@
       {
         "en": "Solid State Drive",
         "ja": "ソリッドステートドライブ",
-        "ja_typings": []
+        "ja_typings": [
+          "soriddosute-todoraibu"
+        ]
       },
       {
         "en": "Storage System Device",
         "ja": "ストレージシステムデバイス",
-        "ja_typings": []
+        "ja_typings": [
+          "sutore-jishisutemudebaisu"
+        ]
       },
       {
         "en": "Secure Service Daemon",
         "ja": "セキュアサービスデーモン",
-        "ja_typings": []
+        "ja_typings": [
+          "sekyuasa-bisude-mon"
+        ]
       },
       {
         "en": "Static Sync Disk",
         "ja": "スタティックシンクディスク",
-        "ja_typings": []
+        "ja_typings": [
+          "sutatikkushinkudisuku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -42394,22 +44571,30 @@
       {
         "en": "Application Programming Interface",
         "ja": "アプリケーションプログラミングインターフェース",
-        "ja_typings": []
+        "ja_typings": [
+          "apurike-shonpuroguraminguinta-fe-su"
+        ]
       },
       {
         "en": "Active Protocol Index",
         "ja": "アクティブプロトコルインデックス",
-        "ja_typings": []
+        "ja_typings": [
+          "akutibupurotokoruindekkusu"
+        ]
       },
       {
         "en": "Auto Program Installer",
         "ja": "オートプログラムインストーラー",
-        "ja_typings": []
+        "ja_typings": [
+          "o-topuroguramuinsuto-ra-"
+        ]
       },
       {
         "en": "Async Process Identifier",
         "ja": "アシンクプロセスアイデンティファイア",
-        "ja_typings": []
+        "ja_typings": [
+          "ashinkupurosesuaidentifaia"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -42427,7 +44612,8 @@
         "en": "443",
         "ja": "ヨンヨンサン",
         "ja_typings": [
-          "yonyonsan"
+          "yonyonsan",
+          "yonnyonsan"
         ]
       },
       {
@@ -42466,22 +44652,30 @@
       {
         "en": "Universal Serial Bus",
         "ja": "ユニバーサルシリアルバス",
-        "ja_typings": []
+        "ja_typings": [
+          "yuniba-sarushiriarubasu"
+        ]
       },
       {
         "en": "Unified System Boot",
         "ja": "ユニファイドシステムブート",
-        "ja_typings": []
+        "ja_typings": [
+          "yunifaidoshisutemubu-to"
+        ]
       },
       {
         "en": "Ultra Speed Bridge",
         "ja": "ウルトラスピードブリッジ",
-        "ja_typings": []
+        "ja_typings": [
+          "urutorasupi-doburijji"
+        ]
       },
       {
         "en": "User Storage Bay",
         "ja": "ユーザーストレージベイ",
-        "ja_typings": []
+        "ja_typings": [
+          "yu-za-sutore-jibei"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -42538,22 +44732,30 @@
       {
         "en": "Amazon Web Services",
         "ja": "アマゾンウェブサービス",
-        "ja_typings": []
+        "ja_typings": [
+          "amazonnwebusa-bisu"
+        ]
       },
       {
         "en": "Active Web System",
         "ja": "アクティブウェブシステム",
-        "ja_typings": []
+        "ja_typings": [
+          "akutibuwebushisutemu"
+        ]
       },
       {
         "en": "Asynchronous Wire Source",
         "ja": "アシンクロナスワイヤーソース",
-        "ja_typings": []
+        "ja_typings": [
+          "ashinkuronasuwaiya-so-su"
+        ]
       },
       {
         "en": "Auto Workflow Suite",
         "ja": "オートワークフロースイート",
-        "ja_typings": []
+        "ja_typings": [
+          "o-towa-kufuro-sui-to"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -42570,22 +44772,30 @@
       {
         "en": "Graphics Processing Unit",
         "ja": "グラフィックスプロセッシングユニット",
-        "ja_typings": []
+        "ja_typings": [
+          "gurafikkusupurosesshinguyunitto"
+        ]
       },
       {
         "en": "General Pipeline Utility",
         "ja": "ジェネラルパイプラインユーティリティ",
-        "ja_typings": []
+        "ja_typings": [
+          "jenerarupaipurainnyu-tiriti"
+        ]
       },
       {
         "en": "Global Program Unit",
         "ja": "グローバルプログラムユニット",
-        "ja_typings": []
+        "ja_typings": [
+          "guro-barupuroguramuyunitto"
+        ]
       },
       {
         "en": "Gigabyte Processing Unit",
         "ja": "ギガバイトプロセッシングユニット",
-        "ja_typings": []
+        "ja_typings": [
+          "gigabaitopurosesshinguyunitto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -42642,22 +44852,30 @@
       {
         "en": "HyperText Markup Language",
         "ja": "ハイパーテキストマークアップランゲージ",
-        "ja_typings": []
+        "ja_typings": [
+          "haipa-tekisutoma-kuappurange-ji"
+        ]
       },
       {
         "en": "Home Tool Markup Language",
         "ja": "ホームツールマークアップランゲージ",
-        "ja_typings": []
+        "ja_typings": [
+          "ho-mutsu-ruma-kuappurange-ji"
+        ]
       },
       {
         "en": "High Tech Modular Language",
         "ja": "ハイテックモジュラーランゲージ",
-        "ja_typings": []
+        "ja_typings": [
+          "haitekkumojura-range-ji"
+        ]
       },
       {
         "en": "Host Transfer Meta Language",
         "ja": "ホストトランスファーメタランゲージ",
-        "ja_typings": []
+        "ja_typings": [
+          "hosutotoransufa-metarange-ji"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -42754,22 +44972,30 @@
       {
         "en": "Virtual Private Network",
         "ja": "バーチャルプライベートネットワーク",
-        "ja_typings": []
+        "ja_typings": [
+          "ba-charupuraibe-tonettowa-ku"
+        ]
       },
       {
         "en": "Verified Public Node",
         "ja": "ベリファイドパブリックノード",
-        "ja_typings": []
+        "ja_typings": [
+          "berifaidopaburikkuno-do"
+        ]
       },
       {
         "en": "Volume Packet Number",
         "ja": "ボリュームパケットナンバー",
-        "ja_typings": []
+        "ja_typings": [
+          "boryu-mupakettonanba-"
+        ]
       },
       {
         "en": "Virtual Protocol Name",
         "ja": "バーチャルプロトコルネーム",
-        "ja_typings": []
+        "ja_typings": [
+          "ba-charupurotokorune-mu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -42786,22 +45012,30 @@
       {
         "en": "Cascading Style Sheets",
         "ja": "カスケーディングスタイルシート",
-        "ja_typings": []
+        "ja_typings": [
+          "kasuke-dingusutairushi-to"
+        ]
       },
       {
         "en": "Computer Style System",
         "ja": "コンピュータスタイルシステム",
-        "ja_typings": []
+        "ja_typings": [
+          "konpyu-tasutairushisutemu"
+        ]
       },
       {
         "en": "Compact Source Script",
         "ja": "コンパクトソーススクリプト",
-        "ja_typings": []
+        "ja_typings": [
+          "konpakutoso-susukuriputo"
+        ]
       },
       {
         "en": "Central Server Stack",
         "ja": "セントラルサーバースタック",
-        "ja_typings": []
+        "ja_typings": [
+          "sentorarusa-ba-sutakku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -42859,7 +45093,8 @@
         "en": "1024 bytes",
         "ja": "センニジュウヨンバイト",
         "ja_typings": [
-          "sennijuuyonbaito"
+          "sennijuuyonbaito",
+          "sennnijuuyonbaito"
         ]
       },
       {
@@ -42880,7 +45115,8 @@
         "en": "2048 bytes",
         "ja": "ニセンヨンジュウハチバイト",
         "ja_typings": [
-          "nisenyonjuuhachibaito"
+          "nisenyonjuuhachibaito",
+          "nisennyonjuuhachibaito"
         ]
       }
     ],
@@ -42898,22 +45134,30 @@
       {
         "en": "Structured Query Language",
         "ja": "ストラクチャードクエリランゲージ",
-        "ja_typings": []
+        "ja_typings": [
+          "sutorakucha-dokuerirange-ji"
+        ]
       },
       {
         "en": "Simple Question Logic",
         "ja": "シンプルクエスチョンロジック",
-        "ja_typings": []
+        "ja_typings": [
+          "shinpurukuesuchonrojikku"
+        ]
       },
       {
         "en": "Secure Query Loader",
         "ja": "セキュアクエリローダー",
-        "ja_typings": []
+        "ja_typings": [
+          "sekyuakueriro-da-"
+        ]
       },
       {
         "en": "Server Quick Link",
         "ja": "サーバークイックリンク",
-        "ja_typings": []
+        "ja_typings": [
+          "sa-ba-kuikkurinku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -42970,22 +45214,30 @@
       {
         "en": "Red Green Blue",
         "ja": "レッドグリーンブルー",
-        "ja_typings": []
+        "ja_typings": [
+          "reddoguri-nburu-"
+        ]
       },
       {
         "en": "Right Grid Base",
         "ja": "ライトグリッドベース",
-        "ja_typings": []
+        "ja_typings": [
+          "raitoguriddobe-su"
+        ]
       },
       {
         "en": "Raw Graphics Buffer",
         "ja": "ローグラフィックスバッファ",
-        "ja_typings": []
+        "ja_typings": [
+          "ro-gurafikkusubaffa"
+        ]
       },
       {
         "en": "Resource Group Base",
         "ja": "リソースグループベース",
-        "ja_typings": []
+        "ja_typings": [
+          "riso-suguru-pube-su"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -43002,22 +45254,30 @@
       {
         "en": "bit",
         "ja": "ビット",
-        "ja_typings": []
+        "ja_typings": [
+          "bitto"
+        ]
       },
       {
         "en": "byte",
         "ja": "バイト",
-        "ja_typings": []
+        "ja_typings": [
+          "baito"
+        ]
       },
       {
         "en": "nibble",
         "ja": "ニブル",
-        "ja_typings": []
+        "ja_typings": [
+          "niburu"
+        ]
       },
       {
         "en": "word",
         "ja": "ワード",
-        "ja_typings": []
+        "ja_typings": [
+          "wa-do"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -43074,22 +45334,30 @@
       {
         "en": "Redundant Array of Independent Disks",
         "ja": "リダンダントアレイオブインディペンデントディスクス",
-        "ja_typings": []
+        "ja_typings": [
+          "ridandantoareiobuindipendentodisukusu"
+        ]
       },
       {
         "en": "Rapid Access Internal Drive",
         "ja": "ラピッドアクセスインターナルドライブ",
-        "ja_typings": []
+        "ja_typings": [
+          "rapiddoakusesuinta-narudoraibu"
+        ]
       },
       {
         "en": "Random Allocated Index Database",
         "ja": "ランダムアロケーテッドインデックスデータベース",
-        "ja_typings": []
+        "ja_typings": [
+          "randamuaroke-teddoindekkusude-tabe-su"
+        ]
       },
       {
         "en": "Remote Async IO Daemon",
         "ja": "リモートアシンクアイオーデーモン",
-        "ja_typings": []
+        "ja_typings": [
+          "rimo-toashinkuaio-de-mon"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -43146,22 +45414,30 @@
       {
         "en": "Sword Art Online",
         "ja": "ソードアート・オンライン",
-        "ja_typings": []
+        "ja_typings": [
+          "so-doa-to/onrain"
+        ]
       },
       {
         "en": ".hack//Sign",
         "ja": "ドットハック・サイン",
-        "ja_typings": []
+        "ja_typings": [
+          "dottohakku/sain"
+        ]
       },
       {
         "en": "Log Horizon",
         "ja": "ログ・ホライズン",
-        "ja_typings": []
+        "ja_typings": [
+          "rogu/horaizun"
+        ]
       },
       {
         "en": "Overlord",
         "ja": "オーバーロード",
-        "ja_typings": []
+        "ja_typings": [
+          "o-ba-ro-do"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -43178,22 +45454,30 @@
       {
         "en": "Boruto",
         "ja": "ボルト",
-        "ja_typings": []
+        "ja_typings": [
+          "boruto"
+        ]
       },
       {
         "en": "Black Clover",
         "ja": "ブラッククローバー",
-        "ja_typings": []
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
       },
       {
         "en": "Fairy Tail",
         "ja": "フェアリーテイル",
-        "ja_typings": []
+        "ja_typings": [
+          "feari-teiru"
+        ]
       },
       {
         "en": "Magi",
         "ja": "マギ",
-        "ja_typings": []
+        "ja_typings": [
+          "magi"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -43210,7 +45494,9 @@
       {
         "en": "CoMix Wave Films",
         "ja": "コミックス・ウェーブ・フィルム",
-        "ja_typings": []
+        "ja_typings": [
+          "komikkusu/we-bu/firumu"
+        ]
       },
       {
         "en": "Kyoto Animation",
@@ -43222,12 +45508,16 @@
       {
         "en": "Production I.G",
         "ja": "プロダクション・アイジー",
-        "ja_typings": []
+        "ja_typings": [
+          "purodakushon/aiji-"
+        ]
       },
       {
         "en": "Bones",
         "ja": "ボンズ",
-        "ja_typings": []
+        "ja_typings": [
+          "bonzu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -43284,12 +45574,17 @@
       {
         "en": "Soul Eater",
         "ja": "ソウルイーター",
-        "ja_typings": []
+        "ja_typings": [
+          "sorui-ta-",
+          "sourui-ta-"
+        ]
       },
       {
         "en": "Noragami",
         "ja": "ノラガミ",
-        "ja_typings": []
+        "ja_typings": [
+          "noragami"
+        ]
       },
       {
         "en": "Yu Yu Hakusho",
@@ -43320,17 +45615,23 @@
       {
         "en": "MAPPA",
         "ja": "マッパ",
-        "ja_typings": []
+        "ja_typings": [
+          "mappa"
+        ]
       },
       {
         "en": "Wit Studio",
         "ja": "ウィットスタジオ",
-        "ja_typings": []
+        "ja_typings": [
+          "wittosutajio"
+        ]
       },
       {
         "en": "Madhouse",
         "ja": "マッドハウス",
-        "ja_typings": []
+        "ja_typings": [
+          "maddohausu"
+        ]
       },
       {
         "en": "Toei Animation",
@@ -43361,12 +45662,16 @@
       {
         "en": "D.Gray-man",
         "ja": "ディーグレイマン",
-        "ja_typings": []
+        "ja_typings": [
+          "di-gureiman"
+        ]
       },
       {
         "en": "Magi",
         "ja": "マギ",
-        "ja_typings": []
+        "ja_typings": [
+          "magi"
+        ]
       },
       {
         "en": "Black Butler",
@@ -43390,7 +45695,9 @@
       {
         "en": "Haikyuu!!",
         "ja": "ハイキュー!!",
-        "ja_typings": []
+        "ja_typings": [
+          "haikyu-"
+        ]
       },
       {
         "en": "Kuroko's Basketball",
@@ -43403,13 +45710,16 @@
         "en": "Ace of Diamond",
         "ja": "ダイヤのA",
         "ja_typings": [
-          "daiyanoeesu"
+          "daiyanoeesu",
+          "daiyanoa"
         ]
       },
       {
         "en": "Blue Lock",
         "ja": "ブルーロック",
-        "ja_typings": []
+        "ja_typings": [
+          "buru-rokku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -43426,17 +45736,23 @@
       {
         "en": "Durarara!!",
         "ja": "デュラララ!!",
-        "ja_typings": []
+        "ja_typings": [
+          "deyurarara"
+        ]
       },
       {
         "en": "Baccano!",
         "ja": "バッカーノ!",
-        "ja_typings": []
+        "ja_typings": [
+          "bakka-no"
+        ]
       },
       {
         "en": "Psycho-Pass",
         "ja": "サイコパス",
-        "ja_typings": []
+        "ja_typings": [
+          "saikopasu"
+        ]
       },
       {
         "en": "91 Days",
@@ -43460,22 +45776,30 @@
       {
         "en": "Love Live!",
         "ja": "ラブライブ!",
-        "ja_typings": []
+        "ja_typings": [
+          "raburaibu"
+        ]
       },
       {
         "en": "The iDOLM@STER",
         "ja": "アイドルマスター",
-        "ja_typings": []
+        "ja_typings": [
+          "aidorumasuta-"
+        ]
       },
       {
         "en": "BanG Dream!",
         "ja": "バンドリ!",
-        "ja_typings": []
+        "ja_typings": [
+          "bandori"
+        ]
       },
       {
         "en": "Wake Up, Girls!",
         "ja": "ウェイクアップ、ガールズ!",
-        "ja_typings": []
+        "ja_typings": [
+          "weikuappu,ga-ruzu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -43499,17 +45823,23 @@
       {
         "en": "Samurai Champloo",
         "ja": "サムライチャンプルー",
-        "ja_typings": []
+        "ja_typings": [
+          "samuraichanpuru-"
+        ]
       },
       {
         "en": "Afro Samurai",
         "ja": "アフロサムライ",
-        "ja_typings": []
+        "ja_typings": [
+          "afurosamurai"
+        ]
       },
       {
         "en": "Dororo",
         "ja": "どろろ",
-        "ja_typings": []
+        "ja_typings": [
+          "dororo"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -43566,22 +45896,31 @@
       {
         "en": "Chihayafuru",
         "ja": "ちはやふる",
-        "ja_typings": []
+        "ja_typings": [
+          "chihayafuru"
+        ]
       },
       {
         "en": "Saki",
         "ja": "咲-Saki-",
-        "ja_typings": []
+        "ja_typings": [
+          "saki",
+          "saki-Saki-"
+        ]
       },
       {
         "en": "Akagi",
         "ja": "アカギ",
-        "ja_typings": []
+        "ja_typings": [
+          "akagi"
+        ]
       },
       {
         "en": "Kaiji",
         "ja": "カイジ",
-        "ja_typings": []
+        "ja_typings": [
+          "kaiji"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -43598,22 +45937,30 @@
       {
         "en": "Cowboy Bebop",
         "ja": "カウボーイビバップ",
-        "ja_typings": []
+        "ja_typings": [
+          "kaubo-ibibappu"
+        ]
       },
       {
         "en": "Outlaw Star",
         "ja": "アウトロースター",
-        "ja_typings": []
+        "ja_typings": [
+          "autoro-suta-"
+        ]
       },
       {
         "en": "Trigun",
         "ja": "トライガン",
-        "ja_typings": []
+        "ja_typings": [
+          "toraigan"
+        ]
       },
       {
         "en": "Black Lagoon",
         "ja": "ブラック・ラグーン",
-        "ja_typings": []
+        "ja_typings": [
+          "burakku/ragu-n"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -43677,7 +46024,9 @@
       {
         "en": "Fruits Basket",
         "ja": "フルーツバスケット",
-        "ja_typings": []
+        "ja_typings": [
+          "furu-tsubasuketto"
+        ]
       },
       {
         "en": "Ouran High School Host Club",
@@ -43689,7 +46038,9 @@
       {
         "en": "Kobato",
         "ja": "こばと。",
-        "ja_typings": []
+        "ja_typings": [
+          "kobato."
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -43720,12 +46071,16 @@
       {
         "en": "RahXephon",
         "ja": "ラーゼフォン",
-        "ja_typings": []
+        "ja_typings": [
+          "ra-zefon"
+        ]
       },
       {
         "en": "Aldnoah.Zero",
         "ja": "アルドノア・ゼロ",
-        "ja_typings": []
+        "ja_typings": [
+          "arudonoa/zero"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -43749,17 +46104,23 @@
       {
         "en": "Beck",
         "ja": "ベック",
-        "ja_typings": []
+        "ja_typings": [
+          "bekku"
+        ]
       },
       {
         "en": "Nana",
         "ja": "ナナ",
-        "ja_typings": []
+        "ja_typings": [
+          "nana"
+        ]
       },
       {
         "en": "Carole & Tuesday",
         "ja": "キャロル&チューズデイ",
-        "ja_typings": []
+        "ja_typings": [
+          "kyaroruchu-zudei"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -43783,17 +46144,23 @@
       {
         "en": "P.A.Works",
         "ja": "ピーエーワークス",
-        "ja_typings": []
+        "ja_typings": [
+          "pi-e-wa-kusu"
+        ]
       },
       {
         "en": "Trigger",
         "ja": "トリガー",
-        "ja_typings": []
+        "ja_typings": [
+          "toriga-"
+        ]
       },
       {
         "en": "Ufotable",
         "ja": "ユーフォーテーブル",
-        "ja_typings": []
+        "ja_typings": [
+          "yu-fo-te-buru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -43810,22 +46177,30 @@
       {
         "en": "Sword Art Online",
         "ja": "ソードアート・オンライン",
-        "ja_typings": []
+        "ja_typings": [
+          "so-doa-to/onrain"
+        ]
       },
       {
         "en": "Accel World",
         "ja": "アクセル・ワールド",
-        "ja_typings": []
+        "ja_typings": [
+          "akuseru/wa-rudo"
+        ]
       },
       {
         "en": "No Game No Life",
         "ja": "ノーゲーム・ノーライフ",
-        "ja_typings": []
+        "ja_typings": [
+          "no-ge-mu/no-raifu"
+        ]
       },
       {
         "en": "Re:Zero",
         "ja": "リゼロ",
-        "ja_typings": []
+        "ja_typings": [
+          "rizero"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -43849,17 +46224,23 @@
       {
         "en": "Vinland Saga",
         "ja": "ヴィンランド・サガ",
-        "ja_typings": []
+        "ja_typings": [
+          "vinrando/saga"
+        ]
       },
       {
         "en": "Berserk",
         "ja": "ベルセルク",
-        "ja_typings": []
+        "ja_typings": [
+          "beruseruku"
+        ]
       },
       {
         "en": "Claymore",
         "ja": "クレイモア",
-        "ja_typings": []
+        "ja_typings": [
+          "kureimoa"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -43883,17 +46264,23 @@
       {
         "en": "Tsurune",
         "ja": "ツルネ",
-        "ja_typings": []
+        "ja_typings": [
+          "tsurune"
+        ]
       },
       {
         "en": "Free!",
         "ja": "フリー!",
-        "ja_typings": []
+        "ja_typings": [
+          "furi-"
+        ]
       },
       {
         "en": "Yuri on Ice",
         "ja": "ユーリ!!! on ICE",
-        "ja_typings": []
+        "ja_typings": [
+          "yu-ri on ice"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -43917,17 +46304,23 @@
       {
         "en": "Bleach",
         "ja": "ブリーチ",
-        "ja_typings": []
+        "ja_typings": [
+          "buri-chi"
+        ]
       },
       {
         "en": "Fairy Tail",
         "ja": "フェアリーテイル",
-        "ja_typings": []
+        "ja_typings": [
+          "feari-teiru"
+        ]
       },
       {
         "en": "Black Clover",
         "ja": "ブラッククローバー",
-        "ja_typings": []
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -43951,17 +46344,23 @@
       {
         "en": "Little Witch Academia",
         "ja": "リトルウィッチアカデミア",
-        "ja_typings": []
+        "ja_typings": [
+          "ritoruwitchiakademia"
+        ]
       },
       {
         "en": "Magi",
         "ja": "マギ",
-        "ja_typings": []
+        "ja_typings": [
+          "magi"
+        ]
       },
       {
         "en": "Witch Hunter Robin",
         "ja": "ウィッチハンターロビン",
-        "ja_typings": []
+        "ja_typings": [
+          "witchihanta-robin"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -43978,12 +46377,16 @@
       {
         "en": "Hunter x Hunter",
         "ja": "ハンターハンター",
-        "ja_typings": []
+        "ja_typings": [
+          "hanta-hanta-"
+        ]
       },
       {
         "en": "Black Cat",
         "ja": "ブラック・キャット",
-        "ja_typings": []
+        "ja_typings": [
+          "burakku/kyatto"
+        ]
       },
       {
         "en": "Katekyo Hitman Reborn",
@@ -43995,7 +46398,9 @@
       {
         "en": "D.Gray-man",
         "ja": "ディーグレイマン",
-        "ja_typings": []
+        "ja_typings": [
+          "di-gureiman"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -44012,7 +46417,9 @@
       {
         "en": "Rosario + Vampire",
         "ja": "ロザリオとバンパイア",
-        "ja_typings": []
+        "ja_typings": [
+          "rozariotobanpaia"
+        ]
       },
       {
         "en": "Vampire Knight",
@@ -44024,12 +46431,16 @@
       {
         "en": "Trinity Blood",
         "ja": "トリニティ・ブラッド",
-        "ja_typings": []
+        "ja_typings": [
+          "toriniti/buraddo"
+        ]
       },
       {
         "en": "Blood+",
         "ja": "ブラッドプラス",
-        "ja_typings": []
+        "ja_typings": [
+          "buraddopurasu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -44046,17 +46457,23 @@
       {
         "en": "Code Geass",
         "ja": "コードギアス",
-        "ja_typings": []
+        "ja_typings": [
+          "ko-dogiasu"
+        ]
       },
       {
         "en": "Guilty Crown",
         "ja": "ギルティクラウン",
-        "ja_typings": []
+        "ja_typings": [
+          "girutikuraun"
+        ]
       },
       {
         "en": "Darker than Black",
         "ja": "ダーカー・ザン・ブラック",
-        "ja_typings": []
+        "ja_typings": [
+          "da-ka-/zan/burakku"
+        ]
       },
       {
         "en": "Mirai Nikki",
@@ -44080,22 +46497,30 @@
       {
         "en": "Steins;Gate",
         "ja": "シュタインズ・ゲート",
-        "ja_typings": []
+        "ja_typings": [
+          "shutainzu/ge-to"
+        ]
       },
       {
         "en": "Chaos;Head",
         "ja": "カオスヘッド",
-        "ja_typings": []
+        "ja_typings": [
+          "kaosuheddo"
+        ]
       },
       {
         "en": "Robotics;Notes",
         "ja": "ロボティクス・ノーツ",
-        "ja_typings": []
+        "ja_typings": [
+          "robotikusu/no-tsu"
+        ]
       },
       {
         "en": "Occultic;Nine",
         "ja": "オカルティック・ナイン",
-        "ja_typings": []
+        "ja_typings": [
+          "okarutikku/nain"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -44112,22 +46537,30 @@
       {
         "en": "Ufotable",
         "ja": "ユーフォーテーブル",
-        "ja_typings": []
+        "ja_typings": [
+          "yu-fo-te-buru"
+        ]
       },
       {
         "en": "MAPPA",
         "ja": "マッパ",
-        "ja_typings": []
+        "ja_typings": [
+          "mappa"
+        ]
       },
       {
         "en": "A-1 Pictures",
         "ja": "エーワン・ピクチャーズ",
-        "ja_typings": []
+        "ja_typings": [
+          "e-wan/pikucha-zu"
+        ]
       },
       {
         "en": "Wit Studio",
         "ja": "ウィットスタジオ",
-        "ja_typings": []
+        "ja_typings": [
+          "wittosutajio"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -44144,7 +46577,9 @@
       {
         "en": "Wolf's Rain",
         "ja": "ウルフズ・レイン",
-        "ja_typings": []
+        "ja_typings": [
+          "urufuzu/rein"
+        ]
       },
       {
         "en": "Spice and Wolf",
@@ -44163,7 +46598,9 @@
       {
         "en": "Princess Tutu",
         "ja": "プリンセスチュチュ",
-        "ja_typings": []
+        "ja_typings": [
+          "purinsesuchuchu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -44188,18 +46625,23 @@
         "en": "Ace of Diamond",
         "ja": "ダイヤのA",
         "ja_typings": [
-          "daiyanoeesu"
+          "daiyanoeesu",
+          "daiyanoa"
         ]
       },
       {
         "en": "Major",
         "ja": "メジャー",
-        "ja_typings": []
+        "ja_typings": [
+          "meja-"
+        ]
       },
       {
         "en": "Cross Game",
         "ja": "クロスゲーム",
-        "ja_typings": []
+        "ja_typings": [
+          "kurosuge-mu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -44230,7 +46672,9 @@
       {
         "en": "Toriko",
         "ja": "トリコ",
-        "ja_typings": []
+        "ja_typings": [
+          "toriko"
+        ]
       },
       {
         "en": "Sweetness and Lightning",
@@ -44268,7 +46712,9 @@
       {
         "en": "Nodame Cantabile",
         "ja": "のだめカンタービレ",
-        "ja_typings": []
+        "ja_typings": [
+          "nodamekanta-bire"
+        ]
       },
       {
         "en": "Forest of Piano",
@@ -44306,12 +46752,16 @@
       {
         "en": "xxxHolic",
         "ja": "ホリック",
-        "ja_typings": []
+        "ja_typings": [
+          "horikku"
+        ]
       },
       {
         "en": "Mononoke",
         "ja": "モノノ怪",
-        "ja_typings": []
+        "ja_typings": [
+          "mononoke"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -44342,7 +46792,9 @@
       {
         "en": "Chainsaw Man",
         "ja": "チェンソーマン",
-        "ja_typings": []
+        "ja_typings": [
+          "chenso-man"
+        ]
       },
       {
         "en": "Hell's Paradise",
@@ -44387,7 +46839,9 @@
       {
         "en": "Log Horizon",
         "ja": "ログ・ホライズン",
-        "ja_typings": []
+        "ja_typings": [
+          "rogu/horaizun"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -44404,7 +46858,9 @@
       {
         "en": "One Punch Man",
         "ja": "ワンパンマン",
-        "ja_typings": []
+        "ja_typings": [
+          "wanpanman"
+        ]
       },
       {
         "en": "Mob Psycho 100",
@@ -44423,7 +46879,9 @@
       {
         "en": "Tiger & Bunny",
         "ja": "タイガー&バニー",
-        "ja_typings": []
+        "ja_typings": [
+          "taiga-bani-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -44440,7 +46898,9 @@
       {
         "en": "Subaru Natsuki",
         "ja": "ナツキ・スバル",
-        "ja_typings": []
+        "ja_typings": [
+          "natsuki/subaru"
+        ]
       },
       {
         "en": "Kazuma Satou",
@@ -44478,7 +46938,9 @@
       {
         "en": "Bleach",
         "ja": "ブリーチ",
-        "ja_typings": []
+        "ja_typings": [
+          "buri-chi"
+        ]
       },
       {
         "en": "Yu Yu Hakusho",
@@ -44490,7 +46952,9 @@
       {
         "en": "Shaman King",
         "ja": "シャーマンキング",
-        "ja_typings": []
+        "ja_typings": [
+          "sha-mankingu"
+        ]
       },
       {
         "en": "Blue Exorcist",
@@ -44521,17 +46985,23 @@
       {
         "en": "Chainsaw Man",
         "ja": "チェンソーマン",
-        "ja_typings": []
+        "ja_typings": [
+          "chenso-man"
+        ]
       },
       {
         "en": "Spy x Family",
         "ja": "スパイファミリー",
-        "ja_typings": []
+        "ja_typings": [
+          "supaifamiri-"
+        ]
       },
       {
         "en": "Kingdom",
         "ja": "キングダム",
-        "ja_typings": []
+        "ja_typings": [
+          "kingudamu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -44715,7 +47185,9 @@
       {
         "en": "Toriko",
         "ja": "トリコ",
-        "ja_typings": []
+        "ja_typings": [
+          "toriko"
+        ]
       },
       {
         "en": "Mister Ajikko",
@@ -44746,22 +47218,30 @@
       {
         "en": "One Piece",
         "ja": "ワンピース",
-        "ja_typings": []
+        "ja_typings": [
+          "wanpi-su"
+        ]
       },
       {
         "en": "Black Clover",
         "ja": "ブラッククローバー",
-        "ja_typings": []
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
       },
       {
         "en": "Fairy Tail",
         "ja": "フェアリーテイル",
-        "ja_typings": []
+        "ja_typings": [
+          "feari-teiru"
+        ]
       },
       {
         "en": "Magi",
         "ja": "マギ",
-        "ja_typings": []
+        "ja_typings": [
+          "magi"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -44778,22 +47258,30 @@
       {
         "en": "Death Note",
         "ja": "デスノート",
-        "ja_typings": []
+        "ja_typings": [
+          "desuno-to"
+        ]
       },
       {
         "en": "Platinum End",
         "ja": "プラチナエンド",
-        "ja_typings": []
+        "ja_typings": [
+          "purachinaendo"
+        ]
       },
       {
         "en": "Bakuman",
         "ja": "バクマン。",
-        "ja_typings": []
+        "ja_typings": [
+          "bakuman."
+        ]
       },
       {
         "en": "Liar Game",
         "ja": "ライアーゲーム",
-        "ja_typings": []
+        "ja_typings": [
+          "raia-ge-mu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -44898,14 +47386,14 @@
         "en": "Rurouni Kenshin",
         "ja": "るろうに剣心",
         "ja_typings": [
-          "rurouninikenshin"
+          "rurounikenshin"
         ]
       },
       {
         "en": "Peacemaker Kurogane",
         "ja": "ピースメーカー鐵",
         "ja_typings": [
-          "piisumeekaakurogane"
+          "pi-sume-ka-kurogane"
         ]
       },
       {
@@ -44970,7 +47458,9 @@
       {
         "en": "Kiyohiko Azuma",
         "ja": "あずまきよひこ",
-        "ja_typings": []
+        "ja_typings": [
+          "azumakiyohiko"
+        ]
       },
       {
         "en": "Tatsuya Endo",
@@ -45009,13 +47499,15 @@
         "en": "Kuroko's Basketball",
         "ja": "黒子のバスケ",
         "ja_typings": [
-          "kuronobasuke"
+          "kurokonobasuke"
         ]
       },
       {
         "en": "Slam Dunk",
         "ja": "スラムダンク",
-        "ja_typings": []
+        "ja_typings": [
+          "suramudanku"
+        ]
       },
       {
         "en": "Ahiru no Sora",
@@ -45027,7 +47519,9 @@
       {
         "en": "Dear Boys",
         "ja": "ディア・ボーイズ",
-        "ja_typings": []
+        "ja_typings": [
+          "dia/bo-izu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -45051,17 +47545,23 @@
       {
         "en": "Claymore",
         "ja": "クレイモア",
-        "ja_typings": []
+        "ja_typings": [
+          "kureimoa"
+        ]
       },
       {
         "en": "Berserk",
         "ja": "ベルセルク",
-        "ja_typings": []
+        "ja_typings": [
+          "beruseruku"
+        ]
       },
       {
         "en": "Goblin Slayer",
         "ja": "ゴブリンスレイヤー",
-        "ja_typings": []
+        "ja_typings": [
+          "goburinsureiya-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -45099,7 +47599,9 @@
       {
         "en": "Dorohedoro",
         "ja": "ドロヘドロ",
-        "ja_typings": []
+        "ja_typings": [
+          "dorohedoro"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -45116,22 +47618,30 @@
       {
         "en": "Death Note",
         "ja": "デスノート",
-        "ja_typings": []
+        "ja_typings": [
+          "desuno-to"
+        ]
       },
       {
         "en": "Bakuman",
         "ja": "バクマン。",
-        "ja_typings": []
+        "ja_typings": [
+          "bakuman."
+        ]
       },
       {
         "en": "Platinum End",
         "ja": "プラチナエンド",
-        "ja_typings": []
+        "ja_typings": [
+          "purachinaendo"
+        ]
       },
       {
         "en": "Liar Game",
         "ja": "ライアーゲーム",
-        "ja_typings": []
+        "ja_typings": [
+          "raia-ge-mu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -45148,22 +47658,30 @@
       {
         "en": "One Piece",
         "ja": "ワンピース",
-        "ja_typings": []
+        "ja_typings": [
+          "wanpi-su"
+        ]
       },
       {
         "en": "Black Lagoon",
         "ja": "ブラック・ラグーン",
-        "ja_typings": []
+        "ja_typings": [
+          "burakku/ragu-n"
+        ]
       },
       {
         "en": "Coyote Ragtime Show",
         "ja": "コヨーテラグタイムショー",
-        "ja_typings": []
+        "ja_typings": [
+          "koyo-teragutaimusho-"
+        ]
       },
       {
         "en": "Outlaw Star",
         "ja": "アウトロースター",
-        "ja_typings": []
+        "ja_typings": [
+          "autoro-suta-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -45180,22 +47698,30 @@
       {
         "en": "Young Animal",
         "ja": "ヤングアニマル",
-        "ja_typings": []
+        "ja_typings": [
+          "yanguanimaru"
+        ]
       },
       {
         "en": "Big Comic",
         "ja": "ビッグコミック",
-        "ja_typings": []
+        "ja_typings": [
+          "biggukomikku"
+        ]
       },
       {
         "en": "Morning",
         "ja": "モーニング",
-        "ja_typings": []
+        "ja_typings": [
+          "mo-ningu"
+        ]
       },
       {
         "en": "Afternoon",
         "ja": "アフタヌーン",
-        "ja_typings": []
+        "ja_typings": [
+          "afutanu-n"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -45234,7 +47760,7 @@
         "en": "Frieren",
         "ja": "葬送のフリーレン",
         "ja_typings": [
-          "sousounofurииren"
+          "sousounofuri-ren"
         ]
       }
     ],
@@ -45313,7 +47839,9 @@
       {
         "en": "CLAMP",
         "ja": "クランプ",
-        "ja_typings": []
+        "ja_typings": [
+          "kuranpu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -45351,7 +47879,9 @@
       {
         "en": "Cooking Papa",
         "ja": "クッキングパパ",
-        "ja_typings": []
+        "ja_typings": [
+          "kukkingupapa"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -45368,22 +47898,30 @@
       {
         "en": "Fairy Tail",
         "ja": "フェアリーテイル",
-        "ja_typings": []
+        "ja_typings": [
+          "feari-teiru"
+        ]
       },
       {
         "en": "Black Clover",
         "ja": "ブラッククローバー",
-        "ja_typings": []
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
       },
       {
         "en": "Magi",
         "ja": "マギ",
-        "ja_typings": []
+        "ja_typings": [
+          "magi"
+        ]
       },
       {
         "en": "Rave Master",
         "ja": "レイヴ",
-        "ja_typings": []
+        "ja_typings": [
+          "reivu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -45400,7 +47938,9 @@
       {
         "en": "Dr. Stone",
         "ja": "ドクターストーン",
-        "ja_typings": []
+        "ja_typings": [
+          "dokuta-suto-n"
+        ]
       },
       {
         "en": "Cells at Work",
@@ -45419,7 +47959,9 @@
       {
         "en": "Eden's Zero",
         "ja": "エデンズゼロ",
-        "ja_typings": []
+        "ja_typings": [
+          "edenzuzero"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -45436,22 +47978,30 @@
       {
         "en": "Capcom",
         "ja": "カプコン",
-        "ja_typings": []
+        "ja_typings": [
+          "kapukon"
+        ]
       },
       {
         "en": "Konami",
         "ja": "コナミ",
-        "ja_typings": []
+        "ja_typings": [
+          "konami"
+        ]
       },
       {
         "en": "Bandai Namco",
         "ja": "バンダイナムコ",
-        "ja_typings": []
+        "ja_typings": [
+          "bandainamuko"
+        ]
       },
       {
         "en": "Sega",
         "ja": "セガ",
-        "ja_typings": []
+        "ja_typings": [
+          "sega"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -45482,12 +48032,17 @@
       {
         "en": "Soul Reaver",
         "ja": "ソウルリーバー",
-        "ja_typings": []
+        "ja_typings": [
+          "soruri-ba-",
+          "soururi-ba-"
+        ]
       },
       {
         "en": "Ico",
         "ja": "イコ",
-        "ja_typings": []
+        "ja_typings": [
+          "iko"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -45504,22 +48059,30 @@
       {
         "en": "Atlus",
         "ja": "アトラス",
-        "ja_typings": []
+        "ja_typings": [
+          "atorasu"
+        ]
       },
       {
         "en": "Square Enix",
         "ja": "スクウェア・エニックス",
-        "ja_typings": []
+        "ja_typings": [
+          "sukuwea/enikkusu"
+        ]
       },
       {
         "en": "Capcom",
         "ja": "カプコン",
-        "ja_typings": []
+        "ja_typings": [
+          "kapukon"
+        ]
       },
       {
         "en": "Bandai Namco",
         "ja": "バンダイナムコ",
-        "ja_typings": []
+        "ja_typings": [
+          "bandainamuko"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -45536,22 +48099,30 @@
       {
         "en": "Final Fantasy VII",
         "ja": "ファイナルファンタジーVII",
-        "ja_typings": []
+        "ja_typings": [
+          "fainarufantaji-vii"
+        ]
       },
       {
         "en": "Kingdom Hearts",
         "ja": "キングダムハーツ",
-        "ja_typings": []
+        "ja_typings": [
+          "kingudamuha-tsu"
+        ]
       },
       {
         "en": "Chrono Trigger",
         "ja": "クロノ・トリガー",
-        "ja_typings": []
+        "ja_typings": [
+          "kurono/toriga-"
+        ]
       },
       {
         "en": "Xenogears",
         "ja": "ゼノギアス",
-        "ja_typings": []
+        "ja_typings": [
+          "zenogiasu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -45568,22 +48139,30 @@
       {
         "en": "FromSoftware",
         "ja": "フロム・ソフトウェア",
-        "ja_typings": []
+        "ja_typings": [
+          "furomu/sofutowea"
+        ]
       },
       {
         "en": "Konami",
         "ja": "コナミ",
-        "ja_typings": []
+        "ja_typings": [
+          "konami"
+        ]
       },
       {
         "en": "Capcom",
         "ja": "カプコン",
-        "ja_typings": []
+        "ja_typings": [
+          "kapukon"
+        ]
       },
       {
         "en": "Bandai Namco",
         "ja": "バンダイナムコ",
-        "ja_typings": []
+        "ja_typings": [
+          "bandainamuko"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -45600,12 +48179,17 @@
       {
         "en": "Bloodborne",
         "ja": "ブラッドボーン",
-        "ja_typings": []
+        "ja_typings": [
+          "buraddobo-n"
+        ]
       },
       {
         "en": "Dark Souls",
         "ja": "ダークソウル",
-        "ja_typings": []
+        "ja_typings": [
+          "da-kusoru",
+          "da-kusouru"
+        ]
       },
       {
         "en": "Sekiro",
@@ -45617,7 +48201,9 @@
       {
         "en": "Elden Ring",
         "ja": "エルデンリング",
-        "ja_typings": []
+        "ja_typings": [
+          "erudenringu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -45641,7 +48227,9 @@
       {
         "en": "Ghost of Tsushima",
         "ja": "ゴースト・オブ・ツシマ",
-        "ja_typings": []
+        "ja_typings": [
+          "go-suto/obu/tsushima"
+        ]
       },
       {
         "en": "Nioh",
@@ -45679,17 +48267,23 @@
       {
         "en": "Sega",
         "ja": "セガ",
-        "ja_typings": []
+        "ja_typings": [
+          "sega"
+        ]
       },
       {
         "en": "Sony",
         "ja": "ソニー",
-        "ja_typings": []
+        "ja_typings": [
+          "soni-"
+        ]
       },
       {
         "en": "Bandai Namco",
         "ja": "バンダイナムコ",
-        "ja_typings": []
+        "ja_typings": [
+          "bandainamuko"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -45706,22 +48300,30 @@
       {
         "en": "Splinter Cell",
         "ja": "スプリンターセル",
-        "ja_typings": []
+        "ja_typings": [
+          "supurinta-seru"
+        ]
       },
       {
         "en": "Hitman",
         "ja": "ヒットマン",
-        "ja_typings": []
+        "ja_typings": [
+          "hittoman"
+        ]
       },
       {
         "en": "Thief",
         "ja": "シーフ",
-        "ja_typings": []
+        "ja_typings": [
+          "shi-fu"
+        ]
       },
       {
         "en": "Dishonored",
         "ja": "ディスオナード",
-        "ja_typings": []
+        "ja_typings": [
+          "disuona-do"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -45738,22 +48340,30 @@
       {
         "en": "Horizon Zero Dawn",
         "ja": "ホライゾン・ゼロ・ドーン",
-        "ja_typings": []
+        "ja_typings": [
+          "horaizon/zero/do-n"
+        ]
       },
       {
         "en": "The Last of Us",
         "ja": "ラスト・オブ・アス",
-        "ja_typings": []
+        "ja_typings": [
+          "rasuto/obu/asu"
+        ]
       },
       {
         "en": "Fallout",
         "ja": "フォールアウト",
-        "ja_typings": []
+        "ja_typings": [
+          "fo-ruauto"
+        ]
       },
       {
         "en": "Metro Exodus",
         "ja": "メトロ・エクソダス",
-        "ja_typings": []
+        "ja_typings": [
+          "metoro/ekusodasu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -45770,22 +48380,30 @@
       {
         "en": "Sega",
         "ja": "セガ",
-        "ja_typings": []
+        "ja_typings": [
+          "sega"
+        ]
       },
       {
         "en": "Capcom",
         "ja": "カプコン",
-        "ja_typings": []
+        "ja_typings": [
+          "kapukon"
+        ]
       },
       {
         "en": "Konami",
         "ja": "コナミ",
-        "ja_typings": []
+        "ja_typings": [
+          "konami"
+        ]
       },
       {
         "en": "Square Enix",
         "ja": "スクウェア・エニックス",
-        "ja_typings": []
+        "ja_typings": [
+          "sukuwea/enikkusu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -45809,12 +48427,16 @@
       {
         "en": "Judgment",
         "ja": "ジャッジアイズ",
-        "ja_typings": []
+        "ja_typings": [
+          "jajjiaizu"
+        ]
       },
       {
         "en": "Shenmue",
         "ja": "シェンムー",
-        "ja_typings": []
+        "ja_typings": [
+          "shenmu-"
+        ]
       },
       {
         "en": "Way of the Samurai",
@@ -45845,12 +48467,16 @@
       {
         "en": "First-person shooter",
         "ja": "ファーストパーソン・シューター",
-        "ja_typings": []
+        "ja_typings": [
+          "fa-sutopa-son/shu-ta-"
+        ]
       },
       {
         "en": "Real-time strategy",
         "ja": "リアルタイム・ストラテジー",
-        "ja_typings": []
+        "ja_typings": [
+          "riarutaimu/sutorateji-"
+        ]
       },
       {
         "en": "Fighting",
@@ -45881,17 +48507,23 @@
       {
         "en": "Final Fantasy",
         "ja": "ファイナルファンタジー",
-        "ja_typings": []
+        "ja_typings": [
+          "fainarufantaji-"
+        ]
       },
       {
         "en": "Dragon Quest",
         "ja": "ドラゴンクエスト",
-        "ja_typings": []
+        "ja_typings": [
+          "doragonkuesuto"
+        ]
       },
       {
         "en": "Xenoblade",
         "ja": "ゼノブレイド",
-        "ja_typings": []
+        "ja_typings": [
+          "zenobureido"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -45908,22 +48540,30 @@
       {
         "en": "Super Mario Bros.",
         "ja": "スーパーマリオブラザーズ",
-        "ja_typings": []
+        "ja_typings": [
+          "su-pa-marioburaza-zu"
+        ]
       },
       {
         "en": "Donkey Kong",
         "ja": "ドンキーコング",
-        "ja_typings": []
+        "ja_typings": [
+          "donki-kongu"
+        ]
       },
       {
         "en": "Wario Land",
         "ja": "ワリオランド",
-        "ja_typings": []
+        "ja_typings": [
+          "wariorando"
+        ]
       },
       {
         "en": "Yoshi's Island",
         "ja": "ヨッシーアイランド",
-        "ja_typings": []
+        "ja_typings": [
+          "yosshi-airando"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -45940,22 +48580,30 @@
       {
         "en": "Capcom",
         "ja": "カプコン",
-        "ja_typings": []
+        "ja_typings": [
+          "kapukon"
+        ]
       },
       {
         "en": "SNK",
         "ja": "エスエヌケー",
-        "ja_typings": []
+        "ja_typings": [
+          "esuenuke-"
+        ]
       },
       {
         "en": "Bandai Namco",
         "ja": "バンダイナムコ",
-        "ja_typings": []
+        "ja_typings": [
+          "bandainamuko"
+        ]
       },
       {
         "en": "Arc System Works",
         "ja": "アークシステムワークス",
-        "ja_typings": []
+        "ja_typings": [
+          "a-kushisutemuwa-kusu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -45972,12 +48620,16 @@
       {
         "en": "Street Fighter",
         "ja": "ストリートファイター",
-        "ja_typings": []
+        "ja_typings": [
+          "sutori-tofaita-"
+        ]
       },
       {
         "en": "King of Fighters",
         "ja": "キング・オブ・ファイターズ",
-        "ja_typings": []
+        "ja_typings": [
+          "kingu/obu/faita-zu"
+        ]
       },
       {
         "en": "Tekken",
@@ -45989,7 +48641,9 @@
       {
         "en": "Virtua Fighter",
         "ja": "バーチャファイター",
-        "ja_typings": []
+        "ja_typings": [
+          "ba-chafaita-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46013,17 +48667,24 @@
       {
         "en": "Soulcalibur",
         "ja": "ソウルキャリバー",
-        "ja_typings": []
+        "ja_typings": [
+          "sorukyariba-",
+          "sourukyariba-"
+        ]
       },
       {
         "en": "Dead or Alive",
         "ja": "デッド・オア・アライブ",
-        "ja_typings": []
+        "ja_typings": [
+          "deddo/oa/araibu"
+        ]
       },
       {
         "en": "Virtua Fighter",
         "ja": "バーチャファイター",
-        "ja_typings": []
+        "ja_typings": [
+          "ba-chafaita-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46040,22 +48701,30 @@
       {
         "en": "Terraria",
         "ja": "テラリア",
-        "ja_typings": []
+        "ja_typings": [
+          "teraria"
+        ]
       },
       {
         "en": "Minecraft Dungeons",
         "ja": "マインクラフト・ダンジョンズ",
-        "ja_typings": []
+        "ja_typings": [
+          "mainkurafuto/danjonzu"
+        ]
       },
       {
         "en": "Minecraft Legends",
         "ja": "マインクラフト・レジェンズ",
-        "ja_typings": []
+        "ja_typings": [
+          "mainkurafuto/rejenzu"
+        ]
       },
       {
         "en": "Minecraft Earth",
         "ja": "マインクラフト・アース",
-        "ja_typings": []
+        "ja_typings": [
+          "mainkurafuto/a-su"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46072,22 +48741,30 @@
       {
         "en": "God of War",
         "ja": "ゴッド・オブ・ウォー",
-        "ja_typings": []
+        "ja_typings": [
+          "goddo/obu/wo-"
+        ]
       },
       {
         "en": "Devil May Cry",
         "ja": "デビル・メイ・クライ",
-        "ja_typings": []
+        "ja_typings": [
+          "debiru/mei/kurai"
+        ]
       },
       {
         "en": "Bayonetta",
         "ja": "ベヨネッタ",
-        "ja_typings": []
+        "ja_typings": [
+          "beyonetta"
+        ]
       },
       {
         "en": "Darksiders",
         "ja": "ダークサイダーズ",
-        "ja_typings": []
+        "ja_typings": [
+          "da-kusaida-zu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46104,22 +48781,30 @@
       {
         "en": "Sega",
         "ja": "セガ",
-        "ja_typings": []
+        "ja_typings": [
+          "sega"
+        ]
       },
       {
         "en": "Square Enix",
         "ja": "スクウェア・エニックス",
-        "ja_typings": []
+        "ja_typings": [
+          "sukuwea/enikkusu"
+        ]
       },
       {
         "en": "Bandai Namco",
         "ja": "バンダイナムコ",
-        "ja_typings": []
+        "ja_typings": [
+          "bandainamuko"
+        ]
       },
       {
         "en": "Koei Tecmo",
         "ja": "コーエーテクモ",
-        "ja_typings": []
+        "ja_typings": [
+          "ko-e-tekumo"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46136,22 +48821,30 @@
       {
         "en": "The Witcher",
         "ja": "ウィッチャー",
-        "ja_typings": []
+        "ja_typings": [
+          "witcha-"
+        ]
       },
       {
         "en": "Skyrim",
         "ja": "スカイリム",
-        "ja_typings": []
+        "ja_typings": [
+          "sukairimu"
+        ]
       },
       {
         "en": "Dragon Age",
         "ja": "ドラゴン・エイジ",
-        "ja_typings": []
+        "ja_typings": [
+          "doragon/eiji"
+        ]
       },
       {
         "en": "Kingdom Come Deliverance",
         "ja": "キングダムカム・デリバランス",
-        "ja_typings": []
+        "ja_typings": [
+          "kingudamukamu/deribaransu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46168,22 +48861,30 @@
       {
         "en": "Turn-based strategy",
         "ja": "ターン制ストラテジー",
-        "ja_typings": []
+        "ja_typings": [
+          "ta-nseisutorateji-"
+        ]
       },
       {
         "en": "Real-time strategy",
         "ja": "リアルタイム・ストラテジー",
-        "ja_typings": []
+        "ja_typings": [
+          "riarutaimu/sutorateji-"
+        ]
       },
       {
         "en": "Action RPG",
         "ja": "アクションRPG",
-        "ja_typings": []
+        "ja_typings": [
+          "akushonrpg"
+        ]
       },
       {
         "en": "Sandbox",
         "ja": "サンドボックス",
-        "ja_typings": []
+        "ja_typings": [
+          "sandobokkusu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46200,22 +48901,30 @@
       {
         "en": "Sonic the Hedgehog",
         "ja": "ソニック・ザ・ヘッジホッグ",
-        "ja_typings": []
+        "ja_typings": [
+          "sonikku/za/hejjihoggu"
+        ]
       },
       {
         "en": "Crash Bandicoot",
         "ja": "クラッシュ・バンディクー",
-        "ja_typings": []
+        "ja_typings": [
+          "kurasshu/bandiku-"
+        ]
       },
       {
         "en": "Spyro the Dragon",
         "ja": "スパイロ・ザ・ドラゴン",
-        "ja_typings": []
+        "ja_typings": [
+          "supairo/za/doragon"
+        ]
       },
       {
         "en": "Rayman",
         "ja": "レイマン",
-        "ja_typings": []
+        "ja_typings": [
+          "reiman"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46232,22 +48941,30 @@
       {
         "en": "Square Enix",
         "ja": "スクウェア・エニックス",
-        "ja_typings": []
+        "ja_typings": [
+          "sukuwea/enikkusu"
+        ]
       },
       {
         "en": "Atlus",
         "ja": "アトラス",
-        "ja_typings": []
+        "ja_typings": [
+          "atorasu"
+        ]
       },
       {
         "en": "Capcom",
         "ja": "カプコン",
-        "ja_typings": []
+        "ja_typings": [
+          "kapukon"
+        ]
       },
       {
         "en": "Bandai Namco",
         "ja": "バンダイナムコ",
-        "ja_typings": []
+        "ja_typings": [
+          "bandainamuko"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46264,12 +48981,16 @@
       {
         "en": "Kingdom Hearts",
         "ja": "キングダムハーツ",
-        "ja_typings": []
+        "ja_typings": [
+          "kingudamuha-tsu"
+        ]
       },
       {
         "en": "Final Fantasy",
         "ja": "ファイナルファンタジー",
-        "ja_typings": []
+        "ja_typings": [
+          "fainarufantaji-"
+        ]
       },
       {
         "en": "The World Ends with You",
@@ -46281,7 +49002,9 @@
       {
         "en": "Nier",
         "ja": "ニーア",
-        "ja_typings": []
+        "ja_typings": [
+          "ni-a"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46298,7 +49021,9 @@
       {
         "en": "Silent Hill",
         "ja": "サイレントヒル",
-        "ja_typings": []
+        "ja_typings": [
+          "sairentohiru"
+        ]
       },
       {
         "en": "Fatal Frame",
@@ -46310,12 +49035,16 @@
       {
         "en": "Clock Tower",
         "ja": "クロックタワー",
-        "ja_typings": []
+        "ja_typings": [
+          "kurokkutawa-"
+        ]
       },
       {
         "en": "Forbidden Siren series",
         "ja": "サイレン シリーズ",
-        "ja_typings": []
+        "ja_typings": [
+          "sairen shiri-zu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46332,22 +49061,30 @@
       {
         "en": "Titanfall",
         "ja": "タイタンフォール",
-        "ja_typings": []
+        "ja_typings": [
+          "taitanfo-ru"
+        ]
       },
       {
         "en": "Armored Core",
         "ja": "アーマード・コア",
-        "ja_typings": []
+        "ja_typings": [
+          "a-ma-do/koa"
+        ]
       },
       {
         "en": "MechWarrior",
         "ja": "メックウォリアー",
-        "ja_typings": []
+        "ja_typings": [
+          "mekkuworia-"
+        ]
       },
       {
         "en": "Front Mission",
         "ja": "フロントミッション",
-        "ja_typings": []
+        "ja_typings": [
+          "furontomisshon"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46364,7 +49101,9 @@
       {
         "en": "Engineer",
         "ja": "エンジニア",
-        "ja_typings": []
+        "ja_typings": [
+          "enjinia"
+        ]
       },
       {
         "en": "Soldier",
@@ -46402,22 +49141,30 @@
       {
         "en": "Nier Automata",
         "ja": "ニーア・オートマタ",
-        "ja_typings": []
+        "ja_typings": [
+          "ni-a/o-tomata"
+        ]
       },
       {
         "en": "Drakengard",
         "ja": "ドラッグ・オン・ドラグーン",
-        "ja_typings": []
+        "ja_typings": [
+          "doraggu/on/doragu-n"
+        ]
       },
       {
         "en": "Stellar Blade",
         "ja": "ステラーブレイド",
-        "ja_typings": []
+        "ja_typings": [
+          "sutera-bureido"
+        ]
       },
       {
         "en": "Scarlet Nexus",
         "ja": "スカーレットネクサス",
-        "ja_typings": []
+        "ja_typings": [
+          "suka-rettonekusasu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46434,22 +49181,30 @@
       {
         "en": "collections.OrderedDict",
         "ja": "コレクションズオーダードディクト",
-        "ja_typings": []
+        "ja_typings": [
+          "korekushonzuo-da-dodikuto"
+        ]
       },
       {
         "en": "collections.deque",
         "ja": "コレクションズデック",
-        "ja_typings": []
+        "ja_typings": [
+          "korekushonzudekku"
+        ]
       },
       {
         "en": "collections.ChainMap",
         "ja": "コレクションズチェインマップ",
-        "ja_typings": []
+        "ja_typings": [
+          "korekushonzucheinmappu"
+        ]
       },
       {
         "en": "collections.UserDict",
         "ja": "コレクションズユーザーディクト",
-        "ja_typings": []
+        "ja_typings": [
+          "korekushonzuyu-za-dikuto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46466,22 +49221,30 @@
       {
         "en": "functools.lru_cache",
         "ja": "ファンクツールズエルアールユーキャッシュ",
-        "ja_typings": []
+        "ja_typings": [
+          "fankutsu-ruzuerua-ruyu-kyasshu"
+        ]
       },
       {
         "en": "functools.partial",
         "ja": "ファンクツールズパーシャル",
-        "ja_typings": []
+        "ja_typings": [
+          "fankutsu-ruzupa-sharu"
+        ]
       },
       {
         "en": "functools.reduce",
         "ja": "ファンクツールズリデュース",
-        "ja_typings": []
+        "ja_typings": [
+          "fankutsu-ruzurideyu-su"
+        ]
       },
       {
         "en": "functools.wraps",
         "ja": "ファンクツールズラップス",
-        "ja_typings": []
+        "ja_typings": [
+          "fankutsu-ruzurappusu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46498,22 +49261,30 @@
       {
         "en": "with",
         "ja": "ウィズ",
-        "ja_typings": []
+        "ja_typings": [
+          "wizu"
+        ]
       },
       {
         "en": "try",
         "ja": "トライ",
-        "ja_typings": []
+        "ja_typings": [
+          "torai"
+        ]
       },
       {
         "en": "yield",
         "ja": "イールド",
-        "ja_typings": []
+        "ja_typings": [
+          "i-rudo"
+        ]
       },
       {
         "en": "async",
         "ja": "エイシンク",
-        "ja_typings": []
+        "ja_typings": [
+          "eishinku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46530,22 +49301,30 @@
       {
         "en": "enumerate",
         "ja": "エニュメレート",
-        "ja_typings": []
+        "ja_typings": [
+          "enyumere-to"
+        ]
       },
       {
         "en": "zip",
         "ja": "ジップ",
-        "ja_typings": []
+        "ja_typings": [
+          "jippu"
+        ]
       },
       {
         "en": "map",
         "ja": "マップ",
-        "ja_typings": []
+        "ja_typings": [
+          "mappu"
+        ]
       },
       {
         "en": "filter",
         "ja": "フィルター",
-        "ja_typings": []
+        "ja_typings": [
+          "firuta-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46562,22 +49341,30 @@
       {
         "en": "async def",
         "ja": "エイシンクデフ",
-        "ja_typings": []
+        "ja_typings": [
+          "eishinkudefu"
+        ]
       },
       {
         "en": "def coroutine",
         "ja": "デフコルーチン",
-        "ja_typings": []
+        "ja_typings": [
+          "defukoru-chin"
+        ]
       },
       {
         "en": "yield from",
         "ja": "イールドフロム",
-        "ja_typings": []
+        "ja_typings": [
+          "i-rudofuromu"
+        ]
       },
       {
         "en": "await def",
         "ja": "アウェイトデフ",
-        "ja_typings": []
+        "ja_typings": [
+          "aweitodefu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46594,22 +49381,30 @@
       {
         "en": ":=",
         "ja": "コロンイコール",
-        "ja_typings": []
+        "ja_typings": [
+          "koronniko-ru"
+        ]
       },
       {
         "en": "=>",
         "ja": "イコールグレーター",
-        "ja_typings": []
+        "ja_typings": [
+          "iko-rugure-ta-"
+        ]
       },
       {
         "en": "<-",
         "ja": "レフトアロー",
-        "ja_typings": []
+        "ja_typings": [
+          "refutoaro-"
+        ]
       },
       {
         "en": "->",
         "ja": "ライトアロー",
-        "ja_typings": []
+        "ja_typings": [
+          "raitoaro-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46626,22 +49421,30 @@
       {
         "en": "collections.abc",
         "ja": "コレクションズエービーシー",
-        "ja_typings": []
+        "ja_typings": [
+          "korekushonzue-bi-shi-"
+        ]
       },
       {
         "en": "typing.abc",
         "ja": "タイピングエービーシー",
-        "ja_typings": []
+        "ja_typings": [
+          "taipingue-bi-shi-"
+        ]
       },
       {
         "en": "abc.collections",
         "ja": "エービーシーコレクションズ",
-        "ja_typings": []
+        "ja_typings": [
+          "e-bi-shi-korekushonzu"
+        ]
       },
       {
         "en": "base.abc",
         "ja": "ベースエービーシー",
-        "ja_typings": []
+        "ja_typings": [
+          "be-sue-bi-shi-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46658,22 +49461,30 @@
       {
         "en": "Global Interpreter Lock",
         "ja": "グローバルインタープリターロック",
-        "ja_typings": []
+        "ja_typings": [
+          "guro-baruinta-purita-rokku"
+        ]
       },
       {
         "en": "General Iteration Loop",
         "ja": "ジェネラルイテレーションループ",
-        "ja_typings": []
+        "ja_typings": [
+          "jeneraruitere-shonru-pu"
+        ]
       },
       {
         "en": "Garbage Inspection Layer",
         "ja": "ガベージインスペクションレイヤー",
-        "ja_typings": []
+        "ja_typings": [
+          "gabe-jiinsupekushonreiya-"
+        ]
       },
       {
         "en": "Generic Internal Library",
         "ja": "ジェネリックインターナルライブラリ",
-        "ja_typings": []
+        "ja_typings": [
+          "jenerikkuinta-naruraiburari"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46690,22 +49501,30 @@
       {
         "en": "const fn",
         "ja": "コンストエフエヌ",
-        "ja_typings": []
+        "ja_typings": [
+          "konsutoefuenu"
+        ]
       },
       {
         "en": "static fn",
         "ja": "スタティックエフエヌ",
-        "ja_typings": []
+        "ja_typings": [
+          "sutatikkuefuenu"
+        ]
       },
       {
         "en": "comptime fn",
         "ja": "コンプタイムエフエヌ",
-        "ja_typings": []
+        "ja_typings": [
+          "konputaimuefuenu"
+        ]
       },
       {
         "en": "eval fn",
         "ja": "イーバルエフエヌ",
-        "ja_typings": []
+        "ja_typings": [
+          "i-baruefuenu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46722,22 +49541,30 @@
       {
         "en": "RefCell",
         "ja": "レフセル",
-        "ja_typings": []
+        "ja_typings": [
+          "refuseru"
+        ]
       },
       {
         "en": "UnsafeCell",
         "ja": "アンセーフセル",
-        "ja_typings": []
+        "ja_typings": [
+          "anse-fuseru"
+        ]
       },
       {
         "en": "Cell",
         "ja": "セル",
-        "ja_typings": []
+        "ja_typings": [
+          "seru"
+        ]
       },
       {
         "en": "OnceCell",
         "ja": "ワンスセル",
-        "ja_typings": []
+        "ja_typings": [
+          "wansuseru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46754,22 +49581,30 @@
       {
         "en": "#[derive(Debug)]",
         "ja": "デライブデバッグ",
-        "ja_typings": []
+        "ja_typings": [
+          "deraibudebaggu"
+        ]
       },
       {
         "en": "#[debug]",
         "ja": "デバッグ",
-        "ja_typings": []
+        "ja_typings": [
+          "debaggu"
+        ]
       },
       {
         "en": "#[impl(Debug)]",
         "ja": "インプルデバッグ",
-        "ja_typings": []
+        "ja_typings": [
+          "inpurudebaggu"
+        ]
       },
       {
         "en": "#[trait(Debug)]",
         "ja": "トレイトデバッグ",
-        "ja_typings": []
+        "ja_typings": [
+          "toreitodebaggu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46787,23 +49622,29 @@
         "en": "? operator",
         "ja": "クエスチョン演算子",
         "ja_typings": [
-          "? エンザンシ"
+          "kuesuchonenzanshi"
         ]
       },
       {
         "en": "try block",
         "ja": "トライブロック",
-        "ja_typings": []
+        "ja_typings": [
+          "toraiburokku"
+        ]
       },
       {
         "en": "panic macro",
         "ja": "パニックマクロ",
-        "ja_typings": []
+        "ja_typings": [
+          "panikkumakuro"
+        ]
       },
       {
         "en": "unwrap chain",
         "ja": "アンラップチェーン",
-        "ja_typings": []
+        "ja_typings": [
+          "anrappuche-n"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46820,22 +49661,30 @@
       {
         "en": "where",
         "ja": "ホエア",
-        "ja_typings": []
+        "ja_typings": [
+          "hoea"
+        ]
       },
       {
         "en": "bound",
         "ja": "バウンド",
-        "ja_typings": []
+        "ja_typings": [
+          "baundo"
+        ]
       },
       {
         "en": "constraint",
         "ja": "コンストレイント",
-        "ja_typings": []
+        "ja_typings": [
+          "konsutoreinto"
+        ]
       },
       {
         "en": "requires",
         "ja": "リクワイアズ",
-        "ja_typings": []
+        "ja_typings": [
+          "rikuwaiazu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46852,22 +49701,30 @@
       {
         "en": "if let",
         "ja": "イフレット",
-        "ja_typings": []
+        "ja_typings": [
+          "ifuretto"
+        ]
       },
       {
         "en": "if match",
         "ja": "イフマッチ",
-        "ja_typings": []
+        "ja_typings": [
+          "ifumatchi"
+        ]
       },
       {
         "en": "when let",
         "ja": "ホエンレット",
-        "ja_typings": []
+        "ja_typings": [
+          "hoenretto"
+        ]
       },
       {
         "en": "case let",
         "ja": "ケースレット",
-        "ja_typings": []
+        "ja_typings": [
+          "ke-suretto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46884,22 +49741,30 @@
       {
         "en": "Array.from",
         "ja": "アレイフロム",
-        "ja_typings": []
+        "ja_typings": [
+          "areifuromu"
+        ]
       },
       {
         "en": "Array.of",
         "ja": "アレイオブ",
-        "ja_typings": []
+        "ja_typings": [
+          "areiobu"
+        ]
       },
       {
         "en": "Array.copy",
         "ja": "アレイコピー",
-        "ja_typings": []
+        "ja_typings": [
+          "areikopi-"
+        ]
       },
       {
         "en": "Array.clone",
         "ja": "アレイクローン",
-        "ja_typings": []
+        "ja_typings": [
+          "areikuro-n"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46916,22 +49781,30 @@
       {
         "en": "??",
         "ja": "ダブルクエスチョン",
-        "ja_typings": []
+        "ja_typings": [
+          "daburukuesuchon"
+        ]
       },
       {
         "en": "||",
         "ja": "ダブルパイプ",
-        "ja_typings": []
+        "ja_typings": [
+          "daburupaipu"
+        ]
       },
       {
         "en": "&&",
         "ja": "ダブルアンパサンド",
-        "ja_typings": []
+        "ja_typings": [
+          "daburuanpasando"
+        ]
       },
       {
         "en": "?:",
         "ja": "クエスチョンコロン",
-        "ja_typings": []
+        "ja_typings": [
+          "kuesuchonkoron"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46948,22 +49821,31 @@
       {
         "en": "Partial",
         "ja": "パーシャル",
-        "ja_typings": []
+        "ja_typings": [
+          "pa-sharu"
+        ]
       },
       {
         "en": "Required",
         "ja": "リクワイアド",
-        "ja_typings": []
+        "ja_typings": [
+          "rikuwaiado"
+        ]
       },
       {
         "en": "Readonly",
         "ja": "リードオンリー",
-        "ja_typings": []
+        "ja_typings": [
+          "ri-donri-",
+          "ri-doonri-"
+        ]
       },
       {
         "en": "Pick",
         "ja": "ピック",
-        "ja_typings": []
+        "ja_typings": [
+          "pikku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -46980,22 +49862,31 @@
       {
         "en": "never",
         "ja": "ネバー",
-        "ja_typings": []
+        "ja_typings": [
+          "neba-"
+        ]
       },
       {
         "en": "void",
         "ja": "ボイド",
-        "ja_typings": []
+        "ja_typings": [
+          "boido"
+        ]
       },
       {
         "en": "unknown",
         "ja": "アンノウン",
-        "ja_typings": []
+        "ja_typings": [
+          "annnon",
+          "annnoun"
+        ]
       },
       {
         "en": "undefined",
         "ja": "アンディファインド",
-        "ja_typings": []
+        "ja_typings": [
+          "andifaindo"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -47012,22 +49903,30 @@
       {
         "en": "Web Worker",
         "ja": "ウェブワーカー",
-        "ja_typings": []
+        "ja_typings": [
+          "webuwa-ka-"
+        ]
       },
       {
         "en": "SharedWorker",
         "ja": "シェアードワーカー",
-        "ja_typings": []
+        "ja_typings": [
+          "shea-dowa-ka-"
+        ]
       },
       {
         "en": "AudioWorklet",
         "ja": "オーディオワークレット",
-        "ja_typings": []
+        "ja_typings": [
+          "o-diowa-kuretto"
+        ]
       },
       {
         "en": "Atomics",
         "ja": "アトミックス",
-        "ja_typings": []
+        "ja_typings": [
+          "atomikkusu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -47044,22 +49943,30 @@
       {
         "en": "Iteration protocol",
         "ja": "イテレーションプロトコル",
-        "ja_typings": []
+        "ja_typings": [
+          "itere-shonpurotokoru"
+        ]
       },
       {
         "en": "Comparison protocol",
         "ja": "コンパリソンプロトコル",
-        "ja_typings": []
+        "ja_typings": [
+          "konparisonpurotokoru"
+        ]
       },
       {
         "en": "Hashing protocol",
         "ja": "ハッシングプロトコル",
-        "ja_typings": []
+        "ja_typings": [
+          "hasshingupurotokoru"
+        ]
       },
       {
         "en": "Serialization protocol",
         "ja": "シリアライゼーションプロトコル",
-        "ja_typings": []
+        "ja_typings": [
+          "shiriaraize-shonpurotokoru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -47076,22 +49983,30 @@
       {
         "en": "Object.freeze",
         "ja": "オブジェクトフリーズ",
-        "ja_typings": []
+        "ja_typings": [
+          "obujekutofuri-zu"
+        ]
       },
       {
         "en": "Object.seal",
         "ja": "オブジェクトシール",
-        "ja_typings": []
+        "ja_typings": [
+          "obujekutoshi-ru"
+        ]
       },
       {
         "en": "Object.lock",
         "ja": "オブジェクトロック",
-        "ja_typings": []
+        "ja_typings": [
+          "obujekutorokku"
+        ]
       },
       {
         "en": "Object.const",
         "ja": "オブジェクトコンスト",
-        "ja_typings": []
+        "ja_typings": [
+          "obujekutokonsuto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -47108,22 +50023,30 @@
       {
         "en": "go",
         "ja": "ゴー",
-        "ja_typings": []
+        "ja_typings": [
+          "go-"
+        ]
       },
       {
         "en": "spawn",
         "ja": "スポーン",
-        "ja_typings": []
+        "ja_typings": [
+          "supo-n"
+        ]
       },
       {
         "en": "async",
         "ja": "エイシンク",
-        "ja_typings": []
+        "ja_typings": [
+          "eishinku"
+        ]
       },
       {
         "en": "thread",
         "ja": "スレッド",
-        "ja_typings": []
+        "ja_typings": [
+          "sureddo"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -47140,22 +50063,30 @@
       {
         "en": "select",
         "ja": "セレクト",
-        "ja_typings": []
+        "ja_typings": [
+          "serekuto"
+        ]
       },
       {
         "en": "switch",
         "ja": "スイッチ",
-        "ja_typings": []
+        "ja_typings": [
+          "suitchi"
+        ]
       },
       {
         "en": "choose",
         "ja": "チューズ",
-        "ja_typings": []
+        "ja_typings": [
+          "chu-zu"
+        ]
       },
       {
         "en": "when",
         "ja": "ホエン",
-        "ja_typings": []
+        "ja_typings": [
+          "hoen"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -47172,22 +50103,30 @@
       {
         "en": "defer",
         "ja": "ディファー",
-        "ja_typings": []
+        "ja_typings": [
+          "difa-"
+        ]
       },
       {
         "en": "finally",
         "ja": "ファイナリー",
-        "ja_typings": []
+        "ja_typings": [
+          "fainari-"
+        ]
       },
       {
         "en": "cleanup",
         "ja": "クリーンアップ",
-        "ja_typings": []
+        "ja_typings": [
+          "kuri-nnappu"
+        ]
       },
       {
         "en": "postpone",
         "ja": "ポストポーン",
-        "ja_typings": []
+        "ja_typings": [
+          "posutopo-n"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -47204,22 +50143,30 @@
       {
         "en": "sync",
         "ja": "シンク",
-        "ja_typings": []
+        "ja_typings": [
+          "shinku"
+        ]
       },
       {
         "en": "atomic",
         "ja": "アトミック",
-        "ja_typings": []
+        "ja_typings": [
+          "atomikku"
+        ]
       },
       {
         "en": "lock",
         "ja": "ロック",
-        "ja_typings": []
+        "ja_typings": [
+          "rokku"
+        ]
       },
       {
         "en": "mutex",
         "ja": "ミューテックス",
-        "ja_typings": []
+        "ja_typings": [
+          "myu-tekkusu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -47236,22 +50183,30 @@
       {
         "en": "unique_ptr",
         "ja": "ユニークピーティーアール",
-        "ja_typings": []
+        "ja_typings": [
+          "yuni-kupi-ti-a-ru"
+        ]
       },
       {
         "en": "shared_ptr",
         "ja": "シェアードピーティーアール",
-        "ja_typings": []
+        "ja_typings": [
+          "shea-dopi-ti-a-ru"
+        ]
       },
       {
         "en": "weak_ptr",
         "ja": "ウィークピーティーアール",
-        "ja_typings": []
+        "ja_typings": [
+          "wi-kupi-ti-a-ru"
+        ]
       },
       {
         "en": "auto_ptr",
         "ja": "オートピーティーアール",
-        "ja_typings": []
+        "ja_typings": [
+          "o-topi-ti-a-ru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -47268,22 +50223,30 @@
       {
         "en": "explicit",
         "ja": "エクスプリシット",
-        "ja_typings": []
+        "ja_typings": [
+          "ekusupurishitto"
+        ]
       },
       {
         "en": "implicit",
         "ja": "インプリシット",
-        "ja_typings": []
+        "ja_typings": [
+          "inpurishitto"
+        ]
       },
       {
         "en": "noexcept",
         "ja": "ノーエクセプト",
-        "ja_typings": []
+        "ja_typings": [
+          "no-ekuseputo"
+        ]
       },
       {
         "en": "constexpr",
         "ja": "コンストエクスパー",
-        "ja_typings": []
+        "ja_typings": [
+          "konsutoekusupa-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -47300,22 +50263,30 @@
       {
         "en": "constexpr",
         "ja": "コンストエクスパー",
-        "ja_typings": []
+        "ja_typings": [
+          "konsutoekusupa-"
+        ]
       },
       {
         "en": "inline",
         "ja": "インライン",
-        "ja_typings": []
+        "ja_typings": [
+          "inrain"
+        ]
       },
       {
         "en": "consteval",
         "ja": "コンストイーバル",
-        "ja_typings": []
+        "ja_typings": [
+          "konsutoi-baru"
+        ]
       },
       {
         "en": "static",
         "ja": "スタティック",
-        "ja_typings": []
+        "ja_typings": [
+          "sutatikku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -47333,28 +50304,32 @@
         "en": "C++20",
         "ja": "シープラプラニジュウ",
         "ja_typings": [
-          "C++20"
+          "C++20",
+          "shi-purapuranijuu"
         ]
       },
       {
         "en": "C++17",
         "ja": "シープラプラジュウナナ",
         "ja_typings": [
-          "C++17"
+          "C++17",
+          "shi-purapurajuunana"
         ]
       },
       {
         "en": "C++14",
         "ja": "シープラプラジュウヨン",
         "ja_typings": [
-          "C++14"
+          "C++14",
+          "shi-purapurajuuyon"
         ]
       },
       {
         "en": "C++11",
         "ja": "シープラプラジュウイチ",
         "ja_typings": [
-          "C++11"
+          "C++11",
+          "shi-purapurajuuichi"
         ]
       }
     ],
@@ -47372,22 +50347,30 @@
       {
         "en": "dynamic_cast",
         "ja": "ダイナミックキャスト",
-        "ja_typings": []
+        "ja_typings": [
+          "dainamikkukyasuto"
+        ]
       },
       {
         "en": "static_cast",
         "ja": "スタティックキャスト",
-        "ja_typings": []
+        "ja_typings": [
+          "sutatikkukyasuto"
+        ]
       },
       {
         "en": "reinterpret_cast",
         "ja": "リインタープリットキャスト",
-        "ja_typings": []
+        "ja_typings": [
+          "riinta-purittokyasuto"
+        ]
       },
       {
         "en": "const_cast",
         "ja": "コンストキャスト",
-        "ja_typings": []
+        "ja_typings": [
+          "konsutokyasuto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -47404,22 +50387,30 @@
       {
         "en": "object",
         "ja": "オブジェクト",
-        "ja_typings": []
+        "ja_typings": [
+          "obujekuto"
+        ]
       },
       {
         "en": "singleton",
         "ja": "シングルトン",
-        "ja_typings": []
+        "ja_typings": [
+          "shinguruton"
+        ]
       },
       {
         "en": "static",
         "ja": "スタティック",
-        "ja_typings": []
+        "ja_typings": [
+          "sutatikku"
+        ]
       },
       {
         "en": "companion",
         "ja": "コンパニオン",
-        "ja_typings": []
+        "ja_typings": [
+          "konpanion"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -47436,22 +50427,30 @@
       {
         "en": "?.",
         "ja": "クエスチョンドット",
-        "ja_typings": []
+        "ja_typings": [
+          "kuesuchondotto"
+        ]
       },
       {
         "en": "!!",
         "ja": "ダブルバン",
-        "ja_typings": []
+        "ja_typings": [
+          "daburuban"
+        ]
       },
       {
         "en": "?:",
         "ja": "エルビス",
-        "ja_typings": []
+        "ja_typings": [
+          "erubisu"
+        ]
       },
       {
         "en": "::",
         "ja": "ダブルコロン",
-        "ja_typings": []
+        "ja_typings": [
+          "daburukoron"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -47468,22 +50467,30 @@
       {
         "en": "let",
         "ja": "レット",
-        "ja_typings": []
+        "ja_typings": [
+          "retto"
+        ]
       },
       {
         "en": "var",
         "ja": "バー",
-        "ja_typings": []
+        "ja_typings": [
+          "ba-"
+        ]
       },
       {
         "en": "const",
         "ja": "コンスト",
-        "ja_typings": []
+        "ja_typings": [
+          "konsuto"
+        ]
       },
       {
         "en": "final",
         "ja": "ファイナル",
-        "ja_typings": []
+        "ja_typings": [
+          "fainaru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -47500,22 +50507,30 @@
       {
         "en": "nil coalescing",
         "ja": "ニルコアレッシング",
-        "ja_typings": []
+        "ja_typings": [
+          "nirukoaresshingu"
+        ]
       },
       {
         "en": "optional binding",
         "ja": "オプショナルバインディング",
-        "ja_typings": []
+        "ja_typings": [
+          "opushonarubaindingu"
+        ]
       },
       {
         "en": "forced unwrap",
         "ja": "フォースドアンラップ",
-        "ja_typings": []
+        "ja_typings": [
+          "fo-sudoanrappu"
+        ]
       },
       {
         "en": "guard let",
         "ja": "ガードレット",
-        "ja_typings": []
+        "ja_typings": [
+          "ga-doretto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -47533,27 +50548,29 @@
         "en": "Doubly linked list + hash map",
         "ja": "双方向連結リスト + ハッシュマップ",
         "ja_typings": [
-          "ソウホウコウレンケツリスト + ハッシュマップ"
+          "souhoukourenketsurisuto/+/hasshumappu"
         ]
       },
       {
         "en": "Singly linked list",
         "ja": "単方向連結リスト",
         "ja_typings": [
-          "タンホウコウレンケツリスト"
+          "tanhoukourenketsurisuto"
         ]
       },
       {
         "en": "Binary heap",
         "ja": "二分ヒープ",
         "ja_typings": [
-          "ニブンヒープ"
+          "nibunhi-pu"
         ]
       },
       {
         "en": "AVL tree",
         "ja": "エーブイエルツリー",
-        "ja_typings": []
+        "ja_typings": [
+          "e-buierutsuri-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -47571,28 +50588,33 @@
         "en": "O(n^2)",
         "ja": "オーエヌジジョウ",
         "ja_typings": [
-          "O(n^2)"
+          "O(n^2)",
+          "o-enujijo",
+          "o-enujijou"
         ]
       },
       {
         "en": "O(n log n)",
         "ja": "オーエヌログエヌ",
         "ja_typings": [
-          "O(n log n)"
+          "O(n log n)",
+          "o-enuroguenu"
         ]
       },
       {
         "en": "O(1)",
         "ja": "オーイチ",
         "ja_typings": [
-          "O(1)"
+          "O(1)",
+          "o-ichi"
         ]
       },
       {
         "en": "O(log n)",
         "ja": "オーログエヌ",
         "ja_typings": [
-          "O(log n)"
+          "O(log n)",
+          "o-roguenu"
         ]
       }
     ],
@@ -47610,22 +50632,30 @@
       {
         "en": "Red-black tree",
         "ja": "レッドブラックツリー",
-        "ja_typings": []
+        "ja_typings": [
+          "reddoburakkutsuri-"
+        ]
       },
       {
         "en": "Splay tree",
         "ja": "スプレイツリー",
-        "ja_typings": []
+        "ja_typings": [
+          "supureitsuri-"
+        ]
       },
       {
         "en": "B-tree",
         "ja": "ビーツリー",
-        "ja_typings": []
+        "ja_typings": [
+          "bi-tsuri-"
+        ]
       },
       {
         "en": "Trie",
         "ja": "トライ",
-        "ja_typings": []
+        "ja_typings": [
+          "torai"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -47642,22 +50672,30 @@
       {
         "en": "Floyd algorithm",
         "ja": "フロイドアルゴリズム",
-        "ja_typings": []
+        "ja_typings": [
+          "furoidoarugorizumu"
+        ]
       },
       {
         "en": "Kruskal algorithm",
         "ja": "クラスカルアルゴリズム",
-        "ja_typings": []
+        "ja_typings": [
+          "kurasukaruarugorizumu"
+        ]
       },
       {
         "en": "Prim algorithm",
         "ja": "プリムアルゴリズム",
-        "ja_typings": []
+        "ja_typings": [
+          "purimuarugorizumu"
+        ]
       },
       {
         "en": "Bellman-Ford",
         "ja": "ベルマンフォード",
-        "ja_typings": []
+        "ja_typings": [
+          "berumanfo-do"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -47675,23 +50713,29 @@
         "en": "Trie",
         "ja": "トライ木",
         "ja_typings": [
-          "トライキ"
+          "toraiki"
         ]
       },
       {
         "en": "Suffix array",
         "ja": "サフィックスアレイ",
-        "ja_typings": []
+        "ja_typings": [
+          "safikkusuarei"
+        ]
       },
       {
         "en": "Segment tree",
         "ja": "セグメントツリー",
-        "ja_typings": []
+        "ja_typings": [
+          "segumentotsuri-"
+        ]
       },
       {
         "en": "Fenwick tree",
         "ja": "フェニックツリー",
-        "ja_typings": []
+        "ja_typings": [
+          "fenikkutsuri-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -47709,28 +50753,28 @@
         "en": "Doubling strategy",
         "ja": "ダブリング戦略",
         "ja_typings": [
-          "ダブリングセンリャク"
+          "daburingusenryaku"
         ]
       },
       {
         "en": "Linear growth",
         "ja": "線形成長",
         "ja_typings": [
-          "センケイセイチョウ"
+          "senkeiseichou"
         ]
       },
       {
         "en": "Constant chunking",
         "ja": "定数チャンク化",
         "ja_typings": [
-          "テイスウチャンクカ"
+          "teisuuchankuka"
         ]
       },
       {
         "en": "Geometric shrinking",
         "ja": "幾何縮小",
         "ja_typings": [
-          "キカシュクショウ"
+          "kikashukushou"
         ]
       }
     ],
@@ -47748,24 +50792,30 @@
       {
         "en": "Deque",
         "ja": "デック",
-        "ja_typings": []
+        "ja_typings": [
+          "dekku"
+        ]
       },
       {
         "en": "Priority queue",
         "ja": "プライオリティキュー",
-        "ja_typings": []
+        "ja_typings": [
+          "puraioritikyu-"
+        ]
       },
       {
         "en": "Circular buffer",
         "ja": "循環バッファ",
         "ja_typings": [
-          "ジュンカンバッファ"
+          "junkanbaffa"
         ]
       },
       {
         "en": "Skip list",
         "ja": "スキップリスト",
-        "ja_typings": []
+        "ja_typings": [
+          "sukippurisuto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -47782,22 +50832,30 @@
       {
         "en": "Knuth-Morris-Pratt",
         "ja": "クヌースモリスプラット",
-        "ja_typings": []
+        "ja_typings": [
+          "kunu-sumorisupuratto"
+        ]
       },
       {
         "en": "Boyer-Moore",
         "ja": "ボイヤームーア",
-        "ja_typings": []
+        "ja_typings": [
+          "boiya-mu-a"
+        ]
       },
       {
         "en": "Rabin-Karp",
         "ja": "ラビンカープ",
-        "ja_typings": []
+        "ja_typings": [
+          "rabinka-pu"
+        ]
       },
       {
         "en": "Aho-Corasick",
         "ja": "エイホコラシック",
-        "ja_typings": []
+        "ja_typings": [
+          "eihokorashikku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -47815,28 +50873,28 @@
         "en": "Copying GC",
         "ja": "コピーGC",
         "ja_typings": [
-          "コピーGC"
+          "kopi-gc"
         ]
       },
       {
         "en": "Mark-sweep GC",
         "ja": "マークスイープGC",
         "ja_typings": [
-          "マークスイープGC"
+          "ma-kusui-pugc"
         ]
       },
       {
         "en": "Mark-compact GC",
         "ja": "マークコンパクトGC",
         "ja_typings": [
-          "マークコンパクトGC"
+          "ma-kukonpakutogc"
         ]
       },
       {
         "en": "Incremental GC",
         "ja": "インクリメンタルGC",
         "ja_typings": [
-          "インクリメンタルGC"
+          "inkurimentarugc"
         ]
       }
     ],
@@ -47855,26 +50913,28 @@
         "en": "Generational GC",
         "ja": "世代別GC",
         "ja_typings": [
-          "セダイベツGC"
+          "sedaibetsugc"
         ]
       },
       {
         "en": "Concurrent GC",
         "ja": "並行GC",
         "ja_typings": [
-          "ヘイコウGC"
+          "heikougc"
         ]
       },
       {
         "en": "Real-time GC",
         "ja": "リアルタイムGC",
-        "ja_typings": []
+        "ja_typings": [
+          "riarutaimugc"
+        ]
       },
       {
         "en": "Conservative GC",
         "ja": "保守的GC",
         "ja_typings": [
-          "ホシュテキGC"
+          "hoshutekigc"
         ]
       }
     ],
@@ -47892,22 +50952,30 @@
       {
         "en": "NaN boxing",
         "ja": "ナンボクシング",
-        "ja_typings": []
+        "ja_typings": [
+          "nanbokushingu"
+        ]
       },
       {
         "en": "Pointer compression",
         "ja": "ポインタコンプレッション",
-        "ja_typings": []
+        "ja_typings": [
+          "pointakonpuresshon"
+        ]
       },
       {
         "en": "Reference folding",
         "ja": "リファレンスフォールディング",
-        "ja_typings": []
+        "ja_typings": [
+          "rifarensufo-rudingu"
+        ]
       },
       {
         "en": "Heap coloring",
         "ja": "ヒープカラーリング",
-        "ja_typings": []
+        "ja_typings": [
+          "hi-pukara-ringu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -47924,22 +50992,30 @@
       {
         "en": "RwLock",
         "ja": "アールダブリューロック",
-        "ja_typings": []
+        "ja_typings": [
+          "a-rudaburyu-rokku"
+        ]
       },
       {
         "en": "Spinlock",
         "ja": "スピンロック",
-        "ja_typings": []
+        "ja_typings": [
+          "supinrokku"
+        ]
       },
       {
         "en": "Semaphore",
         "ja": "セマフォ",
-        "ja_typings": []
+        "ja_typings": [
+          "semafo"
+        ]
       },
       {
         "en": "Barrier",
         "ja": "バリア",
-        "ja_typings": []
+        "ja_typings": [
+          "baria"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -47956,22 +51032,30 @@
       {
         "en": "Actor model",
         "ja": "アクターモデル",
-        "ja_typings": []
+        "ja_typings": [
+          "akuta-moderu"
+        ]
       },
       {
         "en": "CSP model",
         "ja": "シーエスピーモデル",
-        "ja_typings": []
+        "ja_typings": [
+          "shi-esupi-moderu"
+        ]
       },
       {
         "en": "Fork-join model",
         "ja": "フォークジョインモデル",
-        "ja_typings": []
+        "ja_typings": [
+          "fo-kujoinmoderu"
+        ]
       },
       {
         "en": "MapReduce",
         "ja": "マップリデュース",
-        "ja_typings": []
+        "ja_typings": [
+          "mappurideyu-su"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -47988,22 +51072,30 @@
       {
         "en": "Livelock",
         "ja": "ライブロック",
-        "ja_typings": []
+        "ja_typings": [
+          "raiburokku"
+        ]
       },
       {
         "en": "Starvation",
         "ja": "スターベーション",
-        "ja_typings": []
+        "ja_typings": [
+          "suta-be-shon"
+        ]
       },
       {
         "en": "Priority inversion",
         "ja": "プライオリティインバージョン",
-        "ja_typings": []
+        "ja_typings": [
+          "puraioritiinba-jon"
+        ]
       },
       {
         "en": "Convoy effect",
         "ja": "コンボイエフェクト",
-        "ja_typings": []
+        "ja_typings": [
+          "konboiefekuto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48020,22 +51112,30 @@
       {
         "en": "AtomicInteger",
         "ja": "アトミックインテジャー",
-        "ja_typings": []
+        "ja_typings": [
+          "atomikkuinteja-"
+        ]
       },
       {
         "en": "synchronized",
         "ja": "シンクロナイズド",
-        "ja_typings": []
+        "ja_typings": [
+          "shinkuronaizudo"
+        ]
       },
       {
         "en": "volatile",
         "ja": "ボラタイル",
-        "ja_typings": []
+        "ja_typings": [
+          "boratairu"
+        ]
       },
       {
         "en": "ReentrantLock",
         "ja": "リエントラントロック",
-        "ja_typings": []
+        "ja_typings": [
+          "rientorantorokku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48052,22 +51152,30 @@
       {
         "en": "Memory barrier",
         "ja": "メモリバリア",
-        "ja_typings": []
+        "ja_typings": [
+          "memoribaria"
+        ]
       },
       {
         "en": "Cache flush",
         "ja": "キャッシュフラッシュ",
-        "ja_typings": []
+        "ja_typings": [
+          "kyasshufurasshu"
+        ]
       },
       {
         "en": "Thread fence",
         "ja": "スレッドフェンス",
-        "ja_typings": []
+        "ja_typings": [
+          "sureddofensu"
+        ]
       },
       {
         "en": "Lock fence",
         "ja": "ロックフェンス",
-        "ja_typings": []
+        "ja_typings": [
+          "rokkufensu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48085,23 +51193,29 @@
         "en": "Currying",
         "ja": "カリー化",
         "ja_typings": [
-          "カリーカ"
+          "kari-ka"
         ]
       },
       {
         "en": "Composing",
         "ja": "コンポージング",
-        "ja_typings": []
+        "ja_typings": [
+          "konpo-jingu"
+        ]
       },
       {
         "en": "Memoizing",
         "ja": "メモアイジング",
-        "ja_typings": []
+        "ja_typings": [
+          "memoaijingu"
+        ]
       },
       {
         "en": "Folding",
         "ja": "フォールディング",
-        "ja_typings": []
+        "ja_typings": [
+          "fo-rudingu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48118,22 +51232,30 @@
       {
         "en": "bind",
         "ja": "バインド",
-        "ja_typings": []
+        "ja_typings": [
+          "baindo"
+        ]
       },
       {
         "en": "apply",
         "ja": "アプライ",
-        "ja_typings": []
+        "ja_typings": [
+          "apurai"
+        ]
       },
       {
         "en": "lift",
         "ja": "リフト",
-        "ja_typings": []
+        "ja_typings": [
+          "rifuto"
+        ]
       },
       {
         "en": "join",
         "ja": "ジョイン",
-        "ja_typings": []
+        "ja_typings": [
+          "join"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48150,22 +51272,30 @@
       {
         "en": "fold",
         "ja": "フォールド",
-        "ja_typings": []
+        "ja_typings": [
+          "fo-rudo"
+        ]
       },
       {
         "en": "scan",
         "ja": "スキャン",
-        "ja_typings": []
+        "ja_typings": [
+          "sukyan"
+        ]
       },
       {
         "en": "group",
         "ja": "グループ",
-        "ja_typings": []
+        "ja_typings": [
+          "guru-pu"
+        ]
       },
       {
         "en": "zip",
         "ja": "ジップ",
-        "ja_typings": []
+        "ja_typings": [
+          "jippu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48182,22 +51312,30 @@
       {
         "en": "First-class functions",
         "ja": "ファーストクラスファンクションズ",
-        "ja_typings": []
+        "ja_typings": [
+          "fa-sutokurasufankushonzu"
+        ]
       },
       {
         "en": "Higher-order types",
         "ja": "ハイヤーオーダータイプス",
-        "ja_typings": []
+        "ja_typings": [
+          "haiya-o-da-taipusu"
+        ]
       },
       {
         "en": "Anonymous closures",
         "ja": "アノニマスクロージャーズ",
-        "ja_typings": []
+        "ja_typings": [
+          "anonimasukuro-ja-zu"
+        ]
       },
       {
         "en": "Lambda capture",
         "ja": "ラムダキャプチャ",
-        "ja_typings": []
+        "ja_typings": [
+          "ramudakyapucha"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48214,22 +51352,31 @@
       {
         "en": "Ad-hoc polymorphism",
         "ja": "アドホックポリモーフィズム",
-        "ja_typings": []
+        "ja_typings": [
+          "adohokkuporimo-fizumu"
+        ]
       },
       {
         "en": "Parametric polymorphism",
         "ja": "パラメトリックポリモーフィズム",
-        "ja_typings": []
+        "ja_typings": [
+          "parametorikkuporimo-fizumu"
+        ]
       },
       {
         "en": "Subtype polymorphism",
         "ja": "サブタイプポリモーフィズム",
-        "ja_typings": []
+        "ja_typings": [
+          "sabutaipuporimo-fizumu"
+        ]
       },
       {
         "en": "Row polymorphism",
         "ja": "ロウポリモーフィズム",
-        "ja_typings": []
+        "ja_typings": [
+          "roporimo-fizumu",
+          "rouporimo-fizumu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48246,22 +51393,30 @@
       {
         "en": "TCO",
         "ja": "ティーシーオー",
-        "ja_typings": []
+        "ja_typings": [
+          "ti-shi-o-"
+        ]
       },
       {
         "en": "TLS",
         "ja": "ティーエルエス",
-        "ja_typings": []
+        "ja_typings": [
+          "ti-eruesu"
+        ]
       },
       {
         "en": "LTO",
         "ja": "エルティーオー",
-        "ja_typings": []
+        "ja_typings": [
+          "eruti-o-"
+        ]
       },
       {
         "en": "FFI",
         "ja": "エフエフアイ",
-        "ja_typings": []
+        "ja_typings": [
+          "efuefuai"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48278,22 +51433,30 @@
       {
         "en": "Lowering",
         "ja": "ロワリング",
-        "ja_typings": []
+        "ja_typings": [
+          "rowaringu"
+        ]
       },
       {
         "en": "Linking",
         "ja": "リンキング",
-        "ja_typings": []
+        "ja_typings": [
+          "rinkingu"
+        ]
       },
       {
         "en": "Bundling",
         "ja": "バンドリング",
-        "ja_typings": []
+        "ja_typings": [
+          "bandoringu"
+        ]
       },
       {
         "en": "Mangling",
         "ja": "マングリング",
-        "ja_typings": []
+        "ja_typings": [
+          "manguringu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48311,25 +51474,29 @@
         "en": "Recursion",
         "ja": "再帰",
         "ja_typings": [
-          "サイキ"
+          "saiki"
         ]
       },
       {
         "en": "Iteration",
         "ja": "反復",
         "ja_typings": [
-          "ハンプク"
+          "hanpuku"
         ]
       },
       {
         "en": "Reflection",
         "ja": "リフレクション",
-        "ja_typings": []
+        "ja_typings": [
+          "rifurekushon"
+        ]
       },
       {
         "en": "Reification",
         "ja": "リアイフィケーション",
-        "ja_typings": []
+        "ja_typings": [
+          "riaifike-shon"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48346,22 +51513,30 @@
       {
         "en": "Metaprogramming",
         "ja": "メタプログラミング",
-        "ja_typings": []
+        "ja_typings": [
+          "metapuroguramingu"
+        ]
       },
       {
         "en": "Macroprogramming",
         "ja": "マクロプログラミング",
-        "ja_typings": []
+        "ja_typings": [
+          "makuropuroguramingu"
+        ]
       },
       {
         "en": "Polyprogramming",
         "ja": "ポリプログラミング",
-        "ja_typings": []
+        "ja_typings": [
+          "poripuroguramingu"
+        ]
       },
       {
         "en": "Hyperprogramming",
         "ja": "ハイパープログラミング",
-        "ja_typings": []
+        "ja_typings": [
+          "haipa-puroguramingu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48378,22 +51553,30 @@
       {
         "en": "FFI",
         "ja": "エフエフアイ",
-        "ja_typings": []
+        "ja_typings": [
+          "efuefuai"
+        ]
       },
       {
         "en": "RPC",
         "ja": "アールピーシー",
-        "ja_typings": []
+        "ja_typings": [
+          "a-rupi-shi-"
+        ]
       },
       {
         "en": "IPC",
         "ja": "アイピーシー",
-        "ja_typings": []
+        "ja_typings": [
+          "aipi-shi-"
+        ]
       },
       {
         "en": "ABI",
         "ja": "エービーアイ",
-        "ja_typings": []
+        "ja_typings": [
+          "e-bi-ai"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48411,23 +51594,29 @@
         "en": "Inlining",
         "ja": "インライン化",
         "ja_typings": [
-          "インラインカ"
+          "inrainka"
         ]
       },
       {
         "en": "Unrolling",
         "ja": "アンローリング",
-        "ja_typings": []
+        "ja_typings": [
+          "anro-ringu"
+        ]
       },
       {
         "en": "Tiling",
         "ja": "タイリング",
-        "ja_typings": []
+        "ja_typings": [
+          "tairingu"
+        ]
       },
       {
         "en": "Splitting",
         "ja": "スプリッティング",
-        "ja_typings": []
+        "ja_typings": [
+          "supurittingu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48444,22 +51633,30 @@
       {
         "en": "SCREAMING_SNAKE_CASE",
         "ja": "スクリーミングスネークケース",
-        "ja_typings": []
+        "ja_typings": [
+          "sukuri-mingusune-kuke-su"
+        ]
       },
       {
         "en": "camelCase",
         "ja": "キャメルケース",
-        "ja_typings": []
+        "ja_typings": [
+          "kyameruke-su"
+        ]
       },
       {
         "en": "kebab-case",
         "ja": "ケバブケース",
-        "ja_typings": []
+        "ja_typings": [
+          "kebabuke-su"
+        ]
       },
       {
         "en": "PascalCase",
         "ja": "パスカルケース",
-        "ja_typings": []
+        "ja_typings": [
+          "pasukaruke-su"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48476,22 +51673,30 @@
       {
         "en": "Duck typing",
         "ja": "ダックタイピング",
-        "ja_typings": []
+        "ja_typings": [
+          "dakkutaipingu"
+        ]
       },
       {
         "en": "Nominal typing",
         "ja": "ノミナルタイピング",
-        "ja_typings": []
+        "ja_typings": [
+          "nominarutaipingu"
+        ]
       },
       {
         "en": "Strong typing",
         "ja": "ストロングタイピング",
-        "ja_typings": []
+        "ja_typings": [
+          "sutorongutaipingu"
+        ]
       },
       {
         "en": "Dependent typing",
         "ja": "ディペンデントタイピング",
-        "ja_typings": []
+        "ja_typings": [
+          "dipendentotaipingu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48508,25 +51713,29 @@
       {
         "en": "Serialization",
         "ja": "シリアライズ",
-        "ja_typings": []
+        "ja_typings": [
+          "shiriaraizu"
+        ]
       },
       {
         "en": "Compilation",
         "ja": "コンパイル",
-        "ja_typings": []
+        "ja_typings": [
+          "konpairu"
+        ]
       },
       {
         "en": "Tokenization",
         "ja": "トークン化",
         "ja_typings": [
-          "トークンカ"
+          "to-kunka"
         ]
       },
       {
         "en": "Normalization",
         "ja": "正規化",
         "ja_typings": [
-          "セイキカ"
+          "seikika"
         ]
       }
     ],
@@ -48544,22 +51753,30 @@
       {
         "en": "Virtual dispatch",
         "ja": "バーチャルディスパッチ",
-        "ja_typings": []
+        "ja_typings": [
+          "ba-charudisupatchi"
+        ]
       },
       {
         "en": "Static dispatch",
         "ja": "スタティックディスパッチ",
-        "ja_typings": []
+        "ja_typings": [
+          "sutatikkudisupatchi"
+        ]
       },
       {
         "en": "Direct dispatch",
         "ja": "ダイレクトディスパッチ",
-        "ja_typings": []
+        "ja_typings": [
+          "dairekutodisupatchi"
+        ]
       },
       {
         "en": "Inline dispatch",
         "ja": "インラインディスパッチ",
-        "ja_typings": []
+        "ja_typings": [
+          "inraindisupatchi"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48576,22 +51793,30 @@
       {
         "en": "clamp()",
         "ja": "クランプ",
-        "ja_typings": []
+        "ja_typings": [
+          "kuranpu"
+        ]
       },
       {
         "en": "minmax()",
         "ja": "ミンマックス",
-        "ja_typings": []
+        "ja_typings": [
+          "minmakkusu"
+        ]
       },
       {
         "en": "calc()",
         "ja": "キャルク",
-        "ja_typings": []
+        "ja_typings": [
+          "kyaruku"
+        ]
       },
       {
         "en": "fit-content()",
         "ja": "フィットコンテント",
-        "ja_typings": []
+        "ja_typings": [
+          "fittokontento"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48608,22 +51833,30 @@
       {
         "en": "margin-inline-start",
         "ja": "マージンインラインスタート",
-        "ja_typings": []
+        "ja_typings": [
+          "ma-jinninrainsuta-to"
+        ]
       },
       {
         "en": "margin-block-start",
         "ja": "マージンブロックスタート",
-        "ja_typings": []
+        "ja_typings": [
+          "ma-jinburokkusuta-to"
+        ]
       },
       {
         "en": "margin-left-logical",
         "ja": "マージンレフトロジカル",
-        "ja_typings": []
+        "ja_typings": [
+          "ma-jinrefutorojikaru"
+        ]
       },
       {
         "en": "padding-inline-start",
         "ja": "パディングインラインスタート",
-        "ja_typings": []
+        "ja_typings": [
+          "padinguinrainsuta-to"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48640,22 +51873,30 @@
       {
         "en": "svmin",
         "ja": "エスブイミン",
-        "ja_typings": []
+        "ja_typings": [
+          "esubuimin"
+        ]
       },
       {
         "en": "dvmin",
         "ja": "ディーブイミン",
-        "ja_typings": []
+        "ja_typings": [
+          "di-buimin"
+        ]
       },
       {
         "en": "lvmin",
         "ja": "エルブイミン",
-        "ja_typings": []
+        "ja_typings": [
+          "erubuimin"
+        ]
       },
       {
         "en": "qvmin",
         "ja": "キューブイミン",
-        "ja_typings": []
+        "ja_typings": [
+          "kyu-buimin"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48672,22 +51913,30 @@
       {
         "en": "@font-face",
         "ja": "アットフォントフェイス",
-        "ja_typings": []
+        "ja_typings": [
+          "attofontofeisu"
+        ]
       },
       {
         "en": "@font-import",
         "ja": "アットフォントインポート",
-        "ja_typings": []
+        "ja_typings": [
+          "attofontoinpo-to"
+        ]
       },
       {
         "en": "@font-load",
         "ja": "アットフォントロード",
-        "ja_typings": []
+        "ja_typings": [
+          "attofontoro-do"
+        ]
       },
       {
         "en": "@import-font",
         "ja": "アットインポートフォント",
-        "ja_typings": []
+        "ja_typings": [
+          "attoinpo-tofonto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48704,22 +51953,30 @@
       {
         "en": "isolation",
         "ja": "アイソレーション",
-        "ja_typings": []
+        "ja_typings": [
+          "aisore-shon"
+        ]
       },
       {
         "en": "contain",
         "ja": "コンテイン",
-        "ja_typings": []
+        "ja_typings": [
+          "kontein"
+        ]
       },
       {
         "en": "will-change",
         "ja": "ウィルチェンジ",
-        "ja_typings": []
+        "ja_typings": [
+          "wiruchenji"
+        ]
       },
       {
         "en": "transform-style",
         "ja": "トランスフォームスタイル",
-        "ja_typings": []
+        "ja_typings": [
+          "toransufo-musutairu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48736,22 +51993,30 @@
       {
         "en": "CSS scoping",
         "ja": "シーエスエススコーピング",
-        "ja_typings": []
+        "ja_typings": [
+          "shi-esuesusuko-pingu"
+        ]
       },
       {
         "en": "CSS nesting",
         "ja": "シーエスエスネスティング",
-        "ja_typings": []
+        "ja_typings": [
+          "shi-esuesunesutingu"
+        ]
       },
       {
         "en": "CSS layering",
         "ja": "シーエスエスレイヤリング",
-        "ja_typings": []
+        "ja_typings": [
+          "shi-esuesureiyaringu"
+        ]
       },
       {
         "en": "CSS isolation",
         "ja": "シーエスエスアイソレーション",
-        "ja_typings": []
+        "ja_typings": [
+          "shi-esuesuaisore-shon"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48768,22 +52033,30 @@
       {
         "en": ":focus-within",
         "ja": "フォーカスウィズイン",
-        "ja_typings": []
+        "ja_typings": [
+          "fo-kasuwizuin"
+        ]
       },
       {
         "en": ":focus-visible",
         "ja": "フォーカスビジブル",
-        "ja_typings": []
+        "ja_typings": [
+          "fo-kasubijiburu"
+        ]
       },
       {
         "en": ":has-focus",
         "ja": "ハズフォーカス",
-        "ja_typings": []
+        "ja_typings": [
+          "hazufo-kasu"
+        ]
       },
       {
         "en": ":focusable",
         "ja": "フォーカサブル",
-        "ja_typings": []
+        "ja_typings": [
+          "fo-kasaburu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48800,22 +52073,30 @@
       {
         "en": "grid-template-areas",
         "ja": "グリッドテンプレートエリアズ",
-        "ja_typings": []
+        "ja_typings": [
+          "guriddotenpure-toeriazu"
+        ]
       },
       {
         "en": "grid-areas",
         "ja": "グリッドエリアズ",
-        "ja_typings": []
+        "ja_typings": [
+          "guriddoeriazu"
+        ]
       },
       {
         "en": "grid-zones",
         "ja": "グリッドゾーンズ",
-        "ja_typings": []
+        "ja_typings": [
+          "guriddozo-nzu"
+        ]
       },
       {
         "en": "grid-regions",
         "ja": "グリッドリージョンズ",
-        "ja_typings": []
+        "ja_typings": [
+          "guriddori-jonzu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48832,22 +52113,30 @@
       {
         "en": "<details>",
         "ja": "ディテイルズ",
-        "ja_typings": []
+        "ja_typings": [
+          "diteiruzu"
+        ]
       },
       {
         "en": "<summary>",
         "ja": "サマリー",
-        "ja_typings": []
+        "ja_typings": [
+          "samari-"
+        ]
       },
       {
         "en": "<dialog>",
         "ja": "ダイアログ",
-        "ja_typings": []
+        "ja_typings": [
+          "daiarogu"
+        ]
       },
       {
         "en": "<menu>",
         "ja": "メニュー",
-        "ja_typings": []
+        "ja_typings": [
+          "menyu-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48864,22 +52153,30 @@
       {
         "en": "draggable",
         "ja": "ドラッガブル",
-        "ja_typings": []
+        "ja_typings": [
+          "doraggaburu"
+        ]
       },
       {
         "en": "droppable",
         "ja": "ドロッパブル",
-        "ja_typings": []
+        "ja_typings": [
+          "doroppaburu"
+        ]
       },
       {
         "en": "movable",
         "ja": "ムーバブル",
-        "ja_typings": []
+        "ja_typings": [
+          "mu-baburu"
+        ]
       },
       {
         "en": "dragstart",
         "ja": "ドラッグスタート",
-        "ja_typings": []
+        "ja_typings": [
+          "doraggusuta-to"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48896,22 +52193,30 @@
       {
         "en": "type=\"color\"",
         "ja": "タイプカラー",
-        "ja_typings": []
+        "ja_typings": [
+          "taipukara-"
+        ]
       },
       {
         "en": "type=\"picker\"",
         "ja": "タイプピッカー",
-        "ja_typings": []
+        "ja_typings": [
+          "taipupikka-"
+        ]
       },
       {
         "en": "type=\"palette\"",
         "ja": "タイプパレット",
-        "ja_typings": []
+        "ja_typings": [
+          "taipuparetto"
+        ]
       },
       {
         "en": "type=\"hue\"",
         "ja": "タイプヒュー",
-        "ja_typings": []
+        "ja_typings": [
+          "taipuhyu-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48928,22 +52233,30 @@
       {
         "en": "<fieldset>",
         "ja": "フィールドセット",
-        "ja_typings": []
+        "ja_typings": [
+          "fi-rudosetto"
+        ]
       },
       {
         "en": "<formgroup>",
         "ja": "フォームグループ",
-        "ja_typings": []
+        "ja_typings": [
+          "fo-muguru-pu"
+        ]
       },
       {
         "en": "<inputs>",
         "ja": "インプッツ",
-        "ja_typings": []
+        "ja_typings": [
+          "inputtsu"
+        ]
       },
       {
         "en": "<group>",
         "ja": "グループ",
-        "ja_typings": []
+        "ja_typings": [
+          "guru-pu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48960,22 +52273,30 @@
       {
         "en": "Cache API",
         "ja": "キャッシュエーピーアイ",
-        "ja_typings": []
+        "ja_typings": [
+          "kyasshue-pi-ai"
+        ]
       },
       {
         "en": "File System API",
         "ja": "ファイルシステムエーピーアイ",
-        "ja_typings": []
+        "ja_typings": [
+          "fairushisutemue-pi-ai"
+        ]
       },
       {
         "en": "Background Sync API",
         "ja": "バックグラウンドシンクエーピーアイ",
-        "ja_typings": []
+        "ja_typings": [
+          "bakkuguraundoshinkue-pi-ai"
+        ]
       },
       {
         "en": "Storage Foundation API",
         "ja": "ストレージファウンデーションエーピーアイ",
-        "ja_typings": []
+        "ja_typings": [
+          "sutore-jifaunde-shonne-pi-ai"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -48993,28 +52314,32 @@
         "en": "409",
         "ja": "ヨンマルキュウ",
         "ja_typings": [
-          "409"
+          "409",
+          "yonmarukyuu"
         ]
       },
       {
         "en": "410",
         "ja": "ヨンイチマル",
         "ja_typings": [
-          "410"
+          "410",
+          "yonnichimaru"
         ]
       },
       {
         "en": "412",
         "ja": "ヨンイチニ",
         "ja_typings": [
-          "412"
+          "412",
+          "yonnichini"
         ]
       },
       {
         "en": "428",
         "ja": "ヨンニハチ",
         "ja_typings": [
-          "428"
+          "428",
+          "yonnnihachi"
         ]
       }
     ],
@@ -49032,22 +52357,30 @@
       {
         "en": "Gone",
         "ja": "ゴーン",
-        "ja_typings": []
+        "ja_typings": [
+          "go-n"
+        ]
       },
       {
         "en": "Forbidden",
         "ja": "フォービドゥン",
-        "ja_typings": []
+        "ja_typings": [
+          "fo-bidun"
+        ]
       },
       {
         "en": "Unauthorized",
         "ja": "アンオーソライズド",
-        "ja_typings": []
+        "ja_typings": [
+          "anno-soraizudo"
+        ]
       },
       {
         "en": "Locked",
         "ja": "ロックト",
-        "ja_typings": []
+        "ja_typings": [
+          "rokkuto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49064,22 +52397,31 @@
       {
         "en": "Access-Control-Max-Age",
         "ja": "アクセスコントロールマックスエイジ",
-        "ja_typings": []
+        "ja_typings": [
+          "akusesukontoro-rumakkusueiji"
+        ]
       },
       {
         "en": "Access-Control-Allow-Origin",
         "ja": "アクセスコントロールアロウオリジン",
-        "ja_typings": []
+        "ja_typings": [
+          "akusesukontoro-ruaroorijin",
+          "akusesukontoro-ruarouorijin"
+        ]
       },
       {
         "en": "Access-Control-Expose-Headers",
         "ja": "アクセスコントロールエクスポーズヘッダーズ",
-        "ja_typings": []
+        "ja_typings": [
+          "akusesukontoro-ruekusupo-zuhedda-zu"
+        ]
       },
       {
         "en": "Access-Control-Request-Headers",
         "ja": "アクセスコントロールリクエストヘッダーズ",
-        "ja_typings": []
+        "ja_typings": [
+          "akusesukontoro-rurikuesutohedda-zu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49096,22 +52438,30 @@
       {
         "en": "X-Forwarded-Proto",
         "ja": "エックスフォワーデッドプロト",
-        "ja_typings": []
+        "ja_typings": [
+          "ekkusufowa-deddopuroto"
+        ]
       },
       {
         "en": "X-Forwarded-For",
         "ja": "エックスフォワーデッドフォー",
-        "ja_typings": []
+        "ja_typings": [
+          "ekkusufowa-deddofo-"
+        ]
       },
       {
         "en": "X-Real-IP",
         "ja": "エックスリアルアイピー",
-        "ja_typings": []
+        "ja_typings": [
+          "ekkusuriaruaipi-"
+        ]
       },
       {
         "en": "Forwarded",
         "ja": "フォワーデッド",
-        "ja_typings": []
+        "ja_typings": [
+          "fowa-deddo"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49128,22 +52478,30 @@
       {
         "en": "Strict-Transport-Security",
         "ja": "ストリクトトランスポートセキュリティ",
-        "ja_typings": []
+        "ja_typings": [
+          "sutorikutotoransupo-tosekyuriti"
+        ]
       },
       {
         "en": "X-Content-Type-Options",
         "ja": "エックスコンテントタイプオプションズ",
-        "ja_typings": []
+        "ja_typings": [
+          "ekkusukontentotaipuopushonzu"
+        ]
       },
       {
         "en": "Permissions-Policy",
         "ja": "パーミッションズポリシー",
-        "ja_typings": []
+        "ja_typings": [
+          "pa-misshonzuporishi-"
+        ]
       },
       {
         "en": "Referrer-Policy",
         "ja": "リファラーポリシー",
-        "ja_typings": []
+        "ja_typings": [
+          "rifara-porishi-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49160,22 +52518,30 @@
       {
         "en": "HEAD method",
         "ja": "ヘッドメソッド",
-        "ja_typings": []
+        "ja_typings": [
+          "heddomesoddo"
+        ]
       },
       {
         "en": "META method",
         "ja": "メタメソッド",
-        "ja_typings": []
+        "ja_typings": [
+          "metamesoddo"
+        ]
       },
       {
         "en": "INFO method",
         "ja": "インフォメソッド",
-        "ja_typings": []
+        "ja_typings": [
+          "infomesoddo"
+        ]
       },
       {
         "en": "STAT method",
         "ja": "スタットメソッド",
-        "ja_typings": []
+        "ja_typings": [
+          "sutattomesoddo"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49192,22 +52558,30 @@
       {
         "en": "ResizeObserver",
         "ja": "リサイズオブザーバー",
-        "ja_typings": []
+        "ja_typings": [
+          "risaizuobuza-ba-"
+        ]
       },
       {
         "en": "MutationObserver",
         "ja": "ミューテーションオブザーバー",
-        "ja_typings": []
+        "ja_typings": [
+          "myu-te-shonnobuza-ba-"
+        ]
       },
       {
         "en": "IntersectionObserver",
         "ja": "インターセクションオブザーバー",
-        "ja_typings": []
+        "ja_typings": [
+          "inta-sekushonnobuza-ba-"
+        ]
       },
       {
         "en": "PerformanceObserver",
         "ja": "パフォーマンスオブザーバー",
-        "ja_typings": []
+        "ja_typings": [
+          "pafo-mansuobuza-ba-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49224,22 +52598,31 @@
       {
         "en": "Intersection Observer",
         "ja": "インターセクションオブザーバー",
-        "ja_typings": []
+        "ja_typings": [
+          "inta-sekushonnobuza-ba-"
+        ]
       },
       {
         "en": "Visibility Observer",
         "ja": "ビジビリティオブザーバー",
-        "ja_typings": []
+        "ja_typings": [
+          "bijibiritiobuza-ba-"
+        ]
       },
       {
         "en": "Viewport Observer",
         "ja": "ビューポートオブザーバー",
-        "ja_typings": []
+        "ja_typings": [
+          "byu-po-tobuza-ba-",
+          "byu-po-toobuza-ba-"
+        ]
       },
       {
         "en": "Scroll Observer",
         "ja": "スクロールオブザーバー",
-        "ja_typings": []
+        "ja_typings": [
+          "sukuro-ruobuza-ba-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49256,22 +52639,30 @@
       {
         "en": "Push API",
         "ja": "プッシュエーピーアイ",
-        "ja_typings": []
+        "ja_typings": [
+          "pusshue-pi-ai"
+        ]
       },
       {
         "en": "Alert API",
         "ja": "アラートエーピーアイ",
-        "ja_typings": []
+        "ja_typings": [
+          "ara-toe-pi-ai"
+        ]
       },
       {
         "en": "Notification only",
         "ja": "ノティフィケーションオンリー",
-        "ja_typings": []
+        "ja_typings": [
+          "notifike-shonnonri-"
+        ]
       },
       {
         "en": "Background API",
         "ja": "バックグラウンドエーピーアイ",
-        "ja_typings": []
+        "ja_typings": [
+          "bakkuguraundoe-pi-ai"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49288,22 +52679,30 @@
       {
         "en": "CacheStorage",
         "ja": "キャッシュストレージ",
-        "ja_typings": []
+        "ja_typings": [
+          "kyasshusutore-ji"
+        ]
       },
       {
         "en": "FileSystem Access",
         "ja": "ファイルシステムアクセス",
-        "ja_typings": []
+        "ja_typings": [
+          "fairushisutemuakusesu"
+        ]
       },
       {
         "en": "WebSQL",
         "ja": "ウェブエスキューエル",
-        "ja_typings": []
+        "ja_typings": [
+          "webuesukyu-eru"
+        ]
       },
       {
         "en": "AppCache",
         "ja": "アップキャッシュ",
-        "ja_typings": []
+        "ja_typings": [
+          "appukyasshu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49320,22 +52719,30 @@
       {
         "en": "Web Share Target",
         "ja": "ウェブシェアターゲット",
-        "ja_typings": []
+        "ja_typings": [
+          "webusheata-getto"
+        ]
       },
       {
         "en": "Share Receiver API",
         "ja": "シェアレシーバーエーピーアイ",
-        "ja_typings": []
+        "ja_typings": [
+          "sheareshi-ba-e-pi-ai"
+        ]
       },
       {
         "en": "Web Sync",
         "ja": "ウェブシンク",
-        "ja_typings": []
+        "ja_typings": [
+          "webushinku"
+        ]
       },
       {
         "en": "Web Receive",
         "ja": "ウェブレシーブ",
-        "ja_typings": []
+        "ja_typings": [
+          "webureshi-bu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49352,22 +52759,30 @@
       {
         "en": "Performance.now",
         "ja": "パフォーマンスナウ",
-        "ja_typings": []
+        "ja_typings": [
+          "pafo-mansunau"
+        ]
       },
       {
         "en": "Date.now",
         "ja": "デートナウ",
-        "ja_typings": []
+        "ja_typings": [
+          "de-tonau"
+        ]
       },
       {
         "en": "Timing.now",
         "ja": "タイミングナウ",
-        "ja_typings": []
+        "ja_typings": [
+          "taimingunau"
+        ]
       },
       {
         "en": "Clock.now",
         "ja": "クロックナウ",
-        "ja_typings": []
+        "ja_typings": [
+          "kurokkunau"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49384,22 +52799,30 @@
       {
         "en": "Web Speech Recognition",
         "ja": "ウェブスピーチレコグニッション",
-        "ja_typings": []
+        "ja_typings": [
+          "webusupi-chirekogunisshon"
+        ]
       },
       {
         "en": "Web Audio API",
         "ja": "ウェブオーディオエーピーアイ",
-        "ja_typings": []
+        "ja_typings": [
+          "webuo-dioe-pi-ai"
+        ]
       },
       {
         "en": "Media Capture",
         "ja": "メディアキャプチャ",
-        "ja_typings": []
+        "ja_typings": [
+          "mediakyapucha"
+        ]
       },
       {
         "en": "MediaStream API",
         "ja": "メディアストリームエーピーアイ",
-        "ja_typings": []
+        "ja_typings": [
+          "mediasutori-mue-pi-ai"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49416,22 +52839,30 @@
       {
         "en": "useSyncExternalStore",
         "ja": "ユーズシンクエクスターナルストア",
-        "ja_typings": []
+        "ja_typings": [
+          "yu-zushinkuekusuta-narusutoa"
+        ]
       },
       {
         "en": "useStore",
         "ja": "ユーズストア",
-        "ja_typings": []
+        "ja_typings": [
+          "yu-zusutoa"
+        ]
       },
       {
         "en": "useSubscribe",
         "ja": "ユーズサブスクライブ",
-        "ja_typings": []
+        "ja_typings": [
+          "yu-zusabusukuraibu"
+        ]
       },
       {
         "en": "useExternal",
         "ja": "ユーズエクスターナル",
-        "ja_typings": []
+        "ja_typings": [
+          "yu-zuekusuta-naru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49448,22 +52879,30 @@
       {
         "en": "defineProps",
         "ja": "ディファインプロップス",
-        "ja_typings": []
+        "ja_typings": [
+          "difainpuroppusu"
+        ]
       },
       {
         "en": "declareProps",
         "ja": "デクレアプロップス",
-        "ja_typings": []
+        "ja_typings": [
+          "dekureapuroppusu"
+        ]
       },
       {
         "en": "useProps",
         "ja": "ユーズプロップス",
-        "ja_typings": []
+        "ja_typings": [
+          "yu-zupuroppusu"
+        ]
       },
       {
         "en": "propsMacro",
         "ja": "プロップスマクロ",
-        "ja_typings": []
+        "ja_typings": [
+          "puroppusumakuro"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49480,22 +52919,31 @@
       {
         "en": "on:event",
         "ja": "オンイベント",
-        "ja_typings": []
+        "ja_typings": [
+          "onnibento"
+        ]
       },
       {
         "en": "bind:event",
         "ja": "バインドイベント",
-        "ja_typings": []
+        "ja_typings": [
+          "baindoibento"
+        ]
       },
       {
         "en": "use:event",
         "ja": "ユーズイベント",
-        "ja_typings": []
+        "ja_typings": [
+          "yu-zuibento"
+        ]
       },
       {
         "en": "event:on",
         "ja": "イベントオン",
-        "ja_typings": []
+        "ja_typings": [
+          "ibenton",
+          "ibentoon"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49512,22 +52960,30 @@
       {
         "en": "SSR",
         "ja": "エスエスアール",
-        "ja_typings": []
+        "ja_typings": [
+          "esuesua-ru"
+        ]
       },
       {
         "en": "SSG",
         "ja": "エスエスジー",
-        "ja_typings": []
+        "ja_typings": [
+          "esuesuji-"
+        ]
       },
       {
         "en": "ISR",
         "ja": "アイエスアール",
-        "ja_typings": []
+        "ja_typings": [
+          "aiesua-ru"
+        ]
       },
       {
         "en": "CSR",
         "ja": "シーエスアール",
-        "ja_typings": []
+        "ja_typings": [
+          "shi-esua-ru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49544,22 +53000,30 @@
       {
         "en": "Incremental Static Regeneration",
         "ja": "インクリメンタルスタティックリジェネレーション",
-        "ja_typings": []
+        "ja_typings": [
+          "inkurimentarusutatikkurijenere-shon"
+        ]
       },
       {
         "en": "Edge Streaming",
         "ja": "エッジストリーミング",
-        "ja_typings": []
+        "ja_typings": [
+          "ejjisutori-mingu"
+        ]
       },
       {
         "en": "Static Hydration",
         "ja": "スタティックハイドレーション",
-        "ja_typings": []
+        "ja_typings": [
+          "sutatikkuhaidore-shon"
+        ]
       },
       {
         "en": "Parallel Routes",
         "ja": "パラレルルーツ",
-        "ja_typings": []
+        "ja_typings": [
+          "parareruru-tsu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49576,22 +53040,30 @@
       {
         "en": "Islands architecture",
         "ja": "アイランズアーキテクチャ",
-        "ja_typings": []
+        "ja_typings": [
+          "airanzua-kitekucha"
+        ]
       },
       {
         "en": "Edge rendering",
         "ja": "エッジレンダリング",
-        "ja_typings": []
+        "ja_typings": [
+          "ejjirendaringu"
+        ]
       },
       {
         "en": "Static suspense",
         "ja": "スタティックサスペンス",
-        "ja_typings": []
+        "ja_typings": [
+          "sutatikkusasupensu"
+        ]
       },
       {
         "en": "Server components",
         "ja": "サーバーコンポーネンツ",
-        "ja_typings": []
+        "ja_typings": [
+          "sa-ba-konpo-nentsu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49608,22 +53080,30 @@
       {
         "en": "Layout",
         "ja": "レイアウト",
-        "ja_typings": []
+        "ja_typings": [
+          "reiauto"
+        ]
       },
       {
         "en": "Paint",
         "ja": "ペイント",
-        "ja_typings": []
+        "ja_typings": [
+          "peinto"
+        ]
       },
       {
         "en": "Composite",
         "ja": "コンポジット",
-        "ja_typings": []
+        "ja_typings": [
+          "konpojitto"
+        ]
       },
       {
         "en": "Style",
         "ja": "スタイル",
-        "ja_typings": []
+        "ja_typings": [
+          "sutairu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49640,22 +53120,30 @@
       {
         "en": "Compositing",
         "ja": "コンポジティング",
-        "ja_typings": []
+        "ja_typings": [
+          "konpojitingu"
+        ]
       },
       {
         "en": "Layouting",
         "ja": "レイアウティング",
-        "ja_typings": []
+        "ja_typings": [
+          "reiautingu"
+        ]
       },
       {
         "en": "Painting",
         "ja": "ペインティング",
-        "ja_typings": []
+        "ja_typings": [
+          "peintingu"
+        ]
       },
       {
         "en": "Rasterizing",
         "ja": "ラスタライジング",
-        "ja_typings": []
+        "ja_typings": [
+          "rasutaraijingu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49672,22 +53160,30 @@
       {
         "en": "DOMContentLoaded",
         "ja": "ドムコンテントローデッド",
-        "ja_typings": []
+        "ja_typings": [
+          "domukontentoro-deddo"
+        ]
       },
       {
         "en": "load",
         "ja": "ロード",
-        "ja_typings": []
+        "ja_typings": [
+          "ro-do"
+        ]
       },
       {
         "en": "readystatechange",
         "ja": "レディステートチェンジ",
-        "ja_typings": []
+        "ja_typings": [
+          "redisute-tochenji"
+        ]
       },
       {
         "en": "beforeunload",
         "ja": "ビフォアアンロード",
-        "ja_typings": []
+        "ja_typings": [
+          "bifoaanro-do"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49704,22 +53200,30 @@
       {
         "en": "Site Isolation",
         "ja": "サイトアイソレーション",
-        "ja_typings": []
+        "ja_typings": [
+          "saitoaisore-shon"
+        ]
       },
       {
         "en": "Origin Isolation",
         "ja": "オリジンアイソレーション",
-        "ja_typings": []
+        "ja_typings": [
+          "orijinnaisore-shon"
+        ]
       },
       {
         "en": "Frame Sandbox",
         "ja": "フレームサンドボックス",
-        "ja_typings": []
+        "ja_typings": [
+          "fure-musandobokkusu"
+        ]
       },
       {
         "en": "Process Sharding",
         "ja": "プロセスシャーディング",
-        "ja_typings": []
+        "ja_typings": [
+          "purosesusha-dingu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49736,22 +53240,30 @@
       {
         "en": "SharedArrayBuffer",
         "ja": "シェアードアレイバッファ",
-        "ja_typings": []
+        "ja_typings": [
+          "shea-doareibaffa"
+        ]
       },
       {
         "en": "ArrayBuffer",
         "ja": "アレイバッファ",
-        "ja_typings": []
+        "ja_typings": [
+          "areibaffa"
+        ]
       },
       {
         "en": "DataView",
         "ja": "データビュー",
-        "ja_typings": []
+        "ja_typings": [
+          "de-tabyu-"
+        ]
       },
       {
         "en": "ImageBitmap",
         "ja": "イメージビットマップ",
-        "ja_typings": []
+        "ja_typings": [
+          "ime-jibittomappu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49768,22 +53280,30 @@
       {
         "en": "UI redressing",
         "ja": "ユーアイリドレッシング",
-        "ja_typings": []
+        "ja_typings": [
+          "yu-airidoresshingu"
+        ]
       },
       {
         "en": "Click hijacking",
         "ja": "クリックハイジャッキング",
-        "ja_typings": []
+        "ja_typings": [
+          "kurikkuhaijakkingu"
+        ]
       },
       {
         "en": "DOM clobbering",
         "ja": "ドムクロバリング",
-        "ja_typings": []
+        "ja_typings": [
+          "domukurobaringu"
+        ]
       },
       {
         "en": "Tab nabbing",
         "ja": "タブナビング",
-        "ja_typings": []
+        "ja_typings": [
+          "tabunabingu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49801,23 +53321,29 @@
         "en": "Inline script allowlisting",
         "ja": "インラインスクリプト許可リスト",
         "ja_typings": [
-          "インラインスクリプトキョカリスト"
+          "inrainsukuriputokyokarisuto"
         ]
       },
       {
         "en": "CORS preflight",
         "ja": "コルスプリフライト",
-        "ja_typings": []
+        "ja_typings": [
+          "korusupurifuraito"
+        ]
       },
       {
         "en": "HSTS preload",
         "ja": "エイチエスティーエスプリロード",
-        "ja_typings": []
+        "ja_typings": [
+          "eichiesuti-esupuriro-do"
+        ]
       },
       {
         "en": "Mixed content blocking",
         "ja": "ミックスドコンテンツブロッキング",
-        "ja_typings": []
+        "ja_typings": [
+          "mikkusudokontentsuburokkingu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49834,22 +53360,31 @@
       {
         "en": "X-Content-Type-Options",
         "ja": "エックスコンテントタイプオプションズ",
-        "ja_typings": []
+        "ja_typings": [
+          "ekkusukontentotaipuopushonzu"
+        ]
       },
       {
         "en": "X-Frame-Options",
         "ja": "エックスフレームオプションズ",
-        "ja_typings": []
+        "ja_typings": [
+          "ekkusufure-muopushonzu"
+        ]
       },
       {
         "en": "X-XSS-Protection",
         "ja": "エックスエックスエスエスプロテクション",
-        "ja_typings": []
+        "ja_typings": [
+          "ekkusuekkusuesuesupurotekushon"
+        ]
       },
       {
         "en": "X-Download-Options",
         "ja": "エックスダウンロードオプションズ",
-        "ja_typings": []
+        "ja_typings": [
+          "ekkusudaunro-dopushonzu",
+          "ekkusudaunro-doopushonzu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49866,22 +53401,30 @@
       {
         "en": "DNS cache poisoning",
         "ja": "ディーエヌエスキャッシュポイズニング",
-        "ja_typings": []
+        "ja_typings": [
+          "di-enuesukyasshupoizuningu"
+        ]
       },
       {
         "en": "DNS rebinding",
         "ja": "ディーエヌエスリバインディング",
-        "ja_typings": []
+        "ja_typings": [
+          "di-enuesuribaindingu"
+        ]
       },
       {
         "en": "DNS tunneling",
         "ja": "ディーエヌエストンネリング",
-        "ja_typings": []
+        "ja_typings": [
+          "di-enuesutonnneringu"
+        ]
       },
       {
         "en": "DNS spoofing reply",
         "ja": "ディーエヌエススプーフィングリプライ",
-        "ja_typings": []
+        "ja_typings": [
+          "di-enuesusupu-finguripurai"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49898,22 +53441,31 @@
       {
         "en": "frame-ancestors",
         "ja": "フレームアンセスターズ",
-        "ja_typings": []
+        "ja_typings": [
+          "fure-muansesuta-zu"
+        ]
       },
       {
         "en": "frame-src",
         "ja": "フレームエスアールシー",
-        "ja_typings": []
+        "ja_typings": [
+          "fure-muesua-rushi-"
+        ]
       },
       {
         "en": "X-Embed-Options",
         "ja": "エックスエンベッドオプションズ",
-        "ja_typings": []
+        "ja_typings": [
+          "ekkusuenbeddopushonzu",
+          "ekkusuenbeddoopushonzu"
+        ]
       },
       {
         "en": "frame-deny-directive",
         "ja": "フレームデナイディレクティブ",
-        "ja_typings": []
+        "ja_typings": [
+          "fure-mudenaidirekutibu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49930,22 +53482,30 @@
       {
         "en": "Anti-CSRF token",
         "ja": "アンチシーエスアールエフトークン",
-        "ja_typings": []
+        "ja_typings": [
+          "anchishi-esua-ruefuto-kun"
+        ]
       },
       {
         "en": "Bearer token",
         "ja": "ベアラートークン",
-        "ja_typings": []
+        "ja_typings": [
+          "beara-to-kun"
+        ]
       },
       {
         "en": "Session token",
         "ja": "セッショントークン",
-        "ja_typings": []
+        "ja_typings": [
+          "sesshonto-kun"
+        ]
       },
       {
         "en": "Refresh token",
         "ja": "リフレッシュトークン",
-        "ja_typings": []
+        "ja_typings": [
+          "rifuresshuto-kun"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49962,22 +53522,30 @@
       {
         "en": "aria-live",
         "ja": "アリアライブ",
-        "ja_typings": []
+        "ja_typings": [
+          "ariaraibu"
+        ]
       },
       {
         "en": "aria-busy",
         "ja": "アリアビジー",
-        "ja_typings": []
+        "ja_typings": [
+          "ariabiji-"
+        ]
       },
       {
         "en": "aria-atomic",
         "ja": "アリアアトミック",
-        "ja_typings": []
+        "ja_typings": [
+          "ariaatomikku"
+        ]
       },
       {
         "en": "aria-relevant",
         "ja": "アリアレレバント",
-        "ja_typings": []
+        "ja_typings": [
+          "ariarerebanto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -49994,22 +53562,30 @@
       {
         "en": "main",
         "ja": "メイン",
-        "ja_typings": []
+        "ja_typings": [
+          "mein"
+        ]
       },
       {
         "en": "primary",
         "ja": "プライマリ",
-        "ja_typings": []
+        "ja_typings": [
+          "puraimari"
+        ]
       },
       {
         "en": "content",
         "ja": "コンテンツ",
-        "ja_typings": []
+        "ja_typings": [
+          "kontentsu"
+        ]
       },
       {
         "en": "body",
         "ja": "ボディ",
-        "ja_typings": []
+        "ja_typings": [
+          "bodi"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -50026,22 +53602,30 @@
       {
         "en": "aria-hidden",
         "ja": "アリアヒドゥン",
-        "ja_typings": []
+        "ja_typings": [
+          "ariahidun"
+        ]
       },
       {
         "en": "aria-skip",
         "ja": "アリアスキップ",
-        "ja_typings": []
+        "ja_typings": [
+          "ariasukippu"
+        ]
       },
       {
         "en": "aria-decorative",
         "ja": "アリアデコラティブ",
-        "ja_typings": []
+        "ja_typings": [
+          "ariadekoratibu"
+        ]
       },
       {
         "en": "aria-omit",
         "ja": "アリアオミット",
-        "ja_typings": []
+        "ja_typings": [
+          "ariaomitto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -50059,28 +53643,32 @@
         "en": "4.5:1",
         "ja": "ヨンテンゴタイイチ",
         "ja_typings": [
-          "4.5:1"
+          "4.5:1",
+          "yontengotaiichi"
         ]
       },
       {
         "en": "3:1",
         "ja": "サンタイイチ",
         "ja_typings": [
-          "3:1"
+          "3:1",
+          "santaiichi"
         ]
       },
       {
         "en": "7:1",
         "ja": "ナナタイイチ",
         "ja_typings": [
-          "7:1"
+          "7:1",
+          "nanataiichi"
         ]
       },
       {
         "en": "2:1",
         "ja": "ニタイイチ",
         "ja_typings": [
-          "2:1"
+          "2:1",
+          "nitaiichi"
         ]
       }
     ],
@@ -50098,22 +53686,30 @@
       {
         "en": "INP",
         "ja": "アイエヌピー",
-        "ja_typings": []
+        "ja_typings": [
+          "aienupi-"
+        ]
       },
       {
         "en": "FID",
         "ja": "エフアイディー",
-        "ja_typings": []
+        "ja_typings": [
+          "efuaidi-"
+        ]
       },
       {
         "en": "TBT",
         "ja": "ティービーティー",
-        "ja_typings": []
+        "ja_typings": [
+          "ti-bi-ti-"
+        ]
       },
       {
         "en": "TTI",
         "ja": "ティーティーアイ",
-        "ja_typings": []
+        "ja_typings": [
+          "ti-ti-ai"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -50130,22 +53726,30 @@
       {
         "en": "CLS",
         "ja": "シーエルエス",
-        "ja_typings": []
+        "ja_typings": [
+          "shi-eruesu"
+        ]
       },
       {
         "en": "LCP",
         "ja": "エルシーピー",
-        "ja_typings": []
+        "ja_typings": [
+          "erushi-pi-"
+        ]
       },
       {
         "en": "FCP",
         "ja": "エフシーピー",
-        "ja_typings": []
+        "ja_typings": [
+          "efushi-pi-"
+        ]
       },
       {
         "en": "TTFB",
         "ja": "ティーティーエフビー",
-        "ja_typings": []
+        "ja_typings": [
+          "ti-ti-efubi-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -50162,22 +53766,30 @@
       {
         "en": "Dynamic import",
         "ja": "ダイナミックインポート",
-        "ja_typings": []
+        "ja_typings": [
+          "dainamikkuinpo-to"
+        ]
       },
       {
         "en": "Static import",
         "ja": "スタティックインポート",
-        "ja_typings": []
+        "ja_typings": [
+          "sutatikkuinpo-to"
+        ]
       },
       {
         "en": "Eager import",
         "ja": "イーガーインポート",
-        "ja_typings": []
+        "ja_typings": [
+          "i-ga-inpo-to"
+        ]
       },
       {
         "en": "Bundle import",
         "ja": "バンドルインポート",
-        "ja_typings": []
+        "ja_typings": [
+          "bandoruinpo-to"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -50194,22 +53806,30 @@
       {
         "en": "rel=\"preload\"",
         "ja": "レルプリロード",
-        "ja_typings": []
+        "ja_typings": [
+          "rerupuriro-do"
+        ]
       },
       {
         "en": "rel=\"prefetch\"",
         "ja": "レルプリフェッチ",
-        "ja_typings": []
+        "ja_typings": [
+          "rerupurifetchi"
+        ]
       },
       {
         "en": "rel=\"preconnect\"",
         "ja": "レルプリコネクト",
-        "ja_typings": []
+        "ja_typings": [
+          "rerupurikonekuto"
+        ]
       },
       {
         "en": "rel=\"dns-prefetch\"",
         "ja": "レルディーエヌエスプリフェッチ",
-        "ja_typings": []
+        "ja_typings": [
+          "rerudi-enuesupurifetchi"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -50226,22 +53846,30 @@
       {
         "en": "AVIF",
         "ja": "エイビフ",
-        "ja_typings": []
+        "ja_typings": [
+          "eibifu"
+        ]
       },
       {
         "en": "HEIF",
         "ja": "ヘイフ",
-        "ja_typings": []
+        "ja_typings": [
+          "heifu"
+        ]
       },
       {
         "en": "JXL",
         "ja": "ジェイエックスエル",
-        "ja_typings": []
+        "ja_typings": [
+          "jeiekkusueru"
+        ]
       },
       {
         "en": "APNG",
         "ja": "エーピーエヌジー",
-        "ja_typings": []
+        "ja_typings": [
+          "e-pi-enuji-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -50258,22 +53886,30 @@
       {
         "en": "Critical CSS inlining",
         "ja": "クリティカルシーエスエスインライニング",
-        "ja_typings": []
+        "ja_typings": [
+          "kuritikarushi-esuesuinrainingu"
+        ]
       },
       {
         "en": "CSS hoisting",
         "ja": "シーエスエスホイスティング",
-        "ja_typings": []
+        "ja_typings": [
+          "shi-esuesuhoisutingu"
+        ]
       },
       {
         "en": "CSS shaking",
         "ja": "シーエスエスシェイキング",
-        "ja_typings": []
+        "ja_typings": [
+          "shi-esuesusheikingu"
+        ]
       },
       {
         "en": "CSS splitting",
         "ja": "シーエスエススプリッティング",
-        "ja_typings": []
+        "ja_typings": [
+          "shi-esuesusupurittingu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -50290,22 +53926,31 @@
       {
         "en": "HTTP over QUIC",
         "ja": "エイチティーティーピーオーバークイック",
-        "ja_typings": []
+        "ja_typings": [
+          "eichiti-ti-pi-o-ba-kuikku"
+        ]
       },
       {
         "en": "SPDY",
         "ja": "スピーディー",
-        "ja_typings": []
+        "ja_typings": [
+          "supi-di-"
+        ]
       },
       {
         "en": "MPTCP",
         "ja": "エムピーティーシーピー",
-        "ja_typings": []
+        "ja_typings": [
+          "emupi-ti-shi-pi-"
+        ]
       },
       {
         "en": "WebTransport over TCP",
         "ja": "ウェブトランスポートオーバーティーシーピー",
-        "ja_typings": []
+        "ja_typings": [
+          "webutoransupo-to-ba-ti-shi-pi-",
+          "webutoransupo-too-ba-ti-shi-pi-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -50322,24 +53967,31 @@
       {
         "en": "WHATWG URL",
         "ja": "ワットダブリュージーユーアールエル",
-        "ja_typings": []
+        "ja_typings": [
+          "wattodaburyu-ji-yu-a-rueru"
+        ]
       },
       {
         "en": "RFC 3986 strict",
         "ja": "アールエフシーサンキュウハチロクストリクト",
         "ja_typings": [
-          "RFC 3986 strict"
+          "RFC 3986 strict",
+          "a-ruefushi-sankyuuhachirokusutorikuto"
         ]
       },
       {
         "en": "ICANN URL",
         "ja": "アイキャンユーアールエル",
-        "ja_typings": []
+        "ja_typings": [
+          "aikyannyu-a-rueru"
+        ]
       },
       {
         "en": "W3C URL spec",
         "ja": "ダブリュースリーシーユーアールエルスペック",
-        "ja_typings": []
+        "ja_typings": [
+          "daburyu-suri-shi-yu-a-ruerusupekku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -50356,22 +54008,30 @@
       {
         "en": "createDocumentFragment",
         "ja": "クリエイトドキュメントフラグメント",
-        "ja_typings": []
+        "ja_typings": [
+          "kurieitodokyumentofuragumento"
+        ]
       },
       {
         "en": "createFragment",
         "ja": "クリエイトフラグメント",
-        "ja_typings": []
+        "ja_typings": [
+          "kurieitofuragumento"
+        ]
       },
       {
         "en": "makeFragment",
         "ja": "メイクフラグメント",
-        "ja_typings": []
+        "ja_typings": [
+          "meikufuragumento"
+        ]
       },
       {
         "en": "newFragment",
         "ja": "ニューフラグメント",
-        "ja_typings": []
+        "ja_typings": [
+          "nyu-furagumento"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -50388,22 +54048,30 @@
       {
         "en": "PWA manifest",
         "ja": "ピーダブリューエーマニフェスト",
-        "ja_typings": []
+        "ja_typings": [
+          "pi-daburyu-e-manifesuto"
+        ]
       },
       {
         "en": "App shell",
         "ja": "アップシェル",
-        "ja_typings": []
+        "ja_typings": [
+          "appusheru"
+        ]
       },
       {
         "en": "Web bundle",
         "ja": "ウェブバンドル",
-        "ja_typings": []
+        "ja_typings": [
+          "webubandoru"
+        ]
       },
       {
         "en": "Trusted Web Activity",
         "ja": "トラステッドウェブアクティビティ",
-        "ja_typings": []
+        "ja_typings": [
+          "torasuteddowebuakutibiti"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -50421,27 +54089,32 @@
         "en": "base64url",
         "ja": "ベースロクヨンユーアールエル",
         "ja_typings": [
-          "base64url"
+          "base64url",
+          "be-surokuyonnyu-a-rueru"
         ]
       },
       {
         "en": "base32",
         "ja": "ベースサンジュウニ",
         "ja_typings": [
-          "base32"
+          "base32",
+          "be-susanjuuni"
         ]
       },
       {
         "en": "ascii85",
         "ja": "アスキーハチゴ",
         "ja_typings": [
-          "ascii85"
+          "ascii85",
+          "asuki-hachigo"
         ]
       },
       {
         "en": "punycode",
         "ja": "ピュニコード",
-        "ja_typings": []
+        "ja_typings": [
+          "pyuniko-do"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -50458,22 +54131,30 @@
       {
         "en": "contain",
         "ja": "コンテイン",
-        "ja_typings": []
+        "ja_typings": [
+          "kontein"
+        ]
       },
       {
         "en": "isolate",
         "ja": "アイソレート",
-        "ja_typings": []
+        "ja_typings": [
+          "aisore-to"
+        ]
       },
       {
         "en": "scope",
         "ja": "スコープ",
-        "ja_typings": []
+        "ja_typings": [
+          "suko-pu"
+        ]
       },
       {
         "en": "encapsulate",
         "ja": "エンキャプスレート",
-        "ja_typings": []
+        "ja_typings": [
+          "enkyapusure-to"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -50490,22 +54171,30 @@
       {
         "en": "transitionend",
         "ja": "トランジションエンド",
-        "ja_typings": []
+        "ja_typings": [
+          "toranjishonnendo"
+        ]
       },
       {
         "en": "transitioncomplete",
         "ja": "トランジションコンプリート",
-        "ja_typings": []
+        "ja_typings": [
+          "toranjishonkonpuri-to"
+        ]
       },
       {
         "en": "animationend",
         "ja": "アニメーションエンド",
-        "ja_typings": []
+        "ja_typings": [
+          "anime-shonnendo"
+        ]
       },
       {
         "en": "transitionstop",
         "ja": "トランジションストップ",
-        "ja_typings": []
+        "ja_typings": [
+          "toranjishonsutoppu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -50522,12 +54211,16 @@
       {
         "en": "My Neighbor Totoro",
         "ja": "となりのトトロ",
-        "ja_typings": []
+        "ja_typings": [
+          "tonarinototoro"
+        ]
       },
       {
         "en": "Kiki's Delivery Service",
         "ja": "魔女の宅急便",
-        "ja_typings": []
+        "ja_typings": [
+          "majonotakkyuubin"
+        ]
       },
       {
         "en": "Whisper of the Heart",
@@ -50565,7 +54258,9 @@
       {
         "en": "Only Yesterday",
         "ja": "おもひでぽろぽろ",
-        "ja_typings": []
+        "ja_typings": [
+          "omohideporoporo"
+        ]
       },
       {
         "en": "Ocean Waves",
@@ -50650,7 +54345,9 @@
       {
         "en": "Captain Future",
         "ja": "キャプテンフューチャー",
-        "ja_typings": []
+        "ja_typings": [
+          "kyaputenfuyu-cha-"
+        ]
       },
       {
         "en": "Macross",
@@ -50775,7 +54472,9 @@
       {
         "en": "Ghost in the Shell",
         "ja": "GHOST IN THE SHELL",
-        "ja_typings": []
+        "ja_typings": [
+          "ghost in the shell"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -50806,7 +54505,9 @@
       {
         "en": "My Neighbor Totoro",
         "ja": "となりのトトロ",
-        "ja_typings": []
+        "ja_typings": [
+          "tonarinototoro"
+        ]
       },
       {
         "en": "Porco Rosso",
@@ -50878,7 +54579,8 @@
         "en": "Gunbuster",
         "ja": "トップをねらえ!",
         "ja_typings": [
-          "toppuwonerae"
+          "toppuwonerae",
+          "toppuonerae"
         ]
       },
       {
@@ -50891,7 +54593,9 @@
       {
         "en": "Otaku no Video",
         "ja": "おたくのビデオ",
-        "ja_typings": []
+        "ja_typings": [
+          "otakunobideo"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -50909,18 +54613,23 @@
         "en": "Gunbuster",
         "ja": "トップをねらえ!",
         "ja_typings": [
-          "toppuwonerae"
+          "toppuwonerae",
+          "toppuonerae"
         ]
       },
       {
         "en": "Bubblegum Crisis",
         "ja": "バブルガムクライシス",
-        "ja_typings": []
+        "ja_typings": [
+          "baburugamukuraishisu"
+        ]
       },
       {
         "en": "Megazone 23",
         "ja": "メガゾーン23",
-        "ja_typings": []
+        "ja_typings": [
+          "megazo-n23"
+        ]
       },
       {
         "en": "Patlabor",
@@ -51025,7 +54734,8 @@
         "en": "Tomorrow's Joe 2",
         "ja": "あしたのジョー2",
         "ja_typings": [
-          "ashitanojoo2"
+          "ashitanojoo2",
+          "ashitanojo-2"
         ]
       },
       {
@@ -51038,12 +54748,16 @@
       {
         "en": "YAWARA!",
         "ja": "YAWARA!",
-        "ja_typings": []
+        "ja_typings": [
+          "yawara!"
+        ]
       },
       {
         "en": "Slow Step",
         "ja": "スローステップ",
-        "ja_typings": []
+        "ja_typings": [
+          "suro-suteppu"
+        ]
       }
     ],
     "correct_answer_index": 2,
@@ -51074,12 +54788,16 @@
       {
         "en": "Sonny Boy",
         "ja": "サニーボーイ",
-        "ja_typings": []
+        "ja_typings": [
+          "sani-bo-i"
+        ]
       },
       {
         "en": "Odd Taxi",
         "ja": "オッドタクシー",
-        "ja_typings": []
+        "ja_typings": [
+          "oddotakushi-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -51110,12 +54828,16 @@
       {
         "en": "Sonny Boy",
         "ja": "サニーボーイ",
-        "ja_typings": []
+        "ja_typings": [
+          "sani-bo-i"
+        ]
       },
       {
         "en": "Vivy",
         "ja": "Vivy",
-        "ja_typings": []
+        "ja_typings": [
+          "vivy"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -51132,7 +54854,9 @@
       {
         "en": "Odd Taxi",
         "ja": "オッドタクシー",
-        "ja_typings": []
+        "ja_typings": [
+          "oddotakushi-"
+        ]
       },
       {
         "en": "Heike Story",
@@ -51144,12 +54868,16 @@
       {
         "en": "Sonny Boy",
         "ja": "サニーボーイ",
-        "ja_typings": []
+        "ja_typings": [
+          "sani-bo-i"
+        ]
       },
       {
         "en": "Wonder Egg Priority",
         "ja": "ワンダーエッグ・プライオリティ",
-        "ja_typings": []
+        "ja_typings": [
+          "wanda-eggu/puraioriti"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -51166,22 +54894,30 @@
       {
         "en": "Vivy",
         "ja": "Vivy",
-        "ja_typings": []
+        "ja_typings": [
+          "vivy"
+        ]
       },
       {
         "en": "BEASTARS",
         "ja": "BEASTARS",
-        "ja_typings": []
+        "ja_typings": [
+          "beastars"
+        ]
       },
       {
         "en": "ID:INVADED",
         "ja": "イド:インヴェイデッド",
-        "ja_typings": []
+        "ja_typings": [
+          "ido inveideddo"
+        ]
       },
       {
         "en": "Sonny Boy",
         "ja": "サニーボーイ",
-        "ja_typings": []
+        "ja_typings": [
+          "sani-bo-i"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -51198,22 +54934,30 @@
       {
         "en": "Sonny Boy",
         "ja": "サニーボーイ",
-        "ja_typings": []
+        "ja_typings": [
+          "sani-bo-i"
+        ]
       },
       {
         "en": "Odd Taxi",
         "ja": "オッドタクシー",
-        "ja_typings": []
+        "ja_typings": [
+          "oddotakushi-"
+        ]
       },
       {
         "en": "Wonder Egg Priority",
         "ja": "ワンダーエッグ・プライオリティ",
-        "ja_typings": []
+        "ja_typings": [
+          "wanda-eggu/puraioriti"
+        ]
       },
       {
         "en": "Vivy",
         "ja": "Vivy",
-        "ja_typings": []
+        "ja_typings": [
+          "vivy"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -51230,22 +54974,30 @@
       {
         "en": "Bocchi the Rock!",
         "ja": "ぼっち・ざ・ろっく!",
-        "ja_typings": []
+        "ja_typings": [
+          "botchi/za/rokku"
+        ]
       },
       {
         "en": "Skip and Loafer",
         "ja": "スキップとローファー",
-        "ja_typings": []
+        "ja_typings": [
+          "sukipputoro-fa-"
+        ]
       },
       {
         "en": "Buddy Daddies",
         "ja": "バディ・ダディズ",
-        "ja_typings": []
+        "ja_typings": [
+          "badi/dadizu"
+        ]
       },
       {
         "en": "MASHLE",
         "ja": "マッシュル",
-        "ja_typings": []
+        "ja_typings": [
+          "masshuru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -51262,17 +55014,23 @@
       {
         "en": "Skip and Loafer",
         "ja": "スキップとローファー",
-        "ja_typings": []
+        "ja_typings": [
+          "sukipputoro-fa-"
+        ]
       },
       {
         "en": "Bocchi the Rock!",
         "ja": "ぼっち・ざ・ろっく!",
-        "ja_typings": []
+        "ja_typings": [
+          "botchi/za/rokku"
+        ]
       },
       {
         "en": "MASHLE",
         "ja": "マッシュル",
-        "ja_typings": []
+        "ja_typings": [
+          "masshuru"
+        ]
       },
       {
         "en": "Heavenly Delusion",
@@ -51303,12 +55061,16 @@
       {
         "en": "Skip and Loafer",
         "ja": "スキップとローファー",
-        "ja_typings": []
+        "ja_typings": [
+          "sukipputoro-fa-"
+        ]
       },
       {
         "en": "Vinland Saga Season 2",
         "ja": "ヴィンランド・サガ SEASON2",
-        "ja_typings": []
+        "ja_typings": [
+          "vinrando/saga season2"
+        ]
       },
       {
         "en": "Hell's Paradise",
@@ -51332,22 +55094,30 @@
       {
         "en": "Vinland Saga",
         "ja": "ヴィンランド・サガ",
-        "ja_typings": []
+        "ja_typings": [
+          "vinrando/saga"
+        ]
       },
       {
         "en": "Dororo",
         "ja": "どろろ",
-        "ja_typings": []
+        "ja_typings": [
+          "dororo"
+        ]
       },
       {
         "en": "Beastars",
         "ja": "BEASTARS",
-        "ja_typings": []
+        "ja_typings": [
+          "beastars"
+        ]
       },
       {
         "en": "Dr. STONE",
         "ja": "Dr.STONE",
-        "ja_typings": []
+        "ja_typings": [
+          "dr.stone"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -51385,7 +55155,9 @@
       {
         "en": "Summer Wars",
         "ja": "サマーウォーズ",
-        "ja_typings": []
+        "ja_typings": [
+          "sama-wo-zu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -51416,7 +55188,9 @@
       {
         "en": "Summer Wars",
         "ja": "サマーウォーズ",
-        "ja_typings": []
+        "ja_typings": [
+          "sama-wo-zu"
+        ]
       },
       {
         "en": "The Boy and the Beast",
@@ -51441,18 +55215,22 @@
         "en": "Maquia",
         "ja": "さよならの朝に約束の花をかざろう",
         "ja_typings": [
-          "sayonarano朝ni約束no花wokazarou"
+          "sayonaranoasaniyakusokunohanawokazarou"
         ]
       },
       {
         "en": "Mai Mai Miracle",
         "ja": "マイマイ新子と千年の魔法",
-        "ja_typings": []
+        "ja_typings": [
+          "maimaishinkotosennnennnomahou"
+        ]
       },
       {
         "en": "Mind Game",
         "ja": "マインド・ゲーム",
-        "ja_typings": []
+        "ja_typings": [
+          "maindo/ge-mu"
+        ]
       },
       {
         "en": "Tekkonkinkreet",
@@ -51476,7 +55254,9 @@
       {
         "en": "Paprika",
         "ja": "パプリカ",
-        "ja_typings": []
+        "ja_typings": [
+          "papurika"
+        ]
       },
       {
         "en": "Millennium Actress",
@@ -51488,7 +55268,9 @@
       {
         "en": "Perfect Blue",
         "ja": "PERFECT BLUE",
-        "ja_typings": []
+        "ja_typings": [
+          "perfect blue"
+        ]
       },
       {
         "en": "Tokyo Godfathers",
@@ -51519,12 +55301,16 @@
       {
         "en": "Paprika",
         "ja": "パプリカ",
-        "ja_typings": []
+        "ja_typings": [
+          "papurika"
+        ]
       },
       {
         "en": "Perfect Blue",
         "ja": "PERFECT BLUE",
-        "ja_typings": []
+        "ja_typings": [
+          "perfect blue"
+        ]
       },
       {
         "en": "Tokyo Godfathers",
@@ -51548,7 +55334,9 @@
       {
         "en": "Perfect Blue",
         "ja": "PERFECT BLUE",
-        "ja_typings": []
+        "ja_typings": [
+          "perfect blue"
+        ]
       },
       {
         "en": "Millennium Actress",
@@ -51560,7 +55348,9 @@
       {
         "en": "Paprika",
         "ja": "パプリカ",
-        "ja_typings": []
+        "ja_typings": [
+          "papurika"
+        ]
       },
       {
         "en": "Paranoia Agent",
@@ -51584,22 +55374,30 @@
       {
         "en": "Kinema Citrus",
         "ja": "キネマシトラス",
-        "ja_typings": []
+        "ja_typings": [
+          "kinemashitorasu"
+        ]
       },
       {
         "en": "Wit Studio",
         "ja": "WIT STUDIO",
-        "ja_typings": []
+        "ja_typings": [
+          "wit studio"
+        ]
       },
       {
         "en": "MAPPA",
         "ja": "MAPPA",
-        "ja_typings": []
+        "ja_typings": [
+          "mappa"
+        ]
       },
       {
         "en": "Bones",
         "ja": "ボンズ",
-        "ja_typings": []
+        "ja_typings": [
+          "bonzu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -51616,22 +55414,30 @@
       {
         "en": "Bones",
         "ja": "ボンズ",
-        "ja_typings": []
+        "ja_typings": [
+          "bonzu"
+        ]
       },
       {
         "en": "Madhouse",
         "ja": "マッドハウス",
-        "ja_typings": []
+        "ja_typings": [
+          "maddohausu"
+        ]
       },
       {
         "en": "Production I.G",
         "ja": "Production I.G",
-        "ja_typings": []
+        "ja_typings": [
+          "production i.g"
+        ]
       },
       {
         "en": "J.C.Staff",
         "ja": "J.C.STAFF",
-        "ja_typings": []
+        "ja_typings": [
+          "j.c.staff"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -51655,17 +55461,23 @@
       {
         "en": "P.A. Works",
         "ja": "P.A.WORKS",
-        "ja_typings": []
+        "ja_typings": [
+          "p.a.works"
+        ]
       },
       {
         "en": "ufotable",
         "ja": "ufotable",
-        "ja_typings": []
+        "ja_typings": [
+          "ufotable"
+        ]
       },
       {
         "en": "Bones",
         "ja": "ボンズ",
-        "ja_typings": []
+        "ja_typings": [
+          "bonzu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -51682,7 +55494,9 @@
       {
         "en": "P.A. Works",
         "ja": "P.A.WORKS",
-        "ja_typings": []
+        "ja_typings": [
+          "p.a.works"
+        ]
       },
       {
         "en": "Kyoto Animation",
@@ -51694,12 +55508,16 @@
       {
         "en": "Trigger",
         "ja": "TRIGGER",
-        "ja_typings": []
+        "ja_typings": [
+          "trigger"
+        ]
       },
       {
         "en": "Sunrise",
         "ja": "サンライズ",
-        "ja_typings": []
+        "ja_typings": [
+          "sanraizu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -51716,22 +55534,30 @@
       {
         "en": "Trigger",
         "ja": "TRIGGER",
-        "ja_typings": []
+        "ja_typings": [
+          "trigger"
+        ]
       },
       {
         "en": "Gainax",
         "ja": "ガイナックス",
-        "ja_typings": []
+        "ja_typings": [
+          "gainakkusu"
+        ]
       },
       {
         "en": "Bones",
         "ja": "ボンズ",
-        "ja_typings": []
+        "ja_typings": [
+          "bonzu"
+        ]
       },
       {
         "en": "MAPPA",
         "ja": "MAPPA",
-        "ja_typings": []
+        "ja_typings": [
+          "mappa"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -51948,22 +55774,30 @@
       {
         "en": "Samurai Champloo",
         "ja": "サムライチャンプルー",
-        "ja_typings": []
+        "ja_typings": [
+          "samuraichanpuru-"
+        ]
       },
       {
         "en": "Cowboy Bebop",
         "ja": "カウボーイビバップ",
-        "ja_typings": []
+        "ja_typings": [
+          "kaubo-ibibappu"
+        ]
       },
       {
         "en": "Space Dandy",
         "ja": "スペース☆ダンディ",
-        "ja_typings": []
+        "ja_typings": [
+          "supe-sudandi"
+        ]
       },
       {
         "en": "Carole and Tuesday",
         "ja": "キャロル&チューズデイ",
-        "ja_typings": []
+        "ja_typings": [
+          "kyaroruchu-zudei"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -51980,22 +55814,30 @@
       {
         "en": "Cowboy Bebop",
         "ja": "カウボーイビバップ",
-        "ja_typings": []
+        "ja_typings": [
+          "kaubo-ibibappu"
+        ]
       },
       {
         "en": "Outlaw Star",
         "ja": "アウトロースター",
-        "ja_typings": []
+        "ja_typings": [
+          "autoro-suta-"
+        ]
       },
       {
         "en": "Trigun",
         "ja": "トライガン",
-        "ja_typings": []
+        "ja_typings": [
+          "toraigan"
+        ]
       },
       {
         "en": "Black Lagoon",
         "ja": "ブラック・ラグーン",
-        "ja_typings": []
+        "ja_typings": [
+          "burakku/ragu-n"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -52012,22 +55854,30 @@
       {
         "en": "Trigun",
         "ja": "トライガン",
-        "ja_typings": []
+        "ja_typings": [
+          "toraigan"
+        ]
       },
       {
         "en": "Cowboy Bebop",
         "ja": "カウボーイビバップ",
-        "ja_typings": []
+        "ja_typings": [
+          "kaubo-ibibappu"
+        ]
       },
       {
         "en": "Outlaw Star",
         "ja": "アウトロースター",
-        "ja_typings": []
+        "ja_typings": [
+          "autoro-suta-"
+        ]
       },
       {
         "en": "Big O",
         "ja": "THE ビッグオー",
-        "ja_typings": []
+        "ja_typings": [
+          "the bigguo-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -52058,7 +55908,9 @@
       {
         "en": "Ranma 1/2",
         "ja": "らんま1/2",
-        "ja_typings": []
+        "ja_typings": [
+          "ranma1/2"
+        ]
       },
       {
         "en": "Inuyasha",
@@ -52089,7 +55941,9 @@
       {
         "en": "Ranma 1/2",
         "ja": "らんま1/2",
-        "ja_typings": []
+        "ja_typings": [
+          "ranma1/2"
+        ]
       },
       {
         "en": "Urusei Yatsura",
@@ -52127,7 +55981,9 @@
       {
         "en": "Ranma 1/2",
         "ja": "らんま1/2",
-        "ja_typings": []
+        "ja_typings": [
+          "ranma1/2"
+        ]
       },
       {
         "en": "Urusei Yatsura",
@@ -52299,7 +56155,9 @@
       {
         "en": "Tetsuya Chiba",
         "ja": "ちばてつや",
-        "ja_typings": []
+        "ja_typings": [
+          "chibatetsuya"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -52316,7 +56174,9 @@
       {
         "en": "Tetsuya Chiba",
         "ja": "ちばてつや",
-        "ja_typings": []
+        "ja_typings": [
+          "chibatetsuya"
+        ]
       },
       {
         "en": "Asao Takamori",
@@ -52361,7 +56221,9 @@
       {
         "en": "Tetsuya Chiba",
         "ja": "ちばてつや",
-        "ja_typings": []
+        "ja_typings": [
+          "chibatetsuya"
+        ]
       },
       {
         "en": "Takehiko Inoue",
@@ -52406,7 +56268,9 @@
       {
         "en": "Tetsuya Chiba",
         "ja": "ちばてつや",
-        "ja_typings": []
+        "ja_typings": [
+          "chibatetsuya"
+        ]
       },
       {
         "en": "Takehiko Inoue",
@@ -52531,7 +56395,9 @@
       {
         "en": "Big Comic",
         "ja": "ビッグコミック",
-        "ja_typings": []
+        "ja_typings": [
+          "biggukomikku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -52649,7 +56515,9 @@
       {
         "en": "Square Enix",
         "ja": "スクウェア・エニックス",
-        "ja_typings": []
+        "ja_typings": [
+          "sukuwea/enikkusu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -53386,7 +57254,9 @@
       {
         "en": "Kiyohiko Azuma",
         "ja": "あずまきよひこ",
-        "ja_typings": []
+        "ja_typings": [
+          "azumakiyohiko"
+        ]
       },
       {
         "en": "Kentaro Miura",
@@ -53584,7 +57454,9 @@
       {
         "en": "Akihito Tsukushi",
         "ja": "つくしあきひと",
-        "ja_typings": []
+        "ja_typings": [
+          "tsukushiakihito"
+        ]
       },
       {
         "en": "Sui Ishida",
@@ -53629,7 +57501,9 @@
       {
         "en": "Akihito Tsukushi",
         "ja": "つくしあきひと",
-        "ja_typings": []
+        "ja_typings": [
+          "tsukushiakihito"
+        ]
       },
       {
         "en": "Hajime Isayama",
@@ -53660,7 +57534,9 @@
       {
         "en": "Young Animal",
         "ja": "ヤングアニマル",
-        "ja_typings": []
+        "ja_typings": [
+          "yanguanimaru"
+        ]
       },
       {
         "en": "Young Jump",
@@ -53705,7 +57581,9 @@
       {
         "en": "Young Animal",
         "ja": "ヤングアニマル",
-        "ja_typings": []
+        "ja_typings": [
+          "yanguanimaru"
+        ]
       },
       {
         "en": "Morning",
@@ -53717,7 +57595,9 @@
       {
         "en": "Big Comic Original",
         "ja": "ビッグコミックオリジナル",
-        "ja_typings": []
+        "ja_typings": [
+          "biggukomikkuorijinaru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -53741,17 +57621,23 @@
       {
         "en": "Atlus",
         "ja": "アトラス",
-        "ja_typings": []
+        "ja_typings": [
+          "atorasu"
+        ]
       },
       {
         "en": "Tri-Ace",
         "ja": "トライエース",
-        "ja_typings": []
+        "ja_typings": [
+          "toraie-su"
+        ]
       },
       {
         "en": "From Software",
         "ja": "フロム・ソフトウェア",
-        "ja_typings": []
+        "ja_typings": [
+          "furomu/sofutowea"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -53766,24 +57652,32 @@
   {
     "choices": [
       {
+        "en": "Sega",
+        "ja": "セガ",
+        "ja_typings": [
+          "sega"
+        ]
+      },
+      {
         "en": "Atlus",
         "ja": "アトラス",
-        "ja_typings": []
+        "ja_typings": [
+          "atorasu"
+        ]
       },
       {
         "en": "Square Enix",
         "ja": "スクウェア・エニックス",
-        "ja_typings": []
+        "ja_typings": [
+          "sukuwea/enikkusu"
+        ]
       },
       {
         "en": "Bandai Namco",
         "ja": "バンダイナムコ",
-        "ja_typings": []
-      },
-      {
-        "en": "Sega",
-        "ja": "セガ",
-        "ja_typings": []
+        "ja_typings": [
+          "bandainamuko"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -53791,8 +57685,8 @@
     "id": "q01420",
     "image_path": null,
     "question_text": {
-      "en": "Which company developed Persona 5?",
-      "ja": "ペルソナ5を開発した会社は?"
+      "en": "Which company developed the 'Yakuza' (Like a Dragon) series?",
+      "ja": "『龍が如く』シリーズを開発した会社は?"
     }
   },
   {
@@ -53800,22 +57694,30 @@
       {
         "en": "FromSoftware",
         "ja": "フロム・ソフトウェア",
-        "ja_typings": []
+        "ja_typings": [
+          "furomu/sofutowea"
+        ]
       },
       {
         "en": "Capcom",
         "ja": "カプコン",
-        "ja_typings": []
+        "ja_typings": [
+          "kapukon"
+        ]
       },
       {
         "en": "Atlus",
         "ja": "アトラス",
-        "ja_typings": []
+        "ja_typings": [
+          "atorasu"
+        ]
       },
       {
         "en": "Bandai Namco",
         "ja": "バンダイナムコ",
-        "ja_typings": []
+        "ja_typings": [
+          "bandainamuko"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -53830,24 +57732,32 @@
   {
     "choices": [
       {
+        "en": "Square Enix",
+        "ja": "スクウェア・エニックス",
+        "ja_typings": [
+          "sukuwea/enikkusu"
+        ]
+      },
+      {
         "en": "Capcom",
         "ja": "カプコン",
-        "ja_typings": []
+        "ja_typings": [
+          "kapukon"
+        ]
       },
       {
         "en": "FromSoftware",
         "ja": "フロム・ソフトウェア",
-        "ja_typings": []
+        "ja_typings": [
+          "furomu/sofutowea"
+        ]
       },
       {
-        "en": "Bandai Namco",
-        "ja": "バンダイナムコ",
-        "ja_typings": []
-      },
-      {
-        "en": "Koei Tecmo",
-        "ja": "コーエーテクモ",
-        "ja_typings": []
+        "en": "Konami",
+        "ja": "コナミ",
+        "ja_typings": [
+          "konami"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -53855,8 +57765,8 @@
     "id": "q01422",
     "image_path": null,
     "question_text": {
-      "en": "Which company developed Monster Hunter series?",
-      "ja": "モンスターハンターシリーズを開発した会社は?"
+      "en": "Which company developed the 'Dragon Quest' series?",
+      "ja": "『ドラゴンクエスト』シリーズを開発した会社は?"
     }
   },
   {
@@ -53864,22 +57774,30 @@
       {
         "en": "Koei Tecmo",
         "ja": "コーエーテクモ",
-        "ja_typings": []
+        "ja_typings": [
+          "ko-e-tekumo"
+        ]
       },
       {
         "en": "Capcom",
         "ja": "カプコン",
-        "ja_typings": []
+        "ja_typings": [
+          "kapukon"
+        ]
       },
       {
         "en": "Sega",
         "ja": "セガ",
-        "ja_typings": []
+        "ja_typings": [
+          "sega"
+        ]
       },
       {
         "en": "Bandai Namco",
         "ja": "バンダイナムコ",
-        "ja_typings": []
+        "ja_typings": [
+          "bandainamuko"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -53896,22 +57814,30 @@
       {
         "en": "Bandai Namco",
         "ja": "バンダイナムコ",
-        "ja_typings": []
+        "ja_typings": [
+          "bandainamuko"
+        ]
       },
       {
         "en": "Square Enix",
         "ja": "スクウェア・エニックス",
-        "ja_typings": []
+        "ja_typings": [
+          "sukuwea/enikkusu"
+        ]
       },
       {
         "en": "Sega",
         "ja": "セガ",
-        "ja_typings": []
+        "ja_typings": [
+          "sega"
+        ]
       },
       {
         "en": "Atlus",
         "ja": "アトラス",
-        "ja_typings": []
+        "ja_typings": [
+          "atorasu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -53928,22 +57854,30 @@
       {
         "en": "Sega",
         "ja": "セガ",
-        "ja_typings": []
+        "ja_typings": [
+          "sega"
+        ]
       },
       {
         "en": "Bandai Namco",
         "ja": "バンダイナムコ",
-        "ja_typings": []
+        "ja_typings": [
+          "bandainamuko"
+        ]
       },
       {
         "en": "Square Enix",
         "ja": "スクウェア・エニックス",
-        "ja_typings": []
+        "ja_typings": [
+          "sukuwea/enikkusu"
+        ]
       },
       {
         "en": "Capcom",
         "ja": "カプコン",
-        "ja_typings": []
+        "ja_typings": [
+          "kapukon"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -53960,22 +57894,30 @@
       {
         "en": "PlatinumGames",
         "ja": "プラチナゲームズ",
-        "ja_typings": []
+        "ja_typings": [
+          "purachinage-muzu"
+        ]
       },
       {
         "en": "Square Enix",
         "ja": "スクウェア・エニックス",
-        "ja_typings": []
+        "ja_typings": [
+          "sukuwea/enikkusu"
+        ]
       },
       {
         "en": "Atlus",
         "ja": "アトラス",
-        "ja_typings": []
+        "ja_typings": [
+          "atorasu"
+        ]
       },
       {
         "en": "Tri-Ace",
         "ja": "トライエース",
-        "ja_typings": []
+        "ja_typings": [
+          "toraie-su"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -53992,22 +57934,30 @@
       {
         "en": "PlatinumGames",
         "ja": "プラチナゲームズ",
-        "ja_typings": []
+        "ja_typings": [
+          "purachinage-muzu"
+        ]
       },
       {
         "en": "Capcom",
         "ja": "カプコン",
-        "ja_typings": []
+        "ja_typings": [
+          "kapukon"
+        ]
       },
       {
         "en": "FromSoftware",
         "ja": "フロム・ソフトウェア",
-        "ja_typings": []
+        "ja_typings": [
+          "furomu/sofutowea"
+        ]
       },
       {
         "en": "Konami",
         "ja": "コナミ",
-        "ja_typings": []
+        "ja_typings": [
+          "konami"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -54024,22 +57974,30 @@
       {
         "en": "Atlus",
         "ja": "アトラス",
-        "ja_typings": []
+        "ja_typings": [
+          "atorasu"
+        ]
       },
       {
         "en": "Square Enix",
         "ja": "スクウェア・エニックス",
-        "ja_typings": []
+        "ja_typings": [
+          "sukuwea/enikkusu"
+        ]
       },
       {
         "en": "Bandai Namco",
         "ja": "バンダイナムコ",
-        "ja_typings": []
+        "ja_typings": [
+          "bandainamuko"
+        ]
       },
       {
         "en": "Sega",
         "ja": "セガ",
-        "ja_typings": []
+        "ja_typings": [
+          "sega"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -54103,17 +58061,23 @@
       {
         "en": "Judgment",
         "ja": "ジャッジアイズ",
-        "ja_typings": []
+        "ja_typings": [
+          "jajjiaizu"
+        ]
       },
       {
         "en": "Shenmue",
         "ja": "シェンムー",
-        "ja_typings": []
+        "ja_typings": [
+          "shenmu-"
+        ]
       },
       {
         "en": "Sleeping Dogs",
         "ja": "スリーピングドッグス",
-        "ja_typings": []
+        "ja_typings": [
+          "suri-pingudoggusu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -54137,17 +58101,23 @@
       {
         "en": "Judgment",
         "ja": "ジャッジアイズ",
-        "ja_typings": []
+        "ja_typings": [
+          "jajjiaizu"
+        ]
       },
       {
         "en": "Lost Judgment",
         "ja": "ロストジャッジメント",
-        "ja_typings": []
+        "ja_typings": [
+          "rosutojajjimento"
+        ]
       },
       {
         "en": "Shenmue III",
         "ja": "シェンムーIII",
-        "ja_typings": []
+        "ja_typings": [
+          "shenmu-iii"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -54164,22 +58134,30 @@
       {
         "en": "Space Harrier",
         "ja": "スペースハリアー",
-        "ja_typings": []
+        "ja_typings": [
+          "supe-suharia-"
+        ]
       },
       {
         "en": "After Burner",
         "ja": "アフターバーナー",
-        "ja_typings": []
+        "ja_typings": [
+          "afuta-ba-na-"
+        ]
       },
       {
         "en": "OutRun",
         "ja": "アウトラン",
-        "ja_typings": []
+        "ja_typings": [
+          "autoran"
+        ]
       },
       {
         "en": "Hang-On",
         "ja": "ハングオン",
-        "ja_typings": []
+        "ja_typings": [
+          "hanguon"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -54196,22 +58174,30 @@
       {
         "en": "OutRun",
         "ja": "アウトラン",
-        "ja_typings": []
+        "ja_typings": [
+          "autoran"
+        ]
       },
       {
         "en": "Hang-On",
         "ja": "ハングオン",
-        "ja_typings": []
+        "ja_typings": [
+          "hanguon"
+        ]
       },
       {
         "en": "Space Harrier",
         "ja": "スペースハリアー",
-        "ja_typings": []
+        "ja_typings": [
+          "supe-suharia-"
+        ]
       },
       {
         "en": "Power Drift",
         "ja": "パワードリフト",
-        "ja_typings": []
+        "ja_typings": [
+          "pawa-dorifuto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -54228,22 +58214,30 @@
       {
         "en": "Hang-On",
         "ja": "ハングオン",
-        "ja_typings": []
+        "ja_typings": [
+          "hanguon"
+        ]
       },
       {
         "en": "OutRun",
         "ja": "アウトラン",
-        "ja_typings": []
+        "ja_typings": [
+          "autoran"
+        ]
       },
       {
         "en": "Super Hang-On",
         "ja": "スーパーハングオン",
-        "ja_typings": []
+        "ja_typings": [
+          "su-pa-hanguon"
+        ]
       },
       {
         "en": "Power Drift",
         "ja": "パワードリフト",
-        "ja_typings": []
+        "ja_typings": [
+          "pawa-dorifuto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -54260,7 +58254,9 @@
       {
         "en": "Metal Gear",
         "ja": "メタルギア",
-        "ja_typings": []
+        "ja_typings": [
+          "metarugia"
+        ]
       },
       {
         "en": "Castlevania",
@@ -54279,7 +58275,9 @@
       {
         "en": "Gradius",
         "ja": "グラディウス",
-        "ja_typings": []
+        "ja_typings": [
+          "guradiusu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -54310,12 +58308,16 @@
       {
         "en": "Gradius",
         "ja": "グラディウス",
-        "ja_typings": []
+        "ja_typings": [
+          "guradiusu"
+        ]
       },
       {
         "en": "TwinBee",
         "ja": "ツインビー",
-        "ja_typings": []
+        "ja_typings": [
+          "tsuinbi-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -54332,12 +58334,16 @@
       {
         "en": "Gradius",
         "ja": "グラディウス",
-        "ja_typings": []
+        "ja_typings": [
+          "guradiusu"
+        ]
       },
       {
         "en": "Parodius",
         "ja": "パロディウス",
-        "ja_typings": []
+        "ja_typings": [
+          "parodiusu"
+        ]
       },
       {
         "en": "Salamander",
@@ -54349,7 +58355,9 @@
       {
         "en": "TwinBee",
         "ja": "ツインビー",
-        "ja_typings": []
+        "ja_typings": [
+          "tsuinbi-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -54366,7 +58374,9 @@
       {
         "en": "SaGa",
         "ja": "サガ",
-        "ja_typings": []
+        "ja_typings": [
+          "saga"
+        ]
       },
       {
         "en": "Mana",
@@ -54378,12 +58388,16 @@
       {
         "en": "Romancing",
         "ja": "ロマンシング",
-        "ja_typings": []
+        "ja_typings": [
+          "romanshingu"
+        ]
       },
       {
         "en": "Chrono",
         "ja": "クロノ",
-        "ja_typings": []
+        "ja_typings": [
+          "kurono"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -54407,7 +58421,9 @@
       {
         "en": "Chrono Trigger",
         "ja": "クロノ・トリガー",
-        "ja_typings": []
+        "ja_typings": [
+          "kurono/toriga-"
+        ]
       },
       {
         "en": "Terranigma",
@@ -54419,7 +58435,10 @@
       {
         "en": "Soul Blazer",
         "ja": "ソウルブレイダー",
-        "ja_typings": []
+        "ja_typings": [
+          "sorubureida-",
+          "sourubureida-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -54443,7 +58462,10 @@
       {
         "en": "Soul Blazer",
         "ja": "ソウルブレイダー",
-        "ja_typings": []
+        "ja_typings": [
+          "sorubureida-",
+          "sourubureida-"
+        ]
       },
       {
         "en": "Illusion of Gaia",
@@ -54455,7 +58477,9 @@
       {
         "en": "ActRaiser",
         "ja": "アクトレイザー",
-        "ja_typings": []
+        "ja_typings": [
+          "akutoreiza-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -54472,7 +58496,9 @@
       {
         "en": "Section Z",
         "ja": "セクションZ",
-        "ja_typings": []
+        "ja_typings": [
+          "sekushonz"
+        ]
       },
       {
         "en": "Bionic Commando",
@@ -54510,22 +58536,30 @@
       {
         "en": "Darkstalkers",
         "ja": "ヴァンパイア",
-        "ja_typings": []
+        "ja_typings": [
+          "vanpaia"
+        ]
       },
       {
         "en": "Cyberbots",
         "ja": "サイバーボッツ",
-        "ja_typings": []
+        "ja_typings": [
+          "saiba-bottsu"
+        ]
       },
       {
         "en": "Red Earth",
         "ja": "ウォーザード",
-        "ja_typings": []
+        "ja_typings": [
+          "wo-za-do"
+        ]
       },
       {
         "en": "Star Gladiator",
         "ja": "スターグラディエイター",
-        "ja_typings": []
+        "ja_typings": [
+          "suta-guradieita-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -54556,12 +58590,16 @@
       {
         "en": "Samurai Shodown",
         "ja": "サムライスピリッツ",
-        "ja_typings": []
+        "ja_typings": [
+          "samuraisupirittsu"
+        ]
       },
       {
         "en": "King of Fighters",
         "ja": "ザ・キング・オブ・ファイターズ",
-        "ja_typings": []
+        "ja_typings": [
+          "za/kingu/obu/faita-zu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -54592,7 +58630,9 @@
       {
         "en": "Samurai Shodown",
         "ja": "サムライスピリッツ",
-        "ja_typings": []
+        "ja_typings": [
+          "samuraisupirittsu"
+        ]
       },
       {
         "en": "Last Blade",
@@ -54616,7 +58656,9 @@
       {
         "en": "Samurai Shodown",
         "ja": "サムライスピリッツ",
-        "ja_typings": []
+        "ja_typings": [
+          "samuraisupirittsu"
+        ]
       },
       {
         "en": "Last Blade",
@@ -54654,7 +58696,9 @@
       {
         "en": "King of Fighters",
         "ja": "ザ・キング・オブ・ファイターズ",
-        "ja_typings": []
+        "ja_typings": [
+          "za/kingu/obu/faita-zu"
+        ]
       },
       {
         "en": "Fatal Fury",
@@ -54673,7 +58717,9 @@
       {
         "en": "Samurai Shodown",
         "ja": "サムライスピリッツ",
-        "ja_typings": []
+        "ja_typings": [
+          "samuraisupirittsu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -54690,24 +58736,31 @@
       {
         "en": "Dreamcast",
         "ja": "ドリームキャスト",
-        "ja_typings": []
+        "ja_typings": [
+          "dori-mukyasuto"
+        ]
       },
       {
         "en": "Saturn",
         "ja": "セガサターン",
         "ja_typings": [
-          "segasataan"
+          "segasataan",
+          "segasata-n"
         ]
       },
       {
         "en": "Mega Drive",
         "ja": "メガドライブ",
-        "ja_typings": []
+        "ja_typings": [
+          "megadoraibu"
+        ]
       },
       {
         "en": "Game Gear",
         "ja": "ゲームギア",
-        "ja_typings": []
+        "ja_typings": [
+          "ge-mugia"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -54724,22 +58777,30 @@
       {
         "en": "Neo Geo",
         "ja": "ネオジオ",
-        "ja_typings": []
+        "ja_typings": [
+          "neojio"
+        ]
       },
       {
         "en": "PC Engine",
         "ja": "PCエンジン",
-        "ja_typings": []
+        "ja_typings": [
+          "pcenjin"
+        ]
       },
       {
         "en": "Mega Drive",
         "ja": "メガドライブ",
-        "ja_typings": []
+        "ja_typings": [
+          "megadoraibu"
+        ]
       },
       {
         "en": "Wonder Swan",
         "ja": "ワンダースワン",
-        "ja_typings": []
+        "ja_typings": [
+          "wanda-suwan"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -54756,22 +58817,30 @@
       {
         "en": "PC Engine",
         "ja": "PCエンジン",
-        "ja_typings": []
+        "ja_typings": [
+          "pcenjin"
+        ]
       },
       {
         "en": "Neo Geo",
         "ja": "ネオジオ",
-        "ja_typings": []
+        "ja_typings": [
+          "neojio"
+        ]
       },
       {
         "en": "Mega Drive",
         "ja": "メガドライブ",
-        "ja_typings": []
+        "ja_typings": [
+          "megadoraibu"
+        ]
       },
       {
         "en": "FM Towns Marty",
         "ja": "FMタウンズマーティー",
-        "ja_typings": []
+        "ja_typings": [
+          "fmtaunzuma-ti-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -54788,22 +58857,30 @@
       {
         "en": "Wonder Swan",
         "ja": "ワンダースワン",
-        "ja_typings": []
+        "ja_typings": [
+          "wanda-suwan"
+        ]
       },
       {
         "en": "Game Gear",
         "ja": "ゲームギア",
-        "ja_typings": []
+        "ja_typings": [
+          "ge-mugia"
+        ]
       },
       {
         "en": "Neo Geo Pocket",
         "ja": "ネオジオポケット",
-        "ja_typings": []
+        "ja_typings": [
+          "neojiopoketto"
+        ]
       },
       {
         "en": "PC Engine GT",
         "ja": "PCエンジンGT",
-        "ja_typings": []
+        "ja_typings": [
+          "pcenjingt"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -54820,22 +58897,30 @@
       {
         "en": "Neo Geo Pocket",
         "ja": "ネオジオポケット",
-        "ja_typings": []
+        "ja_typings": [
+          "neojiopoketto"
+        ]
       },
       {
         "en": "Wonder Swan",
         "ja": "ワンダースワン",
-        "ja_typings": []
+        "ja_typings": [
+          "wanda-suwan"
+        ]
       },
       {
         "en": "Game Gear",
         "ja": "ゲームギア",
-        "ja_typings": []
+        "ja_typings": [
+          "ge-mugia"
+        ]
       },
       {
         "en": "PC Engine GT",
         "ja": "PCエンジンGT",
-        "ja_typings": []
+        "ja_typings": [
+          "pcenjingt"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -54852,22 +58937,30 @@
       {
         "en": "Celeste",
         "ja": "セレステ",
-        "ja_typings": []
+        "ja_typings": [
+          "seresute"
+        ]
       },
       {
         "en": "Hyper Light Drifter",
         "ja": "ハイパーライトドリフター",
-        "ja_typings": []
+        "ja_typings": [
+          "haipa-raitodorifuta-"
+        ]
       },
       {
         "en": "Hades",
         "ja": "ハデス",
-        "ja_typings": []
+        "ja_typings": [
+          "hadesu"
+        ]
       },
       {
         "en": "Cuphead",
         "ja": "カップヘッド",
-        "ja_typings": []
+        "ja_typings": [
+          "kappuheddo"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -54884,22 +58977,30 @@
       {
         "en": "Hades",
         "ja": "ハデス",
-        "ja_typings": []
+        "ja_typings": [
+          "hadesu"
+        ]
       },
       {
         "en": "Bastion",
         "ja": "バスティオン",
-        "ja_typings": []
+        "ja_typings": [
+          "basution"
+        ]
       },
       {
         "en": "Transistor",
         "ja": "トランジスター",
-        "ja_typings": []
+        "ja_typings": [
+          "toranjisuta-"
+        ]
       },
       {
         "en": "Pyre",
         "ja": "パイア",
-        "ja_typings": []
+        "ja_typings": [
+          "paia"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -54916,22 +59017,30 @@
       {
         "en": "Cuphead",
         "ja": "カップヘッド",
-        "ja_typings": []
+        "ja_typings": [
+          "kappuheddo"
+        ]
       },
       {
         "en": "Celeste",
         "ja": "セレステ",
-        "ja_typings": []
+        "ja_typings": [
+          "seresute"
+        ]
       },
       {
         "en": "Shovel Knight",
         "ja": "ショベルナイト",
-        "ja_typings": []
+        "ja_typings": [
+          "shoberunaito"
+        ]
       },
       {
         "en": "Pizza Tower",
         "ja": "ピザタワー",
-        "ja_typings": []
+        "ja_typings": [
+          "pizatawa-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -54948,22 +59057,30 @@
       {
         "en": "Shovel Knight",
         "ja": "ショベルナイト",
-        "ja_typings": []
+        "ja_typings": [
+          "shoberunaito"
+        ]
       },
       {
         "en": "Cuphead",
         "ja": "カップヘッド",
-        "ja_typings": []
+        "ja_typings": [
+          "kappuheddo"
+        ]
       },
       {
         "en": "Celeste",
         "ja": "セレステ",
-        "ja_typings": []
+        "ja_typings": [
+          "seresute"
+        ]
       },
       {
         "en": "Axiom Verge",
         "ja": "アクシオムバージ",
-        "ja_typings": []
+        "ja_typings": [
+          "akushiomuba-ji"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -54980,22 +59097,30 @@
       {
         "en": "Chrono Cross",
         "ja": "クロノ・クロス",
-        "ja_typings": []
+        "ja_typings": [
+          "kurono/kurosu"
+        ]
       },
       {
         "en": "Xenogears",
         "ja": "ゼノギアス",
-        "ja_typings": []
+        "ja_typings": [
+          "zenogiasu"
+        ]
       },
       {
         "en": "Parasite Eve",
         "ja": "パラサイト・イヴ",
-        "ja_typings": []
+        "ja_typings": [
+          "parasaito/ivu"
+        ]
       },
       {
         "en": "Vagrant Story",
         "ja": "ベイグラントストーリー",
-        "ja_typings": []
+        "ja_typings": [
+          "beigurantosuto-ri-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -55012,22 +59137,30 @@
       {
         "en": "Xenogears",
         "ja": "ゼノギアス",
-        "ja_typings": []
+        "ja_typings": [
+          "zenogiasu"
+        ]
       },
       {
         "en": "Chrono Cross",
         "ja": "クロノ・クロス",
-        "ja_typings": []
+        "ja_typings": [
+          "kurono/kurosu"
+        ]
       },
       {
         "en": "Vagrant Story",
         "ja": "ベイグラントストーリー",
-        "ja_typings": []
+        "ja_typings": [
+          "beigurantosuto-ri-"
+        ]
       },
       {
         "en": "Parasite Eve",
         "ja": "パラサイト・イヴ",
-        "ja_typings": []
+        "ja_typings": [
+          "parasaito/ivu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -55044,22 +59177,30 @@
       {
         "en": "Vagrant Story",
         "ja": "ベイグラントストーリー",
-        "ja_typings": []
+        "ja_typings": [
+          "beigurantosuto-ri-"
+        ]
       },
       {
         "en": "Xenogears",
         "ja": "ゼノギアス",
-        "ja_typings": []
+        "ja_typings": [
+          "zenogiasu"
+        ]
       },
       {
         "en": "Chrono Cross",
         "ja": "クロノ・クロス",
-        "ja_typings": []
+        "ja_typings": [
+          "kurono/kurosu"
+        ]
       },
       {
         "en": "Parasite Eve",
         "ja": "パラサイト・イヴ",
-        "ja_typings": []
+        "ja_typings": [
+          "parasaito/ivu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -55076,22 +59217,30 @@
       {
         "en": "Greece",
         "ja": "ギリシャ",
-        "ja_typings": []
+        "ja_typings": [
+          "girisha"
+        ]
       },
       {
         "en": "Cyprus",
         "ja": "キプロス",
-        "ja_typings": []
+        "ja_typings": [
+          "kipurosu"
+        ]
       },
       {
         "en": "Malta",
         "ja": "マルタ",
-        "ja_typings": []
+        "ja_typings": [
+          "maruta"
+        ]
       },
       {
         "en": "Albania",
         "ja": "アルバニア",
-        "ja_typings": []
+        "ja_typings": [
+          "arubania"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -55108,22 +59257,30 @@
       {
         "en": "Hungary",
         "ja": "ハンガリー",
-        "ja_typings": []
+        "ja_typings": [
+          "hangari-"
+        ]
       },
       {
         "en": "Bulgaria",
         "ja": "ブルガリア",
-        "ja_typings": []
+        "ja_typings": [
+          "burugaria"
+        ]
       },
       {
         "en": "Serbia",
         "ja": "セルビア",
-        "ja_typings": []
+        "ja_typings": [
+          "serubia"
+        ]
       },
       {
         "en": "Romania",
         "ja": "ルーマニア",
-        "ja_typings": []
+        "ja_typings": [
+          "ru-mania"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -55140,22 +59297,30 @@
       {
         "en": "Switzerland",
         "ja": "スイス",
-        "ja_typings": []
+        "ja_typings": [
+          "suisu"
+        ]
       },
       {
         "en": "Liechtenstein",
         "ja": "リヒテンシュタイン",
-        "ja_typings": []
+        "ja_typings": [
+          "rihitenshutain"
+        ]
       },
       {
         "en": "Luxembourg",
         "ja": "ルクセンブルク",
-        "ja_typings": []
+        "ja_typings": [
+          "rukusenburuku"
+        ]
       },
       {
         "en": "Monaco",
         "ja": "モナコ",
-        "ja_typings": []
+        "ja_typings": [
+          "monako"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -55172,22 +59337,30 @@
       {
         "en": "Ireland",
         "ja": "アイルランド",
-        "ja_typings": []
+        "ja_typings": [
+          "airurando"
+        ]
       },
       {
         "en": "Scotland",
         "ja": "スコットランド",
-        "ja_typings": []
+        "ja_typings": [
+          "sukottorando"
+        ]
       },
       {
         "en": "Wales",
         "ja": "ウェールズ",
-        "ja_typings": []
+        "ja_typings": [
+          "we-ruzu"
+        ]
       },
       {
         "en": "Malta",
         "ja": "マルタ",
-        "ja_typings": []
+        "ja_typings": [
+          "maruta"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -55211,17 +59384,23 @@
       {
         "en": "Myanmar",
         "ja": "ミャンマー",
-        "ja_typings": []
+        "ja_typings": [
+          "myanma-"
+        ]
       },
       {
         "en": "Laos",
         "ja": "ラオス",
-        "ja_typings": []
+        "ja_typings": [
+          "raosu"
+        ]
       },
       {
         "en": "Cambodia",
         "ja": "カンボジア",
-        "ja_typings": []
+        "ja_typings": [
+          "kanbojia"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -55238,12 +59417,16 @@
       {
         "en": "Malaysia",
         "ja": "マレーシア",
-        "ja_typings": []
+        "ja_typings": [
+          "mare-shia"
+        ]
       },
       {
         "en": "Brunei",
         "ja": "ブルネイ",
-        "ja_typings": []
+        "ja_typings": [
+          "burunei"
+        ]
       },
       {
         "en": "Philippines",
@@ -55255,7 +59438,9 @@
       {
         "en": "Indonesia",
         "ja": "インドネシア",
-        "ja_typings": []
+        "ja_typings": [
+          "indoneshia"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -55272,22 +59457,30 @@
       {
         "en": "Philippines",
         "ja": "フィリピン",
-        "ja_typings": []
+        "ja_typings": [
+          "firipin"
+        ]
       },
       {
         "en": "Indonesia",
         "ja": "インドネシア",
-        "ja_typings": []
+        "ja_typings": [
+          "indoneshia"
+        ]
       },
       {
         "en": "Malaysia",
         "ja": "マレーシア",
-        "ja_typings": []
+        "ja_typings": [
+          "mare-shia"
+        ]
       },
       {
         "en": "Brunei",
         "ja": "ブルネイ",
-        "ja_typings": []
+        "ja_typings": [
+          "burunei"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -55304,22 +59497,30 @@
       {
         "en": "Iran",
         "ja": "イラン",
-        "ja_typings": []
+        "ja_typings": [
+          "iran"
+        ]
       },
       {
         "en": "Iraq",
         "ja": "イラク",
-        "ja_typings": []
+        "ja_typings": [
+          "iraku"
+        ]
       },
       {
         "en": "Afghanistan",
         "ja": "アフガニスタン",
-        "ja_typings": []
+        "ja_typings": [
+          "afuganisutan"
+        ]
       },
       {
         "en": "Pakistan",
         "ja": "パキスタン",
-        "ja_typings": []
+        "ja_typings": [
+          "pakisutan"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -55336,7 +59537,9 @@
       {
         "en": "Saudi Arabia",
         "ja": "サウジアラビア",
-        "ja_typings": []
+        "ja_typings": [
+          "saujiarabia"
+        ]
       },
       {
         "en": "UAE",
@@ -55348,12 +59551,16 @@
       {
         "en": "Qatar",
         "ja": "カタール",
-        "ja_typings": []
+        "ja_typings": [
+          "kata-ru"
+        ]
       },
       {
         "en": "Kuwait",
         "ja": "クウェート",
-        "ja_typings": []
+        "ja_typings": [
+          "kuwe-to"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -55370,22 +59577,30 @@
       {
         "en": "Ethiopia",
         "ja": "エチオピア",
-        "ja_typings": []
+        "ja_typings": [
+          "echiopia"
+        ]
       },
       {
         "en": "Eritrea",
         "ja": "エリトリア",
-        "ja_typings": []
+        "ja_typings": [
+          "eritoria"
+        ]
       },
       {
         "en": "Somalia",
         "ja": "ソマリア",
-        "ja_typings": []
+        "ja_typings": [
+          "somaria"
+        ]
       },
       {
         "en": "Sudan",
         "ja": "スーダン",
-        "ja_typings": []
+        "ja_typings": [
+          "su-dan"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -55402,22 +59617,30 @@
       {
         "en": "Chile",
         "ja": "チリ",
-        "ja_typings": []
+        "ja_typings": [
+          "chiri"
+        ]
       },
       {
         "en": "Uruguay",
         "ja": "ウルグアイ",
-        "ja_typings": []
+        "ja_typings": [
+          "uruguai"
+        ]
       },
       {
         "en": "Paraguay",
         "ja": "パラグアイ",
-        "ja_typings": []
+        "ja_typings": [
+          "paraguai"
+        ]
       },
       {
         "en": "Bolivia",
         "ja": "ボリビア",
-        "ja_typings": []
+        "ja_typings": [
+          "boribia"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -55434,22 +59657,30 @@
       {
         "en": "Colombia",
         "ja": "コロンビア",
-        "ja_typings": []
+        "ja_typings": [
+          "koronbia"
+        ]
       },
       {
         "en": "Venezuela",
         "ja": "ベネズエラ",
-        "ja_typings": []
+        "ja_typings": [
+          "benezuera"
+        ]
       },
       {
         "en": "Ecuador",
         "ja": "エクアドル",
-        "ja_typings": []
+        "ja_typings": [
+          "ekuadoru"
+        ]
       },
       {
         "en": "Panama",
         "ja": "パナマ",
-        "ja_typings": []
+        "ja_typings": [
+          "panama"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -55466,17 +59697,23 @@
       {
         "en": "Cuba",
         "ja": "キューバ",
-        "ja_typings": []
+        "ja_typings": [
+          "kyu-ba"
+        ]
       },
       {
         "en": "Jamaica",
         "ja": "ジャマイカ",
-        "ja_typings": []
+        "ja_typings": [
+          "jamaika"
+        ]
       },
       {
         "en": "Haiti",
         "ja": "ハイチ",
-        "ja_typings": []
+        "ja_typings": [
+          "haichi"
+        ]
       },
       {
         "en": "Dominican Republic",
@@ -55908,12 +60145,16 @@
       {
         "en": "Oceania",
         "ja": "オセアニア",
-        "ja_typings": []
+        "ja_typings": [
+          "oseania"
+        ]
       },
       {
         "en": "Europe",
         "ja": "ヨーロッパ",
-        "ja_typings": []
+        "ja_typings": [
+          "yo-roppa"
+        ]
       },
       {
         "en": "Antarctica",
@@ -55991,17 +60232,23 @@
       {
         "en": "Argentina",
         "ja": "アルゼンチン",
-        "ja_typings": []
+        "ja_typings": [
+          "aruzenchin"
+        ]
       },
       {
         "en": "Peru",
         "ja": "ペルー",
-        "ja_typings": []
+        "ja_typings": [
+          "peru-"
+        ]
       },
       {
         "en": "Colombia",
         "ja": "コロンビア",
-        "ja_typings": []
+        "ja_typings": [
+          "koronbia"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -56018,22 +60265,30 @@
       {
         "en": "Algeria",
         "ja": "アルジェリア",
-        "ja_typings": []
+        "ja_typings": [
+          "arujeria"
+        ]
       },
       {
         "en": "Sudan",
         "ja": "スーダン",
-        "ja_typings": []
+        "ja_typings": [
+          "su-dan"
+        ]
       },
       {
         "en": "Libya",
         "ja": "リビア",
-        "ja_typings": []
+        "ja_typings": [
+          "ribia"
+        ]
       },
       {
         "en": "Chad",
         "ja": "チャド",
-        "ja_typings": []
+        "ja_typings": [
+          "chado"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -56071,7 +60326,9 @@
       {
         "en": "Mongolia",
         "ja": "モンゴル",
-        "ja_typings": []
+        "ja_typings": [
+          "mongoru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -56095,17 +60352,23 @@
       {
         "en": "Peru",
         "ja": "ペルー",
-        "ja_typings": []
+        "ja_typings": [
+          "peru-"
+        ]
       },
       {
         "en": "Ecuador",
         "ja": "エクアドル",
-        "ja_typings": []
+        "ja_typings": [
+          "ekuadoru"
+        ]
       },
       {
         "en": "Bolivia",
         "ja": "ボリビア",
-        "ja_typings": []
+        "ja_typings": [
+          "boribia"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -56129,17 +60392,23 @@
       {
         "en": "Spain",
         "ja": "スペイン",
-        "ja_typings": []
+        "ja_typings": [
+          "supein"
+        ]
       },
       {
         "en": "France",
         "ja": "フランス",
-        "ja_typings": []
+        "ja_typings": [
+          "furansu"
+        ]
       },
       {
         "en": "Switzerland",
         "ja": "スイス",
-        "ja_typings": []
+        "ja_typings": [
+          "suisu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -56177,7 +60446,9 @@
       {
         "en": "Kublai Khan",
         "ja": "フビライ",
-        "ja_typings": []
+        "ja_typings": [
+          "fubirai"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -56194,7 +60465,9 @@
       {
         "en": "Louis-Napoleon",
         "ja": "ルイ・ナポレオン",
-        "ja_typings": []
+        "ja_typings": [
+          "rui/naporeon"
+        ]
       },
       {
         "en": "Adolphe Thiers",
@@ -56207,7 +60480,9 @@
       {
         "en": "Jules Grevy",
         "ja": "グレヴィ",
-        "ja_typings": []
+        "ja_typings": [
+          "gurevi"
+        ]
       },
       {
         "en": "Sadi Carnot",
@@ -56232,7 +60507,9 @@
       {
         "en": "Bismarck",
         "ja": "ビスマルク",
-        "ja_typings": []
+        "ja_typings": [
+          "bisumaruku"
+        ]
       },
       {
         "en": "Wilhelm I",
@@ -56244,12 +60521,16 @@
       {
         "en": "Metternich",
         "ja": "メッテルニヒ",
-        "ja_typings": []
+        "ja_typings": [
+          "metterunihi"
+        ]
       },
       {
         "en": "Hindenburg",
         "ja": "ヒンデンブルク",
-        "ja_typings": []
+        "ja_typings": [
+          "hindenburuku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -56266,22 +60547,30 @@
       {
         "en": "Stalin",
         "ja": "スターリン",
-        "ja_typings": []
+        "ja_typings": [
+          "suta-rin"
+        ]
       },
       {
         "en": "Lenin",
         "ja": "レーニン",
-        "ja_typings": []
+        "ja_typings": [
+          "re-nin"
+        ]
       },
       {
         "en": "Khrushchev",
         "ja": "フルシチョフ",
-        "ja_typings": []
+        "ja_typings": [
+          "furushichofu"
+        ]
       },
       {
         "en": "Trotsky",
         "ja": "トロツキー",
-        "ja_typings": []
+        "ja_typings": [
+          "torotsuki-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -56298,22 +60587,30 @@
       {
         "en": "Churchill",
         "ja": "チャーチル",
-        "ja_typings": []
+        "ja_typings": [
+          "cha-chiru"
+        ]
       },
       {
         "en": "Chamberlain",
         "ja": "チェンバレン",
-        "ja_typings": []
+        "ja_typings": [
+          "chenbaren"
+        ]
       },
       {
         "en": "Attlee",
         "ja": "アトリー",
-        "ja_typings": []
+        "ja_typings": [
+          "atori-"
+        ]
       },
       {
         "en": "Eden",
         "ja": "イーデン",
-        "ja_typings": []
+        "ja_typings": [
+          "i-den"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -56330,24 +60627,31 @@
       {
         "en": "Roosevelt",
         "ja": "ルーズベルト",
-        "ja_typings": []
+        "ja_typings": [
+          "ru-zuberuto"
+        ]
       },
       {
         "en": "Truman",
         "ja": "トルーマン",
-        "ja_typings": []
+        "ja_typings": [
+          "toru-man"
+        ]
       },
       {
         "en": "Eisenhower",
         "ja": "アイゼンハワー",
-        "ja_typings": []
+        "ja_typings": [
+          "aizenhawa-"
+        ]
       },
       {
         "en": "Hoover",
         "ja": "フーヴァー",
         "ja_typings": [
           "fu-vaa",
-          "fuuvaa"
+          "fuuvaa",
+          "fu-va-"
         ]
       }
     ],
@@ -56365,22 +60669,30 @@
       {
         "en": "Hitler",
         "ja": "ヒトラー",
-        "ja_typings": []
+        "ja_typings": [
+          "hitora-"
+        ]
       },
       {
         "en": "Goering",
         "ja": "ゲーリング",
-        "ja_typings": []
+        "ja_typings": [
+          "ge-ringu"
+        ]
       },
       {
         "en": "Himmler",
         "ja": "ヒムラー",
-        "ja_typings": []
+        "ja_typings": [
+          "himura-"
+        ]
       },
       {
         "en": "Goebbels",
         "ja": "ゲッベルス",
-        "ja_typings": []
+        "ja_typings": [
+          "gebberusu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -56397,22 +60709,30 @@
       {
         "en": "Gandhi",
         "ja": "ガンディー",
-        "ja_typings": []
+        "ja_typings": [
+          "gandi-"
+        ]
       },
       {
         "en": "Nehru",
         "ja": "ネルー",
-        "ja_typings": []
+        "ja_typings": [
+          "neru-"
+        ]
       },
       {
         "en": "Jinnah",
         "ja": "ジンナー",
-        "ja_typings": []
+        "ja_typings": [
+          "jinnna-"
+        ]
       },
       {
         "en": "Bose",
         "ja": "ボース",
-        "ja_typings": []
+        "ja_typings": [
+          "bo-su"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -56429,22 +60749,30 @@
       {
         "en": "Nehru",
         "ja": "ネルー",
-        "ja_typings": []
+        "ja_typings": [
+          "neru-"
+        ]
       },
       {
         "en": "Gandhi",
         "ja": "ガンディー",
-        "ja_typings": []
+        "ja_typings": [
+          "gandi-"
+        ]
       },
       {
         "en": "Patel",
         "ja": "パテル",
-        "ja_typings": []
+        "ja_typings": [
+          "pateru"
+        ]
       },
       {
         "en": "Bose",
         "ja": "ボース",
-        "ja_typings": []
+        "ja_typings": [
+          "bo-su"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -56461,22 +60789,30 @@
       {
         "en": "Mandela",
         "ja": "マンデラ",
-        "ja_typings": []
+        "ja_typings": [
+          "mandera"
+        ]
       },
       {
         "en": "Mbeki",
         "ja": "ムベキ",
-        "ja_typings": []
+        "ja_typings": [
+          "mubeki"
+        ]
       },
       {
         "en": "Zuma",
         "ja": "ズマ",
-        "ja_typings": []
+        "ja_typings": [
+          "zuma"
+        ]
       },
       {
         "en": "De Klerk",
         "ja": "デクラーク",
-        "ja_typings": []
+        "ja_typings": [
+          "dekura-ku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -56507,7 +60843,9 @@
       {
         "en": "Boris Godunov",
         "ja": "ゴドゥノフ",
-        "ja_typings": []
+        "ja_typings": [
+          "godunofu"
+        ]
       },
       {
         "en": "Michael I",
@@ -56613,22 +60951,30 @@
       {
         "en": "Castro",
         "ja": "カストロ",
-        "ja_typings": []
+        "ja_typings": [
+          "kasutoro"
+        ]
       },
       {
         "en": "Guevara",
         "ja": "ゲバラ",
-        "ja_typings": []
+        "ja_typings": [
+          "gebara"
+        ]
       },
       {
         "en": "Batista",
         "ja": "バティスタ",
-        "ja_typings": []
+        "ja_typings": [
+          "batisuta"
+        ]
       },
       {
         "en": "Allende",
         "ja": "アジェンデ",
-        "ja_typings": []
+        "ja_typings": [
+          "ajende"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -56645,22 +60991,30 @@
       {
         "en": "Augustus",
         "ja": "アウグストゥス",
-        "ja_typings": []
+        "ja_typings": [
+          "augusutusu"
+        ]
       },
       {
         "en": "Nero",
         "ja": "ネロ",
-        "ja_typings": []
+        "ja_typings": [
+          "nero"
+        ]
       },
       {
         "en": "Tiberius",
         "ja": "ティベリウス",
-        "ja_typings": []
+        "ja_typings": [
+          "tiberiusu"
+        ]
       },
       {
         "en": "Caligula",
         "ja": "カリギュラ",
-        "ja_typings": []
+        "ja_typings": [
+          "karigyura"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -56677,22 +61031,30 @@
       {
         "en": "Hannibal",
         "ja": "ハンニバル",
-        "ja_typings": []
+        "ja_typings": [
+          "hannnibaru"
+        ]
       },
       {
         "en": "Hasdrubal",
         "ja": "ハスドルバル",
-        "ja_typings": []
+        "ja_typings": [
+          "hasudorubaru"
+        ]
       },
       {
         "en": "Hamilcar",
         "ja": "ハミルカル",
-        "ja_typings": []
+        "ja_typings": [
+          "hamirukaru"
+        ]
       },
       {
         "en": "Scipio",
         "ja": "スキピオ",
-        "ja_typings": []
+        "ja_typings": [
+          "sukipio"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -57234,22 +61596,30 @@
       {
         "en": "Gutenberg",
         "ja": "グーテンベルク",
-        "ja_typings": []
+        "ja_typings": [
+          "gu-tenberuku"
+        ]
       },
       {
         "en": "Caxton",
         "ja": "キャクストン",
-        "ja_typings": []
+        "ja_typings": [
+          "kyakusuton"
+        ]
       },
       {
         "en": "Manutius",
         "ja": "マヌティウス",
-        "ja_typings": []
+        "ja_typings": [
+          "manutiusu"
+        ]
       },
       {
         "en": "Fust",
         "ja": "フスト",
-        "ja_typings": []
+        "ja_typings": [
+          "fusuto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -57266,22 +61636,30 @@
       {
         "en": "Bell",
         "ja": "ベル",
-        "ja_typings": []
+        "ja_typings": [
+          "beru"
+        ]
       },
       {
         "en": "Edison",
         "ja": "エジソン",
-        "ja_typings": []
+        "ja_typings": [
+          "ejison"
+        ]
       },
       {
         "en": "Tesla",
         "ja": "テスラ",
-        "ja_typings": []
+        "ja_typings": [
+          "tesura"
+        ]
       },
       {
         "en": "Marconi",
         "ja": "マルコーニ",
-        "ja_typings": []
+        "ja_typings": [
+          "maruko-ni"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -57298,22 +61676,30 @@
       {
         "en": "Edison",
         "ja": "エジソン",
-        "ja_typings": []
+        "ja_typings": [
+          "ejison"
+        ]
       },
       {
         "en": "Tesla",
         "ja": "テスラ",
-        "ja_typings": []
+        "ja_typings": [
+          "tesura"
+        ]
       },
       {
         "en": "Swan",
         "ja": "スワン",
-        "ja_typings": []
+        "ja_typings": [
+          "suwan"
+        ]
       },
       {
         "en": "Westinghouse",
         "ja": "ウェスティングハウス",
-        "ja_typings": []
+        "ja_typings": [
+          "wesutinguhausu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -57330,22 +61716,30 @@
       {
         "en": "Nobel",
         "ja": "ノーベル",
-        "ja_typings": []
+        "ja_typings": [
+          "no-beru"
+        ]
       },
       {
         "en": "Edison",
         "ja": "エジソン",
-        "ja_typings": []
+        "ja_typings": [
+          "ejison"
+        ]
       },
       {
         "en": "Tesla",
         "ja": "テスラ",
-        "ja_typings": []
+        "ja_typings": [
+          "tesura"
+        ]
       },
       {
         "en": "Maxwell",
         "ja": "マクスウェル",
-        "ja_typings": []
+        "ja_typings": [
+          "makusuweru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -57362,22 +61756,30 @@
       {
         "en": "Luther",
         "ja": "ルター",
-        "ja_typings": []
+        "ja_typings": [
+          "ruta-"
+        ]
       },
       {
         "en": "Calvin",
         "ja": "カルヴァン",
-        "ja_typings": []
+        "ja_typings": [
+          "karuvan"
+        ]
       },
       {
         "en": "Zwingli",
         "ja": "ツヴィングリ",
-        "ja_typings": []
+        "ja_typings": [
+          "tsuvinguri"
+        ]
       },
       {
         "en": "Knox",
         "ja": "ノックス",
-        "ja_typings": []
+        "ja_typings": [
+          "nokkusu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -57474,22 +61876,30 @@
       {
         "en": "Hulagu Khan",
         "ja": "フレグ",
-        "ja_typings": []
+        "ja_typings": [
+          "furegu"
+        ]
       },
       {
         "en": "Kublai Khan",
         "ja": "フビライ",
-        "ja_typings": []
+        "ja_typings": [
+          "fubirai"
+        ]
       },
       {
         "en": "Batu Khan",
         "ja": "バトゥ",
-        "ja_typings": []
+        "ja_typings": [
+          "batu"
+        ]
       },
       {
         "en": "Ogedei Khan",
         "ja": "オゴデイ",
-        "ja_typings": []
+        "ja_typings": [
+          "ogodei"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -57629,22 +62039,30 @@
       {
         "en": "W",
         "ja": "W",
-        "ja_typings": []
+        "ja_typings": [
+          "w"
+        ]
       },
       {
         "en": "Tu",
         "ja": "Tu",
-        "ja_typings": []
+        "ja_typings": [
+          "tu"
+        ]
       },
       {
         "en": "Tg",
         "ja": "Tg",
-        "ja_typings": []
+        "ja_typings": [
+          "tg"
+        ]
       },
       {
         "en": "Tn",
         "ja": "Tn",
-        "ja_typings": []
+        "ja_typings": [
+          "tn"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -57708,12 +62126,16 @@
       {
         "en": "Methane",
         "ja": "メタン",
-        "ja_typings": []
+        "ja_typings": [
+          "metan"
+        ]
       },
       {
         "en": "Ozone",
         "ja": "オゾン",
-        "ja_typings": []
+        "ja_typings": [
+          "ozon"
+        ]
       },
       {
         "en": "Sulfur dioxide",
@@ -57737,22 +62159,30 @@
       {
         "en": "Lithium",
         "ja": "リチウム",
-        "ja_typings": []
+        "ja_typings": [
+          "richiumu"
+        ]
       },
       {
         "en": "Sodium",
         "ja": "ナトリウム",
-        "ja_typings": []
+        "ja_typings": [
+          "natoriumu"
+        ]
       },
       {
         "en": "Magnesium",
         "ja": "マグネシウム",
-        "ja_typings": []
+        "ja_typings": [
+          "maguneshiumu"
+        ]
       },
       {
         "en": "Beryllium",
         "ja": "ベリリウム",
-        "ja_typings": []
+        "ja_typings": [
+          "beririumu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -57807,17 +62237,17 @@
   {
     "choices": [
       {
+        "en": "Jupiter",
+        "ja": "木星",
+        "ja_typings": [
+          "mokusei"
+        ]
+      },
+      {
         "en": "Saturn",
         "ja": "土星",
         "ja_typings": [
           "dosei"
-        ]
-      },
-      {
-        "en": "Uranus",
-        "ja": "天王星",
-        "ja_typings": [
-          "tennousei"
         ]
       },
       {
@@ -57828,10 +62258,10 @@
         ]
       },
       {
-        "en": "Venus",
-        "ja": "金星",
+        "en": "Mars",
+        "ja": "火星",
         "ja_typings": [
-          "kinsei"
+          "kasei"
         ]
       }
     ],
@@ -57840,8 +62270,8 @@
     "id": "q01534",
     "image_path": null,
     "question_text": {
-      "en": "Which planet is known for its prominent rings?",
-      "ja": "顕著な環で知られる惑星は?"
+      "en": "Which planet has the Great Red Spot?",
+      "ja": "大赤斑がある惑星は?"
     }
   },
   {
@@ -57929,22 +62359,30 @@
       {
         "en": "Ganymede",
         "ja": "ガニメデ",
-        "ja_typings": []
+        "ja_typings": [
+          "ganimede"
+        ]
       },
       {
         "en": "Titan",
         "ja": "タイタン",
-        "ja_typings": []
+        "ja_typings": [
+          "taitan"
+        ]
       },
       {
         "en": "Europa",
         "ja": "エウロパ",
-        "ja_typings": []
+        "ja_typings": [
+          "europa"
+        ]
       },
       {
         "en": "Callisto",
         "ja": "カリスト",
-        "ja_typings": []
+        "ja_typings": [
+          "karisuto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -57961,22 +62399,30 @@
       {
         "en": "Titan",
         "ja": "タイタン",
-        "ja_typings": []
+        "ja_typings": [
+          "taitan"
+        ]
       },
       {
         "en": "Enceladus",
         "ja": "エンケラドゥス",
-        "ja_typings": []
+        "ja_typings": [
+          "enkeradusu"
+        ]
       },
       {
         "en": "Mimas",
         "ja": "ミマス",
-        "ja_typings": []
+        "ja_typings": [
+          "mimasu"
+        ]
       },
       {
         "en": "Rhea",
         "ja": "レア",
-        "ja_typings": []
+        "ja_typings": [
+          "rea"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -57993,22 +62439,30 @@
       {
         "en": "Copernicus",
         "ja": "コペルニクス",
-        "ja_typings": []
+        "ja_typings": [
+          "koperunikusu"
+        ]
       },
       {
         "en": "Galileo",
         "ja": "ガリレオ",
-        "ja_typings": []
+        "ja_typings": [
+          "garireo"
+        ]
       },
       {
         "en": "Kepler",
         "ja": "ケプラー",
-        "ja_typings": []
+        "ja_typings": [
+          "kepura-"
+        ]
       },
       {
         "en": "Brahe",
         "ja": "ブラーエ",
-        "ja_typings": []
+        "ja_typings": [
+          "bura-e"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -58025,22 +62479,30 @@
       {
         "en": "Kepler",
         "ja": "ケプラー",
-        "ja_typings": []
+        "ja_typings": [
+          "kepura-"
+        ]
       },
       {
         "en": "Copernicus",
         "ja": "コペルニクス",
-        "ja_typings": []
+        "ja_typings": [
+          "koperunikusu"
+        ]
       },
       {
         "en": "Galileo",
         "ja": "ガリレオ",
-        "ja_typings": []
+        "ja_typings": [
+          "garireo"
+        ]
       },
       {
         "en": "Halley",
         "ja": "ハレー",
-        "ja_typings": []
+        "ja_typings": [
+          "hare-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -58057,22 +62519,30 @@
       {
         "en": "Ampere",
         "ja": "アンペール",
-        "ja_typings": []
+        "ja_typings": [
+          "anpe-ru"
+        ]
       },
       {
         "en": "Volta",
         "ja": "ボルタ",
-        "ja_typings": []
+        "ja_typings": [
+          "boruta"
+        ]
       },
       {
         "en": "Ohm",
         "ja": "オーム",
-        "ja_typings": []
+        "ja_typings": [
+          "o-mu"
+        ]
       },
       {
         "en": "Faraday",
         "ja": "ファラデー",
-        "ja_typings": []
+        "ja_typings": [
+          "farade-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -58089,22 +62559,30 @@
       {
         "en": "Faraday",
         "ja": "ファラデー",
-        "ja_typings": []
+        "ja_typings": [
+          "farade-"
+        ]
       },
       {
         "en": "Maxwell",
         "ja": "マクスウェル",
-        "ja_typings": []
+        "ja_typings": [
+          "makusuweru"
+        ]
       },
       {
         "en": "Hertz",
         "ja": "ヘルツ",
-        "ja_typings": []
+        "ja_typings": [
+          "herutsu"
+        ]
       },
       {
         "en": "Tesla",
         "ja": "テスラ",
-        "ja_typings": []
+        "ja_typings": [
+          "tesura"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -58121,22 +62599,30 @@
       {
         "en": "Maxwell",
         "ja": "マクスウェル",
-        "ja_typings": []
+        "ja_typings": [
+          "makusuweru"
+        ]
       },
       {
         "en": "Faraday",
         "ja": "ファラデー",
-        "ja_typings": []
+        "ja_typings": [
+          "farade-"
+        ]
       },
       {
         "en": "Hertz",
         "ja": "ヘルツ",
-        "ja_typings": []
+        "ja_typings": [
+          "herutsu"
+        ]
       },
       {
         "en": "Lorentz",
         "ja": "ローレンツ",
-        "ja_typings": []
+        "ja_typings": [
+          "ro-rentsu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -58153,22 +62639,30 @@
       {
         "en": "Crick",
         "ja": "クリック",
-        "ja_typings": []
+        "ja_typings": [
+          "kurikku"
+        ]
       },
       {
         "en": "Franklin",
         "ja": "フランクリン",
-        "ja_typings": []
+        "ja_typings": [
+          "furankurin"
+        ]
       },
       {
         "en": "Wilkins",
         "ja": "ウィルキンス",
-        "ja_typings": []
+        "ja_typings": [
+          "wirukinsu"
+        ]
       },
       {
         "en": "Pauling",
         "ja": "ポーリング",
-        "ja_typings": []
+        "ja_typings": [
+          "po-ringu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -58185,22 +62679,30 @@
       {
         "en": "Lavoisier",
         "ja": "ラヴォアジエ",
-        "ja_typings": []
+        "ja_typings": [
+          "ravoajie"
+        ]
       },
       {
         "en": "Mendeleev",
         "ja": "メンデレーエフ",
-        "ja_typings": []
+        "ja_typings": [
+          "mendere-efu"
+        ]
       },
       {
         "en": "Dalton",
         "ja": "ドルトン",
-        "ja_typings": []
+        "ja_typings": [
+          "doruton"
+        ]
       },
       {
         "en": "Boyle",
         "ja": "ボイル",
-        "ja_typings": []
+        "ja_typings": [
+          "boiru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -58217,22 +62719,30 @@
       {
         "en": "Mendeleev",
         "ja": "メンデレーエフ",
-        "ja_typings": []
+        "ja_typings": [
+          "mendere-efu"
+        ]
       },
       {
         "en": "Lavoisier",
         "ja": "ラヴォアジエ",
-        "ja_typings": []
+        "ja_typings": [
+          "ravoajie"
+        ]
       },
       {
         "en": "Dalton",
         "ja": "ドルトン",
-        "ja_typings": []
+        "ja_typings": [
+          "doruton"
+        ]
       },
       {
         "en": "Bohr",
         "ja": "ボーア",
-        "ja_typings": []
+        "ja_typings": [
+          "bo-a"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -58249,22 +62759,30 @@
       {
         "en": "Dalton",
         "ja": "ドルトン",
-        "ja_typings": []
+        "ja_typings": [
+          "doruton"
+        ]
       },
       {
         "en": "Bohr",
         "ja": "ボーア",
-        "ja_typings": []
+        "ja_typings": [
+          "bo-a"
+        ]
       },
       {
         "en": "Rutherford",
         "ja": "ラザフォード",
-        "ja_typings": []
+        "ja_typings": [
+          "razafo-do"
+        ]
       },
       {
         "en": "Thomson",
         "ja": "トムソン",
-        "ja_typings": []
+        "ja_typings": [
+          "tomuson"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -58281,22 +62799,30 @@
       {
         "en": "Thomson",
         "ja": "トムソン",
-        "ja_typings": []
+        "ja_typings": [
+          "tomuson"
+        ]
       },
       {
         "en": "Rutherford",
         "ja": "ラザフォード",
-        "ja_typings": []
+        "ja_typings": [
+          "razafo-do"
+        ]
       },
       {
         "en": "Bohr",
         "ja": "ボーア",
-        "ja_typings": []
+        "ja_typings": [
+          "bo-a"
+        ]
       },
       {
         "en": "Millikan",
         "ja": "ミリカン",
-        "ja_typings": []
+        "ja_typings": [
+          "mirikan"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -58313,22 +62839,30 @@
       {
         "en": "Rutherford",
         "ja": "ラザフォード",
-        "ja_typings": []
+        "ja_typings": [
+          "razafo-do"
+        ]
       },
       {
         "en": "Bohr",
         "ja": "ボーア",
-        "ja_typings": []
+        "ja_typings": [
+          "bo-a"
+        ]
       },
       {
         "en": "Chadwick",
         "ja": "チャドウィック",
-        "ja_typings": []
+        "ja_typings": [
+          "chadowikku"
+        ]
       },
       {
         "en": "Thomson",
         "ja": "トムソン",
-        "ja_typings": []
+        "ja_typings": [
+          "tomuson"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -58345,22 +62879,30 @@
       {
         "en": "Chadwick",
         "ja": "チャドウィック",
-        "ja_typings": []
+        "ja_typings": [
+          "chadowikku"
+        ]
       },
       {
         "en": "Rutherford",
         "ja": "ラザフォード",
-        "ja_typings": []
+        "ja_typings": [
+          "razafo-do"
+        ]
       },
       {
         "en": "Bohr",
         "ja": "ボーア",
-        "ja_typings": []
+        "ja_typings": [
+          "bo-a"
+        ]
       },
       {
         "en": "Fermi",
         "ja": "フェルミ",
-        "ja_typings": []
+        "ja_typings": [
+          "ferumi"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -58377,22 +62919,30 @@
       {
         "en": "Ampere",
         "ja": "アンペア",
-        "ja_typings": []
+        "ja_typings": [
+          "anpea"
+        ]
       },
       {
         "en": "Volt",
         "ja": "ボルト",
-        "ja_typings": []
+        "ja_typings": [
+          "boruto"
+        ]
       },
       {
         "en": "Ohm",
         "ja": "オーム",
-        "ja_typings": []
+        "ja_typings": [
+          "o-mu"
+        ]
       },
       {
         "en": "Watt",
         "ja": "ワット",
-        "ja_typings": []
+        "ja_typings": [
+          "watto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -58409,22 +62959,30 @@
       {
         "en": "Hertz",
         "ja": "ヘルツ",
-        "ja_typings": []
+        "ja_typings": [
+          "herutsu"
+        ]
       },
       {
         "en": "Watt",
         "ja": "ワット",
-        "ja_typings": []
+        "ja_typings": [
+          "watto"
+        ]
       },
       {
         "en": "Joule",
         "ja": "ジュール",
-        "ja_typings": []
+        "ja_typings": [
+          "ju-ru"
+        ]
       },
       {
         "en": "Pascal",
         "ja": "パスカル",
-        "ja_typings": []
+        "ja_typings": [
+          "pasukaru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -58441,22 +62999,30 @@
       {
         "en": "Pascal",
         "ja": "パスカル",
-        "ja_typings": []
+        "ja_typings": [
+          "pasukaru"
+        ]
       },
       {
         "en": "Newton",
         "ja": "ニュートン",
-        "ja_typings": []
+        "ja_typings": [
+          "nyu-ton"
+        ]
       },
       {
         "en": "Joule",
         "ja": "ジュール",
-        "ja_typings": []
+        "ja_typings": [
+          "ju-ru"
+        ]
       },
       {
         "en": "Bar",
         "ja": "バール",
-        "ja_typings": []
+        "ja_typings": [
+          "ba-ru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -58473,22 +63039,30 @@
       {
         "en": "Joule",
         "ja": "ジュール",
-        "ja_typings": []
+        "ja_typings": [
+          "ju-ru"
+        ]
       },
       {
         "en": "Watt",
         "ja": "ワット",
-        "ja_typings": []
+        "ja_typings": [
+          "watto"
+        ]
       },
       {
         "en": "Calorie",
         "ja": "カロリー",
-        "ja_typings": []
+        "ja_typings": [
+          "karori-"
+        ]
       },
       {
         "en": "Erg",
         "ja": "エルグ",
-        "ja_typings": []
+        "ja_typings": [
+          "erugu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -58505,22 +63079,30 @@
       {
         "en": "Newton",
         "ja": "ニュートン",
-        "ja_typings": []
+        "ja_typings": [
+          "nyu-ton"
+        ]
       },
       {
         "en": "Joule",
         "ja": "ジュール",
-        "ja_typings": []
+        "ja_typings": [
+          "ju-ru"
+        ]
       },
       {
         "en": "Pascal",
         "ja": "パスカル",
-        "ja_typings": []
+        "ja_typings": [
+          "pasukaru"
+        ]
       },
       {
         "en": "Dyne",
         "ja": "ダイン",
-        "ja_typings": []
+        "ja_typings": [
+          "dain"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -58625,7 +63207,9 @@
       {
         "en": "Richter scale",
         "ja": "リヒタースケール",
-        "ja_typings": []
+        "ja_typings": [
+          "rihita-suke-ru"
+        ]
       },
       {
         "en": "Beaufort scale",
@@ -58697,22 +63281,30 @@
       {
         "en": "S3",
         "ja": "S3",
-        "ja_typings": []
+        "ja_typings": [
+          "s3"
+        ]
       },
       {
         "en": "Z2",
         "ja": "Z2",
-        "ja_typings": []
+        "ja_typings": [
+          "z2"
+        ]
       },
       {
         "en": "Z4",
         "ja": "Z4",
-        "ja_typings": []
+        "ja_typings": [
+          "z4"
+        ]
       },
       {
         "en": "V4",
         "ja": "V4",
-        "ja_typings": []
+        "ja_typings": [
+          "v4"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -58736,17 +63328,23 @@
       {
         "en": "Goldbach",
         "ja": "ゴールドバッハ予想",
-        "ja_typings": []
+        "ja_typings": [
+          "go-rudobahhayosou"
+        ]
       },
       {
         "en": "Riemann",
         "ja": "リーマン予想",
-        "ja_typings": []
+        "ja_typings": [
+          "ri-manyosou"
+        ]
       },
       {
         "en": "Collatz",
         "ja": "コラッツ予想",
-        "ja_typings": []
+        "ja_typings": [
+          "korattsuyosou"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -58786,7 +63384,9 @@
       {
         "en": "monoid",
         "ja": "モノイド",
-        "ja_typings": []
+        "ja_typings": [
+          "monoido"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -58817,7 +63417,9 @@
       {
         "en": "torus",
         "ja": "トーラス",
-        "ja_typings": []
+        "ja_typings": [
+          "to-rasu"
+        ]
       },
       {
         "en": "hyperbolic plane",
@@ -58848,17 +63450,23 @@
       {
         "en": "octonions",
         "ja": "八元数",
-        "ja_typings": []
+        "ja_typings": [
+          "hachigensuu"
+        ]
       },
       {
         "en": "sedenions",
         "ja": "十六元数",
-        "ja_typings": []
+        "ja_typings": [
+          "juurokugensuu"
+        ]
       },
       {
         "en": "dual numbers",
         "ja": "二重数",
-        "ja_typings": []
+        "ja_typings": [
+          "nijuusuu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -58889,12 +63497,16 @@
       {
         "en": "Green",
         "ja": "グリーンの定理",
-        "ja_typings": []
+        "ja_typings": [
+          "guri-nnnoteiri"
+        ]
       },
       {
         "en": "Cauchy",
         "ja": "コーシーの定理",
-        "ja_typings": []
+        "ja_typings": [
+          "ko-shi-noteiri"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -58925,12 +63537,16 @@
       {
         "en": "Hilbert tenth",
         "ja": "ヒルベルト第十問題",
-        "ja_typings": []
+        "ja_typings": [
+          "hiruberutodaijuumondai"
+        ]
       },
       {
         "en": "Goldbach",
         "ja": "ゴールドバッハ問題",
-        "ja_typings": []
+        "ja_typings": [
+          "go-rudobahhamondai"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -58954,17 +63570,23 @@
       {
         "en": "Lebesgue",
         "ja": "ルベーグ次元",
-        "ja_typings": []
+        "ja_typings": [
+          "rube-gujigen"
+        ]
       },
       {
         "en": "Minkowski",
         "ja": "ミンコフスキー次元",
-        "ja_typings": []
+        "ja_typings": [
+          "minkofusuki-jigen"
+        ]
       },
       {
         "en": "Krull",
         "ja": "クルル次元",
-        "ja_typings": []
+        "ja_typings": [
+          "kururujigen"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -58995,12 +63617,16 @@
       {
         "en": "MST",
         "ja": "最小全域木問題",
-        "ja_typings": []
+        "ja_typings": [
+          "saishouzennnikimondai"
+        ]
       },
       {
         "en": "BFS",
         "ja": "幅優先探索",
-        "ja_typings": []
+        "ja_typings": [
+          "habayuusentansaku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -59018,23 +63644,30 @@
         "en": "aleph one",
         "ja": "アレフ1",
         "ja_typings": [
-          "arefu 1"
+          "arefu 1",
+          "arefu1"
         ]
       },
       {
         "en": "aleph zero",
         "ja": "アレフ0",
-        "ja_typings": []
+        "ja_typings": [
+          "arefu0"
+        ]
       },
       {
         "en": "aleph two",
         "ja": "アレフ2",
-        "ja_typings": []
+        "ja_typings": [
+          "arefu2"
+        ]
       },
       {
         "en": "beth zero",
         "ja": "ベート0",
-        "ja_typings": []
+        "ja_typings": [
+          "be-to0"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -59098,17 +63731,23 @@
       {
         "en": "S5",
         "ja": "S5群",
-        "ja_typings": []
+        "ja_typings": [
+          "s5gun"
+        ]
       },
       {
         "en": "D8",
         "ja": "D8群",
-        "ja_typings": []
+        "ja_typings": [
+          "d8gun"
+        ]
       },
       {
         "en": "Z12",
         "ja": "Z12群",
-        "ja_typings": []
+        "ja_typings": [
+          "z12gun"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -59139,12 +63778,16 @@
       {
         "en": "vector spaces",
         "ja": "ベクトル空間",
-        "ja_typings": []
+        "ja_typings": [
+          "bekutorukuukan"
+        ]
       },
       {
         "en": "Hilbert spaces",
         "ja": "ヒルベルト空間",
-        "ja_typings": []
+        "ja_typings": [
+          "hiruberutokuukan"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -59215,12 +63858,16 @@
       {
         "en": "free group",
         "ja": "自由群",
-        "ja_typings": []
+        "ja_typings": [
+          "jiyuugun"
+        ]
       },
       {
         "en": "nilpotent group",
         "ja": "冪零群",
-        "ja_typings": []
+        "ja_typings": [
+          "bekireigun"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -59244,17 +63891,23 @@
       {
         "en": "vector",
         "ja": "ベクトル",
-        "ja_typings": []
+        "ja_typings": [
+          "bekutoru"
+        ]
       },
       {
         "en": "matrix",
         "ja": "行列",
-        "ja_typings": []
+        "ja_typings": [
+          "gyouretsu"
+        ]
       },
       {
         "en": "tensor",
         "ja": "テンソル",
-        "ja_typings": []
+        "ja_typings": [
+          "tensoru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -59278,17 +63931,23 @@
       {
         "en": "Cauchy-Schwarz",
         "ja": "コーシー・シュワルツの不等式",
-        "ja_typings": []
+        "ja_typings": [
+          "ko-shi-/shuwarutsunofutoushiki"
+        ]
       },
       {
         "en": "Jensen",
         "ja": "イェンセンの不等式",
-        "ja_typings": []
+        "ja_typings": [
+          "iensennnofutoushiki"
+        ]
       },
       {
         "en": "Markov",
         "ja": "マルコフの不等式",
-        "ja_typings": []
+        "ja_typings": [
+          "marukofunofutoushiki"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -59346,23 +64005,29 @@
         "en": "Snake lemma",
         "ja": "蛇の補題",
         "ja_typings": [
-          "hebi no hodai"
+          "hebinohodai"
         ]
       },
       {
         "en": "Zorn lemma",
         "ja": "ツォルンの補題",
-        "ja_typings": []
+        "ja_typings": [
+          "tsorunnohodai"
+        ]
       },
       {
         "en": "Yoneda lemma",
         "ja": "米田の補題",
-        "ja_typings": []
+        "ja_typings": [
+          "yonedanohodai"
+        ]
       },
       {
         "en": "Schur lemma",
         "ja": "シューアの補題",
-        "ja_typings": []
+        "ja_typings": [
+          "shu-anohodai"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -59386,17 +64051,23 @@
       {
         "en": "compact manifold",
         "ja": "コンパクト多様体",
-        "ja_typings": []
+        "ja_typings": [
+          "konpakutotayoutai"
+        ]
       },
       {
         "en": "simply connected space",
         "ja": "単連結空間",
-        "ja_typings": []
+        "ja_typings": [
+          "tanrenketsukuukan"
+        ]
       },
       {
         "en": "Hausdorff space",
         "ja": "ハウスドルフ空間",
-        "ja_typings": []
+        "ja_typings": [
+          "hausudorufukuukan"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -59427,12 +64098,16 @@
       {
         "en": "Laplace",
         "ja": "ラプラス方程式",
-        "ja_typings": []
+        "ja_typings": [
+          "rapurasuhouteishiki"
+        ]
       },
       {
         "en": "Schrodinger",
         "ja": "シュレーディンガー方程式",
-        "ja_typings": []
+        "ja_typings": [
+          "shure-dinga-houteishiki"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -59456,17 +64131,23 @@
       {
         "en": "Newton-Raphson",
         "ja": "ニュートン法",
-        "ja_typings": []
+        "ja_typings": [
+          "nyu-tonhou"
+        ]
       },
       {
         "en": "Simpson",
         "ja": "シンプソン則",
-        "ja_typings": []
+        "ja_typings": [
+          "shinpusonsoku"
+        ]
       },
       {
         "en": "Gauss elimination",
         "ja": "ガウス消去法",
-        "ja_typings": []
+        "ja_typings": [
+          "gausushoukyohou"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -59497,12 +64178,16 @@
       {
         "en": "graph coloring",
         "ja": "グラフ彩色問題",
-        "ja_typings": []
+        "ja_typings": [
+          "gurafusaishokumondai"
+        ]
       },
       {
         "en": "max flow",
         "ja": "最大流問題",
-        "ja_typings": []
+        "ja_typings": [
+          "saidairyuumondai"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -59533,12 +64218,16 @@
       {
         "en": "Z transform",
         "ja": "Z変換",
-        "ja_typings": []
+        "ja_typings": [
+          "zhenkan"
+        ]
       },
       {
         "en": "Hilbert transform",
         "ja": "ヒルベルト変換",
-        "ja_typings": []
+        "ja_typings": [
+          "hiruberutohenkan"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -59569,12 +64258,16 @@
       {
         "en": "Frechet space",
         "ja": "フレシェ空間",
-        "ja_typings": []
+        "ja_typings": [
+          "fureshekuukan"
+        ]
       },
       {
         "en": "Sobolev space",
         "ja": "ソボレフ空間",
-        "ja_typings": []
+        "ja_typings": [
+          "soborefukuukan"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -59605,12 +64298,16 @@
       {
         "en": "Hodge conjecture",
         "ja": "ホッジ予想",
-        "ja_typings": []
+        "ja_typings": [
+          "hojjiyosou"
+        ]
       },
       {
         "en": "Birch-Swinnerton-Dyer",
         "ja": "BSD予想",
-        "ja_typings": []
+        "ja_typings": [
+          "bsdyosou"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -59641,12 +64338,16 @@
       {
         "en": "Carmichael numbers",
         "ja": "カーマイケル数",
-        "ja_typings": []
+        "ja_typings": [
+          "ka-maikerusuu"
+        ]
       },
       {
         "en": "Lucas numbers",
         "ja": "リュカ数",
-        "ja_typings": []
+        "ja_typings": [
+          "ryukasuu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -59677,7 +64378,9 @@
       {
         "en": "minimax",
         "ja": "ミニマックス",
-        "ja_typings": []
+        "ja_typings": [
+          "minimakkusu"
+        ]
       },
       {
         "en": "dominant strategy",
@@ -59722,7 +64425,9 @@
       {
         "en": "cardioid",
         "ja": "カージオイド",
-        "ja_typings": []
+        "ja_typings": [
+          "ka-jioido"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -59740,23 +64445,30 @@
         "en": "Russell paradox",
         "ja": "ラッセルのパラドックス",
         "ja_typings": [
-          "rasseru no paradokkusu"
+          "rasseru no paradokkusu",
+          "rasserunoparadokkusu"
         ]
       },
       {
         "en": "Banach-Tarski",
         "ja": "バナッハ・タルスキー",
-        "ja_typings": []
+        "ja_typings": [
+          "banahha/tarusuki-"
+        ]
       },
       {
         "en": "Zeno",
         "ja": "ゼノンのパラドックス",
-        "ja_typings": []
+        "ja_typings": [
+          "zenonnnoparadokkusu"
+        ]
       },
       {
         "en": "Berry",
         "ja": "ベリーのパラドックス",
-        "ja_typings": []
+        "ja_typings": [
+          "beri-noparadokkusu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -59780,17 +64492,23 @@
       {
         "en": "eternal effort",
         "ja": "永遠の努力",
-        "ja_typings": []
+        "ja_typings": [
+          "eiennnodoryoku"
+        ]
       },
       {
         "en": "rare opportunity",
         "ja": "稀な機会",
-        "ja_typings": []
+        "ja_typings": [
+          "marenakikai"
+        ]
       },
       {
         "en": "strong will",
         "ja": "強い意志",
-        "ja_typings": []
+        "ja_typings": [
+          "tsuyoiishi"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -59814,7 +64532,9 @@
       {
         "en": "Cassiopeia",
         "ja": "カシオペア座",
-        "ja_typings": []
+        "ja_typings": [
+          "kashiopeaza"
+        ]
       },
       {
         "en": "Lyra",
@@ -59826,7 +64546,9 @@
       {
         "en": "Cygnus",
         "ja": "はくちょう座",
-        "ja_typings": []
+        "ja_typings": [
+          "hakuchouza"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -59843,22 +64565,30 @@
       {
         "en": "candela",
         "ja": "カンデラ",
-        "ja_typings": []
+        "ja_typings": [
+          "kandera"
+        ]
       },
       {
         "en": "lumen",
         "ja": "ルーメン",
-        "ja_typings": []
+        "ja_typings": [
+          "ru-men"
+        ]
       },
       {
         "en": "lux",
         "ja": "ルクス",
-        "ja_typings": []
+        "ja_typings": [
+          "rukusu"
+        ]
       },
       {
         "en": "nit",
         "ja": "ニト",
-        "ja_typings": []
+        "ja_typings": [
+          "nito"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -59882,17 +64612,23 @@
       {
         "en": "very lonely",
         "ja": "非常に寂しい",
-        "ja_typings": []
+        "ja_typings": [
+          "hijounisabishii"
+        ]
       },
       {
         "en": "very tired",
         "ja": "非常に疲れた",
-        "ja_typings": []
+        "ja_typings": [
+          "hijounitsukareta"
+        ]
       },
       {
         "en": "very confused",
         "ja": "非常に混乱",
-        "ja_typings": []
+        "ja_typings": [
+          "hijounikonran"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -59949,22 +64685,30 @@
       {
         "en": "weber",
         "ja": "ウェーバ",
-        "ja_typings": []
+        "ja_typings": [
+          "we-ba"
+        ]
       },
       {
         "en": "tesla",
         "ja": "テスラ",
-        "ja_typings": []
+        "ja_typings": [
+          "tesura"
+        ]
       },
       {
         "en": "henry",
         "ja": "ヘンリー",
-        "ja_typings": []
+        "ja_typings": [
+          "henri-"
+        ]
       },
       {
         "en": "gauss",
         "ja": "ガウス",
-        "ja_typings": []
+        "ja_typings": [
+          "gausu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -59988,17 +64732,23 @@
       {
         "en": "Aries",
         "ja": "おひつじ座",
-        "ja_typings": []
+        "ja_typings": [
+          "ohitsujiza"
+        ]
       },
       {
         "en": "Gemini",
         "ja": "ふたご座",
-        "ja_typings": []
+        "ja_typings": [
+          "futagoza"
+        ]
       },
       {
         "en": "Virgo",
         "ja": "おとめ座",
-        "ja_typings": []
+        "ja_typings": [
+          "otomeza"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -60022,17 +64772,23 @@
       {
         "en": "North American Science Agency",
         "ja": "北米科学機関",
-        "ja_typings": []
+        "ja_typings": [
+          "hokubeikagakukikan"
+        ]
       },
       {
         "en": "National Atomic Safety Authority",
         "ja": "国家原子力安全機関",
-        "ja_typings": []
+        "ja_typings": [
+          "kokkagenshiryokuanzenkikan"
+        ]
       },
       {
         "en": "Naval Astronautics Society Association",
         "ja": "海軍宇宙協会",
-        "ja_typings": []
+        "ja_typings": [
+          "kaiguniuchuukyoukai"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -60089,22 +64845,30 @@
       {
         "en": "decibel",
         "ja": "デシベル",
-        "ja_typings": []
+        "ja_typings": [
+          "deshiberu"
+        ]
       },
       {
         "en": "hertz",
         "ja": "ヘルツ",
-        "ja_typings": []
+        "ja_typings": [
+          "herutsu"
+        ]
       },
       {
         "en": "phon",
         "ja": "フォン",
-        "ja_typings": []
+        "ja_typings": [
+          "fon"
+        ]
       },
       {
         "en": "sone",
         "ja": "ソーン",
-        "ja_typings": []
+        "ja_typings": [
+          "so-n"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -60135,7 +64899,9 @@
       {
         "en": "websites",
         "ja": "ウェブサイト",
-        "ja_typings": []
+        "ja_typings": [
+          "webusaito"
+        ]
       },
       {
         "en": "songs",
@@ -60166,17 +64932,23 @@
       {
         "en": "Ursa Major",
         "ja": "おおぐま座",
-        "ja_typings": []
+        "ja_typings": [
+          "oogumaza"
+        ]
       },
       {
         "en": "Draco",
         "ja": "りゅう座",
-        "ja_typings": []
+        "ja_typings": [
+          "ryuuza"
+        ]
       },
       {
         "en": "Cepheus",
         "ja": "ケフェウス座",
-        "ja_typings": []
+        "ja_typings": [
+          "kefeusuza"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -60200,17 +64972,23 @@
       {
         "en": "celebrating victory",
         "ja": "勝利を祝う",
-        "ja_typings": []
+        "ja_typings": [
+          "shouriwoiwau"
+        ]
       },
       {
         "en": "teaching by example",
         "ja": "範を示す",
-        "ja_typings": []
+        "ja_typings": [
+          "hanwoshimesu"
+        ]
       },
       {
         "en": "respecting elders",
         "ja": "長老を敬う",
-        "ja_typings": []
+        "ja_typings": [
+          "chourouwouyamau"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -60227,22 +65005,30 @@
       {
         "en": "rampant",
         "ja": "ランパント",
-        "ja_typings": []
+        "ja_typings": [
+          "ranpanto"
+        ]
       },
       {
         "en": "passant",
         "ja": "パサント",
-        "ja_typings": []
+        "ja_typings": [
+          "pasanto"
+        ]
       },
       {
         "en": "couchant",
         "ja": "クーシャント",
-        "ja_typings": []
+        "ja_typings": [
+          "ku-shanto"
+        ]
       },
       {
         "en": "sejant",
         "ja": "セジャント",
-        "ja_typings": []
+        "ja_typings": [
+          "sejanto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -60259,22 +65045,30 @@
       {
         "en": "sievert",
         "ja": "シーベルト",
-        "ja_typings": []
+        "ja_typings": [
+          "shi-beruto"
+        ]
       },
       {
         "en": "becquerel",
         "ja": "ベクレル",
-        "ja_typings": []
+        "ja_typings": [
+          "bekureru"
+        ]
       },
       {
         "en": "gray",
         "ja": "グレイ",
-        "ja_typings": []
+        "ja_typings": [
+          "gurei"
+        ]
       },
       {
         "en": "roentgen",
         "ja": "レントゲン",
-        "ja_typings": []
+        "ja_typings": [
+          "rentogen"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -60298,17 +65092,23 @@
       {
         "en": "touki bansei",
         "ja": "陶器万歳",
-        "ja_typings": []
+        "ja_typings": [
+          "toukibanzai"
+        ]
       },
       {
         "en": "seiten hekireki",
         "ja": "晴天霹靂",
-        "ja_typings": []
+        "ja_typings": [
+          "seitenhekireki"
+        ]
       },
       {
         "en": "muga muchuu",
         "ja": "無我夢中",
-        "ja_typings": []
+        "ja_typings": [
+          "mugamuchuu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -60332,17 +65132,23 @@
       {
         "en": "reading old books",
         "ja": "古い本を読むこと",
-        "ja_typings": []
+        "ja_typings": [
+          "furuihonwoyomukoto"
+        ]
       },
       {
         "en": "lending out books",
         "ja": "本を貸し出すこと",
-        "ja_typings": []
+        "ja_typings": [
+          "honwokashidasukoto"
+        ]
       },
       {
         "en": "losing a book",
         "ja": "本を失くすこと",
-        "ja_typings": []
+        "ja_typings": [
+          "honwonakusukoto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -60359,22 +65165,30 @@
       {
         "en": "Sirius",
         "ja": "シリウス",
-        "ja_typings": []
+        "ja_typings": [
+          "shiriusu"
+        ]
       },
       {
         "en": "Vega",
         "ja": "ベガ",
-        "ja_typings": []
+        "ja_typings": [
+          "bega"
+        ]
       },
       {
         "en": "Arcturus",
         "ja": "アルクトゥルス",
-        "ja_typings": []
+        "ja_typings": [
+          "arukuturusu"
+        ]
       },
       {
         "en": "Capella",
         "ja": "カペラ",
-        "ja_typings": []
+        "ja_typings": [
+          "kapera"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -60398,17 +65212,23 @@
       {
         "en": "brightness and grandeur",
         "ja": "華やかさ",
-        "ja_typings": []
+        "ja_typings": [
+          "hanayakasa"
+        ]
       },
       {
         "en": "symmetry and order",
         "ja": "対称と秩序",
-        "ja_typings": []
+        "ja_typings": [
+          "taishoutochitsujo"
+        ]
       },
       {
         "en": "color and vibrancy",
         "ja": "色彩と活気",
-        "ja_typings": []
+        "ja_typings": [
+          "shikisaitokakki"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -60425,22 +65245,30 @@
       {
         "en": "pascal",
         "ja": "パスカル",
-        "ja_typings": []
+        "ja_typings": [
+          "pasukaru"
+        ]
       },
       {
         "en": "joule",
         "ja": "ジュール",
-        "ja_typings": []
+        "ja_typings": [
+          "ju-ru"
+        ]
       },
       {
         "en": "watt",
         "ja": "ワット",
-        "ja_typings": []
+        "ja_typings": [
+          "watto"
+        ]
       },
       {
         "en": "newton",
         "ja": "ニュートン",
-        "ja_typings": []
+        "ja_typings": [
+          "nyu-ton"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -60464,7 +65292,9 @@
       {
         "en": "infinite time",
         "ja": "無限の時間",
-        "ja_typings": []
+        "ja_typings": [
+          "mugennnojikan"
+        ]
       },
       {
         "en": "life and death",
@@ -60542,17 +65372,23 @@
       {
         "en": "rare treasure",
         "ja": "希少な宝",
-        "ja_typings": []
+        "ja_typings": [
+          "kishounatakara"
+        ]
       },
       {
         "en": "constant change",
         "ja": "絶え間ない変化",
-        "ja_typings": []
+        "ja_typings": [
+          "taemanaihenka"
+        ]
       },
       {
         "en": "eternal beauty",
         "ja": "永遠の美",
-        "ja_typings": []
+        "ja_typings": [
+          "eiennnobi"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -60569,22 +65405,30 @@
       {
         "en": "FLOPS",
         "ja": "フロップス",
-        "ja_typings": []
+        "ja_typings": [
+          "furoppusu"
+        ]
       },
       {
         "en": "BPS",
         "ja": "ビーピーエス",
-        "ja_typings": []
+        "ja_typings": [
+          "bi-pi-esu"
+        ]
       },
       {
         "en": "MIPS",
         "ja": "ミップス",
-        "ja_typings": []
+        "ja_typings": [
+          "mippusu"
+        ]
       },
       {
         "en": "IPS",
         "ja": "アイピーエス",
-        "ja_typings": []
+        "ja_typings": [
+          "aipi-esu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -60615,12 +65459,16 @@
       {
         "en": "Leo",
         "ja": "しし座",
-        "ja_typings": []
+        "ja_typings": [
+          "shishiza"
+        ]
       },
       {
         "en": "Taurus",
         "ja": "おうし座",
-        "ja_typings": []
+        "ja_typings": [
+          "oushiza"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -60644,17 +65492,23 @@
       {
         "en": "World Hospital Office",
         "ja": "世界病院事務局",
-        "ja_typings": []
+        "ja_typings": [
+          "sekaibyouinjimukyoku"
+        ]
       },
       {
         "en": "Western Health Organization",
         "ja": "西側保健機関",
-        "ja_typings": []
+        "ja_typings": [
+          "nishigawahokenkikan"
+        ]
       },
       {
         "en": "World Hygiene Organization",
         "ja": "世界衛生機関",
-        "ja_typings": []
+        "ja_typings": [
+          "sekaieiseikikan"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -60678,17 +65532,23 @@
       {
         "en": "isseki nichou",
         "ja": "一石二鳥",
-        "ja_typings": []
+        "ja_typings": [
+          "issekinichou"
+        ]
       },
       {
         "en": "kongen kongen",
         "ja": "根本根源",
-        "ja_typings": []
+        "ja_typings": [
+          "konponkongen"
+        ]
       },
       {
         "en": "haru natsu aki fuyu",
         "ja": "春夏秋冬",
-        "ja_typings": []
+        "ja_typings": [
+          "shunkashuutou"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -60705,22 +65565,30 @@
       {
         "en": "diamond",
         "ja": "ダイヤモンド",
-        "ja_typings": []
+        "ja_typings": [
+          "daiyamondo"
+        ]
       },
       {
         "en": "corundum",
         "ja": "コランダム",
-        "ja_typings": []
+        "ja_typings": [
+          "korandamu"
+        ]
       },
       {
         "en": "topaz",
         "ja": "トパーズ",
-        "ja_typings": []
+        "ja_typings": [
+          "topa-zu"
+        ]
       },
       {
         "en": "quartz",
         "ja": "クォーツ",
-        "ja_typings": []
+        "ja_typings": [
+          "kuo-tsu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -60777,12 +65645,16 @@
       {
         "en": "Kizuna AI",
         "ja": "キズナアイ",
-        "ja_typings": []
+        "ja_typings": [
+          "kizunaai"
+        ]
       },
       {
         "en": "Mirai Akari",
         "ja": "ミライアカリ",
-        "ja_typings": []
+        "ja_typings": [
+          "miraiakari"
+        ]
       },
       {
         "en": "Kaguya Luna",
@@ -60794,7 +65666,9 @@
       {
         "en": "Siro",
         "ja": "シロ",
-        "ja_typings": []
+        "ja_typings": [
+          "shiro"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -60811,22 +65685,30 @@
       {
         "en": "Nijisanji",
         "ja": "にじさんじ",
-        "ja_typings": []
+        "ja_typings": [
+          "nijisanji"
+        ]
       },
       {
         "en": "Hololive",
         "ja": "ホロライブ",
-        "ja_typings": []
+        "ja_typings": [
+          "hororaibu"
+        ]
       },
       {
         "en": "Noripro",
         "ja": "のりプロ",
-        "ja_typings": []
+        "ja_typings": [
+          "noripuro"
+        ]
       },
       {
         "en": "VShojo",
         "ja": "ブイショージョ",
-        "ja_typings": []
+        "ja_typings": [
+          "buisho-jo"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -60890,17 +65772,23 @@
       {
         "en": "a private channel",
         "ja": "非公開チャンネル",
-        "ja_typings": []
+        "ja_typings": [
+          "hikoukaichannneru"
+        ]
       },
       {
         "en": "a bot command",
         "ja": "ボットコマンド",
-        "ja_typings": []
+        "ja_typings": [
+          "bottokomando"
+        ]
       },
       {
         "en": "a voice call feature",
         "ja": "音声通話機能",
-        "ja_typings": []
+        "ja_typings": [
+          "onseitsuuwakinou"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -60917,22 +65805,30 @@
       {
         "en": "lurker",
         "ja": "ラーカー",
-        "ja_typings": []
+        "ja_typings": [
+          "ra-ka-"
+        ]
       },
       {
         "en": "raider",
         "ja": "レイダー",
-        "ja_typings": []
+        "ja_typings": [
+          "reida-"
+        ]
       },
       {
         "en": "hyper",
         "ja": "ハイパー",
-        "ja_typings": []
+        "ja_typings": [
+          "haipa-"
+        ]
       },
       {
         "en": "emoter",
         "ja": "エモーター",
-        "ja_typings": []
+        "ja_typings": [
+          "emo-ta-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -60956,17 +65852,23 @@
       {
         "en": "All For Kindness",
         "ja": "親切第一",
-        "ja_typings": []
+        "ja_typings": [
+          "shinsetsudaiichi"
+        ]
       },
       {
         "en": "Anti Friend Kick",
         "ja": "フレンドキック",
-        "ja_typings": []
+        "ja_typings": [
+          "furendokikku"
+        ]
       },
       {
         "en": "Auto Fast Key",
         "ja": "自動高速キー",
-        "ja_typings": []
+        "ja_typings": [
+          "jidoukousokuki-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -60983,22 +65885,30 @@
       {
         "en": "Rythm",
         "ja": "リズム",
-        "ja_typings": []
+        "ja_typings": [
+          "rizumu"
+        ]
       },
       {
         "en": "MEE6",
         "ja": "ミーシックス",
-        "ja_typings": []
+        "ja_typings": [
+          "mi-shikkusu"
+        ]
       },
       {
         "en": "Dyno",
         "ja": "ダイノ",
-        "ja_typings": []
+        "ja_typings": [
+          "daino"
+        ]
       },
       {
         "en": "Carl-bot",
         "ja": "カールボット",
-        "ja_typings": []
+        "ja_typings": [
+          "ka-rubotto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -61022,17 +65932,23 @@
       {
         "en": "a raid command",
         "ja": "レイドコマンド",
-        "ja_typings": []
+        "ja_typings": [
+          "reidokomando"
+        ]
       },
       {
         "en": "a sub tier",
         "ja": "サブスクのランク",
-        "ja_typings": []
+        "ja_typings": [
+          "sabusukunoranku"
+        ]
       },
       {
         "en": "a follower badge",
         "ja": "フォロワーバッジ",
-        "ja_typings": []
+        "ja_typings": [
+          "forowa-bajji"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -61063,12 +65979,16 @@
       {
         "en": "creating fake profiles",
         "ja": "偽プロフ作成",
-        "ja_typings": []
+        "ja_typings": [
+          "nisepurofusakusei"
+        ]
       },
       {
         "en": "spamming chats",
         "ja": "チャットスパム",
-        "ja_typings": []
+        "ja_typings": [
+          "chattosupamu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -61085,22 +66005,30 @@
       {
         "en": "hisashiburu",
         "ja": "ひさしぶる",
-        "ja_typings": []
+        "ja_typings": [
+          "hisashiburu"
+        ]
       },
       {
         "en": "kuriku ri",
         "ja": "クリクリ",
-        "ja_typings": []
+        "ja_typings": [
+          "kurikuri"
+        ]
       },
       {
         "en": "itai",
         "ja": "イタイ",
-        "ja_typings": []
+        "ja_typings": [
+          "itai"
+        ]
       },
       {
         "en": "gugu ru",
         "ja": "ググる",
-        "ja_typings": []
+        "ja_typings": [
+          "guguru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -61124,17 +66052,23 @@
       {
         "en": "dumb idea",
         "ja": "愚かな発想",
-        "ja_typings": []
+        "ja_typings": [
+          "orokanahassou"
+        ]
       },
       {
         "en": "nostalgic feeling",
         "ja": "懐かしい感情",
-        "ja_typings": []
+        "ja_typings": [
+          "natsukashiikanjou"
+        ]
       },
       {
         "en": "angry response",
         "ja": "怒りの反応",
-        "ja_typings": []
+        "ja_typings": [
+          "ikarinohannnou"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -61151,12 +66085,16 @@
       {
         "en": "Gawr Gura",
         "ja": "がうるぐら",
-        "ja_typings": []
+        "ja_typings": [
+          "gaurugura"
+        ]
       },
       {
         "en": "Watson Amelia",
         "ja": "ワトソンアメリア",
-        "ja_typings": []
+        "ja_typings": [
+          "watosonnameria"
+        ]
       },
       {
         "en": "Ninomae Inanis",
@@ -61168,7 +66106,9 @@
       {
         "en": "Mori Calliope",
         "ja": "森カリオペ",
-        "ja_typings": []
+        "ja_typings": [
+          "morikariope"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -61192,17 +66132,23 @@
       {
         "en": "polite greeting",
         "ja": "丁寧な挨拶",
-        "ja_typings": []
+        "ja_typings": [
+          "teineinaaisatsu"
+        ]
       },
       {
         "en": "game over",
         "ja": "ゲーム終了",
-        "ja_typings": []
+        "ja_typings": [
+          "ge-mushuuryou"
+        ]
       },
       {
         "en": "private message",
         "ja": "個別メッセージ",
-        "ja_typings": []
+        "ja_typings": [
+          "kobetsumesse-ji"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -61219,22 +66165,30 @@
       {
         "en": "regulars",
         "ja": "レギュラーズ",
-        "ja_typings": []
+        "ja_typings": [
+          "regyura-zu"
+        ]
       },
       {
         "en": "subbies",
         "ja": "サビーズ",
-        "ja_typings": []
+        "ja_typings": [
+          "sabi-zu"
+        ]
       },
       {
         "en": "hypers",
         "ja": "ハイパーズ",
-        "ja_typings": []
+        "ja_typings": [
+          "haipa-zu"
+        ]
       },
       {
         "en": "nubs",
         "ja": "ナブズ",
-        "ja_typings": []
+        "ja_typings": [
+          "nabuzu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -61258,17 +66212,23 @@
       {
         "en": "Italian recipe",
         "ja": "イタリア料理",
-        "ja_typings": []
+        "ja_typings": [
+          "itariaryouri"
+        ]
       },
       {
         "en": "Discord channel type",
         "ja": "Discordチャンネル種類",
-        "ja_typings": []
+        "ja_typings": [
+          "discordchannnerushurui"
+        ]
       },
       {
         "en": "private DM type",
         "ja": "DMの種類",
-        "ja_typings": []
+        "ja_typings": [
+          "dmnoshurui"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -61285,22 +66245,30 @@
       {
         "en": "wwwwww",
         "ja": "wwwwww",
-        "ja_typings": []
+        "ja_typings": [
+          "wwwwww"
+        ]
       },
       {
         "en": "orz",
         "ja": "orz",
-        "ja_typings": []
+        "ja_typings": [
+          "orz"
+        ]
       },
       {
         "en": "xD",
         "ja": "xD",
-        "ja_typings": []
+        "ja_typings": [
+          "xd"
+        ]
       },
       {
         "en": "T_T",
         "ja": "T_T",
-        "ja_typings": []
+        "ja_typings": [
+          "t_t"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -61364,17 +66332,23 @@
       {
         "en": "temporary kick",
         "ja": "一時キック",
-        "ja_typings": []
+        "ja_typings": [
+          "ichijikikku"
+        ]
       },
       {
         "en": "permanent IP ban",
         "ja": "永久IP遮断",
-        "ja_typings": []
+        "ja_typings": [
+          "eikyuuipshadan"
+        ]
       },
       {
         "en": "warning message",
         "ja": "警告メッセージ",
-        "ja_typings": []
+        "ja_typings": [
+          "keikokumesse-ji"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -61432,23 +66406,30 @@
         "en": "5channel",
         "ja": "5ちゃんねる",
         "ja_typings": [
-          "go channeru"
+          "go channeru",
+          "5channneru"
         ]
       },
       {
         "en": "Yahoo Chiebukuro",
         "ja": "Yahoo知恵袋",
-        "ja_typings": []
+        "ja_typings": [
+          "yahoochiebukuro"
+        ]
       },
       {
         "en": "Mixi",
         "ja": "ミクシィ",
-        "ja_typings": []
+        "ja_typings": [
+          "mikushii"
+        ]
       },
       {
         "en": "Niconico",
         "ja": "ニコニコ動画",
-        "ja_typings": []
+        "ja_typings": [
+          "nikonikodouga"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -61472,17 +66453,23 @@
       {
         "en": "expressing anger",
         "ja": "怒りを表す",
-        "ja_typings": []
+        "ja_typings": [
+          "ikariwoarawasu"
+        ]
       },
       {
         "en": "requesting help",
         "ja": "助けを求める",
-        "ja_typings": []
+        "ja_typings": [
+          "tasukewomotomeru"
+        ]
       },
       {
         "en": "celebrating victory",
         "ja": "勝利を祝う",
-        "ja_typings": []
+        "ja_typings": [
+          "shouriwoiwau"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -61513,7 +66500,9 @@
       {
         "en": "Mafumafu",
         "ja": "まふまふ",
-        "ja_typings": []
+        "ja_typings": [
+          "mafumafu"
+        ]
       },
       {
         "en": "Kanae",
@@ -61544,17 +66533,23 @@
       {
         "en": "clip sharing",
         "ja": "クリップ共有",
-        "ja_typings": []
+        "ja_typings": [
+          "kurippukyouyuu"
+        ]
       },
       {
         "en": "multi-streaming",
         "ja": "マルチ配信",
-        "ja_typings": []
+        "ja_typings": [
+          "maruchihaishin"
+        ]
       },
       {
         "en": "subgifting",
         "ja": "サブギフト",
-        "ja_typings": []
+        "ja_typings": [
+          "sabugifuto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -61578,17 +66573,23 @@
       {
         "en": "offline meet friend",
         "ja": "オフ会の友達",
-        "ja_typings": []
+        "ja_typings": [
+          "ofukainotomodachi"
+        ]
       },
       {
         "en": "old online member",
         "ja": "古参メンバー",
-        "ja_typings": []
+        "ja_typings": [
+          "kosanmenba-"
+        ]
       },
       {
         "en": "out of mind followers",
         "ja": "推し垢",
-        "ja_typings": []
+        "ja_typings": [
+          "oshiaka"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -61619,12 +66620,16 @@
       {
         "en": "ryuugaku",
         "ja": "留学",
-        "ja_typings": []
+        "ja_typings": [
+          "ryuugaku"
+        ]
       },
       {
         "en": "shuugaku",
         "ja": "修学",
-        "ja_typings": []
+        "ja_typings": [
+          "shuugaku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -61641,22 +66646,30 @@
       {
         "en": "Drakeposting",
         "ja": "ドレイクポスティング",
-        "ja_typings": []
+        "ja_typings": [
+          "doreikuposutingu"
+        ]
       },
       {
         "en": "Pepe meme",
         "ja": "ペペミーム",
-        "ja_typings": []
+        "ja_typings": [
+          "pepemi-mu"
+        ]
       },
       {
         "en": "Distracted Boyfriend",
         "ja": "浮気彼氏",
-        "ja_typings": []
+        "ja_typings": [
+          "uwakikareshi"
+        ]
       },
       {
         "en": "Galaxy Brain",
         "ja": "ギャラクシーブレイン",
-        "ja_typings": []
+        "ja_typings": [
+          "gyarakushi-burein"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -61713,22 +66726,30 @@
       {
         "en": "AutoMod",
         "ja": "オートモッド",
-        "ja_typings": []
+        "ja_typings": [
+          "o-tomoddo"
+        ]
       },
       {
         "en": "AutoRole",
         "ja": "オートロール",
-        "ja_typings": []
+        "ja_typings": [
+          "o-toro-ru"
+        ]
       },
       {
         "en": "AutoVoice",
         "ja": "オートボイス",
-        "ja_typings": []
+        "ja_typings": [
+          "o-toboisu"
+        ]
       },
       {
         "en": "AutoChat",
         "ja": "オートチャット",
-        "ja_typings": []
+        "ja_typings": [
+          "o-tochatto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -61785,22 +66806,30 @@
       {
         "en": "Tokino Sora",
         "ja": "ときのそら",
-        "ja_typings": []
+        "ja_typings": [
+          "tokinosora"
+        ]
       },
       {
         "en": "Pekora",
         "ja": "ぺこら",
-        "ja_typings": []
+        "ja_typings": [
+          "pekora"
+        ]
       },
       {
         "en": "Marine",
         "ja": "マリン",
-        "ja_typings": []
+        "ja_typings": [
+          "marin"
+        ]
       },
       {
         "en": "Korone",
         "ja": "ころね",
-        "ja_typings": []
+        "ja_typings": [
+          "korone"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -61817,22 +66846,30 @@
       {
         "en": "HTTP/3",
         "ja": "HTTP/3",
-        "ja_typings": []
+        "ja_typings": [
+          "http/3"
+        ]
       },
       {
         "en": "HTTP/4",
         "ja": "HTTP/4",
-        "ja_typings": []
+        "ja_typings": [
+          "http/4"
+        ]
       },
       {
         "en": "SPDY",
         "ja": "SPDY",
-        "ja_typings": []
+        "ja_typings": [
+          "spdy"
+        ]
       },
       {
         "en": "WebSocket",
         "ja": "WebSocket",
-        "ja_typings": []
+        "ja_typings": [
+          "websocket"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -61849,22 +66886,30 @@
       {
         "en": "OSPF",
         "ja": "OSPF",
-        "ja_typings": []
+        "ja_typings": [
+          "ospf"
+        ]
       },
       {
         "en": "RIP",
         "ja": "RIP",
-        "ja_typings": []
+        "ja_typings": [
+          "rip"
+        ]
       },
       {
         "en": "BGP",
         "ja": "BGP",
-        "ja_typings": []
+        "ja_typings": [
+          "bgp"
+        ]
       },
       {
         "en": "EIGRP",
         "ja": "EIGRP",
-        "ja_typings": []
+        "ja_typings": [
+          "eigrp"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -61881,22 +66926,30 @@
       {
         "en": "NVMe",
         "ja": "NVMe",
-        "ja_typings": []
+        "ja_typings": [
+          "nvme"
+        ]
       },
       {
         "en": "eSATA",
         "ja": "eSATA",
-        "ja_typings": []
+        "ja_typings": [
+          "esata"
+        ]
       },
       {
         "en": "SCSI",
         "ja": "SCSI",
-        "ja_typings": []
+        "ja_typings": [
+          "scsi"
+        ]
       },
       {
         "en": "ATA",
         "ja": "ATA",
-        "ja_typings": []
+        "ja_typings": [
+          "ata"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -61913,22 +66966,30 @@
       {
         "en": "USB-C",
         "ja": "USB-C",
-        "ja_typings": []
+        "ja_typings": [
+          "usb-c"
+        ]
       },
       {
         "en": "USB-A",
         "ja": "USB-A",
-        "ja_typings": []
+        "ja_typings": [
+          "usb-a"
+        ]
       },
       {
         "en": "USB-B",
         "ja": "USB-B",
-        "ja_typings": []
+        "ja_typings": [
+          "usb-b"
+        ]
       },
       {
         "en": "Mini-USB",
         "ja": "Mini-USB",
-        "ja_typings": []
+        "ja_typings": [
+          "mini-usb"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -61945,22 +67006,30 @@
       {
         "en": "DisplayPort 2.0",
         "ja": "DisplayPort 2.0",
-        "ja_typings": []
+        "ja_typings": [
+          "displayport 2.0"
+        ]
       },
       {
         "en": "HDMI 1.4",
         "ja": "HDMI 1.4",
-        "ja_typings": []
+        "ja_typings": [
+          "hdmi 1.4"
+        ]
       },
       {
         "en": "VGA",
         "ja": "VGA",
-        "ja_typings": []
+        "ja_typings": [
+          "vga"
+        ]
       },
       {
         "en": "DVI",
         "ja": "DVI",
-        "ja_typings": []
+        "ja_typings": [
+          "dvi"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -61977,22 +67046,30 @@
       {
         "en": "ARP",
         "ja": "ARP",
-        "ja_typings": []
+        "ja_typings": [
+          "arp"
+        ]
       },
       {
         "en": "RARP",
         "ja": "RARP",
-        "ja_typings": []
+        "ja_typings": [
+          "rarp"
+        ]
       },
       {
         "en": "DHCP",
         "ja": "DHCP",
-        "ja_typings": []
+        "ja_typings": [
+          "dhcp"
+        ]
       },
       {
         "en": "DNS",
         "ja": "DNS",
-        "ja_typings": []
+        "ja_typings": [
+          "dns"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62009,22 +67086,30 @@
       {
         "en": "ICMP",
         "ja": "ICMP",
-        "ja_typings": []
+        "ja_typings": [
+          "icmp"
+        ]
       },
       {
         "en": "IGMP",
         "ja": "IGMP",
-        "ja_typings": []
+        "ja_typings": [
+          "igmp"
+        ]
       },
       {
         "en": "SNMP",
         "ja": "SNMP",
-        "ja_typings": []
+        "ja_typings": [
+          "snmp"
+        ]
       },
       {
         "en": "SMTP",
         "ja": "SMTP",
-        "ja_typings": []
+        "ja_typings": [
+          "smtp"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62041,22 +67126,30 @@
       {
         "en": "RISC-V",
         "ja": "RISC-V",
-        "ja_typings": []
+        "ja_typings": [
+          "risc-v"
+        ]
       },
       {
         "en": "ARM",
         "ja": "ARM",
-        "ja_typings": []
+        "ja_typings": [
+          "arm"
+        ]
       },
       {
         "en": "x86",
         "ja": "x86",
-        "ja_typings": []
+        "ja_typings": [
+          "x86"
+        ]
       },
       {
         "en": "MIPS",
         "ja": "MIPS",
-        "ja_typings": []
+        "ja_typings": [
+          "mips"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62073,22 +67166,30 @@
       {
         "en": "Vulkan",
         "ja": "Vulkan",
-        "ja_typings": []
+        "ja_typings": [
+          "vulkan"
+        ]
       },
       {
         "en": "Direct3D",
         "ja": "Direct3D",
-        "ja_typings": []
+        "ja_typings": [
+          "direct3d"
+        ]
       },
       {
         "en": "Metal",
         "ja": "Metal",
-        "ja_typings": []
+        "ja_typings": [
+          "metal"
+        ]
       },
       {
         "en": "OpenGL",
         "ja": "OpenGL",
-        "ja_typings": []
+        "ja_typings": [
+          "opengl"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62112,17 +67213,23 @@
       {
         "en": "802.11ad",
         "ja": "802.11ad",
-        "ja_typings": []
+        "ja_typings": [
+          "802.11ad"
+        ]
       },
       {
         "en": "802.11n+",
         "ja": "802.11nプラス",
-        "ja_typings": []
+        "ja_typings": [
+          "802.11npurasu"
+        ]
       },
       {
         "en": "802.11ay",
         "ja": "802.11ay",
-        "ja_typings": []
+        "ja_typings": [
+          "802.11ay"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62139,22 +67246,30 @@
       {
         "en": "HFP",
         "ja": "HFP",
-        "ja_typings": []
+        "ja_typings": [
+          "hfp"
+        ]
       },
       {
         "en": "A2DP",
         "ja": "A2DP",
-        "ja_typings": []
+        "ja_typings": [
+          "a2dp"
+        ]
       },
       {
         "en": "AVRCP",
         "ja": "AVRCP",
-        "ja_typings": []
+        "ja_typings": [
+          "avrcp"
+        ]
       },
       {
         "en": "HID",
         "ja": "HID",
-        "ja_typings": []
+        "ja_typings": [
+          "hid"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62171,22 +67286,30 @@
       {
         "en": "AES",
         "ja": "AES",
-        "ja_typings": []
+        "ja_typings": [
+          "aes"
+        ]
       },
       {
         "en": "RSA",
         "ja": "RSA",
-        "ja_typings": []
+        "ja_typings": [
+          "rsa"
+        ]
       },
       {
         "en": "ECC",
         "ja": "ECC",
-        "ja_typings": []
+        "ja_typings": [
+          "ecc"
+        ]
       },
       {
         "en": "MD5",
         "ja": "MD5",
-        "ja_typings": []
+        "ja_typings": [
+          "md5"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62203,22 +67326,30 @@
       {
         "en": "ECDH",
         "ja": "ECDH",
-        "ja_typings": []
+        "ja_typings": [
+          "ecdh"
+        ]
       },
       {
         "en": "RSA-OAEP",
         "ja": "RSA-OAEP",
-        "ja_typings": []
+        "ja_typings": [
+          "rsa-oaep"
+        ]
       },
       {
         "en": "DSA",
         "ja": "DSA",
-        "ja_typings": []
+        "ja_typings": [
+          "dsa"
+        ]
       },
       {
         "en": "3DES",
         "ja": "3DES",
-        "ja_typings": []
+        "ja_typings": [
+          "3des"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62235,22 +67366,30 @@
       {
         "en": "WebRTC",
         "ja": "WebRTC",
-        "ja_typings": []
+        "ja_typings": [
+          "webrtc"
+        ]
       },
       {
         "en": "WebSocket",
         "ja": "WebSocket",
-        "ja_typings": []
+        "ja_typings": [
+          "websocket"
+        ]
       },
       {
         "en": "WebDAV",
         "ja": "WebDAV",
-        "ja_typings": []
+        "ja_typings": [
+          "webdav"
+        ]
       },
       {
         "en": "WebHooks",
         "ja": "WebHooks",
-        "ja_typings": []
+        "ja_typings": [
+          "webhooks"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62274,17 +67413,23 @@
       {
         "en": "trackball",
         "ja": "トラックボール",
-        "ja_typings": []
+        "ja_typings": [
+          "torakkubo-ru"
+        ]
       },
       {
         "en": "touchpad",
         "ja": "タッチパッド",
-        "ja_typings": []
+        "ja_typings": [
+          "tatchipaddo"
+        ]
       },
       {
         "en": "joystick",
         "ja": "ジョイスティック",
-        "ja_typings": []
+        "ja_typings": [
+          "joisutikku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62301,22 +67446,30 @@
       {
         "en": "APFS",
         "ja": "APFS",
-        "ja_typings": []
+        "ja_typings": [
+          "apfs"
+        ]
       },
       {
         "en": "HFS+",
         "ja": "HFS+",
-        "ja_typings": []
+        "ja_typings": [
+          "hfs+"
+        ]
       },
       {
         "en": "exFAT",
         "ja": "exFAT",
-        "ja_typings": []
+        "ja_typings": [
+          "exfat"
+        ]
       },
       {
         "en": "ZFS",
         "ja": "ZFS",
-        "ja_typings": []
+        "ja_typings": [
+          "zfs"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62333,22 +67486,30 @@
       {
         "en": "RAID 5",
         "ja": "RAID 5",
-        "ja_typings": []
+        "ja_typings": [
+          "raid 5"
+        ]
       },
       {
         "en": "RAID 0",
         "ja": "RAID 0",
-        "ja_typings": []
+        "ja_typings": [
+          "raid 0"
+        ]
       },
       {
         "en": "RAID 1",
         "ja": "RAID 1",
-        "ja_typings": []
+        "ja_typings": [
+          "raid 1"
+        ]
       },
       {
         "en": "RAID 10",
         "ja": "RAID 10",
-        "ja_typings": []
+        "ja_typings": [
+          "raid 10"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62365,22 +67526,30 @@
       {
         "en": "AS-PATH",
         "ja": "AS-PATH",
-        "ja_typings": []
+        "ja_typings": [
+          "as-path"
+        ]
       },
       {
         "en": "MED",
         "ja": "MED",
-        "ja_typings": []
+        "ja_typings": [
+          "med"
+        ]
       },
       {
         "en": "ORIGIN",
         "ja": "ORIGIN",
-        "ja_typings": []
+        "ja_typings": [
+          "origin"
+        ]
       },
       {
         "en": "NEXT-HOP",
         "ja": "NEXT-HOP",
-        "ja_typings": []
+        "ja_typings": [
+          "next-hop"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62397,22 +67566,30 @@
       {
         "en": "OLED",
         "ja": "OLED",
-        "ja_typings": []
+        "ja_typings": [
+          "oled"
+        ]
       },
       {
         "en": "LCD",
         "ja": "LCD",
-        "ja_typings": []
+        "ja_typings": [
+          "lcd"
+        ]
       },
       {
         "en": "CRT",
         "ja": "CRT",
-        "ja_typings": []
+        "ja_typings": [
+          "crt"
+        ]
       },
       {
         "en": "EPD",
         "ja": "EPD",
-        "ja_typings": []
+        "ja_typings": [
+          "epd"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62429,22 +67606,30 @@
       {
         "en": "UEFI",
         "ja": "UEFI",
-        "ja_typings": []
+        "ja_typings": [
+          "uefi"
+        ]
       },
       {
         "en": "Legacy BIOS",
         "ja": "Legacy BIOS",
-        "ja_typings": []
+        "ja_typings": [
+          "legacy bios"
+        ]
       },
       {
         "en": "EFI 1.0",
         "ja": "EFI 1.0",
-        "ja_typings": []
+        "ja_typings": [
+          "efi 1.0"
+        ]
       },
       {
         "en": "Open Firmware",
         "ja": "Open Firmware",
-        "ja_typings": []
+        "ja_typings": [
+          "open firmware"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62461,22 +67646,30 @@
       {
         "en": "NTP",
         "ja": "NTP",
-        "ja_typings": []
+        "ja_typings": [
+          "ntp"
+        ]
       },
       {
         "en": "PTP",
         "ja": "PTP",
-        "ja_typings": []
+        "ja_typings": [
+          "ptp"
+        ]
       },
       {
         "en": "SNTP",
         "ja": "SNTP",
-        "ja_typings": []
+        "ja_typings": [
+          "sntp"
+        ]
       },
       {
         "en": "RTSP",
         "ja": "RTSP",
-        "ja_typings": []
+        "ja_typings": [
+          "rtsp"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62493,22 +67686,30 @@
       {
         "en": "router",
         "ja": "ルーター",
-        "ja_typings": []
+        "ja_typings": [
+          "ru-ta-"
+        ]
       },
       {
         "en": "hub",
         "ja": "ハブ",
-        "ja_typings": []
+        "ja_typings": [
+          "habu"
+        ]
       },
       {
         "en": "repeater",
         "ja": "リピーター",
-        "ja_typings": []
+        "ja_typings": [
+          "ripi-ta-"
+        ]
       },
       {
         "en": "bridge",
         "ja": "ブリッジ",
-        "ja_typings": []
+        "ja_typings": [
+          "burijji"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62532,7 +67733,9 @@
       {
         "en": "Cat6",
         "ja": "Cat6",
-        "ja_typings": []
+        "ja_typings": [
+          "cat6"
+        ]
       },
       {
         "en": "Coaxial",
@@ -62544,7 +67747,9 @@
       {
         "en": "Ribbon cable",
         "ja": "リボンケーブル",
-        "ja_typings": []
+        "ja_typings": [
+          "ribonke-buru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62561,22 +67766,30 @@
       {
         "en": "ARMv8",
         "ja": "ARMv8",
-        "ja_typings": []
+        "ja_typings": [
+          "armv8"
+        ]
       },
       {
         "en": "x86-64",
         "ja": "x86-64",
-        "ja_typings": []
+        "ja_typings": [
+          "x86-64"
+        ]
       },
       {
         "en": "POWER9",
         "ja": "POWER9",
-        "ja_typings": []
+        "ja_typings": [
+          "power9"
+        ]
       },
       {
         "en": "SPARC",
         "ja": "SPARC",
-        "ja_typings": []
+        "ja_typings": [
+          "sparc"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62593,22 +67806,30 @@
       {
         "en": "Keccak",
         "ja": "Keccak",
-        "ja_typings": []
+        "ja_typings": [
+          "keccak"
+        ]
       },
       {
         "en": "Merkle-Damgard",
         "ja": "Merkle-Damgard",
-        "ja_typings": []
+        "ja_typings": [
+          "merkle-damgard"
+        ]
       },
       {
         "en": "Blake2",
         "ja": "Blake2",
-        "ja_typings": []
+        "ja_typings": [
+          "blake2"
+        ]
       },
       {
         "en": "MD6",
         "ja": "MD6",
-        "ja_typings": []
+        "ja_typings": [
+          "md6"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62632,17 +67853,23 @@
       {
         "en": "port 21",
         "ja": "21番ポート",
-        "ja_typings": []
+        "ja_typings": [
+          "21banpo-to"
+        ]
       },
       {
         "en": "port 23",
         "ja": "23番ポート",
-        "ja_typings": []
+        "ja_typings": [
+          "23banpo-to"
+        ]
       },
       {
         "en": "port 25",
         "ja": "25番ポート",
-        "ja_typings": []
+        "ja_typings": [
+          "25banpo-to"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62659,22 +67886,30 @@
       {
         "en": "OCI image",
         "ja": "OCIイメージ",
-        "ja_typings": []
+        "ja_typings": [
+          "ociime-ji"
+        ]
       },
       {
         "en": "Docker v1",
         "ja": "Docker v1",
-        "ja_typings": []
+        "ja_typings": [
+          "docker v1"
+        ]
       },
       {
         "en": "LXC",
         "ja": "LXC",
-        "ja_typings": []
+        "ja_typings": [
+          "lxc"
+        ]
       },
       {
         "en": "rkt",
         "ja": "rkt",
-        "ja_typings": []
+        "ja_typings": [
+          "rkt"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62691,22 +67926,30 @@
       {
         "en": "NVIDIA",
         "ja": "NVIDIA",
-        "ja_typings": []
+        "ja_typings": [
+          "nvidia"
+        ]
       },
       {
         "en": "AMD",
         "ja": "AMD",
-        "ja_typings": []
+        "ja_typings": [
+          "amd"
+        ]
       },
       {
         "en": "Intel",
         "ja": "Intel",
-        "ja_typings": []
+        "ja_typings": [
+          "intel"
+        ]
       },
       {
         "en": "Imagination",
         "ja": "Imagination",
-        "ja_typings": []
+        "ja_typings": [
+          "imagination"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62723,22 +67966,30 @@
       {
         "en": "VXLAN",
         "ja": "VXLAN",
-        "ja_typings": []
+        "ja_typings": [
+          "vxlan"
+        ]
       },
       {
         "en": "MPLS",
         "ja": "MPLS",
-        "ja_typings": []
+        "ja_typings": [
+          "mpls"
+        ]
       },
       {
         "en": "GRE",
         "ja": "GRE",
-        "ja_typings": []
+        "ja_typings": [
+          "gre"
+        ]
       },
       {
         "en": "PPP",
         "ja": "PPP",
-        "ja_typings": []
+        "ja_typings": [
+          "ppp"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62755,22 +68006,30 @@
       {
         "en": "Intel VT-x",
         "ja": "Intel VT-x",
-        "ja_typings": []
+        "ja_typings": [
+          "intel vt-x"
+        ]
       },
       {
         "en": "Intel SGX",
         "ja": "Intel SGX",
-        "ja_typings": []
+        "ja_typings": [
+          "intel sgx"
+        ]
       },
       {
         "en": "Intel TXT",
         "ja": "Intel TXT",
-        "ja_typings": []
+        "ja_typings": [
+          "intel txt"
+        ]
       },
       {
         "en": "Intel AMT",
         "ja": "Intel AMT",
-        "ja_typings": []
+        "ja_typings": [
+          "intel amt"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62787,22 +68046,30 @@
       {
         "en": "ArgoCD",
         "ja": "ArgoCD",
-        "ja_typings": []
+        "ja_typings": [
+          "argocd"
+        ]
       },
       {
         "en": "Jenkins X",
         "ja": "Jenkins X",
-        "ja_typings": []
+        "ja_typings": [
+          "jenkins x"
+        ]
       },
       {
         "en": "Spinnaker",
         "ja": "Spinnaker",
-        "ja_typings": []
+        "ja_typings": [
+          "spinnaker"
+        ]
       },
       {
         "en": "Tekton",
         "ja": "Tekton",
-        "ja_typings": []
+        "ja_typings": [
+          "tekton"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62819,22 +68086,30 @@
       {
         "en": "Linkerd",
         "ja": "Linkerd",
-        "ja_typings": []
+        "ja_typings": [
+          "linkerd"
+        ]
       },
       {
         "en": "Istio",
         "ja": "Istio",
-        "ja_typings": []
+        "ja_typings": [
+          "istio"
+        ]
       },
       {
         "en": "Consul Connect",
         "ja": "Consul Connect",
-        "ja_typings": []
+        "ja_typings": [
+          "consul connect"
+        ]
       },
       {
         "en": "Kuma",
         "ja": "Kuma",
-        "ja_typings": []
+        "ja_typings": [
+          "kuma"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62851,22 +68126,30 @@
       {
         "en": "OpenTelemetry",
         "ja": "OpenTelemetry",
-        "ja_typings": []
+        "ja_typings": [
+          "opentelemetry"
+        ]
       },
       {
         "en": "OpenTracing",
         "ja": "OpenTracing",
-        "ja_typings": []
+        "ja_typings": [
+          "opentracing"
+        ]
       },
       {
         "en": "OpenCensus",
         "ja": "OpenCensus",
-        "ja_typings": []
+        "ja_typings": [
+          "opencensus"
+        ]
       },
       {
         "en": "Jaeger",
         "ja": "Jaeger",
-        "ja_typings": []
+        "ja_typings": [
+          "jaeger"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62883,22 +68166,30 @@
       {
         "en": "eBPF",
         "ja": "eBPF",
-        "ja_typings": []
+        "ja_typings": [
+          "ebpf"
+        ]
       },
       {
         "en": "LKM",
         "ja": "LKM",
-        "ja_typings": []
+        "ja_typings": [
+          "lkm"
+        ]
       },
       {
         "en": "SystemTap",
         "ja": "SystemTap",
-        "ja_typings": []
+        "ja_typings": [
+          "systemtap"
+        ]
       },
       {
         "en": "DTrace",
         "ja": "DTrace",
-        "ja_typings": []
+        "ja_typings": [
+          "dtrace"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62922,17 +68213,23 @@
       {
         "en": "Final Operations",
         "ja": "最終運用",
-        "ja_typings": []
+        "ja_typings": [
+          "saishuuunnyou"
+        ]
       },
       {
         "en": "Firmware Operations",
         "ja": "ファームウェア運用",
-        "ja_typings": []
+        "ja_typings": [
+          "fa-muweaunnyou"
+        ]
       },
       {
         "en": "Finished Operations",
         "ja": "完了運用",
-        "ja_typings": []
+        "ja_typings": [
+          "kanryouunnyou"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62949,22 +68246,30 @@
       {
         "en": "Scrum",
         "ja": "スクラム",
-        "ja_typings": []
+        "ja_typings": [
+          "sukuramu"
+        ]
       },
       {
         "en": "Kanban",
         "ja": "カンバン",
-        "ja_typings": []
+        "ja_typings": [
+          "kanban"
+        ]
       },
       {
         "en": "XP",
         "ja": "XP",
-        "ja_typings": []
+        "ja_typings": [
+          "xp"
+        ]
       },
       {
         "en": "Lean",
         "ja": "リーン",
-        "ja_typings": []
+        "ja_typings": [
+          "ri-n"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -62988,17 +68293,23 @@
       {
         "en": "Service Layer Optimization",
         "ja": "サービス層最適化",
-        "ja_typings": []
+        "ja_typings": [
+          "sa-bisusousaitekika"
+        ]
       },
       {
         "en": "Single Login Option",
         "ja": "単一ログイン",
-        "ja_typings": []
+        "ja_typings": [
+          "tannitsuroguin"
+        ]
       },
       {
         "en": "Server Load Output",
         "ja": "サーバ負荷出力",
-        "ja_typings": []
+        "ja_typings": [
+          "sa-bafukashutsuryoku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -63015,12 +68326,16 @@
       {
         "en": "fuzz testing",
         "ja": "ファズテスト",
-        "ja_typings": []
+        "ja_typings": [
+          "fazutesuto"
+        ]
       },
       {
         "en": "smoke testing",
         "ja": "スモークテスト",
-        "ja_typings": []
+        "ja_typings": [
+          "sumo-kutesuto"
+        ]
       },
       {
         "en": "regression testing",
@@ -63051,22 +68366,30 @@
       {
         "en": "Lambda",
         "ja": "Lambda",
-        "ja_typings": []
+        "ja_typings": [
+          "lambda"
+        ]
       },
       {
         "en": "Functions",
         "ja": "Functions",
-        "ja_typings": []
+        "ja_typings": [
+          "functions"
+        ]
       },
       {
         "en": "Cloud Run",
         "ja": "Cloud Run",
-        "ja_typings": []
+        "ja_typings": [
+          "cloud run"
+        ]
       },
       {
         "en": "Cloudflare Workers",
         "ja": "Cloudflare Workers",
-        "ja_typings": []
+        "ja_typings": [
+          "cloudflare workers"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -63090,17 +68413,23 @@
       {
         "en": "Mean Time Through Requests",
         "ja": "平均処理時間",
-        "ja_typings": []
+        "ja_typings": [
+          "heikinshorijikan"
+        ]
       },
       {
         "en": "Mean Test Time Repeat",
         "ja": "平均テスト反復",
-        "ja_typings": []
+        "ja_typings": [
+          "heikintesutohanpuku"
+        ]
       },
       {
         "en": "Manual Time To Restart",
         "ja": "手動再起動時間",
-        "ja_typings": []
+        "ja_typings": [
+          "shudousaikidoujikan"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -63117,22 +68446,30 @@
       {
         "en": "SRE",
         "ja": "SRE",
-        "ja_typings": []
+        "ja_typings": [
+          "sre"
+        ]
       },
       {
         "en": "ITIL",
         "ja": "ITIL",
-        "ja_typings": []
+        "ja_typings": [
+          "itil"
+        ]
       },
       {
         "en": "CMMI",
         "ja": "CMMI",
-        "ja_typings": []
+        "ja_typings": [
+          "cmmi"
+        ]
       },
       {
         "en": "Six Sigma",
         "ja": "Six Sigma",
-        "ja_typings": []
+        "ja_typings": [
+          "six sigma"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -63149,22 +68486,30 @@
       {
         "en": "GitHub Actions",
         "ja": "GitHub Actions",
-        "ja_typings": []
+        "ja_typings": [
+          "github actions"
+        ]
       },
       {
         "en": "CircleCI",
         "ja": "CircleCI",
-        "ja_typings": []
+        "ja_typings": [
+          "circleci"
+        ]
       },
       {
         "en": "GitLab CI",
         "ja": "GitLab CI",
-        "ja_typings": []
+        "ja_typings": [
+          "gitlab ci"
+        ]
       },
       {
         "en": "Travis CI",
         "ja": "Travis CI",
-        "ja_typings": []
+        "ja_typings": [
+          "travis ci"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -63188,17 +68533,23 @@
       {
         "en": "Type Driven Design",
         "ja": "型駆動設計",
-        "ja_typings": []
+        "ja_typings": [
+          "katakudousekkei"
+        ]
       },
       {
         "en": "Task Distribution Daemon",
         "ja": "タスク分配",
-        "ja_typings": []
+        "ja_typings": [
+          "tasukubunpai"
+        ]
       },
       {
         "en": "Tool Dev Diagram",
         "ja": "ツール図",
-        "ja_typings": []
+        "ja_typings": [
+          "tsu-ruzu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -63215,22 +68566,30 @@
       {
         "en": "Kubernetes",
         "ja": "Kubernetes",
-        "ja_typings": []
+        "ja_typings": [
+          "kubernetes"
+        ]
       },
       {
         "en": "Mesos",
         "ja": "Mesos",
-        "ja_typings": []
+        "ja_typings": [
+          "mesos"
+        ]
       },
       {
         "en": "Nomad",
         "ja": "Nomad",
-        "ja_typings": []
+        "ja_typings": [
+          "nomad"
+        ]
       },
       {
         "en": "Swarm",
         "ja": "Swarm",
-        "ja_typings": []
+        "ja_typings": [
+          "swarm"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -63247,22 +68606,30 @@
       {
         "en": "canary release",
         "ja": "カナリアリリース",
-        "ja_typings": []
+        "ja_typings": [
+          "kanariariri-su"
+        ]
       },
       {
         "en": "blue-green",
         "ja": "ブルーグリーン",
-        "ja_typings": []
+        "ja_typings": [
+          "buru-guri-n"
+        ]
       },
       {
         "en": "big bang",
         "ja": "ビッグバン",
-        "ja_typings": []
+        "ja_typings": [
+          "bigguban"
+        ]
       },
       {
         "en": "hotfix",
         "ja": "ホットフィックス",
-        "ja_typings": []
+        "ja_typings": [
+          "hottofikkusu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -63279,22 +68646,30 @@
       {
         "en": "Terraform",
         "ja": "Terraform",
-        "ja_typings": []
+        "ja_typings": [
+          "terraform"
+        ]
       },
       {
         "en": "Ansible",
         "ja": "Ansible",
-        "ja_typings": []
+        "ja_typings": [
+          "ansible"
+        ]
       },
       {
         "en": "Chef",
         "ja": "Chef",
-        "ja_typings": []
+        "ja_typings": [
+          "chef"
+        ]
       },
       {
         "en": "Puppet",
         "ja": "Puppet",
-        "ja_typings": []
+        "ja_typings": [
+          "puppet"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -63318,17 +68693,23 @@
       {
         "en": "deploy late",
         "ja": "後で展開",
-        "ja_typings": []
+        "ja_typings": [
+          "atodetenkai"
+        ]
       },
       {
         "en": "review code last",
         "ja": "最後にレビュー",
-        "ja_typings": []
+        "ja_typings": [
+          "saigonirebyu-"
+        ]
       },
       {
         "en": "avoid testing",
         "ja": "テストを避ける",
-        "ja_typings": []
+        "ja_typings": [
+          "tesutowosakeru"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -63346,23 +68727,29 @@
         "en": "Objectives and Key Results",
         "ja": "目標と主要な成果",
         "ja_typings": [
-          "mokuhyou to shuyou na seika"
+          "mokuhyoutoshuyounaseika"
         ]
       },
       {
         "en": "Operations Key Reports",
         "ja": "運用報告",
-        "ja_typings": []
+        "ja_typings": [
+          "unyouhoukoku"
+        ]
       },
       {
         "en": "Open Knowledge Repository",
         "ja": "知識リポジトリ",
-        "ja_typings": []
+        "ja_typings": [
+          "chishikiripojitori"
+        ]
       },
       {
         "en": "Output Kanban Records",
         "ja": "出力カンバン",
-        "ja_typings": []
+        "ja_typings": [
+          "shutsuryokukanban"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -63379,22 +68766,30 @@
       {
         "en": "Sailboat retrospective",
         "ja": "セイルボート",
-        "ja_typings": []
+        "ja_typings": [
+          "seirubo-to"
+        ]
       },
       {
         "en": "Start Stop Continue",
         "ja": "Start Stop Continue",
-        "ja_typings": []
+        "ja_typings": [
+          "start stop continue"
+        ]
       },
       {
         "en": "4Ls retrospective",
         "ja": "4Ls",
-        "ja_typings": []
+        "ja_typings": [
+          "4ls"
+        ]
       },
       {
         "en": "Mad Sad Glad",
         "ja": "Mad Sad Glad",
-        "ja_typings": []
+        "ja_typings": [
+          "mad sad glad"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -63418,17 +68813,23 @@
       {
         "en": "UI button",
         "ja": "UIボタン",
-        "ja_typings": []
+        "ja_typings": [
+          "uibotan"
+        ]
       },
       {
         "en": "error code",
         "ja": "エラーコード",
-        "ja_typings": []
+        "ja_typings": [
+          "era-ko-do"
+        ]
       },
       {
         "en": "CI badge",
         "ja": "CIバッジ",
-        "ja_typings": []
+        "ja_typings": [
+          "cibajji"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -63452,17 +68853,23 @@
       {
         "en": "Scrum",
         "ja": "スクラム方式",
-        "ja_typings": []
+        "ja_typings": [
+          "sukuramuhoushiki"
+        ]
       },
       {
         "en": "Waterfall",
         "ja": "ウォーターフォール",
-        "ja_typings": []
+        "ja_typings": [
+          "wo-ta-fo-ru"
+        ]
       },
       {
         "en": "RUP",
         "ja": "RUP",
-        "ja_typings": []
+        "ja_typings": [
+          "rup"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -63493,12 +68900,16 @@
       {
         "en": "system test",
         "ja": "システムテスト",
-        "ja_typings": []
+        "ja_typings": [
+          "shisutemutesuto"
+        ]
       },
       {
         "en": "acceptance test",
         "ja": "受入テスト",
-        "ja_typings": []
+        "ja_typings": [
+          "ukeiretesuto"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -63515,22 +68926,30 @@
       {
         "en": "GKE",
         "ja": "GKE",
-        "ja_typings": []
+        "ja_typings": [
+          "gke"
+        ]
       },
       {
         "en": "EKS",
         "ja": "EKS",
-        "ja_typings": []
+        "ja_typings": [
+          "eks"
+        ]
       },
       {
         "en": "AKS",
         "ja": "AKS",
-        "ja_typings": []
+        "ja_typings": [
+          "aks"
+        ]
       },
       {
         "en": "OKE",
         "ja": "OKE",
-        "ja_typings": []
+        "ja_typings": [
+          "oke"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -63554,17 +68973,23 @@
       {
         "en": "random refactoring",
         "ja": "ランダムリファクタ",
-        "ja_typings": []
+        "ja_typings": [
+          "randamurifakuta"
+        ]
       },
       {
         "en": "agile planning",
         "ja": "アジャイル計画",
-        "ja_typings": []
+        "ja_typings": [
+          "ajairukeikaku"
+        ]
       },
       {
         "en": "project chaos",
         "ja": "プロジェクト混乱",
-        "ja_typings": []
+        "ja_typings": [
+          "purojekutokonran"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -63588,17 +69013,24 @@
       {
         "en": "rolling deployment",
         "ja": "ローリングデプロイ",
-        "ja_typings": []
+        "ja_typings": [
+          "ro-ringudepuroi"
+        ]
       },
       {
         "en": "recreate deployment",
         "ja": "再作成デプロイ",
-        "ja_typings": []
+        "ja_typings": [
+          "saisakuseidepuroi"
+        ]
       },
       {
         "en": "shadow deployment",
         "ja": "シャドウデプロイ",
-        "ja_typings": []
+        "ja_typings": [
+          "shadodepuroi",
+          "shadoudepuroi"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -63615,22 +69047,30 @@
       {
         "en": "microservices",
         "ja": "マイクロサービス",
-        "ja_typings": []
+        "ja_typings": [
+          "maikurosa-bisu"
+        ]
       },
       {
         "en": "monolith",
         "ja": "モノリス",
-        "ja_typings": []
+        "ja_typings": [
+          "monorisu"
+        ]
       },
       {
         "en": "SOA",
         "ja": "SOA",
-        "ja_typings": []
+        "ja_typings": [
+          "soa"
+        ]
       },
       {
         "en": "MVC",
         "ja": "MVC",
-        "ja_typings": []
+        "ja_typings": [
+          "mvc"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -63654,17 +69094,23 @@
       {
         "en": "Software License Audit",
         "ja": "ソフトウェアライセンス監査",
-        "ja_typings": []
+        "ja_typings": [
+          "sofutoweairaisensukansa"
+        ]
       },
       {
         "en": "System Log Analyzer",
         "ja": "システムログ解析",
-        "ja_typings": []
+        "ja_typings": [
+          "shisutemurogukaiseki"
+        ]
       },
       {
         "en": "Server Latency Average",
         "ja": "平均レイテンシ",
-        "ja_typings": []
+        "ja_typings": [
+          "heikinreitenshi"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -63681,12 +69127,16 @@
       {
         "en": "penetration testing",
         "ja": "ペネトレーションテスト",
-        "ja_typings": []
+        "ja_typings": [
+          "penetore-shontesuto"
+        ]
       },
       {
         "en": "usability testing",
         "ja": "ユーザビリティテスト",
-        "ja_typings": []
+        "ja_typings": [
+          "yu-zabirititesuto"
+        ]
       },
       {
         "en": "performance testing",
@@ -63717,22 +69167,30 @@
       {
         "en": "Helm",
         "ja": "Helm",
-        "ja_typings": []
+        "ja_typings": [
+          "helm"
+        ]
       },
       {
         "en": "Kustomize",
         "ja": "Kustomize",
-        "ja_typings": []
+        "ja_typings": [
+          "kustomize"
+        ]
       },
       {
         "en": "Skaffold",
         "ja": "Skaffold",
-        "ja_typings": []
+        "ja_typings": [
+          "skaffold"
+        ]
       },
       {
         "en": "Tilt",
         "ja": "Tilt",
-        "ja_typings": []
+        "ja_typings": [
+          "tilt"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -63756,17 +69214,23 @@
       {
         "en": "backup pod",
         "ja": "バックアップPod",
-        "ja_typings": []
+        "ja_typings": [
+          "bakkuappupod"
+        ]
       },
       {
         "en": "frontend service",
         "ja": "フロントエンドサービス",
-        "ja_typings": []
+        "ja_typings": [
+          "furontoendosa-bisu"
+        ]
       },
       {
         "en": "init container only",
         "ja": "初期化のみ",
-        "ja_typings": []
+        "ja_typings": [
+          "shokikanomi"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -63830,7 +69294,9 @@
       {
         "en": "alphabet",
         "ja": "アルファベット",
-        "ja_typings": []
+        "ja_typings": [
+          "arufabetto"
+        ]
       },
       {
         "en": "logogram",
@@ -63842,7 +69308,9 @@
       {
         "en": "abjad",
         "ja": "アブジャド",
-        "ja_typings": []
+        "ja_typings": [
+          "abujado"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -63866,17 +69334,23 @@
       {
         "en": "Indo-European",
         "ja": "インド・ヨーロッパ語族",
-        "ja_typings": []
+        "ja_typings": [
+          "indo/yo-roppagozoku"
+        ]
       },
       {
         "en": "Altaic",
         "ja": "アルタイ語族",
-        "ja_typings": []
+        "ja_typings": [
+          "arutaigozoku"
+        ]
       },
       {
         "en": "Dravidian",
         "ja": "ドラヴィダ語族",
-        "ja_typings": []
+        "ja_typings": [
+          "doravidagozoku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -63893,12 +69367,16 @@
       {
         "en": "abjad",
         "ja": "アブジャド",
-        "ja_typings": []
+        "ja_typings": [
+          "abujado"
+        ]
       },
       {
         "en": "alphabet",
         "ja": "アルファベット",
-        "ja_typings": []
+        "ja_typings": [
+          "arufabetto"
+        ]
       },
       {
         "en": "syllabary",
@@ -63910,7 +69388,9 @@
       {
         "en": "abugida",
         "ja": "アブギダ",
-        "ja_typings": []
+        "ja_typings": [
+          "abugida"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -64014,17 +69494,23 @@
       {
         "en": "Tamil",
         "ja": "タミル語",
-        "ja_typings": []
+        "ja_typings": [
+          "tamirugo"
+        ]
       },
       {
         "en": "Bengali",
         "ja": "ベンガル語",
-        "ja_typings": []
+        "ja_typings": [
+          "bengarugo"
+        ]
       },
       {
         "en": "Telugu",
         "ja": "テルグ語",
-        "ja_typings": []
+        "ja_typings": [
+          "terugugo"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -64048,7 +69534,9 @@
       {
         "en": "apostrophe",
         "ja": "アポストロフィ",
-        "ja_typings": []
+        "ja_typings": [
+          "aposutorofi"
+        ]
       },
       {
         "en": "h symbol",
@@ -64060,7 +69548,9 @@
       {
         "en": "colon style",
         "ja": "コロン型",
-        "ja_typings": []
+        "ja_typings": [
+          "korongata"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -64091,12 +69581,16 @@
       {
         "en": "future perfect",
         "ja": "未来完了",
-        "ja_typings": []
+        "ja_typings": [
+          "miraikanryou"
+        ]
       },
       {
         "en": "simple past",
         "ja": "単純過去",
-        "ja_typings": []
+        "ja_typings": [
+          "tanjunkako"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -64120,17 +69614,23 @@
       {
         "en": "Zulu",
         "ja": "ズールー語",
-        "ja_typings": []
+        "ja_typings": [
+          "zu-ru-go"
+        ]
       },
       {
         "en": "Xhosa",
         "ja": "コーサ語",
-        "ja_typings": []
+        "ja_typings": [
+          "ko-sago"
+        ]
       },
       {
         "en": "Shona",
         "ja": "ショナ語",
-        "ja_typings": []
+        "ja_typings": [
+          "shonago"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -64187,7 +69687,9 @@
       {
         "en": "Hangul",
         "ja": "ハングル",
-        "ja_typings": []
+        "ja_typings": [
+          "hanguru"
+        ]
       },
       {
         "en": "Hanja",
@@ -64206,7 +69708,9 @@
       {
         "en": "Katakana",
         "ja": "カタカナ",
-        "ja_typings": []
+        "ja_typings": [
+          "katakana"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -64244,7 +69748,9 @@
       {
         "en": "forensic phonetics",
         "ja": "法音声学",
-        "ja_typings": []
+        "ja_typings": [
+          "houonseigaku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -64268,17 +69774,23 @@
       {
         "en": "Catalan",
         "ja": "カタルーニャ語",
-        "ja_typings": []
+        "ja_typings": [
+          "kataru-nyago"
+        ]
       },
       {
         "en": "Galician",
         "ja": "ガリシア語",
-        "ja_typings": []
+        "ja_typings": [
+          "garishiago"
+        ]
       },
       {
         "en": "Asturian",
         "ja": "アストゥリアス語",
-        "ja_typings": []
+        "ja_typings": [
+          "asutoriasugo"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -64342,7 +69854,9 @@
       {
         "en": "article gender",
         "ja": "冠詞性",
-        "ja_typings": []
+        "ja_typings": [
+          "kanshisei"
+        ]
       },
       {
         "en": "noun cases",
@@ -64380,17 +69894,23 @@
       {
         "en": "Hebrew",
         "ja": "ヘブライ語",
-        "ja_typings": []
+        "ja_typings": [
+          "heburaigo"
+        ]
       },
       {
         "en": "Arabic",
         "ja": "アラビア語",
-        "ja_typings": []
+        "ja_typings": [
+          "arabiago"
+        ]
       },
       {
         "en": "Amharic",
         "ja": "アムハラ語",
-        "ja_typings": []
+        "ja_typings": [
+          "amuharago"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -64414,17 +69934,23 @@
       {
         "en": "nasal lengthening",
         "ja": "鼻音延長",
-        "ja_typings": []
+        "ja_typings": [
+          "bionnnenchou"
+        ]
       },
       {
         "en": "vowel lowering",
         "ja": "母音低化",
-        "ja_typings": []
+        "ja_typings": [
+          "bointeika"
+        ]
       },
       {
         "en": "consonant doubling",
         "ja": "子音重複",
-        "ja_typings": []
+        "ja_typings": [
+          "shiinjuufuku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -64455,12 +69981,16 @@
       {
         "en": "Hakka",
         "ja": "客家語",
-        "ja_typings": []
+        "ja_typings": [
+          "hakkago"
+        ]
       },
       {
         "en": "Min",
         "ja": "ビン語",
-        "ja_typings": []
+        "ja_typings": [
+          "bingo"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -64484,17 +70014,23 @@
       {
         "en": "horizontal right-to-left",
         "ja": "横書き右から左",
-        "ja_typings": []
+        "ja_typings": [
+          "yokogakimigikarahidari"
+        ]
       },
       {
         "en": "boustrophedon",
         "ja": "牛耕式",
-        "ja_typings": []
+        "ja_typings": [
+          "gyuukoushiki"
+        ]
       },
       {
         "en": "circular",
         "ja": "円書き",
-        "ja_typings": []
+        "ja_typings": [
+          "enkaki"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -64518,17 +70054,23 @@
       {
         "en": "Celtic",
         "ja": "ケルト語派",
-        "ja_typings": []
+        "ja_typings": [
+          "kerutogoha"
+        ]
       },
       {
         "en": "Hellenic",
         "ja": "ギリシャ語派",
-        "ja_typings": []
+        "ja_typings": [
+          "girishagoha"
+        ]
       },
       {
         "en": "Slavic",
         "ja": "スラブ語派",
-        "ja_typings": []
+        "ja_typings": [
+          "surabugoha"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -64552,17 +70094,23 @@
       {
         "en": "tone marking",
         "ja": "声調表記",
-        "ja_typings": []
+        "ja_typings": [
+          "seichouhyouki"
+        ]
       },
       {
         "en": "noun classes",
         "ja": "名詞クラス",
-        "ja_typings": []
+        "ja_typings": [
+          "meishikurasu"
+        ]
       },
       {
         "en": "vowel mutation",
         "ja": "母音変異",
-        "ja_typings": []
+        "ja_typings": [
+          "boinhennni"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -64586,17 +70134,23 @@
       {
         "en": "Egyptian",
         "ja": "エジプト文字",
-        "ja_typings": []
+        "ja_typings": [
+          "ejiputomoji"
+        ]
       },
       {
         "en": "Phoenician",
         "ja": "フェニキア文字",
-        "ja_typings": []
+        "ja_typings": [
+          "fenikiamoji"
+        ]
       },
       {
         "en": "Mayan",
         "ja": "マヤ文字",
-        "ja_typings": []
+        "ja_typings": [
+          "mayamoji"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -64660,17 +70214,23 @@
       {
         "en": "Mongolian",
         "ja": "モンゴル語",
-        "ja_typings": []
+        "ja_typings": [
+          "mongorugo"
+        ]
       },
       {
         "en": "Vietnamese",
         "ja": "ベトナム語",
-        "ja_typings": []
+        "ja_typings": [
+          "betonamugo"
+        ]
       },
       {
         "en": "Persian",
         "ja": "ペルシア語",
-        "ja_typings": []
+        "ja_typings": [
+          "perushiago"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -64734,17 +70294,23 @@
       {
         "en": "Samoan",
         "ja": "サモア語",
-        "ja_typings": []
+        "ja_typings": [
+          "samoago"
+        ]
       },
       {
         "en": "Tongan",
         "ja": "トンガ語",
-        "ja_typings": []
+        "ja_typings": [
+          "tongago"
+        ]
       },
       {
         "en": "Fijian",
         "ja": "フィジー語",
-        "ja_typings": []
+        "ja_typings": [
+          "fiji-go"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -64761,22 +70327,30 @@
       {
         "en": "/s/",
         "ja": "/s/",
-        "ja_typings": []
+        "ja_typings": [
+          "/s/"
+        ]
       },
       {
         "en": "/p/",
         "ja": "/p/",
-        "ja_typings": []
+        "ja_typings": [
+          "/p/"
+        ]
       },
       {
         "en": "/t/",
         "ja": "/t/",
-        "ja_typings": []
+        "ja_typings": [
+          "/t/"
+        ]
       },
       {
         "en": "/k/",
         "ja": "/k/",
-        "ja_typings": []
+        "ja_typings": [
+          "/k/"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -64793,22 +70367,30 @@
       {
         "en": "Esperanto",
         "ja": "エスペラント",
-        "ja_typings": []
+        "ja_typings": [
+          "esuperanto"
+        ]
       },
       {
         "en": "Volapuk",
         "ja": "ボラピュク",
-        "ja_typings": []
+        "ja_typings": [
+          "borapyuku"
+        ]
       },
       {
         "en": "Lojban",
         "ja": "ロジバン",
-        "ja_typings": []
+        "ja_typings": [
+          "rojiban"
+        ]
       },
       {
         "en": "Toki Pona",
         "ja": "トキポナ",
-        "ja_typings": []
+        "ja_typings": [
+          "tokipona"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -64832,17 +70414,23 @@
       {
         "en": "biconsonantal",
         "ja": "二子音",
-        "ja_typings": []
+        "ja_typings": [
+          "nishiin"
+        ]
       },
       {
         "en": "tetraconsonantal default",
         "ja": "四子音標準",
-        "ja_typings": []
+        "ja_typings": [
+          "yonshiinhyoujun"
+        ]
       },
       {
         "en": "vowel-based",
         "ja": "母音基盤",
-        "ja_typings": []
+        "ja_typings": [
+          "boinkiban"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -64859,22 +70447,30 @@
       {
         "en": "paella valenciana",
         "ja": "パエリャ・バレンシアーナ",
-        "ja_typings": []
+        "ja_typings": [
+          "paerya/barenshia-na"
+        ]
       },
       {
         "en": "fideua",
         "ja": "フィデウア",
-        "ja_typings": []
+        "ja_typings": [
+          "fideua"
+        ]
       },
       {
         "en": "arroz negro",
         "ja": "アロス・ネグロ",
-        "ja_typings": []
+        "ja_typings": [
+          "arosu/neguro"
+        ]
       },
       {
         "en": "risotto milanese",
         "ja": "リゾット・ミラネーゼ",
-        "ja_typings": []
+        "ja_typings": [
+          "rizotto/mirane-ze"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -64891,17 +70487,23 @@
       {
         "en": "Capoeira",
         "ja": "カポエイラ",
-        "ja_typings": []
+        "ja_typings": [
+          "kapoeira"
+        ]
       },
       {
         "en": "Vale Tudo",
         "ja": "バーリトゥード",
-        "ja_typings": []
+        "ja_typings": [
+          "ba-ritu-do"
+        ]
       },
       {
         "en": "Luta Livre",
         "ja": "ルタリーブリ",
-        "ja_typings": []
+        "ja_typings": [
+          "rutari-buri"
+        ]
       },
       {
         "en": "Jiu-Jitsu",
@@ -64925,22 +70527,30 @@
       {
         "en": "La Tomatina",
         "ja": "ラ・トマティーナ",
-        "ja_typings": []
+        "ja_typings": [
+          "ra/tomati-na"
+        ]
       },
       {
         "en": "San Fermin",
         "ja": "サン・フェルミン",
-        "ja_typings": []
+        "ja_typings": [
+          "san/ferumin"
+        ]
       },
       {
         "en": "Las Fallas",
         "ja": "ラス・ファジャス",
-        "ja_typings": []
+        "ja_typings": [
+          "rasu/fajasu"
+        ]
       },
       {
         "en": "Feria de Abril",
         "ja": "セビーリャの春祭り",
-        "ja_typings": []
+        "ja_typings": [
+          "sebi-ryanoharumatsuri"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -64957,22 +70567,30 @@
       {
         "en": "sitar",
         "ja": "シタール",
-        "ja_typings": []
+        "ja_typings": [
+          "shita-ru"
+        ]
       },
       {
         "en": "tabla",
         "ja": "タブラ",
-        "ja_typings": []
+        "ja_typings": [
+          "tabura"
+        ]
       },
       {
         "en": "bansuri",
         "ja": "バーンスリー",
-        "ja_typings": []
+        "ja_typings": [
+          "ba-nsuri-"
+        ]
       },
       {
         "en": "sarangi",
         "ja": "サーランギー",
-        "ja_typings": []
+        "ja_typings": [
+          "sa-rangi-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -64989,22 +70607,30 @@
       {
         "en": "Loki",
         "ja": "ロキ",
-        "ja_typings": []
+        "ja_typings": [
+          "roki"
+        ]
       },
       {
         "en": "Thor",
         "ja": "トール",
-        "ja_typings": []
+        "ja_typings": [
+          "to-ru"
+        ]
       },
       {
         "en": "Odin",
         "ja": "オーディン",
-        "ja_typings": []
+        "ja_typings": [
+          "o-din"
+        ]
       },
       {
         "en": "Freyr",
         "ja": "フレイ",
-        "ja_typings": []
+        "ja_typings": [
+          "furei"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -65021,22 +70647,30 @@
       {
         "en": "ger",
         "ja": "ゲル",
-        "ja_typings": []
+        "ja_typings": [
+          "geru"
+        ]
       },
       {
         "en": "yurt-stone hybrid",
         "ja": "ストーンユルト",
-        "ja_typings": []
+        "ja_typings": [
+          "suto-nnyuruto"
+        ]
       },
       {
         "en": "igloo",
         "ja": "イグルー",
-        "ja_typings": []
+        "ja_typings": [
+          "iguru-"
+        ]
       },
       {
         "en": "longhouse",
         "ja": "ロングハウス",
-        "ja_typings": []
+        "ja_typings": [
+          "ronguhausu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -65053,22 +70687,30 @@
       {
         "en": "solea",
         "ja": "ソレア",
-        "ja_typings": []
+        "ja_typings": [
+          "sorea"
+        ]
       },
       {
         "en": "alegrias",
         "ja": "アレグリアス",
-        "ja_typings": []
+        "ja_typings": [
+          "areguriasu"
+        ]
       },
       {
         "en": "bulerias",
         "ja": "ブレリアス",
-        "ja_typings": []
+        "ja_typings": [
+          "bureriasu"
+        ]
       },
       {
         "en": "rumba flamenca",
         "ja": "ルンバ・フラメンカ",
-        "ja_typings": []
+        "ja_typings": [
+          "runba/furamenka"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -65085,22 +70727,30 @@
       {
         "en": "djembe",
         "ja": "ジャンベ",
-        "ja_typings": []
+        "ja_typings": [
+          "janbe"
+        ]
       },
       {
         "en": "dunun",
         "ja": "ドゥヌン",
-        "ja_typings": []
+        "ja_typings": [
+          "dunun"
+        ]
       },
       {
         "en": "sabar",
         "ja": "サバール",
-        "ja_typings": []
+        "ja_typings": [
+          "saba-ru"
+        ]
       },
       {
         "en": "tama",
         "ja": "タマ",
-        "ja_typings": []
+        "ja_typings": [
+          "tama"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -65124,12 +70774,16 @@
       {
         "en": "Salpuri",
         "ja": "サルプリ",
-        "ja_typings": []
+        "ja_typings": [
+          "sarupuri"
+        ]
       },
       {
         "en": "Taepyeongmu",
         "ja": "テピョンム",
-        "ja_typings": []
+        "ja_typings": [
+          "tepyonmu"
+        ]
       },
       {
         "en": "Seungmu",
@@ -65160,12 +70814,16 @@
       {
         "en": "Cinco de Mayo",
         "ja": "シンコ・デ・マヨ",
-        "ja_typings": []
+        "ja_typings": [
+          "shinko/de/mayo"
+        ]
       },
       {
         "en": "Las Posadas",
         "ja": "ラス・ポサダス",
-        "ja_typings": []
+        "ja_typings": [
+          "rasu/posadasu"
+        ]
       },
       {
         "en": "Fiestas Patrias",
@@ -65189,22 +70847,30 @@
       {
         "en": "Wayang Kulit",
         "ja": "ワヤン・クリ",
-        "ja_typings": []
+        "ja_typings": [
+          "wayan/kuri"
+        ]
       },
       {
         "en": "Wayang Golek",
         "ja": "ワヤン・ゴレ",
-        "ja_typings": []
+        "ja_typings": [
+          "wayan/gore"
+        ]
       },
       {
         "en": "Wayang Topeng",
         "ja": "ワヤン・トペン",
-        "ja_typings": []
+        "ja_typings": [
+          "wayan/topen"
+        ]
       },
       {
         "en": "Wayang Wong",
         "ja": "ワヤン・ウォン",
-        "ja_typings": []
+        "ja_typings": [
+          "wayan/won"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -65228,17 +70894,23 @@
       {
         "en": "Borscht",
         "ja": "ボルシチ",
-        "ja_typings": []
+        "ja_typings": [
+          "borushichi"
+        ]
       },
       {
         "en": "Pelmeni",
         "ja": "ペリメニ",
-        "ja_typings": []
+        "ja_typings": [
+          "perimeni"
+        ]
       },
       {
         "en": "Olivier salad",
         "ja": "オリヴィエサラダ",
-        "ja_typings": []
+        "ja_typings": [
+          "oriviesarada"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -65255,22 +70927,30 @@
       {
         "en": "tambouras",
         "ja": "タンブーラス",
-        "ja_typings": []
+        "ja_typings": [
+          "tanbu-rasu"
+        ]
       },
       {
         "en": "kithara",
         "ja": "キタラ",
-        "ja_typings": []
+        "ja_typings": [
+          "kitara"
+        ]
       },
       {
         "en": "aulos",
         "ja": "アウロス",
-        "ja_typings": []
+        "ja_typings": [
+          "aurosu"
+        ]
       },
       {
         "en": "lyra",
         "ja": "リラ",
-        "ja_typings": []
+        "ja_typings": [
+          "rira"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -65287,22 +70967,30 @@
       {
         "en": "siku",
         "ja": "シーク",
-        "ja_typings": []
+        "ja_typings": [
+          "shi-ku"
+        ]
       },
       {
         "en": "quena",
         "ja": "ケーナ",
-        "ja_typings": []
+        "ja_typings": [
+          "ke-na"
+        ]
       },
       {
         "en": "charango",
         "ja": "チャランゴ",
-        "ja_typings": []
+        "ja_typings": [
+          "charango"
+        ]
       },
       {
         "en": "bombo",
         "ja": "ボンボ",
-        "ja_typings": []
+        "ja_typings": [
+          "bonbo"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -65319,22 +71007,30 @@
       {
         "en": "injera",
         "ja": "インジェラ",
-        "ja_typings": []
+        "ja_typings": [
+          "injera"
+        ]
       },
       {
         "en": "kitfo",
         "ja": "キトフォ",
-        "ja_typings": []
+        "ja_typings": [
+          "kitofo"
+        ]
       },
       {
         "en": "doro wat",
         "ja": "ドロワット",
-        "ja_typings": []
+        "ja_typings": [
+          "dorowatto"
+        ]
       },
       {
         "en": "tibs",
         "ja": "ティブス",
-        "ja_typings": []
+        "ja_typings": [
+          "tibusu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -65351,22 +71047,30 @@
       {
         "en": "Sphinx",
         "ja": "スフィンクス",
-        "ja_typings": []
+        "ja_typings": [
+          "sufinkusu"
+        ]
       },
       {
         "en": "Bennu",
         "ja": "ベンヌ",
-        "ja_typings": []
+        "ja_typings": [
+          "bennnu"
+        ]
       },
       {
         "en": "Apep",
         "ja": "アペプ",
-        "ja_typings": []
+        "ja_typings": [
+          "apepu"
+        ]
       },
       {
         "en": "Anubis",
         "ja": "アヌビス",
-        "ja_typings": []
+        "ja_typings": [
+          "anubisu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -65430,17 +71134,23 @@
       {
         "en": "Vodun",
         "ja": "ヴォドゥン",
-        "ja_typings": []
+        "ja_typings": [
+          "vodun"
+        ]
       },
       {
         "en": "Santeria",
         "ja": "サンテリア",
-        "ja_typings": []
+        "ja_typings": [
+          "santeria"
+        ]
       },
       {
         "en": "Candomble",
         "ja": "カンドンブレ",
-        "ja_typings": []
+        "ja_typings": [
+          "kandonbure"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -65457,22 +71167,30 @@
       {
         "en": "Tarantella",
         "ja": "タランテラ",
-        "ja_typings": []
+        "ja_typings": [
+          "tarantera"
+        ]
       },
       {
         "en": "Saltarello",
         "ja": "サルタレロ",
-        "ja_typings": []
+        "ja_typings": [
+          "sarutarero"
+        ]
       },
       {
         "en": "Pizzica",
         "ja": "ピッツィカ",
-        "ja_typings": []
+        "ja_typings": [
+          "pittsika"
+        ]
       },
       {
         "en": "Forlana",
         "ja": "フォルラーナ",
-        "ja_typings": []
+        "ja_typings": [
+          "forura-na"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -65489,22 +71207,30 @@
       {
         "en": "dungchen",
         "ja": "ドゥンチェン",
-        "ja_typings": []
+        "ja_typings": [
+          "dunchen"
+        ]
       },
       {
         "en": "damaru",
         "ja": "ダマル",
-        "ja_typings": []
+        "ja_typings": [
+          "damaru"
+        ]
       },
       {
         "en": "gyaling",
         "ja": "ギャリン",
-        "ja_typings": []
+        "ja_typings": [
+          "gyarin"
+        ]
       },
       {
         "en": "kangling",
         "ja": "カンリン",
-        "ja_typings": []
+        "ja_typings": [
+          "kanrin"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -65521,22 +71247,30 @@
       {
         "en": "Polonaise",
         "ja": "ポロネーズ",
-        "ja_typings": []
+        "ja_typings": [
+          "porone-zu"
+        ]
       },
       {
         "en": "Mazurka",
         "ja": "マズルカ",
-        "ja_typings": []
+        "ja_typings": [
+          "mazuruka"
+        ]
       },
       {
         "en": "Krakowiak",
         "ja": "クラコヴィアク",
-        "ja_typings": []
+        "ja_typings": [
+          "kurakoviaku"
+        ]
       },
       {
         "en": "Oberek",
         "ja": "オベレク",
-        "ja_typings": []
+        "ja_typings": [
+          "obereku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -65553,22 +71287,30 @@
       {
         "en": "ghazal",
         "ja": "ガザル",
-        "ja_typings": []
+        "ja_typings": [
+          "gazaru"
+        ]
       },
       {
         "en": "qasida",
         "ja": "カシーダ",
-        "ja_typings": []
+        "ja_typings": [
+          "kashi-da"
+        ]
       },
       {
         "en": "rubaiyat",
         "ja": "ルバイヤート",
-        "ja_typings": []
+        "ja_typings": [
+          "rubaiya-to"
+        ]
       },
       {
         "en": "masnavi",
         "ja": "マスナヴィー",
-        "ja_typings": []
+        "ja_typings": [
+          "masunavi-"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -65585,22 +71327,30 @@
       {
         "en": "gulab jamun",
         "ja": "グラブジャムン",
-        "ja_typings": []
+        "ja_typings": [
+          "gurabujamun"
+        ]
       },
       {
         "en": "samosa",
         "ja": "サモサ",
-        "ja_typings": []
+        "ja_typings": [
+          "samosa"
+        ]
       },
       {
         "en": "dosa",
         "ja": "ドーサ",
-        "ja_typings": []
+        "ja_typings": [
+          "do-sa"
+        ]
       },
       {
         "en": "biryani",
         "ja": "ビリヤニ",
-        "ja_typings": []
+        "ja_typings": [
+          "biriyani"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -65617,22 +71367,31 @@
       {
         "en": "bagpipes",
         "ja": "バグパイプ",
-        "ja_typings": []
+        "ja_typings": [
+          "bagupaipu"
+        ]
       },
       {
         "en": "fiddle",
         "ja": "フィドル",
-        "ja_typings": []
+        "ja_typings": [
+          "fidoru"
+        ]
       },
       {
         "en": "bodhran",
         "ja": "ボウラン",
-        "ja_typings": []
+        "ja_typings": [
+          "boran",
+          "bouran"
+        ]
       },
       {
         "en": "clarsach",
         "ja": "クラルサッハ",
-        "ja_typings": []
+        "ja_typings": [
+          "kurarusahha"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -65689,22 +71448,30 @@
       {
         "en": "tipi",
         "ja": "ティーピー",
-        "ja_typings": []
+        "ja_typings": [
+          "ti-pi-"
+        ]
       },
       {
         "en": "wigwam",
         "ja": "ウィグワム",
-        "ja_typings": []
+        "ja_typings": [
+          "wiguwamu"
+        ]
       },
       {
         "en": "hogan",
         "ja": "ホーガン",
-        "ja_typings": []
+        "ja_typings": [
+          "ho-gan"
+        ]
       },
       {
         "en": "longhouse",
         "ja": "ロングハウス",
-        "ja_typings": []
+        "ja_typings": [
+          "ronguhausu"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -65721,22 +71488,30 @@
       {
         "en": "Hula",
         "ja": "フラ",
-        "ja_typings": []
+        "ja_typings": [
+          "fura"
+        ]
       },
       {
         "en": "Tahitian dance",
         "ja": "タヒチアンダンス",
-        "ja_typings": []
+        "ja_typings": [
+          "tahichiandansu"
+        ]
       },
       {
         "en": "Haka",
         "ja": "ハカ",
-        "ja_typings": []
+        "ja_typings": [
+          "haka"
+        ]
       },
       {
         "en": "Siva",
         "ja": "シヴァ",
-        "ja_typings": []
+        "ja_typings": [
+          "shiva"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -65753,22 +71528,30 @@
       {
         "en": "moules frites",
         "ja": "ムール・フリット",
-        "ja_typings": []
+        "ja_typings": [
+          "mu-ru/furitto"
+        ]
       },
       {
         "en": "waterzooi",
         "ja": "ワーテルゾーイ",
-        "ja_typings": []
+        "ja_typings": [
+          "wa-teruzo-i"
+        ]
       },
       {
         "en": "carbonade flamande",
         "ja": "カルボナード",
-        "ja_typings": []
+        "ja_typings": [
+          "karubona-do"
+        ]
       },
       {
         "en": "stoofvlees",
         "ja": "ストーフレース",
-        "ja_typings": []
+        "ja_typings": [
+          "suto-fure-su"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -65785,22 +71568,30 @@
       {
         "en": "Quetzalcoatl",
         "ja": "ケツァルコアトル",
-        "ja_typings": []
+        "ja_typings": [
+          "ketsarukoatoru"
+        ]
       },
       {
         "en": "Huitzilopochtli",
         "ja": "ウィツィロポチトリ",
-        "ja_typings": []
+        "ja_typings": [
+          "witsiropochitori"
+        ]
       },
       {
         "en": "Tezcatlipoca",
         "ja": "テスカトリポカ",
-        "ja_typings": []
+        "ja_typings": [
+          "tesukatoripoka"
+        ]
       },
       {
         "en": "Tlaloc",
         "ja": "トラロック",
-        "ja_typings": []
+        "ja_typings": [
+          "torarokku"
+        ]
       }
     ],
     "correct_answer_index": 0,
@@ -65817,22 +71608,30 @@
       {
         "en": "pho",
         "ja": "フォー",
-        "ja_typings": []
+        "ja_typings": [
+          "fo-"
+        ]
       },
       {
         "en": "bun bo Hue",
         "ja": "ブン・ボー・フエ",
-        "ja_typings": []
+        "ja_typings": [
+          "bun/bo-/fue"
+        ]
       },
       {
         "en": "hu tieu",
         "ja": "フーティウ",
-        "ja_typings": []
+        "ja_typings": [
+          "fu-tiu"
+        ]
       },
       {
         "en": "mi quang",
         "ja": "ミー・クアン",
-        "ja_typings": []
+        "ja_typings": [
+          "mi-/kuan"
+        ]
       }
     ],
     "correct_answer_index": 0,

--- a/data/questions_en.json
+++ b/data/questions_en.json
@@ -46428,5 +46428,19420 @@
       "en": "Which game features a girl named 2B fighting machines?",
       "ja": "2Bが機械生命体と戦うゲームは?"
     }
+  },
+  {
+    "choices": [
+      {
+        "en": "collections.OrderedDict",
+        "ja": "コレクションズオーダードディクト",
+        "ja_typings": []
+      },
+      {
+        "en": "collections.deque",
+        "ja": "コレクションズデック",
+        "ja_typings": []
+      },
+      {
+        "en": "collections.ChainMap",
+        "ja": "コレクションズチェインマップ",
+        "ja_typings": []
+      },
+      {
+        "en": "collections.UserDict",
+        "ja": "コレクションズユーザーディクト",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01209",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Python module for ordered dictionaries (insertion-ordered) added in 3.7 as guaranteed?",
+      "ja": "Python 3.7 で挿入順序が保証された辞書の特殊型を提供するモジュールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "functools.lru_cache",
+        "ja": "ファンクツールズエルアールユーキャッシュ",
+        "ja_typings": []
+      },
+      {
+        "en": "functools.partial",
+        "ja": "ファンクツールズパーシャル",
+        "ja_typings": []
+      },
+      {
+        "en": "functools.reduce",
+        "ja": "ファンクツールズリデュース",
+        "ja_typings": []
+      },
+      {
+        "en": "functools.wraps",
+        "ja": "ファンクツールズラップス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01210",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Python decorator caches return values based on arguments?",
+      "ja": "Python で引数に基づいて戻り値をキャッシュするデコレーターは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "with",
+        "ja": "ウィズ",
+        "ja_typings": []
+      },
+      {
+        "en": "try",
+        "ja": "トライ",
+        "ja_typings": []
+      },
+      {
+        "en": "yield",
+        "ja": "イールド",
+        "ja_typings": []
+      },
+      {
+        "en": "async",
+        "ja": "エイシンク",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01211",
+    "image_path": null,
+    "question_text": {
+      "en": "What Python statement creates a context manager inline?",
+      "ja": "Python でコンテキストマネージャをインラインで作成する文は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "enumerate",
+        "ja": "エニュメレート",
+        "ja_typings": []
+      },
+      {
+        "en": "zip",
+        "ja": "ジップ",
+        "ja_typings": []
+      },
+      {
+        "en": "map",
+        "ja": "マップ",
+        "ja_typings": []
+      },
+      {
+        "en": "filter",
+        "ja": "フィルター",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01212",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Python builtin returns an iterator of tuples pairing index and value?",
+      "ja": "インデックスと値をペアにしたタプルのイテレータを返す Python 組み込み関数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "async def",
+        "ja": "エイシンクデフ",
+        "ja_typings": []
+      },
+      {
+        "en": "def coroutine",
+        "ja": "デフコルーチン",
+        "ja_typings": []
+      },
+      {
+        "en": "yield from",
+        "ja": "イールドフロム",
+        "ja_typings": []
+      },
+      {
+        "en": "await def",
+        "ja": "アウェイトデフ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01213",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Python keyword defines a coroutine function?",
+      "ja": "Python でコルーチン関数を定義するキーワードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": ":=",
+        "ja": "コロンイコール",
+        "ja_typings": []
+      },
+      {
+        "en": "=>",
+        "ja": "イコールグレーター",
+        "ja_typings": []
+      },
+      {
+        "en": "<-",
+        "ja": "レフトアロー",
+        "ja_typings": []
+      },
+      {
+        "en": "->",
+        "ja": "ライトアロー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01214",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Python's walrus operator?",
+      "ja": "Python のセイウチ演算子はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "collections.abc",
+        "ja": "コレクションズエービーシー",
+        "ja_typings": []
+      },
+      {
+        "en": "typing.abc",
+        "ja": "タイピングエービーシー",
+        "ja_typings": []
+      },
+      {
+        "en": "abc.collections",
+        "ja": "エービーシーコレクションズ",
+        "ja_typings": []
+      },
+      {
+        "en": "base.abc",
+        "ja": "ベースエービーシー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01215",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Python module provides abstract base classes for containers?",
+      "ja": "コンテナの抽象基底クラスを提供する Python モジュールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Global Interpreter Lock",
+        "ja": "グローバルインタープリターロック",
+        "ja_typings": []
+      },
+      {
+        "en": "General Iteration Loop",
+        "ja": "ジェネラルイテレーションループ",
+        "ja_typings": []
+      },
+      {
+        "en": "Garbage Inspection Layer",
+        "ja": "ガベージインスペクションレイヤー",
+        "ja_typings": []
+      },
+      {
+        "en": "Generic Internal Library",
+        "ja": "ジェネリックインターナルライブラリ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01216",
+    "image_path": null,
+    "question_text": {
+      "en": "What does Python's GIL stand for?",
+      "ja": "Python の GIL の正式名称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "const fn",
+        "ja": "コンストエフエヌ",
+        "ja_typings": []
+      },
+      {
+        "en": "static fn",
+        "ja": "スタティックエフエヌ",
+        "ja_typings": []
+      },
+      {
+        "en": "comptime fn",
+        "ja": "コンプタイムエフエヌ",
+        "ja_typings": []
+      },
+      {
+        "en": "eval fn",
+        "ja": "イーバルエフエヌ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01217",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Rust attribute marks a function for compile-time evaluation?",
+      "ja": "Rust でコンパイル時評価のために関数をマークする属性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "RefCell",
+        "ja": "レフセル",
+        "ja_typings": []
+      },
+      {
+        "en": "UnsafeCell",
+        "ja": "アンセーフセル",
+        "ja_typings": []
+      },
+      {
+        "en": "Cell",
+        "ja": "セル",
+        "ja_typings": []
+      },
+      {
+        "en": "OnceCell",
+        "ja": "ワンスセル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01218",
+    "image_path": null,
+    "question_text": {
+      "en": "What Rust smart pointer enables interior mutability with runtime borrow checking?",
+      "ja": "実行時借用チェックで内部可変性を可能にする Rust のスマートポインタは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "#[derive(Debug)]",
+        "ja": "デライブデバッグ",
+        "ja_typings": []
+      },
+      {
+        "en": "#[debug]",
+        "ja": "デバッグ",
+        "ja_typings": []
+      },
+      {
+        "en": "#[impl(Debug)]",
+        "ja": "インプルデバッグ",
+        "ja_typings": []
+      },
+      {
+        "en": "#[trait(Debug)]",
+        "ja": "トレイトデバッグ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01219",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Rust macro derives Debug formatting?",
+      "ja": "Rust で Debug フォーマットを派生させるマクロは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "? operator",
+        "ja": "クエスチョン演算子",
+        "ja_typings": [
+          "? エンザンシ"
+        ]
+      },
+      {
+        "en": "try block",
+        "ja": "トライブロック",
+        "ja_typings": []
+      },
+      {
+        "en": "panic macro",
+        "ja": "パニックマクロ",
+        "ja_typings": []
+      },
+      {
+        "en": "unwrap chain",
+        "ja": "アンラップチェーン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01220",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Rust's zero-cost abstraction for fallible operations?",
+      "ja": "失敗しうる操作のための Rust のゼロコスト抽象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "where",
+        "ja": "ホエア",
+        "ja_typings": []
+      },
+      {
+        "en": "bound",
+        "ja": "バウンド",
+        "ja_typings": []
+      },
+      {
+        "en": "constraint",
+        "ja": "コンストレイント",
+        "ja_typings": []
+      },
+      {
+        "en": "requires",
+        "ja": "リクワイアズ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01221",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Rust keyword introduces a trait bound on a generic?",
+      "ja": "Rust でジェネリクスにトレイト境界を導入するキーワードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "if let",
+        "ja": "イフレット",
+        "ja_typings": []
+      },
+      {
+        "en": "if match",
+        "ja": "イフマッチ",
+        "ja_typings": []
+      },
+      {
+        "en": "when let",
+        "ja": "ホエンレット",
+        "ja_typings": []
+      },
+      {
+        "en": "case let",
+        "ja": "ケースレット",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01222",
+    "image_path": null,
+    "question_text": {
+      "en": "What Rust feature allows pattern matching on enum variants?",
+      "ja": "Rust で enum バリアントへのパターンマッチを可能にする機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Array.from",
+        "ja": "アレイフロム",
+        "ja_typings": []
+      },
+      {
+        "en": "Array.of",
+        "ja": "アレイオブ",
+        "ja_typings": []
+      },
+      {
+        "en": "Array.copy",
+        "ja": "アレイコピー",
+        "ja_typings": []
+      },
+      {
+        "en": "Array.clone",
+        "ja": "アレイクローン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01223",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript method creates a shallow copy of an array?",
+      "ja": "配列の浅いコピーを作成する JavaScript のメソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "??",
+        "ja": "ダブルクエスチョン",
+        "ja_typings": []
+      },
+      {
+        "en": "||",
+        "ja": "ダブルパイプ",
+        "ja_typings": []
+      },
+      {
+        "en": "&&",
+        "ja": "ダブルアンパサンド",
+        "ja_typings": []
+      },
+      {
+        "en": "?:",
+        "ja": "クエスチョンコロン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01224",
+    "image_path": null,
+    "question_text": {
+      "en": "What JavaScript operator performs nullish coalescing?",
+      "ja": "JavaScript で null 合体演算を行う演算子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Partial",
+        "ja": "パーシャル",
+        "ja_typings": []
+      },
+      {
+        "en": "Required",
+        "ja": "リクワイアド",
+        "ja_typings": []
+      },
+      {
+        "en": "Readonly",
+        "ja": "リードオンリー",
+        "ja_typings": []
+      },
+      {
+        "en": "Pick",
+        "ja": "ピック",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01225",
+    "image_path": null,
+    "question_text": {
+      "en": "Which TypeScript utility type makes all properties optional?",
+      "ja": "全プロパティを省略可能にする TypeScript ユーティリティ型は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "never",
+        "ja": "ネバー",
+        "ja_typings": []
+      },
+      {
+        "en": "void",
+        "ja": "ボイド",
+        "ja_typings": []
+      },
+      {
+        "en": "unknown",
+        "ja": "アンノウン",
+        "ja_typings": []
+      },
+      {
+        "en": "undefined",
+        "ja": "アンディファインド",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01226",
+    "image_path": null,
+    "question_text": {
+      "en": "What TypeScript feature represents a value that never occurs?",
+      "ja": "決して発生しない値を表す TypeScript の機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Web Worker",
+        "ja": "ウェブワーカー",
+        "ja_typings": []
+      },
+      {
+        "en": "SharedWorker",
+        "ja": "シェアードワーカー",
+        "ja_typings": []
+      },
+      {
+        "en": "AudioWorklet",
+        "ja": "オーディオワークレット",
+        "ja_typings": []
+      },
+      {
+        "en": "Atomics",
+        "ja": "アトミックス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01227",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript API provides a way to run code in a separate thread?",
+      "ja": "別スレッドでコードを実行する方法を提供する JavaScript の API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Iteration protocol",
+        "ja": "イテレーションプロトコル",
+        "ja_typings": []
+      },
+      {
+        "en": "Comparison protocol",
+        "ja": "コンパリソンプロトコル",
+        "ja_typings": []
+      },
+      {
+        "en": "Hashing protocol",
+        "ja": "ハッシングプロトコル",
+        "ja_typings": []
+      },
+      {
+        "en": "Serialization protocol",
+        "ja": "シリアライゼーションプロトコル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01228",
+    "image_path": null,
+    "question_text": {
+      "en": "What does JavaScript's Symbol.iterator define?",
+      "ja": "JavaScript の Symbol.iterator が定義するものは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Object.freeze",
+        "ja": "オブジェクトフリーズ",
+        "ja_typings": []
+      },
+      {
+        "en": "Object.seal",
+        "ja": "オブジェクトシール",
+        "ja_typings": []
+      },
+      {
+        "en": "Object.lock",
+        "ja": "オブジェクトロック",
+        "ja_typings": []
+      },
+      {
+        "en": "Object.const",
+        "ja": "オブジェクトコンスト",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01229",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript expression freezes an object?",
+      "ja": "オブジェクトを凍結する JavaScript の式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "go",
+        "ja": "ゴー",
+        "ja_typings": []
+      },
+      {
+        "en": "spawn",
+        "ja": "スポーン",
+        "ja_typings": []
+      },
+      {
+        "en": "async",
+        "ja": "エイシンク",
+        "ja_typings": []
+      },
+      {
+        "en": "thread",
+        "ja": "スレッド",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01230",
+    "image_path": null,
+    "question_text": {
+      "en": "What Go keyword starts a lightweight thread?",
+      "ja": "軽量スレッドを開始する Go のキーワードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "select",
+        "ja": "セレクト",
+        "ja_typings": []
+      },
+      {
+        "en": "switch",
+        "ja": "スイッチ",
+        "ja_typings": []
+      },
+      {
+        "en": "choose",
+        "ja": "チューズ",
+        "ja_typings": []
+      },
+      {
+        "en": "when",
+        "ja": "ホエン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01231",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Go construct enables typed channel communication selection?",
+      "ja": "型付きチャネル通信の選択を可能にする Go の構文は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "defer",
+        "ja": "ディファー",
+        "ja_typings": []
+      },
+      {
+        "en": "finally",
+        "ja": "ファイナリー",
+        "ja_typings": []
+      },
+      {
+        "en": "cleanup",
+        "ja": "クリーンアップ",
+        "ja_typings": []
+      },
+      {
+        "en": "postpone",
+        "ja": "ポストポーン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01232",
+    "image_path": null,
+    "question_text": {
+      "en": "What Go feature is used for deferred function execution at scope end?",
+      "ja": "スコープ末尾での関数実行を遅延する Go の機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sync",
+        "ja": "シンク",
+        "ja_typings": []
+      },
+      {
+        "en": "atomic",
+        "ja": "アトミック",
+        "ja_typings": []
+      },
+      {
+        "en": "lock",
+        "ja": "ロック",
+        "ja_typings": []
+      },
+      {
+        "en": "mutex",
+        "ja": "ミューテックス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01233",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Go package provides synchronization primitives?",
+      "ja": "同期プリミティブを提供する Go のパッケージは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "unique_ptr",
+        "ja": "ユニークピーティーアール",
+        "ja_typings": []
+      },
+      {
+        "en": "shared_ptr",
+        "ja": "シェアードピーティーアール",
+        "ja_typings": []
+      },
+      {
+        "en": "weak_ptr",
+        "ja": "ウィークピーティーアール",
+        "ja_typings": []
+      },
+      {
+        "en": "auto_ptr",
+        "ja": "オートピーティーアール",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01234",
+    "image_path": null,
+    "question_text": {
+      "en": "Which C++ smart pointer represents exclusive ownership?",
+      "ja": "排他的所有権を表す C++ のスマートポインタは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "explicit",
+        "ja": "エクスプリシット",
+        "ja_typings": []
+      },
+      {
+        "en": "implicit",
+        "ja": "インプリシット",
+        "ja_typings": []
+      },
+      {
+        "en": "noexcept",
+        "ja": "ノーエクセプト",
+        "ja_typings": []
+      },
+      {
+        "en": "constexpr",
+        "ja": "コンストエクスパー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01235",
+    "image_path": null,
+    "question_text": {
+      "en": "What C++ keyword prevents implicit conversions for constructors?",
+      "ja": "コンストラクタの暗黙変換を防ぐ C++ のキーワードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "constexpr",
+        "ja": "コンストエクスパー",
+        "ja_typings": []
+      },
+      {
+        "en": "inline",
+        "ja": "インライン",
+        "ja_typings": []
+      },
+      {
+        "en": "consteval",
+        "ja": "コンストイーバル",
+        "ja_typings": []
+      },
+      {
+        "en": "static",
+        "ja": "スタティック",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01236",
+    "image_path": null,
+    "question_text": {
+      "en": "Which C++ feature enables compile-time computation?",
+      "ja": "コンパイル時計算を可能にする C++ の機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "C++20",
+        "ja": "シープラプラニジュウ",
+        "ja_typings": [
+          "C++20"
+        ]
+      },
+      {
+        "en": "C++17",
+        "ja": "シープラプラジュウナナ",
+        "ja_typings": [
+          "C++17"
+        ]
+      },
+      {
+        "en": "C++14",
+        "ja": "シープラプラジュウヨン",
+        "ja_typings": [
+          "C++14"
+        ]
+      },
+      {
+        "en": "C++11",
+        "ja": "シープラプラジュウイチ",
+        "ja_typings": [
+          "C++11"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01237",
+    "image_path": null,
+    "question_text": {
+      "en": "What C++ standard introduced concepts?",
+      "ja": "concepts を導入した C++ 標準は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "dynamic_cast",
+        "ja": "ダイナミックキャスト",
+        "ja_typings": []
+      },
+      {
+        "en": "static_cast",
+        "ja": "スタティックキャスト",
+        "ja_typings": []
+      },
+      {
+        "en": "reinterpret_cast",
+        "ja": "リインタープリットキャスト",
+        "ja_typings": []
+      },
+      {
+        "en": "const_cast",
+        "ja": "コンストキャスト",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01238",
+    "image_path": null,
+    "question_text": {
+      "en": "Which C++ cast performs runtime type checking?",
+      "ja": "実行時型チェックを行う C++ のキャストは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "object",
+        "ja": "オブジェクト",
+        "ja_typings": []
+      },
+      {
+        "en": "singleton",
+        "ja": "シングルトン",
+        "ja_typings": []
+      },
+      {
+        "en": "static",
+        "ja": "スタティック",
+        "ja_typings": []
+      },
+      {
+        "en": "companion",
+        "ja": "コンパニオン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01239",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Kotlin keyword declares a singleton object?",
+      "ja": "Kotlin でシングルトンオブジェクトを宣言するキーワードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "?.",
+        "ja": "クエスチョンドット",
+        "ja_typings": []
+      },
+      {
+        "en": "!!",
+        "ja": "ダブルバン",
+        "ja_typings": []
+      },
+      {
+        "en": "?:",
+        "ja": "エルビス",
+        "ja_typings": []
+      },
+      {
+        "en": "::",
+        "ja": "ダブルコロン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01240",
+    "image_path": null,
+    "question_text": {
+      "en": "What Kotlin function-like type allows null-safe call chaining?",
+      "ja": "null 安全なチェーンを可能にする Kotlin の演算子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "let",
+        "ja": "レット",
+        "ja_typings": []
+      },
+      {
+        "en": "var",
+        "ja": "バー",
+        "ja_typings": []
+      },
+      {
+        "en": "const",
+        "ja": "コンスト",
+        "ja_typings": []
+      },
+      {
+        "en": "final",
+        "ja": "ファイナル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01241",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Swift keyword declares an immutable binding?",
+      "ja": "Swift で不変束縛を宣言するキーワードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "nil coalescing",
+        "ja": "ニルコアレッシング",
+        "ja_typings": []
+      },
+      {
+        "en": "optional binding",
+        "ja": "オプショナルバインディング",
+        "ja_typings": []
+      },
+      {
+        "en": "forced unwrap",
+        "ja": "フォースドアンラップ",
+        "ja_typings": []
+      },
+      {
+        "en": "guard let",
+        "ja": "ガードレット",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01242",
+    "image_path": null,
+    "question_text": {
+      "en": "What Swift feature handles optional values with default fallback?",
+      "ja": "省略可能値をデフォルトでフォールバックする Swift の機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Doubly linked list + hash map",
+        "ja": "双方向連結リスト + ハッシュマップ",
+        "ja_typings": [
+          "ソウホウコウレンケツリスト + ハッシュマップ"
+        ]
+      },
+      {
+        "en": "Singly linked list",
+        "ja": "単方向連結リスト",
+        "ja_typings": [
+          "タンホウコウレンケツリスト"
+        ]
+      },
+      {
+        "en": "Binary heap",
+        "ja": "二分ヒープ",
+        "ja_typings": [
+          "ニブンヒープ"
+        ]
+      },
+      {
+        "en": "AVL tree",
+        "ja": "エーブイエルツリー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01243",
+    "image_path": null,
+    "question_text": {
+      "en": "Which data structure is best for LRU cache implementation?",
+      "ja": "LRU キャッシュ実装に最適なデータ構造は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "O(n^2)",
+        "ja": "オーエヌジジョウ",
+        "ja_typings": [
+          "O(n^2)"
+        ]
+      },
+      {
+        "en": "O(n log n)",
+        "ja": "オーエヌログエヌ",
+        "ja_typings": [
+          "O(n log n)"
+        ]
+      },
+      {
+        "en": "O(1)",
+        "ja": "オーイチ",
+        "ja_typings": [
+          "O(1)"
+        ]
+      },
+      {
+        "en": "O(log n)",
+        "ja": "オーログエヌ",
+        "ja_typings": [
+          "O(log n)"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01244",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the worst-case time complexity of quicksort?",
+      "ja": "クイックソートの最悪計算量は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Red-black tree",
+        "ja": "レッドブラックツリー",
+        "ja_typings": []
+      },
+      {
+        "en": "Splay tree",
+        "ja": "スプレイツリー",
+        "ja_typings": []
+      },
+      {
+        "en": "B-tree",
+        "ja": "ビーツリー",
+        "ja_typings": []
+      },
+      {
+        "en": "Trie",
+        "ja": "トライ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01245",
+    "image_path": null,
+    "question_text": {
+      "en": "Which tree is self-balancing with red and black node coloring?",
+      "ja": "赤黒ノード彩色で自己平衡する木は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Floyd algorithm",
+        "ja": "フロイドアルゴリズム",
+        "ja_typings": []
+      },
+      {
+        "en": "Kruskal algorithm",
+        "ja": "クラスカルアルゴリズム",
+        "ja_typings": []
+      },
+      {
+        "en": "Prim algorithm",
+        "ja": "プリムアルゴリズム",
+        "ja_typings": []
+      },
+      {
+        "en": "Bellman-Ford",
+        "ja": "ベルマンフォード",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01246",
+    "image_path": null,
+    "question_text": {
+      "en": "What algorithm finds shortest paths from all pairs in a graph?",
+      "ja": "グラフの全頂点間最短路を求めるアルゴリズムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Trie",
+        "ja": "トライ木",
+        "ja_typings": [
+          "トライキ"
+        ]
+      },
+      {
+        "en": "Suffix array",
+        "ja": "サフィックスアレイ",
+        "ja_typings": []
+      },
+      {
+        "en": "Segment tree",
+        "ja": "セグメントツリー",
+        "ja_typings": []
+      },
+      {
+        "en": "Fenwick tree",
+        "ja": "フェニックツリー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01247",
+    "image_path": null,
+    "question_text": {
+      "en": "Which data structure supports efficient prefix search of strings?",
+      "ja": "文字列の効率的な前方一致検索を支援するデータ構造は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Doubling strategy",
+        "ja": "ダブリング戦略",
+        "ja_typings": [
+          "ダブリングセンリャク"
+        ]
+      },
+      {
+        "en": "Linear growth",
+        "ja": "線形成長",
+        "ja_typings": [
+          "センケイセイチョウ"
+        ]
+      },
+      {
+        "en": "Constant chunking",
+        "ja": "定数チャンク化",
+        "ja_typings": [
+          "テイスウチャンクカ"
+        ]
+      },
+      {
+        "en": "Geometric shrinking",
+        "ja": "幾何縮小",
+        "ja_typings": [
+          "キカシュクショウ"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01248",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the technique to amortize the cost of dynamic array resizing?",
+      "ja": "動的配列リサイズコストを償却する手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Deque",
+        "ja": "デック",
+        "ja_typings": []
+      },
+      {
+        "en": "Priority queue",
+        "ja": "プライオリティキュー",
+        "ja_typings": []
+      },
+      {
+        "en": "Circular buffer",
+        "ja": "循環バッファ",
+        "ja_typings": [
+          "ジュンカンバッファ"
+        ]
+      },
+      {
+        "en": "Skip list",
+        "ja": "スキップリスト",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01249",
+    "image_path": null,
+    "question_text": {
+      "en": "Which structure provides O(1) amortized push and pop from both ends?",
+      "ja": "両端からの償却 O(1) push/pop を提供する構造は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Knuth-Morris-Pratt",
+        "ja": "クヌースモリスプラット",
+        "ja_typings": []
+      },
+      {
+        "en": "Boyer-Moore",
+        "ja": "ボイヤームーア",
+        "ja_typings": []
+      },
+      {
+        "en": "Rabin-Karp",
+        "ja": "ラビンカープ",
+        "ja_typings": []
+      },
+      {
+        "en": "Aho-Corasick",
+        "ja": "エイホコラシック",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01250",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the name of the algorithm matching strings with KMP failure function?",
+      "ja": "KMP の失敗関数で文字列照合するアルゴリズムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Copying GC",
+        "ja": "コピーGC",
+        "ja_typings": [
+          "コピーGC"
+        ]
+      },
+      {
+        "en": "Mark-sweep GC",
+        "ja": "マークスイープGC",
+        "ja_typings": [
+          "マークスイープGC"
+        ]
+      },
+      {
+        "en": "Mark-compact GC",
+        "ja": "マークコンパクトGC",
+        "ja_typings": [
+          "マークコンパクトGC"
+        ]
+      },
+      {
+        "en": "Incremental GC",
+        "ja": "インクリメンタルGC",
+        "ja_typings": [
+          "インクリメンタルGC"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01251",
+    "image_path": null,
+    "question_text": {
+      "en": "Which GC algorithm uses two semispaces and copies live objects?",
+      "ja": "2 つの半空間を使い生存オブジェクトをコピーする GC は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Generational GC",
+        "ja": "世代別GC",
+        "ja_typings": [
+          "セダイベツGC"
+        ]
+      },
+      {
+        "en": "Concurrent GC",
+        "ja": "並行GC",
+        "ja_typings": [
+          "ヘイコウGC"
+        ]
+      },
+      {
+        "en": "Real-time GC",
+        "ja": "リアルタイムGC",
+        "ja_typings": []
+      },
+      {
+        "en": "Conservative GC",
+        "ja": "保守的GC",
+        "ja_typings": [
+          "ホシュテキGC"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01252",
+    "image_path": null,
+    "question_text": {
+      "en": "What GC technique segregates objects by age?",
+      "ja": "オブジェクトを年齢で分離する GC 技法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NaN boxing",
+        "ja": "ナンボクシング",
+        "ja_typings": []
+      },
+      {
+        "en": "Pointer compression",
+        "ja": "ポインタコンプレッション",
+        "ja_typings": []
+      },
+      {
+        "en": "Reference folding",
+        "ja": "リファレンスフォールディング",
+        "ja_typings": []
+      },
+      {
+        "en": "Heap coloring",
+        "ja": "ヒープカラーリング",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01253",
+    "image_path": null,
+    "question_text": {
+      "en": "Which low-level technique uses pointer tagging to encode types?",
+      "ja": "ポインタタグ付けで型をエンコードする低レベル技法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "RwLock",
+        "ja": "アールダブリューロック",
+        "ja_typings": []
+      },
+      {
+        "en": "Spinlock",
+        "ja": "スピンロック",
+        "ja_typings": []
+      },
+      {
+        "en": "Semaphore",
+        "ja": "セマフォ",
+        "ja_typings": []
+      },
+      {
+        "en": "Barrier",
+        "ja": "バリア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01254",
+    "image_path": null,
+    "question_text": {
+      "en": "What concurrency primitive allows multiple readers or one writer?",
+      "ja": "複数読者または単一書き手を許す並行プリミティブは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Actor model",
+        "ja": "アクターモデル",
+        "ja_typings": []
+      },
+      {
+        "en": "CSP model",
+        "ja": "シーエスピーモデル",
+        "ja_typings": []
+      },
+      {
+        "en": "Fork-join model",
+        "ja": "フォークジョインモデル",
+        "ja_typings": []
+      },
+      {
+        "en": "MapReduce",
+        "ja": "マップリデュース",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01255",
+    "image_path": null,
+    "question_text": {
+      "en": "Which pattern uses message passing between actors?",
+      "ja": "アクター間でメッセージパッシングを行うパターンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Livelock",
+        "ja": "ライブロック",
+        "ja_typings": []
+      },
+      {
+        "en": "Starvation",
+        "ja": "スターベーション",
+        "ja_typings": []
+      },
+      {
+        "en": "Priority inversion",
+        "ja": "プライオリティインバージョン",
+        "ja_typings": []
+      },
+      {
+        "en": "Convoy effect",
+        "ja": "コンボイエフェクト",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01256",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the term for a deadlock-like state where threads keep yielding?",
+      "ja": "スレッドが譲り合い続けるデッドロック類似状態は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "AtomicInteger",
+        "ja": "アトミックインテジャー",
+        "ja_typings": []
+      },
+      {
+        "en": "synchronized",
+        "ja": "シンクロナイズド",
+        "ja_typings": []
+      },
+      {
+        "en": "volatile",
+        "ja": "ボラタイル",
+        "ja_typings": []
+      },
+      {
+        "en": "ReentrantLock",
+        "ja": "リエントラントロック",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01257",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Java construct provides lock-free atomic operations?",
+      "ja": "ロックフリーなアトミック操作を提供する Java 構文は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Memory barrier",
+        "ja": "メモリバリア",
+        "ja_typings": []
+      },
+      {
+        "en": "Cache flush",
+        "ja": "キャッシュフラッシュ",
+        "ja_typings": []
+      },
+      {
+        "en": "Thread fence",
+        "ja": "スレッドフェンス",
+        "ja_typings": []
+      },
+      {
+        "en": "Lock fence",
+        "ja": "ロックフェンス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01258",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the term for ensuring memory ordering across threads?",
+      "ja": "スレッド間のメモリ順序を保証する用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Currying",
+        "ja": "カリー化",
+        "ja_typings": [
+          "カリーカ"
+        ]
+      },
+      {
+        "en": "Composing",
+        "ja": "コンポージング",
+        "ja_typings": []
+      },
+      {
+        "en": "Memoizing",
+        "ja": "メモアイジング",
+        "ja_typings": []
+      },
+      {
+        "en": "Folding",
+        "ja": "フォールディング",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01259",
+    "image_path": null,
+    "question_text": {
+      "en": "Which functional concept transforms a multi-arg function into chained single-arg functions?",
+      "ja": "多引数関数を連鎖した単一引数関数に変換する関数型概念は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "bind",
+        "ja": "バインド",
+        "ja_typings": []
+      },
+      {
+        "en": "apply",
+        "ja": "アプライ",
+        "ja_typings": []
+      },
+      {
+        "en": "lift",
+        "ja": "リフト",
+        "ja_typings": []
+      },
+      {
+        "en": "join",
+        "ja": "ジョイン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01260",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a monad's binding operation commonly named?",
+      "ja": "モナドの束縛操作の一般的な名前は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "fold",
+        "ja": "フォールド",
+        "ja_typings": []
+      },
+      {
+        "en": "scan",
+        "ja": "スキャン",
+        "ja_typings": []
+      },
+      {
+        "en": "group",
+        "ja": "グループ",
+        "ja_typings": []
+      },
+      {
+        "en": "zip",
+        "ja": "ジップ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01261",
+    "image_path": null,
+    "question_text": {
+      "en": "Which higher-order function reduces a list to a single value?",
+      "ja": "リストを単一値に畳み込む高階関数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "First-class functions",
+        "ja": "ファーストクラスファンクションズ",
+        "ja_typings": []
+      },
+      {
+        "en": "Higher-order types",
+        "ja": "ハイヤーオーダータイプス",
+        "ja_typings": []
+      },
+      {
+        "en": "Anonymous closures",
+        "ja": "アノニマスクロージャーズ",
+        "ja_typings": []
+      },
+      {
+        "en": "Lambda capture",
+        "ja": "ラムダキャプチャ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01262",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the term for treating functions as first-class values?",
+      "ja": "関数をファーストクラス値として扱う用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ad-hoc polymorphism",
+        "ja": "アドホックポリモーフィズム",
+        "ja_typings": []
+      },
+      {
+        "en": "Parametric polymorphism",
+        "ja": "パラメトリックポリモーフィズム",
+        "ja_typings": []
+      },
+      {
+        "en": "Subtype polymorphism",
+        "ja": "サブタイプポリモーフィズム",
+        "ja_typings": []
+      },
+      {
+        "en": "Row polymorphism",
+        "ja": "ロウポリモーフィズム",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01263",
+    "image_path": null,
+    "question_text": {
+      "en": "Which type system feature describes Haskell's typeclasses?",
+      "ja": "Haskell の型クラスを表現する型システム機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "TCO",
+        "ja": "ティーシーオー",
+        "ja_typings": []
+      },
+      {
+        "en": "TLS",
+        "ja": "ティーエルエス",
+        "ja_typings": []
+      },
+      {
+        "en": "LTO",
+        "ja": "エルティーオー",
+        "ja_typings": []
+      },
+      {
+        "en": "FFI",
+        "ja": "エフエフアイ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01264",
+    "image_path": null,
+    "question_text": {
+      "en": "What is tail call optimization commonly abbreviated as?",
+      "ja": "末尾呼び出し最適化の略称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lowering",
+        "ja": "ロワリング",
+        "ja_typings": []
+      },
+      {
+        "en": "Linking",
+        "ja": "リンキング",
+        "ja_typings": []
+      },
+      {
+        "en": "Bundling",
+        "ja": "バンドリング",
+        "ja_typings": []
+      },
+      {
+        "en": "Mangling",
+        "ja": "マングリング",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01265",
+    "image_path": null,
+    "question_text": {
+      "en": "Which compilation step converts source to an intermediate representation?",
+      "ja": "ソースを中間表現に変換するコンパイル工程は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Recursion",
+        "ja": "再帰",
+        "ja_typings": [
+          "サイキ"
+        ]
+      },
+      {
+        "en": "Iteration",
+        "ja": "反復",
+        "ja_typings": [
+          "ハンプク"
+        ]
+      },
+      {
+        "en": "Reflection",
+        "ja": "リフレクション",
+        "ja_typings": []
+      },
+      {
+        "en": "Reification",
+        "ja": "リアイフィケーション",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01266",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the term for a function that calls itself?",
+      "ja": "自分自身を呼び出す関数の用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Metaprogramming",
+        "ja": "メタプログラミング",
+        "ja_typings": []
+      },
+      {
+        "en": "Macroprogramming",
+        "ja": "マクロプログラミング",
+        "ja_typings": []
+      },
+      {
+        "en": "Polyprogramming",
+        "ja": "ポリプログラミング",
+        "ja_typings": []
+      },
+      {
+        "en": "Hyperprogramming",
+        "ja": "ハイパープログラミング",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01267",
+    "image_path": null,
+    "question_text": {
+      "en": "Which feature allows mixing code at runtime with reflection-style APIs?",
+      "ja": "リフレクション風 API で実行時にコードを差し込む機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FFI",
+        "ja": "エフエフアイ",
+        "ja_typings": []
+      },
+      {
+        "en": "RPC",
+        "ja": "アールピーシー",
+        "ja_typings": []
+      },
+      {
+        "en": "IPC",
+        "ja": "アイピーシー",
+        "ja_typings": []
+      },
+      {
+        "en": "ABI",
+        "ja": "エービーアイ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01268",
+    "image_path": null,
+    "question_text": {
+      "en": "What term describes calling C functions from another language?",
+      "ja": "他言語から C 関数を呼び出すことを指す用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Inlining",
+        "ja": "インライン化",
+        "ja_typings": [
+          "インラインカ"
+        ]
+      },
+      {
+        "en": "Unrolling",
+        "ja": "アンローリング",
+        "ja_typings": []
+      },
+      {
+        "en": "Tiling",
+        "ja": "タイリング",
+        "ja_typings": []
+      },
+      {
+        "en": "Splitting",
+        "ja": "スプリッティング",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01269",
+    "image_path": null,
+    "question_text": {
+      "en": "Which technique inlines small functions at call sites?",
+      "ja": "呼び出し箇所に小さな関数を展開する技法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SCREAMING_SNAKE_CASE",
+        "ja": "スクリーミングスネークケース",
+        "ja_typings": []
+      },
+      {
+        "en": "camelCase",
+        "ja": "キャメルケース",
+        "ja_typings": []
+      },
+      {
+        "en": "kebab-case",
+        "ja": "ケバブケース",
+        "ja_typings": []
+      },
+      {
+        "en": "PascalCase",
+        "ja": "パスカルケース",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01270",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the convention for naming constants in many languages?",
+      "ja": "多くの言語で定数を命名する慣習は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Duck typing",
+        "ja": "ダックタイピング",
+        "ja_typings": []
+      },
+      {
+        "en": "Nominal typing",
+        "ja": "ノミナルタイピング",
+        "ja_typings": []
+      },
+      {
+        "en": "Strong typing",
+        "ja": "ストロングタイピング",
+        "ja_typings": []
+      },
+      {
+        "en": "Dependent typing",
+        "ja": "ディペンデントタイピング",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01271",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is a structural typing system feature?",
+      "ja": "構造的型付けシステムの特徴は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Serialization",
+        "ja": "シリアライズ",
+        "ja_typings": []
+      },
+      {
+        "en": "Compilation",
+        "ja": "コンパイル",
+        "ja_typings": []
+      },
+      {
+        "en": "Tokenization",
+        "ja": "トークン化",
+        "ja_typings": [
+          "トークンカ"
+        ]
+      },
+      {
+        "en": "Normalization",
+        "ja": "正規化",
+        "ja_typings": [
+          "セイキカ"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01272",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the term for converting an object into a byte stream?",
+      "ja": "オブジェクトをバイト列に変換することを指す用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Virtual dispatch",
+        "ja": "バーチャルディスパッチ",
+        "ja_typings": []
+      },
+      {
+        "en": "Static dispatch",
+        "ja": "スタティックディスパッチ",
+        "ja_typings": []
+      },
+      {
+        "en": "Direct dispatch",
+        "ja": "ダイレクトディスパッチ",
+        "ja_typings": []
+      },
+      {
+        "en": "Inline dispatch",
+        "ja": "インラインディスパッチ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01273",
+    "image_path": null,
+    "question_text": {
+      "en": "Which dispatch mechanism resolves method calls at runtime via vtables?",
+      "ja": "vtable で実行時にメソッド呼び出しを解決する機構は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "clamp()",
+        "ja": "クランプ",
+        "ja_typings": []
+      },
+      {
+        "en": "minmax()",
+        "ja": "ミンマックス",
+        "ja_typings": []
+      },
+      {
+        "en": "calc()",
+        "ja": "キャルク",
+        "ja_typings": []
+      },
+      {
+        "en": "fit-content()",
+        "ja": "フィットコンテント",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01274",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS function clamps a value between min and max?",
+      "ja": "値を最小値と最大値で挟む CSS 関数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "margin-inline-start",
+        "ja": "マージンインラインスタート",
+        "ja_typings": []
+      },
+      {
+        "en": "margin-block-start",
+        "ja": "マージンブロックスタート",
+        "ja_typings": []
+      },
+      {
+        "en": "margin-left-logical",
+        "ja": "マージンレフトロジカル",
+        "ja_typings": []
+      },
+      {
+        "en": "padding-inline-start",
+        "ja": "パディングインラインスタート",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01275",
+    "image_path": null,
+    "question_text": {
+      "en": "What CSS property enables logical inline-start margin?",
+      "ja": "論理的なインライン開始マージンを設定する CSS プロパティは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "svmin",
+        "ja": "エスブイミン",
+        "ja_typings": []
+      },
+      {
+        "en": "dvmin",
+        "ja": "ディーブイミン",
+        "ja_typings": []
+      },
+      {
+        "en": "lvmin",
+        "ja": "エルブイミン",
+        "ja_typings": []
+      },
+      {
+        "en": "qvmin",
+        "ja": "キューブイミン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01276",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS unit is relative to the smaller of viewport width/height?",
+      "ja": "ビューポートの幅と高さの小さい方に対する CSS 単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "@font-face",
+        "ja": "アットフォントフェイス",
+        "ja_typings": []
+      },
+      {
+        "en": "@font-import",
+        "ja": "アットフォントインポート",
+        "ja_typings": []
+      },
+      {
+        "en": "@font-load",
+        "ja": "アットフォントロード",
+        "ja_typings": []
+      },
+      {
+        "en": "@import-font",
+        "ja": "アットインポートフォント",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01277",
+    "image_path": null,
+    "question_text": {
+      "en": "What CSS at-rule defines a font from a remote source?",
+      "ja": "リモートソースからフォントを定義する CSS の at-rule は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "isolation",
+        "ja": "アイソレーション",
+        "ja_typings": []
+      },
+      {
+        "en": "contain",
+        "ja": "コンテイン",
+        "ja_typings": []
+      },
+      {
+        "en": "will-change",
+        "ja": "ウィルチェンジ",
+        "ja_typings": []
+      },
+      {
+        "en": "transform-style",
+        "ja": "トランスフォームスタイル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01278",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS property creates a stacking context without z-index?",
+      "ja": "z-index なしでスタッキングコンテキストを作る CSS プロパティは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CSS scoping",
+        "ja": "シーエスエススコーピング",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS nesting",
+        "ja": "シーエスエスネスティング",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS layering",
+        "ja": "シーエスエスレイヤリング",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS isolation",
+        "ja": "シーエスエスアイソレーション",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01279",
+    "image_path": null,
+    "question_text": {
+      "en": "What CSS feature allows scoping styles with @scope?",
+      "ja": "@scope でスタイルをスコープ化する CSS 機能の名称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": ":focus-within",
+        "ja": "フォーカスウィズイン",
+        "ja_typings": []
+      },
+      {
+        "en": ":focus-visible",
+        "ja": "フォーカスビジブル",
+        "ja_typings": []
+      },
+      {
+        "en": ":has-focus",
+        "ja": "ハズフォーカス",
+        "ja_typings": []
+      },
+      {
+        "en": ":focusable",
+        "ja": "フォーカサブル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01280",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS pseudo-class matches an element that has focus within its tree?",
+      "ja": "要素ツリー内にフォーカスがある要素にマッチする CSS 疑似クラスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "grid-template-areas",
+        "ja": "グリッドテンプレートエリアズ",
+        "ja_typings": []
+      },
+      {
+        "en": "grid-areas",
+        "ja": "グリッドエリアズ",
+        "ja_typings": []
+      },
+      {
+        "en": "grid-zones",
+        "ja": "グリッドゾーンズ",
+        "ja_typings": []
+      },
+      {
+        "en": "grid-regions",
+        "ja": "グリッドリージョンズ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01281",
+    "image_path": null,
+    "question_text": {
+      "en": "What CSS property defines named grid areas?",
+      "ja": "名前付きグリッドエリアを定義する CSS プロパティは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "<details>",
+        "ja": "ディテイルズ",
+        "ja_typings": []
+      },
+      {
+        "en": "<summary>",
+        "ja": "サマリー",
+        "ja_typings": []
+      },
+      {
+        "en": "<dialog>",
+        "ja": "ダイアログ",
+        "ja_typings": []
+      },
+      {
+        "en": "<menu>",
+        "ja": "メニュー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01282",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML element represents a disclosure widget?",
+      "ja": "開閉式ウィジェットを表す HTML 要素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "draggable",
+        "ja": "ドラッガブル",
+        "ja_typings": []
+      },
+      {
+        "en": "droppable",
+        "ja": "ドロッパブル",
+        "ja_typings": []
+      },
+      {
+        "en": "movable",
+        "ja": "ムーバブル",
+        "ja_typings": []
+      },
+      {
+        "en": "dragstart",
+        "ja": "ドラッグスタート",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01283",
+    "image_path": null,
+    "question_text": {
+      "en": "What HTML attribute enables drag-and-drop on any element?",
+      "ja": "任意の要素でドラッグアンドドロップを有効にする HTML 属性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "type=\"color\"",
+        "ja": "タイプカラー",
+        "ja_typings": []
+      },
+      {
+        "en": "type=\"picker\"",
+        "ja": "タイプピッカー",
+        "ja_typings": []
+      },
+      {
+        "en": "type=\"palette\"",
+        "ja": "タイプパレット",
+        "ja_typings": []
+      },
+      {
+        "en": "type=\"hue\"",
+        "ja": "タイプヒュー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01284",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML input type provides a color picker?",
+      "ja": "カラーピッカーを提供する HTML input type は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "<fieldset>",
+        "ja": "フィールドセット",
+        "ja_typings": []
+      },
+      {
+        "en": "<formgroup>",
+        "ja": "フォームグループ",
+        "ja_typings": []
+      },
+      {
+        "en": "<inputs>",
+        "ja": "インプッツ",
+        "ja_typings": []
+      },
+      {
+        "en": "<group>",
+        "ja": "グループ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01285",
+    "image_path": null,
+    "question_text": {
+      "en": "What HTML element groups labeled form controls?",
+      "ja": "ラベル付きフォーム部品をグループ化する HTML 要素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cache API",
+        "ja": "キャッシュエーピーアイ",
+        "ja_typings": []
+      },
+      {
+        "en": "File System API",
+        "ja": "ファイルシステムエーピーアイ",
+        "ja_typings": []
+      },
+      {
+        "en": "Background Sync API",
+        "ja": "バックグラウンドシンクエーピーアイ",
+        "ja_typings": []
+      },
+      {
+        "en": "Storage Foundation API",
+        "ja": "ストレージファウンデーションエーピーアイ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01286",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML5 API allows offline storage of structured data?",
+      "ja": "構造化データのオフライン保存を可能にする HTML5 API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "409",
+        "ja": "ヨンマルキュウ",
+        "ja_typings": [
+          "409"
+        ]
+      },
+      {
+        "en": "410",
+        "ja": "ヨンイチマル",
+        "ja_typings": [
+          "410"
+        ]
+      },
+      {
+        "en": "412",
+        "ja": "ヨンイチニ",
+        "ja_typings": [
+          "412"
+        ]
+      },
+      {
+        "en": "428",
+        "ja": "ヨンニハチ",
+        "ja_typings": [
+          "428"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01287",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status indicates a request conflict?",
+      "ja": "リクエストの競合を示す HTTP ステータスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gone",
+        "ja": "ゴーン",
+        "ja_typings": []
+      },
+      {
+        "en": "Forbidden",
+        "ja": "フォービドゥン",
+        "ja_typings": []
+      },
+      {
+        "en": "Unauthorized",
+        "ja": "アンオーソライズド",
+        "ja_typings": []
+      },
+      {
+        "en": "Locked",
+        "ja": "ロックト",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01288",
+    "image_path": null,
+    "question_text": {
+      "en": "What HTTP status means the resource is permanently gone?",
+      "ja": "リソースが恒久的に消えたことを示す HTTP ステータスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Access-Control-Max-Age",
+        "ja": "アクセスコントロールマックスエイジ",
+        "ja_typings": []
+      },
+      {
+        "en": "Access-Control-Allow-Origin",
+        "ja": "アクセスコントロールアロウオリジン",
+        "ja_typings": []
+      },
+      {
+        "en": "Access-Control-Expose-Headers",
+        "ja": "アクセスコントロールエクスポーズヘッダーズ",
+        "ja_typings": []
+      },
+      {
+        "en": "Access-Control-Request-Headers",
+        "ja": "アクセスコントロールリクエストヘッダーズ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01289",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP header controls how long a preflight response is cached?",
+      "ja": "プリフライト応答のキャッシュ期間を制御する HTTP ヘッダーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "X-Forwarded-Proto",
+        "ja": "エックスフォワーデッドプロト",
+        "ja_typings": []
+      },
+      {
+        "en": "X-Forwarded-For",
+        "ja": "エックスフォワーデッドフォー",
+        "ja_typings": []
+      },
+      {
+        "en": "X-Real-IP",
+        "ja": "エックスリアルアイピー",
+        "ja_typings": []
+      },
+      {
+        "en": "Forwarded",
+        "ja": "フォワーデッド",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01290",
+    "image_path": null,
+    "question_text": {
+      "en": "What HTTP header indicates the original request scheme behind a proxy?",
+      "ja": "プロキシ越しに元のリクエストスキームを示す HTTP ヘッダーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Strict-Transport-Security",
+        "ja": "ストリクトトランスポートセキュリティ",
+        "ja_typings": []
+      },
+      {
+        "en": "X-Content-Type-Options",
+        "ja": "エックスコンテントタイプオプションズ",
+        "ja_typings": []
+      },
+      {
+        "en": "Permissions-Policy",
+        "ja": "パーミッションズポリシー",
+        "ja_typings": []
+      },
+      {
+        "en": "Referrer-Policy",
+        "ja": "リファラーポリシー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01291",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP response header tells browsers to enforce HTTPS?",
+      "ja": "ブラウザに HTTPS を強制させる HTTP 応答ヘッダーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HEAD method",
+        "ja": "ヘッドメソッド",
+        "ja_typings": []
+      },
+      {
+        "en": "META method",
+        "ja": "メタメソッド",
+        "ja_typings": []
+      },
+      {
+        "en": "INFO method",
+        "ja": "インフォメソッド",
+        "ja_typings": []
+      },
+      {
+        "en": "STAT method",
+        "ja": "スタットメソッド",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01292",
+    "image_path": null,
+    "question_text": {
+      "en": "What HTTP method is used to retrieve metadata only?",
+      "ja": "メタデータのみを取得する HTTP メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ResizeObserver",
+        "ja": "リサイズオブザーバー",
+        "ja_typings": []
+      },
+      {
+        "en": "MutationObserver",
+        "ja": "ミューテーションオブザーバー",
+        "ja_typings": []
+      },
+      {
+        "en": "IntersectionObserver",
+        "ja": "インターセクションオブザーバー",
+        "ja_typings": []
+      },
+      {
+        "en": "PerformanceObserver",
+        "ja": "パフォーマンスオブザーバー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01293",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Web API observes element resize events?",
+      "ja": "要素のリサイズイベントを監視する Web API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Intersection Observer",
+        "ja": "インターセクションオブザーバー",
+        "ja_typings": []
+      },
+      {
+        "en": "Visibility Observer",
+        "ja": "ビジビリティオブザーバー",
+        "ja_typings": []
+      },
+      {
+        "en": "Viewport Observer",
+        "ja": "ビューポートオブザーバー",
+        "ja_typings": []
+      },
+      {
+        "en": "Scroll Observer",
+        "ja": "スクロールオブザーバー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01294",
+    "image_path": null,
+    "question_text": {
+      "en": "What Web API detects when an element enters the viewport?",
+      "ja": "要素がビューポートに入ったことを検出する Web API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Push API",
+        "ja": "プッシュエーピーアイ",
+        "ja_typings": []
+      },
+      {
+        "en": "Alert API",
+        "ja": "アラートエーピーアイ",
+        "ja_typings": []
+      },
+      {
+        "en": "Notification only",
+        "ja": "ノティフィケーションオンリー",
+        "ja_typings": []
+      },
+      {
+        "en": "Background API",
+        "ja": "バックグラウンドエーピーアイ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01295",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Web API enables push notifications?",
+      "ja": "プッシュ通知を可能にする Web API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CacheStorage",
+        "ja": "キャッシュストレージ",
+        "ja_typings": []
+      },
+      {
+        "en": "FileSystem Access",
+        "ja": "ファイルシステムアクセス",
+        "ja_typings": []
+      },
+      {
+        "en": "WebSQL",
+        "ja": "ウェブエスキューエル",
+        "ja_typings": []
+      },
+      {
+        "en": "AppCache",
+        "ja": "アップキャッシュ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01296",
+    "image_path": null,
+    "question_text": {
+      "en": "What Web API persists data using a key-value pair with promises?",
+      "ja": "Promise でキーバリュー保存する Web API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Web Share Target",
+        "ja": "ウェブシェアターゲット",
+        "ja_typings": []
+      },
+      {
+        "en": "Share Receiver API",
+        "ja": "シェアレシーバーエーピーアイ",
+        "ja_typings": []
+      },
+      {
+        "en": "Web Sync",
+        "ja": "ウェブシンク",
+        "ja_typings": []
+      },
+      {
+        "en": "Web Receive",
+        "ja": "ウェブレシーブ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01297",
+    "image_path": null,
+    "question_text": {
+      "en": "Which API lets pages register handlers for share targets?",
+      "ja": "共有先ハンドラを登録できる API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Performance.now",
+        "ja": "パフォーマンスナウ",
+        "ja_typings": []
+      },
+      {
+        "en": "Date.now",
+        "ja": "デートナウ",
+        "ja_typings": []
+      },
+      {
+        "en": "Timing.now",
+        "ja": "タイミングナウ",
+        "ja_typings": []
+      },
+      {
+        "en": "Clock.now",
+        "ja": "クロックナウ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01298",
+    "image_path": null,
+    "question_text": {
+      "en": "What API exposes high-resolution monotonic timestamps?",
+      "ja": "高解像度の単調タイムスタンプを提供する API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Web Speech Recognition",
+        "ja": "ウェブスピーチレコグニッション",
+        "ja_typings": []
+      },
+      {
+        "en": "Web Audio API",
+        "ja": "ウェブオーディオエーピーアイ",
+        "ja_typings": []
+      },
+      {
+        "en": "Media Capture",
+        "ja": "メディアキャプチャ",
+        "ja_typings": []
+      },
+      {
+        "en": "MediaStream API",
+        "ja": "メディアストリームエーピーアイ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01299",
+    "image_path": null,
+    "question_text": {
+      "en": "Which API allows speech-to-text in the browser?",
+      "ja": "ブラウザで音声を文字起こしする API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "useSyncExternalStore",
+        "ja": "ユーズシンクエクスターナルストア",
+        "ja_typings": []
+      },
+      {
+        "en": "useStore",
+        "ja": "ユーズストア",
+        "ja_typings": []
+      },
+      {
+        "en": "useSubscribe",
+        "ja": "ユーズサブスクライブ",
+        "ja_typings": []
+      },
+      {
+        "en": "useExternal",
+        "ja": "ユーズエクスターナル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01300",
+    "image_path": null,
+    "question_text": {
+      "en": "Which React hook subscribes to an external store with concurrent safety?",
+      "ja": "並行性安全に外部ストア購読する React フックは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "defineProps",
+        "ja": "ディファインプロップス",
+        "ja_typings": []
+      },
+      {
+        "en": "declareProps",
+        "ja": "デクレアプロップス",
+        "ja_typings": []
+      },
+      {
+        "en": "useProps",
+        "ja": "ユーズプロップス",
+        "ja_typings": []
+      },
+      {
+        "en": "propsMacro",
+        "ja": "プロップスマクロ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01301",
+    "image_path": null,
+    "question_text": {
+      "en": "What Vue 3 macro defines props in script setup?",
+      "ja": "script setup で props を定義する Vue 3 マクロは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "on:event",
+        "ja": "オンイベント",
+        "ja_typings": []
+      },
+      {
+        "en": "bind:event",
+        "ja": "バインドイベント",
+        "ja_typings": []
+      },
+      {
+        "en": "use:event",
+        "ja": "ユーズイベント",
+        "ja_typings": []
+      },
+      {
+        "en": "event:on",
+        "ja": "イベントオン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01302",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Svelte directive listens to DOM events?",
+      "ja": "DOM イベントを購読する Svelte ディレクティブは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SSR",
+        "ja": "エスエスアール",
+        "ja_typings": []
+      },
+      {
+        "en": "SSG",
+        "ja": "エスエスジー",
+        "ja_typings": []
+      },
+      {
+        "en": "ISR",
+        "ja": "アイエスアール",
+        "ja_typings": []
+      },
+      {
+        "en": "CSR",
+        "ja": "シーエスアール",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01303",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the term for rendering on the server at request time?",
+      "ja": "リクエスト時にサーバーでレンダリングすることを指す用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Incremental Static Regeneration",
+        "ja": "インクリメンタルスタティックリジェネレーション",
+        "ja_typings": []
+      },
+      {
+        "en": "Edge Streaming",
+        "ja": "エッジストリーミング",
+        "ja_typings": []
+      },
+      {
+        "en": "Static Hydration",
+        "ja": "スタティックハイドレーション",
+        "ja_typings": []
+      },
+      {
+        "en": "Parallel Routes",
+        "ja": "パラレルルーツ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01304",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Next.js feature regenerates static pages on demand?",
+      "ja": "オンデマンドで静的ページを再生成する Next.js の機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Islands architecture",
+        "ja": "アイランズアーキテクチャ",
+        "ja_typings": []
+      },
+      {
+        "en": "Edge rendering",
+        "ja": "エッジレンダリング",
+        "ja_typings": []
+      },
+      {
+        "en": "Static suspense",
+        "ja": "スタティックサスペンス",
+        "ja_typings": []
+      },
+      {
+        "en": "Server components",
+        "ja": "サーバーコンポーネンツ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01305",
+    "image_path": null,
+    "question_text": {
+      "en": "What Astro feature ships zero JS to the client by default?",
+      "ja": "デフォルトでクライアントに JS を送らない Astro の機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Layout",
+        "ja": "レイアウト",
+        "ja_typings": []
+      },
+      {
+        "en": "Paint",
+        "ja": "ペイント",
+        "ja_typings": []
+      },
+      {
+        "en": "Composite",
+        "ja": "コンポジット",
+        "ja_typings": []
+      },
+      {
+        "en": "Style",
+        "ja": "スタイル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01306",
+    "image_path": null,
+    "question_text": {
+      "en": "Which browser process step computes element geometry?",
+      "ja": "要素の幾何を計算するブラウザ処理工程は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Compositing",
+        "ja": "コンポジティング",
+        "ja_typings": []
+      },
+      {
+        "en": "Layouting",
+        "ja": "レイアウティング",
+        "ja_typings": []
+      },
+      {
+        "en": "Painting",
+        "ja": "ペインティング",
+        "ja_typings": []
+      },
+      {
+        "en": "Rasterizing",
+        "ja": "ラスタライジング",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01307",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the term for the browser combining painted layers?",
+      "ja": "ペイントしたレイヤーをブラウザが合成することを指す用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DOMContentLoaded",
+        "ja": "ドムコンテントローデッド",
+        "ja_typings": []
+      },
+      {
+        "en": "load",
+        "ja": "ロード",
+        "ja_typings": []
+      },
+      {
+        "en": "readystatechange",
+        "ja": "レディステートチェンジ",
+        "ja_typings": []
+      },
+      {
+        "en": "beforeunload",
+        "ja": "ビフォアアンロード",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01308",
+    "image_path": null,
+    "question_text": {
+      "en": "Which event fires after DOM is parsed but before all assets load?",
+      "ja": "DOM 解析後・全アセット読み込み前に発火するイベントは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Site Isolation",
+        "ja": "サイトアイソレーション",
+        "ja_typings": []
+      },
+      {
+        "en": "Origin Isolation",
+        "ja": "オリジンアイソレーション",
+        "ja_typings": []
+      },
+      {
+        "en": "Frame Sandbox",
+        "ja": "フレームサンドボックス",
+        "ja_typings": []
+      },
+      {
+        "en": "Process Sharding",
+        "ja": "プロセスシャーディング",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01309",
+    "image_path": null,
+    "question_text": {
+      "en": "What browser feature isolates iframes in separate processes?",
+      "ja": "iframe を別プロセスに隔離するブラウザ機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SharedArrayBuffer",
+        "ja": "シェアードアレイバッファ",
+        "ja_typings": []
+      },
+      {
+        "en": "ArrayBuffer",
+        "ja": "アレイバッファ",
+        "ja_typings": []
+      },
+      {
+        "en": "DataView",
+        "ja": "データビュー",
+        "ja_typings": []
+      },
+      {
+        "en": "ImageBitmap",
+        "ja": "イメージビットマップ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01310",
+    "image_path": null,
+    "question_text": {
+      "en": "Which API enables sharing memory between threads with locks?",
+      "ja": "ロック付きでスレッド間メモリ共有を可能にする API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "UI redressing",
+        "ja": "ユーアイリドレッシング",
+        "ja_typings": []
+      },
+      {
+        "en": "Click hijacking",
+        "ja": "クリックハイジャッキング",
+        "ja_typings": []
+      },
+      {
+        "en": "DOM clobbering",
+        "ja": "ドムクロバリング",
+        "ja_typings": []
+      },
+      {
+        "en": "Tab nabbing",
+        "ja": "タブナビング",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01311",
+    "image_path": null,
+    "question_text": {
+      "en": "Which attack tricks users into clicking hidden UI elements?",
+      "ja": "隠された UI 要素をクリックさせる攻撃は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Inline script allowlisting",
+        "ja": "インラインスクリプト許可リスト",
+        "ja_typings": [
+          "インラインスクリプトキョカリスト"
+        ]
+      },
+      {
+        "en": "CORS preflight",
+        "ja": "コルスプリフライト",
+        "ja_typings": []
+      },
+      {
+        "en": "HSTS preload",
+        "ja": "エイチエスティーエスプリロード",
+        "ja_typings": []
+      },
+      {
+        "en": "Mixed content blocking",
+        "ja": "ミックスドコンテンツブロッキング",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01312",
+    "image_path": null,
+    "question_text": {
+      "en": "What security mechanism uses a nonce in CSP?",
+      "ja": "CSP で nonce を使うセキュリティ機構は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "X-Content-Type-Options",
+        "ja": "エックスコンテントタイプオプションズ",
+        "ja_typings": []
+      },
+      {
+        "en": "X-Frame-Options",
+        "ja": "エックスフレームオプションズ",
+        "ja_typings": []
+      },
+      {
+        "en": "X-XSS-Protection",
+        "ja": "エックスエックスエスエスプロテクション",
+        "ja_typings": []
+      },
+      {
+        "en": "X-Download-Options",
+        "ja": "エックスダウンロードオプションズ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01313",
+    "image_path": null,
+    "question_text": {
+      "en": "Which header prevents MIME-type sniffing?",
+      "ja": "MIME タイプ推測を防ぐヘッダーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DNS cache poisoning",
+        "ja": "ディーエヌエスキャッシュポイズニング",
+        "ja_typings": []
+      },
+      {
+        "en": "DNS rebinding",
+        "ja": "ディーエヌエスリバインディング",
+        "ja_typings": []
+      },
+      {
+        "en": "DNS tunneling",
+        "ja": "ディーエヌエストンネリング",
+        "ja_typings": []
+      },
+      {
+        "en": "DNS spoofing reply",
+        "ja": "ディーエヌエススプーフィングリプライ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01314",
+    "image_path": null,
+    "question_text": {
+      "en": "What attack exploits trust in cached DNS responses?",
+      "ja": "キャッシュ済み DNS 応答の信頼を悪用する攻撃は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "frame-ancestors",
+        "ja": "フレームアンセスターズ",
+        "ja_typings": []
+      },
+      {
+        "en": "frame-src",
+        "ja": "フレームエスアールシー",
+        "ja_typings": []
+      },
+      {
+        "en": "X-Embed-Options",
+        "ja": "エックスエンベッドオプションズ",
+        "ja_typings": []
+      },
+      {
+        "en": "frame-deny-directive",
+        "ja": "フレームデナイディレクティブ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01315",
+    "image_path": null,
+    "question_text": {
+      "en": "Which feature lets servers opt out of being framed?",
+      "ja": "サーバーがフレーム化拒否を表明する機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Anti-CSRF token",
+        "ja": "アンチシーエスアールエフトークン",
+        "ja_typings": []
+      },
+      {
+        "en": "Bearer token",
+        "ja": "ベアラートークン",
+        "ja_typings": []
+      },
+      {
+        "en": "Session token",
+        "ja": "セッショントークン",
+        "ja_typings": []
+      },
+      {
+        "en": "Refresh token",
+        "ja": "リフレッシュトークン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01316",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the term for embedding tokens to verify form origin?",
+      "ja": "フォーム送信元検証のためにトークンを埋め込むことを指す用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "aria-live",
+        "ja": "アリアライブ",
+        "ja_typings": []
+      },
+      {
+        "en": "aria-busy",
+        "ja": "アリアビジー",
+        "ja_typings": []
+      },
+      {
+        "en": "aria-atomic",
+        "ja": "アリアアトミック",
+        "ja_typings": []
+      },
+      {
+        "en": "aria-relevant",
+        "ja": "アリアレレバント",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01317",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ARIA attribute announces dynamic content politely?",
+      "ja": "動的コンテンツを丁寧に通知する ARIA 属性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "main",
+        "ja": "メイン",
+        "ja_typings": []
+      },
+      {
+        "en": "primary",
+        "ja": "プライマリ",
+        "ja_typings": []
+      },
+      {
+        "en": "content",
+        "ja": "コンテンツ",
+        "ja_typings": []
+      },
+      {
+        "en": "body",
+        "ja": "ボディ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01318",
+    "image_path": null,
+    "question_text": {
+      "en": "What ARIA role marks the main content area?",
+      "ja": "メインコンテンツ領域を示す ARIA ロールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "aria-hidden",
+        "ja": "アリアヒドゥン",
+        "ja_typings": []
+      },
+      {
+        "en": "aria-skip",
+        "ja": "アリアスキップ",
+        "ja_typings": []
+      },
+      {
+        "en": "aria-decorative",
+        "ja": "アリアデコラティブ",
+        "ja_typings": []
+      },
+      {
+        "en": "aria-omit",
+        "ja": "アリアオミット",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01319",
+    "image_path": null,
+    "question_text": {
+      "en": "Which attribute hides decorative elements from assistive tech?",
+      "ja": "支援技術から装飾要素を隠す属性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "4.5:1",
+        "ja": "ヨンテンゴタイイチ",
+        "ja_typings": [
+          "4.5:1"
+        ]
+      },
+      {
+        "en": "3:1",
+        "ja": "サンタイイチ",
+        "ja_typings": [
+          "3:1"
+        ]
+      },
+      {
+        "en": "7:1",
+        "ja": "ナナタイイチ",
+        "ja_typings": [
+          "7:1"
+        ]
+      },
+      {
+        "en": "2:1",
+        "ja": "ニタイイチ",
+        "ja_typings": [
+          "2:1"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01320",
+    "image_path": null,
+    "question_text": {
+      "en": "What WCAG contrast ratio is required for normal text AA?",
+      "ja": "通常テキスト AA に必要な WCAG コントラスト比は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "INP",
+        "ja": "アイエヌピー",
+        "ja_typings": []
+      },
+      {
+        "en": "FID",
+        "ja": "エフアイディー",
+        "ja_typings": []
+      },
+      {
+        "en": "TBT",
+        "ja": "ティービーティー",
+        "ja_typings": []
+      },
+      {
+        "en": "TTI",
+        "ja": "ティーティーアイ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01321",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Core Web Vital measures input responsiveness?",
+      "ja": "入力応答性を測る Core Web Vital は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CLS",
+        "ja": "シーエルエス",
+        "ja_typings": []
+      },
+      {
+        "en": "LCP",
+        "ja": "エルシーピー",
+        "ja_typings": []
+      },
+      {
+        "en": "FCP",
+        "ja": "エフシーピー",
+        "ja_typings": []
+      },
+      {
+        "en": "TTFB",
+        "ja": "ティーティーエフビー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01322",
+    "image_path": null,
+    "question_text": {
+      "en": "What Core Web Vital tracks layout stability?",
+      "ja": "レイアウト安定性を追跡する Core Web Vital は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dynamic import",
+        "ja": "ダイナミックインポート",
+        "ja_typings": []
+      },
+      {
+        "en": "Static import",
+        "ja": "スタティックインポート",
+        "ja_typings": []
+      },
+      {
+        "en": "Eager import",
+        "ja": "イーガーインポート",
+        "ja_typings": []
+      },
+      {
+        "en": "Bundle import",
+        "ja": "バンドルインポート",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01323",
+    "image_path": null,
+    "question_text": {
+      "en": "Which technique loads JS chunks only when needed?",
+      "ja": "必要時のみ JS チャンクを読み込む技法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "rel=\"preload\"",
+        "ja": "レルプリロード",
+        "ja_typings": []
+      },
+      {
+        "en": "rel=\"prefetch\"",
+        "ja": "レルプリフェッチ",
+        "ja_typings": []
+      },
+      {
+        "en": "rel=\"preconnect\"",
+        "ja": "レルプリコネクト",
+        "ja_typings": []
+      },
+      {
+        "en": "rel=\"dns-prefetch\"",
+        "ja": "レルディーエヌエスプリフェッチ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01324",
+    "image_path": null,
+    "question_text": {
+      "en": "What HTML attribute hints the browser to preload a resource?",
+      "ja": "ブラウザにリソースの事前読み込みを指示する HTML 属性値は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "AVIF",
+        "ja": "エイビフ",
+        "ja_typings": []
+      },
+      {
+        "en": "HEIF",
+        "ja": "ヘイフ",
+        "ja_typings": []
+      },
+      {
+        "en": "JXL",
+        "ja": "ジェイエックスエル",
+        "ja_typings": []
+      },
+      {
+        "en": "APNG",
+        "ja": "エーピーエヌジー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01325",
+    "image_path": null,
+    "question_text": {
+      "en": "Which image format uses AV1 video codec for compression?",
+      "ja": "AV1 動画コーデックを使う画像形式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Critical CSS inlining",
+        "ja": "クリティカルシーエスエスインライニング",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS hoisting",
+        "ja": "シーエスエスホイスティング",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS shaking",
+        "ja": "シーエスエスシェイキング",
+        "ja_typings": []
+      },
+      {
+        "en": "CSS splitting",
+        "ja": "シーエスエススプリッティング",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01326",
+    "image_path": null,
+    "question_text": {
+      "en": "What technique sends critical CSS in the HTML to reduce render-blocking?",
+      "ja": "レンダーブロッキング軽減のため HTML に CSS を埋め込む技法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HTTP over QUIC",
+        "ja": "エイチティーティーピーオーバークイック",
+        "ja_typings": []
+      },
+      {
+        "en": "SPDY",
+        "ja": "スピーディー",
+        "ja_typings": []
+      },
+      {
+        "en": "MPTCP",
+        "ja": "エムピーティーシーピー",
+        "ja_typings": []
+      },
+      {
+        "en": "WebTransport over TCP",
+        "ja": "ウェブトランスポートオーバーティーシーピー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01327",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol multiplexes streams over QUIC?",
+      "ja": "QUIC 上でストリームを多重化するプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "WHATWG URL",
+        "ja": "ワットダブリュージーユーアールエル",
+        "ja_typings": []
+      },
+      {
+        "en": "RFC 3986 strict",
+        "ja": "アールエフシーサンキュウハチロクストリクト",
+        "ja_typings": [
+          "RFC 3986 strict"
+        ]
+      },
+      {
+        "en": "ICANN URL",
+        "ja": "アイキャンユーアールエル",
+        "ja_typings": []
+      },
+      {
+        "en": "W3C URL spec",
+        "ja": "ダブリュースリーシーユーアールエルスペック",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01328",
+    "image_path": null,
+    "question_text": {
+      "en": "What standard defines URL parsing across browsers?",
+      "ja": "ブラウザ間で URL 解析を定義する標準は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "createDocumentFragment",
+        "ja": "クリエイトドキュメントフラグメント",
+        "ja_typings": []
+      },
+      {
+        "en": "createFragment",
+        "ja": "クリエイトフラグメント",
+        "ja_typings": []
+      },
+      {
+        "en": "makeFragment",
+        "ja": "メイクフラグメント",
+        "ja_typings": []
+      },
+      {
+        "en": "newFragment",
+        "ja": "ニューフラグメント",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01329",
+    "image_path": null,
+    "question_text": {
+      "en": "Which DOM method creates a document fragment?",
+      "ja": "ドキュメントフラグメントを作成する DOM メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PWA manifest",
+        "ja": "ピーダブリューエーマニフェスト",
+        "ja_typings": []
+      },
+      {
+        "en": "App shell",
+        "ja": "アップシェル",
+        "ja_typings": []
+      },
+      {
+        "en": "Web bundle",
+        "ja": "ウェブバンドル",
+        "ja_typings": []
+      },
+      {
+        "en": "Trusted Web Activity",
+        "ja": "トラステッドウェブアクティビティ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01330",
+    "image_path": null,
+    "question_text": {
+      "en": "What feature lets web apps install like native apps?",
+      "ja": "Web アプリをネイティブのようにインストール可能にする機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "base64url",
+        "ja": "ベースロクヨンユーアールエル",
+        "ja_typings": [
+          "base64url"
+        ]
+      },
+      {
+        "en": "base32",
+        "ja": "ベースサンジュウニ",
+        "ja_typings": [
+          "base32"
+        ]
+      },
+      {
+        "en": "ascii85",
+        "ja": "アスキーハチゴ",
+        "ja_typings": [
+          "ascii85"
+        ]
+      },
+      {
+        "en": "punycode",
+        "ja": "ピュニコード",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01331",
+    "image_path": null,
+    "question_text": {
+      "en": "Which encoding represents binary data as ASCII text in URLs?",
+      "ja": "URL でバイナリデータを ASCII テキストとして表現するエンコードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "contain",
+        "ja": "コンテイン",
+        "ja_typings": []
+      },
+      {
+        "en": "isolate",
+        "ja": "アイソレート",
+        "ja_typings": []
+      },
+      {
+        "en": "scope",
+        "ja": "スコープ",
+        "ja_typings": []
+      },
+      {
+        "en": "encapsulate",
+        "ja": "エンキャプスレート",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01332",
+    "image_path": null,
+    "question_text": {
+      "en": "What CSS property controls how an element is contained for performance?",
+      "ja": "パフォーマンスのために要素の含意を制御する CSS プロパティは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "transitionend",
+        "ja": "トランジションエンド",
+        "ja_typings": []
+      },
+      {
+        "en": "transitioncomplete",
+        "ja": "トランジションコンプリート",
+        "ja_typings": []
+      },
+      {
+        "en": "animationend",
+        "ja": "アニメーションエンド",
+        "ja_typings": []
+      },
+      {
+        "en": "transitionstop",
+        "ja": "トランジションストップ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01333",
+    "image_path": null,
+    "question_text": {
+      "en": "Which DOM event fires when a CSS transition completes?",
+      "ja": "CSS トランジション完了時に発火する DOM イベントは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "My Neighbor Totoro",
+        "ja": "となりのトトロ",
+        "ja_typings": []
+      },
+      {
+        "en": "Kiki's Delivery Service",
+        "ja": "魔女の宅急便",
+        "ja_typings": []
+      },
+      {
+        "en": "Whisper of the Heart",
+        "ja": "耳をすませば",
+        "ja_typings": [
+          "mimiwosumaseba"
+        ]
+      },
+      {
+        "en": "Pom Poko",
+        "ja": "平成狸合戦ぽんぽこ",
+        "ja_typings": [
+          "heiseitanukigassenponpoko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01334",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1988 Studio Ghibli film features two sisters and a cat bus?",
+      "ja": "1988年公開で姉妹と猫バスが登場するジブリ作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Whisper of the Heart",
+        "ja": "耳をすませば",
+        "ja_typings": [
+          "mimiwosumaseba"
+        ]
+      },
+      {
+        "en": "Only Yesterday",
+        "ja": "おもひでぽろぽろ",
+        "ja_typings": []
+      },
+      {
+        "en": "Ocean Waves",
+        "ja": "海がきこえる",
+        "ja_typings": [
+          "umigakikoeru"
+        ]
+      },
+      {
+        "en": "From Up on Poppy Hill",
+        "ja": "コクリコ坂から",
+        "ja_typings": [
+          "kokurikozakakara"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01335",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1995 Ghibli film centers on Shizuku writing a novel?",
+      "ja": "雫が小説を書く1995年のジブリ作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Space Pirate Captain Harlock",
+        "ja": "宇宙海賊キャプテンハーロック",
+        "ja_typings": [
+          "uchuukaizokukyaputenhaarokku"
+        ]
+      },
+      {
+        "en": "Galaxy Express 999",
+        "ja": "銀河鉄道999",
+        "ja_typings": [
+          "gingatetsudousurii"
+        ]
+      },
+      {
+        "en": "Space Battleship Yamato",
+        "ja": "宇宙戦艦ヤマト",
+        "ja_typings": [
+          "uchuusenkanyamato"
+        ]
+      },
+      {
+        "en": "Queen Millennia",
+        "ja": "新竹取物語",
+        "ja_typings": [
+          "shintaketorimonogatari"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01336",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1979 anime features Captain Harlock as the protagonist?",
+      "ja": "ハーロック船長が主人公の1979年アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Space Battleship Yamato",
+        "ja": "宇宙戦艦ヤマト",
+        "ja_typings": [
+          "uchuusenkanyamato"
+        ]
+      },
+      {
+        "en": "Galaxy Express 999",
+        "ja": "銀河鉄道999",
+        "ja_typings": [
+          "gingatetsudousurii"
+        ]
+      },
+      {
+        "en": "Captain Future",
+        "ja": "キャプテンフューチャー",
+        "ja_typings": []
+      },
+      {
+        "en": "Macross",
+        "ja": "超時空要塞マクロス",
+        "ja_typings": [
+          "choujikuuyousaimakurosu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01337",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1974 anime depicts a journey to recover the Cosmo DNA?",
+      "ja": "コスモクリーナーDを取りに行く1974年のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Macross",
+        "ja": "超時空要塞マクロス",
+        "ja_typings": [
+          "choujikuuyousaimakurosu"
+        ]
+      },
+      {
+        "en": "Mobile Police Patlabor",
+        "ja": "機動警察パトレイバー",
+        "ja_typings": [
+          "kidoukeisatsupatoreibaa"
+        ]
+      },
+      {
+        "en": "Aura Battler Dunbine",
+        "ja": "聖戦士ダンバイン",
+        "ja_typings": [
+          "seisenshidanbain"
+        ]
+      },
+      {
+        "en": "Armored Trooper Votoms",
+        "ja": "装甲騎兵ボトムズ",
+        "ja_typings": [
+          "soukoukiheibotomuzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01338",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1982 mecha anime features Hikaru, Misa, and Minmay?",
+      "ja": "輝・未沙・ミンメイが登場する1982年のメカアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aura Battler Dunbine",
+        "ja": "聖戦士ダンバイン",
+        "ja_typings": [
+          "seisenshidanbain"
+        ]
+      },
+      {
+        "en": "Macross",
+        "ja": "超時空要塞マクロス",
+        "ja_typings": [
+          "choujikuuyousaimakurosu"
+        ]
+      },
+      {
+        "en": "Heavy Metal L-Gaim",
+        "ja": "重戦機エルガイム",
+        "ja_typings": [
+          "juusenkierugaimu"
+        ]
+      },
+      {
+        "en": "Layzner",
+        "ja": "蒼き流星SPTレイズナー",
+        "ja_typings": [
+          "aokiryuuseiSPTreizunaa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01339",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1983 anime is set in the world of Byston Well?",
+      "ja": "バイストン・ウェルが舞台の1983年のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Patlabor: The Movie",
+        "ja": "機動警察パトレイバー the Movie",
+        "ja_typings": [
+          "kidoukeisatsupatoreibaatheMovie"
+        ]
+      },
+      {
+        "en": "Angel's Egg",
+        "ja": "天使のたまご",
+        "ja_typings": [
+          "tenshinotamago"
+        ]
+      },
+      {
+        "en": "Urusei Yatsura 2: Beautiful Dreamer",
+        "ja": "うる星やつら2 ビューティフルドリーマー",
+        "ja_typings": [
+          "uruseiyatsura2byuutifurudoriimaa"
+        ]
+      },
+      {
+        "en": "Ghost in the Shell",
+        "ja": "GHOST IN THE SHELL",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01340",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1988 OVA film by Mamoru Oshii features a sentient airliner?",
+      "ja": "意思を持つ旅客機が登場する1988年押井守監督のOVAは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Castle in the Sky",
+        "ja": "天空の城ラピュタ",
+        "ja_typings": [
+          "tenkuunoshiroraputa"
+        ]
+      },
+      {
+        "en": "Nausicaa",
+        "ja": "風の谷のナウシカ",
+        "ja_typings": [
+          "kazenotaninonaushika"
+        ]
+      },
+      {
+        "en": "My Neighbor Totoro",
+        "ja": "となりのトトロ",
+        "ja_typings": []
+      },
+      {
+        "en": "Porco Rosso",
+        "ja": "紅の豚",
+        "ja_typings": [
+          "kurenainobuta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01341",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1985 Ghibli film follows Pazu and Sheeta?",
+      "ja": "パズーとシータが登場する1985年のジブリ作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nausicaa",
+        "ja": "風の谷のナウシカ",
+        "ja_typings": [
+          "kazenotaninonaushika"
+        ]
+      },
+      {
+        "en": "Castle in the Sky",
+        "ja": "天空の城ラピュタ",
+        "ja_typings": [
+          "tenkuunoshiroraputa"
+        ]
+      },
+      {
+        "en": "Royal Space Force",
+        "ja": "王立宇宙軍",
+        "ja_typings": [
+          "ouritsuuchuugun"
+        ]
+      },
+      {
+        "en": "Lensman",
+        "ja": "SF新世紀レンズマン",
+        "ja_typings": [
+          "SFshinseikirenzuman"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01342",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1984 Ghibli-precursor film features Ohmu and toxic jungles?",
+      "ja": "オームと腐海が登場する1984年の作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Royal Space Force",
+        "ja": "王立宇宙軍",
+        "ja_typings": [
+          "ouritsuuchuugun"
+        ]
+      },
+      {
+        "en": "Gunbuster",
+        "ja": "トップをねらえ!",
+        "ja_typings": [
+          "toppuwonerae"
+        ]
+      },
+      {
+        "en": "Nadia",
+        "ja": "ふしぎの海のナディア",
+        "ja_typings": [
+          "fushiginouminonadia"
+        ]
+      },
+      {
+        "en": "Otaku no Video",
+        "ja": "おたくのビデオ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01343",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1987 Gainax film follows Shirotsugh joining a space program?",
+      "ja": "シロツグが宇宙軍に入隊する1987年のガイナックス作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gunbuster",
+        "ja": "トップをねらえ!",
+        "ja_typings": [
+          "toppuwonerae"
+        ]
+      },
+      {
+        "en": "Bubblegum Crisis",
+        "ja": "バブルガムクライシス",
+        "ja_typings": []
+      },
+      {
+        "en": "Megazone 23",
+        "ja": "メガゾーン23",
+        "ja_typings": []
+      },
+      {
+        "en": "Patlabor",
+        "ja": "機動警察パトレイバー",
+        "ja_typings": [
+          "kidoukeisatsupatoreibaa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01344",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1988 OVA features Noriko piloting RX-7?",
+      "ja": "ノリコがRX-7に乗る1988年のOVAは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nadia",
+        "ja": "ふしぎの海のナディア",
+        "ja_typings": [
+          "fushiginouminonadia"
+        ]
+      },
+      {
+        "en": "Future Boy Conan",
+        "ja": "未来少年コナン",
+        "ja_typings": [
+          "miraishounenkonan"
+        ]
+      },
+      {
+        "en": "Anne of Green Gables",
+        "ja": "赤毛のアン",
+        "ja_typings": [
+          "akagenoan"
+        ]
+      },
+      {
+        "en": "Heidi",
+        "ja": "アルプスの少女ハイジ",
+        "ja_typings": [
+          "arupusunoshoujohaiji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01345",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1990 NHK anime follows Jean and Nadia searching for Atlantis?",
+      "ja": "ジャンとナディアがアトランティスを探す1990年のNHKアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Future Boy Conan",
+        "ja": "未来少年コナン",
+        "ja_typings": [
+          "miraishounenkonan"
+        ]
+      },
+      {
+        "en": "Lupin III Part 2",
+        "ja": "ルパン三世 PART2",
+        "ja_typings": [
+          "rupansansei PART2"
+        ]
+      },
+      {
+        "en": "Heidi",
+        "ja": "アルプスの少女ハイジ",
+        "ja_typings": [
+          "arupusunoshoujohaiji"
+        ]
+      },
+      {
+        "en": "3000 Leagues in Search of Mother",
+        "ja": "母をたずねて三千里",
+        "ja_typings": [
+          "hahawotazunetesanzenri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01346",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1978 Miyazaki TV series follows Conan after a global cataclysm?",
+      "ja": "大災害後の世界を描く1978年宮崎駿監督のTVシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tomorrow's Joe 2",
+        "ja": "あしたのジョー2",
+        "ja_typings": [
+          "ashitanojoo2"
+        ]
+      },
+      {
+        "en": "Ginga: Nagareboshi Gin",
+        "ja": "銀牙 流れ星銀",
+        "ja_typings": [
+          "ginganagareboshigin"
+        ]
+      },
+      {
+        "en": "YAWARA!",
+        "ja": "YAWARA!",
+        "ja_typings": []
+      },
+      {
+        "en": "Slow Step",
+        "ja": "スローステップ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 2,
+    "genre": "anime",
+    "id": "q01347",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1992 anime is about a girl boxing kickboxer named Hibiki?",
+      "ja": "響子が主人公の1992年のキックボクシングアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ranking of Kings",
+        "ja": "王様ランキング",
+        "ja_typings": [
+          "ousamarankingu"
+        ]
+      },
+      {
+        "en": "Heike Story",
+        "ja": "平家物語",
+        "ja_typings": [
+          "heikemonogatari"
+        ]
+      },
+      {
+        "en": "Sonny Boy",
+        "ja": "サニーボーイ",
+        "ja_typings": []
+      },
+      {
+        "en": "Odd Taxi",
+        "ja": "オッドタクシー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01348",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2022 anime features Bojji, a deaf prince?",
+      "ja": "耳の聞こえない王子ボッジが主人公の2022年アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Heike Story",
+        "ja": "平家物語",
+        "ja_typings": [
+          "heikemonogatari"
+        ]
+      },
+      {
+        "en": "Ranking of Kings",
+        "ja": "王様ランキング",
+        "ja_typings": [
+          "ousamarankingu"
+        ]
+      },
+      {
+        "en": "Sonny Boy",
+        "ja": "サニーボーイ",
+        "ja_typings": []
+      },
+      {
+        "en": "Vivy",
+        "ja": "Vivy",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01349",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2021 anime by Naoko Yamada retells a classical war chronicle?",
+      "ja": "山田尚子監督による2021年の古典戦記アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Odd Taxi",
+        "ja": "オッドタクシー",
+        "ja_typings": []
+      },
+      {
+        "en": "Heike Story",
+        "ja": "平家物語",
+        "ja_typings": [
+          "heikemonogatari"
+        ]
+      },
+      {
+        "en": "Sonny Boy",
+        "ja": "サニーボーイ",
+        "ja_typings": []
+      },
+      {
+        "en": "Wonder Egg Priority",
+        "ja": "ワンダーエッグ・プライオリティ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01350",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2021 anime features a talking cat solving crimes in Tokyo?",
+      "ja": "東京で事件を解決する話す猫が登場する2021年のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vivy",
+        "ja": "Vivy",
+        "ja_typings": []
+      },
+      {
+        "en": "BEASTARS",
+        "ja": "BEASTARS",
+        "ja_typings": []
+      },
+      {
+        "en": "ID:INVADED",
+        "ja": "イド:インヴェイデッド",
+        "ja_typings": []
+      },
+      {
+        "en": "Sonny Boy",
+        "ja": "サニーボーイ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01351",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2021 anime follows Ai singing diva android?",
+      "ja": "歌姫アンドロイドのヴィヴィが主人公の2021年のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sonny Boy",
+        "ja": "サニーボーイ",
+        "ja_typings": []
+      },
+      {
+        "en": "Odd Taxi",
+        "ja": "オッドタクシー",
+        "ja_typings": []
+      },
+      {
+        "en": "Wonder Egg Priority",
+        "ja": "ワンダーエッグ・プライオリティ",
+        "ja_typings": []
+      },
+      {
+        "en": "Vivy",
+        "ja": "Vivy",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01352",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2021 Madhouse anime features high schoolers stranded on a deserted island?",
+      "ja": "無人島に漂流する高校生が主人公の2021年マッドハウス制作アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bocchi the Rock!",
+        "ja": "ぼっち・ざ・ろっく!",
+        "ja_typings": []
+      },
+      {
+        "en": "Skip and Loafer",
+        "ja": "スキップとローファー",
+        "ja_typings": []
+      },
+      {
+        "en": "Buddy Daddies",
+        "ja": "バディ・ダディズ",
+        "ja_typings": []
+      },
+      {
+        "en": "MASHLE",
+        "ja": "マッシュル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01353",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2023 anime is about a girl band formed at SHIMOKITAZAWA?",
+      "ja": "下北沢で結成された女子バンドを描く2023年のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Skip and Loafer",
+        "ja": "スキップとローファー",
+        "ja_typings": []
+      },
+      {
+        "en": "Bocchi the Rock!",
+        "ja": "ぼっち・ざ・ろっく!",
+        "ja_typings": []
+      },
+      {
+        "en": "MASHLE",
+        "ja": "マッシュル",
+        "ja_typings": []
+      },
+      {
+        "en": "Heavenly Delusion",
+        "ja": "天国大魔境",
+        "ja_typings": [
+          "tengokudaimakyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01354",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2023 anime follows a country girl Mitsumi adjusting to Tokyo high school?",
+      "ja": "上京した田舎の少女みつみが主人公の2023年のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Heavenly Delusion",
+        "ja": "天国大魔境",
+        "ja_typings": [
+          "tengokudaimakyou"
+        ]
+      },
+      {
+        "en": "Skip and Loafer",
+        "ja": "スキップとローファー",
+        "ja_typings": []
+      },
+      {
+        "en": "Vinland Saga Season 2",
+        "ja": "ヴィンランド・サガ SEASON2",
+        "ja_typings": []
+      },
+      {
+        "en": "Hell's Paradise",
+        "ja": "地獄楽",
+        "ja_typings": [
+          "jigokuraku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01355",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2023 anime depicts Maru and Kiruko traveling post-apocalyptic Japan?",
+      "ja": "マルとキルコがポストアポカリプスの日本を旅する2023年アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vinland Saga",
+        "ja": "ヴィンランド・サガ",
+        "ja_typings": []
+      },
+      {
+        "en": "Dororo",
+        "ja": "どろろ",
+        "ja_typings": []
+      },
+      {
+        "en": "Beastars",
+        "ja": "BEASTARS",
+        "ja_typings": []
+      },
+      {
+        "en": "Dr. STONE",
+        "ja": "Dr.STONE",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01356",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2019 anime adapts Makoto Yukimura's Viking epic?",
+      "ja": "幸村誠のヴァイキング叙事詩を原作とする2019年のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mirai",
+        "ja": "未来のミライ",
+        "ja_typings": [
+          "mirainomirai"
+        ]
+      },
+      {
+        "en": "Wolf Children",
+        "ja": "おおかみこどもの雨と雪",
+        "ja_typings": [
+          "ookamikodomonoameToyuki"
+        ]
+      },
+      {
+        "en": "Belle",
+        "ja": "竜とそばかすの姫",
+        "ja_typings": [
+          "ryuutosobakasunohime"
+        ]
+      },
+      {
+        "en": "Summer Wars",
+        "ja": "サマーウォーズ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01357",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2018 Mamoru Hosoda film is about a boy meeting his future sister?",
+      "ja": "未来の妹に出会う少年を描く2018年細田守監督の映画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Belle",
+        "ja": "竜とそばかすの姫",
+        "ja_typings": [
+          "ryuutosobakasunohime"
+        ]
+      },
+      {
+        "en": "Mirai",
+        "ja": "未来のミライ",
+        "ja_typings": [
+          "mirainomirai"
+        ]
+      },
+      {
+        "en": "Summer Wars",
+        "ja": "サマーウォーズ",
+        "ja_typings": []
+      },
+      {
+        "en": "The Boy and the Beast",
+        "ja": "バケモノの子",
+        "ja_typings": [
+          "bakemononoko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01358",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2021 Hosoda film features a VR singer with a dragon?",
+      "ja": "竜とVR世界の歌姫を描く2021年の細田守監督作は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Maquia",
+        "ja": "さよならの朝に約束の花をかざろう",
+        "ja_typings": [
+          "sayonarano朝ni約束no花wokazarou"
+        ]
+      },
+      {
+        "en": "Mai Mai Miracle",
+        "ja": "マイマイ新子と千年の魔法",
+        "ja_typings": []
+      },
+      {
+        "en": "Mind Game",
+        "ja": "マインド・ゲーム",
+        "ja_typings": []
+      },
+      {
+        "en": "Tekkonkinkreet",
+        "ja": "鉄コン筋クリート",
+        "ja_typings": [
+          "tekkonkinkuriito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01359",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2022 film by Mari Okada features a hidden village of red eyes?",
+      "ja": "岡田麿里監督による2022年の赤い瞳の村を描く映画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Paprika",
+        "ja": "パプリカ",
+        "ja_typings": []
+      },
+      {
+        "en": "Millennium Actress",
+        "ja": "千年女優",
+        "ja_typings": [
+          "sennenjoyuu"
+        ]
+      },
+      {
+        "en": "Perfect Blue",
+        "ja": "PERFECT BLUE",
+        "ja_typings": []
+      },
+      {
+        "en": "Tokyo Godfathers",
+        "ja": "東京ゴッドファーザーズ",
+        "ja_typings": [
+          "toukyougoddofaazaazu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01360",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2006 Kon Satoshi film is about a dream-invading device?",
+      "ja": "夢に入る装置を描く2006年今敏監督の映画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Millennium Actress",
+        "ja": "千年女優",
+        "ja_typings": [
+          "sennenjoyuu"
+        ]
+      },
+      {
+        "en": "Paprika",
+        "ja": "パプリカ",
+        "ja_typings": []
+      },
+      {
+        "en": "Perfect Blue",
+        "ja": "PERFECT BLUE",
+        "ja_typings": []
+      },
+      {
+        "en": "Tokyo Godfathers",
+        "ja": "東京ゴッドファーザーズ",
+        "ja_typings": [
+          "toukyougoddofaazaazu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01361",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2001 Kon Satoshi film blends an actress's memories with film history?",
+      "ja": "女優の記憶と映画史を交錯させる2001年今敏監督作は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Perfect Blue",
+        "ja": "PERFECT BLUE",
+        "ja_typings": []
+      },
+      {
+        "en": "Millennium Actress",
+        "ja": "千年女優",
+        "ja_typings": [
+          "sennenjoyuu"
+        ]
+      },
+      {
+        "en": "Paprika",
+        "ja": "パプリカ",
+        "ja_typings": []
+      },
+      {
+        "en": "Paranoia Agent",
+        "ja": "妄想代理人",
+        "ja_typings": [
+          "mousoudairinin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01362",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1997 Satoshi Kon film follows a pop idol turned actress?",
+      "ja": "アイドルから女優に転身した少女を描く1997年今敏監督作は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kinema Citrus",
+        "ja": "キネマシトラス",
+        "ja_typings": []
+      },
+      {
+        "en": "Wit Studio",
+        "ja": "WIT STUDIO",
+        "ja_typings": []
+      },
+      {
+        "en": "MAPPA",
+        "ja": "MAPPA",
+        "ja_typings": []
+      },
+      {
+        "en": "Bones",
+        "ja": "ボンズ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01363",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio produced Made in Abyss?",
+      "ja": "メイドインアビスを制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bones",
+        "ja": "ボンズ",
+        "ja_typings": []
+      },
+      {
+        "en": "Madhouse",
+        "ja": "マッドハウス",
+        "ja_typings": []
+      },
+      {
+        "en": "Production I.G",
+        "ja": "Production I.G",
+        "ja_typings": []
+      },
+      {
+        "en": "J.C.Staff",
+        "ja": "J.C.STAFF",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01364",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio is famous for Mob Psycho 100 and One-Punch Man season 1?",
+      "ja": "モブサイコ100とワンパンマン1期で有名なスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kyoto Animation",
+        "ja": "京都アニメーション",
+        "ja_typings": [
+          "kyouToanimeeshon"
+        ]
+      },
+      {
+        "en": "P.A. Works",
+        "ja": "P.A.WORKS",
+        "ja_typings": []
+      },
+      {
+        "en": "ufotable",
+        "ja": "ufotable",
+        "ja_typings": []
+      },
+      {
+        "en": "Bones",
+        "ja": "ボンズ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01365",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio produced Violet Evergarden?",
+      "ja": "ヴァイオレット・エヴァーガーデンを制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "P.A. Works",
+        "ja": "P.A.WORKS",
+        "ja_typings": []
+      },
+      {
+        "en": "Kyoto Animation",
+        "ja": "京都アニメーション",
+        "ja_typings": [
+          "kyouToanimeeshon"
+        ]
+      },
+      {
+        "en": "Trigger",
+        "ja": "TRIGGER",
+        "ja_typings": []
+      },
+      {
+        "en": "Sunrise",
+        "ja": "サンライズ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01366",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio is known for Hanasaku Iroha and Shirobako?",
+      "ja": "花咲くいろは・SHIROBAKOで知られるスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Trigger",
+        "ja": "TRIGGER",
+        "ja_typings": []
+      },
+      {
+        "en": "Gainax",
+        "ja": "ガイナックス",
+        "ja_typings": []
+      },
+      {
+        "en": "Bones",
+        "ja": "ボンズ",
+        "ja_typings": []
+      },
+      {
+        "en": "MAPPA",
+        "ja": "MAPPA",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01367",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio is famous for Kill la Kill and SSSS.GRIDMAN?",
+      "ja": "キルラキル・SSSS.GRIDMANで有名なスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jun Fukuyama",
+        "ja": "福山潤",
+        "ja_typings": [
+          "fukuyamajun"
+        ]
+      },
+      {
+        "en": "Tomokazu Sugita",
+        "ja": "杉田智和",
+        "ja_typings": [
+          "sugitatomokazu"
+        ]
+      },
+      {
+        "en": "Mamoru Miyano",
+        "ja": "宮野真守",
+        "ja_typings": [
+          "miyanomamoru"
+        ]
+      },
+      {
+        "en": "Daisuke Ono",
+        "ja": "小野大輔",
+        "ja_typings": [
+          "onodaisuke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01368",
+    "image_path": null,
+    "question_text": {
+      "en": "Who voices Lelouch vi Britannia?",
+      "ja": "ルルーシュ・ヴィ・ブリタニアの声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ami Koshimizu",
+        "ja": "小清水亜美",
+        "ja_typings": [
+          "koshimizuami"
+        ]
+      },
+      {
+        "en": "Aya Hirano",
+        "ja": "平野綾",
+        "ja_typings": [
+          "hiranoaya"
+        ]
+      },
+      {
+        "en": "Yui Horie",
+        "ja": "堀江由衣",
+        "ja_typings": [
+          "horieyui"
+        ]
+      },
+      {
+        "en": "Rie Kugimiya",
+        "ja": "釘宮理恵",
+        "ja_typings": [
+          "kugimiyarie"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01369",
+    "image_path": null,
+    "question_text": {
+      "en": "Who voices Holo in Spice and Wolf?",
+      "ja": "狼と香辛料のホロの声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shinichiro Watanabe",
+        "ja": "渡辺信一郎",
+        "ja_typings": [
+          "watanabeshinichirou"
+        ]
+      },
+      {
+        "en": "Yoshiyuki Tomino",
+        "ja": "富野由悠季",
+        "ja_typings": [
+          "tominoyoshiyuki"
+        ]
+      },
+      {
+        "en": "Mamoru Oshii",
+        "ja": "押井守",
+        "ja_typings": [
+          "oshiimamoru"
+        ]
+      },
+      {
+        "en": "Yoshiaki Kawajiri",
+        "ja": "川尻善昭",
+        "ja_typings": [
+          "kawajiriyoshiaki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01370",
+    "image_path": null,
+    "question_text": {
+      "en": "Which director made Cowboy Bebop?",
+      "ja": "カウボーイビバップの監督は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shinichiro Watanabe",
+        "ja": "渡辺信一郎",
+        "ja_typings": [
+          "watanabeshinichirou"
+        ]
+      },
+      {
+        "en": "Goro Taniguchi",
+        "ja": "谷口悟朗",
+        "ja_typings": [
+          "taniguchigorou"
+        ]
+      },
+      {
+        "en": "Sayo Yamamoto",
+        "ja": "山本沙代",
+        "ja_typings": [
+          "yamamotosayo"
+        ]
+      },
+      {
+        "en": "Tensai Okamura",
+        "ja": "岡村天斎",
+        "ja_typings": [
+          "okamuratensai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01371",
+    "image_path": null,
+    "question_text": {
+      "en": "Which director helmed Samurai Champloo?",
+      "ja": "サムライチャンプルーの監督は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Masaaki Yuasa",
+        "ja": "湯浅政明",
+        "ja_typings": [
+          "yuasamasaaki"
+        ]
+      },
+      {
+        "en": "Shinichiro Watanabe",
+        "ja": "渡辺信一郎",
+        "ja_typings": [
+          "watanabeshinichirou"
+        ]
+      },
+      {
+        "en": "Mamoru Hosoda",
+        "ja": "細田守",
+        "ja_typings": [
+          "hosodamamoru"
+        ]
+      },
+      {
+        "en": "Hiroyuki Imaishi",
+        "ja": "今石洋之",
+        "ja_typings": [
+          "imaishihiroyuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01372",
+    "image_path": null,
+    "question_text": {
+      "en": "Which director made Mind Game and Devilman Crybaby?",
+      "ja": "マインド・ゲームとDEVILMAN crybabyの監督は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Samurai Champloo",
+        "ja": "サムライチャンプルー",
+        "ja_typings": []
+      },
+      {
+        "en": "Cowboy Bebop",
+        "ja": "カウボーイビバップ",
+        "ja_typings": []
+      },
+      {
+        "en": "Space Dandy",
+        "ja": "スペース☆ダンディ",
+        "ja_typings": []
+      },
+      {
+        "en": "Carole and Tuesday",
+        "ja": "キャロル&チューズデイ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01373",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2004 anime by Shinichiro Watanabe is set in Edo-period Japan with hip-hop?",
+      "ja": "江戸時代にヒップホップを融合した2004年渡辺信一郎作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cowboy Bebop",
+        "ja": "カウボーイビバップ",
+        "ja_typings": []
+      },
+      {
+        "en": "Outlaw Star",
+        "ja": "アウトロースター",
+        "ja_typings": []
+      },
+      {
+        "en": "Trigun",
+        "ja": "トライガン",
+        "ja_typings": []
+      },
+      {
+        "en": "Black Lagoon",
+        "ja": "ブラック・ラグーン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01374",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1998 anime features bounty hunter Spike Spiegel?",
+      "ja": "賞金稼ぎのスパイク・スピーゲルが主人公の1998年アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Trigun",
+        "ja": "トライガン",
+        "ja_typings": []
+      },
+      {
+        "en": "Cowboy Bebop",
+        "ja": "カウボーイビバップ",
+        "ja_typings": []
+      },
+      {
+        "en": "Outlaw Star",
+        "ja": "アウトロースター",
+        "ja_typings": []
+      },
+      {
+        "en": "Big O",
+        "ja": "THE ビッグオー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01375",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1998 anime features Vash the Stampede on a desert planet?",
+      "ja": "砂漠の惑星でヴァッシュ・ザ・スタンピードが活躍する1998年アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rurouni Kenshin",
+        "ja": "るろうに剣心",
+        "ja_typings": [
+          "ruroun ikenshin"
+        ]
+      },
+      {
+        "en": "Yu Yu Hakusho",
+        "ja": "幽☆遊☆白書",
+        "ja_typings": [
+          "yuuyuuhakusho"
+        ]
+      },
+      {
+        "en": "Ranma 1/2",
+        "ja": "らんま1/2",
+        "ja_typings": []
+      },
+      {
+        "en": "Inuyasha",
+        "ja": "犬夜叉",
+        "ja_typings": [
+          "inuyasha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01376",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1995 anime features Kenshin Himura?",
+      "ja": "緋村剣心が主人公の1995年のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Inuyasha",
+        "ja": "犬夜叉",
+        "ja_typings": [
+          "inuyasha"
+        ]
+      },
+      {
+        "en": "Ranma 1/2",
+        "ja": "らんま1/2",
+        "ja_typings": []
+      },
+      {
+        "en": "Urusei Yatsura",
+        "ja": "うる星やつら",
+        "ja_typings": [
+          "uruseiyatsura"
+        ]
+      },
+      {
+        "en": "Maison Ikkoku",
+        "ja": "めぞん一刻",
+        "ja_typings": [
+          "mezonikkoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01377",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1992 anime by Rumiko Takahashi features a half-demon dog hero?",
+      "ja": "高橋留美子原作、半妖の少年が主人公の長編アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Maison Ikkoku",
+        "ja": "めぞん一刻",
+        "ja_typings": [
+          "mezonikkoku"
+        ]
+      },
+      {
+        "en": "Ranma 1/2",
+        "ja": "らんま1/2",
+        "ja_typings": []
+      },
+      {
+        "en": "Urusei Yatsura",
+        "ja": "うる星やつら",
+        "ja_typings": [
+          "uruseiyatsura"
+        ]
+      },
+      {
+        "en": "Inuyasha",
+        "ja": "犬夜叉",
+        "ja_typings": [
+          "inuyasha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01378",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1989 anime by Rumiko Takahashi is set in Ikkoku-kan apartment?",
+      "ja": "一刻館を舞台にした1989年の高橋留美子原作アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shotaro Ishinomori",
+        "ja": "石ノ森章太郎",
+        "ja_typings": [
+          "ishinomorishoutarou"
+        ]
+      },
+      {
+        "en": "Osamu Tezuka",
+        "ja": "手塚治虫",
+        "ja_typings": [
+          "tezukaosamu"
+        ]
+      },
+      {
+        "en": "Go Nagai",
+        "ja": "永井豪",
+        "ja_typings": [
+          "nagaigou"
+        ]
+      },
+      {
+        "en": "Leiji Matsumoto",
+        "ja": "松本零士",
+        "ja_typings": [
+          "matsumotoreiji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01379",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Cyborg 009 and Kamen Rider?",
+      "ja": "サイボーグ009と仮面ライダーの原作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Go Nagai",
+        "ja": "永井豪",
+        "ja_typings": [
+          "nagaigou"
+        ]
+      },
+      {
+        "en": "Shotaro Ishinomori",
+        "ja": "石ノ森章太郎",
+        "ja_typings": [
+          "ishinomorishoutarou"
+        ]
+      },
+      {
+        "en": "Osamu Tezuka",
+        "ja": "手塚治虫",
+        "ja_typings": [
+          "tezukaosamu"
+        ]
+      },
+      {
+        "en": "Mitsuteru Yokoyama",
+        "ja": "横山光輝",
+        "ja_typings": [
+          "yokoyamamitsuteru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01380",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Mazinger Z and Devilman?",
+      "ja": "マジンガーZとデビルマンの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mitsuteru Yokoyama",
+        "ja": "横山光輝",
+        "ja_typings": [
+          "yokoyamamitsuteru"
+        ]
+      },
+      {
+        "en": "Osamu Tezuka",
+        "ja": "手塚治虫",
+        "ja_typings": [
+          "tezukaosamu"
+        ]
+      },
+      {
+        "en": "Go Nagai",
+        "ja": "永井豪",
+        "ja_typings": [
+          "nagaigou"
+        ]
+      },
+      {
+        "en": "Leiji Matsumoto",
+        "ja": "松本零士",
+        "ja_typings": [
+          "matsumotoreiji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01381",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Tetsujin 28-go?",
+      "ja": "鉄人28号の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Osamu Tezuka",
+        "ja": "手塚治虫",
+        "ja_typings": [
+          "tezukaosamu"
+        ]
+      },
+      {
+        "en": "Shotaro Ishinomori",
+        "ja": "石ノ森章太郎",
+        "ja_typings": [
+          "ishinomorishoutarou"
+        ]
+      },
+      {
+        "en": "Mitsuteru Yokoyama",
+        "ja": "横山光輝",
+        "ja_typings": [
+          "yokoyamamitsuteru"
+        ]
+      },
+      {
+        "en": "Tetsuya Chiba",
+        "ja": "ちばてつや",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01382",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote Phoenix (Hi no Tori)?",
+      "ja": "火の鳥の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tetsuya Chiba",
+        "ja": "ちばてつや",
+        "ja_typings": []
+      },
+      {
+        "en": "Asao Takamori",
+        "ja": "高森朝雄",
+        "ja_typings": [
+          "takamorisaoo"
+        ]
+      },
+      {
+        "en": "Osamu Tezuka",
+        "ja": "手塚治虫",
+        "ja_typings": [
+          "tezukaosamu"
+        ]
+      },
+      {
+        "en": "Mitsuru Adachi",
+        "ja": "あだち充",
+        "ja_typings": [
+          "adachimitsuru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01383",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Tomorrow's Joe?",
+      "ja": "あしたのジョーの作画担当は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mitsuru Adachi",
+        "ja": "あだち充",
+        "ja_typings": [
+          "adachimitsuru"
+        ]
+      },
+      {
+        "en": "Tetsuya Chiba",
+        "ja": "ちばてつや",
+        "ja_typings": []
+      },
+      {
+        "en": "Takehiko Inoue",
+        "ja": "井上雄彦",
+        "ja_typings": [
+          "inouetakehiko"
+        ]
+      },
+      {
+        "en": "Yoichi Takahashi",
+        "ja": "高橋陽一",
+        "ja_typings": [
+          "takahashiyouichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01384",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Touch and Cross Game?",
+      "ja": "タッチとクロスゲームの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yoichi Takahashi",
+        "ja": "高橋陽一",
+        "ja_typings": [
+          "takahashiyouichi"
+        ]
+      },
+      {
+        "en": "Mitsuru Adachi",
+        "ja": "あだち充",
+        "ja_typings": [
+          "adachimitsuru"
+        ]
+      },
+      {
+        "en": "Tetsuya Chiba",
+        "ja": "ちばてつや",
+        "ja_typings": []
+      },
+      {
+        "en": "Takehiko Inoue",
+        "ja": "井上雄彦",
+        "ja_typings": [
+          "inouetakehiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01385",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Captain Tsubasa?",
+      "ja": "キャプテン翼の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Leiji Matsumoto",
+        "ja": "松本零士",
+        "ja_typings": [
+          "matsumotoreiji"
+        ]
+      },
+      {
+        "en": "Go Nagai",
+        "ja": "永井豪",
+        "ja_typings": [
+          "nagaigou"
+        ]
+      },
+      {
+        "en": "Mitsuteru Yokoyama",
+        "ja": "横山光輝",
+        "ja_typings": [
+          "yokoyamamitsuteru"
+        ]
+      },
+      {
+        "en": "Osamu Tezuka",
+        "ja": "手塚治虫",
+        "ja_typings": [
+          "tezukaosamu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01386",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Galaxy Express 999?",
+      "ja": "銀河鉄道999の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shonen Sunday",
+        "ja": "週刊少年サンデー",
+        "ja_typings": [
+          "shuukanshounensandee"
+        ]
+      },
+      {
+        "en": "Shonen Magazine",
+        "ja": "週刊少年マガジン",
+        "ja_typings": [
+          "shuukanshounenmagajin"
+        ]
+      },
+      {
+        "en": "Shonen Jump",
+        "ja": "週刊少年ジャンプ",
+        "ja_typings": [
+          "shuukanshounenjanpu"
+        ]
+      },
+      {
+        "en": "Shonen Champion",
+        "ja": "週刊少年チャンピオン",
+        "ja_typings": [
+          "shuukanshounenchanpion"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01387",
+    "image_path": null,
+    "question_text": {
+      "en": "Which magazine serialized Touch and H2?",
+      "ja": "タッチとH2が連載された雑誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shonen Magazine",
+        "ja": "週刊少年マガジン",
+        "ja_typings": [
+          "shuukanshounenmagajin"
+        ]
+      },
+      {
+        "en": "Shonen Sunday",
+        "ja": "週刊少年サンデー",
+        "ja_typings": [
+          "shuukanshounensandee"
+        ]
+      },
+      {
+        "en": "Shonen Jump",
+        "ja": "週刊少年ジャンプ",
+        "ja_typings": [
+          "shuukanshounenjanpu"
+        ]
+      },
+      {
+        "en": "Big Comic",
+        "ja": "ビッグコミック",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01388",
+    "image_path": null,
+    "question_text": {
+      "en": "Which magazine serialized Tomorrow's Joe?",
+      "ja": "あしたのジョーが連載された雑誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shueisha",
+        "ja": "集英社",
+        "ja_typings": [
+          "shuueisha"
+        ]
+      },
+      {
+        "en": "Kodansha",
+        "ja": "講談社",
+        "ja_typings": [
+          "koudansha"
+        ]
+      },
+      {
+        "en": "Shogakukan",
+        "ja": "小学館",
+        "ja_typings": [
+          "shougakukan"
+        ]
+      },
+      {
+        "en": "Akita Shoten",
+        "ja": "秋田書店",
+        "ja_typings": [
+          "akitashoten"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01389",
+    "image_path": null,
+    "question_text": {
+      "en": "Which publisher releases Shonen Jump?",
+      "ja": "週刊少年ジャンプの出版社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kodansha",
+        "ja": "講談社",
+        "ja_typings": [
+          "koudansha"
+        ]
+      },
+      {
+        "en": "Shueisha",
+        "ja": "集英社",
+        "ja_typings": [
+          "shuueisha"
+        ]
+      },
+      {
+        "en": "Shogakukan",
+        "ja": "小学館",
+        "ja_typings": [
+          "shougakukan"
+        ]
+      },
+      {
+        "en": "Hakusensha",
+        "ja": "白泉社",
+        "ja_typings": [
+          "hakusensha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01390",
+    "image_path": null,
+    "question_text": {
+      "en": "Which publisher releases Shonen Magazine?",
+      "ja": "週刊少年マガジンの出版社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shogakukan",
+        "ja": "小学館",
+        "ja_typings": [
+          "shougakukan"
+        ]
+      },
+      {
+        "en": "Shueisha",
+        "ja": "集英社",
+        "ja_typings": [
+          "shuueisha"
+        ]
+      },
+      {
+        "en": "Kodansha",
+        "ja": "講談社",
+        "ja_typings": [
+          "koudansha"
+        ]
+      },
+      {
+        "en": "Square Enix",
+        "ja": "スクウェア・エニックス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01391",
+    "image_path": null,
+    "question_text": {
+      "en": "Which publisher releases Shonen Sunday?",
+      "ja": "週刊少年サンデーの出版社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Akita Shoten",
+        "ja": "秋田書店",
+        "ja_typings": [
+          "akitashoten"
+        ]
+      },
+      {
+        "en": "Shueisha",
+        "ja": "集英社",
+        "ja_typings": [
+          "shuueisha"
+        ]
+      },
+      {
+        "en": "Kodansha",
+        "ja": "講談社",
+        "ja_typings": [
+          "koudansha"
+        ]
+      },
+      {
+        "en": "Shogakukan",
+        "ja": "小学館",
+        "ja_typings": [
+          "shougakukan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01392",
+    "image_path": null,
+    "question_text": {
+      "en": "Which publisher releases Shonen Champion?",
+      "ja": "週刊少年チャンピオンの出版社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Osamu Tezuka",
+        "ja": "手塚治虫",
+        "ja_typings": [
+          "tezukaosamu"
+        ]
+      },
+      {
+        "en": "Shotaro Ishinomori",
+        "ja": "石ノ森章太郎",
+        "ja_typings": [
+          "ishinomorishoutarou"
+        ]
+      },
+      {
+        "en": "Mitsuteru Yokoyama",
+        "ja": "横山光輝",
+        "ja_typings": [
+          "yokoyamamitsuteru"
+        ]
+      },
+      {
+        "en": "Go Nagai",
+        "ja": "永井豪",
+        "ja_typings": [
+          "nagaigou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01393",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Astro Boy?",
+      "ja": "鉄腕アトムの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Osamu Tezuka",
+        "ja": "手塚治虫",
+        "ja_typings": [
+          "tezukaosamu"
+        ]
+      },
+      {
+        "en": "Shotaro Ishinomori",
+        "ja": "石ノ森章太郎",
+        "ja_typings": [
+          "ishinomorishoutarou"
+        ]
+      },
+      {
+        "en": "Mitsuteru Yokoyama",
+        "ja": "横山光輝",
+        "ja_typings": [
+          "yokoyamamitsuteru"
+        ]
+      },
+      {
+        "en": "Riyoko Ikeda",
+        "ja": "池田理代子",
+        "ja_typings": [
+          "ikedariyoko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01394",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Black Jack?",
+      "ja": "ブラック・ジャックの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Riyoko Ikeda",
+        "ja": "池田理代子",
+        "ja_typings": [
+          "ikedariyoko"
+        ]
+      },
+      {
+        "en": "Moto Hagio",
+        "ja": "萩尾望都",
+        "ja_typings": [
+          "hagiomoto"
+        ]
+      },
+      {
+        "en": "Keiko Takemiya",
+        "ja": "竹宮惠子",
+        "ja_typings": [
+          "takemiyakeiko"
+        ]
+      },
+      {
+        "en": "Yumiko Oshima",
+        "ja": "大島弓子",
+        "ja_typings": [
+          "ooshimayumiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01395",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created The Rose of Versailles?",
+      "ja": "ベルサイユのばらの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Moto Hagio",
+        "ja": "萩尾望都",
+        "ja_typings": [
+          "hagiomoto"
+        ]
+      },
+      {
+        "en": "Riyoko Ikeda",
+        "ja": "池田理代子",
+        "ja_typings": [
+          "ikedariyoko"
+        ]
+      },
+      {
+        "en": "Keiko Takemiya",
+        "ja": "竹宮惠子",
+        "ja_typings": [
+          "takemiyakeiko"
+        ]
+      },
+      {
+        "en": "Yumiko Oshima",
+        "ja": "大島弓子",
+        "ja_typings": [
+          "ooshimayumiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01396",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created The Heart of Thomas?",
+      "ja": "トーマの心臓の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Takehiko Inoue",
+        "ja": "井上雄彦",
+        "ja_typings": [
+          "inouetakehiko"
+        ]
+      },
+      {
+        "en": "Naoki Urasawa",
+        "ja": "浦沢直樹",
+        "ja_typings": [
+          "urasawanaoki"
+        ]
+      },
+      {
+        "en": "Tsugumi Ohba",
+        "ja": "大場つぐみ",
+        "ja_typings": [
+          "oobatsugumi"
+        ]
+      },
+      {
+        "en": "Eiichiro Oda",
+        "ja": "尾田栄一郎",
+        "ja_typings": [
+          "odaeiichirou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01397",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Vagabond and Real?",
+      "ja": "バガボンドとREALの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Naoki Urasawa",
+        "ja": "浦沢直樹",
+        "ja_typings": [
+          "urasawanaoki"
+        ]
+      },
+      {
+        "en": "Takehiko Inoue",
+        "ja": "井上雄彦",
+        "ja_typings": [
+          "inouetakehiko"
+        ]
+      },
+      {
+        "en": "Kentaro Miura",
+        "ja": "三浦建太郎",
+        "ja_typings": [
+          "miurakentarou"
+        ]
+      },
+      {
+        "en": "Hitoshi Iwaaki",
+        "ja": "岩明均",
+        "ja_typings": [
+          "iwaakihitoshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01398",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote Pluto and Billy Bat?",
+      "ja": "PLUTOとBILLY BATの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hitoshi Iwaaki",
+        "ja": "岩明均",
+        "ja_typings": [
+          "iwaakihitoshi"
+        ]
+      },
+      {
+        "en": "Naoki Urasawa",
+        "ja": "浦沢直樹",
+        "ja_typings": [
+          "urasawanaoki"
+        ]
+      },
+      {
+        "en": "Kentaro Miura",
+        "ja": "三浦建太郎",
+        "ja_typings": [
+          "miurakentarou"
+        ]
+      },
+      {
+        "en": "Takehiko Inoue",
+        "ja": "井上雄彦",
+        "ja_typings": [
+          "inouetakehiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01399",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Parasyte (Kiseiju)?",
+      "ja": "寄生獣の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Toru Fujisawa",
+        "ja": "藤沢とおる",
+        "ja_typings": [
+          "fujisawatooru"
+        ]
+      },
+      {
+        "en": "Tsukasa Hojo",
+        "ja": "北条司",
+        "ja_typings": [
+          "houjoutsukasa"
+        ]
+      },
+      {
+        "en": "Yusuke Murata",
+        "ja": "村田雄介",
+        "ja_typings": [
+          "muratayuusuke"
+        ]
+      },
+      {
+        "en": "Hiroshi Takahashi",
+        "ja": "高橋ヒロシ",
+        "ja_typings": [
+          "takahashihiroshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01400",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created the manga GTO?",
+      "ja": "GTOの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tsukasa Hojo",
+        "ja": "北条司",
+        "ja_typings": [
+          "houjoutsukasa"
+        ]
+      },
+      {
+        "en": "Toru Fujisawa",
+        "ja": "藤沢とおる",
+        "ja_typings": [
+          "fujisawatooru"
+        ]
+      },
+      {
+        "en": "Buronson",
+        "ja": "武論尊",
+        "ja_typings": [
+          "buronson"
+        ]
+      },
+      {
+        "en": "Yu Koyama",
+        "ja": "小山ゆう",
+        "ja_typings": [
+          "koyamayuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01401",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created City Hunter?",
+      "ja": "シティーハンターの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hiroshi Takahashi",
+        "ja": "高橋ヒロシ",
+        "ja_typings": [
+          "takahashihiroshi"
+        ]
+      },
+      {
+        "en": "Toru Fujisawa",
+        "ja": "藤沢とおる",
+        "ja_typings": [
+          "fujisawatooru"
+        ]
+      },
+      {
+        "en": "Tsukasa Hojo",
+        "ja": "北条司",
+        "ja_typings": [
+          "houjoutsukasa"
+        ]
+      },
+      {
+        "en": "Naoki Urasawa",
+        "ja": "浦沢直樹",
+        "ja_typings": [
+          "urasawanaoki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01402",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Crows and Worst?",
+      "ja": "クローズとWORSTの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shuichi Shigeno",
+        "ja": "しげの秀一",
+        "ja_typings": [
+          "shigenoshuuichi"
+        ]
+      },
+      {
+        "en": "Buichi Terasawa",
+        "ja": "寺沢武一",
+        "ja_typings": [
+          "terasawabuichi"
+        ]
+      },
+      {
+        "en": "Tsukasa Hojo",
+        "ja": "北条司",
+        "ja_typings": [
+          "houjoutsukasa"
+        ]
+      },
+      {
+        "en": "Yusuke Murata",
+        "ja": "村田雄介",
+        "ja_typings": [
+          "muratayuusuke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01403",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Initial D?",
+      "ja": "頭文字Dの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Suzue Miuchi",
+        "ja": "美内すずえ",
+        "ja_typings": [
+          "miuchisuzue"
+        ]
+      },
+      {
+        "en": "Riyoko Ikeda",
+        "ja": "池田理代子",
+        "ja_typings": [
+          "ikedariyoko"
+        ]
+      },
+      {
+        "en": "Moto Hagio",
+        "ja": "萩尾望都",
+        "ja_typings": [
+          "hagiomoto"
+        ]
+      },
+      {
+        "en": "Waki Yamato",
+        "ja": "大和和紀",
+        "ja_typings": [
+          "yamatowaki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01404",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Glass Mask (Garasu no Kamen)?",
+      "ja": "ガラスの仮面の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tomoko Ninomiya",
+        "ja": "二ノ宮知子",
+        "ja_typings": [
+          "ninomiyatomoko"
+        ]
+      },
+      {
+        "en": "Ai Yazawa",
+        "ja": "矢沢あい",
+        "ja_typings": [
+          "yazawaai"
+        ]
+      },
+      {
+        "en": "Suzue Miuchi",
+        "ja": "美内すずえ",
+        "ja_typings": [
+          "miuchisuzue"
+        ]
+      },
+      {
+        "en": "Yoko Kamio",
+        "ja": "神尾葉子",
+        "ja_typings": [
+          "kamioyouko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01405",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Nodame Cantabile?",
+      "ja": "のだめカンタービレの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ai Yazawa",
+        "ja": "矢沢あい",
+        "ja_typings": [
+          "yazawaai"
+        ]
+      },
+      {
+        "en": "Tomoko Ninomiya",
+        "ja": "二ノ宮知子",
+        "ja_typings": [
+          "ninomiyatomoko"
+        ]
+      },
+      {
+        "en": "Yoko Kamio",
+        "ja": "神尾葉子",
+        "ja_typings": [
+          "kamioyouko"
+        ]
+      },
+      {
+        "en": "Chika Umino",
+        "ja": "羽海野チカ",
+        "ja_typings": [
+          "uminochika"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01406",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created NANA?",
+      "ja": "NANAの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chika Umino",
+        "ja": "羽海野チカ",
+        "ja_typings": [
+          "uminochika"
+        ]
+      },
+      {
+        "en": "Ai Yazawa",
+        "ja": "矢沢あい",
+        "ja_typings": [
+          "yazawaai"
+        ]
+      },
+      {
+        "en": "Tomoko Ninomiya",
+        "ja": "二ノ宮知子",
+        "ja_typings": [
+          "ninomiyatomoko"
+        ]
+      },
+      {
+        "en": "Yumi Tamura",
+        "ja": "田村由美",
+        "ja_typings": [
+          "tamurayumi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01407",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Honey and Clover?",
+      "ja": "ハチミツとクローバーの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chika Umino",
+        "ja": "羽海野チカ",
+        "ja_typings": [
+          "uminochika"
+        ]
+      },
+      {
+        "en": "Ai Yazawa",
+        "ja": "矢沢あい",
+        "ja_typings": [
+          "yazawaai"
+        ]
+      },
+      {
+        "en": "Yumi Tamura",
+        "ja": "田村由美",
+        "ja_typings": [
+          "tamurayumi"
+        ]
+      },
+      {
+        "en": "Akiko Higashimura",
+        "ja": "東村アキコ",
+        "ja_typings": [
+          "higashimuraakiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01408",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created March Comes in Like a Lion (3-gatsu no Lion)?",
+      "ja": "3月のライオンの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Akiko Higashimura",
+        "ja": "東村アキコ",
+        "ja_typings": [
+          "higashimuraakiko"
+        ]
+      },
+      {
+        "en": "Chika Umino",
+        "ja": "羽海野チカ",
+        "ja_typings": [
+          "uminochika"
+        ]
+      },
+      {
+        "en": "Ai Yazawa",
+        "ja": "矢沢あい",
+        "ja_typings": [
+          "yazawaai"
+        ]
+      },
+      {
+        "en": "Yumi Tamura",
+        "ja": "田村由美",
+        "ja_typings": [
+          "tamurayumi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01409",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Princess Jellyfish (Kuragehime)?",
+      "ja": "海月姫の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kiyohiko Azuma",
+        "ja": "あずまきよひこ",
+        "ja_typings": []
+      },
+      {
+        "en": "Kentaro Miura",
+        "ja": "三浦建太郎",
+        "ja_typings": [
+          "miurakentarou"
+        ]
+      },
+      {
+        "en": "Hitoshi Iwaaki",
+        "ja": "岩明均",
+        "ja_typings": [
+          "iwaakihitoshi"
+        ]
+      },
+      {
+        "en": "Takehiko Inoue",
+        "ja": "井上雄彦",
+        "ja_typings": [
+          "inouetakehiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01410",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Yotsuba&!?",
+      "ja": "よつばと!の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Inio Asano",
+        "ja": "浅野いにお",
+        "ja_typings": [
+          "asanoinio"
+        ]
+      },
+      {
+        "en": "Naoki Urasawa",
+        "ja": "浦沢直樹",
+        "ja_typings": [
+          "urasawanaoki"
+        ]
+      },
+      {
+        "en": "Taiyo Matsumoto",
+        "ja": "松本大洋",
+        "ja_typings": [
+          "matsumototaiyou"
+        ]
+      },
+      {
+        "en": "Daisuke Igarashi",
+        "ja": "五十嵐大介",
+        "ja_typings": [
+          "igarashidaisuke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01411",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Oyasumi Punpun?",
+      "ja": "おやすみプンプンの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Taiyo Matsumoto",
+        "ja": "松本大洋",
+        "ja_typings": [
+          "matsumototaiyou"
+        ]
+      },
+      {
+        "en": "Inio Asano",
+        "ja": "浅野いにお",
+        "ja_typings": [
+          "asanoinio"
+        ]
+      },
+      {
+        "en": "Daisuke Igarashi",
+        "ja": "五十嵐大介",
+        "ja_typings": [
+          "igarashidaisuke"
+        ]
+      },
+      {
+        "en": "Jiro Taniguchi",
+        "ja": "谷口ジロー",
+        "ja_typings": [
+          "taniguchijiroo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01412",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Sunny and Number 5?",
+      "ja": "Sunnyとナンバーファイブの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jiro Taniguchi",
+        "ja": "谷口ジロー",
+        "ja_typings": [
+          "taniguchijiroo"
+        ]
+      },
+      {
+        "en": "Taiyo Matsumoto",
+        "ja": "松本大洋",
+        "ja_typings": [
+          "matsumototaiyou"
+        ]
+      },
+      {
+        "en": "Inio Asano",
+        "ja": "浅野いにお",
+        "ja_typings": [
+          "asanoinio"
+        ]
+      },
+      {
+        "en": "Daisuke Igarashi",
+        "ja": "五十嵐大介",
+        "ja_typings": [
+          "igarashidaisuke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01413",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created The Walking Man (Aruku Hito)?",
+      "ja": "歩くひとの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Daisuke Igarashi",
+        "ja": "五十嵐大介",
+        "ja_typings": [
+          "igarashidaisuke"
+        ]
+      },
+      {
+        "en": "Taiyo Matsumoto",
+        "ja": "松本大洋",
+        "ja_typings": [
+          "matsumototaiyou"
+        ]
+      },
+      {
+        "en": "Jiro Taniguchi",
+        "ja": "谷口ジロー",
+        "ja_typings": [
+          "taniguchijiroo"
+        ]
+      },
+      {
+        "en": "Inio Asano",
+        "ja": "浅野いにお",
+        "ja_typings": [
+          "asanoinio"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01414",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Children of the Sea (Kaijuu no Kodomo)?",
+      "ja": "海獣の子供の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Akihito Tsukushi",
+        "ja": "つくしあきひと",
+        "ja_typings": []
+      },
+      {
+        "en": "Sui Ishida",
+        "ja": "石田スイ",
+        "ja_typings": [
+          "ishidasui"
+        ]
+      },
+      {
+        "en": "Hajime Isayama",
+        "ja": "諫山創",
+        "ja_typings": [
+          "isayamahajime"
+        ]
+      },
+      {
+        "en": "Kohei Horikoshi",
+        "ja": "堀越耕平",
+        "ja_typings": [
+          "horikoshikouhei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01415",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Made in Abyss?",
+      "ja": "メイドインアビスの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sui Ishida",
+        "ja": "石田スイ",
+        "ja_typings": [
+          "ishidasui"
+        ]
+      },
+      {
+        "en": "Akihito Tsukushi",
+        "ja": "つくしあきひと",
+        "ja_typings": []
+      },
+      {
+        "en": "Hajime Isayama",
+        "ja": "諫山創",
+        "ja_typings": [
+          "isayamahajime"
+        ]
+      },
+      {
+        "en": "Kohei Horikoshi",
+        "ja": "堀越耕平",
+        "ja_typings": [
+          "horikoshikouhei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01416",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Tokyo Ghoul?",
+      "ja": "東京喰種の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Young Animal",
+        "ja": "ヤングアニマル",
+        "ja_typings": []
+      },
+      {
+        "en": "Young Jump",
+        "ja": "週刊ヤングジャンプ",
+        "ja_typings": [
+          "shuukanyangujanpu"
+        ]
+      },
+      {
+        "en": "Afternoon",
+        "ja": "月刊アフタヌーン",
+        "ja_typings": [
+          "gekkanafutanuun"
+        ]
+      },
+      {
+        "en": "Morning",
+        "ja": "週刊モーニング",
+        "ja_typings": [
+          "shuukanmooningu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01417",
+    "image_path": null,
+    "question_text": {
+      "en": "Which magazine serialized Berserk?",
+      "ja": "ベルセルクが連載された雑誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Afternoon",
+        "ja": "月刊アフタヌーン",
+        "ja_typings": [
+          "gekkanafutanuun"
+        ]
+      },
+      {
+        "en": "Young Animal",
+        "ja": "ヤングアニマル",
+        "ja_typings": []
+      },
+      {
+        "en": "Morning",
+        "ja": "週刊モーニング",
+        "ja_typings": [
+          "shuukanmooningu"
+        ]
+      },
+      {
+        "en": "Big Comic Original",
+        "ja": "ビッグコミックオリジナル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01418",
+    "image_path": null,
+    "question_text": {
+      "en": "Which magazine serialized Vinland Saga?",
+      "ja": "ヴィンランド・サガが連載されている雑誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ryu Ga Gotoku Studio",
+        "ja": "龍が如くスタジオ",
+        "ja_typings": [
+          "ryuugagotokusutajio"
+        ]
+      },
+      {
+        "en": "Atlus",
+        "ja": "アトラス",
+        "ja_typings": []
+      },
+      {
+        "en": "Tri-Ace",
+        "ja": "トライエース",
+        "ja_typings": []
+      },
+      {
+        "en": "From Software",
+        "ja": "フロム・ソフトウェア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01419",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed the Yakuza/Like a Dragon series?",
+      "ja": "龍が如く/ライクアドラゴンを開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Atlus",
+        "ja": "アトラス",
+        "ja_typings": []
+      },
+      {
+        "en": "Square Enix",
+        "ja": "スクウェア・エニックス",
+        "ja_typings": []
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": []
+      },
+      {
+        "en": "Sega",
+        "ja": "セガ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01420",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed Persona 5?",
+      "ja": "ペルソナ5を開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FromSoftware",
+        "ja": "フロム・ソフトウェア",
+        "ja_typings": []
+      },
+      {
+        "en": "Capcom",
+        "ja": "カプコン",
+        "ja_typings": []
+      },
+      {
+        "en": "Atlus",
+        "ja": "アトラス",
+        "ja_typings": []
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01421",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed Dark Souls and Bloodborne?",
+      "ja": "ダークソウルとブラッドボーンを開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Capcom",
+        "ja": "カプコン",
+        "ja_typings": []
+      },
+      {
+        "en": "FromSoftware",
+        "ja": "フロム・ソフトウェア",
+        "ja_typings": []
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": []
+      },
+      {
+        "en": "Koei Tecmo",
+        "ja": "コーエーテクモ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01422",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed Monster Hunter series?",
+      "ja": "モンスターハンターシリーズを開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Koei Tecmo",
+        "ja": "コーエーテクモ",
+        "ja_typings": []
+      },
+      {
+        "en": "Capcom",
+        "ja": "カプコン",
+        "ja_typings": []
+      },
+      {
+        "en": "Sega",
+        "ja": "セガ",
+        "ja_typings": []
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01423",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed Dynasty Warriors?",
+      "ja": "真・三國無双を開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": []
+      },
+      {
+        "en": "Square Enix",
+        "ja": "スクウェア・エニックス",
+        "ja_typings": []
+      },
+      {
+        "en": "Sega",
+        "ja": "セガ",
+        "ja_typings": []
+      },
+      {
+        "en": "Atlus",
+        "ja": "アトラス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01424",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed Tales of series?",
+      "ja": "テイルズオブシリーズを開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sega",
+        "ja": "セガ",
+        "ja_typings": []
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": []
+      },
+      {
+        "en": "Square Enix",
+        "ja": "スクウェア・エニックス",
+        "ja_typings": []
+      },
+      {
+        "en": "Capcom",
+        "ja": "カプコン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01425",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed Phantasy Star Online?",
+      "ja": "ファンタシースターオンラインを開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PlatinumGames",
+        "ja": "プラチナゲームズ",
+        "ja_typings": []
+      },
+      {
+        "en": "Square Enix",
+        "ja": "スクウェア・エニックス",
+        "ja_typings": []
+      },
+      {
+        "en": "Atlus",
+        "ja": "アトラス",
+        "ja_typings": []
+      },
+      {
+        "en": "Tri-Ace",
+        "ja": "トライエース",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01426",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio created Nier Automata?",
+      "ja": "ニーアオートマタを開発したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PlatinumGames",
+        "ja": "プラチナゲームズ",
+        "ja_typings": []
+      },
+      {
+        "en": "Capcom",
+        "ja": "カプコン",
+        "ja_typings": []
+      },
+      {
+        "en": "FromSoftware",
+        "ja": "フロム・ソフトウェア",
+        "ja_typings": []
+      },
+      {
+        "en": "Konami",
+        "ja": "コナミ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01427",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio developed Bayonetta?",
+      "ja": "ベヨネッタを開発したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Atlus",
+        "ja": "アトラス",
+        "ja_typings": []
+      },
+      {
+        "en": "Square Enix",
+        "ja": "スクウェア・エニックス",
+        "ja_typings": []
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": []
+      },
+      {
+        "en": "Sega",
+        "ja": "セガ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01428",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed Persona Q and Etrian Odyssey?",
+      "ja": "ペルソナQと世界樹の迷宮を開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yu Narukami",
+        "ja": "鳴上悠",
+        "ja_typings": [
+          "narukamiyuu"
+        ]
+      },
+      {
+        "en": "Ren Amamiya",
+        "ja": "雨宮蓮",
+        "ja_typings": [
+          "amamiyaren"
+        ]
+      },
+      {
+        "en": "Makoto Yuki",
+        "ja": "結城理",
+        "ja_typings": [
+          "yuukimakoto"
+        ]
+      },
+      {
+        "en": "Tatsuya Suou",
+        "ja": "周防達哉",
+        "ja_typings": [
+          "suoutatsuya"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01429",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the silent protagonist of Persona 4?",
+      "ja": "ペルソナ4の主人公の通称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yakuza",
+        "ja": "龍が如く",
+        "ja_typings": [
+          "ryuugagotoku"
+        ]
+      },
+      {
+        "en": "Judgment",
+        "ja": "ジャッジアイズ",
+        "ja_typings": []
+      },
+      {
+        "en": "Shenmue",
+        "ja": "シェンムー",
+        "ja_typings": []
+      },
+      {
+        "en": "Sleeping Dogs",
+        "ja": "スリーピングドッグス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01430",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features the protagonist Kazuma Kiryu?",
+      "ja": "桐生一馬が主人公のシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Like a Dragon",
+        "ja": "龍が如く7",
+        "ja_typings": [
+          "ryuugagotoku7"
+        ]
+      },
+      {
+        "en": "Judgment",
+        "ja": "ジャッジアイズ",
+        "ja_typings": []
+      },
+      {
+        "en": "Lost Judgment",
+        "ja": "ロストジャッジメント",
+        "ja_typings": []
+      },
+      {
+        "en": "Shenmue III",
+        "ja": "シェンムーIII",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01431",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features Ichiban Kasuga as protagonist?",
+      "ja": "春日一番が主人公のゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Space Harrier",
+        "ja": "スペースハリアー",
+        "ja_typings": []
+      },
+      {
+        "en": "After Burner",
+        "ja": "アフターバーナー",
+        "ja_typings": []
+      },
+      {
+        "en": "OutRun",
+        "ja": "アウトラン",
+        "ja_typings": []
+      },
+      {
+        "en": "Hang-On",
+        "ja": "ハングオン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01432",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1986 Sega arcade game features pilot Harrier?",
+      "ja": "1986年のセガアーケード作品でハリアーが主人公の作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "OutRun",
+        "ja": "アウトラン",
+        "ja_typings": []
+      },
+      {
+        "en": "Hang-On",
+        "ja": "ハングオン",
+        "ja_typings": []
+      },
+      {
+        "en": "Space Harrier",
+        "ja": "スペースハリアー",
+        "ja_typings": []
+      },
+      {
+        "en": "Power Drift",
+        "ja": "パワードリフト",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01433",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1986 Sega arcade game is a coastal driving game?",
+      "ja": "1986年のセガアーケードの海岸線ドライブゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hang-On",
+        "ja": "ハングオン",
+        "ja_typings": []
+      },
+      {
+        "en": "OutRun",
+        "ja": "アウトラン",
+        "ja_typings": []
+      },
+      {
+        "en": "Super Hang-On",
+        "ja": "スーパーハングオン",
+        "ja_typings": []
+      },
+      {
+        "en": "Power Drift",
+        "ja": "パワードリフト",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01434",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1985 Sega arcade game features motorcycle racing?",
+      "ja": "1985年のセガのバイクレースアーケードゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Metal Gear",
+        "ja": "メタルギア",
+        "ja_typings": []
+      },
+      {
+        "en": "Castlevania",
+        "ja": "悪魔城ドラキュラ",
+        "ja_typings": [
+          "akumajoudorakyura"
+        ]
+      },
+      {
+        "en": "Contra",
+        "ja": "魂斗羅",
+        "ja_typings": [
+          "kontora"
+        ]
+      },
+      {
+        "en": "Gradius",
+        "ja": "グラディウス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01435",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Konami series features Solid Snake?",
+      "ja": "ソリッド・スネークが主人公のコナミシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Castlevania",
+        "ja": "悪魔城ドラキュラ",
+        "ja_typings": [
+          "akumajoudorakyura"
+        ]
+      },
+      {
+        "en": "Contra",
+        "ja": "魂斗羅",
+        "ja_typings": [
+          "kontora"
+        ]
+      },
+      {
+        "en": "Gradius",
+        "ja": "グラディウス",
+        "ja_typings": []
+      },
+      {
+        "en": "TwinBee",
+        "ja": "ツインビー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01436",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Konami series is known as Akumajo Dracula in Japan?",
+      "ja": "日本で「悪魔城ドラキュラ」と呼ばれるコナミシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gradius",
+        "ja": "グラディウス",
+        "ja_typings": []
+      },
+      {
+        "en": "Parodius",
+        "ja": "パロディウス",
+        "ja_typings": []
+      },
+      {
+        "en": "Salamander",
+        "ja": "沙羅曼蛇",
+        "ja_typings": [
+          "saramanda"
+        ]
+      },
+      {
+        "en": "TwinBee",
+        "ja": "ツインビー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01437",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Konami shooter features a Vic Viper spaceship?",
+      "ja": "ビックバイパーが主人公機のコナミシューティングは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SaGa",
+        "ja": "サガ",
+        "ja_typings": []
+      },
+      {
+        "en": "Mana",
+        "ja": "聖剣伝説",
+        "ja_typings": [
+          "seikendensetsu"
+        ]
+      },
+      {
+        "en": "Romancing",
+        "ja": "ロマンシング",
+        "ja_typings": []
+      },
+      {
+        "en": "Chrono",
+        "ja": "クロノ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01438",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game series features the SaGa Frontier?",
+      "ja": "サガフロンティアが属するシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Secret of Mana",
+        "ja": "聖剣伝説2",
+        "ja_typings": [
+          "seikendensetsu2"
+        ]
+      },
+      {
+        "en": "Chrono Trigger",
+        "ja": "クロノ・トリガー",
+        "ja_typings": []
+      },
+      {
+        "en": "Terranigma",
+        "ja": "天地創造",
+        "ja_typings": [
+          "tenchisouzou"
+        ]
+      },
+      {
+        "en": "Soul Blazer",
+        "ja": "ソウルブレイダー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01439",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1993 SNES action RPG features the Mana Tree?",
+      "ja": "1993年のスーファミでマナの樹が登場するアクションRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Terranigma",
+        "ja": "天地創造",
+        "ja_typings": [
+          "tenchisouzou"
+        ]
+      },
+      {
+        "en": "Soul Blazer",
+        "ja": "ソウルブレイダー",
+        "ja_typings": []
+      },
+      {
+        "en": "Illusion of Gaia",
+        "ja": "ガイア幻想紀",
+        "ja_typings": [
+          "gaiagensouki"
+        ]
+      },
+      {
+        "en": "ActRaiser",
+        "ja": "アクトレイザー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01440",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1995 SNES action RPG by Quintet is set on a rebuilding Earth?",
+      "ja": "1995年クインテット制作で地球再生がテーマのスーファミ作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Section Z",
+        "ja": "セクションZ",
+        "ja_typings": []
+      },
+      {
+        "en": "Bionic Commando",
+        "ja": "ヒットラーの復活",
+        "ja_typings": [
+          "hittoraanofukkatsu"
+        ]
+      },
+      {
+        "en": "Strider",
+        "ja": "ストライダー飛竜",
+        "ja_typings": [
+          "sutoraidaahiryuu"
+        ]
+      },
+      {
+        "en": "Trojan",
+        "ja": "闘いの挽歌",
+        "ja_typings": [
+          "tatakainobanka"
+        ]
+      }
+    ],
+    "correct_answer_index": 2,
+    "genre": "game",
+    "id": "q01441",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1986 Capcom platformer features the Red Falcon enemies?",
+      "ja": "1986年カプコンの横スクロール作品でレッドファルコンが登場する作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Darkstalkers",
+        "ja": "ヴァンパイア",
+        "ja_typings": []
+      },
+      {
+        "en": "Cyberbots",
+        "ja": "サイバーボッツ",
+        "ja_typings": []
+      },
+      {
+        "en": "Red Earth",
+        "ja": "ウォーザード",
+        "ja_typings": []
+      },
+      {
+        "en": "Star Gladiator",
+        "ja": "スターグラディエイター",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01442",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1994 Capcom 2D fighter starts the Darkstalkers series?",
+      "ja": "1994年カプコンの2D格闘ゲームでヴァンパイアシリーズ第1作は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fatal Fury",
+        "ja": "餓狼伝説",
+        "ja_typings": [
+          "garoudensetsu"
+        ]
+      },
+      {
+        "en": "Art of Fighting",
+        "ja": "龍虎の拳",
+        "ja_typings": [
+          "ryuukonoken"
+        ]
+      },
+      {
+        "en": "Samurai Shodown",
+        "ja": "サムライスピリッツ",
+        "ja_typings": []
+      },
+      {
+        "en": "King of Fighters",
+        "ja": "ザ・キング・オブ・ファイターズ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01443",
+    "image_path": null,
+    "question_text": {
+      "en": "Which SNK series features Terry Bogard?",
+      "ja": "テリー・ボガードが登場するSNKシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Art of Fighting",
+        "ja": "龍虎の拳",
+        "ja_typings": [
+          "ryuukonoken"
+        ]
+      },
+      {
+        "en": "Fatal Fury",
+        "ja": "餓狼伝説",
+        "ja_typings": [
+          "garoudensetsu"
+        ]
+      },
+      {
+        "en": "Samurai Shodown",
+        "ja": "サムライスピリッツ",
+        "ja_typings": []
+      },
+      {
+        "en": "Last Blade",
+        "ja": "幕末浪漫",
+        "ja_typings": [
+          "bakumatsuroman"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01444",
+    "image_path": null,
+    "question_text": {
+      "en": "Which SNK series features Ryo Sakazaki?",
+      "ja": "坂崎良が主人公のSNKシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Samurai Shodown",
+        "ja": "サムライスピリッツ",
+        "ja_typings": []
+      },
+      {
+        "en": "Last Blade",
+        "ja": "幕末浪漫",
+        "ja_typings": [
+          "bakumatsuroman"
+        ]
+      },
+      {
+        "en": "Fatal Fury",
+        "ja": "餓狼伝説",
+        "ja_typings": [
+          "garoudensetsu"
+        ]
+      },
+      {
+        "en": "Art of Fighting",
+        "ja": "龍虎の拳",
+        "ja_typings": [
+          "ryuukonoken"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01445",
+    "image_path": null,
+    "question_text": {
+      "en": "Which SNK series features Haohmaru?",
+      "ja": "覇王丸が主人公のSNKシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "King of Fighters",
+        "ja": "ザ・キング・オブ・ファイターズ",
+        "ja_typings": []
+      },
+      {
+        "en": "Fatal Fury",
+        "ja": "餓狼伝説",
+        "ja_typings": [
+          "garoudensetsu"
+        ]
+      },
+      {
+        "en": "Art of Fighting",
+        "ja": "龍虎の拳",
+        "ja_typings": [
+          "ryuukonoken"
+        ]
+      },
+      {
+        "en": "Samurai Shodown",
+        "ja": "サムライスピリッツ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01446",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1996 SNK fighter introduced team battle with Kyo Kusanagi?",
+      "ja": "草薙京が登場し、チーム制を導入した1996年のSNK格闘は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dreamcast",
+        "ja": "ドリームキャスト",
+        "ja_typings": []
+      },
+      {
+        "en": "Saturn",
+        "ja": "セガサターン",
+        "ja_typings": [
+          "segasataan"
+        ]
+      },
+      {
+        "en": "Mega Drive",
+        "ja": "メガドライブ",
+        "ja_typings": []
+      },
+      {
+        "en": "Game Gear",
+        "ja": "ゲームギア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01447",
+    "image_path": null,
+    "question_text": {
+      "en": "Which platform was released by SEGA in 1998 as a successor to the Saturn?",
+      "ja": "1998年セガがサターンの後継機として発売したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Neo Geo",
+        "ja": "ネオジオ",
+        "ja_typings": []
+      },
+      {
+        "en": "PC Engine",
+        "ja": "PCエンジン",
+        "ja_typings": []
+      },
+      {
+        "en": "Mega Drive",
+        "ja": "メガドライブ",
+        "ja_typings": []
+      },
+      {
+        "en": "Wonder Swan",
+        "ja": "ワンダースワン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01448",
+    "image_path": null,
+    "question_text": {
+      "en": "Which platform was released by SNK in 1990?",
+      "ja": "1990年にSNKが発売した家庭用ゲーム機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PC Engine",
+        "ja": "PCエンジン",
+        "ja_typings": []
+      },
+      {
+        "en": "Neo Geo",
+        "ja": "ネオジオ",
+        "ja_typings": []
+      },
+      {
+        "en": "Mega Drive",
+        "ja": "メガドライブ",
+        "ja_typings": []
+      },
+      {
+        "en": "FM Towns Marty",
+        "ja": "FMタウンズマーティー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01449",
+    "image_path": null,
+    "question_text": {
+      "en": "Which platform was released by NEC in 1987?",
+      "ja": "1987年にNECが発売した家庭用ゲーム機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wonder Swan",
+        "ja": "ワンダースワン",
+        "ja_typings": []
+      },
+      {
+        "en": "Game Gear",
+        "ja": "ゲームギア",
+        "ja_typings": []
+      },
+      {
+        "en": "Neo Geo Pocket",
+        "ja": "ネオジオポケット",
+        "ja_typings": []
+      },
+      {
+        "en": "PC Engine GT",
+        "ja": "PCエンジンGT",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01450",
+    "image_path": null,
+    "question_text": {
+      "en": "Which handheld was released by Bandai in 1999?",
+      "ja": "1999年にバンダイが発売した携帯ゲーム機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Neo Geo Pocket",
+        "ja": "ネオジオポケット",
+        "ja_typings": []
+      },
+      {
+        "en": "Wonder Swan",
+        "ja": "ワンダースワン",
+        "ja_typings": []
+      },
+      {
+        "en": "Game Gear",
+        "ja": "ゲームギア",
+        "ja_typings": []
+      },
+      {
+        "en": "PC Engine GT",
+        "ja": "PCエンジンGT",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01451",
+    "image_path": null,
+    "question_text": {
+      "en": "Which handheld was released by SNK in 1998?",
+      "ja": "1998年にSNKが発売した携帯ゲーム機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Celeste",
+        "ja": "セレステ",
+        "ja_typings": []
+      },
+      {
+        "en": "Hyper Light Drifter",
+        "ja": "ハイパーライトドリフター",
+        "ja_typings": []
+      },
+      {
+        "en": "Hades",
+        "ja": "ハデス",
+        "ja_typings": []
+      },
+      {
+        "en": "Cuphead",
+        "ja": "カップヘッド",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01452",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2017 indie game features Madeline climbing a mountain?",
+      "ja": "マデリーンが山を登る2017年のインディーゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hades",
+        "ja": "ハデス",
+        "ja_typings": []
+      },
+      {
+        "en": "Bastion",
+        "ja": "バスティオン",
+        "ja_typings": []
+      },
+      {
+        "en": "Transistor",
+        "ja": "トランジスター",
+        "ja_typings": []
+      },
+      {
+        "en": "Pyre",
+        "ja": "パイア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01453",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2020 Supergiant indie game features Zagreus escaping the Underworld?",
+      "ja": "ザグレウスが冥界脱出を目指す2020年のスーパージャイアント作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cuphead",
+        "ja": "カップヘッド",
+        "ja_typings": []
+      },
+      {
+        "en": "Celeste",
+        "ja": "セレステ",
+        "ja_typings": []
+      },
+      {
+        "en": "Shovel Knight",
+        "ja": "ショベルナイト",
+        "ja_typings": []
+      },
+      {
+        "en": "Pizza Tower",
+        "ja": "ピザタワー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01454",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2017 run-and-gun indie features 1930s cartoon aesthetics?",
+      "ja": "1930年代カートゥーン風の2017年ラン&ガンインディーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shovel Knight",
+        "ja": "ショベルナイト",
+        "ja_typings": []
+      },
+      {
+        "en": "Cuphead",
+        "ja": "カップヘッド",
+        "ja_typings": []
+      },
+      {
+        "en": "Celeste",
+        "ja": "セレステ",
+        "ja_typings": []
+      },
+      {
+        "en": "Axiom Verge",
+        "ja": "アクシオムバージ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01455",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2014 indie crowdfunded retro platformer features a digging knight?",
+      "ja": "2014年クラウドファンディング発のレトロ調アクションで掘る騎士が主人公の作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chrono Cross",
+        "ja": "クロノ・クロス",
+        "ja_typings": []
+      },
+      {
+        "en": "Xenogears",
+        "ja": "ゼノギアス",
+        "ja_typings": []
+      },
+      {
+        "en": "Parasite Eve",
+        "ja": "パラサイト・イヴ",
+        "ja_typings": []
+      },
+      {
+        "en": "Vagrant Story",
+        "ja": "ベイグラントストーリー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01456",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1998 SquareSoft RPG features Serge and Kid?",
+      "ja": "セルジュとキッドが登場する1998年スクウェアのRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Xenogears",
+        "ja": "ゼノギアス",
+        "ja_typings": []
+      },
+      {
+        "en": "Chrono Cross",
+        "ja": "クロノ・クロス",
+        "ja_typings": []
+      },
+      {
+        "en": "Vagrant Story",
+        "ja": "ベイグラントストーリー",
+        "ja_typings": []
+      },
+      {
+        "en": "Parasite Eve",
+        "ja": "パラサイト・イヴ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01457",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1998 Square RPG by Tetsuya Takahashi features Fei Fong Wong?",
+      "ja": "1998年スクウェアの高橋哲哉作でフェイ・フォン・ウォンが主人公のRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vagrant Story",
+        "ja": "ベイグラントストーリー",
+        "ja_typings": []
+      },
+      {
+        "en": "Xenogears",
+        "ja": "ゼノギアス",
+        "ja_typings": []
+      },
+      {
+        "en": "Chrono Cross",
+        "ja": "クロノ・クロス",
+        "ja_typings": []
+      },
+      {
+        "en": "Parasite Eve",
+        "ja": "パラサイト・イヴ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01458",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2000 Square PS1 game by Yasumi Matsuno features Ashley Riot?",
+      "ja": "2000年スクウェアの松野泰己作品でアシュレイ・ライオットが主人公のPS1作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Greece",
+        "ja": "ギリシャ",
+        "ja_typings": []
+      },
+      {
+        "en": "Cyprus",
+        "ja": "キプロス",
+        "ja_typings": []
+      },
+      {
+        "en": "Malta",
+        "ja": "マルタ",
+        "ja_typings": []
+      },
+      {
+        "en": "Albania",
+        "ja": "アルバニア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01459",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Athens as its capital?",
+      "ja": "アテネを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hungary",
+        "ja": "ハンガリー",
+        "ja_typings": []
+      },
+      {
+        "en": "Bulgaria",
+        "ja": "ブルガリア",
+        "ja_typings": []
+      },
+      {
+        "en": "Serbia",
+        "ja": "セルビア",
+        "ja_typings": []
+      },
+      {
+        "en": "Romania",
+        "ja": "ルーマニア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01460",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Budapest as its capital?",
+      "ja": "ブダペストを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Switzerland",
+        "ja": "スイス",
+        "ja_typings": []
+      },
+      {
+        "en": "Liechtenstein",
+        "ja": "リヒテンシュタイン",
+        "ja_typings": []
+      },
+      {
+        "en": "Luxembourg",
+        "ja": "ルクセンブルク",
+        "ja_typings": []
+      },
+      {
+        "en": "Monaco",
+        "ja": "モナコ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01461",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Bern as its capital?",
+      "ja": "ベルンを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ireland",
+        "ja": "アイルランド",
+        "ja_typings": []
+      },
+      {
+        "en": "Scotland",
+        "ja": "スコットランド",
+        "ja_typings": []
+      },
+      {
+        "en": "Wales",
+        "ja": "ウェールズ",
+        "ja_typings": []
+      },
+      {
+        "en": "Malta",
+        "ja": "マルタ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01462",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Dublin as its capital?",
+      "ja": "ダブリンを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thailand",
+        "ja": "タイ王国",
+        "ja_typings": [
+          "taioukoku"
+        ]
+      },
+      {
+        "en": "Myanmar",
+        "ja": "ミャンマー",
+        "ja_typings": []
+      },
+      {
+        "en": "Laos",
+        "ja": "ラオス",
+        "ja_typings": []
+      },
+      {
+        "en": "Cambodia",
+        "ja": "カンボジア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01463",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Bangkok as its capital?",
+      "ja": "バンコクを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Malaysia",
+        "ja": "マレーシア",
+        "ja_typings": []
+      },
+      {
+        "en": "Brunei",
+        "ja": "ブルネイ",
+        "ja_typings": []
+      },
+      {
+        "en": "Philippines",
+        "ja": "フィリピン共和国",
+        "ja_typings": [
+          "firipinkyouwakoku"
+        ]
+      },
+      {
+        "en": "Indonesia",
+        "ja": "インドネシア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01464",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Kuala Lumpur as its capital?",
+      "ja": "クアラルンプールを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Philippines",
+        "ja": "フィリピン",
+        "ja_typings": []
+      },
+      {
+        "en": "Indonesia",
+        "ja": "インドネシア",
+        "ja_typings": []
+      },
+      {
+        "en": "Malaysia",
+        "ja": "マレーシア",
+        "ja_typings": []
+      },
+      {
+        "en": "Brunei",
+        "ja": "ブルネイ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01465",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Manila as its capital?",
+      "ja": "マニラを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Iran",
+        "ja": "イラン",
+        "ja_typings": []
+      },
+      {
+        "en": "Iraq",
+        "ja": "イラク",
+        "ja_typings": []
+      },
+      {
+        "en": "Afghanistan",
+        "ja": "アフガニスタン",
+        "ja_typings": []
+      },
+      {
+        "en": "Pakistan",
+        "ja": "パキスタン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01466",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Tehran as its capital?",
+      "ja": "テヘランを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Saudi Arabia",
+        "ja": "サウジアラビア",
+        "ja_typings": []
+      },
+      {
+        "en": "UAE",
+        "ja": "アラブ首長国連邦",
+        "ja_typings": [
+          "arabushuchoukokurenpou"
+        ]
+      },
+      {
+        "en": "Qatar",
+        "ja": "カタール",
+        "ja_typings": []
+      },
+      {
+        "en": "Kuwait",
+        "ja": "クウェート",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01467",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Riyadh as its capital?",
+      "ja": "リヤドを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ethiopia",
+        "ja": "エチオピア",
+        "ja_typings": []
+      },
+      {
+        "en": "Eritrea",
+        "ja": "エリトリア",
+        "ja_typings": []
+      },
+      {
+        "en": "Somalia",
+        "ja": "ソマリア",
+        "ja_typings": []
+      },
+      {
+        "en": "Sudan",
+        "ja": "スーダン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01468",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Addis Ababa as its capital?",
+      "ja": "アディスアベバを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chile",
+        "ja": "チリ",
+        "ja_typings": []
+      },
+      {
+        "en": "Uruguay",
+        "ja": "ウルグアイ",
+        "ja_typings": []
+      },
+      {
+        "en": "Paraguay",
+        "ja": "パラグアイ",
+        "ja_typings": []
+      },
+      {
+        "en": "Bolivia",
+        "ja": "ボリビア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01469",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Santiago as its capital?",
+      "ja": "サンティアゴを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Colombia",
+        "ja": "コロンビア",
+        "ja_typings": []
+      },
+      {
+        "en": "Venezuela",
+        "ja": "ベネズエラ",
+        "ja_typings": []
+      },
+      {
+        "en": "Ecuador",
+        "ja": "エクアドル",
+        "ja_typings": []
+      },
+      {
+        "en": "Panama",
+        "ja": "パナマ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01470",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Bogota as its capital?",
+      "ja": "ボゴタを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cuba",
+        "ja": "キューバ",
+        "ja_typings": []
+      },
+      {
+        "en": "Jamaica",
+        "ja": "ジャマイカ",
+        "ja_typings": []
+      },
+      {
+        "en": "Haiti",
+        "ja": "ハイチ",
+        "ja_typings": []
+      },
+      {
+        "en": "Dominican Republic",
+        "ja": "ドミニカ共和国",
+        "ja_typings": [
+          "dominikakyouwakoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01471",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Havana as its capital?",
+      "ja": "ハバナを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Volga",
+        "ja": "ヴォルガ川",
+        "ja_typings": [
+          "vorugagawa"
+        ]
+      },
+      {
+        "en": "Danube",
+        "ja": "ドナウ川",
+        "ja_typings": [
+          "donaugawa"
+        ]
+      },
+      {
+        "en": "Rhine",
+        "ja": "ライン川",
+        "ja_typings": [
+          "raingawa"
+        ]
+      },
+      {
+        "en": "Loire",
+        "ja": "ロワール川",
+        "ja_typings": [
+          "rowaarugawa",
+          "rowa-rugawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01472",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the longest river in Europe?",
+      "ja": "ヨーロッパで最も長い川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Missouri",
+        "ja": "ミズーリ川",
+        "ja_typings": [
+          "mizuurigawa",
+          "mizu-rigawa"
+        ]
+      },
+      {
+        "en": "Mississippi",
+        "ja": "ミシシッピ川",
+        "ja_typings": [
+          "mishishippigawa"
+        ]
+      },
+      {
+        "en": "Colorado",
+        "ja": "コロラド川",
+        "ja_typings": [
+          "kororadogawa"
+        ]
+      },
+      {
+        "en": "Yukon",
+        "ja": "ユーコン川",
+        "ja_typings": [
+          "yuukongawa",
+          "yu-kongawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01473",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the longest river in North America?",
+      "ja": "北米で最も長い川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yangtze",
+        "ja": "長江",
+        "ja_typings": [
+          "choukou"
+        ]
+      },
+      {
+        "en": "Yellow River",
+        "ja": "黄河",
+        "ja_typings": [
+          "kouga"
+        ]
+      },
+      {
+        "en": "Pearl River",
+        "ja": "珠江",
+        "ja_typings": [
+          "shukou",
+          "zhujiang"
+        ]
+      },
+      {
+        "en": "Mekong",
+        "ja": "メコン川",
+        "ja_typings": [
+          "mekongawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01474",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the longest river in China?",
+      "ja": "中国で最も長い川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Apennines",
+        "ja": "アペニン山脈",
+        "ja_typings": [
+          "apeninsanmyaku"
+        ]
+      },
+      {
+        "en": "Alps",
+        "ja": "アルプス山脈",
+        "ja_typings": [
+          "arupususanmyaku"
+        ]
+      },
+      {
+        "en": "Carpathians",
+        "ja": "カルパティア山脈",
+        "ja_typings": [
+          "karupatiasanmyaku"
+        ]
+      },
+      {
+        "en": "Balkans",
+        "ja": "バルカン山脈",
+        "ja_typings": [
+          "barukansanmyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01475",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mountain range runs through Italy?",
+      "ja": "イタリアを縦断する山脈は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Antarctic Desert",
+        "ja": "南極砂漠",
+        "ja_typings": [
+          "nankyokusabaku"
+        ]
+      },
+      {
+        "en": "Arctic Desert",
+        "ja": "北極砂漠",
+        "ja_typings": [
+          "hokkyokusabaku"
+        ]
+      },
+      {
+        "en": "Gobi Desert",
+        "ja": "ゴビ砂漠",
+        "ja_typings": [
+          "gobisabaku"
+        ]
+      },
+      {
+        "en": "Atacama Desert",
+        "ja": "アタカマ砂漠",
+        "ja_typings": [
+          "atakamasabaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01476",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the largest desert on Earth?",
+      "ja": "地球で最も広い砂漠は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gobi",
+        "ja": "ゴビ砂漠",
+        "ja_typings": [
+          "gobisabaku"
+        ]
+      },
+      {
+        "en": "Taklamakan",
+        "ja": "タクラマカン砂漠",
+        "ja_typings": [
+          "takuramakansabaku"
+        ]
+      },
+      {
+        "en": "Karakum",
+        "ja": "カラクム砂漠",
+        "ja_typings": [
+          "karakumusabaku"
+        ]
+      },
+      {
+        "en": "Thar",
+        "ja": "タール砂漠",
+        "ja_typings": [
+          "ta-rusabaku",
+          "taarusabaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01477",
+    "image_path": null,
+    "question_text": {
+      "en": "Which desert is in Mongolia and China?",
+      "ja": "モンゴルと中国にまたがる砂漠は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lake Victoria",
+        "ja": "ヴィクトリア湖",
+        "ja_typings": [
+          "vikutoriako"
+        ]
+      },
+      {
+        "en": "Lake Tanganyika",
+        "ja": "タンガニーカ湖",
+        "ja_typings": [
+          "tangani-kako",
+          "tanganiikako"
+        ]
+      },
+      {
+        "en": "Lake Malawi",
+        "ja": "マラウイ湖",
+        "ja_typings": [
+          "maraiko",
+          "marauiko"
+        ]
+      },
+      {
+        "en": "Lake Chad",
+        "ja": "チャド湖",
+        "ja_typings": [
+          "chadoko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01478",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the largest lake in Africa?",
+      "ja": "アフリカで最大の湖は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Italian Peninsula",
+        "ja": "イタリア半島",
+        "ja_typings": [
+          "itariahantou"
+        ]
+      },
+      {
+        "en": "Iberian Peninsula",
+        "ja": "イベリア半島",
+        "ja_typings": [
+          "iberiahantou"
+        ]
+      },
+      {
+        "en": "Balkan Peninsula",
+        "ja": "バルカン半島",
+        "ja_typings": [
+          "barukanhantou"
+        ]
+      },
+      {
+        "en": "Scandinavian Peninsula",
+        "ja": "スカンディナビア半島",
+        "ja_typings": [
+          "sukandinabiahantou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01479",
+    "image_path": null,
+    "question_text": {
+      "en": "Which peninsula is located in southern Europe and shaped like a boot?",
+      "ja": "ブーツ型の南欧の半島は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Iberian",
+        "ja": "イベリア半島",
+        "ja_typings": [
+          "iberiahantou"
+        ]
+      },
+      {
+        "en": "Balkan",
+        "ja": "バルカン半島",
+        "ja_typings": [
+          "barukanhantou"
+        ]
+      },
+      {
+        "en": "Apennine",
+        "ja": "アペニン半島",
+        "ja_typings": [
+          "apeninhantou"
+        ]
+      },
+      {
+        "en": "Anatolian",
+        "ja": "アナトリア半島",
+        "ja_typings": [
+          "anatoriahantou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01480",
+    "image_path": null,
+    "question_text": {
+      "en": "Which peninsula contains Spain and Portugal?",
+      "ja": "スペインとポルトガルがある半島は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sicily",
+        "ja": "シチリア島",
+        "ja_typings": [
+          "shichiriatou"
+        ]
+      },
+      {
+        "en": "Sardinia",
+        "ja": "サルデーニャ島",
+        "ja_typings": [
+          "sarude-nyatou",
+          "sardeenyatou"
+        ]
+      },
+      {
+        "en": "Cyprus",
+        "ja": "キプロス島",
+        "ja_typings": [
+          "kipurosutou"
+        ]
+      },
+      {
+        "en": "Corsica",
+        "ja": "コルシカ島",
+        "ja_typings": [
+          "korushikatou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01481",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the largest island in the Mediterranean?",
+      "ja": "地中海最大の島は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Oceania",
+        "ja": "オセアニア",
+        "ja_typings": []
+      },
+      {
+        "en": "Europe",
+        "ja": "ヨーロッパ",
+        "ja_typings": []
+      },
+      {
+        "en": "Antarctica",
+        "ja": "南極大陸",
+        "ja_typings": [
+          "nankyokutairiku"
+        ]
+      },
+      {
+        "en": "Africa",
+        "ja": "アフリカ大陸",
+        "ja_typings": [
+          "afurikatairiku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01482",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the smallest continent?",
+      "ja": "最も小さい大陸は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mediterranean Sea",
+        "ja": "地中海",
+        "ja_typings": [
+          "chichuukai"
+        ]
+      },
+      {
+        "en": "Black Sea",
+        "ja": "黒海",
+        "ja_typings": [
+          "kokkai"
+        ]
+      },
+      {
+        "en": "Red Sea",
+        "ja": "紅海",
+        "ja_typings": [
+          "koukai"
+        ]
+      },
+      {
+        "en": "Caspian Sea",
+        "ja": "カスピ海",
+        "ja_typings": [
+          "kasupikai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01483",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sea lies between Europe and Africa?",
+      "ja": "ヨーロッパとアフリカの間にある海は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Brazil",
+        "ja": "ブラジル連邦共和国",
+        "ja_typings": [
+          "burajirurenpoukyouwakoku"
+        ]
+      },
+      {
+        "en": "Argentina",
+        "ja": "アルゼンチン",
+        "ja_typings": []
+      },
+      {
+        "en": "Peru",
+        "ja": "ペルー",
+        "ja_typings": []
+      },
+      {
+        "en": "Colombia",
+        "ja": "コロンビア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01484",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the largest country by area in South America?",
+      "ja": "南米で面積最大の国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Algeria",
+        "ja": "アルジェリア",
+        "ja_typings": []
+      },
+      {
+        "en": "Sudan",
+        "ja": "スーダン",
+        "ja_typings": []
+      },
+      {
+        "en": "Libya",
+        "ja": "リビア",
+        "ja_typings": []
+      },
+      {
+        "en": "Chad",
+        "ja": "チャド",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01485",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the largest country by area in Africa?",
+      "ja": "アフリカで面積最大の国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Japan",
+        "ja": "日出国",
+        "ja_typings": [
+          "hiizurukuni"
+        ]
+      },
+      {
+        "en": "Korea",
+        "ja": "朝鮮",
+        "ja_typings": [
+          "chousen"
+        ]
+      },
+      {
+        "en": "China",
+        "ja": "中華",
+        "ja_typings": [
+          "chuuka"
+        ]
+      },
+      {
+        "en": "Mongolia",
+        "ja": "モンゴル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01486",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country is known as the Land of the Rising Sun?",
+      "ja": "「日出ずる国」と呼ばれる国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chile",
+        "ja": "チリ共和国",
+        "ja_typings": [
+          "chirikyouwakoku"
+        ]
+      },
+      {
+        "en": "Peru",
+        "ja": "ペルー",
+        "ja_typings": []
+      },
+      {
+        "en": "Ecuador",
+        "ja": "エクアドル",
+        "ja_typings": []
+      },
+      {
+        "en": "Bolivia",
+        "ja": "ボリビア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01487",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country is shaped like a long thin strip on the west of South America?",
+      "ja": "南米西岸で細長い形の国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Italy",
+        "ja": "イタリア共和国",
+        "ja_typings": [
+          "itariakyouwakoku"
+        ]
+      },
+      {
+        "en": "Spain",
+        "ja": "スペイン",
+        "ja_typings": []
+      },
+      {
+        "en": "France",
+        "ja": "フランス",
+        "ja_typings": []
+      },
+      {
+        "en": "Switzerland",
+        "ja": "スイス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01488",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country surrounds the Vatican City?",
+      "ja": "バチカン市国を囲む国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Qin Shi Huang",
+        "ja": "始皇帝",
+        "ja_typings": [
+          "shikoutei"
+        ]
+      },
+      {
+        "en": "Liu Bang",
+        "ja": "劉邦",
+        "ja_typings": [
+          "ryuuhou"
+        ]
+      },
+      {
+        "en": "Wu Zetian",
+        "ja": "武則天",
+        "ja_typings": [
+          "sokuten"
+        ]
+      },
+      {
+        "en": "Kublai Khan",
+        "ja": "フビライ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01489",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first Emperor of unified China?",
+      "ja": "中国を初めて統一した皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Louis-Napoleon",
+        "ja": "ルイ・ナポレオン",
+        "ja_typings": []
+      },
+      {
+        "en": "Adolphe Thiers",
+        "ja": "ティエール",
+        "ja_typings": [
+          "tie-ru",
+          "tieeru"
+        ]
+      },
+      {
+        "en": "Jules Grevy",
+        "ja": "グレヴィ",
+        "ja_typings": []
+      },
+      {
+        "en": "Sadi Carnot",
+        "ja": "カルノー",
+        "ja_typings": [
+          "karuno-",
+          "karunoo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01490",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first President of the French Republic?",
+      "ja": "フランス第二共和政の初代大統領は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bismarck",
+        "ja": "ビスマルク",
+        "ja_typings": []
+      },
+      {
+        "en": "Wilhelm I",
+        "ja": "ヴィルヘルム一世",
+        "ja_typings": [
+          "viruherumuissei"
+        ]
+      },
+      {
+        "en": "Metternich",
+        "ja": "メッテルニヒ",
+        "ja_typings": []
+      },
+      {
+        "en": "Hindenburg",
+        "ja": "ヒンデンブルク",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01491",
+    "image_path": null,
+    "question_text": {
+      "en": "Who unified Germany in 1871?",
+      "ja": "1871年にドイツを統一した人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Stalin",
+        "ja": "スターリン",
+        "ja_typings": []
+      },
+      {
+        "en": "Lenin",
+        "ja": "レーニン",
+        "ja_typings": []
+      },
+      {
+        "en": "Khrushchev",
+        "ja": "フルシチョフ",
+        "ja_typings": []
+      },
+      {
+        "en": "Trotsky",
+        "ja": "トロツキー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01492",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led the Soviet Union during World War II?",
+      "ja": "第二次大戦中のソ連指導者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Churchill",
+        "ja": "チャーチル",
+        "ja_typings": []
+      },
+      {
+        "en": "Chamberlain",
+        "ja": "チェンバレン",
+        "ja_typings": []
+      },
+      {
+        "en": "Attlee",
+        "ja": "アトリー",
+        "ja_typings": []
+      },
+      {
+        "en": "Eden",
+        "ja": "イーデン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01493",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the British Prime Minister during most of WWII?",
+      "ja": "第二次大戦中の英首相は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Roosevelt",
+        "ja": "ルーズベルト",
+        "ja_typings": []
+      },
+      {
+        "en": "Truman",
+        "ja": "トルーマン",
+        "ja_typings": []
+      },
+      {
+        "en": "Eisenhower",
+        "ja": "アイゼンハワー",
+        "ja_typings": []
+      },
+      {
+        "en": "Hoover",
+        "ja": "フーヴァー",
+        "ja_typings": [
+          "fu-vaa",
+          "fuuvaa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01494",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the US President during WWII?",
+      "ja": "第二次大戦中の米大統領は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hitler",
+        "ja": "ヒトラー",
+        "ja_typings": []
+      },
+      {
+        "en": "Goering",
+        "ja": "ゲーリング",
+        "ja_typings": []
+      },
+      {
+        "en": "Himmler",
+        "ja": "ヒムラー",
+        "ja_typings": []
+      },
+      {
+        "en": "Goebbels",
+        "ja": "ゲッベルス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01495",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first Chancellor of Nazi Germany?",
+      "ja": "ナチス・ドイツの最初の首相は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gandhi",
+        "ja": "ガンディー",
+        "ja_typings": []
+      },
+      {
+        "en": "Nehru",
+        "ja": "ネルー",
+        "ja_typings": []
+      },
+      {
+        "en": "Jinnah",
+        "ja": "ジンナー",
+        "ja_typings": []
+      },
+      {
+        "en": "Bose",
+        "ja": "ボース",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01496",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led India's independence movement?",
+      "ja": "インド独立運動を率いたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nehru",
+        "ja": "ネルー",
+        "ja_typings": []
+      },
+      {
+        "en": "Gandhi",
+        "ja": "ガンディー",
+        "ja_typings": []
+      },
+      {
+        "en": "Patel",
+        "ja": "パテル",
+        "ja_typings": []
+      },
+      {
+        "en": "Bose",
+        "ja": "ボース",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01497",
+    "image_path": null,
+    "question_text": {
+      "en": "Who became the first Prime Minister of independent India?",
+      "ja": "インド独立後の初代首相は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mandela",
+        "ja": "マンデラ",
+        "ja_typings": []
+      },
+      {
+        "en": "Mbeki",
+        "ja": "ムベキ",
+        "ja_typings": []
+      },
+      {
+        "en": "Zuma",
+        "ja": "ズマ",
+        "ja_typings": []
+      },
+      {
+        "en": "De Klerk",
+        "ja": "デクラーク",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01498",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first President of South Africa after apartheid?",
+      "ja": "南アフリカでアパルトヘイト後初の大統領は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ivan IV",
+        "ja": "イヴァン四世",
+        "ja_typings": [
+          "ivanyonsei"
+        ]
+      },
+      {
+        "en": "Peter I",
+        "ja": "ピョートル一世",
+        "ja_typings": [
+          "pyotoruissei"
+        ]
+      },
+      {
+        "en": "Boris Godunov",
+        "ja": "ゴドゥノフ",
+        "ja_typings": []
+      },
+      {
+        "en": "Michael I",
+        "ja": "ミハイル一世",
+        "ja_typings": [
+          "mihairuissei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01499",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first Tsar of Russia?",
+      "ja": "ロシア最初のツァーリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Peter the Great",
+        "ja": "ピョートル大帝",
+        "ja_typings": [
+          "pyotorutaitei"
+        ]
+      },
+      {
+        "en": "Catherine the Great",
+        "ja": "エカチェリーナ二世",
+        "ja_typings": [
+          "ekacheri-nanisei",
+          "ekacheriinanisei"
+        ]
+      },
+      {
+        "en": "Alexander I",
+        "ja": "アレクサンドル一世",
+        "ja_typings": [
+          "arekusandoruissei"
+        ]
+      },
+      {
+        "en": "Nicholas II",
+        "ja": "ニコライ二世",
+        "ja_typings": [
+          "nikorainisei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01500",
+    "image_path": null,
+    "question_text": {
+      "en": "Who modernized Russia in the early 18th century?",
+      "ja": "18世紀初頭にロシアを近代化した皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Elizabeth I",
+        "ja": "エリザベス一世",
+        "ja_typings": [
+          "erizabesuissei"
+        ]
+      },
+      {
+        "en": "Mary I",
+        "ja": "メアリー一世",
+        "ja_typings": [
+          "meari-issei",
+          "meariiissei"
+        ]
+      },
+      {
+        "en": "Victoria",
+        "ja": "ヴィクトリア女王",
+        "ja_typings": [
+          "vikutoriajoou"
+        ]
+      },
+      {
+        "en": "Anne",
+        "ja": "アン女王",
+        "ja_typings": [
+          "anjoou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01501",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Queen of England during the Spanish Armada defeat?",
+      "ja": "スペイン無敵艦隊撃退時の英女王は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Castro",
+        "ja": "カストロ",
+        "ja_typings": []
+      },
+      {
+        "en": "Guevara",
+        "ja": "ゲバラ",
+        "ja_typings": []
+      },
+      {
+        "en": "Batista",
+        "ja": "バティスタ",
+        "ja_typings": []
+      },
+      {
+        "en": "Allende",
+        "ja": "アジェンデ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01502",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led the Cuban Revolution?",
+      "ja": "キューバ革命を率いたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Augustus",
+        "ja": "アウグストゥス",
+        "ja_typings": []
+      },
+      {
+        "en": "Nero",
+        "ja": "ネロ",
+        "ja_typings": []
+      },
+      {
+        "en": "Tiberius",
+        "ja": "ティベリウス",
+        "ja_typings": []
+      },
+      {
+        "en": "Caligula",
+        "ja": "カリギュラ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01503",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first Emperor of Rome?",
+      "ja": "ローマ初代皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hannibal",
+        "ja": "ハンニバル",
+        "ja_typings": []
+      },
+      {
+        "en": "Hasdrubal",
+        "ja": "ハスドルバル",
+        "ja_typings": []
+      },
+      {
+        "en": "Hamilcar",
+        "ja": "ハミルカル",
+        "ja_typings": []
+      },
+      {
+        "en": "Scipio",
+        "ja": "スキピオ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01504",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Carthaginian general who crossed the Alps?",
+      "ja": "アルプスを越えたカルタゴの将軍は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ming",
+        "ja": "明",
+        "ja_typings": [
+          "min"
+        ]
+      },
+      {
+        "en": "Song",
+        "ja": "宋",
+        "ja_typings": [
+          "sou"
+        ]
+      },
+      {
+        "en": "Jin",
+        "ja": "金",
+        "ja_typings": [
+          "kin"
+        ]
+      },
+      {
+        "en": "Liao",
+        "ja": "遼",
+        "ja_typings": [
+          "ryou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01505",
+    "image_path": null,
+    "question_text": {
+      "en": "Which dynasty built most of the Great Wall as seen today?",
+      "ja": "現在の万里の長城を主に築いた王朝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ming dynasty",
+        "ja": "明朝",
+        "ja_typings": [
+          "minchou"
+        ]
+      },
+      {
+        "en": "Yuan dynasty",
+        "ja": "元朝",
+        "ja_typings": [
+          "genchou"
+        ]
+      },
+      {
+        "en": "Song dynasty",
+        "ja": "宋朝",
+        "ja_typings": [
+          "souchou"
+        ]
+      },
+      {
+        "en": "Jin dynasty",
+        "ja": "金朝",
+        "ja_typings": [
+          "kinchou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01506",
+    "image_path": null,
+    "question_text": {
+      "en": "Which dynasty ruled China just before the Qing?",
+      "ja": "清の直前に中国を統治した王朝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Taisho",
+        "ja": "大正",
+        "ja_typings": [
+          "taishou"
+        ]
+      },
+      {
+        "en": "Showa",
+        "ja": "昭和",
+        "ja_typings": [
+          "shouwa"
+        ]
+      },
+      {
+        "en": "Heisei",
+        "ja": "平成",
+        "ja_typings": [
+          "heisei"
+        ]
+      },
+      {
+        "en": "Reiwa",
+        "ja": "令和",
+        "ja_typings": [
+          "reiwa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01507",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese era came after Meiji?",
+      "ja": "明治の次の時代は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Showa",
+        "ja": "昭和",
+        "ja_typings": [
+          "shouwa"
+        ]
+      },
+      {
+        "en": "Heisei",
+        "ja": "平成",
+        "ja_typings": [
+          "heisei"
+        ]
+      },
+      {
+        "en": "Reiwa",
+        "ja": "令和",
+        "ja_typings": [
+          "reiwa"
+        ]
+      },
+      {
+        "en": "Meiji",
+        "ja": "明治",
+        "ja_typings": [
+          "meiji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01508",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese era came after Taisho?",
+      "ja": "大正の次の時代は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Treaty of Versailles",
+        "ja": "ヴェルサイユ条約",
+        "ja_typings": [
+          "verusaiyujouyaku"
+        ]
+      },
+      {
+        "en": "Treaty of Trianon",
+        "ja": "トリアノン条約",
+        "ja_typings": [
+          "torianonjouyaku"
+        ]
+      },
+      {
+        "en": "Treaty of Sevres",
+        "ja": "セーヴル条約",
+        "ja_typings": [
+          "se-vurujouyaku",
+          "seevurujouyaku"
+        ]
+      },
+      {
+        "en": "Treaty of Brest-Litovsk",
+        "ja": "ブレスト・リトフスク条約",
+        "ja_typings": [
+          "buresutoritofusukujouyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01509",
+    "image_path": null,
+    "question_text": {
+      "en": "Which treaty ended World War I?",
+      "ja": "第一次大戦を終結させた条約は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Korean War",
+        "ja": "朝鮮戦争",
+        "ja_typings": [
+          "chousensensou"
+        ]
+      },
+      {
+        "en": "Vietnam War",
+        "ja": "ベトナム戦争",
+        "ja_typings": [
+          "betonamusensou"
+        ]
+      },
+      {
+        "en": "Cold War",
+        "ja": "冷戦",
+        "ja_typings": [
+          "reisen"
+        ]
+      },
+      {
+        "en": "Gulf War",
+        "ja": "湾岸戦争",
+        "ja_typings": [
+          "wangansensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01510",
+    "image_path": null,
+    "question_text": {
+      "en": "Which war was fought between 1950 and 1953 on the Korean peninsula?",
+      "ja": "1950-1953年に朝鮮半島で起きた戦争は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gulf War",
+        "ja": "湾岸戦争",
+        "ja_typings": [
+          "wangansensou"
+        ]
+      },
+      {
+        "en": "Iraq War",
+        "ja": "イラク戦争",
+        "ja_typings": [
+          "irakusensou"
+        ]
+      },
+      {
+        "en": "Korean War",
+        "ja": "朝鮮戦争",
+        "ja_typings": [
+          "chousensensou"
+        ]
+      },
+      {
+        "en": "Vietnam War",
+        "ja": "ベトナム戦争",
+        "ja_typings": [
+          "betonamusensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01511",
+    "image_path": null,
+    "question_text": {
+      "en": "Which war was fought between US-led forces and Iraq in 1991?",
+      "ja": "1991年の米国主導とイラクの戦争は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1991",
+        "ja": "1991年",
+        "ja_typings": [
+          "1991nen"
+        ]
+      },
+      {
+        "en": "1989",
+        "ja": "1989年",
+        "ja_typings": [
+          "1989nen"
+        ]
+      },
+      {
+        "en": "1990",
+        "ja": "1990年",
+        "ja_typings": [
+          "1990nen"
+        ]
+      },
+      {
+        "en": "1993",
+        "ja": "1993年",
+        "ja_typings": [
+          "1993nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01512",
+    "image_path": null,
+    "question_text": {
+      "en": "In which year did the Soviet Union dissolve?",
+      "ja": "ソ連が崩壊した年は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1492",
+        "ja": "1492年",
+        "ja_typings": [
+          "1492nen"
+        ]
+      },
+      {
+        "en": "1500",
+        "ja": "1500年",
+        "ja_typings": [
+          "1500nen"
+        ]
+      },
+      {
+        "en": "1453",
+        "ja": "1453年",
+        "ja_typings": [
+          "1453nen"
+        ]
+      },
+      {
+        "en": "1488",
+        "ja": "1488年",
+        "ja_typings": [
+          "1488nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01513",
+    "image_path": null,
+    "question_text": {
+      "en": "In which year did Columbus reach the Americas?",
+      "ja": "コロンブスが新大陸に到達した年は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sumerian",
+        "ja": "シュメール文明",
+        "ja_typings": [
+          "shume-rubunmei",
+          "shumeerubunmei"
+        ]
+      },
+      {
+        "en": "Egyptian",
+        "ja": "エジプト文明",
+        "ja_typings": [
+          "ejiputobunmei"
+        ]
+      },
+      {
+        "en": "Indus",
+        "ja": "インダス文明",
+        "ja_typings": [
+          "indasubunmei"
+        ]
+      },
+      {
+        "en": "Chinese",
+        "ja": "中華文明",
+        "ja_typings": [
+          "chuukabunmei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01514",
+    "image_path": null,
+    "question_text": {
+      "en": "Which civilization is credited with inventing cuneiform writing?",
+      "ja": "楔形文字を発明したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Persian Empire",
+        "ja": "アケメネス朝",
+        "ja_typings": [
+          "akemenesuchou"
+        ]
+      },
+      {
+        "en": "Babylonian Empire",
+        "ja": "バビロニア帝国",
+        "ja_typings": [
+          "babironiateikoku"
+        ]
+      },
+      {
+        "en": "Assyrian Empire",
+        "ja": "アッシリア帝国",
+        "ja_typings": [
+          "asshiriateikoku"
+        ]
+      },
+      {
+        "en": "Hittite Empire",
+        "ja": "ヒッタイト帝国",
+        "ja_typings": [
+          "hittaitoteikoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01515",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient empire was led by Cyrus the Great?",
+      "ja": "キュロス大王が築いた古代帝国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Byzantine Empire",
+        "ja": "ビザンツ帝国",
+        "ja_typings": [
+          "bizantsuteikoku"
+        ]
+      },
+      {
+        "en": "Holy Roman Empire",
+        "ja": "神聖ローマ帝国",
+        "ja_typings": [
+          "shinsei-ro-mateikoku",
+          "shinseiroomateikoku"
+        ]
+      },
+      {
+        "en": "Ottoman Empire",
+        "ja": "オスマン帝国",
+        "ja_typings": [
+          "osumanteikoku"
+        ]
+      },
+      {
+        "en": "Sassanid Empire",
+        "ja": "サーサーン朝",
+        "ja_typings": [
+          "sa-saanchou",
+          "saasaanchou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01516",
+    "image_path": null,
+    "question_text": {
+      "en": "Which empire fell in 1453 with the fall of Constantinople?",
+      "ja": "1453年に滅亡した帝国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ottoman Empire",
+        "ja": "オスマン帝国",
+        "ja_typings": [
+          "osumanteikoku"
+        ]
+      },
+      {
+        "en": "Byzantine Empire",
+        "ja": "ビザンツ帝国",
+        "ja_typings": [
+          "bizantsuteikoku"
+        ]
+      },
+      {
+        "en": "Mongol Empire",
+        "ja": "モンゴル帝国",
+        "ja_typings": [
+          "mongoruteikoku"
+        ]
+      },
+      {
+        "en": "Holy Roman Empire",
+        "ja": "神聖ローマ帝国",
+        "ja_typings": [
+          "shinsei-ro-mateikoku",
+          "shinseiroomateikoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01517",
+    "image_path": null,
+    "question_text": {
+      "en": "Which empire captured Constantinople in 1453?",
+      "ja": "1453年にコンスタンティノープルを陥落させたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gutenberg",
+        "ja": "グーテンベルク",
+        "ja_typings": []
+      },
+      {
+        "en": "Caxton",
+        "ja": "キャクストン",
+        "ja_typings": []
+      },
+      {
+        "en": "Manutius",
+        "ja": "マヌティウス",
+        "ja_typings": []
+      },
+      {
+        "en": "Fust",
+        "ja": "フスト",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01518",
+    "image_path": null,
+    "question_text": {
+      "en": "Who invented the printing press in Europe?",
+      "ja": "ヨーロッパで活版印刷を発明したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bell",
+        "ja": "ベル",
+        "ja_typings": []
+      },
+      {
+        "en": "Edison",
+        "ja": "エジソン",
+        "ja_typings": []
+      },
+      {
+        "en": "Tesla",
+        "ja": "テスラ",
+        "ja_typings": []
+      },
+      {
+        "en": "Marconi",
+        "ja": "マルコーニ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01519",
+    "image_path": null,
+    "question_text": {
+      "en": "Who invented the telephone?",
+      "ja": "電話を発明したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Edison",
+        "ja": "エジソン",
+        "ja_typings": []
+      },
+      {
+        "en": "Tesla",
+        "ja": "テスラ",
+        "ja_typings": []
+      },
+      {
+        "en": "Swan",
+        "ja": "スワン",
+        "ja_typings": []
+      },
+      {
+        "en": "Westinghouse",
+        "ja": "ウェスティングハウス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01520",
+    "image_path": null,
+    "question_text": {
+      "en": "Who invented the light bulb commercially?",
+      "ja": "白熱電球を商用化したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nobel",
+        "ja": "ノーベル",
+        "ja_typings": []
+      },
+      {
+        "en": "Edison",
+        "ja": "エジソン",
+        "ja_typings": []
+      },
+      {
+        "en": "Tesla",
+        "ja": "テスラ",
+        "ja_typings": []
+      },
+      {
+        "en": "Maxwell",
+        "ja": "マクスウェル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01521",
+    "image_path": null,
+    "question_text": {
+      "en": "Who invented dynamite?",
+      "ja": "ダイナマイトを発明したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Luther",
+        "ja": "ルター",
+        "ja_typings": []
+      },
+      {
+        "en": "Calvin",
+        "ja": "カルヴァン",
+        "ja_typings": []
+      },
+      {
+        "en": "Zwingli",
+        "ja": "ツヴィングリ",
+        "ja_typings": []
+      },
+      {
+        "en": "Knox",
+        "ja": "ノックス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01522",
+    "image_path": null,
+    "question_text": {
+      "en": "Which religious reformer launched the Protestant Reformation in 1517?",
+      "ja": "1517年に宗教改革を始めたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Louis XVI",
+        "ja": "ルイ十六世",
+        "ja_typings": [
+          "ruijuurokusei"
+        ]
+      },
+      {
+        "en": "Henry IV",
+        "ja": "アンリ四世",
+        "ja_typings": [
+          "anriyonsei"
+        ]
+      },
+      {
+        "en": "Charles X",
+        "ja": "シャルル十世",
+        "ja_typings": [
+          "sharurujussei"
+        ]
+      },
+      {
+        "en": "Francis I",
+        "ja": "フランソワ一世",
+        "ja_typings": [
+          "furansowaissei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01523",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French king was beheaded during the French Revolution?",
+      "ja": "フランス革命で処刑されたフランス王は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Louis XIV",
+        "ja": "ルイ十四世",
+        "ja_typings": [
+          "ruijuuyonsei"
+        ]
+      },
+      {
+        "en": "Louis XV",
+        "ja": "ルイ十五世",
+        "ja_typings": [
+          "ruijuugosei"
+        ]
+      },
+      {
+        "en": "Louis XIII",
+        "ja": "ルイ十三世",
+        "ja_typings": [
+          "ruijuusansei"
+        ]
+      },
+      {
+        "en": "Henry IV",
+        "ja": "アンリ四世",
+        "ja_typings": [
+          "anriyonsei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01524",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French king was called the Sun King?",
+      "ja": "「太陽王」と呼ばれたフランス王は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hulagu Khan",
+        "ja": "フレグ",
+        "ja_typings": []
+      },
+      {
+        "en": "Kublai Khan",
+        "ja": "フビライ",
+        "ja_typings": []
+      },
+      {
+        "en": "Batu Khan",
+        "ja": "バトゥ",
+        "ja_typings": []
+      },
+      {
+        "en": "Ogedei Khan",
+        "ja": "オゴデイ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01525",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mongol leader conquered Baghdad in 1258?",
+      "ja": "1258年にバグダードを陥落させたモンゴル指導者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Anne",
+        "ja": "アン女王",
+        "ja_typings": [
+          "anjoou"
+        ]
+      },
+      {
+        "en": "Mary II",
+        "ja": "メアリー二世",
+        "ja_typings": [
+          "meari-nisei",
+          "meariinisei"
+        ]
+      },
+      {
+        "en": "Victoria",
+        "ja": "ヴィクトリア女王",
+        "ja_typings": [
+          "vikutoriajoou"
+        ]
+      },
+      {
+        "en": "Elizabeth I",
+        "ja": "エリザベス一世",
+        "ja_typings": [
+          "erizabesuissei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01526",
+    "image_path": null,
+    "question_text": {
+      "en": "Which queen ruled both England and Scotland from 1702?",
+      "ja": "1702年から英国とスコットランドを統治した女王は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yamamoto Isoroku",
+        "ja": "山本五十六",
+        "ja_typings": [
+          "yamamotoisoroku"
+        ]
+      },
+      {
+        "en": "Tojo Hideki",
+        "ja": "東条英機",
+        "ja_typings": [
+          "toujouhideki"
+        ]
+      },
+      {
+        "en": "Nagumo Chuichi",
+        "ja": "南雲忠一",
+        "ja_typings": [
+          "nagumochuuichi"
+        ]
+      },
+      {
+        "en": "Yamashita Tomoyuki",
+        "ja": "山下奉文",
+        "ja_typings": [
+          "yamashitatomoyuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01527",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese general led the attack on Pearl Harbor planning?",
+      "ja": "真珠湾攻撃を立案した日本の提督は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "World War One",
+        "ja": "第一次世界大戦",
+        "ja_typings": [
+          "dai1jisekaitaisen",
+          "daiichijisekaitaisen"
+        ]
+      },
+      {
+        "en": "Balkan War",
+        "ja": "バルカン戦争",
+        "ja_typings": [
+          "barukansensou"
+        ]
+      },
+      {
+        "en": "Crimean War",
+        "ja": "クリミア戦争",
+        "ja_typings": [
+          "kurimiasensou"
+        ]
+      },
+      {
+        "en": "Boer War",
+        "ja": "ボーア戦争",
+        "ja_typings": [
+          "bo-asensou",
+          "booasensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01528",
+    "image_path": null,
+    "question_text": {
+      "en": "Which conflict was triggered by the assassination of Archduke Franz Ferdinand?",
+      "ja": "フランツ・フェルディナント大公暗殺が引き金となった戦争は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "W",
+        "ja": "W",
+        "ja_typings": []
+      },
+      {
+        "en": "Tu",
+        "ja": "Tu",
+        "ja_typings": []
+      },
+      {
+        "en": "Tg",
+        "ja": "Tg",
+        "ja_typings": []
+      },
+      {
+        "en": "Tn",
+        "ja": "Tn",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01529",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the chemical symbol for tungsten?",
+      "ja": "タングステンの元素記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nitrogen gas",
+        "ja": "窒素ガス",
+        "ja_typings": [
+          "chissogasu"
+        ]
+      },
+      {
+        "en": "Oxygen gas",
+        "ja": "酸素ガス",
+        "ja_typings": [
+          "sansogasu"
+        ]
+      },
+      {
+        "en": "Argon gas",
+        "ja": "アルゴンガス",
+        "ja_typings": [
+          "arugongasu"
+        ]
+      },
+      {
+        "en": "Methane gas",
+        "ja": "メタンガス",
+        "ja_typings": [
+          "metangasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01530",
+    "image_path": null,
+    "question_text": {
+      "en": "Which gas makes up about 78% of Earth's atmosphere?",
+      "ja": "地球の大気の約78%を占める気体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Carbon dioxide",
+        "ja": "二酸化炭素",
+        "ja_typings": [
+          "nisankatanso"
+        ]
+      },
+      {
+        "en": "Methane",
+        "ja": "メタン",
+        "ja_typings": []
+      },
+      {
+        "en": "Ozone",
+        "ja": "オゾン",
+        "ja_typings": []
+      },
+      {
+        "en": "Sulfur dioxide",
+        "ja": "二酸化硫黄",
+        "ja_typings": [
+          "nisankaiou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01531",
+    "image_path": null,
+    "question_text": {
+      "en": "Which gas is most responsible for global warming from human activity?",
+      "ja": "人為的温暖化の主因となる気体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lithium",
+        "ja": "リチウム",
+        "ja_typings": []
+      },
+      {
+        "en": "Sodium",
+        "ja": "ナトリウム",
+        "ja_typings": []
+      },
+      {
+        "en": "Magnesium",
+        "ja": "マグネシウム",
+        "ja_typings": []
+      },
+      {
+        "en": "Beryllium",
+        "ja": "ベリリウム",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01532",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the lightest metal?",
+      "ja": "最も軽い金属は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Saturn",
+        "ja": "土星",
+        "ja_typings": [
+          "dosei"
+        ]
+      },
+      {
+        "en": "Uranus",
+        "ja": "天王星",
+        "ja_typings": [
+          "tennousei"
+        ]
+      },
+      {
+        "en": "Neptune",
+        "ja": "海王星",
+        "ja_typings": [
+          "kaiousei"
+        ]
+      },
+      {
+        "en": "Mars",
+        "ja": "火星",
+        "ja_typings": [
+          "kasei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01533",
+    "image_path": null,
+    "question_text": {
+      "en": "Which planet has the most moons?",
+      "ja": "最も多くの衛星を持つ惑星は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Saturn",
+        "ja": "土星",
+        "ja_typings": [
+          "dosei"
+        ]
+      },
+      {
+        "en": "Uranus",
+        "ja": "天王星",
+        "ja_typings": [
+          "tennousei"
+        ]
+      },
+      {
+        "en": "Neptune",
+        "ja": "海王星",
+        "ja_typings": [
+          "kaiousei"
+        ]
+      },
+      {
+        "en": "Venus",
+        "ja": "金星",
+        "ja_typings": [
+          "kinsei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01534",
+    "image_path": null,
+    "question_text": {
+      "en": "Which planet is known for its prominent rings?",
+      "ja": "顕著な環で知られる惑星は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mars",
+        "ja": "火星",
+        "ja_typings": [
+          "kasei"
+        ]
+      },
+      {
+        "en": "Venus",
+        "ja": "金星",
+        "ja_typings": [
+          "kinsei"
+        ]
+      },
+      {
+        "en": "Mercury",
+        "ja": "水星",
+        "ja_typings": [
+          "suisei"
+        ]
+      },
+      {
+        "en": "Pluto",
+        "ja": "冥王星",
+        "ja_typings": [
+          "meiousei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01535",
+    "image_path": null,
+    "question_text": {
+      "en": "Which planet is known as the Red Planet?",
+      "ja": "「赤い惑星」と呼ばれるのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Neptune",
+        "ja": "海王星",
+        "ja_typings": [
+          "kaiousei"
+        ]
+      },
+      {
+        "en": "Uranus",
+        "ja": "天王星",
+        "ja_typings": [
+          "tennousei"
+        ]
+      },
+      {
+        "en": "Pluto",
+        "ja": "冥王星",
+        "ja_typings": [
+          "meiousei"
+        ]
+      },
+      {
+        "en": "Saturn",
+        "ja": "土星",
+        "ja_typings": [
+          "dosei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01536",
+    "image_path": null,
+    "question_text": {
+      "en": "Which planet is the farthest from the Sun (recognized as a planet)?",
+      "ja": "太陽系で最遠の惑星(認定されたもの)は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ganymede",
+        "ja": "ガニメデ",
+        "ja_typings": []
+      },
+      {
+        "en": "Titan",
+        "ja": "タイタン",
+        "ja_typings": []
+      },
+      {
+        "en": "Europa",
+        "ja": "エウロパ",
+        "ja_typings": []
+      },
+      {
+        "en": "Callisto",
+        "ja": "カリスト",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01537",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the largest moon in the solar system?",
+      "ja": "太陽系最大の衛星は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Titan",
+        "ja": "タイタン",
+        "ja_typings": []
+      },
+      {
+        "en": "Enceladus",
+        "ja": "エンケラドゥス",
+        "ja_typings": []
+      },
+      {
+        "en": "Mimas",
+        "ja": "ミマス",
+        "ja_typings": []
+      },
+      {
+        "en": "Rhea",
+        "ja": "レア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01538",
+    "image_path": null,
+    "question_text": {
+      "en": "Which moon of Saturn has a thick atmosphere?",
+      "ja": "厚い大気を持つ土星の衛星は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Copernicus",
+        "ja": "コペルニクス",
+        "ja_typings": []
+      },
+      {
+        "en": "Galileo",
+        "ja": "ガリレオ",
+        "ja_typings": []
+      },
+      {
+        "en": "Kepler",
+        "ja": "ケプラー",
+        "ja_typings": []
+      },
+      {
+        "en": "Brahe",
+        "ja": "ブラーエ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01539",
+    "image_path": null,
+    "question_text": {
+      "en": "Who proposed the heliocentric model of the solar system?",
+      "ja": "地動説を唱えたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kepler",
+        "ja": "ケプラー",
+        "ja_typings": []
+      },
+      {
+        "en": "Copernicus",
+        "ja": "コペルニクス",
+        "ja_typings": []
+      },
+      {
+        "en": "Galileo",
+        "ja": "ガリレオ",
+        "ja_typings": []
+      },
+      {
+        "en": "Halley",
+        "ja": "ハレー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01540",
+    "image_path": null,
+    "question_text": {
+      "en": "Who formulated the three laws of planetary motion?",
+      "ja": "惑星運動の三法則を導いたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ampere",
+        "ja": "アンペール",
+        "ja_typings": []
+      },
+      {
+        "en": "Volta",
+        "ja": "ボルタ",
+        "ja_typings": []
+      },
+      {
+        "en": "Ohm",
+        "ja": "オーム",
+        "ja_typings": []
+      },
+      {
+        "en": "Faraday",
+        "ja": "ファラデー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01541",
+    "image_path": null,
+    "question_text": {
+      "en": "Who proposed that current flows in a magnetic field induces force?",
+      "ja": "電流に磁場が力を及ぼすことを示したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Faraday",
+        "ja": "ファラデー",
+        "ja_typings": []
+      },
+      {
+        "en": "Maxwell",
+        "ja": "マクスウェル",
+        "ja_typings": []
+      },
+      {
+        "en": "Hertz",
+        "ja": "ヘルツ",
+        "ja_typings": []
+      },
+      {
+        "en": "Tesla",
+        "ja": "テスラ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01542",
+    "image_path": null,
+    "question_text": {
+      "en": "Who discovered electromagnetic induction?",
+      "ja": "電磁誘導を発見したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Maxwell",
+        "ja": "マクスウェル",
+        "ja_typings": []
+      },
+      {
+        "en": "Faraday",
+        "ja": "ファラデー",
+        "ja_typings": []
+      },
+      {
+        "en": "Hertz",
+        "ja": "ヘルツ",
+        "ja_typings": []
+      },
+      {
+        "en": "Lorentz",
+        "ja": "ローレンツ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01543",
+    "image_path": null,
+    "question_text": {
+      "en": "Who unified electricity and magnetism into a single theory?",
+      "ja": "電気と磁気を統一理論にまとめたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Crick",
+        "ja": "クリック",
+        "ja_typings": []
+      },
+      {
+        "en": "Franklin",
+        "ja": "フランクリン",
+        "ja_typings": []
+      },
+      {
+        "en": "Wilkins",
+        "ja": "ウィルキンス",
+        "ja_typings": []
+      },
+      {
+        "en": "Pauling",
+        "ja": "ポーリング",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01544",
+    "image_path": null,
+    "question_text": {
+      "en": "Who discovered the structure of DNA along with Watson?",
+      "ja": "ワトソンとともにDNA構造を解明したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lavoisier",
+        "ja": "ラヴォアジエ",
+        "ja_typings": []
+      },
+      {
+        "en": "Mendeleev",
+        "ja": "メンデレーエフ",
+        "ja_typings": []
+      },
+      {
+        "en": "Dalton",
+        "ja": "ドルトン",
+        "ja_typings": []
+      },
+      {
+        "en": "Boyle",
+        "ja": "ボイル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01545",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is considered the father of modern chemistry?",
+      "ja": "近代化学の父と呼ばれるのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mendeleev",
+        "ja": "メンデレーエフ",
+        "ja_typings": []
+      },
+      {
+        "en": "Lavoisier",
+        "ja": "ラヴォアジエ",
+        "ja_typings": []
+      },
+      {
+        "en": "Dalton",
+        "ja": "ドルトン",
+        "ja_typings": []
+      },
+      {
+        "en": "Bohr",
+        "ja": "ボーア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01546",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created the periodic table of elements?",
+      "ja": "元素周期表を作ったのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dalton",
+        "ja": "ドルトン",
+        "ja_typings": []
+      },
+      {
+        "en": "Bohr",
+        "ja": "ボーア",
+        "ja_typings": []
+      },
+      {
+        "en": "Rutherford",
+        "ja": "ラザフォード",
+        "ja_typings": []
+      },
+      {
+        "en": "Thomson",
+        "ja": "トムソン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01547",
+    "image_path": null,
+    "question_text": {
+      "en": "Who developed the atomic theory of matter?",
+      "ja": "原子論を提唱したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thomson",
+        "ja": "トムソン",
+        "ja_typings": []
+      },
+      {
+        "en": "Rutherford",
+        "ja": "ラザフォード",
+        "ja_typings": []
+      },
+      {
+        "en": "Bohr",
+        "ja": "ボーア",
+        "ja_typings": []
+      },
+      {
+        "en": "Millikan",
+        "ja": "ミリカン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01548",
+    "image_path": null,
+    "question_text": {
+      "en": "Who discovered the electron?",
+      "ja": "電子を発見したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rutherford",
+        "ja": "ラザフォード",
+        "ja_typings": []
+      },
+      {
+        "en": "Bohr",
+        "ja": "ボーア",
+        "ja_typings": []
+      },
+      {
+        "en": "Chadwick",
+        "ja": "チャドウィック",
+        "ja_typings": []
+      },
+      {
+        "en": "Thomson",
+        "ja": "トムソン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01549",
+    "image_path": null,
+    "question_text": {
+      "en": "Who discovered the atomic nucleus?",
+      "ja": "原子核を発見したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chadwick",
+        "ja": "チャドウィック",
+        "ja_typings": []
+      },
+      {
+        "en": "Rutherford",
+        "ja": "ラザフォード",
+        "ja_typings": []
+      },
+      {
+        "en": "Bohr",
+        "ja": "ボーア",
+        "ja_typings": []
+      },
+      {
+        "en": "Fermi",
+        "ja": "フェルミ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01550",
+    "image_path": null,
+    "question_text": {
+      "en": "Who discovered the neutron?",
+      "ja": "中性子を発見したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ampere",
+        "ja": "アンペア",
+        "ja_typings": []
+      },
+      {
+        "en": "Volt",
+        "ja": "ボルト",
+        "ja_typings": []
+      },
+      {
+        "en": "Ohm",
+        "ja": "オーム",
+        "ja_typings": []
+      },
+      {
+        "en": "Watt",
+        "ja": "ワット",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01551",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the SI unit of electric current?",
+      "ja": "電流のSI単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hertz",
+        "ja": "ヘルツ",
+        "ja_typings": []
+      },
+      {
+        "en": "Watt",
+        "ja": "ワット",
+        "ja_typings": []
+      },
+      {
+        "en": "Joule",
+        "ja": "ジュール",
+        "ja_typings": []
+      },
+      {
+        "en": "Pascal",
+        "ja": "パスカル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01552",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the SI unit of frequency?",
+      "ja": "周波数のSI単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pascal",
+        "ja": "パスカル",
+        "ja_typings": []
+      },
+      {
+        "en": "Newton",
+        "ja": "ニュートン",
+        "ja_typings": []
+      },
+      {
+        "en": "Joule",
+        "ja": "ジュール",
+        "ja_typings": []
+      },
+      {
+        "en": "Bar",
+        "ja": "バール",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01553",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the SI unit of pressure?",
+      "ja": "圧力のSI単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Joule",
+        "ja": "ジュール",
+        "ja_typings": []
+      },
+      {
+        "en": "Watt",
+        "ja": "ワット",
+        "ja_typings": []
+      },
+      {
+        "en": "Calorie",
+        "ja": "カロリー",
+        "ja_typings": []
+      },
+      {
+        "en": "Erg",
+        "ja": "エルグ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01554",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the SI unit of energy?",
+      "ja": "エネルギーのSI単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Newton",
+        "ja": "ニュートン",
+        "ja_typings": []
+      },
+      {
+        "en": "Joule",
+        "ja": "ジュール",
+        "ja_typings": []
+      },
+      {
+        "en": "Pascal",
+        "ja": "パスカル",
+        "ja_typings": []
+      },
+      {
+        "en": "Dyne",
+        "ja": "ダイン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01555",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the SI unit of force?",
+      "ja": "力のSI単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Skin",
+        "ja": "皮膚",
+        "ja_typings": [
+          "hifu"
+        ]
+      },
+      {
+        "en": "Liver",
+        "ja": "肝臓",
+        "ja_typings": [
+          "kanzou"
+        ]
+      },
+      {
+        "en": "Lung",
+        "ja": "肺",
+        "ja_typings": [
+          "hai"
+        ]
+      },
+      {
+        "en": "Intestine",
+        "ja": "腸",
+        "ja_typings": [
+          "chou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01556",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the largest organ of the human body?",
+      "ja": "人体最大の臓器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Red blood cells",
+        "ja": "赤血球",
+        "ja_typings": [
+          "sekkekkyuu"
+        ]
+      },
+      {
+        "en": "White blood cells",
+        "ja": "白血球",
+        "ja_typings": [
+          "hakkekkyuu"
+        ]
+      },
+      {
+        "en": "Platelets",
+        "ja": "血小板",
+        "ja_typings": [
+          "kesshouban"
+        ]
+      },
+      {
+        "en": "Plasma",
+        "ja": "血漿",
+        "ja_typings": [
+          "kesshou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01557",
+    "image_path": null,
+    "question_text": {
+      "en": "Which blood cells carry oxygen?",
+      "ja": "酸素を運ぶ血球は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mohs scale",
+        "ja": "モース硬度",
+        "ja_typings": [
+          "mo-sukoudo",
+          "moosukoudo"
+        ]
+      },
+      {
+        "en": "Richter scale",
+        "ja": "リヒタースケール",
+        "ja_typings": []
+      },
+      {
+        "en": "Beaufort scale",
+        "ja": "ボーフォート階級",
+        "ja_typings": [
+          "bo-foutokaikyuu",
+          "boofoutokaikyuu"
+        ]
+      },
+      {
+        "en": "Brinell scale",
+        "ja": "ブリネル硬度",
+        "ja_typings": [
+          "burinerukoudo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01558",
+    "image_path": null,
+    "question_text": {
+      "en": "Which scale measures mineral hardness?",
+      "ja": "鉱物硬度の尺度は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Refraction",
+        "ja": "屈折",
+        "ja_typings": [
+          "kussetsu"
+        ]
+      },
+      {
+        "en": "Reflection",
+        "ja": "反射",
+        "ja_typings": [
+          "hansha"
+        ]
+      },
+      {
+        "en": "Diffraction",
+        "ja": "回折",
+        "ja_typings": [
+          "kaisetsu"
+        ]
+      },
+      {
+        "en": "Dispersion",
+        "ja": "分散",
+        "ja_typings": [
+          "bunsan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01559",
+    "image_path": null,
+    "question_text": {
+      "en": "Which phenomenon causes the bending of light passing through different media?",
+      "ja": "媒質間で光が曲がる現象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "S3",
+        "ja": "S3",
+        "ja_typings": []
+      },
+      {
+        "en": "Z2",
+        "ja": "Z2",
+        "ja_typings": []
+      },
+      {
+        "en": "Z4",
+        "ja": "Z4",
+        "ja_typings": []
+      },
+      {
+        "en": "V4",
+        "ja": "V4",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01560",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the smallest non-abelian group?",
+      "ja": "最小の非可換群はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "twin prime",
+        "ja": "双子素数予想",
+        "ja_typings": [
+          "futagososuuyosou"
+        ]
+      },
+      {
+        "en": "Goldbach",
+        "ja": "ゴールドバッハ予想",
+        "ja_typings": []
+      },
+      {
+        "en": "Riemann",
+        "ja": "リーマン予想",
+        "ja_typings": []
+      },
+      {
+        "en": "Collatz",
+        "ja": "コラッツ予想",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01561",
+    "image_path": null,
+    "question_text": {
+      "en": "Which conjecture concerns prime gaps of 2?",
+      "ja": "素数の差が2となる予想はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ring",
+        "ja": "環",
+        "ja_typings": [
+          "kan",
+          "wa"
+        ]
+      },
+      {
+        "en": "group",
+        "ja": "群",
+        "ja_typings": [
+          "gun"
+        ]
+      },
+      {
+        "en": "lattice",
+        "ja": "束",
+        "ja_typings": [
+          "soku",
+          "taba"
+        ]
+      },
+      {
+        "en": "monoid",
+        "ja": "モノイド",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01562",
+    "image_path": null,
+    "question_text": {
+      "en": "Which structure has both addition and multiplication?",
+      "ja": "加法と乗法を両方持つ代数構造は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Euclidean space",
+        "ja": "ユークリッド空間",
+        "ja_typings": [
+          "yu-kuriddokuukan"
+        ]
+      },
+      {
+        "en": "sphere",
+        "ja": "球面",
+        "ja_typings": [
+          "kyuumen"
+        ]
+      },
+      {
+        "en": "torus",
+        "ja": "トーラス",
+        "ja_typings": []
+      },
+      {
+        "en": "hyperbolic plane",
+        "ja": "双曲平面",
+        "ja_typings": [
+          "soukyokuheimen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01563",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a manifold locally homeomorphic to?",
+      "ja": "多様体は局所的に何と同相?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "quaternions",
+        "ja": "四元数",
+        "ja_typings": [
+          "shigensuu"
+        ]
+      },
+      {
+        "en": "octonions",
+        "ja": "八元数",
+        "ja_typings": []
+      },
+      {
+        "en": "sedenions",
+        "ja": "十六元数",
+        "ja_typings": []
+      },
+      {
+        "en": "dual numbers",
+        "ja": "二重数",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01564",
+    "image_path": null,
+    "question_text": {
+      "en": "Which number system extends complex numbers to 4D?",
+      "ja": "複素数を4次元に拡張した数体系は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gauss-Bonnet",
+        "ja": "ガウス・ボネの定理",
+        "ja_typings": [
+          "gausu bone no teiri"
+        ]
+      },
+      {
+        "en": "Stokes",
+        "ja": "ストークスの定理",
+        "ja_typings": [
+          "suto-kusu no teiri"
+        ]
+      },
+      {
+        "en": "Green",
+        "ja": "グリーンの定理",
+        "ja_typings": []
+      },
+      {
+        "en": "Cauchy",
+        "ja": "コーシーの定理",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01565",
+    "image_path": null,
+    "question_text": {
+      "en": "Which theorem relates Euler characteristic to genus?",
+      "ja": "オイラー標数と種数を結ぶ定理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "P vs NP",
+        "ja": "P対NP問題",
+        "ja_typings": [
+          "P tai NP mondai"
+        ]
+      },
+      {
+        "en": "halting",
+        "ja": "停止性問題",
+        "ja_typings": [
+          "teishiseimondai"
+        ]
+      },
+      {
+        "en": "Hilbert tenth",
+        "ja": "ヒルベルト第十問題",
+        "ja_typings": []
+      },
+      {
+        "en": "Goldbach",
+        "ja": "ゴールドバッハ問題",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01566",
+    "image_path": null,
+    "question_text": {
+      "en": "Which problem asks if P equals NP?",
+      "ja": "PとNPが等しいかを問う問題は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hausdorff",
+        "ja": "ハウスドルフ次元",
+        "ja_typings": [
+          "hausudorufu jigen"
+        ]
+      },
+      {
+        "en": "Lebesgue",
+        "ja": "ルベーグ次元",
+        "ja_typings": []
+      },
+      {
+        "en": "Minkowski",
+        "ja": "ミンコフスキー次元",
+        "ja_typings": []
+      },
+      {
+        "en": "Krull",
+        "ja": "クルル次元",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01567",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a non-trivial example of a fractal dimension?",
+      "ja": "非自明なフラクタル次元の例は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hamiltonian cycle",
+        "ja": "ハミルトン閉路問題",
+        "ja_typings": [
+          "hamiruton heiro mondai"
+        ]
+      },
+      {
+        "en": "shortest path",
+        "ja": "最短経路問題",
+        "ja_typings": [
+          "saitankeiromondai"
+        ]
+      },
+      {
+        "en": "MST",
+        "ja": "最小全域木問題",
+        "ja_typings": []
+      },
+      {
+        "en": "BFS",
+        "ja": "幅優先探索",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01568",
+    "image_path": null,
+    "question_text": {
+      "en": "Which graph problem is NP-complete?",
+      "ja": "NP完全のグラフ問題は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "aleph one",
+        "ja": "アレフ1",
+        "ja_typings": [
+          "arefu 1"
+        ]
+      },
+      {
+        "en": "aleph zero",
+        "ja": "アレフ0",
+        "ja_typings": []
+      },
+      {
+        "en": "aleph two",
+        "ja": "アレフ2",
+        "ja_typings": []
+      },
+      {
+        "en": "beth zero",
+        "ja": "ベート0",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01569",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the cardinality of the continuum?",
+      "ja": "連続体の濃度の記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "real numbers",
+        "ja": "実数全体",
+        "ja_typings": [
+          "jissuuzentai"
+        ]
+      },
+      {
+        "en": "integers",
+        "ja": "整数全体",
+        "ja_typings": [
+          "seisuuzentai"
+        ]
+      },
+      {
+        "en": "rationals",
+        "ja": "有理数全体",
+        "ja_typings": [
+          "yuurisuuzentai"
+        ]
+      },
+      {
+        "en": "primes",
+        "ja": "素数全体",
+        "ja_typings": [
+          "sosuuzentai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01570",
+    "image_path": null,
+    "question_text": {
+      "en": "Which set is uncountable?",
+      "ja": "非可算集合はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "A4",
+        "ja": "A4群",
+        "ja_typings": [
+          "A4gun"
+        ]
+      },
+      {
+        "en": "S5",
+        "ja": "S5群",
+        "ja_typings": []
+      },
+      {
+        "en": "D8",
+        "ja": "D8群",
+        "ja_typings": []
+      },
+      {
+        "en": "Z12",
+        "ja": "Z12群",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01571",
+    "image_path": null,
+    "question_text": {
+      "en": "Which group describes symmetries of a tetrahedron?",
+      "ja": "正四面体の対称群は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "topological spaces",
+        "ja": "位相空間",
+        "ja_typings": [
+          "isoukuukan"
+        ]
+      },
+      {
+        "en": "metric spaces only",
+        "ja": "距離空間のみ",
+        "ja_typings": [
+          "kyorikuukannnomi"
+        ]
+      },
+      {
+        "en": "vector spaces",
+        "ja": "ベクトル空間",
+        "ja_typings": []
+      },
+      {
+        "en": "Hilbert spaces",
+        "ja": "ヒルベルト空間",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01572",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the formal definition of a continuous map between?",
+      "ja": "連続写像が定義される対象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "logarithm",
+        "ja": "対数関数",
+        "ja_typings": [
+          "taisuukansuu"
+        ]
+      },
+      {
+        "en": "exponential",
+        "ja": "指数関数",
+        "ja_typings": [
+          "shisuukansuu"
+        ]
+      },
+      {
+        "en": "sine",
+        "ja": "正弦関数",
+        "ja_typings": [
+          "seigenkansuu"
+        ]
+      },
+      {
+        "en": "zeta",
+        "ja": "ゼータ関数",
+        "ja_typings": [
+          "ze-takansuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01573",
+    "image_path": null,
+    "question_text": {
+      "en": "Which constant appears in the prime number theorem?",
+      "ja": "素数定理に現れる関数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "abelian group",
+        "ja": "アーベル群",
+        "ja_typings": [
+          "a-berugun"
+        ]
+      },
+      {
+        "en": "non-abelian group",
+        "ja": "非可換群",
+        "ja_typings": [
+          "hikakangun"
+        ]
+      },
+      {
+        "en": "free group",
+        "ja": "自由群",
+        "ja_typings": []
+      },
+      {
+        "en": "nilpotent group",
+        "ja": "冪零群",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01574",
+    "image_path": null,
+    "question_text": {
+      "en": "Which structure is used in elliptic curve cryptography?",
+      "ja": "楕円曲線暗号で用いる構造は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "functor",
+        "ja": "関手",
+        "ja_typings": [
+          "kanshu"
+        ]
+      },
+      {
+        "en": "vector",
+        "ja": "ベクトル",
+        "ja_typings": []
+      },
+      {
+        "en": "matrix",
+        "ja": "行列",
+        "ja_typings": []
+      },
+      {
+        "en": "tensor",
+        "ja": "テンソル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01575",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a key concept in category theory?",
+      "ja": "圏論の中心概念は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chebyshev",
+        "ja": "チェビシェフの不等式",
+        "ja_typings": [
+          "chebishefu no futoushiki"
+        ]
+      },
+      {
+        "en": "Cauchy-Schwarz",
+        "ja": "コーシー・シュワルツの不等式",
+        "ja_typings": []
+      },
+      {
+        "en": "Jensen",
+        "ja": "イェンセンの不等式",
+        "ja_typings": []
+      },
+      {
+        "en": "Markov",
+        "ja": "マルコフの不等式",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01576",
+    "image_path": null,
+    "question_text": {
+      "en": "Which inequality bounds variance and expectation?",
+      "ja": "分散と期待値を結ぶ不等式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Poisson",
+        "ja": "ポアソン分布",
+        "ja_typings": [
+          "poasonbunpu"
+        ]
+      },
+      {
+        "en": "normal",
+        "ja": "正規分布",
+        "ja_typings": [
+          "seikibunpu"
+        ]
+      },
+      {
+        "en": "uniform",
+        "ja": "一様分布",
+        "ja_typings": [
+          "ichiyoubunpu"
+        ]
+      },
+      {
+        "en": "binomial",
+        "ja": "二項分布",
+        "ja_typings": [
+          "nikoubunpu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01577",
+    "image_path": null,
+    "question_text": {
+      "en": "Which distribution describes rare events?",
+      "ja": "稀な事象を表す分布は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Snake lemma",
+        "ja": "蛇の補題",
+        "ja_typings": [
+          "hebi no hodai"
+        ]
+      },
+      {
+        "en": "Zorn lemma",
+        "ja": "ツォルンの補題",
+        "ja_typings": []
+      },
+      {
+        "en": "Yoneda lemma",
+        "ja": "米田の補題",
+        "ja_typings": []
+      },
+      {
+        "en": "Schur lemma",
+        "ja": "シューアの補題",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01578",
+    "image_path": null,
+    "question_text": {
+      "en": "Which lemma is essential in homological algebra?",
+      "ja": "ホモロジー代数で重要な補題は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "non-orientable surface",
+        "ja": "非向き付け可能曲面",
+        "ja_typings": [
+          "himukitsukekanoukyokumen"
+        ]
+      },
+      {
+        "en": "compact manifold",
+        "ja": "コンパクト多様体",
+        "ja_typings": []
+      },
+      {
+        "en": "simply connected space",
+        "ja": "単連結空間",
+        "ja_typings": []
+      },
+      {
+        "en": "Hausdorff space",
+        "ja": "ハウスドルフ空間",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01579",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a Mobius strip an example of?",
+      "ja": "メビウスの帯は何の例?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "heat equation",
+        "ja": "熱方程式",
+        "ja_typings": [
+          "netsuhouteishiki"
+        ]
+      },
+      {
+        "en": "wave equation",
+        "ja": "波動方程式",
+        "ja_typings": [
+          "hadouhouteishiki"
+        ]
+      },
+      {
+        "en": "Laplace",
+        "ja": "ラプラス方程式",
+        "ja_typings": []
+      },
+      {
+        "en": "Schrodinger",
+        "ja": "シュレーディンガー方程式",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01580",
+    "image_path": null,
+    "question_text": {
+      "en": "Which equation governs heat diffusion?",
+      "ja": "熱拡散を表す方程式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Runge-Kutta",
+        "ja": "ルンゲ・クッタ法",
+        "ja_typings": [
+          "runge kutta hou"
+        ]
+      },
+      {
+        "en": "Newton-Raphson",
+        "ja": "ニュートン法",
+        "ja_typings": []
+      },
+      {
+        "en": "Simpson",
+        "ja": "シンプソン則",
+        "ja_typings": []
+      },
+      {
+        "en": "Gauss elimination",
+        "ja": "ガウス消去法",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01581",
+    "image_path": null,
+    "question_text": {
+      "en": "Which method numerically solves ODEs?",
+      "ja": "常微分方程式の数値解法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Eulerian path",
+        "ja": "オイラー路問題",
+        "ja_typings": [
+          "oira-ro mondai"
+        ]
+      },
+      {
+        "en": "traveling salesman",
+        "ja": "巡回セールスマン問題",
+        "ja_typings": [
+          "junkai se-rusuman mondai"
+        ]
+      },
+      {
+        "en": "graph coloring",
+        "ja": "グラフ彩色問題",
+        "ja_typings": []
+      },
+      {
+        "en": "max flow",
+        "ja": "最大流問題",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01582",
+    "image_path": null,
+    "question_text": {
+      "en": "What problem is associated with the Konigsberg bridges?",
+      "ja": "ケーニヒスベルクの橋に関する問題は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fourier transform",
+        "ja": "フーリエ変換",
+        "ja_typings": [
+          "fu-rie henkan"
+        ]
+      },
+      {
+        "en": "Laplace transform",
+        "ja": "ラプラス変換",
+        "ja_typings": [
+          "rapurasu henkan"
+        ]
+      },
+      {
+        "en": "Z transform",
+        "ja": "Z変換",
+        "ja_typings": []
+      },
+      {
+        "en": "Hilbert transform",
+        "ja": "ヒルベルト変換",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01583",
+    "image_path": null,
+    "question_text": {
+      "en": "Which transform converts time to frequency domain?",
+      "ja": "時間領域を周波数領域に変換する手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hilbert space",
+        "ja": "ヒルベルト空間",
+        "ja_typings": [
+          "hiruberutokuukan"
+        ]
+      },
+      {
+        "en": "Banach space",
+        "ja": "バナッハ空間",
+        "ja_typings": [
+          "banahhakuukan"
+        ]
+      },
+      {
+        "en": "Frechet space",
+        "ja": "フレシェ空間",
+        "ja_typings": []
+      },
+      {
+        "en": "Sobolev space",
+        "ja": "ソボレフ空間",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01584",
+    "image_path": null,
+    "question_text": {
+      "en": "Which space is complete and inner-product?",
+      "ja": "完備かつ内積を持つ空間は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Poincare conjecture",
+        "ja": "ポアンカレ予想",
+        "ja_typings": [
+          "poankareyosou"
+        ]
+      },
+      {
+        "en": "Riemann hypothesis",
+        "ja": "リーマン予想",
+        "ja_typings": [
+          "ri-manyosou"
+        ]
+      },
+      {
+        "en": "Hodge conjecture",
+        "ja": "ホッジ予想",
+        "ja_typings": []
+      },
+      {
+        "en": "Birch-Swinnerton-Dyer",
+        "ja": "BSD予想",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01585",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Millennium Prize problem was solved?",
+      "ja": "ミレニアム懸賞問題で解決済みは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mersenne primes",
+        "ja": "メルセンヌ素数",
+        "ja_typings": [
+          "merusennusosuu"
+        ]
+      },
+      {
+        "en": "perfect numbers",
+        "ja": "完全数",
+        "ja_typings": [
+          "kanzensuu"
+        ]
+      },
+      {
+        "en": "Carmichael numbers",
+        "ja": "カーマイケル数",
+        "ja_typings": []
+      },
+      {
+        "en": "Lucas numbers",
+        "ja": "リュカ数",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01586",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sequence is used in cryptographic hashing?",
+      "ja": "暗号ハッシュの基礎となる数列は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nash equilibrium",
+        "ja": "ナッシュ均衡",
+        "ja_typings": [
+          "nasshukinkou"
+        ]
+      },
+      {
+        "en": "Pareto optimum",
+        "ja": "パレート最適",
+        "ja_typings": [
+          "pare-tosaiteki"
+        ]
+      },
+      {
+        "en": "minimax",
+        "ja": "ミニマックス",
+        "ja_typings": []
+      },
+      {
+        "en": "dominant strategy",
+        "ja": "支配戦略",
+        "ja_typings": [
+          "shihaisenryaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01587",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game theory concept is a stable strategy?",
+      "ja": "ゲーム理論で安定戦略を示す概念は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "elliptic curve",
+        "ja": "楕円曲線",
+        "ja_typings": [
+          "daenkyokusen"
+        ]
+      },
+      {
+        "en": "parabola",
+        "ja": "放物線",
+        "ja_typings": [
+          "houbutsusen"
+        ]
+      },
+      {
+        "en": "hyperbola",
+        "ja": "双曲線",
+        "ja_typings": [
+          "soukyokusen"
+        ]
+      },
+      {
+        "en": "cardioid",
+        "ja": "カージオイド",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01588",
+    "image_path": null,
+    "question_text": {
+      "en": "Which curve is defined by y squared equals x cubed plus ax plus b?",
+      "ja": "y² = x³+ax+b で定義される曲線は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Russell paradox",
+        "ja": "ラッセルのパラドックス",
+        "ja_typings": [
+          "rasseru no paradokkusu"
+        ]
+      },
+      {
+        "en": "Banach-Tarski",
+        "ja": "バナッハ・タルスキー",
+        "ja_typings": []
+      },
+      {
+        "en": "Zeno",
+        "ja": "ゼノンのパラドックス",
+        "ja_typings": []
+      },
+      {
+        "en": "Berry",
+        "ja": "ベリーのパラドックス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01589",
+    "image_path": null,
+    "question_text": {
+      "en": "Which paradox involves a set of all sets?",
+      "ja": "全集合の集合に関するパラドックスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "two birds with one stone",
+        "ja": "一度に二つの利益",
+        "ja_typings": [
+          "ichidoni futatsu no rieki"
+        ]
+      },
+      {
+        "en": "eternal effort",
+        "ja": "永遠の努力",
+        "ja_typings": []
+      },
+      {
+        "en": "rare opportunity",
+        "ja": "稀な機会",
+        "ja_typings": []
+      },
+      {
+        "en": "strong will",
+        "ja": "強い意志",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01590",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the four-character idiom 'isseki nichou' mean?",
+      "ja": "四字熟語『一石二鳥』の意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Orion",
+        "ja": "オリオン座",
+        "ja_typings": [
+          "orionza"
+        ]
+      },
+      {
+        "en": "Cassiopeia",
+        "ja": "カシオペア座",
+        "ja_typings": []
+      },
+      {
+        "en": "Lyra",
+        "ja": "こと座",
+        "ja_typings": [
+          "kotoza"
+        ]
+      },
+      {
+        "en": "Cygnus",
+        "ja": "はくちょう座",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01591",
+    "image_path": null,
+    "question_text": {
+      "en": "Which constellation contains Betelgeuse?",
+      "ja": "ベテルギウスを含む星座は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "candela",
+        "ja": "カンデラ",
+        "ja_typings": []
+      },
+      {
+        "en": "lumen",
+        "ja": "ルーメン",
+        "ja_typings": []
+      },
+      {
+        "en": "lux",
+        "ja": "ルクス",
+        "ja_typings": []
+      },
+      {
+        "en": "nit",
+        "ja": "ニト",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01592",
+    "image_path": null,
+    "question_text": {
+      "en": "What unit measures luminous intensity?",
+      "ja": "光度の単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "very busy",
+        "ja": "非常に忙しい",
+        "ja_typings": [
+          "hijouni isogashii"
+        ]
+      },
+      {
+        "en": "very lonely",
+        "ja": "非常に寂しい",
+        "ja_typings": []
+      },
+      {
+        "en": "very tired",
+        "ja": "非常に疲れた",
+        "ja_typings": []
+      },
+      {
+        "en": "very confused",
+        "ja": "非常に混乱",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01593",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the idiom 'neko no te mo karitai' express?",
+      "ja": "『猫の手も借りたい』が表す状況は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tokugawa",
+        "ja": "徳川家",
+        "ja_typings": [
+          "tokugawake"
+        ]
+      },
+      {
+        "en": "Oda",
+        "ja": "織田家",
+        "ja_typings": [
+          "odake"
+        ]
+      },
+      {
+        "en": "Toyotomi",
+        "ja": "豊臣家",
+        "ja_typings": [
+          "toyotomike"
+        ]
+      },
+      {
+        "en": "Takeda",
+        "ja": "武田家",
+        "ja_typings": [
+          "takedake"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01594",
+    "image_path": null,
+    "question_text": {
+      "en": "Which family crest depicts three hollyhock leaves?",
+      "ja": "三つ葉葵を描く家紋を使った家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "weber",
+        "ja": "ウェーバ",
+        "ja_typings": []
+      },
+      {
+        "en": "tesla",
+        "ja": "テスラ",
+        "ja_typings": []
+      },
+      {
+        "en": "henry",
+        "ja": "ヘンリー",
+        "ja_typings": []
+      },
+      {
+        "en": "gauss",
+        "ja": "ガウス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01595",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the SI unit of magnetic flux?",
+      "ja": "磁束のSI単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Libra",
+        "ja": "てんびん座",
+        "ja_typings": [
+          "tenbinza"
+        ]
+      },
+      {
+        "en": "Aries",
+        "ja": "おひつじ座",
+        "ja_typings": []
+      },
+      {
+        "en": "Gemini",
+        "ja": "ふたご座",
+        "ja_typings": []
+      },
+      {
+        "en": "Virgo",
+        "ja": "おとめ座",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01596",
+    "image_path": null,
+    "question_text": {
+      "en": "Which zodiac sign is represented by scales?",
+      "ja": "天秤で表される星座は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "National Aeronautics and Space Administration",
+        "ja": "アメリカ航空宇宙局",
+        "ja_typings": [
+          "amerika koukuuuchuukyoku"
+        ]
+      },
+      {
+        "en": "North American Science Agency",
+        "ja": "北米科学機関",
+        "ja_typings": []
+      },
+      {
+        "en": "National Atomic Safety Authority",
+        "ja": "国家原子力安全機関",
+        "ja_typings": []
+      },
+      {
+        "en": "Naval Astronautics Society Association",
+        "ja": "海軍宇宙協会",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01597",
+    "image_path": null,
+    "question_text": {
+      "en": "What does NASA stand for?",
+      "ja": "NASAは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "kinran no majiwari",
+        "ja": "金蘭の交わり",
+        "ja_typings": [
+          "kinran no majiwari"
+        ]
+      },
+      {
+        "en": "ichigo ichie",
+        "ja": "一期一会",
+        "ja_typings": [
+          "ichigoichie"
+        ]
+      },
+      {
+        "en": "isshin doutai",
+        "ja": "一心同体",
+        "ja_typings": [
+          "isshindoutai"
+        ]
+      },
+      {
+        "en": "ishin denshin",
+        "ja": "以心伝心",
+        "ja_typings": [
+          "ishindenshin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01598",
+    "image_path": null,
+    "question_text": {
+      "en": "Which idiom means inseparable friends?",
+      "ja": "切っても切れない友を意味するのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "decibel",
+        "ja": "デシベル",
+        "ja_typings": []
+      },
+      {
+        "en": "hertz",
+        "ja": "ヘルツ",
+        "ja_typings": []
+      },
+      {
+        "en": "phon",
+        "ja": "フォン",
+        "ja_typings": []
+      },
+      {
+        "en": "sone",
+        "ja": "ソーン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01599",
+    "image_path": null,
+    "question_text": {
+      "en": "What unit measures sound intensity level?",
+      "ja": "音の強さレベルの単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "books",
+        "ja": "書籍",
+        "ja_typings": [
+          "shoseki"
+        ]
+      },
+      {
+        "en": "magazines",
+        "ja": "雑誌",
+        "ja_typings": [
+          "zasshi"
+        ]
+      },
+      {
+        "en": "websites",
+        "ja": "ウェブサイト",
+        "ja_typings": []
+      },
+      {
+        "en": "songs",
+        "ja": "楽曲",
+        "ja_typings": [
+          "gakkyoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01600",
+    "image_path": null,
+    "question_text": {
+      "en": "What does ISBN identify?",
+      "ja": "ISBNが識別するものは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ursa Minor",
+        "ja": "こぐま座",
+        "ja_typings": [
+          "kogumaza"
+        ]
+      },
+      {
+        "en": "Ursa Major",
+        "ja": "おおぐま座",
+        "ja_typings": []
+      },
+      {
+        "en": "Draco",
+        "ja": "りゅう座",
+        "ja_typings": []
+      },
+      {
+        "en": "Cepheus",
+        "ja": "ケフェウス座",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01601",
+    "image_path": null,
+    "question_text": {
+      "en": "Which constellation contains the North Star?",
+      "ja": "北極星を含む星座は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "enduring hardship for revenge",
+        "ja": "復讐のために苦難に耐える",
+        "ja_typings": [
+          "fukushuu no tameni kunan ni taeru"
+        ]
+      },
+      {
+        "en": "celebrating victory",
+        "ja": "勝利を祝う",
+        "ja_typings": []
+      },
+      {
+        "en": "teaching by example",
+        "ja": "範を示す",
+        "ja_typings": []
+      },
+      {
+        "en": "respecting elders",
+        "ja": "長老を敬う",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01602",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'gashin shoutan' mean?",
+      "ja": "『臥薪嘗胆』の意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "rampant",
+        "ja": "ランパント",
+        "ja_typings": []
+      },
+      {
+        "en": "passant",
+        "ja": "パサント",
+        "ja_typings": []
+      },
+      {
+        "en": "couchant",
+        "ja": "クーシャント",
+        "ja_typings": []
+      },
+      {
+        "en": "sejant",
+        "ja": "セジャント",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01603",
+    "image_path": null,
+    "question_text": {
+      "en": "Which heraldic charge represents a lion standing?",
+      "ja": "立ち上がるライオンを表す紋章用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sievert",
+        "ja": "シーベルト",
+        "ja_typings": []
+      },
+      {
+        "en": "becquerel",
+        "ja": "ベクレル",
+        "ja_typings": []
+      },
+      {
+        "en": "gray",
+        "ja": "グレイ",
+        "ja_typings": []
+      },
+      {
+        "en": "roentgen",
+        "ja": "レントゲン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01604",
+    "image_path": null,
+    "question_text": {
+      "en": "What unit measures radiation exposure?",
+      "ja": "放射線被曝量の単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "kinjitou",
+        "ja": "金字塔",
+        "ja_typings": [
+          "kinjitou"
+        ]
+      },
+      {
+        "en": "touki bansei",
+        "ja": "陶器万歳",
+        "ja_typings": []
+      },
+      {
+        "en": "seiten hekireki",
+        "ja": "晴天霹靂",
+        "ja_typings": []
+      },
+      {
+        "en": "muga muchuu",
+        "ja": "無我夢中",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01605",
+    "image_path": null,
+    "question_text": {
+      "en": "Which idiom describes a perfect match?",
+      "ja": "完璧な組合せを表す四字熟語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "buying books without reading",
+        "ja": "本を買って積むこと",
+        "ja_typings": [
+          "hon wo katte tsumu koto"
+        ]
+      },
+      {
+        "en": "reading old books",
+        "ja": "古い本を読むこと",
+        "ja_typings": []
+      },
+      {
+        "en": "lending out books",
+        "ja": "本を貸し出すこと",
+        "ja_typings": []
+      },
+      {
+        "en": "losing a book",
+        "ja": "本を失くすこと",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01606",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the word 'tsundoku' describe?",
+      "ja": "『積ん読』が表すのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sirius",
+        "ja": "シリウス",
+        "ja_typings": []
+      },
+      {
+        "en": "Vega",
+        "ja": "ベガ",
+        "ja_typings": []
+      },
+      {
+        "en": "Arcturus",
+        "ja": "アルクトゥルス",
+        "ja_typings": []
+      },
+      {
+        "en": "Capella",
+        "ja": "カペラ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01607",
+    "image_path": null,
+    "question_text": {
+      "en": "Which star is the brightest in the night sky?",
+      "ja": "夜空で最も明るい恒星は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "beauty in imperfection",
+        "ja": "不完全の中の美",
+        "ja_typings": [
+          "fukanzen no nakano bi"
+        ]
+      },
+      {
+        "en": "brightness and grandeur",
+        "ja": "華やかさ",
+        "ja_typings": []
+      },
+      {
+        "en": "symmetry and order",
+        "ja": "対称と秩序",
+        "ja_typings": []
+      },
+      {
+        "en": "color and vibrancy",
+        "ja": "色彩と活気",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01608",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'wabi sabi' express in aesthetics?",
+      "ja": "美学の『侘び寂び』が表すのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "pascal",
+        "ja": "パスカル",
+        "ja_typings": []
+      },
+      {
+        "en": "joule",
+        "ja": "ジュール",
+        "ja_typings": []
+      },
+      {
+        "en": "watt",
+        "ja": "ワット",
+        "ja_typings": []
+      },
+      {
+        "en": "newton",
+        "ja": "ニュートン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01609",
+    "image_path": null,
+    "question_text": {
+      "en": "Which unit measures atmospheric pressure?",
+      "ja": "気圧の単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "duality and balance",
+        "ja": "二元の調和",
+        "ja_typings": [
+          "nigen no chouwa"
+        ]
+      },
+      {
+        "en": "infinite time",
+        "ja": "無限の時間",
+        "ja_typings": []
+      },
+      {
+        "en": "life and death",
+        "ja": "生と死",
+        "ja_typings": [
+          "seitoshi"
+        ]
+      },
+      {
+        "en": "good and evil",
+        "ja": "善悪",
+        "ja_typings": [
+          "zenaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01610",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the Yin-Yang symbol represent?",
+      "ja": "陰陽のシンボルが表すのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "three rounded sixes",
+        "ja": "三つ盛り亀甲に花菱",
+        "ja_typings": [
+          "mitsumori kikkou ni hanabishi"
+        ]
+      },
+      {
+        "en": "paulownia",
+        "ja": "桐",
+        "ja_typings": [
+          "kiri"
+        ]
+      },
+      {
+        "en": "chrysanthemum",
+        "ja": "菊",
+        "ja_typings": [
+          "kiku"
+        ]
+      },
+      {
+        "en": "plum blossom",
+        "ja": "梅",
+        "ja_typings": [
+          "ume"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01611",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese fan crest is associated with the Asai clan?",
+      "ja": "浅井家の家紋は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "mixture of good and bad",
+        "ja": "良いものと悪いものが混在",
+        "ja_typings": [
+          "yoimonotowaruimonoga konzai"
+        ]
+      },
+      {
+        "en": "rare treasure",
+        "ja": "希少な宝",
+        "ja_typings": []
+      },
+      {
+        "en": "constant change",
+        "ja": "絶え間ない変化",
+        "ja_typings": []
+      },
+      {
+        "en": "eternal beauty",
+        "ja": "永遠の美",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01612",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the idiom 'gyokuseki konkou' mean?",
+      "ja": "『玉石混淆』の意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FLOPS",
+        "ja": "フロップス",
+        "ja_typings": []
+      },
+      {
+        "en": "BPS",
+        "ja": "ビーピーエス",
+        "ja_typings": []
+      },
+      {
+        "en": "MIPS",
+        "ja": "ミップス",
+        "ja_typings": []
+      },
+      {
+        "en": "IPS",
+        "ja": "アイピーエス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01613",
+    "image_path": null,
+    "question_text": {
+      "en": "What unit measures the speed of computer operations?",
+      "ja": "コンピュータ演算速度の単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cassiopeia",
+        "ja": "カシオペア座",
+        "ja_typings": [
+          "kashiopeaza"
+        ]
+      },
+      {
+        "en": "Orion",
+        "ja": "オリオン座",
+        "ja_typings": [
+          "orionza"
+        ]
+      },
+      {
+        "en": "Leo",
+        "ja": "しし座",
+        "ja_typings": []
+      },
+      {
+        "en": "Taurus",
+        "ja": "おうし座",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01614",
+    "image_path": null,
+    "question_text": {
+      "en": "Which constellation is shaped like a W?",
+      "ja": "Wの形をした星座は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "World Health Organization",
+        "ja": "世界保健機関",
+        "ja_typings": [
+          "sekaihokenkikan"
+        ]
+      },
+      {
+        "en": "World Hospital Office",
+        "ja": "世界病院事務局",
+        "ja_typings": []
+      },
+      {
+        "en": "Western Health Organization",
+        "ja": "西側保健機関",
+        "ja_typings": []
+      },
+      {
+        "en": "World Hygiene Organization",
+        "ja": "世界衛生機関",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01615",
+    "image_path": null,
+    "question_text": {
+      "en": "What does WHO stand for?",
+      "ja": "WHOの略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "nou aru taka wa tsume wo kakusu",
+        "ja": "能ある鷹は爪を隠す",
+        "ja_typings": [
+          "nouarutakawatsumewokakusu"
+        ]
+      },
+      {
+        "en": "isseki nichou",
+        "ja": "一石二鳥",
+        "ja_typings": []
+      },
+      {
+        "en": "kongen kongen",
+        "ja": "根本根源",
+        "ja_typings": []
+      },
+      {
+        "en": "haru natsu aki fuyu",
+        "ja": "春夏秋冬",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01616",
+    "image_path": null,
+    "question_text": {
+      "en": "Which idiom describes hidden talents?",
+      "ja": "隠れた才能を表す慣用句は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "diamond",
+        "ja": "ダイヤモンド",
+        "ja_typings": []
+      },
+      {
+        "en": "corundum",
+        "ja": "コランダム",
+        "ja_typings": []
+      },
+      {
+        "en": "topaz",
+        "ja": "トパーズ",
+        "ja_typings": []
+      },
+      {
+        "en": "quartz",
+        "ja": "クォーツ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01617",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mineral has hardness 10 on the Mohs scale?",
+      "ja": "モース硬度10の鉱物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "butterfly",
+        "ja": "蝶",
+        "ja_typings": [
+          "chou"
+        ]
+      },
+      {
+        "en": "crane",
+        "ja": "鶴",
+        "ja_typings": [
+          "tsuru"
+        ]
+      },
+      {
+        "en": "dragonfly",
+        "ja": "蜻蛉",
+        "ja_typings": [
+          "tonbo"
+        ]
+      },
+      {
+        "en": "phoenix",
+        "ja": "鳳凰",
+        "ja_typings": [
+          "houou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01618",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the family crest 'agehacho' depict?",
+      "ja": "家紋『揚羽蝶』が描くのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kizuna AI",
+        "ja": "キズナアイ",
+        "ja_typings": []
+      },
+      {
+        "en": "Mirai Akari",
+        "ja": "ミライアカリ",
+        "ja_typings": []
+      },
+      {
+        "en": "Kaguya Luna",
+        "ja": "輝夜月",
+        "ja_typings": [
+          "kaguyaruna"
+        ]
+      },
+      {
+        "en": "Siro",
+        "ja": "シロ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01619",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is known as the first virtual YouTuber?",
+      "ja": "初代バーチャルYouTuberは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nijisanji",
+        "ja": "にじさんじ",
+        "ja_typings": []
+      },
+      {
+        "en": "Hololive",
+        "ja": "ホロライブ",
+        "ja_typings": []
+      },
+      {
+        "en": "Noripro",
+        "ja": "のりプロ",
+        "ja_typings": []
+      },
+      {
+        "en": "VShojo",
+        "ja": "ブイショージョ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01620",
+    "image_path": null,
+    "question_text": {
+      "en": "Which VTuber agency is operated by Anycolor?",
+      "ja": "Anycolor運営のVTuber事務所は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "laugh",
+        "ja": "笑い",
+        "ja_typings": [
+          "warai"
+        ]
+      },
+      {
+        "en": "anger",
+        "ja": "怒り",
+        "ja_typings": [
+          "ikari"
+        ]
+      },
+      {
+        "en": "sadness",
+        "ja": "悲しみ",
+        "ja_typings": [
+          "kanashimi"
+        ]
+      },
+      {
+        "en": "agreement",
+        "ja": "同意",
+        "ja_typings": [
+          "doui"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01621",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'kusa' mean in Japanese net slang?",
+      "ja": "ネットスラング『草』の意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "mass joining to disrupt",
+        "ja": "大量参加で混乱させる行為",
+        "ja_typings": [
+          "tairyousanka de konransaseru koui"
+        ]
+      },
+      {
+        "en": "a private channel",
+        "ja": "非公開チャンネル",
+        "ja_typings": []
+      },
+      {
+        "en": "a bot command",
+        "ja": "ボットコマンド",
+        "ja_typings": []
+      },
+      {
+        "en": "a voice call feature",
+        "ja": "音声通話機能",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01622",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'Discord raid'?",
+      "ja": "『Discord荒らし』とは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "lurker",
+        "ja": "ラーカー",
+        "ja_typings": []
+      },
+      {
+        "en": "raider",
+        "ja": "レイダー",
+        "ja_typings": []
+      },
+      {
+        "en": "hyper",
+        "ja": "ハイパー",
+        "ja_typings": []
+      },
+      {
+        "en": "emoter",
+        "ja": "エモーター",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01623",
+    "image_path": null,
+    "question_text": {
+      "en": "Which term means 'lurker' in Twitch chat?",
+      "ja": "Twitchチャットで『見るだけの人』を意味するのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Away From Keyboard",
+        "ja": "席を外す",
+        "ja_typings": [
+          "sekiwohazusu"
+        ]
+      },
+      {
+        "en": "All For Kindness",
+        "ja": "親切第一",
+        "ja_typings": []
+      },
+      {
+        "en": "Anti Friend Kick",
+        "ja": "フレンドキック",
+        "ja_typings": []
+      },
+      {
+        "en": "Auto Fast Key",
+        "ja": "自動高速キー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01624",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'AFK' stand for?",
+      "ja": "『AFK』の意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rythm",
+        "ja": "リズム",
+        "ja_typings": []
+      },
+      {
+        "en": "MEE6",
+        "ja": "ミーシックス",
+        "ja_typings": []
+      },
+      {
+        "en": "Dyno",
+        "ja": "ダイノ",
+        "ja_typings": []
+      },
+      {
+        "en": "Carl-bot",
+        "ja": "カールボット",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01625",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Discord bot is famous for music streaming (before shutdown)?",
+      "ja": "音楽配信で有名だったDiscordボット(閉鎖済)は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "a derpy Pepe emote",
+        "ja": "間抜けなPepeエモート",
+        "ja_typings": [
+          "manukenaPepeemo-to"
+        ]
+      },
+      {
+        "en": "a raid command",
+        "ja": "レイドコマンド",
+        "ja_typings": []
+      },
+      {
+        "en": "a sub tier",
+        "ja": "サブスクのランク",
+        "ja_typings": []
+      },
+      {
+        "en": "a follower badge",
+        "ja": "フォロワーバッジ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01626",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'pepega' refer to in Twitch culture?",
+      "ja": "Twitch文化での『pepega』は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "revealing private info",
+        "ja": "個人情報暴露",
+        "ja_typings": [
+          "kojinjouhoubakuro"
+        ]
+      },
+      {
+        "en": "hacking accounts",
+        "ja": "アカウント乗っ取り",
+        "ja_typings": [
+          "akauntonottori"
+        ]
+      },
+      {
+        "en": "creating fake profiles",
+        "ja": "偽プロフ作成",
+        "ja_typings": []
+      },
+      {
+        "en": "spamming chats",
+        "ja": "チャットスパム",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01627",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'doxxing'?",
+      "ja": "『ドキシング』とは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "hisashiburu",
+        "ja": "ひさしぶる",
+        "ja_typings": []
+      },
+      {
+        "en": "kuriku ri",
+        "ja": "クリクリ",
+        "ja_typings": []
+      },
+      {
+        "en": "itai",
+        "ja": "イタイ",
+        "ja_typings": []
+      },
+      {
+        "en": "gugu ru",
+        "ja": "ググる",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01628",
+    "image_path": null,
+    "question_text": {
+      "en": "Which slang phrase originated from 2channel for 'has been a while'?",
+      "ja": "2ちゃん発祥の『久しぶり』系スラングは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "clever idea",
+        "ja": "賢い発想",
+        "ja_typings": [
+          "kashikoihassou"
+        ]
+      },
+      {
+        "en": "dumb idea",
+        "ja": "愚かな発想",
+        "ja_typings": []
+      },
+      {
+        "en": "nostalgic feeling",
+        "ja": "懐かしい感情",
+        "ja_typings": []
+      },
+      {
+        "en": "angry response",
+        "ja": "怒りの反応",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01629",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the meme 'Big Brain' express?",
+      "ja": "ミーム『Big Brain』の意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gawr Gura",
+        "ja": "がうるぐら",
+        "ja_typings": []
+      },
+      {
+        "en": "Watson Amelia",
+        "ja": "ワトソンアメリア",
+        "ja_typings": []
+      },
+      {
+        "en": "Ninomae Inanis",
+        "ja": "一伊那尓栖",
+        "ja_typings": [
+          "ninomaeinanisu"
+        ]
+      },
+      {
+        "en": "Mori Calliope",
+        "ja": "森カリオペ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01630",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive member is known as the shark girl?",
+      "ja": "サメ少女として知られるホロメンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "amazed reaction",
+        "ja": "驚嘆の反応",
+        "ja_typings": [
+          "kyoutan no hannou"
+        ]
+      },
+      {
+        "en": "polite greeting",
+        "ja": "丁寧な挨拶",
+        "ja_typings": []
+      },
+      {
+        "en": "game over",
+        "ja": "ゲーム終了",
+        "ja_typings": []
+      },
+      {
+        "en": "private message",
+        "ja": "個別メッセージ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01631",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'POG' mean in stream chat?",
+      "ja": "配信チャットの『POG』の意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "regulars",
+        "ja": "レギュラーズ",
+        "ja_typings": []
+      },
+      {
+        "en": "subbies",
+        "ja": "サビーズ",
+        "ja_typings": []
+      },
+      {
+        "en": "hypers",
+        "ja": "ハイパーズ",
+        "ja_typings": []
+      },
+      {
+        "en": "nubs",
+        "ja": "ナブズ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01632",
+    "image_path": null,
+    "question_text": {
+      "en": "Which term refers to a Twitch streamer's loyal viewers?",
+      "ja": "Twitch配信者の常連視聴者を指す語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "copied text spread online",
+        "ja": "ネットで拡散される定型文",
+        "ja_typings": [
+          "nettode kakusansareru teikeibun"
+        ]
+      },
+      {
+        "en": "Italian recipe",
+        "ja": "イタリア料理",
+        "ja_typings": []
+      },
+      {
+        "en": "Discord channel type",
+        "ja": "Discordチャンネル種類",
+        "ja_typings": []
+      },
+      {
+        "en": "private DM type",
+        "ja": "DMの種類",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01633",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'copypasta'?",
+      "ja": "『コピペ』とは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "wwwwww",
+        "ja": "wwwwww",
+        "ja_typings": []
+      },
+      {
+        "en": "orz",
+        "ja": "orz",
+        "ja_typings": []
+      },
+      {
+        "en": "xD",
+        "ja": "xD",
+        "ja_typings": []
+      },
+      {
+        "en": "T_T",
+        "ja": "T_T",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01634",
+    "image_path": null,
+    "question_text": {
+      "en": "Which slang means 'crying with laughter' as kaomoji-like?",
+      "ja": "笑い泣きを表す日本のネット表現は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mori Calliope",
+        "ja": "森カリオペ",
+        "ja_typings": [
+          "morikariope"
+        ]
+      },
+      {
+        "en": "Houshou Marine",
+        "ja": "宝鐘マリン",
+        "ja_typings": [
+          "houshoumarine"
+        ]
+      },
+      {
+        "en": "Usada Pekora",
+        "ja": "兎田ぺこら",
+        "ja_typings": [
+          "usadapekora"
+        ]
+      },
+      {
+        "en": "Shirakami Fubuki",
+        "ja": "白上フブキ",
+        "ja_typings": [
+          "shirakamifubuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01635",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Vtuber created the song 'Hyperdontia'?",
+      "ja": "『Hyperdontia』を歌ったVtuberは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "invisible muting by platform",
+        "ja": "プラットフォームによる隠れミュート",
+        "ja_typings": [
+          "puratto-fo-mu ni yoru kakuremyu-to"
+        ]
+      },
+      {
+        "en": "temporary kick",
+        "ja": "一時キック",
+        "ja_typings": []
+      },
+      {
+        "en": "permanent IP ban",
+        "ja": "永久IP遮断",
+        "ja_typings": []
+      },
+      {
+        "en": "warning message",
+        "ja": "警告メッセージ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01636",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'shadowbanning'?",
+      "ja": "『シャドウバン』とは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sarcasm",
+        "ja": "皮肉",
+        "ja_typings": [
+          "hiniku"
+        ]
+      },
+      {
+        "en": "approval",
+        "ja": "称賛",
+        "ja_typings": [
+          "shousan"
+        ]
+      },
+      {
+        "en": "confusion",
+        "ja": "困惑",
+        "ja_typings": [
+          "konwaku"
+        ]
+      },
+      {
+        "en": "greeting",
+        "ja": "挨拶",
+        "ja_typings": [
+          "aisatsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01637",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'Kappa' represent in Twitch chat?",
+      "ja": "Twitchの『Kappa』エモートは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "5channel",
+        "ja": "5ちゃんねる",
+        "ja_typings": [
+          "go channeru"
+        ]
+      },
+      {
+        "en": "Yahoo Chiebukuro",
+        "ja": "Yahoo知恵袋",
+        "ja_typings": []
+      },
+      {
+        "en": "Mixi",
+        "ja": "ミクシィ",
+        "ja_typings": []
+      },
+      {
+        "en": "Niconico",
+        "ja": "ニコニコ動画",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01638",
+    "image_path": null,
+    "question_text": {
+      "en": "Which platform did 2channel evolve into?",
+      "ja": "2ちゃんねるが進化したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "paying respects",
+        "ja": "敬意を表す",
+        "ja_typings": [
+          "keiiwoarawasu"
+        ]
+      },
+      {
+        "en": "expressing anger",
+        "ja": "怒りを表す",
+        "ja_typings": []
+      },
+      {
+        "en": "requesting help",
+        "ja": "助けを求める",
+        "ja_typings": []
+      },
+      {
+        "en": "celebrating victory",
+        "ja": "勝利を祝う",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01639",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the meme 'F in chat' express?",
+      "ja": "ミーム『F in chat』の意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yashiro Kizuku",
+        "ja": "社築",
+        "ja_typings": [
+          "yashirokizuku"
+        ]
+      },
+      {
+        "en": "Kuzuha",
+        "ja": "葛葉",
+        "ja_typings": [
+          "kuzuha"
+        ]
+      },
+      {
+        "en": "Mafumafu",
+        "ja": "まふまふ",
+        "ja_typings": []
+      },
+      {
+        "en": "Kanae",
+        "ja": "叶",
+        "ja_typings": [
+          "kanae"
+        ]
+      }
+    ],
+    "correct_answer_index": 1,
+    "genre": "vtuber_net_culture",
+    "id": "q01640",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nijisanji liver is known as the demon lord?",
+      "ja": "にじさんじで魔王として知られるライバーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "targeting streamers in game",
+        "ja": "配信者を狙う行為",
+        "ja_typings": [
+          "haishinsha wo nerau koui"
+        ]
+      },
+      {
+        "en": "clip sharing",
+        "ja": "クリップ共有",
+        "ja_typings": []
+      },
+      {
+        "en": "multi-streaming",
+        "ja": "マルチ配信",
+        "ja_typings": []
+      },
+      {
+        "en": "subgifting",
+        "ja": "サブギフト",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01641",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'stream sniping'?",
+      "ja": "『ストリームスナイプ』とは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "one of my mutuals",
+        "ja": "相互フォロワー",
+        "ja_typings": [
+          "sougofororowa-"
+        ]
+      },
+      {
+        "en": "offline meet friend",
+        "ja": "オフ会の友達",
+        "ja_typings": []
+      },
+      {
+        "en": "old online member",
+        "ja": "古参メンバー",
+        "ja_typings": []
+      },
+      {
+        "en": "out of mind followers",
+        "ja": "推し垢",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01642",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'OOMfie' refer to on Twitter?",
+      "ja": "X(Twitter)の『OOMfie』は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sotsugyou",
+        "ja": "卒業",
+        "ja_typings": [
+          "sotsugyou"
+        ]
+      },
+      {
+        "en": "nyugaku",
+        "ja": "入学",
+        "ja_typings": [
+          "nyuugaku"
+        ]
+      },
+      {
+        "en": "ryuugaku",
+        "ja": "留学",
+        "ja_typings": []
+      },
+      {
+        "en": "shuugaku",
+        "ja": "修学",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01643",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Vtuber graduation event is called 'sotsugyou'?",
+      "ja": "Vtuberが活動終了することを何という?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Drakeposting",
+        "ja": "ドレイクポスティング",
+        "ja_typings": []
+      },
+      {
+        "en": "Pepe meme",
+        "ja": "ペペミーム",
+        "ja_typings": []
+      },
+      {
+        "en": "Distracted Boyfriend",
+        "ja": "浮気彼氏",
+        "ja_typings": []
+      },
+      {
+        "en": "Galaxy Brain",
+        "ja": "ギャラクシーブレイン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01644",
+    "image_path": null,
+    "question_text": {
+      "en": "Which meme features Drake approving/disapproving?",
+      "ja": "Drakeが承認/否認するミームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "spineless",
+        "ja": "腰抜け",
+        "ja_typings": [
+          "koshinuke"
+        ]
+      },
+      {
+        "en": "brave",
+        "ja": "勇敢",
+        "ja_typings": [
+          "yuukan"
+        ]
+      },
+      {
+        "en": "idle",
+        "ja": "怠け者",
+        "ja_typings": [
+          "namakemono"
+        ]
+      },
+      {
+        "en": "noisy",
+        "ja": "騒がしい",
+        "ja_typings": [
+          "sawagashii"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01645",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'mukoukotsu' mean in net slang?",
+      "ja": "ネット用語『無向骨』に近い意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "AutoMod",
+        "ja": "オートモッド",
+        "ja_typings": []
+      },
+      {
+        "en": "AutoRole",
+        "ja": "オートロール",
+        "ja_typings": []
+      },
+      {
+        "en": "AutoVoice",
+        "ja": "オートボイス",
+        "ja_typings": []
+      },
+      {
+        "en": "AutoChat",
+        "ja": "オートチャット",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01646",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Discord feature allows server moderation?",
+      "ja": "Discordでサーバー管理に使う機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "hard laughter",
+        "ja": "大爆笑",
+        "ja_typings": [
+          "daibakushou"
+        ]
+      },
+      {
+        "en": "crying",
+        "ja": "号泣",
+        "ja_typings": [
+          "goukyuu"
+        ]
+      },
+      {
+        "en": "disgust",
+        "ja": "嫌悪",
+        "ja_typings": [
+          "keno"
+        ]
+      },
+      {
+        "en": "boredom",
+        "ja": "退屈",
+        "ja_typings": [
+          "taikutsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01647",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'KEKW' express in Twitch chat?",
+      "ja": "Twitchの『KEKW』が表すのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tokino Sora",
+        "ja": "ときのそら",
+        "ja_typings": []
+      },
+      {
+        "en": "Pekora",
+        "ja": "ぺこら",
+        "ja_typings": []
+      },
+      {
+        "en": "Marine",
+        "ja": "マリン",
+        "ja_typings": []
+      },
+      {
+        "en": "Korone",
+        "ja": "ころね",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01648",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive branch is JP-based original first gen?",
+      "ja": "ホロライブJP初代1期生に属するのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HTTP/3",
+        "ja": "HTTP/3",
+        "ja_typings": []
+      },
+      {
+        "en": "HTTP/4",
+        "ja": "HTTP/4",
+        "ja_typings": []
+      },
+      {
+        "en": "SPDY",
+        "ja": "SPDY",
+        "ja_typings": []
+      },
+      {
+        "en": "WebSocket",
+        "ja": "WebSocket",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01649",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol is the successor of HTTP/2 over QUIC?",
+      "ja": "QUICベースのHTTP後継プロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "OSPF",
+        "ja": "OSPF",
+        "ja_typings": []
+      },
+      {
+        "en": "RIP",
+        "ja": "RIP",
+        "ja_typings": []
+      },
+      {
+        "en": "BGP",
+        "ja": "BGP",
+        "ja_typings": []
+      },
+      {
+        "en": "EIGRP",
+        "ja": "EIGRP",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01650",
+    "image_path": null,
+    "question_text": {
+      "en": "Which routing protocol uses link-state?",
+      "ja": "リンクステート方式のルーティングプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NVMe",
+        "ja": "NVMe",
+        "ja_typings": []
+      },
+      {
+        "en": "eSATA",
+        "ja": "eSATA",
+        "ja_typings": []
+      },
+      {
+        "en": "SCSI",
+        "ja": "SCSI",
+        "ja_typings": []
+      },
+      {
+        "en": "ATA",
+        "ja": "ATA",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01651",
+    "image_path": null,
+    "question_text": {
+      "en": "Which storage interface is replacing SATA SSDs?",
+      "ja": "SATA SSDを置き換えつつある規格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "USB-C",
+        "ja": "USB-C",
+        "ja_typings": []
+      },
+      {
+        "en": "USB-A",
+        "ja": "USB-A",
+        "ja_typings": []
+      },
+      {
+        "en": "USB-B",
+        "ja": "USB-B",
+        "ja_typings": []
+      },
+      {
+        "en": "Mini-USB",
+        "ja": "Mini-USB",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01652",
+    "image_path": null,
+    "question_text": {
+      "en": "Which port standard supports Thunderbolt 4?",
+      "ja": "Thunderbolt 4が使う物理コネクタは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DisplayPort 2.0",
+        "ja": "DisplayPort 2.0",
+        "ja_typings": []
+      },
+      {
+        "en": "HDMI 1.4",
+        "ja": "HDMI 1.4",
+        "ja_typings": []
+      },
+      {
+        "en": "VGA",
+        "ja": "VGA",
+        "ja_typings": []
+      },
+      {
+        "en": "DVI",
+        "ja": "DVI",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01653",
+    "image_path": null,
+    "question_text": {
+      "en": "Which display interface supports 8K at 60Hz?",
+      "ja": "8K60Hz対応のディスプレイ規格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ARP",
+        "ja": "ARP",
+        "ja_typings": []
+      },
+      {
+        "en": "RARP",
+        "ja": "RARP",
+        "ja_typings": []
+      },
+      {
+        "en": "DHCP",
+        "ja": "DHCP",
+        "ja_typings": []
+      },
+      {
+        "en": "DNS",
+        "ja": "DNS",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01654",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol resolves MAC from IP?",
+      "ja": "IPからMACを解決するプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ICMP",
+        "ja": "ICMP",
+        "ja_typings": []
+      },
+      {
+        "en": "IGMP",
+        "ja": "IGMP",
+        "ja_typings": []
+      },
+      {
+        "en": "SNMP",
+        "ja": "SNMP",
+        "ja_typings": []
+      },
+      {
+        "en": "SMTP",
+        "ja": "SMTP",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01655",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol carries ping packets?",
+      "ja": "pingが使うプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "RISC-V",
+        "ja": "RISC-V",
+        "ja_typings": []
+      },
+      {
+        "en": "ARM",
+        "ja": "ARM",
+        "ja_typings": []
+      },
+      {
+        "en": "x86",
+        "ja": "x86",
+        "ja_typings": []
+      },
+      {
+        "en": "MIPS",
+        "ja": "MIPS",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01656",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CPU architecture is open source?",
+      "ja": "オープンソースなCPUアーキテクチャは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vulkan",
+        "ja": "Vulkan",
+        "ja_typings": []
+      },
+      {
+        "en": "Direct3D",
+        "ja": "Direct3D",
+        "ja_typings": []
+      },
+      {
+        "en": "Metal",
+        "ja": "Metal",
+        "ja_typings": []
+      },
+      {
+        "en": "OpenGL",
+        "ja": "OpenGL",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01657",
+    "image_path": null,
+    "question_text": {
+      "en": "Which GPU API is from Khronos for low-overhead access?",
+      "ja": "Khronos策定の低オーバーヘッドGPU APIは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "802.11ax extended",
+        "ja": "802.11ax拡張",
+        "ja_typings": [
+          "8021axkakuchou"
+        ]
+      },
+      {
+        "en": "802.11ad",
+        "ja": "802.11ad",
+        "ja_typings": []
+      },
+      {
+        "en": "802.11n+",
+        "ja": "802.11nプラス",
+        "ja_typings": []
+      },
+      {
+        "en": "802.11ay",
+        "ja": "802.11ay",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01658",
+    "image_path": null,
+    "question_text": {
+      "en": "Which wireless standard is also called WiFi 6E?",
+      "ja": "WiFi 6Eの正式名称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HFP",
+        "ja": "HFP",
+        "ja_typings": []
+      },
+      {
+        "en": "A2DP",
+        "ja": "A2DP",
+        "ja_typings": []
+      },
+      {
+        "en": "AVRCP",
+        "ja": "AVRCP",
+        "ja_typings": []
+      },
+      {
+        "en": "HID",
+        "ja": "HID",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01659",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Bluetooth profile is used for hands-free calls?",
+      "ja": "ハンズフリー通話のBluetoothプロファイルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "AES",
+        "ja": "AES",
+        "ja_typings": []
+      },
+      {
+        "en": "RSA",
+        "ja": "RSA",
+        "ja_typings": []
+      },
+      {
+        "en": "ECC",
+        "ja": "ECC",
+        "ja_typings": []
+      },
+      {
+        "en": "MD5",
+        "ja": "MD5",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01660",
+    "image_path": null,
+    "question_text": {
+      "en": "Which encryption algorithm replaced DES?",
+      "ja": "DESを置き換えた暗号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ECDH",
+        "ja": "ECDH",
+        "ja_typings": []
+      },
+      {
+        "en": "RSA-OAEP",
+        "ja": "RSA-OAEP",
+        "ja_typings": []
+      },
+      {
+        "en": "DSA",
+        "ja": "DSA",
+        "ja_typings": []
+      },
+      {
+        "en": "3DES",
+        "ja": "3DES",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01661",
+    "image_path": null,
+    "question_text": {
+      "en": "Which key exchange uses elliptic curves?",
+      "ja": "楕円曲線を使う鍵交換は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "WebRTC",
+        "ja": "WebRTC",
+        "ja_typings": []
+      },
+      {
+        "en": "WebSocket",
+        "ja": "WebSocket",
+        "ja_typings": []
+      },
+      {
+        "en": "WebDAV",
+        "ja": "WebDAV",
+        "ja_typings": []
+      },
+      {
+        "en": "WebHooks",
+        "ja": "WebHooks",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01662",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol enables peer-to-peer browser communication?",
+      "ja": "ブラウザ間P2P通信を可能にするのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "graphics tablet",
+        "ja": "ペンタブレット",
+        "ja_typings": [
+          "pentaburetto"
+        ]
+      },
+      {
+        "en": "trackball",
+        "ja": "トラックボール",
+        "ja_typings": []
+      },
+      {
+        "en": "touchpad",
+        "ja": "タッチパッド",
+        "ja_typings": []
+      },
+      {
+        "en": "joystick",
+        "ja": "ジョイスティック",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01663",
+    "image_path": null,
+    "question_text": {
+      "en": "Which input device uses pressure-sensitive stylus?",
+      "ja": "筆圧感知ペンを使う入力機器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "APFS",
+        "ja": "APFS",
+        "ja_typings": []
+      },
+      {
+        "en": "HFS+",
+        "ja": "HFS+",
+        "ja_typings": []
+      },
+      {
+        "en": "exFAT",
+        "ja": "exFAT",
+        "ja_typings": []
+      },
+      {
+        "en": "ZFS",
+        "ja": "ZFS",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01664",
+    "image_path": null,
+    "question_text": {
+      "en": "Which file system is default on modern macOS?",
+      "ja": "現代のmacOSの標準ファイルシステムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "RAID 5",
+        "ja": "RAID 5",
+        "ja_typings": []
+      },
+      {
+        "en": "RAID 0",
+        "ja": "RAID 0",
+        "ja_typings": []
+      },
+      {
+        "en": "RAID 1",
+        "ja": "RAID 1",
+        "ja_typings": []
+      },
+      {
+        "en": "RAID 10",
+        "ja": "RAID 10",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01665",
+    "image_path": null,
+    "question_text": {
+      "en": "Which RAID level provides striping with parity?",
+      "ja": "ストライピング+パリティのRAIDレベルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "AS-PATH",
+        "ja": "AS-PATH",
+        "ja_typings": []
+      },
+      {
+        "en": "MED",
+        "ja": "MED",
+        "ja_typings": []
+      },
+      {
+        "en": "ORIGIN",
+        "ja": "ORIGIN",
+        "ja_typings": []
+      },
+      {
+        "en": "NEXT-HOP",
+        "ja": "NEXT-HOP",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01666",
+    "image_path": null,
+    "question_text": {
+      "en": "Which BGP attribute determines best path?",
+      "ja": "BGP最適経路を決める属性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "OLED",
+        "ja": "OLED",
+        "ja_typings": []
+      },
+      {
+        "en": "LCD",
+        "ja": "LCD",
+        "ja_typings": []
+      },
+      {
+        "en": "CRT",
+        "ja": "CRT",
+        "ja_typings": []
+      },
+      {
+        "en": "EPD",
+        "ja": "EPD",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01667",
+    "image_path": null,
+    "question_text": {
+      "en": "Which display tech uses self-emitting pixels?",
+      "ja": "自発光画素を使うディスプレイは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "UEFI",
+        "ja": "UEFI",
+        "ja_typings": []
+      },
+      {
+        "en": "Legacy BIOS",
+        "ja": "Legacy BIOS",
+        "ja_typings": []
+      },
+      {
+        "en": "EFI 1.0",
+        "ja": "EFI 1.0",
+        "ja_typings": []
+      },
+      {
+        "en": "Open Firmware",
+        "ja": "Open Firmware",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01668",
+    "image_path": null,
+    "question_text": {
+      "en": "Which BIOS replacement uses GPT partitions?",
+      "ja": "GPTパーティションを使うBIOS後継は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NTP",
+        "ja": "NTP",
+        "ja_typings": []
+      },
+      {
+        "en": "PTP",
+        "ja": "PTP",
+        "ja_typings": []
+      },
+      {
+        "en": "SNTP",
+        "ja": "SNTP",
+        "ja_typings": []
+      },
+      {
+        "en": "RTSP",
+        "ja": "RTSP",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01669",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol is used for time synchronization?",
+      "ja": "時刻同期に使うプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "router",
+        "ja": "ルーター",
+        "ja_typings": []
+      },
+      {
+        "en": "hub",
+        "ja": "ハブ",
+        "ja_typings": []
+      },
+      {
+        "en": "repeater",
+        "ja": "リピーター",
+        "ja_typings": []
+      },
+      {
+        "en": "bridge",
+        "ja": "ブリッジ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01670",
+    "image_path": null,
+    "question_text": {
+      "en": "Which network device operates at OSI layer 3?",
+      "ja": "OSI第3層で動作する機器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Single-mode fiber",
+        "ja": "シングルモードファイバ",
+        "ja_typings": [
+          "shingurumo-dofaiba"
+        ]
+      },
+      {
+        "en": "Cat6",
+        "ja": "Cat6",
+        "ja_typings": []
+      },
+      {
+        "en": "Coaxial",
+        "ja": "同軸ケーブル",
+        "ja_typings": [
+          "doujikeburu"
+        ]
+      },
+      {
+        "en": "Ribbon cable",
+        "ja": "リボンケーブル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01671",
+    "image_path": null,
+    "question_text": {
+      "en": "Which cable type uses fiber optics?",
+      "ja": "光ファイバを使うケーブルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ARMv8",
+        "ja": "ARMv8",
+        "ja_typings": []
+      },
+      {
+        "en": "x86-64",
+        "ja": "x86-64",
+        "ja_typings": []
+      },
+      {
+        "en": "POWER9",
+        "ja": "POWER9",
+        "ja_typings": []
+      },
+      {
+        "en": "SPARC",
+        "ja": "SPARC",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01672",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CPU instruction set is used in Apple Silicon?",
+      "ja": "Apple Siliconが採用する命令セットは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Keccak",
+        "ja": "Keccak",
+        "ja_typings": []
+      },
+      {
+        "en": "Merkle-Damgard",
+        "ja": "Merkle-Damgard",
+        "ja_typings": []
+      },
+      {
+        "en": "Blake2",
+        "ja": "Blake2",
+        "ja_typings": []
+      },
+      {
+        "en": "MD6",
+        "ja": "MD6",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01673",
+    "image_path": null,
+    "question_text": {
+      "en": "Which hash function is part of SHA-3?",
+      "ja": "SHA-3の基礎関数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "port 22",
+        "ja": "22番ポート",
+        "ja_typings": [
+          "22ban po-to"
+        ]
+      },
+      {
+        "en": "port 21",
+        "ja": "21番ポート",
+        "ja_typings": []
+      },
+      {
+        "en": "port 23",
+        "ja": "23番ポート",
+        "ja_typings": []
+      },
+      {
+        "en": "port 25",
+        "ja": "25番ポート",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01674",
+    "image_path": null,
+    "question_text": {
+      "en": "Which port number does SSH use?",
+      "ja": "SSHが使うポート番号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "OCI image",
+        "ja": "OCIイメージ",
+        "ja_typings": []
+      },
+      {
+        "en": "Docker v1",
+        "ja": "Docker v1",
+        "ja_typings": []
+      },
+      {
+        "en": "LXC",
+        "ja": "LXC",
+        "ja_typings": []
+      },
+      {
+        "en": "rkt",
+        "ja": "rkt",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01675",
+    "image_path": null,
+    "question_text": {
+      "en": "Which container format is OCI standard?",
+      "ja": "OCI標準のコンテナ形式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NVIDIA",
+        "ja": "NVIDIA",
+        "ja_typings": []
+      },
+      {
+        "en": "AMD",
+        "ja": "AMD",
+        "ja_typings": []
+      },
+      {
+        "en": "Intel",
+        "ja": "Intel",
+        "ja_typings": []
+      },
+      {
+        "en": "Imagination",
+        "ja": "Imagination",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01676",
+    "image_path": null,
+    "question_text": {
+      "en": "Which GPU vendor created CUDA?",
+      "ja": "CUDAを開発したGPUベンダは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "VXLAN",
+        "ja": "VXLAN",
+        "ja_typings": []
+      },
+      {
+        "en": "MPLS",
+        "ja": "MPLS",
+        "ja_typings": []
+      },
+      {
+        "en": "GRE",
+        "ja": "GRE",
+        "ja_typings": []
+      },
+      {
+        "en": "PPP",
+        "ja": "PPP",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01677",
+    "image_path": null,
+    "question_text": {
+      "en": "Which key concept allows VLANs over WAN?",
+      "ja": "WAN越しにVLANを実現する技術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Intel VT-x",
+        "ja": "Intel VT-x",
+        "ja_typings": []
+      },
+      {
+        "en": "Intel SGX",
+        "ja": "Intel SGX",
+        "ja_typings": []
+      },
+      {
+        "en": "Intel TXT",
+        "ja": "Intel TXT",
+        "ja_typings": []
+      },
+      {
+        "en": "Intel AMT",
+        "ja": "Intel AMT",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01678",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CPU feature accelerates virtualization?",
+      "ja": "仮想化を加速するCPU機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ArgoCD",
+        "ja": "ArgoCD",
+        "ja_typings": []
+      },
+      {
+        "en": "Jenkins X",
+        "ja": "Jenkins X",
+        "ja_typings": []
+      },
+      {
+        "en": "Spinnaker",
+        "ja": "Spinnaker",
+        "ja_typings": []
+      },
+      {
+        "en": "Tekton",
+        "ja": "Tekton",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01679",
+    "image_path": null,
+    "question_text": {
+      "en": "Which GitOps tool is part of CNCF?",
+      "ja": "CNCFのGitOpsツールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Linkerd",
+        "ja": "Linkerd",
+        "ja_typings": []
+      },
+      {
+        "en": "Istio",
+        "ja": "Istio",
+        "ja_typings": []
+      },
+      {
+        "en": "Consul Connect",
+        "ja": "Consul Connect",
+        "ja_typings": []
+      },
+      {
+        "en": "Kuma",
+        "ja": "Kuma",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01680",
+    "image_path": null,
+    "question_text": {
+      "en": "Which service mesh is created by Buoyant?",
+      "ja": "Buoyant社のサービスメッシュは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "OpenTelemetry",
+        "ja": "OpenTelemetry",
+        "ja_typings": []
+      },
+      {
+        "en": "OpenTracing",
+        "ja": "OpenTracing",
+        "ja_typings": []
+      },
+      {
+        "en": "OpenCensus",
+        "ja": "OpenCensus",
+        "ja_typings": []
+      },
+      {
+        "en": "Jaeger",
+        "ja": "Jaeger",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01681",
+    "image_path": null,
+    "question_text": {
+      "en": "Which standard unifies observability data?",
+      "ja": "可観測性データを統一する標準は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "eBPF",
+        "ja": "eBPF",
+        "ja_typings": []
+      },
+      {
+        "en": "LKM",
+        "ja": "LKM",
+        "ja_typings": []
+      },
+      {
+        "en": "SystemTap",
+        "ja": "SystemTap",
+        "ja_typings": []
+      },
+      {
+        "en": "DTrace",
+        "ja": "DTrace",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01682",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Linux feature allows safe kernel programmability?",
+      "ja": "Linuxカーネルを安全に拡張する機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Financial Operations",
+        "ja": "クラウド財務運用",
+        "ja_typings": [
+          "kuraudo zaimuunyou"
+        ]
+      },
+      {
+        "en": "Final Operations",
+        "ja": "最終運用",
+        "ja_typings": []
+      },
+      {
+        "en": "Firmware Operations",
+        "ja": "ファームウェア運用",
+        "ja_typings": []
+      },
+      {
+        "en": "Finished Operations",
+        "ja": "完了運用",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01683",
+    "image_path": null,
+    "question_text": {
+      "en": "What does FinOps stand for?",
+      "ja": "FinOpsの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Scrum",
+        "ja": "スクラム",
+        "ja_typings": []
+      },
+      {
+        "en": "Kanban",
+        "ja": "カンバン",
+        "ja_typings": []
+      },
+      {
+        "en": "XP",
+        "ja": "XP",
+        "ja_typings": []
+      },
+      {
+        "en": "Lean",
+        "ja": "リーン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01684",
+    "image_path": null,
+    "question_text": {
+      "en": "Which agile framework uses sprints?",
+      "ja": "スプリントを使うアジャイル手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Service Level Objective",
+        "ja": "サービスレベル目標",
+        "ja_typings": [
+          "sa-bisureberumokuhyou"
+        ]
+      },
+      {
+        "en": "Service Layer Optimization",
+        "ja": "サービス層最適化",
+        "ja_typings": []
+      },
+      {
+        "en": "Single Login Option",
+        "ja": "単一ログイン",
+        "ja_typings": []
+      },
+      {
+        "en": "Server Load Output",
+        "ja": "サーバ負荷出力",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01685",
+    "image_path": null,
+    "question_text": {
+      "en": "What does SLO stand for?",
+      "ja": "SLOの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "fuzz testing",
+        "ja": "ファズテスト",
+        "ja_typings": []
+      },
+      {
+        "en": "smoke testing",
+        "ja": "スモークテスト",
+        "ja_typings": []
+      },
+      {
+        "en": "regression testing",
+        "ja": "回帰テスト",
+        "ja_typings": [
+          "kaikitesuto"
+        ]
+      },
+      {
+        "en": "acceptance testing",
+        "ja": "受入テスト",
+        "ja_typings": [
+          "ukeiretesuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01686",
+    "image_path": null,
+    "question_text": {
+      "en": "Which testing technique tries unexpected inputs?",
+      "ja": "予期しない入力を試すテスト技法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lambda",
+        "ja": "Lambda",
+        "ja_typings": []
+      },
+      {
+        "en": "Functions",
+        "ja": "Functions",
+        "ja_typings": []
+      },
+      {
+        "en": "Cloud Run",
+        "ja": "Cloud Run",
+        "ja_typings": []
+      },
+      {
+        "en": "Cloudflare Workers",
+        "ja": "Cloudflare Workers",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01687",
+    "image_path": null,
+    "question_text": {
+      "en": "Which serverless runtime is by AWS?",
+      "ja": "AWSのサーバーレス基盤は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mean Time To Recovery",
+        "ja": "平均復旧時間",
+        "ja_typings": [
+          "heikinfukkyuujikan"
+        ]
+      },
+      {
+        "en": "Mean Time Through Requests",
+        "ja": "平均処理時間",
+        "ja_typings": []
+      },
+      {
+        "en": "Mean Test Time Repeat",
+        "ja": "平均テスト反復",
+        "ja_typings": []
+      },
+      {
+        "en": "Manual Time To Restart",
+        "ja": "手動再起動時間",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01688",
+    "image_path": null,
+    "question_text": {
+      "en": "What does MTTR mean in SRE?",
+      "ja": "SREの『MTTR』は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SRE",
+        "ja": "SRE",
+        "ja_typings": []
+      },
+      {
+        "en": "ITIL",
+        "ja": "ITIL",
+        "ja_typings": []
+      },
+      {
+        "en": "CMMI",
+        "ja": "CMMI",
+        "ja_typings": []
+      },
+      {
+        "en": "Six Sigma",
+        "ja": "Six Sigma",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01689",
+    "image_path": null,
+    "question_text": {
+      "en": "Which methodology emphasizes blameless postmortems?",
+      "ja": "ブレームレスを重視する手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "GitHub Actions",
+        "ja": "GitHub Actions",
+        "ja_typings": []
+      },
+      {
+        "en": "CircleCI",
+        "ja": "CircleCI",
+        "ja_typings": []
+      },
+      {
+        "en": "GitLab CI",
+        "ja": "GitLab CI",
+        "ja_typings": []
+      },
+      {
+        "en": "Travis CI",
+        "ja": "Travis CI",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01690",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CI/CD service is built into GitHub?",
+      "ja": "GitHub内蔵のCI/CDは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Test Driven Development",
+        "ja": "テスト駆動開発",
+        "ja_typings": [
+          "tesutokudoukaihatsu"
+        ]
+      },
+      {
+        "en": "Type Driven Design",
+        "ja": "型駆動設計",
+        "ja_typings": []
+      },
+      {
+        "en": "Task Distribution Daemon",
+        "ja": "タスク分配",
+        "ja_typings": []
+      },
+      {
+        "en": "Tool Dev Diagram",
+        "ja": "ツール図",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01691",
+    "image_path": null,
+    "question_text": {
+      "en": "What does TDD stand for?",
+      "ja": "TDDの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kubernetes",
+        "ja": "Kubernetes",
+        "ja_typings": []
+      },
+      {
+        "en": "Mesos",
+        "ja": "Mesos",
+        "ja_typings": []
+      },
+      {
+        "en": "Nomad",
+        "ja": "Nomad",
+        "ja_typings": []
+      },
+      {
+        "en": "Swarm",
+        "ja": "Swarm",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01692",
+    "image_path": null,
+    "question_text": {
+      "en": "Which container orchestrator was open-sourced by Google?",
+      "ja": "Google発のコンテナオーケストレータは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "canary release",
+        "ja": "カナリアリリース",
+        "ja_typings": []
+      },
+      {
+        "en": "blue-green",
+        "ja": "ブルーグリーン",
+        "ja_typings": []
+      },
+      {
+        "en": "big bang",
+        "ja": "ビッグバン",
+        "ja_typings": []
+      },
+      {
+        "en": "hotfix",
+        "ja": "ホットフィックス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01693",
+    "image_path": null,
+    "question_text": {
+      "en": "Which DevOps pattern reduces deployment risk by gradual rollout?",
+      "ja": "段階的展開でリスク低減するパターンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Terraform",
+        "ja": "Terraform",
+        "ja_typings": []
+      },
+      {
+        "en": "Ansible",
+        "ja": "Ansible",
+        "ja_typings": []
+      },
+      {
+        "en": "Chef",
+        "ja": "Chef",
+        "ja_typings": []
+      },
+      {
+        "en": "Puppet",
+        "ja": "Puppet",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01694",
+    "image_path": null,
+    "question_text": {
+      "en": "Which IaC tool uses HCL?",
+      "ja": "HCLを使うIaCツールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "test earlier in dev",
+        "ja": "開発の早期段階でテスト",
+        "ja_typings": [
+          "kaihatsunosoukidankaide tesuto"
+        ]
+      },
+      {
+        "en": "deploy late",
+        "ja": "後で展開",
+        "ja_typings": []
+      },
+      {
+        "en": "review code last",
+        "ja": "最後にレビュー",
+        "ja_typings": []
+      },
+      {
+        "en": "avoid testing",
+        "ja": "テストを避ける",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01695",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the term 'shift left' mean?",
+      "ja": "『シフトレフト』の意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Objectives and Key Results",
+        "ja": "目標と主要な成果",
+        "ja_typings": [
+          "mokuhyou to shuyou na seika"
+        ]
+      },
+      {
+        "en": "Operations Key Reports",
+        "ja": "運用報告",
+        "ja_typings": []
+      },
+      {
+        "en": "Open Knowledge Repository",
+        "ja": "知識リポジトリ",
+        "ja_typings": []
+      },
+      {
+        "en": "Output Kanban Records",
+        "ja": "出力カンバン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01696",
+    "image_path": null,
+    "question_text": {
+      "en": "Which framework defines OKRs?",
+      "ja": "OKRsを定める枠組みは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sailboat retrospective",
+        "ja": "セイルボート",
+        "ja_typings": []
+      },
+      {
+        "en": "Start Stop Continue",
+        "ja": "Start Stop Continue",
+        "ja_typings": []
+      },
+      {
+        "en": "4Ls retrospective",
+        "ja": "4Ls",
+        "ja_typings": []
+      },
+      {
+        "en": "Mad Sad Glad",
+        "ja": "Mad Sad Glad",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01697",
+    "image_path": null,
+    "question_text": {
+      "en": "Which retrospective format uses ports?",
+      "ja": "ポート(港)を使うレトロスペクティブは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "toggle for code paths",
+        "ja": "コード経路の切替",
+        "ja_typings": [
+          "ko-do keiro no kirikae"
+        ]
+      },
+      {
+        "en": "UI button",
+        "ja": "UIボタン",
+        "ja_typings": []
+      },
+      {
+        "en": "error code",
+        "ja": "エラーコード",
+        "ja_typings": []
+      },
+      {
+        "en": "CI badge",
+        "ja": "CIバッジ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01698",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a feature flag?",
+      "ja": "フィーチャーフラグとは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kanban",
+        "ja": "カンバン方式",
+        "ja_typings": [
+          "kanbanhoushiki"
+        ]
+      },
+      {
+        "en": "Scrum",
+        "ja": "スクラム方式",
+        "ja_typings": []
+      },
+      {
+        "en": "Waterfall",
+        "ja": "ウォーターフォール",
+        "ja_typings": []
+      },
+      {
+        "en": "RUP",
+        "ja": "RUP",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01699",
+    "image_path": null,
+    "question_text": {
+      "en": "Which methodology limits work in progress?",
+      "ja": "進行中作業を制限する手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "unit test",
+        "ja": "単体テスト",
+        "ja_typings": [
+          "tantaitesuto"
+        ]
+      },
+      {
+        "en": "integration test",
+        "ja": "結合テスト",
+        "ja_typings": [
+          "ketsugoutesuto"
+        ]
+      },
+      {
+        "en": "system test",
+        "ja": "システムテスト",
+        "ja_typings": []
+      },
+      {
+        "en": "acceptance test",
+        "ja": "受入テスト",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01700",
+    "image_path": null,
+    "question_text": {
+      "en": "Which test isolates a single function?",
+      "ja": "単一機能を分離して試すテストは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "GKE",
+        "ja": "GKE",
+        "ja_typings": []
+      },
+      {
+        "en": "EKS",
+        "ja": "EKS",
+        "ja_typings": []
+      },
+      {
+        "en": "AKS",
+        "ja": "AKS",
+        "ja_typings": []
+      },
+      {
+        "en": "OKE",
+        "ja": "OKE",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01701",
+    "image_path": null,
+    "question_text": {
+      "en": "Which platform offers managed K8s by Google?",
+      "ja": "Google提供のマネージドK8sは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "intentional failure injection",
+        "ja": "意図的障害注入",
+        "ja_typings": [
+          "itotekishougainyuunyuu"
+        ]
+      },
+      {
+        "en": "random refactoring",
+        "ja": "ランダムリファクタ",
+        "ja_typings": []
+      },
+      {
+        "en": "agile planning",
+        "ja": "アジャイル計画",
+        "ja_typings": []
+      },
+      {
+        "en": "project chaos",
+        "ja": "プロジェクト混乱",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01702",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'chaos engineering' about?",
+      "ja": "カオスエンジニアリングとは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "blue-green deployment",
+        "ja": "ブルーグリーンデプロイ",
+        "ja_typings": [
+          "buru-guri-ndepuroi"
+        ]
+      },
+      {
+        "en": "rolling deployment",
+        "ja": "ローリングデプロイ",
+        "ja_typings": []
+      },
+      {
+        "en": "recreate deployment",
+        "ja": "再作成デプロイ",
+        "ja_typings": []
+      },
+      {
+        "en": "shadow deployment",
+        "ja": "シャドウデプロイ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01703",
+    "image_path": null,
+    "question_text": {
+      "en": "Which deployment uses identical environment swap?",
+      "ja": "同一環境を切り替える展開は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "microservices",
+        "ja": "マイクロサービス",
+        "ja_typings": []
+      },
+      {
+        "en": "monolith",
+        "ja": "モノリス",
+        "ja_typings": []
+      },
+      {
+        "en": "SOA",
+        "ja": "SOA",
+        "ja_typings": []
+      },
+      {
+        "en": "MVC",
+        "ja": "MVC",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01704",
+    "image_path": null,
+    "question_text": {
+      "en": "Which architecture decomposes apps into small services?",
+      "ja": "アプリを小サービスに分解する設計は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Service Level Agreement",
+        "ja": "サービスレベル合意",
+        "ja_typings": [
+          "sa-bisureberugoui"
+        ]
+      },
+      {
+        "en": "Software License Audit",
+        "ja": "ソフトウェアライセンス監査",
+        "ja_typings": []
+      },
+      {
+        "en": "System Log Analyzer",
+        "ja": "システムログ解析",
+        "ja_typings": []
+      },
+      {
+        "en": "Server Latency Average",
+        "ja": "平均レイテンシ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01705",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a SLA?",
+      "ja": "SLAとは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "penetration testing",
+        "ja": "ペネトレーションテスト",
+        "ja_typings": []
+      },
+      {
+        "en": "usability testing",
+        "ja": "ユーザビリティテスト",
+        "ja_typings": []
+      },
+      {
+        "en": "performance testing",
+        "ja": "性能テスト",
+        "ja_typings": [
+          "seinoutesuto"
+        ]
+      },
+      {
+        "en": "compatibility testing",
+        "ja": "互換性テスト",
+        "ja_typings": [
+          "gokansei tesuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01706",
+    "image_path": null,
+    "question_text": {
+      "en": "Which testing examines security flaws?",
+      "ja": "セキュリティ欠陥を調べるテストは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Helm",
+        "ja": "Helm",
+        "ja_typings": []
+      },
+      {
+        "en": "Kustomize",
+        "ja": "Kustomize",
+        "ja_typings": []
+      },
+      {
+        "en": "Skaffold",
+        "ja": "Skaffold",
+        "ja_typings": []
+      },
+      {
+        "en": "Tilt",
+        "ja": "Tilt",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01707",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manifest tool packages K8s apps?",
+      "ja": "K8sアプリをパッケージ化するツールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "auxiliary container in pod",
+        "ja": "Pod内の補助コンテナ",
+        "ja_typings": [
+          "pod nai no hojokontena"
+        ]
+      },
+      {
+        "en": "backup pod",
+        "ja": "バックアップPod",
+        "ja_typings": []
+      },
+      {
+        "en": "frontend service",
+        "ja": "フロントエンドサービス",
+        "ja_typings": []
+      },
+      {
+        "en": "init container only",
+        "ja": "初期化のみ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01708",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'sidecar' pattern in K8s?",
+      "ja": "K8sの『サイドカー』パターンとは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ergative case",
+        "ja": "能格",
+        "ja_typings": [
+          "nougaku"
+        ]
+      },
+      {
+        "en": "absolutive case",
+        "ja": "絶対格",
+        "ja_typings": [
+          "zettaikaku"
+        ]
+      },
+      {
+        "en": "nominative case",
+        "ja": "主格",
+        "ja_typings": [
+          "shukaku"
+        ]
+      },
+      {
+        "en": "accusative case",
+        "ja": "対格",
+        "ja_typings": [
+          "taikaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01709",
+    "image_path": null,
+    "question_text": {
+      "en": "Which case marks the subject of a transitive verb in ergative languages?",
+      "ja": "能格言語で他動詞の主語を表す格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "syllabary",
+        "ja": "音節文字",
+        "ja_typings": [
+          "onsetsumoji"
+        ]
+      },
+      {
+        "en": "alphabet",
+        "ja": "アルファベット",
+        "ja_typings": []
+      },
+      {
+        "en": "logogram",
+        "ja": "表語文字",
+        "ja_typings": [
+          "hyougomoji"
+        ]
+      },
+      {
+        "en": "abjad",
+        "ja": "アブジャド",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01710",
+    "image_path": null,
+    "question_text": {
+      "en": "Which writing system uses consonant-vowel syllables?",
+      "ja": "子音+母音の音節を表す文字体系は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Uralic",
+        "ja": "ウラル語族",
+        "ja_typings": [
+          "urarugozoku"
+        ]
+      },
+      {
+        "en": "Indo-European",
+        "ja": "インド・ヨーロッパ語族",
+        "ja_typings": []
+      },
+      {
+        "en": "Altaic",
+        "ja": "アルタイ語族",
+        "ja_typings": []
+      },
+      {
+        "en": "Dravidian",
+        "ja": "ドラヴィダ語族",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01711",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language family includes Finnish and Hungarian?",
+      "ja": "フィンランド語とハンガリー語を含む語族は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "abjad",
+        "ja": "アブジャド",
+        "ja_typings": []
+      },
+      {
+        "en": "alphabet",
+        "ja": "アルファベット",
+        "ja_typings": []
+      },
+      {
+        "en": "syllabary",
+        "ja": "音節文字",
+        "ja_typings": [
+          "onsetsumoji"
+        ]
+      },
+      {
+        "en": "abugida",
+        "ja": "アブギダ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01712",
+    "image_path": null,
+    "question_text": {
+      "en": "Which writing system represents only consonants?",
+      "ja": "子音のみを表す文字体系は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "morphology",
+        "ja": "形態論",
+        "ja_typings": [
+          "keitairon"
+        ]
+      },
+      {
+        "en": "phonology",
+        "ja": "音韻論",
+        "ja_typings": [
+          "onninron"
+        ]
+      },
+      {
+        "en": "syntax",
+        "ja": "統語論",
+        "ja_typings": [
+          "tougoron"
+        ]
+      },
+      {
+        "en": "semantics",
+        "ja": "意味論",
+        "ja_typings": [
+          "imiron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01713",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the study of word structure?",
+      "ja": "語形成を研究する分野は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "lexical tone",
+        "ja": "声調",
+        "ja_typings": [
+          "seichou"
+        ]
+      },
+      {
+        "en": "stress accent",
+        "ja": "強勢",
+        "ja_typings": [
+          "kyousei"
+        ]
+      },
+      {
+        "en": "vowel length",
+        "ja": "母音長",
+        "ja_typings": [
+          "boinchou"
+        ]
+      },
+      {
+        "en": "nasalization",
+        "ja": "鼻音化",
+        "ja_typings": [
+          "bionka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01714",
+    "image_path": null,
+    "question_text": {
+      "en": "Which feature describes Mandarin tones?",
+      "ja": "中国語のトーンを表す特徴は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hindi",
+        "ja": "ヒンディー語",
+        "ja_typings": [
+          "hindi-go"
+        ]
+      },
+      {
+        "en": "Tamil",
+        "ja": "タミル語",
+        "ja_typings": []
+      },
+      {
+        "en": "Bengali",
+        "ja": "ベンガル語",
+        "ja_typings": []
+      },
+      {
+        "en": "Telugu",
+        "ja": "テルグ語",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01715",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language uses Devanagari script?",
+      "ja": "デーヴァナーガリーを使う言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "question mark style",
+        "ja": "クェスチョンマーク型",
+        "ja_typings": [
+          "kuesuchonma-kugata"
+        ]
+      },
+      {
+        "en": "apostrophe",
+        "ja": "アポストロフィ",
+        "ja_typings": []
+      },
+      {
+        "en": "h symbol",
+        "ja": "h記号",
+        "ja_typings": [
+          "h kigou"
+        ]
+      },
+      {
+        "en": "colon style",
+        "ja": "コロン型",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01716",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the IPA symbol for the glottal stop?",
+      "ja": "声門閉鎖音のIPA記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "past perfect",
+        "ja": "過去完了",
+        "ja_typings": [
+          "kakokanryou"
+        ]
+      },
+      {
+        "en": "present perfect",
+        "ja": "現在完了",
+        "ja_typings": [
+          "genzaikanryou"
+        ]
+      },
+      {
+        "en": "future perfect",
+        "ja": "未来完了",
+        "ja_typings": []
+      },
+      {
+        "en": "simple past",
+        "ja": "単純過去",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01717",
+    "image_path": null,
+    "question_text": {
+      "en": "Which tense expresses past relative to past?",
+      "ja": "過去より前を表す時制は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Swahili",
+        "ja": "スワヒリ語",
+        "ja_typings": [
+          "suwahirigo"
+        ]
+      },
+      {
+        "en": "Zulu",
+        "ja": "ズールー語",
+        "ja_typings": []
+      },
+      {
+        "en": "Xhosa",
+        "ja": "コーサ語",
+        "ja_typings": []
+      },
+      {
+        "en": "Shona",
+        "ja": "ショナ語",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01718",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language is the most spoken Bantu language?",
+      "ja": "最も話されるバントゥー語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "noun",
+        "ja": "名詞類",
+        "ja_typings": [
+          "meishirui"
+        ]
+      },
+      {
+        "en": "conjunction",
+        "ja": "接続詞",
+        "ja_typings": [
+          "setsuzokushi"
+        ]
+      },
+      {
+        "en": "particle",
+        "ja": "助詞",
+        "ja_typings": [
+          "joshi"
+        ]
+      },
+      {
+        "en": "article",
+        "ja": "冠詞",
+        "ja_typings": [
+          "kanshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01719",
+    "image_path": null,
+    "question_text": {
+      "en": "Which type of word changes form by case in Russian?",
+      "ja": "ロシア語で格によって変化する語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hangul",
+        "ja": "ハングル",
+        "ja_typings": []
+      },
+      {
+        "en": "Hanja",
+        "ja": "漢字",
+        "ja_typings": [
+          "kanji"
+        ]
+      },
+      {
+        "en": "Romaja",
+        "ja": "ローマ字",
+        "ja_typings": [
+          "ro-maji"
+        ]
+      },
+      {
+        "en": "Katakana",
+        "ja": "カタカナ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01720",
+    "image_path": null,
+    "question_text": {
+      "en": "Which script does Korean use natively?",
+      "ja": "韓国語が固有に使う文字は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "articulatory phonetics",
+        "ja": "調音音声学",
+        "ja_typings": [
+          "chouononseigaku"
+        ]
+      },
+      {
+        "en": "acoustic phonetics",
+        "ja": "音響音声学",
+        "ja_typings": [
+          "onkyouonseigaku"
+        ]
+      },
+      {
+        "en": "auditory phonetics",
+        "ja": "聴覚音声学",
+        "ja_typings": [
+          "choukakuonseigaku"
+        ]
+      },
+      {
+        "en": "forensic phonetics",
+        "ja": "法音声学",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01721",
+    "image_path": null,
+    "question_text": {
+      "en": "Which area of phonetics studies sound production?",
+      "ja": "音声生成を研究する分野は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Basque",
+        "ja": "バスク語",
+        "ja_typings": [
+          "basukugo"
+        ]
+      },
+      {
+        "en": "Catalan",
+        "ja": "カタルーニャ語",
+        "ja_typings": []
+      },
+      {
+        "en": "Galician",
+        "ja": "ガリシア語",
+        "ja_typings": []
+      },
+      {
+        "en": "Asturian",
+        "ja": "アストゥリアス語",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01722",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language is an isolate spoken in northern Spain?",
+      "ja": "スペイン北部で話される孤立言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "accusative",
+        "ja": "対格",
+        "ja_typings": [
+          "taikaku"
+        ]
+      },
+      {
+        "en": "dative",
+        "ja": "与格",
+        "ja_typings": [
+          "yokaku"
+        ]
+      },
+      {
+        "en": "genitive",
+        "ja": "属格",
+        "ja_typings": [
+          "zokukaku"
+        ]
+      },
+      {
+        "en": "ablative",
+        "ja": "奪格",
+        "ja_typings": [
+          "dakkaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01723",
+    "image_path": null,
+    "question_text": {
+      "en": "Which case is used for direct objects in Latin?",
+      "ja": "ラテン語の直接目的語に使う格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "verb endings",
+        "ja": "動詞語尾",
+        "ja_typings": [
+          "doushigobi"
+        ]
+      },
+      {
+        "en": "article gender",
+        "ja": "冠詞性",
+        "ja_typings": []
+      },
+      {
+        "en": "noun cases",
+        "ja": "名詞格",
+        "ja_typings": [
+          "meishi kaku"
+        ]
+      },
+      {
+        "en": "vowel harmony",
+        "ja": "母音調和",
+        "ja_typings": [
+          "boinchouwa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01724",
+    "image_path": null,
+    "question_text": {
+      "en": "Which feature distinguishes Korean honorifics?",
+      "ja": "韓国語の敬語を特徴づけるのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aramaic",
+        "ja": "アラム語",
+        "ja_typings": [
+          "aramugo"
+        ]
+      },
+      {
+        "en": "Hebrew",
+        "ja": "ヘブライ語",
+        "ja_typings": []
+      },
+      {
+        "en": "Arabic",
+        "ja": "アラビア語",
+        "ja_typings": []
+      },
+      {
+        "en": "Amharic",
+        "ja": "アムハラ語",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01725",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Semitic language is the oldest still spoken?",
+      "ja": "現在も話される最古のセム語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "shift toward palatal",
+        "ja": "硬口蓋音化",
+        "ja_typings": [
+          "koukougaionka"
+        ]
+      },
+      {
+        "en": "nasal lengthening",
+        "ja": "鼻音延長",
+        "ja_typings": []
+      },
+      {
+        "en": "vowel lowering",
+        "ja": "母音低化",
+        "ja_typings": []
+      },
+      {
+        "en": "consonant doubling",
+        "ja": "子音重複",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01726",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sound change is called palatalization?",
+      "ja": "口蓋化と呼ばれる音変化は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cantonese",
+        "ja": "広東語",
+        "ja_typings": [
+          "kantongo"
+        ]
+      },
+      {
+        "en": "Mandarin",
+        "ja": "標準中国語",
+        "ja_typings": [
+          "hyoujunchuugokugo"
+        ]
+      },
+      {
+        "en": "Hakka",
+        "ja": "客家語",
+        "ja_typings": []
+      },
+      {
+        "en": "Min",
+        "ja": "ビン語",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01727",
+    "image_path": null,
+    "question_text": {
+      "en": "Which dialect of Chinese is spoken in Hong Kong?",
+      "ja": "香港で話される中国語方言は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "vertical top-to-bottom left-to-right",
+        "ja": "縦書き左から右",
+        "ja_typings": [
+          "tategaki hidari kara migi"
+        ]
+      },
+      {
+        "en": "horizontal right-to-left",
+        "ja": "横書き右から左",
+        "ja_typings": []
+      },
+      {
+        "en": "boustrophedon",
+        "ja": "牛耕式",
+        "ja_typings": []
+      },
+      {
+        "en": "circular",
+        "ja": "円書き",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01728",
+    "image_path": null,
+    "question_text": {
+      "en": "Which writing direction is traditional Mongolian?",
+      "ja": "伝統的モンゴル文字の書字方向は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Italic",
+        "ja": "イタリック語派",
+        "ja_typings": [
+          "itarikkugoha"
+        ]
+      },
+      {
+        "en": "Celtic",
+        "ja": "ケルト語派",
+        "ja_typings": []
+      },
+      {
+        "en": "Hellenic",
+        "ja": "ギリシャ語派",
+        "ja_typings": []
+      },
+      {
+        "en": "Slavic",
+        "ja": "スラブ語派",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01729",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Indo-European subgroup includes Latin?",
+      "ja": "ラテン語が属するインド・ヨーロッパ語派は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "affix chains",
+        "ja": "接辞連結",
+        "ja_typings": [
+          "setsujirenketsu"
+        ]
+      },
+      {
+        "en": "tone marking",
+        "ja": "声調表記",
+        "ja_typings": []
+      },
+      {
+        "en": "noun classes",
+        "ja": "名詞クラス",
+        "ja_typings": []
+      },
+      {
+        "en": "vowel mutation",
+        "ja": "母音変異",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01730",
+    "image_path": null,
+    "question_text": {
+      "en": "Which feature distinguishes agglutinative languages?",
+      "ja": "膠着語を特徴づけるのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sumerian",
+        "ja": "シュメール文字",
+        "ja_typings": [
+          "shume-rumoji"
+        ]
+      },
+      {
+        "en": "Egyptian",
+        "ja": "エジプト文字",
+        "ja_typings": []
+      },
+      {
+        "en": "Phoenician",
+        "ja": "フェニキア文字",
+        "ja_typings": []
+      },
+      {
+        "en": "Mayan",
+        "ja": "マヤ文字",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01731",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient writing system is cuneiform?",
+      "ja": "古代の楔形文字は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "subjunctive",
+        "ja": "接続法",
+        "ja_typings": [
+          "setsuzokuhou"
+        ]
+      },
+      {
+        "en": "indicative",
+        "ja": "直説法",
+        "ja_typings": [
+          "chokusetsuhou"
+        ]
+      },
+      {
+        "en": "imperative",
+        "ja": "命令法",
+        "ja_typings": [
+          "meireihou"
+        ]
+      },
+      {
+        "en": "conditional",
+        "ja": "条件法",
+        "ja_typings": [
+          "jouken hou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01732",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mood expresses wish or possibility?",
+      "ja": "願望や可能性を表すムードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Xhosa",
+        "ja": "コーサ語",
+        "ja_typings": [
+          "ko-sago"
+        ]
+      },
+      {
+        "en": "Mongolian",
+        "ja": "モンゴル語",
+        "ja_typings": []
+      },
+      {
+        "en": "Vietnamese",
+        "ja": "ベトナム語",
+        "ja_typings": []
+      },
+      {
+        "en": "Persian",
+        "ja": "ペルシア語",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01733",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language uses click consonants?",
+      "ja": "クリック子音を使う言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "six tones",
+        "ja": "6声調",
+        "ja_typings": [
+          "roku seichou"
+        ]
+      },
+      {
+        "en": "noun gender",
+        "ja": "名詞性",
+        "ja_typings": [
+          "meishisei"
+        ]
+      },
+      {
+        "en": "case marking",
+        "ja": "格表示",
+        "ja_typings": [
+          "kakuhyouji"
+        ]
+      },
+      {
+        "en": "vowel harmony",
+        "ja": "母音調和",
+        "ja_typings": [
+          "boinchouwa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01734",
+    "image_path": null,
+    "question_text": {
+      "en": "Which feature does Vietnamese have?",
+      "ja": "ベトナム語が持つ特徴は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Maori",
+        "ja": "マオリ語",
+        "ja_typings": [
+          "maorigo"
+        ]
+      },
+      {
+        "en": "Samoan",
+        "ja": "サモア語",
+        "ja_typings": []
+      },
+      {
+        "en": "Tongan",
+        "ja": "トンガ語",
+        "ja_typings": []
+      },
+      {
+        "en": "Fijian",
+        "ja": "フィジー語",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01735",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Austronesian language is spoken in New Zealand?",
+      "ja": "ニュージーランドで話されるオーストロネシア語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "/s/",
+        "ja": "/s/",
+        "ja_typings": []
+      },
+      {
+        "en": "/p/",
+        "ja": "/p/",
+        "ja_typings": []
+      },
+      {
+        "en": "/t/",
+        "ja": "/t/",
+        "ja_typings": []
+      },
+      {
+        "en": "/k/",
+        "ja": "/k/",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01736",
+    "image_path": null,
+    "question_text": {
+      "en": "Which speech sound is a fricative?",
+      "ja": "摩擦音はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Esperanto",
+        "ja": "エスペラント",
+        "ja_typings": []
+      },
+      {
+        "en": "Volapuk",
+        "ja": "ボラピュク",
+        "ja_typings": []
+      },
+      {
+        "en": "Lojban",
+        "ja": "ロジバン",
+        "ja_typings": []
+      },
+      {
+        "en": "Toki Pona",
+        "ja": "トキポナ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01737",
+    "image_path": null,
+    "question_text": {
+      "en": "Which constructed language is most spoken?",
+      "ja": "最も話される人工言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "triconsonantal root",
+        "ja": "三子音語根",
+        "ja_typings": [
+          "sanshion gokon"
+        ]
+      },
+      {
+        "en": "biconsonantal",
+        "ja": "二子音",
+        "ja_typings": []
+      },
+      {
+        "en": "tetraconsonantal default",
+        "ja": "四子音標準",
+        "ja_typings": []
+      },
+      {
+        "en": "vowel-based",
+        "ja": "母音基盤",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01738",
+    "image_path": null,
+    "question_text": {
+      "en": "Which feature describes Arabic root system?",
+      "ja": "アラビア語の語根体系の特徴は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "paella valenciana",
+        "ja": "パエリャ・バレンシアーナ",
+        "ja_typings": []
+      },
+      {
+        "en": "fideua",
+        "ja": "フィデウア",
+        "ja_typings": []
+      },
+      {
+        "en": "arroz negro",
+        "ja": "アロス・ネグロ",
+        "ja_typings": []
+      },
+      {
+        "en": "risotto milanese",
+        "ja": "リゾット・ミラネーゼ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01739",
+    "image_path": null,
+    "question_text": {
+      "en": "Which traditional Spanish dish is from Valencia, rice based with rabbit?",
+      "ja": "ウサギ肉入りバレンシア発祥の伝統米料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Capoeira",
+        "ja": "カポエイラ",
+        "ja_typings": []
+      },
+      {
+        "en": "Vale Tudo",
+        "ja": "バーリトゥード",
+        "ja_typings": []
+      },
+      {
+        "en": "Luta Livre",
+        "ja": "ルタリーブリ",
+        "ja_typings": []
+      },
+      {
+        "en": "Jiu-Jitsu",
+        "ja": "柔術",
+        "ja_typings": [
+          "juujutsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01740",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Brazilian martial art combines dance and acrobatics?",
+      "ja": "ダンスとアクロバットを組合せたブラジル武術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "La Tomatina",
+        "ja": "ラ・トマティーナ",
+        "ja_typings": []
+      },
+      {
+        "en": "San Fermin",
+        "ja": "サン・フェルミン",
+        "ja_typings": []
+      },
+      {
+        "en": "Las Fallas",
+        "ja": "ラス・ファジャス",
+        "ja_typings": []
+      },
+      {
+        "en": "Feria de Abril",
+        "ja": "セビーリャの春祭り",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01741",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Spanish festival celebrates tomatoes?",
+      "ja": "トマトの祭りは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sitar",
+        "ja": "シタール",
+        "ja_typings": []
+      },
+      {
+        "en": "tabla",
+        "ja": "タブラ",
+        "ja_typings": []
+      },
+      {
+        "en": "bansuri",
+        "ja": "バーンスリー",
+        "ja_typings": []
+      },
+      {
+        "en": "sarangi",
+        "ja": "サーランギー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01742",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Indian instrument has sympathetic strings?",
+      "ja": "共鳴弦を持つインドの弦楽器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Loki",
+        "ja": "ロキ",
+        "ja_typings": []
+      },
+      {
+        "en": "Thor",
+        "ja": "トール",
+        "ja_typings": []
+      },
+      {
+        "en": "Odin",
+        "ja": "オーディン",
+        "ja_typings": []
+      },
+      {
+        "en": "Freyr",
+        "ja": "フレイ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01743",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Norse mythology figure is the trickster god?",
+      "ja": "北欧神話のいたずら神は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ger",
+        "ja": "ゲル",
+        "ja_typings": []
+      },
+      {
+        "en": "yurt-stone hybrid",
+        "ja": "ストーンユルト",
+        "ja_typings": []
+      },
+      {
+        "en": "igloo",
+        "ja": "イグルー",
+        "ja_typings": []
+      },
+      {
+        "en": "longhouse",
+        "ja": "ロングハウス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01744",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mongolian traditional dwelling is round and portable?",
+      "ja": "丸く可搬なモンゴル伝統住居は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "solea",
+        "ja": "ソレア",
+        "ja_typings": []
+      },
+      {
+        "en": "alegrias",
+        "ja": "アレグリアス",
+        "ja_typings": []
+      },
+      {
+        "en": "bulerias",
+        "ja": "ブレリアス",
+        "ja_typings": []
+      },
+      {
+        "en": "rumba flamenca",
+        "ja": "ルンバ・フラメンカ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01745",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Spanish flamenco rhythm is sad and slow?",
+      "ja": "悲しくゆっくりなフラメンコのリズムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "djembe",
+        "ja": "ジャンベ",
+        "ja_typings": []
+      },
+      {
+        "en": "dunun",
+        "ja": "ドゥヌン",
+        "ja_typings": []
+      },
+      {
+        "en": "sabar",
+        "ja": "サバール",
+        "ja_typings": []
+      },
+      {
+        "en": "tama",
+        "ja": "タマ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01746",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Senegalese drum is goblet-shaped?",
+      "ja": "ゴブレット型のセネガル太鼓は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Buchaechum",
+        "ja": "扇舞",
+        "ja_typings": [
+          "senbu"
+        ]
+      },
+      {
+        "en": "Salpuri",
+        "ja": "サルプリ",
+        "ja_typings": []
+      },
+      {
+        "en": "Taepyeongmu",
+        "ja": "テピョンム",
+        "ja_typings": []
+      },
+      {
+        "en": "Seungmu",
+        "ja": "僧舞",
+        "ja_typings": [
+          "soubu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01747",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Korean court dance uses fans?",
+      "ja": "扇を使う韓国宮廷舞踊は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dia de los Muertos",
+        "ja": "死者の日",
+        "ja_typings": [
+          "shishanohi"
+        ]
+      },
+      {
+        "en": "Cinco de Mayo",
+        "ja": "シンコ・デ・マヨ",
+        "ja_typings": []
+      },
+      {
+        "en": "Las Posadas",
+        "ja": "ラス・ポサダス",
+        "ja_typings": []
+      },
+      {
+        "en": "Fiestas Patrias",
+        "ja": "独立記念",
+        "ja_typings": [
+          "dokuritsukinen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01748",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mexican holiday honors deceased relatives?",
+      "ja": "故人を偲ぶメキシコの祭日は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wayang Kulit",
+        "ja": "ワヤン・クリ",
+        "ja_typings": []
+      },
+      {
+        "en": "Wayang Golek",
+        "ja": "ワヤン・ゴレ",
+        "ja_typings": []
+      },
+      {
+        "en": "Wayang Topeng",
+        "ja": "ワヤン・トペン",
+        "ja_typings": []
+      },
+      {
+        "en": "Wayang Wong",
+        "ja": "ワヤン・ウォン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01749",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Indonesian shadow puppet theater is UNESCO listed?",
+      "ja": "ユネスコ登録のインドネシア影絵芝居は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Selyodka pod shuboy",
+        "ja": "毛皮を着たニシン",
+        "ja_typings": [
+          "kegawawokita nishin"
+        ]
+      },
+      {
+        "en": "Borscht",
+        "ja": "ボルシチ",
+        "ja_typings": []
+      },
+      {
+        "en": "Pelmeni",
+        "ja": "ペリメニ",
+        "ja_typings": []
+      },
+      {
+        "en": "Olivier salad",
+        "ja": "オリヴィエサラダ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01750",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Russian dish is layered with herring and beets?",
+      "ja": "ニシンとビーツの層状ロシア料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "tambouras",
+        "ja": "タンブーラス",
+        "ja_typings": []
+      },
+      {
+        "en": "kithara",
+        "ja": "キタラ",
+        "ja_typings": []
+      },
+      {
+        "en": "aulos",
+        "ja": "アウロス",
+        "ja_typings": []
+      },
+      {
+        "en": "lyra",
+        "ja": "リラ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01751",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Greek instrument is a bouzouki ancestor?",
+      "ja": "ブズーキの祖先となるギリシャ楽器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "siku",
+        "ja": "シーク",
+        "ja_typings": []
+      },
+      {
+        "en": "quena",
+        "ja": "ケーナ",
+        "ja_typings": []
+      },
+      {
+        "en": "charango",
+        "ja": "チャランゴ",
+        "ja_typings": []
+      },
+      {
+        "en": "bombo",
+        "ja": "ボンボ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01752",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Andean instrument is a panpipe?",
+      "ja": "アンデスのパンパイプは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "injera",
+        "ja": "インジェラ",
+        "ja_typings": []
+      },
+      {
+        "en": "kitfo",
+        "ja": "キトフォ",
+        "ja_typings": []
+      },
+      {
+        "en": "doro wat",
+        "ja": "ドロワット",
+        "ja_typings": []
+      },
+      {
+        "en": "tibs",
+        "ja": "ティブス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01753",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Ethiopian bread is spongy and sour?",
+      "ja": "スポンジ状で酸味のあるエチオピアのパンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sphinx",
+        "ja": "スフィンクス",
+        "ja_typings": []
+      },
+      {
+        "en": "Bennu",
+        "ja": "ベンヌ",
+        "ja_typings": []
+      },
+      {
+        "en": "Apep",
+        "ja": "アペプ",
+        "ja_typings": []
+      },
+      {
+        "en": "Anubis",
+        "ja": "アヌビス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01754",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Egyptian mythological creature has lion body and human head?",
+      "ja": "ライオン体に人頭のエジプト神話の生物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kanto Matsuri",
+        "ja": "竿燈まつり",
+        "ja_typings": [
+          "kantoumatsuri"
+        ]
+      },
+      {
+        "en": "Nebuta Matsuri",
+        "ja": "ねぶた祭り",
+        "ja_typings": [
+          "nebutamatsuri"
+        ]
+      },
+      {
+        "en": "Tanabata Matsuri",
+        "ja": "七夕まつり",
+        "ja_typings": [
+          "tanabatamatsuri"
+        ]
+      },
+      {
+        "en": "Yamagata Hanagasa",
+        "ja": "山形花笠",
+        "ja_typings": [
+          "yamagatahanagasa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01755",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese festival is in Akita with paper lanterns balanced on poles?",
+      "ja": "秋田で行われる竿燈の祭りは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yoruba religion",
+        "ja": "ヨルバ宗教",
+        "ja_typings": [
+          "yorubashuukyou"
+        ]
+      },
+      {
+        "en": "Vodun",
+        "ja": "ヴォドゥン",
+        "ja_typings": []
+      },
+      {
+        "en": "Santeria",
+        "ja": "サンテリア",
+        "ja_typings": []
+      },
+      {
+        "en": "Candomble",
+        "ja": "カンドンブレ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01756",
+    "image_path": null,
+    "question_text": {
+      "en": "Which African religion focuses on ancestors and Orishas?",
+      "ja": "祖先とオリシャを崇拝するアフリカ宗教は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tarantella",
+        "ja": "タランテラ",
+        "ja_typings": []
+      },
+      {
+        "en": "Saltarello",
+        "ja": "サルタレロ",
+        "ja_typings": []
+      },
+      {
+        "en": "Pizzica",
+        "ja": "ピッツィカ",
+        "ja_typings": []
+      },
+      {
+        "en": "Forlana",
+        "ja": "フォルラーナ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01757",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian dance is fast paced from Naples?",
+      "ja": "ナポリ発祥の速いイタリア舞踊は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "dungchen",
+        "ja": "ドゥンチェン",
+        "ja_typings": []
+      },
+      {
+        "en": "damaru",
+        "ja": "ダマル",
+        "ja_typings": []
+      },
+      {
+        "en": "gyaling",
+        "ja": "ギャリン",
+        "ja_typings": []
+      },
+      {
+        "en": "kangling",
+        "ja": "カンリン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01758",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Tibetan instrument is a long horn?",
+      "ja": "チベットの長い角笛は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Polonaise",
+        "ja": "ポロネーズ",
+        "ja_typings": []
+      },
+      {
+        "en": "Mazurka",
+        "ja": "マズルカ",
+        "ja_typings": []
+      },
+      {
+        "en": "Krakowiak",
+        "ja": "クラコヴィアク",
+        "ja_typings": []
+      },
+      {
+        "en": "Oberek",
+        "ja": "オベレク",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01759",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Polish dance is in triple meter and elegant?",
+      "ja": "三拍子で優雅なポーランド舞踊は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ghazal",
+        "ja": "ガザル",
+        "ja_typings": []
+      },
+      {
+        "en": "qasida",
+        "ja": "カシーダ",
+        "ja_typings": []
+      },
+      {
+        "en": "rubaiyat",
+        "ja": "ルバイヤート",
+        "ja_typings": []
+      },
+      {
+        "en": "masnavi",
+        "ja": "マスナヴィー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01760",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Persian poetic form has couplets?",
+      "ja": "対句で構成されるペルシア詩形は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "gulab jamun",
+        "ja": "グラブジャムン",
+        "ja_typings": []
+      },
+      {
+        "en": "samosa",
+        "ja": "サモサ",
+        "ja_typings": []
+      },
+      {
+        "en": "dosa",
+        "ja": "ドーサ",
+        "ja_typings": []
+      },
+      {
+        "en": "biryani",
+        "ja": "ビリヤニ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01761",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Indian sweet is made from milk solids?",
+      "ja": "ミルク固形分から作るインドの菓子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "bagpipes",
+        "ja": "バグパイプ",
+        "ja_typings": []
+      },
+      {
+        "en": "fiddle",
+        "ja": "フィドル",
+        "ja_typings": []
+      },
+      {
+        "en": "bodhran",
+        "ja": "ボウラン",
+        "ja_typings": []
+      },
+      {
+        "en": "clarsach",
+        "ja": "クラルサッハ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01762",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Scottish instrument has bag and drones?",
+      "ja": "袋とドローンを持つスコットランド楽器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Beijing opera",
+        "ja": "京劇",
+        "ja_typings": [
+          "kyougeki"
+        ]
+      },
+      {
+        "en": "Cantonese opera",
+        "ja": "粤劇",
+        "ja_typings": [
+          "echigeki"
+        ]
+      },
+      {
+        "en": "Kun opera",
+        "ja": "崑曲",
+        "ja_typings": [
+          "konkyoku"
+        ]
+      },
+      {
+        "en": "Sichuan opera",
+        "ja": "川劇",
+        "ja_typings": [
+          "sengeki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01763",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Chinese opera region is most famous?",
+      "ja": "中国京劇の中心地は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "tipi",
+        "ja": "ティーピー",
+        "ja_typings": []
+      },
+      {
+        "en": "wigwam",
+        "ja": "ウィグワム",
+        "ja_typings": []
+      },
+      {
+        "en": "hogan",
+        "ja": "ホーガン",
+        "ja_typings": []
+      },
+      {
+        "en": "longhouse",
+        "ja": "ロングハウス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01764",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Native American structure is a conical tent?",
+      "ja": "円錐形のネイティブアメリカン住居は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hula",
+        "ja": "フラ",
+        "ja_typings": []
+      },
+      {
+        "en": "Tahitian dance",
+        "ja": "タヒチアンダンス",
+        "ja_typings": []
+      },
+      {
+        "en": "Haka",
+        "ja": "ハカ",
+        "ja_typings": []
+      },
+      {
+        "en": "Siva",
+        "ja": "シヴァ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01765",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hawaiian dance tells stories with hands?",
+      "ja": "手で物語を表すハワイの舞踊は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "moules frites",
+        "ja": "ムール・フリット",
+        "ja_typings": []
+      },
+      {
+        "en": "waterzooi",
+        "ja": "ワーテルゾーイ",
+        "ja_typings": []
+      },
+      {
+        "en": "carbonade flamande",
+        "ja": "カルボナード",
+        "ja_typings": []
+      },
+      {
+        "en": "stoofvlees",
+        "ja": "ストーフレース",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01766",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Belgian dish is mussels with fries?",
+      "ja": "ムール貝とフライドポテトのベルギー料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Quetzalcoatl",
+        "ja": "ケツァルコアトル",
+        "ja_typings": []
+      },
+      {
+        "en": "Huitzilopochtli",
+        "ja": "ウィツィロポチトリ",
+        "ja_typings": []
+      },
+      {
+        "en": "Tezcatlipoca",
+        "ja": "テスカトリポカ",
+        "ja_typings": []
+      },
+      {
+        "en": "Tlaloc",
+        "ja": "トラロック",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01767",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Aztec god is the feathered serpent?",
+      "ja": "羽毛の蛇のアステカ神は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "pho",
+        "ja": "フォー",
+        "ja_typings": []
+      },
+      {
+        "en": "bun bo Hue",
+        "ja": "ブン・ボー・フエ",
+        "ja_typings": []
+      },
+      {
+        "en": "hu tieu",
+        "ja": "フーティウ",
+        "ja_typings": []
+      },
+      {
+        "en": "mi quang",
+        "ja": "ミー・クアン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01768",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Vietnamese soup is broth-based with herbs?",
+      "ja": "ハーブを使うベトナム麺スープは?"
+    }
   }
 ]

--- a/data/questions_en.json
+++ b/data/questions_en.json
@@ -32888,5 +32888,13545 @@
       "en": "Which Portuguese-born explorer led the first expedition to circumnavigate the globe?",
       "ja": "世界一周航海の最初の遠征を率いたポルトガル出身の探検家は?"
     }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vietnam",
+        "ja": "ベトナム",
+        "ja_typings": []
+      },
+      {
+        "en": "Laos",
+        "ja": "ラオス",
+        "ja_typings": []
+      },
+      {
+        "en": "Cambodia",
+        "ja": "カンボジア",
+        "ja_typings": []
+      },
+      {
+        "en": "Myanmar",
+        "ja": "ミャンマー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00822",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Hanoi as its capital?",
+      "ja": "ハノイを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Indonesia",
+        "ja": "インドネシア",
+        "ja_typings": []
+      },
+      {
+        "en": "Malaysia",
+        "ja": "マレーシア",
+        "ja_typings": []
+      },
+      {
+        "en": "Philippines",
+        "ja": "フィリピン",
+        "ja_typings": []
+      },
+      {
+        "en": "Singapore",
+        "ja": "シンガポール",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00823",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Jakarta as its capital?",
+      "ja": "ジャカルタを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Turkey",
+        "ja": "トルコ",
+        "ja_typings": []
+      },
+      {
+        "en": "Greece",
+        "ja": "ギリシャ",
+        "ja_typings": []
+      },
+      {
+        "en": "Bulgaria",
+        "ja": "ブルガリア",
+        "ja_typings": []
+      },
+      {
+        "en": "Romania",
+        "ja": "ルーマニア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00824",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Ankara as its capital?",
+      "ja": "アンカラを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Portugal",
+        "ja": "ポルトガル",
+        "ja_typings": []
+      },
+      {
+        "en": "Spain",
+        "ja": "スペイン",
+        "ja_typings": []
+      },
+      {
+        "en": "Italy",
+        "ja": "イタリア",
+        "ja_typings": []
+      },
+      {
+        "en": "Greece",
+        "ja": "ギリシャ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00825",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Lisbon as its capital?",
+      "ja": "リスボンを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Finland",
+        "ja": "フィンランド",
+        "ja_typings": []
+      },
+      {
+        "en": "Sweden",
+        "ja": "スウェーデン",
+        "ja_typings": []
+      },
+      {
+        "en": "Norway",
+        "ja": "ノルウェー",
+        "ja_typings": []
+      },
+      {
+        "en": "Denmark",
+        "ja": "デンマーク",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00826",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Helsinki as its capital?",
+      "ja": "ヘルシンキを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Norway",
+        "ja": "ノルウェー",
+        "ja_typings": []
+      },
+      {
+        "en": "Sweden",
+        "ja": "スウェーデン",
+        "ja_typings": []
+      },
+      {
+        "en": "Iceland",
+        "ja": "アイスランド",
+        "ja_typings": []
+      },
+      {
+        "en": "Finland",
+        "ja": "フィンランド",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00827",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Oslo as its capital?",
+      "ja": "オスロを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Austria",
+        "ja": "オーストリア",
+        "ja_typings": []
+      },
+      {
+        "en": "Switzerland",
+        "ja": "スイス",
+        "ja_typings": []
+      },
+      {
+        "en": "Hungary",
+        "ja": "ハンガリー",
+        "ja_typings": []
+      },
+      {
+        "en": "Czech Republic",
+        "ja": "チェコ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00828",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Vienna as its capital?",
+      "ja": "ウィーンを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Czech Republic",
+        "ja": "チェコ",
+        "ja_typings": []
+      },
+      {
+        "en": "Slovakia",
+        "ja": "スロバキア",
+        "ja_typings": []
+      },
+      {
+        "en": "Poland",
+        "ja": "ポーランド",
+        "ja_typings": []
+      },
+      {
+        "en": "Hungary",
+        "ja": "ハンガリー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00829",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Prague as its capital?",
+      "ja": "プラハを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Poland",
+        "ja": "ポーランド",
+        "ja_typings": []
+      },
+      {
+        "en": "Czech Republic",
+        "ja": "チェコ",
+        "ja_typings": []
+      },
+      {
+        "en": "Lithuania",
+        "ja": "リトアニア",
+        "ja_typings": []
+      },
+      {
+        "en": "Belarus",
+        "ja": "ベラルーシ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00830",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Warsaw as its capital?",
+      "ja": "ワルシャワを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Argentina",
+        "ja": "アルゼンチン",
+        "ja_typings": []
+      },
+      {
+        "en": "Chile",
+        "ja": "チリ",
+        "ja_typings": []
+      },
+      {
+        "en": "Uruguay",
+        "ja": "ウルグアイ",
+        "ja_typings": []
+      },
+      {
+        "en": "Paraguay",
+        "ja": "パラグアイ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00831",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Buenos Aires as its capital?",
+      "ja": "ブエノスアイレスを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Peru",
+        "ja": "ペルー",
+        "ja_typings": []
+      },
+      {
+        "en": "Ecuador",
+        "ja": "エクアドル",
+        "ja_typings": []
+      },
+      {
+        "en": "Bolivia",
+        "ja": "ボリビア",
+        "ja_typings": []
+      },
+      {
+        "en": "Colombia",
+        "ja": "コロンビア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00832",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Lima as its capital?",
+      "ja": "リマを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kenya",
+        "ja": "ケニア",
+        "ja_typings": []
+      },
+      {
+        "en": "Tanzania",
+        "ja": "タンザニア",
+        "ja_typings": []
+      },
+      {
+        "en": "Uganda",
+        "ja": "ウガンダ",
+        "ja_typings": []
+      },
+      {
+        "en": "Ethiopia",
+        "ja": "エチオピア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00833",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Nairobi as its capital?",
+      "ja": "ナイロビを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Egypt",
+        "ja": "エジプト",
+        "ja_typings": []
+      },
+      {
+        "en": "Libya",
+        "ja": "リビア",
+        "ja_typings": []
+      },
+      {
+        "en": "Sudan",
+        "ja": "スーダン",
+        "ja_typings": []
+      },
+      {
+        "en": "Algeria",
+        "ja": "アルジェリア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00834",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Cairo as its capital?",
+      "ja": "カイロを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "New Zealand",
+        "ja": "ニュージーランド",
+        "ja_typings": []
+      },
+      {
+        "en": "Australia",
+        "ja": "オーストラリア",
+        "ja_typings": []
+      },
+      {
+        "en": "Fiji",
+        "ja": "フィジー",
+        "ja_typings": []
+      },
+      {
+        "en": "Samoa",
+        "ja": "サモア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00835",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Wellington as its capital?",
+      "ja": "ウェリントンを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Australia",
+        "ja": "オーストラリア",
+        "ja_typings": []
+      },
+      {
+        "en": "New Zealand",
+        "ja": "ニュージーランド",
+        "ja_typings": []
+      },
+      {
+        "en": "Papua New Guinea",
+        "ja": "パプアニューギニア",
+        "ja_typings": []
+      },
+      {
+        "en": "Fiji",
+        "ja": "フィジー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00836",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Canberra as its capital?",
+      "ja": "キャンベラを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Canada",
+        "ja": "カナダ",
+        "ja_typings": []
+      },
+      {
+        "en": "United States",
+        "ja": "アメリカ",
+        "ja_typings": []
+      },
+      {
+        "en": "Mexico",
+        "ja": "メキシコ",
+        "ja_typings": []
+      },
+      {
+        "en": "Cuba",
+        "ja": "キューバ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00837",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Ottawa as its capital?",
+      "ja": "オタワを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thames",
+        "ja": "テムズ川",
+        "ja_typings": [
+          "temuzugawa"
+        ]
+      },
+      {
+        "en": "Seine",
+        "ja": "セーヌ川",
+        "ja_typings": [
+          "seenugawa"
+        ]
+      },
+      {
+        "en": "Rhine",
+        "ja": "ライン川",
+        "ja_typings": [
+          "raingawa"
+        ]
+      },
+      {
+        "en": "Danube",
+        "ja": "ドナウ川",
+        "ja_typings": [
+          "donaugawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00838",
+    "image_path": null,
+    "question_text": {
+      "en": "Which river flows through London?",
+      "ja": "ロンドンを流れる河川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Seine",
+        "ja": "セーヌ川",
+        "ja_typings": [
+          "seenugawa"
+        ]
+      },
+      {
+        "en": "Loire",
+        "ja": "ロワール川",
+        "ja_typings": [
+          "rowaarugawa"
+        ]
+      },
+      {
+        "en": "Rhone",
+        "ja": "ローヌ川",
+        "ja_typings": [
+          "roonugawa"
+        ]
+      },
+      {
+        "en": "Garonne",
+        "ja": "ガロンヌ川",
+        "ja_typings": [
+          "garonnugawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00839",
+    "image_path": null,
+    "question_text": {
+      "en": "Which river flows through Paris?",
+      "ja": "パリを流れる河川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yangtze",
+        "ja": "長江",
+        "ja_typings": [
+          "choukou"
+        ]
+      },
+      {
+        "en": "Yellow River",
+        "ja": "黄河",
+        "ja_typings": [
+          "kouga"
+        ]
+      },
+      {
+        "en": "Mekong",
+        "ja": "メコン川",
+        "ja_typings": [
+          "mekongawa"
+        ]
+      },
+      {
+        "en": "Pearl River",
+        "ja": "珠江",
+        "ja_typings": [
+          "shukou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00840",
+    "image_path": null,
+    "question_text": {
+      "en": "Which river is the longest in China?",
+      "ja": "中国最長の河川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Andes",
+        "ja": "アンデス山脈",
+        "ja_typings": [
+          "andesusanmyaku"
+        ]
+      },
+      {
+        "en": "Rockies",
+        "ja": "ロッキー山脈",
+        "ja_typings": [
+          "rokkiisanmyaku"
+        ]
+      },
+      {
+        "en": "Appalachians",
+        "ja": "アパラチア山脈",
+        "ja_typings": [
+          "aparachiasanmyaku"
+        ]
+      },
+      {
+        "en": "Sierra Madre",
+        "ja": "シエラマドレ山脈",
+        "ja_typings": [
+          "sieramadoresanmyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00841",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mountain range stretches across South America's west coast?",
+      "ja": "南米の西海岸に連なる山脈は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Urals",
+        "ja": "ウラル山脈",
+        "ja_typings": [
+          "urarusanmyaku"
+        ]
+      },
+      {
+        "en": "Alps",
+        "ja": "アルプス山脈",
+        "ja_typings": [
+          "arupususanmyaku"
+        ]
+      },
+      {
+        "en": "Caucasus",
+        "ja": "コーカサス山脈",
+        "ja_typings": [
+          "kookasasusanmyaku"
+        ]
+      },
+      {
+        "en": "Pyrenees",
+        "ja": "ピレネー山脈",
+        "ja_typings": [
+          "pireneesanmyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00842",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mountain range divides Europe and Asia?",
+      "ja": "ヨーロッパとアジアを分ける山脈は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Adriatic Sea",
+        "ja": "アドリア海",
+        "ja_typings": [
+          "adoriakai"
+        ]
+      },
+      {
+        "en": "Aegean Sea",
+        "ja": "エーゲ海",
+        "ja_typings": [
+          "eegekai"
+        ]
+      },
+      {
+        "en": "Ionian Sea",
+        "ja": "イオニア海",
+        "ja_typings": [
+          "ioniakai"
+        ]
+      },
+      {
+        "en": "Tyrrhenian Sea",
+        "ja": "ティレニア海",
+        "ja_typings": [
+          "tireniakai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00843",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sea lies between Italy and the Balkans?",
+      "ja": "イタリアとバルカン半島の間の海は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aegean Sea",
+        "ja": "エーゲ海",
+        "ja_typings": [
+          "eegekai"
+        ]
+      },
+      {
+        "en": "Black Sea",
+        "ja": "黒海",
+        "ja_typings": [
+          "kokkai"
+        ]
+      },
+      {
+        "en": "Adriatic Sea",
+        "ja": "アドリア海",
+        "ja_typings": [
+          "adoriakai"
+        ]
+      },
+      {
+        "en": "Caspian Sea",
+        "ja": "カスピ海",
+        "ja_typings": [
+          "kasupikai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00844",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sea lies between Greece and Turkey?",
+      "ja": "ギリシャとトルコの間の海は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sahara",
+        "ja": "サハラ砂漠",
+        "ja_typings": [
+          "saharasabaku"
+        ]
+      },
+      {
+        "en": "Gobi",
+        "ja": "ゴビ砂漠",
+        "ja_typings": [
+          "gobisabaku"
+        ]
+      },
+      {
+        "en": "Kalahari",
+        "ja": "カラハリ砂漠",
+        "ja_typings": [
+          "karaharisabaku"
+        ]
+      },
+      {
+        "en": "Atacama",
+        "ja": "アタカマ砂漠",
+        "ja_typings": [
+          "atakamasabaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00845",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the world's largest desert (after the polar ones)?",
+      "ja": "極地を除く世界最大の砂漠は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gobi",
+        "ja": "ゴビ砂漠",
+        "ja_typings": [
+          "gobisabaku"
+        ]
+      },
+      {
+        "en": "Taklamakan",
+        "ja": "タクラマカン砂漠",
+        "ja_typings": [
+          "takuramakansabaku"
+        ]
+      },
+      {
+        "en": "Karakum",
+        "ja": "カラクム砂漠",
+        "ja_typings": [
+          "karakumusabaku"
+        ]
+      },
+      {
+        "en": "Thar",
+        "ja": "タール砂漠",
+        "ja_typings": [
+          "taarusabaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00846",
+    "image_path": null,
+    "question_text": {
+      "en": "Which desert lies between Mongolia and China?",
+      "ja": "モンゴルと中国の間にある砂漠は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Russia",
+        "ja": "ロシア",
+        "ja_typings": []
+      },
+      {
+        "en": "Canada",
+        "ja": "カナダ",
+        "ja_typings": []
+      },
+      {
+        "en": "China",
+        "ja": "中国",
+        "ja_typings": [
+          "chuugoku"
+        ]
+      },
+      {
+        "en": "Brazil",
+        "ja": "ブラジル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00847",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the largest country by area?",
+      "ja": "面積が世界最大の国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vatican City",
+        "ja": "バチカン市国",
+        "ja_typings": [
+          "bachikanshikoku"
+        ]
+      },
+      {
+        "en": "Monaco",
+        "ja": "モナコ",
+        "ja_typings": []
+      },
+      {
+        "en": "San Marino",
+        "ja": "サンマリノ",
+        "ja_typings": []
+      },
+      {
+        "en": "Liechtenstein",
+        "ja": "リヒテンシュタイン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00848",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the smallest country in the world?",
+      "ja": "世界最小の国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Caspian Sea",
+        "ja": "カスピ海",
+        "ja_typings": [
+          "kasupikai"
+        ]
+      },
+      {
+        "en": "Lake Superior",
+        "ja": "スペリオル湖",
+        "ja_typings": [
+          "superioruko"
+        ]
+      },
+      {
+        "en": "Lake Victoria",
+        "ja": "ビクトリア湖",
+        "ja_typings": [
+          "bikutoriako"
+        ]
+      },
+      {
+        "en": "Lake Baikal",
+        "ja": "バイカル湖",
+        "ja_typings": [
+          "baikaruko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00849",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the world's largest lake by area?",
+      "ja": "世界最大の湖は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lake Baikal",
+        "ja": "バイカル湖",
+        "ja_typings": [
+          "baikaruko"
+        ]
+      },
+      {
+        "en": "Caspian Sea",
+        "ja": "カスピ海",
+        "ja_typings": [
+          "kasupikai"
+        ]
+      },
+      {
+        "en": "Lake Tanganyika",
+        "ja": "タンガニーカ湖",
+        "ja_typings": [
+          "tanganiikako"
+        ]
+      },
+      {
+        "en": "Lake Superior",
+        "ja": "スペリオル湖",
+        "ja_typings": [
+          "superioruko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00850",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the deepest lake in the world?",
+      "ja": "世界で最も深い湖は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Strait of Gibraltar",
+        "ja": "ジブラルタル海峡",
+        "ja_typings": [
+          "jiburarutarukaikyou"
+        ]
+      },
+      {
+        "en": "Strait of Hormuz",
+        "ja": "ホルムズ海峡",
+        "ja_typings": [
+          "horumuzukaikyou"
+        ]
+      },
+      {
+        "en": "Bering Strait",
+        "ja": "ベーリング海峡",
+        "ja_typings": [
+          "beeringukaikyou"
+        ]
+      },
+      {
+        "en": "Strait of Malacca",
+        "ja": "マラッカ海峡",
+        "ja_typings": [
+          "marakkakaikyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00851",
+    "image_path": null,
+    "question_text": {
+      "en": "Which strait separates Europe and Africa?",
+      "ja": "ヨーロッパとアフリカを隔てる海峡は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bering Strait",
+        "ja": "ベーリング海峡",
+        "ja_typings": [
+          "beeringukaikyou"
+        ]
+      },
+      {
+        "en": "Strait of Gibraltar",
+        "ja": "ジブラルタル海峡",
+        "ja_typings": [
+          "jiburarutarukaikyou"
+        ]
+      },
+      {
+        "en": "Strait of Hormuz",
+        "ja": "ホルムズ海峡",
+        "ja_typings": [
+          "horumuzukaikyou"
+        ]
+      },
+      {
+        "en": "Strait of Malacca",
+        "ja": "マラッカ海峡",
+        "ja_typings": [
+          "marakkakaikyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00852",
+    "image_path": null,
+    "question_text": {
+      "en": "Which strait separates Asia and North America?",
+      "ja": "アジアと北米を隔てる海峡は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Africa",
+        "ja": "アフリカ",
+        "ja_typings": []
+      },
+      {
+        "en": "Asia",
+        "ja": "アジア",
+        "ja_typings": []
+      },
+      {
+        "en": "Europe",
+        "ja": "ヨーロッパ",
+        "ja_typings": []
+      },
+      {
+        "en": "Oceania",
+        "ja": "オセアニア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00853",
+    "image_path": null,
+    "question_text": {
+      "en": "Which continent is Egypt located in?",
+      "ja": "エジプトが属する大陸は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Africa",
+        "ja": "アフリカ",
+        "ja_typings": []
+      },
+      {
+        "en": "Asia",
+        "ja": "アジア",
+        "ja_typings": []
+      },
+      {
+        "en": "Europe",
+        "ja": "ヨーロッパ",
+        "ja_typings": []
+      },
+      {
+        "en": "South America",
+        "ja": "南アメリカ",
+        "ja_typings": [
+          "minamiamerika"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00854",
+    "image_path": null,
+    "question_text": {
+      "en": "Which continent has the most countries?",
+      "ja": "国の数が最も多い大陸は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kilimanjaro",
+        "ja": "キリマンジャロ",
+        "ja_typings": []
+      },
+      {
+        "en": "Mount Kenya",
+        "ja": "ケニア山",
+        "ja_typings": [
+          "keniasan"
+        ]
+      },
+      {
+        "en": "Atlas",
+        "ja": "アトラス山脈",
+        "ja_typings": [
+          "atorasusanmyaku"
+        ]
+      },
+      {
+        "en": "Mount Stanley",
+        "ja": "スタンレー山",
+        "ja_typings": [
+          "sutanreesan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00855",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the highest mountain in Africa?",
+      "ja": "アフリカ最高峰は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rome",
+        "ja": "ローマ",
+        "ja_typings": []
+      },
+      {
+        "en": "Athens",
+        "ja": "アテネ",
+        "ja_typings": []
+      },
+      {
+        "en": "Istanbul",
+        "ja": "イスタンブール",
+        "ja_typings": []
+      },
+      {
+        "en": "Jerusalem",
+        "ja": "エルサレム",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00856",
+    "image_path": null,
+    "question_text": {
+      "en": "Which city is known as the Eternal City?",
+      "ja": "永遠の都と呼ばれる都市は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Qin Shi Huang",
+        "ja": "始皇帝",
+        "ja_typings": [
+          "shikoutei"
+        ]
+      },
+      {
+        "en": "Han Wudi",
+        "ja": "漢武帝",
+        "ja_typings": [
+          "kanbutei"
+        ]
+      },
+      {
+        "en": "Tang Taizong",
+        "ja": "唐太宗",
+        "ja_typings": [
+          "toutaisou"
+        ]
+      },
+      {
+        "en": "Kublai Khan",
+        "ja": "フビライハン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00857",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first emperor of unified China?",
+      "ja": "中国を統一した最初の皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Genghis Khan",
+        "ja": "チンギスハン",
+        "ja_typings": []
+      },
+      {
+        "en": "Kublai Khan",
+        "ja": "フビライハン",
+        "ja_typings": []
+      },
+      {
+        "en": "Tamerlane",
+        "ja": "ティムール",
+        "ja_typings": []
+      },
+      {
+        "en": "Attila",
+        "ja": "アッティラ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00858",
+    "image_path": null,
+    "question_text": {
+      "en": "Who founded the Mongol Empire?",
+      "ja": "モンゴル帝国を建国したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cleopatra",
+        "ja": "クレオパトラ",
+        "ja_typings": []
+      },
+      {
+        "en": "Nefertiti",
+        "ja": "ネフェルティティ",
+        "ja_typings": []
+      },
+      {
+        "en": "Hatshepsut",
+        "ja": "ハトシェプスト",
+        "ja_typings": []
+      },
+      {
+        "en": "Isis",
+        "ja": "イシス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00859",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the queen of ancient Egypt famous for relations with Rome?",
+      "ja": "ローマと関係したことで有名な古代エジプトの女王は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rajendra Prasad",
+        "ja": "ラジェンドラプラサド",
+        "ja_typings": []
+      },
+      {
+        "en": "Jawaharlal Nehru",
+        "ja": "ネルー",
+        "ja_typings": []
+      },
+      {
+        "en": "Mahatma Gandhi",
+        "ja": "ガンディー",
+        "ja_typings": []
+      },
+      {
+        "en": "Indira Gandhi",
+        "ja": "インディラガンディー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00860",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first president of independent India?",
+      "ja": "インド独立後の初代大統領は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gandhi",
+        "ja": "ガンディー",
+        "ja_typings": []
+      },
+      {
+        "en": "Nehru",
+        "ja": "ネルー",
+        "ja_typings": []
+      },
+      {
+        "en": "Bose",
+        "ja": "ボース",
+        "ja_typings": []
+      },
+      {
+        "en": "Tagore",
+        "ja": "タゴール",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00861",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led India's independence movement nonviolently?",
+      "ja": "非暴力でインド独立運動を率いたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Churchill",
+        "ja": "チャーチル",
+        "ja_typings": []
+      },
+      {
+        "en": "Chamberlain",
+        "ja": "チェンバレン",
+        "ja_typings": []
+      },
+      {
+        "en": "Attlee",
+        "ja": "アトリー",
+        "ja_typings": []
+      },
+      {
+        "en": "Eden",
+        "ja": "イーデン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00862",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the British Prime Minister during WWII?",
+      "ja": "第二次大戦中のイギリス首相は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hitler",
+        "ja": "ヒトラー",
+        "ja_typings": []
+      },
+      {
+        "en": "Himmler",
+        "ja": "ヒムラー",
+        "ja_typings": []
+      },
+      {
+        "en": "Goebbels",
+        "ja": "ゲッベルス",
+        "ja_typings": []
+      },
+      {
+        "en": "Goering",
+        "ja": "ゲーリング",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00863",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the leader of Nazi Germany?",
+      "ja": "ナチスドイツの指導者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Stalin",
+        "ja": "スターリン",
+        "ja_typings": []
+      },
+      {
+        "en": "Lenin",
+        "ja": "レーニン",
+        "ja_typings": []
+      },
+      {
+        "en": "Khrushchev",
+        "ja": "フルシチョフ",
+        "ja_typings": []
+      },
+      {
+        "en": "Trotsky",
+        "ja": "トロツキー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00864",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led the Soviet Union during WWII?",
+      "ja": "第二次大戦中のソ連を率いたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lenin",
+        "ja": "レーニン",
+        "ja_typings": []
+      },
+      {
+        "en": "Stalin",
+        "ja": "スターリン",
+        "ja_typings": []
+      },
+      {
+        "en": "Trotsky",
+        "ja": "トロツキー",
+        "ja_typings": []
+      },
+      {
+        "en": "Marx",
+        "ja": "マルクス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00865",
+    "image_path": null,
+    "question_text": {
+      "en": "Who founded the Soviet Union?",
+      "ja": "ソ連を建国したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Marx",
+        "ja": "マルクス",
+        "ja_typings": []
+      },
+      {
+        "en": "Lenin",
+        "ja": "レーニン",
+        "ja_typings": []
+      },
+      {
+        "en": "Bakunin",
+        "ja": "バクーニン",
+        "ja_typings": []
+      },
+      {
+        "en": "Proudhon",
+        "ja": "プルードン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00866",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote The Communist Manifesto with Engels?",
+      "ja": "エンゲルスと共産党宣言を書いたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lincoln",
+        "ja": "リンカーン",
+        "ja_typings": []
+      },
+      {
+        "en": "Garfield",
+        "ja": "ガーフィールド",
+        "ja_typings": []
+      },
+      {
+        "en": "McKinley",
+        "ja": "マッキンリー",
+        "ja_typings": []
+      },
+      {
+        "en": "Kennedy",
+        "ja": "ケネディ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00867",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first US president to be assassinated?",
+      "ja": "暗殺された最初のアメリカ大統領は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kennedy",
+        "ja": "ケネディ",
+        "ja_typings": []
+      },
+      {
+        "en": "Eisenhower",
+        "ja": "アイゼンハワー",
+        "ja_typings": []
+      },
+      {
+        "en": "Johnson",
+        "ja": "ジョンソン",
+        "ja_typings": []
+      },
+      {
+        "en": "Nixon",
+        "ja": "ニクソン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00868",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the US president during the Cuban Missile Crisis?",
+      "ja": "キューバ危機時のアメリカ大統領は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Columbus",
+        "ja": "コロンブス",
+        "ja_typings": []
+      },
+      {
+        "en": "Magellan",
+        "ja": "マゼラン",
+        "ja_typings": []
+      },
+      {
+        "en": "Vespucci",
+        "ja": "ベスプッチ",
+        "ja_typings": []
+      },
+      {
+        "en": "Cabot",
+        "ja": "カボット",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00869",
+    "image_path": null,
+    "question_text": {
+      "en": "Who discovered the Americas in 1492?",
+      "ja": "1492年に新大陸に到達したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Magellan's expedition",
+        "ja": "マゼラン隊",
+        "ja_typings": [
+          "mazerantai"
+        ]
+      },
+      {
+        "en": "Columbus",
+        "ja": "コロンブス",
+        "ja_typings": []
+      },
+      {
+        "en": "Vasco da Gama",
+        "ja": "バスコダガマ",
+        "ja_typings": []
+      },
+      {
+        "en": "Drake",
+        "ja": "ドレーク",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00870",
+    "image_path": null,
+    "question_text": {
+      "en": "Who first circumnavigated the globe?",
+      "ja": "世界一周航海を最初に成し遂げたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Leonardo da Vinci",
+        "ja": "ダヴィンチ",
+        "ja_typings": []
+      },
+      {
+        "en": "Michelangelo",
+        "ja": "ミケランジェロ",
+        "ja_typings": []
+      },
+      {
+        "en": "Raphael",
+        "ja": "ラファエロ",
+        "ja_typings": []
+      },
+      {
+        "en": "Botticelli",
+        "ja": "ボッティチェリ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00871",
+    "image_path": null,
+    "question_text": {
+      "en": "Who painted the Mona Lisa?",
+      "ja": "モナリザを描いたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Copernicus",
+        "ja": "コペルニクス",
+        "ja_typings": []
+      },
+      {
+        "en": "Galileo",
+        "ja": "ガリレオ",
+        "ja_typings": []
+      },
+      {
+        "en": "Kepler",
+        "ja": "ケプラー",
+        "ja_typings": []
+      },
+      {
+        "en": "Brahe",
+        "ja": "ブラーエ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00872",
+    "image_path": null,
+    "question_text": {
+      "en": "Who proposed heliocentrism in the 16th century?",
+      "ja": "16世紀に地動説を唱えたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Babur",
+        "ja": "バーブル",
+        "ja_typings": []
+      },
+      {
+        "en": "Akbar",
+        "ja": "アクバル",
+        "ja_typings": []
+      },
+      {
+        "en": "Aurangzeb",
+        "ja": "アウラングゼーブ",
+        "ja_typings": []
+      },
+      {
+        "en": "Shah Jahan",
+        "ja": "シャージャハン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00873",
+    "image_path": null,
+    "question_text": {
+      "en": "Who founded the Mughal Empire in India?",
+      "ja": "インドのムガル帝国を建国したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shah Jahan",
+        "ja": "シャージャハン",
+        "ja_typings": []
+      },
+      {
+        "en": "Akbar",
+        "ja": "アクバル",
+        "ja_typings": []
+      },
+      {
+        "en": "Babur",
+        "ja": "バーブル",
+        "ja_typings": []
+      },
+      {
+        "en": "Aurangzeb",
+        "ja": "アウラングゼーブ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00874",
+    "image_path": null,
+    "question_text": {
+      "en": "Who built the Taj Mahal?",
+      "ja": "タージマハルを建てたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sui",
+        "ja": "隋",
+        "ja_typings": [
+          "zui"
+        ]
+      },
+      {
+        "en": "Han",
+        "ja": "漢",
+        "ja_typings": [
+          "kan"
+        ]
+      },
+      {
+        "en": "Song",
+        "ja": "宋",
+        "ja_typings": [
+          "sou"
+        ]
+      },
+      {
+        "en": "Yuan",
+        "ja": "元",
+        "ja_typings": [
+          "gen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00875",
+    "image_path": null,
+    "question_text": {
+      "en": "Which dynasty preceded the Tang in China?",
+      "ja": "中国で唐の前の王朝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Song",
+        "ja": "宋",
+        "ja_typings": [
+          "sou"
+        ]
+      },
+      {
+        "en": "Yuan",
+        "ja": "元",
+        "ja_typings": [
+          "gen"
+        ]
+      },
+      {
+        "en": "Ming",
+        "ja": "明",
+        "ja_typings": [
+          "min"
+        ]
+      },
+      {
+        "en": "Qing",
+        "ja": "清",
+        "ja_typings": [
+          "shin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00876",
+    "image_path": null,
+    "question_text": {
+      "en": "Which dynasty followed the Tang in China?",
+      "ja": "中国で唐の次の王朝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Qing",
+        "ja": "清",
+        "ja_typings": [
+          "shin"
+        ]
+      },
+      {
+        "en": "Ming",
+        "ja": "明",
+        "ja_typings": [
+          "min"
+        ]
+      },
+      {
+        "en": "Yuan",
+        "ja": "元",
+        "ja_typings": [
+          "gen"
+        ]
+      },
+      {
+        "en": "Song",
+        "ja": "宋",
+        "ja_typings": [
+          "sou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00877",
+    "image_path": null,
+    "question_text": {
+      "en": "Which dynasty was the last imperial dynasty of China?",
+      "ja": "中国最後の王朝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "WWI",
+        "ja": "第一次大戦",
+        "ja_typings": [
+          "daiichijitaisen"
+        ]
+      },
+      {
+        "en": "Balkan War",
+        "ja": "バルカン戦争",
+        "ja_typings": [
+          "barukansensou"
+        ]
+      },
+      {
+        "en": "Russo-Japanese War",
+        "ja": "日露戦争",
+        "ja_typings": [
+          "nichirosensou"
+        ]
+      },
+      {
+        "en": "Crimean War",
+        "ja": "クリミア戦争",
+        "ja_typings": [
+          "kurimiasensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00878",
+    "image_path": null,
+    "question_text": {
+      "en": "Which war was triggered by the assassination in Sarajevo?",
+      "ja": "サラエボ事件で勃発した戦争は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "WWI",
+        "ja": "第一次大戦",
+        "ja_typings": [
+          "daiichijitaisen"
+        ]
+      },
+      {
+        "en": "Napoleonic Wars",
+        "ja": "ナポレオン戦争",
+        "ja_typings": [
+          "naporeonsensou"
+        ]
+      },
+      {
+        "en": "Franco-Prussian War",
+        "ja": "普仏戦争",
+        "ja_typings": [
+          "fufutsusensou"
+        ]
+      },
+      {
+        "en": "Crimean War",
+        "ja": "クリミア戦争",
+        "ja_typings": [
+          "kurimiasensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00879",
+    "image_path": null,
+    "question_text": {
+      "en": "Which war ended with the Treaty of Versailles?",
+      "ja": "ベルサイユ条約で終わった戦争は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Treaty of Portsmouth",
+        "ja": "ポーツマス条約",
+        "ja_typings": [
+          "pootsumasujouyaku"
+        ]
+      },
+      {
+        "en": "Treaty of Shimonoseki",
+        "ja": "下関条約",
+        "ja_typings": [
+          "shimonosekijouyaku"
+        ]
+      },
+      {
+        "en": "Treaty of Versailles",
+        "ja": "ベルサイユ条約",
+        "ja_typings": [
+          "berusaiyujouyaku"
+        ]
+      },
+      {
+        "en": "Treaty of Tianjin",
+        "ja": "天津条約",
+        "ja_typings": [
+          "tenshinjouyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00880",
+    "image_path": null,
+    "question_text": {
+      "en": "Which treaty ended the Russo-Japanese War?",
+      "ja": "日露戦争を終結させた条約は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Treaty of Shimonoseki",
+        "ja": "下関条約",
+        "ja_typings": [
+          "shimonosekijouyaku"
+        ]
+      },
+      {
+        "en": "Treaty of Portsmouth",
+        "ja": "ポーツマス条約",
+        "ja_typings": [
+          "pootsumasujouyaku"
+        ]
+      },
+      {
+        "en": "Treaty of Nanking",
+        "ja": "南京条約",
+        "ja_typings": [
+          "nankinjouyaku"
+        ]
+      },
+      {
+        "en": "Boxer Protocol",
+        "ja": "北京議定書",
+        "ja_typings": [
+          "pekingiteisho"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00881",
+    "image_path": null,
+    "question_text": {
+      "en": "Which treaty ended the Sino-Japanese War of 1894-95?",
+      "ja": "日清戦争を終結させた条約は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Inca",
+        "ja": "インカ",
+        "ja_typings": []
+      },
+      {
+        "en": "Maya",
+        "ja": "マヤ",
+        "ja_typings": []
+      },
+      {
+        "en": "Aztec",
+        "ja": "アステカ",
+        "ja_typings": []
+      },
+      {
+        "en": "Olmec",
+        "ja": "オルメカ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00882",
+    "image_path": null,
+    "question_text": {
+      "en": "Which civilization built Machu Picchu?",
+      "ja": "マチュピチュを築いた文明は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Maya",
+        "ja": "マヤ",
+        "ja_typings": []
+      },
+      {
+        "en": "Aztec",
+        "ja": "アステカ",
+        "ja_typings": []
+      },
+      {
+        "en": "Inca",
+        "ja": "インカ",
+        "ja_typings": []
+      },
+      {
+        "en": "Toltec",
+        "ja": "トルテカ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00883",
+    "image_path": null,
+    "question_text": {
+      "en": "Which civilization built Chichen Itza?",
+      "ja": "チチェンイツァを築いた文明は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aztec",
+        "ja": "アステカ",
+        "ja_typings": []
+      },
+      {
+        "en": "Maya",
+        "ja": "マヤ",
+        "ja_typings": []
+      },
+      {
+        "en": "Inca",
+        "ja": "インカ",
+        "ja_typings": []
+      },
+      {
+        "en": "Olmec",
+        "ja": "オルメカ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00884",
+    "image_path": null,
+    "question_text": {
+      "en": "Which civilization was centered at Tenochtitlan?",
+      "ja": "テノチティトランを首都とした文明は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Indus civilization",
+        "ja": "インダス文明",
+        "ja_typings": [
+          "indasubunmei"
+        ]
+      },
+      {
+        "en": "Sumerian",
+        "ja": "シュメール文明",
+        "ja_typings": [
+          "shumeerubunmei"
+        ]
+      },
+      {
+        "en": "Egyptian",
+        "ja": "エジプト文明",
+        "ja_typings": [
+          "ejiputobunmei"
+        ]
+      },
+      {
+        "en": "Chinese",
+        "ja": "黄河文明",
+        "ja_typings": [
+          "kougabunmei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00885",
+    "image_path": null,
+    "question_text": {
+      "en": "Which civilization flourished along the Indus river?",
+      "ja": "インダス川流域で栄えた文明は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ataturk",
+        "ja": "アタチュルク",
+        "ja_typings": []
+      },
+      {
+        "en": "Erdogan",
+        "ja": "エルドアン",
+        "ja_typings": []
+      },
+      {
+        "en": "Inonu",
+        "ja": "イノニュ",
+        "ja_typings": []
+      },
+      {
+        "en": "Ozal",
+        "ja": "オザル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00886",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is regarded as the father of modern Turkey?",
+      "ja": "近代トルコの父と呼ばれるのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Storming of the Bastille",
+        "ja": "バスティーユ襲撃",
+        "ja_typings": [
+          "basutiiyuushuugeki"
+        ]
+      },
+      {
+        "en": "Tennis Court Oath",
+        "ja": "テニスコートの誓い",
+        "ja_typings": [
+          "tenisukootonochikai"
+        ]
+      },
+      {
+        "en": "Reign of Terror",
+        "ja": "恐怖政治",
+        "ja_typings": [
+          "kyoufuseiji"
+        ]
+      },
+      {
+        "en": "Thermidorian Reaction",
+        "ja": "テルミドール反動",
+        "ja_typings": [
+          "terumidooruhandou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00887",
+    "image_path": null,
+    "question_text": {
+      "en": "Which event in 1789 began the French Revolution?",
+      "ja": "1789年フランス革命の発端となった事件は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Battle of Waterloo",
+        "ja": "ワーテルローの戦い",
+        "ja_typings": [
+          "waaterurroonotatakai"
+        ]
+      },
+      {
+        "en": "Battle of Trafalgar",
+        "ja": "トラファルガーの戦い",
+        "ja_typings": [
+          "torafarugaanotatakai"
+        ]
+      },
+      {
+        "en": "Battle of Austerlitz",
+        "ja": "アウステルリッツの戦い",
+        "ja_typings": [
+          "ausuterurittsunotatakai"
+        ]
+      },
+      {
+        "en": "Battle of Leipzig",
+        "ja": "ライプチヒの戦い",
+        "ja_typings": [
+          "raipuchihinotatakai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00888",
+    "image_path": null,
+    "question_text": {
+      "en": "Which battle marked Napoleon's final defeat?",
+      "ja": "ナポレオンが最終的に敗れた戦いは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1989",
+        "ja": "1989年",
+        "ja_typings": [
+          "1989nen"
+        ]
+      },
+      {
+        "en": "1991",
+        "ja": "1991年",
+        "ja_typings": [
+          "1991nen"
+        ]
+      },
+      {
+        "en": "1987",
+        "ja": "1987年",
+        "ja_typings": [
+          "1987nen"
+        ]
+      },
+      {
+        "en": "1985",
+        "ja": "1985年",
+        "ja_typings": [
+          "1985nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00889",
+    "image_path": null,
+    "question_text": {
+      "en": "Which year did the Berlin Wall fall?",
+      "ja": "ベルリンの壁が崩壊した年は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1868",
+        "ja": "1868年",
+        "ja_typings": [
+          "1868nen"
+        ]
+      },
+      {
+        "en": "1853",
+        "ja": "1853年",
+        "ja_typings": [
+          "1853nen"
+        ]
+      },
+      {
+        "en": "1871",
+        "ja": "1871年",
+        "ja_typings": [
+          "1871nen"
+        ]
+      },
+      {
+        "en": "1877",
+        "ja": "1877年",
+        "ja_typings": [
+          "1877nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00890",
+    "image_path": null,
+    "question_text": {
+      "en": "Which year did the Meiji era begin?",
+      "ja": "明治時代が始まった年は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Minamoto no Yoritomo",
+        "ja": "源頼朝",
+        "ja_typings": [
+          "minamotonoyoritomo"
+        ]
+      },
+      {
+        "en": "Minamoto no Yoshitsune",
+        "ja": "源義経",
+        "ja_typings": [
+          "minamotonoyoshitsune"
+        ]
+      },
+      {
+        "en": "Taira no Kiyomori",
+        "ja": "平清盛",
+        "ja_typings": [
+          "tairanokiyomori"
+        ]
+      },
+      {
+        "en": "Hojo Tokimasa",
+        "ja": "北条時政",
+        "ja_typings": [
+          "houjoutokimasa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00891",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first shogun of the Kamakura shogunate?",
+      "ja": "鎌倉幕府の初代将軍は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ag",
+        "ja": "Ag",
+        "ja_typings": []
+      },
+      {
+        "en": "Au",
+        "ja": "Au",
+        "ja_typings": []
+      },
+      {
+        "en": "Al",
+        "ja": "Al",
+        "ja_typings": []
+      },
+      {
+        "en": "As",
+        "ja": "As",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00892",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the chemical symbol for silver?",
+      "ja": "銀の元素記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Na",
+        "ja": "Na",
+        "ja_typings": []
+      },
+      {
+        "en": "So",
+        "ja": "So",
+        "ja_typings": []
+      },
+      {
+        "en": "Sn",
+        "ja": "Sn",
+        "ja_typings": []
+      },
+      {
+        "en": "Ni",
+        "ja": "Ni",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00893",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the chemical symbol for sodium?",
+      "ja": "ナトリウムの元素記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "K",
+        "ja": "K",
+        "ja_typings": []
+      },
+      {
+        "en": "P",
+        "ja": "P",
+        "ja_typings": []
+      },
+      {
+        "en": "Ca",
+        "ja": "Ca",
+        "ja_typings": []
+      },
+      {
+        "en": "Po",
+        "ja": "Po",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00894",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the chemical symbol for potassium?",
+      "ja": "カリウムの元素記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nitrogen",
+        "ja": "窒素",
+        "ja_typings": [
+          "chisso"
+        ]
+      },
+      {
+        "en": "Oxygen",
+        "ja": "酸素",
+        "ja_typings": [
+          "sanso"
+        ]
+      },
+      {
+        "en": "Argon",
+        "ja": "アルゴン",
+        "ja_typings": []
+      },
+      {
+        "en": "Carbon dioxide",
+        "ja": "二酸化炭素",
+        "ja_typings": [
+          "nisankatanso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00895",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the most abundant gas in Earth's atmosphere?",
+      "ja": "地球大気で最も多い気体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Carbon dioxide",
+        "ja": "二酸化炭素",
+        "ja_typings": [
+          "nisankatanso"
+        ]
+      },
+      {
+        "en": "Methane",
+        "ja": "メタン",
+        "ja_typings": []
+      },
+      {
+        "en": "Ozone",
+        "ja": "オゾン",
+        "ja_typings": []
+      },
+      {
+        "en": "Argon",
+        "ja": "アルゴン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00896",
+    "image_path": null,
+    "question_text": {
+      "en": "Which gas is most responsible for the greenhouse effect from human activity?",
+      "ja": "人類活動由来で温室効果に最も寄与する気体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mars",
+        "ja": "火星",
+        "ja_typings": [
+          "kasei"
+        ]
+      },
+      {
+        "en": "Venus",
+        "ja": "金星",
+        "ja_typings": [
+          "kinsei"
+        ]
+      },
+      {
+        "en": "Saturn",
+        "ja": "土星",
+        "ja_typings": [
+          "dosei"
+        ]
+      },
+      {
+        "en": "Neptune",
+        "ja": "海王星",
+        "ja_typings": [
+          "kaiousei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00897",
+    "image_path": null,
+    "question_text": {
+      "en": "What planet is known as the Red Planet?",
+      "ja": "赤い惑星と呼ばれるのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Saturn",
+        "ja": "土星",
+        "ja_typings": [
+          "dosei"
+        ]
+      },
+      {
+        "en": "Uranus",
+        "ja": "天王星",
+        "ja_typings": [
+          "tennousei"
+        ]
+      },
+      {
+        "en": "Neptune",
+        "ja": "海王星",
+        "ja_typings": [
+          "kaiousei"
+        ]
+      },
+      {
+        "en": "Mars",
+        "ja": "火星",
+        "ja_typings": [
+          "kasei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00898",
+    "image_path": null,
+    "question_text": {
+      "en": "Which planet has the most prominent ring system?",
+      "ja": "最も目立つ環を持つ惑星は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Neptune",
+        "ja": "海王星",
+        "ja_typings": [
+          "kaiousei"
+        ]
+      },
+      {
+        "en": "Uranus",
+        "ja": "天王星",
+        "ja_typings": [
+          "tennousei"
+        ]
+      },
+      {
+        "en": "Saturn",
+        "ja": "土星",
+        "ja_typings": [
+          "dosei"
+        ]
+      },
+      {
+        "en": "Jupiter",
+        "ja": "木星",
+        "ja_typings": [
+          "mokusei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00899",
+    "image_path": null,
+    "question_text": {
+      "en": "Which planet is farthest from the Sun (excluding Pluto)?",
+      "ja": "太陽から最も遠い惑星（冥王星除く）は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mitochondria",
+        "ja": "ミトコンドリア",
+        "ja_typings": []
+      },
+      {
+        "en": "Ribosome",
+        "ja": "リボソーム",
+        "ja_typings": []
+      },
+      {
+        "en": "Nucleus",
+        "ja": "核",
+        "ja_typings": [
+          "kaku"
+        ]
+      },
+      {
+        "en": "Lysosome",
+        "ja": "リソソーム",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00900",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the powerhouse of the cell?",
+      "ja": "細胞のエネルギー工場と呼ばれる小器官は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Photosynthesis",
+        "ja": "光合成",
+        "ja_typings": [
+          "kougousei"
+        ]
+      },
+      {
+        "en": "Respiration",
+        "ja": "呼吸",
+        "ja_typings": [
+          "kokyuu"
+        ]
+      },
+      {
+        "en": "Transpiration",
+        "ja": "蒸散",
+        "ja_typings": [
+          "jousan"
+        ]
+      },
+      {
+        "en": "Fermentation",
+        "ja": "発酵",
+        "ja_typings": [
+          "hakkou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00901",
+    "image_path": null,
+    "question_text": {
+      "en": "Which process do plants use to make food?",
+      "ja": "植物が栄養を作る働きは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Newton",
+        "ja": "ニュートン",
+        "ja_typings": []
+      },
+      {
+        "en": "Galileo",
+        "ja": "ガリレオ",
+        "ja_typings": []
+      },
+      {
+        "en": "Kepler",
+        "ja": "ケプラー",
+        "ja_typings": []
+      },
+      {
+        "en": "Einstein",
+        "ja": "アインシュタイン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00902",
+    "image_path": null,
+    "question_text": {
+      "en": "Who formulated the three laws of motion?",
+      "ja": "運動の三法則を定式化したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Darwin",
+        "ja": "ダーウィン",
+        "ja_typings": []
+      },
+      {
+        "en": "Mendel",
+        "ja": "メンデル",
+        "ja_typings": []
+      },
+      {
+        "en": "Lamarck",
+        "ja": "ラマルク",
+        "ja_typings": []
+      },
+      {
+        "en": "Wallace",
+        "ja": "ウォレス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00903",
+    "image_path": null,
+    "question_text": {
+      "en": "Who proposed the theory of evolution by natural selection?",
+      "ja": "自然選択による進化論を唱えたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mendel",
+        "ja": "メンデル",
+        "ja_typings": []
+      },
+      {
+        "en": "Darwin",
+        "ja": "ダーウィン",
+        "ja_typings": []
+      },
+      {
+        "en": "Watson",
+        "ja": "ワトソン",
+        "ja_typings": []
+      },
+      {
+        "en": "Crick",
+        "ja": "クリック",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00904",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is regarded as the father of genetics?",
+      "ja": "遺伝学の父と呼ばれるのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Marie Curie",
+        "ja": "マリーキュリー",
+        "ja_typings": []
+      },
+      {
+        "en": "Lise Meitner",
+        "ja": "リーゼマイトナー",
+        "ja_typings": []
+      },
+      {
+        "en": "Rosalind Franklin",
+        "ja": "フランクリン",
+        "ja_typings": []
+      },
+      {
+        "en": "Irene Joliot-Curie",
+        "ja": "ジョリオキュリー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00905",
+    "image_path": null,
+    "question_text": {
+      "en": "Who discovered radium together with Pierre Curie?",
+      "ja": "ピエールキュリーと共にラジウムを発見したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Boyle's law",
+        "ja": "ボイルの法則",
+        "ja_typings": [
+          "boirunohousoku"
+        ]
+      },
+      {
+        "en": "Charles's law",
+        "ja": "シャルルの法則",
+        "ja_typings": [
+          "sharurunohousoku"
+        ]
+      },
+      {
+        "en": "Avogadro's law",
+        "ja": "アボガドロの法則",
+        "ja_typings": [
+          "abogadoronohousoku"
+        ]
+      },
+      {
+        "en": "Hooke's law",
+        "ja": "フックの法則",
+        "ja_typings": [
+          "fukkunohousoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00906",
+    "image_path": null,
+    "question_text": {
+      "en": "What law states pressure and volume are inversely related at constant temperature?",
+      "ja": "一定温度で圧力と体積が反比例する法則は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Charles's law",
+        "ja": "シャルルの法則",
+        "ja_typings": [
+          "sharurunohousoku"
+        ]
+      },
+      {
+        "en": "Boyle's law",
+        "ja": "ボイルの法則",
+        "ja_typings": [
+          "boirunohousoku"
+        ]
+      },
+      {
+        "en": "Ohm's law",
+        "ja": "オームの法則",
+        "ja_typings": [
+          "oomunohousoku"
+        ]
+      },
+      {
+        "en": "Hooke's law",
+        "ja": "フックの法則",
+        "ja_typings": [
+          "fukkunohousoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00907",
+    "image_path": null,
+    "question_text": {
+      "en": "What law relates volume and temperature of a gas at constant pressure?",
+      "ja": "一定圧力で気体の体積と温度を関係づける法則は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Acidity",
+        "ja": "酸性度",
+        "ja_typings": [
+          "sanseido"
+        ]
+      },
+      {
+        "en": "Temperature",
+        "ja": "温度",
+        "ja_typings": [
+          "ondo"
+        ]
+      },
+      {
+        "en": "Salinity",
+        "ja": "塩分濃度",
+        "ja_typings": [
+          "enbunnoudo"
+        ]
+      },
+      {
+        "en": "Pressure",
+        "ja": "圧力",
+        "ja_typings": [
+          "atsuryoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00908",
+    "image_path": null,
+    "question_text": {
+      "en": "What does pH measure?",
+      "ja": "pHが測定するのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Diamond",
+        "ja": "ダイヤモンド",
+        "ja_typings": []
+      },
+      {
+        "en": "Quartz",
+        "ja": "石英",
+        "ja_typings": [
+          "sekiei"
+        ]
+      },
+      {
+        "en": "Corundum",
+        "ja": "コランダム",
+        "ja_typings": []
+      },
+      {
+        "en": "Topaz",
+        "ja": "トパーズ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00909",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the hardest natural substance?",
+      "ja": "天然で最も硬い物質は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "O negative",
+        "ja": "O型マイナス",
+        "ja_typings": [
+          "ogatamainasu"
+        ]
+      },
+      {
+        "en": "AB positive",
+        "ja": "AB型プラス",
+        "ja_typings": [
+          "abugatapurasu"
+        ]
+      },
+      {
+        "en": "A positive",
+        "ja": "A型プラス",
+        "ja_typings": [
+          "agatapurasu"
+        ]
+      },
+      {
+        "en": "B negative",
+        "ja": "B型マイナス",
+        "ja_typings": [
+          "bigatamainasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00910",
+    "image_path": null,
+    "question_text": {
+      "en": "What blood type is the universal donor?",
+      "ja": "万能供血者とされる血液型は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pancreas",
+        "ja": "膵臓",
+        "ja_typings": [
+          "suizou"
+        ]
+      },
+      {
+        "en": "Liver",
+        "ja": "肝臓",
+        "ja_typings": [
+          "kanzou"
+        ]
+      },
+      {
+        "en": "Kidney",
+        "ja": "腎臓",
+        "ja_typings": [
+          "jinzou"
+        ]
+      },
+      {
+        "en": "Spleen",
+        "ja": "脾臓",
+        "ja_typings": [
+          "hizou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00911",
+    "image_path": null,
+    "question_text": {
+      "en": "Which organ produces insulin?",
+      "ja": "インスリンを分泌する臓器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Femur",
+        "ja": "大腿骨",
+        "ja_typings": [
+          "daitaikotsu"
+        ]
+      },
+      {
+        "en": "Tibia",
+        "ja": "脛骨",
+        "ja_typings": [
+          "keikotsu"
+        ]
+      },
+      {
+        "en": "Humerus",
+        "ja": "上腕骨",
+        "ja_typings": [
+          "jouwankotsu"
+        ]
+      },
+      {
+        "en": "Fibula",
+        "ja": "腓骨",
+        "ja_typings": [
+          "hikotsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00912",
+    "image_path": null,
+    "question_text": {
+      "en": "Which bone is the longest in the human body?",
+      "ja": "人体で最も長い骨は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Watt",
+        "ja": "ワット",
+        "ja_typings": []
+      },
+      {
+        "en": "Joule",
+        "ja": "ジュール",
+        "ja_typings": []
+      },
+      {
+        "en": "Pascal",
+        "ja": "パスカル",
+        "ja_typings": []
+      },
+      {
+        "en": "Newton",
+        "ja": "ニュートン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00913",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the speed unit named after a Scottish engineer?",
+      "ja": "スコットランドの技術者にちなんだ仕事率の単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Igneous rock",
+        "ja": "火成岩",
+        "ja_typings": [
+          "kaseigan"
+        ]
+      },
+      {
+        "en": "Sedimentary rock",
+        "ja": "堆積岩",
+        "ja_typings": [
+          "taisekigan"
+        ]
+      },
+      {
+        "en": "Metamorphic rock",
+        "ja": "変成岩",
+        "ja_typings": [
+          "henseigan"
+        ]
+      },
+      {
+        "en": "Limestone",
+        "ja": "石灰岩",
+        "ja_typings": [
+          "sekkaigan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00914",
+    "image_path": null,
+    "question_text": {
+      "en": "What rock type forms from cooled magma?",
+      "ja": "マグマが冷えて固まってできる岩石は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Richter scale",
+        "ja": "リヒタースケール",
+        "ja_typings": []
+      },
+      {
+        "en": "Mohs scale",
+        "ja": "モース硬度",
+        "ja_typings": [
+          "moosukoudo"
+        ]
+      },
+      {
+        "en": "Beaufort scale",
+        "ja": "ビューフォート風力階級",
+        "ja_typings": [
+          "byuufoortofuuryokukaikyuu"
+        ]
+      },
+      {
+        "en": "Kelvin scale",
+        "ja": "ケルビン温度",
+        "ja_typings": [
+          "kerubinondo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00915",
+    "image_path": null,
+    "question_text": {
+      "en": "Which scale measures earthquake magnitude?",
+      "ja": "地震のマグニチュードを表す尺度は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Flask",
+        "ja": "フラスク",
+        "ja_typings": []
+      },
+      {
+        "en": "Django",
+        "ja": "ジャンゴ",
+        "ja_typings": []
+      },
+      {
+        "en": "FastAPI",
+        "ja": "ファストエーピーアイ",
+        "ja_typings": []
+      },
+      {
+        "en": "Tornado",
+        "ja": "トルネード",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00916",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Python framework is known as a microframework?",
+      "ja": "Python のマイクロフレームワークと呼ばれるのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FastAPI",
+        "ja": "ファストエーピーアイ",
+        "ja_typings": []
+      },
+      {
+        "en": "Flask",
+        "ja": "フラスク",
+        "ja_typings": []
+      },
+      {
+        "en": "Django",
+        "ja": "ジャンゴ",
+        "ja_typings": []
+      },
+      {
+        "en": "Pyramid",
+        "ja": "ピラミッド",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00917",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Python framework is async-first and based on type hints?",
+      "ja": "型ヒントベースで非同期前提の Python フレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NumPy",
+        "ja": "ナンパイ",
+        "ja_typings": []
+      },
+      {
+        "en": "SciPy",
+        "ja": "サイパイ",
+        "ja_typings": []
+      },
+      {
+        "en": "SymPy",
+        "ja": "シンパイ",
+        "ja_typings": []
+      },
+      {
+        "en": "Numba",
+        "ja": "ナンバ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00918",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Python library is the de facto standard for numerical arrays?",
+      "ja": "Python の数値配列の事実上の標準ライブラリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "pandas",
+        "ja": "パンダス",
+        "ja_typings": []
+      },
+      {
+        "en": "polars",
+        "ja": "ポーラーズ",
+        "ja_typings": []
+      },
+      {
+        "en": "dask",
+        "ja": "ダスク",
+        "ja_typings": []
+      },
+      {
+        "en": "modin",
+        "ja": "モディン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00919",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Python library is the standard for DataFrames?",
+      "ja": "Python のデータフレームの標準ライブラリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PyTorch",
+        "ja": "パイトーチ",
+        "ja_typings": []
+      },
+      {
+        "en": "TensorFlow",
+        "ja": "テンソルフロー",
+        "ja_typings": []
+      },
+      {
+        "en": "JAX",
+        "ja": "ジャックス",
+        "ja_typings": []
+      },
+      {
+        "en": "MXNet",
+        "ja": "エムエックスネット",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00920",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Python deep learning framework was developed by Meta?",
+      "ja": "Meta が開発した Python の深層学習フレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Django",
+        "ja": "ジャンゴ",
+        "ja_typings": []
+      },
+      {
+        "en": "Flask",
+        "ja": "フラスク",
+        "ja_typings": []
+      },
+      {
+        "en": "Bottle",
+        "ja": "ボトル",
+        "ja_typings": []
+      },
+      {
+        "en": "CherryPy",
+        "ja": "チェリーパイ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00921",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Python web framework is full-stack and batteries-included?",
+      "ja": "フルスタックでバッテリー同梱型の Python Web フレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "uv",
+        "ja": "ユーブイ",
+        "ja_typings": []
+      },
+      {
+        "en": "poetry",
+        "ja": "ポエトリー",
+        "ja_typings": []
+      },
+      {
+        "en": "pipenv",
+        "ja": "ピップエンブ",
+        "ja_typings": []
+      },
+      {
+        "en": "conda",
+        "ja": "コンダ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00922",
+    "image_path": null,
+    "question_text": {
+      "en": "Which extremely fast Python package manager is written in Rust?",
+      "ja": "Rust で書かれた高速な Python パッケージマネージャーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ruff",
+        "ja": "ラフ",
+        "ja_typings": []
+      },
+      {
+        "en": "Black",
+        "ja": "ブラック",
+        "ja_typings": []
+      },
+      {
+        "en": "Flake8",
+        "ja": "フレイクエイト",
+        "ja_typings": []
+      },
+      {
+        "en": "Pylint",
+        "ja": "パイリント",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00923",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Python tool combines a fast linter and formatter in Rust?",
+      "ja": "Rust 製の高速な Python のリンター兼フォーマッターは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Clone",
+        "ja": "クローン",
+        "ja_typings": []
+      },
+      {
+        "en": "Copy",
+        "ja": "コピー",
+        "ja_typings": []
+      },
+      {
+        "en": "Drop",
+        "ja": "ドロップ",
+        "ja_typings": []
+      },
+      {
+        "en": "Move",
+        "ja": "ムーブ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00924",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Rust trait represents types that own a clone operation?",
+      "ja": "複製操作を表す Rust のトレイトは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Copy",
+        "ja": "コピー",
+        "ja_typings": []
+      },
+      {
+        "en": "Clone",
+        "ja": "クローン",
+        "ja_typings": []
+      },
+      {
+        "en": "Sized",
+        "ja": "サイズド",
+        "ja_typings": []
+      },
+      {
+        "en": "Send",
+        "ja": "センド",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00925",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Rust trait marks types that are bitwise-copyable?",
+      "ja": "ビット単位でコピー可能な型を示す Rust のトレイトは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "format!",
+        "ja": "フォーマット",
+        "ja_typings": []
+      },
+      {
+        "en": "println!",
+        "ja": "プリントエルエヌ",
+        "ja_typings": []
+      },
+      {
+        "en": "write!",
+        "ja": "ライト",
+        "ja_typings": []
+      },
+      {
+        "en": "eprintln!",
+        "ja": "イープリントエルエヌ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00926",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Rust macro formats a string without printing it?",
+      "ja": "出力せずに文字列を整形する Rust のマクロは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "derive",
+        "ja": "デライブ",
+        "ja_typings": []
+      },
+      {
+        "en": "inline",
+        "ja": "インライン",
+        "ja_typings": []
+      },
+      {
+        "en": "repr",
+        "ja": "リプル",
+        "ja_typings": []
+      },
+      {
+        "en": "cfg",
+        "ja": "シーエフジー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00927",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Rust attribute auto-implements common traits?",
+      "ja": "一般的なトレイトを自動実装する Rust の属性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "tokio",
+        "ja": "トーキオ",
+        "ja_typings": []
+      },
+      {
+        "en": "smol",
+        "ja": "スモル",
+        "ja_typings": []
+      },
+      {
+        "en": "async-std",
+        "ja": "エイシンクエスティーディー",
+        "ja_typings": []
+      },
+      {
+        "en": "glommio",
+        "ja": "グロミオ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00928",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Rust async runtime is most widely used?",
+      "ja": "Rust で最も広く使われている非同期ランタイムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "axum",
+        "ja": "アクサム",
+        "ja_typings": []
+      },
+      {
+        "en": "actix-web",
+        "ja": "アクティクスウェブ",
+        "ja_typings": []
+      },
+      {
+        "en": "rocket",
+        "ja": "ロケット",
+        "ja_typings": []
+      },
+      {
+        "en": "warp",
+        "ja": "ワープ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00929",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Rust web framework is built on top of tokio and hyper?",
+      "ja": "tokio と hyper の上に構築された Rust の Web フレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Deno",
+        "ja": "デノ",
+        "ja_typings": []
+      },
+      {
+        "en": "Bun",
+        "ja": "バン",
+        "ja_typings": []
+      },
+      {
+        "en": "Node.js",
+        "ja": "ノードジェイエス",
+        "ja_typings": []
+      },
+      {
+        "en": "Workers",
+        "ja": "ワーカーズ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00930",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript runtime was created by Ryan Dahl after Node.js?",
+      "ja": "Ryan Dahl が Node.js の後に作った JavaScript ランタイムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bun",
+        "ja": "バン",
+        "ja_typings": []
+      },
+      {
+        "en": "Deno",
+        "ja": "デノ",
+        "ja_typings": []
+      },
+      {
+        "en": "Node.js",
+        "ja": "ノードジェイエス",
+        "ja_typings": []
+      },
+      {
+        "en": "QuickJS",
+        "ja": "クイックジェイエス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00931",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript runtime is written in Zig and focuses on speed?",
+      "ja": "Zig で書かれた高速志向の JavaScript ランタイムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Microsoft",
+        "ja": "マイクロソフト",
+        "ja_typings": []
+      },
+      {
+        "en": "Google",
+        "ja": "グーグル",
+        "ja_typings": []
+      },
+      {
+        "en": "Meta",
+        "ja": "メタ",
+        "ja_typings": []
+      },
+      {
+        "en": "Apple",
+        "ja": "アップル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00932",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed TypeScript?",
+      "ja": "TypeScript を開発した企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "esbuild",
+        "ja": "イーエスビルド",
+        "ja_typings": []
+      },
+      {
+        "en": "Webpack",
+        "ja": "ウェブパック",
+        "ja_typings": []
+      },
+      {
+        "en": "Rollup",
+        "ja": "ロールアップ",
+        "ja_typings": []
+      },
+      {
+        "en": "Parcel",
+        "ja": "パーセル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00933",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript bundler is known for zero-config and being extremely fast?",
+      "ja": "ゼロ設定で高速な JavaScript バンドラーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vite",
+        "ja": "ヴィート",
+        "ja_typings": []
+      },
+      {
+        "en": "Snowpack",
+        "ja": "スノーパック",
+        "ja_typings": []
+      },
+      {
+        "en": "Webpack",
+        "ja": "ウェブパック",
+        "ja_typings": []
+      },
+      {
+        "en": "Browserify",
+        "ja": "ブラウザリファイ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00934",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript dev server is built on top of esbuild and Rollup by Evan You?",
+      "ja": "Evan You が作った esbuild と Rollup ベースの開発サーバーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vitest",
+        "ja": "ヴァイテスト",
+        "ja_typings": []
+      },
+      {
+        "en": "Mocha",
+        "ja": "モカ",
+        "ja_typings": []
+      },
+      {
+        "en": "Jasmine",
+        "ja": "ジャスミン",
+        "ja_typings": []
+      },
+      {
+        "en": "AVA",
+        "ja": "エイバ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00935",
+    "image_path": null,
+    "question_text": {
+      "en": "Which test runner ships with Jest-compatible API and is by Vite team?",
+      "ja": "Vite チームの Jest 互換テストランナーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Elixir",
+        "ja": "エリクサー",
+        "ja_typings": []
+      },
+      {
+        "en": "Clojure",
+        "ja": "クロージャ",
+        "ja_typings": []
+      },
+      {
+        "en": "Scala",
+        "ja": "スカラ",
+        "ja_typings": []
+      },
+      {
+        "en": "F#",
+        "ja": "エフシャープ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00936",
+    "image_path": null,
+    "question_text": {
+      "en": "Which functional language runs on the BEAM VM and is Erlang-based?",
+      "ja": "BEAM 仮想マシン上で動く Erlang 系の関数型言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Clojure",
+        "ja": "クロージャ",
+        "ja_typings": []
+      },
+      {
+        "en": "Scala",
+        "ja": "スカラ",
+        "ja_typings": []
+      },
+      {
+        "en": "Groovy",
+        "ja": "グルービー",
+        "ja_typings": []
+      },
+      {
+        "en": "Kotlin",
+        "ja": "コトリン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00937",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JVM language emphasizes immutability and is a Lisp dialect?",
+      "ja": "不変性重視で Lisp 方言の JVM 言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kotlin",
+        "ja": "コトリン",
+        "ja_typings": []
+      },
+      {
+        "en": "Java",
+        "ja": "ジャバ",
+        "ja_typings": []
+      },
+      {
+        "en": "Dart",
+        "ja": "ダート",
+        "ja_typings": []
+      },
+      {
+        "en": "Swift",
+        "ja": "スウィフト",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00938",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language is the official language for Android development today?",
+      "ja": "現在の Android 開発の公式言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dart",
+        "ja": "ダート",
+        "ja_typings": []
+      },
+      {
+        "en": "Kotlin",
+        "ja": "コトリン",
+        "ja_typings": []
+      },
+      {
+        "en": "Swift",
+        "ja": "スウィフト",
+        "ja_typings": []
+      },
+      {
+        "en": "TypeScript",
+        "ja": "タイプスクリプト",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00939",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language powers the Flutter framework?",
+      "ja": "Flutter フレームワークの言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lua",
+        "ja": "ルア",
+        "ja_typings": []
+      },
+      {
+        "en": "Tcl",
+        "ja": "ティーシーエル",
+        "ja_typings": []
+      },
+      {
+        "en": "Squirrel",
+        "ja": "スクィレル",
+        "ja_typings": []
+      },
+      {
+        "en": "AngelScript",
+        "ja": "エンジェルスクリプト",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00940",
+    "image_path": null,
+    "question_text": {
+      "en": "Which scripting language is embedded in many games and apps?",
+      "ja": "ゲームやアプリに組み込まれることが多いスクリプト言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "F#",
+        "ja": "エフシャープ",
+        "ja_typings": []
+      },
+      {
+        "en": "OCaml",
+        "ja": "オーキャムル",
+        "ja_typings": []
+      },
+      {
+        "en": "Haskell",
+        "ja": "ハスケル",
+        "ja_typings": []
+      },
+      {
+        "en": "Elm",
+        "ja": "エルム",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00941",
+    "image_path": null,
+    "question_text": {
+      "en": "Which statically typed functional language is from Microsoft Research?",
+      "ja": "Microsoft Research 発の静的型付け関数型言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Swift",
+        "ja": "スウィフト",
+        "ja_typings": []
+      },
+      {
+        "en": "Kotlin",
+        "ja": "コトリン",
+        "ja_typings": []
+      },
+      {
+        "en": "Rust",
+        "ja": "ラスト",
+        "ja_typings": []
+      },
+      {
+        "en": "Go",
+        "ja": "ゴー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00942",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language is the spiritual successor to Objective-C on Apple platforms?",
+      "ja": "Apple プラットフォームでの Objective-C の後継言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rust",
+        "ja": "ラスト",
+        "ja_typings": []
+      },
+      {
+        "en": "Go",
+        "ja": "ゴー",
+        "ja_typings": []
+      },
+      {
+        "en": "Zig",
+        "ja": "ジグ",
+        "ja_typings": []
+      },
+      {
+        "en": "Nim",
+        "ja": "ニム",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00943",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language was created at Mozilla for systems programming?",
+      "ja": "Mozilla がシステムプログラミング向けに作った言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Zig",
+        "ja": "ジグ",
+        "ja_typings": []
+      },
+      {
+        "en": "Rust",
+        "ja": "ラスト",
+        "ja_typings": []
+      },
+      {
+        "en": "D",
+        "ja": "ディー",
+        "ja_typings": []
+      },
+      {
+        "en": "Nim",
+        "ja": "ニム",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00944",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language emphasizes manual memory management as a C replacement?",
+      "ja": "C の代替を意識した手動メモリ管理重視の言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Merge sort",
+        "ja": "マージソート",
+        "ja_typings": []
+      },
+      {
+        "en": "Quicksort",
+        "ja": "クイックソート",
+        "ja_typings": []
+      },
+      {
+        "en": "Heapsort",
+        "ja": "ヒープソート",
+        "ja_typings": []
+      },
+      {
+        "en": "Bubble sort",
+        "ja": "バブルソート",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00945",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sorting algorithm is stable and runs in O(n log n) worst case?",
+      "ja": "最悪 O(n log n) で安定なソートアルゴリズムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Heap",
+        "ja": "ヒープ",
+        "ja_typings": []
+      },
+      {
+        "en": "Stack",
+        "ja": "スタック",
+        "ja_typings": []
+      },
+      {
+        "en": "Linked list",
+        "ja": "連結リスト",
+        "ja_typings": [
+          "renketsurisuto"
+        ]
+      },
+      {
+        "en": "Hash table",
+        "ja": "ハッシュテーブル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00946",
+    "image_path": null,
+    "question_text": {
+      "en": "Which data structure is best suited for implementing priority queues?",
+      "ja": "プライオリティキューに最適なデータ構造は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Trie",
+        "ja": "トライ",
+        "ja_typings": []
+      },
+      {
+        "en": "Heap",
+        "ja": "ヒープ",
+        "ja_typings": []
+      },
+      {
+        "en": "B-tree",
+        "ja": "ビーツリー",
+        "ja_typings": []
+      },
+      {
+        "en": "Skip list",
+        "ja": "スキップリスト",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00947",
+    "image_path": null,
+    "question_text": {
+      "en": "Which data structure provides efficient prefix string search?",
+      "ja": "プレフィックス検索に効率的なデータ構造は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "In-order",
+        "ja": "インオーダー",
+        "ja_typings": []
+      },
+      {
+        "en": "Pre-order",
+        "ja": "プリオーダー",
+        "ja_typings": []
+      },
+      {
+        "en": "Post-order",
+        "ja": "ポストオーダー",
+        "ja_typings": []
+      },
+      {
+        "en": "Level-order",
+        "ja": "レベルオーダー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00948",
+    "image_path": null,
+    "question_text": {
+      "en": "Which traversal visits a binary tree in left-root-right order?",
+      "ja": "二分木を左-根-右の順で巡回するのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Floyd-Warshall",
+        "ja": "フロイドワーシャル",
+        "ja_typings": []
+      },
+      {
+        "en": "Dijkstra",
+        "ja": "ダイクストラ",
+        "ja_typings": []
+      },
+      {
+        "en": "Bellman-Ford",
+        "ja": "ベルマンフォード",
+        "ja_typings": []
+      },
+      {
+        "en": "A-star",
+        "ja": "エースター",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00949",
+    "image_path": null,
+    "question_text": {
+      "en": "Which algorithm finds shortest paths from all sources to all destinations?",
+      "ja": "全頂点対の最短経路を求めるアルゴリズムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dynamic programming",
+        "ja": "動的計画法",
+        "ja_typings": [
+          "doutekikeikakuhou"
+        ]
+      },
+      {
+        "en": "Greedy",
+        "ja": "貪欲法",
+        "ja_typings": [
+          "donyokuhou"
+        ]
+      },
+      {
+        "en": "Backtracking",
+        "ja": "バックトラッキング",
+        "ja_typings": []
+      },
+      {
+        "en": "Brute force",
+        "ja": "総当たり",
+        "ja_typings": [
+          "souatari"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00950",
+    "image_path": null,
+    "question_text": {
+      "en": "Which technique solves problems by combining solutions to subproblems?",
+      "ja": "部分問題の解を結合して解くアルゴリズム技法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Functional programming",
+        "ja": "関数型プログラミング",
+        "ja_typings": [
+          "kansuugatapuroguramingu"
+        ]
+      },
+      {
+        "en": "Imperative",
+        "ja": "命令型",
+        "ja_typings": [
+          "meireigata"
+        ]
+      },
+      {
+        "en": "Procedural",
+        "ja": "手続き型",
+        "ja_typings": [
+          "tetsuzukigata"
+        ]
+      },
+      {
+        "en": "Logic",
+        "ja": "論理型",
+        "ja_typings": [
+          "ronrigata"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00951",
+    "image_path": null,
+    "question_text": {
+      "en": "Which paradigm builds programs by composing pure functions?",
+      "ja": "純粋関数の合成でプログラムを構成するパラダイムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Docker image",
+        "ja": "ドッカーイメージ",
+        "ja_typings": []
+      },
+      {
+        "en": "Vagrant box",
+        "ja": "ベイグラントボックス",
+        "ja_typings": []
+      },
+      {
+        "en": "AMI",
+        "ja": "エーエムアイ",
+        "ja_typings": []
+      },
+      {
+        "en": "LXD image",
+        "ja": "エルエックスディーイメージ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00952",
+    "image_path": null,
+    "question_text": {
+      "en": "Which container image format is the OCI industry standard?",
+      "ja": "OCI 業界標準のコンテナイメージ形式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "curl",
+        "ja": "カール",
+        "ja_typings": []
+      },
+      {
+        "en": "wget",
+        "ja": "ダブルゲット",
+        "ja_typings": []
+      },
+      {
+        "en": "httpie",
+        "ja": "エイチティーティーピーアイイー",
+        "ja_typings": []
+      },
+      {
+        "en": "aria2",
+        "ja": "アリアツー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00953",
+    "image_path": null,
+    "question_text": {
+      "en": "Which command-line tool is the standard for HTTP transfers in scripts?",
+      "ja": "スクリプトで HTTP 通信を行う標準的な CLI ツールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Subversion",
+        "ja": "サブバージョン",
+        "ja_typings": []
+      },
+      {
+        "en": "Git",
+        "ja": "ギット",
+        "ja_typings": []
+      },
+      {
+        "en": "Mercurial",
+        "ja": "マーキュリアル",
+        "ja_typings": []
+      },
+      {
+        "en": "Bazaar",
+        "ja": "バザール",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00954",
+    "image_path": null,
+    "question_text": {
+      "en": "Which version control system is centralized rather than distributed?",
+      "ja": "分散型ではなく集中型のバージョン管理システムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "GitHub Actions",
+        "ja": "ギットハブアクションズ",
+        "ja_typings": []
+      },
+      {
+        "en": "CircleCI",
+        "ja": "サークルシーアイ",
+        "ja_typings": []
+      },
+      {
+        "en": "Travis CI",
+        "ja": "トラビスシーアイ",
+        "ja_typings": []
+      },
+      {
+        "en": "Jenkins",
+        "ja": "ジェンキンス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00955",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CI service is built into GitHub itself?",
+      "ja": "GitHub に組み込まれている CI サービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Markdown",
+        "ja": "マークダウン",
+        "ja_typings": []
+      },
+      {
+        "en": "reStructuredText",
+        "ja": "アールエスティー",
+        "ja_typings": []
+      },
+      {
+        "en": "AsciiDoc",
+        "ja": "アスキードック",
+        "ja_typings": []
+      },
+      {
+        "en": "Textile",
+        "ja": "テクスタイル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00956",
+    "image_path": null,
+    "question_text": {
+      "en": "Which markup language is commonly used for README files on GitHub?",
+      "ja": "GitHub の README で使われるマークアップは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "TOML",
+        "ja": "トムル",
+        "ja_typings": []
+      },
+      {
+        "en": "YAML",
+        "ja": "ヤムル",
+        "ja_typings": []
+      },
+      {
+        "en": "XML",
+        "ja": "エックスエムエル",
+        "ja_typings": []
+      },
+      {
+        "en": "INI",
+        "ja": "アイエヌアイ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00957",
+    "image_path": null,
+    "question_text": {
+      "en": "Which serialization format is line-oriented and key-value-like for configs?",
+      "ja": "設定用のキーバリュー型シリアライズ形式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "YAML",
+        "ja": "ヤムル",
+        "ja_typings": []
+      },
+      {
+        "en": "TOML",
+        "ja": "トムル",
+        "ja_typings": []
+      },
+      {
+        "en": "JSON",
+        "ja": "ジェイソン",
+        "ja_typings": []
+      },
+      {
+        "en": "XML",
+        "ja": "エックスエムエル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00958",
+    "image_path": null,
+    "question_text": {
+      "en": "Which data format is whitespace-significant and widely used in CI configs?",
+      "ja": "インデントに意味があり CI 設定で多用されるデータ形式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Niklaus Wirth",
+        "ja": "ニクラウス・ヴィルト",
+        "ja_typings": []
+      },
+      {
+        "en": "Anders Hejlsberg",
+        "ja": "アンダース・ヘルスバーグ",
+        "ja_typings": []
+      },
+      {
+        "en": "Donald Knuth",
+        "ja": "ドナルド・クヌース",
+        "ja_typings": []
+      },
+      {
+        "en": "Edsger Dijkstra",
+        "ja": "エドガー・ダイクストラ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00959",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created the Pascal language and Turbo Pascal?",
+      "ja": "Pascal と Turbo Pascal を作ったのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Anders Hejlsberg",
+        "ja": "アンダース・ヘルスバーグ",
+        "ja_typings": []
+      },
+      {
+        "en": "Brendan Eich",
+        "ja": "ブレンダン・アイク",
+        "ja_typings": []
+      },
+      {
+        "en": "Bjarne Stroustrup",
+        "ja": "ビャーネ・ストロヴストルップ",
+        "ja_typings": []
+      },
+      {
+        "en": "James Gosling",
+        "ja": "ジェームズ・ゴスリン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00960",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the lead architect of TypeScript and C#?",
+      "ja": "TypeScript と C# の主任設計者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "James Gosling",
+        "ja": "ジェームズ・ゴスリン",
+        "ja_typings": []
+      },
+      {
+        "en": "Guido van Rossum",
+        "ja": "グイド・ヴァン・ロッサム",
+        "ja_typings": []
+      },
+      {
+        "en": "Bjarne Stroustrup",
+        "ja": "ビャーネ・ストロヴストルップ",
+        "ja_typings": []
+      },
+      {
+        "en": "Ken Thompson",
+        "ja": "ケン・トンプソン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00961",
+    "image_path": null,
+    "question_text": {
+      "en": "Who designed the Java language?",
+      "ja": "Java 言語を設計したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Donald Knuth",
+        "ja": "ドナルド・クヌース",
+        "ja_typings": []
+      },
+      {
+        "en": "Edsger Dijkstra",
+        "ja": "エドガー・ダイクストラ",
+        "ja_typings": []
+      },
+      {
+        "en": "Tony Hoare",
+        "ja": "トニー・ホーア",
+        "ja_typings": []
+      },
+      {
+        "en": "John McCarthy",
+        "ja": "ジョン・マッカーシー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00962",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is famous for The Art of Computer Programming and TeX?",
+      "ja": "The Art of Computer Programming と TeX で有名な人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "John McCarthy",
+        "ja": "ジョン・マッカーシー",
+        "ja_typings": []
+      },
+      {
+        "en": "Alan Kay",
+        "ja": "アラン・ケイ",
+        "ja_typings": []
+      },
+      {
+        "en": "Grace Hopper",
+        "ja": "グレース・ホッパー",
+        "ja_typings": []
+      },
+      {
+        "en": "Niklaus Wirth",
+        "ja": "ニクラウス・ヴィルト",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00963",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is credited with creating Lisp?",
+      "ja": "Lisp を生み出した人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Alan Kay",
+        "ja": "アラン・ケイ",
+        "ja_typings": []
+      },
+      {
+        "en": "Bjarne Stroustrup",
+        "ja": "ビャーネ・ストロヴストルップ",
+        "ja_typings": []
+      },
+      {
+        "en": "Grady Booch",
+        "ja": "グラディ・ブーチ",
+        "ja_typings": []
+      },
+      {
+        "en": "James Gosling",
+        "ja": "ジェームズ・ゴスリン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00964",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is credited with creating Smalltalk and coining 'object-oriented'?",
+      "ja": "Smalltalk を作りオブジェクト指向の語を定着させたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Isolation",
+        "ja": "独立性",
+        "ja_typings": [
+          "dokuritsusei"
+        ]
+      },
+      {
+        "en": "Atomicity",
+        "ja": "原子性",
+        "ja_typings": [
+          "genshisei"
+        ]
+      },
+      {
+        "en": "Consistency",
+        "ja": "一貫性",
+        "ja_typings": [
+          "ikkansei"
+        ]
+      },
+      {
+        "en": "Durability",
+        "ja": "永続性",
+        "ja_typings": [
+          "eizokusei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00965",
+    "image_path": null,
+    "question_text": {
+      "en": "What does ACID stand for in database transactions?",
+      "ja": "データベースの ACID 特性のうち独立性を示すのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Declarative",
+        "ja": "宣言型",
+        "ja_typings": [
+          "sengengata"
+        ]
+      },
+      {
+        "en": "Imperative",
+        "ja": "命令型",
+        "ja_typings": [
+          "meireigata"
+        ]
+      },
+      {
+        "en": "Procedural",
+        "ja": "手続き型",
+        "ja_typings": [
+          "tetsuzukigata"
+        ]
+      },
+      {
+        "en": "Object-oriented",
+        "ja": "オブジェクト指向",
+        "ja_typings": [
+          "obujekutoshikou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00966",
+    "image_path": null,
+    "question_text": {
+      "en": "Which paradigm focuses on what to compute, not how?",
+      "ja": "「何を計算するか」を記述するパラダイムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Test-driven development",
+        "ja": "テスト駆動開発",
+        "ja_typings": [
+          "tesutokudoukaihatsu"
+        ]
+      },
+      {
+        "en": "Behavior-driven development",
+        "ja": "振る舞い駆動開発",
+        "ja_typings": [
+          "furumaikudoukaihatsu"
+        ]
+      },
+      {
+        "en": "Pair programming",
+        "ja": "ペアプログラミング",
+        "ja_typings": []
+      },
+      {
+        "en": "Continuous integration",
+        "ja": "継続的インテグレーション",
+        "ja_typings": [
+          "keizokutekiintegure-shon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00967",
+    "image_path": null,
+    "question_text": {
+      "en": "Which testing approach writes tests before implementation?",
+      "ja": "実装前にテストを書く開発手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<article>`",
+        "ja": "アーティクル",
+        "ja_typings": []
+      },
+      {
+        "en": "`<section>`",
+        "ja": "セクション",
+        "ja_typings": []
+      },
+      {
+        "en": "`<aside>`",
+        "ja": "アサイド",
+        "ja_typings": []
+      },
+      {
+        "en": "`<main>`",
+        "ja": "メイン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00968",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML5 tag represents a self-contained article?",
+      "ja": "自己完結した記事を表す HTML5 タグは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<section>`",
+        "ja": "セクション",
+        "ja_typings": []
+      },
+      {
+        "en": "`<article>`",
+        "ja": "アーティクル",
+        "ja_typings": []
+      },
+      {
+        "en": "`<div>`",
+        "ja": "ディブ",
+        "ja_typings": []
+      },
+      {
+        "en": "`<aside>`",
+        "ja": "アサイド",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00969",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML5 tag groups thematically related content?",
+      "ja": "テーマで関連する内容をまとめる HTML5 タグは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<aside>`",
+        "ja": "アサイド",
+        "ja_typings": []
+      },
+      {
+        "en": "`<footer>`",
+        "ja": "フッター",
+        "ja_typings": []
+      },
+      {
+        "en": "`<header>`",
+        "ja": "ヘッダー",
+        "ja_typings": []
+      },
+      {
+        "en": "`<nav>`",
+        "ja": "ナブ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00970",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML5 tag represents tangentially related content like a sidebar?",
+      "ja": "サイドバー等の補足的内容を表す HTML5 タグは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<svg>`",
+        "ja": "エスブイジー",
+        "ja_typings": []
+      },
+      {
+        "en": "`<canvas>`",
+        "ja": "キャンバス",
+        "ja_typings": []
+      },
+      {
+        "en": "`<picture>`",
+        "ja": "ピクチャー",
+        "ja_typings": []
+      },
+      {
+        "en": "`<object>`",
+        "ja": "オブジェクト",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00971",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML element is used to embed scalable vector graphics?",
+      "ja": "ベクター画像を埋め込む HTML 要素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<canvas>`",
+        "ja": "キャンバス",
+        "ja_typings": []
+      },
+      {
+        "en": "`<svg>`",
+        "ja": "エスブイジー",
+        "ja_typings": []
+      },
+      {
+        "en": "`<picture>`",
+        "ja": "ピクチャー",
+        "ja_typings": []
+      },
+      {
+        "en": "`<figure>`",
+        "ja": "フィギュア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00972",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML element provides scriptable bitmap drawing?",
+      "ja": "スクリプトでビットマップ描画できる HTML 要素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`list`",
+        "ja": "リスト",
+        "ja_typings": []
+      },
+      {
+        "en": "`select`",
+        "ja": "セレクト",
+        "ja_typings": []
+      },
+      {
+        "en": "`options`",
+        "ja": "オプションズ",
+        "ja_typings": []
+      },
+      {
+        "en": "`combo`",
+        "ja": "コンボ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00973",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML attribute enables a drop-down list bound to an input?",
+      "ja": "input に紐づく候補リストを実現する HTML 属性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`color`",
+        "ja": "カラー",
+        "ja_typings": []
+      },
+      {
+        "en": "`picker`",
+        "ja": "ピッカー",
+        "ja_typings": []
+      },
+      {
+        "en": "`hex`",
+        "ja": "ヘックス",
+        "ja_typings": []
+      },
+      {
+        "en": "`palette`",
+        "ja": "パレット",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00974",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML input type provides a native color picker?",
+      "ja": "ネイティブのカラーピッカーを表示する input type は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`:first-child`",
+        "ja": "ファーストチャイルド",
+        "ja_typings": []
+      },
+      {
+        "en": "`:nth-child(1)`",
+        "ja": "エヌスチャイルド",
+        "ja_typings": []
+      },
+      {
+        "en": "`:first-of-type`",
+        "ja": "ファーストオブタイプ",
+        "ja_typings": []
+      },
+      {
+        "en": "`:root`",
+        "ja": "ルート",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00975",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS pseudo-class targets the first child element?",
+      "ja": "最初の子要素を選択する CSS 疑似クラスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`rem`",
+        "ja": "レム",
+        "ja_typings": []
+      },
+      {
+        "en": "`em`",
+        "ja": "エム",
+        "ja_typings": []
+      },
+      {
+        "en": "`px`",
+        "ja": "ピクセル",
+        "ja_typings": []
+      },
+      {
+        "en": "`pt`",
+        "ja": "ポイント",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00976",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS unit is relative to the root font-size?",
+      "ja": "ルートフォントサイズに対する CSS の単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`vw`",
+        "ja": "ブイダブリュ",
+        "ja_typings": []
+      },
+      {
+        "en": "`vh`",
+        "ja": "ブイエイチ",
+        "ja_typings": []
+      },
+      {
+        "en": "`vmin`",
+        "ja": "ブイミン",
+        "ja_typings": []
+      },
+      {
+        "en": "`vmax`",
+        "ja": "ブイマックス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00977",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS unit equals one percent of the viewport width?",
+      "ja": "ビューポート幅の 1% を表す CSS の単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`z-index`",
+        "ja": "ゼットインデックス",
+        "ja_typings": []
+      },
+      {
+        "en": "`order`",
+        "ja": "オーダー",
+        "ja_typings": []
+      },
+      {
+        "en": "`stack`",
+        "ja": "スタック",
+        "ja_typings": []
+      },
+      {
+        "en": "`layer`",
+        "ja": "レイヤー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00978",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS property controls stacking order along the z-axis?",
+      "ja": "Z 軸方向の重なり順を制御する CSS プロパティは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`calc()`",
+        "ja": "カルク",
+        "ja_typings": []
+      },
+      {
+        "en": "`min()`",
+        "ja": "ミン",
+        "ja_typings": []
+      },
+      {
+        "en": "`max()`",
+        "ja": "マックス",
+        "ja_typings": []
+      },
+      {
+        "en": "`clamp()`",
+        "ja": "クランプ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00979",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS function performs simple arithmetic with mixed units?",
+      "ja": "異なる単位の四則演算を行う CSS 関数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`@media`",
+        "ja": "アットメディア",
+        "ja_typings": []
+      },
+      {
+        "en": "`@supports`",
+        "ja": "アットサポーツ",
+        "ja_typings": []
+      },
+      {
+        "en": "`@container`",
+        "ja": "アットコンテナ",
+        "ja_typings": []
+      },
+      {
+        "en": "`@layer`",
+        "ja": "アットレイヤー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00980",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS at-rule defines media-query-based styles?",
+      "ja": "メディアクエリに基づくスタイルを定義する CSS の at-rule は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`@container`",
+        "ja": "アットコンテナ",
+        "ja_typings": []
+      },
+      {
+        "en": "`@media`",
+        "ja": "アットメディア",
+        "ja_typings": []
+      },
+      {
+        "en": "`@scope`",
+        "ja": "アットスコープ",
+        "ja_typings": []
+      },
+      {
+        "en": "`@supports`",
+        "ja": "アットサポーツ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00981",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS at-rule scopes styles by container queries?",
+      "ja": "コンテナクエリでスタイルをスコープする at-rule は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`transition`",
+        "ja": "トランジション",
+        "ja_typings": []
+      },
+      {
+        "en": "`animation`",
+        "ja": "アニメーション",
+        "ja_typings": []
+      },
+      {
+        "en": "`transform`",
+        "ja": "トランスフォーム",
+        "ja_typings": []
+      },
+      {
+        "en": "`filter`",
+        "ja": "フィルター",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00982",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS property smoothly animates between value changes?",
+      "ja": "値の変化を滑らかに補間する CSS プロパティは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`filter`",
+        "ja": "フィルター",
+        "ja_typings": []
+      },
+      {
+        "en": "`opacity`",
+        "ja": "オパシティ",
+        "ja_typings": []
+      },
+      {
+        "en": "`mix-blend-mode`",
+        "ja": "ミックスブレンドモード",
+        "ja_typings": []
+      },
+      {
+        "en": "`backdrop`",
+        "ja": "バックドロップ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00983",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS property applies blur, grayscale, and similar effects?",
+      "ja": "ぼかしやグレースケール等の効果を適用する CSS プロパティは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`querySelector`",
+        "ja": "クエリセレクタ",
+        "ja_typings": []
+      },
+      {
+        "en": "`getElementById`",
+        "ja": "ゲットエレメントバイアイディー",
+        "ja_typings": []
+      },
+      {
+        "en": "`getElementsByTagName`",
+        "ja": "ゲットエレメンツバイタグネーム",
+        "ja_typings": []
+      },
+      {
+        "en": "`find`",
+        "ja": "ファインド",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00984",
+    "image_path": null,
+    "question_text": {
+      "en": "Which method selects the first element matching a CSS selector?",
+      "ja": "CSS セレクタに合う最初の要素を取得する DOM メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`fetch`",
+        "ja": "フェッチ",
+        "ja_typings": []
+      },
+      {
+        "en": "`axios`",
+        "ja": "アクシオス",
+        "ja_typings": []
+      },
+      {
+        "en": "`ajax`",
+        "ja": "エイジャックス",
+        "ja_typings": []
+      },
+      {
+        "en": "`request`",
+        "ja": "リクエスト",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00985",
+    "image_path": null,
+    "question_text": {
+      "en": "Which DOM API replaces XMLHttpRequest in modern code?",
+      "ja": "XMLHttpRequest に代わる現代の DOM API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "IntersectionObserver",
+        "ja": "インターセクションオブザーバー",
+        "ja_typings": []
+      },
+      {
+        "en": "MutationObserver",
+        "ja": "ミューテーションオブザーバー",
+        "ja_typings": []
+      },
+      {
+        "en": "ResizeObserver",
+        "ja": "リサイズオブザーバー",
+        "ja_typings": []
+      },
+      {
+        "en": "PerformanceObserver",
+        "ja": "パフォーマンスオブザーバー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00986",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Web API observes elements crossing the viewport?",
+      "ja": "ビューポート交差を監視する Web API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MutationObserver",
+        "ja": "ミューテーションオブザーバー",
+        "ja_typings": []
+      },
+      {
+        "en": "IntersectionObserver",
+        "ja": "インターセクションオブザーバー",
+        "ja_typings": []
+      },
+      {
+        "en": "ResizeObserver",
+        "ja": "リサイズオブザーバー",
+        "ja_typings": []
+      },
+      {
+        "en": "PerformanceObserver",
+        "ja": "パフォーマンスオブザーバー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00987",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Web API watches changes to the DOM tree?",
+      "ja": "DOM ツリーの変化を監視する Web API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ResizeObserver",
+        "ja": "リサイズオブザーバー",
+        "ja_typings": []
+      },
+      {
+        "en": "MutationObserver",
+        "ja": "ミューテーションオブザーバー",
+        "ja_typings": []
+      },
+      {
+        "en": "IntersectionObserver",
+        "ja": "インターセクションオブザーバー",
+        "ja_typings": []
+      },
+      {
+        "en": "Layout API",
+        "ja": "レイアウトエーピーアイ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00988",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Web API monitors element size changes?",
+      "ja": "要素サイズの変化を監視する Web API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`requestAnimationFrame`",
+        "ja": "リクエストアニメーションフレーム",
+        "ja_typings": []
+      },
+      {
+        "en": "`setTimeout`",
+        "ja": "セットタイムアウト",
+        "ja_typings": []
+      },
+      {
+        "en": "`setInterval`",
+        "ja": "セットインターバル",
+        "ja_typings": []
+      },
+      {
+        "en": "`queueMicrotask`",
+        "ja": "キューマイクロタスク",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00989",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript timer schedules a callback for the next animation frame?",
+      "ja": "次の描画フレームでコールバックを呼ぶ JavaScript のタイマーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Promise",
+        "ja": "プロミス",
+        "ja_typings": []
+      },
+      {
+        "en": "Observable",
+        "ja": "オブザーバブル",
+        "ja_typings": []
+      },
+      {
+        "en": "Stream",
+        "ja": "ストリーム",
+        "ja_typings": []
+      },
+      {
+        "en": "Channel",
+        "ja": "チャネル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00990",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript construct represents a one-time async value?",
+      "ja": "1 回限りの非同期値を表す JavaScript の構文は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "302",
+        "ja": "サンマルニ",
+        "ja_typings": []
+      },
+      {
+        "en": "301",
+        "ja": "サンマルイチ",
+        "ja_typings": []
+      },
+      {
+        "en": "303",
+        "ja": "サンマルサン",
+        "ja_typings": []
+      },
+      {
+        "en": "307",
+        "ja": "サンマルナナ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00991",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status code indicates a temporary redirect?",
+      "ja": "一時的リダイレクトを示す HTTP ステータスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "503",
+        "ja": "ゴーマルサン",
+        "ja_typings": []
+      },
+      {
+        "en": "502",
+        "ja": "ゴーマルニ",
+        "ja_typings": []
+      },
+      {
+        "en": "504",
+        "ja": "ゴーマルヨン",
+        "ja_typings": []
+      },
+      {
+        "en": "500",
+        "ja": "ゴヒャク",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00992",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status code indicates the server is temporarily unavailable?",
+      "ja": "サーバーが一時的に利用不能であることを示す HTTP ステータスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "413",
+        "ja": "ヨンイチサン",
+        "ja_typings": []
+      },
+      {
+        "en": "414",
+        "ja": "ヨンイチヨン",
+        "ja_typings": []
+      },
+      {
+        "en": "400",
+        "ja": "ヨンヒャク",
+        "ja_typings": []
+      },
+      {
+        "en": "411",
+        "ja": "ヨンイチイチ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00993",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status code indicates the request body exceeds the server limit?",
+      "ja": "リクエストボディがサーバー制限を超えたことを示す HTTP ステータスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "304",
+        "ja": "サンマルヨン",
+        "ja_typings": []
+      },
+      {
+        "en": "305",
+        "ja": "サンマルゴ",
+        "ja_typings": []
+      },
+      {
+        "en": "306",
+        "ja": "サンマルロク",
+        "ja_typings": []
+      },
+      {
+        "en": "302",
+        "ja": "サンマルニ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00994",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status indicates the resource has not been modified?",
+      "ja": "リソースが未更新であることを示す HTTP ステータスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Authorization",
+        "ja": "オーソライゼーション",
+        "ja_typings": []
+      },
+      {
+        "en": "Authentication",
+        "ja": "オーセンティケーション",
+        "ja_typings": []
+      },
+      {
+        "en": "Credentials",
+        "ja": "クレデンシャルズ",
+        "ja_typings": []
+      },
+      {
+        "en": "X-Token",
+        "ja": "エックストークン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00995",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP header sends authentication credentials with the request?",
+      "ja": "リクエストに認証情報を載せる HTTP ヘッダーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Content-Type",
+        "ja": "コンテントタイプ",
+        "ja_typings": []
+      },
+      {
+        "en": "Accept",
+        "ja": "アクセプト",
+        "ja_typings": []
+      },
+      {
+        "en": "Content-Length",
+        "ja": "コンテントレングス",
+        "ja_typings": []
+      },
+      {
+        "en": "Content-Encoding",
+        "ja": "コンテントエンコーディング",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00996",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP header indicates the format of the request body?",
+      "ja": "リクエストボディの形式を示す HTTP ヘッダーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Accept",
+        "ja": "アクセプト",
+        "ja_typings": []
+      },
+      {
+        "en": "Content-Type",
+        "ja": "コンテントタイプ",
+        "ja_typings": []
+      },
+      {
+        "en": "Vary",
+        "ja": "ベアリー",
+        "ja_typings": []
+      },
+      {
+        "en": "Allow",
+        "ja": "アロー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00997",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP header declares acceptable response media types?",
+      "ja": "受け入れ可能なレスポンス形式を宣言する HTTP ヘッダーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "User-Agent",
+        "ja": "ユーザーエージェント",
+        "ja_typings": []
+      },
+      {
+        "en": "Referer",
+        "ja": "リファラー",
+        "ja_typings": []
+      },
+      {
+        "en": "From",
+        "ja": "フロム",
+        "ja_typings": []
+      },
+      {
+        "en": "Host",
+        "ja": "ホスト",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00998",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP header is used by browsers to identify the client software?",
+      "ja": "クライアントソフトを識別する HTTP ヘッダーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SQL injection",
+        "ja": "エスキューエルインジェクション",
+        "ja_typings": []
+      },
+      {
+        "en": "XSS",
+        "ja": "クロスサイトスクリプティング",
+        "ja_typings": []
+      },
+      {
+        "en": "CSRF",
+        "ja": "クロスサイトリクエストフォージェリ",
+        "ja_typings": []
+      },
+      {
+        "en": "Path traversal",
+        "ja": "パストラバーサル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00999",
+    "image_path": null,
+    "question_text": {
+      "en": "Which attack manipulates database queries via unsanitized input?",
+      "ja": "未検証の入力で DB クエリを改ざんする攻撃は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Path traversal",
+        "ja": "パストラバーサル",
+        "ja_typings": []
+      },
+      {
+        "en": "SQL injection",
+        "ja": "エスキューエルインジェクション",
+        "ja_typings": []
+      },
+      {
+        "en": "XSS",
+        "ja": "クロスサイトスクリプティング",
+        "ja_typings": []
+      },
+      {
+        "en": "Clickjacking",
+        "ja": "クリックジャッキング",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01000",
+    "image_path": null,
+    "question_text": {
+      "en": "Which attack reads files outside the intended directory?",
+      "ja": "意図したディレクトリ外のファイルを読む攻撃は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Clickjacking",
+        "ja": "クリックジャッキング",
+        "ja_typings": []
+      },
+      {
+        "en": "Phishing",
+        "ja": "フィッシング",
+        "ja_typings": []
+      },
+      {
+        "en": "CSRF",
+        "ja": "クロスサイトリクエストフォージェリ",
+        "ja_typings": []
+      },
+      {
+        "en": "XSS",
+        "ja": "クロスサイトスクリプティング",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01001",
+    "image_path": null,
+    "question_text": {
+      "en": "Which attack overlays an invisible UI to trick clicks?",
+      "ja": "見えない UI を被せてクリックを誘う攻撃は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "X-Frame-Options",
+        "ja": "エックスフレームオプションズ",
+        "ja_typings": []
+      },
+      {
+        "en": "Content-Security-Policy",
+        "ja": "コンテンツセキュリティポリシー",
+        "ja_typings": []
+      },
+      {
+        "en": "X-Content-Type-Options",
+        "ja": "エックスコンテンツタイプオプションズ",
+        "ja_typings": []
+      },
+      {
+        "en": "Referrer-Policy",
+        "ja": "リファラーポリシー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01002",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP header forbids embedding the page in a frame?",
+      "ja": "ページをフレームに埋め込むことを禁じる HTTP ヘッダーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Strict-Transport-Security",
+        "ja": "ストリクトトランスポートセキュリティ",
+        "ja_typings": []
+      },
+      {
+        "en": "Content-Security-Policy",
+        "ja": "コンテンツセキュリティポリシー",
+        "ja_typings": []
+      },
+      {
+        "en": "X-Frame-Options",
+        "ja": "エックスフレームオプションズ",
+        "ja_typings": []
+      },
+      {
+        "en": "Permissions-Policy",
+        "ja": "パーミッションズポリシー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01003",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP header forces browsers to use HTTPS for a period?",
+      "ja": "一定期間 HTTPS 強制を伝える HTTP ヘッダーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Redux",
+        "ja": "リダックス",
+        "ja_typings": []
+      },
+      {
+        "en": "MobX",
+        "ja": "モブエックス",
+        "ja_typings": []
+      },
+      {
+        "en": "Recoil",
+        "ja": "リコイル",
+        "ja_typings": []
+      },
+      {
+        "en": "Zustand",
+        "ja": "ズスタンド",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01004",
+    "image_path": null,
+    "question_text": {
+      "en": "Which state management library is most associated with React?",
+      "ja": "React と最も結びつく状態管理ライブラリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "styled-components",
+        "ja": "スタイルドコンポーネンツ",
+        "ja_typings": []
+      },
+      {
+        "en": "Emotion",
+        "ja": "エモーション",
+        "ja_typings": []
+      },
+      {
+        "en": "JSS",
+        "ja": "ジェイエスエス",
+        "ja_typings": []
+      },
+      {
+        "en": "Linaria",
+        "ja": "リナリア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01005",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS-in-JS library popularized tagged template literals for styles?",
+      "ja": "タグ付きテンプレートリテラルによる CSS-in-JS を広めたライブラリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Astro",
+        "ja": "アストロ",
+        "ja_typings": []
+      },
+      {
+        "en": "Remix",
+        "ja": "リミックス",
+        "ja_typings": []
+      },
+      {
+        "en": "SolidStart",
+        "ja": "ソリッドスタート",
+        "ja_typings": []
+      },
+      {
+        "en": "Qwik",
+        "ja": "クィック",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01006",
+    "image_path": null,
+    "question_text": {
+      "en": "Which framework introduced the Islands Architecture concept?",
+      "ja": "アイランズアーキテクチャを広めたフレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SolidJS",
+        "ja": "ソリッドジェイエス",
+        "ja_typings": []
+      },
+      {
+        "en": "Svelte",
+        "ja": "スベルト",
+        "ja_typings": []
+      },
+      {
+        "en": "Vue",
+        "ja": "ビュー",
+        "ja_typings": []
+      },
+      {
+        "en": "Preact",
+        "ja": "プリアクト",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01007",
+    "image_path": null,
+    "question_text": {
+      "en": "Which fine-grained reactive framework was created by Ryan Carniato?",
+      "ja": "Ryan Carniato による細粒度リアクティブなフレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Qwik",
+        "ja": "クィック",
+        "ja_typings": []
+      },
+      {
+        "en": "Astro",
+        "ja": "アストロ",
+        "ja_typings": []
+      },
+      {
+        "en": "Remix",
+        "ja": "リミックス",
+        "ja_typings": []
+      },
+      {
+        "en": "SolidJS",
+        "ja": "ソリッドジェイエス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01008",
+    "image_path": null,
+    "question_text": {
+      "en": "Which framework focuses on resumability instead of hydration?",
+      "ja": "ハイドレーションではなく resumability を志向するフレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Remix",
+        "ja": "リミックス",
+        "ja_typings": []
+      },
+      {
+        "en": "Next.js",
+        "ja": "ネクストジェイエス",
+        "ja_typings": []
+      },
+      {
+        "en": "Gatsby",
+        "ja": "ギャツビー",
+        "ja_typings": []
+      },
+      {
+        "en": "Redwood",
+        "ja": "レッドウッド",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01009",
+    "image_path": null,
+    "question_text": {
+      "en": "Which React framework focuses on web fundamentals and is by Shopify now?",
+      "ja": "Web 基礎重視で現在は Shopify が運用する React フレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "WHATWG",
+        "ja": "ワットダブリュージー",
+        "ja_typings": []
+      },
+      {
+        "en": "W3C",
+        "ja": "ダブリュースリーシー",
+        "ja_typings": []
+      },
+      {
+        "en": "ECMA",
+        "ja": "エクマ",
+        "ja_typings": []
+      },
+      {
+        "en": "IETF",
+        "ja": "アイイーティーエフ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01010",
+    "image_path": null,
+    "question_text": {
+      "en": "Which standards body publishes HTML specifications today?",
+      "ja": "現在 HTML 仕様を発行している標準化団体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ECMA International",
+        "ja": "エクマインターナショナル",
+        "ja_typings": []
+      },
+      {
+        "en": "WHATWG",
+        "ja": "ワットダブリュージー",
+        "ja_typings": []
+      },
+      {
+        "en": "W3C",
+        "ja": "ダブリュースリーシー",
+        "ja_typings": []
+      },
+      {
+        "en": "IETF",
+        "ja": "アイイーティーエフ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01011",
+    "image_path": null,
+    "question_text": {
+      "en": "Which group standardizes JavaScript (ECMAScript)?",
+      "ja": "JavaScript すなわち ECMAScript を標準化する団体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "WebKit",
+        "ja": "ウェブキット",
+        "ja_typings": []
+      },
+      {
+        "en": "Blink",
+        "ja": "ブリンク",
+        "ja_typings": []
+      },
+      {
+        "en": "Gecko",
+        "ja": "ゲッコー",
+        "ja_typings": []
+      },
+      {
+        "en": "Servo",
+        "ja": "サーボ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01012",
+    "image_path": null,
+    "question_text": {
+      "en": "Which rendering engine powers Safari and WebKit-based browsers?",
+      "ja": "Safari や WebKit 系ブラウザのレンダリングエンジンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gecko",
+        "ja": "ゲッコー",
+        "ja_typings": []
+      },
+      {
+        "en": "WebKit",
+        "ja": "ウェブキット",
+        "ja_typings": []
+      },
+      {
+        "en": "Blink",
+        "ja": "ブリンク",
+        "ja_typings": []
+      },
+      {
+        "en": "Trident",
+        "ja": "トライデント",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01013",
+    "image_path": null,
+    "question_text": {
+      "en": "Which rendering engine powers Firefox?",
+      "ja": "Firefox のレンダリングエンジンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Blink",
+        "ja": "ブリンク",
+        "ja_typings": []
+      },
+      {
+        "en": "WebKit",
+        "ja": "ウェブキット",
+        "ja_typings": []
+      },
+      {
+        "en": "Gecko",
+        "ja": "ゲッコー",
+        "ja_typings": []
+      },
+      {
+        "en": "EdgeHTML",
+        "ja": "エッジエイチティーエムエル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01014",
+    "image_path": null,
+    "question_text": {
+      "en": "Which engine powers Chrome and modern Edge?",
+      "ja": "Chrome と現行 Edge のエンジンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "WebAssembly",
+        "ja": "ウェブアセンブリ",
+        "ja_typings": []
+      },
+      {
+        "en": "asm.js",
+        "ja": "エイエスエムジェイエス",
+        "ja_typings": []
+      },
+      {
+        "en": "NaCl",
+        "ja": "ネイティブクライアント",
+        "ja_typings": []
+      },
+      {
+        "en": "PNaCl",
+        "ja": "ピーネイティブクライアント",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01015",
+    "image_path": null,
+    "question_text": {
+      "en": "Which technology lets browsers run near-native compiled code?",
+      "ja": "ブラウザでネイティブ近い速度のコンパイル済みコードを動かす技術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Web App Manifest",
+        "ja": "ウェブアプリマニフェスト",
+        "ja_typings": []
+      },
+      {
+        "en": "robots.txt",
+        "ja": "ロボッツテキスト",
+        "ja_typings": []
+      },
+      {
+        "en": "sitemap.xml",
+        "ja": "サイトマップエックスエムエル",
+        "ja_typings": []
+      },
+      {
+        "en": "favicon.ico",
+        "ja": "ファビコン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01016",
+    "image_path": null,
+    "question_text": {
+      "en": "Which file makes a website installable as a PWA?",
+      "ja": "サイトを PWA としてインストール可能にするファイルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "robots.txt",
+        "ja": "ロボッツテキスト",
+        "ja_typings": []
+      },
+      {
+        "en": "sitemap.xml",
+        "ja": "サイトマップエックスエムエル",
+        "ja_typings": []
+      },
+      {
+        "en": "humans.txt",
+        "ja": "ヒューマンズテキスト",
+        "ja_typings": []
+      },
+      {
+        "en": "ads.txt",
+        "ja": "アドステキスト",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01017",
+    "image_path": null,
+    "question_text": {
+      "en": "Which file directs crawlers about allowed and disallowed paths?",
+      "ja": "クローラーに巡回可否を伝えるファイルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sitemap.xml",
+        "ja": "サイトマップエックスエムエル",
+        "ja_typings": []
+      },
+      {
+        "en": "robots.txt",
+        "ja": "ロボッツテキスト",
+        "ja_typings": []
+      },
+      {
+        "en": "manifest.json",
+        "ja": "マニフェストジェイソン",
+        "ja_typings": []
+      },
+      {
+        "en": "feed.xml",
+        "ja": "フィードエックスエムエル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01018",
+    "image_path": null,
+    "question_text": {
+      "en": "Which file lists URLs for search engines to index?",
+      "ja": "検索エンジンが巡回すべき URL を列挙するファイルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "WebRTC",
+        "ja": "ウェブアールティーシー",
+        "ja_typings": []
+      },
+      {
+        "en": "WebSocket",
+        "ja": "ウェブソケット",
+        "ja_typings": []
+      },
+      {
+        "en": "WebTransport",
+        "ja": "ウェブトランスポート",
+        "ja_typings": []
+      },
+      {
+        "en": "SSE",
+        "ja": "エスエスイー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01019",
+    "image_path": null,
+    "question_text": {
+      "en": "Which standard defines real-time peer-to-peer media in browsers?",
+      "ja": "ブラウザのリアルタイム P2P メディア通信を定める標準は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Server-Sent Events",
+        "ja": "サーバーセントイベンツ",
+        "ja_typings": []
+      },
+      {
+        "en": "WebSocket",
+        "ja": "ウェブソケット",
+        "ja_typings": []
+      },
+      {
+        "en": "Long polling",
+        "ja": "ロングポーリング",
+        "ja_typings": []
+      },
+      {
+        "en": "Webhook",
+        "ja": "ウェブフック",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01020",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mechanism pushes server-sent events over a long-lived HTTP response?",
+      "ja": "長時間 HTTP 応答上でサーバー発のイベントを配信する仕組みは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1024",
+        "ja": "センニジュウヨン",
+        "ja_typings": [
+          "sennijuuyon"
+        ]
+      },
+      {
+        "en": "512",
+        "ja": "ゴヒャクジュウニ",
+        "ja_typings": [
+          "gohyakujuuni"
+        ]
+      },
+      {
+        "en": "2048",
+        "ja": "ニセンヨンジュウハチ",
+        "ja_typings": [
+          "nisenyonjuuhachi"
+        ]
+      },
+      {
+        "en": "256",
+        "ja": "ニヒャクゴジュウロク",
+        "ja_typings": [
+          "nihyakugojuuroku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01021",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 2 to the power of 10?",
+      "ja": "2の10乗はいくつ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "12",
+        "ja": "ジュウニ",
+        "ja_typings": [
+          "juuni"
+        ]
+      },
+      {
+        "en": "14",
+        "ja": "ジュウヨン",
+        "ja_typings": [
+          "juuyon"
+        ]
+      },
+      {
+        "en": "16",
+        "ja": "ジュウロク",
+        "ja_typings": [
+          "juuroku"
+        ]
+      },
+      {
+        "en": "11",
+        "ja": "ジュウイチ",
+        "ja_typings": [
+          "juuichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01022",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the square root of 144?",
+      "ja": "144の平方根はいくつ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "120",
+        "ja": "ヒャクニジュウ",
+        "ja_typings": [
+          "hyakunijuu"
+        ]
+      },
+      {
+        "en": "60",
+        "ja": "ロクジュウ",
+        "ja_typings": [
+          "rokujuu"
+        ]
+      },
+      {
+        "en": "125",
+        "ja": "ヒャクニジュウゴ",
+        "ja_typings": [
+          "hyakunijuugo"
+        ]
+      },
+      {
+        "en": "100",
+        "ja": "ヒャク",
+        "ja_typings": [
+          "hyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01023",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the factorial of 5?",
+      "ja": "5の階乗はいくつ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "2.7",
+        "ja": "ニテンナナ",
+        "ja_typings": []
+      },
+      {
+        "en": "3.1",
+        "ja": "サンテンイチ",
+        "ja_typings": []
+      },
+      {
+        "en": "1.6",
+        "ja": "イッテンロク",
+        "ja_typings": []
+      },
+      {
+        "en": "2.3",
+        "ja": "ニテンサン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01024",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the value of e to one decimal place?",
+      "ja": "ネイピア数を小数点以下1桁で表すと?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "17",
+        "ja": "ジュウナナ",
+        "ja_typings": [
+          "juunana"
+        ]
+      },
+      {
+        "en": "21",
+        "ja": "ニジュウイチ",
+        "ja_typings": [
+          "nijuuichi"
+        ]
+      },
+      {
+        "en": "27",
+        "ja": "ニジュウナナ",
+        "ja_typings": [
+          "nijuunana"
+        ]
+      },
+      {
+        "en": "33",
+        "ja": "サンジュウサン",
+        "ja_typings": [
+          "sanjuusan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01025",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is a prime number?",
+      "ja": "次のうち素数はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "pi r squared",
+        "ja": "パイアールジジョウ",
+        "ja_typings": [
+          "paiaaru jijou",
+          "pai a-ru jijou"
+        ]
+      },
+      {
+        "en": "two pi r",
+        "ja": "ニパイアール",
+        "ja_typings": [
+          "nipaiaaru",
+          "ni pai a-ru"
+        ]
+      },
+      {
+        "en": "pi d",
+        "ja": "パイディー",
+        "ja_typings": [
+          "paidi-"
+        ]
+      },
+      {
+        "en": "four pi r squared",
+        "ja": "ヨンパイアールジジョウ",
+        "ja_typings": [
+          "yonpaiaaru jijou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01026",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the area formula for a circle?",
+      "ja": "円の面積を求める公式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "360 degrees",
+        "ja": "サンビャクロクジュウド",
+        "ja_typings": [
+          "sanbyakurokujuudo"
+        ]
+      },
+      {
+        "en": "180 degrees",
+        "ja": "ヒャクハチジュウド",
+        "ja_typings": [
+          "hyakuhachijuudo"
+        ]
+      },
+      {
+        "en": "270 degrees",
+        "ja": "ニヒャクナナジュウド",
+        "ja_typings": [
+          "nihyakunanajuudo"
+        ]
+      },
+      {
+        "en": "540 degrees",
+        "ja": "ゴヒャクヨンジュウド",
+        "ja_typings": [
+          "gohyakuyonjuudo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01027",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the sum of angles in a quadrilateral?",
+      "ja": "四角形の内角の和は何度?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "56",
+        "ja": "ゴジュウロク",
+        "ja_typings": [
+          "gojuuroku"
+        ]
+      },
+      {
+        "en": "54",
+        "ja": "ゴジュウヨン",
+        "ja_typings": [
+          "gojuuyon"
+        ]
+      },
+      {
+        "en": "63",
+        "ja": "ロクジュウサン",
+        "ja_typings": [
+          "rokujuusan"
+        ]
+      },
+      {
+        "en": "49",
+        "ja": "ヨンジュウキュウ",
+        "ja_typings": [
+          "yonjuukyuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01028",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 7 times 8?",
+      "ja": "7かける8はいくつ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1/6",
+        "ja": "ロクブンノイチ",
+        "ja_typings": [
+          "rokubunnoichi"
+        ]
+      },
+      {
+        "en": "1/3",
+        "ja": "サンブンノイチ",
+        "ja_typings": [
+          "sanbunnoichi"
+        ]
+      },
+      {
+        "en": "1/2",
+        "ja": "ニブンノイチ",
+        "ja_typings": [
+          "nibunnoichi"
+        ]
+      },
+      {
+        "en": "1/12",
+        "ja": "ジュウニブンノイチ",
+        "ja_typings": [
+          "juunibunnoichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01029",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the probability of rolling a 6 on a fair die?",
+      "ja": "サイコロで6が出る確率は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "32",
+        "ja": "サンジュウニ",
+        "ja_typings": [
+          "sanjuuni"
+        ]
+      },
+      {
+        "en": "24",
+        "ja": "ニジュウヨン",
+        "ja_typings": [
+          "nijuuyon"
+        ]
+      },
+      {
+        "en": "20",
+        "ja": "ニジュウ",
+        "ja_typings": [
+          "nijuu"
+        ]
+      },
+      {
+        "en": "64",
+        "ja": "ロクジュウヨン",
+        "ja_typings": [
+          "rokujuuyon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01030",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the next number: 2, 4, 8, 16, ?",
+      "ja": "次の数列の次は: 2, 4, 8, 16, ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "6",
+        "ja": "ロク",
+        "ja_typings": [
+          "roku"
+        ]
+      },
+      {
+        "en": "5",
+        "ja": "ゴ",
+        "ja_typings": [
+          "go"
+        ]
+      },
+      {
+        "en": "7",
+        "ja": "ナナ",
+        "ja_typings": [
+          "nana"
+        ]
+      },
+      {
+        "en": "8",
+        "ja": "ハチ",
+        "ja_typings": [
+          "hachi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01031",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the mean of 2, 4, 6, 8, 10?",
+      "ja": "2, 4, 6, 8, 10の平均は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "middle value",
+        "ja": "マンナカノアタイ",
+        "ja_typings": [
+          "mannakanoatai"
+        ]
+      },
+      {
+        "en": "most frequent value",
+        "ja": "サイヒンチ",
+        "ja_typings": [
+          "saihinchi"
+        ]
+      },
+      {
+        "en": "average value",
+        "ja": "ヘイキンチ",
+        "ja_typings": [
+          "heikinchi"
+        ]
+      },
+      {
+        "en": "total sum",
+        "ja": "ゴウケイ",
+        "ja_typings": [
+          "goukei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01032",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the median represent?",
+      "ja": "中央値とは何か?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "cube",
+        "ja": "リッポウタイ",
+        "ja_typings": [
+          "rippoutai"
+        ]
+      },
+      {
+        "en": "tetrahedron",
+        "ja": "セイシメンタイ",
+        "ja_typings": [
+          "seishimentai"
+        ]
+      },
+      {
+        "en": "sphere",
+        "ja": "キュウ",
+        "ja_typings": [
+          "kyuu"
+        ]
+      },
+      {
+        "en": "cone",
+        "ja": "エンスイ",
+        "ja_typings": [
+          "ensui"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01033",
+    "image_path": null,
+    "question_text": {
+      "en": "What shape has 6 faces?",
+      "ja": "面が6つある立体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "12 edges",
+        "ja": "ジュウニホン",
+        "ja_typings": [
+          "juunihon"
+        ]
+      },
+      {
+        "en": "8 edges",
+        "ja": "ハチホン",
+        "ja_typings": [
+          "hachihon"
+        ]
+      },
+      {
+        "en": "6 edges",
+        "ja": "ロクホン",
+        "ja_typings": [
+          "rokuhon"
+        ]
+      },
+      {
+        "en": "24 edges",
+        "ja": "ニジュウヨンホン",
+        "ja_typings": [
+          "nijuuyonhon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01034",
+    "image_path": null,
+    "question_text": {
+      "en": "How many edges does a cube have?",
+      "ja": "立方体の辺の数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "rise over run",
+        "ja": "タテワルヨコ",
+        "ja_typings": [
+          "tatewaruyoko"
+        ]
+      },
+      {
+        "en": "run over rise",
+        "ja": "ヨコワルタテ",
+        "ja_typings": [
+          "yokowarutate"
+        ]
+      },
+      {
+        "en": "base times height",
+        "ja": "テイヘンカケルタカサ",
+        "ja_typings": [
+          "teihenkakerutakasa"
+        ]
+      },
+      {
+        "en": "squared sum",
+        "ja": "ジジョウワ",
+        "ja_typings": [
+          "jijouwa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01035",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the slope formula?",
+      "ja": "傾きを求める公式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "3",
+        "ja": "サン",
+        "ja_typings": [
+          "san"
+        ]
+      },
+      {
+        "en": "2",
+        "ja": "ニ",
+        "ja_typings": [
+          "ni"
+        ]
+      },
+      {
+        "en": "4",
+        "ja": "ヨン",
+        "ja_typings": [
+          "yon"
+        ]
+      },
+      {
+        "en": "10",
+        "ja": "ジュウ",
+        "ja_typings": [
+          "juu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01036",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the value of log base 10 of 1000?",
+      "ja": "10を底とする1000の対数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "30",
+        "ja": "サンジュウ",
+        "ja_typings": [
+          "sanjuu"
+        ]
+      },
+      {
+        "en": "25",
+        "ja": "ニジュウゴ",
+        "ja_typings": [
+          "nijuugo"
+        ]
+      },
+      {
+        "en": "35",
+        "ja": "サンジュウゴ",
+        "ja_typings": [
+          "sanjuugo"
+        ]
+      },
+      {
+        "en": "45",
+        "ja": "ヨンジュウゴ",
+        "ja_typings": [
+          "yonjuugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01037",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 15 percent of 200?",
+      "ja": "200の15パーセントはいくつ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "root 2",
+        "ja": "ルートニ",
+        "ja_typings": [
+          "ru-toni"
+        ]
+      },
+      {
+        "en": "root 3",
+        "ja": "ルートサン",
+        "ja_typings": [
+          "ru-tosan"
+        ]
+      },
+      {
+        "en": "root 5",
+        "ja": "ルートゴ",
+        "ja_typings": [
+          "ru-togo"
+        ]
+      },
+      {
+        "en": "2",
+        "ja": "ニ",
+        "ja_typings": [
+          "ni"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01038",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the diagonal of a unit square?",
+      "ja": "1辺1の正方形の対角線の長さは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "101",
+        "ja": "イチゼロイチ",
+        "ja_typings": [
+          "ichizeroichi"
+        ]
+      },
+      {
+        "en": "110",
+        "ja": "イチイチゼロ",
+        "ja_typings": [
+          "ichiichizero"
+        ]
+      },
+      {
+        "en": "111",
+        "ja": "イチイチイチ",
+        "ja_typings": [
+          "ichiichiichi"
+        ]
+      },
+      {
+        "en": "100",
+        "ja": "イチゼロゼロ",
+        "ja_typings": [
+          "ichizerozero"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01039",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the binary representation of 5?",
+      "ja": "10進数の5を2進数で表すと?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1/2",
+        "ja": "ニブンノイチ",
+        "ja_typings": [
+          "nibunnoichi"
+        ]
+      },
+      {
+        "en": "root 3 over 2",
+        "ja": "ルートサンブンノニ",
+        "ja_typings": [
+          "ru-tosanbunnoni"
+        ]
+      },
+      {
+        "en": "root 2 over 2",
+        "ja": "ルートニブンノニ",
+        "ja_typings": [
+          "ru-tonibunnoni"
+        ]
+      },
+      {
+        "en": "1",
+        "ja": "イチ",
+        "ja_typings": [
+          "ichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01040",
+    "image_path": null,
+    "question_text": {
+      "en": "What is sin of 30 degrees?",
+      "ja": "サイン30度の値は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "2x",
+        "ja": "ニエックス",
+        "ja_typings": [
+          "niekkusu"
+        ]
+      },
+      {
+        "en": "only x",
+        "ja": "エックスダケ",
+        "ja_typings": [
+          "ekkusudake"
+        ]
+      },
+      {
+        "en": "x cubed",
+        "ja": "エックスサンジョウ",
+        "ja_typings": [
+          "ekkususanjou"
+        ]
+      },
+      {
+        "en": "constant",
+        "ja": "テイスウ",
+        "ja_typings": [
+          "teisuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01041",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the derivative of x squared?",
+      "ja": "xの2乗の微分は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "natural log of x",
+        "ja": "シゼンタイスウエックス",
+        "ja_typings": [
+          "shizentaisuuekkusu"
+        ]
+      },
+      {
+        "en": "x squared",
+        "ja": "エックスニジョウ",
+        "ja_typings": [
+          "ekkusunijou"
+        ]
+      },
+      {
+        "en": "e to the x",
+        "ja": "イーノエックスジョウ",
+        "ja_typings": [
+          "i-noekkusujou"
+        ]
+      },
+      {
+        "en": "zero",
+        "ja": "ゼロ",
+        "ja_typings": [
+          "zero"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01042",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the integral of 1 over x?",
+      "ja": "xぶんの1の積分は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "19",
+        "ja": "ジュウキュウ",
+        "ja_typings": [
+          "juukyuu"
+        ]
+      },
+      {
+        "en": "18",
+        "ja": "ジュウハチ",
+        "ja_typings": [
+          "juuhachi"
+        ]
+      },
+      {
+        "en": "21",
+        "ja": "ニジュウイチ",
+        "ja_typings": [
+          "nijuuichi"
+        ]
+      },
+      {
+        "en": "17",
+        "ja": "ジュウナナ",
+        "ja_typings": [
+          "juunana"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01043",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 10 squared minus 9 squared?",
+      "ja": "10の2乗ひく9の2乗は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "6",
+        "ja": "ロク",
+        "ja_typings": [
+          "roku"
+        ]
+      },
+      {
+        "en": "4",
+        "ja": "ヨン",
+        "ja_typings": [
+          "yon"
+        ]
+      },
+      {
+        "en": "8",
+        "ja": "ハチ",
+        "ja_typings": [
+          "hachi"
+        ]
+      },
+      {
+        "en": "28",
+        "ja": "ニジュウハチ",
+        "ja_typings": [
+          "nijuuhachi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01044",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the smallest perfect number?",
+      "ja": "最小の完全数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Automated Teller Machine",
+        "ja": "オートメイテッドテラーマシン",
+        "ja_typings": []
+      },
+      {
+        "en": "Auto Transfer Money",
+        "ja": "オートトランスファーマネー",
+        "ja_typings": []
+      },
+      {
+        "en": "Account Transfer Method",
+        "ja": "アカウントトランスファーメソッド",
+        "ja_typings": []
+      },
+      {
+        "en": "Active Time Manager",
+        "ja": "アクティブタイムマネージャー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01045",
+    "image_path": null,
+    "question_text": {
+      "en": "What does ATM stand for?",
+      "ja": "ATMは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "206 bones",
+        "ja": "ニヒャクロッポン",
+        "ja_typings": [
+          "nihyakuroppon"
+        ]
+      },
+      {
+        "en": "150 bones",
+        "ja": "ヒャクゴジッポン",
+        "ja_typings": [
+          "hyakugojippon"
+        ]
+      },
+      {
+        "en": "300 bones",
+        "ja": "サンビャッポン",
+        "ja_typings": [
+          "sanbyappon"
+        ]
+      },
+      {
+        "en": "250 bones",
+        "ja": "ニヒャクゴジッポン",
+        "ja_typings": [
+          "nihyakugojippon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01046",
+    "image_path": null,
+    "question_text": {
+      "en": "How many bones are in the adult human body?",
+      "ja": "成人の人間の骨の数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "3600 seconds",
+        "ja": "サンゼンロッピャクビョウ",
+        "ja_typings": [
+          "sanzenroppyakubyou"
+        ]
+      },
+      {
+        "en": "60 seconds",
+        "ja": "ロクジュウビョウ",
+        "ja_typings": [
+          "rokujuubyou"
+        ]
+      },
+      {
+        "en": "7200 seconds",
+        "ja": "ナナセンニヒャクビョウ",
+        "ja_typings": [
+          "nanasennihyakubyou"
+        ]
+      },
+      {
+        "en": "1800 seconds",
+        "ja": "センハッピャクビョウ",
+        "ja_typings": [
+          "senhappyakubyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01047",
+    "image_path": null,
+    "question_text": {
+      "en": "How many seconds are in an hour?",
+      "ja": "1時間は何秒?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "300000 km per second",
+        "ja": "サンジュウマンキロメートルマイビョウ",
+        "ja_typings": [
+          "sanjuumankiromeetorumaibyou"
+        ]
+      },
+      {
+        "en": "30000 km per second",
+        "ja": "サンマンキロメートルマイビョウ",
+        "ja_typings": [
+          "sanmankiromeetorumaibyou"
+        ]
+      },
+      {
+        "en": "3 million km per second",
+        "ja": "サンビャクマンキロメートルマイビョウ",
+        "ja_typings": [
+          "sanbyakumankiromeetorumaibyou"
+        ]
+      },
+      {
+        "en": "3000 km per second",
+        "ja": "サンゼンキロメートルマイビョウ",
+        "ja_typings": [
+          "sanzenkiromeetorumaibyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01048",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the speed of light approximately?",
+      "ja": "光の速さはおよそ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chief Executive Officer",
+        "ja": "チーフエグゼクティブオフィサー",
+        "ja_typings": []
+      },
+      {
+        "en": "Central Executive Order",
+        "ja": "セントラルエグゼクティブオーダー",
+        "ja_typings": []
+      },
+      {
+        "en": "Corporate Engineer Officer",
+        "ja": "コーポレートエンジニアオフィサー",
+        "ja_typings": []
+      },
+      {
+        "en": "Chief Engineering Operator",
+        "ja": "チーフエンジニアリングオペレーター",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01049",
+    "image_path": null,
+    "question_text": {
+      "en": "What does CEO stand for?",
+      "ja": "CEOは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "8 planets",
+        "ja": "ハッコ",
+        "ja_typings": [
+          "hakko"
+        ]
+      },
+      {
+        "en": "9 planets",
+        "ja": "キュウコ",
+        "ja_typings": [
+          "kyuuko"
+        ]
+      },
+      {
+        "en": "7 planets",
+        "ja": "ナナコ",
+        "ja_typings": [
+          "nanako"
+        ]
+      },
+      {
+        "en": "10 planets",
+        "ja": "ジッコ",
+        "ja_typings": [
+          "jikko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01050",
+    "image_path": null,
+    "question_text": {
+      "en": "How many planets are in our solar system?",
+      "ja": "太陽系の惑星の数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pacific Ocean",
+        "ja": "タイヘイヨウ",
+        "ja_typings": [
+          "taiheiyou"
+        ]
+      },
+      {
+        "en": "Atlantic Ocean",
+        "ja": "タイセイヨウ",
+        "ja_typings": [
+          "taiseiyou"
+        ]
+      },
+      {
+        "en": "Indian Ocean",
+        "ja": "インドヨウ",
+        "ja_typings": [
+          "indoyou"
+        ]
+      },
+      {
+        "en": "Arctic Ocean",
+        "ja": "ホッキョクカイ",
+        "ja_typings": [
+          "hokkyokukai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01051",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the largest ocean?",
+      "ja": "世界最大の海は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mount Everest",
+        "ja": "エベレスト",
+        "ja_typings": []
+      },
+      {
+        "en": "K2",
+        "ja": "ケーツー",
+        "ja_typings": [
+          "ke-tsu-"
+        ]
+      },
+      {
+        "en": "Mount Fuji",
+        "ja": "フジサン",
+        "ja_typings": [
+          "fujisan"
+        ]
+      },
+      {
+        "en": "Mont Blanc",
+        "ja": "モンブラン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01052",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the tallest mountain in the world?",
+      "ja": "世界一高い山は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Canada",
+        "ja": "カナダ",
+        "ja_typings": []
+      },
+      {
+        "en": "Russia",
+        "ja": "ロシア",
+        "ja_typings": []
+      },
+      {
+        "en": "Australia",
+        "ja": "オーストラリア",
+        "ja_typings": []
+      },
+      {
+        "en": "Indonesia",
+        "ja": "インドネシア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01053",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has the longest coastline?",
+      "ja": "海岸線が世界一長い国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Global Positioning System",
+        "ja": "グローバルポジショニングシステム",
+        "ja_typings": []
+      },
+      {
+        "en": "General Position Service",
+        "ja": "ジェネラルポジションサービス",
+        "ja_typings": []
+      },
+      {
+        "en": "Geographic Plot Standard",
+        "ja": "ジオグラフィックプロットスタンダード",
+        "ja_typings": []
+      },
+      {
+        "en": "Ground Path Sensor",
+        "ja": "グラウンドパスセンサー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01054",
+    "image_path": null,
+    "question_text": {
+      "en": "What does GPS stand for?",
+      "ja": "GPSは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Czech",
+        "ja": "チェコゴ",
+        "ja_typings": [
+          "chekogo"
+        ]
+      },
+      {
+        "en": "Greek",
+        "ja": "ギリシャゴ",
+        "ja_typings": [
+          "girishago"
+        ]
+      },
+      {
+        "en": "Latin",
+        "ja": "ラテンゴ",
+        "ja_typings": [
+          "ratengo"
+        ]
+      },
+      {
+        "en": "German",
+        "ja": "ドイツゴ",
+        "ja_typings": [
+          "doitsugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01055",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the origin of the word robot?",
+      "ja": "ロボットの語源となった言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "pascal",
+        "ja": "パスカル",
+        "ja_typings": []
+      },
+      {
+        "en": "hertz",
+        "ja": "ヘルツ",
+        "ja_typings": []
+      },
+      {
+        "en": "joule",
+        "ja": "ジュール",
+        "ja_typings": []
+      },
+      {
+        "en": "newton",
+        "ja": "ニュートン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01056",
+    "image_path": null,
+    "question_text": {
+      "en": "What unit measures pressure?",
+      "ja": "圧力の単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "6 strings",
+        "ja": "ロッポン",
+        "ja_typings": [
+          "roppon"
+        ]
+      },
+      {
+        "en": "4 strings",
+        "ja": "ヨンホン",
+        "ja_typings": [
+          "yonhon"
+        ]
+      },
+      {
+        "en": "7 strings",
+        "ja": "ナナホン",
+        "ja_typings": [
+          "nanahon"
+        ]
+      },
+      {
+        "en": "12 strings",
+        "ja": "ジュウニホン",
+        "ja_typings": [
+          "juunihon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01057",
+    "image_path": null,
+    "question_text": {
+      "en": "How many strings does a standard guitar have?",
+      "ja": "標準的なギターの弦の数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "distress signal",
+        "ja": "ソウナンシンゴウ",
+        "ja_typings": [
+          "sounanshingou"
+        ]
+      },
+      {
+        "en": "save our ship",
+        "ja": "セーブアワーシップ",
+        "ja_typings": []
+      },
+      {
+        "en": "ship out signal",
+        "ja": "シップアウトシグナル",
+        "ja_typings": []
+      },
+      {
+        "en": "standard order set",
+        "ja": "スタンダードオーダーセット",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01058",
+    "image_path": null,
+    "question_text": {
+      "en": "What does SOS represent?",
+      "ja": "SOSは何を表すか?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Very Important Person",
+        "ja": "ベリーインポータントパーソン",
+        "ja_typings": []
+      },
+      {
+        "en": "Vital Information Pass",
+        "ja": "バイタルインフォメーションパス",
+        "ja_typings": []
+      },
+      {
+        "en": "Visual Identity Profile",
+        "ja": "ビジュアルアイデンティティプロファイル",
+        "ja_typings": []
+      },
+      {
+        "en": "Verified Internal Pass",
+        "ja": "ベリファイドインターナルパス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01059",
+    "image_path": null,
+    "question_text": {
+      "en": "What does VIP stand for?",
+      "ja": "VIPは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "7 continents",
+        "ja": "ナナタイリク",
+        "ja_typings": [
+          "nanatairiku"
+        ]
+      },
+      {
+        "en": "5 continents",
+        "ja": "ゴタイリク",
+        "ja_typings": [
+          "gotairiku"
+        ]
+      },
+      {
+        "en": "6 continents",
+        "ja": "ロクタイリク",
+        "ja_typings": [
+          "rokutairiku"
+        ]
+      },
+      {
+        "en": "8 continents",
+        "ja": "ハチタイリク",
+        "ja_typings": [
+          "hachitairiku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01060",
+    "image_path": null,
+    "question_text": {
+      "en": "How many continents are there?",
+      "ja": "大陸はいくつある?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vatican City",
+        "ja": "バチカンシコク",
+        "ja_typings": [
+          "bachikanshikoku"
+        ]
+      },
+      {
+        "en": "Monaco",
+        "ja": "モナコ",
+        "ja_typings": []
+      },
+      {
+        "en": "San Marino",
+        "ja": "サンマリノ",
+        "ja_typings": []
+      },
+      {
+        "en": "Liechtenstein",
+        "ja": "リヒテンシュタイン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01061",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the smallest country in the world?",
+      "ja": "世界で一番小さい国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Portable Document Format",
+        "ja": "ポータブルドキュメントフォーマット",
+        "ja_typings": []
+      },
+      {
+        "en": "Personal Data File",
+        "ja": "パーソナルデータファイル",
+        "ja_typings": []
+      },
+      {
+        "en": "Public Document Folder",
+        "ja": "パブリックドキュメントフォルダ",
+        "ja_typings": []
+      },
+      {
+        "en": "Print Direct Form",
+        "ja": "プリントダイレクトフォーム",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01062",
+    "image_path": null,
+    "question_text": {
+      "en": "What does PDF stand for?",
+      "ja": "PDFは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "100 degrees Celsius",
+        "ja": "ヒャクド",
+        "ja_typings": [
+          "hyakudo"
+        ]
+      },
+      {
+        "en": "90 degrees Celsius",
+        "ja": "キュウジュウド",
+        "ja_typings": [
+          "kyuujuudo"
+        ]
+      },
+      {
+        "en": "212 degrees Celsius",
+        "ja": "ニヒャクジュウニド",
+        "ja_typings": [
+          "nihyakujuunido"
+        ]
+      },
+      {
+        "en": "80 degrees Celsius",
+        "ja": "ハチジュウド",
+        "ja_typings": [
+          "hachijuudo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01063",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the boiling point of water at sea level?",
+      "ja": "海面における水の沸点は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "7 colors",
+        "ja": "ナナショク",
+        "ja_typings": [
+          "nanashoku"
+        ]
+      },
+      {
+        "en": "5 colors",
+        "ja": "ゴショク",
+        "ja_typings": [
+          "goshoku"
+        ]
+      },
+      {
+        "en": "6 colors",
+        "ja": "ロクショク",
+        "ja_typings": [
+          "rokushoku"
+        ]
+      },
+      {
+        "en": "8 colors",
+        "ja": "ハッショク",
+        "ja_typings": [
+          "hasshoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01064",
+    "image_path": null,
+    "question_text": {
+      "en": "How many colors are in a rainbow?",
+      "ja": "虹の色の数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "good game",
+        "ja": "グッドゲーム",
+        "ja_typings": []
+      },
+      {
+        "en": "get going",
+        "ja": "ゲットゴーイング",
+        "ja_typings": []
+      },
+      {
+        "en": "great gain",
+        "ja": "グレートゲイン",
+        "ja_typings": []
+      },
+      {
+        "en": "game guide",
+        "ja": "ゲームガイド",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01065",
+    "image_path": null,
+    "question_text": {
+      "en": "What does GG mean in gaming?",
+      "ja": "ゲームで使われるGGの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Away From Keyboard",
+        "ja": "アウェイフロムキーボード",
+        "ja_typings": []
+      },
+      {
+        "en": "All For Kicks",
+        "ja": "オールフォーキックス",
+        "ja_typings": []
+      },
+      {
+        "en": "Asking For Knowledge",
+        "ja": "アスキングフォーナレッジ",
+        "ja_typings": []
+      },
+      {
+        "en": "Active Friend Killer",
+        "ja": "アクティブフレンドキラー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01066",
+    "image_path": null,
+    "question_text": {
+      "en": "What does AFK stand for?",
+      "ja": "AFKは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "laughter",
+        "ja": "ワライ",
+        "ja_typings": [
+          "warai"
+        ]
+      },
+      {
+        "en": "anger",
+        "ja": "イカリ",
+        "ja_typings": [
+          "ikari"
+        ]
+      },
+      {
+        "en": "sadness",
+        "ja": "カナシミ",
+        "ja_typings": [
+          "kanashimi"
+        ]
+      },
+      {
+        "en": "surprise",
+        "ja": "オドロキ",
+        "ja_typings": [
+          "odoroki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01067",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the slang 'kusa' mean?",
+      "ja": "ネットスラング草の意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Live2D model",
+        "ja": "ライブツーディーモデル",
+        "ja_typings": []
+      },
+      {
+        "en": "flat avatar",
+        "ja": "フラットアバター",
+        "ja_typings": []
+      },
+      {
+        "en": "paper avatar",
+        "ja": "ペーパーアバター",
+        "ja_typings": []
+      },
+      {
+        "en": "static icon",
+        "ja": "スタティックアイコン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01068",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a VTuber's avatar called?",
+      "ja": "VTuberが使うアバターの呼び方は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "paid comment",
+        "ja": "ユウリョウコメント",
+        "ja_typings": [
+          "yuuryoukomento"
+        ]
+      },
+      {
+        "en": "free comment",
+        "ja": "ムリョウコメント",
+        "ja_typings": [
+          "muryoukomento"
+        ]
+      },
+      {
+        "en": "system message",
+        "ja": "システムメッセージ",
+        "ja_typings": []
+      },
+      {
+        "en": "auto reply",
+        "ja": "オートヘンシン",
+        "ja_typings": [
+          "o-tohenshin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01069",
+    "image_path": null,
+    "question_text": {
+      "en": "What does superchat mean on YouTube?",
+      "ja": "YouTubeのスパチャの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "good luck have fun",
+        "ja": "グッドラックハブファン",
+        "ja_typings": []
+      },
+      {
+        "en": "get level high first",
+        "ja": "ゲットレベルハイファースト",
+        "ja_typings": []
+      },
+      {
+        "en": "go left hit fast",
+        "ja": "ゴーレフトヒットファスト",
+        "ja_typings": []
+      },
+      {
+        "en": "great loss huge fight",
+        "ja": "グレートロスヒュージファイト",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01070",
+    "image_path": null,
+    "question_text": {
+      "en": "What does GLHF mean?",
+      "ja": "GLHFの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "beginner",
+        "ja": "ショシンシャ",
+        "ja_typings": [
+          "shoshinsha"
+        ]
+      },
+      {
+        "en": "expert",
+        "ja": "ジョウキュウシャ",
+        "ja_typings": [
+          "joukyuusha"
+        ]
+      },
+      {
+        "en": "cheater",
+        "ja": "フセイシャ",
+        "ja_typings": [
+          "fuseisha"
+        ]
+      },
+      {
+        "en": "spectator",
+        "ja": "カンセンシャ",
+        "ja_typings": [
+          "kansensha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01071",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'noob' in gaming?",
+      "ja": "ゲームでnoobの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "very serious player",
+        "ja": "シンケンプレイヤー",
+        "ja_typings": [
+          "shinkenpureiya-"
+        ]
+      },
+      {
+        "en": "casual player",
+        "ja": "ライトプレイヤー",
+        "ja_typings": []
+      },
+      {
+        "en": "cheating player",
+        "ja": "チートプレイヤー",
+        "ja_typings": []
+      },
+      {
+        "en": "new player",
+        "ja": "ニュープレイヤー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01072",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'tryhard' refer to?",
+      "ja": "tryhardが指す意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "excitement",
+        "ja": "コウフン",
+        "ja_typings": [
+          "koufun"
+        ]
+      },
+      {
+        "en": "anger",
+        "ja": "イカリ",
+        "ja_typings": [
+          "ikari"
+        ]
+      },
+      {
+        "en": "fatigue",
+        "ja": "ツカレ",
+        "ja_typings": [
+          "tsukare"
+        ]
+      },
+      {
+        "en": "regret",
+        "ja": "コウカイ",
+        "ja_typings": [
+          "koukai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01073",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the meaning of 'pog'?",
+      "ja": "pogの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "most effective tactic",
+        "ja": "サイコウセンリャク",
+        "ja_typings": [
+          "saikousenryaku"
+        ]
+      },
+      {
+        "en": "mini event",
+        "ja": "ミニイベント",
+        "ja_typings": []
+      },
+      {
+        "en": "modder area",
+        "ja": "モッダーエリア",
+        "ja_typings": []
+      },
+      {
+        "en": "main enemy target",
+        "ja": "メインエネミーターゲット",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01074",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'meta' mean in games?",
+      "ja": "ゲーム用語のメタの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Selfish Gene book",
+        "ja": "リコテキイデンシ",
+        "ja_typings": [
+          "rikotekiidenshi"
+        ]
+      },
+      {
+        "en": "ancient Greek myth",
+        "ja": "ギリシャシンワ",
+        "ja_typings": [
+          "girishashinwa"
+        ]
+      },
+      {
+        "en": "modern AI research",
+        "ja": "ゲンダイエーアイケンキュウ",
+        "ja_typings": [
+          "gendaie-aikenkyuu"
+        ]
+      },
+      {
+        "en": "Roman philosophy",
+        "ja": "ローマテツガク",
+        "ja_typings": [
+          "ro-matetsugaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01075",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the origin of meme?",
+      "ja": "ミームの語源は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "low quality post",
+        "ja": "ヒンシツノヒクイトウコウ",
+        "ja_typings": [
+          "hinshitsunohikuitoukou"
+        ]
+      },
+      {
+        "en": "serious essay",
+        "ja": "ホンキノロンブン",
+        "ja_typings": [
+          "honkinoronbun"
+        ]
+      },
+      {
+        "en": "paid sponsorship",
+        "ja": "ユウリョウスポンサー",
+        "ja_typings": [
+          "yuuryousuponsa-"
+        ]
+      },
+      {
+        "en": "legal notice",
+        "ja": "ホウテキツウチ",
+        "ja_typings": [
+          "houtekitsuuchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01076",
+    "image_path": null,
+    "question_text": {
+      "en": "What is shitposting?",
+      "ja": "シットポストとは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "silent viewer",
+        "ja": "ムゲンシチョウシャ",
+        "ja_typings": [
+          "mugenshichousha"
+        ]
+      },
+      {
+        "en": "active chatter",
+        "ja": "カッパツナチャッター",
+        "ja_typings": [
+          "kappatsunachatta-"
+        ]
+      },
+      {
+        "en": "paid member",
+        "ja": "ユウリョウメンバー",
+        "ja_typings": [
+          "yuuryoumenba-"
+        ]
+      },
+      {
+        "en": "auto bot",
+        "ja": "ジドウボット",
+        "ja_typings": [
+          "jidoubotto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01077",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'lurker' mean in livestreams?",
+      "ja": "配信用語のlurkerの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "leaking personal info",
+        "ja": "コジンジョウホウバクロ",
+        "ja_typings": [
+          "kojinjouhoubakuro"
+        ]
+      },
+      {
+        "en": "sharing memes",
+        "ja": "ミームキョウユウ",
+        "ja_typings": [
+          "mi-mukyouyuu"
+        ]
+      },
+      {
+        "en": "editing photos",
+        "ja": "シャシンヘンシュウ",
+        "ja_typings": [
+          "shashinhenshuu"
+        ]
+      },
+      {
+        "en": "posting reviews",
+        "ja": "レビュートウコウ",
+        "ja_typings": [
+          "rebyu-toukou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01078",
+    "image_path": null,
+    "question_text": {
+      "en": "What is meant by 'doxxing'?",
+      "ja": "ドキシングの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "First Person Shooter",
+        "ja": "ファーストパーソンシューター",
+        "ja_typings": []
+      },
+      {
+        "en": "Fast Paced Style",
+        "ja": "ファストペーストスタイル",
+        "ja_typings": []
+      },
+      {
+        "en": "Final Play Set",
+        "ja": "ファイナルプレイセット",
+        "ja_typings": []
+      },
+      {
+        "en": "Front Page Score",
+        "ja": "フロントページスコア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01079",
+    "image_path": null,
+    "question_text": {
+      "en": "What does FPS stand for in gaming?",
+      "ja": "ゲーム用語のFPSは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "clearing a game as fast as possible",
+        "ja": "ゲームサイソクコウリャク",
+        "ja_typings": [
+          "ge-musaisokukouryaku"
+        ]
+      },
+      {
+        "en": "slow exploration",
+        "ja": "ジックリタンサク",
+        "ja_typings": [
+          "jikkuritansaku"
+        ]
+      },
+      {
+        "en": "competitive ranking",
+        "ja": "ランキングタイセン",
+        "ja_typings": [
+          "rankingutaisen"
+        ]
+      },
+      {
+        "en": "multiplayer raid",
+        "ja": "マルチレイド",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01080",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'speedrun'?",
+      "ja": "スピードランとは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sending viewers to another channel",
+        "ja": "ベツチャンネルニシチョウシャヲオクル",
+        "ja_typings": [
+          "betsuchannnerunishichoushawookuru"
+        ]
+      },
+      {
+        "en": "hacking attack",
+        "ja": "ハッキングコウゲキ",
+        "ja_typings": [
+          "hakkingukougeki"
+        ]
+      },
+      {
+        "en": "payment refund",
+        "ja": "シハライヘンキン",
+        "ja_typings": [
+          "shiharaihenkin"
+        ]
+      },
+      {
+        "en": "login bonus",
+        "ja": "ログインボーナス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01081",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the meaning of 'raid' on streaming sites?",
+      "ja": "配信サイトのレイドの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "very good song",
+        "ja": "メイキョク",
+        "ja_typings": [
+          "meikyoku"
+        ]
+      },
+      {
+        "en": "very bad song",
+        "ja": "ヒドイキョク",
+        "ja_typings": [
+          "hidoikyoku"
+        ]
+      },
+      {
+        "en": "long song",
+        "ja": "ナガイキョク",
+        "ja_typings": [
+          "nagaikyoku"
+        ]
+      },
+      {
+        "en": "ad song",
+        "ja": "コウコクキョク",
+        "ja_typings": [
+          "koukokukyoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01082",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'banger' track?",
+      "ja": "bangerトラックの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "frustration",
+        "ja": "イラダチ",
+        "ja_typings": [
+          "iradachi"
+        ]
+      },
+      {
+        "en": "joy",
+        "ja": "ヨロコビ",
+        "ja_typings": [
+          "yorokobi"
+        ]
+      },
+      {
+        "en": "luck",
+        "ja": "ウン",
+        "ja_typings": [
+          "un"
+        ]
+      },
+      {
+        "en": "speed",
+        "ja": "ハヤサ",
+        "ja_typings": [
+          "hayasa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01083",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the meaning of 'salt' in gaming?",
+      "ja": "ゲームのsaltの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "quitting in anger",
+        "ja": "イカッテヤメル",
+        "ja_typings": [
+          "ikatteyameru"
+        ]
+      },
+      {
+        "en": "winning fast",
+        "ja": "ハヤクカツ",
+        "ja_typings": [
+          "hayakukatsu"
+        ]
+      },
+      {
+        "en": "calm goodbye",
+        "ja": "オダヤカナサヨウナラ",
+        "ja_typings": [
+          "odayakanasayounara"
+        ]
+      },
+      {
+        "en": "auto save",
+        "ja": "ジドウホゾン",
+        "ja_typings": [
+          "jidouhozon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01084",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the meaning of 'rage quit'?",
+      "ja": "rage quitの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Player versus Player",
+        "ja": "プレイヤータイプレイヤー",
+        "ja_typings": [
+          "pureiya-taipureiya-"
+        ]
+      },
+      {
+        "en": "Plot versus Plot",
+        "ja": "プロットタイプロット",
+        "ja_typings": [
+          "purottotaipurotto"
+        ]
+      },
+      {
+        "en": "Public versus Private",
+        "ja": "パブリックタイプライベート",
+        "ja_typings": []
+      },
+      {
+        "en": "Pick versus Pull",
+        "ja": "ピックタイプル",
+        "ja_typings": [
+          "pikkutaipuru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01085",
+    "image_path": null,
+    "question_text": {
+      "en": "What does PvP mean?",
+      "ja": "PvPの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "embarrassment",
+        "ja": "キョウシュク",
+        "ja_typings": [
+          "kyoushuku"
+        ]
+      },
+      {
+        "en": "happiness",
+        "ja": "シアワセ",
+        "ja_typings": [
+          "shiawase"
+        ]
+      },
+      {
+        "en": "courage",
+        "ja": "ユウキ",
+        "ja_typings": [
+          "yuuki"
+        ]
+      },
+      {
+        "en": "calmness",
+        "ja": "オチツキ",
+        "ja_typings": [
+          "ochitsuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01086",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'cringe' describe?",
+      "ja": "cringeが表す感情は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "indecent content",
+        "ja": "セイテキナナイヨウ",
+        "ja_typings": [
+          "seitekinanaiyou"
+        ]
+      },
+      {
+        "en": "educational topic",
+        "ja": "キョウイクテーマ",
+        "ja_typings": [
+          "kyouikute-ma"
+        ]
+      },
+      {
+        "en": "political opinion",
+        "ja": "セイジテキイケン",
+        "ja_typings": [
+          "seijitekiiken"
+        ]
+      },
+      {
+        "en": "musical genre",
+        "ja": "オンガクジャンル",
+        "ja_typings": [
+          "ongakujanru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01087",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'lewd' refer to?",
+      "ja": "lewdの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "very funny",
+        "ja": "オオワライ",
+        "ja_typings": [
+          "oowarai"
+        ]
+      },
+      {
+        "en": "very sad",
+        "ja": "オオナキ",
+        "ja_typings": [
+          "oonaki"
+        ]
+      },
+      {
+        "en": "very angry",
+        "ja": "オオイカリ",
+        "ja_typings": [
+          "ooikari"
+        ]
+      },
+      {
+        "en": "very scared",
+        "ja": "オオオビエ",
+        "ja_typings": [
+          "ooobie"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01088",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the meaning of '草生える'?",
+      "ja": "草生えるの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "clip video",
+        "ja": "クリップドウガ",
+        "ja_typings": [
+          "kurippudouga"
+        ]
+      },
+      {
+        "en": "trim video",
+        "ja": "トリムドウガ",
+        "ja_typings": [
+          "torimudouga"
+        ]
+      },
+      {
+        "en": "snippet video",
+        "ja": "スニペットドウガ",
+        "ja_typings": [
+          "sunipettodouga"
+        ]
+      },
+      {
+        "en": "flash video",
+        "ja": "フラッシュドウガ",
+        "ja_typings": [
+          "furasshudouga"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01089",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the term for a clipped highlight?",
+      "ja": "切り抜き動画の英語呼称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Central Processing Unit",
+        "ja": "セントラルプロセッシングユニット",
+        "ja_typings": []
+      },
+      {
+        "en": "Computer Program Utility",
+        "ja": "コンピュータプログラムユーティリティ",
+        "ja_typings": []
+      },
+      {
+        "en": "Cache Processing Update",
+        "ja": "キャッシュプロセッシングアップデート",
+        "ja_typings": []
+      },
+      {
+        "en": "Code Pipeline Unit",
+        "ja": "コードパイプラインユニット",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01090",
+    "image_path": null,
+    "question_text": {
+      "en": "What does CPU stand for?",
+      "ja": "CPUは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Random Access Memory",
+        "ja": "ランダムアクセスメモリ",
+        "ja_typings": []
+      },
+      {
+        "en": "Read Access Mode",
+        "ja": "リードアクセスモード",
+        "ja_typings": []
+      },
+      {
+        "en": "Rapid Address Manager",
+        "ja": "ラピッドアドレスマネージャー",
+        "ja_typings": []
+      },
+      {
+        "en": "Recursive Allocation Method",
+        "ja": "リカーシブアロケーションメソッド",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01091",
+    "image_path": null,
+    "question_text": {
+      "en": "What does RAM stand for?",
+      "ja": "RAMは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "port 22",
+        "ja": "ニジュウニバン",
+        "ja_typings": [
+          "nijuunipan",
+          "nijuunipan",
+          "nijuuniban"
+        ]
+      },
+      {
+        "en": "port 21",
+        "ja": "ニジュウイチバン",
+        "ja_typings": [
+          "nijuuichiban"
+        ]
+      },
+      {
+        "en": "port 80",
+        "ja": "ハチジュウバン",
+        "ja_typings": [
+          "hachijuuban"
+        ]
+      },
+      {
+        "en": "port 443",
+        "ja": "ヨンヒャクヨンジュウサンバン",
+        "ja_typings": [
+          "yonhyakuyonjuusanban"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01092",
+    "image_path": null,
+    "question_text": {
+      "en": "What port does SSH typically use?",
+      "ja": "SSHが通常使うポート番号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Solid State Drive",
+        "ja": "ソリッドステートドライブ",
+        "ja_typings": []
+      },
+      {
+        "en": "Storage System Device",
+        "ja": "ストレージシステムデバイス",
+        "ja_typings": []
+      },
+      {
+        "en": "Secure Service Daemon",
+        "ja": "セキュアサービスデーモン",
+        "ja_typings": []
+      },
+      {
+        "en": "Static Sync Disk",
+        "ja": "スタティックシンクディスク",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01093",
+    "image_path": null,
+    "question_text": {
+      "en": "What does SSD stand for?",
+      "ja": "SSDは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Application Programming Interface",
+        "ja": "アプリケーションプログラミングインターフェース",
+        "ja_typings": []
+      },
+      {
+        "en": "Active Protocol Index",
+        "ja": "アクティブプロトコルインデックス",
+        "ja_typings": []
+      },
+      {
+        "en": "Auto Program Installer",
+        "ja": "オートプログラムインストーラー",
+        "ja_typings": []
+      },
+      {
+        "en": "Async Process Identifier",
+        "ja": "アシンクプロセスアイデンティファイア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01094",
+    "image_path": null,
+    "question_text": {
+      "en": "What does API stand for?",
+      "ja": "APIは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "443",
+        "ja": "ヨンヨンサン",
+        "ja_typings": [
+          "yonyonsan"
+        ]
+      },
+      {
+        "en": "80",
+        "ja": "ハチマル",
+        "ja_typings": [
+          "hachimaru"
+        ]
+      },
+      {
+        "en": "22",
+        "ja": "ニジュウニ",
+        "ja_typings": [
+          "nijuuni"
+        ]
+      },
+      {
+        "en": "8080",
+        "ja": "ハチゼロハチゼロ",
+        "ja_typings": [
+          "hachizerohachizero"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01095",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the default port for HTTPS?",
+      "ja": "HTTPSのデフォルトポート番号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Universal Serial Bus",
+        "ja": "ユニバーサルシリアルバス",
+        "ja_typings": []
+      },
+      {
+        "en": "Unified System Boot",
+        "ja": "ユニファイドシステムブート",
+        "ja_typings": []
+      },
+      {
+        "en": "Ultra Speed Bridge",
+        "ja": "ウルトラスピードブリッジ",
+        "ja_typings": []
+      },
+      {
+        "en": "User Storage Bay",
+        "ja": "ユーザーストレージベイ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01096",
+    "image_path": null,
+    "question_text": {
+      "en": "What does USB stand for?",
+      "ja": "USBは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "32 bits",
+        "ja": "サンジュウニビット",
+        "ja_typings": [
+          "sanjuunibitto"
+        ]
+      },
+      {
+        "en": "64 bits",
+        "ja": "ロクジュウヨンビット",
+        "ja_typings": [
+          "rokujuuyonbitto"
+        ]
+      },
+      {
+        "en": "128 bits",
+        "ja": "ヒャクニジュウハチビット",
+        "ja_typings": [
+          "hyakunijuuhachibitto"
+        ]
+      },
+      {
+        "en": "16 bits",
+        "ja": "ジュウロクビット",
+        "ja_typings": [
+          "juurokubitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01097",
+    "image_path": null,
+    "question_text": {
+      "en": "What is IPv4 address length in bits?",
+      "ja": "IPv4アドレスのビット長は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Amazon Web Services",
+        "ja": "アマゾンウェブサービス",
+        "ja_typings": []
+      },
+      {
+        "en": "Active Web System",
+        "ja": "アクティブウェブシステム",
+        "ja_typings": []
+      },
+      {
+        "en": "Asynchronous Wire Source",
+        "ja": "アシンクロナスワイヤーソース",
+        "ja_typings": []
+      },
+      {
+        "en": "Auto Workflow Suite",
+        "ja": "オートワークフロースイート",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01098",
+    "image_path": null,
+    "question_text": {
+      "en": "What does AWS stand for?",
+      "ja": "AWSは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Graphics Processing Unit",
+        "ja": "グラフィックスプロセッシングユニット",
+        "ja_typings": []
+      },
+      {
+        "en": "General Pipeline Utility",
+        "ja": "ジェネラルパイプラインユーティリティ",
+        "ja_typings": []
+      },
+      {
+        "en": "Global Program Unit",
+        "ja": "グローバルプログラムユニット",
+        "ja_typings": []
+      },
+      {
+        "en": "Gigabyte Processing Unit",
+        "ja": "ギガバイトプロセッシングユニット",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01099",
+    "image_path": null,
+    "question_text": {
+      "en": "What does GPU stand for?",
+      "ja": "GPUは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "16",
+        "ja": "ジュウロク",
+        "ja_typings": [
+          "juuroku"
+        ]
+      },
+      {
+        "en": "2",
+        "ja": "ニ",
+        "ja_typings": [
+          "ni"
+        ]
+      },
+      {
+        "en": "8",
+        "ja": "ハチ",
+        "ja_typings": [
+          "hachi"
+        ]
+      },
+      {
+        "en": "10",
+        "ja": "ジュウ",
+        "ja_typings": [
+          "juu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01100",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the base of hexadecimal?",
+      "ja": "16進数の基数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HyperText Markup Language",
+        "ja": "ハイパーテキストマークアップランゲージ",
+        "ja_typings": []
+      },
+      {
+        "en": "Home Tool Markup Language",
+        "ja": "ホームツールマークアップランゲージ",
+        "ja_typings": []
+      },
+      {
+        "en": "High Tech Modular Language",
+        "ja": "ハイテックモジュラーランゲージ",
+        "ja_typings": []
+      },
+      {
+        "en": "Host Transfer Meta Language",
+        "ja": "ホストトランスファーメタランゲージ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01101",
+    "image_path": null,
+    "question_text": {
+      "en": "What does HTML stand for?",
+      "ja": "HTMLは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "48 bits",
+        "ja": "ヨンジュウハチビット",
+        "ja_typings": [
+          "yonjuuhachibitto"
+        ]
+      },
+      {
+        "en": "32 bits",
+        "ja": "サンジュウニビット",
+        "ja_typings": [
+          "sanjuunibitto"
+        ]
+      },
+      {
+        "en": "64 bits",
+        "ja": "ロクジュウヨンビット",
+        "ja_typings": [
+          "rokujuuyonbitto"
+        ]
+      },
+      {
+        "en": "16 bits",
+        "ja": "ジュウロクビット",
+        "ja_typings": [
+          "juurokubitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01102",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the size of a standard MAC address in bits?",
+      "ja": "MACアドレスのビット長は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "21",
+        "ja": "ニジュウイチ",
+        "ja_typings": [
+          "nijuuichi"
+        ]
+      },
+      {
+        "en": "22",
+        "ja": "ニジュウニ",
+        "ja_typings": [
+          "nijuuni"
+        ]
+      },
+      {
+        "en": "23",
+        "ja": "ニジュウサン",
+        "ja_typings": [
+          "nijuusan"
+        ]
+      },
+      {
+        "en": "25",
+        "ja": "ニジュウゴ",
+        "ja_typings": [
+          "nijuugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01103",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the default port for FTP?",
+      "ja": "FTPのデフォルトポート番号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Virtual Private Network",
+        "ja": "バーチャルプライベートネットワーク",
+        "ja_typings": []
+      },
+      {
+        "en": "Verified Public Node",
+        "ja": "ベリファイドパブリックノード",
+        "ja_typings": []
+      },
+      {
+        "en": "Volume Packet Number",
+        "ja": "ボリュームパケットナンバー",
+        "ja_typings": []
+      },
+      {
+        "en": "Virtual Protocol Name",
+        "ja": "バーチャルプロトコルネーム",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01104",
+    "image_path": null,
+    "question_text": {
+      "en": "What does VPN stand for?",
+      "ja": "VPNは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cascading Style Sheets",
+        "ja": "カスケーディングスタイルシート",
+        "ja_typings": []
+      },
+      {
+        "en": "Computer Style System",
+        "ja": "コンピュータスタイルシステム",
+        "ja_typings": []
+      },
+      {
+        "en": "Compact Source Script",
+        "ja": "コンパクトソーススクリプト",
+        "ja_typings": []
+      },
+      {
+        "en": "Central Server Stack",
+        "ja": "セントラルサーバースタック",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01105",
+    "image_path": null,
+    "question_text": {
+      "en": "What does CSS stand for?",
+      "ja": "CSSは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SMTP",
+        "ja": "エスエムティーピー",
+        "ja_typings": [
+          "esuemuti-pi-"
+        ]
+      },
+      {
+        "en": "POP3",
+        "ja": "ピーオーピースリー",
+        "ja_typings": [
+          "pi-o-pi-suri-"
+        ]
+      },
+      {
+        "en": "IMAP",
+        "ja": "アイマップ",
+        "ja_typings": [
+          "aimappu"
+        ]
+      },
+      {
+        "en": "FTP",
+        "ja": "エフティーピー",
+        "ja_typings": [
+          "efuti-pi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01106",
+    "image_path": null,
+    "question_text": {
+      "en": "What protocol is used to send email?",
+      "ja": "電子メール送信に使うプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1024 bytes",
+        "ja": "センニジュウヨンバイト",
+        "ja_typings": [
+          "sennijuuyonbaito"
+        ]
+      },
+      {
+        "en": "100 bytes",
+        "ja": "ヒャクバイト",
+        "ja_typings": [
+          "hyakubaito"
+        ]
+      },
+      {
+        "en": "500 bytes",
+        "ja": "ゴヒャクバイト",
+        "ja_typings": [
+          "gohyakubaito"
+        ]
+      },
+      {
+        "en": "2048 bytes",
+        "ja": "ニセンヨンジュウハチバイト",
+        "ja_typings": [
+          "nisenyonjuuhachibaito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01107",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a kilobyte equal to?",
+      "ja": "1キロバイトは何バイト?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Structured Query Language",
+        "ja": "ストラクチャードクエリランゲージ",
+        "ja_typings": []
+      },
+      {
+        "en": "Simple Question Logic",
+        "ja": "シンプルクエスチョンロジック",
+        "ja_typings": []
+      },
+      {
+        "en": "Secure Query Loader",
+        "ja": "セキュアクエリローダー",
+        "ja_typings": []
+      },
+      {
+        "en": "Server Quick Link",
+        "ja": "サーバークイックリンク",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01108",
+    "image_path": null,
+    "question_text": {
+      "en": "What does SQL stand for?",
+      "ja": "SQLは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "25",
+        "ja": "ニジュウゴ",
+        "ja_typings": [
+          "nijuugo"
+        ]
+      },
+      {
+        "en": "21",
+        "ja": "ニジュウイチ",
+        "ja_typings": [
+          "nijuuichi"
+        ]
+      },
+      {
+        "en": "22",
+        "ja": "ニジュウニ",
+        "ja_typings": [
+          "nijuuni"
+        ]
+      },
+      {
+        "en": "23",
+        "ja": "ニジュウサン",
+        "ja_typings": [
+          "nijuusan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01109",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the default port for SMTP?",
+      "ja": "SMTPのデフォルトポート番号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Red Green Blue",
+        "ja": "レッドグリーンブルー",
+        "ja_typings": []
+      },
+      {
+        "en": "Right Grid Base",
+        "ja": "ライトグリッドベース",
+        "ja_typings": []
+      },
+      {
+        "en": "Raw Graphics Buffer",
+        "ja": "ローグラフィックスバッファ",
+        "ja_typings": []
+      },
+      {
+        "en": "Resource Group Base",
+        "ja": "リソースグループベース",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01110",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the acronym RGB represent?",
+      "ja": "RGBは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "bit",
+        "ja": "ビット",
+        "ja_typings": []
+      },
+      {
+        "en": "byte",
+        "ja": "バイト",
+        "ja_typings": []
+      },
+      {
+        "en": "nibble",
+        "ja": "ニブル",
+        "ja_typings": []
+      },
+      {
+        "en": "word",
+        "ja": "ワード",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01111",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the smallest unit of digital information?",
+      "ja": "デジタル情報の最小単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1010",
+        "ja": "イチゼロイチゼロ",
+        "ja_typings": [
+          "ichizeroichizero"
+        ]
+      },
+      {
+        "en": "1100",
+        "ja": "イチイチゼロゼロ",
+        "ja_typings": [
+          "ichiichizerozero"
+        ]
+      },
+      {
+        "en": "1001",
+        "ja": "イチゼロゼロイチ",
+        "ja_typings": [
+          "ichizerozeroichi"
+        ]
+      },
+      {
+        "en": "1110",
+        "ja": "イチイチイチゼロ",
+        "ja_typings": [
+          "ichiichiichizero"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01112",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the binary value of decimal 10?",
+      "ja": "10進数10の2進数表現は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Redundant Array of Independent Disks",
+        "ja": "リダンダントアレイオブインディペンデントディスクス",
+        "ja_typings": []
+      },
+      {
+        "en": "Rapid Access Internal Drive",
+        "ja": "ラピッドアクセスインターナルドライブ",
+        "ja_typings": []
+      },
+      {
+        "en": "Random Allocated Index Database",
+        "ja": "ランダムアロケーテッドインデックスデータベース",
+        "ja_typings": []
+      },
+      {
+        "en": "Remote Async IO Daemon",
+        "ja": "リモートアシンクアイオーデーモン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01113",
+    "image_path": null,
+    "question_text": {
+      "en": "What does RAID stand for in storage?",
+      "ja": "ストレージのRAIDは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Detective Conan",
+        "ja": "名探偵コナン",
+        "ja_typings": [
+          "meitanteikonan"
+        ]
+      },
+      {
+        "en": "Kindaichi Case Files",
+        "ja": "金田一少年の事件簿",
+        "ja_typings": [
+          "kindaichishounennojikenbo"
+        ]
+      },
+      {
+        "en": "Hyouka",
+        "ja": "氷菓",
+        "ja_typings": [
+          "hyouka"
+        ]
+      },
+      {
+        "en": "Moriarty the Patriot",
+        "ja": "憂国のモリアーティ",
+        "ja_typings": [
+          "yuukokunomoriaati"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01114",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features a high school detective shrunk into a child?",
+      "ja": "高校生探偵が子供の姿にされるアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sword Art Online",
+        "ja": "ソードアート・オンライン",
+        "ja_typings": []
+      },
+      {
+        "en": ".hack//Sign",
+        "ja": "ドットハック・サイン",
+        "ja_typings": []
+      },
+      {
+        "en": "Log Horizon",
+        "ja": "ログ・ホライズン",
+        "ja_typings": []
+      },
+      {
+        "en": "Overlord",
+        "ja": "オーバーロード",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01115",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is set in a virtual MMORPG where players are trapped?",
+      "ja": "仮想MMORPGに閉じ込められるアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Boruto",
+        "ja": "ボルト",
+        "ja_typings": []
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": []
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "フェアリーテイル",
+        "ja_typings": []
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01116",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features a boy aiming to be Hokage?",
+      "ja": "火影を目指す少年のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CoMix Wave Films",
+        "ja": "コミックス・ウェーブ・フィルム",
+        "ja_typings": []
+      },
+      {
+        "en": "Kyoto Animation",
+        "ja": "京都アニメーション",
+        "ja_typings": [
+          "kyoutoanimeeshon"
+        ]
+      },
+      {
+        "en": "Production I.G",
+        "ja": "プロダクション・アイジー",
+        "ja_typings": []
+      },
+      {
+        "en": "Bones",
+        "ja": "ボンズ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01117",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime studio produced 'Your Name'?",
+      "ja": "『君の名は。』を制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hayao Miyazaki",
+        "ja": "宮崎駿",
+        "ja_typings": [
+          "miyazakihayao"
+        ]
+      },
+      {
+        "en": "Isao Takahata",
+        "ja": "高畑勲",
+        "ja_typings": [
+          "takahataisao"
+        ]
+      },
+      {
+        "en": "Mamoru Hosoda",
+        "ja": "細田守",
+        "ja_typings": [
+          "hosodamamoru"
+        ]
+      },
+      {
+        "en": "Makoto Shinkai",
+        "ja": "新海誠",
+        "ja_typings": [
+          "shinkaimakoto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01118",
+    "image_path": null,
+    "question_text": {
+      "en": "Who directed 'Princess Mononoke'?",
+      "ja": "『もののけ姫』の監督は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Soul Eater",
+        "ja": "ソウルイーター",
+        "ja_typings": []
+      },
+      {
+        "en": "Noragami",
+        "ja": "ノラガミ",
+        "ja_typings": []
+      },
+      {
+        "en": "Yu Yu Hakusho",
+        "ja": "幽☆遊☆白書",
+        "ja_typings": [
+          "yuuyuuhakusho"
+        ]
+      },
+      {
+        "en": "Inuyasha",
+        "ja": "犬夜叉",
+        "ja_typings": [
+          "inuyasha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01119",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is about a girl who becomes a Soul Reaper?",
+      "ja": "死神になる少女が登場するアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MAPPA",
+        "ja": "マッパ",
+        "ja_typings": []
+      },
+      {
+        "en": "Wit Studio",
+        "ja": "ウィットスタジオ",
+        "ja_typings": []
+      },
+      {
+        "en": "Madhouse",
+        "ja": "マッドハウス",
+        "ja_typings": []
+      },
+      {
+        "en": "Toei Animation",
+        "ja": "東映アニメーション",
+        "ja_typings": [
+          "toueianimeeshon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01120",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime studio made 'Attack on Titan' final seasons?",
+      "ja": "『進撃の巨人』最終章を制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fullmetal Alchemist",
+        "ja": "鋼の錬金術師",
+        "ja_typings": [
+          "haganenorenkinjutsushi"
+        ]
+      },
+      {
+        "en": "D.Gray-man",
+        "ja": "ディーグレイマン",
+        "ja_typings": []
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": []
+      },
+      {
+        "en": "Black Butler",
+        "ja": "黒執事",
+        "ja_typings": [
+          "kuroshitsuji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01121",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features alchemists searching for the Philosopher's Stone?",
+      "ja": "賢者の石を探す錬金術師のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Haikyuu!!",
+        "ja": "ハイキュー!!",
+        "ja_typings": []
+      },
+      {
+        "en": "Kuroko's Basketball",
+        "ja": "黒子のバスケ",
+        "ja_typings": [
+          "kuronobasuke"
+        ]
+      },
+      {
+        "en": "Ace of Diamond",
+        "ja": "ダイヤのA",
+        "ja_typings": [
+          "daiyanoeesu"
+        ]
+      },
+      {
+        "en": "Blue Lock",
+        "ja": "ブルーロック",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01122",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is about volleyball at Karasuno High?",
+      "ja": "烏野高校のバレーボールのアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Durarara!!",
+        "ja": "デュラララ!!",
+        "ja_typings": []
+      },
+      {
+        "en": "Baccano!",
+        "ja": "バッカーノ!",
+        "ja_typings": []
+      },
+      {
+        "en": "Psycho-Pass",
+        "ja": "サイコパス",
+        "ja_typings": []
+      },
+      {
+        "en": "91 Days",
+        "ja": "91デイズ",
+        "ja_typings": [
+          "91deizu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01123",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is set in the fictional city of Ikebukuro with gang wars?",
+      "ja": "池袋を舞台にした抗争アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Love Live!",
+        "ja": "ラブライブ!",
+        "ja_typings": []
+      },
+      {
+        "en": "The iDOLM@STER",
+        "ja": "アイドルマスター",
+        "ja_typings": []
+      },
+      {
+        "en": "BanG Dream!",
+        "ja": "バンドリ!",
+        "ja_typings": []
+      },
+      {
+        "en": "Wake Up, Girls!",
+        "ja": "ウェイクアップ、ガールズ!",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01124",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features the school idol group μ's?",
+      "ja": "μ'sが登場するアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rurouni Kenshin",
+        "ja": "るろうに剣心",
+        "ja_typings": [
+          "rurouninikenshin"
+        ]
+      },
+      {
+        "en": "Samurai Champloo",
+        "ja": "サムライチャンプルー",
+        "ja_typings": []
+      },
+      {
+        "en": "Afro Samurai",
+        "ja": "アフロサムライ",
+        "ja_typings": []
+      },
+      {
+        "en": "Dororo",
+        "ja": "どろろ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01125",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is about a samurai who wanders Meiji-era Japan?",
+      "ja": "明治時代を流浪する侍のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Makoto Shinkai",
+        "ja": "新海誠",
+        "ja_typings": [
+          "shinkaimakoto"
+        ]
+      },
+      {
+        "en": "Mamoru Hosoda",
+        "ja": "細田守",
+        "ja_typings": [
+          "hosodamamoru"
+        ]
+      },
+      {
+        "en": "Naoko Yamada",
+        "ja": "山田尚子",
+        "ja_typings": [
+          "yamadanaoko"
+        ]
+      },
+      {
+        "en": "Tetsuro Araki",
+        "ja": "荒木哲郎",
+        "ja_typings": [
+          "arakitetsurou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01126",
+    "image_path": null,
+    "question_text": {
+      "en": "Which director made 'Weathering with You'?",
+      "ja": "『天気の子』の監督は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chihayafuru",
+        "ja": "ちはやふる",
+        "ja_typings": []
+      },
+      {
+        "en": "Saki",
+        "ja": "咲-Saki-",
+        "ja_typings": []
+      },
+      {
+        "en": "Akagi",
+        "ja": "アカギ",
+        "ja_typings": []
+      },
+      {
+        "en": "Kaiji",
+        "ja": "カイジ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01127",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features four siblings playing card games?",
+      "ja": "カードゲームをする四姉妹のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cowboy Bebop",
+        "ja": "カウボーイビバップ",
+        "ja_typings": []
+      },
+      {
+        "en": "Outlaw Star",
+        "ja": "アウトロースター",
+        "ja_typings": []
+      },
+      {
+        "en": "Trigun",
+        "ja": "トライガン",
+        "ja_typings": []
+      },
+      {
+        "en": "Black Lagoon",
+        "ja": "ブラック・ラグーン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01128",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features Spike Spiegel as a bounty hunter?",
+      "ja": "スパイク・スピーゲルが賞金稼ぎとして登場するアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Masako Nozawa",
+        "ja": "野沢雅子",
+        "ja_typings": [
+          "nozawamasako"
+        ]
+      },
+      {
+        "en": "Megumi Hayashibara",
+        "ja": "林原めぐみ",
+        "ja_typings": [
+          "hayashibaramegumi"
+        ]
+      },
+      {
+        "en": "Aya Hirano",
+        "ja": "平野綾",
+        "ja_typings": [
+          "hiranoaya"
+        ]
+      },
+      {
+        "en": "Mamoru Miyano",
+        "ja": "宮野真守",
+        "ja_typings": [
+          "miyanomamoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01129",
+    "image_path": null,
+    "question_text": {
+      "en": "Who voices Goku in the Japanese dub of Dragon Ball?",
+      "ja": "ドラゴンボールの孫悟空の日本語声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kamisama Kiss",
+        "ja": "神様はじめました",
+        "ja_typings": [
+          "kamisamahajimemashita"
+        ]
+      },
+      {
+        "en": "Fruits Basket",
+        "ja": "フルーツバスケット",
+        "ja_typings": []
+      },
+      {
+        "en": "Ouran High School Host Club",
+        "ja": "桜蘭高校ホスト部",
+        "ja_typings": [
+          "ourankoukouhosutobu"
+        ]
+      },
+      {
+        "en": "Kobato",
+        "ja": "こばと。",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01130",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is about a girl who befriends a fox spirit?",
+      "ja": "狐の妖怪と仲良くなる少女のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gurren Lagann",
+        "ja": "天元突破グレンラガン",
+        "ja_typings": [
+          "tengentoppagurenragan"
+        ]
+      },
+      {
+        "en": "Eureka Seven",
+        "ja": "交響詩篇エウレカセブン",
+        "ja_typings": [
+          "koukyoushiheneurekasebun"
+        ]
+      },
+      {
+        "en": "RahXephon",
+        "ja": "ラーゼフォン",
+        "ja_typings": []
+      },
+      {
+        "en": "Aldnoah.Zero",
+        "ja": "アルドノア・ゼロ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01131",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features a giant mecha called Lagann?",
+      "ja": "ラガンというロボットが登場するアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "K-On!",
+        "ja": "けいおん!",
+        "ja_typings": [
+          "keion"
+        ]
+      },
+      {
+        "en": "Beck",
+        "ja": "ベック",
+        "ja_typings": []
+      },
+      {
+        "en": "Nana",
+        "ja": "ナナ",
+        "ja_typings": []
+      },
+      {
+        "en": "Carole & Tuesday",
+        "ja": "キャロル&チューズデイ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01132",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is about a high school light music club?",
+      "ja": "高校の軽音部が舞台のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kyoto Animation",
+        "ja": "京都アニメーション",
+        "ja_typings": [
+          "kyoutoanimeeshon"
+        ]
+      },
+      {
+        "en": "P.A.Works",
+        "ja": "ピーエーワークス",
+        "ja_typings": []
+      },
+      {
+        "en": "Trigger",
+        "ja": "トリガー",
+        "ja_typings": []
+      },
+      {
+        "en": "Ufotable",
+        "ja": "ユーフォーテーブル",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01133",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime studio produced 'Violet Evergarden'?",
+      "ja": "『ヴァイオレット・エヴァーガーデン』を制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sword Art Online",
+        "ja": "ソードアート・オンライン",
+        "ja_typings": []
+      },
+      {
+        "en": "Accel World",
+        "ja": "アクセル・ワールド",
+        "ja_typings": []
+      },
+      {
+        "en": "No Game No Life",
+        "ja": "ノーゲーム・ノーライフ",
+        "ja_typings": []
+      },
+      {
+        "en": "Re:Zero",
+        "ja": "リゼロ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01134",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features a girl named Asuna in a virtual world?",
+      "ja": "アスナという少女が仮想世界で活躍するアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Attack on Titan",
+        "ja": "進撃の巨人",
+        "ja_typings": [
+          "shingekinokyojin"
+        ]
+      },
+      {
+        "en": "Vinland Saga",
+        "ja": "ヴィンランド・サガ",
+        "ja_typings": []
+      },
+      {
+        "en": "Berserk",
+        "ja": "ベルセルク",
+        "ja_typings": []
+      },
+      {
+        "en": "Claymore",
+        "ja": "クレイモア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01135",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features a girl named Mikasa Ackerman?",
+      "ja": "ミカサ・アッカーマンが登場するアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Taisou Zamurai",
+        "ja": "体操ザムライ",
+        "ja_typings": [
+          "taisouzamurai"
+        ]
+      },
+      {
+        "en": "Tsurune",
+        "ja": "ツルネ",
+        "ja_typings": []
+      },
+      {
+        "en": "Free!",
+        "ja": "フリー!",
+        "ja_typings": []
+      },
+      {
+        "en": "Yuri on Ice",
+        "ja": "ユーリ!!! on ICE",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01136",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is about gymnastics rhythmic at Hanazono?",
+      "ja": "花園を目指す体操のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Naruto Shippuden",
+        "ja": "ナルト疾風伝",
+        "ja_typings": [
+          "narutoshippuuden"
+        ]
+      },
+      {
+        "en": "Bleach",
+        "ja": "ブリーチ",
+        "ja_typings": []
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "フェアリーテイル",
+        "ja_typings": []
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01137",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features the Akatsuki organization?",
+      "ja": "暁という組織が登場するアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "A Certain Magical Index",
+        "ja": "とある魔術の禁書目録",
+        "ja_typings": [
+          "toarumajutsunoindekkusu"
+        ]
+      },
+      {
+        "en": "Little Witch Academia",
+        "ja": "リトルウィッチアカデミア",
+        "ja_typings": []
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": []
+      },
+      {
+        "en": "Witch Hunter Robin",
+        "ja": "ウィッチハンターロビン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01138",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is set in a magical library city called Academy City?",
+      "ja": "学園都市が舞台のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hunter x Hunter",
+        "ja": "ハンターハンター",
+        "ja_typings": []
+      },
+      {
+        "en": "Black Cat",
+        "ja": "ブラック・キャット",
+        "ja_typings": []
+      },
+      {
+        "en": "Katekyo Hitman Reborn",
+        "ja": "家庭教師ヒットマンリボーン",
+        "ja_typings": [
+          "kateikyoushihittomanribouun"
+        ]
+      },
+      {
+        "en": "D.Gray-man",
+        "ja": "ディーグレイマン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01139",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features the Phantom Troupe?",
+      "ja": "幻影旅団が登場するアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rosario + Vampire",
+        "ja": "ロザリオとバンパイア",
+        "ja_typings": []
+      },
+      {
+        "en": "Vampire Knight",
+        "ja": "ヴァンパイア騎士",
+        "ja_typings": [
+          "vanpaiakishi"
+        ]
+      },
+      {
+        "en": "Trinity Blood",
+        "ja": "トリニティ・ブラッド",
+        "ja_typings": []
+      },
+      {
+        "en": "Blood+",
+        "ja": "ブラッドプラス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01140",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is about a girl in a magical school for vampires?",
+      "ja": "ヴァンパイアの学園が舞台のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Code Geass",
+        "ja": "コードギアス",
+        "ja_typings": []
+      },
+      {
+        "en": "Guilty Crown",
+        "ja": "ギルティクラウン",
+        "ja_typings": []
+      },
+      {
+        "en": "Darker than Black",
+        "ja": "ダーカー・ザン・ブラック",
+        "ja_typings": []
+      },
+      {
+        "en": "Mirai Nikki",
+        "ja": "未来日記",
+        "ja_typings": [
+          "mirainikki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01141",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features Lelouch and Geass powers?",
+      "ja": "ルルーシュとギアスの力が登場するアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Steins;Gate",
+        "ja": "シュタインズ・ゲート",
+        "ja_typings": []
+      },
+      {
+        "en": "Chaos;Head",
+        "ja": "カオスヘッド",
+        "ja_typings": []
+      },
+      {
+        "en": "Robotics;Notes",
+        "ja": "ロボティクス・ノーツ",
+        "ja_typings": []
+      },
+      {
+        "en": "Occultic;Nine",
+        "ja": "オカルティック・ナイン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01142",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features a time-traveling microwave?",
+      "ja": "電子レンジで時間移動するアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ufotable",
+        "ja": "ユーフォーテーブル",
+        "ja_typings": []
+      },
+      {
+        "en": "MAPPA",
+        "ja": "マッパ",
+        "ja_typings": []
+      },
+      {
+        "en": "A-1 Pictures",
+        "ja": "エーワン・ピクチャーズ",
+        "ja_typings": []
+      },
+      {
+        "en": "Wit Studio",
+        "ja": "ウィットスタジオ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01143",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime studio produced 'Demon Slayer'?",
+      "ja": "『鬼滅の刃』を制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wolf's Rain",
+        "ja": "ウルフズ・レイン",
+        "ja_typings": []
+      },
+      {
+        "en": "Spice and Wolf",
+        "ja": "狼と香辛料",
+        "ja_typings": [
+          "ookamitokoushinryou"
+        ]
+      },
+      {
+        "en": "Wolf Children",
+        "ja": "おおかみこどもの雨と雪",
+        "ja_typings": [
+          "ookamikodomonoametoyuki"
+        ]
+      },
+      {
+        "en": "Princess Tutu",
+        "ja": "プリンセスチュチュ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01144",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features a girl who can turn into a wolf?",
+      "ja": "狼に変身する少女のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Big Windup!",
+        "ja": "おおきく振りかぶって",
+        "ja_typings": [
+          "ookikufurikabutte"
+        ]
+      },
+      {
+        "en": "Ace of Diamond",
+        "ja": "ダイヤのA",
+        "ja_typings": [
+          "daiyanoeesu"
+        ]
+      },
+      {
+        "en": "Major",
+        "ja": "メジャー",
+        "ja_typings": []
+      },
+      {
+        "en": "Cross Game",
+        "ja": "クロスゲーム",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01145",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features a high school baseball team called Nishiura?",
+      "ja": "西浦高校野球部のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Food Wars!",
+        "ja": "食戟のソーマ",
+        "ja_typings": [
+          "shokugekinosouma"
+        ]
+      },
+      {
+        "en": "Yakitate!! Japan",
+        "ja": "焼きたて!!ジャぱん",
+        "ja_typings": [
+          "yakitatejapan"
+        ]
+      },
+      {
+        "en": "Toriko",
+        "ja": "トリコ",
+        "ja_typings": []
+      },
+      {
+        "en": "Sweetness and Lightning",
+        "ja": "甘々と稲妻",
+        "ja_typings": [
+          "amaamatoinazuma"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01146",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features a cooking competition at Totsuki Academy?",
+      "ja": "遠月学園の料理対決のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Your Lie in April",
+        "ja": "四月は君の嘘",
+        "ja_typings": [
+          "shigatsuhakiminouso"
+        ]
+      },
+      {
+        "en": "Piano no Mori",
+        "ja": "ピアノの森",
+        "ja_typings": [
+          "pianonomori"
+        ]
+      },
+      {
+        "en": "Nodame Cantabile",
+        "ja": "のだめカンタービレ",
+        "ja_typings": []
+      },
+      {
+        "en": "Forest of Piano",
+        "ja": "森のピアノ",
+        "ja_typings": [
+          "morinopiano"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01147",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features a piano prodigy named Kousei?",
+      "ja": "公生というピアノの天才が登場するアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Natsume's Book of Friends",
+        "ja": "夏目友人帳",
+        "ja_typings": [
+          "natsumeyuujinchou"
+        ]
+      },
+      {
+        "en": "Mushishi",
+        "ja": "蟲師",
+        "ja_typings": [
+          "mushishi"
+        ]
+      },
+      {
+        "en": "xxxHolic",
+        "ja": "ホリック",
+        "ja_typings": []
+      },
+      {
+        "en": "Mononoke",
+        "ja": "モノノ怪",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01148",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is about a girl who befriends a yokai cat?",
+      "ja": "妖怪の猫を友達にする少女のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Demon Slayer",
+        "ja": "鬼滅の刃",
+        "ja_typings": [
+          "kimetsunoyaiba"
+        ]
+      },
+      {
+        "en": "Jujutsu Kaisen",
+        "ja": "呪術廻戦",
+        "ja_typings": [
+          "jujutsukaisen"
+        ]
+      },
+      {
+        "en": "Chainsaw Man",
+        "ja": "チェンソーマン",
+        "ja_typings": []
+      },
+      {
+        "en": "Hell's Paradise",
+        "ja": "地獄楽",
+        "ja_typings": [
+          "jigokuraku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01149",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features Tanjiro Kamado?",
+      "ja": "竈門炭治郎が主人公のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Spice and Wolf",
+        "ja": "狼と香辛料",
+        "ja_typings": [
+          "ookamitokoushinryou"
+        ]
+      },
+      {
+        "en": "Maoyu",
+        "ja": "魔王勇者",
+        "ja_typings": [
+          "maouyuusha"
+        ]
+      },
+      {
+        "en": "Restaurant to Another World",
+        "ja": "異世界食堂",
+        "ja_typings": [
+          "isekaishokudou"
+        ]
+      },
+      {
+        "en": "Log Horizon",
+        "ja": "ログ・ホライズン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01150",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features a girl named Holo with wolf ears?",
+      "ja": "狼の耳を持つホロが登場するアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "One Punch Man",
+        "ja": "ワンパンマン",
+        "ja_typings": []
+      },
+      {
+        "en": "Mob Psycho 100",
+        "ja": "モブサイコ100",
+        "ja_typings": [
+          "mobusaiko100"
+        ]
+      },
+      {
+        "en": "My Hero Academia",
+        "ja": "僕のヒーローアカデミア",
+        "ja_typings": [
+          "bokunohiiroakademia"
+        ]
+      },
+      {
+        "en": "Tiger & Bunny",
+        "ja": "タイガー&バニー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01151",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features Saitama, a hero who defeats enemies in one punch?",
+      "ja": "一撃で敵を倒すサイタマのアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Subaru Natsuki",
+        "ja": "ナツキ・スバル",
+        "ja_typings": []
+      },
+      {
+        "en": "Kazuma Satou",
+        "ja": "佐藤和真",
+        "ja_typings": [
+          "satoukazuma"
+        ]
+      },
+      {
+        "en": "Touya Mochizuki",
+        "ja": "望月冬夜",
+        "ja_typings": [
+          "mochizukitouya"
+        ]
+      },
+      {
+        "en": "Hajime Nagumo",
+        "ja": "南雲ハジメ",
+        "ja_typings": [
+          "nagumohajime"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01152",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is about kart racing in another world with Re:Zero?",
+      "ja": "リゼロの主人公の名前は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bleach",
+        "ja": "ブリーチ",
+        "ja_typings": []
+      },
+      {
+        "en": "Yu Yu Hakusho",
+        "ja": "幽☆遊☆白書",
+        "ja_typings": [
+          "yuuyuuhakusho"
+        ]
+      },
+      {
+        "en": "Shaman King",
+        "ja": "シャーマンキング",
+        "ja_typings": []
+      },
+      {
+        "en": "Blue Exorcist",
+        "ja": "青の祓魔師",
+        "ja_typings": [
+          "aonoekusoshisuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01153",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features a Quincy named Uryu Ishida?",
+      "ja": "石田雨竜というクインシーが登場するアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Detective Conan",
+        "ja": "名探偵コナン",
+        "ja_typings": [
+          "meitanteikonan"
+        ]
+      },
+      {
+        "en": "Chainsaw Man",
+        "ja": "チェンソーマン",
+        "ja_typings": []
+      },
+      {
+        "en": "Spy x Family",
+        "ja": "スパイファミリー",
+        "ja_typings": []
+      },
+      {
+        "en": "Kingdom",
+        "ja": "キングダム",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01154",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga is published in Weekly Shonen Sunday?",
+      "ja": "週刊少年サンデーで連載されている漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Naoki Urasawa",
+        "ja": "浦沢直樹",
+        "ja_typings": [
+          "urasawanaoki"
+        ]
+      },
+      {
+        "en": "Hirohiko Araki",
+        "ja": "荒木飛呂彦",
+        "ja_typings": [
+          "arakihirohiko"
+        ]
+      },
+      {
+        "en": "Osamu Tezuka",
+        "ja": "手塚治虫",
+        "ja_typings": [
+          "tezukaosamu"
+        ]
+      },
+      {
+        "en": "Mitsuru Adachi",
+        "ja": "あだち充",
+        "ja_typings": [
+          "adachimitsuru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01155",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of 'Monster' and '20th Century Boys'?",
+      "ja": "『モンスター』『20世紀少年』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Weekly Shonen Jump",
+        "ja": "週刊少年ジャンプ",
+        "ja_typings": [
+          "shuukanshounenjanpu"
+        ]
+      },
+      {
+        "en": "Weekly Shonen Magazine",
+        "ja": "週刊少年マガジン",
+        "ja_typings": [
+          "shuukanshounenmagajin"
+        ]
+      },
+      {
+        "en": "Weekly Shonen Sunday",
+        "ja": "週刊少年サンデー",
+        "ja_typings": [
+          "shuukanshounensandee"
+        ]
+      },
+      {
+        "en": "Weekly Young Jump",
+        "ja": "週刊ヤングジャンプ",
+        "ja_typings": [
+          "shuukanyangujanpu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01156",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga magazine publishes 'One Piece'?",
+      "ja": "『ONE PIECE』を連載している雑誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Takehiko Inoue",
+        "ja": "井上雄彦",
+        "ja_typings": [
+          "inouetakehiko"
+        ]
+      },
+      {
+        "en": "Eiichiro Oda",
+        "ja": "尾田栄一郎",
+        "ja_typings": [
+          "odaeiichirou"
+        ]
+      },
+      {
+        "en": "Masashi Kishimoto",
+        "ja": "岸本斉史",
+        "ja_typings": [
+          "kishimotomasashi"
+        ]
+      },
+      {
+        "en": "Tite Kubo",
+        "ja": "久保帯人",
+        "ja_typings": [
+          "kubotaito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01157",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of 'Vagabond' and 'Slam Dunk'?",
+      "ja": "『バガボンド』『スラムダンク』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JoJo's Bizarre Adventure",
+        "ja": "ジョジョの奇妙な冒険",
+        "ja_typings": [
+          "jojonokimyounabouken"
+        ]
+      },
+      {
+        "en": "Baki the Grappler",
+        "ja": "グラップラー刃牙",
+        "ja_typings": [
+          "gurappuraabaki"
+        ]
+      },
+      {
+        "en": "Fist of the North Star",
+        "ja": "北斗の拳",
+        "ja_typings": [
+          "hokutonoken"
+        ]
+      },
+      {
+        "en": "Saint Seiya",
+        "ja": "聖闘士星矢",
+        "ja_typings": [
+          "seintoseiya"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01158",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga features the Joestar family across generations?",
+      "ja": "ジョースター家の物語の漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Food Wars!",
+        "ja": "食戟のソーマ",
+        "ja_typings": [
+          "shokugekinosouma"
+        ]
+      },
+      {
+        "en": "Toriko",
+        "ja": "トリコ",
+        "ja_typings": []
+      },
+      {
+        "en": "Mister Ajikko",
+        "ja": "ミスター味っ子",
+        "ja_typings": [
+          "misutaaajikko"
+        ]
+      },
+      {
+        "en": "Sweetness and Lightning",
+        "ja": "甘々と稲妻",
+        "ja_typings": [
+          "amaamatoinazuma"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01159",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga features chefs competing at Totsuki Academy?",
+      "ja": "遠月学園で料理を競う漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "One Piece",
+        "ja": "ワンピース",
+        "ja_typings": []
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": []
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "フェアリーテイル",
+        "ja_typings": []
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01160",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga is about a boy who can stretch his body?",
+      "ja": "体を伸ばせる少年の漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Death Note",
+        "ja": "デスノート",
+        "ja_typings": []
+      },
+      {
+        "en": "Platinum End",
+        "ja": "プラチナエンド",
+        "ja_typings": []
+      },
+      {
+        "en": "Bakuman",
+        "ja": "バクマン。",
+        "ja_typings": []
+      },
+      {
+        "en": "Liar Game",
+        "ja": "ライアーゲーム",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01161",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga features a serial killer note?",
+      "ja": "殺人ノートが登場する漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Makoto Yukimura",
+        "ja": "幸村誠",
+        "ja_typings": [
+          "yukimuramakoto"
+        ]
+      },
+      {
+        "en": "Kentaro Miura",
+        "ja": "三浦建太郎",
+        "ja_typings": [
+          "miurakentarou"
+        ]
+      },
+      {
+        "en": "Hajime Isayama",
+        "ja": "諫山創",
+        "ja_typings": [
+          "isayamahajime"
+        ]
+      },
+      {
+        "en": "Hiromu Arakawa",
+        "ja": "荒川弘",
+        "ja_typings": [
+          "arakawahiromu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01162",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of 'Vinland Saga'?",
+      "ja": "『ヴィンランド・サガ』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Maid Sama!",
+        "ja": "会長はメイド様!",
+        "ja_typings": [
+          "kaichouhameidosama"
+        ]
+      },
+      {
+        "en": "Hayate the Combat Butler",
+        "ja": "ハヤテのごとく!",
+        "ja_typings": [
+          "hayatenogotoku"
+        ]
+      },
+      {
+        "en": "Emma: A Victorian Romance",
+        "ja": "エマ",
+        "ja_typings": [
+          "ema"
+        ]
+      },
+      {
+        "en": "Black Butler",
+        "ja": "黒執事",
+        "ja_typings": [
+          "kuroshitsuji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01163",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga features a maid named Misaki Ayuzawa?",
+      "ja": "鮎沢美咲というメイドが登場する漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gintama",
+        "ja": "銀魂",
+        "ja_typings": [
+          "gintama"
+        ]
+      },
+      {
+        "en": "Rurouni Kenshin",
+        "ja": "るろうに剣心",
+        "ja_typings": [
+          "rurouninikenshin"
+        ]
+      },
+      {
+        "en": "Peacemaker Kurogane",
+        "ja": "ピースメーカー鐵",
+        "ja_typings": [
+          "piisumeekaakurogane"
+        ]
+      },
+      {
+        "en": "Hakuouki",
+        "ja": "薄桜鬼",
+        "ja_typings": [
+          "hakuouki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01164",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga is set in the Bakumatsu era with Gintoki?",
+      "ja": "幕末を舞台にした銀時の漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kodansha",
+        "ja": "講談社",
+        "ja_typings": [
+          "koudansha"
+        ]
+      },
+      {
+        "en": "Shueisha",
+        "ja": "集英社",
+        "ja_typings": [
+          "shueisha"
+        ]
+      },
+      {
+        "en": "Shogakukan",
+        "ja": "小学館",
+        "ja_typings": [
+          "shougakukan"
+        ]
+      },
+      {
+        "en": "Kadokawa",
+        "ja": "角川",
+        "ja_typings": [
+          "kadokawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01165",
+    "image_path": null,
+    "question_text": {
+      "en": "Which publisher releases 'Attack on Titan'?",
+      "ja": "『進撃の巨人』の出版社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kiyohiko Azuma",
+        "ja": "あずまきよひこ",
+        "ja_typings": []
+      },
+      {
+        "en": "Tatsuya Endo",
+        "ja": "遠藤達哉",
+        "ja_typings": [
+          "endoutatsuya"
+        ]
+      },
+      {
+        "en": "Sui Ishida",
+        "ja": "石田スイ",
+        "ja_typings": [
+          "ishidasui"
+        ]
+      },
+      {
+        "en": "Q Hayashida",
+        "ja": "林田球",
+        "ja_typings": [
+          "hayashidakyuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01166",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of 'Yotsuba&!'?",
+      "ja": "『よつばと!』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kuroko's Basketball",
+        "ja": "黒子のバスケ",
+        "ja_typings": [
+          "kuronobasuke"
+        ]
+      },
+      {
+        "en": "Slam Dunk",
+        "ja": "スラムダンク",
+        "ja_typings": []
+      },
+      {
+        "en": "Ahiru no Sora",
+        "ja": "あひるの空",
+        "ja_typings": [
+          "ahirunosora"
+        ]
+      },
+      {
+        "en": "Dear Boys",
+        "ja": "ディア・ボーイズ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01167",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga features a basketball team called Seirin?",
+      "ja": "誠凛高校バスケ部の漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Attack on Titan",
+        "ja": "進撃の巨人",
+        "ja_typings": [
+          "shingekinokyojin"
+        ]
+      },
+      {
+        "en": "Claymore",
+        "ja": "クレイモア",
+        "ja_typings": []
+      },
+      {
+        "en": "Berserk",
+        "ja": "ベルセルク",
+        "ja_typings": []
+      },
+      {
+        "en": "Goblin Slayer",
+        "ja": "ゴブリンスレイヤー",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01168",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga features the Survey Corps?",
+      "ja": "調査兵団が登場する漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tokyo Ghoul",
+        "ja": "東京喰種",
+        "ja_typings": [
+          "toukyouguuru"
+        ]
+      },
+      {
+        "en": "Parasyte",
+        "ja": "寄生獣",
+        "ja_typings": [
+          "kiseijuu"
+        ]
+      },
+      {
+        "en": "Ajin",
+        "ja": "亜人",
+        "ja_typings": [
+          "ajin"
+        ]
+      },
+      {
+        "en": "Dorohedoro",
+        "ja": "ドロヘドロ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01169",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga features ghouls in modern Tokyo?",
+      "ja": "現代東京の喰種が登場する漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Death Note",
+        "ja": "デスノート",
+        "ja_typings": []
+      },
+      {
+        "en": "Bakuman",
+        "ja": "バクマン。",
+        "ja_typings": []
+      },
+      {
+        "en": "Platinum End",
+        "ja": "プラチナエンド",
+        "ja_typings": []
+      },
+      {
+        "en": "Liar Game",
+        "ja": "ライアーゲーム",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01170",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga features the Yagami family?",
+      "ja": "夜神家が登場する漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "One Piece",
+        "ja": "ワンピース",
+        "ja_typings": []
+      },
+      {
+        "en": "Black Lagoon",
+        "ja": "ブラック・ラグーン",
+        "ja_typings": []
+      },
+      {
+        "en": "Coyote Ragtime Show",
+        "ja": "コヨーテラグタイムショー",
+        "ja_typings": []
+      },
+      {
+        "en": "Outlaw Star",
+        "ja": "アウトロースター",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01171",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga is about a boy who becomes a pirate king?",
+      "ja": "海賊王を目指す少年の漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Young Animal",
+        "ja": "ヤングアニマル",
+        "ja_typings": []
+      },
+      {
+        "en": "Big Comic",
+        "ja": "ビッグコミック",
+        "ja_typings": []
+      },
+      {
+        "en": "Morning",
+        "ja": "モーニング",
+        "ja_typings": []
+      },
+      {
+        "en": "Afternoon",
+        "ja": "アフタヌーン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01172",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga magazine publishes 'Berserk'?",
+      "ja": "『ベルセルク』を連載している雑誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Spice and Wolf",
+        "ja": "狼と香辛料",
+        "ja_typings": [
+          "ookamitokoushinryou"
+        ]
+      },
+      {
+        "en": "Kino's Journey",
+        "ja": "キノの旅",
+        "ja_typings": [
+          "kinonotabi"
+        ]
+      },
+      {
+        "en": "Maoyu",
+        "ja": "魔王勇者",
+        "ja_typings": [
+          "maouyuusha"
+        ]
+      },
+      {
+        "en": "Frieren",
+        "ja": "葬送のフリーレン",
+        "ja_typings": [
+          "sousounofurииren"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01173",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga features a girl who travels with a wolf merchant?",
+      "ja": "狼の商人と旅をする漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Delicious in Dungeon",
+        "ja": "ダンジョン飯",
+        "ja_typings": [
+          "danjonmeshi"
+        ]
+      },
+      {
+        "en": "Restaurant to Another World",
+        "ja": "異世界食堂",
+        "ja_typings": [
+          "isekaishokudou"
+        ]
+      },
+      {
+        "en": "Spice and Wolf",
+        "ja": "狼と香辛料",
+        "ja_typings": [
+          "ookamitokoushinryou"
+        ]
+      },
+      {
+        "en": "Maoyu",
+        "ja": "魔王勇者",
+        "ja_typings": [
+          "maouyuusha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01174",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga is about a delivery service in a fantasy world?",
+      "ja": "異世界の配達サービスが題材の漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rumiko Takahashi",
+        "ja": "高橋留美子",
+        "ja_typings": [
+          "takahashirumiko"
+        ]
+      },
+      {
+        "en": "Mitsuru Adachi",
+        "ja": "あだち充",
+        "ja_typings": [
+          "adachimitsuru"
+        ]
+      },
+      {
+        "en": "Naoko Takeuchi",
+        "ja": "武内直子",
+        "ja_typings": [
+          "takeuchinaoko"
+        ]
+      },
+      {
+        "en": "CLAMP",
+        "ja": "クランプ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01175",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of 'Inuyasha' and 'Ranma 1/2'?",
+      "ja": "『犬夜叉』『らんま1/2』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shota no Sushi",
+        "ja": "将太の寿司",
+        "ja_typings": [
+          "shoutanosushi"
+        ]
+      },
+      {
+        "en": "Oishinbo",
+        "ja": "美味しんぼ",
+        "ja_typings": [
+          "oishinbo"
+        ]
+      },
+      {
+        "en": "Mister Ajikko",
+        "ja": "ミスター味っ子",
+        "ja_typings": [
+          "misutaaajikko"
+        ]
+      },
+      {
+        "en": "Cooking Papa",
+        "ja": "クッキングパパ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01176",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga features a sushi chef apprentice named Shota?",
+      "ja": "翔太という寿司職人見習いの漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fairy Tail",
+        "ja": "フェアリーテイル",
+        "ja_typings": []
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": []
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": []
+      },
+      {
+        "en": "Rave Master",
+        "ja": "レイヴ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01177",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga is about wizards at Fairy Tail guild?",
+      "ja": "妖精の尻尾ギルドの魔法使いの漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dr. Stone",
+        "ja": "ドクターストーン",
+        "ja_typings": []
+      },
+      {
+        "en": "Cells at Work",
+        "ja": "はたらく細胞",
+        "ja_typings": [
+          "hatarakusaibou"
+        ]
+      },
+      {
+        "en": "Moriarty the Patriot",
+        "ja": "憂国のモリアーティ",
+        "ja_typings": [
+          "yuukokunomoriaati"
+        ]
+      },
+      {
+        "en": "Eden's Zero",
+        "ja": "エデンズゼロ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01178",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga features Senku, a science genius rebuilding civilization?",
+      "ja": "千空が文明を再建する科学漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Capcom",
+        "ja": "カプコン",
+        "ja_typings": []
+      },
+      {
+        "en": "Konami",
+        "ja": "コナミ",
+        "ja_typings": []
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": []
+      },
+      {
+        "en": "Sega",
+        "ja": "セガ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01179",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed 'Monster Hunter'?",
+      "ja": "『モンスターハンター』を開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Legend of Zelda",
+        "ja": "ゼルダの伝説",
+        "ja_typings": [
+          "zerudanodensetsu"
+        ]
+      },
+      {
+        "en": "Okami",
+        "ja": "大神",
+        "ja_typings": [
+          "ookami"
+        ]
+      },
+      {
+        "en": "Soul Reaver",
+        "ja": "ソウルリーバー",
+        "ja_typings": []
+      },
+      {
+        "en": "Ico",
+        "ja": "イコ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01180",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features a silent protagonist named Link?",
+      "ja": "リンクという主人公が登場するゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Atlus",
+        "ja": "アトラス",
+        "ja_typings": []
+      },
+      {
+        "en": "Square Enix",
+        "ja": "スクウェア・エニックス",
+        "ja_typings": []
+      },
+      {
+        "en": "Capcom",
+        "ja": "カプコン",
+        "ja_typings": []
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01181",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed 'Persona 5'?",
+      "ja": "『ペルソナ5』を開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Final Fantasy VII",
+        "ja": "ファイナルファンタジーVII",
+        "ja_typings": []
+      },
+      {
+        "en": "Kingdom Hearts",
+        "ja": "キングダムハーツ",
+        "ja_typings": []
+      },
+      {
+        "en": "Chrono Trigger",
+        "ja": "クロノ・トリガー",
+        "ja_typings": []
+      },
+      {
+        "en": "Xenogears",
+        "ja": "ゼノギアス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01182",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features Cloud Strife as the protagonist?",
+      "ja": "クラウド・ストライフが主人公のゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FromSoftware",
+        "ja": "フロム・ソフトウェア",
+        "ja_typings": []
+      },
+      {
+        "en": "Konami",
+        "ja": "コナミ",
+        "ja_typings": []
+      },
+      {
+        "en": "Capcom",
+        "ja": "カプコン",
+        "ja_typings": []
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01183",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed 'Dark Souls'?",
+      "ja": "『ダークソウル』を開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bloodborne",
+        "ja": "ブラッドボーン",
+        "ja_typings": []
+      },
+      {
+        "en": "Dark Souls",
+        "ja": "ダークソウル",
+        "ja_typings": []
+      },
+      {
+        "en": "Sekiro",
+        "ja": "隻狼",
+        "ja_typings": [
+          "sekirou"
+        ]
+      },
+      {
+        "en": "Elden Ring",
+        "ja": "エルデンリング",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01184",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features the city of Yharnam?",
+      "ja": "ヤーナムが舞台のゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sekiro: Shadows Die Twice",
+        "ja": "隻狼",
+        "ja_typings": [
+          "sekirou"
+        ]
+      },
+      {
+        "en": "Ghost of Tsushima",
+        "ja": "ゴースト・オブ・ツシマ",
+        "ja_typings": []
+      },
+      {
+        "en": "Nioh",
+        "ja": "仁王",
+        "ja_typings": [
+          "niou"
+        ]
+      },
+      {
+        "en": "Onimusha",
+        "ja": "鬼武者",
+        "ja_typings": [
+          "onimusha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01185",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features a samurai named Wolf in Sengoku Japan?",
+      "ja": "戦国時代の隻腕の狼が主人公のゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nintendo",
+        "ja": "任天堂",
+        "ja_typings": [
+          "nintendou"
+        ]
+      },
+      {
+        "en": "Sega",
+        "ja": "セガ",
+        "ja_typings": []
+      },
+      {
+        "en": "Sony",
+        "ja": "ソニー",
+        "ja_typings": []
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01186",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed 'Splatoon'?",
+      "ja": "『スプラトゥーン』を開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Splinter Cell",
+        "ja": "スプリンターセル",
+        "ja_typings": []
+      },
+      {
+        "en": "Hitman",
+        "ja": "ヒットマン",
+        "ja_typings": []
+      },
+      {
+        "en": "Thief",
+        "ja": "シーフ",
+        "ja_typings": []
+      },
+      {
+        "en": "Dishonored",
+        "ja": "ディスオナード",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01187",
+    "image_path": null,
+    "question_text": {
+      "en": "Which stealth game series features Sam Fisher?",
+      "ja": "サム・フィッシャーが主人公のステルスゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Horizon Zero Dawn",
+        "ja": "ホライゾン・ゼロ・ドーン",
+        "ja_typings": []
+      },
+      {
+        "en": "The Last of Us",
+        "ja": "ラスト・オブ・アス",
+        "ja_typings": []
+      },
+      {
+        "en": "Fallout",
+        "ja": "フォールアウト",
+        "ja_typings": []
+      },
+      {
+        "en": "Metro Exodus",
+        "ja": "メトロ・エクソダス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01188",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features the protagonist Aloy in a post-apocalyptic world?",
+      "ja": "アーロイが主人公のポストアポカリプスゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sega",
+        "ja": "セガ",
+        "ja_typings": []
+      },
+      {
+        "en": "Capcom",
+        "ja": "カプコン",
+        "ja_typings": []
+      },
+      {
+        "en": "Konami",
+        "ja": "コナミ",
+        "ja_typings": []
+      },
+      {
+        "en": "Square Enix",
+        "ja": "スクウェア・エニックス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01189",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed 'Yakuza' (Ryu ga Gotoku) series?",
+      "ja": "『龍が如く』を開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yakuza",
+        "ja": "龍が如く",
+        "ja_typings": [
+          "ryuugagotoku"
+        ]
+      },
+      {
+        "en": "Judgment",
+        "ja": "ジャッジアイズ",
+        "ja_typings": []
+      },
+      {
+        "en": "Shenmue",
+        "ja": "シェンムー",
+        "ja_typings": []
+      },
+      {
+        "en": "Way of the Samurai",
+        "ja": "侍道",
+        "ja_typings": [
+          "samuraidou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01190",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features Kazuma Kiryu as the dragon of Dojima?",
+      "ja": "堂島の龍・桐生一馬が主人公のゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Farming simulation",
+        "ja": "農場シミュレーション",
+        "ja_typings": [
+          "noujoushimyureeshon"
+        ]
+      },
+      {
+        "en": "First-person shooter",
+        "ja": "ファーストパーソン・シューター",
+        "ja_typings": []
+      },
+      {
+        "en": "Real-time strategy",
+        "ja": "リアルタイム・ストラテジー",
+        "ja_typings": []
+      },
+      {
+        "en": "Fighting",
+        "ja": "格闘",
+        "ja_typings": [
+          "kakutou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01191",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game genre is 'Stardew Valley'?",
+      "ja": "『スターデュー・バレー』のジャンルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Legend of Zelda",
+        "ja": "ゼルダの伝説",
+        "ja_typings": [
+          "zerudanodensetsu"
+        ]
+      },
+      {
+        "en": "Final Fantasy",
+        "ja": "ファイナルファンタジー",
+        "ja_typings": []
+      },
+      {
+        "en": "Dragon Quest",
+        "ja": "ドラゴンクエスト",
+        "ja_typings": []
+      },
+      {
+        "en": "Xenoblade",
+        "ja": "ゼノブレイド",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01192",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features the world of Hyrule?",
+      "ja": "ハイラルが舞台のゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Super Mario Bros.",
+        "ja": "スーパーマリオブラザーズ",
+        "ja_typings": []
+      },
+      {
+        "en": "Donkey Kong",
+        "ja": "ドンキーコング",
+        "ja_typings": []
+      },
+      {
+        "en": "Wario Land",
+        "ja": "ワリオランド",
+        "ja_typings": []
+      },
+      {
+        "en": "Yoshi's Island",
+        "ja": "ヨッシーアイランド",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01193",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features a plumber's brother named Luigi?",
+      "ja": "ルイージが登場するゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Capcom",
+        "ja": "カプコン",
+        "ja_typings": []
+      },
+      {
+        "en": "SNK",
+        "ja": "エスエヌケー",
+        "ja_typings": []
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": []
+      },
+      {
+        "en": "Arc System Works",
+        "ja": "アークシステムワークス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01194",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed 'Street Fighter'?",
+      "ja": "『ストリートファイター』を開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Street Fighter",
+        "ja": "ストリートファイター",
+        "ja_typings": []
+      },
+      {
+        "en": "King of Fighters",
+        "ja": "キング・オブ・ファイターズ",
+        "ja_typings": []
+      },
+      {
+        "en": "Tekken",
+        "ja": "鉄拳",
+        "ja_typings": [
+          "tekken"
+        ]
+      },
+      {
+        "en": "Virtua Fighter",
+        "ja": "バーチャファイター",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01195",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features Ryu and his Hadouken?",
+      "ja": "リュウと波動拳が登場するゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tekken",
+        "ja": "鉄拳",
+        "ja_typings": [
+          "tekken"
+        ]
+      },
+      {
+        "en": "Soulcalibur",
+        "ja": "ソウルキャリバー",
+        "ja_typings": []
+      },
+      {
+        "en": "Dead or Alive",
+        "ja": "デッド・オア・アライブ",
+        "ja_typings": []
+      },
+      {
+        "en": "Virtua Fighter",
+        "ja": "バーチャファイター",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01196",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game series features the Mishima family rivalry?",
+      "ja": "三島家の確執が描かれる格闘ゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Terraria",
+        "ja": "テラリア",
+        "ja_typings": []
+      },
+      {
+        "en": "Minecraft Dungeons",
+        "ja": "マインクラフト・ダンジョンズ",
+        "ja_typings": []
+      },
+      {
+        "en": "Minecraft Legends",
+        "ja": "マインクラフト・レジェンズ",
+        "ja_typings": []
+      },
+      {
+        "en": "Minecraft Earth",
+        "ja": "マインクラフト・アース",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01197",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features building with blocks named NOT Minecraft?",
+      "ja": "ブロックを積むゲームでマインクラフトではないのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "God of War",
+        "ja": "ゴッド・オブ・ウォー",
+        "ja_typings": []
+      },
+      {
+        "en": "Devil May Cry",
+        "ja": "デビル・メイ・クライ",
+        "ja_typings": []
+      },
+      {
+        "en": "Bayonetta",
+        "ja": "ベヨネッタ",
+        "ja_typings": []
+      },
+      {
+        "en": "Darksiders",
+        "ja": "ダークサイダーズ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01198",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features the protagonist Kratos?",
+      "ja": "クレイトスが主人公のゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sega",
+        "ja": "セガ",
+        "ja_typings": []
+      },
+      {
+        "en": "Square Enix",
+        "ja": "スクウェア・エニックス",
+        "ja_typings": []
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": []
+      },
+      {
+        "en": "Koei Tecmo",
+        "ja": "コーエーテクモ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01199",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed 'Phantasy Star Online'?",
+      "ja": "『ファンタシースターオンライン』を開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Witcher",
+        "ja": "ウィッチャー",
+        "ja_typings": []
+      },
+      {
+        "en": "Skyrim",
+        "ja": "スカイリム",
+        "ja_typings": []
+      },
+      {
+        "en": "Dragon Age",
+        "ja": "ドラゴン・エイジ",
+        "ja_typings": []
+      },
+      {
+        "en": "Kingdom Come Deliverance",
+        "ja": "キングダムカム・デリバランス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01200",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features Geralt of Rivia?",
+      "ja": "リヴィアのゲラルトが主人公のゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Turn-based strategy",
+        "ja": "ターン制ストラテジー",
+        "ja_typings": []
+      },
+      {
+        "en": "Real-time strategy",
+        "ja": "リアルタイム・ストラテジー",
+        "ja_typings": []
+      },
+      {
+        "en": "Action RPG",
+        "ja": "アクションRPG",
+        "ja_typings": []
+      },
+      {
+        "en": "Sandbox",
+        "ja": "サンドボックス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01201",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game genre is 'Civilization'?",
+      "ja": "『シヴィライゼーション』のジャンルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sonic the Hedgehog",
+        "ja": "ソニック・ザ・ヘッジホッグ",
+        "ja_typings": []
+      },
+      {
+        "en": "Crash Bandicoot",
+        "ja": "クラッシュ・バンディクー",
+        "ja_typings": []
+      },
+      {
+        "en": "Spyro the Dragon",
+        "ja": "スパイロ・ザ・ドラゴン",
+        "ja_typings": []
+      },
+      {
+        "en": "Rayman",
+        "ja": "レイマン",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01202",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features Sonic the hedgehog?",
+      "ja": "ソニックが登場するゲームシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Square Enix",
+        "ja": "スクウェア・エニックス",
+        "ja_typings": []
+      },
+      {
+        "en": "Atlus",
+        "ja": "アトラス",
+        "ja_typings": []
+      },
+      {
+        "en": "Capcom",
+        "ja": "カプコン",
+        "ja_typings": []
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01203",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed 'Kingdom Hearts'?",
+      "ja": "『キングダムハーツ』を開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kingdom Hearts",
+        "ja": "キングダムハーツ",
+        "ja_typings": []
+      },
+      {
+        "en": "Final Fantasy",
+        "ja": "ファイナルファンタジー",
+        "ja_typings": []
+      },
+      {
+        "en": "The World Ends with You",
+        "ja": "すばらしきこのせかい",
+        "ja_typings": [
+          "subarashikikonosekai"
+        ]
+      },
+      {
+        "en": "Nier",
+        "ja": "ニーア",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01204",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features Sora wielding a Keyblade?",
+      "ja": "ソラがキーブレードを使うゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Silent Hill",
+        "ja": "サイレントヒル",
+        "ja_typings": []
+      },
+      {
+        "en": "Fatal Frame",
+        "ja": "零",
+        "ja_typings": [
+          "zero"
+        ]
+      },
+      {
+        "en": "Clock Tower",
+        "ja": "クロックタワー",
+        "ja_typings": []
+      },
+      {
+        "en": "Forbidden Siren series",
+        "ja": "サイレン シリーズ",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01205",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game series features survival in a haunted town?",
+      "ja": "幽霊の町でのサバイバルゲームシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Titanfall",
+        "ja": "タイタンフォール",
+        "ja_typings": []
+      },
+      {
+        "en": "Armored Core",
+        "ja": "アーマード・コア",
+        "ja_typings": []
+      },
+      {
+        "en": "MechWarrior",
+        "ja": "メックウォリアー",
+        "ja_typings": []
+      },
+      {
+        "en": "Front Mission",
+        "ja": "フロントミッション",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01206",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features pilots and Titans in combat?",
+      "ja": "パイロットとタイタンが戦うゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Engineer",
+        "ja": "エンジニア",
+        "ja_typings": []
+      },
+      {
+        "en": "Soldier",
+        "ja": "兵士",
+        "ja_typings": [
+          "heishi"
+        ]
+      },
+      {
+        "en": "Doctor",
+        "ja": "医者",
+        "ja_typings": [
+          "isha"
+        ]
+      },
+      {
+        "en": "Scientist",
+        "ja": "科学者",
+        "ja_typings": [
+          "kagakusha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01207",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features a janitor turned hero named Isaac in Dead Space?",
+      "ja": "デッドスペースの主人公アイザックの職業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nier Automata",
+        "ja": "ニーア・オートマタ",
+        "ja_typings": []
+      },
+      {
+        "en": "Drakengard",
+        "ja": "ドラッグ・オン・ドラグーン",
+        "ja_typings": []
+      },
+      {
+        "en": "Stellar Blade",
+        "ja": "ステラーブレイド",
+        "ja_typings": []
+      },
+      {
+        "en": "Scarlet Nexus",
+        "ja": "スカーレットネクサス",
+        "ja_typings": []
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01208",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features a girl named 2B fighting machines?",
+      "ja": "2Bが機械生命体と戦うゲームは?"
+    }
   }
 ]

--- a/data/questions_ja.json
+++ b/data/questions_ja.json
@@ -49175,5 +49175,22472 @@
       "en": "Which game features a girl named 2B fighting machines?",
       "ja": "2Bが機械生命体と戦うゲームは?"
     }
+  },
+  {
+    "choices": [
+      {
+        "en": "collections.OrderedDict",
+        "ja": "コレクションズオーダードディクト",
+        "ja_typings": [
+          "korekushonzuo-da-dodikuto"
+        ]
+      },
+      {
+        "en": "collections.deque",
+        "ja": "コレクションズデック",
+        "ja_typings": [
+          "korekushonzudekku"
+        ]
+      },
+      {
+        "en": "collections.ChainMap",
+        "ja": "コレクションズチェインマップ",
+        "ja_typings": [
+          "korekushonzucheinmappu"
+        ]
+      },
+      {
+        "en": "collections.UserDict",
+        "ja": "コレクションズユーザーディクト",
+        "ja_typings": [
+          "korekushonzuyu-za-dikuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01209",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Python module for ordered dictionaries (insertion-ordered) added in 3.7 as guaranteed?",
+      "ja": "Python 3.7 で挿入順序が保証された辞書の特殊型を提供するモジュールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "functools.lru_cache",
+        "ja": "ファンクツールズエルアールユーキャッシュ",
+        "ja_typings": [
+          "fankutsu-ruzuerua-ruyu-kyasshu"
+        ]
+      },
+      {
+        "en": "functools.partial",
+        "ja": "ファンクツールズパーシャル",
+        "ja_typings": [
+          "fankutsu-ruzupa-sharu"
+        ]
+      },
+      {
+        "en": "functools.reduce",
+        "ja": "ファンクツールズリデュース",
+        "ja_typings": [
+          "fankutsu-ruzurideyu-su"
+        ]
+      },
+      {
+        "en": "functools.wraps",
+        "ja": "ファンクツールズラップス",
+        "ja_typings": [
+          "fankutsu-ruzurappusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01210",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Python decorator caches return values based on arguments?",
+      "ja": "Python で引数に基づいて戻り値をキャッシュするデコレーターは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "with",
+        "ja": "ウィズ",
+        "ja_typings": [
+          "wizu"
+        ]
+      },
+      {
+        "en": "try",
+        "ja": "トライ",
+        "ja_typings": [
+          "torai"
+        ]
+      },
+      {
+        "en": "yield",
+        "ja": "イールド",
+        "ja_typings": [
+          "i-rudo"
+        ]
+      },
+      {
+        "en": "async",
+        "ja": "エイシンク",
+        "ja_typings": [
+          "eishinku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01211",
+    "image_path": null,
+    "question_text": {
+      "en": "What Python statement creates a context manager inline?",
+      "ja": "Python でコンテキストマネージャをインラインで作成する文は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "enumerate",
+        "ja": "エニュメレート",
+        "ja_typings": [
+          "enyumere-to"
+        ]
+      },
+      {
+        "en": "zip",
+        "ja": "ジップ",
+        "ja_typings": [
+          "jippu"
+        ]
+      },
+      {
+        "en": "map",
+        "ja": "マップ",
+        "ja_typings": [
+          "mappu"
+        ]
+      },
+      {
+        "en": "filter",
+        "ja": "フィルター",
+        "ja_typings": [
+          "firuta-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01212",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Python builtin returns an iterator of tuples pairing index and value?",
+      "ja": "インデックスと値をペアにしたタプルのイテレータを返す Python 組み込み関数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "async def",
+        "ja": "エイシンクデフ",
+        "ja_typings": [
+          "eishinkudefu"
+        ]
+      },
+      {
+        "en": "def coroutine",
+        "ja": "デフコルーチン",
+        "ja_typings": [
+          "defukoru-chin"
+        ]
+      },
+      {
+        "en": "yield from",
+        "ja": "イールドフロム",
+        "ja_typings": [
+          "i-rudofuromu"
+        ]
+      },
+      {
+        "en": "await def",
+        "ja": "アウェイトデフ",
+        "ja_typings": [
+          "aweitodefu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01213",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Python keyword defines a coroutine function?",
+      "ja": "Python でコルーチン関数を定義するキーワードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": ":=",
+        "ja": "コロンイコール",
+        "ja_typings": [
+          "koronniko-ru"
+        ]
+      },
+      {
+        "en": "=>",
+        "ja": "イコールグレーター",
+        "ja_typings": [
+          "iko-rugure-ta-"
+        ]
+      },
+      {
+        "en": "<-",
+        "ja": "レフトアロー",
+        "ja_typings": [
+          "refutoaro-"
+        ]
+      },
+      {
+        "en": "->",
+        "ja": "ライトアロー",
+        "ja_typings": [
+          "raitoaro-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01214",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Python's walrus operator?",
+      "ja": "Python のセイウチ演算子はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "collections.abc",
+        "ja": "コレクションズエービーシー",
+        "ja_typings": [
+          "korekushonzue-bi-shi-"
+        ]
+      },
+      {
+        "en": "typing.abc",
+        "ja": "タイピングエービーシー",
+        "ja_typings": [
+          "taipingue-bi-shi-"
+        ]
+      },
+      {
+        "en": "abc.collections",
+        "ja": "エービーシーコレクションズ",
+        "ja_typings": [
+          "e-bi-shi-korekushonzu"
+        ]
+      },
+      {
+        "en": "base.abc",
+        "ja": "ベースエービーシー",
+        "ja_typings": [
+          "be-sue-bi-shi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01215",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Python module provides abstract base classes for containers?",
+      "ja": "コンテナの抽象基底クラスを提供する Python モジュールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Global Interpreter Lock",
+        "ja": "グローバルインタープリターロック",
+        "ja_typings": [
+          "guro-baruinta-purita-rokku"
+        ]
+      },
+      {
+        "en": "General Iteration Loop",
+        "ja": "ジェネラルイテレーションループ",
+        "ja_typings": [
+          "jeneraruitere-shonru-pu"
+        ]
+      },
+      {
+        "en": "Garbage Inspection Layer",
+        "ja": "ガベージインスペクションレイヤー",
+        "ja_typings": [
+          "gabe-jiinsupekushonreiya-"
+        ]
+      },
+      {
+        "en": "Generic Internal Library",
+        "ja": "ジェネリックインターナルライブラリ",
+        "ja_typings": [
+          "jenerikkuinta-naruraiburari"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01216",
+    "image_path": null,
+    "question_text": {
+      "en": "What does Python's GIL stand for?",
+      "ja": "Python の GIL の正式名称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "const fn",
+        "ja": "コンストエフエヌ",
+        "ja_typings": [
+          "konsutoefuenu"
+        ]
+      },
+      {
+        "en": "static fn",
+        "ja": "スタティックエフエヌ",
+        "ja_typings": [
+          "sutatikkuefuenu"
+        ]
+      },
+      {
+        "en": "comptime fn",
+        "ja": "コンプタイムエフエヌ",
+        "ja_typings": [
+          "konputaimuefuenu"
+        ]
+      },
+      {
+        "en": "eval fn",
+        "ja": "イーバルエフエヌ",
+        "ja_typings": [
+          "i-baruefuenu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01217",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Rust attribute marks a function for compile-time evaluation?",
+      "ja": "Rust でコンパイル時評価のために関数をマークする属性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "RefCell",
+        "ja": "レフセル",
+        "ja_typings": [
+          "refuseru"
+        ]
+      },
+      {
+        "en": "UnsafeCell",
+        "ja": "アンセーフセル",
+        "ja_typings": [
+          "anse-fuseru"
+        ]
+      },
+      {
+        "en": "Cell",
+        "ja": "セル",
+        "ja_typings": [
+          "seru"
+        ]
+      },
+      {
+        "en": "OnceCell",
+        "ja": "ワンスセル",
+        "ja_typings": [
+          "wansuseru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01218",
+    "image_path": null,
+    "question_text": {
+      "en": "What Rust smart pointer enables interior mutability with runtime borrow checking?",
+      "ja": "実行時借用チェックで内部可変性を可能にする Rust のスマートポインタは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "#[derive(Debug)]",
+        "ja": "デライブデバッグ",
+        "ja_typings": [
+          "deraibudebaggu"
+        ]
+      },
+      {
+        "en": "#[debug]",
+        "ja": "デバッグ",
+        "ja_typings": [
+          "debaggu"
+        ]
+      },
+      {
+        "en": "#[impl(Debug)]",
+        "ja": "インプルデバッグ",
+        "ja_typings": [
+          "inpurudebaggu"
+        ]
+      },
+      {
+        "en": "#[trait(Debug)]",
+        "ja": "トレイトデバッグ",
+        "ja_typings": [
+          "toreitodebaggu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01219",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Rust macro derives Debug formatting?",
+      "ja": "Rust で Debug フォーマットを派生させるマクロは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "? operator",
+        "ja": "クエスチョン演算子",
+        "ja_typings": [
+          "kuesuchonenzanshi"
+        ]
+      },
+      {
+        "en": "try block",
+        "ja": "トライブロック",
+        "ja_typings": [
+          "toraiburokku"
+        ]
+      },
+      {
+        "en": "panic macro",
+        "ja": "パニックマクロ",
+        "ja_typings": [
+          "panikkumakuro"
+        ]
+      },
+      {
+        "en": "unwrap chain",
+        "ja": "アンラップチェーン",
+        "ja_typings": [
+          "anrappuche-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01220",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Rust's zero-cost abstraction for fallible operations?",
+      "ja": "失敗しうる操作のための Rust のゼロコスト抽象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "where",
+        "ja": "ホエア",
+        "ja_typings": [
+          "hoea"
+        ]
+      },
+      {
+        "en": "bound",
+        "ja": "バウンド",
+        "ja_typings": [
+          "baundo"
+        ]
+      },
+      {
+        "en": "constraint",
+        "ja": "コンストレイント",
+        "ja_typings": [
+          "konsutoreinto"
+        ]
+      },
+      {
+        "en": "requires",
+        "ja": "リクワイアズ",
+        "ja_typings": [
+          "rikuwaiazu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01221",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Rust keyword introduces a trait bound on a generic?",
+      "ja": "Rust でジェネリクスにトレイト境界を導入するキーワードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "if let",
+        "ja": "イフレット",
+        "ja_typings": [
+          "ifuretto"
+        ]
+      },
+      {
+        "en": "if match",
+        "ja": "イフマッチ",
+        "ja_typings": [
+          "ifumatchi"
+        ]
+      },
+      {
+        "en": "when let",
+        "ja": "ホエンレット",
+        "ja_typings": [
+          "hoenretto"
+        ]
+      },
+      {
+        "en": "case let",
+        "ja": "ケースレット",
+        "ja_typings": [
+          "ke-suretto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01222",
+    "image_path": null,
+    "question_text": {
+      "en": "What Rust feature allows pattern matching on enum variants?",
+      "ja": "Rust で enum バリアントへのパターンマッチを可能にする機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Array.from",
+        "ja": "アレイフロム",
+        "ja_typings": [
+          "areifuromu"
+        ]
+      },
+      {
+        "en": "Array.of",
+        "ja": "アレイオブ",
+        "ja_typings": [
+          "areiobu"
+        ]
+      },
+      {
+        "en": "Array.copy",
+        "ja": "アレイコピー",
+        "ja_typings": [
+          "areikopi-"
+        ]
+      },
+      {
+        "en": "Array.clone",
+        "ja": "アレイクローン",
+        "ja_typings": [
+          "areikuro-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01223",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript method creates a shallow copy of an array?",
+      "ja": "配列の浅いコピーを作成する JavaScript のメソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "??",
+        "ja": "ダブルクエスチョン",
+        "ja_typings": [
+          "daburukuesuchon"
+        ]
+      },
+      {
+        "en": "||",
+        "ja": "ダブルパイプ",
+        "ja_typings": [
+          "daburupaipu"
+        ]
+      },
+      {
+        "en": "&&",
+        "ja": "ダブルアンパサンド",
+        "ja_typings": [
+          "daburuanpasando"
+        ]
+      },
+      {
+        "en": "?:",
+        "ja": "クエスチョンコロン",
+        "ja_typings": [
+          "kuesuchonkoron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01224",
+    "image_path": null,
+    "question_text": {
+      "en": "What JavaScript operator performs nullish coalescing?",
+      "ja": "JavaScript で null 合体演算を行う演算子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Partial",
+        "ja": "パーシャル",
+        "ja_typings": [
+          "pa-sharu"
+        ]
+      },
+      {
+        "en": "Required",
+        "ja": "リクワイアド",
+        "ja_typings": [
+          "rikuwaiado"
+        ]
+      },
+      {
+        "en": "Readonly",
+        "ja": "リードオンリー",
+        "ja_typings": [
+          "ri-donri-",
+          "ri-doonri-"
+        ]
+      },
+      {
+        "en": "Pick",
+        "ja": "ピック",
+        "ja_typings": [
+          "pikku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01225",
+    "image_path": null,
+    "question_text": {
+      "en": "Which TypeScript utility type makes all properties optional?",
+      "ja": "全プロパティを省略可能にする TypeScript ユーティリティ型は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "never",
+        "ja": "ネバー",
+        "ja_typings": [
+          "neba-"
+        ]
+      },
+      {
+        "en": "void",
+        "ja": "ボイド",
+        "ja_typings": [
+          "boido"
+        ]
+      },
+      {
+        "en": "unknown",
+        "ja": "アンノウン",
+        "ja_typings": [
+          "annnon",
+          "annnoun"
+        ]
+      },
+      {
+        "en": "undefined",
+        "ja": "アンディファインド",
+        "ja_typings": [
+          "andifaindo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01226",
+    "image_path": null,
+    "question_text": {
+      "en": "What TypeScript feature represents a value that never occurs?",
+      "ja": "決して発生しない値を表す TypeScript の機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Web Worker",
+        "ja": "ウェブワーカー",
+        "ja_typings": [
+          "webuwa-ka-"
+        ]
+      },
+      {
+        "en": "SharedWorker",
+        "ja": "シェアードワーカー",
+        "ja_typings": [
+          "shea-dowa-ka-"
+        ]
+      },
+      {
+        "en": "AudioWorklet",
+        "ja": "オーディオワークレット",
+        "ja_typings": [
+          "o-diowa-kuretto"
+        ]
+      },
+      {
+        "en": "Atomics",
+        "ja": "アトミックス",
+        "ja_typings": [
+          "atomikkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01227",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript API provides a way to run code in a separate thread?",
+      "ja": "別スレッドでコードを実行する方法を提供する JavaScript の API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Iteration protocol",
+        "ja": "イテレーションプロトコル",
+        "ja_typings": [
+          "itere-shonpurotokoru"
+        ]
+      },
+      {
+        "en": "Comparison protocol",
+        "ja": "コンパリソンプロトコル",
+        "ja_typings": [
+          "konparisonpurotokoru"
+        ]
+      },
+      {
+        "en": "Hashing protocol",
+        "ja": "ハッシングプロトコル",
+        "ja_typings": [
+          "hasshingupurotokoru"
+        ]
+      },
+      {
+        "en": "Serialization protocol",
+        "ja": "シリアライゼーションプロトコル",
+        "ja_typings": [
+          "shiriaraize-shonpurotokoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01228",
+    "image_path": null,
+    "question_text": {
+      "en": "What does JavaScript's Symbol.iterator define?",
+      "ja": "JavaScript の Symbol.iterator が定義するものは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Object.freeze",
+        "ja": "オブジェクトフリーズ",
+        "ja_typings": [
+          "obujekutofuri-zu"
+        ]
+      },
+      {
+        "en": "Object.seal",
+        "ja": "オブジェクトシール",
+        "ja_typings": [
+          "obujekutoshi-ru"
+        ]
+      },
+      {
+        "en": "Object.lock",
+        "ja": "オブジェクトロック",
+        "ja_typings": [
+          "obujekutorokku"
+        ]
+      },
+      {
+        "en": "Object.const",
+        "ja": "オブジェクトコンスト",
+        "ja_typings": [
+          "obujekutokonsuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01229",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript expression freezes an object?",
+      "ja": "オブジェクトを凍結する JavaScript の式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "go",
+        "ja": "ゴー",
+        "ja_typings": [
+          "go-"
+        ]
+      },
+      {
+        "en": "spawn",
+        "ja": "スポーン",
+        "ja_typings": [
+          "supo-n"
+        ]
+      },
+      {
+        "en": "async",
+        "ja": "エイシンク",
+        "ja_typings": [
+          "eishinku"
+        ]
+      },
+      {
+        "en": "thread",
+        "ja": "スレッド",
+        "ja_typings": [
+          "sureddo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01230",
+    "image_path": null,
+    "question_text": {
+      "en": "What Go keyword starts a lightweight thread?",
+      "ja": "軽量スレッドを開始する Go のキーワードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "select",
+        "ja": "セレクト",
+        "ja_typings": [
+          "serekuto"
+        ]
+      },
+      {
+        "en": "switch",
+        "ja": "スイッチ",
+        "ja_typings": [
+          "suitchi"
+        ]
+      },
+      {
+        "en": "choose",
+        "ja": "チューズ",
+        "ja_typings": [
+          "chu-zu"
+        ]
+      },
+      {
+        "en": "when",
+        "ja": "ホエン",
+        "ja_typings": [
+          "hoen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01231",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Go construct enables typed channel communication selection?",
+      "ja": "型付きチャネル通信の選択を可能にする Go の構文は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "defer",
+        "ja": "ディファー",
+        "ja_typings": [
+          "difa-"
+        ]
+      },
+      {
+        "en": "finally",
+        "ja": "ファイナリー",
+        "ja_typings": [
+          "fainari-"
+        ]
+      },
+      {
+        "en": "cleanup",
+        "ja": "クリーンアップ",
+        "ja_typings": [
+          "kuri-nnappu"
+        ]
+      },
+      {
+        "en": "postpone",
+        "ja": "ポストポーン",
+        "ja_typings": [
+          "posutopo-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01232",
+    "image_path": null,
+    "question_text": {
+      "en": "What Go feature is used for deferred function execution at scope end?",
+      "ja": "スコープ末尾での関数実行を遅延する Go の機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sync",
+        "ja": "シンク",
+        "ja_typings": [
+          "shinku"
+        ]
+      },
+      {
+        "en": "atomic",
+        "ja": "アトミック",
+        "ja_typings": [
+          "atomikku"
+        ]
+      },
+      {
+        "en": "lock",
+        "ja": "ロック",
+        "ja_typings": [
+          "rokku"
+        ]
+      },
+      {
+        "en": "mutex",
+        "ja": "ミューテックス",
+        "ja_typings": [
+          "myu-tekkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01233",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Go package provides synchronization primitives?",
+      "ja": "同期プリミティブを提供する Go のパッケージは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "unique_ptr",
+        "ja": "ユニークピーティーアール",
+        "ja_typings": [
+          "yuni-kupi-ti-a-ru"
+        ]
+      },
+      {
+        "en": "shared_ptr",
+        "ja": "シェアードピーティーアール",
+        "ja_typings": [
+          "shea-dopi-ti-a-ru"
+        ]
+      },
+      {
+        "en": "weak_ptr",
+        "ja": "ウィークピーティーアール",
+        "ja_typings": [
+          "wi-kupi-ti-a-ru"
+        ]
+      },
+      {
+        "en": "auto_ptr",
+        "ja": "オートピーティーアール",
+        "ja_typings": [
+          "o-topi-ti-a-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01234",
+    "image_path": null,
+    "question_text": {
+      "en": "Which C++ smart pointer represents exclusive ownership?",
+      "ja": "排他的所有権を表す C++ のスマートポインタは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "explicit",
+        "ja": "エクスプリシット",
+        "ja_typings": [
+          "ekusupurishitto"
+        ]
+      },
+      {
+        "en": "implicit",
+        "ja": "インプリシット",
+        "ja_typings": [
+          "inpurishitto"
+        ]
+      },
+      {
+        "en": "noexcept",
+        "ja": "ノーエクセプト",
+        "ja_typings": [
+          "no-ekuseputo"
+        ]
+      },
+      {
+        "en": "constexpr",
+        "ja": "コンストエクスパー",
+        "ja_typings": [
+          "konsutoekusupa-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01235",
+    "image_path": null,
+    "question_text": {
+      "en": "What C++ keyword prevents implicit conversions for constructors?",
+      "ja": "コンストラクタの暗黙変換を防ぐ C++ のキーワードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "constexpr",
+        "ja": "コンストエクスパー",
+        "ja_typings": [
+          "konsutoekusupa-"
+        ]
+      },
+      {
+        "en": "inline",
+        "ja": "インライン",
+        "ja_typings": [
+          "inrain"
+        ]
+      },
+      {
+        "en": "consteval",
+        "ja": "コンストイーバル",
+        "ja_typings": [
+          "konsutoi-baru"
+        ]
+      },
+      {
+        "en": "static",
+        "ja": "スタティック",
+        "ja_typings": [
+          "sutatikku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01236",
+    "image_path": null,
+    "question_text": {
+      "en": "Which C++ feature enables compile-time computation?",
+      "ja": "コンパイル時計算を可能にする C++ の機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "C++20",
+        "ja": "シープラプラニジュウ",
+        "ja_typings": [
+          "C++20",
+          "shi-purapuranijuu"
+        ]
+      },
+      {
+        "en": "C++17",
+        "ja": "シープラプラジュウナナ",
+        "ja_typings": [
+          "C++17",
+          "shi-purapurajuunana"
+        ]
+      },
+      {
+        "en": "C++14",
+        "ja": "シープラプラジュウヨン",
+        "ja_typings": [
+          "C++14",
+          "shi-purapurajuuyon"
+        ]
+      },
+      {
+        "en": "C++11",
+        "ja": "シープラプラジュウイチ",
+        "ja_typings": [
+          "C++11",
+          "shi-purapurajuuichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01237",
+    "image_path": null,
+    "question_text": {
+      "en": "What C++ standard introduced concepts?",
+      "ja": "concepts を導入した C++ 標準は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "dynamic_cast",
+        "ja": "ダイナミックキャスト",
+        "ja_typings": [
+          "dainamikkukyasuto"
+        ]
+      },
+      {
+        "en": "static_cast",
+        "ja": "スタティックキャスト",
+        "ja_typings": [
+          "sutatikkukyasuto"
+        ]
+      },
+      {
+        "en": "reinterpret_cast",
+        "ja": "リインタープリットキャスト",
+        "ja_typings": [
+          "riinta-purittokyasuto"
+        ]
+      },
+      {
+        "en": "const_cast",
+        "ja": "コンストキャスト",
+        "ja_typings": [
+          "konsutokyasuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01238",
+    "image_path": null,
+    "question_text": {
+      "en": "Which C++ cast performs runtime type checking?",
+      "ja": "実行時型チェックを行う C++ のキャストは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "object",
+        "ja": "オブジェクト",
+        "ja_typings": [
+          "obujekuto"
+        ]
+      },
+      {
+        "en": "singleton",
+        "ja": "シングルトン",
+        "ja_typings": [
+          "shinguruton"
+        ]
+      },
+      {
+        "en": "static",
+        "ja": "スタティック",
+        "ja_typings": [
+          "sutatikku"
+        ]
+      },
+      {
+        "en": "companion",
+        "ja": "コンパニオン",
+        "ja_typings": [
+          "konpanion"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01239",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Kotlin keyword declares a singleton object?",
+      "ja": "Kotlin でシングルトンオブジェクトを宣言するキーワードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "?.",
+        "ja": "クエスチョンドット",
+        "ja_typings": [
+          "kuesuchondotto"
+        ]
+      },
+      {
+        "en": "!!",
+        "ja": "ダブルバン",
+        "ja_typings": [
+          "daburuban"
+        ]
+      },
+      {
+        "en": "?:",
+        "ja": "エルビス",
+        "ja_typings": [
+          "erubisu"
+        ]
+      },
+      {
+        "en": "::",
+        "ja": "ダブルコロン",
+        "ja_typings": [
+          "daburukoron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01240",
+    "image_path": null,
+    "question_text": {
+      "en": "What Kotlin function-like type allows null-safe call chaining?",
+      "ja": "null 安全なチェーンを可能にする Kotlin の演算子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "let",
+        "ja": "レット",
+        "ja_typings": [
+          "retto"
+        ]
+      },
+      {
+        "en": "var",
+        "ja": "バー",
+        "ja_typings": [
+          "ba-"
+        ]
+      },
+      {
+        "en": "const",
+        "ja": "コンスト",
+        "ja_typings": [
+          "konsuto"
+        ]
+      },
+      {
+        "en": "final",
+        "ja": "ファイナル",
+        "ja_typings": [
+          "fainaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01241",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Swift keyword declares an immutable binding?",
+      "ja": "Swift で不変束縛を宣言するキーワードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "nil coalescing",
+        "ja": "ニルコアレッシング",
+        "ja_typings": [
+          "nirukoaresshingu"
+        ]
+      },
+      {
+        "en": "optional binding",
+        "ja": "オプショナルバインディング",
+        "ja_typings": [
+          "opushonarubaindingu"
+        ]
+      },
+      {
+        "en": "forced unwrap",
+        "ja": "フォースドアンラップ",
+        "ja_typings": [
+          "fo-sudoanrappu"
+        ]
+      },
+      {
+        "en": "guard let",
+        "ja": "ガードレット",
+        "ja_typings": [
+          "ga-doretto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01242",
+    "image_path": null,
+    "question_text": {
+      "en": "What Swift feature handles optional values with default fallback?",
+      "ja": "省略可能値をデフォルトでフォールバックする Swift の機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Doubly linked list + hash map",
+        "ja": "双方向連結リスト + ハッシュマップ",
+        "ja_typings": [
+          "souhoukourenketsurisuto/+/hasshumappu"
+        ]
+      },
+      {
+        "en": "Singly linked list",
+        "ja": "単方向連結リスト",
+        "ja_typings": [
+          "tanhoukourenketsurisuto"
+        ]
+      },
+      {
+        "en": "Binary heap",
+        "ja": "二分ヒープ",
+        "ja_typings": [
+          "nibunhi-pu"
+        ]
+      },
+      {
+        "en": "AVL tree",
+        "ja": "エーブイエルツリー",
+        "ja_typings": [
+          "e-buierutsuri-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01243",
+    "image_path": null,
+    "question_text": {
+      "en": "Which data structure is best for LRU cache implementation?",
+      "ja": "LRU キャッシュ実装に最適なデータ構造は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "O(n^2)",
+        "ja": "オーエヌジジョウ",
+        "ja_typings": [
+          "O(n^2)",
+          "o-enujijo",
+          "o-enujijou"
+        ]
+      },
+      {
+        "en": "O(n log n)",
+        "ja": "オーエヌログエヌ",
+        "ja_typings": [
+          "O(n log n)",
+          "o-enuroguenu"
+        ]
+      },
+      {
+        "en": "O(1)",
+        "ja": "オーイチ",
+        "ja_typings": [
+          "O(1)",
+          "o-ichi"
+        ]
+      },
+      {
+        "en": "O(log n)",
+        "ja": "オーログエヌ",
+        "ja_typings": [
+          "O(log n)",
+          "o-roguenu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01244",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the worst-case time complexity of quicksort?",
+      "ja": "クイックソートの最悪計算量は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Red-black tree",
+        "ja": "レッドブラックツリー",
+        "ja_typings": [
+          "reddoburakkutsuri-"
+        ]
+      },
+      {
+        "en": "Splay tree",
+        "ja": "スプレイツリー",
+        "ja_typings": [
+          "supureitsuri-"
+        ]
+      },
+      {
+        "en": "B-tree",
+        "ja": "ビーツリー",
+        "ja_typings": [
+          "bi-tsuri-"
+        ]
+      },
+      {
+        "en": "Trie",
+        "ja": "トライ",
+        "ja_typings": [
+          "torai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01245",
+    "image_path": null,
+    "question_text": {
+      "en": "Which tree is self-balancing with red and black node coloring?",
+      "ja": "赤黒ノード彩色で自己平衡する木は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Floyd algorithm",
+        "ja": "フロイドアルゴリズム",
+        "ja_typings": [
+          "furoidoarugorizumu"
+        ]
+      },
+      {
+        "en": "Kruskal algorithm",
+        "ja": "クラスカルアルゴリズム",
+        "ja_typings": [
+          "kurasukaruarugorizumu"
+        ]
+      },
+      {
+        "en": "Prim algorithm",
+        "ja": "プリムアルゴリズム",
+        "ja_typings": [
+          "purimuarugorizumu"
+        ]
+      },
+      {
+        "en": "Bellman-Ford",
+        "ja": "ベルマンフォード",
+        "ja_typings": [
+          "berumanfo-do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01246",
+    "image_path": null,
+    "question_text": {
+      "en": "What algorithm finds shortest paths from all pairs in a graph?",
+      "ja": "グラフの全頂点間最短路を求めるアルゴリズムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Trie",
+        "ja": "トライ木",
+        "ja_typings": [
+          "toraiki"
+        ]
+      },
+      {
+        "en": "Suffix array",
+        "ja": "サフィックスアレイ",
+        "ja_typings": [
+          "safikkusuarei"
+        ]
+      },
+      {
+        "en": "Segment tree",
+        "ja": "セグメントツリー",
+        "ja_typings": [
+          "segumentotsuri-"
+        ]
+      },
+      {
+        "en": "Fenwick tree",
+        "ja": "フェニックツリー",
+        "ja_typings": [
+          "fenikkutsuri-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01247",
+    "image_path": null,
+    "question_text": {
+      "en": "Which data structure supports efficient prefix search of strings?",
+      "ja": "文字列の効率的な前方一致検索を支援するデータ構造は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Doubling strategy",
+        "ja": "ダブリング戦略",
+        "ja_typings": [
+          "daburingusenryaku"
+        ]
+      },
+      {
+        "en": "Linear growth",
+        "ja": "線形成長",
+        "ja_typings": [
+          "senkeiseichou"
+        ]
+      },
+      {
+        "en": "Constant chunking",
+        "ja": "定数チャンク化",
+        "ja_typings": [
+          "teisuuchankuka"
+        ]
+      },
+      {
+        "en": "Geometric shrinking",
+        "ja": "幾何縮小",
+        "ja_typings": [
+          "kikashukushou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01248",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the technique to amortize the cost of dynamic array resizing?",
+      "ja": "動的配列リサイズコストを償却する手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Deque",
+        "ja": "デック",
+        "ja_typings": [
+          "dekku"
+        ]
+      },
+      {
+        "en": "Priority queue",
+        "ja": "プライオリティキュー",
+        "ja_typings": [
+          "puraioritikyu-"
+        ]
+      },
+      {
+        "en": "Circular buffer",
+        "ja": "循環バッファ",
+        "ja_typings": [
+          "junkanbaffa"
+        ]
+      },
+      {
+        "en": "Skip list",
+        "ja": "スキップリスト",
+        "ja_typings": [
+          "sukippurisuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01249",
+    "image_path": null,
+    "question_text": {
+      "en": "Which structure provides O(1) amortized push and pop from both ends?",
+      "ja": "両端からの償却 O(1) push/pop を提供する構造は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Knuth-Morris-Pratt",
+        "ja": "クヌースモリスプラット",
+        "ja_typings": [
+          "kunu-sumorisupuratto"
+        ]
+      },
+      {
+        "en": "Boyer-Moore",
+        "ja": "ボイヤームーア",
+        "ja_typings": [
+          "boiya-mu-a"
+        ]
+      },
+      {
+        "en": "Rabin-Karp",
+        "ja": "ラビンカープ",
+        "ja_typings": [
+          "rabinka-pu"
+        ]
+      },
+      {
+        "en": "Aho-Corasick",
+        "ja": "エイホコラシック",
+        "ja_typings": [
+          "eihokorashikku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01250",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the name of the algorithm matching strings with KMP failure function?",
+      "ja": "KMP の失敗関数で文字列照合するアルゴリズムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Copying GC",
+        "ja": "コピーGC",
+        "ja_typings": [
+          "kopi-gc"
+        ]
+      },
+      {
+        "en": "Mark-sweep GC",
+        "ja": "マークスイープGC",
+        "ja_typings": [
+          "ma-kusui-pugc"
+        ]
+      },
+      {
+        "en": "Mark-compact GC",
+        "ja": "マークコンパクトGC",
+        "ja_typings": [
+          "ma-kukonpakutogc"
+        ]
+      },
+      {
+        "en": "Incremental GC",
+        "ja": "インクリメンタルGC",
+        "ja_typings": [
+          "inkurimentarugc"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01251",
+    "image_path": null,
+    "question_text": {
+      "en": "Which GC algorithm uses two semispaces and copies live objects?",
+      "ja": "2 つの半空間を使い生存オブジェクトをコピーする GC は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Generational GC",
+        "ja": "世代別GC",
+        "ja_typings": [
+          "sedaibetsugc"
+        ]
+      },
+      {
+        "en": "Concurrent GC",
+        "ja": "並行GC",
+        "ja_typings": [
+          "heikougc"
+        ]
+      },
+      {
+        "en": "Real-time GC",
+        "ja": "リアルタイムGC",
+        "ja_typings": [
+          "riarutaimugc"
+        ]
+      },
+      {
+        "en": "Conservative GC",
+        "ja": "保守的GC",
+        "ja_typings": [
+          "hoshutekigc"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01252",
+    "image_path": null,
+    "question_text": {
+      "en": "What GC technique segregates objects by age?",
+      "ja": "オブジェクトを年齢で分離する GC 技法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NaN boxing",
+        "ja": "ナンボクシング",
+        "ja_typings": [
+          "nanbokushingu"
+        ]
+      },
+      {
+        "en": "Pointer compression",
+        "ja": "ポインタコンプレッション",
+        "ja_typings": [
+          "pointakonpuresshon"
+        ]
+      },
+      {
+        "en": "Reference folding",
+        "ja": "リファレンスフォールディング",
+        "ja_typings": [
+          "rifarensufo-rudingu"
+        ]
+      },
+      {
+        "en": "Heap coloring",
+        "ja": "ヒープカラーリング",
+        "ja_typings": [
+          "hi-pukara-ringu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01253",
+    "image_path": null,
+    "question_text": {
+      "en": "Which low-level technique uses pointer tagging to encode types?",
+      "ja": "ポインタタグ付けで型をエンコードする低レベル技法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "RwLock",
+        "ja": "アールダブリューロック",
+        "ja_typings": [
+          "a-rudaburyu-rokku"
+        ]
+      },
+      {
+        "en": "Spinlock",
+        "ja": "スピンロック",
+        "ja_typings": [
+          "supinrokku"
+        ]
+      },
+      {
+        "en": "Semaphore",
+        "ja": "セマフォ",
+        "ja_typings": [
+          "semafo"
+        ]
+      },
+      {
+        "en": "Barrier",
+        "ja": "バリア",
+        "ja_typings": [
+          "baria"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01254",
+    "image_path": null,
+    "question_text": {
+      "en": "What concurrency primitive allows multiple readers or one writer?",
+      "ja": "複数読者または単一書き手を許す並行プリミティブは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Actor model",
+        "ja": "アクターモデル",
+        "ja_typings": [
+          "akuta-moderu"
+        ]
+      },
+      {
+        "en": "CSP model",
+        "ja": "シーエスピーモデル",
+        "ja_typings": [
+          "shi-esupi-moderu"
+        ]
+      },
+      {
+        "en": "Fork-join model",
+        "ja": "フォークジョインモデル",
+        "ja_typings": [
+          "fo-kujoinmoderu"
+        ]
+      },
+      {
+        "en": "MapReduce",
+        "ja": "マップリデュース",
+        "ja_typings": [
+          "mappurideyu-su"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01255",
+    "image_path": null,
+    "question_text": {
+      "en": "Which pattern uses message passing between actors?",
+      "ja": "アクター間でメッセージパッシングを行うパターンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Livelock",
+        "ja": "ライブロック",
+        "ja_typings": [
+          "raiburokku"
+        ]
+      },
+      {
+        "en": "Starvation",
+        "ja": "スターベーション",
+        "ja_typings": [
+          "suta-be-shon"
+        ]
+      },
+      {
+        "en": "Priority inversion",
+        "ja": "プライオリティインバージョン",
+        "ja_typings": [
+          "puraioritiinba-jon"
+        ]
+      },
+      {
+        "en": "Convoy effect",
+        "ja": "コンボイエフェクト",
+        "ja_typings": [
+          "konboiefekuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01256",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the term for a deadlock-like state where threads keep yielding?",
+      "ja": "スレッドが譲り合い続けるデッドロック類似状態は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "AtomicInteger",
+        "ja": "アトミックインテジャー",
+        "ja_typings": [
+          "atomikkuinteja-"
+        ]
+      },
+      {
+        "en": "synchronized",
+        "ja": "シンクロナイズド",
+        "ja_typings": [
+          "shinkuronaizudo"
+        ]
+      },
+      {
+        "en": "volatile",
+        "ja": "ボラタイル",
+        "ja_typings": [
+          "boratairu"
+        ]
+      },
+      {
+        "en": "ReentrantLock",
+        "ja": "リエントラントロック",
+        "ja_typings": [
+          "rientorantorokku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01257",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Java construct provides lock-free atomic operations?",
+      "ja": "ロックフリーなアトミック操作を提供する Java 構文は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Memory barrier",
+        "ja": "メモリバリア",
+        "ja_typings": [
+          "memoribaria"
+        ]
+      },
+      {
+        "en": "Cache flush",
+        "ja": "キャッシュフラッシュ",
+        "ja_typings": [
+          "kyasshufurasshu"
+        ]
+      },
+      {
+        "en": "Thread fence",
+        "ja": "スレッドフェンス",
+        "ja_typings": [
+          "sureddofensu"
+        ]
+      },
+      {
+        "en": "Lock fence",
+        "ja": "ロックフェンス",
+        "ja_typings": [
+          "rokkufensu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01258",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the term for ensuring memory ordering across threads?",
+      "ja": "スレッド間のメモリ順序を保証する用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Currying",
+        "ja": "カリー化",
+        "ja_typings": [
+          "kari-ka"
+        ]
+      },
+      {
+        "en": "Composing",
+        "ja": "コンポージング",
+        "ja_typings": [
+          "konpo-jingu"
+        ]
+      },
+      {
+        "en": "Memoizing",
+        "ja": "メモアイジング",
+        "ja_typings": [
+          "memoaijingu"
+        ]
+      },
+      {
+        "en": "Folding",
+        "ja": "フォールディング",
+        "ja_typings": [
+          "fo-rudingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01259",
+    "image_path": null,
+    "question_text": {
+      "en": "Which functional concept transforms a multi-arg function into chained single-arg functions?",
+      "ja": "多引数関数を連鎖した単一引数関数に変換する関数型概念は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "bind",
+        "ja": "バインド",
+        "ja_typings": [
+          "baindo"
+        ]
+      },
+      {
+        "en": "apply",
+        "ja": "アプライ",
+        "ja_typings": [
+          "apurai"
+        ]
+      },
+      {
+        "en": "lift",
+        "ja": "リフト",
+        "ja_typings": [
+          "rifuto"
+        ]
+      },
+      {
+        "en": "join",
+        "ja": "ジョイン",
+        "ja_typings": [
+          "join"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01260",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a monad's binding operation commonly named?",
+      "ja": "モナドの束縛操作の一般的な名前は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "fold",
+        "ja": "フォールド",
+        "ja_typings": [
+          "fo-rudo"
+        ]
+      },
+      {
+        "en": "scan",
+        "ja": "スキャン",
+        "ja_typings": [
+          "sukyan"
+        ]
+      },
+      {
+        "en": "group",
+        "ja": "グループ",
+        "ja_typings": [
+          "guru-pu"
+        ]
+      },
+      {
+        "en": "zip",
+        "ja": "ジップ",
+        "ja_typings": [
+          "jippu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01261",
+    "image_path": null,
+    "question_text": {
+      "en": "Which higher-order function reduces a list to a single value?",
+      "ja": "リストを単一値に畳み込む高階関数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "First-class functions",
+        "ja": "ファーストクラスファンクションズ",
+        "ja_typings": [
+          "fa-sutokurasufankushonzu"
+        ]
+      },
+      {
+        "en": "Higher-order types",
+        "ja": "ハイヤーオーダータイプス",
+        "ja_typings": [
+          "haiya-o-da-taipusu"
+        ]
+      },
+      {
+        "en": "Anonymous closures",
+        "ja": "アノニマスクロージャーズ",
+        "ja_typings": [
+          "anonimasukuro-ja-zu"
+        ]
+      },
+      {
+        "en": "Lambda capture",
+        "ja": "ラムダキャプチャ",
+        "ja_typings": [
+          "ramudakyapucha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01262",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the term for treating functions as first-class values?",
+      "ja": "関数をファーストクラス値として扱う用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ad-hoc polymorphism",
+        "ja": "アドホックポリモーフィズム",
+        "ja_typings": [
+          "adohokkuporimo-fizumu"
+        ]
+      },
+      {
+        "en": "Parametric polymorphism",
+        "ja": "パラメトリックポリモーフィズム",
+        "ja_typings": [
+          "parametorikkuporimo-fizumu"
+        ]
+      },
+      {
+        "en": "Subtype polymorphism",
+        "ja": "サブタイプポリモーフィズム",
+        "ja_typings": [
+          "sabutaipuporimo-fizumu"
+        ]
+      },
+      {
+        "en": "Row polymorphism",
+        "ja": "ロウポリモーフィズム",
+        "ja_typings": [
+          "roporimo-fizumu",
+          "rouporimo-fizumu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01263",
+    "image_path": null,
+    "question_text": {
+      "en": "Which type system feature describes Haskell's typeclasses?",
+      "ja": "Haskell の型クラスを表現する型システム機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "TCO",
+        "ja": "ティーシーオー",
+        "ja_typings": [
+          "ti-shi-o-"
+        ]
+      },
+      {
+        "en": "TLS",
+        "ja": "ティーエルエス",
+        "ja_typings": [
+          "ti-eruesu"
+        ]
+      },
+      {
+        "en": "LTO",
+        "ja": "エルティーオー",
+        "ja_typings": [
+          "eruti-o-"
+        ]
+      },
+      {
+        "en": "FFI",
+        "ja": "エフエフアイ",
+        "ja_typings": [
+          "efuefuai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01264",
+    "image_path": null,
+    "question_text": {
+      "en": "What is tail call optimization commonly abbreviated as?",
+      "ja": "末尾呼び出し最適化の略称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lowering",
+        "ja": "ロワリング",
+        "ja_typings": [
+          "rowaringu"
+        ]
+      },
+      {
+        "en": "Linking",
+        "ja": "リンキング",
+        "ja_typings": [
+          "rinkingu"
+        ]
+      },
+      {
+        "en": "Bundling",
+        "ja": "バンドリング",
+        "ja_typings": [
+          "bandoringu"
+        ]
+      },
+      {
+        "en": "Mangling",
+        "ja": "マングリング",
+        "ja_typings": [
+          "manguringu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01265",
+    "image_path": null,
+    "question_text": {
+      "en": "Which compilation step converts source to an intermediate representation?",
+      "ja": "ソースを中間表現に変換するコンパイル工程は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Recursion",
+        "ja": "再帰",
+        "ja_typings": [
+          "saiki"
+        ]
+      },
+      {
+        "en": "Iteration",
+        "ja": "反復",
+        "ja_typings": [
+          "hanpuku"
+        ]
+      },
+      {
+        "en": "Reflection",
+        "ja": "リフレクション",
+        "ja_typings": [
+          "rifurekushon"
+        ]
+      },
+      {
+        "en": "Reification",
+        "ja": "リアイフィケーション",
+        "ja_typings": [
+          "riaifike-shon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01266",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the term for a function that calls itself?",
+      "ja": "自分自身を呼び出す関数の用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Metaprogramming",
+        "ja": "メタプログラミング",
+        "ja_typings": [
+          "metapuroguramingu"
+        ]
+      },
+      {
+        "en": "Macroprogramming",
+        "ja": "マクロプログラミング",
+        "ja_typings": [
+          "makuropuroguramingu"
+        ]
+      },
+      {
+        "en": "Polyprogramming",
+        "ja": "ポリプログラミング",
+        "ja_typings": [
+          "poripuroguramingu"
+        ]
+      },
+      {
+        "en": "Hyperprogramming",
+        "ja": "ハイパープログラミング",
+        "ja_typings": [
+          "haipa-puroguramingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01267",
+    "image_path": null,
+    "question_text": {
+      "en": "Which feature allows mixing code at runtime with reflection-style APIs?",
+      "ja": "リフレクション風 API で実行時にコードを差し込む機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FFI",
+        "ja": "エフエフアイ",
+        "ja_typings": [
+          "efuefuai"
+        ]
+      },
+      {
+        "en": "RPC",
+        "ja": "アールピーシー",
+        "ja_typings": [
+          "a-rupi-shi-"
+        ]
+      },
+      {
+        "en": "IPC",
+        "ja": "アイピーシー",
+        "ja_typings": [
+          "aipi-shi-"
+        ]
+      },
+      {
+        "en": "ABI",
+        "ja": "エービーアイ",
+        "ja_typings": [
+          "e-bi-ai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01268",
+    "image_path": null,
+    "question_text": {
+      "en": "What term describes calling C functions from another language?",
+      "ja": "他言語から C 関数を呼び出すことを指す用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Inlining",
+        "ja": "インライン化",
+        "ja_typings": [
+          "inrainka"
+        ]
+      },
+      {
+        "en": "Unrolling",
+        "ja": "アンローリング",
+        "ja_typings": [
+          "anro-ringu"
+        ]
+      },
+      {
+        "en": "Tiling",
+        "ja": "タイリング",
+        "ja_typings": [
+          "tairingu"
+        ]
+      },
+      {
+        "en": "Splitting",
+        "ja": "スプリッティング",
+        "ja_typings": [
+          "supurittingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01269",
+    "image_path": null,
+    "question_text": {
+      "en": "Which technique inlines small functions at call sites?",
+      "ja": "呼び出し箇所に小さな関数を展開する技法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SCREAMING_SNAKE_CASE",
+        "ja": "スクリーミングスネークケース",
+        "ja_typings": [
+          "sukuri-mingusune-kuke-su"
+        ]
+      },
+      {
+        "en": "camelCase",
+        "ja": "キャメルケース",
+        "ja_typings": [
+          "kyameruke-su"
+        ]
+      },
+      {
+        "en": "kebab-case",
+        "ja": "ケバブケース",
+        "ja_typings": [
+          "kebabuke-su"
+        ]
+      },
+      {
+        "en": "PascalCase",
+        "ja": "パスカルケース",
+        "ja_typings": [
+          "pasukaruke-su"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01270",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the convention for naming constants in many languages?",
+      "ja": "多くの言語で定数を命名する慣習は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Duck typing",
+        "ja": "ダックタイピング",
+        "ja_typings": [
+          "dakkutaipingu"
+        ]
+      },
+      {
+        "en": "Nominal typing",
+        "ja": "ノミナルタイピング",
+        "ja_typings": [
+          "nominarutaipingu"
+        ]
+      },
+      {
+        "en": "Strong typing",
+        "ja": "ストロングタイピング",
+        "ja_typings": [
+          "sutorongutaipingu"
+        ]
+      },
+      {
+        "en": "Dependent typing",
+        "ja": "ディペンデントタイピング",
+        "ja_typings": [
+          "dipendentotaipingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01271",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is a structural typing system feature?",
+      "ja": "構造的型付けシステムの特徴は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Serialization",
+        "ja": "シリアライズ",
+        "ja_typings": [
+          "shiriaraizu"
+        ]
+      },
+      {
+        "en": "Compilation",
+        "ja": "コンパイル",
+        "ja_typings": [
+          "konpairu"
+        ]
+      },
+      {
+        "en": "Tokenization",
+        "ja": "トークン化",
+        "ja_typings": [
+          "to-kunka"
+        ]
+      },
+      {
+        "en": "Normalization",
+        "ja": "正規化",
+        "ja_typings": [
+          "seikika"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01272",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the term for converting an object into a byte stream?",
+      "ja": "オブジェクトをバイト列に変換することを指す用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Virtual dispatch",
+        "ja": "バーチャルディスパッチ",
+        "ja_typings": [
+          "ba-charudisupatchi"
+        ]
+      },
+      {
+        "en": "Static dispatch",
+        "ja": "スタティックディスパッチ",
+        "ja_typings": [
+          "sutatikkudisupatchi"
+        ]
+      },
+      {
+        "en": "Direct dispatch",
+        "ja": "ダイレクトディスパッチ",
+        "ja_typings": [
+          "dairekutodisupatchi"
+        ]
+      },
+      {
+        "en": "Inline dispatch",
+        "ja": "インラインディスパッチ",
+        "ja_typings": [
+          "inraindisupatchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01273",
+    "image_path": null,
+    "question_text": {
+      "en": "Which dispatch mechanism resolves method calls at runtime via vtables?",
+      "ja": "vtable で実行時にメソッド呼び出しを解決する機構は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "clamp()",
+        "ja": "クランプ",
+        "ja_typings": [
+          "kuranpu"
+        ]
+      },
+      {
+        "en": "minmax()",
+        "ja": "ミンマックス",
+        "ja_typings": [
+          "minmakkusu"
+        ]
+      },
+      {
+        "en": "calc()",
+        "ja": "キャルク",
+        "ja_typings": [
+          "kyaruku"
+        ]
+      },
+      {
+        "en": "fit-content()",
+        "ja": "フィットコンテント",
+        "ja_typings": [
+          "fittokontento"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01274",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS function clamps a value between min and max?",
+      "ja": "値を最小値と最大値で挟む CSS 関数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "margin-inline-start",
+        "ja": "マージンインラインスタート",
+        "ja_typings": [
+          "ma-jinninrainsuta-to"
+        ]
+      },
+      {
+        "en": "margin-block-start",
+        "ja": "マージンブロックスタート",
+        "ja_typings": [
+          "ma-jinburokkusuta-to"
+        ]
+      },
+      {
+        "en": "margin-left-logical",
+        "ja": "マージンレフトロジカル",
+        "ja_typings": [
+          "ma-jinrefutorojikaru"
+        ]
+      },
+      {
+        "en": "padding-inline-start",
+        "ja": "パディングインラインスタート",
+        "ja_typings": [
+          "padinguinrainsuta-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01275",
+    "image_path": null,
+    "question_text": {
+      "en": "What CSS property enables logical inline-start margin?",
+      "ja": "論理的なインライン開始マージンを設定する CSS プロパティは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "svmin",
+        "ja": "エスブイミン",
+        "ja_typings": [
+          "esubuimin"
+        ]
+      },
+      {
+        "en": "dvmin",
+        "ja": "ディーブイミン",
+        "ja_typings": [
+          "di-buimin"
+        ]
+      },
+      {
+        "en": "lvmin",
+        "ja": "エルブイミン",
+        "ja_typings": [
+          "erubuimin"
+        ]
+      },
+      {
+        "en": "qvmin",
+        "ja": "キューブイミン",
+        "ja_typings": [
+          "kyu-buimin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01276",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS unit is relative to the smaller of viewport width/height?",
+      "ja": "ビューポートの幅と高さの小さい方に対する CSS 単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "@font-face",
+        "ja": "アットフォントフェイス",
+        "ja_typings": [
+          "attofontofeisu"
+        ]
+      },
+      {
+        "en": "@font-import",
+        "ja": "アットフォントインポート",
+        "ja_typings": [
+          "attofontoinpo-to"
+        ]
+      },
+      {
+        "en": "@font-load",
+        "ja": "アットフォントロード",
+        "ja_typings": [
+          "attofontoro-do"
+        ]
+      },
+      {
+        "en": "@import-font",
+        "ja": "アットインポートフォント",
+        "ja_typings": [
+          "attoinpo-tofonto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01277",
+    "image_path": null,
+    "question_text": {
+      "en": "What CSS at-rule defines a font from a remote source?",
+      "ja": "リモートソースからフォントを定義する CSS の at-rule は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "isolation",
+        "ja": "アイソレーション",
+        "ja_typings": [
+          "aisore-shon"
+        ]
+      },
+      {
+        "en": "contain",
+        "ja": "コンテイン",
+        "ja_typings": [
+          "kontein"
+        ]
+      },
+      {
+        "en": "will-change",
+        "ja": "ウィルチェンジ",
+        "ja_typings": [
+          "wiruchenji"
+        ]
+      },
+      {
+        "en": "transform-style",
+        "ja": "トランスフォームスタイル",
+        "ja_typings": [
+          "toransufo-musutairu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01278",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS property creates a stacking context without z-index?",
+      "ja": "z-index なしでスタッキングコンテキストを作る CSS プロパティは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CSS scoping",
+        "ja": "シーエスエススコーピング",
+        "ja_typings": [
+          "shi-esuesusuko-pingu"
+        ]
+      },
+      {
+        "en": "CSS nesting",
+        "ja": "シーエスエスネスティング",
+        "ja_typings": [
+          "shi-esuesunesutingu"
+        ]
+      },
+      {
+        "en": "CSS layering",
+        "ja": "シーエスエスレイヤリング",
+        "ja_typings": [
+          "shi-esuesureiyaringu"
+        ]
+      },
+      {
+        "en": "CSS isolation",
+        "ja": "シーエスエスアイソレーション",
+        "ja_typings": [
+          "shi-esuesuaisore-shon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01279",
+    "image_path": null,
+    "question_text": {
+      "en": "What CSS feature allows scoping styles with @scope?",
+      "ja": "@scope でスタイルをスコープ化する CSS 機能の名称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": ":focus-within",
+        "ja": "フォーカスウィズイン",
+        "ja_typings": [
+          "fo-kasuwizuin"
+        ]
+      },
+      {
+        "en": ":focus-visible",
+        "ja": "フォーカスビジブル",
+        "ja_typings": [
+          "fo-kasubijiburu"
+        ]
+      },
+      {
+        "en": ":has-focus",
+        "ja": "ハズフォーカス",
+        "ja_typings": [
+          "hazufo-kasu"
+        ]
+      },
+      {
+        "en": ":focusable",
+        "ja": "フォーカサブル",
+        "ja_typings": [
+          "fo-kasaburu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01280",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS pseudo-class matches an element that has focus within its tree?",
+      "ja": "要素ツリー内にフォーカスがある要素にマッチする CSS 疑似クラスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "grid-template-areas",
+        "ja": "グリッドテンプレートエリアズ",
+        "ja_typings": [
+          "guriddotenpure-toeriazu"
+        ]
+      },
+      {
+        "en": "grid-areas",
+        "ja": "グリッドエリアズ",
+        "ja_typings": [
+          "guriddoeriazu"
+        ]
+      },
+      {
+        "en": "grid-zones",
+        "ja": "グリッドゾーンズ",
+        "ja_typings": [
+          "guriddozo-nzu"
+        ]
+      },
+      {
+        "en": "grid-regions",
+        "ja": "グリッドリージョンズ",
+        "ja_typings": [
+          "guriddori-jonzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01281",
+    "image_path": null,
+    "question_text": {
+      "en": "What CSS property defines named grid areas?",
+      "ja": "名前付きグリッドエリアを定義する CSS プロパティは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "<details>",
+        "ja": "ディテイルズ",
+        "ja_typings": [
+          "diteiruzu"
+        ]
+      },
+      {
+        "en": "<summary>",
+        "ja": "サマリー",
+        "ja_typings": [
+          "samari-"
+        ]
+      },
+      {
+        "en": "<dialog>",
+        "ja": "ダイアログ",
+        "ja_typings": [
+          "daiarogu"
+        ]
+      },
+      {
+        "en": "<menu>",
+        "ja": "メニュー",
+        "ja_typings": [
+          "menyu-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01282",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML element represents a disclosure widget?",
+      "ja": "開閉式ウィジェットを表す HTML 要素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "draggable",
+        "ja": "ドラッガブル",
+        "ja_typings": [
+          "doraggaburu"
+        ]
+      },
+      {
+        "en": "droppable",
+        "ja": "ドロッパブル",
+        "ja_typings": [
+          "doroppaburu"
+        ]
+      },
+      {
+        "en": "movable",
+        "ja": "ムーバブル",
+        "ja_typings": [
+          "mu-baburu"
+        ]
+      },
+      {
+        "en": "dragstart",
+        "ja": "ドラッグスタート",
+        "ja_typings": [
+          "doraggusuta-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01283",
+    "image_path": null,
+    "question_text": {
+      "en": "What HTML attribute enables drag-and-drop on any element?",
+      "ja": "任意の要素でドラッグアンドドロップを有効にする HTML 属性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "type=\"color\"",
+        "ja": "タイプカラー",
+        "ja_typings": [
+          "taipukara-"
+        ]
+      },
+      {
+        "en": "type=\"picker\"",
+        "ja": "タイプピッカー",
+        "ja_typings": [
+          "taipupikka-"
+        ]
+      },
+      {
+        "en": "type=\"palette\"",
+        "ja": "タイプパレット",
+        "ja_typings": [
+          "taipuparetto"
+        ]
+      },
+      {
+        "en": "type=\"hue\"",
+        "ja": "タイプヒュー",
+        "ja_typings": [
+          "taipuhyu-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01284",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML input type provides a color picker?",
+      "ja": "カラーピッカーを提供する HTML input type は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "<fieldset>",
+        "ja": "フィールドセット",
+        "ja_typings": [
+          "fi-rudosetto"
+        ]
+      },
+      {
+        "en": "<formgroup>",
+        "ja": "フォームグループ",
+        "ja_typings": [
+          "fo-muguru-pu"
+        ]
+      },
+      {
+        "en": "<inputs>",
+        "ja": "インプッツ",
+        "ja_typings": [
+          "inputtsu"
+        ]
+      },
+      {
+        "en": "<group>",
+        "ja": "グループ",
+        "ja_typings": [
+          "guru-pu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01285",
+    "image_path": null,
+    "question_text": {
+      "en": "What HTML element groups labeled form controls?",
+      "ja": "ラベル付きフォーム部品をグループ化する HTML 要素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cache API",
+        "ja": "キャッシュエーピーアイ",
+        "ja_typings": [
+          "kyasshue-pi-ai"
+        ]
+      },
+      {
+        "en": "File System API",
+        "ja": "ファイルシステムエーピーアイ",
+        "ja_typings": [
+          "fairushisutemue-pi-ai"
+        ]
+      },
+      {
+        "en": "Background Sync API",
+        "ja": "バックグラウンドシンクエーピーアイ",
+        "ja_typings": [
+          "bakkuguraundoshinkue-pi-ai"
+        ]
+      },
+      {
+        "en": "Storage Foundation API",
+        "ja": "ストレージファウンデーションエーピーアイ",
+        "ja_typings": [
+          "sutore-jifaunde-shonne-pi-ai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01286",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML5 API allows offline storage of structured data?",
+      "ja": "構造化データのオフライン保存を可能にする HTML5 API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "409",
+        "ja": "ヨンマルキュウ",
+        "ja_typings": [
+          "409",
+          "yonmarukyuu"
+        ]
+      },
+      {
+        "en": "410",
+        "ja": "ヨンイチマル",
+        "ja_typings": [
+          "410",
+          "yonnichimaru"
+        ]
+      },
+      {
+        "en": "412",
+        "ja": "ヨンイチニ",
+        "ja_typings": [
+          "412",
+          "yonnichini"
+        ]
+      },
+      {
+        "en": "428",
+        "ja": "ヨンニハチ",
+        "ja_typings": [
+          "428",
+          "yonnnihachi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01287",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status indicates a request conflict?",
+      "ja": "リクエストの競合を示す HTTP ステータスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gone",
+        "ja": "ゴーン",
+        "ja_typings": [
+          "go-n"
+        ]
+      },
+      {
+        "en": "Forbidden",
+        "ja": "フォービドゥン",
+        "ja_typings": [
+          "fo-bidun"
+        ]
+      },
+      {
+        "en": "Unauthorized",
+        "ja": "アンオーソライズド",
+        "ja_typings": [
+          "anno-soraizudo"
+        ]
+      },
+      {
+        "en": "Locked",
+        "ja": "ロックト",
+        "ja_typings": [
+          "rokkuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01288",
+    "image_path": null,
+    "question_text": {
+      "en": "What HTTP status means the resource is permanently gone?",
+      "ja": "リソースが恒久的に消えたことを示す HTTP ステータスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Access-Control-Max-Age",
+        "ja": "アクセスコントロールマックスエイジ",
+        "ja_typings": [
+          "akusesukontoro-rumakkusueiji"
+        ]
+      },
+      {
+        "en": "Access-Control-Allow-Origin",
+        "ja": "アクセスコントロールアロウオリジン",
+        "ja_typings": [
+          "akusesukontoro-ruaroorijin",
+          "akusesukontoro-ruarouorijin"
+        ]
+      },
+      {
+        "en": "Access-Control-Expose-Headers",
+        "ja": "アクセスコントロールエクスポーズヘッダーズ",
+        "ja_typings": [
+          "akusesukontoro-ruekusupo-zuhedda-zu"
+        ]
+      },
+      {
+        "en": "Access-Control-Request-Headers",
+        "ja": "アクセスコントロールリクエストヘッダーズ",
+        "ja_typings": [
+          "akusesukontoro-rurikuesutohedda-zu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01289",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP header controls how long a preflight response is cached?",
+      "ja": "プリフライト応答のキャッシュ期間を制御する HTTP ヘッダーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "X-Forwarded-Proto",
+        "ja": "エックスフォワーデッドプロト",
+        "ja_typings": [
+          "ekkusufowa-deddopuroto"
+        ]
+      },
+      {
+        "en": "X-Forwarded-For",
+        "ja": "エックスフォワーデッドフォー",
+        "ja_typings": [
+          "ekkusufowa-deddofo-"
+        ]
+      },
+      {
+        "en": "X-Real-IP",
+        "ja": "エックスリアルアイピー",
+        "ja_typings": [
+          "ekkusuriaruaipi-"
+        ]
+      },
+      {
+        "en": "Forwarded",
+        "ja": "フォワーデッド",
+        "ja_typings": [
+          "fowa-deddo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01290",
+    "image_path": null,
+    "question_text": {
+      "en": "What HTTP header indicates the original request scheme behind a proxy?",
+      "ja": "プロキシ越しに元のリクエストスキームを示す HTTP ヘッダーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Strict-Transport-Security",
+        "ja": "ストリクトトランスポートセキュリティ",
+        "ja_typings": [
+          "sutorikutotoransupo-tosekyuriti"
+        ]
+      },
+      {
+        "en": "X-Content-Type-Options",
+        "ja": "エックスコンテントタイプオプションズ",
+        "ja_typings": [
+          "ekkusukontentotaipuopushonzu"
+        ]
+      },
+      {
+        "en": "Permissions-Policy",
+        "ja": "パーミッションズポリシー",
+        "ja_typings": [
+          "pa-misshonzuporishi-"
+        ]
+      },
+      {
+        "en": "Referrer-Policy",
+        "ja": "リファラーポリシー",
+        "ja_typings": [
+          "rifara-porishi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01291",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP response header tells browsers to enforce HTTPS?",
+      "ja": "ブラウザに HTTPS を強制させる HTTP 応答ヘッダーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HEAD method",
+        "ja": "ヘッドメソッド",
+        "ja_typings": [
+          "heddomesoddo"
+        ]
+      },
+      {
+        "en": "META method",
+        "ja": "メタメソッド",
+        "ja_typings": [
+          "metamesoddo"
+        ]
+      },
+      {
+        "en": "INFO method",
+        "ja": "インフォメソッド",
+        "ja_typings": [
+          "infomesoddo"
+        ]
+      },
+      {
+        "en": "STAT method",
+        "ja": "スタットメソッド",
+        "ja_typings": [
+          "sutattomesoddo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01292",
+    "image_path": null,
+    "question_text": {
+      "en": "What HTTP method is used to retrieve metadata only?",
+      "ja": "メタデータのみを取得する HTTP メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ResizeObserver",
+        "ja": "リサイズオブザーバー",
+        "ja_typings": [
+          "risaizuobuza-ba-"
+        ]
+      },
+      {
+        "en": "MutationObserver",
+        "ja": "ミューテーションオブザーバー",
+        "ja_typings": [
+          "myu-te-shonnobuza-ba-"
+        ]
+      },
+      {
+        "en": "IntersectionObserver",
+        "ja": "インターセクションオブザーバー",
+        "ja_typings": [
+          "inta-sekushonnobuza-ba-"
+        ]
+      },
+      {
+        "en": "PerformanceObserver",
+        "ja": "パフォーマンスオブザーバー",
+        "ja_typings": [
+          "pafo-mansuobuza-ba-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01293",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Web API observes element resize events?",
+      "ja": "要素のリサイズイベントを監視する Web API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Intersection Observer",
+        "ja": "インターセクションオブザーバー",
+        "ja_typings": [
+          "inta-sekushonnobuza-ba-"
+        ]
+      },
+      {
+        "en": "Visibility Observer",
+        "ja": "ビジビリティオブザーバー",
+        "ja_typings": [
+          "bijibiritiobuza-ba-"
+        ]
+      },
+      {
+        "en": "Viewport Observer",
+        "ja": "ビューポートオブザーバー",
+        "ja_typings": [
+          "byu-po-tobuza-ba-",
+          "byu-po-toobuza-ba-"
+        ]
+      },
+      {
+        "en": "Scroll Observer",
+        "ja": "スクロールオブザーバー",
+        "ja_typings": [
+          "sukuro-ruobuza-ba-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01294",
+    "image_path": null,
+    "question_text": {
+      "en": "What Web API detects when an element enters the viewport?",
+      "ja": "要素がビューポートに入ったことを検出する Web API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Push API",
+        "ja": "プッシュエーピーアイ",
+        "ja_typings": [
+          "pusshue-pi-ai"
+        ]
+      },
+      {
+        "en": "Alert API",
+        "ja": "アラートエーピーアイ",
+        "ja_typings": [
+          "ara-toe-pi-ai"
+        ]
+      },
+      {
+        "en": "Notification only",
+        "ja": "ノティフィケーションオンリー",
+        "ja_typings": [
+          "notifike-shonnonri-"
+        ]
+      },
+      {
+        "en": "Background API",
+        "ja": "バックグラウンドエーピーアイ",
+        "ja_typings": [
+          "bakkuguraundoe-pi-ai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01295",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Web API enables push notifications?",
+      "ja": "プッシュ通知を可能にする Web API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CacheStorage",
+        "ja": "キャッシュストレージ",
+        "ja_typings": [
+          "kyasshusutore-ji"
+        ]
+      },
+      {
+        "en": "FileSystem Access",
+        "ja": "ファイルシステムアクセス",
+        "ja_typings": [
+          "fairushisutemuakusesu"
+        ]
+      },
+      {
+        "en": "WebSQL",
+        "ja": "ウェブエスキューエル",
+        "ja_typings": [
+          "webuesukyu-eru"
+        ]
+      },
+      {
+        "en": "AppCache",
+        "ja": "アップキャッシュ",
+        "ja_typings": [
+          "appukyasshu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01296",
+    "image_path": null,
+    "question_text": {
+      "en": "What Web API persists data using a key-value pair with promises?",
+      "ja": "Promise でキーバリュー保存する Web API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Web Share Target",
+        "ja": "ウェブシェアターゲット",
+        "ja_typings": [
+          "webusheata-getto"
+        ]
+      },
+      {
+        "en": "Share Receiver API",
+        "ja": "シェアレシーバーエーピーアイ",
+        "ja_typings": [
+          "sheareshi-ba-e-pi-ai"
+        ]
+      },
+      {
+        "en": "Web Sync",
+        "ja": "ウェブシンク",
+        "ja_typings": [
+          "webushinku"
+        ]
+      },
+      {
+        "en": "Web Receive",
+        "ja": "ウェブレシーブ",
+        "ja_typings": [
+          "webureshi-bu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01297",
+    "image_path": null,
+    "question_text": {
+      "en": "Which API lets pages register handlers for share targets?",
+      "ja": "共有先ハンドラを登録できる API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Performance.now",
+        "ja": "パフォーマンスナウ",
+        "ja_typings": [
+          "pafo-mansunau"
+        ]
+      },
+      {
+        "en": "Date.now",
+        "ja": "デートナウ",
+        "ja_typings": [
+          "de-tonau"
+        ]
+      },
+      {
+        "en": "Timing.now",
+        "ja": "タイミングナウ",
+        "ja_typings": [
+          "taimingunau"
+        ]
+      },
+      {
+        "en": "Clock.now",
+        "ja": "クロックナウ",
+        "ja_typings": [
+          "kurokkunau"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01298",
+    "image_path": null,
+    "question_text": {
+      "en": "What API exposes high-resolution monotonic timestamps?",
+      "ja": "高解像度の単調タイムスタンプを提供する API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Web Speech Recognition",
+        "ja": "ウェブスピーチレコグニッション",
+        "ja_typings": [
+          "webusupi-chirekogunisshon"
+        ]
+      },
+      {
+        "en": "Web Audio API",
+        "ja": "ウェブオーディオエーピーアイ",
+        "ja_typings": [
+          "webuo-dioe-pi-ai"
+        ]
+      },
+      {
+        "en": "Media Capture",
+        "ja": "メディアキャプチャ",
+        "ja_typings": [
+          "mediakyapucha"
+        ]
+      },
+      {
+        "en": "MediaStream API",
+        "ja": "メディアストリームエーピーアイ",
+        "ja_typings": [
+          "mediasutori-mue-pi-ai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01299",
+    "image_path": null,
+    "question_text": {
+      "en": "Which API allows speech-to-text in the browser?",
+      "ja": "ブラウザで音声を文字起こしする API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "useSyncExternalStore",
+        "ja": "ユーズシンクエクスターナルストア",
+        "ja_typings": [
+          "yu-zushinkuekusuta-narusutoa"
+        ]
+      },
+      {
+        "en": "useStore",
+        "ja": "ユーズストア",
+        "ja_typings": [
+          "yu-zusutoa"
+        ]
+      },
+      {
+        "en": "useSubscribe",
+        "ja": "ユーズサブスクライブ",
+        "ja_typings": [
+          "yu-zusabusukuraibu"
+        ]
+      },
+      {
+        "en": "useExternal",
+        "ja": "ユーズエクスターナル",
+        "ja_typings": [
+          "yu-zuekusuta-naru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01300",
+    "image_path": null,
+    "question_text": {
+      "en": "Which React hook subscribes to an external store with concurrent safety?",
+      "ja": "並行性安全に外部ストア購読する React フックは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "defineProps",
+        "ja": "ディファインプロップス",
+        "ja_typings": [
+          "difainpuroppusu"
+        ]
+      },
+      {
+        "en": "declareProps",
+        "ja": "デクレアプロップス",
+        "ja_typings": [
+          "dekureapuroppusu"
+        ]
+      },
+      {
+        "en": "useProps",
+        "ja": "ユーズプロップス",
+        "ja_typings": [
+          "yu-zupuroppusu"
+        ]
+      },
+      {
+        "en": "propsMacro",
+        "ja": "プロップスマクロ",
+        "ja_typings": [
+          "puroppusumakuro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01301",
+    "image_path": null,
+    "question_text": {
+      "en": "What Vue 3 macro defines props in script setup?",
+      "ja": "script setup で props を定義する Vue 3 マクロは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "on:event",
+        "ja": "オンイベント",
+        "ja_typings": [
+          "onnibento"
+        ]
+      },
+      {
+        "en": "bind:event",
+        "ja": "バインドイベント",
+        "ja_typings": [
+          "baindoibento"
+        ]
+      },
+      {
+        "en": "use:event",
+        "ja": "ユーズイベント",
+        "ja_typings": [
+          "yu-zuibento"
+        ]
+      },
+      {
+        "en": "event:on",
+        "ja": "イベントオン",
+        "ja_typings": [
+          "ibenton",
+          "ibentoon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01302",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Svelte directive listens to DOM events?",
+      "ja": "DOM イベントを購読する Svelte ディレクティブは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SSR",
+        "ja": "エスエスアール",
+        "ja_typings": [
+          "esuesua-ru"
+        ]
+      },
+      {
+        "en": "SSG",
+        "ja": "エスエスジー",
+        "ja_typings": [
+          "esuesuji-"
+        ]
+      },
+      {
+        "en": "ISR",
+        "ja": "アイエスアール",
+        "ja_typings": [
+          "aiesua-ru"
+        ]
+      },
+      {
+        "en": "CSR",
+        "ja": "シーエスアール",
+        "ja_typings": [
+          "shi-esua-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01303",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the term for rendering on the server at request time?",
+      "ja": "リクエスト時にサーバーでレンダリングすることを指す用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Incremental Static Regeneration",
+        "ja": "インクリメンタルスタティックリジェネレーション",
+        "ja_typings": [
+          "inkurimentarusutatikkurijenere-shon"
+        ]
+      },
+      {
+        "en": "Edge Streaming",
+        "ja": "エッジストリーミング",
+        "ja_typings": [
+          "ejjisutori-mingu"
+        ]
+      },
+      {
+        "en": "Static Hydration",
+        "ja": "スタティックハイドレーション",
+        "ja_typings": [
+          "sutatikkuhaidore-shon"
+        ]
+      },
+      {
+        "en": "Parallel Routes",
+        "ja": "パラレルルーツ",
+        "ja_typings": [
+          "parareruru-tsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01304",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Next.js feature regenerates static pages on demand?",
+      "ja": "オンデマンドで静的ページを再生成する Next.js の機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Islands architecture",
+        "ja": "アイランズアーキテクチャ",
+        "ja_typings": [
+          "airanzua-kitekucha"
+        ]
+      },
+      {
+        "en": "Edge rendering",
+        "ja": "エッジレンダリング",
+        "ja_typings": [
+          "ejjirendaringu"
+        ]
+      },
+      {
+        "en": "Static suspense",
+        "ja": "スタティックサスペンス",
+        "ja_typings": [
+          "sutatikkusasupensu"
+        ]
+      },
+      {
+        "en": "Server components",
+        "ja": "サーバーコンポーネンツ",
+        "ja_typings": [
+          "sa-ba-konpo-nentsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01305",
+    "image_path": null,
+    "question_text": {
+      "en": "What Astro feature ships zero JS to the client by default?",
+      "ja": "デフォルトでクライアントに JS を送らない Astro の機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Layout",
+        "ja": "レイアウト",
+        "ja_typings": [
+          "reiauto"
+        ]
+      },
+      {
+        "en": "Paint",
+        "ja": "ペイント",
+        "ja_typings": [
+          "peinto"
+        ]
+      },
+      {
+        "en": "Composite",
+        "ja": "コンポジット",
+        "ja_typings": [
+          "konpojitto"
+        ]
+      },
+      {
+        "en": "Style",
+        "ja": "スタイル",
+        "ja_typings": [
+          "sutairu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01306",
+    "image_path": null,
+    "question_text": {
+      "en": "Which browser process step computes element geometry?",
+      "ja": "要素の幾何を計算するブラウザ処理工程は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Compositing",
+        "ja": "コンポジティング",
+        "ja_typings": [
+          "konpojitingu"
+        ]
+      },
+      {
+        "en": "Layouting",
+        "ja": "レイアウティング",
+        "ja_typings": [
+          "reiautingu"
+        ]
+      },
+      {
+        "en": "Painting",
+        "ja": "ペインティング",
+        "ja_typings": [
+          "peintingu"
+        ]
+      },
+      {
+        "en": "Rasterizing",
+        "ja": "ラスタライジング",
+        "ja_typings": [
+          "rasutaraijingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01307",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the term for the browser combining painted layers?",
+      "ja": "ペイントしたレイヤーをブラウザが合成することを指す用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DOMContentLoaded",
+        "ja": "ドムコンテントローデッド",
+        "ja_typings": [
+          "domukontentoro-deddo"
+        ]
+      },
+      {
+        "en": "load",
+        "ja": "ロード",
+        "ja_typings": [
+          "ro-do"
+        ]
+      },
+      {
+        "en": "readystatechange",
+        "ja": "レディステートチェンジ",
+        "ja_typings": [
+          "redisute-tochenji"
+        ]
+      },
+      {
+        "en": "beforeunload",
+        "ja": "ビフォアアンロード",
+        "ja_typings": [
+          "bifoaanro-do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01308",
+    "image_path": null,
+    "question_text": {
+      "en": "Which event fires after DOM is parsed but before all assets load?",
+      "ja": "DOM 解析後・全アセット読み込み前に発火するイベントは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Site Isolation",
+        "ja": "サイトアイソレーション",
+        "ja_typings": [
+          "saitoaisore-shon"
+        ]
+      },
+      {
+        "en": "Origin Isolation",
+        "ja": "オリジンアイソレーション",
+        "ja_typings": [
+          "orijinnaisore-shon"
+        ]
+      },
+      {
+        "en": "Frame Sandbox",
+        "ja": "フレームサンドボックス",
+        "ja_typings": [
+          "fure-musandobokkusu"
+        ]
+      },
+      {
+        "en": "Process Sharding",
+        "ja": "プロセスシャーディング",
+        "ja_typings": [
+          "purosesusha-dingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01309",
+    "image_path": null,
+    "question_text": {
+      "en": "What browser feature isolates iframes in separate processes?",
+      "ja": "iframe を別プロセスに隔離するブラウザ機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SharedArrayBuffer",
+        "ja": "シェアードアレイバッファ",
+        "ja_typings": [
+          "shea-doareibaffa"
+        ]
+      },
+      {
+        "en": "ArrayBuffer",
+        "ja": "アレイバッファ",
+        "ja_typings": [
+          "areibaffa"
+        ]
+      },
+      {
+        "en": "DataView",
+        "ja": "データビュー",
+        "ja_typings": [
+          "de-tabyu-"
+        ]
+      },
+      {
+        "en": "ImageBitmap",
+        "ja": "イメージビットマップ",
+        "ja_typings": [
+          "ime-jibittomappu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01310",
+    "image_path": null,
+    "question_text": {
+      "en": "Which API enables sharing memory between threads with locks?",
+      "ja": "ロック付きでスレッド間メモリ共有を可能にする API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "UI redressing",
+        "ja": "ユーアイリドレッシング",
+        "ja_typings": [
+          "yu-airidoresshingu"
+        ]
+      },
+      {
+        "en": "Click hijacking",
+        "ja": "クリックハイジャッキング",
+        "ja_typings": [
+          "kurikkuhaijakkingu"
+        ]
+      },
+      {
+        "en": "DOM clobbering",
+        "ja": "ドムクロバリング",
+        "ja_typings": [
+          "domukurobaringu"
+        ]
+      },
+      {
+        "en": "Tab nabbing",
+        "ja": "タブナビング",
+        "ja_typings": [
+          "tabunabingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01311",
+    "image_path": null,
+    "question_text": {
+      "en": "Which attack tricks users into clicking hidden UI elements?",
+      "ja": "隠された UI 要素をクリックさせる攻撃は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Inline script allowlisting",
+        "ja": "インラインスクリプト許可リスト",
+        "ja_typings": [
+          "inrainsukuriputokyokarisuto"
+        ]
+      },
+      {
+        "en": "CORS preflight",
+        "ja": "コルスプリフライト",
+        "ja_typings": [
+          "korusupurifuraito"
+        ]
+      },
+      {
+        "en": "HSTS preload",
+        "ja": "エイチエスティーエスプリロード",
+        "ja_typings": [
+          "eichiesuti-esupuriro-do"
+        ]
+      },
+      {
+        "en": "Mixed content blocking",
+        "ja": "ミックスドコンテンツブロッキング",
+        "ja_typings": [
+          "mikkusudokontentsuburokkingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01312",
+    "image_path": null,
+    "question_text": {
+      "en": "What security mechanism uses a nonce in CSP?",
+      "ja": "CSP で nonce を使うセキュリティ機構は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "X-Content-Type-Options",
+        "ja": "エックスコンテントタイプオプションズ",
+        "ja_typings": [
+          "ekkusukontentotaipuopushonzu"
+        ]
+      },
+      {
+        "en": "X-Frame-Options",
+        "ja": "エックスフレームオプションズ",
+        "ja_typings": [
+          "ekkusufure-muopushonzu"
+        ]
+      },
+      {
+        "en": "X-XSS-Protection",
+        "ja": "エックスエックスエスエスプロテクション",
+        "ja_typings": [
+          "ekkusuekkusuesuesupurotekushon"
+        ]
+      },
+      {
+        "en": "X-Download-Options",
+        "ja": "エックスダウンロードオプションズ",
+        "ja_typings": [
+          "ekkusudaunro-dopushonzu",
+          "ekkusudaunro-doopushonzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01313",
+    "image_path": null,
+    "question_text": {
+      "en": "Which header prevents MIME-type sniffing?",
+      "ja": "MIME タイプ推測を防ぐヘッダーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DNS cache poisoning",
+        "ja": "ディーエヌエスキャッシュポイズニング",
+        "ja_typings": [
+          "di-enuesukyasshupoizuningu"
+        ]
+      },
+      {
+        "en": "DNS rebinding",
+        "ja": "ディーエヌエスリバインディング",
+        "ja_typings": [
+          "di-enuesuribaindingu"
+        ]
+      },
+      {
+        "en": "DNS tunneling",
+        "ja": "ディーエヌエストンネリング",
+        "ja_typings": [
+          "di-enuesutonnneringu"
+        ]
+      },
+      {
+        "en": "DNS spoofing reply",
+        "ja": "ディーエヌエススプーフィングリプライ",
+        "ja_typings": [
+          "di-enuesusupu-finguripurai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01314",
+    "image_path": null,
+    "question_text": {
+      "en": "What attack exploits trust in cached DNS responses?",
+      "ja": "キャッシュ済み DNS 応答の信頼を悪用する攻撃は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "frame-ancestors",
+        "ja": "フレームアンセスターズ",
+        "ja_typings": [
+          "fure-muansesuta-zu"
+        ]
+      },
+      {
+        "en": "frame-src",
+        "ja": "フレームエスアールシー",
+        "ja_typings": [
+          "fure-muesua-rushi-"
+        ]
+      },
+      {
+        "en": "X-Embed-Options",
+        "ja": "エックスエンベッドオプションズ",
+        "ja_typings": [
+          "ekkusuenbeddopushonzu",
+          "ekkusuenbeddoopushonzu"
+        ]
+      },
+      {
+        "en": "frame-deny-directive",
+        "ja": "フレームデナイディレクティブ",
+        "ja_typings": [
+          "fure-mudenaidirekutibu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01315",
+    "image_path": null,
+    "question_text": {
+      "en": "Which feature lets servers opt out of being framed?",
+      "ja": "サーバーがフレーム化拒否を表明する機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Anti-CSRF token",
+        "ja": "アンチシーエスアールエフトークン",
+        "ja_typings": [
+          "anchishi-esua-ruefuto-kun"
+        ]
+      },
+      {
+        "en": "Bearer token",
+        "ja": "ベアラートークン",
+        "ja_typings": [
+          "beara-to-kun"
+        ]
+      },
+      {
+        "en": "Session token",
+        "ja": "セッショントークン",
+        "ja_typings": [
+          "sesshonto-kun"
+        ]
+      },
+      {
+        "en": "Refresh token",
+        "ja": "リフレッシュトークン",
+        "ja_typings": [
+          "rifuresshuto-kun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01316",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the term for embedding tokens to verify form origin?",
+      "ja": "フォーム送信元検証のためにトークンを埋め込むことを指す用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "aria-live",
+        "ja": "アリアライブ",
+        "ja_typings": [
+          "ariaraibu"
+        ]
+      },
+      {
+        "en": "aria-busy",
+        "ja": "アリアビジー",
+        "ja_typings": [
+          "ariabiji-"
+        ]
+      },
+      {
+        "en": "aria-atomic",
+        "ja": "アリアアトミック",
+        "ja_typings": [
+          "ariaatomikku"
+        ]
+      },
+      {
+        "en": "aria-relevant",
+        "ja": "アリアレレバント",
+        "ja_typings": [
+          "ariarerebanto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01317",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ARIA attribute announces dynamic content politely?",
+      "ja": "動的コンテンツを丁寧に通知する ARIA 属性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "main",
+        "ja": "メイン",
+        "ja_typings": [
+          "mein"
+        ]
+      },
+      {
+        "en": "primary",
+        "ja": "プライマリ",
+        "ja_typings": [
+          "puraimari"
+        ]
+      },
+      {
+        "en": "content",
+        "ja": "コンテンツ",
+        "ja_typings": [
+          "kontentsu"
+        ]
+      },
+      {
+        "en": "body",
+        "ja": "ボディ",
+        "ja_typings": [
+          "bodi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01318",
+    "image_path": null,
+    "question_text": {
+      "en": "What ARIA role marks the main content area?",
+      "ja": "メインコンテンツ領域を示す ARIA ロールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "aria-hidden",
+        "ja": "アリアヒドゥン",
+        "ja_typings": [
+          "ariahidun"
+        ]
+      },
+      {
+        "en": "aria-skip",
+        "ja": "アリアスキップ",
+        "ja_typings": [
+          "ariasukippu"
+        ]
+      },
+      {
+        "en": "aria-decorative",
+        "ja": "アリアデコラティブ",
+        "ja_typings": [
+          "ariadekoratibu"
+        ]
+      },
+      {
+        "en": "aria-omit",
+        "ja": "アリアオミット",
+        "ja_typings": [
+          "ariaomitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01319",
+    "image_path": null,
+    "question_text": {
+      "en": "Which attribute hides decorative elements from assistive tech?",
+      "ja": "支援技術から装飾要素を隠す属性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "4.5:1",
+        "ja": "ヨンテンゴタイイチ",
+        "ja_typings": [
+          "4.5:1",
+          "yontengotaiichi"
+        ]
+      },
+      {
+        "en": "3:1",
+        "ja": "サンタイイチ",
+        "ja_typings": [
+          "3:1",
+          "santaiichi"
+        ]
+      },
+      {
+        "en": "7:1",
+        "ja": "ナナタイイチ",
+        "ja_typings": [
+          "7:1",
+          "nanataiichi"
+        ]
+      },
+      {
+        "en": "2:1",
+        "ja": "ニタイイチ",
+        "ja_typings": [
+          "2:1",
+          "nitaiichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01320",
+    "image_path": null,
+    "question_text": {
+      "en": "What WCAG contrast ratio is required for normal text AA?",
+      "ja": "通常テキスト AA に必要な WCAG コントラスト比は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "INP",
+        "ja": "アイエヌピー",
+        "ja_typings": [
+          "aienupi-"
+        ]
+      },
+      {
+        "en": "FID",
+        "ja": "エフアイディー",
+        "ja_typings": [
+          "efuaidi-"
+        ]
+      },
+      {
+        "en": "TBT",
+        "ja": "ティービーティー",
+        "ja_typings": [
+          "ti-bi-ti-"
+        ]
+      },
+      {
+        "en": "TTI",
+        "ja": "ティーティーアイ",
+        "ja_typings": [
+          "ti-ti-ai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01321",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Core Web Vital measures input responsiveness?",
+      "ja": "入力応答性を測る Core Web Vital は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CLS",
+        "ja": "シーエルエス",
+        "ja_typings": [
+          "shi-eruesu"
+        ]
+      },
+      {
+        "en": "LCP",
+        "ja": "エルシーピー",
+        "ja_typings": [
+          "erushi-pi-"
+        ]
+      },
+      {
+        "en": "FCP",
+        "ja": "エフシーピー",
+        "ja_typings": [
+          "efushi-pi-"
+        ]
+      },
+      {
+        "en": "TTFB",
+        "ja": "ティーティーエフビー",
+        "ja_typings": [
+          "ti-ti-efubi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01322",
+    "image_path": null,
+    "question_text": {
+      "en": "What Core Web Vital tracks layout stability?",
+      "ja": "レイアウト安定性を追跡する Core Web Vital は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dynamic import",
+        "ja": "ダイナミックインポート",
+        "ja_typings": [
+          "dainamikkuinpo-to"
+        ]
+      },
+      {
+        "en": "Static import",
+        "ja": "スタティックインポート",
+        "ja_typings": [
+          "sutatikkuinpo-to"
+        ]
+      },
+      {
+        "en": "Eager import",
+        "ja": "イーガーインポート",
+        "ja_typings": [
+          "i-ga-inpo-to"
+        ]
+      },
+      {
+        "en": "Bundle import",
+        "ja": "バンドルインポート",
+        "ja_typings": [
+          "bandoruinpo-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01323",
+    "image_path": null,
+    "question_text": {
+      "en": "Which technique loads JS chunks only when needed?",
+      "ja": "必要時のみ JS チャンクを読み込む技法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "rel=\"preload\"",
+        "ja": "レルプリロード",
+        "ja_typings": [
+          "rerupuriro-do"
+        ]
+      },
+      {
+        "en": "rel=\"prefetch\"",
+        "ja": "レルプリフェッチ",
+        "ja_typings": [
+          "rerupurifetchi"
+        ]
+      },
+      {
+        "en": "rel=\"preconnect\"",
+        "ja": "レルプリコネクト",
+        "ja_typings": [
+          "rerupurikonekuto"
+        ]
+      },
+      {
+        "en": "rel=\"dns-prefetch\"",
+        "ja": "レルディーエヌエスプリフェッチ",
+        "ja_typings": [
+          "rerudi-enuesupurifetchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01324",
+    "image_path": null,
+    "question_text": {
+      "en": "What HTML attribute hints the browser to preload a resource?",
+      "ja": "ブラウザにリソースの事前読み込みを指示する HTML 属性値は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "AVIF",
+        "ja": "エイビフ",
+        "ja_typings": [
+          "eibifu"
+        ]
+      },
+      {
+        "en": "HEIF",
+        "ja": "ヘイフ",
+        "ja_typings": [
+          "heifu"
+        ]
+      },
+      {
+        "en": "JXL",
+        "ja": "ジェイエックスエル",
+        "ja_typings": [
+          "jeiekkusueru"
+        ]
+      },
+      {
+        "en": "APNG",
+        "ja": "エーピーエヌジー",
+        "ja_typings": [
+          "e-pi-enuji-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01325",
+    "image_path": null,
+    "question_text": {
+      "en": "Which image format uses AV1 video codec for compression?",
+      "ja": "AV1 動画コーデックを使う画像形式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Critical CSS inlining",
+        "ja": "クリティカルシーエスエスインライニング",
+        "ja_typings": [
+          "kuritikarushi-esuesuinrainingu"
+        ]
+      },
+      {
+        "en": "CSS hoisting",
+        "ja": "シーエスエスホイスティング",
+        "ja_typings": [
+          "shi-esuesuhoisutingu"
+        ]
+      },
+      {
+        "en": "CSS shaking",
+        "ja": "シーエスエスシェイキング",
+        "ja_typings": [
+          "shi-esuesusheikingu"
+        ]
+      },
+      {
+        "en": "CSS splitting",
+        "ja": "シーエスエススプリッティング",
+        "ja_typings": [
+          "shi-esuesusupurittingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01326",
+    "image_path": null,
+    "question_text": {
+      "en": "What technique sends critical CSS in the HTML to reduce render-blocking?",
+      "ja": "レンダーブロッキング軽減のため HTML に CSS を埋め込む技法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HTTP over QUIC",
+        "ja": "エイチティーティーピーオーバークイック",
+        "ja_typings": [
+          "eichiti-ti-pi-o-ba-kuikku"
+        ]
+      },
+      {
+        "en": "SPDY",
+        "ja": "スピーディー",
+        "ja_typings": [
+          "supi-di-"
+        ]
+      },
+      {
+        "en": "MPTCP",
+        "ja": "エムピーティーシーピー",
+        "ja_typings": [
+          "emupi-ti-shi-pi-"
+        ]
+      },
+      {
+        "en": "WebTransport over TCP",
+        "ja": "ウェブトランスポートオーバーティーシーピー",
+        "ja_typings": [
+          "webutoransupo-to-ba-ti-shi-pi-",
+          "webutoransupo-too-ba-ti-shi-pi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01327",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol multiplexes streams over QUIC?",
+      "ja": "QUIC 上でストリームを多重化するプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "WHATWG URL",
+        "ja": "ワットダブリュージーユーアールエル",
+        "ja_typings": [
+          "wattodaburyu-ji-yu-a-rueru"
+        ]
+      },
+      {
+        "en": "RFC 3986 strict",
+        "ja": "アールエフシーサンキュウハチロクストリクト",
+        "ja_typings": [
+          "RFC 3986 strict",
+          "a-ruefushi-sankyuuhachirokusutorikuto"
+        ]
+      },
+      {
+        "en": "ICANN URL",
+        "ja": "アイキャンユーアールエル",
+        "ja_typings": [
+          "aikyannyu-a-rueru"
+        ]
+      },
+      {
+        "en": "W3C URL spec",
+        "ja": "ダブリュースリーシーユーアールエルスペック",
+        "ja_typings": [
+          "daburyu-suri-shi-yu-a-ruerusupekku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01328",
+    "image_path": null,
+    "question_text": {
+      "en": "What standard defines URL parsing across browsers?",
+      "ja": "ブラウザ間で URL 解析を定義する標準は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "createDocumentFragment",
+        "ja": "クリエイトドキュメントフラグメント",
+        "ja_typings": [
+          "kurieitodokyumentofuragumento"
+        ]
+      },
+      {
+        "en": "createFragment",
+        "ja": "クリエイトフラグメント",
+        "ja_typings": [
+          "kurieitofuragumento"
+        ]
+      },
+      {
+        "en": "makeFragment",
+        "ja": "メイクフラグメント",
+        "ja_typings": [
+          "meikufuragumento"
+        ]
+      },
+      {
+        "en": "newFragment",
+        "ja": "ニューフラグメント",
+        "ja_typings": [
+          "nyu-furagumento"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01329",
+    "image_path": null,
+    "question_text": {
+      "en": "Which DOM method creates a document fragment?",
+      "ja": "ドキュメントフラグメントを作成する DOM メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PWA manifest",
+        "ja": "ピーダブリューエーマニフェスト",
+        "ja_typings": [
+          "pi-daburyu-e-manifesuto"
+        ]
+      },
+      {
+        "en": "App shell",
+        "ja": "アップシェル",
+        "ja_typings": [
+          "appusheru"
+        ]
+      },
+      {
+        "en": "Web bundle",
+        "ja": "ウェブバンドル",
+        "ja_typings": [
+          "webubandoru"
+        ]
+      },
+      {
+        "en": "Trusted Web Activity",
+        "ja": "トラステッドウェブアクティビティ",
+        "ja_typings": [
+          "torasuteddowebuakutibiti"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01330",
+    "image_path": null,
+    "question_text": {
+      "en": "What feature lets web apps install like native apps?",
+      "ja": "Web アプリをネイティブのようにインストール可能にする機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "base64url",
+        "ja": "ベースロクヨンユーアールエル",
+        "ja_typings": [
+          "base64url",
+          "be-surokuyonnyu-a-rueru"
+        ]
+      },
+      {
+        "en": "base32",
+        "ja": "ベースサンジュウニ",
+        "ja_typings": [
+          "base32",
+          "be-susanjuuni"
+        ]
+      },
+      {
+        "en": "ascii85",
+        "ja": "アスキーハチゴ",
+        "ja_typings": [
+          "ascii85",
+          "asuki-hachigo"
+        ]
+      },
+      {
+        "en": "punycode",
+        "ja": "ピュニコード",
+        "ja_typings": [
+          "pyuniko-do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01331",
+    "image_path": null,
+    "question_text": {
+      "en": "Which encoding represents binary data as ASCII text in URLs?",
+      "ja": "URL でバイナリデータを ASCII テキストとして表現するエンコードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "contain",
+        "ja": "コンテイン",
+        "ja_typings": [
+          "kontein"
+        ]
+      },
+      {
+        "en": "isolate",
+        "ja": "アイソレート",
+        "ja_typings": [
+          "aisore-to"
+        ]
+      },
+      {
+        "en": "scope",
+        "ja": "スコープ",
+        "ja_typings": [
+          "suko-pu"
+        ]
+      },
+      {
+        "en": "encapsulate",
+        "ja": "エンキャプスレート",
+        "ja_typings": [
+          "enkyapusure-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01332",
+    "image_path": null,
+    "question_text": {
+      "en": "What CSS property controls how an element is contained for performance?",
+      "ja": "パフォーマンスのために要素の含意を制御する CSS プロパティは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "transitionend",
+        "ja": "トランジションエンド",
+        "ja_typings": [
+          "toranjishonnendo"
+        ]
+      },
+      {
+        "en": "transitioncomplete",
+        "ja": "トランジションコンプリート",
+        "ja_typings": [
+          "toranjishonkonpuri-to"
+        ]
+      },
+      {
+        "en": "animationend",
+        "ja": "アニメーションエンド",
+        "ja_typings": [
+          "anime-shonnendo"
+        ]
+      },
+      {
+        "en": "transitionstop",
+        "ja": "トランジションストップ",
+        "ja_typings": [
+          "toranjishonsutoppu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01333",
+    "image_path": null,
+    "question_text": {
+      "en": "Which DOM event fires when a CSS transition completes?",
+      "ja": "CSS トランジション完了時に発火する DOM イベントは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "My Neighbor Totoro",
+        "ja": "となりのトトロ",
+        "ja_typings": [
+          "tonarinototoro"
+        ]
+      },
+      {
+        "en": "Kiki's Delivery Service",
+        "ja": "魔女の宅急便",
+        "ja_typings": [
+          "majonotakkyuubin"
+        ]
+      },
+      {
+        "en": "Whisper of the Heart",
+        "ja": "耳をすませば",
+        "ja_typings": [
+          "mimiwosumaseba"
+        ]
+      },
+      {
+        "en": "Pom Poko",
+        "ja": "平成狸合戦ぽんぽこ",
+        "ja_typings": [
+          "heiseitanukigassenponpoko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01334",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1988 Studio Ghibli film features two sisters and a cat bus?",
+      "ja": "1988年公開で姉妹と猫バスが登場するジブリ作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Whisper of the Heart",
+        "ja": "耳をすませば",
+        "ja_typings": [
+          "mimiwosumaseba"
+        ]
+      },
+      {
+        "en": "Only Yesterday",
+        "ja": "おもひでぽろぽろ",
+        "ja_typings": [
+          "omohideporoporo"
+        ]
+      },
+      {
+        "en": "Ocean Waves",
+        "ja": "海がきこえる",
+        "ja_typings": [
+          "umigakikoeru"
+        ]
+      },
+      {
+        "en": "From Up on Poppy Hill",
+        "ja": "コクリコ坂から",
+        "ja_typings": [
+          "kokurikozakakara"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01335",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1995 Ghibli film centers on Shizuku writing a novel?",
+      "ja": "雫が小説を書く1995年のジブリ作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Space Pirate Captain Harlock",
+        "ja": "宇宙海賊キャプテンハーロック",
+        "ja_typings": [
+          "uchuukaizokukyaputenhaarokku"
+        ]
+      },
+      {
+        "en": "Galaxy Express 999",
+        "ja": "銀河鉄道999",
+        "ja_typings": [
+          "gingatetsudousurii"
+        ]
+      },
+      {
+        "en": "Space Battleship Yamato",
+        "ja": "宇宙戦艦ヤマト",
+        "ja_typings": [
+          "uchuusenkanyamato"
+        ]
+      },
+      {
+        "en": "Queen Millennia",
+        "ja": "新竹取物語",
+        "ja_typings": [
+          "shintaketorimonogatari"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01336",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1979 anime features Captain Harlock as the protagonist?",
+      "ja": "ハーロック船長が主人公の1979年アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Space Battleship Yamato",
+        "ja": "宇宙戦艦ヤマト",
+        "ja_typings": [
+          "uchuusenkanyamato"
+        ]
+      },
+      {
+        "en": "Galaxy Express 999",
+        "ja": "銀河鉄道999",
+        "ja_typings": [
+          "gingatetsudousurii"
+        ]
+      },
+      {
+        "en": "Captain Future",
+        "ja": "キャプテンフューチャー",
+        "ja_typings": [
+          "kyaputenfuyu-cha-"
+        ]
+      },
+      {
+        "en": "Macross",
+        "ja": "超時空要塞マクロス",
+        "ja_typings": [
+          "choujikuuyousaimakurosu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01337",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1974 anime depicts a journey to recover the Cosmo DNA?",
+      "ja": "コスモクリーナーDを取りに行く1974年のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Macross",
+        "ja": "超時空要塞マクロス",
+        "ja_typings": [
+          "choujikuuyousaimakurosu"
+        ]
+      },
+      {
+        "en": "Mobile Police Patlabor",
+        "ja": "機動警察パトレイバー",
+        "ja_typings": [
+          "kidoukeisatsupatoreibaa"
+        ]
+      },
+      {
+        "en": "Aura Battler Dunbine",
+        "ja": "聖戦士ダンバイン",
+        "ja_typings": [
+          "seisenshidanbain"
+        ]
+      },
+      {
+        "en": "Armored Trooper Votoms",
+        "ja": "装甲騎兵ボトムズ",
+        "ja_typings": [
+          "soukoukiheibotomuzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01338",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1982 mecha anime features Hikaru, Misa, and Minmay?",
+      "ja": "輝・未沙・ミンメイが登場する1982年のメカアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aura Battler Dunbine",
+        "ja": "聖戦士ダンバイン",
+        "ja_typings": [
+          "seisenshidanbain"
+        ]
+      },
+      {
+        "en": "Macross",
+        "ja": "超時空要塞マクロス",
+        "ja_typings": [
+          "choujikuuyousaimakurosu"
+        ]
+      },
+      {
+        "en": "Heavy Metal L-Gaim",
+        "ja": "重戦機エルガイム",
+        "ja_typings": [
+          "juusenkierugaimu"
+        ]
+      },
+      {
+        "en": "Layzner",
+        "ja": "蒼き流星SPTレイズナー",
+        "ja_typings": [
+          "aokiryuuseiSPTreizunaa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01339",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1983 anime is set in the world of Byston Well?",
+      "ja": "バイストン・ウェルが舞台の1983年のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Patlabor: The Movie",
+        "ja": "機動警察パトレイバー the Movie",
+        "ja_typings": [
+          "kidoukeisatsupatoreibaatheMovie"
+        ]
+      },
+      {
+        "en": "Angel's Egg",
+        "ja": "天使のたまご",
+        "ja_typings": [
+          "tenshinotamago"
+        ]
+      },
+      {
+        "en": "Urusei Yatsura 2: Beautiful Dreamer",
+        "ja": "うる星やつら2 ビューティフルドリーマー",
+        "ja_typings": [
+          "uruseiyatsura2byuutifurudoriimaa"
+        ]
+      },
+      {
+        "en": "Ghost in the Shell",
+        "ja": "GHOST IN THE SHELL",
+        "ja_typings": [
+          "ghost in the shell"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01340",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1988 OVA film by Mamoru Oshii features a sentient airliner?",
+      "ja": "意思を持つ旅客機が登場する1988年押井守監督のOVAは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Castle in the Sky",
+        "ja": "天空の城ラピュタ",
+        "ja_typings": [
+          "tenkuunoshiroraputa"
+        ]
+      },
+      {
+        "en": "Nausicaa",
+        "ja": "風の谷のナウシカ",
+        "ja_typings": [
+          "kazenotaninonaushika"
+        ]
+      },
+      {
+        "en": "My Neighbor Totoro",
+        "ja": "となりのトトロ",
+        "ja_typings": [
+          "tonarinototoro"
+        ]
+      },
+      {
+        "en": "Porco Rosso",
+        "ja": "紅の豚",
+        "ja_typings": [
+          "kurenainobuta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01341",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1985 Ghibli film follows Pazu and Sheeta?",
+      "ja": "パズーとシータが登場する1985年のジブリ作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nausicaa",
+        "ja": "風の谷のナウシカ",
+        "ja_typings": [
+          "kazenotaninonaushika"
+        ]
+      },
+      {
+        "en": "Castle in the Sky",
+        "ja": "天空の城ラピュタ",
+        "ja_typings": [
+          "tenkuunoshiroraputa"
+        ]
+      },
+      {
+        "en": "Royal Space Force",
+        "ja": "王立宇宙軍",
+        "ja_typings": [
+          "ouritsuuchuugun"
+        ]
+      },
+      {
+        "en": "Lensman",
+        "ja": "SF新世紀レンズマン",
+        "ja_typings": [
+          "SFshinseikirenzuman"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01342",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1984 Ghibli-precursor film features Ohmu and toxic jungles?",
+      "ja": "オームと腐海が登場する1984年の作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Royal Space Force",
+        "ja": "王立宇宙軍",
+        "ja_typings": [
+          "ouritsuuchuugun"
+        ]
+      },
+      {
+        "en": "Gunbuster",
+        "ja": "トップをねらえ!",
+        "ja_typings": [
+          "toppuwonerae",
+          "toppuonerae"
+        ]
+      },
+      {
+        "en": "Nadia",
+        "ja": "ふしぎの海のナディア",
+        "ja_typings": [
+          "fushiginouminonadia"
+        ]
+      },
+      {
+        "en": "Otaku no Video",
+        "ja": "おたくのビデオ",
+        "ja_typings": [
+          "otakunobideo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01343",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1987 Gainax film follows Shirotsugh joining a space program?",
+      "ja": "シロツグが宇宙軍に入隊する1987年のガイナックス作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gunbuster",
+        "ja": "トップをねらえ!",
+        "ja_typings": [
+          "toppuwonerae",
+          "toppuonerae"
+        ]
+      },
+      {
+        "en": "Bubblegum Crisis",
+        "ja": "バブルガムクライシス",
+        "ja_typings": [
+          "baburugamukuraishisu"
+        ]
+      },
+      {
+        "en": "Megazone 23",
+        "ja": "メガゾーン23",
+        "ja_typings": [
+          "megazo-n23"
+        ]
+      },
+      {
+        "en": "Patlabor",
+        "ja": "機動警察パトレイバー",
+        "ja_typings": [
+          "kidoukeisatsupatoreibaa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01344",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1988 OVA features Noriko piloting RX-7?",
+      "ja": "ノリコがRX-7に乗る1988年のOVAは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nadia",
+        "ja": "ふしぎの海のナディア",
+        "ja_typings": [
+          "fushiginouminonadia"
+        ]
+      },
+      {
+        "en": "Future Boy Conan",
+        "ja": "未来少年コナン",
+        "ja_typings": [
+          "miraishounenkonan"
+        ]
+      },
+      {
+        "en": "Anne of Green Gables",
+        "ja": "赤毛のアン",
+        "ja_typings": [
+          "akagenoan"
+        ]
+      },
+      {
+        "en": "Heidi",
+        "ja": "アルプスの少女ハイジ",
+        "ja_typings": [
+          "arupusunoshoujohaiji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01345",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1990 NHK anime follows Jean and Nadia searching for Atlantis?",
+      "ja": "ジャンとナディアがアトランティスを探す1990年のNHKアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Future Boy Conan",
+        "ja": "未来少年コナン",
+        "ja_typings": [
+          "miraishounenkonan"
+        ]
+      },
+      {
+        "en": "Lupin III Part 2",
+        "ja": "ルパン三世 PART2",
+        "ja_typings": [
+          "rupansansei PART2"
+        ]
+      },
+      {
+        "en": "Heidi",
+        "ja": "アルプスの少女ハイジ",
+        "ja_typings": [
+          "arupusunoshoujohaiji"
+        ]
+      },
+      {
+        "en": "3000 Leagues in Search of Mother",
+        "ja": "母をたずねて三千里",
+        "ja_typings": [
+          "hahawotazunetesanzenri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01346",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1978 Miyazaki TV series follows Conan after a global cataclysm?",
+      "ja": "大災害後の世界を描く1978年宮崎駿監督のTVシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tomorrow's Joe 2",
+        "ja": "あしたのジョー2",
+        "ja_typings": [
+          "ashitanojoo2",
+          "ashitanojo-2"
+        ]
+      },
+      {
+        "en": "Ginga: Nagareboshi Gin",
+        "ja": "銀牙 流れ星銀",
+        "ja_typings": [
+          "ginganagareboshigin"
+        ]
+      },
+      {
+        "en": "YAWARA!",
+        "ja": "YAWARA!",
+        "ja_typings": [
+          "yawara!"
+        ]
+      },
+      {
+        "en": "Slow Step",
+        "ja": "スローステップ",
+        "ja_typings": [
+          "suro-suteppu"
+        ]
+      }
+    ],
+    "correct_answer_index": 2,
+    "genre": "anime",
+    "id": "q01347",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1992 anime is about a girl boxing kickboxer named Hibiki?",
+      "ja": "響子が主人公の1992年のキックボクシングアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ranking of Kings",
+        "ja": "王様ランキング",
+        "ja_typings": [
+          "ousamarankingu"
+        ]
+      },
+      {
+        "en": "Heike Story",
+        "ja": "平家物語",
+        "ja_typings": [
+          "heikemonogatari"
+        ]
+      },
+      {
+        "en": "Sonny Boy",
+        "ja": "サニーボーイ",
+        "ja_typings": [
+          "sani-bo-i"
+        ]
+      },
+      {
+        "en": "Odd Taxi",
+        "ja": "オッドタクシー",
+        "ja_typings": [
+          "oddotakushi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01348",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2022 anime features Bojji, a deaf prince?",
+      "ja": "耳の聞こえない王子ボッジが主人公の2022年アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Heike Story",
+        "ja": "平家物語",
+        "ja_typings": [
+          "heikemonogatari"
+        ]
+      },
+      {
+        "en": "Ranking of Kings",
+        "ja": "王様ランキング",
+        "ja_typings": [
+          "ousamarankingu"
+        ]
+      },
+      {
+        "en": "Sonny Boy",
+        "ja": "サニーボーイ",
+        "ja_typings": [
+          "sani-bo-i"
+        ]
+      },
+      {
+        "en": "Vivy",
+        "ja": "Vivy",
+        "ja_typings": [
+          "vivy"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01349",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2021 anime by Naoko Yamada retells a classical war chronicle?",
+      "ja": "山田尚子監督による2021年の古典戦記アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Odd Taxi",
+        "ja": "オッドタクシー",
+        "ja_typings": [
+          "oddotakushi-"
+        ]
+      },
+      {
+        "en": "Heike Story",
+        "ja": "平家物語",
+        "ja_typings": [
+          "heikemonogatari"
+        ]
+      },
+      {
+        "en": "Sonny Boy",
+        "ja": "サニーボーイ",
+        "ja_typings": [
+          "sani-bo-i"
+        ]
+      },
+      {
+        "en": "Wonder Egg Priority",
+        "ja": "ワンダーエッグ・プライオリティ",
+        "ja_typings": [
+          "wanda-eggu/puraioriti"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01350",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2021 anime features a talking cat solving crimes in Tokyo?",
+      "ja": "東京で事件を解決する話す猫が登場する2021年のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vivy",
+        "ja": "Vivy",
+        "ja_typings": [
+          "vivy"
+        ]
+      },
+      {
+        "en": "BEASTARS",
+        "ja": "BEASTARS",
+        "ja_typings": [
+          "beastars"
+        ]
+      },
+      {
+        "en": "ID:INVADED",
+        "ja": "イド:インヴェイデッド",
+        "ja_typings": [
+          "ido inveideddo"
+        ]
+      },
+      {
+        "en": "Sonny Boy",
+        "ja": "サニーボーイ",
+        "ja_typings": [
+          "sani-bo-i"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01351",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2021 anime follows Ai singing diva android?",
+      "ja": "歌姫アンドロイドのヴィヴィが主人公の2021年のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sonny Boy",
+        "ja": "サニーボーイ",
+        "ja_typings": [
+          "sani-bo-i"
+        ]
+      },
+      {
+        "en": "Odd Taxi",
+        "ja": "オッドタクシー",
+        "ja_typings": [
+          "oddotakushi-"
+        ]
+      },
+      {
+        "en": "Wonder Egg Priority",
+        "ja": "ワンダーエッグ・プライオリティ",
+        "ja_typings": [
+          "wanda-eggu/puraioriti"
+        ]
+      },
+      {
+        "en": "Vivy",
+        "ja": "Vivy",
+        "ja_typings": [
+          "vivy"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01352",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2021 Madhouse anime features high schoolers stranded on a deserted island?",
+      "ja": "無人島に漂流する高校生が主人公の2021年マッドハウス制作アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bocchi the Rock!",
+        "ja": "ぼっち・ざ・ろっく!",
+        "ja_typings": [
+          "botchi/za/rokku"
+        ]
+      },
+      {
+        "en": "Skip and Loafer",
+        "ja": "スキップとローファー",
+        "ja_typings": [
+          "sukipputoro-fa-"
+        ]
+      },
+      {
+        "en": "Buddy Daddies",
+        "ja": "バディ・ダディズ",
+        "ja_typings": [
+          "badi/dadizu"
+        ]
+      },
+      {
+        "en": "MASHLE",
+        "ja": "マッシュル",
+        "ja_typings": [
+          "masshuru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01353",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2023 anime is about a girl band formed at SHIMOKITAZAWA?",
+      "ja": "下北沢で結成された女子バンドを描く2023年のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Skip and Loafer",
+        "ja": "スキップとローファー",
+        "ja_typings": [
+          "sukipputoro-fa-"
+        ]
+      },
+      {
+        "en": "Bocchi the Rock!",
+        "ja": "ぼっち・ざ・ろっく!",
+        "ja_typings": [
+          "botchi/za/rokku"
+        ]
+      },
+      {
+        "en": "MASHLE",
+        "ja": "マッシュル",
+        "ja_typings": [
+          "masshuru"
+        ]
+      },
+      {
+        "en": "Heavenly Delusion",
+        "ja": "天国大魔境",
+        "ja_typings": [
+          "tengokudaimakyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01354",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2023 anime follows a country girl Mitsumi adjusting to Tokyo high school?",
+      "ja": "上京した田舎の少女みつみが主人公の2023年のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Heavenly Delusion",
+        "ja": "天国大魔境",
+        "ja_typings": [
+          "tengokudaimakyou"
+        ]
+      },
+      {
+        "en": "Skip and Loafer",
+        "ja": "スキップとローファー",
+        "ja_typings": [
+          "sukipputoro-fa-"
+        ]
+      },
+      {
+        "en": "Vinland Saga Season 2",
+        "ja": "ヴィンランド・サガ SEASON2",
+        "ja_typings": [
+          "vinrando/saga season2"
+        ]
+      },
+      {
+        "en": "Hell's Paradise",
+        "ja": "地獄楽",
+        "ja_typings": [
+          "jigokuraku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01355",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2023 anime depicts Maru and Kiruko traveling post-apocalyptic Japan?",
+      "ja": "マルとキルコがポストアポカリプスの日本を旅する2023年アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vinland Saga",
+        "ja": "ヴィンランド・サガ",
+        "ja_typings": [
+          "vinrando/saga"
+        ]
+      },
+      {
+        "en": "Dororo",
+        "ja": "どろろ",
+        "ja_typings": [
+          "dororo"
+        ]
+      },
+      {
+        "en": "Beastars",
+        "ja": "BEASTARS",
+        "ja_typings": [
+          "beastars"
+        ]
+      },
+      {
+        "en": "Dr. STONE",
+        "ja": "Dr.STONE",
+        "ja_typings": [
+          "dr.stone"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01356",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2019 anime adapts Makoto Yukimura's Viking epic?",
+      "ja": "幸村誠のヴァイキング叙事詩を原作とする2019年のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mirai",
+        "ja": "未来のミライ",
+        "ja_typings": [
+          "mirainomirai"
+        ]
+      },
+      {
+        "en": "Wolf Children",
+        "ja": "おおかみこどもの雨と雪",
+        "ja_typings": [
+          "ookamikodomonoameToyuki"
+        ]
+      },
+      {
+        "en": "Belle",
+        "ja": "竜とそばかすの姫",
+        "ja_typings": [
+          "ryuutosobakasunohime"
+        ]
+      },
+      {
+        "en": "Summer Wars",
+        "ja": "サマーウォーズ",
+        "ja_typings": [
+          "sama-wo-zu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01357",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2018 Mamoru Hosoda film is about a boy meeting his future sister?",
+      "ja": "未来の妹に出会う少年を描く2018年細田守監督の映画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Belle",
+        "ja": "竜とそばかすの姫",
+        "ja_typings": [
+          "ryuutosobakasunohime"
+        ]
+      },
+      {
+        "en": "Mirai",
+        "ja": "未来のミライ",
+        "ja_typings": [
+          "mirainomirai"
+        ]
+      },
+      {
+        "en": "Summer Wars",
+        "ja": "サマーウォーズ",
+        "ja_typings": [
+          "sama-wo-zu"
+        ]
+      },
+      {
+        "en": "The Boy and the Beast",
+        "ja": "バケモノの子",
+        "ja_typings": [
+          "bakemononoko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01358",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2021 Hosoda film features a VR singer with a dragon?",
+      "ja": "竜とVR世界の歌姫を描く2021年の細田守監督作は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Maquia",
+        "ja": "さよならの朝に約束の花をかざろう",
+        "ja_typings": [
+          "sayonaranoasaniyakusokunohanawokazarou"
+        ]
+      },
+      {
+        "en": "Mai Mai Miracle",
+        "ja": "マイマイ新子と千年の魔法",
+        "ja_typings": [
+          "maimaishinkotosennnennnomahou"
+        ]
+      },
+      {
+        "en": "Mind Game",
+        "ja": "マインド・ゲーム",
+        "ja_typings": [
+          "maindo/ge-mu"
+        ]
+      },
+      {
+        "en": "Tekkonkinkreet",
+        "ja": "鉄コン筋クリート",
+        "ja_typings": [
+          "tekkonkinkuriito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01359",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2022 film by Mari Okada features a hidden village of red eyes?",
+      "ja": "岡田麿里監督による2022年の赤い瞳の村を描く映画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Paprika",
+        "ja": "パプリカ",
+        "ja_typings": [
+          "papurika"
+        ]
+      },
+      {
+        "en": "Millennium Actress",
+        "ja": "千年女優",
+        "ja_typings": [
+          "sennenjoyuu"
+        ]
+      },
+      {
+        "en": "Perfect Blue",
+        "ja": "PERFECT BLUE",
+        "ja_typings": [
+          "perfect blue"
+        ]
+      },
+      {
+        "en": "Tokyo Godfathers",
+        "ja": "東京ゴッドファーザーズ",
+        "ja_typings": [
+          "toukyougoddofaazaazu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01360",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2006 Kon Satoshi film is about a dream-invading device?",
+      "ja": "夢に入る装置を描く2006年今敏監督の映画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Millennium Actress",
+        "ja": "千年女優",
+        "ja_typings": [
+          "sennenjoyuu"
+        ]
+      },
+      {
+        "en": "Paprika",
+        "ja": "パプリカ",
+        "ja_typings": [
+          "papurika"
+        ]
+      },
+      {
+        "en": "Perfect Blue",
+        "ja": "PERFECT BLUE",
+        "ja_typings": [
+          "perfect blue"
+        ]
+      },
+      {
+        "en": "Tokyo Godfathers",
+        "ja": "東京ゴッドファーザーズ",
+        "ja_typings": [
+          "toukyougoddofaazaazu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01361",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2001 Kon Satoshi film blends an actress's memories with film history?",
+      "ja": "女優の記憶と映画史を交錯させる2001年今敏監督作は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Perfect Blue",
+        "ja": "PERFECT BLUE",
+        "ja_typings": [
+          "perfect blue"
+        ]
+      },
+      {
+        "en": "Millennium Actress",
+        "ja": "千年女優",
+        "ja_typings": [
+          "sennenjoyuu"
+        ]
+      },
+      {
+        "en": "Paprika",
+        "ja": "パプリカ",
+        "ja_typings": [
+          "papurika"
+        ]
+      },
+      {
+        "en": "Paranoia Agent",
+        "ja": "妄想代理人",
+        "ja_typings": [
+          "mousoudairinin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01362",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1997 Satoshi Kon film follows a pop idol turned actress?",
+      "ja": "アイドルから女優に転身した少女を描く1997年今敏監督作は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kinema Citrus",
+        "ja": "キネマシトラス",
+        "ja_typings": [
+          "kinemashitorasu"
+        ]
+      },
+      {
+        "en": "Wit Studio",
+        "ja": "WIT STUDIO",
+        "ja_typings": [
+          "wit studio"
+        ]
+      },
+      {
+        "en": "MAPPA",
+        "ja": "MAPPA",
+        "ja_typings": [
+          "mappa"
+        ]
+      },
+      {
+        "en": "Bones",
+        "ja": "ボンズ",
+        "ja_typings": [
+          "bonzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01363",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio produced Made in Abyss?",
+      "ja": "メイドインアビスを制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bones",
+        "ja": "ボンズ",
+        "ja_typings": [
+          "bonzu"
+        ]
+      },
+      {
+        "en": "Madhouse",
+        "ja": "マッドハウス",
+        "ja_typings": [
+          "maddohausu"
+        ]
+      },
+      {
+        "en": "Production I.G",
+        "ja": "Production I.G",
+        "ja_typings": [
+          "production i.g"
+        ]
+      },
+      {
+        "en": "J.C.Staff",
+        "ja": "J.C.STAFF",
+        "ja_typings": [
+          "j.c.staff"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01364",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio is famous for Mob Psycho 100 and One-Punch Man season 1?",
+      "ja": "モブサイコ100とワンパンマン1期で有名なスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kyoto Animation",
+        "ja": "京都アニメーション",
+        "ja_typings": [
+          "kyouToanimeeshon"
+        ]
+      },
+      {
+        "en": "P.A. Works",
+        "ja": "P.A.WORKS",
+        "ja_typings": [
+          "p.a.works"
+        ]
+      },
+      {
+        "en": "ufotable",
+        "ja": "ufotable",
+        "ja_typings": [
+          "ufotable"
+        ]
+      },
+      {
+        "en": "Bones",
+        "ja": "ボンズ",
+        "ja_typings": [
+          "bonzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01365",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio produced Violet Evergarden?",
+      "ja": "ヴァイオレット・エヴァーガーデンを制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "P.A. Works",
+        "ja": "P.A.WORKS",
+        "ja_typings": [
+          "p.a.works"
+        ]
+      },
+      {
+        "en": "Kyoto Animation",
+        "ja": "京都アニメーション",
+        "ja_typings": [
+          "kyouToanimeeshon"
+        ]
+      },
+      {
+        "en": "Trigger",
+        "ja": "TRIGGER",
+        "ja_typings": [
+          "trigger"
+        ]
+      },
+      {
+        "en": "Sunrise",
+        "ja": "サンライズ",
+        "ja_typings": [
+          "sanraizu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01366",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio is known for Hanasaku Iroha and Shirobako?",
+      "ja": "花咲くいろは・SHIROBAKOで知られるスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Trigger",
+        "ja": "TRIGGER",
+        "ja_typings": [
+          "trigger"
+        ]
+      },
+      {
+        "en": "Gainax",
+        "ja": "ガイナックス",
+        "ja_typings": [
+          "gainakkusu"
+        ]
+      },
+      {
+        "en": "Bones",
+        "ja": "ボンズ",
+        "ja_typings": [
+          "bonzu"
+        ]
+      },
+      {
+        "en": "MAPPA",
+        "ja": "MAPPA",
+        "ja_typings": [
+          "mappa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01367",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio is famous for Kill la Kill and SSSS.GRIDMAN?",
+      "ja": "キルラキル・SSSS.GRIDMANで有名なスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jun Fukuyama",
+        "ja": "福山潤",
+        "ja_typings": [
+          "fukuyamajun"
+        ]
+      },
+      {
+        "en": "Tomokazu Sugita",
+        "ja": "杉田智和",
+        "ja_typings": [
+          "sugitatomokazu"
+        ]
+      },
+      {
+        "en": "Mamoru Miyano",
+        "ja": "宮野真守",
+        "ja_typings": [
+          "miyanomamoru"
+        ]
+      },
+      {
+        "en": "Daisuke Ono",
+        "ja": "小野大輔",
+        "ja_typings": [
+          "onodaisuke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01368",
+    "image_path": null,
+    "question_text": {
+      "en": "Who voices Lelouch vi Britannia?",
+      "ja": "ルルーシュ・ヴィ・ブリタニアの声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ami Koshimizu",
+        "ja": "小清水亜美",
+        "ja_typings": [
+          "koshimizuami"
+        ]
+      },
+      {
+        "en": "Aya Hirano",
+        "ja": "平野綾",
+        "ja_typings": [
+          "hiranoaya"
+        ]
+      },
+      {
+        "en": "Yui Horie",
+        "ja": "堀江由衣",
+        "ja_typings": [
+          "horieyui"
+        ]
+      },
+      {
+        "en": "Rie Kugimiya",
+        "ja": "釘宮理恵",
+        "ja_typings": [
+          "kugimiyarie"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01369",
+    "image_path": null,
+    "question_text": {
+      "en": "Who voices Holo in Spice and Wolf?",
+      "ja": "狼と香辛料のホロの声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shinichiro Watanabe",
+        "ja": "渡辺信一郎",
+        "ja_typings": [
+          "watanabeshinichirou"
+        ]
+      },
+      {
+        "en": "Yoshiyuki Tomino",
+        "ja": "富野由悠季",
+        "ja_typings": [
+          "tominoyoshiyuki"
+        ]
+      },
+      {
+        "en": "Mamoru Oshii",
+        "ja": "押井守",
+        "ja_typings": [
+          "oshiimamoru"
+        ]
+      },
+      {
+        "en": "Yoshiaki Kawajiri",
+        "ja": "川尻善昭",
+        "ja_typings": [
+          "kawajiriyoshiaki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01370",
+    "image_path": null,
+    "question_text": {
+      "en": "Which director made Cowboy Bebop?",
+      "ja": "カウボーイビバップの監督は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shinichiro Watanabe",
+        "ja": "渡辺信一郎",
+        "ja_typings": [
+          "watanabeshinichirou"
+        ]
+      },
+      {
+        "en": "Goro Taniguchi",
+        "ja": "谷口悟朗",
+        "ja_typings": [
+          "taniguchigorou"
+        ]
+      },
+      {
+        "en": "Sayo Yamamoto",
+        "ja": "山本沙代",
+        "ja_typings": [
+          "yamamotosayo"
+        ]
+      },
+      {
+        "en": "Tensai Okamura",
+        "ja": "岡村天斎",
+        "ja_typings": [
+          "okamuratensai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01371",
+    "image_path": null,
+    "question_text": {
+      "en": "Which director helmed Samurai Champloo?",
+      "ja": "サムライチャンプルーの監督は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Masaaki Yuasa",
+        "ja": "湯浅政明",
+        "ja_typings": [
+          "yuasamasaaki"
+        ]
+      },
+      {
+        "en": "Shinichiro Watanabe",
+        "ja": "渡辺信一郎",
+        "ja_typings": [
+          "watanabeshinichirou"
+        ]
+      },
+      {
+        "en": "Mamoru Hosoda",
+        "ja": "細田守",
+        "ja_typings": [
+          "hosodamamoru"
+        ]
+      },
+      {
+        "en": "Hiroyuki Imaishi",
+        "ja": "今石洋之",
+        "ja_typings": [
+          "imaishihiroyuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01372",
+    "image_path": null,
+    "question_text": {
+      "en": "Which director made Mind Game and Devilman Crybaby?",
+      "ja": "マインド・ゲームとDEVILMAN crybabyの監督は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Samurai Champloo",
+        "ja": "サムライチャンプルー",
+        "ja_typings": [
+          "samuraichanpuru-"
+        ]
+      },
+      {
+        "en": "Cowboy Bebop",
+        "ja": "カウボーイビバップ",
+        "ja_typings": [
+          "kaubo-ibibappu"
+        ]
+      },
+      {
+        "en": "Space Dandy",
+        "ja": "スペース☆ダンディ",
+        "ja_typings": [
+          "supe-sudandi"
+        ]
+      },
+      {
+        "en": "Carole and Tuesday",
+        "ja": "キャロル&チューズデイ",
+        "ja_typings": [
+          "kyaroruchu-zudei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01373",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2004 anime by Shinichiro Watanabe is set in Edo-period Japan with hip-hop?",
+      "ja": "江戸時代にヒップホップを融合した2004年渡辺信一郎作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cowboy Bebop",
+        "ja": "カウボーイビバップ",
+        "ja_typings": [
+          "kaubo-ibibappu"
+        ]
+      },
+      {
+        "en": "Outlaw Star",
+        "ja": "アウトロースター",
+        "ja_typings": [
+          "autoro-suta-"
+        ]
+      },
+      {
+        "en": "Trigun",
+        "ja": "トライガン",
+        "ja_typings": [
+          "toraigan"
+        ]
+      },
+      {
+        "en": "Black Lagoon",
+        "ja": "ブラック・ラグーン",
+        "ja_typings": [
+          "burakku/ragu-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01374",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1998 anime features bounty hunter Spike Spiegel?",
+      "ja": "賞金稼ぎのスパイク・スピーゲルが主人公の1998年アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Trigun",
+        "ja": "トライガン",
+        "ja_typings": [
+          "toraigan"
+        ]
+      },
+      {
+        "en": "Cowboy Bebop",
+        "ja": "カウボーイビバップ",
+        "ja_typings": [
+          "kaubo-ibibappu"
+        ]
+      },
+      {
+        "en": "Outlaw Star",
+        "ja": "アウトロースター",
+        "ja_typings": [
+          "autoro-suta-"
+        ]
+      },
+      {
+        "en": "Big O",
+        "ja": "THE ビッグオー",
+        "ja_typings": [
+          "the bigguo-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01375",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1998 anime features Vash the Stampede on a desert planet?",
+      "ja": "砂漠の惑星でヴァッシュ・ザ・スタンピードが活躍する1998年アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rurouni Kenshin",
+        "ja": "るろうに剣心",
+        "ja_typings": [
+          "ruroun ikenshin"
+        ]
+      },
+      {
+        "en": "Yu Yu Hakusho",
+        "ja": "幽☆遊☆白書",
+        "ja_typings": [
+          "yuuyuuhakusho"
+        ]
+      },
+      {
+        "en": "Ranma 1/2",
+        "ja": "らんま1/2",
+        "ja_typings": [
+          "ranma1/2"
+        ]
+      },
+      {
+        "en": "Inuyasha",
+        "ja": "犬夜叉",
+        "ja_typings": [
+          "inuyasha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01376",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1995 anime features Kenshin Himura?",
+      "ja": "緋村剣心が主人公の1995年のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Inuyasha",
+        "ja": "犬夜叉",
+        "ja_typings": [
+          "inuyasha"
+        ]
+      },
+      {
+        "en": "Ranma 1/2",
+        "ja": "らんま1/2",
+        "ja_typings": [
+          "ranma1/2"
+        ]
+      },
+      {
+        "en": "Urusei Yatsura",
+        "ja": "うる星やつら",
+        "ja_typings": [
+          "uruseiyatsura"
+        ]
+      },
+      {
+        "en": "Maison Ikkoku",
+        "ja": "めぞん一刻",
+        "ja_typings": [
+          "mezonikkoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01377",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1992 anime by Rumiko Takahashi features a half-demon dog hero?",
+      "ja": "高橋留美子原作、半妖の少年が主人公の長編アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Maison Ikkoku",
+        "ja": "めぞん一刻",
+        "ja_typings": [
+          "mezonikkoku"
+        ]
+      },
+      {
+        "en": "Ranma 1/2",
+        "ja": "らんま1/2",
+        "ja_typings": [
+          "ranma1/2"
+        ]
+      },
+      {
+        "en": "Urusei Yatsura",
+        "ja": "うる星やつら",
+        "ja_typings": [
+          "uruseiyatsura"
+        ]
+      },
+      {
+        "en": "Inuyasha",
+        "ja": "犬夜叉",
+        "ja_typings": [
+          "inuyasha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01378",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1989 anime by Rumiko Takahashi is set in Ikkoku-kan apartment?",
+      "ja": "一刻館を舞台にした1989年の高橋留美子原作アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shotaro Ishinomori",
+        "ja": "石ノ森章太郎",
+        "ja_typings": [
+          "ishinomorishoutarou"
+        ]
+      },
+      {
+        "en": "Osamu Tezuka",
+        "ja": "手塚治虫",
+        "ja_typings": [
+          "tezukaosamu"
+        ]
+      },
+      {
+        "en": "Go Nagai",
+        "ja": "永井豪",
+        "ja_typings": [
+          "nagaigou"
+        ]
+      },
+      {
+        "en": "Leiji Matsumoto",
+        "ja": "松本零士",
+        "ja_typings": [
+          "matsumotoreiji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01379",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Cyborg 009 and Kamen Rider?",
+      "ja": "サイボーグ009と仮面ライダーの原作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Go Nagai",
+        "ja": "永井豪",
+        "ja_typings": [
+          "nagaigou"
+        ]
+      },
+      {
+        "en": "Shotaro Ishinomori",
+        "ja": "石ノ森章太郎",
+        "ja_typings": [
+          "ishinomorishoutarou"
+        ]
+      },
+      {
+        "en": "Osamu Tezuka",
+        "ja": "手塚治虫",
+        "ja_typings": [
+          "tezukaosamu"
+        ]
+      },
+      {
+        "en": "Mitsuteru Yokoyama",
+        "ja": "横山光輝",
+        "ja_typings": [
+          "yokoyamamitsuteru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01380",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Mazinger Z and Devilman?",
+      "ja": "マジンガーZとデビルマンの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mitsuteru Yokoyama",
+        "ja": "横山光輝",
+        "ja_typings": [
+          "yokoyamamitsuteru"
+        ]
+      },
+      {
+        "en": "Osamu Tezuka",
+        "ja": "手塚治虫",
+        "ja_typings": [
+          "tezukaosamu"
+        ]
+      },
+      {
+        "en": "Go Nagai",
+        "ja": "永井豪",
+        "ja_typings": [
+          "nagaigou"
+        ]
+      },
+      {
+        "en": "Leiji Matsumoto",
+        "ja": "松本零士",
+        "ja_typings": [
+          "matsumotoreiji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01381",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Tetsujin 28-go?",
+      "ja": "鉄人28号の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Osamu Tezuka",
+        "ja": "手塚治虫",
+        "ja_typings": [
+          "tezukaosamu"
+        ]
+      },
+      {
+        "en": "Shotaro Ishinomori",
+        "ja": "石ノ森章太郎",
+        "ja_typings": [
+          "ishinomorishoutarou"
+        ]
+      },
+      {
+        "en": "Mitsuteru Yokoyama",
+        "ja": "横山光輝",
+        "ja_typings": [
+          "yokoyamamitsuteru"
+        ]
+      },
+      {
+        "en": "Tetsuya Chiba",
+        "ja": "ちばてつや",
+        "ja_typings": [
+          "chibatetsuya"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01382",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote Phoenix (Hi no Tori)?",
+      "ja": "火の鳥の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tetsuya Chiba",
+        "ja": "ちばてつや",
+        "ja_typings": [
+          "chibatetsuya"
+        ]
+      },
+      {
+        "en": "Asao Takamori",
+        "ja": "高森朝雄",
+        "ja_typings": [
+          "takamorisaoo"
+        ]
+      },
+      {
+        "en": "Osamu Tezuka",
+        "ja": "手塚治虫",
+        "ja_typings": [
+          "tezukaosamu"
+        ]
+      },
+      {
+        "en": "Mitsuru Adachi",
+        "ja": "あだち充",
+        "ja_typings": [
+          "adachimitsuru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01383",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Tomorrow's Joe?",
+      "ja": "あしたのジョーの作画担当は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mitsuru Adachi",
+        "ja": "あだち充",
+        "ja_typings": [
+          "adachimitsuru"
+        ]
+      },
+      {
+        "en": "Tetsuya Chiba",
+        "ja": "ちばてつや",
+        "ja_typings": [
+          "chibatetsuya"
+        ]
+      },
+      {
+        "en": "Takehiko Inoue",
+        "ja": "井上雄彦",
+        "ja_typings": [
+          "inouetakehiko"
+        ]
+      },
+      {
+        "en": "Yoichi Takahashi",
+        "ja": "高橋陽一",
+        "ja_typings": [
+          "takahashiyouichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01384",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Touch and Cross Game?",
+      "ja": "タッチとクロスゲームの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yoichi Takahashi",
+        "ja": "高橋陽一",
+        "ja_typings": [
+          "takahashiyouichi"
+        ]
+      },
+      {
+        "en": "Mitsuru Adachi",
+        "ja": "あだち充",
+        "ja_typings": [
+          "adachimitsuru"
+        ]
+      },
+      {
+        "en": "Tetsuya Chiba",
+        "ja": "ちばてつや",
+        "ja_typings": [
+          "chibatetsuya"
+        ]
+      },
+      {
+        "en": "Takehiko Inoue",
+        "ja": "井上雄彦",
+        "ja_typings": [
+          "inouetakehiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01385",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Captain Tsubasa?",
+      "ja": "キャプテン翼の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Leiji Matsumoto",
+        "ja": "松本零士",
+        "ja_typings": [
+          "matsumotoreiji"
+        ]
+      },
+      {
+        "en": "Go Nagai",
+        "ja": "永井豪",
+        "ja_typings": [
+          "nagaigou"
+        ]
+      },
+      {
+        "en": "Mitsuteru Yokoyama",
+        "ja": "横山光輝",
+        "ja_typings": [
+          "yokoyamamitsuteru"
+        ]
+      },
+      {
+        "en": "Osamu Tezuka",
+        "ja": "手塚治虫",
+        "ja_typings": [
+          "tezukaosamu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01386",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Galaxy Express 999?",
+      "ja": "銀河鉄道999の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shonen Sunday",
+        "ja": "週刊少年サンデー",
+        "ja_typings": [
+          "shuukanshounensandee"
+        ]
+      },
+      {
+        "en": "Shonen Magazine",
+        "ja": "週刊少年マガジン",
+        "ja_typings": [
+          "shuukanshounenmagajin"
+        ]
+      },
+      {
+        "en": "Shonen Jump",
+        "ja": "週刊少年ジャンプ",
+        "ja_typings": [
+          "shuukanshounenjanpu"
+        ]
+      },
+      {
+        "en": "Shonen Champion",
+        "ja": "週刊少年チャンピオン",
+        "ja_typings": [
+          "shuukanshounenchanpion"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01387",
+    "image_path": null,
+    "question_text": {
+      "en": "Which magazine serialized Touch and H2?",
+      "ja": "タッチとH2が連載された雑誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shonen Magazine",
+        "ja": "週刊少年マガジン",
+        "ja_typings": [
+          "shuukanshounenmagajin"
+        ]
+      },
+      {
+        "en": "Shonen Sunday",
+        "ja": "週刊少年サンデー",
+        "ja_typings": [
+          "shuukanshounensandee"
+        ]
+      },
+      {
+        "en": "Shonen Jump",
+        "ja": "週刊少年ジャンプ",
+        "ja_typings": [
+          "shuukanshounenjanpu"
+        ]
+      },
+      {
+        "en": "Big Comic",
+        "ja": "ビッグコミック",
+        "ja_typings": [
+          "biggukomikku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01388",
+    "image_path": null,
+    "question_text": {
+      "en": "Which magazine serialized Tomorrow's Joe?",
+      "ja": "あしたのジョーが連載された雑誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shueisha",
+        "ja": "集英社",
+        "ja_typings": [
+          "shuueisha"
+        ]
+      },
+      {
+        "en": "Kodansha",
+        "ja": "講談社",
+        "ja_typings": [
+          "koudansha"
+        ]
+      },
+      {
+        "en": "Shogakukan",
+        "ja": "小学館",
+        "ja_typings": [
+          "shougakukan"
+        ]
+      },
+      {
+        "en": "Akita Shoten",
+        "ja": "秋田書店",
+        "ja_typings": [
+          "akitashoten"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01389",
+    "image_path": null,
+    "question_text": {
+      "en": "Which publisher releases Shonen Jump?",
+      "ja": "週刊少年ジャンプの出版社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kodansha",
+        "ja": "講談社",
+        "ja_typings": [
+          "koudansha"
+        ]
+      },
+      {
+        "en": "Shueisha",
+        "ja": "集英社",
+        "ja_typings": [
+          "shuueisha"
+        ]
+      },
+      {
+        "en": "Shogakukan",
+        "ja": "小学館",
+        "ja_typings": [
+          "shougakukan"
+        ]
+      },
+      {
+        "en": "Hakusensha",
+        "ja": "白泉社",
+        "ja_typings": [
+          "hakusensha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01390",
+    "image_path": null,
+    "question_text": {
+      "en": "Which publisher releases Shonen Magazine?",
+      "ja": "週刊少年マガジンの出版社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shogakukan",
+        "ja": "小学館",
+        "ja_typings": [
+          "shougakukan"
+        ]
+      },
+      {
+        "en": "Shueisha",
+        "ja": "集英社",
+        "ja_typings": [
+          "shuueisha"
+        ]
+      },
+      {
+        "en": "Kodansha",
+        "ja": "講談社",
+        "ja_typings": [
+          "koudansha"
+        ]
+      },
+      {
+        "en": "Square Enix",
+        "ja": "スクウェア・エニックス",
+        "ja_typings": [
+          "sukuwea/enikkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01391",
+    "image_path": null,
+    "question_text": {
+      "en": "Which publisher releases Shonen Sunday?",
+      "ja": "週刊少年サンデーの出版社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Akita Shoten",
+        "ja": "秋田書店",
+        "ja_typings": [
+          "akitashoten"
+        ]
+      },
+      {
+        "en": "Shueisha",
+        "ja": "集英社",
+        "ja_typings": [
+          "shuueisha"
+        ]
+      },
+      {
+        "en": "Kodansha",
+        "ja": "講談社",
+        "ja_typings": [
+          "koudansha"
+        ]
+      },
+      {
+        "en": "Shogakukan",
+        "ja": "小学館",
+        "ja_typings": [
+          "shougakukan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01392",
+    "image_path": null,
+    "question_text": {
+      "en": "Which publisher releases Shonen Champion?",
+      "ja": "週刊少年チャンピオンの出版社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Osamu Tezuka",
+        "ja": "手塚治虫",
+        "ja_typings": [
+          "tezukaosamu"
+        ]
+      },
+      {
+        "en": "Shotaro Ishinomori",
+        "ja": "石ノ森章太郎",
+        "ja_typings": [
+          "ishinomorishoutarou"
+        ]
+      },
+      {
+        "en": "Mitsuteru Yokoyama",
+        "ja": "横山光輝",
+        "ja_typings": [
+          "yokoyamamitsuteru"
+        ]
+      },
+      {
+        "en": "Go Nagai",
+        "ja": "永井豪",
+        "ja_typings": [
+          "nagaigou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01393",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Astro Boy?",
+      "ja": "鉄腕アトムの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Osamu Tezuka",
+        "ja": "手塚治虫",
+        "ja_typings": [
+          "tezukaosamu"
+        ]
+      },
+      {
+        "en": "Shotaro Ishinomori",
+        "ja": "石ノ森章太郎",
+        "ja_typings": [
+          "ishinomorishoutarou"
+        ]
+      },
+      {
+        "en": "Mitsuteru Yokoyama",
+        "ja": "横山光輝",
+        "ja_typings": [
+          "yokoyamamitsuteru"
+        ]
+      },
+      {
+        "en": "Riyoko Ikeda",
+        "ja": "池田理代子",
+        "ja_typings": [
+          "ikedariyoko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01394",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Black Jack?",
+      "ja": "ブラック・ジャックの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Riyoko Ikeda",
+        "ja": "池田理代子",
+        "ja_typings": [
+          "ikedariyoko"
+        ]
+      },
+      {
+        "en": "Moto Hagio",
+        "ja": "萩尾望都",
+        "ja_typings": [
+          "hagiomoto"
+        ]
+      },
+      {
+        "en": "Keiko Takemiya",
+        "ja": "竹宮惠子",
+        "ja_typings": [
+          "takemiyakeiko"
+        ]
+      },
+      {
+        "en": "Yumiko Oshima",
+        "ja": "大島弓子",
+        "ja_typings": [
+          "ooshimayumiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01395",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created The Rose of Versailles?",
+      "ja": "ベルサイユのばらの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Moto Hagio",
+        "ja": "萩尾望都",
+        "ja_typings": [
+          "hagiomoto"
+        ]
+      },
+      {
+        "en": "Riyoko Ikeda",
+        "ja": "池田理代子",
+        "ja_typings": [
+          "ikedariyoko"
+        ]
+      },
+      {
+        "en": "Keiko Takemiya",
+        "ja": "竹宮惠子",
+        "ja_typings": [
+          "takemiyakeiko"
+        ]
+      },
+      {
+        "en": "Yumiko Oshima",
+        "ja": "大島弓子",
+        "ja_typings": [
+          "ooshimayumiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01396",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created The Heart of Thomas?",
+      "ja": "トーマの心臓の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Takehiko Inoue",
+        "ja": "井上雄彦",
+        "ja_typings": [
+          "inouetakehiko"
+        ]
+      },
+      {
+        "en": "Naoki Urasawa",
+        "ja": "浦沢直樹",
+        "ja_typings": [
+          "urasawanaoki"
+        ]
+      },
+      {
+        "en": "Tsugumi Ohba",
+        "ja": "大場つぐみ",
+        "ja_typings": [
+          "oobatsugumi"
+        ]
+      },
+      {
+        "en": "Eiichiro Oda",
+        "ja": "尾田栄一郎",
+        "ja_typings": [
+          "odaeiichirou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01397",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Vagabond and Real?",
+      "ja": "バガボンドとREALの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Naoki Urasawa",
+        "ja": "浦沢直樹",
+        "ja_typings": [
+          "urasawanaoki"
+        ]
+      },
+      {
+        "en": "Takehiko Inoue",
+        "ja": "井上雄彦",
+        "ja_typings": [
+          "inouetakehiko"
+        ]
+      },
+      {
+        "en": "Kentaro Miura",
+        "ja": "三浦建太郎",
+        "ja_typings": [
+          "miurakentarou"
+        ]
+      },
+      {
+        "en": "Hitoshi Iwaaki",
+        "ja": "岩明均",
+        "ja_typings": [
+          "iwaakihitoshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01398",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote Pluto and Billy Bat?",
+      "ja": "PLUTOとBILLY BATの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hitoshi Iwaaki",
+        "ja": "岩明均",
+        "ja_typings": [
+          "iwaakihitoshi"
+        ]
+      },
+      {
+        "en": "Naoki Urasawa",
+        "ja": "浦沢直樹",
+        "ja_typings": [
+          "urasawanaoki"
+        ]
+      },
+      {
+        "en": "Kentaro Miura",
+        "ja": "三浦建太郎",
+        "ja_typings": [
+          "miurakentarou"
+        ]
+      },
+      {
+        "en": "Takehiko Inoue",
+        "ja": "井上雄彦",
+        "ja_typings": [
+          "inouetakehiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01399",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Parasyte (Kiseiju)?",
+      "ja": "寄生獣の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Toru Fujisawa",
+        "ja": "藤沢とおる",
+        "ja_typings": [
+          "fujisawatooru"
+        ]
+      },
+      {
+        "en": "Tsukasa Hojo",
+        "ja": "北条司",
+        "ja_typings": [
+          "houjoutsukasa"
+        ]
+      },
+      {
+        "en": "Yusuke Murata",
+        "ja": "村田雄介",
+        "ja_typings": [
+          "muratayuusuke"
+        ]
+      },
+      {
+        "en": "Hiroshi Takahashi",
+        "ja": "高橋ヒロシ",
+        "ja_typings": [
+          "takahashihiroshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01400",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created the manga GTO?",
+      "ja": "GTOの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tsukasa Hojo",
+        "ja": "北条司",
+        "ja_typings": [
+          "houjoutsukasa"
+        ]
+      },
+      {
+        "en": "Toru Fujisawa",
+        "ja": "藤沢とおる",
+        "ja_typings": [
+          "fujisawatooru"
+        ]
+      },
+      {
+        "en": "Buronson",
+        "ja": "武論尊",
+        "ja_typings": [
+          "buronson"
+        ]
+      },
+      {
+        "en": "Yu Koyama",
+        "ja": "小山ゆう",
+        "ja_typings": [
+          "koyamayuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01401",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created City Hunter?",
+      "ja": "シティーハンターの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hiroshi Takahashi",
+        "ja": "高橋ヒロシ",
+        "ja_typings": [
+          "takahashihiroshi"
+        ]
+      },
+      {
+        "en": "Toru Fujisawa",
+        "ja": "藤沢とおる",
+        "ja_typings": [
+          "fujisawatooru"
+        ]
+      },
+      {
+        "en": "Tsukasa Hojo",
+        "ja": "北条司",
+        "ja_typings": [
+          "houjoutsukasa"
+        ]
+      },
+      {
+        "en": "Naoki Urasawa",
+        "ja": "浦沢直樹",
+        "ja_typings": [
+          "urasawanaoki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01402",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Crows and Worst?",
+      "ja": "クローズとWORSTの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shuichi Shigeno",
+        "ja": "しげの秀一",
+        "ja_typings": [
+          "shigenoshuuichi"
+        ]
+      },
+      {
+        "en": "Buichi Terasawa",
+        "ja": "寺沢武一",
+        "ja_typings": [
+          "terasawabuichi"
+        ]
+      },
+      {
+        "en": "Tsukasa Hojo",
+        "ja": "北条司",
+        "ja_typings": [
+          "houjoutsukasa"
+        ]
+      },
+      {
+        "en": "Yusuke Murata",
+        "ja": "村田雄介",
+        "ja_typings": [
+          "muratayuusuke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01403",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Initial D?",
+      "ja": "頭文字Dの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Suzue Miuchi",
+        "ja": "美内すずえ",
+        "ja_typings": [
+          "miuchisuzue"
+        ]
+      },
+      {
+        "en": "Riyoko Ikeda",
+        "ja": "池田理代子",
+        "ja_typings": [
+          "ikedariyoko"
+        ]
+      },
+      {
+        "en": "Moto Hagio",
+        "ja": "萩尾望都",
+        "ja_typings": [
+          "hagiomoto"
+        ]
+      },
+      {
+        "en": "Waki Yamato",
+        "ja": "大和和紀",
+        "ja_typings": [
+          "yamatowaki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01404",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Glass Mask (Garasu no Kamen)?",
+      "ja": "ガラスの仮面の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tomoko Ninomiya",
+        "ja": "二ノ宮知子",
+        "ja_typings": [
+          "ninomiyatomoko"
+        ]
+      },
+      {
+        "en": "Ai Yazawa",
+        "ja": "矢沢あい",
+        "ja_typings": [
+          "yazawaai"
+        ]
+      },
+      {
+        "en": "Suzue Miuchi",
+        "ja": "美内すずえ",
+        "ja_typings": [
+          "miuchisuzue"
+        ]
+      },
+      {
+        "en": "Yoko Kamio",
+        "ja": "神尾葉子",
+        "ja_typings": [
+          "kamioyouko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01405",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Nodame Cantabile?",
+      "ja": "のだめカンタービレの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ai Yazawa",
+        "ja": "矢沢あい",
+        "ja_typings": [
+          "yazawaai"
+        ]
+      },
+      {
+        "en": "Tomoko Ninomiya",
+        "ja": "二ノ宮知子",
+        "ja_typings": [
+          "ninomiyatomoko"
+        ]
+      },
+      {
+        "en": "Yoko Kamio",
+        "ja": "神尾葉子",
+        "ja_typings": [
+          "kamioyouko"
+        ]
+      },
+      {
+        "en": "Chika Umino",
+        "ja": "羽海野チカ",
+        "ja_typings": [
+          "uminochika"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01406",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created NANA?",
+      "ja": "NANAの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chika Umino",
+        "ja": "羽海野チカ",
+        "ja_typings": [
+          "uminochika"
+        ]
+      },
+      {
+        "en": "Ai Yazawa",
+        "ja": "矢沢あい",
+        "ja_typings": [
+          "yazawaai"
+        ]
+      },
+      {
+        "en": "Tomoko Ninomiya",
+        "ja": "二ノ宮知子",
+        "ja_typings": [
+          "ninomiyatomoko"
+        ]
+      },
+      {
+        "en": "Yumi Tamura",
+        "ja": "田村由美",
+        "ja_typings": [
+          "tamurayumi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01407",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Honey and Clover?",
+      "ja": "ハチミツとクローバーの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chika Umino",
+        "ja": "羽海野チカ",
+        "ja_typings": [
+          "uminochika"
+        ]
+      },
+      {
+        "en": "Ai Yazawa",
+        "ja": "矢沢あい",
+        "ja_typings": [
+          "yazawaai"
+        ]
+      },
+      {
+        "en": "Yumi Tamura",
+        "ja": "田村由美",
+        "ja_typings": [
+          "tamurayumi"
+        ]
+      },
+      {
+        "en": "Akiko Higashimura",
+        "ja": "東村アキコ",
+        "ja_typings": [
+          "higashimuraakiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01408",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created March Comes in Like a Lion (3-gatsu no Lion)?",
+      "ja": "3月のライオンの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Akiko Higashimura",
+        "ja": "東村アキコ",
+        "ja_typings": [
+          "higashimuraakiko"
+        ]
+      },
+      {
+        "en": "Chika Umino",
+        "ja": "羽海野チカ",
+        "ja_typings": [
+          "uminochika"
+        ]
+      },
+      {
+        "en": "Ai Yazawa",
+        "ja": "矢沢あい",
+        "ja_typings": [
+          "yazawaai"
+        ]
+      },
+      {
+        "en": "Yumi Tamura",
+        "ja": "田村由美",
+        "ja_typings": [
+          "tamurayumi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01409",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Princess Jellyfish (Kuragehime)?",
+      "ja": "海月姫の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kiyohiko Azuma",
+        "ja": "あずまきよひこ",
+        "ja_typings": [
+          "azumakiyohiko"
+        ]
+      },
+      {
+        "en": "Kentaro Miura",
+        "ja": "三浦建太郎",
+        "ja_typings": [
+          "miurakentarou"
+        ]
+      },
+      {
+        "en": "Hitoshi Iwaaki",
+        "ja": "岩明均",
+        "ja_typings": [
+          "iwaakihitoshi"
+        ]
+      },
+      {
+        "en": "Takehiko Inoue",
+        "ja": "井上雄彦",
+        "ja_typings": [
+          "inouetakehiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01410",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Yotsuba&!?",
+      "ja": "よつばと!の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Inio Asano",
+        "ja": "浅野いにお",
+        "ja_typings": [
+          "asanoinio"
+        ]
+      },
+      {
+        "en": "Naoki Urasawa",
+        "ja": "浦沢直樹",
+        "ja_typings": [
+          "urasawanaoki"
+        ]
+      },
+      {
+        "en": "Taiyo Matsumoto",
+        "ja": "松本大洋",
+        "ja_typings": [
+          "matsumototaiyou"
+        ]
+      },
+      {
+        "en": "Daisuke Igarashi",
+        "ja": "五十嵐大介",
+        "ja_typings": [
+          "igarashidaisuke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01411",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Oyasumi Punpun?",
+      "ja": "おやすみプンプンの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Taiyo Matsumoto",
+        "ja": "松本大洋",
+        "ja_typings": [
+          "matsumototaiyou"
+        ]
+      },
+      {
+        "en": "Inio Asano",
+        "ja": "浅野いにお",
+        "ja_typings": [
+          "asanoinio"
+        ]
+      },
+      {
+        "en": "Daisuke Igarashi",
+        "ja": "五十嵐大介",
+        "ja_typings": [
+          "igarashidaisuke"
+        ]
+      },
+      {
+        "en": "Jiro Taniguchi",
+        "ja": "谷口ジロー",
+        "ja_typings": [
+          "taniguchijiroo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01412",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Sunny and Number 5?",
+      "ja": "Sunnyとナンバーファイブの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jiro Taniguchi",
+        "ja": "谷口ジロー",
+        "ja_typings": [
+          "taniguchijiroo"
+        ]
+      },
+      {
+        "en": "Taiyo Matsumoto",
+        "ja": "松本大洋",
+        "ja_typings": [
+          "matsumototaiyou"
+        ]
+      },
+      {
+        "en": "Inio Asano",
+        "ja": "浅野いにお",
+        "ja_typings": [
+          "asanoinio"
+        ]
+      },
+      {
+        "en": "Daisuke Igarashi",
+        "ja": "五十嵐大介",
+        "ja_typings": [
+          "igarashidaisuke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01413",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created The Walking Man (Aruku Hito)?",
+      "ja": "歩くひとの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Daisuke Igarashi",
+        "ja": "五十嵐大介",
+        "ja_typings": [
+          "igarashidaisuke"
+        ]
+      },
+      {
+        "en": "Taiyo Matsumoto",
+        "ja": "松本大洋",
+        "ja_typings": [
+          "matsumototaiyou"
+        ]
+      },
+      {
+        "en": "Jiro Taniguchi",
+        "ja": "谷口ジロー",
+        "ja_typings": [
+          "taniguchijiroo"
+        ]
+      },
+      {
+        "en": "Inio Asano",
+        "ja": "浅野いにお",
+        "ja_typings": [
+          "asanoinio"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01414",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Children of the Sea (Kaijuu no Kodomo)?",
+      "ja": "海獣の子供の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Akihito Tsukushi",
+        "ja": "つくしあきひと",
+        "ja_typings": [
+          "tsukushiakihito"
+        ]
+      },
+      {
+        "en": "Sui Ishida",
+        "ja": "石田スイ",
+        "ja_typings": [
+          "ishidasui"
+        ]
+      },
+      {
+        "en": "Hajime Isayama",
+        "ja": "諫山創",
+        "ja_typings": [
+          "isayamahajime"
+        ]
+      },
+      {
+        "en": "Kohei Horikoshi",
+        "ja": "堀越耕平",
+        "ja_typings": [
+          "horikoshikouhei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01415",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Made in Abyss?",
+      "ja": "メイドインアビスの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sui Ishida",
+        "ja": "石田スイ",
+        "ja_typings": [
+          "ishidasui"
+        ]
+      },
+      {
+        "en": "Akihito Tsukushi",
+        "ja": "つくしあきひと",
+        "ja_typings": [
+          "tsukushiakihito"
+        ]
+      },
+      {
+        "en": "Hajime Isayama",
+        "ja": "諫山創",
+        "ja_typings": [
+          "isayamahajime"
+        ]
+      },
+      {
+        "en": "Kohei Horikoshi",
+        "ja": "堀越耕平",
+        "ja_typings": [
+          "horikoshikouhei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01416",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Tokyo Ghoul?",
+      "ja": "東京喰種の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Young Animal",
+        "ja": "ヤングアニマル",
+        "ja_typings": [
+          "yanguanimaru"
+        ]
+      },
+      {
+        "en": "Young Jump",
+        "ja": "週刊ヤングジャンプ",
+        "ja_typings": [
+          "shuukanyangujanpu"
+        ]
+      },
+      {
+        "en": "Afternoon",
+        "ja": "月刊アフタヌーン",
+        "ja_typings": [
+          "gekkanafutanuun"
+        ]
+      },
+      {
+        "en": "Morning",
+        "ja": "週刊モーニング",
+        "ja_typings": [
+          "shuukanmooningu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01417",
+    "image_path": null,
+    "question_text": {
+      "en": "Which magazine serialized Berserk?",
+      "ja": "ベルセルクが連載された雑誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Afternoon",
+        "ja": "月刊アフタヌーン",
+        "ja_typings": [
+          "gekkanafutanuun"
+        ]
+      },
+      {
+        "en": "Young Animal",
+        "ja": "ヤングアニマル",
+        "ja_typings": [
+          "yanguanimaru"
+        ]
+      },
+      {
+        "en": "Morning",
+        "ja": "週刊モーニング",
+        "ja_typings": [
+          "shuukanmooningu"
+        ]
+      },
+      {
+        "en": "Big Comic Original",
+        "ja": "ビッグコミックオリジナル",
+        "ja_typings": [
+          "biggukomikkuorijinaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01418",
+    "image_path": null,
+    "question_text": {
+      "en": "Which magazine serialized Vinland Saga?",
+      "ja": "ヴィンランド・サガが連載されている雑誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ryu Ga Gotoku Studio",
+        "ja": "龍が如くスタジオ",
+        "ja_typings": [
+          "ryuugagotokusutajio"
+        ]
+      },
+      {
+        "en": "Atlus",
+        "ja": "アトラス",
+        "ja_typings": [
+          "atorasu"
+        ]
+      },
+      {
+        "en": "Tri-Ace",
+        "ja": "トライエース",
+        "ja_typings": [
+          "toraie-su"
+        ]
+      },
+      {
+        "en": "From Software",
+        "ja": "フロム・ソフトウェア",
+        "ja_typings": [
+          "furomu/sofutowea"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01419",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed the Yakuza/Like a Dragon series?",
+      "ja": "龍が如く/ライクアドラゴンを開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Atlus",
+        "ja": "アトラス",
+        "ja_typings": [
+          "atorasu"
+        ]
+      },
+      {
+        "en": "Square Enix",
+        "ja": "スクウェア・エニックス",
+        "ja_typings": [
+          "sukuwea/enikkusu"
+        ]
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": [
+          "bandainamuko"
+        ]
+      },
+      {
+        "en": "Sega",
+        "ja": "セガ",
+        "ja_typings": [
+          "sega"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01420",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed Persona 5?",
+      "ja": "ペルソナ5を開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FromSoftware",
+        "ja": "フロム・ソフトウェア",
+        "ja_typings": [
+          "furomu/sofutowea"
+        ]
+      },
+      {
+        "en": "Capcom",
+        "ja": "カプコン",
+        "ja_typings": [
+          "kapukon"
+        ]
+      },
+      {
+        "en": "Atlus",
+        "ja": "アトラス",
+        "ja_typings": [
+          "atorasu"
+        ]
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": [
+          "bandainamuko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01421",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed Dark Souls and Bloodborne?",
+      "ja": "ダークソウルとブラッドボーンを開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Capcom",
+        "ja": "カプコン",
+        "ja_typings": [
+          "kapukon"
+        ]
+      },
+      {
+        "en": "FromSoftware",
+        "ja": "フロム・ソフトウェア",
+        "ja_typings": [
+          "furomu/sofutowea"
+        ]
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": [
+          "bandainamuko"
+        ]
+      },
+      {
+        "en": "Koei Tecmo",
+        "ja": "コーエーテクモ",
+        "ja_typings": [
+          "ko-e-tekumo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01422",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed Monster Hunter series?",
+      "ja": "モンスターハンターシリーズを開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Koei Tecmo",
+        "ja": "コーエーテクモ",
+        "ja_typings": [
+          "ko-e-tekumo"
+        ]
+      },
+      {
+        "en": "Capcom",
+        "ja": "カプコン",
+        "ja_typings": [
+          "kapukon"
+        ]
+      },
+      {
+        "en": "Sega",
+        "ja": "セガ",
+        "ja_typings": [
+          "sega"
+        ]
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": [
+          "bandainamuko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01423",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed Dynasty Warriors?",
+      "ja": "真・三國無双を開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": [
+          "bandainamuko"
+        ]
+      },
+      {
+        "en": "Square Enix",
+        "ja": "スクウェア・エニックス",
+        "ja_typings": [
+          "sukuwea/enikkusu"
+        ]
+      },
+      {
+        "en": "Sega",
+        "ja": "セガ",
+        "ja_typings": [
+          "sega"
+        ]
+      },
+      {
+        "en": "Atlus",
+        "ja": "アトラス",
+        "ja_typings": [
+          "atorasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01424",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed Tales of series?",
+      "ja": "テイルズオブシリーズを開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sega",
+        "ja": "セガ",
+        "ja_typings": [
+          "sega"
+        ]
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": [
+          "bandainamuko"
+        ]
+      },
+      {
+        "en": "Square Enix",
+        "ja": "スクウェア・エニックス",
+        "ja_typings": [
+          "sukuwea/enikkusu"
+        ]
+      },
+      {
+        "en": "Capcom",
+        "ja": "カプコン",
+        "ja_typings": [
+          "kapukon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01425",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed Phantasy Star Online?",
+      "ja": "ファンタシースターオンラインを開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PlatinumGames",
+        "ja": "プラチナゲームズ",
+        "ja_typings": [
+          "purachinage-muzu"
+        ]
+      },
+      {
+        "en": "Square Enix",
+        "ja": "スクウェア・エニックス",
+        "ja_typings": [
+          "sukuwea/enikkusu"
+        ]
+      },
+      {
+        "en": "Atlus",
+        "ja": "アトラス",
+        "ja_typings": [
+          "atorasu"
+        ]
+      },
+      {
+        "en": "Tri-Ace",
+        "ja": "トライエース",
+        "ja_typings": [
+          "toraie-su"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01426",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio created Nier Automata?",
+      "ja": "ニーアオートマタを開発したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PlatinumGames",
+        "ja": "プラチナゲームズ",
+        "ja_typings": [
+          "purachinage-muzu"
+        ]
+      },
+      {
+        "en": "Capcom",
+        "ja": "カプコン",
+        "ja_typings": [
+          "kapukon"
+        ]
+      },
+      {
+        "en": "FromSoftware",
+        "ja": "フロム・ソフトウェア",
+        "ja_typings": [
+          "furomu/sofutowea"
+        ]
+      },
+      {
+        "en": "Konami",
+        "ja": "コナミ",
+        "ja_typings": [
+          "konami"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01427",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio developed Bayonetta?",
+      "ja": "ベヨネッタを開発したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Atlus",
+        "ja": "アトラス",
+        "ja_typings": [
+          "atorasu"
+        ]
+      },
+      {
+        "en": "Square Enix",
+        "ja": "スクウェア・エニックス",
+        "ja_typings": [
+          "sukuwea/enikkusu"
+        ]
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": [
+          "bandainamuko"
+        ]
+      },
+      {
+        "en": "Sega",
+        "ja": "セガ",
+        "ja_typings": [
+          "sega"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01428",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed Persona Q and Etrian Odyssey?",
+      "ja": "ペルソナQと世界樹の迷宮を開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yu Narukami",
+        "ja": "鳴上悠",
+        "ja_typings": [
+          "narukamiyuu"
+        ]
+      },
+      {
+        "en": "Ren Amamiya",
+        "ja": "雨宮蓮",
+        "ja_typings": [
+          "amamiyaren"
+        ]
+      },
+      {
+        "en": "Makoto Yuki",
+        "ja": "結城理",
+        "ja_typings": [
+          "yuukimakoto"
+        ]
+      },
+      {
+        "en": "Tatsuya Suou",
+        "ja": "周防達哉",
+        "ja_typings": [
+          "suoutatsuya"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01429",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the silent protagonist of Persona 4?",
+      "ja": "ペルソナ4の主人公の通称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yakuza",
+        "ja": "龍が如く",
+        "ja_typings": [
+          "ryuugagotoku"
+        ]
+      },
+      {
+        "en": "Judgment",
+        "ja": "ジャッジアイズ",
+        "ja_typings": [
+          "jajjiaizu"
+        ]
+      },
+      {
+        "en": "Shenmue",
+        "ja": "シェンムー",
+        "ja_typings": [
+          "shenmu-"
+        ]
+      },
+      {
+        "en": "Sleeping Dogs",
+        "ja": "スリーピングドッグス",
+        "ja_typings": [
+          "suri-pingudoggusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01430",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features the protagonist Kazuma Kiryu?",
+      "ja": "桐生一馬が主人公のシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Like a Dragon",
+        "ja": "龍が如く7",
+        "ja_typings": [
+          "ryuugagotoku7"
+        ]
+      },
+      {
+        "en": "Judgment",
+        "ja": "ジャッジアイズ",
+        "ja_typings": [
+          "jajjiaizu"
+        ]
+      },
+      {
+        "en": "Lost Judgment",
+        "ja": "ロストジャッジメント",
+        "ja_typings": [
+          "rosutojajjimento"
+        ]
+      },
+      {
+        "en": "Shenmue III",
+        "ja": "シェンムーIII",
+        "ja_typings": [
+          "shenmu-iii"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01431",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features Ichiban Kasuga as protagonist?",
+      "ja": "春日一番が主人公のゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Space Harrier",
+        "ja": "スペースハリアー",
+        "ja_typings": [
+          "supe-suharia-"
+        ]
+      },
+      {
+        "en": "After Burner",
+        "ja": "アフターバーナー",
+        "ja_typings": [
+          "afuta-ba-na-"
+        ]
+      },
+      {
+        "en": "OutRun",
+        "ja": "アウトラン",
+        "ja_typings": [
+          "autoran"
+        ]
+      },
+      {
+        "en": "Hang-On",
+        "ja": "ハングオン",
+        "ja_typings": [
+          "hanguon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01432",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1986 Sega arcade game features pilot Harrier?",
+      "ja": "1986年のセガアーケード作品でハリアーが主人公の作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "OutRun",
+        "ja": "アウトラン",
+        "ja_typings": [
+          "autoran"
+        ]
+      },
+      {
+        "en": "Hang-On",
+        "ja": "ハングオン",
+        "ja_typings": [
+          "hanguon"
+        ]
+      },
+      {
+        "en": "Space Harrier",
+        "ja": "スペースハリアー",
+        "ja_typings": [
+          "supe-suharia-"
+        ]
+      },
+      {
+        "en": "Power Drift",
+        "ja": "パワードリフト",
+        "ja_typings": [
+          "pawa-dorifuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01433",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1986 Sega arcade game is a coastal driving game?",
+      "ja": "1986年のセガアーケードの海岸線ドライブゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hang-On",
+        "ja": "ハングオン",
+        "ja_typings": [
+          "hanguon"
+        ]
+      },
+      {
+        "en": "OutRun",
+        "ja": "アウトラン",
+        "ja_typings": [
+          "autoran"
+        ]
+      },
+      {
+        "en": "Super Hang-On",
+        "ja": "スーパーハングオン",
+        "ja_typings": [
+          "su-pa-hanguon"
+        ]
+      },
+      {
+        "en": "Power Drift",
+        "ja": "パワードリフト",
+        "ja_typings": [
+          "pawa-dorifuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01434",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1985 Sega arcade game features motorcycle racing?",
+      "ja": "1985年のセガのバイクレースアーケードゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Metal Gear",
+        "ja": "メタルギア",
+        "ja_typings": [
+          "metarugia"
+        ]
+      },
+      {
+        "en": "Castlevania",
+        "ja": "悪魔城ドラキュラ",
+        "ja_typings": [
+          "akumajoudorakyura"
+        ]
+      },
+      {
+        "en": "Contra",
+        "ja": "魂斗羅",
+        "ja_typings": [
+          "kontora"
+        ]
+      },
+      {
+        "en": "Gradius",
+        "ja": "グラディウス",
+        "ja_typings": [
+          "guradiusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01435",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Konami series features Solid Snake?",
+      "ja": "ソリッド・スネークが主人公のコナミシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Castlevania",
+        "ja": "悪魔城ドラキュラ",
+        "ja_typings": [
+          "akumajoudorakyura"
+        ]
+      },
+      {
+        "en": "Contra",
+        "ja": "魂斗羅",
+        "ja_typings": [
+          "kontora"
+        ]
+      },
+      {
+        "en": "Gradius",
+        "ja": "グラディウス",
+        "ja_typings": [
+          "guradiusu"
+        ]
+      },
+      {
+        "en": "TwinBee",
+        "ja": "ツインビー",
+        "ja_typings": [
+          "tsuinbi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01436",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Konami series is known as Akumajo Dracula in Japan?",
+      "ja": "日本で「悪魔城ドラキュラ」と呼ばれるコナミシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gradius",
+        "ja": "グラディウス",
+        "ja_typings": [
+          "guradiusu"
+        ]
+      },
+      {
+        "en": "Parodius",
+        "ja": "パロディウス",
+        "ja_typings": [
+          "parodiusu"
+        ]
+      },
+      {
+        "en": "Salamander",
+        "ja": "沙羅曼蛇",
+        "ja_typings": [
+          "saramanda"
+        ]
+      },
+      {
+        "en": "TwinBee",
+        "ja": "ツインビー",
+        "ja_typings": [
+          "tsuinbi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01437",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Konami shooter features a Vic Viper spaceship?",
+      "ja": "ビックバイパーが主人公機のコナミシューティングは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SaGa",
+        "ja": "サガ",
+        "ja_typings": [
+          "saga"
+        ]
+      },
+      {
+        "en": "Mana",
+        "ja": "聖剣伝説",
+        "ja_typings": [
+          "seikendensetsu"
+        ]
+      },
+      {
+        "en": "Romancing",
+        "ja": "ロマンシング",
+        "ja_typings": [
+          "romanshingu"
+        ]
+      },
+      {
+        "en": "Chrono",
+        "ja": "クロノ",
+        "ja_typings": [
+          "kurono"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01438",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game series features the SaGa Frontier?",
+      "ja": "サガフロンティアが属するシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Secret of Mana",
+        "ja": "聖剣伝説2",
+        "ja_typings": [
+          "seikendensetsu2"
+        ]
+      },
+      {
+        "en": "Chrono Trigger",
+        "ja": "クロノ・トリガー",
+        "ja_typings": [
+          "kurono/toriga-"
+        ]
+      },
+      {
+        "en": "Terranigma",
+        "ja": "天地創造",
+        "ja_typings": [
+          "tenchisouzou"
+        ]
+      },
+      {
+        "en": "Soul Blazer",
+        "ja": "ソウルブレイダー",
+        "ja_typings": [
+          "sorubureida-",
+          "sourubureida-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01439",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1993 SNES action RPG features the Mana Tree?",
+      "ja": "1993年のスーファミでマナの樹が登場するアクションRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Terranigma",
+        "ja": "天地創造",
+        "ja_typings": [
+          "tenchisouzou"
+        ]
+      },
+      {
+        "en": "Soul Blazer",
+        "ja": "ソウルブレイダー",
+        "ja_typings": [
+          "sorubureida-",
+          "sourubureida-"
+        ]
+      },
+      {
+        "en": "Illusion of Gaia",
+        "ja": "ガイア幻想紀",
+        "ja_typings": [
+          "gaiagensouki"
+        ]
+      },
+      {
+        "en": "ActRaiser",
+        "ja": "アクトレイザー",
+        "ja_typings": [
+          "akutoreiza-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01440",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1995 SNES action RPG by Quintet is set on a rebuilding Earth?",
+      "ja": "1995年クインテット制作で地球再生がテーマのスーファミ作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Section Z",
+        "ja": "セクションZ",
+        "ja_typings": [
+          "sekushonz"
+        ]
+      },
+      {
+        "en": "Bionic Commando",
+        "ja": "ヒットラーの復活",
+        "ja_typings": [
+          "hittoraanofukkatsu"
+        ]
+      },
+      {
+        "en": "Strider",
+        "ja": "ストライダー飛竜",
+        "ja_typings": [
+          "sutoraidaahiryuu"
+        ]
+      },
+      {
+        "en": "Trojan",
+        "ja": "闘いの挽歌",
+        "ja_typings": [
+          "tatakainobanka"
+        ]
+      }
+    ],
+    "correct_answer_index": 2,
+    "genre": "game",
+    "id": "q01441",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1986 Capcom platformer features the Red Falcon enemies?",
+      "ja": "1986年カプコンの横スクロール作品でレッドファルコンが登場する作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Darkstalkers",
+        "ja": "ヴァンパイア",
+        "ja_typings": [
+          "vanpaia"
+        ]
+      },
+      {
+        "en": "Cyberbots",
+        "ja": "サイバーボッツ",
+        "ja_typings": [
+          "saiba-bottsu"
+        ]
+      },
+      {
+        "en": "Red Earth",
+        "ja": "ウォーザード",
+        "ja_typings": [
+          "wo-za-do"
+        ]
+      },
+      {
+        "en": "Star Gladiator",
+        "ja": "スターグラディエイター",
+        "ja_typings": [
+          "suta-guradieita-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01442",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1994 Capcom 2D fighter starts the Darkstalkers series?",
+      "ja": "1994年カプコンの2D格闘ゲームでヴァンパイアシリーズ第1作は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fatal Fury",
+        "ja": "餓狼伝説",
+        "ja_typings": [
+          "garoudensetsu"
+        ]
+      },
+      {
+        "en": "Art of Fighting",
+        "ja": "龍虎の拳",
+        "ja_typings": [
+          "ryuukonoken"
+        ]
+      },
+      {
+        "en": "Samurai Shodown",
+        "ja": "サムライスピリッツ",
+        "ja_typings": [
+          "samuraisupirittsu"
+        ]
+      },
+      {
+        "en": "King of Fighters",
+        "ja": "ザ・キング・オブ・ファイターズ",
+        "ja_typings": [
+          "za/kingu/obu/faita-zu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01443",
+    "image_path": null,
+    "question_text": {
+      "en": "Which SNK series features Terry Bogard?",
+      "ja": "テリー・ボガードが登場するSNKシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Art of Fighting",
+        "ja": "龍虎の拳",
+        "ja_typings": [
+          "ryuukonoken"
+        ]
+      },
+      {
+        "en": "Fatal Fury",
+        "ja": "餓狼伝説",
+        "ja_typings": [
+          "garoudensetsu"
+        ]
+      },
+      {
+        "en": "Samurai Shodown",
+        "ja": "サムライスピリッツ",
+        "ja_typings": [
+          "samuraisupirittsu"
+        ]
+      },
+      {
+        "en": "Last Blade",
+        "ja": "幕末浪漫",
+        "ja_typings": [
+          "bakumatsuroman"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01444",
+    "image_path": null,
+    "question_text": {
+      "en": "Which SNK series features Ryo Sakazaki?",
+      "ja": "坂崎良が主人公のSNKシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Samurai Shodown",
+        "ja": "サムライスピリッツ",
+        "ja_typings": [
+          "samuraisupirittsu"
+        ]
+      },
+      {
+        "en": "Last Blade",
+        "ja": "幕末浪漫",
+        "ja_typings": [
+          "bakumatsuroman"
+        ]
+      },
+      {
+        "en": "Fatal Fury",
+        "ja": "餓狼伝説",
+        "ja_typings": [
+          "garoudensetsu"
+        ]
+      },
+      {
+        "en": "Art of Fighting",
+        "ja": "龍虎の拳",
+        "ja_typings": [
+          "ryuukonoken"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01445",
+    "image_path": null,
+    "question_text": {
+      "en": "Which SNK series features Haohmaru?",
+      "ja": "覇王丸が主人公のSNKシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "King of Fighters",
+        "ja": "ザ・キング・オブ・ファイターズ",
+        "ja_typings": [
+          "za/kingu/obu/faita-zu"
+        ]
+      },
+      {
+        "en": "Fatal Fury",
+        "ja": "餓狼伝説",
+        "ja_typings": [
+          "garoudensetsu"
+        ]
+      },
+      {
+        "en": "Art of Fighting",
+        "ja": "龍虎の拳",
+        "ja_typings": [
+          "ryuukonoken"
+        ]
+      },
+      {
+        "en": "Samurai Shodown",
+        "ja": "サムライスピリッツ",
+        "ja_typings": [
+          "samuraisupirittsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01446",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1996 SNK fighter introduced team battle with Kyo Kusanagi?",
+      "ja": "草薙京が登場し、チーム制を導入した1996年のSNK格闘は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dreamcast",
+        "ja": "ドリームキャスト",
+        "ja_typings": [
+          "dori-mukyasuto"
+        ]
+      },
+      {
+        "en": "Saturn",
+        "ja": "セガサターン",
+        "ja_typings": [
+          "segasataan",
+          "segasata-n"
+        ]
+      },
+      {
+        "en": "Mega Drive",
+        "ja": "メガドライブ",
+        "ja_typings": [
+          "megadoraibu"
+        ]
+      },
+      {
+        "en": "Game Gear",
+        "ja": "ゲームギア",
+        "ja_typings": [
+          "ge-mugia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01447",
+    "image_path": null,
+    "question_text": {
+      "en": "Which platform was released by SEGA in 1998 as a successor to the Saturn?",
+      "ja": "1998年セガがサターンの後継機として発売したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Neo Geo",
+        "ja": "ネオジオ",
+        "ja_typings": [
+          "neojio"
+        ]
+      },
+      {
+        "en": "PC Engine",
+        "ja": "PCエンジン",
+        "ja_typings": [
+          "pcenjin"
+        ]
+      },
+      {
+        "en": "Mega Drive",
+        "ja": "メガドライブ",
+        "ja_typings": [
+          "megadoraibu"
+        ]
+      },
+      {
+        "en": "Wonder Swan",
+        "ja": "ワンダースワン",
+        "ja_typings": [
+          "wanda-suwan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01448",
+    "image_path": null,
+    "question_text": {
+      "en": "Which platform was released by SNK in 1990?",
+      "ja": "1990年にSNKが発売した家庭用ゲーム機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PC Engine",
+        "ja": "PCエンジン",
+        "ja_typings": [
+          "pcenjin"
+        ]
+      },
+      {
+        "en": "Neo Geo",
+        "ja": "ネオジオ",
+        "ja_typings": [
+          "neojio"
+        ]
+      },
+      {
+        "en": "Mega Drive",
+        "ja": "メガドライブ",
+        "ja_typings": [
+          "megadoraibu"
+        ]
+      },
+      {
+        "en": "FM Towns Marty",
+        "ja": "FMタウンズマーティー",
+        "ja_typings": [
+          "fmtaunzuma-ti-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01449",
+    "image_path": null,
+    "question_text": {
+      "en": "Which platform was released by NEC in 1987?",
+      "ja": "1987年にNECが発売した家庭用ゲーム機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wonder Swan",
+        "ja": "ワンダースワン",
+        "ja_typings": [
+          "wanda-suwan"
+        ]
+      },
+      {
+        "en": "Game Gear",
+        "ja": "ゲームギア",
+        "ja_typings": [
+          "ge-mugia"
+        ]
+      },
+      {
+        "en": "Neo Geo Pocket",
+        "ja": "ネオジオポケット",
+        "ja_typings": [
+          "neojiopoketto"
+        ]
+      },
+      {
+        "en": "PC Engine GT",
+        "ja": "PCエンジンGT",
+        "ja_typings": [
+          "pcenjingt"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01450",
+    "image_path": null,
+    "question_text": {
+      "en": "Which handheld was released by Bandai in 1999?",
+      "ja": "1999年にバンダイが発売した携帯ゲーム機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Neo Geo Pocket",
+        "ja": "ネオジオポケット",
+        "ja_typings": [
+          "neojiopoketto"
+        ]
+      },
+      {
+        "en": "Wonder Swan",
+        "ja": "ワンダースワン",
+        "ja_typings": [
+          "wanda-suwan"
+        ]
+      },
+      {
+        "en": "Game Gear",
+        "ja": "ゲームギア",
+        "ja_typings": [
+          "ge-mugia"
+        ]
+      },
+      {
+        "en": "PC Engine GT",
+        "ja": "PCエンジンGT",
+        "ja_typings": [
+          "pcenjingt"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01451",
+    "image_path": null,
+    "question_text": {
+      "en": "Which handheld was released by SNK in 1998?",
+      "ja": "1998年にSNKが発売した携帯ゲーム機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Celeste",
+        "ja": "セレステ",
+        "ja_typings": [
+          "seresute"
+        ]
+      },
+      {
+        "en": "Hyper Light Drifter",
+        "ja": "ハイパーライトドリフター",
+        "ja_typings": [
+          "haipa-raitodorifuta-"
+        ]
+      },
+      {
+        "en": "Hades",
+        "ja": "ハデス",
+        "ja_typings": [
+          "hadesu"
+        ]
+      },
+      {
+        "en": "Cuphead",
+        "ja": "カップヘッド",
+        "ja_typings": [
+          "kappuheddo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01452",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2017 indie game features Madeline climbing a mountain?",
+      "ja": "マデリーンが山を登る2017年のインディーゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hades",
+        "ja": "ハデス",
+        "ja_typings": [
+          "hadesu"
+        ]
+      },
+      {
+        "en": "Bastion",
+        "ja": "バスティオン",
+        "ja_typings": [
+          "basution"
+        ]
+      },
+      {
+        "en": "Transistor",
+        "ja": "トランジスター",
+        "ja_typings": [
+          "toranjisuta-"
+        ]
+      },
+      {
+        "en": "Pyre",
+        "ja": "パイア",
+        "ja_typings": [
+          "paia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01453",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2020 Supergiant indie game features Zagreus escaping the Underworld?",
+      "ja": "ザグレウスが冥界脱出を目指す2020年のスーパージャイアント作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cuphead",
+        "ja": "カップヘッド",
+        "ja_typings": [
+          "kappuheddo"
+        ]
+      },
+      {
+        "en": "Celeste",
+        "ja": "セレステ",
+        "ja_typings": [
+          "seresute"
+        ]
+      },
+      {
+        "en": "Shovel Knight",
+        "ja": "ショベルナイト",
+        "ja_typings": [
+          "shoberunaito"
+        ]
+      },
+      {
+        "en": "Pizza Tower",
+        "ja": "ピザタワー",
+        "ja_typings": [
+          "pizatawa-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01454",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2017 run-and-gun indie features 1930s cartoon aesthetics?",
+      "ja": "1930年代カートゥーン風の2017年ラン&ガンインディーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shovel Knight",
+        "ja": "ショベルナイト",
+        "ja_typings": [
+          "shoberunaito"
+        ]
+      },
+      {
+        "en": "Cuphead",
+        "ja": "カップヘッド",
+        "ja_typings": [
+          "kappuheddo"
+        ]
+      },
+      {
+        "en": "Celeste",
+        "ja": "セレステ",
+        "ja_typings": [
+          "seresute"
+        ]
+      },
+      {
+        "en": "Axiom Verge",
+        "ja": "アクシオムバージ",
+        "ja_typings": [
+          "akushiomuba-ji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01455",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2014 indie crowdfunded retro platformer features a digging knight?",
+      "ja": "2014年クラウドファンディング発のレトロ調アクションで掘る騎士が主人公の作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chrono Cross",
+        "ja": "クロノ・クロス",
+        "ja_typings": [
+          "kurono/kurosu"
+        ]
+      },
+      {
+        "en": "Xenogears",
+        "ja": "ゼノギアス",
+        "ja_typings": [
+          "zenogiasu"
+        ]
+      },
+      {
+        "en": "Parasite Eve",
+        "ja": "パラサイト・イヴ",
+        "ja_typings": [
+          "parasaito/ivu"
+        ]
+      },
+      {
+        "en": "Vagrant Story",
+        "ja": "ベイグラントストーリー",
+        "ja_typings": [
+          "beigurantosuto-ri-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01456",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1998 SquareSoft RPG features Serge and Kid?",
+      "ja": "セルジュとキッドが登場する1998年スクウェアのRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Xenogears",
+        "ja": "ゼノギアス",
+        "ja_typings": [
+          "zenogiasu"
+        ]
+      },
+      {
+        "en": "Chrono Cross",
+        "ja": "クロノ・クロス",
+        "ja_typings": [
+          "kurono/kurosu"
+        ]
+      },
+      {
+        "en": "Vagrant Story",
+        "ja": "ベイグラントストーリー",
+        "ja_typings": [
+          "beigurantosuto-ri-"
+        ]
+      },
+      {
+        "en": "Parasite Eve",
+        "ja": "パラサイト・イヴ",
+        "ja_typings": [
+          "parasaito/ivu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01457",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1998 Square RPG by Tetsuya Takahashi features Fei Fong Wong?",
+      "ja": "1998年スクウェアの高橋哲哉作でフェイ・フォン・ウォンが主人公のRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vagrant Story",
+        "ja": "ベイグラントストーリー",
+        "ja_typings": [
+          "beigurantosuto-ri-"
+        ]
+      },
+      {
+        "en": "Xenogears",
+        "ja": "ゼノギアス",
+        "ja_typings": [
+          "zenogiasu"
+        ]
+      },
+      {
+        "en": "Chrono Cross",
+        "ja": "クロノ・クロス",
+        "ja_typings": [
+          "kurono/kurosu"
+        ]
+      },
+      {
+        "en": "Parasite Eve",
+        "ja": "パラサイト・イヴ",
+        "ja_typings": [
+          "parasaito/ivu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01458",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2000 Square PS1 game by Yasumi Matsuno features Ashley Riot?",
+      "ja": "2000年スクウェアの松野泰己作品でアシュレイ・ライオットが主人公のPS1作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Greece",
+        "ja": "ギリシャ",
+        "ja_typings": [
+          "girisha"
+        ]
+      },
+      {
+        "en": "Cyprus",
+        "ja": "キプロス",
+        "ja_typings": [
+          "kipurosu"
+        ]
+      },
+      {
+        "en": "Malta",
+        "ja": "マルタ",
+        "ja_typings": [
+          "maruta"
+        ]
+      },
+      {
+        "en": "Albania",
+        "ja": "アルバニア",
+        "ja_typings": [
+          "arubania"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01459",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Athens as its capital?",
+      "ja": "アテネを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hungary",
+        "ja": "ハンガリー",
+        "ja_typings": [
+          "hangari-"
+        ]
+      },
+      {
+        "en": "Bulgaria",
+        "ja": "ブルガリア",
+        "ja_typings": [
+          "burugaria"
+        ]
+      },
+      {
+        "en": "Serbia",
+        "ja": "セルビア",
+        "ja_typings": [
+          "serubia"
+        ]
+      },
+      {
+        "en": "Romania",
+        "ja": "ルーマニア",
+        "ja_typings": [
+          "ru-mania"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01460",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Budapest as its capital?",
+      "ja": "ブダペストを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Switzerland",
+        "ja": "スイス",
+        "ja_typings": [
+          "suisu"
+        ]
+      },
+      {
+        "en": "Liechtenstein",
+        "ja": "リヒテンシュタイン",
+        "ja_typings": [
+          "rihitenshutain"
+        ]
+      },
+      {
+        "en": "Luxembourg",
+        "ja": "ルクセンブルク",
+        "ja_typings": [
+          "rukusenburuku"
+        ]
+      },
+      {
+        "en": "Monaco",
+        "ja": "モナコ",
+        "ja_typings": [
+          "monako"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01461",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Bern as its capital?",
+      "ja": "ベルンを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ireland",
+        "ja": "アイルランド",
+        "ja_typings": [
+          "airurando"
+        ]
+      },
+      {
+        "en": "Scotland",
+        "ja": "スコットランド",
+        "ja_typings": [
+          "sukottorando"
+        ]
+      },
+      {
+        "en": "Wales",
+        "ja": "ウェールズ",
+        "ja_typings": [
+          "we-ruzu"
+        ]
+      },
+      {
+        "en": "Malta",
+        "ja": "マルタ",
+        "ja_typings": [
+          "maruta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01462",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Dublin as its capital?",
+      "ja": "ダブリンを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thailand",
+        "ja": "タイ王国",
+        "ja_typings": [
+          "taioukoku"
+        ]
+      },
+      {
+        "en": "Myanmar",
+        "ja": "ミャンマー",
+        "ja_typings": [
+          "myanma-"
+        ]
+      },
+      {
+        "en": "Laos",
+        "ja": "ラオス",
+        "ja_typings": [
+          "raosu"
+        ]
+      },
+      {
+        "en": "Cambodia",
+        "ja": "カンボジア",
+        "ja_typings": [
+          "kanbojia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01463",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Bangkok as its capital?",
+      "ja": "バンコクを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Malaysia",
+        "ja": "マレーシア",
+        "ja_typings": [
+          "mare-shia"
+        ]
+      },
+      {
+        "en": "Brunei",
+        "ja": "ブルネイ",
+        "ja_typings": [
+          "burunei"
+        ]
+      },
+      {
+        "en": "Philippines",
+        "ja": "フィリピン共和国",
+        "ja_typings": [
+          "firipinkyouwakoku"
+        ]
+      },
+      {
+        "en": "Indonesia",
+        "ja": "インドネシア",
+        "ja_typings": [
+          "indoneshia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01464",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Kuala Lumpur as its capital?",
+      "ja": "クアラルンプールを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Philippines",
+        "ja": "フィリピン",
+        "ja_typings": [
+          "firipin"
+        ]
+      },
+      {
+        "en": "Indonesia",
+        "ja": "インドネシア",
+        "ja_typings": [
+          "indoneshia"
+        ]
+      },
+      {
+        "en": "Malaysia",
+        "ja": "マレーシア",
+        "ja_typings": [
+          "mare-shia"
+        ]
+      },
+      {
+        "en": "Brunei",
+        "ja": "ブルネイ",
+        "ja_typings": [
+          "burunei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01465",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Manila as its capital?",
+      "ja": "マニラを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Iran",
+        "ja": "イラン",
+        "ja_typings": [
+          "iran"
+        ]
+      },
+      {
+        "en": "Iraq",
+        "ja": "イラク",
+        "ja_typings": [
+          "iraku"
+        ]
+      },
+      {
+        "en": "Afghanistan",
+        "ja": "アフガニスタン",
+        "ja_typings": [
+          "afuganisutan"
+        ]
+      },
+      {
+        "en": "Pakistan",
+        "ja": "パキスタン",
+        "ja_typings": [
+          "pakisutan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01466",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Tehran as its capital?",
+      "ja": "テヘランを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Saudi Arabia",
+        "ja": "サウジアラビア",
+        "ja_typings": [
+          "saujiarabia"
+        ]
+      },
+      {
+        "en": "UAE",
+        "ja": "アラブ首長国連邦",
+        "ja_typings": [
+          "arabushuchoukokurenpou"
+        ]
+      },
+      {
+        "en": "Qatar",
+        "ja": "カタール",
+        "ja_typings": [
+          "kata-ru"
+        ]
+      },
+      {
+        "en": "Kuwait",
+        "ja": "クウェート",
+        "ja_typings": [
+          "kuwe-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01467",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Riyadh as its capital?",
+      "ja": "リヤドを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ethiopia",
+        "ja": "エチオピア",
+        "ja_typings": [
+          "echiopia"
+        ]
+      },
+      {
+        "en": "Eritrea",
+        "ja": "エリトリア",
+        "ja_typings": [
+          "eritoria"
+        ]
+      },
+      {
+        "en": "Somalia",
+        "ja": "ソマリア",
+        "ja_typings": [
+          "somaria"
+        ]
+      },
+      {
+        "en": "Sudan",
+        "ja": "スーダン",
+        "ja_typings": [
+          "su-dan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01468",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Addis Ababa as its capital?",
+      "ja": "アディスアベバを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chile",
+        "ja": "チリ",
+        "ja_typings": [
+          "chiri"
+        ]
+      },
+      {
+        "en": "Uruguay",
+        "ja": "ウルグアイ",
+        "ja_typings": [
+          "uruguai"
+        ]
+      },
+      {
+        "en": "Paraguay",
+        "ja": "パラグアイ",
+        "ja_typings": [
+          "paraguai"
+        ]
+      },
+      {
+        "en": "Bolivia",
+        "ja": "ボリビア",
+        "ja_typings": [
+          "boribia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01469",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Santiago as its capital?",
+      "ja": "サンティアゴを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Colombia",
+        "ja": "コロンビア",
+        "ja_typings": [
+          "koronbia"
+        ]
+      },
+      {
+        "en": "Venezuela",
+        "ja": "ベネズエラ",
+        "ja_typings": [
+          "benezuera"
+        ]
+      },
+      {
+        "en": "Ecuador",
+        "ja": "エクアドル",
+        "ja_typings": [
+          "ekuadoru"
+        ]
+      },
+      {
+        "en": "Panama",
+        "ja": "パナマ",
+        "ja_typings": [
+          "panama"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01470",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Bogota as its capital?",
+      "ja": "ボゴタを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cuba",
+        "ja": "キューバ",
+        "ja_typings": [
+          "kyu-ba"
+        ]
+      },
+      {
+        "en": "Jamaica",
+        "ja": "ジャマイカ",
+        "ja_typings": [
+          "jamaika"
+        ]
+      },
+      {
+        "en": "Haiti",
+        "ja": "ハイチ",
+        "ja_typings": [
+          "haichi"
+        ]
+      },
+      {
+        "en": "Dominican Republic",
+        "ja": "ドミニカ共和国",
+        "ja_typings": [
+          "dominikakyouwakoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01471",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Havana as its capital?",
+      "ja": "ハバナを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Volga",
+        "ja": "ヴォルガ川",
+        "ja_typings": [
+          "vorugagawa"
+        ]
+      },
+      {
+        "en": "Danube",
+        "ja": "ドナウ川",
+        "ja_typings": [
+          "donaugawa"
+        ]
+      },
+      {
+        "en": "Rhine",
+        "ja": "ライン川",
+        "ja_typings": [
+          "raingawa"
+        ]
+      },
+      {
+        "en": "Loire",
+        "ja": "ロワール川",
+        "ja_typings": [
+          "rowaarugawa",
+          "rowa-rugawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01472",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the longest river in Europe?",
+      "ja": "ヨーロッパで最も長い川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Missouri",
+        "ja": "ミズーリ川",
+        "ja_typings": [
+          "mizuurigawa",
+          "mizu-rigawa"
+        ]
+      },
+      {
+        "en": "Mississippi",
+        "ja": "ミシシッピ川",
+        "ja_typings": [
+          "mishishippigawa"
+        ]
+      },
+      {
+        "en": "Colorado",
+        "ja": "コロラド川",
+        "ja_typings": [
+          "kororadogawa"
+        ]
+      },
+      {
+        "en": "Yukon",
+        "ja": "ユーコン川",
+        "ja_typings": [
+          "yuukongawa",
+          "yu-kongawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01473",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the longest river in North America?",
+      "ja": "北米で最も長い川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yangtze",
+        "ja": "長江",
+        "ja_typings": [
+          "choukou"
+        ]
+      },
+      {
+        "en": "Yellow River",
+        "ja": "黄河",
+        "ja_typings": [
+          "kouga"
+        ]
+      },
+      {
+        "en": "Pearl River",
+        "ja": "珠江",
+        "ja_typings": [
+          "shukou",
+          "zhujiang"
+        ]
+      },
+      {
+        "en": "Mekong",
+        "ja": "メコン川",
+        "ja_typings": [
+          "mekongawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01474",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the longest river in China?",
+      "ja": "中国で最も長い川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Apennines",
+        "ja": "アペニン山脈",
+        "ja_typings": [
+          "apeninsanmyaku"
+        ]
+      },
+      {
+        "en": "Alps",
+        "ja": "アルプス山脈",
+        "ja_typings": [
+          "arupususanmyaku"
+        ]
+      },
+      {
+        "en": "Carpathians",
+        "ja": "カルパティア山脈",
+        "ja_typings": [
+          "karupatiasanmyaku"
+        ]
+      },
+      {
+        "en": "Balkans",
+        "ja": "バルカン山脈",
+        "ja_typings": [
+          "barukansanmyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01475",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mountain range runs through Italy?",
+      "ja": "イタリアを縦断する山脈は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Antarctic Desert",
+        "ja": "南極砂漠",
+        "ja_typings": [
+          "nankyokusabaku"
+        ]
+      },
+      {
+        "en": "Arctic Desert",
+        "ja": "北極砂漠",
+        "ja_typings": [
+          "hokkyokusabaku"
+        ]
+      },
+      {
+        "en": "Gobi Desert",
+        "ja": "ゴビ砂漠",
+        "ja_typings": [
+          "gobisabaku"
+        ]
+      },
+      {
+        "en": "Atacama Desert",
+        "ja": "アタカマ砂漠",
+        "ja_typings": [
+          "atakamasabaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01476",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the largest desert on Earth?",
+      "ja": "地球で最も広い砂漠は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gobi",
+        "ja": "ゴビ砂漠",
+        "ja_typings": [
+          "gobisabaku"
+        ]
+      },
+      {
+        "en": "Taklamakan",
+        "ja": "タクラマカン砂漠",
+        "ja_typings": [
+          "takuramakansabaku"
+        ]
+      },
+      {
+        "en": "Karakum",
+        "ja": "カラクム砂漠",
+        "ja_typings": [
+          "karakumusabaku"
+        ]
+      },
+      {
+        "en": "Thar",
+        "ja": "タール砂漠",
+        "ja_typings": [
+          "ta-rusabaku",
+          "taarusabaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01477",
+    "image_path": null,
+    "question_text": {
+      "en": "Which desert is in Mongolia and China?",
+      "ja": "モンゴルと中国にまたがる砂漠は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lake Victoria",
+        "ja": "ヴィクトリア湖",
+        "ja_typings": [
+          "vikutoriako"
+        ]
+      },
+      {
+        "en": "Lake Tanganyika",
+        "ja": "タンガニーカ湖",
+        "ja_typings": [
+          "tangani-kako",
+          "tanganiikako"
+        ]
+      },
+      {
+        "en": "Lake Malawi",
+        "ja": "マラウイ湖",
+        "ja_typings": [
+          "maraiko",
+          "marauiko"
+        ]
+      },
+      {
+        "en": "Lake Chad",
+        "ja": "チャド湖",
+        "ja_typings": [
+          "chadoko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01478",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the largest lake in Africa?",
+      "ja": "アフリカで最大の湖は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Italian Peninsula",
+        "ja": "イタリア半島",
+        "ja_typings": [
+          "itariahantou"
+        ]
+      },
+      {
+        "en": "Iberian Peninsula",
+        "ja": "イベリア半島",
+        "ja_typings": [
+          "iberiahantou"
+        ]
+      },
+      {
+        "en": "Balkan Peninsula",
+        "ja": "バルカン半島",
+        "ja_typings": [
+          "barukanhantou"
+        ]
+      },
+      {
+        "en": "Scandinavian Peninsula",
+        "ja": "スカンディナビア半島",
+        "ja_typings": [
+          "sukandinabiahantou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01479",
+    "image_path": null,
+    "question_text": {
+      "en": "Which peninsula is located in southern Europe and shaped like a boot?",
+      "ja": "ブーツ型の南欧の半島は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Iberian",
+        "ja": "イベリア半島",
+        "ja_typings": [
+          "iberiahantou"
+        ]
+      },
+      {
+        "en": "Balkan",
+        "ja": "バルカン半島",
+        "ja_typings": [
+          "barukanhantou"
+        ]
+      },
+      {
+        "en": "Apennine",
+        "ja": "アペニン半島",
+        "ja_typings": [
+          "apeninhantou"
+        ]
+      },
+      {
+        "en": "Anatolian",
+        "ja": "アナトリア半島",
+        "ja_typings": [
+          "anatoriahantou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01480",
+    "image_path": null,
+    "question_text": {
+      "en": "Which peninsula contains Spain and Portugal?",
+      "ja": "スペインとポルトガルがある半島は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sicily",
+        "ja": "シチリア島",
+        "ja_typings": [
+          "shichiriatou"
+        ]
+      },
+      {
+        "en": "Sardinia",
+        "ja": "サルデーニャ島",
+        "ja_typings": [
+          "sarude-nyatou",
+          "sardeenyatou"
+        ]
+      },
+      {
+        "en": "Cyprus",
+        "ja": "キプロス島",
+        "ja_typings": [
+          "kipurosutou"
+        ]
+      },
+      {
+        "en": "Corsica",
+        "ja": "コルシカ島",
+        "ja_typings": [
+          "korushikatou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01481",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the largest island in the Mediterranean?",
+      "ja": "地中海最大の島は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Oceania",
+        "ja": "オセアニア",
+        "ja_typings": [
+          "oseania"
+        ]
+      },
+      {
+        "en": "Europe",
+        "ja": "ヨーロッパ",
+        "ja_typings": [
+          "yo-roppa"
+        ]
+      },
+      {
+        "en": "Antarctica",
+        "ja": "南極大陸",
+        "ja_typings": [
+          "nankyokutairiku"
+        ]
+      },
+      {
+        "en": "Africa",
+        "ja": "アフリカ大陸",
+        "ja_typings": [
+          "afurikatairiku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01482",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the smallest continent?",
+      "ja": "最も小さい大陸は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mediterranean Sea",
+        "ja": "地中海",
+        "ja_typings": [
+          "chichuukai"
+        ]
+      },
+      {
+        "en": "Black Sea",
+        "ja": "黒海",
+        "ja_typings": [
+          "kokkai"
+        ]
+      },
+      {
+        "en": "Red Sea",
+        "ja": "紅海",
+        "ja_typings": [
+          "koukai"
+        ]
+      },
+      {
+        "en": "Caspian Sea",
+        "ja": "カスピ海",
+        "ja_typings": [
+          "kasupikai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01483",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sea lies between Europe and Africa?",
+      "ja": "ヨーロッパとアフリカの間にある海は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Brazil",
+        "ja": "ブラジル連邦共和国",
+        "ja_typings": [
+          "burajirurenpoukyouwakoku"
+        ]
+      },
+      {
+        "en": "Argentina",
+        "ja": "アルゼンチン",
+        "ja_typings": [
+          "aruzenchin"
+        ]
+      },
+      {
+        "en": "Peru",
+        "ja": "ペルー",
+        "ja_typings": [
+          "peru-"
+        ]
+      },
+      {
+        "en": "Colombia",
+        "ja": "コロンビア",
+        "ja_typings": [
+          "koronbia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01484",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the largest country by area in South America?",
+      "ja": "南米で面積最大の国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Algeria",
+        "ja": "アルジェリア",
+        "ja_typings": [
+          "arujeria"
+        ]
+      },
+      {
+        "en": "Sudan",
+        "ja": "スーダン",
+        "ja_typings": [
+          "su-dan"
+        ]
+      },
+      {
+        "en": "Libya",
+        "ja": "リビア",
+        "ja_typings": [
+          "ribia"
+        ]
+      },
+      {
+        "en": "Chad",
+        "ja": "チャド",
+        "ja_typings": [
+          "chado"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01485",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the largest country by area in Africa?",
+      "ja": "アフリカで面積最大の国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Japan",
+        "ja": "日出国",
+        "ja_typings": [
+          "hiizurukuni"
+        ]
+      },
+      {
+        "en": "Korea",
+        "ja": "朝鮮",
+        "ja_typings": [
+          "chousen"
+        ]
+      },
+      {
+        "en": "China",
+        "ja": "中華",
+        "ja_typings": [
+          "chuuka"
+        ]
+      },
+      {
+        "en": "Mongolia",
+        "ja": "モンゴル",
+        "ja_typings": [
+          "mongoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01486",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country is known as the Land of the Rising Sun?",
+      "ja": "「日出ずる国」と呼ばれる国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chile",
+        "ja": "チリ共和国",
+        "ja_typings": [
+          "chirikyouwakoku"
+        ]
+      },
+      {
+        "en": "Peru",
+        "ja": "ペルー",
+        "ja_typings": [
+          "peru-"
+        ]
+      },
+      {
+        "en": "Ecuador",
+        "ja": "エクアドル",
+        "ja_typings": [
+          "ekuadoru"
+        ]
+      },
+      {
+        "en": "Bolivia",
+        "ja": "ボリビア",
+        "ja_typings": [
+          "boribia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01487",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country is shaped like a long thin strip on the west of South America?",
+      "ja": "南米西岸で細長い形の国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Italy",
+        "ja": "イタリア共和国",
+        "ja_typings": [
+          "itariakyouwakoku"
+        ]
+      },
+      {
+        "en": "Spain",
+        "ja": "スペイン",
+        "ja_typings": [
+          "supein"
+        ]
+      },
+      {
+        "en": "France",
+        "ja": "フランス",
+        "ja_typings": [
+          "furansu"
+        ]
+      },
+      {
+        "en": "Switzerland",
+        "ja": "スイス",
+        "ja_typings": [
+          "suisu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q01488",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country surrounds the Vatican City?",
+      "ja": "バチカン市国を囲む国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Qin Shi Huang",
+        "ja": "始皇帝",
+        "ja_typings": [
+          "shikoutei"
+        ]
+      },
+      {
+        "en": "Liu Bang",
+        "ja": "劉邦",
+        "ja_typings": [
+          "ryuuhou"
+        ]
+      },
+      {
+        "en": "Wu Zetian",
+        "ja": "武則天",
+        "ja_typings": [
+          "sokuten"
+        ]
+      },
+      {
+        "en": "Kublai Khan",
+        "ja": "フビライ",
+        "ja_typings": [
+          "fubirai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01489",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first Emperor of unified China?",
+      "ja": "中国を初めて統一した皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Louis-Napoleon",
+        "ja": "ルイ・ナポレオン",
+        "ja_typings": [
+          "rui/naporeon"
+        ]
+      },
+      {
+        "en": "Adolphe Thiers",
+        "ja": "ティエール",
+        "ja_typings": [
+          "tie-ru",
+          "tieeru"
+        ]
+      },
+      {
+        "en": "Jules Grevy",
+        "ja": "グレヴィ",
+        "ja_typings": [
+          "gurevi"
+        ]
+      },
+      {
+        "en": "Sadi Carnot",
+        "ja": "カルノー",
+        "ja_typings": [
+          "karuno-",
+          "karunoo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01490",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first President of the French Republic?",
+      "ja": "フランス第二共和政の初代大統領は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bismarck",
+        "ja": "ビスマルク",
+        "ja_typings": [
+          "bisumaruku"
+        ]
+      },
+      {
+        "en": "Wilhelm I",
+        "ja": "ヴィルヘルム一世",
+        "ja_typings": [
+          "viruherumuissei"
+        ]
+      },
+      {
+        "en": "Metternich",
+        "ja": "メッテルニヒ",
+        "ja_typings": [
+          "metterunihi"
+        ]
+      },
+      {
+        "en": "Hindenburg",
+        "ja": "ヒンデンブルク",
+        "ja_typings": [
+          "hindenburuku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01491",
+    "image_path": null,
+    "question_text": {
+      "en": "Who unified Germany in 1871?",
+      "ja": "1871年にドイツを統一した人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Stalin",
+        "ja": "スターリン",
+        "ja_typings": [
+          "suta-rin"
+        ]
+      },
+      {
+        "en": "Lenin",
+        "ja": "レーニン",
+        "ja_typings": [
+          "re-nin"
+        ]
+      },
+      {
+        "en": "Khrushchev",
+        "ja": "フルシチョフ",
+        "ja_typings": [
+          "furushichofu"
+        ]
+      },
+      {
+        "en": "Trotsky",
+        "ja": "トロツキー",
+        "ja_typings": [
+          "torotsuki-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01492",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led the Soviet Union during World War II?",
+      "ja": "第二次大戦中のソ連指導者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Churchill",
+        "ja": "チャーチル",
+        "ja_typings": [
+          "cha-chiru"
+        ]
+      },
+      {
+        "en": "Chamberlain",
+        "ja": "チェンバレン",
+        "ja_typings": [
+          "chenbaren"
+        ]
+      },
+      {
+        "en": "Attlee",
+        "ja": "アトリー",
+        "ja_typings": [
+          "atori-"
+        ]
+      },
+      {
+        "en": "Eden",
+        "ja": "イーデン",
+        "ja_typings": [
+          "i-den"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01493",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the British Prime Minister during most of WWII?",
+      "ja": "第二次大戦中の英首相は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Roosevelt",
+        "ja": "ルーズベルト",
+        "ja_typings": [
+          "ru-zuberuto"
+        ]
+      },
+      {
+        "en": "Truman",
+        "ja": "トルーマン",
+        "ja_typings": [
+          "toru-man"
+        ]
+      },
+      {
+        "en": "Eisenhower",
+        "ja": "アイゼンハワー",
+        "ja_typings": [
+          "aizenhawa-"
+        ]
+      },
+      {
+        "en": "Hoover",
+        "ja": "フーヴァー",
+        "ja_typings": [
+          "fu-vaa",
+          "fuuvaa",
+          "fu-va-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01494",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the US President during WWII?",
+      "ja": "第二次大戦中の米大統領は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hitler",
+        "ja": "ヒトラー",
+        "ja_typings": [
+          "hitora-"
+        ]
+      },
+      {
+        "en": "Goering",
+        "ja": "ゲーリング",
+        "ja_typings": [
+          "ge-ringu"
+        ]
+      },
+      {
+        "en": "Himmler",
+        "ja": "ヒムラー",
+        "ja_typings": [
+          "himura-"
+        ]
+      },
+      {
+        "en": "Goebbels",
+        "ja": "ゲッベルス",
+        "ja_typings": [
+          "gebberusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01495",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first Chancellor of Nazi Germany?",
+      "ja": "ナチス・ドイツの最初の首相は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gandhi",
+        "ja": "ガンディー",
+        "ja_typings": [
+          "gandi-"
+        ]
+      },
+      {
+        "en": "Nehru",
+        "ja": "ネルー",
+        "ja_typings": [
+          "neru-"
+        ]
+      },
+      {
+        "en": "Jinnah",
+        "ja": "ジンナー",
+        "ja_typings": [
+          "jinnna-"
+        ]
+      },
+      {
+        "en": "Bose",
+        "ja": "ボース",
+        "ja_typings": [
+          "bo-su"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01496",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led India's independence movement?",
+      "ja": "インド独立運動を率いたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nehru",
+        "ja": "ネルー",
+        "ja_typings": [
+          "neru-"
+        ]
+      },
+      {
+        "en": "Gandhi",
+        "ja": "ガンディー",
+        "ja_typings": [
+          "gandi-"
+        ]
+      },
+      {
+        "en": "Patel",
+        "ja": "パテル",
+        "ja_typings": [
+          "pateru"
+        ]
+      },
+      {
+        "en": "Bose",
+        "ja": "ボース",
+        "ja_typings": [
+          "bo-su"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01497",
+    "image_path": null,
+    "question_text": {
+      "en": "Who became the first Prime Minister of independent India?",
+      "ja": "インド独立後の初代首相は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mandela",
+        "ja": "マンデラ",
+        "ja_typings": [
+          "mandera"
+        ]
+      },
+      {
+        "en": "Mbeki",
+        "ja": "ムベキ",
+        "ja_typings": [
+          "mubeki"
+        ]
+      },
+      {
+        "en": "Zuma",
+        "ja": "ズマ",
+        "ja_typings": [
+          "zuma"
+        ]
+      },
+      {
+        "en": "De Klerk",
+        "ja": "デクラーク",
+        "ja_typings": [
+          "dekura-ku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01498",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first President of South Africa after apartheid?",
+      "ja": "南アフリカでアパルトヘイト後初の大統領は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ivan IV",
+        "ja": "イヴァン四世",
+        "ja_typings": [
+          "ivanyonsei"
+        ]
+      },
+      {
+        "en": "Peter I",
+        "ja": "ピョートル一世",
+        "ja_typings": [
+          "pyotoruissei"
+        ]
+      },
+      {
+        "en": "Boris Godunov",
+        "ja": "ゴドゥノフ",
+        "ja_typings": [
+          "godunofu"
+        ]
+      },
+      {
+        "en": "Michael I",
+        "ja": "ミハイル一世",
+        "ja_typings": [
+          "mihairuissei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01499",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first Tsar of Russia?",
+      "ja": "ロシア最初のツァーリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Peter the Great",
+        "ja": "ピョートル大帝",
+        "ja_typings": [
+          "pyotorutaitei"
+        ]
+      },
+      {
+        "en": "Catherine the Great",
+        "ja": "エカチェリーナ二世",
+        "ja_typings": [
+          "ekacheri-nanisei",
+          "ekacheriinanisei"
+        ]
+      },
+      {
+        "en": "Alexander I",
+        "ja": "アレクサンドル一世",
+        "ja_typings": [
+          "arekusandoruissei"
+        ]
+      },
+      {
+        "en": "Nicholas II",
+        "ja": "ニコライ二世",
+        "ja_typings": [
+          "nikorainisei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01500",
+    "image_path": null,
+    "question_text": {
+      "en": "Who modernized Russia in the early 18th century?",
+      "ja": "18世紀初頭にロシアを近代化した皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Elizabeth I",
+        "ja": "エリザベス一世",
+        "ja_typings": [
+          "erizabesuissei"
+        ]
+      },
+      {
+        "en": "Mary I",
+        "ja": "メアリー一世",
+        "ja_typings": [
+          "meari-issei",
+          "meariiissei"
+        ]
+      },
+      {
+        "en": "Victoria",
+        "ja": "ヴィクトリア女王",
+        "ja_typings": [
+          "vikutoriajoou"
+        ]
+      },
+      {
+        "en": "Anne",
+        "ja": "アン女王",
+        "ja_typings": [
+          "anjoou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01501",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Queen of England during the Spanish Armada defeat?",
+      "ja": "スペイン無敵艦隊撃退時の英女王は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Castro",
+        "ja": "カストロ",
+        "ja_typings": [
+          "kasutoro"
+        ]
+      },
+      {
+        "en": "Guevara",
+        "ja": "ゲバラ",
+        "ja_typings": [
+          "gebara"
+        ]
+      },
+      {
+        "en": "Batista",
+        "ja": "バティスタ",
+        "ja_typings": [
+          "batisuta"
+        ]
+      },
+      {
+        "en": "Allende",
+        "ja": "アジェンデ",
+        "ja_typings": [
+          "ajende"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01502",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led the Cuban Revolution?",
+      "ja": "キューバ革命を率いたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Augustus",
+        "ja": "アウグストゥス",
+        "ja_typings": [
+          "augusutusu"
+        ]
+      },
+      {
+        "en": "Nero",
+        "ja": "ネロ",
+        "ja_typings": [
+          "nero"
+        ]
+      },
+      {
+        "en": "Tiberius",
+        "ja": "ティベリウス",
+        "ja_typings": [
+          "tiberiusu"
+        ]
+      },
+      {
+        "en": "Caligula",
+        "ja": "カリギュラ",
+        "ja_typings": [
+          "karigyura"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01503",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first Emperor of Rome?",
+      "ja": "ローマ初代皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hannibal",
+        "ja": "ハンニバル",
+        "ja_typings": [
+          "hannnibaru"
+        ]
+      },
+      {
+        "en": "Hasdrubal",
+        "ja": "ハスドルバル",
+        "ja_typings": [
+          "hasudorubaru"
+        ]
+      },
+      {
+        "en": "Hamilcar",
+        "ja": "ハミルカル",
+        "ja_typings": [
+          "hamirukaru"
+        ]
+      },
+      {
+        "en": "Scipio",
+        "ja": "スキピオ",
+        "ja_typings": [
+          "sukipio"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01504",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Carthaginian general who crossed the Alps?",
+      "ja": "アルプスを越えたカルタゴの将軍は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ming",
+        "ja": "明",
+        "ja_typings": [
+          "min"
+        ]
+      },
+      {
+        "en": "Song",
+        "ja": "宋",
+        "ja_typings": [
+          "sou"
+        ]
+      },
+      {
+        "en": "Jin",
+        "ja": "金",
+        "ja_typings": [
+          "kin"
+        ]
+      },
+      {
+        "en": "Liao",
+        "ja": "遼",
+        "ja_typings": [
+          "ryou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01505",
+    "image_path": null,
+    "question_text": {
+      "en": "Which dynasty built most of the Great Wall as seen today?",
+      "ja": "現在の万里の長城を主に築いた王朝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ming dynasty",
+        "ja": "明朝",
+        "ja_typings": [
+          "minchou"
+        ]
+      },
+      {
+        "en": "Yuan dynasty",
+        "ja": "元朝",
+        "ja_typings": [
+          "genchou"
+        ]
+      },
+      {
+        "en": "Song dynasty",
+        "ja": "宋朝",
+        "ja_typings": [
+          "souchou"
+        ]
+      },
+      {
+        "en": "Jin dynasty",
+        "ja": "金朝",
+        "ja_typings": [
+          "kinchou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01506",
+    "image_path": null,
+    "question_text": {
+      "en": "Which dynasty ruled China just before the Qing?",
+      "ja": "清の直前に中国を統治した王朝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Taisho",
+        "ja": "大正",
+        "ja_typings": [
+          "taishou"
+        ]
+      },
+      {
+        "en": "Showa",
+        "ja": "昭和",
+        "ja_typings": [
+          "shouwa"
+        ]
+      },
+      {
+        "en": "Heisei",
+        "ja": "平成",
+        "ja_typings": [
+          "heisei"
+        ]
+      },
+      {
+        "en": "Reiwa",
+        "ja": "令和",
+        "ja_typings": [
+          "reiwa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01507",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese era came after Meiji?",
+      "ja": "明治の次の時代は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Showa",
+        "ja": "昭和",
+        "ja_typings": [
+          "shouwa"
+        ]
+      },
+      {
+        "en": "Heisei",
+        "ja": "平成",
+        "ja_typings": [
+          "heisei"
+        ]
+      },
+      {
+        "en": "Reiwa",
+        "ja": "令和",
+        "ja_typings": [
+          "reiwa"
+        ]
+      },
+      {
+        "en": "Meiji",
+        "ja": "明治",
+        "ja_typings": [
+          "meiji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01508",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese era came after Taisho?",
+      "ja": "大正の次の時代は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Treaty of Versailles",
+        "ja": "ヴェルサイユ条約",
+        "ja_typings": [
+          "verusaiyujouyaku"
+        ]
+      },
+      {
+        "en": "Treaty of Trianon",
+        "ja": "トリアノン条約",
+        "ja_typings": [
+          "torianonjouyaku"
+        ]
+      },
+      {
+        "en": "Treaty of Sevres",
+        "ja": "セーヴル条約",
+        "ja_typings": [
+          "se-vurujouyaku",
+          "seevurujouyaku"
+        ]
+      },
+      {
+        "en": "Treaty of Brest-Litovsk",
+        "ja": "ブレスト・リトフスク条約",
+        "ja_typings": [
+          "buresutoritofusukujouyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01509",
+    "image_path": null,
+    "question_text": {
+      "en": "Which treaty ended World War I?",
+      "ja": "第一次大戦を終結させた条約は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Korean War",
+        "ja": "朝鮮戦争",
+        "ja_typings": [
+          "chousensensou"
+        ]
+      },
+      {
+        "en": "Vietnam War",
+        "ja": "ベトナム戦争",
+        "ja_typings": [
+          "betonamusensou"
+        ]
+      },
+      {
+        "en": "Cold War",
+        "ja": "冷戦",
+        "ja_typings": [
+          "reisen"
+        ]
+      },
+      {
+        "en": "Gulf War",
+        "ja": "湾岸戦争",
+        "ja_typings": [
+          "wangansensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01510",
+    "image_path": null,
+    "question_text": {
+      "en": "Which war was fought between 1950 and 1953 on the Korean peninsula?",
+      "ja": "1950-1953年に朝鮮半島で起きた戦争は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gulf War",
+        "ja": "湾岸戦争",
+        "ja_typings": [
+          "wangansensou"
+        ]
+      },
+      {
+        "en": "Iraq War",
+        "ja": "イラク戦争",
+        "ja_typings": [
+          "irakusensou"
+        ]
+      },
+      {
+        "en": "Korean War",
+        "ja": "朝鮮戦争",
+        "ja_typings": [
+          "chousensensou"
+        ]
+      },
+      {
+        "en": "Vietnam War",
+        "ja": "ベトナム戦争",
+        "ja_typings": [
+          "betonamusensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01511",
+    "image_path": null,
+    "question_text": {
+      "en": "Which war was fought between US-led forces and Iraq in 1991?",
+      "ja": "1991年の米国主導とイラクの戦争は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1991",
+        "ja": "1991年",
+        "ja_typings": [
+          "1991nen"
+        ]
+      },
+      {
+        "en": "1989",
+        "ja": "1989年",
+        "ja_typings": [
+          "1989nen"
+        ]
+      },
+      {
+        "en": "1990",
+        "ja": "1990年",
+        "ja_typings": [
+          "1990nen"
+        ]
+      },
+      {
+        "en": "1993",
+        "ja": "1993年",
+        "ja_typings": [
+          "1993nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01512",
+    "image_path": null,
+    "question_text": {
+      "en": "In which year did the Soviet Union dissolve?",
+      "ja": "ソ連が崩壊した年は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1492",
+        "ja": "1492年",
+        "ja_typings": [
+          "1492nen"
+        ]
+      },
+      {
+        "en": "1500",
+        "ja": "1500年",
+        "ja_typings": [
+          "1500nen"
+        ]
+      },
+      {
+        "en": "1453",
+        "ja": "1453年",
+        "ja_typings": [
+          "1453nen"
+        ]
+      },
+      {
+        "en": "1488",
+        "ja": "1488年",
+        "ja_typings": [
+          "1488nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01513",
+    "image_path": null,
+    "question_text": {
+      "en": "In which year did Columbus reach the Americas?",
+      "ja": "コロンブスが新大陸に到達した年は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sumerian",
+        "ja": "シュメール文明",
+        "ja_typings": [
+          "shume-rubunmei",
+          "shumeerubunmei"
+        ]
+      },
+      {
+        "en": "Egyptian",
+        "ja": "エジプト文明",
+        "ja_typings": [
+          "ejiputobunmei"
+        ]
+      },
+      {
+        "en": "Indus",
+        "ja": "インダス文明",
+        "ja_typings": [
+          "indasubunmei"
+        ]
+      },
+      {
+        "en": "Chinese",
+        "ja": "中華文明",
+        "ja_typings": [
+          "chuukabunmei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01514",
+    "image_path": null,
+    "question_text": {
+      "en": "Which civilization is credited with inventing cuneiform writing?",
+      "ja": "楔形文字を発明したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Persian Empire",
+        "ja": "アケメネス朝",
+        "ja_typings": [
+          "akemenesuchou"
+        ]
+      },
+      {
+        "en": "Babylonian Empire",
+        "ja": "バビロニア帝国",
+        "ja_typings": [
+          "babironiateikoku"
+        ]
+      },
+      {
+        "en": "Assyrian Empire",
+        "ja": "アッシリア帝国",
+        "ja_typings": [
+          "asshiriateikoku"
+        ]
+      },
+      {
+        "en": "Hittite Empire",
+        "ja": "ヒッタイト帝国",
+        "ja_typings": [
+          "hittaitoteikoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01515",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient empire was led by Cyrus the Great?",
+      "ja": "キュロス大王が築いた古代帝国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Byzantine Empire",
+        "ja": "ビザンツ帝国",
+        "ja_typings": [
+          "bizantsuteikoku"
+        ]
+      },
+      {
+        "en": "Holy Roman Empire",
+        "ja": "神聖ローマ帝国",
+        "ja_typings": [
+          "shinsei-ro-mateikoku",
+          "shinseiroomateikoku"
+        ]
+      },
+      {
+        "en": "Ottoman Empire",
+        "ja": "オスマン帝国",
+        "ja_typings": [
+          "osumanteikoku"
+        ]
+      },
+      {
+        "en": "Sassanid Empire",
+        "ja": "サーサーン朝",
+        "ja_typings": [
+          "sa-saanchou",
+          "saasaanchou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01516",
+    "image_path": null,
+    "question_text": {
+      "en": "Which empire fell in 1453 with the fall of Constantinople?",
+      "ja": "1453年に滅亡した帝国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ottoman Empire",
+        "ja": "オスマン帝国",
+        "ja_typings": [
+          "osumanteikoku"
+        ]
+      },
+      {
+        "en": "Byzantine Empire",
+        "ja": "ビザンツ帝国",
+        "ja_typings": [
+          "bizantsuteikoku"
+        ]
+      },
+      {
+        "en": "Mongol Empire",
+        "ja": "モンゴル帝国",
+        "ja_typings": [
+          "mongoruteikoku"
+        ]
+      },
+      {
+        "en": "Holy Roman Empire",
+        "ja": "神聖ローマ帝国",
+        "ja_typings": [
+          "shinsei-ro-mateikoku",
+          "shinseiroomateikoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01517",
+    "image_path": null,
+    "question_text": {
+      "en": "Which empire captured Constantinople in 1453?",
+      "ja": "1453年にコンスタンティノープルを陥落させたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gutenberg",
+        "ja": "グーテンベルク",
+        "ja_typings": [
+          "gu-tenberuku"
+        ]
+      },
+      {
+        "en": "Caxton",
+        "ja": "キャクストン",
+        "ja_typings": [
+          "kyakusuton"
+        ]
+      },
+      {
+        "en": "Manutius",
+        "ja": "マヌティウス",
+        "ja_typings": [
+          "manutiusu"
+        ]
+      },
+      {
+        "en": "Fust",
+        "ja": "フスト",
+        "ja_typings": [
+          "fusuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01518",
+    "image_path": null,
+    "question_text": {
+      "en": "Who invented the printing press in Europe?",
+      "ja": "ヨーロッパで活版印刷を発明したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bell",
+        "ja": "ベル",
+        "ja_typings": [
+          "beru"
+        ]
+      },
+      {
+        "en": "Edison",
+        "ja": "エジソン",
+        "ja_typings": [
+          "ejison"
+        ]
+      },
+      {
+        "en": "Tesla",
+        "ja": "テスラ",
+        "ja_typings": [
+          "tesura"
+        ]
+      },
+      {
+        "en": "Marconi",
+        "ja": "マルコーニ",
+        "ja_typings": [
+          "maruko-ni"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01519",
+    "image_path": null,
+    "question_text": {
+      "en": "Who invented the telephone?",
+      "ja": "電話を発明したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Edison",
+        "ja": "エジソン",
+        "ja_typings": [
+          "ejison"
+        ]
+      },
+      {
+        "en": "Tesla",
+        "ja": "テスラ",
+        "ja_typings": [
+          "tesura"
+        ]
+      },
+      {
+        "en": "Swan",
+        "ja": "スワン",
+        "ja_typings": [
+          "suwan"
+        ]
+      },
+      {
+        "en": "Westinghouse",
+        "ja": "ウェスティングハウス",
+        "ja_typings": [
+          "wesutinguhausu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01520",
+    "image_path": null,
+    "question_text": {
+      "en": "Who invented the light bulb commercially?",
+      "ja": "白熱電球を商用化したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nobel",
+        "ja": "ノーベル",
+        "ja_typings": [
+          "no-beru"
+        ]
+      },
+      {
+        "en": "Edison",
+        "ja": "エジソン",
+        "ja_typings": [
+          "ejison"
+        ]
+      },
+      {
+        "en": "Tesla",
+        "ja": "テスラ",
+        "ja_typings": [
+          "tesura"
+        ]
+      },
+      {
+        "en": "Maxwell",
+        "ja": "マクスウェル",
+        "ja_typings": [
+          "makusuweru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01521",
+    "image_path": null,
+    "question_text": {
+      "en": "Who invented dynamite?",
+      "ja": "ダイナマイトを発明したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Luther",
+        "ja": "ルター",
+        "ja_typings": [
+          "ruta-"
+        ]
+      },
+      {
+        "en": "Calvin",
+        "ja": "カルヴァン",
+        "ja_typings": [
+          "karuvan"
+        ]
+      },
+      {
+        "en": "Zwingli",
+        "ja": "ツヴィングリ",
+        "ja_typings": [
+          "tsuvinguri"
+        ]
+      },
+      {
+        "en": "Knox",
+        "ja": "ノックス",
+        "ja_typings": [
+          "nokkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01522",
+    "image_path": null,
+    "question_text": {
+      "en": "Which religious reformer launched the Protestant Reformation in 1517?",
+      "ja": "1517年に宗教改革を始めたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Louis XVI",
+        "ja": "ルイ十六世",
+        "ja_typings": [
+          "ruijuurokusei"
+        ]
+      },
+      {
+        "en": "Henry IV",
+        "ja": "アンリ四世",
+        "ja_typings": [
+          "anriyonsei"
+        ]
+      },
+      {
+        "en": "Charles X",
+        "ja": "シャルル十世",
+        "ja_typings": [
+          "sharurujussei"
+        ]
+      },
+      {
+        "en": "Francis I",
+        "ja": "フランソワ一世",
+        "ja_typings": [
+          "furansowaissei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01523",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French king was beheaded during the French Revolution?",
+      "ja": "フランス革命で処刑されたフランス王は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Louis XIV",
+        "ja": "ルイ十四世",
+        "ja_typings": [
+          "ruijuuyonsei"
+        ]
+      },
+      {
+        "en": "Louis XV",
+        "ja": "ルイ十五世",
+        "ja_typings": [
+          "ruijuugosei"
+        ]
+      },
+      {
+        "en": "Louis XIII",
+        "ja": "ルイ十三世",
+        "ja_typings": [
+          "ruijuusansei"
+        ]
+      },
+      {
+        "en": "Henry IV",
+        "ja": "アンリ四世",
+        "ja_typings": [
+          "anriyonsei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01524",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French king was called the Sun King?",
+      "ja": "「太陽王」と呼ばれたフランス王は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hulagu Khan",
+        "ja": "フレグ",
+        "ja_typings": [
+          "furegu"
+        ]
+      },
+      {
+        "en": "Kublai Khan",
+        "ja": "フビライ",
+        "ja_typings": [
+          "fubirai"
+        ]
+      },
+      {
+        "en": "Batu Khan",
+        "ja": "バトゥ",
+        "ja_typings": [
+          "batu"
+        ]
+      },
+      {
+        "en": "Ogedei Khan",
+        "ja": "オゴデイ",
+        "ja_typings": [
+          "ogodei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01525",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mongol leader conquered Baghdad in 1258?",
+      "ja": "1258年にバグダードを陥落させたモンゴル指導者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Anne",
+        "ja": "アン女王",
+        "ja_typings": [
+          "anjoou"
+        ]
+      },
+      {
+        "en": "Mary II",
+        "ja": "メアリー二世",
+        "ja_typings": [
+          "meari-nisei",
+          "meariinisei"
+        ]
+      },
+      {
+        "en": "Victoria",
+        "ja": "ヴィクトリア女王",
+        "ja_typings": [
+          "vikutoriajoou"
+        ]
+      },
+      {
+        "en": "Elizabeth I",
+        "ja": "エリザベス一世",
+        "ja_typings": [
+          "erizabesuissei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01526",
+    "image_path": null,
+    "question_text": {
+      "en": "Which queen ruled both England and Scotland from 1702?",
+      "ja": "1702年から英国とスコットランドを統治した女王は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yamamoto Isoroku",
+        "ja": "山本五十六",
+        "ja_typings": [
+          "yamamotoisoroku"
+        ]
+      },
+      {
+        "en": "Tojo Hideki",
+        "ja": "東条英機",
+        "ja_typings": [
+          "toujouhideki"
+        ]
+      },
+      {
+        "en": "Nagumo Chuichi",
+        "ja": "南雲忠一",
+        "ja_typings": [
+          "nagumochuuichi"
+        ]
+      },
+      {
+        "en": "Yamashita Tomoyuki",
+        "ja": "山下奉文",
+        "ja_typings": [
+          "yamashitatomoyuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01527",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese general led the attack on Pearl Harbor planning?",
+      "ja": "真珠湾攻撃を立案した日本の提督は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "World War One",
+        "ja": "第一次世界大戦",
+        "ja_typings": [
+          "dai1jisekaitaisen",
+          "daiichijisekaitaisen"
+        ]
+      },
+      {
+        "en": "Balkan War",
+        "ja": "バルカン戦争",
+        "ja_typings": [
+          "barukansensou"
+        ]
+      },
+      {
+        "en": "Crimean War",
+        "ja": "クリミア戦争",
+        "ja_typings": [
+          "kurimiasensou"
+        ]
+      },
+      {
+        "en": "Boer War",
+        "ja": "ボーア戦争",
+        "ja_typings": [
+          "bo-asensou",
+          "booasensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q01528",
+    "image_path": null,
+    "question_text": {
+      "en": "Which conflict was triggered by the assassination of Archduke Franz Ferdinand?",
+      "ja": "フランツ・フェルディナント大公暗殺が引き金となった戦争は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "W",
+        "ja": "W",
+        "ja_typings": [
+          "w"
+        ]
+      },
+      {
+        "en": "Tu",
+        "ja": "Tu",
+        "ja_typings": [
+          "tu"
+        ]
+      },
+      {
+        "en": "Tg",
+        "ja": "Tg",
+        "ja_typings": [
+          "tg"
+        ]
+      },
+      {
+        "en": "Tn",
+        "ja": "Tn",
+        "ja_typings": [
+          "tn"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01529",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the chemical symbol for tungsten?",
+      "ja": "タングステンの元素記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nitrogen gas",
+        "ja": "窒素ガス",
+        "ja_typings": [
+          "chissogasu"
+        ]
+      },
+      {
+        "en": "Oxygen gas",
+        "ja": "酸素ガス",
+        "ja_typings": [
+          "sansogasu"
+        ]
+      },
+      {
+        "en": "Argon gas",
+        "ja": "アルゴンガス",
+        "ja_typings": [
+          "arugongasu"
+        ]
+      },
+      {
+        "en": "Methane gas",
+        "ja": "メタンガス",
+        "ja_typings": [
+          "metangasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01530",
+    "image_path": null,
+    "question_text": {
+      "en": "Which gas makes up about 78% of Earth's atmosphere?",
+      "ja": "地球の大気の約78%を占める気体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Carbon dioxide",
+        "ja": "二酸化炭素",
+        "ja_typings": [
+          "nisankatanso"
+        ]
+      },
+      {
+        "en": "Methane",
+        "ja": "メタン",
+        "ja_typings": [
+          "metan"
+        ]
+      },
+      {
+        "en": "Ozone",
+        "ja": "オゾン",
+        "ja_typings": [
+          "ozon"
+        ]
+      },
+      {
+        "en": "Sulfur dioxide",
+        "ja": "二酸化硫黄",
+        "ja_typings": [
+          "nisankaiou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01531",
+    "image_path": null,
+    "question_text": {
+      "en": "Which gas is most responsible for global warming from human activity?",
+      "ja": "人為的温暖化の主因となる気体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lithium",
+        "ja": "リチウム",
+        "ja_typings": [
+          "richiumu"
+        ]
+      },
+      {
+        "en": "Sodium",
+        "ja": "ナトリウム",
+        "ja_typings": [
+          "natoriumu"
+        ]
+      },
+      {
+        "en": "Magnesium",
+        "ja": "マグネシウム",
+        "ja_typings": [
+          "maguneshiumu"
+        ]
+      },
+      {
+        "en": "Beryllium",
+        "ja": "ベリリウム",
+        "ja_typings": [
+          "beririumu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01532",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the lightest metal?",
+      "ja": "最も軽い金属は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Saturn",
+        "ja": "土星",
+        "ja_typings": [
+          "dosei"
+        ]
+      },
+      {
+        "en": "Uranus",
+        "ja": "天王星",
+        "ja_typings": [
+          "tennousei"
+        ]
+      },
+      {
+        "en": "Neptune",
+        "ja": "海王星",
+        "ja_typings": [
+          "kaiousei"
+        ]
+      },
+      {
+        "en": "Mars",
+        "ja": "火星",
+        "ja_typings": [
+          "kasei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01533",
+    "image_path": null,
+    "question_text": {
+      "en": "Which planet has the most moons?",
+      "ja": "最も多くの衛星を持つ惑星は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Saturn",
+        "ja": "土星",
+        "ja_typings": [
+          "dosei"
+        ]
+      },
+      {
+        "en": "Uranus",
+        "ja": "天王星",
+        "ja_typings": [
+          "tennousei"
+        ]
+      },
+      {
+        "en": "Neptune",
+        "ja": "海王星",
+        "ja_typings": [
+          "kaiousei"
+        ]
+      },
+      {
+        "en": "Venus",
+        "ja": "金星",
+        "ja_typings": [
+          "kinsei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01534",
+    "image_path": null,
+    "question_text": {
+      "en": "Which planet is known for its prominent rings?",
+      "ja": "顕著な環で知られる惑星は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mars",
+        "ja": "火星",
+        "ja_typings": [
+          "kasei"
+        ]
+      },
+      {
+        "en": "Venus",
+        "ja": "金星",
+        "ja_typings": [
+          "kinsei"
+        ]
+      },
+      {
+        "en": "Mercury",
+        "ja": "水星",
+        "ja_typings": [
+          "suisei"
+        ]
+      },
+      {
+        "en": "Pluto",
+        "ja": "冥王星",
+        "ja_typings": [
+          "meiousei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01535",
+    "image_path": null,
+    "question_text": {
+      "en": "Which planet is known as the Red Planet?",
+      "ja": "「赤い惑星」と呼ばれるのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Neptune",
+        "ja": "海王星",
+        "ja_typings": [
+          "kaiousei"
+        ]
+      },
+      {
+        "en": "Uranus",
+        "ja": "天王星",
+        "ja_typings": [
+          "tennousei"
+        ]
+      },
+      {
+        "en": "Pluto",
+        "ja": "冥王星",
+        "ja_typings": [
+          "meiousei"
+        ]
+      },
+      {
+        "en": "Saturn",
+        "ja": "土星",
+        "ja_typings": [
+          "dosei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01536",
+    "image_path": null,
+    "question_text": {
+      "en": "Which planet is the farthest from the Sun (recognized as a planet)?",
+      "ja": "太陽系で最遠の惑星(認定されたもの)は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ganymede",
+        "ja": "ガニメデ",
+        "ja_typings": [
+          "ganimede"
+        ]
+      },
+      {
+        "en": "Titan",
+        "ja": "タイタン",
+        "ja_typings": [
+          "taitan"
+        ]
+      },
+      {
+        "en": "Europa",
+        "ja": "エウロパ",
+        "ja_typings": [
+          "europa"
+        ]
+      },
+      {
+        "en": "Callisto",
+        "ja": "カリスト",
+        "ja_typings": [
+          "karisuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01537",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the largest moon in the solar system?",
+      "ja": "太陽系最大の衛星は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Titan",
+        "ja": "タイタン",
+        "ja_typings": [
+          "taitan"
+        ]
+      },
+      {
+        "en": "Enceladus",
+        "ja": "エンケラドゥス",
+        "ja_typings": [
+          "enkeradusu"
+        ]
+      },
+      {
+        "en": "Mimas",
+        "ja": "ミマス",
+        "ja_typings": [
+          "mimasu"
+        ]
+      },
+      {
+        "en": "Rhea",
+        "ja": "レア",
+        "ja_typings": [
+          "rea"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01538",
+    "image_path": null,
+    "question_text": {
+      "en": "Which moon of Saturn has a thick atmosphere?",
+      "ja": "厚い大気を持つ土星の衛星は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Copernicus",
+        "ja": "コペルニクス",
+        "ja_typings": [
+          "koperunikusu"
+        ]
+      },
+      {
+        "en": "Galileo",
+        "ja": "ガリレオ",
+        "ja_typings": [
+          "garireo"
+        ]
+      },
+      {
+        "en": "Kepler",
+        "ja": "ケプラー",
+        "ja_typings": [
+          "kepura-"
+        ]
+      },
+      {
+        "en": "Brahe",
+        "ja": "ブラーエ",
+        "ja_typings": [
+          "bura-e"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01539",
+    "image_path": null,
+    "question_text": {
+      "en": "Who proposed the heliocentric model of the solar system?",
+      "ja": "地動説を唱えたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kepler",
+        "ja": "ケプラー",
+        "ja_typings": [
+          "kepura-"
+        ]
+      },
+      {
+        "en": "Copernicus",
+        "ja": "コペルニクス",
+        "ja_typings": [
+          "koperunikusu"
+        ]
+      },
+      {
+        "en": "Galileo",
+        "ja": "ガリレオ",
+        "ja_typings": [
+          "garireo"
+        ]
+      },
+      {
+        "en": "Halley",
+        "ja": "ハレー",
+        "ja_typings": [
+          "hare-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01540",
+    "image_path": null,
+    "question_text": {
+      "en": "Who formulated the three laws of planetary motion?",
+      "ja": "惑星運動の三法則を導いたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ampere",
+        "ja": "アンペール",
+        "ja_typings": [
+          "anpe-ru"
+        ]
+      },
+      {
+        "en": "Volta",
+        "ja": "ボルタ",
+        "ja_typings": [
+          "boruta"
+        ]
+      },
+      {
+        "en": "Ohm",
+        "ja": "オーム",
+        "ja_typings": [
+          "o-mu"
+        ]
+      },
+      {
+        "en": "Faraday",
+        "ja": "ファラデー",
+        "ja_typings": [
+          "farade-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01541",
+    "image_path": null,
+    "question_text": {
+      "en": "Who proposed that current flows in a magnetic field induces force?",
+      "ja": "電流に磁場が力を及ぼすことを示したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Faraday",
+        "ja": "ファラデー",
+        "ja_typings": [
+          "farade-"
+        ]
+      },
+      {
+        "en": "Maxwell",
+        "ja": "マクスウェル",
+        "ja_typings": [
+          "makusuweru"
+        ]
+      },
+      {
+        "en": "Hertz",
+        "ja": "ヘルツ",
+        "ja_typings": [
+          "herutsu"
+        ]
+      },
+      {
+        "en": "Tesla",
+        "ja": "テスラ",
+        "ja_typings": [
+          "tesura"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01542",
+    "image_path": null,
+    "question_text": {
+      "en": "Who discovered electromagnetic induction?",
+      "ja": "電磁誘導を発見したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Maxwell",
+        "ja": "マクスウェル",
+        "ja_typings": [
+          "makusuweru"
+        ]
+      },
+      {
+        "en": "Faraday",
+        "ja": "ファラデー",
+        "ja_typings": [
+          "farade-"
+        ]
+      },
+      {
+        "en": "Hertz",
+        "ja": "ヘルツ",
+        "ja_typings": [
+          "herutsu"
+        ]
+      },
+      {
+        "en": "Lorentz",
+        "ja": "ローレンツ",
+        "ja_typings": [
+          "ro-rentsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01543",
+    "image_path": null,
+    "question_text": {
+      "en": "Who unified electricity and magnetism into a single theory?",
+      "ja": "電気と磁気を統一理論にまとめたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Crick",
+        "ja": "クリック",
+        "ja_typings": [
+          "kurikku"
+        ]
+      },
+      {
+        "en": "Franklin",
+        "ja": "フランクリン",
+        "ja_typings": [
+          "furankurin"
+        ]
+      },
+      {
+        "en": "Wilkins",
+        "ja": "ウィルキンス",
+        "ja_typings": [
+          "wirukinsu"
+        ]
+      },
+      {
+        "en": "Pauling",
+        "ja": "ポーリング",
+        "ja_typings": [
+          "po-ringu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01544",
+    "image_path": null,
+    "question_text": {
+      "en": "Who discovered the structure of DNA along with Watson?",
+      "ja": "ワトソンとともにDNA構造を解明したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lavoisier",
+        "ja": "ラヴォアジエ",
+        "ja_typings": [
+          "ravoajie"
+        ]
+      },
+      {
+        "en": "Mendeleev",
+        "ja": "メンデレーエフ",
+        "ja_typings": [
+          "mendere-efu"
+        ]
+      },
+      {
+        "en": "Dalton",
+        "ja": "ドルトン",
+        "ja_typings": [
+          "doruton"
+        ]
+      },
+      {
+        "en": "Boyle",
+        "ja": "ボイル",
+        "ja_typings": [
+          "boiru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01545",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is considered the father of modern chemistry?",
+      "ja": "近代化学の父と呼ばれるのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mendeleev",
+        "ja": "メンデレーエフ",
+        "ja_typings": [
+          "mendere-efu"
+        ]
+      },
+      {
+        "en": "Lavoisier",
+        "ja": "ラヴォアジエ",
+        "ja_typings": [
+          "ravoajie"
+        ]
+      },
+      {
+        "en": "Dalton",
+        "ja": "ドルトン",
+        "ja_typings": [
+          "doruton"
+        ]
+      },
+      {
+        "en": "Bohr",
+        "ja": "ボーア",
+        "ja_typings": [
+          "bo-a"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01546",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created the periodic table of elements?",
+      "ja": "元素周期表を作ったのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dalton",
+        "ja": "ドルトン",
+        "ja_typings": [
+          "doruton"
+        ]
+      },
+      {
+        "en": "Bohr",
+        "ja": "ボーア",
+        "ja_typings": [
+          "bo-a"
+        ]
+      },
+      {
+        "en": "Rutherford",
+        "ja": "ラザフォード",
+        "ja_typings": [
+          "razafo-do"
+        ]
+      },
+      {
+        "en": "Thomson",
+        "ja": "トムソン",
+        "ja_typings": [
+          "tomuson"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01547",
+    "image_path": null,
+    "question_text": {
+      "en": "Who developed the atomic theory of matter?",
+      "ja": "原子論を提唱したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thomson",
+        "ja": "トムソン",
+        "ja_typings": [
+          "tomuson"
+        ]
+      },
+      {
+        "en": "Rutherford",
+        "ja": "ラザフォード",
+        "ja_typings": [
+          "razafo-do"
+        ]
+      },
+      {
+        "en": "Bohr",
+        "ja": "ボーア",
+        "ja_typings": [
+          "bo-a"
+        ]
+      },
+      {
+        "en": "Millikan",
+        "ja": "ミリカン",
+        "ja_typings": [
+          "mirikan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01548",
+    "image_path": null,
+    "question_text": {
+      "en": "Who discovered the electron?",
+      "ja": "電子を発見したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rutherford",
+        "ja": "ラザフォード",
+        "ja_typings": [
+          "razafo-do"
+        ]
+      },
+      {
+        "en": "Bohr",
+        "ja": "ボーア",
+        "ja_typings": [
+          "bo-a"
+        ]
+      },
+      {
+        "en": "Chadwick",
+        "ja": "チャドウィック",
+        "ja_typings": [
+          "chadowikku"
+        ]
+      },
+      {
+        "en": "Thomson",
+        "ja": "トムソン",
+        "ja_typings": [
+          "tomuson"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01549",
+    "image_path": null,
+    "question_text": {
+      "en": "Who discovered the atomic nucleus?",
+      "ja": "原子核を発見したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chadwick",
+        "ja": "チャドウィック",
+        "ja_typings": [
+          "chadowikku"
+        ]
+      },
+      {
+        "en": "Rutherford",
+        "ja": "ラザフォード",
+        "ja_typings": [
+          "razafo-do"
+        ]
+      },
+      {
+        "en": "Bohr",
+        "ja": "ボーア",
+        "ja_typings": [
+          "bo-a"
+        ]
+      },
+      {
+        "en": "Fermi",
+        "ja": "フェルミ",
+        "ja_typings": [
+          "ferumi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01550",
+    "image_path": null,
+    "question_text": {
+      "en": "Who discovered the neutron?",
+      "ja": "中性子を発見したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ampere",
+        "ja": "アンペア",
+        "ja_typings": [
+          "anpea"
+        ]
+      },
+      {
+        "en": "Volt",
+        "ja": "ボルト",
+        "ja_typings": [
+          "boruto"
+        ]
+      },
+      {
+        "en": "Ohm",
+        "ja": "オーム",
+        "ja_typings": [
+          "o-mu"
+        ]
+      },
+      {
+        "en": "Watt",
+        "ja": "ワット",
+        "ja_typings": [
+          "watto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01551",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the SI unit of electric current?",
+      "ja": "電流のSI単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hertz",
+        "ja": "ヘルツ",
+        "ja_typings": [
+          "herutsu"
+        ]
+      },
+      {
+        "en": "Watt",
+        "ja": "ワット",
+        "ja_typings": [
+          "watto"
+        ]
+      },
+      {
+        "en": "Joule",
+        "ja": "ジュール",
+        "ja_typings": [
+          "ju-ru"
+        ]
+      },
+      {
+        "en": "Pascal",
+        "ja": "パスカル",
+        "ja_typings": [
+          "pasukaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01552",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the SI unit of frequency?",
+      "ja": "周波数のSI単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pascal",
+        "ja": "パスカル",
+        "ja_typings": [
+          "pasukaru"
+        ]
+      },
+      {
+        "en": "Newton",
+        "ja": "ニュートン",
+        "ja_typings": [
+          "nyu-ton"
+        ]
+      },
+      {
+        "en": "Joule",
+        "ja": "ジュール",
+        "ja_typings": [
+          "ju-ru"
+        ]
+      },
+      {
+        "en": "Bar",
+        "ja": "バール",
+        "ja_typings": [
+          "ba-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01553",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the SI unit of pressure?",
+      "ja": "圧力のSI単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Joule",
+        "ja": "ジュール",
+        "ja_typings": [
+          "ju-ru"
+        ]
+      },
+      {
+        "en": "Watt",
+        "ja": "ワット",
+        "ja_typings": [
+          "watto"
+        ]
+      },
+      {
+        "en": "Calorie",
+        "ja": "カロリー",
+        "ja_typings": [
+          "karori-"
+        ]
+      },
+      {
+        "en": "Erg",
+        "ja": "エルグ",
+        "ja_typings": [
+          "erugu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01554",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the SI unit of energy?",
+      "ja": "エネルギーのSI単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Newton",
+        "ja": "ニュートン",
+        "ja_typings": [
+          "nyu-ton"
+        ]
+      },
+      {
+        "en": "Joule",
+        "ja": "ジュール",
+        "ja_typings": [
+          "ju-ru"
+        ]
+      },
+      {
+        "en": "Pascal",
+        "ja": "パスカル",
+        "ja_typings": [
+          "pasukaru"
+        ]
+      },
+      {
+        "en": "Dyne",
+        "ja": "ダイン",
+        "ja_typings": [
+          "dain"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01555",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the SI unit of force?",
+      "ja": "力のSI単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Skin",
+        "ja": "皮膚",
+        "ja_typings": [
+          "hifu"
+        ]
+      },
+      {
+        "en": "Liver",
+        "ja": "肝臓",
+        "ja_typings": [
+          "kanzou"
+        ]
+      },
+      {
+        "en": "Lung",
+        "ja": "肺",
+        "ja_typings": [
+          "hai"
+        ]
+      },
+      {
+        "en": "Intestine",
+        "ja": "腸",
+        "ja_typings": [
+          "chou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01556",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the largest organ of the human body?",
+      "ja": "人体最大の臓器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Red blood cells",
+        "ja": "赤血球",
+        "ja_typings": [
+          "sekkekkyuu"
+        ]
+      },
+      {
+        "en": "White blood cells",
+        "ja": "白血球",
+        "ja_typings": [
+          "hakkekkyuu"
+        ]
+      },
+      {
+        "en": "Platelets",
+        "ja": "血小板",
+        "ja_typings": [
+          "kesshouban"
+        ]
+      },
+      {
+        "en": "Plasma",
+        "ja": "血漿",
+        "ja_typings": [
+          "kesshou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01557",
+    "image_path": null,
+    "question_text": {
+      "en": "Which blood cells carry oxygen?",
+      "ja": "酸素を運ぶ血球は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mohs scale",
+        "ja": "モース硬度",
+        "ja_typings": [
+          "mo-sukoudo",
+          "moosukoudo"
+        ]
+      },
+      {
+        "en": "Richter scale",
+        "ja": "リヒタースケール",
+        "ja_typings": [
+          "rihita-suke-ru"
+        ]
+      },
+      {
+        "en": "Beaufort scale",
+        "ja": "ボーフォート階級",
+        "ja_typings": [
+          "bo-foutokaikyuu",
+          "boofoutokaikyuu"
+        ]
+      },
+      {
+        "en": "Brinell scale",
+        "ja": "ブリネル硬度",
+        "ja_typings": [
+          "burinerukoudo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01558",
+    "image_path": null,
+    "question_text": {
+      "en": "Which scale measures mineral hardness?",
+      "ja": "鉱物硬度の尺度は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Refraction",
+        "ja": "屈折",
+        "ja_typings": [
+          "kussetsu"
+        ]
+      },
+      {
+        "en": "Reflection",
+        "ja": "反射",
+        "ja_typings": [
+          "hansha"
+        ]
+      },
+      {
+        "en": "Diffraction",
+        "ja": "回折",
+        "ja_typings": [
+          "kaisetsu"
+        ]
+      },
+      {
+        "en": "Dispersion",
+        "ja": "分散",
+        "ja_typings": [
+          "bunsan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q01559",
+    "image_path": null,
+    "question_text": {
+      "en": "Which phenomenon causes the bending of light passing through different media?",
+      "ja": "媒質間で光が曲がる現象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "S3",
+        "ja": "S3",
+        "ja_typings": [
+          "s3"
+        ]
+      },
+      {
+        "en": "Z2",
+        "ja": "Z2",
+        "ja_typings": [
+          "z2"
+        ]
+      },
+      {
+        "en": "Z4",
+        "ja": "Z4",
+        "ja_typings": [
+          "z4"
+        ]
+      },
+      {
+        "en": "V4",
+        "ja": "V4",
+        "ja_typings": [
+          "v4"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01560",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the smallest non-abelian group?",
+      "ja": "最小の非可換群はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "twin prime",
+        "ja": "双子素数予想",
+        "ja_typings": [
+          "futagososuuyosou"
+        ]
+      },
+      {
+        "en": "Goldbach",
+        "ja": "ゴールドバッハ予想",
+        "ja_typings": [
+          "go-rudobahhayosou"
+        ]
+      },
+      {
+        "en": "Riemann",
+        "ja": "リーマン予想",
+        "ja_typings": [
+          "ri-manyosou"
+        ]
+      },
+      {
+        "en": "Collatz",
+        "ja": "コラッツ予想",
+        "ja_typings": [
+          "korattsuyosou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01561",
+    "image_path": null,
+    "question_text": {
+      "en": "Which conjecture concerns prime gaps of 2?",
+      "ja": "素数の差が2となる予想はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ring",
+        "ja": "環",
+        "ja_typings": [
+          "kan",
+          "wa"
+        ]
+      },
+      {
+        "en": "group",
+        "ja": "群",
+        "ja_typings": [
+          "gun"
+        ]
+      },
+      {
+        "en": "lattice",
+        "ja": "束",
+        "ja_typings": [
+          "soku",
+          "taba"
+        ]
+      },
+      {
+        "en": "monoid",
+        "ja": "モノイド",
+        "ja_typings": [
+          "monoido"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01562",
+    "image_path": null,
+    "question_text": {
+      "en": "Which structure has both addition and multiplication?",
+      "ja": "加法と乗法を両方持つ代数構造は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Euclidean space",
+        "ja": "ユークリッド空間",
+        "ja_typings": [
+          "yu-kuriddokuukan"
+        ]
+      },
+      {
+        "en": "sphere",
+        "ja": "球面",
+        "ja_typings": [
+          "kyuumen"
+        ]
+      },
+      {
+        "en": "torus",
+        "ja": "トーラス",
+        "ja_typings": [
+          "to-rasu"
+        ]
+      },
+      {
+        "en": "hyperbolic plane",
+        "ja": "双曲平面",
+        "ja_typings": [
+          "soukyokuheimen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01563",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a manifold locally homeomorphic to?",
+      "ja": "多様体は局所的に何と同相?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "quaternions",
+        "ja": "四元数",
+        "ja_typings": [
+          "shigensuu"
+        ]
+      },
+      {
+        "en": "octonions",
+        "ja": "八元数",
+        "ja_typings": [
+          "hachigensuu"
+        ]
+      },
+      {
+        "en": "sedenions",
+        "ja": "十六元数",
+        "ja_typings": [
+          "juurokugensuu"
+        ]
+      },
+      {
+        "en": "dual numbers",
+        "ja": "二重数",
+        "ja_typings": [
+          "nijuusuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01564",
+    "image_path": null,
+    "question_text": {
+      "en": "Which number system extends complex numbers to 4D?",
+      "ja": "複素数を4次元に拡張した数体系は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gauss-Bonnet",
+        "ja": "ガウス・ボネの定理",
+        "ja_typings": [
+          "gausu bone no teiri"
+        ]
+      },
+      {
+        "en": "Stokes",
+        "ja": "ストークスの定理",
+        "ja_typings": [
+          "suto-kusu no teiri"
+        ]
+      },
+      {
+        "en": "Green",
+        "ja": "グリーンの定理",
+        "ja_typings": [
+          "guri-nnnoteiri"
+        ]
+      },
+      {
+        "en": "Cauchy",
+        "ja": "コーシーの定理",
+        "ja_typings": [
+          "ko-shi-noteiri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01565",
+    "image_path": null,
+    "question_text": {
+      "en": "Which theorem relates Euler characteristic to genus?",
+      "ja": "オイラー標数と種数を結ぶ定理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "P vs NP",
+        "ja": "P対NP問題",
+        "ja_typings": [
+          "P tai NP mondai"
+        ]
+      },
+      {
+        "en": "halting",
+        "ja": "停止性問題",
+        "ja_typings": [
+          "teishiseimondai"
+        ]
+      },
+      {
+        "en": "Hilbert tenth",
+        "ja": "ヒルベルト第十問題",
+        "ja_typings": [
+          "hiruberutodaijuumondai"
+        ]
+      },
+      {
+        "en": "Goldbach",
+        "ja": "ゴールドバッハ問題",
+        "ja_typings": [
+          "go-rudobahhamondai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01566",
+    "image_path": null,
+    "question_text": {
+      "en": "Which problem asks if P equals NP?",
+      "ja": "PとNPが等しいかを問う問題は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hausdorff",
+        "ja": "ハウスドルフ次元",
+        "ja_typings": [
+          "hausudorufu jigen"
+        ]
+      },
+      {
+        "en": "Lebesgue",
+        "ja": "ルベーグ次元",
+        "ja_typings": [
+          "rube-gujigen"
+        ]
+      },
+      {
+        "en": "Minkowski",
+        "ja": "ミンコフスキー次元",
+        "ja_typings": [
+          "minkofusuki-jigen"
+        ]
+      },
+      {
+        "en": "Krull",
+        "ja": "クルル次元",
+        "ja_typings": [
+          "kururujigen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01567",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a non-trivial example of a fractal dimension?",
+      "ja": "非自明なフラクタル次元の例は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hamiltonian cycle",
+        "ja": "ハミルトン閉路問題",
+        "ja_typings": [
+          "hamiruton heiro mondai"
+        ]
+      },
+      {
+        "en": "shortest path",
+        "ja": "最短経路問題",
+        "ja_typings": [
+          "saitankeiromondai"
+        ]
+      },
+      {
+        "en": "MST",
+        "ja": "最小全域木問題",
+        "ja_typings": [
+          "saishouzennnikimondai"
+        ]
+      },
+      {
+        "en": "BFS",
+        "ja": "幅優先探索",
+        "ja_typings": [
+          "habayuusentansaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01568",
+    "image_path": null,
+    "question_text": {
+      "en": "Which graph problem is NP-complete?",
+      "ja": "NP完全のグラフ問題は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "aleph one",
+        "ja": "アレフ1",
+        "ja_typings": [
+          "arefu 1",
+          "arefu1"
+        ]
+      },
+      {
+        "en": "aleph zero",
+        "ja": "アレフ0",
+        "ja_typings": [
+          "arefu0"
+        ]
+      },
+      {
+        "en": "aleph two",
+        "ja": "アレフ2",
+        "ja_typings": [
+          "arefu2"
+        ]
+      },
+      {
+        "en": "beth zero",
+        "ja": "ベート0",
+        "ja_typings": [
+          "be-to0"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01569",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the cardinality of the continuum?",
+      "ja": "連続体の濃度の記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "real numbers",
+        "ja": "実数全体",
+        "ja_typings": [
+          "jissuuzentai"
+        ]
+      },
+      {
+        "en": "integers",
+        "ja": "整数全体",
+        "ja_typings": [
+          "seisuuzentai"
+        ]
+      },
+      {
+        "en": "rationals",
+        "ja": "有理数全体",
+        "ja_typings": [
+          "yuurisuuzentai"
+        ]
+      },
+      {
+        "en": "primes",
+        "ja": "素数全体",
+        "ja_typings": [
+          "sosuuzentai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01570",
+    "image_path": null,
+    "question_text": {
+      "en": "Which set is uncountable?",
+      "ja": "非可算集合はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "A4",
+        "ja": "A4群",
+        "ja_typings": [
+          "A4gun"
+        ]
+      },
+      {
+        "en": "S5",
+        "ja": "S5群",
+        "ja_typings": [
+          "s5gun"
+        ]
+      },
+      {
+        "en": "D8",
+        "ja": "D8群",
+        "ja_typings": [
+          "d8gun"
+        ]
+      },
+      {
+        "en": "Z12",
+        "ja": "Z12群",
+        "ja_typings": [
+          "z12gun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01571",
+    "image_path": null,
+    "question_text": {
+      "en": "Which group describes symmetries of a tetrahedron?",
+      "ja": "正四面体の対称群は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "topological spaces",
+        "ja": "位相空間",
+        "ja_typings": [
+          "isoukuukan"
+        ]
+      },
+      {
+        "en": "metric spaces only",
+        "ja": "距離空間のみ",
+        "ja_typings": [
+          "kyorikuukannnomi"
+        ]
+      },
+      {
+        "en": "vector spaces",
+        "ja": "ベクトル空間",
+        "ja_typings": [
+          "bekutorukuukan"
+        ]
+      },
+      {
+        "en": "Hilbert spaces",
+        "ja": "ヒルベルト空間",
+        "ja_typings": [
+          "hiruberutokuukan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01572",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the formal definition of a continuous map between?",
+      "ja": "連続写像が定義される対象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "logarithm",
+        "ja": "対数関数",
+        "ja_typings": [
+          "taisuukansuu"
+        ]
+      },
+      {
+        "en": "exponential",
+        "ja": "指数関数",
+        "ja_typings": [
+          "shisuukansuu"
+        ]
+      },
+      {
+        "en": "sine",
+        "ja": "正弦関数",
+        "ja_typings": [
+          "seigenkansuu"
+        ]
+      },
+      {
+        "en": "zeta",
+        "ja": "ゼータ関数",
+        "ja_typings": [
+          "ze-takansuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01573",
+    "image_path": null,
+    "question_text": {
+      "en": "Which constant appears in the prime number theorem?",
+      "ja": "素数定理に現れる関数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "abelian group",
+        "ja": "アーベル群",
+        "ja_typings": [
+          "a-berugun"
+        ]
+      },
+      {
+        "en": "non-abelian group",
+        "ja": "非可換群",
+        "ja_typings": [
+          "hikakangun"
+        ]
+      },
+      {
+        "en": "free group",
+        "ja": "自由群",
+        "ja_typings": [
+          "jiyuugun"
+        ]
+      },
+      {
+        "en": "nilpotent group",
+        "ja": "冪零群",
+        "ja_typings": [
+          "bekireigun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01574",
+    "image_path": null,
+    "question_text": {
+      "en": "Which structure is used in elliptic curve cryptography?",
+      "ja": "楕円曲線暗号で用いる構造は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "functor",
+        "ja": "関手",
+        "ja_typings": [
+          "kanshu"
+        ]
+      },
+      {
+        "en": "vector",
+        "ja": "ベクトル",
+        "ja_typings": [
+          "bekutoru"
+        ]
+      },
+      {
+        "en": "matrix",
+        "ja": "行列",
+        "ja_typings": [
+          "gyouretsu"
+        ]
+      },
+      {
+        "en": "tensor",
+        "ja": "テンソル",
+        "ja_typings": [
+          "tensoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01575",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a key concept in category theory?",
+      "ja": "圏論の中心概念は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chebyshev",
+        "ja": "チェビシェフの不等式",
+        "ja_typings": [
+          "chebishefu no futoushiki"
+        ]
+      },
+      {
+        "en": "Cauchy-Schwarz",
+        "ja": "コーシー・シュワルツの不等式",
+        "ja_typings": [
+          "ko-shi-/shuwarutsunofutoushiki"
+        ]
+      },
+      {
+        "en": "Jensen",
+        "ja": "イェンセンの不等式",
+        "ja_typings": [
+          "iensennnofutoushiki"
+        ]
+      },
+      {
+        "en": "Markov",
+        "ja": "マルコフの不等式",
+        "ja_typings": [
+          "marukofunofutoushiki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01576",
+    "image_path": null,
+    "question_text": {
+      "en": "Which inequality bounds variance and expectation?",
+      "ja": "分散と期待値を結ぶ不等式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Poisson",
+        "ja": "ポアソン分布",
+        "ja_typings": [
+          "poasonbunpu"
+        ]
+      },
+      {
+        "en": "normal",
+        "ja": "正規分布",
+        "ja_typings": [
+          "seikibunpu"
+        ]
+      },
+      {
+        "en": "uniform",
+        "ja": "一様分布",
+        "ja_typings": [
+          "ichiyoubunpu"
+        ]
+      },
+      {
+        "en": "binomial",
+        "ja": "二項分布",
+        "ja_typings": [
+          "nikoubunpu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01577",
+    "image_path": null,
+    "question_text": {
+      "en": "Which distribution describes rare events?",
+      "ja": "稀な事象を表す分布は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Snake lemma",
+        "ja": "蛇の補題",
+        "ja_typings": [
+          "hebi no hodai"
+        ]
+      },
+      {
+        "en": "Zorn lemma",
+        "ja": "ツォルンの補題",
+        "ja_typings": [
+          "tsorunnnohodai"
+        ]
+      },
+      {
+        "en": "Yoneda lemma",
+        "ja": "米田の補題",
+        "ja_typings": [
+          "yonedanohodai"
+        ]
+      },
+      {
+        "en": "Schur lemma",
+        "ja": "シューアの補題",
+        "ja_typings": [
+          "shu-anohodai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01578",
+    "image_path": null,
+    "question_text": {
+      "en": "Which lemma is essential in homological algebra?",
+      "ja": "ホモロジー代数で重要な補題は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "non-orientable surface",
+        "ja": "非向き付け可能曲面",
+        "ja_typings": [
+          "himukitsukekanoukyokumen"
+        ]
+      },
+      {
+        "en": "compact manifold",
+        "ja": "コンパクト多様体",
+        "ja_typings": [
+          "konpakutotayoutai"
+        ]
+      },
+      {
+        "en": "simply connected space",
+        "ja": "単連結空間",
+        "ja_typings": [
+          "tanrenketsukuukan"
+        ]
+      },
+      {
+        "en": "Hausdorff space",
+        "ja": "ハウスドルフ空間",
+        "ja_typings": [
+          "hausudorufukuukan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01579",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a Mobius strip an example of?",
+      "ja": "メビウスの帯は何の例?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "heat equation",
+        "ja": "熱方程式",
+        "ja_typings": [
+          "netsuhouteishiki"
+        ]
+      },
+      {
+        "en": "wave equation",
+        "ja": "波動方程式",
+        "ja_typings": [
+          "hadouhouteishiki"
+        ]
+      },
+      {
+        "en": "Laplace",
+        "ja": "ラプラス方程式",
+        "ja_typings": [
+          "rapurasuhouteishiki"
+        ]
+      },
+      {
+        "en": "Schrodinger",
+        "ja": "シュレーディンガー方程式",
+        "ja_typings": [
+          "shure-dinga-houteishiki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01580",
+    "image_path": null,
+    "question_text": {
+      "en": "Which equation governs heat diffusion?",
+      "ja": "熱拡散を表す方程式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Runge-Kutta",
+        "ja": "ルンゲ・クッタ法",
+        "ja_typings": [
+          "runge kutta hou"
+        ]
+      },
+      {
+        "en": "Newton-Raphson",
+        "ja": "ニュートン法",
+        "ja_typings": [
+          "nyu-tonhou"
+        ]
+      },
+      {
+        "en": "Simpson",
+        "ja": "シンプソン則",
+        "ja_typings": [
+          "shinpusonsoku"
+        ]
+      },
+      {
+        "en": "Gauss elimination",
+        "ja": "ガウス消去法",
+        "ja_typings": [
+          "gausushoukyohou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01581",
+    "image_path": null,
+    "question_text": {
+      "en": "Which method numerically solves ODEs?",
+      "ja": "常微分方程式の数値解法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Eulerian path",
+        "ja": "オイラー路問題",
+        "ja_typings": [
+          "oira-ro mondai"
+        ]
+      },
+      {
+        "en": "traveling salesman",
+        "ja": "巡回セールスマン問題",
+        "ja_typings": [
+          "junkai se-rusuman mondai"
+        ]
+      },
+      {
+        "en": "graph coloring",
+        "ja": "グラフ彩色問題",
+        "ja_typings": [
+          "gurafusaishokumondai"
+        ]
+      },
+      {
+        "en": "max flow",
+        "ja": "最大流問題",
+        "ja_typings": [
+          "saidairyuumondai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01582",
+    "image_path": null,
+    "question_text": {
+      "en": "What problem is associated with the Konigsberg bridges?",
+      "ja": "ケーニヒスベルクの橋に関する問題は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fourier transform",
+        "ja": "フーリエ変換",
+        "ja_typings": [
+          "fu-rie henkan"
+        ]
+      },
+      {
+        "en": "Laplace transform",
+        "ja": "ラプラス変換",
+        "ja_typings": [
+          "rapurasu henkan"
+        ]
+      },
+      {
+        "en": "Z transform",
+        "ja": "Z変換",
+        "ja_typings": [
+          "zhenkan"
+        ]
+      },
+      {
+        "en": "Hilbert transform",
+        "ja": "ヒルベルト変換",
+        "ja_typings": [
+          "hiruberutohenkan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01583",
+    "image_path": null,
+    "question_text": {
+      "en": "Which transform converts time to frequency domain?",
+      "ja": "時間領域を周波数領域に変換する手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hilbert space",
+        "ja": "ヒルベルト空間",
+        "ja_typings": [
+          "hiruberutokuukan"
+        ]
+      },
+      {
+        "en": "Banach space",
+        "ja": "バナッハ空間",
+        "ja_typings": [
+          "banahhakuukan"
+        ]
+      },
+      {
+        "en": "Frechet space",
+        "ja": "フレシェ空間",
+        "ja_typings": [
+          "fureshekuukan"
+        ]
+      },
+      {
+        "en": "Sobolev space",
+        "ja": "ソボレフ空間",
+        "ja_typings": [
+          "soborefukuukan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01584",
+    "image_path": null,
+    "question_text": {
+      "en": "Which space is complete and inner-product?",
+      "ja": "完備かつ内積を持つ空間は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Poincare conjecture",
+        "ja": "ポアンカレ予想",
+        "ja_typings": [
+          "poankareyosou"
+        ]
+      },
+      {
+        "en": "Riemann hypothesis",
+        "ja": "リーマン予想",
+        "ja_typings": [
+          "ri-manyosou"
+        ]
+      },
+      {
+        "en": "Hodge conjecture",
+        "ja": "ホッジ予想",
+        "ja_typings": [
+          "hojjiyosou"
+        ]
+      },
+      {
+        "en": "Birch-Swinnerton-Dyer",
+        "ja": "BSD予想",
+        "ja_typings": [
+          "bsdyosou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01585",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Millennium Prize problem was solved?",
+      "ja": "ミレニアム懸賞問題で解決済みは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mersenne primes",
+        "ja": "メルセンヌ素数",
+        "ja_typings": [
+          "merusennusosuu"
+        ]
+      },
+      {
+        "en": "perfect numbers",
+        "ja": "完全数",
+        "ja_typings": [
+          "kanzensuu"
+        ]
+      },
+      {
+        "en": "Carmichael numbers",
+        "ja": "カーマイケル数",
+        "ja_typings": [
+          "ka-maikerusuu"
+        ]
+      },
+      {
+        "en": "Lucas numbers",
+        "ja": "リュカ数",
+        "ja_typings": [
+          "ryukasuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01586",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sequence is used in cryptographic hashing?",
+      "ja": "暗号ハッシュの基礎となる数列は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nash equilibrium",
+        "ja": "ナッシュ均衡",
+        "ja_typings": [
+          "nasshukinkou"
+        ]
+      },
+      {
+        "en": "Pareto optimum",
+        "ja": "パレート最適",
+        "ja_typings": [
+          "pare-tosaiteki"
+        ]
+      },
+      {
+        "en": "minimax",
+        "ja": "ミニマックス",
+        "ja_typings": [
+          "minimakkusu"
+        ]
+      },
+      {
+        "en": "dominant strategy",
+        "ja": "支配戦略",
+        "ja_typings": [
+          "shihaisenryaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01587",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game theory concept is a stable strategy?",
+      "ja": "ゲーム理論で安定戦略を示す概念は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "elliptic curve",
+        "ja": "楕円曲線",
+        "ja_typings": [
+          "daenkyokusen"
+        ]
+      },
+      {
+        "en": "parabola",
+        "ja": "放物線",
+        "ja_typings": [
+          "houbutsusen"
+        ]
+      },
+      {
+        "en": "hyperbola",
+        "ja": "双曲線",
+        "ja_typings": [
+          "soukyokusen"
+        ]
+      },
+      {
+        "en": "cardioid",
+        "ja": "カージオイド",
+        "ja_typings": [
+          "ka-jioido"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01588",
+    "image_path": null,
+    "question_text": {
+      "en": "Which curve is defined by y squared equals x cubed plus ax plus b?",
+      "ja": "y² = x³+ax+b で定義される曲線は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Russell paradox",
+        "ja": "ラッセルのパラドックス",
+        "ja_typings": [
+          "rasseru no paradokkusu",
+          "rasserunoparadokkusu"
+        ]
+      },
+      {
+        "en": "Banach-Tarski",
+        "ja": "バナッハ・タルスキー",
+        "ja_typings": [
+          "banahha/tarusuki-"
+        ]
+      },
+      {
+        "en": "Zeno",
+        "ja": "ゼノンのパラドックス",
+        "ja_typings": [
+          "zenonnnoparadokkusu"
+        ]
+      },
+      {
+        "en": "Berry",
+        "ja": "ベリーのパラドックス",
+        "ja_typings": [
+          "beri-noparadokkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01589",
+    "image_path": null,
+    "question_text": {
+      "en": "Which paradox involves a set of all sets?",
+      "ja": "全集合の集合に関するパラドックスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "two birds with one stone",
+        "ja": "一度に二つの利益",
+        "ja_typings": [
+          "ichidoni futatsu no rieki"
+        ]
+      },
+      {
+        "en": "eternal effort",
+        "ja": "永遠の努力",
+        "ja_typings": [
+          "eiennnodoryoku"
+        ]
+      },
+      {
+        "en": "rare opportunity",
+        "ja": "稀な機会",
+        "ja_typings": [
+          "marenakikai"
+        ]
+      },
+      {
+        "en": "strong will",
+        "ja": "強い意志",
+        "ja_typings": [
+          "tsuyoiishi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01590",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the four-character idiom 'isseki nichou' mean?",
+      "ja": "四字熟語『一石二鳥』の意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Orion",
+        "ja": "オリオン座",
+        "ja_typings": [
+          "orionza"
+        ]
+      },
+      {
+        "en": "Cassiopeia",
+        "ja": "カシオペア座",
+        "ja_typings": [
+          "kashiopeaza"
+        ]
+      },
+      {
+        "en": "Lyra",
+        "ja": "こと座",
+        "ja_typings": [
+          "kotoza"
+        ]
+      },
+      {
+        "en": "Cygnus",
+        "ja": "はくちょう座",
+        "ja_typings": [
+          "hakuchouza"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01591",
+    "image_path": null,
+    "question_text": {
+      "en": "Which constellation contains Betelgeuse?",
+      "ja": "ベテルギウスを含む星座は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "candela",
+        "ja": "カンデラ",
+        "ja_typings": [
+          "kandera"
+        ]
+      },
+      {
+        "en": "lumen",
+        "ja": "ルーメン",
+        "ja_typings": [
+          "ru-men"
+        ]
+      },
+      {
+        "en": "lux",
+        "ja": "ルクス",
+        "ja_typings": [
+          "rukusu"
+        ]
+      },
+      {
+        "en": "nit",
+        "ja": "ニト",
+        "ja_typings": [
+          "nito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01592",
+    "image_path": null,
+    "question_text": {
+      "en": "What unit measures luminous intensity?",
+      "ja": "光度の単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "very busy",
+        "ja": "非常に忙しい",
+        "ja_typings": [
+          "hijouni isogashii"
+        ]
+      },
+      {
+        "en": "very lonely",
+        "ja": "非常に寂しい",
+        "ja_typings": [
+          "hijounisabishii"
+        ]
+      },
+      {
+        "en": "very tired",
+        "ja": "非常に疲れた",
+        "ja_typings": [
+          "hijounitsukareta"
+        ]
+      },
+      {
+        "en": "very confused",
+        "ja": "非常に混乱",
+        "ja_typings": [
+          "hijounikonran"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01593",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the idiom 'neko no te mo karitai' express?",
+      "ja": "『猫の手も借りたい』が表す状況は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tokugawa",
+        "ja": "徳川家",
+        "ja_typings": [
+          "tokugawake"
+        ]
+      },
+      {
+        "en": "Oda",
+        "ja": "織田家",
+        "ja_typings": [
+          "odake"
+        ]
+      },
+      {
+        "en": "Toyotomi",
+        "ja": "豊臣家",
+        "ja_typings": [
+          "toyotomike"
+        ]
+      },
+      {
+        "en": "Takeda",
+        "ja": "武田家",
+        "ja_typings": [
+          "takedake"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01594",
+    "image_path": null,
+    "question_text": {
+      "en": "Which family crest depicts three hollyhock leaves?",
+      "ja": "三つ葉葵を描く家紋を使った家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "weber",
+        "ja": "ウェーバ",
+        "ja_typings": [
+          "we-ba"
+        ]
+      },
+      {
+        "en": "tesla",
+        "ja": "テスラ",
+        "ja_typings": [
+          "tesura"
+        ]
+      },
+      {
+        "en": "henry",
+        "ja": "ヘンリー",
+        "ja_typings": [
+          "henri-"
+        ]
+      },
+      {
+        "en": "gauss",
+        "ja": "ガウス",
+        "ja_typings": [
+          "gausu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01595",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the SI unit of magnetic flux?",
+      "ja": "磁束のSI単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Libra",
+        "ja": "てんびん座",
+        "ja_typings": [
+          "tenbinza"
+        ]
+      },
+      {
+        "en": "Aries",
+        "ja": "おひつじ座",
+        "ja_typings": [
+          "ohitsujiza"
+        ]
+      },
+      {
+        "en": "Gemini",
+        "ja": "ふたご座",
+        "ja_typings": [
+          "futagoza"
+        ]
+      },
+      {
+        "en": "Virgo",
+        "ja": "おとめ座",
+        "ja_typings": [
+          "otomeza"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01596",
+    "image_path": null,
+    "question_text": {
+      "en": "Which zodiac sign is represented by scales?",
+      "ja": "天秤で表される星座は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "National Aeronautics and Space Administration",
+        "ja": "アメリカ航空宇宙局",
+        "ja_typings": [
+          "amerika koukuuuchuukyoku"
+        ]
+      },
+      {
+        "en": "North American Science Agency",
+        "ja": "北米科学機関",
+        "ja_typings": [
+          "hokubeikagakukikan"
+        ]
+      },
+      {
+        "en": "National Atomic Safety Authority",
+        "ja": "国家原子力安全機関",
+        "ja_typings": [
+          "kokkagenshiryokuanzenkikan"
+        ]
+      },
+      {
+        "en": "Naval Astronautics Society Association",
+        "ja": "海軍宇宙協会",
+        "ja_typings": [
+          "kaiguniuchuukyoukai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01597",
+    "image_path": null,
+    "question_text": {
+      "en": "What does NASA stand for?",
+      "ja": "NASAは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "kinran no majiwari",
+        "ja": "金蘭の交わり",
+        "ja_typings": [
+          "kinran no majiwari"
+        ]
+      },
+      {
+        "en": "ichigo ichie",
+        "ja": "一期一会",
+        "ja_typings": [
+          "ichigoichie"
+        ]
+      },
+      {
+        "en": "isshin doutai",
+        "ja": "一心同体",
+        "ja_typings": [
+          "isshindoutai"
+        ]
+      },
+      {
+        "en": "ishin denshin",
+        "ja": "以心伝心",
+        "ja_typings": [
+          "ishindenshin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01598",
+    "image_path": null,
+    "question_text": {
+      "en": "Which idiom means inseparable friends?",
+      "ja": "切っても切れない友を意味するのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "decibel",
+        "ja": "デシベル",
+        "ja_typings": [
+          "deshiberu"
+        ]
+      },
+      {
+        "en": "hertz",
+        "ja": "ヘルツ",
+        "ja_typings": [
+          "herutsu"
+        ]
+      },
+      {
+        "en": "phon",
+        "ja": "フォン",
+        "ja_typings": [
+          "fon"
+        ]
+      },
+      {
+        "en": "sone",
+        "ja": "ソーン",
+        "ja_typings": [
+          "so-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01599",
+    "image_path": null,
+    "question_text": {
+      "en": "What unit measures sound intensity level?",
+      "ja": "音の強さレベルの単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "books",
+        "ja": "書籍",
+        "ja_typings": [
+          "shoseki"
+        ]
+      },
+      {
+        "en": "magazines",
+        "ja": "雑誌",
+        "ja_typings": [
+          "zasshi"
+        ]
+      },
+      {
+        "en": "websites",
+        "ja": "ウェブサイト",
+        "ja_typings": [
+          "webusaito"
+        ]
+      },
+      {
+        "en": "songs",
+        "ja": "楽曲",
+        "ja_typings": [
+          "gakkyoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01600",
+    "image_path": null,
+    "question_text": {
+      "en": "What does ISBN identify?",
+      "ja": "ISBNが識別するものは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ursa Minor",
+        "ja": "こぐま座",
+        "ja_typings": [
+          "kogumaza"
+        ]
+      },
+      {
+        "en": "Ursa Major",
+        "ja": "おおぐま座",
+        "ja_typings": [
+          "oogumaza"
+        ]
+      },
+      {
+        "en": "Draco",
+        "ja": "りゅう座",
+        "ja_typings": [
+          "ryuuza"
+        ]
+      },
+      {
+        "en": "Cepheus",
+        "ja": "ケフェウス座",
+        "ja_typings": [
+          "kefeusuza"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01601",
+    "image_path": null,
+    "question_text": {
+      "en": "Which constellation contains the North Star?",
+      "ja": "北極星を含む星座は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "enduring hardship for revenge",
+        "ja": "復讐のために苦難に耐える",
+        "ja_typings": [
+          "fukushuu no tameni kunan ni taeru"
+        ]
+      },
+      {
+        "en": "celebrating victory",
+        "ja": "勝利を祝う",
+        "ja_typings": [
+          "shouriwoiwau"
+        ]
+      },
+      {
+        "en": "teaching by example",
+        "ja": "範を示す",
+        "ja_typings": [
+          "hanwoshimesu"
+        ]
+      },
+      {
+        "en": "respecting elders",
+        "ja": "長老を敬う",
+        "ja_typings": [
+          "chourouwouyamau"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01602",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'gashin shoutan' mean?",
+      "ja": "『臥薪嘗胆』の意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "rampant",
+        "ja": "ランパント",
+        "ja_typings": [
+          "ranpanto"
+        ]
+      },
+      {
+        "en": "passant",
+        "ja": "パサント",
+        "ja_typings": [
+          "pasanto"
+        ]
+      },
+      {
+        "en": "couchant",
+        "ja": "クーシャント",
+        "ja_typings": [
+          "ku-shanto"
+        ]
+      },
+      {
+        "en": "sejant",
+        "ja": "セジャント",
+        "ja_typings": [
+          "sejanto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01603",
+    "image_path": null,
+    "question_text": {
+      "en": "Which heraldic charge represents a lion standing?",
+      "ja": "立ち上がるライオンを表す紋章用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sievert",
+        "ja": "シーベルト",
+        "ja_typings": [
+          "shi-beruto"
+        ]
+      },
+      {
+        "en": "becquerel",
+        "ja": "ベクレル",
+        "ja_typings": [
+          "bekureru"
+        ]
+      },
+      {
+        "en": "gray",
+        "ja": "グレイ",
+        "ja_typings": [
+          "gurei"
+        ]
+      },
+      {
+        "en": "roentgen",
+        "ja": "レントゲン",
+        "ja_typings": [
+          "rentogen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01604",
+    "image_path": null,
+    "question_text": {
+      "en": "What unit measures radiation exposure?",
+      "ja": "放射線被曝量の単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "kinjitou",
+        "ja": "金字塔",
+        "ja_typings": [
+          "kinjitou"
+        ]
+      },
+      {
+        "en": "touki bansei",
+        "ja": "陶器万歳",
+        "ja_typings": [
+          "toukibanzai"
+        ]
+      },
+      {
+        "en": "seiten hekireki",
+        "ja": "晴天霹靂",
+        "ja_typings": [
+          "seitenhekireki"
+        ]
+      },
+      {
+        "en": "muga muchuu",
+        "ja": "無我夢中",
+        "ja_typings": [
+          "mugamuchuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01605",
+    "image_path": null,
+    "question_text": {
+      "en": "Which idiom describes a perfect match?",
+      "ja": "完璧な組合せを表す四字熟語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "buying books without reading",
+        "ja": "本を買って積むこと",
+        "ja_typings": [
+          "hon wo katte tsumu koto"
+        ]
+      },
+      {
+        "en": "reading old books",
+        "ja": "古い本を読むこと",
+        "ja_typings": [
+          "furuihonwoyomukoto"
+        ]
+      },
+      {
+        "en": "lending out books",
+        "ja": "本を貸し出すこと",
+        "ja_typings": [
+          "honwokashidasukoto"
+        ]
+      },
+      {
+        "en": "losing a book",
+        "ja": "本を失くすこと",
+        "ja_typings": [
+          "honwonakusukoto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01606",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the word 'tsundoku' describe?",
+      "ja": "『積ん読』が表すのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sirius",
+        "ja": "シリウス",
+        "ja_typings": [
+          "shiriusu"
+        ]
+      },
+      {
+        "en": "Vega",
+        "ja": "ベガ",
+        "ja_typings": [
+          "bega"
+        ]
+      },
+      {
+        "en": "Arcturus",
+        "ja": "アルクトゥルス",
+        "ja_typings": [
+          "arukuturusu"
+        ]
+      },
+      {
+        "en": "Capella",
+        "ja": "カペラ",
+        "ja_typings": [
+          "kapera"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01607",
+    "image_path": null,
+    "question_text": {
+      "en": "Which star is the brightest in the night sky?",
+      "ja": "夜空で最も明るい恒星は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "beauty in imperfection",
+        "ja": "不完全の中の美",
+        "ja_typings": [
+          "fukanzen no nakano bi"
+        ]
+      },
+      {
+        "en": "brightness and grandeur",
+        "ja": "華やかさ",
+        "ja_typings": [
+          "hanayakasa"
+        ]
+      },
+      {
+        "en": "symmetry and order",
+        "ja": "対称と秩序",
+        "ja_typings": [
+          "taishoutochitsujo"
+        ]
+      },
+      {
+        "en": "color and vibrancy",
+        "ja": "色彩と活気",
+        "ja_typings": [
+          "shikisaitokakki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01608",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'wabi sabi' express in aesthetics?",
+      "ja": "美学の『侘び寂び』が表すのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "pascal",
+        "ja": "パスカル",
+        "ja_typings": [
+          "pasukaru"
+        ]
+      },
+      {
+        "en": "joule",
+        "ja": "ジュール",
+        "ja_typings": [
+          "ju-ru"
+        ]
+      },
+      {
+        "en": "watt",
+        "ja": "ワット",
+        "ja_typings": [
+          "watto"
+        ]
+      },
+      {
+        "en": "newton",
+        "ja": "ニュートン",
+        "ja_typings": [
+          "nyu-ton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01609",
+    "image_path": null,
+    "question_text": {
+      "en": "Which unit measures atmospheric pressure?",
+      "ja": "気圧の単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "duality and balance",
+        "ja": "二元の調和",
+        "ja_typings": [
+          "nigen no chouwa"
+        ]
+      },
+      {
+        "en": "infinite time",
+        "ja": "無限の時間",
+        "ja_typings": [
+          "mugennnojikan"
+        ]
+      },
+      {
+        "en": "life and death",
+        "ja": "生と死",
+        "ja_typings": [
+          "seitoshi"
+        ]
+      },
+      {
+        "en": "good and evil",
+        "ja": "善悪",
+        "ja_typings": [
+          "zenaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01610",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the Yin-Yang symbol represent?",
+      "ja": "陰陽のシンボルが表すのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "three rounded sixes",
+        "ja": "三つ盛り亀甲に花菱",
+        "ja_typings": [
+          "mitsumori kikkou ni hanabishi"
+        ]
+      },
+      {
+        "en": "paulownia",
+        "ja": "桐",
+        "ja_typings": [
+          "kiri"
+        ]
+      },
+      {
+        "en": "chrysanthemum",
+        "ja": "菊",
+        "ja_typings": [
+          "kiku"
+        ]
+      },
+      {
+        "en": "plum blossom",
+        "ja": "梅",
+        "ja_typings": [
+          "ume"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01611",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese fan crest is associated with the Asai clan?",
+      "ja": "浅井家の家紋は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "mixture of good and bad",
+        "ja": "良いものと悪いものが混在",
+        "ja_typings": [
+          "yoimonotowaruimonoga konzai"
+        ]
+      },
+      {
+        "en": "rare treasure",
+        "ja": "希少な宝",
+        "ja_typings": [
+          "kishounatakara"
+        ]
+      },
+      {
+        "en": "constant change",
+        "ja": "絶え間ない変化",
+        "ja_typings": [
+          "taemanaihenka"
+        ]
+      },
+      {
+        "en": "eternal beauty",
+        "ja": "永遠の美",
+        "ja_typings": [
+          "eiennnobi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01612",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the idiom 'gyokuseki konkou' mean?",
+      "ja": "『玉石混淆』の意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FLOPS",
+        "ja": "フロップス",
+        "ja_typings": [
+          "furoppusu"
+        ]
+      },
+      {
+        "en": "BPS",
+        "ja": "ビーピーエス",
+        "ja_typings": [
+          "bi-pi-esu"
+        ]
+      },
+      {
+        "en": "MIPS",
+        "ja": "ミップス",
+        "ja_typings": [
+          "mippusu"
+        ]
+      },
+      {
+        "en": "IPS",
+        "ja": "アイピーエス",
+        "ja_typings": [
+          "aipi-esu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01613",
+    "image_path": null,
+    "question_text": {
+      "en": "What unit measures the speed of computer operations?",
+      "ja": "コンピュータ演算速度の単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cassiopeia",
+        "ja": "カシオペア座",
+        "ja_typings": [
+          "kashiopeaza"
+        ]
+      },
+      {
+        "en": "Orion",
+        "ja": "オリオン座",
+        "ja_typings": [
+          "orionza"
+        ]
+      },
+      {
+        "en": "Leo",
+        "ja": "しし座",
+        "ja_typings": [
+          "shishiza"
+        ]
+      },
+      {
+        "en": "Taurus",
+        "ja": "おうし座",
+        "ja_typings": [
+          "oushiza"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01614",
+    "image_path": null,
+    "question_text": {
+      "en": "Which constellation is shaped like a W?",
+      "ja": "Wの形をした星座は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "World Health Organization",
+        "ja": "世界保健機関",
+        "ja_typings": [
+          "sekaihokenkikan"
+        ]
+      },
+      {
+        "en": "World Hospital Office",
+        "ja": "世界病院事務局",
+        "ja_typings": [
+          "sekaibyouinjimukyoku"
+        ]
+      },
+      {
+        "en": "Western Health Organization",
+        "ja": "西側保健機関",
+        "ja_typings": [
+          "nishigawahokenkikan"
+        ]
+      },
+      {
+        "en": "World Hygiene Organization",
+        "ja": "世界衛生機関",
+        "ja_typings": [
+          "sekaieiseikikan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01615",
+    "image_path": null,
+    "question_text": {
+      "en": "What does WHO stand for?",
+      "ja": "WHOの略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "nou aru taka wa tsume wo kakusu",
+        "ja": "能ある鷹は爪を隠す",
+        "ja_typings": [
+          "nouarutakawatsumewokakusu"
+        ]
+      },
+      {
+        "en": "isseki nichou",
+        "ja": "一石二鳥",
+        "ja_typings": [
+          "issekinichou"
+        ]
+      },
+      {
+        "en": "kongen kongen",
+        "ja": "根本根源",
+        "ja_typings": [
+          "konponkongen"
+        ]
+      },
+      {
+        "en": "haru natsu aki fuyu",
+        "ja": "春夏秋冬",
+        "ja_typings": [
+          "shunkashuutou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01616",
+    "image_path": null,
+    "question_text": {
+      "en": "Which idiom describes hidden talents?",
+      "ja": "隠れた才能を表す慣用句は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "diamond",
+        "ja": "ダイヤモンド",
+        "ja_typings": [
+          "daiyamondo"
+        ]
+      },
+      {
+        "en": "corundum",
+        "ja": "コランダム",
+        "ja_typings": [
+          "korandamu"
+        ]
+      },
+      {
+        "en": "topaz",
+        "ja": "トパーズ",
+        "ja_typings": [
+          "topa-zu"
+        ]
+      },
+      {
+        "en": "quartz",
+        "ja": "クォーツ",
+        "ja_typings": [
+          "kuo-tsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01617",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mineral has hardness 10 on the Mohs scale?",
+      "ja": "モース硬度10の鉱物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "butterfly",
+        "ja": "蝶",
+        "ja_typings": [
+          "chou"
+        ]
+      },
+      {
+        "en": "crane",
+        "ja": "鶴",
+        "ja_typings": [
+          "tsuru"
+        ]
+      },
+      {
+        "en": "dragonfly",
+        "ja": "蜻蛉",
+        "ja_typings": [
+          "tonbo"
+        ]
+      },
+      {
+        "en": "phoenix",
+        "ja": "鳳凰",
+        "ja_typings": [
+          "houou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01618",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the family crest 'agehacho' depict?",
+      "ja": "家紋『揚羽蝶』が描くのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kizuna AI",
+        "ja": "キズナアイ",
+        "ja_typings": [
+          "kizunaai"
+        ]
+      },
+      {
+        "en": "Mirai Akari",
+        "ja": "ミライアカリ",
+        "ja_typings": [
+          "miraiakari"
+        ]
+      },
+      {
+        "en": "Kaguya Luna",
+        "ja": "輝夜月",
+        "ja_typings": [
+          "kaguyaruna"
+        ]
+      },
+      {
+        "en": "Siro",
+        "ja": "シロ",
+        "ja_typings": [
+          "shiro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01619",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is known as the first virtual YouTuber?",
+      "ja": "初代バーチャルYouTuberは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nijisanji",
+        "ja": "にじさんじ",
+        "ja_typings": [
+          "nijisanji"
+        ]
+      },
+      {
+        "en": "Hololive",
+        "ja": "ホロライブ",
+        "ja_typings": [
+          "hororaibu"
+        ]
+      },
+      {
+        "en": "Noripro",
+        "ja": "のりプロ",
+        "ja_typings": [
+          "noripuro"
+        ]
+      },
+      {
+        "en": "VShojo",
+        "ja": "ブイショージョ",
+        "ja_typings": [
+          "buisho-jo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01620",
+    "image_path": null,
+    "question_text": {
+      "en": "Which VTuber agency is operated by Anycolor?",
+      "ja": "Anycolor運営のVTuber事務所は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "laugh",
+        "ja": "笑い",
+        "ja_typings": [
+          "warai"
+        ]
+      },
+      {
+        "en": "anger",
+        "ja": "怒り",
+        "ja_typings": [
+          "ikari"
+        ]
+      },
+      {
+        "en": "sadness",
+        "ja": "悲しみ",
+        "ja_typings": [
+          "kanashimi"
+        ]
+      },
+      {
+        "en": "agreement",
+        "ja": "同意",
+        "ja_typings": [
+          "doui"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01621",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'kusa' mean in Japanese net slang?",
+      "ja": "ネットスラング『草』の意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "mass joining to disrupt",
+        "ja": "大量参加で混乱させる行為",
+        "ja_typings": [
+          "tairyousanka de konransaseru koui"
+        ]
+      },
+      {
+        "en": "a private channel",
+        "ja": "非公開チャンネル",
+        "ja_typings": [
+          "hikoukaichannneru"
+        ]
+      },
+      {
+        "en": "a bot command",
+        "ja": "ボットコマンド",
+        "ja_typings": [
+          "bottokomando"
+        ]
+      },
+      {
+        "en": "a voice call feature",
+        "ja": "音声通話機能",
+        "ja_typings": [
+          "onseitsuuwakinou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01622",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'Discord raid'?",
+      "ja": "『Discord荒らし』とは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "lurker",
+        "ja": "ラーカー",
+        "ja_typings": [
+          "ra-ka-"
+        ]
+      },
+      {
+        "en": "raider",
+        "ja": "レイダー",
+        "ja_typings": [
+          "reida-"
+        ]
+      },
+      {
+        "en": "hyper",
+        "ja": "ハイパー",
+        "ja_typings": [
+          "haipa-"
+        ]
+      },
+      {
+        "en": "emoter",
+        "ja": "エモーター",
+        "ja_typings": [
+          "emo-ta-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01623",
+    "image_path": null,
+    "question_text": {
+      "en": "Which term means 'lurker' in Twitch chat?",
+      "ja": "Twitchチャットで『見るだけの人』を意味するのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Away From Keyboard",
+        "ja": "席を外す",
+        "ja_typings": [
+          "sekiwohazusu"
+        ]
+      },
+      {
+        "en": "All For Kindness",
+        "ja": "親切第一",
+        "ja_typings": [
+          "shinsetsudaiichi"
+        ]
+      },
+      {
+        "en": "Anti Friend Kick",
+        "ja": "フレンドキック",
+        "ja_typings": [
+          "furendokikku"
+        ]
+      },
+      {
+        "en": "Auto Fast Key",
+        "ja": "自動高速キー",
+        "ja_typings": [
+          "jidoukousokuki-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01624",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'AFK' stand for?",
+      "ja": "『AFK』の意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rythm",
+        "ja": "リズム",
+        "ja_typings": [
+          "rizumu"
+        ]
+      },
+      {
+        "en": "MEE6",
+        "ja": "ミーシックス",
+        "ja_typings": [
+          "mi-shikkusu"
+        ]
+      },
+      {
+        "en": "Dyno",
+        "ja": "ダイノ",
+        "ja_typings": [
+          "daino"
+        ]
+      },
+      {
+        "en": "Carl-bot",
+        "ja": "カールボット",
+        "ja_typings": [
+          "ka-rubotto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01625",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Discord bot is famous for music streaming (before shutdown)?",
+      "ja": "音楽配信で有名だったDiscordボット(閉鎖済)は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "a derpy Pepe emote",
+        "ja": "間抜けなPepeエモート",
+        "ja_typings": [
+          "manukenaPepeemo-to"
+        ]
+      },
+      {
+        "en": "a raid command",
+        "ja": "レイドコマンド",
+        "ja_typings": [
+          "reidokomando"
+        ]
+      },
+      {
+        "en": "a sub tier",
+        "ja": "サブスクのランク",
+        "ja_typings": [
+          "sabusukunoranku"
+        ]
+      },
+      {
+        "en": "a follower badge",
+        "ja": "フォロワーバッジ",
+        "ja_typings": [
+          "forowa-bajji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01626",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'pepega' refer to in Twitch culture?",
+      "ja": "Twitch文化での『pepega』は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "revealing private info",
+        "ja": "個人情報暴露",
+        "ja_typings": [
+          "kojinjouhoubakuro"
+        ]
+      },
+      {
+        "en": "hacking accounts",
+        "ja": "アカウント乗っ取り",
+        "ja_typings": [
+          "akauntonottori"
+        ]
+      },
+      {
+        "en": "creating fake profiles",
+        "ja": "偽プロフ作成",
+        "ja_typings": [
+          "nisepurofusakusei"
+        ]
+      },
+      {
+        "en": "spamming chats",
+        "ja": "チャットスパム",
+        "ja_typings": [
+          "chattosupamu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01627",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'doxxing'?",
+      "ja": "『ドキシング』とは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "hisashiburu",
+        "ja": "ひさしぶる",
+        "ja_typings": [
+          "hisashiburu"
+        ]
+      },
+      {
+        "en": "kuriku ri",
+        "ja": "クリクリ",
+        "ja_typings": [
+          "kurikuri"
+        ]
+      },
+      {
+        "en": "itai",
+        "ja": "イタイ",
+        "ja_typings": [
+          "itai"
+        ]
+      },
+      {
+        "en": "gugu ru",
+        "ja": "ググる",
+        "ja_typings": [
+          "guguru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01628",
+    "image_path": null,
+    "question_text": {
+      "en": "Which slang phrase originated from 2channel for 'has been a while'?",
+      "ja": "2ちゃん発祥の『久しぶり』系スラングは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "clever idea",
+        "ja": "賢い発想",
+        "ja_typings": [
+          "kashikoihassou"
+        ]
+      },
+      {
+        "en": "dumb idea",
+        "ja": "愚かな発想",
+        "ja_typings": [
+          "orokanahassou"
+        ]
+      },
+      {
+        "en": "nostalgic feeling",
+        "ja": "懐かしい感情",
+        "ja_typings": [
+          "natsukashiikanjou"
+        ]
+      },
+      {
+        "en": "angry response",
+        "ja": "怒りの反応",
+        "ja_typings": [
+          "ikarinohannnou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01629",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the meme 'Big Brain' express?",
+      "ja": "ミーム『Big Brain』の意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gawr Gura",
+        "ja": "がうるぐら",
+        "ja_typings": [
+          "gaurugura"
+        ]
+      },
+      {
+        "en": "Watson Amelia",
+        "ja": "ワトソンアメリア",
+        "ja_typings": [
+          "watosonnameria"
+        ]
+      },
+      {
+        "en": "Ninomae Inanis",
+        "ja": "一伊那尓栖",
+        "ja_typings": [
+          "ninomaeinanisu"
+        ]
+      },
+      {
+        "en": "Mori Calliope",
+        "ja": "森カリオペ",
+        "ja_typings": [
+          "morikariope"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01630",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive member is known as the shark girl?",
+      "ja": "サメ少女として知られるホロメンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "amazed reaction",
+        "ja": "驚嘆の反応",
+        "ja_typings": [
+          "kyoutan no hannou"
+        ]
+      },
+      {
+        "en": "polite greeting",
+        "ja": "丁寧な挨拶",
+        "ja_typings": [
+          "teineinaaisatsu"
+        ]
+      },
+      {
+        "en": "game over",
+        "ja": "ゲーム終了",
+        "ja_typings": [
+          "ge-mushuuryou"
+        ]
+      },
+      {
+        "en": "private message",
+        "ja": "個別メッセージ",
+        "ja_typings": [
+          "kobetsumesse-ji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01631",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'POG' mean in stream chat?",
+      "ja": "配信チャットの『POG』の意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "regulars",
+        "ja": "レギュラーズ",
+        "ja_typings": [
+          "regyura-zu"
+        ]
+      },
+      {
+        "en": "subbies",
+        "ja": "サビーズ",
+        "ja_typings": [
+          "sabi-zu"
+        ]
+      },
+      {
+        "en": "hypers",
+        "ja": "ハイパーズ",
+        "ja_typings": [
+          "haipa-zu"
+        ]
+      },
+      {
+        "en": "nubs",
+        "ja": "ナブズ",
+        "ja_typings": [
+          "nabuzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01632",
+    "image_path": null,
+    "question_text": {
+      "en": "Which term refers to a Twitch streamer's loyal viewers?",
+      "ja": "Twitch配信者の常連視聴者を指す語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "copied text spread online",
+        "ja": "ネットで拡散される定型文",
+        "ja_typings": [
+          "nettode kakusansareru teikeibun"
+        ]
+      },
+      {
+        "en": "Italian recipe",
+        "ja": "イタリア料理",
+        "ja_typings": [
+          "itariaryouri"
+        ]
+      },
+      {
+        "en": "Discord channel type",
+        "ja": "Discordチャンネル種類",
+        "ja_typings": [
+          "discordchannnerushurui"
+        ]
+      },
+      {
+        "en": "private DM type",
+        "ja": "DMの種類",
+        "ja_typings": [
+          "dmnoshurui"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01633",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'copypasta'?",
+      "ja": "『コピペ』とは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "wwwwww",
+        "ja": "wwwwww",
+        "ja_typings": [
+          "wwwwww"
+        ]
+      },
+      {
+        "en": "orz",
+        "ja": "orz",
+        "ja_typings": [
+          "orz"
+        ]
+      },
+      {
+        "en": "xD",
+        "ja": "xD",
+        "ja_typings": [
+          "xd"
+        ]
+      },
+      {
+        "en": "T_T",
+        "ja": "T_T",
+        "ja_typings": [
+          "t_t"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01634",
+    "image_path": null,
+    "question_text": {
+      "en": "Which slang means 'crying with laughter' as kaomoji-like?",
+      "ja": "笑い泣きを表す日本のネット表現は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mori Calliope",
+        "ja": "森カリオペ",
+        "ja_typings": [
+          "morikariope"
+        ]
+      },
+      {
+        "en": "Houshou Marine",
+        "ja": "宝鐘マリン",
+        "ja_typings": [
+          "houshoumarine"
+        ]
+      },
+      {
+        "en": "Usada Pekora",
+        "ja": "兎田ぺこら",
+        "ja_typings": [
+          "usadapekora"
+        ]
+      },
+      {
+        "en": "Shirakami Fubuki",
+        "ja": "白上フブキ",
+        "ja_typings": [
+          "shirakamifubuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01635",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Vtuber created the song 'Hyperdontia'?",
+      "ja": "『Hyperdontia』を歌ったVtuberは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "invisible muting by platform",
+        "ja": "プラットフォームによる隠れミュート",
+        "ja_typings": [
+          "puratto-fo-mu ni yoru kakuremyu-to"
+        ]
+      },
+      {
+        "en": "temporary kick",
+        "ja": "一時キック",
+        "ja_typings": [
+          "ichijikikku"
+        ]
+      },
+      {
+        "en": "permanent IP ban",
+        "ja": "永久IP遮断",
+        "ja_typings": [
+          "eikyuuipshadan"
+        ]
+      },
+      {
+        "en": "warning message",
+        "ja": "警告メッセージ",
+        "ja_typings": [
+          "keikokumesse-ji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01636",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'shadowbanning'?",
+      "ja": "『シャドウバン』とは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sarcasm",
+        "ja": "皮肉",
+        "ja_typings": [
+          "hiniku"
+        ]
+      },
+      {
+        "en": "approval",
+        "ja": "称賛",
+        "ja_typings": [
+          "shousan"
+        ]
+      },
+      {
+        "en": "confusion",
+        "ja": "困惑",
+        "ja_typings": [
+          "konwaku"
+        ]
+      },
+      {
+        "en": "greeting",
+        "ja": "挨拶",
+        "ja_typings": [
+          "aisatsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01637",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'Kappa' represent in Twitch chat?",
+      "ja": "Twitchの『Kappa』エモートは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "5channel",
+        "ja": "5ちゃんねる",
+        "ja_typings": [
+          "go channeru",
+          "5channneru"
+        ]
+      },
+      {
+        "en": "Yahoo Chiebukuro",
+        "ja": "Yahoo知恵袋",
+        "ja_typings": [
+          "yahoochiebukuro"
+        ]
+      },
+      {
+        "en": "Mixi",
+        "ja": "ミクシィ",
+        "ja_typings": [
+          "mikushii"
+        ]
+      },
+      {
+        "en": "Niconico",
+        "ja": "ニコニコ動画",
+        "ja_typings": [
+          "nikonikodouga"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01638",
+    "image_path": null,
+    "question_text": {
+      "en": "Which platform did 2channel evolve into?",
+      "ja": "2ちゃんねるが進化したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "paying respects",
+        "ja": "敬意を表す",
+        "ja_typings": [
+          "keiiwoarawasu"
+        ]
+      },
+      {
+        "en": "expressing anger",
+        "ja": "怒りを表す",
+        "ja_typings": [
+          "ikariwoarawasu"
+        ]
+      },
+      {
+        "en": "requesting help",
+        "ja": "助けを求める",
+        "ja_typings": [
+          "tasukewomotomeru"
+        ]
+      },
+      {
+        "en": "celebrating victory",
+        "ja": "勝利を祝う",
+        "ja_typings": [
+          "shouriwoiwau"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01639",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the meme 'F in chat' express?",
+      "ja": "ミーム『F in chat』の意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yashiro Kizuku",
+        "ja": "社築",
+        "ja_typings": [
+          "yashirokizuku"
+        ]
+      },
+      {
+        "en": "Kuzuha",
+        "ja": "葛葉",
+        "ja_typings": [
+          "kuzuha"
+        ]
+      },
+      {
+        "en": "Mafumafu",
+        "ja": "まふまふ",
+        "ja_typings": [
+          "mafumafu"
+        ]
+      },
+      {
+        "en": "Kanae",
+        "ja": "叶",
+        "ja_typings": [
+          "kanae"
+        ]
+      }
+    ],
+    "correct_answer_index": 1,
+    "genre": "vtuber_net_culture",
+    "id": "q01640",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nijisanji liver is known as the demon lord?",
+      "ja": "にじさんじで魔王として知られるライバーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "targeting streamers in game",
+        "ja": "配信者を狙う行為",
+        "ja_typings": [
+          "haishinsha wo nerau koui"
+        ]
+      },
+      {
+        "en": "clip sharing",
+        "ja": "クリップ共有",
+        "ja_typings": [
+          "kurippukyouyuu"
+        ]
+      },
+      {
+        "en": "multi-streaming",
+        "ja": "マルチ配信",
+        "ja_typings": [
+          "maruchihaishin"
+        ]
+      },
+      {
+        "en": "subgifting",
+        "ja": "サブギフト",
+        "ja_typings": [
+          "sabugifuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01641",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'stream sniping'?",
+      "ja": "『ストリームスナイプ』とは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "one of my mutuals",
+        "ja": "相互フォロワー",
+        "ja_typings": [
+          "sougofororowa-"
+        ]
+      },
+      {
+        "en": "offline meet friend",
+        "ja": "オフ会の友達",
+        "ja_typings": [
+          "ofukainotomodachi"
+        ]
+      },
+      {
+        "en": "old online member",
+        "ja": "古参メンバー",
+        "ja_typings": [
+          "kosanmenba-"
+        ]
+      },
+      {
+        "en": "out of mind followers",
+        "ja": "推し垢",
+        "ja_typings": [
+          "oshiaka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01642",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'OOMfie' refer to on Twitter?",
+      "ja": "X(Twitter)の『OOMfie』は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sotsugyou",
+        "ja": "卒業",
+        "ja_typings": [
+          "sotsugyou"
+        ]
+      },
+      {
+        "en": "nyugaku",
+        "ja": "入学",
+        "ja_typings": [
+          "nyuugaku"
+        ]
+      },
+      {
+        "en": "ryuugaku",
+        "ja": "留学",
+        "ja_typings": [
+          "ryuugaku"
+        ]
+      },
+      {
+        "en": "shuugaku",
+        "ja": "修学",
+        "ja_typings": [
+          "shuugaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01643",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Vtuber graduation event is called 'sotsugyou'?",
+      "ja": "Vtuberが活動終了することを何という?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Drakeposting",
+        "ja": "ドレイクポスティング",
+        "ja_typings": [
+          "doreikuposutingu"
+        ]
+      },
+      {
+        "en": "Pepe meme",
+        "ja": "ペペミーム",
+        "ja_typings": [
+          "pepemi-mu"
+        ]
+      },
+      {
+        "en": "Distracted Boyfriend",
+        "ja": "浮気彼氏",
+        "ja_typings": [
+          "uwakikareshi"
+        ]
+      },
+      {
+        "en": "Galaxy Brain",
+        "ja": "ギャラクシーブレイン",
+        "ja_typings": [
+          "gyarakushi-burein"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01644",
+    "image_path": null,
+    "question_text": {
+      "en": "Which meme features Drake approving/disapproving?",
+      "ja": "Drakeが承認/否認するミームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "spineless",
+        "ja": "腰抜け",
+        "ja_typings": [
+          "koshinuke"
+        ]
+      },
+      {
+        "en": "brave",
+        "ja": "勇敢",
+        "ja_typings": [
+          "yuukan"
+        ]
+      },
+      {
+        "en": "idle",
+        "ja": "怠け者",
+        "ja_typings": [
+          "namakemono"
+        ]
+      },
+      {
+        "en": "noisy",
+        "ja": "騒がしい",
+        "ja_typings": [
+          "sawagashii"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01645",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'mukoukotsu' mean in net slang?",
+      "ja": "ネット用語『無向骨』に近い意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "AutoMod",
+        "ja": "オートモッド",
+        "ja_typings": [
+          "o-tomoddo"
+        ]
+      },
+      {
+        "en": "AutoRole",
+        "ja": "オートロール",
+        "ja_typings": [
+          "o-toro-ru"
+        ]
+      },
+      {
+        "en": "AutoVoice",
+        "ja": "オートボイス",
+        "ja_typings": [
+          "o-toboisu"
+        ]
+      },
+      {
+        "en": "AutoChat",
+        "ja": "オートチャット",
+        "ja_typings": [
+          "o-tochatto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01646",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Discord feature allows server moderation?",
+      "ja": "Discordでサーバー管理に使う機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "hard laughter",
+        "ja": "大爆笑",
+        "ja_typings": [
+          "daibakushou"
+        ]
+      },
+      {
+        "en": "crying",
+        "ja": "号泣",
+        "ja_typings": [
+          "goukyuu"
+        ]
+      },
+      {
+        "en": "disgust",
+        "ja": "嫌悪",
+        "ja_typings": [
+          "keno"
+        ]
+      },
+      {
+        "en": "boredom",
+        "ja": "退屈",
+        "ja_typings": [
+          "taikutsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01647",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'KEKW' express in Twitch chat?",
+      "ja": "Twitchの『KEKW』が表すのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tokino Sora",
+        "ja": "ときのそら",
+        "ja_typings": [
+          "tokinosora"
+        ]
+      },
+      {
+        "en": "Pekora",
+        "ja": "ぺこら",
+        "ja_typings": [
+          "pekora"
+        ]
+      },
+      {
+        "en": "Marine",
+        "ja": "マリン",
+        "ja_typings": [
+          "marin"
+        ]
+      },
+      {
+        "en": "Korone",
+        "ja": "ころね",
+        "ja_typings": [
+          "korone"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01648",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive branch is JP-based original first gen?",
+      "ja": "ホロライブJP初代1期生に属するのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HTTP/3",
+        "ja": "HTTP/3",
+        "ja_typings": [
+          "http/3"
+        ]
+      },
+      {
+        "en": "HTTP/4",
+        "ja": "HTTP/4",
+        "ja_typings": [
+          "http/4"
+        ]
+      },
+      {
+        "en": "SPDY",
+        "ja": "SPDY",
+        "ja_typings": [
+          "spdy"
+        ]
+      },
+      {
+        "en": "WebSocket",
+        "ja": "WebSocket",
+        "ja_typings": [
+          "websocket"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01649",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol is the successor of HTTP/2 over QUIC?",
+      "ja": "QUICベースのHTTP後継プロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "OSPF",
+        "ja": "OSPF",
+        "ja_typings": [
+          "ospf"
+        ]
+      },
+      {
+        "en": "RIP",
+        "ja": "RIP",
+        "ja_typings": [
+          "rip"
+        ]
+      },
+      {
+        "en": "BGP",
+        "ja": "BGP",
+        "ja_typings": [
+          "bgp"
+        ]
+      },
+      {
+        "en": "EIGRP",
+        "ja": "EIGRP",
+        "ja_typings": [
+          "eigrp"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01650",
+    "image_path": null,
+    "question_text": {
+      "en": "Which routing protocol uses link-state?",
+      "ja": "リンクステート方式のルーティングプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NVMe",
+        "ja": "NVMe",
+        "ja_typings": [
+          "nvme"
+        ]
+      },
+      {
+        "en": "eSATA",
+        "ja": "eSATA",
+        "ja_typings": [
+          "esata"
+        ]
+      },
+      {
+        "en": "SCSI",
+        "ja": "SCSI",
+        "ja_typings": [
+          "scsi"
+        ]
+      },
+      {
+        "en": "ATA",
+        "ja": "ATA",
+        "ja_typings": [
+          "ata"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01651",
+    "image_path": null,
+    "question_text": {
+      "en": "Which storage interface is replacing SATA SSDs?",
+      "ja": "SATA SSDを置き換えつつある規格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "USB-C",
+        "ja": "USB-C",
+        "ja_typings": [
+          "usb-c"
+        ]
+      },
+      {
+        "en": "USB-A",
+        "ja": "USB-A",
+        "ja_typings": [
+          "usb-a"
+        ]
+      },
+      {
+        "en": "USB-B",
+        "ja": "USB-B",
+        "ja_typings": [
+          "usb-b"
+        ]
+      },
+      {
+        "en": "Mini-USB",
+        "ja": "Mini-USB",
+        "ja_typings": [
+          "mini-usb"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01652",
+    "image_path": null,
+    "question_text": {
+      "en": "Which port standard supports Thunderbolt 4?",
+      "ja": "Thunderbolt 4が使う物理コネクタは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DisplayPort 2.0",
+        "ja": "DisplayPort 2.0",
+        "ja_typings": [
+          "displayport 2.0"
+        ]
+      },
+      {
+        "en": "HDMI 1.4",
+        "ja": "HDMI 1.4",
+        "ja_typings": [
+          "hdmi 1.4"
+        ]
+      },
+      {
+        "en": "VGA",
+        "ja": "VGA",
+        "ja_typings": [
+          "vga"
+        ]
+      },
+      {
+        "en": "DVI",
+        "ja": "DVI",
+        "ja_typings": [
+          "dvi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01653",
+    "image_path": null,
+    "question_text": {
+      "en": "Which display interface supports 8K at 60Hz?",
+      "ja": "8K60Hz対応のディスプレイ規格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ARP",
+        "ja": "ARP",
+        "ja_typings": [
+          "arp"
+        ]
+      },
+      {
+        "en": "RARP",
+        "ja": "RARP",
+        "ja_typings": [
+          "rarp"
+        ]
+      },
+      {
+        "en": "DHCP",
+        "ja": "DHCP",
+        "ja_typings": [
+          "dhcp"
+        ]
+      },
+      {
+        "en": "DNS",
+        "ja": "DNS",
+        "ja_typings": [
+          "dns"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01654",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol resolves MAC from IP?",
+      "ja": "IPからMACを解決するプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ICMP",
+        "ja": "ICMP",
+        "ja_typings": [
+          "icmp"
+        ]
+      },
+      {
+        "en": "IGMP",
+        "ja": "IGMP",
+        "ja_typings": [
+          "igmp"
+        ]
+      },
+      {
+        "en": "SNMP",
+        "ja": "SNMP",
+        "ja_typings": [
+          "snmp"
+        ]
+      },
+      {
+        "en": "SMTP",
+        "ja": "SMTP",
+        "ja_typings": [
+          "smtp"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01655",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol carries ping packets?",
+      "ja": "pingが使うプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "RISC-V",
+        "ja": "RISC-V",
+        "ja_typings": [
+          "risc-v"
+        ]
+      },
+      {
+        "en": "ARM",
+        "ja": "ARM",
+        "ja_typings": [
+          "arm"
+        ]
+      },
+      {
+        "en": "x86",
+        "ja": "x86",
+        "ja_typings": [
+          "x86"
+        ]
+      },
+      {
+        "en": "MIPS",
+        "ja": "MIPS",
+        "ja_typings": [
+          "mips"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01656",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CPU architecture is open source?",
+      "ja": "オープンソースなCPUアーキテクチャは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vulkan",
+        "ja": "Vulkan",
+        "ja_typings": [
+          "vulkan"
+        ]
+      },
+      {
+        "en": "Direct3D",
+        "ja": "Direct3D",
+        "ja_typings": [
+          "direct3d"
+        ]
+      },
+      {
+        "en": "Metal",
+        "ja": "Metal",
+        "ja_typings": [
+          "metal"
+        ]
+      },
+      {
+        "en": "OpenGL",
+        "ja": "OpenGL",
+        "ja_typings": [
+          "opengl"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01657",
+    "image_path": null,
+    "question_text": {
+      "en": "Which GPU API is from Khronos for low-overhead access?",
+      "ja": "Khronos策定の低オーバーヘッドGPU APIは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "802.11ax extended",
+        "ja": "802.11ax拡張",
+        "ja_typings": [
+          "8021axkakuchou"
+        ]
+      },
+      {
+        "en": "802.11ad",
+        "ja": "802.11ad",
+        "ja_typings": [
+          "802.11ad"
+        ]
+      },
+      {
+        "en": "802.11n+",
+        "ja": "802.11nプラス",
+        "ja_typings": [
+          "802.11npurasu"
+        ]
+      },
+      {
+        "en": "802.11ay",
+        "ja": "802.11ay",
+        "ja_typings": [
+          "802.11ay"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01658",
+    "image_path": null,
+    "question_text": {
+      "en": "Which wireless standard is also called WiFi 6E?",
+      "ja": "WiFi 6Eの正式名称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HFP",
+        "ja": "HFP",
+        "ja_typings": [
+          "hfp"
+        ]
+      },
+      {
+        "en": "A2DP",
+        "ja": "A2DP",
+        "ja_typings": [
+          "a2dp"
+        ]
+      },
+      {
+        "en": "AVRCP",
+        "ja": "AVRCP",
+        "ja_typings": [
+          "avrcp"
+        ]
+      },
+      {
+        "en": "HID",
+        "ja": "HID",
+        "ja_typings": [
+          "hid"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01659",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Bluetooth profile is used for hands-free calls?",
+      "ja": "ハンズフリー通話のBluetoothプロファイルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "AES",
+        "ja": "AES",
+        "ja_typings": [
+          "aes"
+        ]
+      },
+      {
+        "en": "RSA",
+        "ja": "RSA",
+        "ja_typings": [
+          "rsa"
+        ]
+      },
+      {
+        "en": "ECC",
+        "ja": "ECC",
+        "ja_typings": [
+          "ecc"
+        ]
+      },
+      {
+        "en": "MD5",
+        "ja": "MD5",
+        "ja_typings": [
+          "md5"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01660",
+    "image_path": null,
+    "question_text": {
+      "en": "Which encryption algorithm replaced DES?",
+      "ja": "DESを置き換えた暗号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ECDH",
+        "ja": "ECDH",
+        "ja_typings": [
+          "ecdh"
+        ]
+      },
+      {
+        "en": "RSA-OAEP",
+        "ja": "RSA-OAEP",
+        "ja_typings": [
+          "rsa-oaep"
+        ]
+      },
+      {
+        "en": "DSA",
+        "ja": "DSA",
+        "ja_typings": [
+          "dsa"
+        ]
+      },
+      {
+        "en": "3DES",
+        "ja": "3DES",
+        "ja_typings": [
+          "3des"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01661",
+    "image_path": null,
+    "question_text": {
+      "en": "Which key exchange uses elliptic curves?",
+      "ja": "楕円曲線を使う鍵交換は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "WebRTC",
+        "ja": "WebRTC",
+        "ja_typings": [
+          "webrtc"
+        ]
+      },
+      {
+        "en": "WebSocket",
+        "ja": "WebSocket",
+        "ja_typings": [
+          "websocket"
+        ]
+      },
+      {
+        "en": "WebDAV",
+        "ja": "WebDAV",
+        "ja_typings": [
+          "webdav"
+        ]
+      },
+      {
+        "en": "WebHooks",
+        "ja": "WebHooks",
+        "ja_typings": [
+          "webhooks"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01662",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol enables peer-to-peer browser communication?",
+      "ja": "ブラウザ間P2P通信を可能にするのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "graphics tablet",
+        "ja": "ペンタブレット",
+        "ja_typings": [
+          "pentaburetto"
+        ]
+      },
+      {
+        "en": "trackball",
+        "ja": "トラックボール",
+        "ja_typings": [
+          "torakkubo-ru"
+        ]
+      },
+      {
+        "en": "touchpad",
+        "ja": "タッチパッド",
+        "ja_typings": [
+          "tatchipaddo"
+        ]
+      },
+      {
+        "en": "joystick",
+        "ja": "ジョイスティック",
+        "ja_typings": [
+          "joisutikku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01663",
+    "image_path": null,
+    "question_text": {
+      "en": "Which input device uses pressure-sensitive stylus?",
+      "ja": "筆圧感知ペンを使う入力機器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "APFS",
+        "ja": "APFS",
+        "ja_typings": [
+          "apfs"
+        ]
+      },
+      {
+        "en": "HFS+",
+        "ja": "HFS+",
+        "ja_typings": [
+          "hfs+"
+        ]
+      },
+      {
+        "en": "exFAT",
+        "ja": "exFAT",
+        "ja_typings": [
+          "exfat"
+        ]
+      },
+      {
+        "en": "ZFS",
+        "ja": "ZFS",
+        "ja_typings": [
+          "zfs"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01664",
+    "image_path": null,
+    "question_text": {
+      "en": "Which file system is default on modern macOS?",
+      "ja": "現代のmacOSの標準ファイルシステムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "RAID 5",
+        "ja": "RAID 5",
+        "ja_typings": [
+          "raid 5"
+        ]
+      },
+      {
+        "en": "RAID 0",
+        "ja": "RAID 0",
+        "ja_typings": [
+          "raid 0"
+        ]
+      },
+      {
+        "en": "RAID 1",
+        "ja": "RAID 1",
+        "ja_typings": [
+          "raid 1"
+        ]
+      },
+      {
+        "en": "RAID 10",
+        "ja": "RAID 10",
+        "ja_typings": [
+          "raid 10"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01665",
+    "image_path": null,
+    "question_text": {
+      "en": "Which RAID level provides striping with parity?",
+      "ja": "ストライピング+パリティのRAIDレベルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "AS-PATH",
+        "ja": "AS-PATH",
+        "ja_typings": [
+          "as-path"
+        ]
+      },
+      {
+        "en": "MED",
+        "ja": "MED",
+        "ja_typings": [
+          "med"
+        ]
+      },
+      {
+        "en": "ORIGIN",
+        "ja": "ORIGIN",
+        "ja_typings": [
+          "origin"
+        ]
+      },
+      {
+        "en": "NEXT-HOP",
+        "ja": "NEXT-HOP",
+        "ja_typings": [
+          "next-hop"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01666",
+    "image_path": null,
+    "question_text": {
+      "en": "Which BGP attribute determines best path?",
+      "ja": "BGP最適経路を決める属性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "OLED",
+        "ja": "OLED",
+        "ja_typings": [
+          "oled"
+        ]
+      },
+      {
+        "en": "LCD",
+        "ja": "LCD",
+        "ja_typings": [
+          "lcd"
+        ]
+      },
+      {
+        "en": "CRT",
+        "ja": "CRT",
+        "ja_typings": [
+          "crt"
+        ]
+      },
+      {
+        "en": "EPD",
+        "ja": "EPD",
+        "ja_typings": [
+          "epd"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01667",
+    "image_path": null,
+    "question_text": {
+      "en": "Which display tech uses self-emitting pixels?",
+      "ja": "自発光画素を使うディスプレイは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "UEFI",
+        "ja": "UEFI",
+        "ja_typings": [
+          "uefi"
+        ]
+      },
+      {
+        "en": "Legacy BIOS",
+        "ja": "Legacy BIOS",
+        "ja_typings": [
+          "legacy bios"
+        ]
+      },
+      {
+        "en": "EFI 1.0",
+        "ja": "EFI 1.0",
+        "ja_typings": [
+          "efi 1.0"
+        ]
+      },
+      {
+        "en": "Open Firmware",
+        "ja": "Open Firmware",
+        "ja_typings": [
+          "open firmware"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01668",
+    "image_path": null,
+    "question_text": {
+      "en": "Which BIOS replacement uses GPT partitions?",
+      "ja": "GPTパーティションを使うBIOS後継は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NTP",
+        "ja": "NTP",
+        "ja_typings": [
+          "ntp"
+        ]
+      },
+      {
+        "en": "PTP",
+        "ja": "PTP",
+        "ja_typings": [
+          "ptp"
+        ]
+      },
+      {
+        "en": "SNTP",
+        "ja": "SNTP",
+        "ja_typings": [
+          "sntp"
+        ]
+      },
+      {
+        "en": "RTSP",
+        "ja": "RTSP",
+        "ja_typings": [
+          "rtsp"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01669",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol is used for time synchronization?",
+      "ja": "時刻同期に使うプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "router",
+        "ja": "ルーター",
+        "ja_typings": [
+          "ru-ta-"
+        ]
+      },
+      {
+        "en": "hub",
+        "ja": "ハブ",
+        "ja_typings": [
+          "habu"
+        ]
+      },
+      {
+        "en": "repeater",
+        "ja": "リピーター",
+        "ja_typings": [
+          "ripi-ta-"
+        ]
+      },
+      {
+        "en": "bridge",
+        "ja": "ブリッジ",
+        "ja_typings": [
+          "burijji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01670",
+    "image_path": null,
+    "question_text": {
+      "en": "Which network device operates at OSI layer 3?",
+      "ja": "OSI第3層で動作する機器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Single-mode fiber",
+        "ja": "シングルモードファイバ",
+        "ja_typings": [
+          "shingurumo-dofaiba"
+        ]
+      },
+      {
+        "en": "Cat6",
+        "ja": "Cat6",
+        "ja_typings": [
+          "cat6"
+        ]
+      },
+      {
+        "en": "Coaxial",
+        "ja": "同軸ケーブル",
+        "ja_typings": [
+          "doujikeburu"
+        ]
+      },
+      {
+        "en": "Ribbon cable",
+        "ja": "リボンケーブル",
+        "ja_typings": [
+          "ribonke-buru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01671",
+    "image_path": null,
+    "question_text": {
+      "en": "Which cable type uses fiber optics?",
+      "ja": "光ファイバを使うケーブルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ARMv8",
+        "ja": "ARMv8",
+        "ja_typings": [
+          "armv8"
+        ]
+      },
+      {
+        "en": "x86-64",
+        "ja": "x86-64",
+        "ja_typings": [
+          "x86-64"
+        ]
+      },
+      {
+        "en": "POWER9",
+        "ja": "POWER9",
+        "ja_typings": [
+          "power9"
+        ]
+      },
+      {
+        "en": "SPARC",
+        "ja": "SPARC",
+        "ja_typings": [
+          "sparc"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01672",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CPU instruction set is used in Apple Silicon?",
+      "ja": "Apple Siliconが採用する命令セットは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Keccak",
+        "ja": "Keccak",
+        "ja_typings": [
+          "keccak"
+        ]
+      },
+      {
+        "en": "Merkle-Damgard",
+        "ja": "Merkle-Damgard",
+        "ja_typings": [
+          "merkle-damgard"
+        ]
+      },
+      {
+        "en": "Blake2",
+        "ja": "Blake2",
+        "ja_typings": [
+          "blake2"
+        ]
+      },
+      {
+        "en": "MD6",
+        "ja": "MD6",
+        "ja_typings": [
+          "md6"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01673",
+    "image_path": null,
+    "question_text": {
+      "en": "Which hash function is part of SHA-3?",
+      "ja": "SHA-3の基礎関数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "port 22",
+        "ja": "22番ポート",
+        "ja_typings": [
+          "22ban po-to"
+        ]
+      },
+      {
+        "en": "port 21",
+        "ja": "21番ポート",
+        "ja_typings": [
+          "21banpo-to"
+        ]
+      },
+      {
+        "en": "port 23",
+        "ja": "23番ポート",
+        "ja_typings": [
+          "23banpo-to"
+        ]
+      },
+      {
+        "en": "port 25",
+        "ja": "25番ポート",
+        "ja_typings": [
+          "25banpo-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01674",
+    "image_path": null,
+    "question_text": {
+      "en": "Which port number does SSH use?",
+      "ja": "SSHが使うポート番号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "OCI image",
+        "ja": "OCIイメージ",
+        "ja_typings": [
+          "ociime-ji"
+        ]
+      },
+      {
+        "en": "Docker v1",
+        "ja": "Docker v1",
+        "ja_typings": [
+          "docker v1"
+        ]
+      },
+      {
+        "en": "LXC",
+        "ja": "LXC",
+        "ja_typings": [
+          "lxc"
+        ]
+      },
+      {
+        "en": "rkt",
+        "ja": "rkt",
+        "ja_typings": [
+          "rkt"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01675",
+    "image_path": null,
+    "question_text": {
+      "en": "Which container format is OCI standard?",
+      "ja": "OCI標準のコンテナ形式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NVIDIA",
+        "ja": "NVIDIA",
+        "ja_typings": [
+          "nvidia"
+        ]
+      },
+      {
+        "en": "AMD",
+        "ja": "AMD",
+        "ja_typings": [
+          "amd"
+        ]
+      },
+      {
+        "en": "Intel",
+        "ja": "Intel",
+        "ja_typings": [
+          "intel"
+        ]
+      },
+      {
+        "en": "Imagination",
+        "ja": "Imagination",
+        "ja_typings": [
+          "imagination"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01676",
+    "image_path": null,
+    "question_text": {
+      "en": "Which GPU vendor created CUDA?",
+      "ja": "CUDAを開発したGPUベンダは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "VXLAN",
+        "ja": "VXLAN",
+        "ja_typings": [
+          "vxlan"
+        ]
+      },
+      {
+        "en": "MPLS",
+        "ja": "MPLS",
+        "ja_typings": [
+          "mpls"
+        ]
+      },
+      {
+        "en": "GRE",
+        "ja": "GRE",
+        "ja_typings": [
+          "gre"
+        ]
+      },
+      {
+        "en": "PPP",
+        "ja": "PPP",
+        "ja_typings": [
+          "ppp"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01677",
+    "image_path": null,
+    "question_text": {
+      "en": "Which key concept allows VLANs over WAN?",
+      "ja": "WAN越しにVLANを実現する技術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Intel VT-x",
+        "ja": "Intel VT-x",
+        "ja_typings": [
+          "intel vt-x"
+        ]
+      },
+      {
+        "en": "Intel SGX",
+        "ja": "Intel SGX",
+        "ja_typings": [
+          "intel sgx"
+        ]
+      },
+      {
+        "en": "Intel TXT",
+        "ja": "Intel TXT",
+        "ja_typings": [
+          "intel txt"
+        ]
+      },
+      {
+        "en": "Intel AMT",
+        "ja": "Intel AMT",
+        "ja_typings": [
+          "intel amt"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01678",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CPU feature accelerates virtualization?",
+      "ja": "仮想化を加速するCPU機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ArgoCD",
+        "ja": "ArgoCD",
+        "ja_typings": [
+          "argocd"
+        ]
+      },
+      {
+        "en": "Jenkins X",
+        "ja": "Jenkins X",
+        "ja_typings": [
+          "jenkins x"
+        ]
+      },
+      {
+        "en": "Spinnaker",
+        "ja": "Spinnaker",
+        "ja_typings": [
+          "spinnaker"
+        ]
+      },
+      {
+        "en": "Tekton",
+        "ja": "Tekton",
+        "ja_typings": [
+          "tekton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01679",
+    "image_path": null,
+    "question_text": {
+      "en": "Which GitOps tool is part of CNCF?",
+      "ja": "CNCFのGitOpsツールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Linkerd",
+        "ja": "Linkerd",
+        "ja_typings": [
+          "linkerd"
+        ]
+      },
+      {
+        "en": "Istio",
+        "ja": "Istio",
+        "ja_typings": [
+          "istio"
+        ]
+      },
+      {
+        "en": "Consul Connect",
+        "ja": "Consul Connect",
+        "ja_typings": [
+          "consul connect"
+        ]
+      },
+      {
+        "en": "Kuma",
+        "ja": "Kuma",
+        "ja_typings": [
+          "kuma"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01680",
+    "image_path": null,
+    "question_text": {
+      "en": "Which service mesh is created by Buoyant?",
+      "ja": "Buoyant社のサービスメッシュは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "OpenTelemetry",
+        "ja": "OpenTelemetry",
+        "ja_typings": [
+          "opentelemetry"
+        ]
+      },
+      {
+        "en": "OpenTracing",
+        "ja": "OpenTracing",
+        "ja_typings": [
+          "opentracing"
+        ]
+      },
+      {
+        "en": "OpenCensus",
+        "ja": "OpenCensus",
+        "ja_typings": [
+          "opencensus"
+        ]
+      },
+      {
+        "en": "Jaeger",
+        "ja": "Jaeger",
+        "ja_typings": [
+          "jaeger"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01681",
+    "image_path": null,
+    "question_text": {
+      "en": "Which standard unifies observability data?",
+      "ja": "可観測性データを統一する標準は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "eBPF",
+        "ja": "eBPF",
+        "ja_typings": [
+          "ebpf"
+        ]
+      },
+      {
+        "en": "LKM",
+        "ja": "LKM",
+        "ja_typings": [
+          "lkm"
+        ]
+      },
+      {
+        "en": "SystemTap",
+        "ja": "SystemTap",
+        "ja_typings": [
+          "systemtap"
+        ]
+      },
+      {
+        "en": "DTrace",
+        "ja": "DTrace",
+        "ja_typings": [
+          "dtrace"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01682",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Linux feature allows safe kernel programmability?",
+      "ja": "Linuxカーネルを安全に拡張する機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Financial Operations",
+        "ja": "クラウド財務運用",
+        "ja_typings": [
+          "kuraudo zaimuunyou"
+        ]
+      },
+      {
+        "en": "Final Operations",
+        "ja": "最終運用",
+        "ja_typings": [
+          "saishuuunnyou"
+        ]
+      },
+      {
+        "en": "Firmware Operations",
+        "ja": "ファームウェア運用",
+        "ja_typings": [
+          "fa-muweaunnyou"
+        ]
+      },
+      {
+        "en": "Finished Operations",
+        "ja": "完了運用",
+        "ja_typings": [
+          "kanryouunnyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01683",
+    "image_path": null,
+    "question_text": {
+      "en": "What does FinOps stand for?",
+      "ja": "FinOpsの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Scrum",
+        "ja": "スクラム",
+        "ja_typings": [
+          "sukuramu"
+        ]
+      },
+      {
+        "en": "Kanban",
+        "ja": "カンバン",
+        "ja_typings": [
+          "kanban"
+        ]
+      },
+      {
+        "en": "XP",
+        "ja": "XP",
+        "ja_typings": [
+          "xp"
+        ]
+      },
+      {
+        "en": "Lean",
+        "ja": "リーン",
+        "ja_typings": [
+          "ri-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01684",
+    "image_path": null,
+    "question_text": {
+      "en": "Which agile framework uses sprints?",
+      "ja": "スプリントを使うアジャイル手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Service Level Objective",
+        "ja": "サービスレベル目標",
+        "ja_typings": [
+          "sa-bisureberumokuhyou"
+        ]
+      },
+      {
+        "en": "Service Layer Optimization",
+        "ja": "サービス層最適化",
+        "ja_typings": [
+          "sa-bisusousaitekika"
+        ]
+      },
+      {
+        "en": "Single Login Option",
+        "ja": "単一ログイン",
+        "ja_typings": [
+          "tannitsuroguin"
+        ]
+      },
+      {
+        "en": "Server Load Output",
+        "ja": "サーバ負荷出力",
+        "ja_typings": [
+          "sa-bafukashutsuryoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01685",
+    "image_path": null,
+    "question_text": {
+      "en": "What does SLO stand for?",
+      "ja": "SLOの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "fuzz testing",
+        "ja": "ファズテスト",
+        "ja_typings": [
+          "fazutesuto"
+        ]
+      },
+      {
+        "en": "smoke testing",
+        "ja": "スモークテスト",
+        "ja_typings": [
+          "sumo-kutesuto"
+        ]
+      },
+      {
+        "en": "regression testing",
+        "ja": "回帰テスト",
+        "ja_typings": [
+          "kaikitesuto"
+        ]
+      },
+      {
+        "en": "acceptance testing",
+        "ja": "受入テスト",
+        "ja_typings": [
+          "ukeiretesuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01686",
+    "image_path": null,
+    "question_text": {
+      "en": "Which testing technique tries unexpected inputs?",
+      "ja": "予期しない入力を試すテスト技法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lambda",
+        "ja": "Lambda",
+        "ja_typings": [
+          "lambda"
+        ]
+      },
+      {
+        "en": "Functions",
+        "ja": "Functions",
+        "ja_typings": [
+          "functions"
+        ]
+      },
+      {
+        "en": "Cloud Run",
+        "ja": "Cloud Run",
+        "ja_typings": [
+          "cloud run"
+        ]
+      },
+      {
+        "en": "Cloudflare Workers",
+        "ja": "Cloudflare Workers",
+        "ja_typings": [
+          "cloudflare workers"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01687",
+    "image_path": null,
+    "question_text": {
+      "en": "Which serverless runtime is by AWS?",
+      "ja": "AWSのサーバーレス基盤は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mean Time To Recovery",
+        "ja": "平均復旧時間",
+        "ja_typings": [
+          "heikinfukkyuujikan"
+        ]
+      },
+      {
+        "en": "Mean Time Through Requests",
+        "ja": "平均処理時間",
+        "ja_typings": [
+          "heikinshorijikan"
+        ]
+      },
+      {
+        "en": "Mean Test Time Repeat",
+        "ja": "平均テスト反復",
+        "ja_typings": [
+          "heikintesutohanpuku"
+        ]
+      },
+      {
+        "en": "Manual Time To Restart",
+        "ja": "手動再起動時間",
+        "ja_typings": [
+          "shudousaikidoujikan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01688",
+    "image_path": null,
+    "question_text": {
+      "en": "What does MTTR mean in SRE?",
+      "ja": "SREの『MTTR』は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SRE",
+        "ja": "SRE",
+        "ja_typings": [
+          "sre"
+        ]
+      },
+      {
+        "en": "ITIL",
+        "ja": "ITIL",
+        "ja_typings": [
+          "itil"
+        ]
+      },
+      {
+        "en": "CMMI",
+        "ja": "CMMI",
+        "ja_typings": [
+          "cmmi"
+        ]
+      },
+      {
+        "en": "Six Sigma",
+        "ja": "Six Sigma",
+        "ja_typings": [
+          "six sigma"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01689",
+    "image_path": null,
+    "question_text": {
+      "en": "Which methodology emphasizes blameless postmortems?",
+      "ja": "ブレームレスを重視する手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "GitHub Actions",
+        "ja": "GitHub Actions",
+        "ja_typings": [
+          "github actions"
+        ]
+      },
+      {
+        "en": "CircleCI",
+        "ja": "CircleCI",
+        "ja_typings": [
+          "circleci"
+        ]
+      },
+      {
+        "en": "GitLab CI",
+        "ja": "GitLab CI",
+        "ja_typings": [
+          "gitlab ci"
+        ]
+      },
+      {
+        "en": "Travis CI",
+        "ja": "Travis CI",
+        "ja_typings": [
+          "travis ci"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01690",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CI/CD service is built into GitHub?",
+      "ja": "GitHub内蔵のCI/CDは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Test Driven Development",
+        "ja": "テスト駆動開発",
+        "ja_typings": [
+          "tesutokudoukaihatsu"
+        ]
+      },
+      {
+        "en": "Type Driven Design",
+        "ja": "型駆動設計",
+        "ja_typings": [
+          "katakudousekkei"
+        ]
+      },
+      {
+        "en": "Task Distribution Daemon",
+        "ja": "タスク分配",
+        "ja_typings": [
+          "tasukubunpai"
+        ]
+      },
+      {
+        "en": "Tool Dev Diagram",
+        "ja": "ツール図",
+        "ja_typings": [
+          "tsu-ruzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01691",
+    "image_path": null,
+    "question_text": {
+      "en": "What does TDD stand for?",
+      "ja": "TDDの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kubernetes",
+        "ja": "Kubernetes",
+        "ja_typings": [
+          "kubernetes"
+        ]
+      },
+      {
+        "en": "Mesos",
+        "ja": "Mesos",
+        "ja_typings": [
+          "mesos"
+        ]
+      },
+      {
+        "en": "Nomad",
+        "ja": "Nomad",
+        "ja_typings": [
+          "nomad"
+        ]
+      },
+      {
+        "en": "Swarm",
+        "ja": "Swarm",
+        "ja_typings": [
+          "swarm"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01692",
+    "image_path": null,
+    "question_text": {
+      "en": "Which container orchestrator was open-sourced by Google?",
+      "ja": "Google発のコンテナオーケストレータは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "canary release",
+        "ja": "カナリアリリース",
+        "ja_typings": [
+          "kanariariri-su"
+        ]
+      },
+      {
+        "en": "blue-green",
+        "ja": "ブルーグリーン",
+        "ja_typings": [
+          "buru-guri-n"
+        ]
+      },
+      {
+        "en": "big bang",
+        "ja": "ビッグバン",
+        "ja_typings": [
+          "bigguban"
+        ]
+      },
+      {
+        "en": "hotfix",
+        "ja": "ホットフィックス",
+        "ja_typings": [
+          "hottofikkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01693",
+    "image_path": null,
+    "question_text": {
+      "en": "Which DevOps pattern reduces deployment risk by gradual rollout?",
+      "ja": "段階的展開でリスク低減するパターンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Terraform",
+        "ja": "Terraform",
+        "ja_typings": [
+          "terraform"
+        ]
+      },
+      {
+        "en": "Ansible",
+        "ja": "Ansible",
+        "ja_typings": [
+          "ansible"
+        ]
+      },
+      {
+        "en": "Chef",
+        "ja": "Chef",
+        "ja_typings": [
+          "chef"
+        ]
+      },
+      {
+        "en": "Puppet",
+        "ja": "Puppet",
+        "ja_typings": [
+          "puppet"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01694",
+    "image_path": null,
+    "question_text": {
+      "en": "Which IaC tool uses HCL?",
+      "ja": "HCLを使うIaCツールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "test earlier in dev",
+        "ja": "開発の早期段階でテスト",
+        "ja_typings": [
+          "kaihatsunosoukidankaide tesuto"
+        ]
+      },
+      {
+        "en": "deploy late",
+        "ja": "後で展開",
+        "ja_typings": [
+          "atodetenkai"
+        ]
+      },
+      {
+        "en": "review code last",
+        "ja": "最後にレビュー",
+        "ja_typings": [
+          "saigonirebyu-"
+        ]
+      },
+      {
+        "en": "avoid testing",
+        "ja": "テストを避ける",
+        "ja_typings": [
+          "tesutowosakeru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01695",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the term 'shift left' mean?",
+      "ja": "『シフトレフト』の意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Objectives and Key Results",
+        "ja": "目標と主要な成果",
+        "ja_typings": [
+          "mokuhyou to shuyou na seika"
+        ]
+      },
+      {
+        "en": "Operations Key Reports",
+        "ja": "運用報告",
+        "ja_typings": [
+          "unnyouhoukoku"
+        ]
+      },
+      {
+        "en": "Open Knowledge Repository",
+        "ja": "知識リポジトリ",
+        "ja_typings": [
+          "chishikiripojitori"
+        ]
+      },
+      {
+        "en": "Output Kanban Records",
+        "ja": "出力カンバン",
+        "ja_typings": [
+          "shutsuryokukanban"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01696",
+    "image_path": null,
+    "question_text": {
+      "en": "Which framework defines OKRs?",
+      "ja": "OKRsを定める枠組みは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sailboat retrospective",
+        "ja": "セイルボート",
+        "ja_typings": [
+          "seirubo-to"
+        ]
+      },
+      {
+        "en": "Start Stop Continue",
+        "ja": "Start Stop Continue",
+        "ja_typings": [
+          "start stop continue"
+        ]
+      },
+      {
+        "en": "4Ls retrospective",
+        "ja": "4Ls",
+        "ja_typings": [
+          "4ls"
+        ]
+      },
+      {
+        "en": "Mad Sad Glad",
+        "ja": "Mad Sad Glad",
+        "ja_typings": [
+          "mad sad glad"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01697",
+    "image_path": null,
+    "question_text": {
+      "en": "Which retrospective format uses ports?",
+      "ja": "ポート(港)を使うレトロスペクティブは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "toggle for code paths",
+        "ja": "コード経路の切替",
+        "ja_typings": [
+          "ko-do keiro no kirikae"
+        ]
+      },
+      {
+        "en": "UI button",
+        "ja": "UIボタン",
+        "ja_typings": [
+          "uibotan"
+        ]
+      },
+      {
+        "en": "error code",
+        "ja": "エラーコード",
+        "ja_typings": [
+          "era-ko-do"
+        ]
+      },
+      {
+        "en": "CI badge",
+        "ja": "CIバッジ",
+        "ja_typings": [
+          "cibajji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01698",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a feature flag?",
+      "ja": "フィーチャーフラグとは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kanban",
+        "ja": "カンバン方式",
+        "ja_typings": [
+          "kanbanhoushiki"
+        ]
+      },
+      {
+        "en": "Scrum",
+        "ja": "スクラム方式",
+        "ja_typings": [
+          "sukuramuhoushiki"
+        ]
+      },
+      {
+        "en": "Waterfall",
+        "ja": "ウォーターフォール",
+        "ja_typings": [
+          "wo-ta-fo-ru"
+        ]
+      },
+      {
+        "en": "RUP",
+        "ja": "RUP",
+        "ja_typings": [
+          "rup"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01699",
+    "image_path": null,
+    "question_text": {
+      "en": "Which methodology limits work in progress?",
+      "ja": "進行中作業を制限する手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "unit test",
+        "ja": "単体テスト",
+        "ja_typings": [
+          "tantaitesuto"
+        ]
+      },
+      {
+        "en": "integration test",
+        "ja": "結合テスト",
+        "ja_typings": [
+          "ketsugoutesuto"
+        ]
+      },
+      {
+        "en": "system test",
+        "ja": "システムテスト",
+        "ja_typings": [
+          "shisutemutesuto"
+        ]
+      },
+      {
+        "en": "acceptance test",
+        "ja": "受入テスト",
+        "ja_typings": [
+          "ukeiretesuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01700",
+    "image_path": null,
+    "question_text": {
+      "en": "Which test isolates a single function?",
+      "ja": "単一機能を分離して試すテストは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "GKE",
+        "ja": "GKE",
+        "ja_typings": [
+          "gke"
+        ]
+      },
+      {
+        "en": "EKS",
+        "ja": "EKS",
+        "ja_typings": [
+          "eks"
+        ]
+      },
+      {
+        "en": "AKS",
+        "ja": "AKS",
+        "ja_typings": [
+          "aks"
+        ]
+      },
+      {
+        "en": "OKE",
+        "ja": "OKE",
+        "ja_typings": [
+          "oke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01701",
+    "image_path": null,
+    "question_text": {
+      "en": "Which platform offers managed K8s by Google?",
+      "ja": "Google提供のマネージドK8sは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "intentional failure injection",
+        "ja": "意図的障害注入",
+        "ja_typings": [
+          "itotekishougainyuunyuu"
+        ]
+      },
+      {
+        "en": "random refactoring",
+        "ja": "ランダムリファクタ",
+        "ja_typings": [
+          "randamurifakuta"
+        ]
+      },
+      {
+        "en": "agile planning",
+        "ja": "アジャイル計画",
+        "ja_typings": [
+          "ajairukeikaku"
+        ]
+      },
+      {
+        "en": "project chaos",
+        "ja": "プロジェクト混乱",
+        "ja_typings": [
+          "purojekutokonran"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01702",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 'chaos engineering' about?",
+      "ja": "カオスエンジニアリングとは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "blue-green deployment",
+        "ja": "ブルーグリーンデプロイ",
+        "ja_typings": [
+          "buru-guri-ndepuroi"
+        ]
+      },
+      {
+        "en": "rolling deployment",
+        "ja": "ローリングデプロイ",
+        "ja_typings": [
+          "ro-ringudepuroi"
+        ]
+      },
+      {
+        "en": "recreate deployment",
+        "ja": "再作成デプロイ",
+        "ja_typings": [
+          "saisakuseidepuroi"
+        ]
+      },
+      {
+        "en": "shadow deployment",
+        "ja": "シャドウデプロイ",
+        "ja_typings": [
+          "shadodepuroi",
+          "shadoudepuroi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01703",
+    "image_path": null,
+    "question_text": {
+      "en": "Which deployment uses identical environment swap?",
+      "ja": "同一環境を切り替える展開は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "microservices",
+        "ja": "マイクロサービス",
+        "ja_typings": [
+          "maikurosa-bisu"
+        ]
+      },
+      {
+        "en": "monolith",
+        "ja": "モノリス",
+        "ja_typings": [
+          "monorisu"
+        ]
+      },
+      {
+        "en": "SOA",
+        "ja": "SOA",
+        "ja_typings": [
+          "soa"
+        ]
+      },
+      {
+        "en": "MVC",
+        "ja": "MVC",
+        "ja_typings": [
+          "mvc"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01704",
+    "image_path": null,
+    "question_text": {
+      "en": "Which architecture decomposes apps into small services?",
+      "ja": "アプリを小サービスに分解する設計は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Service Level Agreement",
+        "ja": "サービスレベル合意",
+        "ja_typings": [
+          "sa-bisureberugoui"
+        ]
+      },
+      {
+        "en": "Software License Audit",
+        "ja": "ソフトウェアライセンス監査",
+        "ja_typings": [
+          "sofutoweairaisensukansa"
+        ]
+      },
+      {
+        "en": "System Log Analyzer",
+        "ja": "システムログ解析",
+        "ja_typings": [
+          "shisutemurogukaiseki"
+        ]
+      },
+      {
+        "en": "Server Latency Average",
+        "ja": "平均レイテンシ",
+        "ja_typings": [
+          "heikinreitenshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01705",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a SLA?",
+      "ja": "SLAとは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "penetration testing",
+        "ja": "ペネトレーションテスト",
+        "ja_typings": [
+          "penetore-shontesuto"
+        ]
+      },
+      {
+        "en": "usability testing",
+        "ja": "ユーザビリティテスト",
+        "ja_typings": [
+          "yu-zabirititesuto"
+        ]
+      },
+      {
+        "en": "performance testing",
+        "ja": "性能テスト",
+        "ja_typings": [
+          "seinoutesuto"
+        ]
+      },
+      {
+        "en": "compatibility testing",
+        "ja": "互換性テスト",
+        "ja_typings": [
+          "gokansei tesuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01706",
+    "image_path": null,
+    "question_text": {
+      "en": "Which testing examines security flaws?",
+      "ja": "セキュリティ欠陥を調べるテストは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Helm",
+        "ja": "Helm",
+        "ja_typings": [
+          "helm"
+        ]
+      },
+      {
+        "en": "Kustomize",
+        "ja": "Kustomize",
+        "ja_typings": [
+          "kustomize"
+        ]
+      },
+      {
+        "en": "Skaffold",
+        "ja": "Skaffold",
+        "ja_typings": [
+          "skaffold"
+        ]
+      },
+      {
+        "en": "Tilt",
+        "ja": "Tilt",
+        "ja_typings": [
+          "tilt"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01707",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manifest tool packages K8s apps?",
+      "ja": "K8sアプリをパッケージ化するツールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "auxiliary container in pod",
+        "ja": "Pod内の補助コンテナ",
+        "ja_typings": [
+          "pod nai no hojokontena"
+        ]
+      },
+      {
+        "en": "backup pod",
+        "ja": "バックアップPod",
+        "ja_typings": [
+          "bakkuappupod"
+        ]
+      },
+      {
+        "en": "frontend service",
+        "ja": "フロントエンドサービス",
+        "ja_typings": [
+          "furontoendosa-bisu"
+        ]
+      },
+      {
+        "en": "init container only",
+        "ja": "初期化のみ",
+        "ja_typings": [
+          "shokikanomi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q01708",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'sidecar' pattern in K8s?",
+      "ja": "K8sの『サイドカー』パターンとは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ergative case",
+        "ja": "能格",
+        "ja_typings": [
+          "nougaku"
+        ]
+      },
+      {
+        "en": "absolutive case",
+        "ja": "絶対格",
+        "ja_typings": [
+          "zettaikaku"
+        ]
+      },
+      {
+        "en": "nominative case",
+        "ja": "主格",
+        "ja_typings": [
+          "shukaku"
+        ]
+      },
+      {
+        "en": "accusative case",
+        "ja": "対格",
+        "ja_typings": [
+          "taikaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01709",
+    "image_path": null,
+    "question_text": {
+      "en": "Which case marks the subject of a transitive verb in ergative languages?",
+      "ja": "能格言語で他動詞の主語を表す格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "syllabary",
+        "ja": "音節文字",
+        "ja_typings": [
+          "onsetsumoji"
+        ]
+      },
+      {
+        "en": "alphabet",
+        "ja": "アルファベット",
+        "ja_typings": [
+          "arufabetto"
+        ]
+      },
+      {
+        "en": "logogram",
+        "ja": "表語文字",
+        "ja_typings": [
+          "hyougomoji"
+        ]
+      },
+      {
+        "en": "abjad",
+        "ja": "アブジャド",
+        "ja_typings": [
+          "abujado"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01710",
+    "image_path": null,
+    "question_text": {
+      "en": "Which writing system uses consonant-vowel syllables?",
+      "ja": "子音+母音の音節を表す文字体系は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Uralic",
+        "ja": "ウラル語族",
+        "ja_typings": [
+          "urarugozoku"
+        ]
+      },
+      {
+        "en": "Indo-European",
+        "ja": "インド・ヨーロッパ語族",
+        "ja_typings": [
+          "indo/yo-roppagozoku"
+        ]
+      },
+      {
+        "en": "Altaic",
+        "ja": "アルタイ語族",
+        "ja_typings": [
+          "arutaigozoku"
+        ]
+      },
+      {
+        "en": "Dravidian",
+        "ja": "ドラヴィダ語族",
+        "ja_typings": [
+          "doravidagozoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01711",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language family includes Finnish and Hungarian?",
+      "ja": "フィンランド語とハンガリー語を含む語族は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "abjad",
+        "ja": "アブジャド",
+        "ja_typings": [
+          "abujado"
+        ]
+      },
+      {
+        "en": "alphabet",
+        "ja": "アルファベット",
+        "ja_typings": [
+          "arufabetto"
+        ]
+      },
+      {
+        "en": "syllabary",
+        "ja": "音節文字",
+        "ja_typings": [
+          "onsetsumoji"
+        ]
+      },
+      {
+        "en": "abugida",
+        "ja": "アブギダ",
+        "ja_typings": [
+          "abugida"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01712",
+    "image_path": null,
+    "question_text": {
+      "en": "Which writing system represents only consonants?",
+      "ja": "子音のみを表す文字体系は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "morphology",
+        "ja": "形態論",
+        "ja_typings": [
+          "keitairon"
+        ]
+      },
+      {
+        "en": "phonology",
+        "ja": "音韻論",
+        "ja_typings": [
+          "onninron"
+        ]
+      },
+      {
+        "en": "syntax",
+        "ja": "統語論",
+        "ja_typings": [
+          "tougoron"
+        ]
+      },
+      {
+        "en": "semantics",
+        "ja": "意味論",
+        "ja_typings": [
+          "imiron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01713",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the study of word structure?",
+      "ja": "語形成を研究する分野は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "lexical tone",
+        "ja": "声調",
+        "ja_typings": [
+          "seichou"
+        ]
+      },
+      {
+        "en": "stress accent",
+        "ja": "強勢",
+        "ja_typings": [
+          "kyousei"
+        ]
+      },
+      {
+        "en": "vowel length",
+        "ja": "母音長",
+        "ja_typings": [
+          "boinchou"
+        ]
+      },
+      {
+        "en": "nasalization",
+        "ja": "鼻音化",
+        "ja_typings": [
+          "bionka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01714",
+    "image_path": null,
+    "question_text": {
+      "en": "Which feature describes Mandarin tones?",
+      "ja": "中国語のトーンを表す特徴は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hindi",
+        "ja": "ヒンディー語",
+        "ja_typings": [
+          "hindi-go"
+        ]
+      },
+      {
+        "en": "Tamil",
+        "ja": "タミル語",
+        "ja_typings": [
+          "tamirugo"
+        ]
+      },
+      {
+        "en": "Bengali",
+        "ja": "ベンガル語",
+        "ja_typings": [
+          "bengarugo"
+        ]
+      },
+      {
+        "en": "Telugu",
+        "ja": "テルグ語",
+        "ja_typings": [
+          "terugugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01715",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language uses Devanagari script?",
+      "ja": "デーヴァナーガリーを使う言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "question mark style",
+        "ja": "クェスチョンマーク型",
+        "ja_typings": [
+          "kuesuchonma-kugata"
+        ]
+      },
+      {
+        "en": "apostrophe",
+        "ja": "アポストロフィ",
+        "ja_typings": [
+          "aposutorofi"
+        ]
+      },
+      {
+        "en": "h symbol",
+        "ja": "h記号",
+        "ja_typings": [
+          "h kigou"
+        ]
+      },
+      {
+        "en": "colon style",
+        "ja": "コロン型",
+        "ja_typings": [
+          "korongata"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01716",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the IPA symbol for the glottal stop?",
+      "ja": "声門閉鎖音のIPA記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "past perfect",
+        "ja": "過去完了",
+        "ja_typings": [
+          "kakokanryou"
+        ]
+      },
+      {
+        "en": "present perfect",
+        "ja": "現在完了",
+        "ja_typings": [
+          "genzaikanryou"
+        ]
+      },
+      {
+        "en": "future perfect",
+        "ja": "未来完了",
+        "ja_typings": [
+          "miraikanryou"
+        ]
+      },
+      {
+        "en": "simple past",
+        "ja": "単純過去",
+        "ja_typings": [
+          "tanjunkako"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01717",
+    "image_path": null,
+    "question_text": {
+      "en": "Which tense expresses past relative to past?",
+      "ja": "過去より前を表す時制は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Swahili",
+        "ja": "スワヒリ語",
+        "ja_typings": [
+          "suwahirigo"
+        ]
+      },
+      {
+        "en": "Zulu",
+        "ja": "ズールー語",
+        "ja_typings": [
+          "zu-ru-go"
+        ]
+      },
+      {
+        "en": "Xhosa",
+        "ja": "コーサ語",
+        "ja_typings": [
+          "ko-sago"
+        ]
+      },
+      {
+        "en": "Shona",
+        "ja": "ショナ語",
+        "ja_typings": [
+          "shonago"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01718",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language is the most spoken Bantu language?",
+      "ja": "最も話されるバントゥー語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "noun",
+        "ja": "名詞類",
+        "ja_typings": [
+          "meishirui"
+        ]
+      },
+      {
+        "en": "conjunction",
+        "ja": "接続詞",
+        "ja_typings": [
+          "setsuzokushi"
+        ]
+      },
+      {
+        "en": "particle",
+        "ja": "助詞",
+        "ja_typings": [
+          "joshi"
+        ]
+      },
+      {
+        "en": "article",
+        "ja": "冠詞",
+        "ja_typings": [
+          "kanshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01719",
+    "image_path": null,
+    "question_text": {
+      "en": "Which type of word changes form by case in Russian?",
+      "ja": "ロシア語で格によって変化する語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hangul",
+        "ja": "ハングル",
+        "ja_typings": [
+          "hanguru"
+        ]
+      },
+      {
+        "en": "Hanja",
+        "ja": "漢字",
+        "ja_typings": [
+          "kanji"
+        ]
+      },
+      {
+        "en": "Romaja",
+        "ja": "ローマ字",
+        "ja_typings": [
+          "ro-maji"
+        ]
+      },
+      {
+        "en": "Katakana",
+        "ja": "カタカナ",
+        "ja_typings": [
+          "katakana"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01720",
+    "image_path": null,
+    "question_text": {
+      "en": "Which script does Korean use natively?",
+      "ja": "韓国語が固有に使う文字は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "articulatory phonetics",
+        "ja": "調音音声学",
+        "ja_typings": [
+          "chouononseigaku"
+        ]
+      },
+      {
+        "en": "acoustic phonetics",
+        "ja": "音響音声学",
+        "ja_typings": [
+          "onkyouonseigaku"
+        ]
+      },
+      {
+        "en": "auditory phonetics",
+        "ja": "聴覚音声学",
+        "ja_typings": [
+          "choukakuonseigaku"
+        ]
+      },
+      {
+        "en": "forensic phonetics",
+        "ja": "法音声学",
+        "ja_typings": [
+          "houonseigaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01721",
+    "image_path": null,
+    "question_text": {
+      "en": "Which area of phonetics studies sound production?",
+      "ja": "音声生成を研究する分野は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Basque",
+        "ja": "バスク語",
+        "ja_typings": [
+          "basukugo"
+        ]
+      },
+      {
+        "en": "Catalan",
+        "ja": "カタルーニャ語",
+        "ja_typings": [
+          "kataru-nyago"
+        ]
+      },
+      {
+        "en": "Galician",
+        "ja": "ガリシア語",
+        "ja_typings": [
+          "garishiago"
+        ]
+      },
+      {
+        "en": "Asturian",
+        "ja": "アストゥリアス語",
+        "ja_typings": [
+          "asutoriasugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01722",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language is an isolate spoken in northern Spain?",
+      "ja": "スペイン北部で話される孤立言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "accusative",
+        "ja": "対格",
+        "ja_typings": [
+          "taikaku"
+        ]
+      },
+      {
+        "en": "dative",
+        "ja": "与格",
+        "ja_typings": [
+          "yokaku"
+        ]
+      },
+      {
+        "en": "genitive",
+        "ja": "属格",
+        "ja_typings": [
+          "zokukaku"
+        ]
+      },
+      {
+        "en": "ablative",
+        "ja": "奪格",
+        "ja_typings": [
+          "dakkaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01723",
+    "image_path": null,
+    "question_text": {
+      "en": "Which case is used for direct objects in Latin?",
+      "ja": "ラテン語の直接目的語に使う格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "verb endings",
+        "ja": "動詞語尾",
+        "ja_typings": [
+          "doushigobi"
+        ]
+      },
+      {
+        "en": "article gender",
+        "ja": "冠詞性",
+        "ja_typings": [
+          "kanshisei"
+        ]
+      },
+      {
+        "en": "noun cases",
+        "ja": "名詞格",
+        "ja_typings": [
+          "meishi kaku"
+        ]
+      },
+      {
+        "en": "vowel harmony",
+        "ja": "母音調和",
+        "ja_typings": [
+          "boinchouwa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01724",
+    "image_path": null,
+    "question_text": {
+      "en": "Which feature distinguishes Korean honorifics?",
+      "ja": "韓国語の敬語を特徴づけるのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aramaic",
+        "ja": "アラム語",
+        "ja_typings": [
+          "aramugo"
+        ]
+      },
+      {
+        "en": "Hebrew",
+        "ja": "ヘブライ語",
+        "ja_typings": [
+          "heburaigo"
+        ]
+      },
+      {
+        "en": "Arabic",
+        "ja": "アラビア語",
+        "ja_typings": [
+          "arabiago"
+        ]
+      },
+      {
+        "en": "Amharic",
+        "ja": "アムハラ語",
+        "ja_typings": [
+          "amuharago"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01725",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Semitic language is the oldest still spoken?",
+      "ja": "現在も話される最古のセム語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "shift toward palatal",
+        "ja": "硬口蓋音化",
+        "ja_typings": [
+          "koukougaionka"
+        ]
+      },
+      {
+        "en": "nasal lengthening",
+        "ja": "鼻音延長",
+        "ja_typings": [
+          "bionnnenchou"
+        ]
+      },
+      {
+        "en": "vowel lowering",
+        "ja": "母音低化",
+        "ja_typings": [
+          "bointeika"
+        ]
+      },
+      {
+        "en": "consonant doubling",
+        "ja": "子音重複",
+        "ja_typings": [
+          "shiinjuufuku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01726",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sound change is called palatalization?",
+      "ja": "口蓋化と呼ばれる音変化は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cantonese",
+        "ja": "広東語",
+        "ja_typings": [
+          "kantongo"
+        ]
+      },
+      {
+        "en": "Mandarin",
+        "ja": "標準中国語",
+        "ja_typings": [
+          "hyoujunchuugokugo"
+        ]
+      },
+      {
+        "en": "Hakka",
+        "ja": "客家語",
+        "ja_typings": [
+          "hakkago"
+        ]
+      },
+      {
+        "en": "Min",
+        "ja": "ビン語",
+        "ja_typings": [
+          "bingo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01727",
+    "image_path": null,
+    "question_text": {
+      "en": "Which dialect of Chinese is spoken in Hong Kong?",
+      "ja": "香港で話される中国語方言は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "vertical top-to-bottom left-to-right",
+        "ja": "縦書き左から右",
+        "ja_typings": [
+          "tategaki hidari kara migi"
+        ]
+      },
+      {
+        "en": "horizontal right-to-left",
+        "ja": "横書き右から左",
+        "ja_typings": [
+          "yokogakimigikarahidari"
+        ]
+      },
+      {
+        "en": "boustrophedon",
+        "ja": "牛耕式",
+        "ja_typings": [
+          "gyuukoushiki"
+        ]
+      },
+      {
+        "en": "circular",
+        "ja": "円書き",
+        "ja_typings": [
+          "enkaki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01728",
+    "image_path": null,
+    "question_text": {
+      "en": "Which writing direction is traditional Mongolian?",
+      "ja": "伝統的モンゴル文字の書字方向は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Italic",
+        "ja": "イタリック語派",
+        "ja_typings": [
+          "itarikkugoha"
+        ]
+      },
+      {
+        "en": "Celtic",
+        "ja": "ケルト語派",
+        "ja_typings": [
+          "kerutogoha"
+        ]
+      },
+      {
+        "en": "Hellenic",
+        "ja": "ギリシャ語派",
+        "ja_typings": [
+          "girishagoha"
+        ]
+      },
+      {
+        "en": "Slavic",
+        "ja": "スラブ語派",
+        "ja_typings": [
+          "surabugoha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01729",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Indo-European subgroup includes Latin?",
+      "ja": "ラテン語が属するインド・ヨーロッパ語派は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "affix chains",
+        "ja": "接辞連結",
+        "ja_typings": [
+          "setsujirenketsu"
+        ]
+      },
+      {
+        "en": "tone marking",
+        "ja": "声調表記",
+        "ja_typings": [
+          "seichouhyouki"
+        ]
+      },
+      {
+        "en": "noun classes",
+        "ja": "名詞クラス",
+        "ja_typings": [
+          "meishikurasu"
+        ]
+      },
+      {
+        "en": "vowel mutation",
+        "ja": "母音変異",
+        "ja_typings": [
+          "boinhennni"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01730",
+    "image_path": null,
+    "question_text": {
+      "en": "Which feature distinguishes agglutinative languages?",
+      "ja": "膠着語を特徴づけるのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sumerian",
+        "ja": "シュメール文字",
+        "ja_typings": [
+          "shume-rumoji"
+        ]
+      },
+      {
+        "en": "Egyptian",
+        "ja": "エジプト文字",
+        "ja_typings": [
+          "ejiputomoji"
+        ]
+      },
+      {
+        "en": "Phoenician",
+        "ja": "フェニキア文字",
+        "ja_typings": [
+          "fenikiamoji"
+        ]
+      },
+      {
+        "en": "Mayan",
+        "ja": "マヤ文字",
+        "ja_typings": [
+          "mayamoji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01731",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient writing system is cuneiform?",
+      "ja": "古代の楔形文字は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "subjunctive",
+        "ja": "接続法",
+        "ja_typings": [
+          "setsuzokuhou"
+        ]
+      },
+      {
+        "en": "indicative",
+        "ja": "直説法",
+        "ja_typings": [
+          "chokusetsuhou"
+        ]
+      },
+      {
+        "en": "imperative",
+        "ja": "命令法",
+        "ja_typings": [
+          "meireihou"
+        ]
+      },
+      {
+        "en": "conditional",
+        "ja": "条件法",
+        "ja_typings": [
+          "jouken hou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01732",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mood expresses wish or possibility?",
+      "ja": "願望や可能性を表すムードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Xhosa",
+        "ja": "コーサ語",
+        "ja_typings": [
+          "ko-sago"
+        ]
+      },
+      {
+        "en": "Mongolian",
+        "ja": "モンゴル語",
+        "ja_typings": [
+          "mongorugo"
+        ]
+      },
+      {
+        "en": "Vietnamese",
+        "ja": "ベトナム語",
+        "ja_typings": [
+          "betonamugo"
+        ]
+      },
+      {
+        "en": "Persian",
+        "ja": "ペルシア語",
+        "ja_typings": [
+          "perushiago"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01733",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language uses click consonants?",
+      "ja": "クリック子音を使う言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "six tones",
+        "ja": "6声調",
+        "ja_typings": [
+          "roku seichou"
+        ]
+      },
+      {
+        "en": "noun gender",
+        "ja": "名詞性",
+        "ja_typings": [
+          "meishisei"
+        ]
+      },
+      {
+        "en": "case marking",
+        "ja": "格表示",
+        "ja_typings": [
+          "kakuhyouji"
+        ]
+      },
+      {
+        "en": "vowel harmony",
+        "ja": "母音調和",
+        "ja_typings": [
+          "boinchouwa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01734",
+    "image_path": null,
+    "question_text": {
+      "en": "Which feature does Vietnamese have?",
+      "ja": "ベトナム語が持つ特徴は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Maori",
+        "ja": "マオリ語",
+        "ja_typings": [
+          "maorigo"
+        ]
+      },
+      {
+        "en": "Samoan",
+        "ja": "サモア語",
+        "ja_typings": [
+          "samoago"
+        ]
+      },
+      {
+        "en": "Tongan",
+        "ja": "トンガ語",
+        "ja_typings": [
+          "tongago"
+        ]
+      },
+      {
+        "en": "Fijian",
+        "ja": "フィジー語",
+        "ja_typings": [
+          "fiji-go"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01735",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Austronesian language is spoken in New Zealand?",
+      "ja": "ニュージーランドで話されるオーストロネシア語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "/s/",
+        "ja": "/s/",
+        "ja_typings": [
+          "/s/"
+        ]
+      },
+      {
+        "en": "/p/",
+        "ja": "/p/",
+        "ja_typings": [
+          "/p/"
+        ]
+      },
+      {
+        "en": "/t/",
+        "ja": "/t/",
+        "ja_typings": [
+          "/t/"
+        ]
+      },
+      {
+        "en": "/k/",
+        "ja": "/k/",
+        "ja_typings": [
+          "/k/"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01736",
+    "image_path": null,
+    "question_text": {
+      "en": "Which speech sound is a fricative?",
+      "ja": "摩擦音はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Esperanto",
+        "ja": "エスペラント",
+        "ja_typings": [
+          "esuperanto"
+        ]
+      },
+      {
+        "en": "Volapuk",
+        "ja": "ボラピュク",
+        "ja_typings": [
+          "borapyuku"
+        ]
+      },
+      {
+        "en": "Lojban",
+        "ja": "ロジバン",
+        "ja_typings": [
+          "rojiban"
+        ]
+      },
+      {
+        "en": "Toki Pona",
+        "ja": "トキポナ",
+        "ja_typings": [
+          "tokipona"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01737",
+    "image_path": null,
+    "question_text": {
+      "en": "Which constructed language is most spoken?",
+      "ja": "最も話される人工言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "triconsonantal root",
+        "ja": "三子音語根",
+        "ja_typings": [
+          "sanshion gokon"
+        ]
+      },
+      {
+        "en": "biconsonantal",
+        "ja": "二子音",
+        "ja_typings": [
+          "nishiin"
+        ]
+      },
+      {
+        "en": "tetraconsonantal default",
+        "ja": "四子音標準",
+        "ja_typings": [
+          "yonshiinhyoujun"
+        ]
+      },
+      {
+        "en": "vowel-based",
+        "ja": "母音基盤",
+        "ja_typings": [
+          "boinkiban"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q01738",
+    "image_path": null,
+    "question_text": {
+      "en": "Which feature describes Arabic root system?",
+      "ja": "アラビア語の語根体系の特徴は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "paella valenciana",
+        "ja": "パエリャ・バレンシアーナ",
+        "ja_typings": [
+          "paerya/barenshia-na"
+        ]
+      },
+      {
+        "en": "fideua",
+        "ja": "フィデウア",
+        "ja_typings": [
+          "fideua"
+        ]
+      },
+      {
+        "en": "arroz negro",
+        "ja": "アロス・ネグロ",
+        "ja_typings": [
+          "arosu/neguro"
+        ]
+      },
+      {
+        "en": "risotto milanese",
+        "ja": "リゾット・ミラネーゼ",
+        "ja_typings": [
+          "rizotto/mirane-ze"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01739",
+    "image_path": null,
+    "question_text": {
+      "en": "Which traditional Spanish dish is from Valencia, rice based with rabbit?",
+      "ja": "ウサギ肉入りバレンシア発祥の伝統米料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Capoeira",
+        "ja": "カポエイラ",
+        "ja_typings": [
+          "kapoeira"
+        ]
+      },
+      {
+        "en": "Vale Tudo",
+        "ja": "バーリトゥード",
+        "ja_typings": [
+          "ba-ritu-do"
+        ]
+      },
+      {
+        "en": "Luta Livre",
+        "ja": "ルタリーブリ",
+        "ja_typings": [
+          "rutari-buri"
+        ]
+      },
+      {
+        "en": "Jiu-Jitsu",
+        "ja": "柔術",
+        "ja_typings": [
+          "juujutsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01740",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Brazilian martial art combines dance and acrobatics?",
+      "ja": "ダンスとアクロバットを組合せたブラジル武術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "La Tomatina",
+        "ja": "ラ・トマティーナ",
+        "ja_typings": [
+          "ra/tomati-na"
+        ]
+      },
+      {
+        "en": "San Fermin",
+        "ja": "サン・フェルミン",
+        "ja_typings": [
+          "san/ferumin"
+        ]
+      },
+      {
+        "en": "Las Fallas",
+        "ja": "ラス・ファジャス",
+        "ja_typings": [
+          "rasu/fajasu"
+        ]
+      },
+      {
+        "en": "Feria de Abril",
+        "ja": "セビーリャの春祭り",
+        "ja_typings": [
+          "sebi-ryanoharumatsuri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01741",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Spanish festival celebrates tomatoes?",
+      "ja": "トマトの祭りは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sitar",
+        "ja": "シタール",
+        "ja_typings": [
+          "shita-ru"
+        ]
+      },
+      {
+        "en": "tabla",
+        "ja": "タブラ",
+        "ja_typings": [
+          "tabura"
+        ]
+      },
+      {
+        "en": "bansuri",
+        "ja": "バーンスリー",
+        "ja_typings": [
+          "ba-nsuri-"
+        ]
+      },
+      {
+        "en": "sarangi",
+        "ja": "サーランギー",
+        "ja_typings": [
+          "sa-rangi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01742",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Indian instrument has sympathetic strings?",
+      "ja": "共鳴弦を持つインドの弦楽器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Loki",
+        "ja": "ロキ",
+        "ja_typings": [
+          "roki"
+        ]
+      },
+      {
+        "en": "Thor",
+        "ja": "トール",
+        "ja_typings": [
+          "to-ru"
+        ]
+      },
+      {
+        "en": "Odin",
+        "ja": "オーディン",
+        "ja_typings": [
+          "o-din"
+        ]
+      },
+      {
+        "en": "Freyr",
+        "ja": "フレイ",
+        "ja_typings": [
+          "furei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01743",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Norse mythology figure is the trickster god?",
+      "ja": "北欧神話のいたずら神は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ger",
+        "ja": "ゲル",
+        "ja_typings": [
+          "geru"
+        ]
+      },
+      {
+        "en": "yurt-stone hybrid",
+        "ja": "ストーンユルト",
+        "ja_typings": [
+          "suto-nnyuruto"
+        ]
+      },
+      {
+        "en": "igloo",
+        "ja": "イグルー",
+        "ja_typings": [
+          "iguru-"
+        ]
+      },
+      {
+        "en": "longhouse",
+        "ja": "ロングハウス",
+        "ja_typings": [
+          "ronguhausu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01744",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mongolian traditional dwelling is round and portable?",
+      "ja": "丸く可搬なモンゴル伝統住居は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "solea",
+        "ja": "ソレア",
+        "ja_typings": [
+          "sorea"
+        ]
+      },
+      {
+        "en": "alegrias",
+        "ja": "アレグリアス",
+        "ja_typings": [
+          "areguriasu"
+        ]
+      },
+      {
+        "en": "bulerias",
+        "ja": "ブレリアス",
+        "ja_typings": [
+          "bureriasu"
+        ]
+      },
+      {
+        "en": "rumba flamenca",
+        "ja": "ルンバ・フラメンカ",
+        "ja_typings": [
+          "runba/furamenka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01745",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Spanish flamenco rhythm is sad and slow?",
+      "ja": "悲しくゆっくりなフラメンコのリズムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "djembe",
+        "ja": "ジャンベ",
+        "ja_typings": [
+          "janbe"
+        ]
+      },
+      {
+        "en": "dunun",
+        "ja": "ドゥヌン",
+        "ja_typings": [
+          "dunun"
+        ]
+      },
+      {
+        "en": "sabar",
+        "ja": "サバール",
+        "ja_typings": [
+          "saba-ru"
+        ]
+      },
+      {
+        "en": "tama",
+        "ja": "タマ",
+        "ja_typings": [
+          "tama"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01746",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Senegalese drum is goblet-shaped?",
+      "ja": "ゴブレット型のセネガル太鼓は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Buchaechum",
+        "ja": "扇舞",
+        "ja_typings": [
+          "senbu"
+        ]
+      },
+      {
+        "en": "Salpuri",
+        "ja": "サルプリ",
+        "ja_typings": [
+          "sarupuri"
+        ]
+      },
+      {
+        "en": "Taepyeongmu",
+        "ja": "テピョンム",
+        "ja_typings": [
+          "tepyonmu"
+        ]
+      },
+      {
+        "en": "Seungmu",
+        "ja": "僧舞",
+        "ja_typings": [
+          "soubu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01747",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Korean court dance uses fans?",
+      "ja": "扇を使う韓国宮廷舞踊は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dia de los Muertos",
+        "ja": "死者の日",
+        "ja_typings": [
+          "shishanohi"
+        ]
+      },
+      {
+        "en": "Cinco de Mayo",
+        "ja": "シンコ・デ・マヨ",
+        "ja_typings": [
+          "shinko/de/mayo"
+        ]
+      },
+      {
+        "en": "Las Posadas",
+        "ja": "ラス・ポサダス",
+        "ja_typings": [
+          "rasu/posadasu"
+        ]
+      },
+      {
+        "en": "Fiestas Patrias",
+        "ja": "独立記念",
+        "ja_typings": [
+          "dokuritsukinen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01748",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mexican holiday honors deceased relatives?",
+      "ja": "故人を偲ぶメキシコの祭日は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wayang Kulit",
+        "ja": "ワヤン・クリ",
+        "ja_typings": [
+          "wayan/kuri"
+        ]
+      },
+      {
+        "en": "Wayang Golek",
+        "ja": "ワヤン・ゴレ",
+        "ja_typings": [
+          "wayan/gore"
+        ]
+      },
+      {
+        "en": "Wayang Topeng",
+        "ja": "ワヤン・トペン",
+        "ja_typings": [
+          "wayan/topen"
+        ]
+      },
+      {
+        "en": "Wayang Wong",
+        "ja": "ワヤン・ウォン",
+        "ja_typings": [
+          "wayan/won"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01749",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Indonesian shadow puppet theater is UNESCO listed?",
+      "ja": "ユネスコ登録のインドネシア影絵芝居は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Selyodka pod shuboy",
+        "ja": "毛皮を着たニシン",
+        "ja_typings": [
+          "kegawawokita nishin"
+        ]
+      },
+      {
+        "en": "Borscht",
+        "ja": "ボルシチ",
+        "ja_typings": [
+          "borushichi"
+        ]
+      },
+      {
+        "en": "Pelmeni",
+        "ja": "ペリメニ",
+        "ja_typings": [
+          "perimeni"
+        ]
+      },
+      {
+        "en": "Olivier salad",
+        "ja": "オリヴィエサラダ",
+        "ja_typings": [
+          "oriviesarada"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01750",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Russian dish is layered with herring and beets?",
+      "ja": "ニシンとビーツの層状ロシア料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "tambouras",
+        "ja": "タンブーラス",
+        "ja_typings": [
+          "tanbu-rasu"
+        ]
+      },
+      {
+        "en": "kithara",
+        "ja": "キタラ",
+        "ja_typings": [
+          "kitara"
+        ]
+      },
+      {
+        "en": "aulos",
+        "ja": "アウロス",
+        "ja_typings": [
+          "aurosu"
+        ]
+      },
+      {
+        "en": "lyra",
+        "ja": "リラ",
+        "ja_typings": [
+          "rira"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01751",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Greek instrument is a bouzouki ancestor?",
+      "ja": "ブズーキの祖先となるギリシャ楽器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "siku",
+        "ja": "シーク",
+        "ja_typings": [
+          "shi-ku"
+        ]
+      },
+      {
+        "en": "quena",
+        "ja": "ケーナ",
+        "ja_typings": [
+          "ke-na"
+        ]
+      },
+      {
+        "en": "charango",
+        "ja": "チャランゴ",
+        "ja_typings": [
+          "charango"
+        ]
+      },
+      {
+        "en": "bombo",
+        "ja": "ボンボ",
+        "ja_typings": [
+          "bonbo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01752",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Andean instrument is a panpipe?",
+      "ja": "アンデスのパンパイプは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "injera",
+        "ja": "インジェラ",
+        "ja_typings": [
+          "injera"
+        ]
+      },
+      {
+        "en": "kitfo",
+        "ja": "キトフォ",
+        "ja_typings": [
+          "kitofo"
+        ]
+      },
+      {
+        "en": "doro wat",
+        "ja": "ドロワット",
+        "ja_typings": [
+          "dorowatto"
+        ]
+      },
+      {
+        "en": "tibs",
+        "ja": "ティブス",
+        "ja_typings": [
+          "tibusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01753",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Ethiopian bread is spongy and sour?",
+      "ja": "スポンジ状で酸味のあるエチオピアのパンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sphinx",
+        "ja": "スフィンクス",
+        "ja_typings": [
+          "sufinkusu"
+        ]
+      },
+      {
+        "en": "Bennu",
+        "ja": "ベンヌ",
+        "ja_typings": [
+          "bennnu"
+        ]
+      },
+      {
+        "en": "Apep",
+        "ja": "アペプ",
+        "ja_typings": [
+          "apepu"
+        ]
+      },
+      {
+        "en": "Anubis",
+        "ja": "アヌビス",
+        "ja_typings": [
+          "anubisu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01754",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Egyptian mythological creature has lion body and human head?",
+      "ja": "ライオン体に人頭のエジプト神話の生物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kanto Matsuri",
+        "ja": "竿燈まつり",
+        "ja_typings": [
+          "kantoumatsuri"
+        ]
+      },
+      {
+        "en": "Nebuta Matsuri",
+        "ja": "ねぶた祭り",
+        "ja_typings": [
+          "nebutamatsuri"
+        ]
+      },
+      {
+        "en": "Tanabata Matsuri",
+        "ja": "七夕まつり",
+        "ja_typings": [
+          "tanabatamatsuri"
+        ]
+      },
+      {
+        "en": "Yamagata Hanagasa",
+        "ja": "山形花笠",
+        "ja_typings": [
+          "yamagatahanagasa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01755",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese festival is in Akita with paper lanterns balanced on poles?",
+      "ja": "秋田で行われる竿燈の祭りは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yoruba religion",
+        "ja": "ヨルバ宗教",
+        "ja_typings": [
+          "yorubashuukyou"
+        ]
+      },
+      {
+        "en": "Vodun",
+        "ja": "ヴォドゥン",
+        "ja_typings": [
+          "vodun"
+        ]
+      },
+      {
+        "en": "Santeria",
+        "ja": "サンテリア",
+        "ja_typings": [
+          "santeria"
+        ]
+      },
+      {
+        "en": "Candomble",
+        "ja": "カンドンブレ",
+        "ja_typings": [
+          "kandonbure"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01756",
+    "image_path": null,
+    "question_text": {
+      "en": "Which African religion focuses on ancestors and Orishas?",
+      "ja": "祖先とオリシャを崇拝するアフリカ宗教は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tarantella",
+        "ja": "タランテラ",
+        "ja_typings": [
+          "tarantera"
+        ]
+      },
+      {
+        "en": "Saltarello",
+        "ja": "サルタレロ",
+        "ja_typings": [
+          "sarutarero"
+        ]
+      },
+      {
+        "en": "Pizzica",
+        "ja": "ピッツィカ",
+        "ja_typings": [
+          "pittsika"
+        ]
+      },
+      {
+        "en": "Forlana",
+        "ja": "フォルラーナ",
+        "ja_typings": [
+          "forura-na"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01757",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian dance is fast paced from Naples?",
+      "ja": "ナポリ発祥の速いイタリア舞踊は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "dungchen",
+        "ja": "ドゥンチェン",
+        "ja_typings": [
+          "dunchen"
+        ]
+      },
+      {
+        "en": "damaru",
+        "ja": "ダマル",
+        "ja_typings": [
+          "damaru"
+        ]
+      },
+      {
+        "en": "gyaling",
+        "ja": "ギャリン",
+        "ja_typings": [
+          "gyarin"
+        ]
+      },
+      {
+        "en": "kangling",
+        "ja": "カンリン",
+        "ja_typings": [
+          "kanrin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01758",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Tibetan instrument is a long horn?",
+      "ja": "チベットの長い角笛は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Polonaise",
+        "ja": "ポロネーズ",
+        "ja_typings": [
+          "porone-zu"
+        ]
+      },
+      {
+        "en": "Mazurka",
+        "ja": "マズルカ",
+        "ja_typings": [
+          "mazuruka"
+        ]
+      },
+      {
+        "en": "Krakowiak",
+        "ja": "クラコヴィアク",
+        "ja_typings": [
+          "kurakoviaku"
+        ]
+      },
+      {
+        "en": "Oberek",
+        "ja": "オベレク",
+        "ja_typings": [
+          "obereku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01759",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Polish dance is in triple meter and elegant?",
+      "ja": "三拍子で優雅なポーランド舞踊は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ghazal",
+        "ja": "ガザル",
+        "ja_typings": [
+          "gazaru"
+        ]
+      },
+      {
+        "en": "qasida",
+        "ja": "カシーダ",
+        "ja_typings": [
+          "kashi-da"
+        ]
+      },
+      {
+        "en": "rubaiyat",
+        "ja": "ルバイヤート",
+        "ja_typings": [
+          "rubaiya-to"
+        ]
+      },
+      {
+        "en": "masnavi",
+        "ja": "マスナヴィー",
+        "ja_typings": [
+          "masunavi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01760",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Persian poetic form has couplets?",
+      "ja": "対句で構成されるペルシア詩形は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "gulab jamun",
+        "ja": "グラブジャムン",
+        "ja_typings": [
+          "gurabujamun"
+        ]
+      },
+      {
+        "en": "samosa",
+        "ja": "サモサ",
+        "ja_typings": [
+          "samosa"
+        ]
+      },
+      {
+        "en": "dosa",
+        "ja": "ドーサ",
+        "ja_typings": [
+          "do-sa"
+        ]
+      },
+      {
+        "en": "biryani",
+        "ja": "ビリヤニ",
+        "ja_typings": [
+          "biriyani"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01761",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Indian sweet is made from milk solids?",
+      "ja": "ミルク固形分から作るインドの菓子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "bagpipes",
+        "ja": "バグパイプ",
+        "ja_typings": [
+          "bagupaipu"
+        ]
+      },
+      {
+        "en": "fiddle",
+        "ja": "フィドル",
+        "ja_typings": [
+          "fidoru"
+        ]
+      },
+      {
+        "en": "bodhran",
+        "ja": "ボウラン",
+        "ja_typings": [
+          "boran",
+          "bouran"
+        ]
+      },
+      {
+        "en": "clarsach",
+        "ja": "クラルサッハ",
+        "ja_typings": [
+          "kurarusahha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01762",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Scottish instrument has bag and drones?",
+      "ja": "袋とドローンを持つスコットランド楽器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Beijing opera",
+        "ja": "京劇",
+        "ja_typings": [
+          "kyougeki"
+        ]
+      },
+      {
+        "en": "Cantonese opera",
+        "ja": "粤劇",
+        "ja_typings": [
+          "echigeki"
+        ]
+      },
+      {
+        "en": "Kun opera",
+        "ja": "崑曲",
+        "ja_typings": [
+          "konkyoku"
+        ]
+      },
+      {
+        "en": "Sichuan opera",
+        "ja": "川劇",
+        "ja_typings": [
+          "sengeki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01763",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Chinese opera region is most famous?",
+      "ja": "中国京劇の中心地は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "tipi",
+        "ja": "ティーピー",
+        "ja_typings": [
+          "ti-pi-"
+        ]
+      },
+      {
+        "en": "wigwam",
+        "ja": "ウィグワム",
+        "ja_typings": [
+          "wiguwamu"
+        ]
+      },
+      {
+        "en": "hogan",
+        "ja": "ホーガン",
+        "ja_typings": [
+          "ho-gan"
+        ]
+      },
+      {
+        "en": "longhouse",
+        "ja": "ロングハウス",
+        "ja_typings": [
+          "ronguhausu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01764",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Native American structure is a conical tent?",
+      "ja": "円錐形のネイティブアメリカン住居は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hula",
+        "ja": "フラ",
+        "ja_typings": [
+          "fura"
+        ]
+      },
+      {
+        "en": "Tahitian dance",
+        "ja": "タヒチアンダンス",
+        "ja_typings": [
+          "tahichiandansu"
+        ]
+      },
+      {
+        "en": "Haka",
+        "ja": "ハカ",
+        "ja_typings": [
+          "haka"
+        ]
+      },
+      {
+        "en": "Siva",
+        "ja": "シヴァ",
+        "ja_typings": [
+          "shiva"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01765",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hawaiian dance tells stories with hands?",
+      "ja": "手で物語を表すハワイの舞踊は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "moules frites",
+        "ja": "ムール・フリット",
+        "ja_typings": [
+          "mu-ru/furitto"
+        ]
+      },
+      {
+        "en": "waterzooi",
+        "ja": "ワーテルゾーイ",
+        "ja_typings": [
+          "wa-teruzo-i"
+        ]
+      },
+      {
+        "en": "carbonade flamande",
+        "ja": "カルボナード",
+        "ja_typings": [
+          "karubona-do"
+        ]
+      },
+      {
+        "en": "stoofvlees",
+        "ja": "ストーフレース",
+        "ja_typings": [
+          "suto-fure-su"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01766",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Belgian dish is mussels with fries?",
+      "ja": "ムール貝とフライドポテトのベルギー料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Quetzalcoatl",
+        "ja": "ケツァルコアトル",
+        "ja_typings": [
+          "ketsarukoatoru"
+        ]
+      },
+      {
+        "en": "Huitzilopochtli",
+        "ja": "ウィツィロポチトリ",
+        "ja_typings": [
+          "witsiropochitori"
+        ]
+      },
+      {
+        "en": "Tezcatlipoca",
+        "ja": "テスカトリポカ",
+        "ja_typings": [
+          "tesukatoripoka"
+        ]
+      },
+      {
+        "en": "Tlaloc",
+        "ja": "トラロック",
+        "ja_typings": [
+          "torarokku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01767",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Aztec god is the feathered serpent?",
+      "ja": "羽毛の蛇のアステカ神は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "pho",
+        "ja": "フォー",
+        "ja_typings": [
+          "fo-"
+        ]
+      },
+      {
+        "en": "bun bo Hue",
+        "ja": "ブン・ボー・フエ",
+        "ja_typings": [
+          "bun/bo-/fue"
+        ]
+      },
+      {
+        "en": "hu tieu",
+        "ja": "フーティウ",
+        "ja_typings": [
+          "fu-tiu"
+        ]
+      },
+      {
+        "en": "mi quang",
+        "ja": "ミー・クアン",
+        "ja_typings": [
+          "mi-/kuan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q01768",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Vietnamese soup is broth-based with herbs?",
+      "ja": "ハーブを使うベトナム麺スープは?"
+    }
   }
 ]

--- a/data/questions_ja.json
+++ b/data/questions_ja.json
@@ -7018,8 +7018,8 @@
     "id": "q0172",
     "genre": "programming",
     "question_text": {
-      "ja": "1 バイトは何ビット？",
-      "en": "How many bits are in one byte?"
+      "ja": "現代のコンピューティングで 1 バイトを構成するビット数は?",
+      "en": "How many bits make up one byte in modern computing?"
     },
     "choices": [
       {
@@ -47386,14 +47386,14 @@
         "en": "Rurouni Kenshin",
         "ja": "るろうに剣心",
         "ja_typings": [
-          "rurouninikenshin"
+          "rurounikenshin"
         ]
       },
       {
         "en": "Peacemaker Kurogane",
         "ja": "ピースメーカー鐵",
         "ja_typings": [
-          "piisumeekaakurogane"
+          "pi-sume-ka-kurogane"
         ]
       },
       {
@@ -47499,7 +47499,7 @@
         "en": "Kuroko's Basketball",
         "ja": "黒子のバスケ",
         "ja_typings": [
-          "kuronobasuke"
+          "kurokonobasuke"
         ]
       },
       {
@@ -57652,6 +57652,13 @@
   {
     "choices": [
       {
+        "en": "Sega",
+        "ja": "セガ",
+        "ja_typings": [
+          "sega"
+        ]
+      },
+      {
         "en": "Atlus",
         "ja": "アトラス",
         "ja_typings": [
@@ -57671,13 +57678,6 @@
         "ja_typings": [
           "bandainamuko"
         ]
-      },
-      {
-        "en": "Sega",
-        "ja": "セガ",
-        "ja_typings": [
-          "sega"
-        ]
       }
     ],
     "correct_answer_index": 0,
@@ -57685,8 +57685,8 @@
     "id": "q01420",
     "image_path": null,
     "question_text": {
-      "en": "Which company developed Persona 5?",
-      "ja": "ペルソナ5を開発した会社は?"
+      "en": "Which company developed the 'Yakuza' (Like a Dragon) series?",
+      "ja": "『龍が如く』シリーズを開発した会社は?"
     }
   },
   {
@@ -57732,6 +57732,13 @@
   {
     "choices": [
       {
+        "en": "Square Enix",
+        "ja": "スクウェア・エニックス",
+        "ja_typings": [
+          "sukuwea/enikkusu"
+        ]
+      },
+      {
         "en": "Capcom",
         "ja": "カプコン",
         "ja_typings": [
@@ -57746,17 +57753,10 @@
         ]
       },
       {
-        "en": "Bandai Namco",
-        "ja": "バンダイナムコ",
+        "en": "Konami",
+        "ja": "コナミ",
         "ja_typings": [
-          "bandainamuko"
-        ]
-      },
-      {
-        "en": "Koei Tecmo",
-        "ja": "コーエーテクモ",
-        "ja_typings": [
-          "ko-e-tekumo"
+          "konami"
         ]
       }
     ],
@@ -57765,8 +57765,8 @@
     "id": "q01422",
     "image_path": null,
     "question_text": {
-      "en": "Which company developed Monster Hunter series?",
-      "ja": "モンスターハンターシリーズを開発した会社は?"
+      "en": "Which company developed the 'Dragon Quest' series?",
+      "ja": "『ドラゴンクエスト』シリーズを開発した会社は?"
     }
   },
   {
@@ -62237,17 +62237,17 @@
   {
     "choices": [
       {
+        "en": "Jupiter",
+        "ja": "木星",
+        "ja_typings": [
+          "mokusei"
+        ]
+      },
+      {
         "en": "Saturn",
         "ja": "土星",
         "ja_typings": [
           "dosei"
-        ]
-      },
-      {
-        "en": "Uranus",
-        "ja": "天王星",
-        "ja_typings": [
-          "tennousei"
         ]
       },
       {
@@ -62258,10 +62258,10 @@
         ]
       },
       {
-        "en": "Venus",
-        "ja": "金星",
+        "en": "Mars",
+        "ja": "火星",
         "ja_typings": [
-          "kinsei"
+          "kasei"
         ]
       }
     ],
@@ -62270,8 +62270,8 @@
     "id": "q01534",
     "image_path": null,
     "question_text": {
-      "en": "Which planet is known for its prominent rings?",
-      "ja": "顕著な環で知られる惑星は?"
+      "en": "Which planet has the Great Red Spot?",
+      "ja": "大赤斑がある惑星は?"
     }
   },
   {
@@ -64005,14 +64005,14 @@
         "en": "Snake lemma",
         "ja": "蛇の補題",
         "ja_typings": [
-          "hebi no hodai"
+          "hebinohodai"
         ]
       },
       {
         "en": "Zorn lemma",
         "ja": "ツォルンの補題",
         "ja_typings": [
-          "tsorunnnohodai"
+          "tsorunnohodai"
         ]
       },
       {
@@ -68727,14 +68727,14 @@
         "en": "Objectives and Key Results",
         "ja": "目標と主要な成果",
         "ja_typings": [
-          "mokuhyou to shuyou na seika"
+          "mokuhyoutoshuyounaseika"
         ]
       },
       {
         "en": "Operations Key Reports",
         "ja": "運用報告",
         "ja_typings": [
-          "unnyouhoukoku"
+          "unyouhoukoku"
         ]
       },
       {

--- a/data/questions_ja.json
+++ b/data/questions_ja.json
@@ -33608,5 +33608,15572 @@
       "en": "Which Portuguese-born explorer led the first expedition to circumnavigate the globe?",
       "ja": "世界一周航海の最初の遠征を率いたポルトガル出身の探検家は?"
     }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vietnam",
+        "ja": "ベトナム",
+        "ja_typings": [
+          "betonamu"
+        ]
+      },
+      {
+        "en": "Laos",
+        "ja": "ラオス",
+        "ja_typings": [
+          "raosu"
+        ]
+      },
+      {
+        "en": "Cambodia",
+        "ja": "カンボジア",
+        "ja_typings": [
+          "kanbojia"
+        ]
+      },
+      {
+        "en": "Myanmar",
+        "ja": "ミャンマー",
+        "ja_typings": [
+          "myanma-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00822",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Hanoi as its capital?",
+      "ja": "ハノイを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Indonesia",
+        "ja": "インドネシア",
+        "ja_typings": [
+          "indoneshia"
+        ]
+      },
+      {
+        "en": "Malaysia",
+        "ja": "マレーシア",
+        "ja_typings": [
+          "mare-shia"
+        ]
+      },
+      {
+        "en": "Philippines",
+        "ja": "フィリピン",
+        "ja_typings": [
+          "firipin"
+        ]
+      },
+      {
+        "en": "Singapore",
+        "ja": "シンガポール",
+        "ja_typings": [
+          "shingapo-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00823",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Jakarta as its capital?",
+      "ja": "ジャカルタを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Turkey",
+        "ja": "トルコ",
+        "ja_typings": [
+          "toruko"
+        ]
+      },
+      {
+        "en": "Greece",
+        "ja": "ギリシャ",
+        "ja_typings": [
+          "girisha"
+        ]
+      },
+      {
+        "en": "Bulgaria",
+        "ja": "ブルガリア",
+        "ja_typings": [
+          "burugaria"
+        ]
+      },
+      {
+        "en": "Romania",
+        "ja": "ルーマニア",
+        "ja_typings": [
+          "ru-mania"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00824",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Ankara as its capital?",
+      "ja": "アンカラを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Portugal",
+        "ja": "ポルトガル",
+        "ja_typings": [
+          "porutogaru"
+        ]
+      },
+      {
+        "en": "Spain",
+        "ja": "スペイン",
+        "ja_typings": [
+          "supein"
+        ]
+      },
+      {
+        "en": "Italy",
+        "ja": "イタリア",
+        "ja_typings": [
+          "itaria"
+        ]
+      },
+      {
+        "en": "Greece",
+        "ja": "ギリシャ",
+        "ja_typings": [
+          "girisha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00825",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Lisbon as its capital?",
+      "ja": "リスボンを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Finland",
+        "ja": "フィンランド",
+        "ja_typings": [
+          "finrando"
+        ]
+      },
+      {
+        "en": "Sweden",
+        "ja": "スウェーデン",
+        "ja_typings": [
+          "suwe-den"
+        ]
+      },
+      {
+        "en": "Norway",
+        "ja": "ノルウェー",
+        "ja_typings": [
+          "noruwe-"
+        ]
+      },
+      {
+        "en": "Denmark",
+        "ja": "デンマーク",
+        "ja_typings": [
+          "denma-ku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00826",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Helsinki as its capital?",
+      "ja": "ヘルシンキを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Norway",
+        "ja": "ノルウェー",
+        "ja_typings": [
+          "noruwe-"
+        ]
+      },
+      {
+        "en": "Sweden",
+        "ja": "スウェーデン",
+        "ja_typings": [
+          "suwe-den"
+        ]
+      },
+      {
+        "en": "Iceland",
+        "ja": "アイスランド",
+        "ja_typings": [
+          "aisurando"
+        ]
+      },
+      {
+        "en": "Finland",
+        "ja": "フィンランド",
+        "ja_typings": [
+          "finrando"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00827",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Oslo as its capital?",
+      "ja": "オスロを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Austria",
+        "ja": "オーストリア",
+        "ja_typings": [
+          "o-sutoria"
+        ]
+      },
+      {
+        "en": "Switzerland",
+        "ja": "スイス",
+        "ja_typings": [
+          "suisu"
+        ]
+      },
+      {
+        "en": "Hungary",
+        "ja": "ハンガリー",
+        "ja_typings": [
+          "hangari-"
+        ]
+      },
+      {
+        "en": "Czech Republic",
+        "ja": "チェコ",
+        "ja_typings": [
+          "cheko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00828",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Vienna as its capital?",
+      "ja": "ウィーンを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Czech Republic",
+        "ja": "チェコ",
+        "ja_typings": [
+          "cheko"
+        ]
+      },
+      {
+        "en": "Slovakia",
+        "ja": "スロバキア",
+        "ja_typings": [
+          "surobakia"
+        ]
+      },
+      {
+        "en": "Poland",
+        "ja": "ポーランド",
+        "ja_typings": [
+          "po-rando"
+        ]
+      },
+      {
+        "en": "Hungary",
+        "ja": "ハンガリー",
+        "ja_typings": [
+          "hangari-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00829",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Prague as its capital?",
+      "ja": "プラハを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Poland",
+        "ja": "ポーランド",
+        "ja_typings": [
+          "po-rando"
+        ]
+      },
+      {
+        "en": "Czech Republic",
+        "ja": "チェコ",
+        "ja_typings": [
+          "cheko"
+        ]
+      },
+      {
+        "en": "Lithuania",
+        "ja": "リトアニア",
+        "ja_typings": [
+          "ritoania"
+        ]
+      },
+      {
+        "en": "Belarus",
+        "ja": "ベラルーシ",
+        "ja_typings": [
+          "beraru-shi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00830",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Warsaw as its capital?",
+      "ja": "ワルシャワを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Argentina",
+        "ja": "アルゼンチン",
+        "ja_typings": [
+          "aruzenchin"
+        ]
+      },
+      {
+        "en": "Chile",
+        "ja": "チリ",
+        "ja_typings": [
+          "chiri"
+        ]
+      },
+      {
+        "en": "Uruguay",
+        "ja": "ウルグアイ",
+        "ja_typings": [
+          "uruguai"
+        ]
+      },
+      {
+        "en": "Paraguay",
+        "ja": "パラグアイ",
+        "ja_typings": [
+          "paraguai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00831",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Buenos Aires as its capital?",
+      "ja": "ブエノスアイレスを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Peru",
+        "ja": "ペルー",
+        "ja_typings": [
+          "peru-"
+        ]
+      },
+      {
+        "en": "Ecuador",
+        "ja": "エクアドル",
+        "ja_typings": [
+          "ekuadoru"
+        ]
+      },
+      {
+        "en": "Bolivia",
+        "ja": "ボリビア",
+        "ja_typings": [
+          "boribia"
+        ]
+      },
+      {
+        "en": "Colombia",
+        "ja": "コロンビア",
+        "ja_typings": [
+          "koronbia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00832",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Lima as its capital?",
+      "ja": "リマを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kenya",
+        "ja": "ケニア",
+        "ja_typings": [
+          "kenia"
+        ]
+      },
+      {
+        "en": "Tanzania",
+        "ja": "タンザニア",
+        "ja_typings": [
+          "tanzania"
+        ]
+      },
+      {
+        "en": "Uganda",
+        "ja": "ウガンダ",
+        "ja_typings": [
+          "uganda"
+        ]
+      },
+      {
+        "en": "Ethiopia",
+        "ja": "エチオピア",
+        "ja_typings": [
+          "echiopia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00833",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Nairobi as its capital?",
+      "ja": "ナイロビを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Egypt",
+        "ja": "エジプト",
+        "ja_typings": [
+          "ejiputo"
+        ]
+      },
+      {
+        "en": "Libya",
+        "ja": "リビア",
+        "ja_typings": [
+          "ribia"
+        ]
+      },
+      {
+        "en": "Sudan",
+        "ja": "スーダン",
+        "ja_typings": [
+          "su-dan"
+        ]
+      },
+      {
+        "en": "Algeria",
+        "ja": "アルジェリア",
+        "ja_typings": [
+          "arujeria"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00834",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Cairo as its capital?",
+      "ja": "カイロを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "New Zealand",
+        "ja": "ニュージーランド",
+        "ja_typings": [
+          "nyu-ji-rando"
+        ]
+      },
+      {
+        "en": "Australia",
+        "ja": "オーストラリア",
+        "ja_typings": [
+          "o-sutoraria"
+        ]
+      },
+      {
+        "en": "Fiji",
+        "ja": "フィジー",
+        "ja_typings": [
+          "fiji-"
+        ]
+      },
+      {
+        "en": "Samoa",
+        "ja": "サモア",
+        "ja_typings": [
+          "samoa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00835",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Wellington as its capital?",
+      "ja": "ウェリントンを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Australia",
+        "ja": "オーストラリア",
+        "ja_typings": [
+          "o-sutoraria"
+        ]
+      },
+      {
+        "en": "New Zealand",
+        "ja": "ニュージーランド",
+        "ja_typings": [
+          "nyu-ji-rando"
+        ]
+      },
+      {
+        "en": "Papua New Guinea",
+        "ja": "パプアニューギニア",
+        "ja_typings": [
+          "papuanyu-ginia"
+        ]
+      },
+      {
+        "en": "Fiji",
+        "ja": "フィジー",
+        "ja_typings": [
+          "fiji-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00836",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Canberra as its capital?",
+      "ja": "キャンベラを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Canada",
+        "ja": "カナダ",
+        "ja_typings": [
+          "kanada"
+        ]
+      },
+      {
+        "en": "United States",
+        "ja": "アメリカ",
+        "ja_typings": [
+          "amerika"
+        ]
+      },
+      {
+        "en": "Mexico",
+        "ja": "メキシコ",
+        "ja_typings": [
+          "mekishiko"
+        ]
+      },
+      {
+        "en": "Cuba",
+        "ja": "キューバ",
+        "ja_typings": [
+          "kyu-ba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00837",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Ottawa as its capital?",
+      "ja": "オタワを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thames",
+        "ja": "テムズ川",
+        "ja_typings": [
+          "temuzugawa"
+        ]
+      },
+      {
+        "en": "Seine",
+        "ja": "セーヌ川",
+        "ja_typings": [
+          "seenugawa"
+        ]
+      },
+      {
+        "en": "Rhine",
+        "ja": "ライン川",
+        "ja_typings": [
+          "raingawa"
+        ]
+      },
+      {
+        "en": "Danube",
+        "ja": "ドナウ川",
+        "ja_typings": [
+          "donaugawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00838",
+    "image_path": null,
+    "question_text": {
+      "en": "Which river flows through London?",
+      "ja": "ロンドンを流れる河川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Seine",
+        "ja": "セーヌ川",
+        "ja_typings": [
+          "seenugawa"
+        ]
+      },
+      {
+        "en": "Loire",
+        "ja": "ロワール川",
+        "ja_typings": [
+          "rowaarugawa"
+        ]
+      },
+      {
+        "en": "Rhone",
+        "ja": "ローヌ川",
+        "ja_typings": [
+          "roonugawa"
+        ]
+      },
+      {
+        "en": "Garonne",
+        "ja": "ガロンヌ川",
+        "ja_typings": [
+          "garonnugawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00839",
+    "image_path": null,
+    "question_text": {
+      "en": "Which river flows through Paris?",
+      "ja": "パリを流れる河川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yangtze",
+        "ja": "長江",
+        "ja_typings": [
+          "choukou"
+        ]
+      },
+      {
+        "en": "Yellow River",
+        "ja": "黄河",
+        "ja_typings": [
+          "kouga"
+        ]
+      },
+      {
+        "en": "Mekong",
+        "ja": "メコン川",
+        "ja_typings": [
+          "mekongawa"
+        ]
+      },
+      {
+        "en": "Pearl River",
+        "ja": "珠江",
+        "ja_typings": [
+          "shukou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00840",
+    "image_path": null,
+    "question_text": {
+      "en": "Which river is the longest in China?",
+      "ja": "中国最長の河川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Andes",
+        "ja": "アンデス山脈",
+        "ja_typings": [
+          "andesusanmyaku"
+        ]
+      },
+      {
+        "en": "Rockies",
+        "ja": "ロッキー山脈",
+        "ja_typings": [
+          "rokkiisanmyaku"
+        ]
+      },
+      {
+        "en": "Appalachians",
+        "ja": "アパラチア山脈",
+        "ja_typings": [
+          "aparachiasanmyaku"
+        ]
+      },
+      {
+        "en": "Sierra Madre",
+        "ja": "シエラマドレ山脈",
+        "ja_typings": [
+          "sieramadoresanmyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00841",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mountain range stretches across South America's west coast?",
+      "ja": "南米の西海岸に連なる山脈は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Urals",
+        "ja": "ウラル山脈",
+        "ja_typings": [
+          "urarusanmyaku"
+        ]
+      },
+      {
+        "en": "Alps",
+        "ja": "アルプス山脈",
+        "ja_typings": [
+          "arupususanmyaku"
+        ]
+      },
+      {
+        "en": "Caucasus",
+        "ja": "コーカサス山脈",
+        "ja_typings": [
+          "kookasasusanmyaku"
+        ]
+      },
+      {
+        "en": "Pyrenees",
+        "ja": "ピレネー山脈",
+        "ja_typings": [
+          "pireneesanmyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00842",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mountain range divides Europe and Asia?",
+      "ja": "ヨーロッパとアジアを分ける山脈は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Adriatic Sea",
+        "ja": "アドリア海",
+        "ja_typings": [
+          "adoriakai"
+        ]
+      },
+      {
+        "en": "Aegean Sea",
+        "ja": "エーゲ海",
+        "ja_typings": [
+          "eegekai"
+        ]
+      },
+      {
+        "en": "Ionian Sea",
+        "ja": "イオニア海",
+        "ja_typings": [
+          "ioniakai"
+        ]
+      },
+      {
+        "en": "Tyrrhenian Sea",
+        "ja": "ティレニア海",
+        "ja_typings": [
+          "tireniakai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00843",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sea lies between Italy and the Balkans?",
+      "ja": "イタリアとバルカン半島の間の海は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aegean Sea",
+        "ja": "エーゲ海",
+        "ja_typings": [
+          "eegekai"
+        ]
+      },
+      {
+        "en": "Black Sea",
+        "ja": "黒海",
+        "ja_typings": [
+          "kokkai"
+        ]
+      },
+      {
+        "en": "Adriatic Sea",
+        "ja": "アドリア海",
+        "ja_typings": [
+          "adoriakai"
+        ]
+      },
+      {
+        "en": "Caspian Sea",
+        "ja": "カスピ海",
+        "ja_typings": [
+          "kasupikai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00844",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sea lies between Greece and Turkey?",
+      "ja": "ギリシャとトルコの間の海は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sahara",
+        "ja": "サハラ砂漠",
+        "ja_typings": [
+          "saharasabaku"
+        ]
+      },
+      {
+        "en": "Gobi",
+        "ja": "ゴビ砂漠",
+        "ja_typings": [
+          "gobisabaku"
+        ]
+      },
+      {
+        "en": "Kalahari",
+        "ja": "カラハリ砂漠",
+        "ja_typings": [
+          "karaharisabaku"
+        ]
+      },
+      {
+        "en": "Atacama",
+        "ja": "アタカマ砂漠",
+        "ja_typings": [
+          "atakamasabaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00845",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the world's largest desert (after the polar ones)?",
+      "ja": "極地を除く世界最大の砂漠は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gobi",
+        "ja": "ゴビ砂漠",
+        "ja_typings": [
+          "gobisabaku"
+        ]
+      },
+      {
+        "en": "Taklamakan",
+        "ja": "タクラマカン砂漠",
+        "ja_typings": [
+          "takuramakansabaku"
+        ]
+      },
+      {
+        "en": "Karakum",
+        "ja": "カラクム砂漠",
+        "ja_typings": [
+          "karakumusabaku"
+        ]
+      },
+      {
+        "en": "Thar",
+        "ja": "タール砂漠",
+        "ja_typings": [
+          "taarusabaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00846",
+    "image_path": null,
+    "question_text": {
+      "en": "Which desert lies between Mongolia and China?",
+      "ja": "モンゴルと中国の間にある砂漠は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Russia",
+        "ja": "ロシア",
+        "ja_typings": [
+          "roshia"
+        ]
+      },
+      {
+        "en": "Canada",
+        "ja": "カナダ",
+        "ja_typings": [
+          "kanada"
+        ]
+      },
+      {
+        "en": "China",
+        "ja": "中国",
+        "ja_typings": [
+          "chuugoku"
+        ]
+      },
+      {
+        "en": "Brazil",
+        "ja": "ブラジル",
+        "ja_typings": [
+          "burajiru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00847",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the largest country by area?",
+      "ja": "面積が世界最大の国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vatican City",
+        "ja": "バチカン市国",
+        "ja_typings": [
+          "bachikanshikoku"
+        ]
+      },
+      {
+        "en": "Monaco",
+        "ja": "モナコ",
+        "ja_typings": [
+          "monako"
+        ]
+      },
+      {
+        "en": "San Marino",
+        "ja": "サンマリノ",
+        "ja_typings": [
+          "sanmarino"
+        ]
+      },
+      {
+        "en": "Liechtenstein",
+        "ja": "リヒテンシュタイン",
+        "ja_typings": [
+          "rihitenshutain"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00848",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the smallest country in the world?",
+      "ja": "世界最小の国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Caspian Sea",
+        "ja": "カスピ海",
+        "ja_typings": [
+          "kasupikai"
+        ]
+      },
+      {
+        "en": "Lake Superior",
+        "ja": "スペリオル湖",
+        "ja_typings": [
+          "superioruko"
+        ]
+      },
+      {
+        "en": "Lake Victoria",
+        "ja": "ビクトリア湖",
+        "ja_typings": [
+          "bikutoriako"
+        ]
+      },
+      {
+        "en": "Lake Baikal",
+        "ja": "バイカル湖",
+        "ja_typings": [
+          "baikaruko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00849",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the world's largest lake by area?",
+      "ja": "世界最大の湖は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lake Baikal",
+        "ja": "バイカル湖",
+        "ja_typings": [
+          "baikaruko"
+        ]
+      },
+      {
+        "en": "Caspian Sea",
+        "ja": "カスピ海",
+        "ja_typings": [
+          "kasupikai"
+        ]
+      },
+      {
+        "en": "Lake Tanganyika",
+        "ja": "タンガニーカ湖",
+        "ja_typings": [
+          "tanganiikako"
+        ]
+      },
+      {
+        "en": "Lake Superior",
+        "ja": "スペリオル湖",
+        "ja_typings": [
+          "superioruko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00850",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the deepest lake in the world?",
+      "ja": "世界で最も深い湖は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Strait of Gibraltar",
+        "ja": "ジブラルタル海峡",
+        "ja_typings": [
+          "jiburarutarukaikyou"
+        ]
+      },
+      {
+        "en": "Strait of Hormuz",
+        "ja": "ホルムズ海峡",
+        "ja_typings": [
+          "horumuzukaikyou"
+        ]
+      },
+      {
+        "en": "Bering Strait",
+        "ja": "ベーリング海峡",
+        "ja_typings": [
+          "beeringukaikyou"
+        ]
+      },
+      {
+        "en": "Strait of Malacca",
+        "ja": "マラッカ海峡",
+        "ja_typings": [
+          "marakkakaikyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00851",
+    "image_path": null,
+    "question_text": {
+      "en": "Which strait separates Europe and Africa?",
+      "ja": "ヨーロッパとアフリカを隔てる海峡は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bering Strait",
+        "ja": "ベーリング海峡",
+        "ja_typings": [
+          "beeringukaikyou"
+        ]
+      },
+      {
+        "en": "Strait of Gibraltar",
+        "ja": "ジブラルタル海峡",
+        "ja_typings": [
+          "jiburarutarukaikyou"
+        ]
+      },
+      {
+        "en": "Strait of Hormuz",
+        "ja": "ホルムズ海峡",
+        "ja_typings": [
+          "horumuzukaikyou"
+        ]
+      },
+      {
+        "en": "Strait of Malacca",
+        "ja": "マラッカ海峡",
+        "ja_typings": [
+          "marakkakaikyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00852",
+    "image_path": null,
+    "question_text": {
+      "en": "Which strait separates Asia and North America?",
+      "ja": "アジアと北米を隔てる海峡は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Africa",
+        "ja": "アフリカ",
+        "ja_typings": [
+          "afurika"
+        ]
+      },
+      {
+        "en": "Asia",
+        "ja": "アジア",
+        "ja_typings": [
+          "ajia"
+        ]
+      },
+      {
+        "en": "Europe",
+        "ja": "ヨーロッパ",
+        "ja_typings": [
+          "yo-roppa"
+        ]
+      },
+      {
+        "en": "Oceania",
+        "ja": "オセアニア",
+        "ja_typings": [
+          "oseania"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00853",
+    "image_path": null,
+    "question_text": {
+      "en": "Which continent is Egypt located in?",
+      "ja": "エジプトが属する大陸は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Africa",
+        "ja": "アフリカ",
+        "ja_typings": [
+          "afurika"
+        ]
+      },
+      {
+        "en": "Asia",
+        "ja": "アジア",
+        "ja_typings": [
+          "ajia"
+        ]
+      },
+      {
+        "en": "Europe",
+        "ja": "ヨーロッパ",
+        "ja_typings": [
+          "yo-roppa"
+        ]
+      },
+      {
+        "en": "South America",
+        "ja": "南アメリカ",
+        "ja_typings": [
+          "minamiamerika"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00854",
+    "image_path": null,
+    "question_text": {
+      "en": "Which continent has the most countries?",
+      "ja": "国の数が最も多い大陸は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kilimanjaro",
+        "ja": "キリマンジャロ",
+        "ja_typings": [
+          "kirimanjaro"
+        ]
+      },
+      {
+        "en": "Mount Kenya",
+        "ja": "ケニア山",
+        "ja_typings": [
+          "keniasan"
+        ]
+      },
+      {
+        "en": "Atlas",
+        "ja": "アトラス山脈",
+        "ja_typings": [
+          "atorasusanmyaku"
+        ]
+      },
+      {
+        "en": "Mount Stanley",
+        "ja": "スタンレー山",
+        "ja_typings": [
+          "sutanreesan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00855",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the highest mountain in Africa?",
+      "ja": "アフリカ最高峰は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rome",
+        "ja": "ローマ",
+        "ja_typings": [
+          "ro-ma"
+        ]
+      },
+      {
+        "en": "Athens",
+        "ja": "アテネ",
+        "ja_typings": [
+          "atene"
+        ]
+      },
+      {
+        "en": "Istanbul",
+        "ja": "イスタンブール",
+        "ja_typings": [
+          "isutanbu-ru"
+        ]
+      },
+      {
+        "en": "Jerusalem",
+        "ja": "エルサレム",
+        "ja_typings": [
+          "erusaremu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q00856",
+    "image_path": null,
+    "question_text": {
+      "en": "Which city is known as the Eternal City?",
+      "ja": "永遠の都と呼ばれる都市は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Qin Shi Huang",
+        "ja": "始皇帝",
+        "ja_typings": [
+          "shikoutei"
+        ]
+      },
+      {
+        "en": "Han Wudi",
+        "ja": "漢武帝",
+        "ja_typings": [
+          "kanbutei"
+        ]
+      },
+      {
+        "en": "Tang Taizong",
+        "ja": "唐太宗",
+        "ja_typings": [
+          "toutaisou"
+        ]
+      },
+      {
+        "en": "Kublai Khan",
+        "ja": "フビライハン",
+        "ja_typings": [
+          "fubiraihan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00857",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first emperor of unified China?",
+      "ja": "中国を統一した最初の皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Genghis Khan",
+        "ja": "チンギスハン",
+        "ja_typings": [
+          "chingisuhan"
+        ]
+      },
+      {
+        "en": "Kublai Khan",
+        "ja": "フビライハン",
+        "ja_typings": [
+          "fubiraihan"
+        ]
+      },
+      {
+        "en": "Tamerlane",
+        "ja": "ティムール",
+        "ja_typings": [
+          "timu-ru"
+        ]
+      },
+      {
+        "en": "Attila",
+        "ja": "アッティラ",
+        "ja_typings": [
+          "attira"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00858",
+    "image_path": null,
+    "question_text": {
+      "en": "Who founded the Mongol Empire?",
+      "ja": "モンゴル帝国を建国したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cleopatra",
+        "ja": "クレオパトラ",
+        "ja_typings": [
+          "kureopatora"
+        ]
+      },
+      {
+        "en": "Nefertiti",
+        "ja": "ネフェルティティ",
+        "ja_typings": [
+          "neferutiti"
+        ]
+      },
+      {
+        "en": "Hatshepsut",
+        "ja": "ハトシェプスト",
+        "ja_typings": [
+          "hatoshepusuto"
+        ]
+      },
+      {
+        "en": "Isis",
+        "ja": "イシス",
+        "ja_typings": [
+          "ishisu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00859",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the queen of ancient Egypt famous for relations with Rome?",
+      "ja": "ローマと関係したことで有名な古代エジプトの女王は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rajendra Prasad",
+        "ja": "ラジェンドラプラサド",
+        "ja_typings": [
+          "rajendorapurasado"
+        ]
+      },
+      {
+        "en": "Jawaharlal Nehru",
+        "ja": "ネルー",
+        "ja_typings": [
+          "neru-"
+        ]
+      },
+      {
+        "en": "Mahatma Gandhi",
+        "ja": "ガンディー",
+        "ja_typings": [
+          "gandi-"
+        ]
+      },
+      {
+        "en": "Indira Gandhi",
+        "ja": "インディラガンディー",
+        "ja_typings": [
+          "indiragandi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00860",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first president of independent India?",
+      "ja": "インド独立後の初代大統領は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gandhi",
+        "ja": "ガンディー",
+        "ja_typings": [
+          "gandi-"
+        ]
+      },
+      {
+        "en": "Nehru",
+        "ja": "ネルー",
+        "ja_typings": [
+          "neru-"
+        ]
+      },
+      {
+        "en": "Bose",
+        "ja": "ボース",
+        "ja_typings": [
+          "bo-su"
+        ]
+      },
+      {
+        "en": "Tagore",
+        "ja": "タゴール",
+        "ja_typings": [
+          "tago-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00861",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led India's independence movement nonviolently?",
+      "ja": "非暴力でインド独立運動を率いたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Churchill",
+        "ja": "チャーチル",
+        "ja_typings": [
+          "cha-chiru"
+        ]
+      },
+      {
+        "en": "Chamberlain",
+        "ja": "チェンバレン",
+        "ja_typings": [
+          "chenbaren"
+        ]
+      },
+      {
+        "en": "Attlee",
+        "ja": "アトリー",
+        "ja_typings": [
+          "atori-"
+        ]
+      },
+      {
+        "en": "Eden",
+        "ja": "イーデン",
+        "ja_typings": [
+          "i-den"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00862",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the British Prime Minister during WWII?",
+      "ja": "第二次大戦中のイギリス首相は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hitler",
+        "ja": "ヒトラー",
+        "ja_typings": [
+          "hitora-"
+        ]
+      },
+      {
+        "en": "Himmler",
+        "ja": "ヒムラー",
+        "ja_typings": [
+          "himura-"
+        ]
+      },
+      {
+        "en": "Goebbels",
+        "ja": "ゲッベルス",
+        "ja_typings": [
+          "gebberusu"
+        ]
+      },
+      {
+        "en": "Goering",
+        "ja": "ゲーリング",
+        "ja_typings": [
+          "ge-ringu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00863",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the leader of Nazi Germany?",
+      "ja": "ナチスドイツの指導者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Stalin",
+        "ja": "スターリン",
+        "ja_typings": [
+          "suta-rin"
+        ]
+      },
+      {
+        "en": "Lenin",
+        "ja": "レーニン",
+        "ja_typings": [
+          "re-nin"
+        ]
+      },
+      {
+        "en": "Khrushchev",
+        "ja": "フルシチョフ",
+        "ja_typings": [
+          "furushichofu"
+        ]
+      },
+      {
+        "en": "Trotsky",
+        "ja": "トロツキー",
+        "ja_typings": [
+          "torotsuki-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00864",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led the Soviet Union during WWII?",
+      "ja": "第二次大戦中のソ連を率いたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lenin",
+        "ja": "レーニン",
+        "ja_typings": [
+          "re-nin"
+        ]
+      },
+      {
+        "en": "Stalin",
+        "ja": "スターリン",
+        "ja_typings": [
+          "suta-rin"
+        ]
+      },
+      {
+        "en": "Trotsky",
+        "ja": "トロツキー",
+        "ja_typings": [
+          "torotsuki-"
+        ]
+      },
+      {
+        "en": "Marx",
+        "ja": "マルクス",
+        "ja_typings": [
+          "marukusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00865",
+    "image_path": null,
+    "question_text": {
+      "en": "Who founded the Soviet Union?",
+      "ja": "ソ連を建国したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Marx",
+        "ja": "マルクス",
+        "ja_typings": [
+          "marukusu"
+        ]
+      },
+      {
+        "en": "Lenin",
+        "ja": "レーニン",
+        "ja_typings": [
+          "re-nin"
+        ]
+      },
+      {
+        "en": "Bakunin",
+        "ja": "バクーニン",
+        "ja_typings": [
+          "baku-nin"
+        ]
+      },
+      {
+        "en": "Proudhon",
+        "ja": "プルードン",
+        "ja_typings": [
+          "puru-don"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00866",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote The Communist Manifesto with Engels?",
+      "ja": "エンゲルスと共産党宣言を書いたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lincoln",
+        "ja": "リンカーン",
+        "ja_typings": [
+          "rinka-n"
+        ]
+      },
+      {
+        "en": "Garfield",
+        "ja": "ガーフィールド",
+        "ja_typings": [
+          "ga-fi-rudo"
+        ]
+      },
+      {
+        "en": "McKinley",
+        "ja": "マッキンリー",
+        "ja_typings": [
+          "makkinri-"
+        ]
+      },
+      {
+        "en": "Kennedy",
+        "ja": "ケネディ",
+        "ja_typings": [
+          "kenedi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00867",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first US president to be assassinated?",
+      "ja": "暗殺された最初のアメリカ大統領は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kennedy",
+        "ja": "ケネディ",
+        "ja_typings": [
+          "kenedi"
+        ]
+      },
+      {
+        "en": "Eisenhower",
+        "ja": "アイゼンハワー",
+        "ja_typings": [
+          "aizenhawa-"
+        ]
+      },
+      {
+        "en": "Johnson",
+        "ja": "ジョンソン",
+        "ja_typings": [
+          "jonson"
+        ]
+      },
+      {
+        "en": "Nixon",
+        "ja": "ニクソン",
+        "ja_typings": [
+          "nikuson"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00868",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the US president during the Cuban Missile Crisis?",
+      "ja": "キューバ危機時のアメリカ大統領は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Columbus",
+        "ja": "コロンブス",
+        "ja_typings": [
+          "koronbusu"
+        ]
+      },
+      {
+        "en": "Magellan",
+        "ja": "マゼラン",
+        "ja_typings": [
+          "mazeran"
+        ]
+      },
+      {
+        "en": "Vespucci",
+        "ja": "ベスプッチ",
+        "ja_typings": [
+          "besuputchi"
+        ]
+      },
+      {
+        "en": "Cabot",
+        "ja": "カボット",
+        "ja_typings": [
+          "kabotto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00869",
+    "image_path": null,
+    "question_text": {
+      "en": "Who discovered the Americas in 1492?",
+      "ja": "1492年に新大陸に到達したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Magellan's expedition",
+        "ja": "マゼラン隊",
+        "ja_typings": [
+          "mazerantai"
+        ]
+      },
+      {
+        "en": "Columbus",
+        "ja": "コロンブス",
+        "ja_typings": [
+          "koronbusu"
+        ]
+      },
+      {
+        "en": "Vasco da Gama",
+        "ja": "バスコダガマ",
+        "ja_typings": [
+          "basukodagama"
+        ]
+      },
+      {
+        "en": "Drake",
+        "ja": "ドレーク",
+        "ja_typings": [
+          "dore-ku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00870",
+    "image_path": null,
+    "question_text": {
+      "en": "Who first circumnavigated the globe?",
+      "ja": "世界一周航海を最初に成し遂げたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Leonardo da Vinci",
+        "ja": "ダヴィンチ",
+        "ja_typings": [
+          "davinchi"
+        ]
+      },
+      {
+        "en": "Michelangelo",
+        "ja": "ミケランジェロ",
+        "ja_typings": [
+          "mikeranjero"
+        ]
+      },
+      {
+        "en": "Raphael",
+        "ja": "ラファエロ",
+        "ja_typings": [
+          "rafaero"
+        ]
+      },
+      {
+        "en": "Botticelli",
+        "ja": "ボッティチェリ",
+        "ja_typings": [
+          "botticheri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00871",
+    "image_path": null,
+    "question_text": {
+      "en": "Who painted the Mona Lisa?",
+      "ja": "モナリザを描いたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Copernicus",
+        "ja": "コペルニクス",
+        "ja_typings": [
+          "koperunikusu"
+        ]
+      },
+      {
+        "en": "Galileo",
+        "ja": "ガリレオ",
+        "ja_typings": [
+          "garireo"
+        ]
+      },
+      {
+        "en": "Kepler",
+        "ja": "ケプラー",
+        "ja_typings": [
+          "kepura-"
+        ]
+      },
+      {
+        "en": "Brahe",
+        "ja": "ブラーエ",
+        "ja_typings": [
+          "bura-e"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00872",
+    "image_path": null,
+    "question_text": {
+      "en": "Who proposed heliocentrism in the 16th century?",
+      "ja": "16世紀に地動説を唱えたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Babur",
+        "ja": "バーブル",
+        "ja_typings": [
+          "ba-buru"
+        ]
+      },
+      {
+        "en": "Akbar",
+        "ja": "アクバル",
+        "ja_typings": [
+          "akubaru"
+        ]
+      },
+      {
+        "en": "Aurangzeb",
+        "ja": "アウラングゼーブ",
+        "ja_typings": [
+          "auranguze-bu"
+        ]
+      },
+      {
+        "en": "Shah Jahan",
+        "ja": "シャージャハン",
+        "ja_typings": [
+          "sha-jahan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00873",
+    "image_path": null,
+    "question_text": {
+      "en": "Who founded the Mughal Empire in India?",
+      "ja": "インドのムガル帝国を建国したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shah Jahan",
+        "ja": "シャージャハン",
+        "ja_typings": [
+          "sha-jahan"
+        ]
+      },
+      {
+        "en": "Akbar",
+        "ja": "アクバル",
+        "ja_typings": [
+          "akubaru"
+        ]
+      },
+      {
+        "en": "Babur",
+        "ja": "バーブル",
+        "ja_typings": [
+          "ba-buru"
+        ]
+      },
+      {
+        "en": "Aurangzeb",
+        "ja": "アウラングゼーブ",
+        "ja_typings": [
+          "auranguze-bu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00874",
+    "image_path": null,
+    "question_text": {
+      "en": "Who built the Taj Mahal?",
+      "ja": "タージマハルを建てたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sui",
+        "ja": "隋",
+        "ja_typings": [
+          "zui"
+        ]
+      },
+      {
+        "en": "Han",
+        "ja": "漢",
+        "ja_typings": [
+          "kan"
+        ]
+      },
+      {
+        "en": "Song",
+        "ja": "宋",
+        "ja_typings": [
+          "sou"
+        ]
+      },
+      {
+        "en": "Yuan",
+        "ja": "元",
+        "ja_typings": [
+          "gen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00875",
+    "image_path": null,
+    "question_text": {
+      "en": "Which dynasty preceded the Tang in China?",
+      "ja": "中国で唐の前の王朝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Song",
+        "ja": "宋",
+        "ja_typings": [
+          "sou"
+        ]
+      },
+      {
+        "en": "Yuan",
+        "ja": "元",
+        "ja_typings": [
+          "gen"
+        ]
+      },
+      {
+        "en": "Ming",
+        "ja": "明",
+        "ja_typings": [
+          "min"
+        ]
+      },
+      {
+        "en": "Qing",
+        "ja": "清",
+        "ja_typings": [
+          "shin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00876",
+    "image_path": null,
+    "question_text": {
+      "en": "Which dynasty followed the Tang in China?",
+      "ja": "中国で唐の次の王朝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Qing",
+        "ja": "清",
+        "ja_typings": [
+          "shin"
+        ]
+      },
+      {
+        "en": "Ming",
+        "ja": "明",
+        "ja_typings": [
+          "min"
+        ]
+      },
+      {
+        "en": "Yuan",
+        "ja": "元",
+        "ja_typings": [
+          "gen"
+        ]
+      },
+      {
+        "en": "Song",
+        "ja": "宋",
+        "ja_typings": [
+          "sou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00877",
+    "image_path": null,
+    "question_text": {
+      "en": "Which dynasty was the last imperial dynasty of China?",
+      "ja": "中国最後の王朝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "WWI",
+        "ja": "第一次大戦",
+        "ja_typings": [
+          "daiichijitaisen"
+        ]
+      },
+      {
+        "en": "Balkan War",
+        "ja": "バルカン戦争",
+        "ja_typings": [
+          "barukansensou"
+        ]
+      },
+      {
+        "en": "Russo-Japanese War",
+        "ja": "日露戦争",
+        "ja_typings": [
+          "nichirosensou"
+        ]
+      },
+      {
+        "en": "Crimean War",
+        "ja": "クリミア戦争",
+        "ja_typings": [
+          "kurimiasensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00878",
+    "image_path": null,
+    "question_text": {
+      "en": "Which war was triggered by the assassination in Sarajevo?",
+      "ja": "サラエボ事件で勃発した戦争は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "WWI",
+        "ja": "第一次大戦",
+        "ja_typings": [
+          "daiichijitaisen"
+        ]
+      },
+      {
+        "en": "Napoleonic Wars",
+        "ja": "ナポレオン戦争",
+        "ja_typings": [
+          "naporeonsensou"
+        ]
+      },
+      {
+        "en": "Franco-Prussian War",
+        "ja": "普仏戦争",
+        "ja_typings": [
+          "fufutsusensou"
+        ]
+      },
+      {
+        "en": "Crimean War",
+        "ja": "クリミア戦争",
+        "ja_typings": [
+          "kurimiasensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00879",
+    "image_path": null,
+    "question_text": {
+      "en": "Which war ended with the Treaty of Versailles?",
+      "ja": "ベルサイユ条約で終わった戦争は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Treaty of Portsmouth",
+        "ja": "ポーツマス条約",
+        "ja_typings": [
+          "pootsumasujouyaku"
+        ]
+      },
+      {
+        "en": "Treaty of Shimonoseki",
+        "ja": "下関条約",
+        "ja_typings": [
+          "shimonosekijouyaku"
+        ]
+      },
+      {
+        "en": "Treaty of Versailles",
+        "ja": "ベルサイユ条約",
+        "ja_typings": [
+          "berusaiyujouyaku"
+        ]
+      },
+      {
+        "en": "Treaty of Tianjin",
+        "ja": "天津条約",
+        "ja_typings": [
+          "tenshinjouyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00880",
+    "image_path": null,
+    "question_text": {
+      "en": "Which treaty ended the Russo-Japanese War?",
+      "ja": "日露戦争を終結させた条約は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Treaty of Shimonoseki",
+        "ja": "下関条約",
+        "ja_typings": [
+          "shimonosekijouyaku"
+        ]
+      },
+      {
+        "en": "Treaty of Portsmouth",
+        "ja": "ポーツマス条約",
+        "ja_typings": [
+          "pootsumasujouyaku"
+        ]
+      },
+      {
+        "en": "Treaty of Nanking",
+        "ja": "南京条約",
+        "ja_typings": [
+          "nankinjouyaku"
+        ]
+      },
+      {
+        "en": "Boxer Protocol",
+        "ja": "北京議定書",
+        "ja_typings": [
+          "pekingiteisho"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00881",
+    "image_path": null,
+    "question_text": {
+      "en": "Which treaty ended the Sino-Japanese War of 1894-95?",
+      "ja": "日清戦争を終結させた条約は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Inca",
+        "ja": "インカ",
+        "ja_typings": [
+          "inka"
+        ]
+      },
+      {
+        "en": "Maya",
+        "ja": "マヤ",
+        "ja_typings": [
+          "maya"
+        ]
+      },
+      {
+        "en": "Aztec",
+        "ja": "アステカ",
+        "ja_typings": [
+          "asuteka"
+        ]
+      },
+      {
+        "en": "Olmec",
+        "ja": "オルメカ",
+        "ja_typings": [
+          "orumeka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00882",
+    "image_path": null,
+    "question_text": {
+      "en": "Which civilization built Machu Picchu?",
+      "ja": "マチュピチュを築いた文明は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Maya",
+        "ja": "マヤ",
+        "ja_typings": [
+          "maya"
+        ]
+      },
+      {
+        "en": "Aztec",
+        "ja": "アステカ",
+        "ja_typings": [
+          "asuteka"
+        ]
+      },
+      {
+        "en": "Inca",
+        "ja": "インカ",
+        "ja_typings": [
+          "inka"
+        ]
+      },
+      {
+        "en": "Toltec",
+        "ja": "トルテカ",
+        "ja_typings": [
+          "toruteka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00883",
+    "image_path": null,
+    "question_text": {
+      "en": "Which civilization built Chichen Itza?",
+      "ja": "チチェンイツァを築いた文明は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aztec",
+        "ja": "アステカ",
+        "ja_typings": [
+          "asuteka"
+        ]
+      },
+      {
+        "en": "Maya",
+        "ja": "マヤ",
+        "ja_typings": [
+          "maya"
+        ]
+      },
+      {
+        "en": "Inca",
+        "ja": "インカ",
+        "ja_typings": [
+          "inka"
+        ]
+      },
+      {
+        "en": "Olmec",
+        "ja": "オルメカ",
+        "ja_typings": [
+          "orumeka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00884",
+    "image_path": null,
+    "question_text": {
+      "en": "Which civilization was centered at Tenochtitlan?",
+      "ja": "テノチティトランを首都とした文明は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Indus civilization",
+        "ja": "インダス文明",
+        "ja_typings": [
+          "indasubunmei"
+        ]
+      },
+      {
+        "en": "Sumerian",
+        "ja": "シュメール文明",
+        "ja_typings": [
+          "shumeerubunmei"
+        ]
+      },
+      {
+        "en": "Egyptian",
+        "ja": "エジプト文明",
+        "ja_typings": [
+          "ejiputobunmei"
+        ]
+      },
+      {
+        "en": "Chinese",
+        "ja": "黄河文明",
+        "ja_typings": [
+          "kougabunmei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00885",
+    "image_path": null,
+    "question_text": {
+      "en": "Which civilization flourished along the Indus river?",
+      "ja": "インダス川流域で栄えた文明は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ataturk",
+        "ja": "アタチュルク",
+        "ja_typings": [
+          "atachuruku"
+        ]
+      },
+      {
+        "en": "Erdogan",
+        "ja": "エルドアン",
+        "ja_typings": [
+          "erudoan"
+        ]
+      },
+      {
+        "en": "Inonu",
+        "ja": "イノニュ",
+        "ja_typings": [
+          "inonyu"
+        ]
+      },
+      {
+        "en": "Ozal",
+        "ja": "オザル",
+        "ja_typings": [
+          "ozaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00886",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is regarded as the father of modern Turkey?",
+      "ja": "近代トルコの父と呼ばれるのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Storming of the Bastille",
+        "ja": "バスティーユ襲撃",
+        "ja_typings": [
+          "basutiiyuushuugeki"
+        ]
+      },
+      {
+        "en": "Tennis Court Oath",
+        "ja": "テニスコートの誓い",
+        "ja_typings": [
+          "tenisukootonochikai"
+        ]
+      },
+      {
+        "en": "Reign of Terror",
+        "ja": "恐怖政治",
+        "ja_typings": [
+          "kyoufuseiji"
+        ]
+      },
+      {
+        "en": "Thermidorian Reaction",
+        "ja": "テルミドール反動",
+        "ja_typings": [
+          "terumidooruhandou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00887",
+    "image_path": null,
+    "question_text": {
+      "en": "Which event in 1789 began the French Revolution?",
+      "ja": "1789年フランス革命の発端となった事件は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Battle of Waterloo",
+        "ja": "ワーテルローの戦い",
+        "ja_typings": [
+          "waaterurroonotatakai"
+        ]
+      },
+      {
+        "en": "Battle of Trafalgar",
+        "ja": "トラファルガーの戦い",
+        "ja_typings": [
+          "torafarugaanotatakai"
+        ]
+      },
+      {
+        "en": "Battle of Austerlitz",
+        "ja": "アウステルリッツの戦い",
+        "ja_typings": [
+          "ausuterurittsunotatakai"
+        ]
+      },
+      {
+        "en": "Battle of Leipzig",
+        "ja": "ライプチヒの戦い",
+        "ja_typings": [
+          "raipuchihinotatakai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00888",
+    "image_path": null,
+    "question_text": {
+      "en": "Which battle marked Napoleon's final defeat?",
+      "ja": "ナポレオンが最終的に敗れた戦いは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1989",
+        "ja": "1989年",
+        "ja_typings": [
+          "1989nen"
+        ]
+      },
+      {
+        "en": "1991",
+        "ja": "1991年",
+        "ja_typings": [
+          "1991nen"
+        ]
+      },
+      {
+        "en": "1987",
+        "ja": "1987年",
+        "ja_typings": [
+          "1987nen"
+        ]
+      },
+      {
+        "en": "1985",
+        "ja": "1985年",
+        "ja_typings": [
+          "1985nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00889",
+    "image_path": null,
+    "question_text": {
+      "en": "Which year did the Berlin Wall fall?",
+      "ja": "ベルリンの壁が崩壊した年は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1868",
+        "ja": "1868年",
+        "ja_typings": [
+          "1868nen"
+        ]
+      },
+      {
+        "en": "1853",
+        "ja": "1853年",
+        "ja_typings": [
+          "1853nen"
+        ]
+      },
+      {
+        "en": "1871",
+        "ja": "1871年",
+        "ja_typings": [
+          "1871nen"
+        ]
+      },
+      {
+        "en": "1877",
+        "ja": "1877年",
+        "ja_typings": [
+          "1877nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00890",
+    "image_path": null,
+    "question_text": {
+      "en": "Which year did the Meiji era begin?",
+      "ja": "明治時代が始まった年は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Minamoto no Yoritomo",
+        "ja": "源頼朝",
+        "ja_typings": [
+          "minamotonoyoritomo"
+        ]
+      },
+      {
+        "en": "Minamoto no Yoshitsune",
+        "ja": "源義経",
+        "ja_typings": [
+          "minamotonoyoshitsune"
+        ]
+      },
+      {
+        "en": "Taira no Kiyomori",
+        "ja": "平清盛",
+        "ja_typings": [
+          "tairanokiyomori"
+        ]
+      },
+      {
+        "en": "Hojo Tokimasa",
+        "ja": "北条時政",
+        "ja_typings": [
+          "houjoutokimasa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00891",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first shogun of the Kamakura shogunate?",
+      "ja": "鎌倉幕府の初代将軍は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ag",
+        "ja": "Ag",
+        "ja_typings": [
+          "ag"
+        ]
+      },
+      {
+        "en": "Au",
+        "ja": "Au",
+        "ja_typings": [
+          "au"
+        ]
+      },
+      {
+        "en": "Al",
+        "ja": "Al",
+        "ja_typings": [
+          "al"
+        ]
+      },
+      {
+        "en": "As",
+        "ja": "As",
+        "ja_typings": [
+          "as"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00892",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the chemical symbol for silver?",
+      "ja": "銀の元素記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Na",
+        "ja": "Na",
+        "ja_typings": [
+          "na"
+        ]
+      },
+      {
+        "en": "So",
+        "ja": "So",
+        "ja_typings": [
+          "so"
+        ]
+      },
+      {
+        "en": "Sn",
+        "ja": "Sn",
+        "ja_typings": [
+          "sn"
+        ]
+      },
+      {
+        "en": "Ni",
+        "ja": "Ni",
+        "ja_typings": [
+          "ni"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00893",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the chemical symbol for sodium?",
+      "ja": "ナトリウムの元素記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "K",
+        "ja": "K",
+        "ja_typings": [
+          "k"
+        ]
+      },
+      {
+        "en": "P",
+        "ja": "P",
+        "ja_typings": [
+          "p"
+        ]
+      },
+      {
+        "en": "Ca",
+        "ja": "Ca",
+        "ja_typings": [
+          "ca"
+        ]
+      },
+      {
+        "en": "Po",
+        "ja": "Po",
+        "ja_typings": [
+          "po"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00894",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the chemical symbol for potassium?",
+      "ja": "カリウムの元素記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nitrogen",
+        "ja": "窒素",
+        "ja_typings": [
+          "chisso"
+        ]
+      },
+      {
+        "en": "Oxygen",
+        "ja": "酸素",
+        "ja_typings": [
+          "sanso"
+        ]
+      },
+      {
+        "en": "Argon",
+        "ja": "アルゴン",
+        "ja_typings": [
+          "arugon"
+        ]
+      },
+      {
+        "en": "Carbon dioxide",
+        "ja": "二酸化炭素",
+        "ja_typings": [
+          "nisankatanso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00895",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the most abundant gas in Earth's atmosphere?",
+      "ja": "地球大気で最も多い気体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Carbon dioxide",
+        "ja": "二酸化炭素",
+        "ja_typings": [
+          "nisankatanso"
+        ]
+      },
+      {
+        "en": "Methane",
+        "ja": "メタン",
+        "ja_typings": [
+          "metan"
+        ]
+      },
+      {
+        "en": "Ozone",
+        "ja": "オゾン",
+        "ja_typings": [
+          "ozon"
+        ]
+      },
+      {
+        "en": "Argon",
+        "ja": "アルゴン",
+        "ja_typings": [
+          "arugon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00896",
+    "image_path": null,
+    "question_text": {
+      "en": "Which gas is most responsible for the greenhouse effect from human activity?",
+      "ja": "人類活動由来で温室効果に最も寄与する気体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mars",
+        "ja": "火星",
+        "ja_typings": [
+          "kasei"
+        ]
+      },
+      {
+        "en": "Venus",
+        "ja": "金星",
+        "ja_typings": [
+          "kinsei"
+        ]
+      },
+      {
+        "en": "Saturn",
+        "ja": "土星",
+        "ja_typings": [
+          "dosei"
+        ]
+      },
+      {
+        "en": "Neptune",
+        "ja": "海王星",
+        "ja_typings": [
+          "kaiousei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00897",
+    "image_path": null,
+    "question_text": {
+      "en": "What planet is known as the Red Planet?",
+      "ja": "赤い惑星と呼ばれるのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Saturn",
+        "ja": "土星",
+        "ja_typings": [
+          "dosei"
+        ]
+      },
+      {
+        "en": "Uranus",
+        "ja": "天王星",
+        "ja_typings": [
+          "tennousei"
+        ]
+      },
+      {
+        "en": "Neptune",
+        "ja": "海王星",
+        "ja_typings": [
+          "kaiousei"
+        ]
+      },
+      {
+        "en": "Mars",
+        "ja": "火星",
+        "ja_typings": [
+          "kasei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00898",
+    "image_path": null,
+    "question_text": {
+      "en": "Which planet has the most prominent ring system?",
+      "ja": "最も目立つ環を持つ惑星は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Neptune",
+        "ja": "海王星",
+        "ja_typings": [
+          "kaiousei"
+        ]
+      },
+      {
+        "en": "Uranus",
+        "ja": "天王星",
+        "ja_typings": [
+          "tennousei"
+        ]
+      },
+      {
+        "en": "Saturn",
+        "ja": "土星",
+        "ja_typings": [
+          "dosei"
+        ]
+      },
+      {
+        "en": "Jupiter",
+        "ja": "木星",
+        "ja_typings": [
+          "mokusei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00899",
+    "image_path": null,
+    "question_text": {
+      "en": "Which planet is farthest from the Sun (excluding Pluto)?",
+      "ja": "太陽から最も遠い惑星（冥王星除く）は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mitochondria",
+        "ja": "ミトコンドリア",
+        "ja_typings": [
+          "mitokondoria"
+        ]
+      },
+      {
+        "en": "Ribosome",
+        "ja": "リボソーム",
+        "ja_typings": [
+          "riboso-mu"
+        ]
+      },
+      {
+        "en": "Nucleus",
+        "ja": "核",
+        "ja_typings": [
+          "kaku"
+        ]
+      },
+      {
+        "en": "Lysosome",
+        "ja": "リソソーム",
+        "ja_typings": [
+          "risoso-mu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00900",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the powerhouse of the cell?",
+      "ja": "細胞のエネルギー工場と呼ばれる小器官は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Photosynthesis",
+        "ja": "光合成",
+        "ja_typings": [
+          "kougousei"
+        ]
+      },
+      {
+        "en": "Respiration",
+        "ja": "呼吸",
+        "ja_typings": [
+          "kokyuu"
+        ]
+      },
+      {
+        "en": "Transpiration",
+        "ja": "蒸散",
+        "ja_typings": [
+          "jousan"
+        ]
+      },
+      {
+        "en": "Fermentation",
+        "ja": "発酵",
+        "ja_typings": [
+          "hakkou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00901",
+    "image_path": null,
+    "question_text": {
+      "en": "Which process do plants use to make food?",
+      "ja": "植物が栄養を作る働きは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Newton",
+        "ja": "ニュートン",
+        "ja_typings": [
+          "nyu-ton"
+        ]
+      },
+      {
+        "en": "Galileo",
+        "ja": "ガリレオ",
+        "ja_typings": [
+          "garireo"
+        ]
+      },
+      {
+        "en": "Kepler",
+        "ja": "ケプラー",
+        "ja_typings": [
+          "kepura-"
+        ]
+      },
+      {
+        "en": "Einstein",
+        "ja": "アインシュタイン",
+        "ja_typings": [
+          "ainshutain"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00902",
+    "image_path": null,
+    "question_text": {
+      "en": "Who formulated the three laws of motion?",
+      "ja": "運動の三法則を定式化したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Darwin",
+        "ja": "ダーウィン",
+        "ja_typings": [
+          "da-win"
+        ]
+      },
+      {
+        "en": "Mendel",
+        "ja": "メンデル",
+        "ja_typings": [
+          "menderu"
+        ]
+      },
+      {
+        "en": "Lamarck",
+        "ja": "ラマルク",
+        "ja_typings": [
+          "ramaruku"
+        ]
+      },
+      {
+        "en": "Wallace",
+        "ja": "ウォレス",
+        "ja_typings": [
+          "woresu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00903",
+    "image_path": null,
+    "question_text": {
+      "en": "Who proposed the theory of evolution by natural selection?",
+      "ja": "自然選択による進化論を唱えたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mendel",
+        "ja": "メンデル",
+        "ja_typings": [
+          "menderu"
+        ]
+      },
+      {
+        "en": "Darwin",
+        "ja": "ダーウィン",
+        "ja_typings": [
+          "da-win"
+        ]
+      },
+      {
+        "en": "Watson",
+        "ja": "ワトソン",
+        "ja_typings": [
+          "watoson"
+        ]
+      },
+      {
+        "en": "Crick",
+        "ja": "クリック",
+        "ja_typings": [
+          "kurikku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00904",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is regarded as the father of genetics?",
+      "ja": "遺伝学の父と呼ばれるのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Marie Curie",
+        "ja": "マリーキュリー",
+        "ja_typings": [
+          "mari-kyuri-"
+        ]
+      },
+      {
+        "en": "Lise Meitner",
+        "ja": "リーゼマイトナー",
+        "ja_typings": [
+          "ri-zemaitona-"
+        ]
+      },
+      {
+        "en": "Rosalind Franklin",
+        "ja": "フランクリン",
+        "ja_typings": [
+          "furankurin"
+        ]
+      },
+      {
+        "en": "Irene Joliot-Curie",
+        "ja": "ジョリオキュリー",
+        "ja_typings": [
+          "joriokyuri-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00905",
+    "image_path": null,
+    "question_text": {
+      "en": "Who discovered radium together with Pierre Curie?",
+      "ja": "ピエールキュリーと共にラジウムを発見したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Boyle's law",
+        "ja": "ボイルの法則",
+        "ja_typings": [
+          "boirunohousoku"
+        ]
+      },
+      {
+        "en": "Charles's law",
+        "ja": "シャルルの法則",
+        "ja_typings": [
+          "sharurunohousoku"
+        ]
+      },
+      {
+        "en": "Avogadro's law",
+        "ja": "アボガドロの法則",
+        "ja_typings": [
+          "abogadoronohousoku"
+        ]
+      },
+      {
+        "en": "Hooke's law",
+        "ja": "フックの法則",
+        "ja_typings": [
+          "fukkunohousoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00906",
+    "image_path": null,
+    "question_text": {
+      "en": "What law states pressure and volume are inversely related at constant temperature?",
+      "ja": "一定温度で圧力と体積が反比例する法則は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Charles's law",
+        "ja": "シャルルの法則",
+        "ja_typings": [
+          "sharurunohousoku"
+        ]
+      },
+      {
+        "en": "Boyle's law",
+        "ja": "ボイルの法則",
+        "ja_typings": [
+          "boirunohousoku"
+        ]
+      },
+      {
+        "en": "Ohm's law",
+        "ja": "オームの法則",
+        "ja_typings": [
+          "oomunohousoku"
+        ]
+      },
+      {
+        "en": "Hooke's law",
+        "ja": "フックの法則",
+        "ja_typings": [
+          "fukkunohousoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00907",
+    "image_path": null,
+    "question_text": {
+      "en": "What law relates volume and temperature of a gas at constant pressure?",
+      "ja": "一定圧力で気体の体積と温度を関係づける法則は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Acidity",
+        "ja": "酸性度",
+        "ja_typings": [
+          "sanseido"
+        ]
+      },
+      {
+        "en": "Temperature",
+        "ja": "温度",
+        "ja_typings": [
+          "ondo"
+        ]
+      },
+      {
+        "en": "Salinity",
+        "ja": "塩分濃度",
+        "ja_typings": [
+          "enbunnoudo"
+        ]
+      },
+      {
+        "en": "Pressure",
+        "ja": "圧力",
+        "ja_typings": [
+          "atsuryoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00908",
+    "image_path": null,
+    "question_text": {
+      "en": "What does pH measure?",
+      "ja": "pHが測定するのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Diamond",
+        "ja": "ダイヤモンド",
+        "ja_typings": [
+          "daiyamondo"
+        ]
+      },
+      {
+        "en": "Quartz",
+        "ja": "石英",
+        "ja_typings": [
+          "sekiei"
+        ]
+      },
+      {
+        "en": "Corundum",
+        "ja": "コランダム",
+        "ja_typings": [
+          "korandamu"
+        ]
+      },
+      {
+        "en": "Topaz",
+        "ja": "トパーズ",
+        "ja_typings": [
+          "topa-zu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00909",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the hardest natural substance?",
+      "ja": "天然で最も硬い物質は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "O negative",
+        "ja": "O型マイナス",
+        "ja_typings": [
+          "ogatamainasu"
+        ]
+      },
+      {
+        "en": "AB positive",
+        "ja": "AB型プラス",
+        "ja_typings": [
+          "abugatapurasu"
+        ]
+      },
+      {
+        "en": "A positive",
+        "ja": "A型プラス",
+        "ja_typings": [
+          "agatapurasu"
+        ]
+      },
+      {
+        "en": "B negative",
+        "ja": "B型マイナス",
+        "ja_typings": [
+          "bigatamainasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00910",
+    "image_path": null,
+    "question_text": {
+      "en": "What blood type is the universal donor?",
+      "ja": "万能供血者とされる血液型は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pancreas",
+        "ja": "膵臓",
+        "ja_typings": [
+          "suizou"
+        ]
+      },
+      {
+        "en": "Liver",
+        "ja": "肝臓",
+        "ja_typings": [
+          "kanzou"
+        ]
+      },
+      {
+        "en": "Kidney",
+        "ja": "腎臓",
+        "ja_typings": [
+          "jinzou"
+        ]
+      },
+      {
+        "en": "Spleen",
+        "ja": "脾臓",
+        "ja_typings": [
+          "hizou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00911",
+    "image_path": null,
+    "question_text": {
+      "en": "Which organ produces insulin?",
+      "ja": "インスリンを分泌する臓器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Femur",
+        "ja": "大腿骨",
+        "ja_typings": [
+          "daitaikotsu"
+        ]
+      },
+      {
+        "en": "Tibia",
+        "ja": "脛骨",
+        "ja_typings": [
+          "keikotsu"
+        ]
+      },
+      {
+        "en": "Humerus",
+        "ja": "上腕骨",
+        "ja_typings": [
+          "jouwankotsu"
+        ]
+      },
+      {
+        "en": "Fibula",
+        "ja": "腓骨",
+        "ja_typings": [
+          "hikotsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00912",
+    "image_path": null,
+    "question_text": {
+      "en": "Which bone is the longest in the human body?",
+      "ja": "人体で最も長い骨は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Watt",
+        "ja": "ワット",
+        "ja_typings": [
+          "watto"
+        ]
+      },
+      {
+        "en": "Joule",
+        "ja": "ジュール",
+        "ja_typings": [
+          "ju-ru"
+        ]
+      },
+      {
+        "en": "Pascal",
+        "ja": "パスカル",
+        "ja_typings": [
+          "pasukaru"
+        ]
+      },
+      {
+        "en": "Newton",
+        "ja": "ニュートン",
+        "ja_typings": [
+          "nyu-ton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00913",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the speed unit named after a Scottish engineer?",
+      "ja": "スコットランドの技術者にちなんだ仕事率の単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Igneous rock",
+        "ja": "火成岩",
+        "ja_typings": [
+          "kaseigan"
+        ]
+      },
+      {
+        "en": "Sedimentary rock",
+        "ja": "堆積岩",
+        "ja_typings": [
+          "taisekigan"
+        ]
+      },
+      {
+        "en": "Metamorphic rock",
+        "ja": "変成岩",
+        "ja_typings": [
+          "henseigan"
+        ]
+      },
+      {
+        "en": "Limestone",
+        "ja": "石灰岩",
+        "ja_typings": [
+          "sekkaigan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00914",
+    "image_path": null,
+    "question_text": {
+      "en": "What rock type forms from cooled magma?",
+      "ja": "マグマが冷えて固まってできる岩石は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Richter scale",
+        "ja": "リヒタースケール",
+        "ja_typings": [
+          "rihita-suke-ru"
+        ]
+      },
+      {
+        "en": "Mohs scale",
+        "ja": "モース硬度",
+        "ja_typings": [
+          "moosukoudo"
+        ]
+      },
+      {
+        "en": "Beaufort scale",
+        "ja": "ビューフォート風力階級",
+        "ja_typings": [
+          "byuufoortofuuryokukaikyuu"
+        ]
+      },
+      {
+        "en": "Kelvin scale",
+        "ja": "ケルビン温度",
+        "ja_typings": [
+          "kerubinondo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00915",
+    "image_path": null,
+    "question_text": {
+      "en": "Which scale measures earthquake magnitude?",
+      "ja": "地震のマグニチュードを表す尺度は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Flask",
+        "ja": "フラスク",
+        "ja_typings": [
+          "furasuku"
+        ]
+      },
+      {
+        "en": "Django",
+        "ja": "ジャンゴ",
+        "ja_typings": [
+          "jango"
+        ]
+      },
+      {
+        "en": "FastAPI",
+        "ja": "ファストエーピーアイ",
+        "ja_typings": [
+          "fasutoe-pi-ai"
+        ]
+      },
+      {
+        "en": "Tornado",
+        "ja": "トルネード",
+        "ja_typings": [
+          "torune-do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00916",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Python framework is known as a microframework?",
+      "ja": "Python のマイクロフレームワークと呼ばれるのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FastAPI",
+        "ja": "ファストエーピーアイ",
+        "ja_typings": [
+          "fasutoe-pi-ai"
+        ]
+      },
+      {
+        "en": "Flask",
+        "ja": "フラスク",
+        "ja_typings": [
+          "furasuku"
+        ]
+      },
+      {
+        "en": "Django",
+        "ja": "ジャンゴ",
+        "ja_typings": [
+          "jango"
+        ]
+      },
+      {
+        "en": "Pyramid",
+        "ja": "ピラミッド",
+        "ja_typings": [
+          "piramiddo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00917",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Python framework is async-first and based on type hints?",
+      "ja": "型ヒントベースで非同期前提の Python フレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NumPy",
+        "ja": "ナンパイ",
+        "ja_typings": [
+          "nanpai"
+        ]
+      },
+      {
+        "en": "SciPy",
+        "ja": "サイパイ",
+        "ja_typings": [
+          "saipai"
+        ]
+      },
+      {
+        "en": "SymPy",
+        "ja": "シンパイ",
+        "ja_typings": [
+          "shinpai"
+        ]
+      },
+      {
+        "en": "Numba",
+        "ja": "ナンバ",
+        "ja_typings": [
+          "nanba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00918",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Python library is the de facto standard for numerical arrays?",
+      "ja": "Python の数値配列の事実上の標準ライブラリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "pandas",
+        "ja": "パンダス",
+        "ja_typings": [
+          "pandasu"
+        ]
+      },
+      {
+        "en": "polars",
+        "ja": "ポーラーズ",
+        "ja_typings": [
+          "po-ra-zu"
+        ]
+      },
+      {
+        "en": "dask",
+        "ja": "ダスク",
+        "ja_typings": [
+          "dasuku"
+        ]
+      },
+      {
+        "en": "modin",
+        "ja": "モディン",
+        "ja_typings": [
+          "modin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00919",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Python library is the standard for DataFrames?",
+      "ja": "Python のデータフレームの標準ライブラリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PyTorch",
+        "ja": "パイトーチ",
+        "ja_typings": [
+          "paito-chi"
+        ]
+      },
+      {
+        "en": "TensorFlow",
+        "ja": "テンソルフロー",
+        "ja_typings": [
+          "tensorufuro-"
+        ]
+      },
+      {
+        "en": "JAX",
+        "ja": "ジャックス",
+        "ja_typings": [
+          "jakkusu"
+        ]
+      },
+      {
+        "en": "MXNet",
+        "ja": "エムエックスネット",
+        "ja_typings": [
+          "emuekkusunetto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00920",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Python deep learning framework was developed by Meta?",
+      "ja": "Meta が開発した Python の深層学習フレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Django",
+        "ja": "ジャンゴ",
+        "ja_typings": [
+          "jango"
+        ]
+      },
+      {
+        "en": "Flask",
+        "ja": "フラスク",
+        "ja_typings": [
+          "furasuku"
+        ]
+      },
+      {
+        "en": "Bottle",
+        "ja": "ボトル",
+        "ja_typings": [
+          "botoru"
+        ]
+      },
+      {
+        "en": "CherryPy",
+        "ja": "チェリーパイ",
+        "ja_typings": [
+          "cheri-pai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00921",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Python web framework is full-stack and batteries-included?",
+      "ja": "フルスタックでバッテリー同梱型の Python Web フレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "uv",
+        "ja": "ユーブイ",
+        "ja_typings": [
+          "yu-bui"
+        ]
+      },
+      {
+        "en": "poetry",
+        "ja": "ポエトリー",
+        "ja_typings": [
+          "poetori-"
+        ]
+      },
+      {
+        "en": "pipenv",
+        "ja": "ピップエンブ",
+        "ja_typings": [
+          "pippuenbu"
+        ]
+      },
+      {
+        "en": "conda",
+        "ja": "コンダ",
+        "ja_typings": [
+          "konda"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00922",
+    "image_path": null,
+    "question_text": {
+      "en": "Which extremely fast Python package manager is written in Rust?",
+      "ja": "Rust で書かれた高速な Python パッケージマネージャーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ruff",
+        "ja": "ラフ",
+        "ja_typings": [
+          "rafu"
+        ]
+      },
+      {
+        "en": "Black",
+        "ja": "ブラック",
+        "ja_typings": [
+          "burakku"
+        ]
+      },
+      {
+        "en": "Flake8",
+        "ja": "フレイクエイト",
+        "ja_typings": [
+          "fureikueito"
+        ]
+      },
+      {
+        "en": "Pylint",
+        "ja": "パイリント",
+        "ja_typings": [
+          "pairinto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00923",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Python tool combines a fast linter and formatter in Rust?",
+      "ja": "Rust 製の高速な Python のリンター兼フォーマッターは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Clone",
+        "ja": "クローン",
+        "ja_typings": [
+          "kuro-n"
+        ]
+      },
+      {
+        "en": "Copy",
+        "ja": "コピー",
+        "ja_typings": [
+          "kopi-"
+        ]
+      },
+      {
+        "en": "Drop",
+        "ja": "ドロップ",
+        "ja_typings": [
+          "doroppu"
+        ]
+      },
+      {
+        "en": "Move",
+        "ja": "ムーブ",
+        "ja_typings": [
+          "mu-bu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00924",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Rust trait represents types that own a clone operation?",
+      "ja": "複製操作を表す Rust のトレイトは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Copy",
+        "ja": "コピー",
+        "ja_typings": [
+          "kopi-"
+        ]
+      },
+      {
+        "en": "Clone",
+        "ja": "クローン",
+        "ja_typings": [
+          "kuro-n"
+        ]
+      },
+      {
+        "en": "Sized",
+        "ja": "サイズド",
+        "ja_typings": [
+          "saizudo"
+        ]
+      },
+      {
+        "en": "Send",
+        "ja": "センド",
+        "ja_typings": [
+          "sendo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00925",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Rust trait marks types that are bitwise-copyable?",
+      "ja": "ビット単位でコピー可能な型を示す Rust のトレイトは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "format!",
+        "ja": "フォーマット",
+        "ja_typings": [
+          "fo-matto"
+        ]
+      },
+      {
+        "en": "println!",
+        "ja": "プリントエルエヌ",
+        "ja_typings": [
+          "purintoeruenu"
+        ]
+      },
+      {
+        "en": "write!",
+        "ja": "ライト",
+        "ja_typings": [
+          "raito"
+        ]
+      },
+      {
+        "en": "eprintln!",
+        "ja": "イープリントエルエヌ",
+        "ja_typings": [
+          "i-purintoeruenu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00926",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Rust macro formats a string without printing it?",
+      "ja": "出力せずに文字列を整形する Rust のマクロは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "derive",
+        "ja": "デライブ",
+        "ja_typings": [
+          "deraibu"
+        ]
+      },
+      {
+        "en": "inline",
+        "ja": "インライン",
+        "ja_typings": [
+          "inrain"
+        ]
+      },
+      {
+        "en": "repr",
+        "ja": "リプル",
+        "ja_typings": [
+          "ripuru"
+        ]
+      },
+      {
+        "en": "cfg",
+        "ja": "シーエフジー",
+        "ja_typings": [
+          "shi-efuji-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00927",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Rust attribute auto-implements common traits?",
+      "ja": "一般的なトレイトを自動実装する Rust の属性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "tokio",
+        "ja": "トーキオ",
+        "ja_typings": [
+          "to-kio"
+        ]
+      },
+      {
+        "en": "smol",
+        "ja": "スモル",
+        "ja_typings": [
+          "sumoru"
+        ]
+      },
+      {
+        "en": "async-std",
+        "ja": "エイシンクエスティーディー",
+        "ja_typings": [
+          "eishinkuesuti-di-"
+        ]
+      },
+      {
+        "en": "glommio",
+        "ja": "グロミオ",
+        "ja_typings": [
+          "guromio"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00928",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Rust async runtime is most widely used?",
+      "ja": "Rust で最も広く使われている非同期ランタイムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "axum",
+        "ja": "アクサム",
+        "ja_typings": [
+          "akusamu"
+        ]
+      },
+      {
+        "en": "actix-web",
+        "ja": "アクティクスウェブ",
+        "ja_typings": [
+          "akutikusuwebu"
+        ]
+      },
+      {
+        "en": "rocket",
+        "ja": "ロケット",
+        "ja_typings": [
+          "roketto"
+        ]
+      },
+      {
+        "en": "warp",
+        "ja": "ワープ",
+        "ja_typings": [
+          "wa-pu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00929",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Rust web framework is built on top of tokio and hyper?",
+      "ja": "tokio と hyper の上に構築された Rust の Web フレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Deno",
+        "ja": "デノ",
+        "ja_typings": [
+          "deno"
+        ]
+      },
+      {
+        "en": "Bun",
+        "ja": "バン",
+        "ja_typings": [
+          "ban"
+        ]
+      },
+      {
+        "en": "Node.js",
+        "ja": "ノードジェイエス",
+        "ja_typings": [
+          "no-dojeiesu"
+        ]
+      },
+      {
+        "en": "Workers",
+        "ja": "ワーカーズ",
+        "ja_typings": [
+          "wa-ka-zu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00930",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript runtime was created by Ryan Dahl after Node.js?",
+      "ja": "Ryan Dahl が Node.js の後に作った JavaScript ランタイムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bun",
+        "ja": "バン",
+        "ja_typings": [
+          "ban"
+        ]
+      },
+      {
+        "en": "Deno",
+        "ja": "デノ",
+        "ja_typings": [
+          "deno"
+        ]
+      },
+      {
+        "en": "Node.js",
+        "ja": "ノードジェイエス",
+        "ja_typings": [
+          "no-dojeiesu"
+        ]
+      },
+      {
+        "en": "QuickJS",
+        "ja": "クイックジェイエス",
+        "ja_typings": [
+          "kuikkujeiesu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00931",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript runtime is written in Zig and focuses on speed?",
+      "ja": "Zig で書かれた高速志向の JavaScript ランタイムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Microsoft",
+        "ja": "マイクロソフト",
+        "ja_typings": [
+          "maikurosofuto"
+        ]
+      },
+      {
+        "en": "Google",
+        "ja": "グーグル",
+        "ja_typings": [
+          "gu-guru"
+        ]
+      },
+      {
+        "en": "Meta",
+        "ja": "メタ",
+        "ja_typings": [
+          "meta"
+        ]
+      },
+      {
+        "en": "Apple",
+        "ja": "アップル",
+        "ja_typings": [
+          "appuru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00932",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed TypeScript?",
+      "ja": "TypeScript を開発した企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "esbuild",
+        "ja": "イーエスビルド",
+        "ja_typings": [
+          "i-esubirudo"
+        ]
+      },
+      {
+        "en": "Webpack",
+        "ja": "ウェブパック",
+        "ja_typings": [
+          "webupakku"
+        ]
+      },
+      {
+        "en": "Rollup",
+        "ja": "ロールアップ",
+        "ja_typings": [
+          "ro-ruappu"
+        ]
+      },
+      {
+        "en": "Parcel",
+        "ja": "パーセル",
+        "ja_typings": [
+          "pa-seru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00933",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript bundler is known for zero-config and being extremely fast?",
+      "ja": "ゼロ設定で高速な JavaScript バンドラーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vite",
+        "ja": "ヴィート",
+        "ja_typings": [
+          "vi-to"
+        ]
+      },
+      {
+        "en": "Snowpack",
+        "ja": "スノーパック",
+        "ja_typings": [
+          "suno-pakku"
+        ]
+      },
+      {
+        "en": "Webpack",
+        "ja": "ウェブパック",
+        "ja_typings": [
+          "webupakku"
+        ]
+      },
+      {
+        "en": "Browserify",
+        "ja": "ブラウザリファイ",
+        "ja_typings": [
+          "burauzarifai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00934",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript dev server is built on top of esbuild and Rollup by Evan You?",
+      "ja": "Evan You が作った esbuild と Rollup ベースの開発サーバーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vitest",
+        "ja": "ヴァイテスト",
+        "ja_typings": [
+          "vaitesuto"
+        ]
+      },
+      {
+        "en": "Mocha",
+        "ja": "モカ",
+        "ja_typings": [
+          "moka"
+        ]
+      },
+      {
+        "en": "Jasmine",
+        "ja": "ジャスミン",
+        "ja_typings": [
+          "jasumin"
+        ]
+      },
+      {
+        "en": "AVA",
+        "ja": "エイバ",
+        "ja_typings": [
+          "eiba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00935",
+    "image_path": null,
+    "question_text": {
+      "en": "Which test runner ships with Jest-compatible API and is by Vite team?",
+      "ja": "Vite チームの Jest 互換テストランナーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Elixir",
+        "ja": "エリクサー",
+        "ja_typings": [
+          "erikusa-"
+        ]
+      },
+      {
+        "en": "Clojure",
+        "ja": "クロージャ",
+        "ja_typings": [
+          "kuro-ja"
+        ]
+      },
+      {
+        "en": "Scala",
+        "ja": "スカラ",
+        "ja_typings": [
+          "sukara"
+        ]
+      },
+      {
+        "en": "F#",
+        "ja": "エフシャープ",
+        "ja_typings": [
+          "efusha-pu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00936",
+    "image_path": null,
+    "question_text": {
+      "en": "Which functional language runs on the BEAM VM and is Erlang-based?",
+      "ja": "BEAM 仮想マシン上で動く Erlang 系の関数型言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Clojure",
+        "ja": "クロージャ",
+        "ja_typings": [
+          "kuro-ja"
+        ]
+      },
+      {
+        "en": "Scala",
+        "ja": "スカラ",
+        "ja_typings": [
+          "sukara"
+        ]
+      },
+      {
+        "en": "Groovy",
+        "ja": "グルービー",
+        "ja_typings": [
+          "guru-bi-"
+        ]
+      },
+      {
+        "en": "Kotlin",
+        "ja": "コトリン",
+        "ja_typings": [
+          "kotorin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00937",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JVM language emphasizes immutability and is a Lisp dialect?",
+      "ja": "不変性重視で Lisp 方言の JVM 言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kotlin",
+        "ja": "コトリン",
+        "ja_typings": [
+          "kotorin"
+        ]
+      },
+      {
+        "en": "Java",
+        "ja": "ジャバ",
+        "ja_typings": [
+          "jaba"
+        ]
+      },
+      {
+        "en": "Dart",
+        "ja": "ダート",
+        "ja_typings": [
+          "da-to"
+        ]
+      },
+      {
+        "en": "Swift",
+        "ja": "スウィフト",
+        "ja_typings": [
+          "suwifuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00938",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language is the official language for Android development today?",
+      "ja": "現在の Android 開発の公式言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dart",
+        "ja": "ダート",
+        "ja_typings": [
+          "da-to"
+        ]
+      },
+      {
+        "en": "Kotlin",
+        "ja": "コトリン",
+        "ja_typings": [
+          "kotorin"
+        ]
+      },
+      {
+        "en": "Swift",
+        "ja": "スウィフト",
+        "ja_typings": [
+          "suwifuto"
+        ]
+      },
+      {
+        "en": "TypeScript",
+        "ja": "タイプスクリプト",
+        "ja_typings": [
+          "taipusukuriputo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00939",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language powers the Flutter framework?",
+      "ja": "Flutter フレームワークの言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lua",
+        "ja": "ルア",
+        "ja_typings": [
+          "rua"
+        ]
+      },
+      {
+        "en": "Tcl",
+        "ja": "ティーシーエル",
+        "ja_typings": [
+          "ti-shi-eru"
+        ]
+      },
+      {
+        "en": "Squirrel",
+        "ja": "スクィレル",
+        "ja_typings": [
+          "sukuireru"
+        ]
+      },
+      {
+        "en": "AngelScript",
+        "ja": "エンジェルスクリプト",
+        "ja_typings": [
+          "enjerusukuriputo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00940",
+    "image_path": null,
+    "question_text": {
+      "en": "Which scripting language is embedded in many games and apps?",
+      "ja": "ゲームやアプリに組み込まれることが多いスクリプト言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "F#",
+        "ja": "エフシャープ",
+        "ja_typings": [
+          "efusha-pu"
+        ]
+      },
+      {
+        "en": "OCaml",
+        "ja": "オーキャムル",
+        "ja_typings": [
+          "o-kyamuru"
+        ]
+      },
+      {
+        "en": "Haskell",
+        "ja": "ハスケル",
+        "ja_typings": [
+          "hasukeru"
+        ]
+      },
+      {
+        "en": "Elm",
+        "ja": "エルム",
+        "ja_typings": [
+          "erumu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00941",
+    "image_path": null,
+    "question_text": {
+      "en": "Which statically typed functional language is from Microsoft Research?",
+      "ja": "Microsoft Research 発の静的型付け関数型言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Swift",
+        "ja": "スウィフト",
+        "ja_typings": [
+          "suwifuto"
+        ]
+      },
+      {
+        "en": "Kotlin",
+        "ja": "コトリン",
+        "ja_typings": [
+          "kotorin"
+        ]
+      },
+      {
+        "en": "Rust",
+        "ja": "ラスト",
+        "ja_typings": [
+          "rasuto"
+        ]
+      },
+      {
+        "en": "Go",
+        "ja": "ゴー",
+        "ja_typings": [
+          "go-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00942",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language is the spiritual successor to Objective-C on Apple platforms?",
+      "ja": "Apple プラットフォームでの Objective-C の後継言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rust",
+        "ja": "ラスト",
+        "ja_typings": [
+          "rasuto"
+        ]
+      },
+      {
+        "en": "Go",
+        "ja": "ゴー",
+        "ja_typings": [
+          "go-"
+        ]
+      },
+      {
+        "en": "Zig",
+        "ja": "ジグ",
+        "ja_typings": [
+          "jigu"
+        ]
+      },
+      {
+        "en": "Nim",
+        "ja": "ニム",
+        "ja_typings": [
+          "nimu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00943",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language was created at Mozilla for systems programming?",
+      "ja": "Mozilla がシステムプログラミング向けに作った言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Zig",
+        "ja": "ジグ",
+        "ja_typings": [
+          "jigu"
+        ]
+      },
+      {
+        "en": "Rust",
+        "ja": "ラスト",
+        "ja_typings": [
+          "rasuto"
+        ]
+      },
+      {
+        "en": "D",
+        "ja": "ディー",
+        "ja_typings": [
+          "di-"
+        ]
+      },
+      {
+        "en": "Nim",
+        "ja": "ニム",
+        "ja_typings": [
+          "nimu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00944",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language emphasizes manual memory management as a C replacement?",
+      "ja": "C の代替を意識した手動メモリ管理重視の言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Merge sort",
+        "ja": "マージソート",
+        "ja_typings": [
+          "ma-jiso-to"
+        ]
+      },
+      {
+        "en": "Quicksort",
+        "ja": "クイックソート",
+        "ja_typings": [
+          "kuikkuso-to"
+        ]
+      },
+      {
+        "en": "Heapsort",
+        "ja": "ヒープソート",
+        "ja_typings": [
+          "hi-puso-to"
+        ]
+      },
+      {
+        "en": "Bubble sort",
+        "ja": "バブルソート",
+        "ja_typings": [
+          "baburuso-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00945",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sorting algorithm is stable and runs in O(n log n) worst case?",
+      "ja": "最悪 O(n log n) で安定なソートアルゴリズムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Heap",
+        "ja": "ヒープ",
+        "ja_typings": [
+          "hi-pu"
+        ]
+      },
+      {
+        "en": "Stack",
+        "ja": "スタック",
+        "ja_typings": [
+          "sutakku"
+        ]
+      },
+      {
+        "en": "Linked list",
+        "ja": "連結リスト",
+        "ja_typings": [
+          "renketsurisuto"
+        ]
+      },
+      {
+        "en": "Hash table",
+        "ja": "ハッシュテーブル",
+        "ja_typings": [
+          "hasshute-buru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00946",
+    "image_path": null,
+    "question_text": {
+      "en": "Which data structure is best suited for implementing priority queues?",
+      "ja": "プライオリティキューに最適なデータ構造は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Trie",
+        "ja": "トライ",
+        "ja_typings": [
+          "torai"
+        ]
+      },
+      {
+        "en": "Heap",
+        "ja": "ヒープ",
+        "ja_typings": [
+          "hi-pu"
+        ]
+      },
+      {
+        "en": "B-tree",
+        "ja": "ビーツリー",
+        "ja_typings": [
+          "bi-tsuri-"
+        ]
+      },
+      {
+        "en": "Skip list",
+        "ja": "スキップリスト",
+        "ja_typings": [
+          "sukippurisuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00947",
+    "image_path": null,
+    "question_text": {
+      "en": "Which data structure provides efficient prefix string search?",
+      "ja": "プレフィックス検索に効率的なデータ構造は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "In-order",
+        "ja": "インオーダー",
+        "ja_typings": [
+          "inno-da-"
+        ]
+      },
+      {
+        "en": "Pre-order",
+        "ja": "プリオーダー",
+        "ja_typings": [
+          "purio-da-"
+        ]
+      },
+      {
+        "en": "Post-order",
+        "ja": "ポストオーダー",
+        "ja_typings": [
+          "posuto-da-",
+          "posutoo-da-"
+        ]
+      },
+      {
+        "en": "Level-order",
+        "ja": "レベルオーダー",
+        "ja_typings": [
+          "reberuo-da-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00948",
+    "image_path": null,
+    "question_text": {
+      "en": "Which traversal visits a binary tree in left-root-right order?",
+      "ja": "二分木を左-根-右の順で巡回するのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Floyd-Warshall",
+        "ja": "フロイドワーシャル",
+        "ja_typings": [
+          "furoidowa-sharu"
+        ]
+      },
+      {
+        "en": "Dijkstra",
+        "ja": "ダイクストラ",
+        "ja_typings": [
+          "daikusutora"
+        ]
+      },
+      {
+        "en": "Bellman-Ford",
+        "ja": "ベルマンフォード",
+        "ja_typings": [
+          "berumanfo-do"
+        ]
+      },
+      {
+        "en": "A-star",
+        "ja": "エースター",
+        "ja_typings": [
+          "e-suta-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00949",
+    "image_path": null,
+    "question_text": {
+      "en": "Which algorithm finds shortest paths from all sources to all destinations?",
+      "ja": "全頂点対の最短経路を求めるアルゴリズムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dynamic programming",
+        "ja": "動的計画法",
+        "ja_typings": [
+          "doutekikeikakuhou"
+        ]
+      },
+      {
+        "en": "Greedy",
+        "ja": "貪欲法",
+        "ja_typings": [
+          "donyokuhou"
+        ]
+      },
+      {
+        "en": "Backtracking",
+        "ja": "バックトラッキング",
+        "ja_typings": [
+          "bakkutorakkingu"
+        ]
+      },
+      {
+        "en": "Brute force",
+        "ja": "総当たり",
+        "ja_typings": [
+          "souatari"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00950",
+    "image_path": null,
+    "question_text": {
+      "en": "Which technique solves problems by combining solutions to subproblems?",
+      "ja": "部分問題の解を結合して解くアルゴリズム技法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Functional programming",
+        "ja": "関数型プログラミング",
+        "ja_typings": [
+          "kansuugatapuroguramingu"
+        ]
+      },
+      {
+        "en": "Imperative",
+        "ja": "命令型",
+        "ja_typings": [
+          "meireigata"
+        ]
+      },
+      {
+        "en": "Procedural",
+        "ja": "手続き型",
+        "ja_typings": [
+          "tetsuzukigata"
+        ]
+      },
+      {
+        "en": "Logic",
+        "ja": "論理型",
+        "ja_typings": [
+          "ronrigata"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00951",
+    "image_path": null,
+    "question_text": {
+      "en": "Which paradigm builds programs by composing pure functions?",
+      "ja": "純粋関数の合成でプログラムを構成するパラダイムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Docker image",
+        "ja": "ドッカーイメージ",
+        "ja_typings": [
+          "dokka-ime-ji"
+        ]
+      },
+      {
+        "en": "Vagrant box",
+        "ja": "ベイグラントボックス",
+        "ja_typings": [
+          "beigurantobokkusu"
+        ]
+      },
+      {
+        "en": "AMI",
+        "ja": "エーエムアイ",
+        "ja_typings": [
+          "e-emuai"
+        ]
+      },
+      {
+        "en": "LXD image",
+        "ja": "エルエックスディーイメージ",
+        "ja_typings": [
+          "eruekkusudi-ime-ji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00952",
+    "image_path": null,
+    "question_text": {
+      "en": "Which container image format is the OCI industry standard?",
+      "ja": "OCI 業界標準のコンテナイメージ形式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "curl",
+        "ja": "カール",
+        "ja_typings": [
+          "ka-ru"
+        ]
+      },
+      {
+        "en": "wget",
+        "ja": "ダブルゲット",
+        "ja_typings": [
+          "daburugetto"
+        ]
+      },
+      {
+        "en": "httpie",
+        "ja": "エイチティーティーピーアイイー",
+        "ja_typings": [
+          "eichiti-ti-pi-aii-"
+        ]
+      },
+      {
+        "en": "aria2",
+        "ja": "アリアツー",
+        "ja_typings": [
+          "ariatsu-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00953",
+    "image_path": null,
+    "question_text": {
+      "en": "Which command-line tool is the standard for HTTP transfers in scripts?",
+      "ja": "スクリプトで HTTP 通信を行う標準的な CLI ツールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Subversion",
+        "ja": "サブバージョン",
+        "ja_typings": [
+          "sabuba-jon"
+        ]
+      },
+      {
+        "en": "Git",
+        "ja": "ギット",
+        "ja_typings": [
+          "gitto"
+        ]
+      },
+      {
+        "en": "Mercurial",
+        "ja": "マーキュリアル",
+        "ja_typings": [
+          "ma-kyuriaru"
+        ]
+      },
+      {
+        "en": "Bazaar",
+        "ja": "バザール",
+        "ja_typings": [
+          "baza-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00954",
+    "image_path": null,
+    "question_text": {
+      "en": "Which version control system is centralized rather than distributed?",
+      "ja": "分散型ではなく集中型のバージョン管理システムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "GitHub Actions",
+        "ja": "ギットハブアクションズ",
+        "ja_typings": [
+          "gittohabuakushonzu"
+        ]
+      },
+      {
+        "en": "CircleCI",
+        "ja": "サークルシーアイ",
+        "ja_typings": [
+          "sa-kurushi-ai"
+        ]
+      },
+      {
+        "en": "Travis CI",
+        "ja": "トラビスシーアイ",
+        "ja_typings": [
+          "torabisushi-ai"
+        ]
+      },
+      {
+        "en": "Jenkins",
+        "ja": "ジェンキンス",
+        "ja_typings": [
+          "jenkinsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00955",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CI service is built into GitHub itself?",
+      "ja": "GitHub に組み込まれている CI サービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Markdown",
+        "ja": "マークダウン",
+        "ja_typings": [
+          "ma-kudaun"
+        ]
+      },
+      {
+        "en": "reStructuredText",
+        "ja": "アールエスティー",
+        "ja_typings": [
+          "a-ruesuti-"
+        ]
+      },
+      {
+        "en": "AsciiDoc",
+        "ja": "アスキードック",
+        "ja_typings": [
+          "asuki-dokku"
+        ]
+      },
+      {
+        "en": "Textile",
+        "ja": "テクスタイル",
+        "ja_typings": [
+          "tekusutairu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00956",
+    "image_path": null,
+    "question_text": {
+      "en": "Which markup language is commonly used for README files on GitHub?",
+      "ja": "GitHub の README で使われるマークアップは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "TOML",
+        "ja": "トムル",
+        "ja_typings": [
+          "tomuru"
+        ]
+      },
+      {
+        "en": "YAML",
+        "ja": "ヤムル",
+        "ja_typings": [
+          "yamuru"
+        ]
+      },
+      {
+        "en": "XML",
+        "ja": "エックスエムエル",
+        "ja_typings": [
+          "ekkusuemueru"
+        ]
+      },
+      {
+        "en": "INI",
+        "ja": "アイエヌアイ",
+        "ja_typings": [
+          "aienuai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00957",
+    "image_path": null,
+    "question_text": {
+      "en": "Which serialization format is line-oriented and key-value-like for configs?",
+      "ja": "設定用のキーバリュー型シリアライズ形式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "YAML",
+        "ja": "ヤムル",
+        "ja_typings": [
+          "yamuru"
+        ]
+      },
+      {
+        "en": "TOML",
+        "ja": "トムル",
+        "ja_typings": [
+          "tomuru"
+        ]
+      },
+      {
+        "en": "JSON",
+        "ja": "ジェイソン",
+        "ja_typings": [
+          "jeison"
+        ]
+      },
+      {
+        "en": "XML",
+        "ja": "エックスエムエル",
+        "ja_typings": [
+          "ekkusuemueru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00958",
+    "image_path": null,
+    "question_text": {
+      "en": "Which data format is whitespace-significant and widely used in CI configs?",
+      "ja": "インデントに意味があり CI 設定で多用されるデータ形式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Niklaus Wirth",
+        "ja": "ニクラウス・ヴィルト",
+        "ja_typings": [
+          "nikurausu/viruto"
+        ]
+      },
+      {
+        "en": "Anders Hejlsberg",
+        "ja": "アンダース・ヘルスバーグ",
+        "ja_typings": [
+          "anda-su/herusuba-gu"
+        ]
+      },
+      {
+        "en": "Donald Knuth",
+        "ja": "ドナルド・クヌース",
+        "ja_typings": [
+          "donarudo/kunu-su"
+        ]
+      },
+      {
+        "en": "Edsger Dijkstra",
+        "ja": "エドガー・ダイクストラ",
+        "ja_typings": [
+          "edoga-/daikusutora"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00959",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created the Pascal language and Turbo Pascal?",
+      "ja": "Pascal と Turbo Pascal を作ったのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Anders Hejlsberg",
+        "ja": "アンダース・ヘルスバーグ",
+        "ja_typings": [
+          "anda-su/herusuba-gu"
+        ]
+      },
+      {
+        "en": "Brendan Eich",
+        "ja": "ブレンダン・アイク",
+        "ja_typings": [
+          "burendan/aiku"
+        ]
+      },
+      {
+        "en": "Bjarne Stroustrup",
+        "ja": "ビャーネ・ストロヴストルップ",
+        "ja_typings": [
+          "bya-ne/sutorovusutoruppu"
+        ]
+      },
+      {
+        "en": "James Gosling",
+        "ja": "ジェームズ・ゴスリン",
+        "ja_typings": [
+          "je-muzu/gosurin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00960",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the lead architect of TypeScript and C#?",
+      "ja": "TypeScript と C# の主任設計者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "James Gosling",
+        "ja": "ジェームズ・ゴスリン",
+        "ja_typings": [
+          "je-muzu/gosurin"
+        ]
+      },
+      {
+        "en": "Guido van Rossum",
+        "ja": "グイド・ヴァン・ロッサム",
+        "ja_typings": [
+          "guido/van/rossamu"
+        ]
+      },
+      {
+        "en": "Bjarne Stroustrup",
+        "ja": "ビャーネ・ストロヴストルップ",
+        "ja_typings": [
+          "bya-ne/sutorovusutoruppu"
+        ]
+      },
+      {
+        "en": "Ken Thompson",
+        "ja": "ケン・トンプソン",
+        "ja_typings": [
+          "ken/tonpuson"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00961",
+    "image_path": null,
+    "question_text": {
+      "en": "Who designed the Java language?",
+      "ja": "Java 言語を設計したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Donald Knuth",
+        "ja": "ドナルド・クヌース",
+        "ja_typings": [
+          "donarudo/kunu-su"
+        ]
+      },
+      {
+        "en": "Edsger Dijkstra",
+        "ja": "エドガー・ダイクストラ",
+        "ja_typings": [
+          "edoga-/daikusutora"
+        ]
+      },
+      {
+        "en": "Tony Hoare",
+        "ja": "トニー・ホーア",
+        "ja_typings": [
+          "toni-/ho-a"
+        ]
+      },
+      {
+        "en": "John McCarthy",
+        "ja": "ジョン・マッカーシー",
+        "ja_typings": [
+          "jon/makka-shi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00962",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is famous for The Art of Computer Programming and TeX?",
+      "ja": "The Art of Computer Programming と TeX で有名な人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "John McCarthy",
+        "ja": "ジョン・マッカーシー",
+        "ja_typings": [
+          "jon/makka-shi-"
+        ]
+      },
+      {
+        "en": "Alan Kay",
+        "ja": "アラン・ケイ",
+        "ja_typings": [
+          "aran/kei"
+        ]
+      },
+      {
+        "en": "Grace Hopper",
+        "ja": "グレース・ホッパー",
+        "ja_typings": [
+          "gure-su/hoppa-"
+        ]
+      },
+      {
+        "en": "Niklaus Wirth",
+        "ja": "ニクラウス・ヴィルト",
+        "ja_typings": [
+          "nikurausu/viruto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00963",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is credited with creating Lisp?",
+      "ja": "Lisp を生み出した人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Alan Kay",
+        "ja": "アラン・ケイ",
+        "ja_typings": [
+          "aran/kei"
+        ]
+      },
+      {
+        "en": "Bjarne Stroustrup",
+        "ja": "ビャーネ・ストロヴストルップ",
+        "ja_typings": [
+          "bya-ne/sutorovusutoruppu"
+        ]
+      },
+      {
+        "en": "Grady Booch",
+        "ja": "グラディ・ブーチ",
+        "ja_typings": [
+          "guradi/bu-chi"
+        ]
+      },
+      {
+        "en": "James Gosling",
+        "ja": "ジェームズ・ゴスリン",
+        "ja_typings": [
+          "je-muzu/gosurin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00964",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is credited with creating Smalltalk and coining 'object-oriented'?",
+      "ja": "Smalltalk を作りオブジェクト指向の語を定着させたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Isolation",
+        "ja": "独立性",
+        "ja_typings": [
+          "dokuritsusei"
+        ]
+      },
+      {
+        "en": "Atomicity",
+        "ja": "原子性",
+        "ja_typings": [
+          "genshisei"
+        ]
+      },
+      {
+        "en": "Consistency",
+        "ja": "一貫性",
+        "ja_typings": [
+          "ikkansei"
+        ]
+      },
+      {
+        "en": "Durability",
+        "ja": "永続性",
+        "ja_typings": [
+          "eizokusei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00965",
+    "image_path": null,
+    "question_text": {
+      "en": "What does ACID stand for in database transactions?",
+      "ja": "データベースの ACID 特性のうち独立性を示すのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Declarative",
+        "ja": "宣言型",
+        "ja_typings": [
+          "sengengata"
+        ]
+      },
+      {
+        "en": "Imperative",
+        "ja": "命令型",
+        "ja_typings": [
+          "meireigata"
+        ]
+      },
+      {
+        "en": "Procedural",
+        "ja": "手続き型",
+        "ja_typings": [
+          "tetsuzukigata"
+        ]
+      },
+      {
+        "en": "Object-oriented",
+        "ja": "オブジェクト指向",
+        "ja_typings": [
+          "obujekutoshikou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00966",
+    "image_path": null,
+    "question_text": {
+      "en": "Which paradigm focuses on what to compute, not how?",
+      "ja": "「何を計算するか」を記述するパラダイムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Test-driven development",
+        "ja": "テスト駆動開発",
+        "ja_typings": [
+          "tesutokudoukaihatsu"
+        ]
+      },
+      {
+        "en": "Behavior-driven development",
+        "ja": "振る舞い駆動開発",
+        "ja_typings": [
+          "furumaikudoukaihatsu"
+        ]
+      },
+      {
+        "en": "Pair programming",
+        "ja": "ペアプログラミング",
+        "ja_typings": [
+          "peapuroguramingu"
+        ]
+      },
+      {
+        "en": "Continuous integration",
+        "ja": "継続的インテグレーション",
+        "ja_typings": [
+          "keizokutekiintegure-shon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q00967",
+    "image_path": null,
+    "question_text": {
+      "en": "Which testing approach writes tests before implementation?",
+      "ja": "実装前にテストを書く開発手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<article>`",
+        "ja": "アーティクル",
+        "ja_typings": [
+          "a-tikuru"
+        ]
+      },
+      {
+        "en": "`<section>`",
+        "ja": "セクション",
+        "ja_typings": [
+          "sekushon"
+        ]
+      },
+      {
+        "en": "`<aside>`",
+        "ja": "アサイド",
+        "ja_typings": [
+          "asaido"
+        ]
+      },
+      {
+        "en": "`<main>`",
+        "ja": "メイン",
+        "ja_typings": [
+          "mein"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00968",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML5 tag represents a self-contained article?",
+      "ja": "自己完結した記事を表す HTML5 タグは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<section>`",
+        "ja": "セクション",
+        "ja_typings": [
+          "sekushon"
+        ]
+      },
+      {
+        "en": "`<article>`",
+        "ja": "アーティクル",
+        "ja_typings": [
+          "a-tikuru"
+        ]
+      },
+      {
+        "en": "`<div>`",
+        "ja": "ディブ",
+        "ja_typings": [
+          "dibu"
+        ]
+      },
+      {
+        "en": "`<aside>`",
+        "ja": "アサイド",
+        "ja_typings": [
+          "asaido"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00969",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML5 tag groups thematically related content?",
+      "ja": "テーマで関連する内容をまとめる HTML5 タグは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<aside>`",
+        "ja": "アサイド",
+        "ja_typings": [
+          "asaido"
+        ]
+      },
+      {
+        "en": "`<footer>`",
+        "ja": "フッター",
+        "ja_typings": [
+          "futta-"
+        ]
+      },
+      {
+        "en": "`<header>`",
+        "ja": "ヘッダー",
+        "ja_typings": [
+          "hedda-"
+        ]
+      },
+      {
+        "en": "`<nav>`",
+        "ja": "ナブ",
+        "ja_typings": [
+          "nabu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00970",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML5 tag represents tangentially related content like a sidebar?",
+      "ja": "サイドバー等の補足的内容を表す HTML5 タグは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<svg>`",
+        "ja": "エスブイジー",
+        "ja_typings": [
+          "esubuiji-"
+        ]
+      },
+      {
+        "en": "`<canvas>`",
+        "ja": "キャンバス",
+        "ja_typings": [
+          "kyanbasu"
+        ]
+      },
+      {
+        "en": "`<picture>`",
+        "ja": "ピクチャー",
+        "ja_typings": [
+          "pikucha-"
+        ]
+      },
+      {
+        "en": "`<object>`",
+        "ja": "オブジェクト",
+        "ja_typings": [
+          "obujekuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00971",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML element is used to embed scalable vector graphics?",
+      "ja": "ベクター画像を埋め込む HTML 要素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<canvas>`",
+        "ja": "キャンバス",
+        "ja_typings": [
+          "kyanbasu"
+        ]
+      },
+      {
+        "en": "`<svg>`",
+        "ja": "エスブイジー",
+        "ja_typings": [
+          "esubuiji-"
+        ]
+      },
+      {
+        "en": "`<picture>`",
+        "ja": "ピクチャー",
+        "ja_typings": [
+          "pikucha-"
+        ]
+      },
+      {
+        "en": "`<figure>`",
+        "ja": "フィギュア",
+        "ja_typings": [
+          "figyua"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00972",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML element provides scriptable bitmap drawing?",
+      "ja": "スクリプトでビットマップ描画できる HTML 要素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`list`",
+        "ja": "リスト",
+        "ja_typings": [
+          "risuto"
+        ]
+      },
+      {
+        "en": "`select`",
+        "ja": "セレクト",
+        "ja_typings": [
+          "serekuto"
+        ]
+      },
+      {
+        "en": "`options`",
+        "ja": "オプションズ",
+        "ja_typings": [
+          "opushonzu"
+        ]
+      },
+      {
+        "en": "`combo`",
+        "ja": "コンボ",
+        "ja_typings": [
+          "konbo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00973",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML attribute enables a drop-down list bound to an input?",
+      "ja": "input に紐づく候補リストを実現する HTML 属性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`color`",
+        "ja": "カラー",
+        "ja_typings": [
+          "kara-"
+        ]
+      },
+      {
+        "en": "`picker`",
+        "ja": "ピッカー",
+        "ja_typings": [
+          "pikka-"
+        ]
+      },
+      {
+        "en": "`hex`",
+        "ja": "ヘックス",
+        "ja_typings": [
+          "hekkusu"
+        ]
+      },
+      {
+        "en": "`palette`",
+        "ja": "パレット",
+        "ja_typings": [
+          "paretto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00974",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML input type provides a native color picker?",
+      "ja": "ネイティブのカラーピッカーを表示する input type は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`:first-child`",
+        "ja": "ファーストチャイルド",
+        "ja_typings": [
+          "fa-sutochairudo"
+        ]
+      },
+      {
+        "en": "`:nth-child(1)`",
+        "ja": "エヌスチャイルド",
+        "ja_typings": [
+          "enusuchairudo"
+        ]
+      },
+      {
+        "en": "`:first-of-type`",
+        "ja": "ファーストオブタイプ",
+        "ja_typings": [
+          "fa-sutobutaipu",
+          "fa-sutoobutaipu"
+        ]
+      },
+      {
+        "en": "`:root`",
+        "ja": "ルート",
+        "ja_typings": [
+          "ru-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00975",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS pseudo-class targets the first child element?",
+      "ja": "最初の子要素を選択する CSS 疑似クラスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`rem`",
+        "ja": "レム",
+        "ja_typings": [
+          "remu"
+        ]
+      },
+      {
+        "en": "`em`",
+        "ja": "エム",
+        "ja_typings": [
+          "emu"
+        ]
+      },
+      {
+        "en": "`px`",
+        "ja": "ピクセル",
+        "ja_typings": [
+          "pikuseru"
+        ]
+      },
+      {
+        "en": "`pt`",
+        "ja": "ポイント",
+        "ja_typings": [
+          "pointo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00976",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS unit is relative to the root font-size?",
+      "ja": "ルートフォントサイズに対する CSS の単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`vw`",
+        "ja": "ブイダブリュ",
+        "ja_typings": [
+          "buidaburyu"
+        ]
+      },
+      {
+        "en": "`vh`",
+        "ja": "ブイエイチ",
+        "ja_typings": [
+          "buieichi"
+        ]
+      },
+      {
+        "en": "`vmin`",
+        "ja": "ブイミン",
+        "ja_typings": [
+          "buimin"
+        ]
+      },
+      {
+        "en": "`vmax`",
+        "ja": "ブイマックス",
+        "ja_typings": [
+          "buimakkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00977",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS unit equals one percent of the viewport width?",
+      "ja": "ビューポート幅の 1% を表す CSS の単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`z-index`",
+        "ja": "ゼットインデックス",
+        "ja_typings": [
+          "zettoindekkusu"
+        ]
+      },
+      {
+        "en": "`order`",
+        "ja": "オーダー",
+        "ja_typings": [
+          "o-da-"
+        ]
+      },
+      {
+        "en": "`stack`",
+        "ja": "スタック",
+        "ja_typings": [
+          "sutakku"
+        ]
+      },
+      {
+        "en": "`layer`",
+        "ja": "レイヤー",
+        "ja_typings": [
+          "reiya-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00978",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS property controls stacking order along the z-axis?",
+      "ja": "Z 軸方向の重なり順を制御する CSS プロパティは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`calc()`",
+        "ja": "カルク",
+        "ja_typings": [
+          "karuku"
+        ]
+      },
+      {
+        "en": "`min()`",
+        "ja": "ミン",
+        "ja_typings": [
+          "min"
+        ]
+      },
+      {
+        "en": "`max()`",
+        "ja": "マックス",
+        "ja_typings": [
+          "makkusu"
+        ]
+      },
+      {
+        "en": "`clamp()`",
+        "ja": "クランプ",
+        "ja_typings": [
+          "kuranpu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00979",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS function performs simple arithmetic with mixed units?",
+      "ja": "異なる単位の四則演算を行う CSS 関数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`@media`",
+        "ja": "アットメディア",
+        "ja_typings": [
+          "attomedia"
+        ]
+      },
+      {
+        "en": "`@supports`",
+        "ja": "アットサポーツ",
+        "ja_typings": [
+          "attosapo-tsu"
+        ]
+      },
+      {
+        "en": "`@container`",
+        "ja": "アットコンテナ",
+        "ja_typings": [
+          "attokontena"
+        ]
+      },
+      {
+        "en": "`@layer`",
+        "ja": "アットレイヤー",
+        "ja_typings": [
+          "attoreiya-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00980",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS at-rule defines media-query-based styles?",
+      "ja": "メディアクエリに基づくスタイルを定義する CSS の at-rule は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`@container`",
+        "ja": "アットコンテナ",
+        "ja_typings": [
+          "attokontena"
+        ]
+      },
+      {
+        "en": "`@media`",
+        "ja": "アットメディア",
+        "ja_typings": [
+          "attomedia"
+        ]
+      },
+      {
+        "en": "`@scope`",
+        "ja": "アットスコープ",
+        "ja_typings": [
+          "attosuko-pu"
+        ]
+      },
+      {
+        "en": "`@supports`",
+        "ja": "アットサポーツ",
+        "ja_typings": [
+          "attosapo-tsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00981",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS at-rule scopes styles by container queries?",
+      "ja": "コンテナクエリでスタイルをスコープする at-rule は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`transition`",
+        "ja": "トランジション",
+        "ja_typings": [
+          "toranjishon"
+        ]
+      },
+      {
+        "en": "`animation`",
+        "ja": "アニメーション",
+        "ja_typings": [
+          "anime-shon"
+        ]
+      },
+      {
+        "en": "`transform`",
+        "ja": "トランスフォーム",
+        "ja_typings": [
+          "toransufo-mu"
+        ]
+      },
+      {
+        "en": "`filter`",
+        "ja": "フィルター",
+        "ja_typings": [
+          "firuta-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00982",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS property smoothly animates between value changes?",
+      "ja": "値の変化を滑らかに補間する CSS プロパティは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`filter`",
+        "ja": "フィルター",
+        "ja_typings": [
+          "firuta-"
+        ]
+      },
+      {
+        "en": "`opacity`",
+        "ja": "オパシティ",
+        "ja_typings": [
+          "opashiti"
+        ]
+      },
+      {
+        "en": "`mix-blend-mode`",
+        "ja": "ミックスブレンドモード",
+        "ja_typings": [
+          "mikkusuburendomo-do"
+        ]
+      },
+      {
+        "en": "`backdrop`",
+        "ja": "バックドロップ",
+        "ja_typings": [
+          "bakkudoroppu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00983",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS property applies blur, grayscale, and similar effects?",
+      "ja": "ぼかしやグレースケール等の効果を適用する CSS プロパティは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`querySelector`",
+        "ja": "クエリセレクタ",
+        "ja_typings": [
+          "kueriserekuta"
+        ]
+      },
+      {
+        "en": "`getElementById`",
+        "ja": "ゲットエレメントバイアイディー",
+        "ja_typings": [
+          "gettoerementobaiaidi-"
+        ]
+      },
+      {
+        "en": "`getElementsByTagName`",
+        "ja": "ゲットエレメンツバイタグネーム",
+        "ja_typings": [
+          "gettoerementsubaitagune-mu"
+        ]
+      },
+      {
+        "en": "`find`",
+        "ja": "ファインド",
+        "ja_typings": [
+          "faindo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00984",
+    "image_path": null,
+    "question_text": {
+      "en": "Which method selects the first element matching a CSS selector?",
+      "ja": "CSS セレクタに合う最初の要素を取得する DOM メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`fetch`",
+        "ja": "フェッチ",
+        "ja_typings": [
+          "fetchi"
+        ]
+      },
+      {
+        "en": "`axios`",
+        "ja": "アクシオス",
+        "ja_typings": [
+          "akushiosu"
+        ]
+      },
+      {
+        "en": "`ajax`",
+        "ja": "エイジャックス",
+        "ja_typings": [
+          "eijakkusu"
+        ]
+      },
+      {
+        "en": "`request`",
+        "ja": "リクエスト",
+        "ja_typings": [
+          "rikuesuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00985",
+    "image_path": null,
+    "question_text": {
+      "en": "Which DOM API replaces XMLHttpRequest in modern code?",
+      "ja": "XMLHttpRequest に代わる現代の DOM API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "IntersectionObserver",
+        "ja": "インターセクションオブザーバー",
+        "ja_typings": [
+          "inta-sekushonnobuza-ba-"
+        ]
+      },
+      {
+        "en": "MutationObserver",
+        "ja": "ミューテーションオブザーバー",
+        "ja_typings": [
+          "myu-te-shonnobuza-ba-"
+        ]
+      },
+      {
+        "en": "ResizeObserver",
+        "ja": "リサイズオブザーバー",
+        "ja_typings": [
+          "risaizuobuza-ba-"
+        ]
+      },
+      {
+        "en": "PerformanceObserver",
+        "ja": "パフォーマンスオブザーバー",
+        "ja_typings": [
+          "pafo-mansuobuza-ba-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00986",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Web API observes elements crossing the viewport?",
+      "ja": "ビューポート交差を監視する Web API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MutationObserver",
+        "ja": "ミューテーションオブザーバー",
+        "ja_typings": [
+          "myu-te-shonnobuza-ba-"
+        ]
+      },
+      {
+        "en": "IntersectionObserver",
+        "ja": "インターセクションオブザーバー",
+        "ja_typings": [
+          "inta-sekushonnobuza-ba-"
+        ]
+      },
+      {
+        "en": "ResizeObserver",
+        "ja": "リサイズオブザーバー",
+        "ja_typings": [
+          "risaizuobuza-ba-"
+        ]
+      },
+      {
+        "en": "PerformanceObserver",
+        "ja": "パフォーマンスオブザーバー",
+        "ja_typings": [
+          "pafo-mansuobuza-ba-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00987",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Web API watches changes to the DOM tree?",
+      "ja": "DOM ツリーの変化を監視する Web API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ResizeObserver",
+        "ja": "リサイズオブザーバー",
+        "ja_typings": [
+          "risaizuobuza-ba-"
+        ]
+      },
+      {
+        "en": "MutationObserver",
+        "ja": "ミューテーションオブザーバー",
+        "ja_typings": [
+          "myu-te-shonnobuza-ba-"
+        ]
+      },
+      {
+        "en": "IntersectionObserver",
+        "ja": "インターセクションオブザーバー",
+        "ja_typings": [
+          "inta-sekushonnobuza-ba-"
+        ]
+      },
+      {
+        "en": "Layout API",
+        "ja": "レイアウトエーピーアイ",
+        "ja_typings": [
+          "reiautoe-pi-ai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00988",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Web API monitors element size changes?",
+      "ja": "要素サイズの変化を監視する Web API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`requestAnimationFrame`",
+        "ja": "リクエストアニメーションフレーム",
+        "ja_typings": [
+          "rikuesutoanime-shonfure-mu"
+        ]
+      },
+      {
+        "en": "`setTimeout`",
+        "ja": "セットタイムアウト",
+        "ja_typings": [
+          "settotaimuauto"
+        ]
+      },
+      {
+        "en": "`setInterval`",
+        "ja": "セットインターバル",
+        "ja_typings": [
+          "settointa-baru"
+        ]
+      },
+      {
+        "en": "`queueMicrotask`",
+        "ja": "キューマイクロタスク",
+        "ja_typings": [
+          "kyu-maikurotasuku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00989",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript timer schedules a callback for the next animation frame?",
+      "ja": "次の描画フレームでコールバックを呼ぶ JavaScript のタイマーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Promise",
+        "ja": "プロミス",
+        "ja_typings": [
+          "puromisu"
+        ]
+      },
+      {
+        "en": "Observable",
+        "ja": "オブザーバブル",
+        "ja_typings": [
+          "obuza-baburu"
+        ]
+      },
+      {
+        "en": "Stream",
+        "ja": "ストリーム",
+        "ja_typings": [
+          "sutori-mu"
+        ]
+      },
+      {
+        "en": "Channel",
+        "ja": "チャネル",
+        "ja_typings": [
+          "chaneru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00990",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript construct represents a one-time async value?",
+      "ja": "1 回限りの非同期値を表す JavaScript の構文は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "302",
+        "ja": "サンマルニ",
+        "ja_typings": [
+          "sanmaruni"
+        ]
+      },
+      {
+        "en": "301",
+        "ja": "サンマルイチ",
+        "ja_typings": [
+          "sanmaruichi"
+        ]
+      },
+      {
+        "en": "303",
+        "ja": "サンマルサン",
+        "ja_typings": [
+          "sanmarusan"
+        ]
+      },
+      {
+        "en": "307",
+        "ja": "サンマルナナ",
+        "ja_typings": [
+          "sanmarunana"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00991",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status code indicates a temporary redirect?",
+      "ja": "一時的リダイレクトを示す HTTP ステータスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "503",
+        "ja": "ゴーマルサン",
+        "ja_typings": [
+          "go-marusan"
+        ]
+      },
+      {
+        "en": "502",
+        "ja": "ゴーマルニ",
+        "ja_typings": [
+          "go-maruni"
+        ]
+      },
+      {
+        "en": "504",
+        "ja": "ゴーマルヨン",
+        "ja_typings": [
+          "go-maruyon"
+        ]
+      },
+      {
+        "en": "500",
+        "ja": "ゴヒャク",
+        "ja_typings": [
+          "gohyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00992",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status code indicates the server is temporarily unavailable?",
+      "ja": "サーバーが一時的に利用不能であることを示す HTTP ステータスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "413",
+        "ja": "ヨンイチサン",
+        "ja_typings": [
+          "yonnichisan"
+        ]
+      },
+      {
+        "en": "414",
+        "ja": "ヨンイチヨン",
+        "ja_typings": [
+          "yonnichiyon"
+        ]
+      },
+      {
+        "en": "400",
+        "ja": "ヨンヒャク",
+        "ja_typings": [
+          "yonhyaku"
+        ]
+      },
+      {
+        "en": "411",
+        "ja": "ヨンイチイチ",
+        "ja_typings": [
+          "yonnichiichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00993",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status code indicates the request body exceeds the server limit?",
+      "ja": "リクエストボディがサーバー制限を超えたことを示す HTTP ステータスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "304",
+        "ja": "サンマルヨン",
+        "ja_typings": [
+          "sanmaruyon"
+        ]
+      },
+      {
+        "en": "305",
+        "ja": "サンマルゴ",
+        "ja_typings": [
+          "sanmarugo"
+        ]
+      },
+      {
+        "en": "306",
+        "ja": "サンマルロク",
+        "ja_typings": [
+          "sanmaruroku"
+        ]
+      },
+      {
+        "en": "302",
+        "ja": "サンマルニ",
+        "ja_typings": [
+          "sanmaruni"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00994",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status indicates the resource has not been modified?",
+      "ja": "リソースが未更新であることを示す HTTP ステータスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Authorization",
+        "ja": "オーソライゼーション",
+        "ja_typings": [
+          "o-soraize-shon"
+        ]
+      },
+      {
+        "en": "Authentication",
+        "ja": "オーセンティケーション",
+        "ja_typings": [
+          "o-sentike-shon"
+        ]
+      },
+      {
+        "en": "Credentials",
+        "ja": "クレデンシャルズ",
+        "ja_typings": [
+          "kuredensharuzu"
+        ]
+      },
+      {
+        "en": "X-Token",
+        "ja": "エックストークン",
+        "ja_typings": [
+          "ekkusuto-kun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00995",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP header sends authentication credentials with the request?",
+      "ja": "リクエストに認証情報を載せる HTTP ヘッダーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Content-Type",
+        "ja": "コンテントタイプ",
+        "ja_typings": [
+          "kontentotaipu"
+        ]
+      },
+      {
+        "en": "Accept",
+        "ja": "アクセプト",
+        "ja_typings": [
+          "akuseputo"
+        ]
+      },
+      {
+        "en": "Content-Length",
+        "ja": "コンテントレングス",
+        "ja_typings": [
+          "kontentorengusu"
+        ]
+      },
+      {
+        "en": "Content-Encoding",
+        "ja": "コンテントエンコーディング",
+        "ja_typings": [
+          "kontentoenko-dingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00996",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP header indicates the format of the request body?",
+      "ja": "リクエストボディの形式を示す HTTP ヘッダーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Accept",
+        "ja": "アクセプト",
+        "ja_typings": [
+          "akuseputo"
+        ]
+      },
+      {
+        "en": "Content-Type",
+        "ja": "コンテントタイプ",
+        "ja_typings": [
+          "kontentotaipu"
+        ]
+      },
+      {
+        "en": "Vary",
+        "ja": "ベアリー",
+        "ja_typings": [
+          "beari-"
+        ]
+      },
+      {
+        "en": "Allow",
+        "ja": "アロー",
+        "ja_typings": [
+          "aro-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00997",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP header declares acceptable response media types?",
+      "ja": "受け入れ可能なレスポンス形式を宣言する HTTP ヘッダーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "User-Agent",
+        "ja": "ユーザーエージェント",
+        "ja_typings": [
+          "yu-za-e-jento"
+        ]
+      },
+      {
+        "en": "Referer",
+        "ja": "リファラー",
+        "ja_typings": [
+          "rifara-"
+        ]
+      },
+      {
+        "en": "From",
+        "ja": "フロム",
+        "ja_typings": [
+          "furomu"
+        ]
+      },
+      {
+        "en": "Host",
+        "ja": "ホスト",
+        "ja_typings": [
+          "hosuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00998",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP header is used by browsers to identify the client software?",
+      "ja": "クライアントソフトを識別する HTTP ヘッダーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SQL injection",
+        "ja": "エスキューエルインジェクション",
+        "ja_typings": [
+          "esukyu-eruinjekushon"
+        ]
+      },
+      {
+        "en": "XSS",
+        "ja": "クロスサイトスクリプティング",
+        "ja_typings": [
+          "kurosusaitosukuriputingu"
+        ]
+      },
+      {
+        "en": "CSRF",
+        "ja": "クロスサイトリクエストフォージェリ",
+        "ja_typings": [
+          "kurosusaitorikuesutofo-jeri"
+        ]
+      },
+      {
+        "en": "Path traversal",
+        "ja": "パストラバーサル",
+        "ja_typings": [
+          "pasutoraba-saru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q00999",
+    "image_path": null,
+    "question_text": {
+      "en": "Which attack manipulates database queries via unsanitized input?",
+      "ja": "未検証の入力で DB クエリを改ざんする攻撃は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Path traversal",
+        "ja": "パストラバーサル",
+        "ja_typings": [
+          "pasutoraba-saru"
+        ]
+      },
+      {
+        "en": "SQL injection",
+        "ja": "エスキューエルインジェクション",
+        "ja_typings": [
+          "esukyu-eruinjekushon"
+        ]
+      },
+      {
+        "en": "XSS",
+        "ja": "クロスサイトスクリプティング",
+        "ja_typings": [
+          "kurosusaitosukuriputingu"
+        ]
+      },
+      {
+        "en": "Clickjacking",
+        "ja": "クリックジャッキング",
+        "ja_typings": [
+          "kurikkujakkingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01000",
+    "image_path": null,
+    "question_text": {
+      "en": "Which attack reads files outside the intended directory?",
+      "ja": "意図したディレクトリ外のファイルを読む攻撃は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Clickjacking",
+        "ja": "クリックジャッキング",
+        "ja_typings": [
+          "kurikkujakkingu"
+        ]
+      },
+      {
+        "en": "Phishing",
+        "ja": "フィッシング",
+        "ja_typings": [
+          "fisshingu"
+        ]
+      },
+      {
+        "en": "CSRF",
+        "ja": "クロスサイトリクエストフォージェリ",
+        "ja_typings": [
+          "kurosusaitorikuesutofo-jeri"
+        ]
+      },
+      {
+        "en": "XSS",
+        "ja": "クロスサイトスクリプティング",
+        "ja_typings": [
+          "kurosusaitosukuriputingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01001",
+    "image_path": null,
+    "question_text": {
+      "en": "Which attack overlays an invisible UI to trick clicks?",
+      "ja": "見えない UI を被せてクリックを誘う攻撃は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "X-Frame-Options",
+        "ja": "エックスフレームオプションズ",
+        "ja_typings": [
+          "ekkusufure-muopushonzu"
+        ]
+      },
+      {
+        "en": "Content-Security-Policy",
+        "ja": "コンテンツセキュリティポリシー",
+        "ja_typings": [
+          "kontentsusekyuritiporishi-"
+        ]
+      },
+      {
+        "en": "X-Content-Type-Options",
+        "ja": "エックスコンテンツタイプオプションズ",
+        "ja_typings": [
+          "ekkusukontentsutaipuopushonzu"
+        ]
+      },
+      {
+        "en": "Referrer-Policy",
+        "ja": "リファラーポリシー",
+        "ja_typings": [
+          "rifara-porishi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01002",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP header forbids embedding the page in a frame?",
+      "ja": "ページをフレームに埋め込むことを禁じる HTTP ヘッダーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Strict-Transport-Security",
+        "ja": "ストリクトトランスポートセキュリティ",
+        "ja_typings": [
+          "sutorikutotoransupo-tosekyuriti"
+        ]
+      },
+      {
+        "en": "Content-Security-Policy",
+        "ja": "コンテンツセキュリティポリシー",
+        "ja_typings": [
+          "kontentsusekyuritiporishi-"
+        ]
+      },
+      {
+        "en": "X-Frame-Options",
+        "ja": "エックスフレームオプションズ",
+        "ja_typings": [
+          "ekkusufure-muopushonzu"
+        ]
+      },
+      {
+        "en": "Permissions-Policy",
+        "ja": "パーミッションズポリシー",
+        "ja_typings": [
+          "pa-misshonzuporishi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01003",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP header forces browsers to use HTTPS for a period?",
+      "ja": "一定期間 HTTPS 強制を伝える HTTP ヘッダーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Redux",
+        "ja": "リダックス",
+        "ja_typings": [
+          "ridakkusu"
+        ]
+      },
+      {
+        "en": "MobX",
+        "ja": "モブエックス",
+        "ja_typings": [
+          "mobuekkusu"
+        ]
+      },
+      {
+        "en": "Recoil",
+        "ja": "リコイル",
+        "ja_typings": [
+          "rikoiru"
+        ]
+      },
+      {
+        "en": "Zustand",
+        "ja": "ズスタンド",
+        "ja_typings": [
+          "zusutando"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01004",
+    "image_path": null,
+    "question_text": {
+      "en": "Which state management library is most associated with React?",
+      "ja": "React と最も結びつく状態管理ライブラリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "styled-components",
+        "ja": "スタイルドコンポーネンツ",
+        "ja_typings": [
+          "sutairudokonpo-nentsu"
+        ]
+      },
+      {
+        "en": "Emotion",
+        "ja": "エモーション",
+        "ja_typings": [
+          "emo-shon"
+        ]
+      },
+      {
+        "en": "JSS",
+        "ja": "ジェイエスエス",
+        "ja_typings": [
+          "jeiesuesu"
+        ]
+      },
+      {
+        "en": "Linaria",
+        "ja": "リナリア",
+        "ja_typings": [
+          "rinaria"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01005",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS-in-JS library popularized tagged template literals for styles?",
+      "ja": "タグ付きテンプレートリテラルによる CSS-in-JS を広めたライブラリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Astro",
+        "ja": "アストロ",
+        "ja_typings": [
+          "asutoro"
+        ]
+      },
+      {
+        "en": "Remix",
+        "ja": "リミックス",
+        "ja_typings": [
+          "rimikkusu"
+        ]
+      },
+      {
+        "en": "SolidStart",
+        "ja": "ソリッドスタート",
+        "ja_typings": [
+          "soriddosuta-to"
+        ]
+      },
+      {
+        "en": "Qwik",
+        "ja": "クィック",
+        "ja_typings": [
+          "kuikku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01006",
+    "image_path": null,
+    "question_text": {
+      "en": "Which framework introduced the Islands Architecture concept?",
+      "ja": "アイランズアーキテクチャを広めたフレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SolidJS",
+        "ja": "ソリッドジェイエス",
+        "ja_typings": [
+          "soriddojeiesu"
+        ]
+      },
+      {
+        "en": "Svelte",
+        "ja": "スベルト",
+        "ja_typings": [
+          "suberuto"
+        ]
+      },
+      {
+        "en": "Vue",
+        "ja": "ビュー",
+        "ja_typings": [
+          "byu-"
+        ]
+      },
+      {
+        "en": "Preact",
+        "ja": "プリアクト",
+        "ja_typings": [
+          "puriakuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01007",
+    "image_path": null,
+    "question_text": {
+      "en": "Which fine-grained reactive framework was created by Ryan Carniato?",
+      "ja": "Ryan Carniato による細粒度リアクティブなフレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Qwik",
+        "ja": "クィック",
+        "ja_typings": [
+          "kuikku"
+        ]
+      },
+      {
+        "en": "Astro",
+        "ja": "アストロ",
+        "ja_typings": [
+          "asutoro"
+        ]
+      },
+      {
+        "en": "Remix",
+        "ja": "リミックス",
+        "ja_typings": [
+          "rimikkusu"
+        ]
+      },
+      {
+        "en": "SolidJS",
+        "ja": "ソリッドジェイエス",
+        "ja_typings": [
+          "soriddojeiesu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01008",
+    "image_path": null,
+    "question_text": {
+      "en": "Which framework focuses on resumability instead of hydration?",
+      "ja": "ハイドレーションではなく resumability を志向するフレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Remix",
+        "ja": "リミックス",
+        "ja_typings": [
+          "rimikkusu"
+        ]
+      },
+      {
+        "en": "Next.js",
+        "ja": "ネクストジェイエス",
+        "ja_typings": [
+          "nekusutojeiesu"
+        ]
+      },
+      {
+        "en": "Gatsby",
+        "ja": "ギャツビー",
+        "ja_typings": [
+          "gyatsubi-"
+        ]
+      },
+      {
+        "en": "Redwood",
+        "ja": "レッドウッド",
+        "ja_typings": [
+          "reddoddo",
+          "reddouddo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01009",
+    "image_path": null,
+    "question_text": {
+      "en": "Which React framework focuses on web fundamentals and is by Shopify now?",
+      "ja": "Web 基礎重視で現在は Shopify が運用する React フレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "WHATWG",
+        "ja": "ワットダブリュージー",
+        "ja_typings": [
+          "wattodaburyu-ji-"
+        ]
+      },
+      {
+        "en": "W3C",
+        "ja": "ダブリュースリーシー",
+        "ja_typings": [
+          "daburyu-suri-shi-"
+        ]
+      },
+      {
+        "en": "ECMA",
+        "ja": "エクマ",
+        "ja_typings": [
+          "ekuma"
+        ]
+      },
+      {
+        "en": "IETF",
+        "ja": "アイイーティーエフ",
+        "ja_typings": [
+          "aii-ti-efu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01010",
+    "image_path": null,
+    "question_text": {
+      "en": "Which standards body publishes HTML specifications today?",
+      "ja": "現在 HTML 仕様を発行している標準化団体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ECMA International",
+        "ja": "エクマインターナショナル",
+        "ja_typings": [
+          "ekumainta-nashonaru"
+        ]
+      },
+      {
+        "en": "WHATWG",
+        "ja": "ワットダブリュージー",
+        "ja_typings": [
+          "wattodaburyu-ji-"
+        ]
+      },
+      {
+        "en": "W3C",
+        "ja": "ダブリュースリーシー",
+        "ja_typings": [
+          "daburyu-suri-shi-"
+        ]
+      },
+      {
+        "en": "IETF",
+        "ja": "アイイーティーエフ",
+        "ja_typings": [
+          "aii-ti-efu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01011",
+    "image_path": null,
+    "question_text": {
+      "en": "Which group standardizes JavaScript (ECMAScript)?",
+      "ja": "JavaScript すなわち ECMAScript を標準化する団体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "WebKit",
+        "ja": "ウェブキット",
+        "ja_typings": [
+          "webukitto"
+        ]
+      },
+      {
+        "en": "Blink",
+        "ja": "ブリンク",
+        "ja_typings": [
+          "burinku"
+        ]
+      },
+      {
+        "en": "Gecko",
+        "ja": "ゲッコー",
+        "ja_typings": [
+          "gekko-"
+        ]
+      },
+      {
+        "en": "Servo",
+        "ja": "サーボ",
+        "ja_typings": [
+          "sa-bo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01012",
+    "image_path": null,
+    "question_text": {
+      "en": "Which rendering engine powers Safari and WebKit-based browsers?",
+      "ja": "Safari や WebKit 系ブラウザのレンダリングエンジンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gecko",
+        "ja": "ゲッコー",
+        "ja_typings": [
+          "gekko-"
+        ]
+      },
+      {
+        "en": "WebKit",
+        "ja": "ウェブキット",
+        "ja_typings": [
+          "webukitto"
+        ]
+      },
+      {
+        "en": "Blink",
+        "ja": "ブリンク",
+        "ja_typings": [
+          "burinku"
+        ]
+      },
+      {
+        "en": "Trident",
+        "ja": "トライデント",
+        "ja_typings": [
+          "toraidento"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01013",
+    "image_path": null,
+    "question_text": {
+      "en": "Which rendering engine powers Firefox?",
+      "ja": "Firefox のレンダリングエンジンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Blink",
+        "ja": "ブリンク",
+        "ja_typings": [
+          "burinku"
+        ]
+      },
+      {
+        "en": "WebKit",
+        "ja": "ウェブキット",
+        "ja_typings": [
+          "webukitto"
+        ]
+      },
+      {
+        "en": "Gecko",
+        "ja": "ゲッコー",
+        "ja_typings": [
+          "gekko-"
+        ]
+      },
+      {
+        "en": "EdgeHTML",
+        "ja": "エッジエイチティーエムエル",
+        "ja_typings": [
+          "ejjieichiti-emueru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01014",
+    "image_path": null,
+    "question_text": {
+      "en": "Which engine powers Chrome and modern Edge?",
+      "ja": "Chrome と現行 Edge のエンジンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "WebAssembly",
+        "ja": "ウェブアセンブリ",
+        "ja_typings": [
+          "webuasenburi"
+        ]
+      },
+      {
+        "en": "asm.js",
+        "ja": "エイエスエムジェイエス",
+        "ja_typings": [
+          "eiesuemujeiesu"
+        ]
+      },
+      {
+        "en": "NaCl",
+        "ja": "ネイティブクライアント",
+        "ja_typings": [
+          "neitibukuraianto"
+        ]
+      },
+      {
+        "en": "PNaCl",
+        "ja": "ピーネイティブクライアント",
+        "ja_typings": [
+          "pi-neitibukuraianto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01015",
+    "image_path": null,
+    "question_text": {
+      "en": "Which technology lets browsers run near-native compiled code?",
+      "ja": "ブラウザでネイティブ近い速度のコンパイル済みコードを動かす技術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Web App Manifest",
+        "ja": "ウェブアプリマニフェスト",
+        "ja_typings": [
+          "webuapurimanifesuto"
+        ]
+      },
+      {
+        "en": "robots.txt",
+        "ja": "ロボッツテキスト",
+        "ja_typings": [
+          "robottsutekisuto"
+        ]
+      },
+      {
+        "en": "sitemap.xml",
+        "ja": "サイトマップエックスエムエル",
+        "ja_typings": [
+          "saitomappuekkusuemueru"
+        ]
+      },
+      {
+        "en": "favicon.ico",
+        "ja": "ファビコン",
+        "ja_typings": [
+          "fabikon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01016",
+    "image_path": null,
+    "question_text": {
+      "en": "Which file makes a website installable as a PWA?",
+      "ja": "サイトを PWA としてインストール可能にするファイルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "robots.txt",
+        "ja": "ロボッツテキスト",
+        "ja_typings": [
+          "robottsutekisuto"
+        ]
+      },
+      {
+        "en": "sitemap.xml",
+        "ja": "サイトマップエックスエムエル",
+        "ja_typings": [
+          "saitomappuekkusuemueru"
+        ]
+      },
+      {
+        "en": "humans.txt",
+        "ja": "ヒューマンズテキスト",
+        "ja_typings": [
+          "hyu-manzutekisuto"
+        ]
+      },
+      {
+        "en": "ads.txt",
+        "ja": "アドステキスト",
+        "ja_typings": [
+          "adosutekisuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01017",
+    "image_path": null,
+    "question_text": {
+      "en": "Which file directs crawlers about allowed and disallowed paths?",
+      "ja": "クローラーに巡回可否を伝えるファイルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sitemap.xml",
+        "ja": "サイトマップエックスエムエル",
+        "ja_typings": [
+          "saitomappuekkusuemueru"
+        ]
+      },
+      {
+        "en": "robots.txt",
+        "ja": "ロボッツテキスト",
+        "ja_typings": [
+          "robottsutekisuto"
+        ]
+      },
+      {
+        "en": "manifest.json",
+        "ja": "マニフェストジェイソン",
+        "ja_typings": [
+          "manifesutojeison"
+        ]
+      },
+      {
+        "en": "feed.xml",
+        "ja": "フィードエックスエムエル",
+        "ja_typings": [
+          "fi-doekkusuemueru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01018",
+    "image_path": null,
+    "question_text": {
+      "en": "Which file lists URLs for search engines to index?",
+      "ja": "検索エンジンが巡回すべき URL を列挙するファイルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "WebRTC",
+        "ja": "ウェブアールティーシー",
+        "ja_typings": [
+          "webua-ruti-shi-"
+        ]
+      },
+      {
+        "en": "WebSocket",
+        "ja": "ウェブソケット",
+        "ja_typings": [
+          "webusoketto"
+        ]
+      },
+      {
+        "en": "WebTransport",
+        "ja": "ウェブトランスポート",
+        "ja_typings": [
+          "webutoransupo-to"
+        ]
+      },
+      {
+        "en": "SSE",
+        "ja": "エスエスイー",
+        "ja_typings": [
+          "esuesui-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01019",
+    "image_path": null,
+    "question_text": {
+      "en": "Which standard defines real-time peer-to-peer media in browsers?",
+      "ja": "ブラウザのリアルタイム P2P メディア通信を定める標準は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Server-Sent Events",
+        "ja": "サーバーセントイベンツ",
+        "ja_typings": [
+          "sa-ba-sentoibentsu"
+        ]
+      },
+      {
+        "en": "WebSocket",
+        "ja": "ウェブソケット",
+        "ja_typings": [
+          "webusoketto"
+        ]
+      },
+      {
+        "en": "Long polling",
+        "ja": "ロングポーリング",
+        "ja_typings": [
+          "rongupo-ringu"
+        ]
+      },
+      {
+        "en": "Webhook",
+        "ja": "ウェブフック",
+        "ja_typings": [
+          "webufukku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01020",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mechanism pushes server-sent events over a long-lived HTTP response?",
+      "ja": "長時間 HTTP 応答上でサーバー発のイベントを配信する仕組みは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1024",
+        "ja": "センニジュウヨン",
+        "ja_typings": [
+          "sennijuuyon",
+          "sennnijuuyon"
+        ]
+      },
+      {
+        "en": "512",
+        "ja": "ゴヒャクジュウニ",
+        "ja_typings": [
+          "gohyakujuuni"
+        ]
+      },
+      {
+        "en": "2048",
+        "ja": "ニセンヨンジュウハチ",
+        "ja_typings": [
+          "nisenyonjuuhachi",
+          "nisennyonjuuhachi"
+        ]
+      },
+      {
+        "en": "256",
+        "ja": "ニヒャクゴジュウロク",
+        "ja_typings": [
+          "nihyakugojuuroku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01021",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 2 to the power of 10?",
+      "ja": "2の10乗はいくつ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "12",
+        "ja": "ジュウニ",
+        "ja_typings": [
+          "juuni"
+        ]
+      },
+      {
+        "en": "14",
+        "ja": "ジュウヨン",
+        "ja_typings": [
+          "juuyon"
+        ]
+      },
+      {
+        "en": "16",
+        "ja": "ジュウロク",
+        "ja_typings": [
+          "juuroku"
+        ]
+      },
+      {
+        "en": "11",
+        "ja": "ジュウイチ",
+        "ja_typings": [
+          "juuichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01022",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the square root of 144?",
+      "ja": "144の平方根はいくつ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "120",
+        "ja": "ヒャクニジュウ",
+        "ja_typings": [
+          "hyakunijuu"
+        ]
+      },
+      {
+        "en": "60",
+        "ja": "ロクジュウ",
+        "ja_typings": [
+          "rokujuu"
+        ]
+      },
+      {
+        "en": "125",
+        "ja": "ヒャクニジュウゴ",
+        "ja_typings": [
+          "hyakunijuugo"
+        ]
+      },
+      {
+        "en": "100",
+        "ja": "ヒャク",
+        "ja_typings": [
+          "hyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01023",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the factorial of 5?",
+      "ja": "5の階乗はいくつ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "2.7",
+        "ja": "ニテンナナ",
+        "ja_typings": [
+          "nitennnana"
+        ]
+      },
+      {
+        "en": "3.1",
+        "ja": "サンテンイチ",
+        "ja_typings": [
+          "santennichi"
+        ]
+      },
+      {
+        "en": "1.6",
+        "ja": "イッテンロク",
+        "ja_typings": [
+          "ittenroku"
+        ]
+      },
+      {
+        "en": "2.3",
+        "ja": "ニテンサン",
+        "ja_typings": [
+          "nitensan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01024",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the value of e to one decimal place?",
+      "ja": "ネイピア数を小数点以下1桁で表すと?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "17",
+        "ja": "ジュウナナ",
+        "ja_typings": [
+          "juunana"
+        ]
+      },
+      {
+        "en": "21",
+        "ja": "ニジュウイチ",
+        "ja_typings": [
+          "nijuuichi"
+        ]
+      },
+      {
+        "en": "27",
+        "ja": "ニジュウナナ",
+        "ja_typings": [
+          "nijuunana"
+        ]
+      },
+      {
+        "en": "33",
+        "ja": "サンジュウサン",
+        "ja_typings": [
+          "sanjuusan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01025",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is a prime number?",
+      "ja": "次のうち素数はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "pi r squared",
+        "ja": "パイアールジジョウ",
+        "ja_typings": [
+          "paiaaru jijou",
+          "pai a-ru jijou",
+          "paia-rujijo",
+          "paia-rujijou"
+        ]
+      },
+      {
+        "en": "two pi r",
+        "ja": "ニパイアール",
+        "ja_typings": [
+          "nipaiaaru",
+          "ni pai a-ru",
+          "nipaia-ru"
+        ]
+      },
+      {
+        "en": "pi d",
+        "ja": "パイディー",
+        "ja_typings": [
+          "paidi-"
+        ]
+      },
+      {
+        "en": "four pi r squared",
+        "ja": "ヨンパイアールジジョウ",
+        "ja_typings": [
+          "yonpaiaaru jijou",
+          "yonpaia-rujijo",
+          "yonpaia-rujijou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01026",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the area formula for a circle?",
+      "ja": "円の面積を求める公式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "360 degrees",
+        "ja": "サンビャクロクジュウド",
+        "ja_typings": [
+          "sanbyakurokujuudo"
+        ]
+      },
+      {
+        "en": "180 degrees",
+        "ja": "ヒャクハチジュウド",
+        "ja_typings": [
+          "hyakuhachijuudo"
+        ]
+      },
+      {
+        "en": "270 degrees",
+        "ja": "ニヒャクナナジュウド",
+        "ja_typings": [
+          "nihyakunanajuudo"
+        ]
+      },
+      {
+        "en": "540 degrees",
+        "ja": "ゴヒャクヨンジュウド",
+        "ja_typings": [
+          "gohyakuyonjuudo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01027",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the sum of angles in a quadrilateral?",
+      "ja": "四角形の内角の和は何度?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "56",
+        "ja": "ゴジュウロク",
+        "ja_typings": [
+          "gojuuroku"
+        ]
+      },
+      {
+        "en": "54",
+        "ja": "ゴジュウヨン",
+        "ja_typings": [
+          "gojuuyon"
+        ]
+      },
+      {
+        "en": "63",
+        "ja": "ロクジュウサン",
+        "ja_typings": [
+          "rokujuusan"
+        ]
+      },
+      {
+        "en": "49",
+        "ja": "ヨンジュウキュウ",
+        "ja_typings": [
+          "yonjuukyuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01028",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 7 times 8?",
+      "ja": "7かける8はいくつ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1/6",
+        "ja": "ロクブンノイチ",
+        "ja_typings": [
+          "rokubunnoichi",
+          "rokubunnnoichi"
+        ]
+      },
+      {
+        "en": "1/3",
+        "ja": "サンブンノイチ",
+        "ja_typings": [
+          "sanbunnoichi",
+          "sanbunnnoichi"
+        ]
+      },
+      {
+        "en": "1/2",
+        "ja": "ニブンノイチ",
+        "ja_typings": [
+          "nibunnoichi",
+          "nibunnnoichi"
+        ]
+      },
+      {
+        "en": "1/12",
+        "ja": "ジュウニブンノイチ",
+        "ja_typings": [
+          "juunibunnoichi",
+          "juunibunnnoichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01029",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the probability of rolling a 6 on a fair die?",
+      "ja": "サイコロで6が出る確率は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "32",
+        "ja": "サンジュウニ",
+        "ja_typings": [
+          "sanjuuni"
+        ]
+      },
+      {
+        "en": "24",
+        "ja": "ニジュウヨン",
+        "ja_typings": [
+          "nijuuyon"
+        ]
+      },
+      {
+        "en": "20",
+        "ja": "ニジュウ",
+        "ja_typings": [
+          "nijuu"
+        ]
+      },
+      {
+        "en": "64",
+        "ja": "ロクジュウヨン",
+        "ja_typings": [
+          "rokujuuyon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01030",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the next number: 2, 4, 8, 16, ?",
+      "ja": "次の数列の次は: 2, 4, 8, 16, ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "6",
+        "ja": "ロク",
+        "ja_typings": [
+          "roku"
+        ]
+      },
+      {
+        "en": "5",
+        "ja": "ゴ",
+        "ja_typings": [
+          "go"
+        ]
+      },
+      {
+        "en": "7",
+        "ja": "ナナ",
+        "ja_typings": [
+          "nana"
+        ]
+      },
+      {
+        "en": "8",
+        "ja": "ハチ",
+        "ja_typings": [
+          "hachi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01031",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the mean of 2, 4, 6, 8, 10?",
+      "ja": "2, 4, 6, 8, 10の平均は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "middle value",
+        "ja": "マンナカノアタイ",
+        "ja_typings": [
+          "mannakanoatai",
+          "mannnakanoatai"
+        ]
+      },
+      {
+        "en": "most frequent value",
+        "ja": "サイヒンチ",
+        "ja_typings": [
+          "saihinchi"
+        ]
+      },
+      {
+        "en": "average value",
+        "ja": "ヘイキンチ",
+        "ja_typings": [
+          "heikinchi"
+        ]
+      },
+      {
+        "en": "total sum",
+        "ja": "ゴウケイ",
+        "ja_typings": [
+          "goukei",
+          "gokei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01032",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the median represent?",
+      "ja": "中央値とは何か?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "cube",
+        "ja": "リッポウタイ",
+        "ja_typings": [
+          "rippoutai",
+          "rippotai"
+        ]
+      },
+      {
+        "en": "tetrahedron",
+        "ja": "セイシメンタイ",
+        "ja_typings": [
+          "seishimentai"
+        ]
+      },
+      {
+        "en": "sphere",
+        "ja": "キュウ",
+        "ja_typings": [
+          "kyuu"
+        ]
+      },
+      {
+        "en": "cone",
+        "ja": "エンスイ",
+        "ja_typings": [
+          "ensui"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01033",
+    "image_path": null,
+    "question_text": {
+      "en": "What shape has 6 faces?",
+      "ja": "面が6つある立体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "12 edges",
+        "ja": "ジュウニホン",
+        "ja_typings": [
+          "juunihon"
+        ]
+      },
+      {
+        "en": "8 edges",
+        "ja": "ハチホン",
+        "ja_typings": [
+          "hachihon"
+        ]
+      },
+      {
+        "en": "6 edges",
+        "ja": "ロクホン",
+        "ja_typings": [
+          "rokuhon"
+        ]
+      },
+      {
+        "en": "24 edges",
+        "ja": "ニジュウヨンホン",
+        "ja_typings": [
+          "nijuuyonhon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01034",
+    "image_path": null,
+    "question_text": {
+      "en": "How many edges does a cube have?",
+      "ja": "立方体の辺の数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "rise over run",
+        "ja": "タテワルヨコ",
+        "ja_typings": [
+          "tatewaruyoko"
+        ]
+      },
+      {
+        "en": "run over rise",
+        "ja": "ヨコワルタテ",
+        "ja_typings": [
+          "yokowarutate"
+        ]
+      },
+      {
+        "en": "base times height",
+        "ja": "テイヘンカケルタカサ",
+        "ja_typings": [
+          "teihenkakerutakasa"
+        ]
+      },
+      {
+        "en": "squared sum",
+        "ja": "ジジョウワ",
+        "ja_typings": [
+          "jijouwa",
+          "jijowa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01035",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the slope formula?",
+      "ja": "傾きを求める公式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "3",
+        "ja": "サン",
+        "ja_typings": [
+          "san"
+        ]
+      },
+      {
+        "en": "2",
+        "ja": "ニ",
+        "ja_typings": [
+          "ni"
+        ]
+      },
+      {
+        "en": "4",
+        "ja": "ヨン",
+        "ja_typings": [
+          "yon"
+        ]
+      },
+      {
+        "en": "10",
+        "ja": "ジュウ",
+        "ja_typings": [
+          "juu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01036",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the value of log base 10 of 1000?",
+      "ja": "10を底とする1000の対数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "30",
+        "ja": "サンジュウ",
+        "ja_typings": [
+          "sanjuu"
+        ]
+      },
+      {
+        "en": "25",
+        "ja": "ニジュウゴ",
+        "ja_typings": [
+          "nijuugo"
+        ]
+      },
+      {
+        "en": "35",
+        "ja": "サンジュウゴ",
+        "ja_typings": [
+          "sanjuugo"
+        ]
+      },
+      {
+        "en": "45",
+        "ja": "ヨンジュウゴ",
+        "ja_typings": [
+          "yonjuugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01037",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 15 percent of 200?",
+      "ja": "200の15パーセントはいくつ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "root 2",
+        "ja": "ルートニ",
+        "ja_typings": [
+          "ru-toni"
+        ]
+      },
+      {
+        "en": "root 3",
+        "ja": "ルートサン",
+        "ja_typings": [
+          "ru-tosan"
+        ]
+      },
+      {
+        "en": "root 5",
+        "ja": "ルートゴ",
+        "ja_typings": [
+          "ru-togo"
+        ]
+      },
+      {
+        "en": "2",
+        "ja": "ニ",
+        "ja_typings": [
+          "ni"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01038",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the diagonal of a unit square?",
+      "ja": "1辺1の正方形の対角線の長さは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "101",
+        "ja": "イチゼロイチ",
+        "ja_typings": [
+          "ichizeroichi"
+        ]
+      },
+      {
+        "en": "110",
+        "ja": "イチイチゼロ",
+        "ja_typings": [
+          "ichiichizero"
+        ]
+      },
+      {
+        "en": "111",
+        "ja": "イチイチイチ",
+        "ja_typings": [
+          "ichiichiichi"
+        ]
+      },
+      {
+        "en": "100",
+        "ja": "イチゼロゼロ",
+        "ja_typings": [
+          "ichizerozero"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01039",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the binary representation of 5?",
+      "ja": "10進数の5を2進数で表すと?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1/2",
+        "ja": "ニブンノイチ",
+        "ja_typings": [
+          "nibunnoichi",
+          "nibunnnoichi"
+        ]
+      },
+      {
+        "en": "root 3 over 2",
+        "ja": "ルートサンブンノニ",
+        "ja_typings": [
+          "ru-tosanbunnoni",
+          "ru-tosanbunnnoni"
+        ]
+      },
+      {
+        "en": "root 2 over 2",
+        "ja": "ルートニブンノニ",
+        "ja_typings": [
+          "ru-tonibunnoni",
+          "ru-tonibunnnoni"
+        ]
+      },
+      {
+        "en": "1",
+        "ja": "イチ",
+        "ja_typings": [
+          "ichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01040",
+    "image_path": null,
+    "question_text": {
+      "en": "What is sin of 30 degrees?",
+      "ja": "サイン30度の値は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "2x",
+        "ja": "ニエックス",
+        "ja_typings": [
+          "niekkusu"
+        ]
+      },
+      {
+        "en": "only x",
+        "ja": "エックスダケ",
+        "ja_typings": [
+          "ekkusudake"
+        ]
+      },
+      {
+        "en": "x cubed",
+        "ja": "エックスサンジョウ",
+        "ja_typings": [
+          "ekkususanjou",
+          "ekkususanjo"
+        ]
+      },
+      {
+        "en": "constant",
+        "ja": "テイスウ",
+        "ja_typings": [
+          "teisuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01041",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the derivative of x squared?",
+      "ja": "xの2乗の微分は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "natural log of x",
+        "ja": "シゼンタイスウエックス",
+        "ja_typings": [
+          "shizentaisuuekkusu"
+        ]
+      },
+      {
+        "en": "x squared",
+        "ja": "エックスニジョウ",
+        "ja_typings": [
+          "ekkusunijou",
+          "ekkusunijo"
+        ]
+      },
+      {
+        "en": "e to the x",
+        "ja": "イーノエックスジョウ",
+        "ja_typings": [
+          "i-noekkusujou",
+          "i-noekkusujo"
+        ]
+      },
+      {
+        "en": "zero",
+        "ja": "ゼロ",
+        "ja_typings": [
+          "zero"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01042",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the integral of 1 over x?",
+      "ja": "xぶんの1の積分は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "19",
+        "ja": "ジュウキュウ",
+        "ja_typings": [
+          "juukyuu"
+        ]
+      },
+      {
+        "en": "18",
+        "ja": "ジュウハチ",
+        "ja_typings": [
+          "juuhachi"
+        ]
+      },
+      {
+        "en": "21",
+        "ja": "ニジュウイチ",
+        "ja_typings": [
+          "nijuuichi"
+        ]
+      },
+      {
+        "en": "17",
+        "ja": "ジュウナナ",
+        "ja_typings": [
+          "juunana"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01043",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 10 squared minus 9 squared?",
+      "ja": "10の2乗ひく9の2乗は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "6",
+        "ja": "ロク",
+        "ja_typings": [
+          "roku"
+        ]
+      },
+      {
+        "en": "4",
+        "ja": "ヨン",
+        "ja_typings": [
+          "yon"
+        ]
+      },
+      {
+        "en": "8",
+        "ja": "ハチ",
+        "ja_typings": [
+          "hachi"
+        ]
+      },
+      {
+        "en": "28",
+        "ja": "ニジュウハチ",
+        "ja_typings": [
+          "nijuuhachi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q01044",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the smallest perfect number?",
+      "ja": "最小の完全数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Automated Teller Machine",
+        "ja": "オートメイテッドテラーマシン",
+        "ja_typings": [
+          "o-tomeiteddotera-mashin"
+        ]
+      },
+      {
+        "en": "Auto Transfer Money",
+        "ja": "オートトランスファーマネー",
+        "ja_typings": [
+          "o-totoransufa-mane-"
+        ]
+      },
+      {
+        "en": "Account Transfer Method",
+        "ja": "アカウントトランスファーメソッド",
+        "ja_typings": [
+          "akauntotoransufa-mesoddo"
+        ]
+      },
+      {
+        "en": "Active Time Manager",
+        "ja": "アクティブタイムマネージャー",
+        "ja_typings": [
+          "akutibutaimumane-ja-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01045",
+    "image_path": null,
+    "question_text": {
+      "en": "What does ATM stand for?",
+      "ja": "ATMは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "206 bones",
+        "ja": "ニヒャクロッポン",
+        "ja_typings": [
+          "nihyakuroppon"
+        ]
+      },
+      {
+        "en": "150 bones",
+        "ja": "ヒャクゴジッポン",
+        "ja_typings": [
+          "hyakugojippon"
+        ]
+      },
+      {
+        "en": "300 bones",
+        "ja": "サンビャッポン",
+        "ja_typings": [
+          "sanbyappon"
+        ]
+      },
+      {
+        "en": "250 bones",
+        "ja": "ニヒャクゴジッポン",
+        "ja_typings": [
+          "nihyakugojippon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01046",
+    "image_path": null,
+    "question_text": {
+      "en": "How many bones are in the adult human body?",
+      "ja": "成人の人間の骨の数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "3600 seconds",
+        "ja": "サンゼンロッピャクビョウ",
+        "ja_typings": [
+          "sanzenroppyakubyou",
+          "sanzenroppyakubyo"
+        ]
+      },
+      {
+        "en": "60 seconds",
+        "ja": "ロクジュウビョウ",
+        "ja_typings": [
+          "rokujuubyou",
+          "rokujuubyo"
+        ]
+      },
+      {
+        "en": "7200 seconds",
+        "ja": "ナナセンニヒャクビョウ",
+        "ja_typings": [
+          "nanasennihyakubyou",
+          "nanasennnihyakubyo",
+          "nanasennnihyakubyou"
+        ]
+      },
+      {
+        "en": "1800 seconds",
+        "ja": "センハッピャクビョウ",
+        "ja_typings": [
+          "senhappyakubyou",
+          "senhappyakubyo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01047",
+    "image_path": null,
+    "question_text": {
+      "en": "How many seconds are in an hour?",
+      "ja": "1時間は何秒?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "300000 km per second",
+        "ja": "サンジュウマンキロメートルマイビョウ",
+        "ja_typings": [
+          "sanjuumankiromeetorumaibyou",
+          "sanjuumankirome-torumaibyo",
+          "sanjuumankirome-torumaibyou"
+        ]
+      },
+      {
+        "en": "30000 km per second",
+        "ja": "サンマンキロメートルマイビョウ",
+        "ja_typings": [
+          "sanmankiromeetorumaibyou",
+          "sanmankirome-torumaibyo",
+          "sanmankirome-torumaibyou"
+        ]
+      },
+      {
+        "en": "3 million km per second",
+        "ja": "サンビャクマンキロメートルマイビョウ",
+        "ja_typings": [
+          "sanbyakumankiromeetorumaibyou",
+          "sanbyakumankirome-torumaibyo",
+          "sanbyakumankirome-torumaibyou"
+        ]
+      },
+      {
+        "en": "3000 km per second",
+        "ja": "サンゼンキロメートルマイビョウ",
+        "ja_typings": [
+          "sanzenkiromeetorumaibyou",
+          "sanzenkirome-torumaibyo",
+          "sanzenkirome-torumaibyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01048",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the speed of light approximately?",
+      "ja": "光の速さはおよそ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chief Executive Officer",
+        "ja": "チーフエグゼクティブオフィサー",
+        "ja_typings": [
+          "chi-fueguzekutibuofisa-"
+        ]
+      },
+      {
+        "en": "Central Executive Order",
+        "ja": "セントラルエグゼクティブオーダー",
+        "ja_typings": [
+          "sentorarueguzekutibuo-da-"
+        ]
+      },
+      {
+        "en": "Corporate Engineer Officer",
+        "ja": "コーポレートエンジニアオフィサー",
+        "ja_typings": [
+          "ko-pore-toenjiniaofisa-"
+        ]
+      },
+      {
+        "en": "Chief Engineering Operator",
+        "ja": "チーフエンジニアリングオペレーター",
+        "ja_typings": [
+          "chi-fuenjiniaringuopere-ta-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01049",
+    "image_path": null,
+    "question_text": {
+      "en": "What does CEO stand for?",
+      "ja": "CEOは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "8 planets",
+        "ja": "ハッコ",
+        "ja_typings": [
+          "hakko"
+        ]
+      },
+      {
+        "en": "9 planets",
+        "ja": "キュウコ",
+        "ja_typings": [
+          "kyuuko"
+        ]
+      },
+      {
+        "en": "7 planets",
+        "ja": "ナナコ",
+        "ja_typings": [
+          "nanako"
+        ]
+      },
+      {
+        "en": "10 planets",
+        "ja": "ジッコ",
+        "ja_typings": [
+          "jikko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01050",
+    "image_path": null,
+    "question_text": {
+      "en": "How many planets are in our solar system?",
+      "ja": "太陽系の惑星の数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pacific Ocean",
+        "ja": "タイヘイヨウ",
+        "ja_typings": [
+          "taiheiyou",
+          "taiheiyo"
+        ]
+      },
+      {
+        "en": "Atlantic Ocean",
+        "ja": "タイセイヨウ",
+        "ja_typings": [
+          "taiseiyou",
+          "taiseiyo"
+        ]
+      },
+      {
+        "en": "Indian Ocean",
+        "ja": "インドヨウ",
+        "ja_typings": [
+          "indoyou",
+          "indoyo"
+        ]
+      },
+      {
+        "en": "Arctic Ocean",
+        "ja": "ホッキョクカイ",
+        "ja_typings": [
+          "hokkyokukai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01051",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the largest ocean?",
+      "ja": "世界最大の海は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mount Everest",
+        "ja": "エベレスト",
+        "ja_typings": [
+          "eberesuto"
+        ]
+      },
+      {
+        "en": "K2",
+        "ja": "ケーツー",
+        "ja_typings": [
+          "ke-tsu-"
+        ]
+      },
+      {
+        "en": "Mount Fuji",
+        "ja": "フジサン",
+        "ja_typings": [
+          "fujisan"
+        ]
+      },
+      {
+        "en": "Mont Blanc",
+        "ja": "モンブラン",
+        "ja_typings": [
+          "monburan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01052",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the tallest mountain in the world?",
+      "ja": "世界一高い山は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Canada",
+        "ja": "カナダ",
+        "ja_typings": [
+          "kanada"
+        ]
+      },
+      {
+        "en": "Russia",
+        "ja": "ロシア",
+        "ja_typings": [
+          "roshia"
+        ]
+      },
+      {
+        "en": "Australia",
+        "ja": "オーストラリア",
+        "ja_typings": [
+          "o-sutoraria"
+        ]
+      },
+      {
+        "en": "Indonesia",
+        "ja": "インドネシア",
+        "ja_typings": [
+          "indoneshia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01053",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has the longest coastline?",
+      "ja": "海岸線が世界一長い国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Global Positioning System",
+        "ja": "グローバルポジショニングシステム",
+        "ja_typings": [
+          "guro-barupojishoningushisutemu"
+        ]
+      },
+      {
+        "en": "General Position Service",
+        "ja": "ジェネラルポジションサービス",
+        "ja_typings": [
+          "jenerarupojishonsa-bisu"
+        ]
+      },
+      {
+        "en": "Geographic Plot Standard",
+        "ja": "ジオグラフィックプロットスタンダード",
+        "ja_typings": [
+          "jiogurafikkupurottosutanda-do"
+        ]
+      },
+      {
+        "en": "Ground Path Sensor",
+        "ja": "グラウンドパスセンサー",
+        "ja_typings": [
+          "guraundopasusensa-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01054",
+    "image_path": null,
+    "question_text": {
+      "en": "What does GPS stand for?",
+      "ja": "GPSは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Czech",
+        "ja": "チェコゴ",
+        "ja_typings": [
+          "chekogo"
+        ]
+      },
+      {
+        "en": "Greek",
+        "ja": "ギリシャゴ",
+        "ja_typings": [
+          "girishago"
+        ]
+      },
+      {
+        "en": "Latin",
+        "ja": "ラテンゴ",
+        "ja_typings": [
+          "ratengo"
+        ]
+      },
+      {
+        "en": "German",
+        "ja": "ドイツゴ",
+        "ja_typings": [
+          "doitsugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01055",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the origin of the word robot?",
+      "ja": "ロボットの語源となった言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "pascal",
+        "ja": "パスカル",
+        "ja_typings": [
+          "pasukaru"
+        ]
+      },
+      {
+        "en": "hertz",
+        "ja": "ヘルツ",
+        "ja_typings": [
+          "herutsu"
+        ]
+      },
+      {
+        "en": "joule",
+        "ja": "ジュール",
+        "ja_typings": [
+          "ju-ru"
+        ]
+      },
+      {
+        "en": "newton",
+        "ja": "ニュートン",
+        "ja_typings": [
+          "nyu-ton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01056",
+    "image_path": null,
+    "question_text": {
+      "en": "What unit measures pressure?",
+      "ja": "圧力の単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "6 strings",
+        "ja": "ロッポン",
+        "ja_typings": [
+          "roppon"
+        ]
+      },
+      {
+        "en": "4 strings",
+        "ja": "ヨンホン",
+        "ja_typings": [
+          "yonhon"
+        ]
+      },
+      {
+        "en": "7 strings",
+        "ja": "ナナホン",
+        "ja_typings": [
+          "nanahon"
+        ]
+      },
+      {
+        "en": "12 strings",
+        "ja": "ジュウニホン",
+        "ja_typings": [
+          "juunihon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01057",
+    "image_path": null,
+    "question_text": {
+      "en": "How many strings does a standard guitar have?",
+      "ja": "標準的なギターの弦の数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "distress signal",
+        "ja": "ソウナンシンゴウ",
+        "ja_typings": [
+          "sounanshingou",
+          "sonanshingo"
+        ]
+      },
+      {
+        "en": "save our ship",
+        "ja": "セーブアワーシップ",
+        "ja_typings": [
+          "se-buawa-shippu"
+        ]
+      },
+      {
+        "en": "ship out signal",
+        "ja": "シップアウトシグナル",
+        "ja_typings": [
+          "shippuautoshigunaru"
+        ]
+      },
+      {
+        "en": "standard order set",
+        "ja": "スタンダードオーダーセット",
+        "ja_typings": [
+          "sutanda-do-da-setto",
+          "sutanda-doo-da-setto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01058",
+    "image_path": null,
+    "question_text": {
+      "en": "What does SOS represent?",
+      "ja": "SOSは何を表すか?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Very Important Person",
+        "ja": "ベリーインポータントパーソン",
+        "ja_typings": [
+          "beri-inpo-tantopa-son"
+        ]
+      },
+      {
+        "en": "Vital Information Pass",
+        "ja": "バイタルインフォメーションパス",
+        "ja_typings": [
+          "baitaruinfome-shonpasu"
+        ]
+      },
+      {
+        "en": "Visual Identity Profile",
+        "ja": "ビジュアルアイデンティティプロファイル",
+        "ja_typings": [
+          "bijuaruaidentitipurofairu"
+        ]
+      },
+      {
+        "en": "Verified Internal Pass",
+        "ja": "ベリファイドインターナルパス",
+        "ja_typings": [
+          "berifaidointa-narupasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01059",
+    "image_path": null,
+    "question_text": {
+      "en": "What does VIP stand for?",
+      "ja": "VIPは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "7 continents",
+        "ja": "ナナタイリク",
+        "ja_typings": [
+          "nanatairiku"
+        ]
+      },
+      {
+        "en": "5 continents",
+        "ja": "ゴタイリク",
+        "ja_typings": [
+          "gotairiku"
+        ]
+      },
+      {
+        "en": "6 continents",
+        "ja": "ロクタイリク",
+        "ja_typings": [
+          "rokutairiku"
+        ]
+      },
+      {
+        "en": "8 continents",
+        "ja": "ハチタイリク",
+        "ja_typings": [
+          "hachitairiku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01060",
+    "image_path": null,
+    "question_text": {
+      "en": "How many continents are there?",
+      "ja": "大陸はいくつある?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vatican City",
+        "ja": "バチカンシコク",
+        "ja_typings": [
+          "bachikanshikoku"
+        ]
+      },
+      {
+        "en": "Monaco",
+        "ja": "モナコ",
+        "ja_typings": [
+          "monako"
+        ]
+      },
+      {
+        "en": "San Marino",
+        "ja": "サンマリノ",
+        "ja_typings": [
+          "sanmarino"
+        ]
+      },
+      {
+        "en": "Liechtenstein",
+        "ja": "リヒテンシュタイン",
+        "ja_typings": [
+          "rihitenshutain"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01061",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the smallest country in the world?",
+      "ja": "世界で一番小さい国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Portable Document Format",
+        "ja": "ポータブルドキュメントフォーマット",
+        "ja_typings": [
+          "po-taburudokyumentofo-matto"
+        ]
+      },
+      {
+        "en": "Personal Data File",
+        "ja": "パーソナルデータファイル",
+        "ja_typings": [
+          "pa-sonarude-tafairu"
+        ]
+      },
+      {
+        "en": "Public Document Folder",
+        "ja": "パブリックドキュメントフォルダ",
+        "ja_typings": [
+          "paburikkudokyumentoforuda"
+        ]
+      },
+      {
+        "en": "Print Direct Form",
+        "ja": "プリントダイレクトフォーム",
+        "ja_typings": [
+          "purintodairekutofo-mu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01062",
+    "image_path": null,
+    "question_text": {
+      "en": "What does PDF stand for?",
+      "ja": "PDFは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "100 degrees Celsius",
+        "ja": "ヒャクド",
+        "ja_typings": [
+          "hyakudo"
+        ]
+      },
+      {
+        "en": "90 degrees Celsius",
+        "ja": "キュウジュウド",
+        "ja_typings": [
+          "kyuujuudo"
+        ]
+      },
+      {
+        "en": "212 degrees Celsius",
+        "ja": "ニヒャクジュウニド",
+        "ja_typings": [
+          "nihyakujuunido"
+        ]
+      },
+      {
+        "en": "80 degrees Celsius",
+        "ja": "ハチジュウド",
+        "ja_typings": [
+          "hachijuudo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01063",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the boiling point of water at sea level?",
+      "ja": "海面における水の沸点は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "7 colors",
+        "ja": "ナナショク",
+        "ja_typings": [
+          "nanashoku"
+        ]
+      },
+      {
+        "en": "5 colors",
+        "ja": "ゴショク",
+        "ja_typings": [
+          "goshoku"
+        ]
+      },
+      {
+        "en": "6 colors",
+        "ja": "ロクショク",
+        "ja_typings": [
+          "rokushoku"
+        ]
+      },
+      {
+        "en": "8 colors",
+        "ja": "ハッショク",
+        "ja_typings": [
+          "hasshoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q01064",
+    "image_path": null,
+    "question_text": {
+      "en": "How many colors are in a rainbow?",
+      "ja": "虹の色の数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "good game",
+        "ja": "グッドゲーム",
+        "ja_typings": [
+          "guddoge-mu"
+        ]
+      },
+      {
+        "en": "get going",
+        "ja": "ゲットゴーイング",
+        "ja_typings": [
+          "gettogo-ingu"
+        ]
+      },
+      {
+        "en": "great gain",
+        "ja": "グレートゲイン",
+        "ja_typings": [
+          "gure-togein"
+        ]
+      },
+      {
+        "en": "game guide",
+        "ja": "ゲームガイド",
+        "ja_typings": [
+          "ge-mugaido"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01065",
+    "image_path": null,
+    "question_text": {
+      "en": "What does GG mean in gaming?",
+      "ja": "ゲームで使われるGGの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Away From Keyboard",
+        "ja": "アウェイフロムキーボード",
+        "ja_typings": [
+          "aweifuromuki-bo-do"
+        ]
+      },
+      {
+        "en": "All For Kicks",
+        "ja": "オールフォーキックス",
+        "ja_typings": [
+          "o-rufo-kikkusu"
+        ]
+      },
+      {
+        "en": "Asking For Knowledge",
+        "ja": "アスキングフォーナレッジ",
+        "ja_typings": [
+          "asukingufo-narejji"
+        ]
+      },
+      {
+        "en": "Active Friend Killer",
+        "ja": "アクティブフレンドキラー",
+        "ja_typings": [
+          "akutibufurendokira-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01066",
+    "image_path": null,
+    "question_text": {
+      "en": "What does AFK stand for?",
+      "ja": "AFKは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "laughter",
+        "ja": "ワライ",
+        "ja_typings": [
+          "warai"
+        ]
+      },
+      {
+        "en": "anger",
+        "ja": "イカリ",
+        "ja_typings": [
+          "ikari"
+        ]
+      },
+      {
+        "en": "sadness",
+        "ja": "カナシミ",
+        "ja_typings": [
+          "kanashimi"
+        ]
+      },
+      {
+        "en": "surprise",
+        "ja": "オドロキ",
+        "ja_typings": [
+          "odoroki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01067",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the slang 'kusa' mean?",
+      "ja": "ネットスラング草の意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Live2D model",
+        "ja": "ライブツーディーモデル",
+        "ja_typings": [
+          "raibutsu-di-moderu"
+        ]
+      },
+      {
+        "en": "flat avatar",
+        "ja": "フラットアバター",
+        "ja_typings": [
+          "furattoabata-"
+        ]
+      },
+      {
+        "en": "paper avatar",
+        "ja": "ペーパーアバター",
+        "ja_typings": [
+          "pe-pa-abata-"
+        ]
+      },
+      {
+        "en": "static icon",
+        "ja": "スタティックアイコン",
+        "ja_typings": [
+          "sutatikkuaikon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01068",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a VTuber's avatar called?",
+      "ja": "VTuberが使うアバターの呼び方は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "paid comment",
+        "ja": "ユウリョウコメント",
+        "ja_typings": [
+          "yuuryoukomento",
+          "yuuryokomento"
+        ]
+      },
+      {
+        "en": "free comment",
+        "ja": "ムリョウコメント",
+        "ja_typings": [
+          "muryoukomento",
+          "muryokomento"
+        ]
+      },
+      {
+        "en": "system message",
+        "ja": "システムメッセージ",
+        "ja_typings": [
+          "shisutemumesse-ji"
+        ]
+      },
+      {
+        "en": "auto reply",
+        "ja": "オートヘンシン",
+        "ja_typings": [
+          "o-tohenshin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01069",
+    "image_path": null,
+    "question_text": {
+      "en": "What does superchat mean on YouTube?",
+      "ja": "YouTubeのスパチャの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "good luck have fun",
+        "ja": "グッドラックハブファン",
+        "ja_typings": [
+          "guddorakkuhabufan"
+        ]
+      },
+      {
+        "en": "get level high first",
+        "ja": "ゲットレベルハイファースト",
+        "ja_typings": [
+          "gettoreberuhaifa-suto"
+        ]
+      },
+      {
+        "en": "go left hit fast",
+        "ja": "ゴーレフトヒットファスト",
+        "ja_typings": [
+          "go-refutohittofasuto"
+        ]
+      },
+      {
+        "en": "great loss huge fight",
+        "ja": "グレートロスヒュージファイト",
+        "ja_typings": [
+          "gure-torosuhyu-jifaito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01070",
+    "image_path": null,
+    "question_text": {
+      "en": "What does GLHF mean?",
+      "ja": "GLHFの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "beginner",
+        "ja": "ショシンシャ",
+        "ja_typings": [
+          "shoshinsha"
+        ]
+      },
+      {
+        "en": "expert",
+        "ja": "ジョウキュウシャ",
+        "ja_typings": [
+          "joukyuusha",
+          "jokyuusha"
+        ]
+      },
+      {
+        "en": "cheater",
+        "ja": "フセイシャ",
+        "ja_typings": [
+          "fuseisha"
+        ]
+      },
+      {
+        "en": "spectator",
+        "ja": "カンセンシャ",
+        "ja_typings": [
+          "kansensha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01071",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'noob' in gaming?",
+      "ja": "ゲームでnoobの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "very serious player",
+        "ja": "シンケンプレイヤー",
+        "ja_typings": [
+          "shinkenpureiya-"
+        ]
+      },
+      {
+        "en": "casual player",
+        "ja": "ライトプレイヤー",
+        "ja_typings": [
+          "raitopureiya-"
+        ]
+      },
+      {
+        "en": "cheating player",
+        "ja": "チートプレイヤー",
+        "ja_typings": [
+          "chi-topureiya-"
+        ]
+      },
+      {
+        "en": "new player",
+        "ja": "ニュープレイヤー",
+        "ja_typings": [
+          "nyu-pureiya-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01072",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'tryhard' refer to?",
+      "ja": "tryhardが指す意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "excitement",
+        "ja": "コウフン",
+        "ja_typings": [
+          "koufun",
+          "kofun"
+        ]
+      },
+      {
+        "en": "anger",
+        "ja": "イカリ",
+        "ja_typings": [
+          "ikari"
+        ]
+      },
+      {
+        "en": "fatigue",
+        "ja": "ツカレ",
+        "ja_typings": [
+          "tsukare"
+        ]
+      },
+      {
+        "en": "regret",
+        "ja": "コウカイ",
+        "ja_typings": [
+          "koukai",
+          "kokai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01073",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the meaning of 'pog'?",
+      "ja": "pogの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "most effective tactic",
+        "ja": "サイコウセンリャク",
+        "ja_typings": [
+          "saikousenryaku",
+          "saikosenryaku"
+        ]
+      },
+      {
+        "en": "mini event",
+        "ja": "ミニイベント",
+        "ja_typings": [
+          "miniibento"
+        ]
+      },
+      {
+        "en": "modder area",
+        "ja": "モッダーエリア",
+        "ja_typings": [
+          "modda-eria"
+        ]
+      },
+      {
+        "en": "main enemy target",
+        "ja": "メインエネミーターゲット",
+        "ja_typings": [
+          "meinnenemi-ta-getto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01074",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'meta' mean in games?",
+      "ja": "ゲーム用語のメタの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Selfish Gene book",
+        "ja": "リコテキイデンシ",
+        "ja_typings": [
+          "rikotekiidenshi"
+        ]
+      },
+      {
+        "en": "ancient Greek myth",
+        "ja": "ギリシャシンワ",
+        "ja_typings": [
+          "girishashinwa"
+        ]
+      },
+      {
+        "en": "modern AI research",
+        "ja": "ゲンダイエーアイケンキュウ",
+        "ja_typings": [
+          "gendaie-aikenkyuu"
+        ]
+      },
+      {
+        "en": "Roman philosophy",
+        "ja": "ローマテツガク",
+        "ja_typings": [
+          "ro-matetsugaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01075",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the origin of meme?",
+      "ja": "ミームの語源は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "low quality post",
+        "ja": "ヒンシツノヒクイトウコウ",
+        "ja_typings": [
+          "hinshitsunohikuitoukou",
+          "hinshitsunohikuitoko"
+        ]
+      },
+      {
+        "en": "serious essay",
+        "ja": "ホンキノロンブン",
+        "ja_typings": [
+          "honkinoronbun"
+        ]
+      },
+      {
+        "en": "paid sponsorship",
+        "ja": "ユウリョウスポンサー",
+        "ja_typings": [
+          "yuuryousuponsa-",
+          "yuuryosuponsa-"
+        ]
+      },
+      {
+        "en": "legal notice",
+        "ja": "ホウテキツウチ",
+        "ja_typings": [
+          "houtekitsuuchi",
+          "hotekitsuuchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01076",
+    "image_path": null,
+    "question_text": {
+      "en": "What is shitposting?",
+      "ja": "シットポストとは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "silent viewer",
+        "ja": "ムゲンシチョウシャ",
+        "ja_typings": [
+          "mugenshichousha",
+          "mugenshichosha"
+        ]
+      },
+      {
+        "en": "active chatter",
+        "ja": "カッパツナチャッター",
+        "ja_typings": [
+          "kappatsunachatta-"
+        ]
+      },
+      {
+        "en": "paid member",
+        "ja": "ユウリョウメンバー",
+        "ja_typings": [
+          "yuuryoumenba-",
+          "yuuryomenba-"
+        ]
+      },
+      {
+        "en": "auto bot",
+        "ja": "ジドウボット",
+        "ja_typings": [
+          "jidoubotto",
+          "jidobotto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01077",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'lurker' mean in livestreams?",
+      "ja": "配信用語のlurkerの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "leaking personal info",
+        "ja": "コジンジョウホウバクロ",
+        "ja_typings": [
+          "kojinjouhoubakuro",
+          "kojinjohobakuro"
+        ]
+      },
+      {
+        "en": "sharing memes",
+        "ja": "ミームキョウユウ",
+        "ja_typings": [
+          "mi-mukyouyuu",
+          "mi-mukyoyuu"
+        ]
+      },
+      {
+        "en": "editing photos",
+        "ja": "シャシンヘンシュウ",
+        "ja_typings": [
+          "shashinhenshuu"
+        ]
+      },
+      {
+        "en": "posting reviews",
+        "ja": "レビュートウコウ",
+        "ja_typings": [
+          "rebyu-toukou",
+          "rebyu-toko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01078",
+    "image_path": null,
+    "question_text": {
+      "en": "What is meant by 'doxxing'?",
+      "ja": "ドキシングの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "First Person Shooter",
+        "ja": "ファーストパーソンシューター",
+        "ja_typings": [
+          "fa-sutopa-sonshu-ta-"
+        ]
+      },
+      {
+        "en": "Fast Paced Style",
+        "ja": "ファストペーストスタイル",
+        "ja_typings": [
+          "fasutope-sutosutairu"
+        ]
+      },
+      {
+        "en": "Final Play Set",
+        "ja": "ファイナルプレイセット",
+        "ja_typings": [
+          "fainarupureisetto"
+        ]
+      },
+      {
+        "en": "Front Page Score",
+        "ja": "フロントページスコア",
+        "ja_typings": [
+          "furontope-jisukoa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01079",
+    "image_path": null,
+    "question_text": {
+      "en": "What does FPS stand for in gaming?",
+      "ja": "ゲーム用語のFPSは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "clearing a game as fast as possible",
+        "ja": "ゲームサイソクコウリャク",
+        "ja_typings": [
+          "ge-musaisokukouryaku",
+          "ge-musaisokukoryaku"
+        ]
+      },
+      {
+        "en": "slow exploration",
+        "ja": "ジックリタンサク",
+        "ja_typings": [
+          "jikkuritansaku"
+        ]
+      },
+      {
+        "en": "competitive ranking",
+        "ja": "ランキングタイセン",
+        "ja_typings": [
+          "rankingutaisen"
+        ]
+      },
+      {
+        "en": "multiplayer raid",
+        "ja": "マルチレイド",
+        "ja_typings": [
+          "maruchireido"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01080",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'speedrun'?",
+      "ja": "スピードランとは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sending viewers to another channel",
+        "ja": "ベツチャンネルニシチョウシャヲオクル",
+        "ja_typings": [
+          "betsuchannnerunishichoushawookuru",
+          "betsuchannnerunishichoshaokuru",
+          "betsuchannnerunishichoushaookuru"
+        ]
+      },
+      {
+        "en": "hacking attack",
+        "ja": "ハッキングコウゲキ",
+        "ja_typings": [
+          "hakkingukougeki",
+          "hakkingukogeki"
+        ]
+      },
+      {
+        "en": "payment refund",
+        "ja": "シハライヘンキン",
+        "ja_typings": [
+          "shiharaihenkin"
+        ]
+      },
+      {
+        "en": "login bonus",
+        "ja": "ログインボーナス",
+        "ja_typings": [
+          "roguinbo-nasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01081",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the meaning of 'raid' on streaming sites?",
+      "ja": "配信サイトのレイドの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "very good song",
+        "ja": "メイキョク",
+        "ja_typings": [
+          "meikyoku"
+        ]
+      },
+      {
+        "en": "very bad song",
+        "ja": "ヒドイキョク",
+        "ja_typings": [
+          "hidoikyoku"
+        ]
+      },
+      {
+        "en": "long song",
+        "ja": "ナガイキョク",
+        "ja_typings": [
+          "nagaikyoku"
+        ]
+      },
+      {
+        "en": "ad song",
+        "ja": "コウコクキョク",
+        "ja_typings": [
+          "koukokukyoku",
+          "kokokukyoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01082",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a 'banger' track?",
+      "ja": "bangerトラックの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "frustration",
+        "ja": "イラダチ",
+        "ja_typings": [
+          "iradachi"
+        ]
+      },
+      {
+        "en": "joy",
+        "ja": "ヨロコビ",
+        "ja_typings": [
+          "yorokobi"
+        ]
+      },
+      {
+        "en": "luck",
+        "ja": "ウン",
+        "ja_typings": [
+          "un"
+        ]
+      },
+      {
+        "en": "speed",
+        "ja": "ハヤサ",
+        "ja_typings": [
+          "hayasa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01083",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the meaning of 'salt' in gaming?",
+      "ja": "ゲームのsaltの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "quitting in anger",
+        "ja": "イカッテヤメル",
+        "ja_typings": [
+          "ikatteyameru"
+        ]
+      },
+      {
+        "en": "winning fast",
+        "ja": "ハヤクカツ",
+        "ja_typings": [
+          "hayakukatsu"
+        ]
+      },
+      {
+        "en": "calm goodbye",
+        "ja": "オダヤカナサヨウナラ",
+        "ja_typings": [
+          "odayakanasayounara",
+          "odayakanasayonara"
+        ]
+      },
+      {
+        "en": "auto save",
+        "ja": "ジドウホゾン",
+        "ja_typings": [
+          "jidouhozon",
+          "jidohozon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01084",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the meaning of 'rage quit'?",
+      "ja": "rage quitの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Player versus Player",
+        "ja": "プレイヤータイプレイヤー",
+        "ja_typings": [
+          "pureiya-taipureiya-"
+        ]
+      },
+      {
+        "en": "Plot versus Plot",
+        "ja": "プロットタイプロット",
+        "ja_typings": [
+          "purottotaipurotto"
+        ]
+      },
+      {
+        "en": "Public versus Private",
+        "ja": "パブリックタイプライベート",
+        "ja_typings": [
+          "paburikkutaipuraibe-to"
+        ]
+      },
+      {
+        "en": "Pick versus Pull",
+        "ja": "ピックタイプル",
+        "ja_typings": [
+          "pikkutaipuru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01085",
+    "image_path": null,
+    "question_text": {
+      "en": "What does PvP mean?",
+      "ja": "PvPの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "embarrassment",
+        "ja": "キョウシュク",
+        "ja_typings": [
+          "kyoushuku",
+          "kyoshuku"
+        ]
+      },
+      {
+        "en": "happiness",
+        "ja": "シアワセ",
+        "ja_typings": [
+          "shiawase"
+        ]
+      },
+      {
+        "en": "courage",
+        "ja": "ユウキ",
+        "ja_typings": [
+          "yuuki"
+        ]
+      },
+      {
+        "en": "calmness",
+        "ja": "オチツキ",
+        "ja_typings": [
+          "ochitsuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01086",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'cringe' describe?",
+      "ja": "cringeが表す感情は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "indecent content",
+        "ja": "セイテキナナイヨウ",
+        "ja_typings": [
+          "seitekinanaiyou",
+          "seitekinanaiyo"
+        ]
+      },
+      {
+        "en": "educational topic",
+        "ja": "キョウイクテーマ",
+        "ja_typings": [
+          "kyouikute-ma",
+          "kyoikute-ma"
+        ]
+      },
+      {
+        "en": "political opinion",
+        "ja": "セイジテキイケン",
+        "ja_typings": [
+          "seijitekiiken"
+        ]
+      },
+      {
+        "en": "musical genre",
+        "ja": "オンガクジャンル",
+        "ja_typings": [
+          "ongakujanru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01087",
+    "image_path": null,
+    "question_text": {
+      "en": "What does 'lewd' refer to?",
+      "ja": "lewdの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "very funny",
+        "ja": "オオワライ",
+        "ja_typings": [
+          "oowarai",
+          "owarai"
+        ]
+      },
+      {
+        "en": "very sad",
+        "ja": "オオナキ",
+        "ja_typings": [
+          "oonaki",
+          "onaki"
+        ]
+      },
+      {
+        "en": "very angry",
+        "ja": "オオイカリ",
+        "ja_typings": [
+          "ooikari",
+          "oikari"
+        ]
+      },
+      {
+        "en": "very scared",
+        "ja": "オオオビエ",
+        "ja_typings": [
+          "ooobie",
+          "oobie"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01088",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the meaning of '草生える'?",
+      "ja": "草生えるの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "clip video",
+        "ja": "クリップドウガ",
+        "ja_typings": [
+          "kurippudouga",
+          "kurippudoga"
+        ]
+      },
+      {
+        "en": "trim video",
+        "ja": "トリムドウガ",
+        "ja_typings": [
+          "torimudouga",
+          "torimudoga"
+        ]
+      },
+      {
+        "en": "snippet video",
+        "ja": "スニペットドウガ",
+        "ja_typings": [
+          "sunipettodouga",
+          "sunipettodoga"
+        ]
+      },
+      {
+        "en": "flash video",
+        "ja": "フラッシュドウガ",
+        "ja_typings": [
+          "furasshudouga",
+          "furasshudoga"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q01089",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the term for a clipped highlight?",
+      "ja": "切り抜き動画の英語呼称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Central Processing Unit",
+        "ja": "セントラルプロセッシングユニット",
+        "ja_typings": [
+          "sentorarupurosesshinguyunitto"
+        ]
+      },
+      {
+        "en": "Computer Program Utility",
+        "ja": "コンピュータプログラムユーティリティ",
+        "ja_typings": [
+          "konpyu-tapuroguramuyu-tiriti"
+        ]
+      },
+      {
+        "en": "Cache Processing Update",
+        "ja": "キャッシュプロセッシングアップデート",
+        "ja_typings": [
+          "kyasshupurosesshinguappude-to"
+        ]
+      },
+      {
+        "en": "Code Pipeline Unit",
+        "ja": "コードパイプラインユニット",
+        "ja_typings": [
+          "ko-dopaipurainnyunitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01090",
+    "image_path": null,
+    "question_text": {
+      "en": "What does CPU stand for?",
+      "ja": "CPUは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Random Access Memory",
+        "ja": "ランダムアクセスメモリ",
+        "ja_typings": [
+          "randamuakusesumemori"
+        ]
+      },
+      {
+        "en": "Read Access Mode",
+        "ja": "リードアクセスモード",
+        "ja_typings": [
+          "ri-doakusesumo-do"
+        ]
+      },
+      {
+        "en": "Rapid Address Manager",
+        "ja": "ラピッドアドレスマネージャー",
+        "ja_typings": [
+          "rapiddoadoresumane-ja-"
+        ]
+      },
+      {
+        "en": "Recursive Allocation Method",
+        "ja": "リカーシブアロケーションメソッド",
+        "ja_typings": [
+          "rika-shibuaroke-shonmesoddo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01091",
+    "image_path": null,
+    "question_text": {
+      "en": "What does RAM stand for?",
+      "ja": "RAMは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "port 22",
+        "ja": "ニジュウニバン",
+        "ja_typings": [
+          "nijuuniban"
+        ]
+      },
+      {
+        "en": "port 21",
+        "ja": "ニジュウイチバン",
+        "ja_typings": [
+          "nijuuichiban"
+        ]
+      },
+      {
+        "en": "port 80",
+        "ja": "ハチジュウバン",
+        "ja_typings": [
+          "hachijuuban"
+        ]
+      },
+      {
+        "en": "port 443",
+        "ja": "ヨンヒャクヨンジュウサンバン",
+        "ja_typings": [
+          "yonhyakuyonjuusanban"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01092",
+    "image_path": null,
+    "question_text": {
+      "en": "What port does SSH typically use?",
+      "ja": "SSHが通常使うポート番号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Solid State Drive",
+        "ja": "ソリッドステートドライブ",
+        "ja_typings": [
+          "soriddosute-todoraibu"
+        ]
+      },
+      {
+        "en": "Storage System Device",
+        "ja": "ストレージシステムデバイス",
+        "ja_typings": [
+          "sutore-jishisutemudebaisu"
+        ]
+      },
+      {
+        "en": "Secure Service Daemon",
+        "ja": "セキュアサービスデーモン",
+        "ja_typings": [
+          "sekyuasa-bisude-mon"
+        ]
+      },
+      {
+        "en": "Static Sync Disk",
+        "ja": "スタティックシンクディスク",
+        "ja_typings": [
+          "sutatikkushinkudisuku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01093",
+    "image_path": null,
+    "question_text": {
+      "en": "What does SSD stand for?",
+      "ja": "SSDは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Application Programming Interface",
+        "ja": "アプリケーションプログラミングインターフェース",
+        "ja_typings": [
+          "apurike-shonpuroguraminguinta-fe-su"
+        ]
+      },
+      {
+        "en": "Active Protocol Index",
+        "ja": "アクティブプロトコルインデックス",
+        "ja_typings": [
+          "akutibupurotokoruindekkusu"
+        ]
+      },
+      {
+        "en": "Auto Program Installer",
+        "ja": "オートプログラムインストーラー",
+        "ja_typings": [
+          "o-topuroguramuinsuto-ra-"
+        ]
+      },
+      {
+        "en": "Async Process Identifier",
+        "ja": "アシンクプロセスアイデンティファイア",
+        "ja_typings": [
+          "ashinkupurosesuaidentifaia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01094",
+    "image_path": null,
+    "question_text": {
+      "en": "What does API stand for?",
+      "ja": "APIは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "443",
+        "ja": "ヨンヨンサン",
+        "ja_typings": [
+          "yonyonsan",
+          "yonnyonsan"
+        ]
+      },
+      {
+        "en": "80",
+        "ja": "ハチマル",
+        "ja_typings": [
+          "hachimaru"
+        ]
+      },
+      {
+        "en": "22",
+        "ja": "ニジュウニ",
+        "ja_typings": [
+          "nijuuni"
+        ]
+      },
+      {
+        "en": "8080",
+        "ja": "ハチゼロハチゼロ",
+        "ja_typings": [
+          "hachizerohachizero"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01095",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the default port for HTTPS?",
+      "ja": "HTTPSのデフォルトポート番号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Universal Serial Bus",
+        "ja": "ユニバーサルシリアルバス",
+        "ja_typings": [
+          "yuniba-sarushiriarubasu"
+        ]
+      },
+      {
+        "en": "Unified System Boot",
+        "ja": "ユニファイドシステムブート",
+        "ja_typings": [
+          "yunifaidoshisutemubu-to"
+        ]
+      },
+      {
+        "en": "Ultra Speed Bridge",
+        "ja": "ウルトラスピードブリッジ",
+        "ja_typings": [
+          "urutorasupi-doburijji"
+        ]
+      },
+      {
+        "en": "User Storage Bay",
+        "ja": "ユーザーストレージベイ",
+        "ja_typings": [
+          "yu-za-sutore-jibei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01096",
+    "image_path": null,
+    "question_text": {
+      "en": "What does USB stand for?",
+      "ja": "USBは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "32 bits",
+        "ja": "サンジュウニビット",
+        "ja_typings": [
+          "sanjuunibitto"
+        ]
+      },
+      {
+        "en": "64 bits",
+        "ja": "ロクジュウヨンビット",
+        "ja_typings": [
+          "rokujuuyonbitto"
+        ]
+      },
+      {
+        "en": "128 bits",
+        "ja": "ヒャクニジュウハチビット",
+        "ja_typings": [
+          "hyakunijuuhachibitto"
+        ]
+      },
+      {
+        "en": "16 bits",
+        "ja": "ジュウロクビット",
+        "ja_typings": [
+          "juurokubitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01097",
+    "image_path": null,
+    "question_text": {
+      "en": "What is IPv4 address length in bits?",
+      "ja": "IPv4アドレスのビット長は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Amazon Web Services",
+        "ja": "アマゾンウェブサービス",
+        "ja_typings": [
+          "amazonnwebusa-bisu"
+        ]
+      },
+      {
+        "en": "Active Web System",
+        "ja": "アクティブウェブシステム",
+        "ja_typings": [
+          "akutibuwebushisutemu"
+        ]
+      },
+      {
+        "en": "Asynchronous Wire Source",
+        "ja": "アシンクロナスワイヤーソース",
+        "ja_typings": [
+          "ashinkuronasuwaiya-so-su"
+        ]
+      },
+      {
+        "en": "Auto Workflow Suite",
+        "ja": "オートワークフロースイート",
+        "ja_typings": [
+          "o-towa-kufuro-sui-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01098",
+    "image_path": null,
+    "question_text": {
+      "en": "What does AWS stand for?",
+      "ja": "AWSは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Graphics Processing Unit",
+        "ja": "グラフィックスプロセッシングユニット",
+        "ja_typings": [
+          "gurafikkusupurosesshinguyunitto"
+        ]
+      },
+      {
+        "en": "General Pipeline Utility",
+        "ja": "ジェネラルパイプラインユーティリティ",
+        "ja_typings": [
+          "jenerarupaipurainnyu-tiriti"
+        ]
+      },
+      {
+        "en": "Global Program Unit",
+        "ja": "グローバルプログラムユニット",
+        "ja_typings": [
+          "guro-barupuroguramuyunitto"
+        ]
+      },
+      {
+        "en": "Gigabyte Processing Unit",
+        "ja": "ギガバイトプロセッシングユニット",
+        "ja_typings": [
+          "gigabaitopurosesshinguyunitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01099",
+    "image_path": null,
+    "question_text": {
+      "en": "What does GPU stand for?",
+      "ja": "GPUは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "16",
+        "ja": "ジュウロク",
+        "ja_typings": [
+          "juuroku"
+        ]
+      },
+      {
+        "en": "2",
+        "ja": "ニ",
+        "ja_typings": [
+          "ni"
+        ]
+      },
+      {
+        "en": "8",
+        "ja": "ハチ",
+        "ja_typings": [
+          "hachi"
+        ]
+      },
+      {
+        "en": "10",
+        "ja": "ジュウ",
+        "ja_typings": [
+          "juu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01100",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the base of hexadecimal?",
+      "ja": "16進数の基数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HyperText Markup Language",
+        "ja": "ハイパーテキストマークアップランゲージ",
+        "ja_typings": [
+          "haipa-tekisutoma-kuappurange-ji"
+        ]
+      },
+      {
+        "en": "Home Tool Markup Language",
+        "ja": "ホームツールマークアップランゲージ",
+        "ja_typings": [
+          "ho-mutsu-ruma-kuappurange-ji"
+        ]
+      },
+      {
+        "en": "High Tech Modular Language",
+        "ja": "ハイテックモジュラーランゲージ",
+        "ja_typings": [
+          "haitekkumojura-range-ji"
+        ]
+      },
+      {
+        "en": "Host Transfer Meta Language",
+        "ja": "ホストトランスファーメタランゲージ",
+        "ja_typings": [
+          "hosutotoransufa-metarange-ji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01101",
+    "image_path": null,
+    "question_text": {
+      "en": "What does HTML stand for?",
+      "ja": "HTMLは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "48 bits",
+        "ja": "ヨンジュウハチビット",
+        "ja_typings": [
+          "yonjuuhachibitto"
+        ]
+      },
+      {
+        "en": "32 bits",
+        "ja": "サンジュウニビット",
+        "ja_typings": [
+          "sanjuunibitto"
+        ]
+      },
+      {
+        "en": "64 bits",
+        "ja": "ロクジュウヨンビット",
+        "ja_typings": [
+          "rokujuuyonbitto"
+        ]
+      },
+      {
+        "en": "16 bits",
+        "ja": "ジュウロクビット",
+        "ja_typings": [
+          "juurokubitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01102",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the size of a standard MAC address in bits?",
+      "ja": "MACアドレスのビット長は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "21",
+        "ja": "ニジュウイチ",
+        "ja_typings": [
+          "nijuuichi"
+        ]
+      },
+      {
+        "en": "22",
+        "ja": "ニジュウニ",
+        "ja_typings": [
+          "nijuuni"
+        ]
+      },
+      {
+        "en": "23",
+        "ja": "ニジュウサン",
+        "ja_typings": [
+          "nijuusan"
+        ]
+      },
+      {
+        "en": "25",
+        "ja": "ニジュウゴ",
+        "ja_typings": [
+          "nijuugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01103",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the default port for FTP?",
+      "ja": "FTPのデフォルトポート番号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Virtual Private Network",
+        "ja": "バーチャルプライベートネットワーク",
+        "ja_typings": [
+          "ba-charupuraibe-tonettowa-ku"
+        ]
+      },
+      {
+        "en": "Verified Public Node",
+        "ja": "ベリファイドパブリックノード",
+        "ja_typings": [
+          "berifaidopaburikkuno-do"
+        ]
+      },
+      {
+        "en": "Volume Packet Number",
+        "ja": "ボリュームパケットナンバー",
+        "ja_typings": [
+          "boryu-mupakettonanba-"
+        ]
+      },
+      {
+        "en": "Virtual Protocol Name",
+        "ja": "バーチャルプロトコルネーム",
+        "ja_typings": [
+          "ba-charupurotokorune-mu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01104",
+    "image_path": null,
+    "question_text": {
+      "en": "What does VPN stand for?",
+      "ja": "VPNは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cascading Style Sheets",
+        "ja": "カスケーディングスタイルシート",
+        "ja_typings": [
+          "kasuke-dingusutairushi-to"
+        ]
+      },
+      {
+        "en": "Computer Style System",
+        "ja": "コンピュータスタイルシステム",
+        "ja_typings": [
+          "konpyu-tasutairushisutemu"
+        ]
+      },
+      {
+        "en": "Compact Source Script",
+        "ja": "コンパクトソーススクリプト",
+        "ja_typings": [
+          "konpakutoso-susukuriputo"
+        ]
+      },
+      {
+        "en": "Central Server Stack",
+        "ja": "セントラルサーバースタック",
+        "ja_typings": [
+          "sentorarusa-ba-sutakku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01105",
+    "image_path": null,
+    "question_text": {
+      "en": "What does CSS stand for?",
+      "ja": "CSSは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SMTP",
+        "ja": "エスエムティーピー",
+        "ja_typings": [
+          "esuemuti-pi-"
+        ]
+      },
+      {
+        "en": "POP3",
+        "ja": "ピーオーピースリー",
+        "ja_typings": [
+          "pi-o-pi-suri-"
+        ]
+      },
+      {
+        "en": "IMAP",
+        "ja": "アイマップ",
+        "ja_typings": [
+          "aimappu"
+        ]
+      },
+      {
+        "en": "FTP",
+        "ja": "エフティーピー",
+        "ja_typings": [
+          "efuti-pi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01106",
+    "image_path": null,
+    "question_text": {
+      "en": "What protocol is used to send email?",
+      "ja": "電子メール送信に使うプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1024 bytes",
+        "ja": "センニジュウヨンバイト",
+        "ja_typings": [
+          "sennijuuyonbaito",
+          "sennnijuuyonbaito"
+        ]
+      },
+      {
+        "en": "100 bytes",
+        "ja": "ヒャクバイト",
+        "ja_typings": [
+          "hyakubaito"
+        ]
+      },
+      {
+        "en": "500 bytes",
+        "ja": "ゴヒャクバイト",
+        "ja_typings": [
+          "gohyakubaito"
+        ]
+      },
+      {
+        "en": "2048 bytes",
+        "ja": "ニセンヨンジュウハチバイト",
+        "ja_typings": [
+          "nisenyonjuuhachibaito",
+          "nisennyonjuuhachibaito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01107",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a kilobyte equal to?",
+      "ja": "1キロバイトは何バイト?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Structured Query Language",
+        "ja": "ストラクチャードクエリランゲージ",
+        "ja_typings": [
+          "sutorakucha-dokuerirange-ji"
+        ]
+      },
+      {
+        "en": "Simple Question Logic",
+        "ja": "シンプルクエスチョンロジック",
+        "ja_typings": [
+          "shinpurukuesuchonrojikku"
+        ]
+      },
+      {
+        "en": "Secure Query Loader",
+        "ja": "セキュアクエリローダー",
+        "ja_typings": [
+          "sekyuakueriro-da-"
+        ]
+      },
+      {
+        "en": "Server Quick Link",
+        "ja": "サーバークイックリンク",
+        "ja_typings": [
+          "sa-ba-kuikkurinku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01108",
+    "image_path": null,
+    "question_text": {
+      "en": "What does SQL stand for?",
+      "ja": "SQLは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "25",
+        "ja": "ニジュウゴ",
+        "ja_typings": [
+          "nijuugo"
+        ]
+      },
+      {
+        "en": "21",
+        "ja": "ニジュウイチ",
+        "ja_typings": [
+          "nijuuichi"
+        ]
+      },
+      {
+        "en": "22",
+        "ja": "ニジュウニ",
+        "ja_typings": [
+          "nijuuni"
+        ]
+      },
+      {
+        "en": "23",
+        "ja": "ニジュウサン",
+        "ja_typings": [
+          "nijuusan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01109",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the default port for SMTP?",
+      "ja": "SMTPのデフォルトポート番号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Red Green Blue",
+        "ja": "レッドグリーンブルー",
+        "ja_typings": [
+          "reddoguri-nburu-"
+        ]
+      },
+      {
+        "en": "Right Grid Base",
+        "ja": "ライトグリッドベース",
+        "ja_typings": [
+          "raitoguriddobe-su"
+        ]
+      },
+      {
+        "en": "Raw Graphics Buffer",
+        "ja": "ローグラフィックスバッファ",
+        "ja_typings": [
+          "ro-gurafikkusubaffa"
+        ]
+      },
+      {
+        "en": "Resource Group Base",
+        "ja": "リソースグループベース",
+        "ja_typings": [
+          "riso-suguru-pube-su"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01110",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the acronym RGB represent?",
+      "ja": "RGBは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "bit",
+        "ja": "ビット",
+        "ja_typings": [
+          "bitto"
+        ]
+      },
+      {
+        "en": "byte",
+        "ja": "バイト",
+        "ja_typings": [
+          "baito"
+        ]
+      },
+      {
+        "en": "nibble",
+        "ja": "ニブル",
+        "ja_typings": [
+          "niburu"
+        ]
+      },
+      {
+        "en": "word",
+        "ja": "ワード",
+        "ja_typings": [
+          "wa-do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01111",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the smallest unit of digital information?",
+      "ja": "デジタル情報の最小単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1010",
+        "ja": "イチゼロイチゼロ",
+        "ja_typings": [
+          "ichizeroichizero"
+        ]
+      },
+      {
+        "en": "1100",
+        "ja": "イチイチゼロゼロ",
+        "ja_typings": [
+          "ichiichizerozero"
+        ]
+      },
+      {
+        "en": "1001",
+        "ja": "イチゼロゼロイチ",
+        "ja_typings": [
+          "ichizerozeroichi"
+        ]
+      },
+      {
+        "en": "1110",
+        "ja": "イチイチイチゼロ",
+        "ja_typings": [
+          "ichiichiichizero"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01112",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the binary value of decimal 10?",
+      "ja": "10進数10の2進数表現は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Redundant Array of Independent Disks",
+        "ja": "リダンダントアレイオブインディペンデントディスクス",
+        "ja_typings": [
+          "ridandantoareiobuindipendentodisukusu"
+        ]
+      },
+      {
+        "en": "Rapid Access Internal Drive",
+        "ja": "ラピッドアクセスインターナルドライブ",
+        "ja_typings": [
+          "rapiddoakusesuinta-narudoraibu"
+        ]
+      },
+      {
+        "en": "Random Allocated Index Database",
+        "ja": "ランダムアロケーテッドインデックスデータベース",
+        "ja_typings": [
+          "randamuaroke-teddoindekkusude-tabe-su"
+        ]
+      },
+      {
+        "en": "Remote Async IO Daemon",
+        "ja": "リモートアシンクアイオーデーモン",
+        "ja_typings": [
+          "rimo-toashinkuaio-de-mon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q01113",
+    "image_path": null,
+    "question_text": {
+      "en": "What does RAID stand for in storage?",
+      "ja": "ストレージのRAIDは何の略?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Detective Conan",
+        "ja": "名探偵コナン",
+        "ja_typings": [
+          "meitanteikonan"
+        ]
+      },
+      {
+        "en": "Kindaichi Case Files",
+        "ja": "金田一少年の事件簿",
+        "ja_typings": [
+          "kindaichishounennojikenbo"
+        ]
+      },
+      {
+        "en": "Hyouka",
+        "ja": "氷菓",
+        "ja_typings": [
+          "hyouka"
+        ]
+      },
+      {
+        "en": "Moriarty the Patriot",
+        "ja": "憂国のモリアーティ",
+        "ja_typings": [
+          "yuukokunomoriaati"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01114",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features a high school detective shrunk into a child?",
+      "ja": "高校生探偵が子供の姿にされるアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sword Art Online",
+        "ja": "ソードアート・オンライン",
+        "ja_typings": [
+          "so-doa-to/onrain"
+        ]
+      },
+      {
+        "en": ".hack//Sign",
+        "ja": "ドットハック・サイン",
+        "ja_typings": [
+          "dottohakku/sain"
+        ]
+      },
+      {
+        "en": "Log Horizon",
+        "ja": "ログ・ホライズン",
+        "ja_typings": [
+          "rogu/horaizun"
+        ]
+      },
+      {
+        "en": "Overlord",
+        "ja": "オーバーロード",
+        "ja_typings": [
+          "o-ba-ro-do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01115",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is set in a virtual MMORPG where players are trapped?",
+      "ja": "仮想MMORPGに閉じ込められるアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Boruto",
+        "ja": "ボルト",
+        "ja_typings": [
+          "boruto"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "フェアリーテイル",
+        "ja_typings": [
+          "feari-teiru"
+        ]
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": [
+          "magi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01116",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features a boy aiming to be Hokage?",
+      "ja": "火影を目指す少年のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CoMix Wave Films",
+        "ja": "コミックス・ウェーブ・フィルム",
+        "ja_typings": [
+          "komikkusu/we-bu/firumu"
+        ]
+      },
+      {
+        "en": "Kyoto Animation",
+        "ja": "京都アニメーション",
+        "ja_typings": [
+          "kyoutoanimeeshon"
+        ]
+      },
+      {
+        "en": "Production I.G",
+        "ja": "プロダクション・アイジー",
+        "ja_typings": [
+          "purodakushon/aiji-"
+        ]
+      },
+      {
+        "en": "Bones",
+        "ja": "ボンズ",
+        "ja_typings": [
+          "bonzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01117",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime studio produced 'Your Name'?",
+      "ja": "『君の名は。』を制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hayao Miyazaki",
+        "ja": "宮崎駿",
+        "ja_typings": [
+          "miyazakihayao"
+        ]
+      },
+      {
+        "en": "Isao Takahata",
+        "ja": "高畑勲",
+        "ja_typings": [
+          "takahataisao"
+        ]
+      },
+      {
+        "en": "Mamoru Hosoda",
+        "ja": "細田守",
+        "ja_typings": [
+          "hosodamamoru"
+        ]
+      },
+      {
+        "en": "Makoto Shinkai",
+        "ja": "新海誠",
+        "ja_typings": [
+          "shinkaimakoto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01118",
+    "image_path": null,
+    "question_text": {
+      "en": "Who directed 'Princess Mononoke'?",
+      "ja": "『もののけ姫』の監督は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Soul Eater",
+        "ja": "ソウルイーター",
+        "ja_typings": [
+          "sorui-ta-",
+          "sourui-ta-"
+        ]
+      },
+      {
+        "en": "Noragami",
+        "ja": "ノラガミ",
+        "ja_typings": [
+          "noragami"
+        ]
+      },
+      {
+        "en": "Yu Yu Hakusho",
+        "ja": "幽☆遊☆白書",
+        "ja_typings": [
+          "yuuyuuhakusho"
+        ]
+      },
+      {
+        "en": "Inuyasha",
+        "ja": "犬夜叉",
+        "ja_typings": [
+          "inuyasha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01119",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is about a girl who becomes a Soul Reaper?",
+      "ja": "死神になる少女が登場するアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MAPPA",
+        "ja": "マッパ",
+        "ja_typings": [
+          "mappa"
+        ]
+      },
+      {
+        "en": "Wit Studio",
+        "ja": "ウィットスタジオ",
+        "ja_typings": [
+          "wittosutajio"
+        ]
+      },
+      {
+        "en": "Madhouse",
+        "ja": "マッドハウス",
+        "ja_typings": [
+          "maddohausu"
+        ]
+      },
+      {
+        "en": "Toei Animation",
+        "ja": "東映アニメーション",
+        "ja_typings": [
+          "toueianimeeshon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01120",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime studio made 'Attack on Titan' final seasons?",
+      "ja": "『進撃の巨人』最終章を制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fullmetal Alchemist",
+        "ja": "鋼の錬金術師",
+        "ja_typings": [
+          "haganenorenkinjutsushi"
+        ]
+      },
+      {
+        "en": "D.Gray-man",
+        "ja": "ディーグレイマン",
+        "ja_typings": [
+          "di-gureiman"
+        ]
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": [
+          "magi"
+        ]
+      },
+      {
+        "en": "Black Butler",
+        "ja": "黒執事",
+        "ja_typings": [
+          "kuroshitsuji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01121",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features alchemists searching for the Philosopher's Stone?",
+      "ja": "賢者の石を探す錬金術師のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Haikyuu!!",
+        "ja": "ハイキュー!!",
+        "ja_typings": [
+          "haikyu-"
+        ]
+      },
+      {
+        "en": "Kuroko's Basketball",
+        "ja": "黒子のバスケ",
+        "ja_typings": [
+          "kuronobasuke"
+        ]
+      },
+      {
+        "en": "Ace of Diamond",
+        "ja": "ダイヤのA",
+        "ja_typings": [
+          "daiyanoeesu",
+          "daiyanoa"
+        ]
+      },
+      {
+        "en": "Blue Lock",
+        "ja": "ブルーロック",
+        "ja_typings": [
+          "buru-rokku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01122",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is about volleyball at Karasuno High?",
+      "ja": "烏野高校のバレーボールのアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Durarara!!",
+        "ja": "デュラララ!!",
+        "ja_typings": [
+          "deyurarara"
+        ]
+      },
+      {
+        "en": "Baccano!",
+        "ja": "バッカーノ!",
+        "ja_typings": [
+          "bakka-no"
+        ]
+      },
+      {
+        "en": "Psycho-Pass",
+        "ja": "サイコパス",
+        "ja_typings": [
+          "saikopasu"
+        ]
+      },
+      {
+        "en": "91 Days",
+        "ja": "91デイズ",
+        "ja_typings": [
+          "91deizu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01123",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is set in the fictional city of Ikebukuro with gang wars?",
+      "ja": "池袋を舞台にした抗争アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Love Live!",
+        "ja": "ラブライブ!",
+        "ja_typings": [
+          "raburaibu"
+        ]
+      },
+      {
+        "en": "The iDOLM@STER",
+        "ja": "アイドルマスター",
+        "ja_typings": [
+          "aidorumasuta-"
+        ]
+      },
+      {
+        "en": "BanG Dream!",
+        "ja": "バンドリ!",
+        "ja_typings": [
+          "bandori"
+        ]
+      },
+      {
+        "en": "Wake Up, Girls!",
+        "ja": "ウェイクアップ、ガールズ!",
+        "ja_typings": [
+          "weikuappu,ga-ruzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01124",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features the school idol group μ's?",
+      "ja": "μ'sが登場するアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rurouni Kenshin",
+        "ja": "るろうに剣心",
+        "ja_typings": [
+          "rurouninikenshin"
+        ]
+      },
+      {
+        "en": "Samurai Champloo",
+        "ja": "サムライチャンプルー",
+        "ja_typings": [
+          "samuraichanpuru-"
+        ]
+      },
+      {
+        "en": "Afro Samurai",
+        "ja": "アフロサムライ",
+        "ja_typings": [
+          "afurosamurai"
+        ]
+      },
+      {
+        "en": "Dororo",
+        "ja": "どろろ",
+        "ja_typings": [
+          "dororo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01125",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is about a samurai who wanders Meiji-era Japan?",
+      "ja": "明治時代を流浪する侍のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Makoto Shinkai",
+        "ja": "新海誠",
+        "ja_typings": [
+          "shinkaimakoto"
+        ]
+      },
+      {
+        "en": "Mamoru Hosoda",
+        "ja": "細田守",
+        "ja_typings": [
+          "hosodamamoru"
+        ]
+      },
+      {
+        "en": "Naoko Yamada",
+        "ja": "山田尚子",
+        "ja_typings": [
+          "yamadanaoko"
+        ]
+      },
+      {
+        "en": "Tetsuro Araki",
+        "ja": "荒木哲郎",
+        "ja_typings": [
+          "arakitetsurou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01126",
+    "image_path": null,
+    "question_text": {
+      "en": "Which director made 'Weathering with You'?",
+      "ja": "『天気の子』の監督は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chihayafuru",
+        "ja": "ちはやふる",
+        "ja_typings": [
+          "chihayafuru"
+        ]
+      },
+      {
+        "en": "Saki",
+        "ja": "咲-Saki-",
+        "ja_typings": [
+          "saki",
+          "saki-Saki-"
+        ]
+      },
+      {
+        "en": "Akagi",
+        "ja": "アカギ",
+        "ja_typings": [
+          "akagi"
+        ]
+      },
+      {
+        "en": "Kaiji",
+        "ja": "カイジ",
+        "ja_typings": [
+          "kaiji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01127",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features four siblings playing card games?",
+      "ja": "カードゲームをする四姉妹のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cowboy Bebop",
+        "ja": "カウボーイビバップ",
+        "ja_typings": [
+          "kaubo-ibibappu"
+        ]
+      },
+      {
+        "en": "Outlaw Star",
+        "ja": "アウトロースター",
+        "ja_typings": [
+          "autoro-suta-"
+        ]
+      },
+      {
+        "en": "Trigun",
+        "ja": "トライガン",
+        "ja_typings": [
+          "toraigan"
+        ]
+      },
+      {
+        "en": "Black Lagoon",
+        "ja": "ブラック・ラグーン",
+        "ja_typings": [
+          "burakku/ragu-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01128",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features Spike Spiegel as a bounty hunter?",
+      "ja": "スパイク・スピーゲルが賞金稼ぎとして登場するアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Masako Nozawa",
+        "ja": "野沢雅子",
+        "ja_typings": [
+          "nozawamasako"
+        ]
+      },
+      {
+        "en": "Megumi Hayashibara",
+        "ja": "林原めぐみ",
+        "ja_typings": [
+          "hayashibaramegumi"
+        ]
+      },
+      {
+        "en": "Aya Hirano",
+        "ja": "平野綾",
+        "ja_typings": [
+          "hiranoaya"
+        ]
+      },
+      {
+        "en": "Mamoru Miyano",
+        "ja": "宮野真守",
+        "ja_typings": [
+          "miyanomamoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01129",
+    "image_path": null,
+    "question_text": {
+      "en": "Who voices Goku in the Japanese dub of Dragon Ball?",
+      "ja": "ドラゴンボールの孫悟空の日本語声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kamisama Kiss",
+        "ja": "神様はじめました",
+        "ja_typings": [
+          "kamisamahajimemashita"
+        ]
+      },
+      {
+        "en": "Fruits Basket",
+        "ja": "フルーツバスケット",
+        "ja_typings": [
+          "furu-tsubasuketto"
+        ]
+      },
+      {
+        "en": "Ouran High School Host Club",
+        "ja": "桜蘭高校ホスト部",
+        "ja_typings": [
+          "ourankoukouhosutobu"
+        ]
+      },
+      {
+        "en": "Kobato",
+        "ja": "こばと。",
+        "ja_typings": [
+          "kobato."
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01130",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is about a girl who befriends a fox spirit?",
+      "ja": "狐の妖怪と仲良くなる少女のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gurren Lagann",
+        "ja": "天元突破グレンラガン",
+        "ja_typings": [
+          "tengentoppagurenragan"
+        ]
+      },
+      {
+        "en": "Eureka Seven",
+        "ja": "交響詩篇エウレカセブン",
+        "ja_typings": [
+          "koukyoushiheneurekasebun"
+        ]
+      },
+      {
+        "en": "RahXephon",
+        "ja": "ラーゼフォン",
+        "ja_typings": [
+          "ra-zefon"
+        ]
+      },
+      {
+        "en": "Aldnoah.Zero",
+        "ja": "アルドノア・ゼロ",
+        "ja_typings": [
+          "arudonoa/zero"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01131",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features a giant mecha called Lagann?",
+      "ja": "ラガンというロボットが登場するアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "K-On!",
+        "ja": "けいおん!",
+        "ja_typings": [
+          "keion"
+        ]
+      },
+      {
+        "en": "Beck",
+        "ja": "ベック",
+        "ja_typings": [
+          "bekku"
+        ]
+      },
+      {
+        "en": "Nana",
+        "ja": "ナナ",
+        "ja_typings": [
+          "nana"
+        ]
+      },
+      {
+        "en": "Carole & Tuesday",
+        "ja": "キャロル&チューズデイ",
+        "ja_typings": [
+          "kyaroruchu-zudei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01132",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is about a high school light music club?",
+      "ja": "高校の軽音部が舞台のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kyoto Animation",
+        "ja": "京都アニメーション",
+        "ja_typings": [
+          "kyoutoanimeeshon"
+        ]
+      },
+      {
+        "en": "P.A.Works",
+        "ja": "ピーエーワークス",
+        "ja_typings": [
+          "pi-e-wa-kusu"
+        ]
+      },
+      {
+        "en": "Trigger",
+        "ja": "トリガー",
+        "ja_typings": [
+          "toriga-"
+        ]
+      },
+      {
+        "en": "Ufotable",
+        "ja": "ユーフォーテーブル",
+        "ja_typings": [
+          "yu-fo-te-buru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01133",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime studio produced 'Violet Evergarden'?",
+      "ja": "『ヴァイオレット・エヴァーガーデン』を制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sword Art Online",
+        "ja": "ソードアート・オンライン",
+        "ja_typings": [
+          "so-doa-to/onrain"
+        ]
+      },
+      {
+        "en": "Accel World",
+        "ja": "アクセル・ワールド",
+        "ja_typings": [
+          "akuseru/wa-rudo"
+        ]
+      },
+      {
+        "en": "No Game No Life",
+        "ja": "ノーゲーム・ノーライフ",
+        "ja_typings": [
+          "no-ge-mu/no-raifu"
+        ]
+      },
+      {
+        "en": "Re:Zero",
+        "ja": "リゼロ",
+        "ja_typings": [
+          "rizero"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01134",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features a girl named Asuna in a virtual world?",
+      "ja": "アスナという少女が仮想世界で活躍するアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Attack on Titan",
+        "ja": "進撃の巨人",
+        "ja_typings": [
+          "shingekinokyojin"
+        ]
+      },
+      {
+        "en": "Vinland Saga",
+        "ja": "ヴィンランド・サガ",
+        "ja_typings": [
+          "vinrando/saga"
+        ]
+      },
+      {
+        "en": "Berserk",
+        "ja": "ベルセルク",
+        "ja_typings": [
+          "beruseruku"
+        ]
+      },
+      {
+        "en": "Claymore",
+        "ja": "クレイモア",
+        "ja_typings": [
+          "kureimoa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01135",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features a girl named Mikasa Ackerman?",
+      "ja": "ミカサ・アッカーマンが登場するアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Taisou Zamurai",
+        "ja": "体操ザムライ",
+        "ja_typings": [
+          "taisouzamurai"
+        ]
+      },
+      {
+        "en": "Tsurune",
+        "ja": "ツルネ",
+        "ja_typings": [
+          "tsurune"
+        ]
+      },
+      {
+        "en": "Free!",
+        "ja": "フリー!",
+        "ja_typings": [
+          "furi-"
+        ]
+      },
+      {
+        "en": "Yuri on Ice",
+        "ja": "ユーリ!!! on ICE",
+        "ja_typings": [
+          "yu-ri on ice"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01136",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is about gymnastics rhythmic at Hanazono?",
+      "ja": "花園を目指す体操のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Naruto Shippuden",
+        "ja": "ナルト疾風伝",
+        "ja_typings": [
+          "narutoshippuuden"
+        ]
+      },
+      {
+        "en": "Bleach",
+        "ja": "ブリーチ",
+        "ja_typings": [
+          "buri-chi"
+        ]
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "フェアリーテイル",
+        "ja_typings": [
+          "feari-teiru"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01137",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features the Akatsuki organization?",
+      "ja": "暁という組織が登場するアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "A Certain Magical Index",
+        "ja": "とある魔術の禁書目録",
+        "ja_typings": [
+          "toarumajutsunoindekkusu"
+        ]
+      },
+      {
+        "en": "Little Witch Academia",
+        "ja": "リトルウィッチアカデミア",
+        "ja_typings": [
+          "ritoruwitchiakademia"
+        ]
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": [
+          "magi"
+        ]
+      },
+      {
+        "en": "Witch Hunter Robin",
+        "ja": "ウィッチハンターロビン",
+        "ja_typings": [
+          "witchihanta-robin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01138",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is set in a magical library city called Academy City?",
+      "ja": "学園都市が舞台のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hunter x Hunter",
+        "ja": "ハンターハンター",
+        "ja_typings": [
+          "hanta-hanta-"
+        ]
+      },
+      {
+        "en": "Black Cat",
+        "ja": "ブラック・キャット",
+        "ja_typings": [
+          "burakku/kyatto"
+        ]
+      },
+      {
+        "en": "Katekyo Hitman Reborn",
+        "ja": "家庭教師ヒットマンリボーン",
+        "ja_typings": [
+          "kateikyoushihittomanribouun"
+        ]
+      },
+      {
+        "en": "D.Gray-man",
+        "ja": "ディーグレイマン",
+        "ja_typings": [
+          "di-gureiman"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01139",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features the Phantom Troupe?",
+      "ja": "幻影旅団が登場するアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rosario + Vampire",
+        "ja": "ロザリオとバンパイア",
+        "ja_typings": [
+          "rozariotobanpaia"
+        ]
+      },
+      {
+        "en": "Vampire Knight",
+        "ja": "ヴァンパイア騎士",
+        "ja_typings": [
+          "vanpaiakishi"
+        ]
+      },
+      {
+        "en": "Trinity Blood",
+        "ja": "トリニティ・ブラッド",
+        "ja_typings": [
+          "toriniti/buraddo"
+        ]
+      },
+      {
+        "en": "Blood+",
+        "ja": "ブラッドプラス",
+        "ja_typings": [
+          "buraddopurasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01140",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is about a girl in a magical school for vampires?",
+      "ja": "ヴァンパイアの学園が舞台のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Code Geass",
+        "ja": "コードギアス",
+        "ja_typings": [
+          "ko-dogiasu"
+        ]
+      },
+      {
+        "en": "Guilty Crown",
+        "ja": "ギルティクラウン",
+        "ja_typings": [
+          "girutikuraun"
+        ]
+      },
+      {
+        "en": "Darker than Black",
+        "ja": "ダーカー・ザン・ブラック",
+        "ja_typings": [
+          "da-ka-/zan/burakku"
+        ]
+      },
+      {
+        "en": "Mirai Nikki",
+        "ja": "未来日記",
+        "ja_typings": [
+          "mirainikki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01141",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features Lelouch and Geass powers?",
+      "ja": "ルルーシュとギアスの力が登場するアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Steins;Gate",
+        "ja": "シュタインズ・ゲート",
+        "ja_typings": [
+          "shutainzu/ge-to"
+        ]
+      },
+      {
+        "en": "Chaos;Head",
+        "ja": "カオスヘッド",
+        "ja_typings": [
+          "kaosuheddo"
+        ]
+      },
+      {
+        "en": "Robotics;Notes",
+        "ja": "ロボティクス・ノーツ",
+        "ja_typings": [
+          "robotikusu/no-tsu"
+        ]
+      },
+      {
+        "en": "Occultic;Nine",
+        "ja": "オカルティック・ナイン",
+        "ja_typings": [
+          "okarutikku/nain"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01142",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features a time-traveling microwave?",
+      "ja": "電子レンジで時間移動するアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ufotable",
+        "ja": "ユーフォーテーブル",
+        "ja_typings": [
+          "yu-fo-te-buru"
+        ]
+      },
+      {
+        "en": "MAPPA",
+        "ja": "マッパ",
+        "ja_typings": [
+          "mappa"
+        ]
+      },
+      {
+        "en": "A-1 Pictures",
+        "ja": "エーワン・ピクチャーズ",
+        "ja_typings": [
+          "e-wan/pikucha-zu"
+        ]
+      },
+      {
+        "en": "Wit Studio",
+        "ja": "ウィットスタジオ",
+        "ja_typings": [
+          "wittosutajio"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01143",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime studio produced 'Demon Slayer'?",
+      "ja": "『鬼滅の刃』を制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wolf's Rain",
+        "ja": "ウルフズ・レイン",
+        "ja_typings": [
+          "urufuzu/rein"
+        ]
+      },
+      {
+        "en": "Spice and Wolf",
+        "ja": "狼と香辛料",
+        "ja_typings": [
+          "ookamitokoushinryou"
+        ]
+      },
+      {
+        "en": "Wolf Children",
+        "ja": "おおかみこどもの雨と雪",
+        "ja_typings": [
+          "ookamikodomonoametoyuki"
+        ]
+      },
+      {
+        "en": "Princess Tutu",
+        "ja": "プリンセスチュチュ",
+        "ja_typings": [
+          "purinsesuchuchu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01144",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features a girl who can turn into a wolf?",
+      "ja": "狼に変身する少女のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Big Windup!",
+        "ja": "おおきく振りかぶって",
+        "ja_typings": [
+          "ookikufurikabutte"
+        ]
+      },
+      {
+        "en": "Ace of Diamond",
+        "ja": "ダイヤのA",
+        "ja_typings": [
+          "daiyanoeesu",
+          "daiyanoa"
+        ]
+      },
+      {
+        "en": "Major",
+        "ja": "メジャー",
+        "ja_typings": [
+          "meja-"
+        ]
+      },
+      {
+        "en": "Cross Game",
+        "ja": "クロスゲーム",
+        "ja_typings": [
+          "kurosuge-mu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01145",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features a high school baseball team called Nishiura?",
+      "ja": "西浦高校野球部のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Food Wars!",
+        "ja": "食戟のソーマ",
+        "ja_typings": [
+          "shokugekinosouma"
+        ]
+      },
+      {
+        "en": "Yakitate!! Japan",
+        "ja": "焼きたて!!ジャぱん",
+        "ja_typings": [
+          "yakitatejapan"
+        ]
+      },
+      {
+        "en": "Toriko",
+        "ja": "トリコ",
+        "ja_typings": [
+          "toriko"
+        ]
+      },
+      {
+        "en": "Sweetness and Lightning",
+        "ja": "甘々と稲妻",
+        "ja_typings": [
+          "amaamatoinazuma"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01146",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features a cooking competition at Totsuki Academy?",
+      "ja": "遠月学園の料理対決のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Your Lie in April",
+        "ja": "四月は君の嘘",
+        "ja_typings": [
+          "shigatsuhakiminouso"
+        ]
+      },
+      {
+        "en": "Piano no Mori",
+        "ja": "ピアノの森",
+        "ja_typings": [
+          "pianonomori"
+        ]
+      },
+      {
+        "en": "Nodame Cantabile",
+        "ja": "のだめカンタービレ",
+        "ja_typings": [
+          "nodamekanta-bire"
+        ]
+      },
+      {
+        "en": "Forest of Piano",
+        "ja": "森のピアノ",
+        "ja_typings": [
+          "morinopiano"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01147",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features a piano prodigy named Kousei?",
+      "ja": "公生というピアノの天才が登場するアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Natsume's Book of Friends",
+        "ja": "夏目友人帳",
+        "ja_typings": [
+          "natsumeyuujinchou"
+        ]
+      },
+      {
+        "en": "Mushishi",
+        "ja": "蟲師",
+        "ja_typings": [
+          "mushishi"
+        ]
+      },
+      {
+        "en": "xxxHolic",
+        "ja": "ホリック",
+        "ja_typings": [
+          "horikku"
+        ]
+      },
+      {
+        "en": "Mononoke",
+        "ja": "モノノ怪",
+        "ja_typings": [
+          "mononoke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01148",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is about a girl who befriends a yokai cat?",
+      "ja": "妖怪の猫を友達にする少女のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Demon Slayer",
+        "ja": "鬼滅の刃",
+        "ja_typings": [
+          "kimetsunoyaiba"
+        ]
+      },
+      {
+        "en": "Jujutsu Kaisen",
+        "ja": "呪術廻戦",
+        "ja_typings": [
+          "jujutsukaisen"
+        ]
+      },
+      {
+        "en": "Chainsaw Man",
+        "ja": "チェンソーマン",
+        "ja_typings": [
+          "chenso-man"
+        ]
+      },
+      {
+        "en": "Hell's Paradise",
+        "ja": "地獄楽",
+        "ja_typings": [
+          "jigokuraku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01149",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features Tanjiro Kamado?",
+      "ja": "竈門炭治郎が主人公のアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Spice and Wolf",
+        "ja": "狼と香辛料",
+        "ja_typings": [
+          "ookamitokoushinryou"
+        ]
+      },
+      {
+        "en": "Maoyu",
+        "ja": "魔王勇者",
+        "ja_typings": [
+          "maouyuusha"
+        ]
+      },
+      {
+        "en": "Restaurant to Another World",
+        "ja": "異世界食堂",
+        "ja_typings": [
+          "isekaishokudou"
+        ]
+      },
+      {
+        "en": "Log Horizon",
+        "ja": "ログ・ホライズン",
+        "ja_typings": [
+          "rogu/horaizun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01150",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features a girl named Holo with wolf ears?",
+      "ja": "狼の耳を持つホロが登場するアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "One Punch Man",
+        "ja": "ワンパンマン",
+        "ja_typings": [
+          "wanpanman"
+        ]
+      },
+      {
+        "en": "Mob Psycho 100",
+        "ja": "モブサイコ100",
+        "ja_typings": [
+          "mobusaiko100"
+        ]
+      },
+      {
+        "en": "My Hero Academia",
+        "ja": "僕のヒーローアカデミア",
+        "ja_typings": [
+          "bokunohiiroakademia"
+        ]
+      },
+      {
+        "en": "Tiger & Bunny",
+        "ja": "タイガー&バニー",
+        "ja_typings": [
+          "taiga-bani-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01151",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features Saitama, a hero who defeats enemies in one punch?",
+      "ja": "一撃で敵を倒すサイタマのアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Subaru Natsuki",
+        "ja": "ナツキ・スバル",
+        "ja_typings": [
+          "natsuki/subaru"
+        ]
+      },
+      {
+        "en": "Kazuma Satou",
+        "ja": "佐藤和真",
+        "ja_typings": [
+          "satoukazuma"
+        ]
+      },
+      {
+        "en": "Touya Mochizuki",
+        "ja": "望月冬夜",
+        "ja_typings": [
+          "mochizukitouya"
+        ]
+      },
+      {
+        "en": "Hajime Nagumo",
+        "ja": "南雲ハジメ",
+        "ja_typings": [
+          "nagumohajime"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01152",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime is about kart racing in another world with Re:Zero?",
+      "ja": "リゼロの主人公の名前は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bleach",
+        "ja": "ブリーチ",
+        "ja_typings": [
+          "buri-chi"
+        ]
+      },
+      {
+        "en": "Yu Yu Hakusho",
+        "ja": "幽☆遊☆白書",
+        "ja_typings": [
+          "yuuyuuhakusho"
+        ]
+      },
+      {
+        "en": "Shaman King",
+        "ja": "シャーマンキング",
+        "ja_typings": [
+          "sha-mankingu"
+        ]
+      },
+      {
+        "en": "Blue Exorcist",
+        "ja": "青の祓魔師",
+        "ja_typings": [
+          "aonoekusoshisuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01153",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime features a Quincy named Uryu Ishida?",
+      "ja": "石田雨竜というクインシーが登場するアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Detective Conan",
+        "ja": "名探偵コナン",
+        "ja_typings": [
+          "meitanteikonan"
+        ]
+      },
+      {
+        "en": "Chainsaw Man",
+        "ja": "チェンソーマン",
+        "ja_typings": [
+          "chenso-man"
+        ]
+      },
+      {
+        "en": "Spy x Family",
+        "ja": "スパイファミリー",
+        "ja_typings": [
+          "supaifamiri-"
+        ]
+      },
+      {
+        "en": "Kingdom",
+        "ja": "キングダム",
+        "ja_typings": [
+          "kingudamu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01154",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga is published in Weekly Shonen Sunday?",
+      "ja": "週刊少年サンデーで連載されている漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Naoki Urasawa",
+        "ja": "浦沢直樹",
+        "ja_typings": [
+          "urasawanaoki"
+        ]
+      },
+      {
+        "en": "Hirohiko Araki",
+        "ja": "荒木飛呂彦",
+        "ja_typings": [
+          "arakihirohiko"
+        ]
+      },
+      {
+        "en": "Osamu Tezuka",
+        "ja": "手塚治虫",
+        "ja_typings": [
+          "tezukaosamu"
+        ]
+      },
+      {
+        "en": "Mitsuru Adachi",
+        "ja": "あだち充",
+        "ja_typings": [
+          "adachimitsuru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01155",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of 'Monster' and '20th Century Boys'?",
+      "ja": "『モンスター』『20世紀少年』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Weekly Shonen Jump",
+        "ja": "週刊少年ジャンプ",
+        "ja_typings": [
+          "shuukanshounenjanpu"
+        ]
+      },
+      {
+        "en": "Weekly Shonen Magazine",
+        "ja": "週刊少年マガジン",
+        "ja_typings": [
+          "shuukanshounenmagajin"
+        ]
+      },
+      {
+        "en": "Weekly Shonen Sunday",
+        "ja": "週刊少年サンデー",
+        "ja_typings": [
+          "shuukanshounensandee"
+        ]
+      },
+      {
+        "en": "Weekly Young Jump",
+        "ja": "週刊ヤングジャンプ",
+        "ja_typings": [
+          "shuukanyangujanpu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01156",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga magazine publishes 'One Piece'?",
+      "ja": "『ONE PIECE』を連載している雑誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Takehiko Inoue",
+        "ja": "井上雄彦",
+        "ja_typings": [
+          "inouetakehiko"
+        ]
+      },
+      {
+        "en": "Eiichiro Oda",
+        "ja": "尾田栄一郎",
+        "ja_typings": [
+          "odaeiichirou"
+        ]
+      },
+      {
+        "en": "Masashi Kishimoto",
+        "ja": "岸本斉史",
+        "ja_typings": [
+          "kishimotomasashi"
+        ]
+      },
+      {
+        "en": "Tite Kubo",
+        "ja": "久保帯人",
+        "ja_typings": [
+          "kubotaito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01157",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of 'Vagabond' and 'Slam Dunk'?",
+      "ja": "『バガボンド』『スラムダンク』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JoJo's Bizarre Adventure",
+        "ja": "ジョジョの奇妙な冒険",
+        "ja_typings": [
+          "jojonokimyounabouken"
+        ]
+      },
+      {
+        "en": "Baki the Grappler",
+        "ja": "グラップラー刃牙",
+        "ja_typings": [
+          "gurappuraabaki"
+        ]
+      },
+      {
+        "en": "Fist of the North Star",
+        "ja": "北斗の拳",
+        "ja_typings": [
+          "hokutonoken"
+        ]
+      },
+      {
+        "en": "Saint Seiya",
+        "ja": "聖闘士星矢",
+        "ja_typings": [
+          "seintoseiya"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01158",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga features the Joestar family across generations?",
+      "ja": "ジョースター家の物語の漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Food Wars!",
+        "ja": "食戟のソーマ",
+        "ja_typings": [
+          "shokugekinosouma"
+        ]
+      },
+      {
+        "en": "Toriko",
+        "ja": "トリコ",
+        "ja_typings": [
+          "toriko"
+        ]
+      },
+      {
+        "en": "Mister Ajikko",
+        "ja": "ミスター味っ子",
+        "ja_typings": [
+          "misutaaajikko"
+        ]
+      },
+      {
+        "en": "Sweetness and Lightning",
+        "ja": "甘々と稲妻",
+        "ja_typings": [
+          "amaamatoinazuma"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01159",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga features chefs competing at Totsuki Academy?",
+      "ja": "遠月学園で料理を競う漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "One Piece",
+        "ja": "ワンピース",
+        "ja_typings": [
+          "wanpi-su"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "フェアリーテイル",
+        "ja_typings": [
+          "feari-teiru"
+        ]
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": [
+          "magi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01160",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga is about a boy who can stretch his body?",
+      "ja": "体を伸ばせる少年の漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Death Note",
+        "ja": "デスノート",
+        "ja_typings": [
+          "desuno-to"
+        ]
+      },
+      {
+        "en": "Platinum End",
+        "ja": "プラチナエンド",
+        "ja_typings": [
+          "purachinaendo"
+        ]
+      },
+      {
+        "en": "Bakuman",
+        "ja": "バクマン。",
+        "ja_typings": [
+          "bakuman."
+        ]
+      },
+      {
+        "en": "Liar Game",
+        "ja": "ライアーゲーム",
+        "ja_typings": [
+          "raia-ge-mu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01161",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga features a serial killer note?",
+      "ja": "殺人ノートが登場する漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Makoto Yukimura",
+        "ja": "幸村誠",
+        "ja_typings": [
+          "yukimuramakoto"
+        ]
+      },
+      {
+        "en": "Kentaro Miura",
+        "ja": "三浦建太郎",
+        "ja_typings": [
+          "miurakentarou"
+        ]
+      },
+      {
+        "en": "Hajime Isayama",
+        "ja": "諫山創",
+        "ja_typings": [
+          "isayamahajime"
+        ]
+      },
+      {
+        "en": "Hiromu Arakawa",
+        "ja": "荒川弘",
+        "ja_typings": [
+          "arakawahiromu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01162",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of 'Vinland Saga'?",
+      "ja": "『ヴィンランド・サガ』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Maid Sama!",
+        "ja": "会長はメイド様!",
+        "ja_typings": [
+          "kaichouhameidosama"
+        ]
+      },
+      {
+        "en": "Hayate the Combat Butler",
+        "ja": "ハヤテのごとく!",
+        "ja_typings": [
+          "hayatenogotoku"
+        ]
+      },
+      {
+        "en": "Emma: A Victorian Romance",
+        "ja": "エマ",
+        "ja_typings": [
+          "ema"
+        ]
+      },
+      {
+        "en": "Black Butler",
+        "ja": "黒執事",
+        "ja_typings": [
+          "kuroshitsuji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01163",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga features a maid named Misaki Ayuzawa?",
+      "ja": "鮎沢美咲というメイドが登場する漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gintama",
+        "ja": "銀魂",
+        "ja_typings": [
+          "gintama"
+        ]
+      },
+      {
+        "en": "Rurouni Kenshin",
+        "ja": "るろうに剣心",
+        "ja_typings": [
+          "rurouninikenshin"
+        ]
+      },
+      {
+        "en": "Peacemaker Kurogane",
+        "ja": "ピースメーカー鐵",
+        "ja_typings": [
+          "piisumeekaakurogane"
+        ]
+      },
+      {
+        "en": "Hakuouki",
+        "ja": "薄桜鬼",
+        "ja_typings": [
+          "hakuouki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01164",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga is set in the Bakumatsu era with Gintoki?",
+      "ja": "幕末を舞台にした銀時の漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kodansha",
+        "ja": "講談社",
+        "ja_typings": [
+          "koudansha"
+        ]
+      },
+      {
+        "en": "Shueisha",
+        "ja": "集英社",
+        "ja_typings": [
+          "shueisha"
+        ]
+      },
+      {
+        "en": "Shogakukan",
+        "ja": "小学館",
+        "ja_typings": [
+          "shougakukan"
+        ]
+      },
+      {
+        "en": "Kadokawa",
+        "ja": "角川",
+        "ja_typings": [
+          "kadokawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01165",
+    "image_path": null,
+    "question_text": {
+      "en": "Which publisher releases 'Attack on Titan'?",
+      "ja": "『進撃の巨人』の出版社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kiyohiko Azuma",
+        "ja": "あずまきよひこ",
+        "ja_typings": [
+          "azumakiyohiko"
+        ]
+      },
+      {
+        "en": "Tatsuya Endo",
+        "ja": "遠藤達哉",
+        "ja_typings": [
+          "endoutatsuya"
+        ]
+      },
+      {
+        "en": "Sui Ishida",
+        "ja": "石田スイ",
+        "ja_typings": [
+          "ishidasui"
+        ]
+      },
+      {
+        "en": "Q Hayashida",
+        "ja": "林田球",
+        "ja_typings": [
+          "hayashidakyuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01166",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of 'Yotsuba&!'?",
+      "ja": "『よつばと!』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kuroko's Basketball",
+        "ja": "黒子のバスケ",
+        "ja_typings": [
+          "kuronobasuke"
+        ]
+      },
+      {
+        "en": "Slam Dunk",
+        "ja": "スラムダンク",
+        "ja_typings": [
+          "suramudanku"
+        ]
+      },
+      {
+        "en": "Ahiru no Sora",
+        "ja": "あひるの空",
+        "ja_typings": [
+          "ahirunosora"
+        ]
+      },
+      {
+        "en": "Dear Boys",
+        "ja": "ディア・ボーイズ",
+        "ja_typings": [
+          "dia/bo-izu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01167",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga features a basketball team called Seirin?",
+      "ja": "誠凛高校バスケ部の漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Attack on Titan",
+        "ja": "進撃の巨人",
+        "ja_typings": [
+          "shingekinokyojin"
+        ]
+      },
+      {
+        "en": "Claymore",
+        "ja": "クレイモア",
+        "ja_typings": [
+          "kureimoa"
+        ]
+      },
+      {
+        "en": "Berserk",
+        "ja": "ベルセルク",
+        "ja_typings": [
+          "beruseruku"
+        ]
+      },
+      {
+        "en": "Goblin Slayer",
+        "ja": "ゴブリンスレイヤー",
+        "ja_typings": [
+          "goburinsureiya-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01168",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga features the Survey Corps?",
+      "ja": "調査兵団が登場する漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tokyo Ghoul",
+        "ja": "東京喰種",
+        "ja_typings": [
+          "toukyouguuru"
+        ]
+      },
+      {
+        "en": "Parasyte",
+        "ja": "寄生獣",
+        "ja_typings": [
+          "kiseijuu"
+        ]
+      },
+      {
+        "en": "Ajin",
+        "ja": "亜人",
+        "ja_typings": [
+          "ajin"
+        ]
+      },
+      {
+        "en": "Dorohedoro",
+        "ja": "ドロヘドロ",
+        "ja_typings": [
+          "dorohedoro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01169",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga features ghouls in modern Tokyo?",
+      "ja": "現代東京の喰種が登場する漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Death Note",
+        "ja": "デスノート",
+        "ja_typings": [
+          "desuno-to"
+        ]
+      },
+      {
+        "en": "Bakuman",
+        "ja": "バクマン。",
+        "ja_typings": [
+          "bakuman."
+        ]
+      },
+      {
+        "en": "Platinum End",
+        "ja": "プラチナエンド",
+        "ja_typings": [
+          "purachinaendo"
+        ]
+      },
+      {
+        "en": "Liar Game",
+        "ja": "ライアーゲーム",
+        "ja_typings": [
+          "raia-ge-mu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01170",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga features the Yagami family?",
+      "ja": "夜神家が登場する漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "One Piece",
+        "ja": "ワンピース",
+        "ja_typings": [
+          "wanpi-su"
+        ]
+      },
+      {
+        "en": "Black Lagoon",
+        "ja": "ブラック・ラグーン",
+        "ja_typings": [
+          "burakku/ragu-n"
+        ]
+      },
+      {
+        "en": "Coyote Ragtime Show",
+        "ja": "コヨーテラグタイムショー",
+        "ja_typings": [
+          "koyo-teragutaimusho-"
+        ]
+      },
+      {
+        "en": "Outlaw Star",
+        "ja": "アウトロースター",
+        "ja_typings": [
+          "autoro-suta-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01171",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga is about a boy who becomes a pirate king?",
+      "ja": "海賊王を目指す少年の漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Young Animal",
+        "ja": "ヤングアニマル",
+        "ja_typings": [
+          "yanguanimaru"
+        ]
+      },
+      {
+        "en": "Big Comic",
+        "ja": "ビッグコミック",
+        "ja_typings": [
+          "biggukomikku"
+        ]
+      },
+      {
+        "en": "Morning",
+        "ja": "モーニング",
+        "ja_typings": [
+          "mo-ningu"
+        ]
+      },
+      {
+        "en": "Afternoon",
+        "ja": "アフタヌーン",
+        "ja_typings": [
+          "afutanu-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01172",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga magazine publishes 'Berserk'?",
+      "ja": "『ベルセルク』を連載している雑誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Spice and Wolf",
+        "ja": "狼と香辛料",
+        "ja_typings": [
+          "ookamitokoushinryou"
+        ]
+      },
+      {
+        "en": "Kino's Journey",
+        "ja": "キノの旅",
+        "ja_typings": [
+          "kinonotabi"
+        ]
+      },
+      {
+        "en": "Maoyu",
+        "ja": "魔王勇者",
+        "ja_typings": [
+          "maouyuusha"
+        ]
+      },
+      {
+        "en": "Frieren",
+        "ja": "葬送のフリーレン",
+        "ja_typings": [
+          "sousounofuri-ren"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01173",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga features a girl who travels with a wolf merchant?",
+      "ja": "狼の商人と旅をする漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Delicious in Dungeon",
+        "ja": "ダンジョン飯",
+        "ja_typings": [
+          "danjonmeshi"
+        ]
+      },
+      {
+        "en": "Restaurant to Another World",
+        "ja": "異世界食堂",
+        "ja_typings": [
+          "isekaishokudou"
+        ]
+      },
+      {
+        "en": "Spice and Wolf",
+        "ja": "狼と香辛料",
+        "ja_typings": [
+          "ookamitokoushinryou"
+        ]
+      },
+      {
+        "en": "Maoyu",
+        "ja": "魔王勇者",
+        "ja_typings": [
+          "maouyuusha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01174",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga is about a delivery service in a fantasy world?",
+      "ja": "異世界の配達サービスが題材の漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rumiko Takahashi",
+        "ja": "高橋留美子",
+        "ja_typings": [
+          "takahashirumiko"
+        ]
+      },
+      {
+        "en": "Mitsuru Adachi",
+        "ja": "あだち充",
+        "ja_typings": [
+          "adachimitsuru"
+        ]
+      },
+      {
+        "en": "Naoko Takeuchi",
+        "ja": "武内直子",
+        "ja_typings": [
+          "takeuchinaoko"
+        ]
+      },
+      {
+        "en": "CLAMP",
+        "ja": "クランプ",
+        "ja_typings": [
+          "kuranpu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01175",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of 'Inuyasha' and 'Ranma 1/2'?",
+      "ja": "『犬夜叉』『らんま1/2』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shota no Sushi",
+        "ja": "将太の寿司",
+        "ja_typings": [
+          "shoutanosushi"
+        ]
+      },
+      {
+        "en": "Oishinbo",
+        "ja": "美味しんぼ",
+        "ja_typings": [
+          "oishinbo"
+        ]
+      },
+      {
+        "en": "Mister Ajikko",
+        "ja": "ミスター味っ子",
+        "ja_typings": [
+          "misutaaajikko"
+        ]
+      },
+      {
+        "en": "Cooking Papa",
+        "ja": "クッキングパパ",
+        "ja_typings": [
+          "kukkingupapa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01176",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga features a sushi chef apprentice named Shota?",
+      "ja": "翔太という寿司職人見習いの漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fairy Tail",
+        "ja": "フェアリーテイル",
+        "ja_typings": [
+          "feari-teiru"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": [
+          "magi"
+        ]
+      },
+      {
+        "en": "Rave Master",
+        "ja": "レイヴ",
+        "ja_typings": [
+          "reivu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01177",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga is about wizards at Fairy Tail guild?",
+      "ja": "妖精の尻尾ギルドの魔法使いの漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dr. Stone",
+        "ja": "ドクターストーン",
+        "ja_typings": [
+          "dokuta-suto-n"
+        ]
+      },
+      {
+        "en": "Cells at Work",
+        "ja": "はたらく細胞",
+        "ja_typings": [
+          "hatarakusaibou"
+        ]
+      },
+      {
+        "en": "Moriarty the Patriot",
+        "ja": "憂国のモリアーティ",
+        "ja_typings": [
+          "yuukokunomoriaati"
+        ]
+      },
+      {
+        "en": "Eden's Zero",
+        "ja": "エデンズゼロ",
+        "ja_typings": [
+          "edenzuzero"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01178",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga features Senku, a science genius rebuilding civilization?",
+      "ja": "千空が文明を再建する科学漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Capcom",
+        "ja": "カプコン",
+        "ja_typings": [
+          "kapukon"
+        ]
+      },
+      {
+        "en": "Konami",
+        "ja": "コナミ",
+        "ja_typings": [
+          "konami"
+        ]
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": [
+          "bandainamuko"
+        ]
+      },
+      {
+        "en": "Sega",
+        "ja": "セガ",
+        "ja_typings": [
+          "sega"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01179",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed 'Monster Hunter'?",
+      "ja": "『モンスターハンター』を開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Legend of Zelda",
+        "ja": "ゼルダの伝説",
+        "ja_typings": [
+          "zerudanodensetsu"
+        ]
+      },
+      {
+        "en": "Okami",
+        "ja": "大神",
+        "ja_typings": [
+          "ookami"
+        ]
+      },
+      {
+        "en": "Soul Reaver",
+        "ja": "ソウルリーバー",
+        "ja_typings": [
+          "soruri-ba-",
+          "soururi-ba-"
+        ]
+      },
+      {
+        "en": "Ico",
+        "ja": "イコ",
+        "ja_typings": [
+          "iko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01180",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features a silent protagonist named Link?",
+      "ja": "リンクという主人公が登場するゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Atlus",
+        "ja": "アトラス",
+        "ja_typings": [
+          "atorasu"
+        ]
+      },
+      {
+        "en": "Square Enix",
+        "ja": "スクウェア・エニックス",
+        "ja_typings": [
+          "sukuwea/enikkusu"
+        ]
+      },
+      {
+        "en": "Capcom",
+        "ja": "カプコン",
+        "ja_typings": [
+          "kapukon"
+        ]
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": [
+          "bandainamuko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01181",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed 'Persona 5'?",
+      "ja": "『ペルソナ5』を開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Final Fantasy VII",
+        "ja": "ファイナルファンタジーVII",
+        "ja_typings": [
+          "fainarufantaji-vii"
+        ]
+      },
+      {
+        "en": "Kingdom Hearts",
+        "ja": "キングダムハーツ",
+        "ja_typings": [
+          "kingudamuha-tsu"
+        ]
+      },
+      {
+        "en": "Chrono Trigger",
+        "ja": "クロノ・トリガー",
+        "ja_typings": [
+          "kurono/toriga-"
+        ]
+      },
+      {
+        "en": "Xenogears",
+        "ja": "ゼノギアス",
+        "ja_typings": [
+          "zenogiasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01182",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features Cloud Strife as the protagonist?",
+      "ja": "クラウド・ストライフが主人公のゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FromSoftware",
+        "ja": "フロム・ソフトウェア",
+        "ja_typings": [
+          "furomu/sofutowea"
+        ]
+      },
+      {
+        "en": "Konami",
+        "ja": "コナミ",
+        "ja_typings": [
+          "konami"
+        ]
+      },
+      {
+        "en": "Capcom",
+        "ja": "カプコン",
+        "ja_typings": [
+          "kapukon"
+        ]
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": [
+          "bandainamuko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01183",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed 'Dark Souls'?",
+      "ja": "『ダークソウル』を開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bloodborne",
+        "ja": "ブラッドボーン",
+        "ja_typings": [
+          "buraddobo-n"
+        ]
+      },
+      {
+        "en": "Dark Souls",
+        "ja": "ダークソウル",
+        "ja_typings": [
+          "da-kusoru",
+          "da-kusouru"
+        ]
+      },
+      {
+        "en": "Sekiro",
+        "ja": "隻狼",
+        "ja_typings": [
+          "sekirou"
+        ]
+      },
+      {
+        "en": "Elden Ring",
+        "ja": "エルデンリング",
+        "ja_typings": [
+          "erudenringu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01184",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features the city of Yharnam?",
+      "ja": "ヤーナムが舞台のゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sekiro: Shadows Die Twice",
+        "ja": "隻狼",
+        "ja_typings": [
+          "sekirou"
+        ]
+      },
+      {
+        "en": "Ghost of Tsushima",
+        "ja": "ゴースト・オブ・ツシマ",
+        "ja_typings": [
+          "go-suto/obu/tsushima"
+        ]
+      },
+      {
+        "en": "Nioh",
+        "ja": "仁王",
+        "ja_typings": [
+          "niou"
+        ]
+      },
+      {
+        "en": "Onimusha",
+        "ja": "鬼武者",
+        "ja_typings": [
+          "onimusha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01185",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features a samurai named Wolf in Sengoku Japan?",
+      "ja": "戦国時代の隻腕の狼が主人公のゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nintendo",
+        "ja": "任天堂",
+        "ja_typings": [
+          "nintendou"
+        ]
+      },
+      {
+        "en": "Sega",
+        "ja": "セガ",
+        "ja_typings": [
+          "sega"
+        ]
+      },
+      {
+        "en": "Sony",
+        "ja": "ソニー",
+        "ja_typings": [
+          "soni-"
+        ]
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": [
+          "bandainamuko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01186",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed 'Splatoon'?",
+      "ja": "『スプラトゥーン』を開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Splinter Cell",
+        "ja": "スプリンターセル",
+        "ja_typings": [
+          "supurinta-seru"
+        ]
+      },
+      {
+        "en": "Hitman",
+        "ja": "ヒットマン",
+        "ja_typings": [
+          "hittoman"
+        ]
+      },
+      {
+        "en": "Thief",
+        "ja": "シーフ",
+        "ja_typings": [
+          "shi-fu"
+        ]
+      },
+      {
+        "en": "Dishonored",
+        "ja": "ディスオナード",
+        "ja_typings": [
+          "disuona-do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01187",
+    "image_path": null,
+    "question_text": {
+      "en": "Which stealth game series features Sam Fisher?",
+      "ja": "サム・フィッシャーが主人公のステルスゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Horizon Zero Dawn",
+        "ja": "ホライゾン・ゼロ・ドーン",
+        "ja_typings": [
+          "horaizon/zero/do-n"
+        ]
+      },
+      {
+        "en": "The Last of Us",
+        "ja": "ラスト・オブ・アス",
+        "ja_typings": [
+          "rasuto/obu/asu"
+        ]
+      },
+      {
+        "en": "Fallout",
+        "ja": "フォールアウト",
+        "ja_typings": [
+          "fo-ruauto"
+        ]
+      },
+      {
+        "en": "Metro Exodus",
+        "ja": "メトロ・エクソダス",
+        "ja_typings": [
+          "metoro/ekusodasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01188",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features the protagonist Aloy in a post-apocalyptic world?",
+      "ja": "アーロイが主人公のポストアポカリプスゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sega",
+        "ja": "セガ",
+        "ja_typings": [
+          "sega"
+        ]
+      },
+      {
+        "en": "Capcom",
+        "ja": "カプコン",
+        "ja_typings": [
+          "kapukon"
+        ]
+      },
+      {
+        "en": "Konami",
+        "ja": "コナミ",
+        "ja_typings": [
+          "konami"
+        ]
+      },
+      {
+        "en": "Square Enix",
+        "ja": "スクウェア・エニックス",
+        "ja_typings": [
+          "sukuwea/enikkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01189",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed 'Yakuza' (Ryu ga Gotoku) series?",
+      "ja": "『龍が如く』を開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yakuza",
+        "ja": "龍が如く",
+        "ja_typings": [
+          "ryuugagotoku"
+        ]
+      },
+      {
+        "en": "Judgment",
+        "ja": "ジャッジアイズ",
+        "ja_typings": [
+          "jajjiaizu"
+        ]
+      },
+      {
+        "en": "Shenmue",
+        "ja": "シェンムー",
+        "ja_typings": [
+          "shenmu-"
+        ]
+      },
+      {
+        "en": "Way of the Samurai",
+        "ja": "侍道",
+        "ja_typings": [
+          "samuraidou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01190",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features Kazuma Kiryu as the dragon of Dojima?",
+      "ja": "堂島の龍・桐生一馬が主人公のゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Farming simulation",
+        "ja": "農場シミュレーション",
+        "ja_typings": [
+          "noujoushimyureeshon"
+        ]
+      },
+      {
+        "en": "First-person shooter",
+        "ja": "ファーストパーソン・シューター",
+        "ja_typings": [
+          "fa-sutopa-son/shu-ta-"
+        ]
+      },
+      {
+        "en": "Real-time strategy",
+        "ja": "リアルタイム・ストラテジー",
+        "ja_typings": [
+          "riarutaimu/sutorateji-"
+        ]
+      },
+      {
+        "en": "Fighting",
+        "ja": "格闘",
+        "ja_typings": [
+          "kakutou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01191",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game genre is 'Stardew Valley'?",
+      "ja": "『スターデュー・バレー』のジャンルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Legend of Zelda",
+        "ja": "ゼルダの伝説",
+        "ja_typings": [
+          "zerudanodensetsu"
+        ]
+      },
+      {
+        "en": "Final Fantasy",
+        "ja": "ファイナルファンタジー",
+        "ja_typings": [
+          "fainarufantaji-"
+        ]
+      },
+      {
+        "en": "Dragon Quest",
+        "ja": "ドラゴンクエスト",
+        "ja_typings": [
+          "doragonkuesuto"
+        ]
+      },
+      {
+        "en": "Xenoblade",
+        "ja": "ゼノブレイド",
+        "ja_typings": [
+          "zenobureido"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01192",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features the world of Hyrule?",
+      "ja": "ハイラルが舞台のゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Super Mario Bros.",
+        "ja": "スーパーマリオブラザーズ",
+        "ja_typings": [
+          "su-pa-marioburaza-zu"
+        ]
+      },
+      {
+        "en": "Donkey Kong",
+        "ja": "ドンキーコング",
+        "ja_typings": [
+          "donki-kongu"
+        ]
+      },
+      {
+        "en": "Wario Land",
+        "ja": "ワリオランド",
+        "ja_typings": [
+          "wariorando"
+        ]
+      },
+      {
+        "en": "Yoshi's Island",
+        "ja": "ヨッシーアイランド",
+        "ja_typings": [
+          "yosshi-airando"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01193",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features a plumber's brother named Luigi?",
+      "ja": "ルイージが登場するゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Capcom",
+        "ja": "カプコン",
+        "ja_typings": [
+          "kapukon"
+        ]
+      },
+      {
+        "en": "SNK",
+        "ja": "エスエヌケー",
+        "ja_typings": [
+          "esuenuke-"
+        ]
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": [
+          "bandainamuko"
+        ]
+      },
+      {
+        "en": "Arc System Works",
+        "ja": "アークシステムワークス",
+        "ja_typings": [
+          "a-kushisutemuwa-kusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01194",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed 'Street Fighter'?",
+      "ja": "『ストリートファイター』を開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Street Fighter",
+        "ja": "ストリートファイター",
+        "ja_typings": [
+          "sutori-tofaita-"
+        ]
+      },
+      {
+        "en": "King of Fighters",
+        "ja": "キング・オブ・ファイターズ",
+        "ja_typings": [
+          "kingu/obu/faita-zu"
+        ]
+      },
+      {
+        "en": "Tekken",
+        "ja": "鉄拳",
+        "ja_typings": [
+          "tekken"
+        ]
+      },
+      {
+        "en": "Virtua Fighter",
+        "ja": "バーチャファイター",
+        "ja_typings": [
+          "ba-chafaita-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01195",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features Ryu and his Hadouken?",
+      "ja": "リュウと波動拳が登場するゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tekken",
+        "ja": "鉄拳",
+        "ja_typings": [
+          "tekken"
+        ]
+      },
+      {
+        "en": "Soulcalibur",
+        "ja": "ソウルキャリバー",
+        "ja_typings": [
+          "sorukyariba-",
+          "sourukyariba-"
+        ]
+      },
+      {
+        "en": "Dead or Alive",
+        "ja": "デッド・オア・アライブ",
+        "ja_typings": [
+          "deddo/oa/araibu"
+        ]
+      },
+      {
+        "en": "Virtua Fighter",
+        "ja": "バーチャファイター",
+        "ja_typings": [
+          "ba-chafaita-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01196",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game series features the Mishima family rivalry?",
+      "ja": "三島家の確執が描かれる格闘ゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Terraria",
+        "ja": "テラリア",
+        "ja_typings": [
+          "teraria"
+        ]
+      },
+      {
+        "en": "Minecraft Dungeons",
+        "ja": "マインクラフト・ダンジョンズ",
+        "ja_typings": [
+          "mainkurafuto/danjonzu"
+        ]
+      },
+      {
+        "en": "Minecraft Legends",
+        "ja": "マインクラフト・レジェンズ",
+        "ja_typings": [
+          "mainkurafuto/rejenzu"
+        ]
+      },
+      {
+        "en": "Minecraft Earth",
+        "ja": "マインクラフト・アース",
+        "ja_typings": [
+          "mainkurafuto/a-su"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01197",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features building with blocks named NOT Minecraft?",
+      "ja": "ブロックを積むゲームでマインクラフトではないのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "God of War",
+        "ja": "ゴッド・オブ・ウォー",
+        "ja_typings": [
+          "goddo/obu/wo-"
+        ]
+      },
+      {
+        "en": "Devil May Cry",
+        "ja": "デビル・メイ・クライ",
+        "ja_typings": [
+          "debiru/mei/kurai"
+        ]
+      },
+      {
+        "en": "Bayonetta",
+        "ja": "ベヨネッタ",
+        "ja_typings": [
+          "beyonetta"
+        ]
+      },
+      {
+        "en": "Darksiders",
+        "ja": "ダークサイダーズ",
+        "ja_typings": [
+          "da-kusaida-zu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01198",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features the protagonist Kratos?",
+      "ja": "クレイトスが主人公のゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sega",
+        "ja": "セガ",
+        "ja_typings": [
+          "sega"
+        ]
+      },
+      {
+        "en": "Square Enix",
+        "ja": "スクウェア・エニックス",
+        "ja_typings": [
+          "sukuwea/enikkusu"
+        ]
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": [
+          "bandainamuko"
+        ]
+      },
+      {
+        "en": "Koei Tecmo",
+        "ja": "コーエーテクモ",
+        "ja_typings": [
+          "ko-e-tekumo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01199",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed 'Phantasy Star Online'?",
+      "ja": "『ファンタシースターオンライン』を開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Witcher",
+        "ja": "ウィッチャー",
+        "ja_typings": [
+          "witcha-"
+        ]
+      },
+      {
+        "en": "Skyrim",
+        "ja": "スカイリム",
+        "ja_typings": [
+          "sukairimu"
+        ]
+      },
+      {
+        "en": "Dragon Age",
+        "ja": "ドラゴン・エイジ",
+        "ja_typings": [
+          "doragon/eiji"
+        ]
+      },
+      {
+        "en": "Kingdom Come Deliverance",
+        "ja": "キングダムカム・デリバランス",
+        "ja_typings": [
+          "kingudamukamu/deribaransu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01200",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features Geralt of Rivia?",
+      "ja": "リヴィアのゲラルトが主人公のゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Turn-based strategy",
+        "ja": "ターン制ストラテジー",
+        "ja_typings": [
+          "ta-nseisutorateji-"
+        ]
+      },
+      {
+        "en": "Real-time strategy",
+        "ja": "リアルタイム・ストラテジー",
+        "ja_typings": [
+          "riarutaimu/sutorateji-"
+        ]
+      },
+      {
+        "en": "Action RPG",
+        "ja": "アクションRPG",
+        "ja_typings": [
+          "akushonrpg"
+        ]
+      },
+      {
+        "en": "Sandbox",
+        "ja": "サンドボックス",
+        "ja_typings": [
+          "sandobokkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01201",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game genre is 'Civilization'?",
+      "ja": "『シヴィライゼーション』のジャンルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sonic the Hedgehog",
+        "ja": "ソニック・ザ・ヘッジホッグ",
+        "ja_typings": [
+          "sonikku/za/hejjihoggu"
+        ]
+      },
+      {
+        "en": "Crash Bandicoot",
+        "ja": "クラッシュ・バンディクー",
+        "ja_typings": [
+          "kurasshu/bandiku-"
+        ]
+      },
+      {
+        "en": "Spyro the Dragon",
+        "ja": "スパイロ・ザ・ドラゴン",
+        "ja_typings": [
+          "supairo/za/doragon"
+        ]
+      },
+      {
+        "en": "Rayman",
+        "ja": "レイマン",
+        "ja_typings": [
+          "reiman"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01202",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features Sonic the hedgehog?",
+      "ja": "ソニックが登場するゲームシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Square Enix",
+        "ja": "スクウェア・エニックス",
+        "ja_typings": [
+          "sukuwea/enikkusu"
+        ]
+      },
+      {
+        "en": "Atlus",
+        "ja": "アトラス",
+        "ja_typings": [
+          "atorasu"
+        ]
+      },
+      {
+        "en": "Capcom",
+        "ja": "カプコン",
+        "ja_typings": [
+          "kapukon"
+        ]
+      },
+      {
+        "en": "Bandai Namco",
+        "ja": "バンダイナムコ",
+        "ja_typings": [
+          "bandainamuko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01203",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed 'Kingdom Hearts'?",
+      "ja": "『キングダムハーツ』を開発した会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kingdom Hearts",
+        "ja": "キングダムハーツ",
+        "ja_typings": [
+          "kingudamuha-tsu"
+        ]
+      },
+      {
+        "en": "Final Fantasy",
+        "ja": "ファイナルファンタジー",
+        "ja_typings": [
+          "fainarufantaji-"
+        ]
+      },
+      {
+        "en": "The World Ends with You",
+        "ja": "すばらしきこのせかい",
+        "ja_typings": [
+          "subarashikikonosekai"
+        ]
+      },
+      {
+        "en": "Nier",
+        "ja": "ニーア",
+        "ja_typings": [
+          "ni-a"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01204",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features Sora wielding a Keyblade?",
+      "ja": "ソラがキーブレードを使うゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Silent Hill",
+        "ja": "サイレントヒル",
+        "ja_typings": [
+          "sairentohiru"
+        ]
+      },
+      {
+        "en": "Fatal Frame",
+        "ja": "零",
+        "ja_typings": [
+          "zero"
+        ]
+      },
+      {
+        "en": "Clock Tower",
+        "ja": "クロックタワー",
+        "ja_typings": [
+          "kurokkutawa-"
+        ]
+      },
+      {
+        "en": "Forbidden Siren series",
+        "ja": "サイレン シリーズ",
+        "ja_typings": [
+          "sairen shiri-zu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01205",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game series features survival in a haunted town?",
+      "ja": "幽霊の町でのサバイバルゲームシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Titanfall",
+        "ja": "タイタンフォール",
+        "ja_typings": [
+          "taitanfo-ru"
+        ]
+      },
+      {
+        "en": "Armored Core",
+        "ja": "アーマード・コア",
+        "ja_typings": [
+          "a-ma-do/koa"
+        ]
+      },
+      {
+        "en": "MechWarrior",
+        "ja": "メックウォリアー",
+        "ja_typings": [
+          "mekkuworia-"
+        ]
+      },
+      {
+        "en": "Front Mission",
+        "ja": "フロントミッション",
+        "ja_typings": [
+          "furontomisshon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01206",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features pilots and Titans in combat?",
+      "ja": "パイロットとタイタンが戦うゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Engineer",
+        "ja": "エンジニア",
+        "ja_typings": [
+          "enjinia"
+        ]
+      },
+      {
+        "en": "Soldier",
+        "ja": "兵士",
+        "ja_typings": [
+          "heishi"
+        ]
+      },
+      {
+        "en": "Doctor",
+        "ja": "医者",
+        "ja_typings": [
+          "isha"
+        ]
+      },
+      {
+        "en": "Scientist",
+        "ja": "科学者",
+        "ja_typings": [
+          "kagakusha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01207",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features a janitor turned hero named Isaac in Dead Space?",
+      "ja": "デッドスペースの主人公アイザックの職業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nier Automata",
+        "ja": "ニーア・オートマタ",
+        "ja_typings": [
+          "ni-a/o-tomata"
+        ]
+      },
+      {
+        "en": "Drakengard",
+        "ja": "ドラッグ・オン・ドラグーン",
+        "ja_typings": [
+          "doraggu/on/doragu-n"
+        ]
+      },
+      {
+        "en": "Stellar Blade",
+        "ja": "ステラーブレイド",
+        "ja_typings": [
+          "sutera-bureido"
+        ]
+      },
+      {
+        "en": "Scarlet Nexus",
+        "ja": "スカーレットネクサス",
+        "ja_typings": [
+          "suka-rettonekusasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01208",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game features a girl named 2B fighting machines?",
+      "ja": "2Bが機械生命体と戦うゲームは?"
+    }
   }
 ]

--- a/data/questions_ja.json
+++ b/data/questions_ja.json
@@ -2430,7 +2430,8 @@
         "ja": "ソウル",
         "en": "Seoul",
         "ja_typings": [
-          "souru"
+          "souru",
+          "soru"
         ]
       },
       {
@@ -2642,7 +2643,7 @@
         "ja": "エディンバラ",
         "en": "Edinburgh",
         "ja_typings": [
-          "edhinbara"
+          "edinbara"
         ]
       },
       {
@@ -3168,7 +3169,8 @@
         "ja": "メキシコシティ",
         "en": "Mexico City",
         "ja_typings": [
-          "mekishikoshithi"
+          "mekishikoshithi",
+          "mekishikoshiti"
         ]
       },
       {
@@ -3640,7 +3642,7 @@
         "ja": "メディナ",
         "en": "Medina",
         "ja_typings": [
-          "medhina"
+          "medina"
         ]
       }
     ],
@@ -3872,7 +3874,8 @@
         "ja": "サンティアゴ",
         "en": "Santiago",
         "ja_typings": [
-          "santhiago"
+          "santhiago",
+          "santiago"
         ]
       },
       {
@@ -5888,7 +5891,8 @@
         "ja": "ティム・バーナーズ＝リー",
         "en": "Tim Berners-Lee",
         "ja_typings": [
-          "thimu/ba-na-zuri-"
+          "thimu/ba-na-zuri-",
+          "timu/ba-na-zuri-"
         ]
       },
       {
@@ -12318,7 +12322,8 @@
         "ja": "プロダクトオーナー",
         "en": "Product Owner",
         "ja_typings": [
-          "purodakutoo-na-"
+          "purodakutoo-na-",
+          "purodakuto-na-"
         ]
       },
       {
@@ -12851,7 +12856,8 @@
         "ja": "レトロスペクティブ",
         "en": "Retrospective",
         "ja_typings": [
-          "retorosupekuthibu"
+          "retorosupekuthibu",
+          "retorosupekutibu"
         ]
       },
       {
@@ -15981,7 +15987,8 @@
         "ja": "サガフロンティア",
         "en": "SaGa Frontier",
         "ja_typings": [
-          "sagafuronthia"
+          "sagafuronthia",
+          "sagafurontia"
         ]
       }
     ],
@@ -16992,7 +16999,7 @@
         "ja": "ディグダグ",
         "en": "Dig Dug",
         "ja_typings": [
-          "dhigudagu"
+          "digudagu"
         ]
       },
       {
@@ -17108,7 +17115,8 @@
         "ja": "コール オブ デューティ",
         "en": "Call of Duty",
         "ja_typings": [
-          "ko-ru obu deyu-thi"
+          "ko-ru obu deyu-thi",
+          "ko-ru obu deyu-ti"
         ]
       },
       {
@@ -17156,7 +17164,8 @@
         "ja": "コール オブ デューティ",
         "en": "Call of Duty",
         "ja_typings": [
-          "ko-ru obu deyu-thi"
+          "ko-ru obu deyu-thi",
+          "ko-ru obu deyu-ti"
         ]
       },
       {
@@ -17286,7 +17295,7 @@
         "ja": "パラディンズ",
         "en": "Paladins",
         "ja_typings": [
-          "paradhinzu"
+          "paradinzu"
         ]
       },
       {
@@ -17484,7 +17493,8 @@
         "ja": "ダークソウル",
         "en": "Dark Souls",
         "ja_typings": [
-          "da-kusouru"
+          "da-kusouru",
+          "da-kusoru"
         ]
       },
       {
@@ -17607,7 +17617,8 @@
         "ja": "トゥームレイダー",
         "en": "Tomb Raider",
         "ja_typings": [
-          "twu-mureida-"
+          "twu-mureida-",
+          "tu-mureida-"
         ]
       },
       {
@@ -17744,7 +17755,8 @@
         "ja": "シャドウバース",
         "en": "Shadowverse",
         "ja_typings": [
-          "shadouba-su"
+          "shadouba-su",
+          "shadoba-su"
         ]
       }
     ],
@@ -17894,7 +17906,8 @@
         "ja": "マリオパーティ",
         "en": "Mario Party",
         "ja_typings": [
-          "mariopa-thi"
+          "mariopa-thi",
+          "mariopa-ti"
         ]
       },
       {
@@ -17908,7 +17921,8 @@
         "ja": "スプラトゥーン",
         "en": "Splatoon",
         "ja_typings": [
-          "supuratwu-n"
+          "supuratwu-n",
+          "supuratu-n"
         ]
       }
     ],
@@ -17928,7 +17942,8 @@
         "ja": "スプラトゥーン",
         "en": "Splatoon",
         "ja_typings": [
-          "supuratwu-n"
+          "supuratwu-n",
+          "supuratu-n"
         ]
       },
       {
@@ -20348,7 +20363,8 @@
         "ja": "アウグストゥス",
         "en": "Augustus",
         "ja_typings": [
-          "augusutwusu"
+          "augusutwusu",
+          "augusutusu"
         ]
       },
       {
@@ -20861,7 +20877,8 @@
         "ja": "ボッティチェリ",
         "en": "Botticelli",
         "ja_typings": [
-          "botthicheri"
+          "botthicheri",
+          "botticheri"
         ]
       }
     ],
@@ -20881,7 +20898,8 @@
         "ja": "マルティン・ルター",
         "en": "Martin Luther",
         "ja_typings": [
-          "maruthin/ruta-"
+          "maruthin/ruta-",
+          "marutin/ruta-"
         ]
       },
       {
@@ -21298,7 +21316,8 @@
         "ja": "マーティン・ルーサー・キング",
         "en": "Martin Luther King Jr.",
         "ja_typings": [
-          "ma-thin/ru-sa-/kingu"
+          "ma-thin/ru-sa-/kingu",
+          "ma-tin/ru-sa-/kingu"
         ]
       },
       {
@@ -21373,7 +21392,7 @@
         "ja": "ガンディー",
         "en": "Mahatma Gandhi",
         "ja_typings": [
-          "gandhi-"
+          "gandi-"
         ]
       },
       {
@@ -21517,7 +21536,8 @@
         "ja": "ティムール",
         "en": "Timur",
         "ja_typings": [
-          "thimu-ru"
+          "thimu-ru",
+          "timu-ru"
         ]
       }
     ],
@@ -21619,7 +21639,7 @@
         "ja": "ケネディとフルシチョフ",
         "en": "Kennedy and Khrushchev",
         "ja_typings": [
-          "kenedhitofurushichofu"
+          "keneditofurushichofu"
         ]
       },
       {
@@ -21749,7 +21769,8 @@
         "ja": "トゥキディデス",
         "en": "Thucydides",
         "ja_typings": [
-          "twukidhidesu"
+          "twukidhidesu",
+          "tukididesu"
         ]
       },
       {
@@ -22208,7 +22229,7 @@
         "ja": "カトリーヌ・ド・メディシス",
         "en": "Catherine de' Medici",
         "ja_typings": [
-          "katori-nu/do/medhishisu"
+          "katori-nu/do/medishisu"
         ]
       },
       {
@@ -23800,7 +23821,7 @@
         "ja": "ハーディ",
         "en": "Hardy",
         "ja_typings": [
-          "ha-dhi"
+          "ha-di"
         ]
       },
       {
@@ -25522,7 +25543,7 @@
         "ja": "ディワリ",
         "en": "Diwali",
         "ja_typings": [
-          "dhiwari"
+          "diwari"
         ]
       },
       {
@@ -25782,7 +25803,8 @@
         "ja": "ラ・トマティーナ",
         "en": "La Tomatina",
         "ja_typings": [
-          "ra/tomathi-na"
+          "ra/tomathi-na",
+          "ra/tomati-na"
         ]
       }
     ],
@@ -25802,7 +25824,8 @@
         "ja": "ラ・トマティーナ",
         "en": "La Tomatina",
         "ja_typings": [
-          "ra/tomathi-na"
+          "ra/tomathi-na",
+          "ra/tomati-na"
         ]
       },
       {
@@ -25884,7 +25907,8 @@
         "ja": "ラタトゥイユ",
         "en": "Ratatouille",
         "ja_typings": [
-          "ratatwuiyu"
+          "ratatwuiyu",
+          "ratatuiyu"
         ]
       },
       {
@@ -25932,7 +25956,8 @@
         "ja": "ドーティ",
         "en": "Dhoti",
         "ja_typings": [
-          "do-thi"
+          "do-thi",
+          "do-ti"
         ]
       },
       {
@@ -26356,7 +26381,7 @@
         "ja": "ピアディーナ",
         "en": "Piadina",
         "ja_typings": [
-          "piadhi-na"
+          "piadi-na"
         ]
       }
     ],
@@ -26663,7 +26688,7 @@
         "ja": "アントニ・ガウディ",
         "en": "Antoni Gaudi",
         "ja_typings": [
-          "antoni/gaudhi"
+          "antoni/gaudi"
         ]
       },
       {
@@ -26684,7 +26709,7 @@
         "ja": "ザハ・ハディド",
         "en": "Zaha Hadid",
         "ja_typings": [
-          "zaha/hadhido"
+          "zaha/hadido"
         ]
       }
     ],
@@ -26704,7 +26729,8 @@
         "ja": "トルティーヤ",
         "en": "Tortilla",
         "ja_typings": [
-          "toruthi-ya"
+          "toruthi-ya",
+          "toruti-ya"
         ]
       },
       {
@@ -27299,7 +27325,8 @@
         "ja": "ヒョウ",
         "en": "leopard",
         "ja_typings": [
-          "hyou"
+          "hyou",
+          "hyo"
         ]
       }
     ],
@@ -27415,7 +27442,8 @@
         "ja": "スティーブンソン",
         "en": "George Stephenson",
         "ja_typings": [
-          "suthi-bunson"
+          "suthi-bunson",
+          "suti-bunson"
         ]
       },
       {
@@ -28235,7 +28263,7 @@
         "ja": "ディケンズ",
         "en": "Charles Dickens",
         "ja_typings": [
-          "dhikenzu"
+          "dikenzu"
         ]
       },
       {
@@ -28467,7 +28495,8 @@
         "ja": "スティーブ・ジョブズ",
         "en": "Steve Jobs",
         "ja_typings": [
-          "suthi-bu/jobuzu"
+          "suthi-bu/jobuzu",
+          "suti-bu/jobuzu"
         ]
       },
       {
@@ -28481,7 +28510,8 @@
         "ja": "ティム・クック",
         "en": "Tim Cook",
         "ja_typings": [
-          "thimu/kukku"
+          "thimu/kukku",
+          "timu/kukku"
         ]
       },
       {
@@ -29951,14 +29981,16 @@
         "ja": "ありがとう",
         "en": "Thanks",
         "ja_typings": [
-          "arigatou"
+          "arigatou",
+          "arigato"
         ]
       },
       {
         "ja": "おはよう",
         "en": "Good morning",
         "ja_typings": [
-          "ohayou"
+          "ohayou",
+          "ohayo"
         ]
       },
       {
@@ -30136,5 +30168,3445 @@
     "correct_answer_index": 1,
     "image_path": null,
     "ja_reviewed": true
+  },
+  {
+    "choices": [
+      {
+        "en": "merge --no-ff",
+        "ja": "マージノーエフエフ",
+        "ja_typings": [
+          "ma-jino-efuefu"
+        ]
+      },
+      {
+        "en": "rebase",
+        "ja": "リベース",
+        "ja_typings": [
+          "ribe-su"
+        ]
+      },
+      {
+        "en": "cherry-pick",
+        "ja": "チェリーピック",
+        "ja_typings": [
+          "cheri-pikku"
+        ]
+      },
+      {
+        "en": "squash",
+        "ja": "スカッシュ",
+        "ja_typings": [
+          "sukasshu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00736",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Git command merges by creating a new commit that combines branch histories without fast-forward?",
+      "ja": "ファストフォワードなしで新しいコミットを作ってブランチ履歴をマージする Git コマンドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "301",
+        "ja": "サンマルイチ",
+        "ja_typings": [
+          "sanmaruichi"
+        ]
+      },
+      {
+        "en": "302",
+        "ja": "サンマルニ",
+        "ja_typings": [
+          "sanmaruni"
+        ]
+      },
+      {
+        "en": "307",
+        "ja": "サンマルナナ",
+        "ja_typings": [
+          "sanmarunana"
+        ]
+      },
+      {
+        "en": "308",
+        "ja": "サンマルハチ",
+        "ja_typings": [
+          "sanmaruhachi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00737",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status code indicates that the requested resource was permanently moved?",
+      "ja": "リクエストされたリソースが恒久的に移動したことを示す HTTP ステータスコードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Singleton",
+        "ja": "シングルトン",
+        "ja_typings": [
+          "shinguruton"
+        ]
+      },
+      {
+        "en": "Factory",
+        "ja": "ファクトリー",
+        "ja_typings": [
+          "fakutori-"
+        ]
+      },
+      {
+        "en": "Builder",
+        "ja": "ビルダー",
+        "ja_typings": [
+          "biruda-"
+        ]
+      },
+      {
+        "en": "Prototype",
+        "ja": "プロトタイプ",
+        "ja_typings": [
+          "purototaipu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00738",
+    "image_path": null,
+    "question_text": {
+      "en": "Which design pattern ensures a class has only one instance?",
+      "ja": "クラスがただ一つのインスタンスしか持たないことを保証するデザインパターンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SFTP",
+        "ja": "エスエフティーピー",
+        "ja_typings": [
+          "esuefuti-pi-"
+        ]
+      },
+      {
+        "en": "FTPS",
+        "ja": "エフティーピーエス",
+        "ja_typings": [
+          "efuti-pi-esu"
+        ]
+      },
+      {
+        "en": "FTP",
+        "ja": "エフティーピー",
+        "ja_typings": [
+          "efuti-pi-"
+        ]
+      },
+      {
+        "en": "TFTP",
+        "ja": "ティーエフティーピー",
+        "ja_typings": [
+          "ti-efuti-pi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00739",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol is used to securely transfer files over SSH?",
+      "ja": "SSH 経由で安全にファイルを転送するプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ReplicaSet",
+        "ja": "レプリカセット",
+        "ja_typings": [
+          "repurikasetto"
+        ]
+      },
+      {
+        "en": "DaemonSet",
+        "ja": "デーモンセット",
+        "ja_typings": [
+          "de-monsetto"
+        ]
+      },
+      {
+        "en": "StatefulSet",
+        "ja": "ステートフルセット",
+        "ja_typings": [
+          "sute-tofurusetto"
+        ]
+      },
+      {
+        "en": "Job",
+        "ja": "ジョブ",
+        "ja_typings": [
+          "jobu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00740",
+    "image_path": null,
+    "question_text": {
+      "en": "In Kubernetes, what controller maintains a stable set of replica Pods?",
+      "ja": "Kubernetes でレプリカ Pod の安定集合を維持するコントローラーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aurora",
+        "ja": "オーロラ",
+        "ja_typings": [
+          "o-rora"
+        ]
+      },
+      {
+        "en": "DynamoDB",
+        "ja": "ダイナモディービー",
+        "ja_typings": [
+          "dainamodi-bi-"
+        ]
+      },
+      {
+        "en": "Redshift",
+        "ja": "レッドシフト",
+        "ja_typings": [
+          "reddoshifuto"
+        ]
+      },
+      {
+        "en": "Neptune",
+        "ja": "ネプチューン",
+        "ja_typings": [
+          "nepuchu-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00741",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS service provides a fully managed relational database for PostgreSQL with Aurora compatibility?",
+      "ja": "Aurora 互換のマネージドリレーショナル DB を提供する AWS サービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Consistency",
+        "ja": "コンシステンシー",
+        "ja_typings": [
+          "konshisutenshi-"
+        ]
+      },
+      {
+        "en": "Availability",
+        "ja": "アベイラビリティ",
+        "ja_typings": [
+          "abeirabiriti"
+        ]
+      },
+      {
+        "en": "Partition tolerance",
+        "ja": "パーティショントレランス",
+        "ja_typings": [
+          "pa-tishontoreransu"
+        ]
+      },
+      {
+        "en": "Durability",
+        "ja": "デュラビリティ",
+        "ja_typings": [
+          "deyurabiriti"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00742",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CAP theorem property guarantees every read returns the most recent write?",
+      "ja": "CAP 定理で、すべての読み出しが最新の書き込みを返すことを保証する性質は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Integration test",
+        "ja": "インテグレーションテスト",
+        "ja_typings": [
+          "integure-shontesuto"
+        ]
+      },
+      {
+        "en": "Unit test",
+        "ja": "ユニットテスト",
+        "ja_typings": [
+          "yunittotesuto"
+        ]
+      },
+      {
+        "en": "End-to-end test",
+        "ja": "エンドトゥーエンドテスト",
+        "ja_typings": [
+          "endotu-endotesuto"
+        ]
+      },
+      {
+        "en": "Smoke test",
+        "ja": "スモークテスト",
+        "ja_typings": [
+          "sumo-kutesuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00743",
+    "image_path": null,
+    "question_text": {
+      "en": "Which test type checks the integration of multiple modules working together?",
+      "ja": "複数のモジュールが連携して動作することを検証するテストの種類は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Transport layer",
+        "ja": "トランスポート層",
+        "ja_typings": [
+          "toransupo-tosou"
+        ]
+      },
+      {
+        "en": "Network layer",
+        "ja": "ネットワーク層",
+        "ja_typings": [
+          "nettowa-kusou"
+        ]
+      },
+      {
+        "en": "Session layer",
+        "ja": "セッション層",
+        "ja_typings": [
+          "sesshonsou"
+        ]
+      },
+      {
+        "en": "Data link layer",
+        "ja": "データリンク層",
+        "ja_typings": [
+          "de-tarinkusou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00744",
+    "image_path": null,
+    "question_text": {
+      "en": "Which OSI model layer is responsible for end-to-end communication and reliability?",
+      "ja": "OSI 参照モデルでエンドツーエンドの通信と信頼性を担う層は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Durability",
+        "ja": "デュラビリティ",
+        "ja_typings": [
+          "deyurabiriti"
+        ]
+      },
+      {
+        "en": "Isolation",
+        "ja": "アイソレーション",
+        "ja_typings": [
+          "aisore-shon"
+        ]
+      },
+      {
+        "en": "Consistency",
+        "ja": "コンシステンシー",
+        "ja_typings": [
+          "konshisutenshi-"
+        ]
+      },
+      {
+        "en": "Atomicity",
+        "ja": "アトミシティ",
+        "ja_typings": [
+          "atomishiti"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00745",
+    "image_path": null,
+    "question_text": {
+      "en": "Which database concept ensures that committed data survives system failures?",
+      "ja": "コミット済みのデータがシステム障害後も残ることを保証する DB の概念は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ip route",
+        "ja": "アイピールート",
+        "ja_typings": [
+          "aipi-ru-to"
+        ]
+      },
+      {
+        "en": "netstat",
+        "ja": "ネットスタット",
+        "ja_typings": [
+          "nettosutatto"
+        ]
+      },
+      {
+        "en": "traceroute",
+        "ja": "トレースルート",
+        "ja_typings": [
+          "tore-suru-to"
+        ]
+      },
+      {
+        "en": "ifconfig",
+        "ja": "アイエフコンフィグ",
+        "ja_typings": [
+          "aiefukonfigu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00746",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Linux command shows the routing table?",
+      "ja": "Linux でルーティングテーブルを表示するコマンドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Retrospective",
+        "ja": "レトロスペクティブ",
+        "ja_typings": [
+          "retorosupekutibu"
+        ]
+      },
+      {
+        "en": "Sprint Review",
+        "ja": "スプリントレビュー",
+        "ja_typings": [
+          "supurintorebyu-"
+        ]
+      },
+      {
+        "en": "Daily Stand-up",
+        "ja": "デイリースタンドアップ",
+        "ja_typings": [
+          "deiri-sutandoappu"
+        ]
+      },
+      {
+        "en": "Sprint Planning",
+        "ja": "スプリントプランニング",
+        "ja_typings": [
+          "supurintopurannningu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00747",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Agile ceremony reviews what the team learned during the sprint to improve processes?",
+      "ja": "プロセス改善のためスプリント中の学びを振り返るアジャイルのセレモニーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SQS",
+        "ja": "エスキューエス",
+        "ja_typings": [
+          "esukyu-esu"
+        ]
+      },
+      {
+        "en": "SNS",
+        "ja": "エスエヌエス",
+        "ja_typings": [
+          "esuenuesu"
+        ]
+      },
+      {
+        "en": "Kinesis",
+        "ja": "キネシス",
+        "ja_typings": [
+          "kineshisu"
+        ]
+      },
+      {
+        "en": "EventBridge",
+        "ja": "イベントブリッジ",
+        "ja_typings": [
+          "ibentoburijji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00748",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS service provides a managed message queue?",
+      "ja": "マネージドメッセージキューを提供する AWS サービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Functional programming",
+        "ja": "関数型プログラミング",
+        "ja_typings": [
+          "kansuugatapuroguramingu"
+        ]
+      },
+      {
+        "en": "Object-oriented programming",
+        "ja": "オブジェクト指向プログラミング",
+        "ja_typings": [
+          "obujekutoshikoupuroguramingu"
+        ]
+      },
+      {
+        "en": "Procedural programming",
+        "ja": "手続き型プログラミング",
+        "ja_typings": [
+          "tetsudukigatapuroguramingu"
+        ]
+      },
+      {
+        "en": "Logic programming",
+        "ja": "論理型プログラミング",
+        "ja_typings": [
+          "ronrigatapuroguramingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00749",
+    "image_path": null,
+    "question_text": {
+      "en": "Which programming paradigm treats computation as evaluation of mathematical functions?",
+      "ja": "計算を数学的関数の評価として扱うプログラミングパラダイムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SAML",
+        "ja": "サムル",
+        "ja_typings": [
+          "samuru"
+        ]
+      },
+      {
+        "en": "OAuth",
+        "ja": "オーオース",
+        "ja_typings": [
+          "o-o-su"
+        ]
+      },
+      {
+        "en": "OpenID Connect",
+        "ja": "オープンアイディーコネクト",
+        "ja_typings": [
+          "o-punnaidi-konekuto"
+        ]
+      },
+      {
+        "en": "Kerberos",
+        "ja": "ケルベロス",
+        "ja_typings": [
+          "keruberosu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00750",
+    "image_path": null,
+    "question_text": {
+      "en": "Which authentication standard is widely used for federated single sign-on with XML assertions?",
+      "ja": "XML アサーションでフェデレーテッド SSO に広く使われる認証規格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lead Time for Changes",
+        "ja": "リードタイムフォーチェンジズ",
+        "ja_typings": [
+          "ri-dotaimufo-chenjizu"
+        ]
+      },
+      {
+        "en": "Mean Time to Recover",
+        "ja": "ミーンタイムトゥーリカバー",
+        "ja_typings": [
+          "mi-ntaimutu-rikaba-"
+        ]
+      },
+      {
+        "en": "Change Failure Rate",
+        "ja": "チェンジフェイリャーレート",
+        "ja_typings": [
+          "chenjifeirya-re-to"
+        ]
+      },
+      {
+        "en": "Deployment Frequency",
+        "ja": "デプロイメントフリークエンシー",
+        "ja_typings": [
+          "depuroimentofuri-kuenshi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00751",
+    "image_path": null,
+    "question_text": {
+      "en": "Which DevOps metric measures the time from code commit to production deployment?",
+      "ja": "コミットから本番デプロイまでの時間を計測する DevOps メトリクスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SaaS",
+        "ja": "サース",
+        "ja_typings": [
+          "sa-su"
+        ]
+      },
+      {
+        "en": "PaaS",
+        "ja": "パース",
+        "ja_typings": [
+          "pa-su"
+        ]
+      },
+      {
+        "en": "IaaS",
+        "ja": "アイアース",
+        "ja_typings": [
+          "aia-su"
+        ]
+      },
+      {
+        "en": "FaaS",
+        "ja": "ファース",
+        "ja_typings": [
+          "fa-su"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00752",
+    "image_path": null,
+    "question_text": {
+      "en": "Which type of cloud computing service provides ready-to-use applications over the internet?",
+      "ja": "利用可能なアプリケーションをインターネット経由で提供するクラウドサービス種別は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "wa",
+        "ja": "は",
+        "ja_typings": [
+          "ha"
+        ]
+      },
+      {
+        "en": "ga",
+        "ja": "が",
+        "ja_typings": [
+          "ga"
+        ]
+      },
+      {
+        "en": "wo",
+        "ja": "を",
+        "ja_typings": [
+          "o"
+        ]
+      },
+      {
+        "en": "ni",
+        "ja": "に",
+        "ja_typings": [
+          "ni"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00753",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese particle marks the topic of a sentence?",
+      "ja": "日本語で文の主題を示す助詞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Uralic",
+        "ja": "ウラル語族",
+        "ja_typings": [
+          "urarugozoku"
+        ]
+      },
+      {
+        "en": "Indo-European",
+        "ja": "インドヨーロッパ語族",
+        "ja_typings": [
+          "indoyo-roppagozoku"
+        ]
+      },
+      {
+        "en": "Turkic",
+        "ja": "テュルク語族",
+        "ja_typings": [
+          "tyurukugozoku"
+        ]
+      },
+      {
+        "en": "Altaic",
+        "ja": "アルタイ語族",
+        "ja_typings": [
+          "arutaigozoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00754",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language family does Finnish belong to?",
+      "ja": "フィンランド語が属する語族は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Homophone",
+        "ja": "同音異義語",
+        "ja_typings": [
+          "douonigigo"
+        ]
+      },
+      {
+        "en": "Synonym",
+        "ja": "類義語",
+        "ja_typings": [
+          "ruigigo"
+        ]
+      },
+      {
+        "en": "Antonym",
+        "ja": "対義語",
+        "ja_typings": [
+          "taigigo"
+        ]
+      },
+      {
+        "en": "Hyponym",
+        "ja": "下位語",
+        "ja_typings": [
+          "kaigo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00755",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the linguistic term for words that sound the same but have different meanings?",
+      "ja": "音は同じだが意味が異なる単語を指す言語学用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cuneiform",
+        "ja": "楔形文字",
+        "ja_typings": [
+          "kusabigatamoji"
+        ]
+      },
+      {
+        "en": "Hieroglyphs",
+        "ja": "ヒエログリフ",
+        "ja_typings": [
+          "hierogurifu"
+        ]
+      },
+      {
+        "en": "Linear A",
+        "ja": "線文字A",
+        "ja_typings": [
+          "senmojiA"
+        ]
+      },
+      {
+        "en": "Phoenician",
+        "ja": "フェニキア文字",
+        "ja_typings": [
+          "fenikiamoji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00756",
+    "image_path": null,
+    "question_text": {
+      "en": "Which writing system was used in ancient Mesopotamia?",
+      "ja": "古代メソポタミアで使われた文字体系は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Humble language",
+        "ja": "謙譲語",
+        "ja_typings": [
+          "kenjougo"
+        ]
+      },
+      {
+        "en": "Respectful language",
+        "ja": "尊敬語",
+        "ja_typings": [
+          "sonkeigo"
+        ]
+      },
+      {
+        "en": "Polite language",
+        "ja": "丁寧語",
+        "ja_typings": [
+          "teineigo"
+        ]
+      },
+      {
+        "en": "Beautified language",
+        "ja": "美化語",
+        "ja_typings": [
+          "bikago"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00757",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese honorific form lowers the speaker to elevate the listener?",
+      "ja": "話者を低めて聴者を高める日本語の敬語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Accusative",
+        "ja": "対格",
+        "ja_typings": [
+          "taikaku"
+        ]
+      },
+      {
+        "en": "Nominative",
+        "ja": "主格",
+        "ja_typings": [
+          "shukaku"
+        ]
+      },
+      {
+        "en": "Genitive",
+        "ja": "属格",
+        "ja_typings": [
+          "zokkaku"
+        ]
+      },
+      {
+        "en": "Dative",
+        "ja": "与格",
+        "ja_typings": [
+          "yokaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00758",
+    "image_path": null,
+    "question_text": {
+      "en": "Which grammatical case marks the direct object in Latin?",
+      "ja": "ラテン語で直接目的語を示す格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fourth tone",
+        "ja": "第四声",
+        "ja_typings": [
+          "daiyonsei"
+        ]
+      },
+      {
+        "en": "First tone",
+        "ja": "第一声",
+        "ja_typings": [
+          "daiissei"
+        ]
+      },
+      {
+        "en": "Second tone",
+        "ja": "第二声",
+        "ja_typings": [
+          "dainisei"
+        ]
+      },
+      {
+        "en": "Third tone",
+        "ja": "第三声",
+        "ja_typings": [
+          "daisansei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00759",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Chinese tone is described as a sharp falling tone?",
+      "ja": "中国語で鋭く下がる調子とされる四声は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Loanword",
+        "ja": "借用語",
+        "ja_typings": [
+          "shakuyougo"
+        ]
+      },
+      {
+        "en": "Calque",
+        "ja": "翻訳借用",
+        "ja_typings": [
+          "honyakushakuyou"
+        ]
+      },
+      {
+        "en": "Cognate",
+        "ja": "同源語",
+        "ja_typings": [
+          "dougengo"
+        ]
+      },
+      {
+        "en": "Neologism",
+        "ja": "新造語",
+        "ja_typings": [
+          "shinzougo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00760",
+    "image_path": null,
+    "question_text": {
+      "en": "Which term refers to the borrowing of a word from another language with adaptation?",
+      "ja": "他言語からの適応付き単語借用を指す用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Past perfect",
+        "ja": "過去完了",
+        "ja_typings": [
+          "kakokanryou"
+        ]
+      },
+      {
+        "en": "Present perfect",
+        "ja": "現在完了",
+        "ja_typings": [
+          "genzaikanryou"
+        ]
+      },
+      {
+        "en": "Future perfect",
+        "ja": "未来完了",
+        "ja_typings": [
+          "miraikanryou"
+        ]
+      },
+      {
+        "en": "Simple past",
+        "ja": "過去",
+        "ja_typings": [
+          "kako"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00761",
+    "image_path": null,
+    "question_text": {
+      "en": "In English grammar, which tense expresses an action completed before another past action?",
+      "ja": "英文法で、別の過去の行為より前に完了した行為を表す時制は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Romanian",
+        "ja": "ルーマニア語",
+        "ja_typings": [
+          "ru-maniago"
+        ]
+      },
+      {
+        "en": "Italian",
+        "ja": "イタリア語",
+        "ja_typings": [
+          "itariago"
+        ]
+      },
+      {
+        "en": "Spanish",
+        "ja": "スペイン語",
+        "ja_typings": [
+          "supeingo"
+        ]
+      },
+      {
+        "en": "Catalan",
+        "ja": "カタルーニャ語",
+        "ja_typings": [
+          "kataru-nyago"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00762",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Romance language is the official language of Romania?",
+      "ja": "ルーマニアの公用語であるロマンス諸語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hangul",
+        "ja": "ハングル",
+        "ja_typings": [
+          "hanguru"
+        ]
+      },
+      {
+        "en": "Hanja",
+        "ja": "ハンジャ",
+        "ja_typings": [
+          "hanja"
+        ]
+      },
+      {
+        "en": "Katakana",
+        "ja": "カタカナ",
+        "ja_typings": [
+          "katakana"
+        ]
+      },
+      {
+        "en": "Cyrillic",
+        "ja": "キリル文字",
+        "ja_typings": [
+          "kirirumoji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00763",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the official script used to write Korean?",
+      "ja": "朝鮮語の表記に使われる公式文字は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Verb",
+        "ja": "動詞",
+        "ja_typings": [
+          "doushi"
+        ]
+      },
+      {
+        "en": "i-adjective",
+        "ja": "イ形容詞",
+        "ja_typings": [
+          "ikeiyoushi"
+        ]
+      },
+      {
+        "en": "na-adjective",
+        "ja": "ナ形容詞",
+        "ja_typings": [
+          "nakeiyoushi"
+        ]
+      },
+      {
+        "en": "Adverb",
+        "ja": "副詞",
+        "ja_typings": [
+          "fukushi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00764",
+    "image_path": null,
+    "question_text": {
+      "en": "Which kind of word in Japanese conjugates and ends in u?",
+      "ja": "日本語でウ段で終わり活用する品詞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Simile",
+        "ja": "直喩",
+        "ja_typings": [
+          "chokuyu"
+        ]
+      },
+      {
+        "en": "Metaphor",
+        "ja": "隠喩",
+        "ja_typings": [
+          "inyu"
+        ]
+      },
+      {
+        "en": "Personification",
+        "ja": "擬人法",
+        "ja_typings": [
+          "gijinhou"
+        ]
+      },
+      {
+        "en": "Hyperbole",
+        "ja": "誇張法",
+        "ja_typings": [
+          "kochouhou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00765",
+    "image_path": null,
+    "question_text": {
+      "en": "Which figure of speech compares two things using like or as?",
+      "ja": "「ようだ」「みたいに」を使って似たものを喩える修辞法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Serbian",
+        "ja": "セルビア語",
+        "ja_typings": [
+          "serubiago"
+        ]
+      },
+      {
+        "en": "Russian",
+        "ja": "ロシア語",
+        "ja_typings": [
+          "roshiago"
+        ]
+      },
+      {
+        "en": "Polish",
+        "ja": "ポーランド語",
+        "ja_typings": [
+          "po-randogo"
+        ]
+      },
+      {
+        "en": "Czech",
+        "ja": "チェコ語",
+        "ja_typings": [
+          "chekogo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00766",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Slavic language is written with both Latin and Cyrillic scripts officially?",
+      "ja": "ラテン文字とキリル文字の両方が公式に使われるスラブ語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Niger-Congo",
+        "ja": "ニジェールコンゴ語族",
+        "ja_typings": [
+          "nije-rukongogozoku"
+        ]
+      },
+      {
+        "en": "Indo-European",
+        "ja": "インドヨーロッパ語族",
+        "ja_typings": [
+          "indoyo-roppagozoku"
+        ]
+      },
+      {
+        "en": "Sino-Tibetan",
+        "ja": "シナチベット語族",
+        "ja_typings": [
+          "shinachibettogozoku"
+        ]
+      },
+      {
+        "en": "Austronesian",
+        "ja": "オーストロネシア語族",
+        "ja_typings": [
+          "o-sutoroneshiagozoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00767",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the largest language family in the world by number of languages?",
+      "ja": "言語数で世界最大の語族は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "To-on",
+        "ja": "唐音",
+        "ja_typings": [
+          "touon"
+        ]
+      },
+      {
+        "en": "Go-on",
+        "ja": "呉音",
+        "ja_typings": [
+          "goon"
+        ]
+      },
+      {
+        "en": "Kan-on",
+        "ja": "漢音",
+        "ja_typings": [
+          "kanon"
+        ]
+      },
+      {
+        "en": "Kun-yomi",
+        "ja": "訓読み",
+        "ja_typings": [
+          "kunyomi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00768",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese kanji reading was brought from Tang-dynasty China?",
+      "ja": "唐代中国から伝わった漢字の読みは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sumerian cuneiform",
+        "ja": "シュメール楔形文字",
+        "ja_typings": [
+          "shume-rukusabigatamoji"
+        ]
+      },
+      {
+        "en": "Egyptian hieroglyphs",
+        "ja": "エジプトヒエログリフ",
+        "ja_typings": [
+          "ejiputohierogurifu"
+        ]
+      },
+      {
+        "en": "Chinese oracle bone script",
+        "ja": "中国甲骨文字",
+        "ja_typings": [
+          "chuugokukoukotsumoji"
+        ]
+      },
+      {
+        "en": "Indus script",
+        "ja": "インダス文字",
+        "ja_typings": [
+          "indasumoji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00769",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the oldest known fully deciphered writing system?",
+      "ja": "完全に解読された最古の文字体系は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kimchi",
+        "ja": "キムチ",
+        "ja_typings": [
+          "kimuchi"
+        ]
+      },
+      {
+        "en": "Bibimbap",
+        "ja": "ビビンバ",
+        "ja_typings": [
+          "bibinba"
+        ]
+      },
+      {
+        "en": "Bulgogi",
+        "ja": "プルコギ",
+        "ja_typings": [
+          "purukogi"
+        ]
+      },
+      {
+        "en": "Japchae",
+        "ja": "チャプチェ",
+        "ja_typings": [
+          "chapuche"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00770",
+    "image_path": null,
+    "question_text": {
+      "en": "Which traditional Korean dish consists of fermented vegetables, typically cabbage?",
+      "ja": "発酵野菜、特に白菜を使った韓国の伝統料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Galette",
+        "ja": "ガレット",
+        "ja_typings": [
+          "garetto"
+        ]
+      },
+      {
+        "en": "Crepe",
+        "ja": "クレープ",
+        "ja_typings": [
+          "kure-pu"
+        ]
+      },
+      {
+        "en": "Frittata",
+        "ja": "フリッタータ",
+        "ja_typings": [
+          "furitta-ta"
+        ]
+      },
+      {
+        "en": "Quiche",
+        "ja": "キッシュ",
+        "ja_typings": [
+          "kisshu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00771",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French dish is a thin pancake filled with savory ingredients, originally from Brittany?",
+      "ja": "ブルターニュ地方発祥の塩味の薄焼き菓子料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Obon",
+        "ja": "お盆",
+        "ja_typings": [
+          "obon"
+        ]
+      },
+      {
+        "en": "Tanabata",
+        "ja": "七夕",
+        "ja_typings": [
+          "tanabata"
+        ]
+      },
+      {
+        "en": "Hanami",
+        "ja": "花見",
+        "ja_typings": [
+          "hanami"
+        ]
+      },
+      {
+        "en": "Shichigosan",
+        "ja": "七五三",
+        "ja_typings": [
+          "shichigosan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00772",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese summer festival features paper lanterns and is held in mid-August to honor ancestors?",
+      "ja": "8月中旬に先祖供養のため灯籠を掲げる日本の夏祭りは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Paella",
+        "ja": "パエリア",
+        "ja_typings": [
+          "paeria"
+        ]
+      },
+      {
+        "en": "Risotto",
+        "ja": "リゾット",
+        "ja_typings": [
+          "rizotto"
+        ]
+      },
+      {
+        "en": "Jambalaya",
+        "ja": "ジャンバラヤ",
+        "ja_typings": [
+          "janbaraya"
+        ]
+      },
+      {
+        "en": "Biryani",
+        "ja": "ビリヤニ",
+        "ja_typings": [
+          "biriyani"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00773",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Spanish dish features saffron-flavored rice with seafood or meat?",
+      "ja": "サフラン風味の米にシーフードや肉を入れたスペイン料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Day of the Dead",
+        "ja": "死者の日",
+        "ja_typings": [
+          "shishanohi"
+        ]
+      },
+      {
+        "en": "Cinco de Mayo",
+        "ja": "シンコデマヨ",
+        "ja_typings": [
+          "shinkodemayo"
+        ]
+      },
+      {
+        "en": "Las Posadas",
+        "ja": "ラスポサダス",
+        "ja_typings": [
+          "rasuposadasu"
+        ]
+      },
+      {
+        "en": "Carnival",
+        "ja": "カーニバル",
+        "ja_typings": [
+          "ka-nibaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00774",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mexican festival on November 1-2 honors deceased relatives?",
+      "ja": "11月1日から2日に故人を讃えるメキシコの祭りは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Karesansui",
+        "ja": "枯山水",
+        "ja_typings": [
+          "karesansui"
+        ]
+      },
+      {
+        "en": "Tsukiyama",
+        "ja": "築山",
+        "ja_typings": [
+          "tsukiyama"
+        ]
+      },
+      {
+        "en": "Chaniwa",
+        "ja": "茶庭",
+        "ja_typings": [
+          "chaniwa"
+        ]
+      },
+      {
+        "en": "Kaiyu-shiki",
+        "ja": "回遊式",
+        "ja_typings": [
+          "kaiyuushiki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00775",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese garden style uses raked gravel and rocks to represent landscapes?",
+      "ja": "砂利や岩で景色を表現する日本庭園の様式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sari",
+        "ja": "サリー",
+        "ja_typings": [
+          "sari-"
+        ]
+      },
+      {
+        "en": "Dhoti",
+        "ja": "ドーティ",
+        "ja_typings": [
+          "do-ti"
+        ]
+      },
+      {
+        "en": "Lehenga",
+        "ja": "レヘンガ",
+        "ja_typings": [
+          "rehenga"
+        ]
+      },
+      {
+        "en": "Salwar",
+        "ja": "サルワール",
+        "ja_typings": [
+          "saruwa-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00776",
+    "image_path": null,
+    "question_text": {
+      "en": "Which traditional Indian garment is a long unstitched cloth wrapped around the body?",
+      "ja": "長く縫っていない布を体に巻くインドの伝統衣装は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Opera cake",
+        "ja": "オペラ",
+        "ja_typings": [
+          "opera"
+        ]
+      },
+      {
+        "en": "Mille-feuille",
+        "ja": "ミルフィーユ",
+        "ja_typings": [
+          "mirufi-yu"
+        ]
+      },
+      {
+        "en": "Eclair",
+        "ja": "エクレア",
+        "ja_typings": [
+          "ekurea"
+        ]
+      },
+      {
+        "en": "Macaron",
+        "ja": "マカロン",
+        "ja_typings": [
+          "makaron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00777",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French dessert is a layered cake with coffee buttercream and chocolate?",
+      "ja": "コーヒーバタークリームとチョコレートの層状ケーキはフランスの何という菓子?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cezve",
+        "ja": "ジェズベ",
+        "ja_typings": [
+          "jezube"
+        ]
+      },
+      {
+        "en": "Drip",
+        "ja": "ドリップ",
+        "ja_typings": [
+          "dorippu"
+        ]
+      },
+      {
+        "en": "French press",
+        "ja": "フレンチプレス",
+        "ja_typings": [
+          "furenchipuresu"
+        ]
+      },
+      {
+        "en": "Espresso",
+        "ja": "エスプレッソ",
+        "ja_typings": [
+          "esupuresso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00778",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Turkish coffee preparation involves boiling finely ground coffee in a small pot?",
+      "ja": "小さな鍋で細かく挽いたコーヒーを煮詰めるトルコのコーヒー抽出法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Piobaireachd",
+        "ja": "ピーブロック",
+        "ja_typings": [
+          "pi-burokku"
+        ]
+      },
+      {
+        "en": "Reel",
+        "ja": "リール",
+        "ja_typings": [
+          "ri-ru"
+        ]
+      },
+      {
+        "en": "Jig",
+        "ja": "ジグ",
+        "ja_typings": [
+          "jigu"
+        ]
+      },
+      {
+        "en": "Strathspey",
+        "ja": "ストラススペイ",
+        "ja_typings": [
+          "sutorasusupei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00779",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Scottish bagpipe music style features ornate variations on a theme?",
+      "ja": "主題への装飾的変奏が特徴のスコットランドのバグパイプ曲は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tango",
+        "ja": "タンゴ",
+        "ja_typings": [
+          "tango"
+        ]
+      },
+      {
+        "en": "Samba",
+        "ja": "サンバ",
+        "ja_typings": [
+          "sanba"
+        ]
+      },
+      {
+        "en": "Salsa",
+        "ja": "サルサ",
+        "ja_typings": [
+          "sarusa"
+        ]
+      },
+      {
+        "en": "Bachata",
+        "ja": "バチャータ",
+        "ja_typings": [
+          "bacha-ta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00780",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Argentine dance originated in Buenos Aires and Montevideo in the late 19th century?",
+      "ja": "19世紀後半にブエノスアイレスとモンテビデオで生まれたアルゼンチンの舞踊は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Borscht",
+        "ja": "ボルシチ",
+        "ja_typings": [
+          "borushichi"
+        ]
+      },
+      {
+        "en": "Solyanka",
+        "ja": "ソリャンカ",
+        "ja_typings": [
+          "soryanka"
+        ]
+      },
+      {
+        "en": "Shchi",
+        "ja": "シチー",
+        "ja_typings": [
+          "shichi-"
+        ]
+      },
+      {
+        "en": "Okroshka",
+        "ja": "オクローシカ",
+        "ja_typings": [
+          "okuro-shika"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00781",
+    "image_path": null,
+    "question_text": {
+      "en": "Which traditional Russian soup is made with beetroot?",
+      "ja": "ビーツを使ったロシアの伝統スープは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "La Scala",
+        "ja": "ラ・スカラ",
+        "ja_typings": [
+          "ra/sukara"
+        ]
+      },
+      {
+        "en": "Teatro Massimo",
+        "ja": "テアトロマッシモ",
+        "ja_typings": [
+          "teatoromasshimo"
+        ]
+      },
+      {
+        "en": "La Fenice",
+        "ja": "ラ・フェニーチェ",
+        "ja_typings": [
+          "ra/feni-che"
+        ]
+      },
+      {
+        "en": "San Carlo",
+        "ja": "サンカルロ",
+        "ja_typings": [
+          "sankaruro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00782",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian opera house in Milan opened in 1778?",
+      "ja": "1778年に開館したミラノのオペラ劇場は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Capoeira",
+        "ja": "カポエイラ",
+        "ja_typings": [
+          "kapoeira"
+        ]
+      },
+      {
+        "en": "Vale tudo",
+        "ja": "バーリトゥード",
+        "ja_typings": [
+          "ba-ritu-do"
+        ]
+      },
+      {
+        "en": "Luta livre",
+        "ja": "ルタリーブリ",
+        "ja_typings": [
+          "rutari-buri"
+        ]
+      },
+      {
+        "en": "Jiu-jitsu",
+        "ja": "ジュージツ",
+        "ja_typings": [
+          "ju-jitsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00783",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Brazilian martial art combines dance, acrobatics, and music?",
+      "ja": "ダンス、アクロバット、音楽を組み合わせたブラジルの武術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Symposium",
+        "ja": "シンポシウム",
+        "ja_typings": [
+          "shinposhiumu"
+        ]
+      },
+      {
+        "en": "Agora",
+        "ja": "アゴラ",
+        "ja_typings": [
+          "agora"
+        ]
+      },
+      {
+        "en": "Hetairia",
+        "ja": "ヘタイリア",
+        "ja_typings": [
+          "hetairia"
+        ]
+      },
+      {
+        "en": "Andron",
+        "ja": "アンドロン",
+        "ja_typings": [
+          "andoron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00784",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Greek philosophical drinking party was the subject of works by Plato and Xenophon?",
+      "ja": "プラトンとクセノフォンの著作の主題となったギリシャの哲学的宴会は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Daiginjo",
+        "ja": "大吟醸",
+        "ja_typings": [
+          "daiginjou"
+        ]
+      },
+      {
+        "en": "Ginjo",
+        "ja": "吟醸",
+        "ja_typings": [
+          "ginjou"
+        ]
+      },
+      {
+        "en": "Junmai",
+        "ja": "純米",
+        "ja_typings": [
+          "junmai"
+        ]
+      },
+      {
+        "en": "Honjozo",
+        "ja": "本醸造",
+        "ja_typings": [
+          "honjouzou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00785",
+    "image_path": null,
+    "question_text": {
+      "en": "Which type of Japanese sake brewing requires polishing rice to at least 50% of its original size?",
+      "ja": "米を原料の50%以下まで精米する日本酒の種類は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Samba",
+        "ja": "サンバ",
+        "ja_typings": [
+          "sanba"
+        ]
+      },
+      {
+        "en": "Tango",
+        "ja": "タンゴ",
+        "ja_typings": [
+          "tango"
+        ]
+      },
+      {
+        "en": "Bachata",
+        "ja": "バチャータ",
+        "ja_typings": [
+          "bacha-ta"
+        ]
+      },
+      {
+        "en": "Salsa",
+        "ja": "サルサ",
+        "ja_typings": [
+          "sarusa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00786",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Brazilian dance is the signature of the Rio Carnival?",
+      "ja": "リオのカーニバルを代表するブラジルのダンスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cheongsam",
+        "ja": "チャイナドレス",
+        "ja_typings": [
+          "chainadoresu"
+        ]
+      },
+      {
+        "en": "Hanfu",
+        "ja": "漢服",
+        "ja_typings": [
+          "kanfuku"
+        ]
+      },
+      {
+        "en": "Tangzhuang",
+        "ja": "唐装",
+        "ja_typings": [
+          "tousou"
+        ]
+      },
+      {
+        "en": "Ao Dai",
+        "ja": "アオザイ",
+        "ja_typings": [
+          "aozai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00787",
+    "image_path": null,
+    "question_text": {
+      "en": "Which traditional Chinese dress for women features a high collar and side slits?",
+      "ja": "高い襟とサイドスリットが特徴の中国伝統衣装(女性用)は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cinco de Mayo",
+        "ja": "シンコデマヨ",
+        "ja_typings": [
+          "shinkodemayo"
+        ]
+      },
+      {
+        "en": "Day of the Dead",
+        "ja": "死者の日",
+        "ja_typings": [
+          "shishanohi"
+        ]
+      },
+      {
+        "en": "Las Posadas",
+        "ja": "ラスポサダス",
+        "ja_typings": [
+          "rasuposadasu"
+        ]
+      },
+      {
+        "en": "Independence Day",
+        "ja": "独立記念日",
+        "ja_typings": [
+          "dokuritsukinenbi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00788",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mexican holiday on May 5 commemorates the 1862 victory over the French at Puebla?",
+      "ja": "1862年のプエブラでの対仏勝利を讃える5月5日のメキシコの祝日は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "San Fermin",
+        "ja": "サンフェルミン",
+        "ja_typings": [
+          "sanferumin"
+        ]
+      },
+      {
+        "en": "La Tomatina",
+        "ja": "ラ・トマティーナ",
+        "ja_typings": [
+          "ra/tomati-na"
+        ]
+      },
+      {
+        "en": "Las Fallas",
+        "ja": "ラスファジャス",
+        "ja_typings": [
+          "rasufajasu"
+        ]
+      },
+      {
+        "en": "Feria de Abril",
+        "ja": "フェリアデアブリル",
+        "ja_typings": [
+          "feriadeaburiru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00789",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Spanish festival is famous for the running of the bulls in Pamplona?",
+      "ja": "パンプローナでの牛追いで有名なスペインの祭りは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Salsa",
+        "ja": "サルサ",
+        "ja_typings": [
+          "sarusa"
+        ]
+      },
+      {
+        "en": "Tango",
+        "ja": "タンゴ",
+        "ja_typings": [
+          "tango"
+        ]
+      },
+      {
+        "en": "Samba",
+        "ja": "サンバ",
+        "ja_typings": [
+          "sanba"
+        ]
+      },
+      {
+        "en": "Flamenco",
+        "ja": "フラメンコ",
+        "ja_typings": [
+          "furamenko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00790",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Cuban-origin dance is known for its quick step patterns and is popular worldwide?",
+      "ja": "キューバ発祥で速いステップで世界的に普及している舞踊は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Diwali",
+        "ja": "ディワリ",
+        "ja_typings": [
+          "diwari"
+        ]
+      },
+      {
+        "en": "Holi",
+        "ja": "ホーリー",
+        "ja_typings": [
+          "ho-ri-"
+        ]
+      },
+      {
+        "en": "Navratri",
+        "ja": "ナヴラトリ",
+        "ja_typings": [
+          "navuratori"
+        ]
+      },
+      {
+        "en": "Pongal",
+        "ja": "ポンガル",
+        "ja_typings": [
+          "pongaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q00791",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hindu festival of lights is celebrated in autumn?",
+      "ja": "秋に祝われるヒンドゥー教の光の祭りは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Semantics",
+        "ja": "意味論",
+        "ja_typings": [
+          "imiron"
+        ]
+      },
+      {
+        "en": "Syntax",
+        "ja": "統語論",
+        "ja_typings": [
+          "tougoron"
+        ]
+      },
+      {
+        "en": "Phonology",
+        "ja": "音韻論",
+        "ja_typings": [
+          "onninron"
+        ]
+      },
+      {
+        "en": "Pragmatics",
+        "ja": "語用論",
+        "ja_typings": [
+          "goyouron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00792",
+    "image_path": null,
+    "question_text": {
+      "en": "Which field of linguistics studies meaning in language?",
+      "ja": "言語の意味を研究する言語学の分野は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kanji",
+        "ja": "漢字",
+        "ja_typings": [
+          "kanji"
+        ]
+      },
+      {
+        "en": "Hiragana",
+        "ja": "ひらがな",
+        "ja_typings": [
+          "hiragana"
+        ]
+      },
+      {
+        "en": "Katakana",
+        "ja": "カタカナ",
+        "ja_typings": [
+          "katakana"
+        ]
+      },
+      {
+        "en": "Romaji",
+        "ja": "ローマ字",
+        "ja_typings": [
+          "ro-maji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00793",
+    "image_path": null,
+    "question_text": {
+      "en": "Which kind of Japanese characters represent meaning rather than sound?",
+      "ja": "音ではなく意味を表現する日本語の文字は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Active voice",
+        "ja": "能動態",
+        "ja_typings": [
+          "noudoutai"
+        ]
+      },
+      {
+        "en": "Passive voice",
+        "ja": "受動態",
+        "ja_typings": [
+          "judoutai"
+        ]
+      },
+      {
+        "en": "Middle voice",
+        "ja": "中動態",
+        "ja_typings": [
+          "chuudoutai"
+        ]
+      },
+      {
+        "en": "Causative voice",
+        "ja": "使役態",
+        "ja_typings": [
+          "shiekitai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00794",
+    "image_path": null,
+    "question_text": {
+      "en": "In English grammar, which voice has the subject performing the action?",
+      "ja": "主語が動作を行う英文法の態は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Adverb",
+        "ja": "副詞",
+        "ja_typings": [
+          "fukushi"
+        ]
+      },
+      {
+        "en": "Noun",
+        "ja": "名詞",
+        "ja_typings": [
+          "meishi"
+        ]
+      },
+      {
+        "en": "Particle",
+        "ja": "助詞",
+        "ja_typings": [
+          "joshi"
+        ]
+      },
+      {
+        "en": "Conjunction",
+        "ja": "接続詞",
+        "ja_typings": [
+          "setsuzokushi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00795",
+    "image_path": null,
+    "question_text": {
+      "en": "Which part of speech modifies verbs, adjectives, or other adverbs?",
+      "ja": "動詞、形容詞、または他の副詞を修飾する品詞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sino-Tibetan",
+        "ja": "シナチベット語族",
+        "ja_typings": [
+          "shinachibettogozoku"
+        ]
+      },
+      {
+        "en": "Indo-European",
+        "ja": "インドヨーロッパ語族",
+        "ja_typings": [
+          "indoyo-roppagozoku"
+        ]
+      },
+      {
+        "en": "Austroasiatic",
+        "ja": "オーストロアジア語族",
+        "ja_typings": [
+          "o-sutoroajiagozoku"
+        ]
+      },
+      {
+        "en": "Altaic",
+        "ja": "アルタイ語族",
+        "ja_typings": [
+          "arutaigozoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00796",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language family includes Mandarin Chinese and Tibetan?",
+      "ja": "中国語とチベット語を含む語族は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Austronesian",
+        "ja": "オーストロネシア語族",
+        "ja_typings": [
+          "o-sutoroneshiagozoku"
+        ]
+      },
+      {
+        "en": "Sino-Tibetan",
+        "ja": "シナチベット語族",
+        "ja_typings": [
+          "shinachibettogozoku"
+        ]
+      },
+      {
+        "en": "Dravidian",
+        "ja": "ドラビダ語族",
+        "ja_typings": [
+          "dorabidagozoku"
+        ]
+      },
+      {
+        "en": "Niger-Congo",
+        "ja": "ニジェールコンゴ語族",
+        "ja_typings": [
+          "nije-rukongogozoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00797",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language family includes Indonesian, Tagalog, and Malagasy?",
+      "ja": "インドネシア語、タガログ語、マダガスカル語を含む語族は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hyperbole",
+        "ja": "誇張法",
+        "ja_typings": [
+          "kochouhou"
+        ]
+      },
+      {
+        "en": "Metaphor",
+        "ja": "隠喩",
+        "ja_typings": [
+          "inyu"
+        ]
+      },
+      {
+        "en": "Litotes",
+        "ja": "緩叙法",
+        "ja_typings": [
+          "kankyokuhou"
+        ]
+      },
+      {
+        "en": "Irony",
+        "ja": "皮肉",
+        "ja_typings": [
+          "hiniku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00798",
+    "image_path": null,
+    "question_text": {
+      "en": "Which figure of speech exaggerates for emphasis or effect?",
+      "ja": "強調や効果のため誇張する修辞法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bopomofo",
+        "ja": "ボポモフォ",
+        "ja_typings": [
+          "bopomofo"
+        ]
+      },
+      {
+        "en": "Pinyin",
+        "ja": "ピンイン",
+        "ja_typings": [
+          "pinnin"
+        ]
+      },
+      {
+        "en": "Wade-Giles",
+        "ja": "ウェード式",
+        "ja_typings": [
+          "we-doshiki"
+        ]
+      },
+      {
+        "en": "Zhuyin Fuhao",
+        "ja": "注音符号",
+        "ja_typings": [
+          "chuuonfugou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q00799",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mandarin phonetic system uses zhuyin symbols and is used in Taiwan?",
+      "ja": "台湾で使われる注音符号のマンダリン発音表記は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fargate",
+        "ja": "ファーゲート",
+        "ja_typings": [
+          "fa-ge-to"
+        ]
+      },
+      {
+        "en": "ECS",
+        "ja": "イーシーエス",
+        "ja_typings": [
+          "i-shi-esu"
+        ]
+      },
+      {
+        "en": "EKS",
+        "ja": "イーケーエス",
+        "ja_typings": [
+          "i-ke-esu"
+        ]
+      },
+      {
+        "en": "Lambda",
+        "ja": "ラムダ",
+        "ja_typings": [
+          "ramuda"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00800",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS service provides serverless container compute that runs without managing servers?",
+      "ja": "サーバー管理不要でコンテナ実行環境を提供する AWS サービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "IaaS",
+        "ja": "アイアース",
+        "ja_typings": [
+          "aia-su"
+        ]
+      },
+      {
+        "en": "PaaS",
+        "ja": "パース",
+        "ja_typings": [
+          "pa-su"
+        ]
+      },
+      {
+        "en": "SaaS",
+        "ja": "サース",
+        "ja_typings": [
+          "sa-su"
+        ]
+      },
+      {
+        "en": "FaaS",
+        "ja": "ファース",
+        "ja_typings": [
+          "fa-su"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00801",
+    "image_path": null,
+    "question_text": {
+      "en": "Which type of cloud computing provides raw virtualized hardware resources?",
+      "ja": "生の仮想化ハードウェアリソースを提供するクラウドの種類は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FaaS",
+        "ja": "ファース",
+        "ja_typings": [
+          "fa-su"
+        ]
+      },
+      {
+        "en": "PaaS",
+        "ja": "パース",
+        "ja_typings": [
+          "pa-su"
+        ]
+      },
+      {
+        "en": "IaaS",
+        "ja": "アイアース",
+        "ja_typings": [
+          "aia-su"
+        ]
+      },
+      {
+        "en": "SaaS",
+        "ja": "サース",
+        "ja_typings": [
+          "sa-su"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00802",
+    "image_path": null,
+    "question_text": {
+      "en": "Which cloud computing model executes code in response to events without managing infrastructure?",
+      "ja": "インフラ管理不要でイベント応答コード実行をするクラウドモデルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DynamoDB",
+        "ja": "ダイナモディービー",
+        "ja_typings": [
+          "dainamodi-bi-"
+        ]
+      },
+      {
+        "en": "RDS",
+        "ja": "アールディーエス",
+        "ja_typings": [
+          "a-rudi-esu"
+        ]
+      },
+      {
+        "en": "Aurora",
+        "ja": "オーロラ",
+        "ja_typings": [
+          "o-rora"
+        ]
+      },
+      {
+        "en": "Redshift",
+        "ja": "レッドシフト",
+        "ja_typings": [
+          "reddoshifuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00803",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS service is a fully managed NoSQL key-value database?",
+      "ja": "マネージドな NoSQL キーバリュー DB である AWS サービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Redshift",
+        "ja": "レッドシフト",
+        "ja_typings": [
+          "reddoshifuto"
+        ]
+      },
+      {
+        "en": "RDS",
+        "ja": "アールディーエス",
+        "ja_typings": [
+          "a-rudi-esu"
+        ]
+      },
+      {
+        "en": "Athena",
+        "ja": "アテナ",
+        "ja_typings": [
+          "atena"
+        ]
+      },
+      {
+        "en": "Aurora",
+        "ja": "オーロラ",
+        "ja_typings": [
+          "o-rora"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00804",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS service is a petabyte-scale data warehouse?",
+      "ja": "ペタバイト規模のデータウェアハウスである AWS サービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Terraform",
+        "ja": "テラフォーム",
+        "ja_typings": [
+          "terafo-mu"
+        ]
+      },
+      {
+        "en": "Pulumi",
+        "ja": "プルミ",
+        "ja_typings": [
+          "purumi"
+        ]
+      },
+      {
+        "en": "Ansible",
+        "ja": "アンシブル",
+        "ja_typings": [
+          "anshiburu"
+        ]
+      },
+      {
+        "en": "CloudFormation",
+        "ja": "クラウドフォーメーション",
+        "ja_typings": [
+          "kuraudofo-me-shon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00805",
+    "image_path": null,
+    "question_text": {
+      "en": "Which open-source IaC tool by HashiCorp uses HCL to define cloud infrastructure?",
+      "ja": "HashiCorp 製で HCL でクラウドインフラを定義する IaC ツールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ansible",
+        "ja": "アンシブル",
+        "ja_typings": [
+          "anshiburu"
+        ]
+      },
+      {
+        "en": "Chef",
+        "ja": "シェフ",
+        "ja_typings": [
+          "shefu"
+        ]
+      },
+      {
+        "en": "Puppet",
+        "ja": "パペット",
+        "ja_typings": [
+          "papetto"
+        ]
+      },
+      {
+        "en": "Salt",
+        "ja": "ソルト",
+        "ja_typings": [
+          "soruto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00806",
+    "image_path": null,
+    "question_text": {
+      "en": "Which open-source configuration management tool uses YAML playbooks?",
+      "ja": "YAML プレイブックを使う構成管理ツールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sprint Review",
+        "ja": "スプリントレビュー",
+        "ja_typings": [
+          "supurintorebyu-"
+        ]
+      },
+      {
+        "en": "Retrospective",
+        "ja": "レトロスペクティブ",
+        "ja_typings": [
+          "retorosupekutibu"
+        ]
+      },
+      {
+        "en": "Daily Stand-up",
+        "ja": "デイリースタンドアップ",
+        "ja_typings": [
+          "deiri-sutandoappu"
+        ]
+      },
+      {
+        "en": "Sprint Planning",
+        "ja": "スプリントプランニング",
+        "ja_typings": [
+          "supurintopurannningu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q00807",
+    "image_path": null,
+    "question_text": {
+      "en": "In Scrum, which ceremony lets the team demo completed work to stakeholders?",
+      "ja": "Scrum でステークホルダーに完了作業をデモするセレモニーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kepler",
+        "ja": "ケプラー",
+        "ja_typings": [
+          "kepura-"
+        ]
+      },
+      {
+        "en": "Galileo",
+        "ja": "ガリレオ",
+        "ja_typings": [
+          "garireo"
+        ]
+      },
+      {
+        "en": "Copernicus",
+        "ja": "コペルニクス",
+        "ja_typings": [
+          "koperunikusu"
+        ]
+      },
+      {
+        "en": "Brahe",
+        "ja": "ブラーエ",
+        "ja_typings": [
+          "bura-e"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00808",
+    "image_path": null,
+    "question_text": {
+      "en": "Which German astronomer formulated the laws of planetary motion?",
+      "ja": "惑星運動の法則を定式化したドイツの天文学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Koch",
+        "ja": "コッホ",
+        "ja_typings": [
+          "kohho"
+        ]
+      },
+      {
+        "en": "Pasteur",
+        "ja": "パスツール",
+        "ja_typings": [
+          "pasutsu-ru"
+        ]
+      },
+      {
+        "en": "Lister",
+        "ja": "リスター",
+        "ja_typings": [
+          "risuta-"
+        ]
+      },
+      {
+        "en": "Jenner",
+        "ja": "ジェンナー",
+        "ja_typings": [
+          "jennna-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00809",
+    "image_path": null,
+    "question_text": {
+      "en": "Which German physician proved that specific microorganisms cause specific diseases?",
+      "ja": "特定の微生物が特定の病気を引き起こすことを証明したドイツの医師は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Helium",
+        "ja": "ヘリウム",
+        "ja_typings": [
+          "heriumu"
+        ]
+      },
+      {
+        "en": "Neon",
+        "ja": "ネオン",
+        "ja_typings": [
+          "neon"
+        ]
+      },
+      {
+        "en": "Argon",
+        "ja": "アルゴン",
+        "ja_typings": [
+          "arugon"
+        ]
+      },
+      {
+        "en": "Hydrogen",
+        "ja": "水素",
+        "ja_typings": [
+          "suiso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00810",
+    "image_path": null,
+    "question_text": {
+      "en": "Which noble gas is used to inflate party balloons and is the second lightest element?",
+      "ja": "パーティー用風船に使われ、2番目に軽い気体元素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Liver",
+        "ja": "肝臓",
+        "ja_typings": [
+          "kanzou"
+        ]
+      },
+      {
+        "en": "Pancreas",
+        "ja": "膵臓",
+        "ja_typings": [
+          "suizou"
+        ]
+      },
+      {
+        "en": "Kidney",
+        "ja": "腎臓",
+        "ja_typings": [
+          "jinzou"
+        ]
+      },
+      {
+        "en": "Spleen",
+        "ja": "脾臓",
+        "ja_typings": [
+          "hizou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00811",
+    "image_path": null,
+    "question_text": {
+      "en": "Which human organ produces bile and detoxifies the blood?",
+      "ja": "胆汁を分泌し血液を解毒するヒトの臓器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Volt",
+        "ja": "ボルト",
+        "ja_typings": [
+          "boruto"
+        ]
+      },
+      {
+        "en": "Watt",
+        "ja": "ワット",
+        "ja_typings": [
+          "watto"
+        ]
+      },
+      {
+        "en": "Ohm",
+        "ja": "オーム",
+        "ja_typings": [
+          "o-mu"
+        ]
+      },
+      {
+        "en": "Ampere",
+        "ja": "アンペア",
+        "ja_typings": [
+          "anpea"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00812",
+    "image_path": null,
+    "question_text": {
+      "en": "Which unit of electric potential difference is named after an Italian physicist?",
+      "ja": "イタリア人物理学者にちなんだ電位差の単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Watt",
+        "ja": "ワット",
+        "ja_typings": [
+          "watto"
+        ]
+      },
+      {
+        "en": "Volt",
+        "ja": "ボルト",
+        "ja_typings": [
+          "boruto"
+        ]
+      },
+      {
+        "en": "Joule",
+        "ja": "ジュール",
+        "ja_typings": [
+          "ju-ru"
+        ]
+      },
+      {
+        "en": "Newton",
+        "ja": "ニュートン",
+        "ja_typings": [
+          "nyu-ton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00813",
+    "image_path": null,
+    "question_text": {
+      "en": "Which SI unit of power equals one joule per second?",
+      "ja": "毎秒1ジュールに相当する SI 単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rutherford",
+        "ja": "ラザフォード",
+        "ja_typings": [
+          "razafo-do"
+        ]
+      },
+      {
+        "en": "Bohr",
+        "ja": "ボーア",
+        "ja_typings": [
+          "bo-a"
+        ]
+      },
+      {
+        "en": "Thomson",
+        "ja": "トムソン",
+        "ja_typings": [
+          "tomuson"
+        ]
+      },
+      {
+        "en": "Curie",
+        "ja": "キュリー",
+        "ja_typings": [
+          "kyuri-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00814",
+    "image_path": null,
+    "question_text": {
+      "en": "Which physicist discovered the atomic nucleus through the gold foil experiment?",
+      "ja": "金箔実験で原子核を発見した物理学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pascal",
+        "ja": "パスカル",
+        "ja_typings": [
+          "pasukaru"
+        ]
+      },
+      {
+        "en": "Bar",
+        "ja": "バール",
+        "ja_typings": [
+          "ba-ru"
+        ]
+      },
+      {
+        "en": "Torr",
+        "ja": "トール",
+        "ja_typings": [
+          "to-ru"
+        ]
+      },
+      {
+        "en": "Atmosphere",
+        "ja": "アトモスフィア",
+        "ja_typings": [
+          "atomosufia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q00815",
+    "image_path": null,
+    "question_text": {
+      "en": "Which unit of pressure equals one newton per square meter?",
+      "ja": "平方メートルあたり1ニュートンの圧力単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nero",
+        "ja": "ネロ",
+        "ja_typings": [
+          "nero"
+        ]
+      },
+      {
+        "en": "Caligula",
+        "ja": "カリグラ",
+        "ja_typings": [
+          "karigura"
+        ]
+      },
+      {
+        "en": "Domitian",
+        "ja": "ドミティアヌス",
+        "ja_typings": [
+          "domitianusu"
+        ]
+      },
+      {
+        "en": "Commodus",
+        "ja": "コンモドゥス",
+        "ja_typings": [
+          "konmodusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00816",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Roman emperor is infamous for allegedly playing music while Rome burned?",
+      "ja": "ローマ市街炎上中に演奏したと言われる悪名高いローマ皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hadrian",
+        "ja": "ハドリアヌス",
+        "ja_typings": [
+          "hadorianusu"
+        ]
+      },
+      {
+        "en": "Trajan",
+        "ja": "トラヤヌス",
+        "ja_typings": [
+          "torayanusu"
+        ]
+      },
+      {
+        "en": "Antoninus Pius",
+        "ja": "アントニヌスピウス",
+        "ja_typings": [
+          "antoninusupiusu"
+        ]
+      },
+      {
+        "en": "Marcus Aurelius",
+        "ja": "マルクスアウレリウス",
+        "ja_typings": [
+          "marukusuaureriusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00817",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Roman emperor built a famous wall across northern Britain?",
+      "ja": "北ブリテンに有名な城壁を築いたローマ皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Battle of Waterloo",
+        "ja": "ワーテルローの戦い",
+        "ja_typings": [
+          "wa-teru-notatakai"
+        ]
+      },
+      {
+        "en": "Battle of Leipzig",
+        "ja": "ライプツィヒの戦い",
+        "ja_typings": [
+          "raiputsihinotatakai"
+        ]
+      },
+      {
+        "en": "Battle of Valmy",
+        "ja": "バルミーの戦い",
+        "ja_typings": [
+          "barumi-notatakai"
+        ]
+      },
+      {
+        "en": "Battle of Borodino",
+        "ja": "ボロジノの戦い",
+        "ja_typings": [
+          "borojinonotatakai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00818",
+    "image_path": null,
+    "question_text": {
+      "en": "In which 1815 battle was Napoleon finally defeated?",
+      "ja": "1815年にナポレオンが最終的に敗北した戦闘は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vasco da Gama",
+        "ja": "ヴァスコ・ダ・ガマ",
+        "ja_typings": [
+          "vasuko/da/gama"
+        ]
+      },
+      {
+        "en": "Magellan",
+        "ja": "マゼラン",
+        "ja_typings": [
+          "mazeran"
+        ]
+      },
+      {
+        "en": "Columbus",
+        "ja": "コロンブス",
+        "ja_typings": [
+          "koronbusu"
+        ]
+      },
+      {
+        "en": "Henry the Navigator",
+        "ja": "エンリケ航海王子",
+        "ja_typings": [
+          "enrikekoukaiouji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00819",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Portuguese explorer was the first European to reach India by sea?",
+      "ja": "海路で初めてインドに到達したポルトガル人探検家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Amerigo Vespucci",
+        "ja": "アメリゴ・ヴェスプッチ",
+        "ja_typings": [
+          "amerigo/vesuputchi"
+        ]
+      },
+      {
+        "en": "Magellan",
+        "ja": "マゼラン",
+        "ja_typings": [
+          "mazeran"
+        ]
+      },
+      {
+        "en": "Columbus",
+        "ja": "コロンブス",
+        "ja_typings": [
+          "koronbusu"
+        ]
+      },
+      {
+        "en": "Marco Polo",
+        "ja": "マルコ・ポーロ",
+        "ja_typings": [
+          "maruko/po-ro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00820",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian explorer's first name became the basis for the name 'America'?",
+      "ja": "「アメリカ」の語源となったイタリア人探検家の名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Magellan",
+        "ja": "マゼラン",
+        "ja_typings": [
+          "mazeran"
+        ]
+      },
+      {
+        "en": "Vasco da Gama",
+        "ja": "ヴァスコ・ダ・ガマ",
+        "ja_typings": [
+          "vasuko/da/gama"
+        ]
+      },
+      {
+        "en": "Cabral",
+        "ja": "カブラル",
+        "ja_typings": [
+          "kaburaru"
+        ]
+      },
+      {
+        "en": "Dias",
+        "ja": "ディアス",
+        "ja_typings": [
+          "diasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q00821",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Portuguese-born explorer led the first expedition to circumnavigate the globe?",
+      "ja": "世界一周航海の最初の遠征を率いたポルトガル出身の探検家は?"
+    }
   }
 ]


### PR DESCRIPTION
## Summary
- **+1033問追加** (735 → 1768)
- 全15ジャンル横断
- 4択全てが同分野の妥当な候補となる方針で作問（Issue #116）
- 既存ja_typings redundant-variant 13件もついでに修正

## ジャンル分布
| genre | before | after | delta |
|---|---|---|---|
| programming | 80 | 197 | +117 |
| web_development | 60 | 173 | +113 |
| anime | 60 | 145 | +85 |
| manga | 50 | 115 | +65 |
| game | 60 | 130 | +70 |
| geography | 50 | 115 | +65 |
| history | 50 | 131 | +81 |
| science | 50 | 113 | +63 |
| math | 40 | 94 | +54 |
| general_knowledge | 40 | 89 | +49 |
| vtuber_net_culture | 40 | 95 | +55 |
| technology | 50 | 104 | +54 |
| it_terminology | 35 | 90 | +55 |
| language | 35 | 90 | +55 |
| culture | 35 | 87 | +52 |

## 作問方針 (Issue #116)
4択すべて同分野の妥当な候補となるよう作問。問題文を読まずに選択肢だけ見て正解を当てる戦略を防ぐ。

## Test plan
- [x] backfill-ja-typing 通過
- [x] lint-questions: 0 conflicts, 0 errors
- [x] cargo test --release: 236 passed