### PR TITLE
feat: Round 3 — 誤答→正解化に特化 (+734問、1768→2502)

### DIFF
--- a/data/questions_en.json
+++ b/data/questions_en.json
@@ -71708,10 +71708,9 @@
       },
       {
         "en": "Yuki Kaji",
-        "ja": "梶裕介",
+        "ja": "梶裕貴",
         "ja_typings": [
-          "kajiyuuki",
-          "kajiyuusuke"
+          "kajiyuuki"
         ]
       }
     ],
@@ -75317,7 +75316,7 @@
       }
     ],
     "correct_answer_index": 0,
-    "genre": "manga",
+    "genre": "general_knowledge",
     "id": "q01860",
     "image_path": null,
     "question_text": {
@@ -75357,7 +75356,7 @@
       }
     ],
     "correct_answer_index": 0,
-    "genre": "manga",
+    "genre": "general_knowledge",
     "id": "q01861",
     "image_path": null,
     "question_text": {
@@ -75397,7 +75396,7 @@
       }
     ],
     "correct_answer_index": 0,
-    "genre": "manga",
+    "genre": "general_knowledge",
     "id": "q01862",
     "image_path": null,
     "question_text": {
@@ -75437,7 +75436,7 @@
       }
     ],
     "correct_answer_index": 0,
-    "genre": "manga",
+    "genre": "general_knowledge",
     "id": "q01863",
     "image_path": null,
     "question_text": {
@@ -91660,7 +91659,7 @@
       }
     ],
     "correct_answer_index": 0,
-    "genre": "vtuber_net_culture",
+    "genre": "general_knowledge",
     "id": "q02267",
     "image_path": null,
     "question_text": {
@@ -91700,7 +91699,7 @@
       }
     ],
     "correct_answer_index": 0,
-    "genre": "vtuber_net_culture",
+    "genre": "general_knowledge",
     "id": "q02268",
     "image_path": null,
     "question_text": {

--- a/data/questions_en.json
+++ b/data/questions_en.json
@@ -71642,5 +71642,29774 @@
       "en": "Which Vietnamese soup is broth-based with herbs?",
       "ja": "ハーブを使うベトナム麺スープは?"
     }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fumiko Orikasa",
+        "ja": "折笠富美子",
+        "ja_typings": [
+          "orikasafumiko"
+        ]
+      },
+      {
+        "en": "Aya Hirano",
+        "ja": "平野綾",
+        "ja_typings": [
+          "hiranoaya"
+        ]
+      },
+      {
+        "en": "Maaya Sakamoto",
+        "ja": "坂本真綾",
+        "ja_typings": [
+          "sakamotomaaya"
+        ]
+      },
+      {
+        "en": "Rie Kugimiya",
+        "ja": "釘宮理恵",
+        "ja_typings": [
+          "kugimiyarie"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01769",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actress voices Rukia Kuchiki in Bleach?",
+      "ja": "『BLEACH』で朽木ルキアを演じる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hiroshi Kamiya",
+        "ja": "神谷浩史",
+        "ja_typings": [
+          "kamiyahiroshi"
+        ]
+      },
+      {
+        "en": "Tomokazu Sugita",
+        "ja": "杉田智和",
+        "ja_typings": [
+          "sugitatomokazu"
+        ]
+      },
+      {
+        "en": "Daisuke Ono",
+        "ja": "小野大輔",
+        "ja_typings": [
+          "onodaisuke"
+        ]
+      },
+      {
+        "en": "Yuki Kaji",
+        "ja": "梶裕介",
+        "ja_typings": [
+          "kajiyuuki",
+          "kajiyuusuke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01770",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actor voices Izaya Orihara in Durarara!!?",
+      "ja": "『デュラララ!!』で折原臨也を演じる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tomokazu Sugita",
+        "ja": "杉田智和",
+        "ja_typings": [
+          "sugitatomokazu"
+        ]
+      },
+      {
+        "en": "Hiroshi Kamiya",
+        "ja": "神谷浩史",
+        "ja_typings": [
+          "kamiyahiroshi"
+        ]
+      },
+      {
+        "en": "Takahiro Sakurai",
+        "ja": "桜井孝宏",
+        "ja_typings": [
+          "sakuraitakahiro"
+        ]
+      },
+      {
+        "en": "Kensho Ono",
+        "ja": "小野賢章",
+        "ja_typings": [
+          "onokenshou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01771",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actor voices Gintoki Sakata in Gintama?",
+      "ja": "『銀魂』で坂田銀時を演じる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yuki Kaji",
+        "ja": "梶裕貴",
+        "ja_typings": [
+          "kajiyuuki"
+        ]
+      },
+      {
+        "en": "Yuma Uchida",
+        "ja": "内田雄馬",
+        "ja_typings": [
+          "uchidayuuma"
+        ]
+      },
+      {
+        "en": "Yoshitsugu Matsuoka",
+        "ja": "松岡禎丞",
+        "ja_typings": [
+          "matsuokayoshitsugu"
+        ]
+      },
+      {
+        "en": "Takahiro Sakurai",
+        "ja": "桜井孝宏",
+        "ja_typings": [
+          "sakuraitakahiro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01772",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actor voices Eren Yeager in Attack on Titan?",
+      "ja": "『進撃の巨人』でエレン・イェーガーを演じる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Daisuke Ono",
+        "ja": "小野大輔",
+        "ja_typings": [
+          "onodaisuke"
+        ]
+      },
+      {
+        "en": "Hiroshi Kamiya",
+        "ja": "神谷浩史",
+        "ja_typings": [
+          "kamiyahiroshi"
+        ]
+      },
+      {
+        "en": "Tomokazu Sugita",
+        "ja": "杉田智和",
+        "ja_typings": [
+          "sugitatomokazu"
+        ]
+      },
+      {
+        "en": "Kazuhiko Inoue",
+        "ja": "井上和彦",
+        "ja_typings": [
+          "inouekazuhiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01773",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actor voices Sebastian Michaelis in Black Butler?",
+      "ja": "『黒執事』でセバスチャン・ミカエリスを演じる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rie Kugimiya",
+        "ja": "釘宮理恵",
+        "ja_typings": [
+          "kugimiyarie"
+        ]
+      },
+      {
+        "en": "Aya Hirano",
+        "ja": "平野綾",
+        "ja_typings": [
+          "hiranoaya"
+        ]
+      },
+      {
+        "en": "Saori Hayami",
+        "ja": "早見沙織",
+        "ja_typings": [
+          "hayamisaori"
+        ]
+      },
+      {
+        "en": "Maaya Sakamoto",
+        "ja": "坂本真綾",
+        "ja_typings": [
+          "sakamotomaaya"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01774",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actress is well known for tsundere roles like Shana and Louise?",
+      "ja": "シャナやルイズなどツンデレ役で知られる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yoshitsugu Matsuoka",
+        "ja": "松岡禎丞",
+        "ja_typings": [
+          "matsuokayoshitsugu"
+        ]
+      },
+      {
+        "en": "Yuki Kaji",
+        "ja": "梶裕貴",
+        "ja_typings": [
+          "kajiyuuki"
+        ]
+      },
+      {
+        "en": "Yuma Uchida",
+        "ja": "内田雄馬",
+        "ja_typings": [
+          "uchidayuuma"
+        ]
+      },
+      {
+        "en": "Daisuke Ono",
+        "ja": "小野大輔",
+        "ja_typings": [
+          "onodaisuke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01775",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actor voices Kirito in Sword Art Online?",
+      "ja": "『ソードアート・オンライン』でキリトを演じる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yuma Uchida",
+        "ja": "内田雄馬",
+        "ja_typings": [
+          "uchidayuuma"
+        ]
+      },
+      {
+        "en": "Yuki Kaji",
+        "ja": "梶裕貴",
+        "ja_typings": [
+          "kajiyuuki"
+        ]
+      },
+      {
+        "en": "Yoshitsugu Matsuoka",
+        "ja": "松岡禎丞",
+        "ja_typings": [
+          "matsuokayoshitsugu"
+        ]
+      },
+      {
+        "en": "Hiroshi Kamiya",
+        "ja": "神谷浩史",
+        "ja_typings": [
+          "kamiyahiroshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01776",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actor voices Iida Tenya in My Hero Academia?",
+      "ja": "『僕のヒーローアカデミア』で飯田天哉を演じる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Takahiro Sakurai",
+        "ja": "桜井孝宏",
+        "ja_typings": [
+          "sakuraitakahiro"
+        ]
+      },
+      {
+        "en": "Daisuke Ono",
+        "ja": "小野大輔",
+        "ja_typings": [
+          "onodaisuke"
+        ]
+      },
+      {
+        "en": "Tomokazu Sugita",
+        "ja": "杉田智和",
+        "ja_typings": [
+          "sugitatomokazu"
+        ]
+      },
+      {
+        "en": "Kazuhiko Inoue",
+        "ja": "井上和彦",
+        "ja_typings": [
+          "inouekazuhiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01777",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actor is widely known for roles like Cloud Strife and Suzaku Kururugi?",
+      "ja": "クラウド・ストライフや枢木スザクなどで知られる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kensho Ono",
+        "ja": "小野賢章",
+        "ja_typings": [
+          "onokenshou"
+        ]
+      },
+      {
+        "en": "Yuki Kaji",
+        "ja": "梶裕貴",
+        "ja_typings": [
+          "kajiyuuki"
+        ]
+      },
+      {
+        "en": "Yuma Uchida",
+        "ja": "内田雄馬",
+        "ja_typings": [
+          "uchidayuuma"
+        ]
+      },
+      {
+        "en": "Yoshitsugu Matsuoka",
+        "ja": "松岡禎丞",
+        "ja_typings": [
+          "matsuokayoshitsugu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01778",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actor voices Tetsuya Kuroko in Kuroko's Basketball?",
+      "ja": "『黒子のバスケ』で黒子テツヤを演じる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kenichi Matsuyama",
+        "ja": "松山ケンイチ",
+        "ja_typings": [
+          "matsuyamakennichi"
+        ]
+      },
+      {
+        "en": "Takahiro Sakurai",
+        "ja": "桜井孝宏",
+        "ja_typings": [
+          "sakuraitakahiro"
+        ]
+      },
+      {
+        "en": "Daisuke Ono",
+        "ja": "小野大輔",
+        "ja_typings": [
+          "onodaisuke"
+        ]
+      },
+      {
+        "en": "Tomokazu Sugita",
+        "ja": "杉田智和",
+        "ja_typings": [
+          "sugitatomokazu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01779",
+    "image_path": null,
+    "question_text": {
+      "en": "Which actor voices L in the live-action Death Note films?",
+      "ja": "実写映画『デスノート』でLを演じた俳優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Maaya Sakamoto",
+        "ja": "坂本真綾",
+        "ja_typings": [
+          "sakamotomaaya"
+        ]
+      },
+      {
+        "en": "Aya Hirano",
+        "ja": "平野綾",
+        "ja_typings": [
+          "hiranoaya"
+        ]
+      },
+      {
+        "en": "Saori Hayami",
+        "ja": "早見沙織",
+        "ja_typings": [
+          "hayamisaori"
+        ]
+      },
+      {
+        "en": "Aya Hisakawa",
+        "ja": "久川綾",
+        "ja_typings": [
+          "hisakawaaya"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01780",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actress voices Hitagi Senjogahara in the Monogatari series?",
+      "ja": "『〈物語〉シリーズ』で戦場ヶ原ひたぎを演じる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kotono Mitsuishi",
+        "ja": "三石琴乃",
+        "ja_typings": [
+          "mitsuishikotono"
+        ]
+      },
+      {
+        "en": "Aya Hisakawa",
+        "ja": "久川綾",
+        "ja_typings": [
+          "hisakawaaya"
+        ]
+      },
+      {
+        "en": "Maaya Sakamoto",
+        "ja": "坂本真綾",
+        "ja_typings": [
+          "sakamotomaaya"
+        ]
+      },
+      {
+        "en": "Fumiko Orikasa",
+        "ja": "折笠富美子",
+        "ja_typings": [
+          "orikasafumiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01781",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actress voices Usagi Tsukino in the original Sailor Moon anime?",
+      "ja": "初代『美少女戦士セーラームーン』アニメで月野うさぎを演じた声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aya Hisakawa",
+        "ja": "久川綾",
+        "ja_typings": [
+          "hisakawaaya"
+        ]
+      },
+      {
+        "en": "Kotono Mitsuishi",
+        "ja": "三石琴乃",
+        "ja_typings": [
+          "mitsuishikotono"
+        ]
+      },
+      {
+        "en": "Maaya Sakamoto",
+        "ja": "坂本真綾",
+        "ja_typings": [
+          "sakamotomaaya"
+        ]
+      },
+      {
+        "en": "Aya Hirano",
+        "ja": "平野綾",
+        "ja_typings": [
+          "hiranoaya"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01782",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actress voices Sailor Mercury / Ami Mizuno in the original Sailor Moon anime?",
+      "ja": "初代『セーラームーン』アニメで水野亜美/セーラーマーキュリーを演じた声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shuichi Ikeda",
+        "ja": "池田秀一",
+        "ja_typings": [
+          "ikedashuuichi"
+        ]
+      },
+      {
+        "en": "Kazuhiko Inoue",
+        "ja": "井上和彦",
+        "ja_typings": [
+          "inouekazuhiko"
+        ]
+      },
+      {
+        "en": "Tomokazu Sugita",
+        "ja": "杉田智和",
+        "ja_typings": [
+          "sugitatomokazu"
+        ]
+      },
+      {
+        "en": "Hiroshi Kamiya",
+        "ja": "神谷浩史",
+        "ja_typings": [
+          "kamiyahiroshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01783",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actor voices Char Aznable in Mobile Suit Gundam?",
+      "ja": "『機動戦士ガンダム』でシャア・アズナブルを演じる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kazuhiko Inoue",
+        "ja": "井上和彦",
+        "ja_typings": [
+          "inouekazuhiko"
+        ]
+      },
+      {
+        "en": "Shuichi Ikeda",
+        "ja": "池田秀一",
+        "ja_typings": [
+          "ikedashuuichi"
+        ]
+      },
+      {
+        "en": "Takahiro Sakurai",
+        "ja": "桜井孝宏",
+        "ja_typings": [
+          "sakuraitakahiro"
+        ]
+      },
+      {
+        "en": "Daisuke Ono",
+        "ja": "小野大輔",
+        "ja_typings": [
+          "onodaisuke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01784",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actor is famous for playing Kakashi Hatake in Naruto?",
+      "ja": "『NARUTO』ではたけカカシを演じる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Saori Hayami",
+        "ja": "早見沙織",
+        "ja_typings": [
+          "hayamisaori"
+        ]
+      },
+      {
+        "en": "Maaya Sakamoto",
+        "ja": "坂本真綾",
+        "ja_typings": [
+          "sakamotomaaya"
+        ]
+      },
+      {
+        "en": "Aya Hirano",
+        "ja": "平野綾",
+        "ja_typings": [
+          "hiranoaya"
+        ]
+      },
+      {
+        "en": "Fumiko Orikasa",
+        "ja": "折笠富美子",
+        "ja_typings": [
+          "orikasafumiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01785",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actress voices Yor Forger in Spy x Family?",
+      "ja": "『SPY×FAMILY』でヨル・フォージャーを演じる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aya Hirano",
+        "ja": "平野綾",
+        "ja_typings": [
+          "hiranoaya"
+        ]
+      },
+      {
+        "en": "Maaya Sakamoto",
+        "ja": "坂本真綾",
+        "ja_typings": [
+          "sakamotomaaya"
+        ]
+      },
+      {
+        "en": "Saori Hayami",
+        "ja": "早見沙織",
+        "ja_typings": [
+          "hayamisaori"
+        ]
+      },
+      {
+        "en": "Rie Kugimiya",
+        "ja": "釘宮理恵",
+        "ja_typings": [
+          "kugimiyarie"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01786",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actress voices Haruhi Suzumiya in The Melancholy of Haruhi Suzumiya?",
+      "ja": "『涼宮ハルヒの憂鬱』で涼宮ハルヒを演じる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Production I.G",
+        "ja": "プロダクション・アイジー",
+        "ja_typings": [
+          "purodakushon/aiji-"
+        ]
+      },
+      {
+        "en": "Madhouse",
+        "ja": "マッドハウス",
+        "ja_typings": [
+          "maddohausu"
+        ]
+      },
+      {
+        "en": "Wit Studio",
+        "ja": "ウィットスタジオ",
+        "ja_typings": [
+          "wittosutajio"
+        ]
+      },
+      {
+        "en": "A-1 Pictures",
+        "ja": "エーワン・ピクチャーズ",
+        "ja_typings": [
+          "e-wan/pikucha-zu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01787",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio produced Ghost in the Shell: Stand Alone Complex?",
+      "ja": "『攻殻機動隊 STAND ALONE COMPLEX』を制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Madhouse",
+        "ja": "マッドハウス",
+        "ja_typings": [
+          "maddohausu"
+        ]
+      },
+      {
+        "en": "Production I.G",
+        "ja": "プロダクション・アイジー",
+        "ja_typings": [
+          "purodakushon/aiji-"
+        ]
+      },
+      {
+        "en": "Wit Studio",
+        "ja": "ウィットスタジオ",
+        "ja_typings": [
+          "wittosutajio"
+        ]
+      },
+      {
+        "en": "Pierrot",
+        "ja": "ぴえろ",
+        "ja_typings": [
+          "piero"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01788",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio produced Death Note and One-Punch Man (Season 1)?",
+      "ja": "『デスノート』『ワンパンマン』(1期) を制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wit Studio",
+        "ja": "ウィットスタジオ",
+        "ja_typings": [
+          "wittosutajio"
+        ]
+      },
+      {
+        "en": "Madhouse",
+        "ja": "マッドハウス",
+        "ja_typings": [
+          "maddohausu"
+        ]
+      },
+      {
+        "en": "Production I.G",
+        "ja": "プロダクション・アイジー",
+        "ja_typings": [
+          "purodakushon/aiji-"
+        ]
+      },
+      {
+        "en": "A-1 Pictures",
+        "ja": "エーワン・ピクチャーズ",
+        "ja_typings": [
+          "e-wan/pikucha-zu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01789",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio produced Attack on Titan (Seasons 1-3)?",
+      "ja": "『進撃の巨人』(1-3期) を制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "A-1 Pictures",
+        "ja": "エーワン・ピクチャーズ",
+        "ja_typings": [
+          "e-wan/pikucha-zu"
+        ]
+      },
+      {
+        "en": "Wit Studio",
+        "ja": "ウィットスタジオ",
+        "ja_typings": [
+          "wittosutajio"
+        ]
+      },
+      {
+        "en": "Madhouse",
+        "ja": "マッドハウス",
+        "ja_typings": [
+          "maddohausu"
+        ]
+      },
+      {
+        "en": "Pierrot",
+        "ja": "ぴえろ",
+        "ja_typings": [
+          "piero"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01790",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio produced Sword Art Online and Fairy Tail?",
+      "ja": "『ソードアート・オンライン』『フェアリーテイル』を制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pierrot",
+        "ja": "ぴえろ",
+        "ja_typings": [
+          "piero"
+        ]
+      },
+      {
+        "en": "Madhouse",
+        "ja": "マッドハウス",
+        "ja_typings": [
+          "maddohausu"
+        ]
+      },
+      {
+        "en": "A-1 Pictures",
+        "ja": "エーワン・ピクチャーズ",
+        "ja_typings": [
+          "e-wan/pikucha-zu"
+        ]
+      },
+      {
+        "en": "Wit Studio",
+        "ja": "ウィットスタジオ",
+        "ja_typings": [
+          "wittosutajio"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01791",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio produced Naruto and Bleach?",
+      "ja": "『NARUTO』『BLEACH』を制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": [
+          "magi"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "フェアリーテイル",
+        "ja_typings": [
+          "feari-teiru"
+        ]
+      },
+      {
+        "en": "D.Gray-man",
+        "ja": "ディーグレイマン",
+        "ja_typings": [
+          "di-gureiman"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01792",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime follows Aladdin and Alibaba exploring mysterious dungeons?",
+      "ja": "アラジンとアリババがダンジョンに挑む冒険アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yu Yu Hakusho",
+        "ja": "幽☆遊☆白書",
+        "ja_typings": [
+          "yuuyuuhakusho"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "フェアリーテイル",
+        "ja_typings": [
+          "feari-teiru"
+        ]
+      },
+      {
+        "en": "Hell's Paradise",
+        "ja": "地獄楽",
+        "ja_typings": [
+          "jigokuraku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01793",
+    "image_path": null,
+    "question_text": {
+      "en": "Which classic anime features Yusuke Urameshi as a Spirit Detective?",
+      "ja": "浦飯幽助が霊界探偵を務める名作アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Outlaw Star",
+        "ja": "アウトロースター",
+        "ja_typings": [
+          "autoro-suta-"
+        ]
+      },
+      {
+        "en": "Galaxy Express 999",
+        "ja": "銀河鉄道999",
+        "ja_typings": [
+          "gingatetsudou999"
+        ]
+      },
+      {
+        "en": "Log Horizon",
+        "ja": "ログ・ホライズン",
+        "ja_typings": [
+          "rogu/horaizun"
+        ]
+      },
+      {
+        "en": "Black Lagoon",
+        "ja": "ブラック・ラグーン",
+        "ja_typings": [
+          "burakku/ragu-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01794",
+    "image_path": null,
+    "question_text": {
+      "en": "Which space western anime features Gene Starwind and his ship the Outlaw?",
+      "ja": "ジーン・スターウィンドが主人公の宇宙ウェスタンアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ranma 1/2",
+        "ja": "らんま1/2",
+        "ja_typings": [
+          "ranma1/2"
+        ]
+      },
+      {
+        "en": "Urusei Yatsura",
+        "ja": "うる星やつら",
+        "ja_typings": [
+          "uruseiyatsura"
+        ]
+      },
+      {
+        "en": "Galaxy Express 999",
+        "ja": "銀河鉄道999",
+        "ja_typings": [
+          "gingatetsudou999"
+        ]
+      },
+      {
+        "en": "Dororo",
+        "ja": "どろろ",
+        "ja_typings": [
+          "dororo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01795",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Rumiko Takahashi work follows a boy who turns into a girl when splashed with cold water?",
+      "ja": "高橋留美子作で水をかぶると女になる少年の物語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Urusei Yatsura",
+        "ja": "うる星やつら",
+        "ja_typings": [
+          "uruseiyatsura"
+        ]
+      },
+      {
+        "en": "Ranma 1/2",
+        "ja": "らんま1/2",
+        "ja_typings": [
+          "ranma1/2"
+        ]
+      },
+      {
+        "en": "Galaxy Express 999",
+        "ja": "銀河鉄道999",
+        "ja_typings": [
+          "gingatetsudou999"
+        ]
+      },
+      {
+        "en": "Heidi",
+        "ja": "アルプスの少女ハイジ",
+        "ja_typings": [
+          "arupusunoshoujohaiji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01796",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Rumiko Takahashi work features the alien Lum and Ataru Moroboshi?",
+      "ja": "高橋留美子作でラムちゃんと諸星あたるが登場する作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Log Horizon",
+        "ja": "ログ・ホライズン",
+        "ja_typings": [
+          "rogu/horaizun"
+        ]
+      },
+      {
+        "en": "Outlaw Star",
+        "ja": "アウトロースター",
+        "ja_typings": [
+          "autoro-suta-"
+        ]
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": [
+          "magi"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01797",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime, based on Mamare Touno's novels, traps players inside an MMORPG world?",
+      "ja": "橙乃ままれ原作で MMO 世界に閉じ込められる作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "フェアリーテイル",
+        "ja_typings": [
+          "feari-teiru"
+        ]
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": [
+          "magi"
+        ]
+      },
+      {
+        "en": "D.Gray-man",
+        "ja": "ディーグレイマン",
+        "ja_typings": [
+          "di-gureiman"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01798",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Shonen Jump anime follows Asta, a magicless boy in a magical kingdom?",
+      "ja": "魔法が使えない少年アスタを描くジャンプアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fairy Tail",
+        "ja": "フェアリーテイル",
+        "ja_typings": [
+          "feari-teiru"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": [
+          "magi"
+        ]
+      },
+      {
+        "en": "Hell's Paradise",
+        "ja": "地獄楽",
+        "ja_typings": [
+          "jigokuraku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01799",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hiro Mashima anime follows Natsu and his guild of mages?",
+      "ja": "真島ヒロ原作、ナツが所属する魔導士ギルドの物語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "D.Gray-man",
+        "ja": "ディーグレイマン",
+        "ja_typings": [
+          "di-gureiman"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "フェアリーテイル",
+        "ja_typings": [
+          "feari-teiru"
+        ]
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": [
+          "magi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01800",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Katsura Hoshino anime follows exorcists fighting Akuma with Innocence?",
+      "ja": "星野桂原作、イノセンスでアクマと戦うエクソシストたちの物語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ace of Diamond",
+        "ja": "ダイヤのエース",
+        "ja_typings": [
+          "daiyanoe-su"
+        ]
+      },
+      {
+        "en": "Hell's Paradise",
+        "ja": "地獄楽",
+        "ja_typings": [
+          "jigokuraku"
+        ]
+      },
+      {
+        "en": "MASHLE",
+        "ja": "マッシュル",
+        "ja_typings": [
+          "masshuru"
+        ]
+      },
+      {
+        "en": "Dororo",
+        "ja": "どろろ",
+        "ja_typings": [
+          "dororo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01801",
+    "image_path": null,
+    "question_text": {
+      "en": "Which baseball anime follows the Seido High pitching ace Eijun Sawamura?",
+      "ja": "沢村栄純が主人公の高校野球アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dororo",
+        "ja": "どろろ",
+        "ja_typings": [
+          "dororo"
+        ]
+      },
+      {
+        "en": "Hell's Paradise",
+        "ja": "地獄楽",
+        "ja_typings": [
+          "jigokuraku"
+        ]
+      },
+      {
+        "en": "MASHLE",
+        "ja": "マッシュル",
+        "ja_typings": [
+          "masshuru"
+        ]
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": [
+          "magi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01802",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Osamu Tezuka work features a boy reclaiming his body parts from demons?",
+      "ja": "手塚治虫原作、体の部位を魔物から取り戻す少年の物語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Black Lagoon",
+        "ja": "ブラック・ラグーン",
+        "ja_typings": [
+          "burakku/ragu-n"
+        ]
+      },
+      {
+        "en": "Outlaw Star",
+        "ja": "アウトロースター",
+        "ja_typings": [
+          "autoro-suta-"
+        ]
+      },
+      {
+        "en": "Hell's Paradise",
+        "ja": "地獄楽",
+        "ja_typings": [
+          "jigokuraku"
+        ]
+      },
+      {
+        "en": "Log Horizon",
+        "ja": "ログ・ホライズン",
+        "ja_typings": [
+          "rogu/horaizun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01803",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Rei Hiroe anime follows the mercenary crew of the Black Lagoon Company?",
+      "ja": "広江礼威原作、傭兵チーム『ブラック・ラグーン商会』の物語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wolf Children",
+        "ja": "おおかみこどもの雨と雪",
+        "ja_typings": [
+          "ookamikodomonoametoyuki"
+        ]
+      },
+      {
+        "en": "Summer Wars",
+        "ja": "サマーウォーズ",
+        "ja_typings": [
+          "sama-wo-zu"
+        ]
+      },
+      {
+        "en": "Tokyo Godfathers",
+        "ja": "東京ゴッドファーザーズ",
+        "ja_typings": [
+          "toukyougoddofa-za-zu"
+        ]
+      },
+      {
+        "en": "Heidi",
+        "ja": "アルプスの少女ハイジ",
+        "ja_typings": [
+          "arupusunoshoujohaiji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01804",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mamoru Hosoda film features a single mother raising two half-wolf children?",
+      "ja": "細田守監督、狼男との間に生まれた姉弟を描く映画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Summer Wars",
+        "ja": "サマーウォーズ",
+        "ja_typings": [
+          "sama-wo-zu"
+        ]
+      },
+      {
+        "en": "Wolf Children",
+        "ja": "おおかみこどもの雨と雪",
+        "ja_typings": [
+          "ookamikodomonoametoyuki"
+        ]
+      },
+      {
+        "en": "Tokyo Godfathers",
+        "ja": "東京ゴッドファーザーズ",
+        "ja_typings": [
+          "toukyougoddofa-za-zu"
+        ]
+      },
+      {
+        "en": "Galaxy Express 999",
+        "ja": "銀河鉄道999",
+        "ja_typings": [
+          "gingatetsudou999"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01805",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mamoru Hosoda film centers on a virtual world called OZ?",
+      "ja": "細田守監督、仮想空間 OZ を舞台にした映画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tokyo Godfathers",
+        "ja": "東京ゴッドファーザーズ",
+        "ja_typings": [
+          "toukyougoddofa-za-zu"
+        ]
+      },
+      {
+        "en": "Summer Wars",
+        "ja": "サマーウォーズ",
+        "ja_typings": [
+          "sama-wo-zu"
+        ]
+      },
+      {
+        "en": "Wolf Children",
+        "ja": "おおかみこどもの雨と雪",
+        "ja_typings": [
+          "ookamikodomonoametoyuki"
+        ]
+      },
+      {
+        "en": "Heidi",
+        "ja": "アルプスの少女ハイジ",
+        "ja_typings": [
+          "arupusunoshoujohaiji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01806",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Satoshi Kon film follows three homeless people who find an abandoned baby?",
+      "ja": "今敏監督、ホームレス3人が捨て子を拾う物語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hell's Paradise",
+        "ja": "地獄楽",
+        "ja_typings": [
+          "jigokuraku"
+        ]
+      },
+      {
+        "en": "Dororo",
+        "ja": "どろろ",
+        "ja_typings": [
+          "dororo"
+        ]
+      },
+      {
+        "en": "MASHLE",
+        "ja": "マッシュル",
+        "ja_typings": [
+          "masshuru"
+        ]
+      },
+      {
+        "en": "Wonder Egg Priority",
+        "ja": "ワンダーエッグ・プライオリティ",
+        "ja_typings": [
+          "wanda-eggu/puraioriti"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01807",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Yutaka Yamamoto-directed anime follows an Edo-period executioner sent to a flower island?",
+      "ja": "江戸時代の処刑人が花の島に派遣される死刑囚との物語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Galaxy Express 999",
+        "ja": "銀河鉄道999",
+        "ja_typings": [
+          "gingatetsudou999"
+        ]
+      },
+      {
+        "en": "Outlaw Star",
+        "ja": "アウトロースター",
+        "ja_typings": [
+          "autoro-suta-"
+        ]
+      },
+      {
+        "en": "Heidi",
+        "ja": "アルプスの少女ハイジ",
+        "ja_typings": [
+          "arupusunoshoujohaiji"
+        ]
+      },
+      {
+        "en": "Urusei Yatsura",
+        "ja": "うる星やつら",
+        "ja_typings": [
+          "uruseiyatsura"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01808",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Leiji Matsumoto work features a steam locomotive traveling through space?",
+      "ja": "松本零士原作で宇宙を走る蒸気機関車を描く作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Heidi",
+        "ja": "アルプスの少女ハイジ",
+        "ja_typings": [
+          "arupusunoshoujohaiji"
+        ]
+      },
+      {
+        "en": "Galaxy Express 999",
+        "ja": "銀河鉄道999",
+        "ja_typings": [
+          "gingatetsudou999"
+        ]
+      },
+      {
+        "en": "Wolf Children",
+        "ja": "おおかみこどもの雨と雪",
+        "ja_typings": [
+          "ookamikodomonoametoyuki"
+        ]
+      },
+      {
+        "en": "Summer Wars",
+        "ja": "サマーウォーズ",
+        "ja_typings": [
+          "sama-wo-zu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01809",
+    "image_path": null,
+    "question_text": {
+      "en": "Which World Masterpiece Theater anime is set in the Swiss Alps?",
+      "ja": "世界名作劇場でスイスアルプスを舞台にした作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wonder Egg Priority",
+        "ja": "ワンダーエッグ・プライオリティ",
+        "ja_typings": [
+          "wanda-eggu/puraioriti"
+        ]
+      },
+      {
+        "en": "Hell's Paradise",
+        "ja": "地獄楽",
+        "ja_typings": [
+          "jigokuraku"
+        ]
+      },
+      {
+        "en": "MASHLE",
+        "ja": "マッシュル",
+        "ja_typings": [
+          "masshuru"
+        ]
+      },
+      {
+        "en": "Dororo",
+        "ja": "どろろ",
+        "ja_typings": [
+          "dororo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01810",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2021 original anime by CloverWorks features girls fighting in dream worlds to bring back the dead?",
+      "ja": "2021年クローバーワークス制作、夢の世界で戦う少女たちのオリジナルアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MASHLE",
+        "ja": "マッシュル",
+        "ja_typings": [
+          "masshuru"
+        ]
+      },
+      {
+        "en": "Hell's Paradise",
+        "ja": "地獄楽",
+        "ja_typings": [
+          "jigokuraku"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": [
+          "magi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01811",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hajime Komoto anime follows Mash Burnedead, a magicless boy attending magic school?",
+      "ja": "甲本一原作、魔法が使えない少年マッシュが魔法学校に通う作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Katsuhiro Otomo",
+        "ja": "大友克洋",
+        "ja_typings": [
+          "ootomokatsuhiro"
+        ]
+      },
+      {
+        "en": "Goro Miyazaki",
+        "ja": "宮崎吾朗",
+        "ja_typings": [
+          "miyazakigorou"
+        ]
+      },
+      {
+        "en": "Yoshiyuki Sadamoto",
+        "ja": "貞本義行",
+        "ja_typings": [
+          "sadamotoyoshiyuki"
+        ]
+      },
+      {
+        "en": "Tatsuki Fujimoto",
+        "ja": "藤本タツキ",
+        "ja_typings": [
+          "fujimototatsuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01812",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Akira and directed its 1988 film adaptation?",
+      "ja": "『AKIRA』の原作者で1988年映画版の監督も務めたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Goro Miyazaki",
+        "ja": "宮崎吾朗",
+        "ja_typings": [
+          "miyazakigorou"
+        ]
+      },
+      {
+        "en": "Katsuhiro Otomo",
+        "ja": "大友克洋",
+        "ja_typings": [
+          "ootomokatsuhiro"
+        ]
+      },
+      {
+        "en": "Yoshiyuki Sadamoto",
+        "ja": "貞本義行",
+        "ja_typings": [
+          "sadamotoyoshiyuki"
+        ]
+      },
+      {
+        "en": "Tatsuki Fujimoto",
+        "ja": "藤本タツキ",
+        "ja_typings": [
+          "fujimototatsuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01813",
+    "image_path": null,
+    "question_text": {
+      "en": "Who directed Tales from Earthsea and From Up on Poppy Hill at Studio Ghibli?",
+      "ja": "ジブリで『ゲド戦記』『コクリコ坂から』を監督したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yoshiyuki Sadamoto",
+        "ja": "貞本義行",
+        "ja_typings": [
+          "sadamotoyoshiyuki"
+        ]
+      },
+      {
+        "en": "Katsuhiro Otomo",
+        "ja": "大友克洋",
+        "ja_typings": [
+          "ootomokatsuhiro"
+        ]
+      },
+      {
+        "en": "Goro Miyazaki",
+        "ja": "宮崎吾朗",
+        "ja_typings": [
+          "miyazakigorou"
+        ]
+      },
+      {
+        "en": "Tatsuki Fujimoto",
+        "ja": "藤本タツキ",
+        "ja_typings": [
+          "fujimototatsuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01814",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the character designer for Neon Genesis Evangelion?",
+      "ja": "『新世紀エヴァンゲリオン』のキャラクターデザイナーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jiraiya",
+        "ja": "ジライヤ",
+        "ja_typings": [
+          "jiraiya"
+        ]
+      },
+      {
+        "en": "Chimera Shadow Garden",
+        "ja": "キメラ・シャドウガーデン",
+        "ja_typings": [
+          "kimera/shadoga-den",
+          "kimera/shadouga-den"
+        ]
+      },
+      {
+        "en": "Log Horizon",
+        "ja": "ログ・ホライズン",
+        "ja_typings": [
+          "rogu/horaizun"
+        ]
+      },
+      {
+        "en": "Outlaw Star",
+        "ja": "アウトロースター",
+        "ja_typings": [
+          "autoro-suta-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01815",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the name of Saitama's S-Class hero disciple in One-Punch Man?",
+      "ja": "『ワンパンマン』でサイタマの弟子となる S級ヒーローの名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Weekly Shonen Magazine",
+        "ja": "週刊少年マガジン",
+        "ja_typings": [
+          "shuukanshounenmagajin"
+        ]
+      },
+      {
+        "en": "Weekly Shonen Champion",
+        "ja": "週刊少年チャンピオン",
+        "ja_typings": [
+          "shuukanshounenchanpion"
+        ]
+      },
+      {
+        "en": "Shonen Jump",
+        "ja": "少年ジャンプ",
+        "ja_typings": [
+          "shounenjanpu"
+        ]
+      },
+      {
+        "en": "Big Comic",
+        "ja": "ビッグコミック",
+        "ja_typings": [
+          "biggukomikku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01816",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Kodansha weekly serializes Fairy Tail and Hajime no Ippo?",
+      "ja": "『フェアリーテイル』『はじめの一歩』を連載する講談社の週刊誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Morning",
+        "ja": "モーニング",
+        "ja_typings": [
+          "mo-ningu"
+        ]
+      },
+      {
+        "en": "Monthly Afternoon",
+        "ja": "月刊アフタヌーン",
+        "ja_typings": [
+          "gekkanafutanu-n"
+        ]
+      },
+      {
+        "en": "Big Comic Original",
+        "ja": "ビッグコミックオリジナル",
+        "ja_typings": [
+          "biggukomikkuorijinaru"
+        ]
+      },
+      {
+        "en": "Weekly Shonen Champion",
+        "ja": "週刊少年チャンピオン",
+        "ja_typings": [
+          "shuukanshounenchanpion"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01817",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Kodansha seinen magazine serializes Vagabond and Vinland Saga?",
+      "ja": "『バガボンド』『ヴィンランド・サガ』を連載する講談社の青年誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Monthly Afternoon",
+        "ja": "月刊アフタヌーン",
+        "ja_typings": [
+          "gekkanafutanu-n"
+        ]
+      },
+      {
+        "en": "Morning",
+        "ja": "モーニング",
+        "ja_typings": [
+          "mo-ningu"
+        ]
+      },
+      {
+        "en": "Big Comic",
+        "ja": "ビッグコミック",
+        "ja_typings": [
+          "biggukomikku"
+        ]
+      },
+      {
+        "en": "Weekly Shonen Magazine",
+        "ja": "週刊少年マガジン",
+        "ja_typings": [
+          "shuukanshounenmagajin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01818",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Kodansha monthly serialized Blame! and Mushishi?",
+      "ja": "『BLAME!』『蟲師』を連載した講談社の月刊誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Big Comic",
+        "ja": "ビッグコミック",
+        "ja_typings": [
+          "biggukomikku"
+        ]
+      },
+      {
+        "en": "Morning",
+        "ja": "モーニング",
+        "ja_typings": [
+          "mo-ningu"
+        ]
+      },
+      {
+        "en": "Monthly Afternoon",
+        "ja": "月刊アフタヌーン",
+        "ja_typings": [
+          "gekkanafutanu-n"
+        ]
+      },
+      {
+        "en": "Weekly Shonen Magazine",
+        "ja": "週刊少年マガジン",
+        "ja_typings": [
+          "shuukanshounenmagajin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01819",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Shogakukan biweekly serializes Golgo 13?",
+      "ja": "『ゴルゴ13』を連載する小学館の隔週誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Big Comic Original",
+        "ja": "ビッグコミックオリジナル",
+        "ja_typings": [
+          "biggukomikkuorijinaru"
+        ]
+      },
+      {
+        "en": "Morning",
+        "ja": "モーニング",
+        "ja_typings": [
+          "mo-ningu"
+        ]
+      },
+      {
+        "en": "Monthly Afternoon",
+        "ja": "月刊アフタヌーン",
+        "ja_typings": [
+          "gekkanafutanu-n"
+        ]
+      },
+      {
+        "en": "Weekly Shonen Champion",
+        "ja": "週刊少年チャンピオン",
+        "ja_typings": [
+          "shuukanshounenchanpion"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01820",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Shogakukan biweekly serialized Sanctuary and 3-gatsu no Lion?",
+      "ja": "『サンクチュアリ』『3月のライオン』を連載した小学館の隔週誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Weekly Shonen Champion",
+        "ja": "週刊少年チャンピオン",
+        "ja_typings": [
+          "shuukanshounenchanpion"
+        ]
+      },
+      {
+        "en": "Weekly Shonen Magazine",
+        "ja": "週刊少年マガジン",
+        "ja_typings": [
+          "shuukanshounenmagajin"
+        ]
+      },
+      {
+        "en": "Shonen Jump",
+        "ja": "少年ジャンプ",
+        "ja_typings": [
+          "shounenjanpu"
+        ]
+      },
+      {
+        "en": "Morning",
+        "ja": "モーニング",
+        "ja_typings": [
+          "mo-ningu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01821",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Akita Shoten weekly serializes Baki and serialized Grappler Baki?",
+      "ja": "『バキ』を連載する秋田書店の週刊誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shonen Jump",
+        "ja": "少年ジャンプ",
+        "ja_typings": [
+          "shounenjanpu"
+        ]
+      },
+      {
+        "en": "Weekly Shonen Magazine",
+        "ja": "週刊少年マガジン",
+        "ja_typings": [
+          "shuukanshounenmagajin"
+        ]
+      },
+      {
+        "en": "Weekly Shonen Champion",
+        "ja": "週刊少年チャンピオン",
+        "ja_typings": [
+          "shuukanshounenchanpion"
+        ]
+      },
+      {
+        "en": "Morning",
+        "ja": "モーニング",
+        "ja_typings": [
+          "mo-ningu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01822",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Shueisha magazine serializes One Piece and Jujutsu Kaisen?",
+      "ja": "『ONE PIECE』『呪術廻戦』を連載する集英社の雑誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": [
+          "magi"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
+      },
+      {
+        "en": "Bakuman",
+        "ja": "バクマン。",
+        "ja_typings": [
+          "bakuman."
+        ]
+      },
+      {
+        "en": "Platinum End",
+        "ja": "プラチナエンド",
+        "ja_typings": [
+          "purachinaendo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01823",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga features Akira Yuki training under his master in Edo-era Japan?",
+      "ja": "アスタが魔法の国で修行する少年漫画は? (誤) — 正: アラジンとアリババがダンジョンに挑む小学館連載作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": [
+          "magi"
+        ]
+      },
+      {
+        "en": "Bakuman",
+        "ja": "バクマン。",
+        "ja_typings": [
+          "bakuman."
+        ]
+      },
+      {
+        "en": "Platinum End",
+        "ja": "プラチナエンド",
+        "ja_typings": [
+          "purachinaendo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01824",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Yuki Tabata manga follows Asta in the Clover Kingdom?",
+      "ja": "田畠裕基の漫画で、アスタがクローバー王国で活躍する作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bakuman",
+        "ja": "バクマン。",
+        "ja_typings": [
+          "bakuman."
+        ]
+      },
+      {
+        "en": "Platinum End",
+        "ja": "プラチナエンド",
+        "ja_typings": [
+          "purachinaendo"
+        ]
+      },
+      {
+        "en": "Liar Game",
+        "ja": "ライアーゲーム",
+        "ja_typings": [
+          "raia-ge-mu"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01825",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Tsugumi Ohba & Takeshi Obata manga follows two boys aiming to become manga artists?",
+      "ja": "大場つぐみ・小畑健で、漫画家を目指す二人の少年の物語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Platinum End",
+        "ja": "プラチナエンド",
+        "ja_typings": [
+          "purachinaendo"
+        ]
+      },
+      {
+        "en": "Bakuman",
+        "ja": "バクマン。",
+        "ja_typings": [
+          "bakuman."
+        ]
+      },
+      {
+        "en": "Liar Game",
+        "ja": "ライアーゲーム",
+        "ja_typings": [
+          "raia-ge-mu"
+        ]
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": [
+          "magi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01826",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Ohba & Obata manga features a boy chosen by an angel competing to become god?",
+      "ja": "大場つぐみ・小畑健で、天使に選ばれた少年が神を目指す作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Liar Game",
+        "ja": "ライアーゲーム",
+        "ja_typings": [
+          "raia-ge-mu"
+        ]
+      },
+      {
+        "en": "Bakuman",
+        "ja": "バクマン。",
+        "ja_typings": [
+          "bakuman."
+        ]
+      },
+      {
+        "en": "Platinum End",
+        "ja": "プラチナエンド",
+        "ja_typings": [
+          "purachinaendo"
+        ]
+      },
+      {
+        "en": "Mister Ajikko",
+        "ja": "ミスター味っ子",
+        "ja_typings": [
+          "misuta-ajikko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01827",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Shinobu Kaitani manga revolves around a deception tournament with huge debts?",
+      "ja": "甲斐谷忍の漫画で、巨額の借金を賭けた騙し合いトーナメントを描く作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mister Ajikko",
+        "ja": "ミスター味っ子",
+        "ja_typings": [
+          "misuta-ajikko"
+        ]
+      },
+      {
+        "en": "Liar Game",
+        "ja": "ライアーゲーム",
+        "ja_typings": [
+          "raia-ge-mu"
+        ]
+      },
+      {
+        "en": "Bakuman",
+        "ja": "バクマン。",
+        "ja_typings": [
+          "bakuman."
+        ]
+      },
+      {
+        "en": "Platinum End",
+        "ja": "プラチナエンド",
+        "ja_typings": [
+          "purachinaendo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01828",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Daisuke Hashimoto cooking manga follows young chef Yoichi Ajiyoshi?",
+      "ja": "味吉陽一を主人公とする料理漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Maoyu",
+        "ja": "まおゆう魔王勇者",
+        "ja_typings": [
+          "maoyuumaouyuusha"
+        ]
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": [
+          "magi"
+        ]
+      },
+      {
+        "en": "Platinum End",
+        "ja": "プラチナエンド",
+        "ja_typings": [
+          "purachinaendo"
+        ]
+      },
+      {
+        "en": "Bakuman",
+        "ja": "バクマン。",
+        "ja_typings": [
+          "bakuman."
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01829",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mamare Touno light-novel-based manga is set in a dark fantasy of demon-human peace?",
+      "ja": "魔王と勇者の和平を描く橙乃ままれ原作のダーク・ファンタジー漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Masakazu Katsura",
+        "ja": "桂正和",
+        "ja_typings": [
+          "katsuramasakazu"
+        ]
+      },
+      {
+        "en": "Masanori Morita",
+        "ja": "森田まさのり",
+        "ja_typings": [
+          "moritamasanori"
+        ]
+      },
+      {
+        "en": "Yusuke Murata",
+        "ja": "村田雄介",
+        "ja_typings": [
+          "muratayuusuke"
+        ]
+      },
+      {
+        "en": "Buronson",
+        "ja": "武論尊",
+        "ja_typings": [
+          "buronson"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01830",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Video Girl Ai and I\"s?",
+      "ja": "『電影少女』『I\"s』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Masanori Morita",
+        "ja": "森田まさのり",
+        "ja_typings": [
+          "moritamasanori"
+        ]
+      },
+      {
+        "en": "Masakazu Katsura",
+        "ja": "桂正和",
+        "ja_typings": [
+          "katsuramasakazu"
+        ]
+      },
+      {
+        "en": "Yusuke Murata",
+        "ja": "村田雄介",
+        "ja_typings": [
+          "muratayuusuke"
+        ]
+      },
+      {
+        "en": "Buronson",
+        "ja": "武論尊",
+        "ja_typings": [
+          "buronson"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01831",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Rookies and Rokudenashi Blues?",
+      "ja": "『ROOKIES』『ろくでなしBLUES』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Keiko Takemiya",
+        "ja": "竹宮惠子",
+        "ja_typings": [
+          "takemiyakeiko"
+        ]
+      },
+      {
+        "en": "Yumiko Oshima",
+        "ja": "大島弓子",
+        "ja_typings": [
+          "ooshimayumiko"
+        ]
+      },
+      {
+        "en": "Yumi Tamura",
+        "ja": "田村由美",
+        "ja_typings": [
+          "tamurayumi"
+        ]
+      },
+      {
+        "en": "Akimi Yoshida",
+        "ja": "吉田秋生",
+        "ja_typings": [
+          "yoshidaakimi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01832",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the Year 24 Group member behind Kaze to Ki no Uta and Toward the Terra?",
+      "ja": "『風と木の詩』『地球へ…』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yumi Tamura",
+        "ja": "田村由美",
+        "ja_typings": [
+          "tamurayumi"
+        ]
+      },
+      {
+        "en": "Keiko Takemiya",
+        "ja": "竹宮惠子",
+        "ja_typings": [
+          "takemiyakeiko"
+        ]
+      },
+      {
+        "en": "Yumiko Oshima",
+        "ja": "大島弓子",
+        "ja_typings": [
+          "ooshimayumiko"
+        ]
+      },
+      {
+        "en": "Akimi Yoshida",
+        "ja": "吉田秋生",
+        "ja_typings": [
+          "yoshidaakimi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01833",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Basara and 7 Seeds?",
+      "ja": "『BASARA』『7SEEDS』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Masami Kurumada",
+        "ja": "車田正美",
+        "ja_typings": [
+          "kurumadamasami"
+        ]
+      },
+      {
+        "en": "Masakazu Katsura",
+        "ja": "桂正和",
+        "ja_typings": [
+          "katsuramasakazu"
+        ]
+      },
+      {
+        "en": "Buronson",
+        "ja": "武論尊",
+        "ja_typings": [
+          "buronson"
+        ]
+      },
+      {
+        "en": "Yusuke Murata",
+        "ja": "村田雄介",
+        "ja_typings": [
+          "muratayuusuke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01834",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Saint Seiya?",
+      "ja": "『聖闘士星矢』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fujio Akatsuka",
+        "ja": "赤塚不二夫",
+        "ja_typings": [
+          "akatsukafujio"
+        ]
+      },
+      {
+        "en": "Fujiko Fujio A",
+        "ja": "藤子不二雄A",
+        "ja_typings": [
+          "fujikofujioe-"
+        ]
+      },
+      {
+        "en": "Kazuo Umezu",
+        "ja": "楳図かずお",
+        "ja_typings": [
+          "umezukazuo"
+        ]
+      },
+      {
+        "en": "Shinji Mizushima",
+        "ja": "水島新司",
+        "ja_typings": [
+          "mizushimashinji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01835",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Tensai Bakabon and Osomatsu-kun?",
+      "ja": "『天才バカボン』『おそ松くん』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CLAMP",
+        "ja": "クランプ",
+        "ja_typings": [
+          "kuranpu"
+        ]
+      },
+      {
+        "en": "Yudetamago",
+        "ja": "ゆでたまご",
+        "ja_typings": [
+          "yudetamago"
+        ]
+      },
+      {
+        "en": "Buronson",
+        "ja": "武論尊",
+        "ja_typings": [
+          "buronson"
+        ]
+      },
+      {
+        "en": "Yusuke Murata",
+        "ja": "村田雄介",
+        "ja_typings": [
+          "muratayuusuke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01836",
+    "image_path": null,
+    "question_text": {
+      "en": "Which all-female group created Cardcaptor Sakura and X/1999?",
+      "ja": "『カードキャプターさくら』『X』を生み出した女性作家グループは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Buronson",
+        "ja": "武論尊",
+        "ja_typings": [
+          "buronson"
+        ]
+      },
+      {
+        "en": "Masakazu Katsura",
+        "ja": "桂正和",
+        "ja_typings": [
+          "katsuramasakazu"
+        ]
+      },
+      {
+        "en": "Masanori Morita",
+        "ja": "森田まさのり",
+        "ja_typings": [
+          "moritamasanori"
+        ]
+      },
+      {
+        "en": "Ikki Kajiwara",
+        "ja": "梶原一騎",
+        "ja_typings": [
+          "kajiwaraikki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01837",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote the original story for Fist of the North Star?",
+      "ja": "『北斗の拳』の原作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ikki Kajiwara",
+        "ja": "梶原一騎",
+        "ja_typings": [
+          "kajiwaraikki"
+        ]
+      },
+      {
+        "en": "Buronson",
+        "ja": "武論尊",
+        "ja_typings": [
+          "buronson"
+        ]
+      },
+      {
+        "en": "Masanori Morita",
+        "ja": "森田まさのり",
+        "ja_typings": [
+          "moritamasanori"
+        ]
+      },
+      {
+        "en": "Masakazu Katsura",
+        "ja": "桂正和",
+        "ja_typings": [
+          "katsuramasakazu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01838",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote the original story for Star of the Giants and Tomorrow's Joe?",
+      "ja": "『巨人の星』『あしたのジョー』の原作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yudetamago",
+        "ja": "ゆでたまご",
+        "ja_typings": [
+          "yudetamago"
+        ]
+      },
+      {
+        "en": "CLAMP",
+        "ja": "クランプ",
+        "ja_typings": [
+          "kuranpu"
+        ]
+      },
+      {
+        "en": "Buronson",
+        "ja": "武論尊",
+        "ja_typings": [
+          "buronson"
+        ]
+      },
+      {
+        "en": "Yusuke Murata",
+        "ja": "村田雄介",
+        "ja_typings": [
+          "muratayuusuke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01839",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the duo behind Kinnikuman?",
+      "ja": "『キン肉マン』の作者コンビは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yusuke Murata",
+        "ja": "村田雄介",
+        "ja_typings": [
+          "muratayuusuke"
+        ]
+      },
+      {
+        "en": "Masakazu Katsura",
+        "ja": "桂正和",
+        "ja_typings": [
+          "katsuramasakazu"
+        ]
+      },
+      {
+        "en": "Masanori Morita",
+        "ja": "森田まさのり",
+        "ja_typings": [
+          "moritamasanori"
+        ]
+      },
+      {
+        "en": "Buronson",
+        "ja": "武論尊",
+        "ja_typings": [
+          "buronson"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01840",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the artist behind the One-Punch Man remake and Eyeshield 21?",
+      "ja": "ワンパンマン作画版や『アイシールド21』作画の漫画家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yoko Kamio",
+        "ja": "神尾葉子",
+        "ja_typings": [
+          "kamiyouko"
+        ]
+      },
+      {
+        "en": "Yumi Tamura",
+        "ja": "田村由美",
+        "ja_typings": [
+          "tamurayumi"
+        ]
+      },
+      {
+        "en": "Karuho Shiina",
+        "ja": "椎名軽穂",
+        "ja_typings": [
+          "shiinakaruho"
+        ]
+      },
+      {
+        "en": "Akimi Yoshida",
+        "ja": "吉田秋生",
+        "ja_typings": [
+          "yoshidaakimi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01841",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Boys Over Flowers (Hana Yori Dango)?",
+      "ja": "『花より男子』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yumiko Oshima",
+        "ja": "大島弓子",
+        "ja_typings": [
+          "ooshimayumiko"
+        ]
+      },
+      {
+        "en": "Keiko Takemiya",
+        "ja": "竹宮惠子",
+        "ja_typings": [
+          "takemiyakeiko"
+        ]
+      },
+      {
+        "en": "Yumi Tamura",
+        "ja": "田村由美",
+        "ja_typings": [
+          "tamurayumi"
+        ]
+      },
+      {
+        "en": "Machiko Satonaka",
+        "ja": "里中満智子",
+        "ja_typings": [
+          "satonakamachiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01842",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of The Star of Cottonland?",
+      "ja": "『綿の国星』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fujiko Fujio A",
+        "ja": "藤子不二雄A",
+        "ja_typings": [
+          "fujikofujioe-"
+        ]
+      },
+      {
+        "en": "Fujio Akatsuka",
+        "ja": "赤塚不二夫",
+        "ja_typings": [
+          "akatsukafujio"
+        ]
+      },
+      {
+        "en": "Kazuo Umezu",
+        "ja": "楳図かずお",
+        "ja_typings": [
+          "umezukazuo"
+        ]
+      },
+      {
+        "en": "Hiroshi Motomiya",
+        "ja": "本宮ひろ志",
+        "ja_typings": [
+          "motomiyahiroshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01843",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Doraemon as one half of the duo, and later worked solo on Laughing Salesman?",
+      "ja": "藤子不二雄コンビの片割れで『笑ゥせぇるすまん』も手がけたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kenshi Hirokane",
+        "ja": "弘兼憲史",
+        "ja_typings": [
+          "hirokanekenshi"
+        ]
+      },
+      {
+        "en": "Fujio Akatsuka",
+        "ja": "赤塚不二夫",
+        "ja_typings": [
+          "akatsukafujio"
+        ]
+      },
+      {
+        "en": "Kazuo Umezu",
+        "ja": "楳図かずお",
+        "ja_typings": [
+          "umezukazuo"
+        ]
+      },
+      {
+        "en": "Hiroshi Motomiya",
+        "ja": "本宮ひろ志",
+        "ja_typings": [
+          "motomiyahiroshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01844",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Section Chief Kosaku Shima?",
+      "ja": "『課長島耕作』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kazuo Umezu",
+        "ja": "楳図かずお",
+        "ja_typings": [
+          "umezukazuo"
+        ]
+      },
+      {
+        "en": "Fujio Akatsuka",
+        "ja": "赤塚不二夫",
+        "ja_typings": [
+          "akatsukafujio"
+        ]
+      },
+      {
+        "en": "Hiroshi Motomiya",
+        "ja": "本宮ひろ志",
+        "ja_typings": [
+          "motomiyahiroshi"
+        ]
+      },
+      {
+        "en": "Kenshi Hirokane",
+        "ja": "弘兼憲史",
+        "ja_typings": [
+          "hirokanekenshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01845",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the horror manga master behind The Drifting Classroom?",
+      "ja": "『漂流教室』の作者であるホラー漫画の巨匠は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hiroshi Motomiya",
+        "ja": "本宮ひろ志",
+        "ja_typings": [
+          "motomiyahiroshi"
+        ]
+      },
+      {
+        "en": "Kenshi Hirokane",
+        "ja": "弘兼憲史",
+        "ja_typings": [
+          "hirokanekenshi"
+        ]
+      },
+      {
+        "en": "Fujio Akatsuka",
+        "ja": "赤塚不二夫",
+        "ja_typings": [
+          "akatsukafujio"
+        ]
+      },
+      {
+        "en": "Kazuo Umezu",
+        "ja": "楳図かずお",
+        "ja_typings": [
+          "umezukazuo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01846",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Otoko Oidon and Salaryman Kintaro?",
+      "ja": "『男一匹ガキ大将』『サラリーマン金太郎』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yoshihiro Takahashi",
+        "ja": "高橋よしひろ",
+        "ja_typings": [
+          "takahashiyoshihiro"
+        ]
+      },
+      {
+        "en": "Akio Chiba",
+        "ja": "ちばあきお",
+        "ja_typings": [
+          "chibaakio"
+        ]
+      },
+      {
+        "en": "Shinji Mizushima",
+        "ja": "水島新司",
+        "ja_typings": [
+          "mizushimashinji"
+        ]
+      },
+      {
+        "en": "Fujihiko Hosono",
+        "ja": "細野不二彦",
+        "ja_typings": [
+          "hosonofujihiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01847",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created the dog adventure manga Silver Fang?",
+      "ja": "犬の冒険漫画『銀牙 -流れ星 銀-』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fujihiko Hosono",
+        "ja": "細野不二彦",
+        "ja_typings": [
+          "hosonofujihiko"
+        ]
+      },
+      {
+        "en": "Akio Chiba",
+        "ja": "ちばあきお",
+        "ja_typings": [
+          "chibaakio"
+        ]
+      },
+      {
+        "en": "Shinji Mizushima",
+        "ja": "水島新司",
+        "ja_typings": [
+          "mizushimashinji"
+        ]
+      },
+      {
+        "en": "Yoshihiro Takahashi",
+        "ja": "高橋よしひろ",
+        "ja_typings": [
+          "takahashiyoshihiro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01848",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Gallery Fake and Gaki Deka counterpart Yawara!? — namely the author of Gallery Fake?",
+      "ja": "『ギャラリーフェイク』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Akio Chiba",
+        "ja": "ちばあきお",
+        "ja_typings": [
+          "chibaakio"
+        ]
+      },
+      {
+        "en": "Shinji Mizushima",
+        "ja": "水島新司",
+        "ja_typings": [
+          "mizushimashinji"
+        ]
+      },
+      {
+        "en": "Yoshihiro Takahashi",
+        "ja": "高橋よしひろ",
+        "ja_typings": [
+          "takahashiyoshihiro"
+        ]
+      },
+      {
+        "en": "Fujihiko Hosono",
+        "ja": "細野不二彦",
+        "ja_typings": [
+          "hosonofujihiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01849",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Captain and Play Ball?",
+      "ja": "『キャプテン』『プレイボール』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shinji Mizushima",
+        "ja": "水島新司",
+        "ja_typings": [
+          "mizushimashinji"
+        ]
+      },
+      {
+        "en": "Akio Chiba",
+        "ja": "ちばあきお",
+        "ja_typings": [
+          "chibaakio"
+        ]
+      },
+      {
+        "en": "Yoshihiro Takahashi",
+        "ja": "高橋よしひろ",
+        "ja_typings": [
+          "takahashiyoshihiro"
+        ]
+      },
+      {
+        "en": "Fujihiko Hosono",
+        "ja": "細野不二彦",
+        "ja_typings": [
+          "hosonofujihiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01850",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the baseball manga master behind Dokaben?",
+      "ja": "『ドカベン』の作者である野球漫画の巨匠は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Masami Yuki",
+        "ja": "ゆうきまさみ",
+        "ja_typings": [
+          "yuukimasami"
+        ]
+      },
+      {
+        "en": "Mamoru Nagano",
+        "ja": "永野護",
+        "ja_typings": [
+          "naganomamoru"
+        ]
+      },
+      {
+        "en": "Akimi Yoshida",
+        "ja": "吉田秋生",
+        "ja_typings": [
+          "yoshidaakimi"
+        ]
+      },
+      {
+        "en": "Karuho Shiina",
+        "ja": "椎名軽穂",
+        "ja_typings": [
+          "shiinakaruho"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01851",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Patlabor (manga)?",
+      "ja": "漫画版『機動警察パトレイバー』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mamoru Nagano",
+        "ja": "永野護",
+        "ja_typings": [
+          "naganomamoru"
+        ]
+      },
+      {
+        "en": "Masami Yuki",
+        "ja": "ゆうきまさみ",
+        "ja_typings": [
+          "yuukimasami"
+        ]
+      },
+      {
+        "en": "Akimi Yoshida",
+        "ja": "吉田秋生",
+        "ja_typings": [
+          "yoshidaakimi"
+        ]
+      },
+      {
+        "en": "Karuho Shiina",
+        "ja": "椎名軽穂",
+        "ja_typings": [
+          "shiinakaruho"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01852",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of The Five Star Stories?",
+      "ja": "『ファイブスター物語』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kazuhiro Fujita",
+        "ja": "藤田和日郎",
+        "ja_typings": [
+          "fujitakazuhiro"
+        ]
+      },
+      {
+        "en": "Masami Yuki",
+        "ja": "ゆうきまさみ",
+        "ja_typings": [
+          "yuukimasami"
+        ]
+      },
+      {
+        "en": "Koji Kumeta",
+        "ja": "久米田康治",
+        "ja_typings": [
+          "kumetakouji"
+        ]
+      },
+      {
+        "en": "Mamoru Nagano",
+        "ja": "永野護",
+        "ja_typings": [
+          "naganomamoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01853",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Ushio and Tora?",
+      "ja": "『うしおととら』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Satoru Makimura",
+        "ja": "室山まゆみ",
+        "ja_typings": [
+          "muroyamamayumi"
+        ]
+      },
+      {
+        "en": "Machiko Satonaka",
+        "ja": "里中満智子",
+        "ja_typings": [
+          "satonakamachiko"
+        ]
+      },
+      {
+        "en": "Fusako Kuramochi",
+        "ja": "倉持房子",
+        "ja_typings": [
+          "kuramochifusako"
+        ]
+      },
+      {
+        "en": "Karuho Shiina",
+        "ja": "椎名軽穂",
+        "ja_typings": [
+          "shiinakaruho"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01854",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Asari-chan?",
+      "ja": "『あさりちゃん』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fusako Kuramochi",
+        "ja": "倉持房子",
+        "ja_typings": [
+          "kuramochifusako"
+        ]
+      },
+      {
+        "en": "Machiko Satonaka",
+        "ja": "里中満智子",
+        "ja_typings": [
+          "satonakamachiko"
+        ]
+      },
+      {
+        "en": "Karuho Shiina",
+        "ja": "椎名軽穂",
+        "ja_typings": [
+          "shiinakaruho"
+        ]
+      },
+      {
+        "en": "Yoko Kamio",
+        "ja": "神尾葉子",
+        "ja_typings": [
+          "kamiyouko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01855",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Tenshi nanka ja nai?",
+      "ja": "『天使なんかじゃない』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Akimi Yoshida",
+        "ja": "吉田秋生",
+        "ja_typings": [
+          "yoshidaakimi"
+        ]
+      },
+      {
+        "en": "Yumi Tamura",
+        "ja": "田村由美",
+        "ja_typings": [
+          "tamurayumi"
+        ]
+      },
+      {
+        "en": "Fusako Kuramochi",
+        "ja": "倉持房子",
+        "ja_typings": [
+          "kuramochifusako"
+        ]
+      },
+      {
+        "en": "Machiko Satonaka",
+        "ja": "里中満智子",
+        "ja_typings": [
+          "satonakamachiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01856",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Banana Fish?",
+      "ja": "『BANANA FISH』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Karuho Shiina",
+        "ja": "椎名軽穂",
+        "ja_typings": [
+          "shiinakaruho"
+        ]
+      },
+      {
+        "en": "Yoko Kamio",
+        "ja": "神尾葉子",
+        "ja_typings": [
+          "kamiyouko"
+        ]
+      },
+      {
+        "en": "Akimi Yoshida",
+        "ja": "吉田秋生",
+        "ja_typings": [
+          "yoshidaakimi"
+        ]
+      },
+      {
+        "en": "Fusako Kuramochi",
+        "ja": "倉持房子",
+        "ja_typings": [
+          "kuramochifusako"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01857",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Kimi ni Todoke?",
+      "ja": "『君に届け』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Koji Kumeta",
+        "ja": "久米田康治",
+        "ja_typings": [
+          "kumetakouji"
+        ]
+      },
+      {
+        "en": "Kazuhiro Fujita",
+        "ja": "藤田和日郎",
+        "ja_typings": [
+          "fujitakazuhiro"
+        ]
+      },
+      {
+        "en": "Masami Yuki",
+        "ja": "ゆうきまさみ",
+        "ja_typings": [
+          "yuukimasami"
+        ]
+      },
+      {
+        "en": "Mamoru Nagano",
+        "ja": "永野護",
+        "ja_typings": [
+          "naganomamoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01858",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Sayonara, Zetsubou-Sensei?",
+      "ja": "『さよなら絶望先生』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Machiko Satonaka",
+        "ja": "里中満智子",
+        "ja_typings": [
+          "satonakamachiko"
+        ]
+      },
+      {
+        "en": "Fusako Kuramochi",
+        "ja": "倉持房子",
+        "ja_typings": [
+          "kuramochifusako"
+        ]
+      },
+      {
+        "en": "Yumi Tamura",
+        "ja": "田村由美",
+        "ja_typings": [
+          "tamurayumi"
+        ]
+      },
+      {
+        "en": "Akimi Yoshida",
+        "ja": "吉田秋生",
+        "ja_typings": [
+          "yoshidaakimi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01859",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the historical-josei master behind Tenjo no Niji?",
+      "ja": "『天上の虹』を描いた歴史少女漫画の巨匠は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kadokawa Shoten",
+        "ja": "角川書店",
+        "ja_typings": [
+          "kadokawashoten"
+        ]
+      },
+      {
+        "en": "The Yomiuri Shimbun",
+        "ja": "読売新聞",
+        "ja_typings": [
+          "yomiurishinbun"
+        ]
+      },
+      {
+        "en": "The Mainichi Shimbun",
+        "ja": "毎日新聞",
+        "ja_typings": [
+          "mainichishinbun"
+        ]
+      },
+      {
+        "en": "Nikkei",
+        "ja": "日本経済新聞",
+        "ja_typings": [
+          "nihonkeizaishinbun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01860",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese publisher releases Kadokawa Bunko and many light novels?",
+      "ja": "角川文庫やライトノベルを多数出す日本の出版社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Yomiuri Shimbun",
+        "ja": "読売新聞",
+        "ja_typings": [
+          "yomiurishinbun"
+        ]
+      },
+      {
+        "en": "The Mainichi Shimbun",
+        "ja": "毎日新聞",
+        "ja_typings": [
+          "mainichishinbun"
+        ]
+      },
+      {
+        "en": "Nikkei",
+        "ja": "日本経済新聞",
+        "ja_typings": [
+          "nihonkeizaishinbun"
+        ]
+      },
+      {
+        "en": "Kadokawa Shoten",
+        "ja": "角川書店",
+        "ja_typings": [
+          "kadokawashoten"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01861",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese newspaper has the largest circulation and sponsors the Giants?",
+      "ja": "発行部数最大、巨人を所有する日本の新聞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Mainichi Shimbun",
+        "ja": "毎日新聞",
+        "ja_typings": [
+          "mainichishinbun"
+        ]
+      },
+      {
+        "en": "The Yomiuri Shimbun",
+        "ja": "読売新聞",
+        "ja_typings": [
+          "yomiurishinbun"
+        ]
+      },
+      {
+        "en": "Nikkei",
+        "ja": "日本経済新聞",
+        "ja_typings": [
+          "nihonkeizaishinbun"
+        ]
+      },
+      {
+        "en": "Kadokawa Shoten",
+        "ja": "角川書店",
+        "ja_typings": [
+          "kadokawashoten"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01862",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese newspaper sponsors the high school baseball Summer Koshien?",
+      "ja": "夏の甲子園を主催する日本の新聞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nikkei",
+        "ja": "日本経済新聞",
+        "ja_typings": [
+          "nihonkeizaishinbun"
+        ]
+      },
+      {
+        "en": "The Yomiuri Shimbun",
+        "ja": "読売新聞",
+        "ja_typings": [
+          "yomiurishinbun"
+        ]
+      },
+      {
+        "en": "The Mainichi Shimbun",
+        "ja": "毎日新聞",
+        "ja_typings": [
+          "mainichishinbun"
+        ]
+      },
+      {
+        "en": "Kadokawa Shoten",
+        "ja": "角川書店",
+        "ja_typings": [
+          "kadokawashoten"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01863",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese newspaper focuses on business and economics?",
+      "ja": "経済を専門に扱う日本の新聞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ayumi Himekawa",
+        "ja": "姫川亜弓",
+        "ja_typings": [
+          "himekawaayumi"
+        ]
+      },
+      {
+        "en": "Chigusa Tsukikage",
+        "ja": "月影千草",
+        "ja_typings": [
+          "tsukikagechigusa"
+        ]
+      },
+      {
+        "en": "Fusako Kuramochi",
+        "ja": "倉持房子",
+        "ja_typings": [
+          "kuramochifusako"
+        ]
+      },
+      {
+        "en": "Karuho Shiina",
+        "ja": "椎名軽穂",
+        "ja_typings": [
+          "shiinakaruho"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01864",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the heir to Hanagumi at the Imperial Theatre in Sakura Wars?",
+      "ja": "『サクラ大戦』で帝国華撃団・花組の隊員は神崎すみれと誰? (新人の少女の名)"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ayumi Himekawa",
+        "ja": "姫川亜弓",
+        "ja_typings": [
+          "himekawaayumi"
+        ]
+      },
+      {
+        "en": "Chigusa Tsukikage",
+        "ja": "月影千草",
+        "ja_typings": [
+          "tsukikagechigusa"
+        ]
+      },
+      {
+        "en": "Machiko Satonaka",
+        "ja": "里中満智子",
+        "ja_typings": [
+          "satonakamachiko"
+        ]
+      },
+      {
+        "en": "Fusako Kuramochi",
+        "ja": "倉持房子",
+        "ja_typings": [
+          "kuramochifusako"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01865",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the rival actress in Glass Mask (Garasu no Kamen)?",
+      "ja": "『ガラスの仮面』で北島マヤのライバルとなる天才女優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chigusa Tsukikage",
+        "ja": "月影千草",
+        "ja_typings": [
+          "tsukikagechigusa"
+        ]
+      },
+      {
+        "en": "Ayumi Himekawa",
+        "ja": "姫川亜弓",
+        "ja_typings": [
+          "himekawaayumi"
+        ]
+      },
+      {
+        "en": "Machiko Satonaka",
+        "ja": "里中満智子",
+        "ja_typings": [
+          "satonakamachiko"
+        ]
+      },
+      {
+        "en": "Fusako Kuramochi",
+        "ja": "倉持房子",
+        "ja_typings": [
+          "kuramochifusako"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01866",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the legendary actress and mentor in Glass Mask?",
+      "ja": "『ガラスの仮面』で月影先生として知られる伝説の女優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Konami",
+        "ja": "コナミ",
+        "ja_typings": [
+          "konami"
+        ]
+      },
+      {
+        "en": "Tri-Ace",
+        "ja": "トライエース",
+        "ja_typings": [
+          "toraie-su"
+        ]
+      },
+      {
+        "en": "Capcom",
+        "ja": "カプコン",
+        "ja_typings": [
+          "kapukon"
+        ]
+      },
+      {
+        "en": "Sega",
+        "ja": "セガ",
+        "ja_typings": [
+          "sega"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01867",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese game company developed the Metal Gear and Castlevania series?",
+      "ja": "『メタルギア』『悪魔城ドラキュラ』を開発した日本のゲーム会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yu Suzuki",
+        "ja": "鈴木裕",
+        "ja_typings": [
+          "suzukiyuu"
+        ]
+      },
+      {
+        "en": "Tri-Ace",
+        "ja": "トライエース",
+        "ja_typings": [
+          "toraie-su"
+        ]
+      },
+      {
+        "en": "Konami",
+        "ja": "コナミ",
+        "ja_typings": [
+          "konami"
+        ]
+      },
+      {
+        "en": "Onimusha",
+        "ja": "鬼武者",
+        "ja_typings": [
+          "onimusha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01868",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the creator of Virtua Fighter and Shenmue at Sega?",
+      "ja": "セガで『バーチャファイター』『シェンムー』を生み出したクリエイターは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tri-Ace",
+        "ja": "トライエース",
+        "ja_typings": [
+          "toraie-su"
+        ]
+      },
+      {
+        "en": "Konami",
+        "ja": "コナミ",
+        "ja_typings": [
+          "konami"
+        ]
+      },
+      {
+        "en": "Capcom",
+        "ja": "カプコン",
+        "ja_typings": [
+          "kapukon"
+        ]
+      },
+      {
+        "en": "Sega",
+        "ja": "セガ",
+        "ja_typings": [
+          "sega"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01869",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese developer is known for Star Ocean and Valkyrie Profile?",
+      "ja": "『スターオーシャン』『ヴァルキリープロファイル』で知られるデベロッパーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chrono Trigger",
+        "ja": "クロノ・トリガー",
+        "ja_typings": [
+          "kurono/toriga-"
+        ]
+      },
+      {
+        "en": "Final Fantasy",
+        "ja": "ファイナルファンタジー",
+        "ja_typings": [
+          "fainarufantaji-"
+        ]
+      },
+      {
+        "en": "Xenoblade",
+        "ja": "ゼノブレイド",
+        "ja_typings": [
+          "zenobureido"
+        ]
+      },
+      {
+        "en": "Seiken Densetsu",
+        "ja": "聖剣伝説",
+        "ja_typings": [
+          "seikendensetsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01870",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1995 Square JRPG features Crono and time-traveling adventures?",
+      "ja": "1995年スクウェアのRPGで、クロノが時を超える物語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Final Fantasy",
+        "ja": "ファイナルファンタジー",
+        "ja_typings": [
+          "fainarufantaji-"
+        ]
+      },
+      {
+        "en": "Chrono Trigger",
+        "ja": "クロノ・トリガー",
+        "ja_typings": [
+          "kurono/toriga-"
+        ]
+      },
+      {
+        "en": "Seiken Densetsu",
+        "ja": "聖剣伝説",
+        "ja_typings": [
+          "seikendensetsu"
+        ]
+      },
+      {
+        "en": "SaGa Frontier",
+        "ja": "サガ・フロンティア",
+        "ja_typings": [
+          "saga/furontia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01871",
+    "image_path": null,
+    "question_text": {
+      "en": "Which long-running Square Enix JRPG series began on the Famicom in 1987?",
+      "ja": "1987年ファミコンで始まったスクウェアの長寿RPGシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Virtua Fighter",
+        "ja": "バーチャファイター",
+        "ja_typings": [
+          "ba-chafaita-"
+        ]
+      },
+      {
+        "en": "Last Blade",
+        "ja": "ラストブレイド",
+        "ja_typings": [
+          "rasutobureido"
+        ]
+      },
+      {
+        "en": "Devil May Cry",
+        "ja": "デビルメイクライ",
+        "ja_typings": [
+          "debirumeikurai"
+        ]
+      },
+      {
+        "en": "Bayonetta",
+        "ja": "ベヨネッタ",
+        "ja_typings": [
+          "beyonetta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01872",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Sega 3D fighting series began in 1993 starring Akira Yuki?",
+      "ja": "1993年に始まったセガの3D格闘ゲームシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dragon Age",
+        "ja": "ドラゴンエイジ",
+        "ja_typings": [
+          "doragonneiji"
+        ]
+      },
+      {
+        "en": "Mass Effect",
+        "ja": "マスエフェクト",
+        "ja_typings": [
+          "masuefekuto"
+        ]
+      },
+      {
+        "en": "Dark Souls",
+        "ja": "ダークソウル",
+        "ja_typings": [
+          "da-kusoru",
+          "da-kusouru"
+        ]
+      },
+      {
+        "en": "Dragon Quest Builders",
+        "ja": "ドラゴンクエストビルダーズ",
+        "ja_typings": [
+          "doragonkuesutobiruda-zu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01873",
+    "image_path": null,
+    "question_text": {
+      "en": "Which BioWare RPG series features Grey Wardens fighting darkspawn?",
+      "ja": "BioWare 製、灰色の守人がダークスポーンと戦うRPGシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nioh",
+        "ja": "仁王",
+        "ja_typings": [
+          "nioh"
+        ]
+      },
+      {
+        "en": "Onimusha",
+        "ja": "鬼武者",
+        "ja_typings": [
+          "onimusha"
+        ]
+      },
+      {
+        "en": "Way of the Samurai",
+        "ja": "侍道",
+        "ja_typings": [
+          "samuraidou"
+        ]
+      },
+      {
+        "en": "Dark Souls",
+        "ja": "ダークソウル",
+        "ja_typings": [
+          "da-kusoru",
+          "da-kusouru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01874",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Team Ninja action RPG is set in Sengoku Japan starring William Adams?",
+      "ja": "コーエーテクモ製、戦国時代を舞台にウィリアムが戦うアクションRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Judgment",
+        "ja": "ジャッジアイズ",
+        "ja_typings": [
+          "jajjiaizu"
+        ]
+      },
+      {
+        "en": "Nioh",
+        "ja": "仁王",
+        "ja_typings": [
+          "nioh"
+        ]
+      },
+      {
+        "en": "Onimusha",
+        "ja": "鬼武者",
+        "ja_typings": [
+          "onimusha"
+        ]
+      },
+      {
+        "en": "Shenmue",
+        "ja": "シェンムー",
+        "ja_typings": [
+          "shenmu-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01875",
+    "image_path": null,
+    "question_text": {
+      "en": "Which RGG Studio spin-off stars lawyer-turned-detective Takayuki Yagami?",
+      "ja": "龍が如くスタジオのスピンオフで、八神隆之が主人公の作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mega Drive",
+        "ja": "メガドライブ",
+        "ja_typings": [
+          "megadoraibu"
+        ]
+      },
+      {
+        "en": "Game Gear",
+        "ja": "ゲームギア",
+        "ja_typings": [
+          "ge-mugia"
+        ]
+      },
+      {
+        "en": "Sega Saturn",
+        "ja": "セガサターン",
+        "ja_typings": [
+          "segasata-n"
+        ]
+      },
+      {
+        "en": "PC Engine GT",
+        "ja": "PCエンジンGT",
+        "ja_typings": [
+          "pcenjingt"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01876",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Sega 16-bit home console competed with the Super Famicom in the early 1990s?",
+      "ja": "1990年代初頭にスーパーファミコンと競合したセガの16ビット家庭用機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Game Gear",
+        "ja": "ゲームギア",
+        "ja_typings": [
+          "ge-mugia"
+        ]
+      },
+      {
+        "en": "Mega Drive",
+        "ja": "メガドライブ",
+        "ja_typings": [
+          "megadoraibu"
+        ]
+      },
+      {
+        "en": "Sega Saturn",
+        "ja": "セガサターン",
+        "ja_typings": [
+          "segasata-n"
+        ]
+      },
+      {
+        "en": "PC Engine GT",
+        "ja": "PCエンジンGT",
+        "ja_typings": [
+          "pcenjingt"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01877",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Sega handheld competed with the Game Boy?",
+      "ja": "ゲームボーイと競合したセガの携帯ゲーム機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Parasite Eve",
+        "ja": "パラサイト・イヴ",
+        "ja_typings": [
+          "parasaito/ivu"
+        ]
+      },
+      {
+        "en": "Chrono Trigger",
+        "ja": "クロノ・トリガー",
+        "ja_typings": [
+          "kurono/toriga-"
+        ]
+      },
+      {
+        "en": "Onimusha",
+        "ja": "鬼武者",
+        "ja_typings": [
+          "onimusha"
+        ]
+      },
+      {
+        "en": "Soul Blazer",
+        "ja": "ソウルブレイダー",
+        "ja_typings": [
+          "sorubureida-",
+          "sourubureida-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01878",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Square horror RPG is set in NYC starring Aya Brea?",
+      "ja": "ニューヨークを舞台にアヤ・ブレアが活躍するスクウェアのホラーRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Xenoblade",
+        "ja": "ゼノブレイド",
+        "ja_typings": [
+          "zenobureido"
+        ]
+      },
+      {
+        "en": "Chrono Trigger",
+        "ja": "クロノ・トリガー",
+        "ja_typings": [
+          "kurono/toriga-"
+        ]
+      },
+      {
+        "en": "Seiken Densetsu",
+        "ja": "聖剣伝説",
+        "ja_typings": [
+          "seikendensetsu"
+        ]
+      },
+      {
+        "en": "SaGa Frontier",
+        "ja": "サガ・フロンティア",
+        "ja_typings": [
+          "saga/furontia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01879",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Monolith Soft JRPG series features giant Titans and the Monado?",
+      "ja": "モノリスソフトの巨神とモナドが登場するJRPGシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bayonetta",
+        "ja": "ベヨネッタ",
+        "ja_typings": [
+          "beyonetta"
+        ]
+      },
+      {
+        "en": "Devil May Cry",
+        "ja": "デビルメイクライ",
+        "ja_typings": [
+          "debirumeikurai"
+        ]
+      },
+      {
+        "en": "Nioh",
+        "ja": "仁王",
+        "ja_typings": [
+          "nioh"
+        ]
+      },
+      {
+        "en": "Onimusha",
+        "ja": "鬼武者",
+        "ja_typings": [
+          "onimusha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01880",
+    "image_path": null,
+    "question_text": {
+      "en": "Which PlatinumGames action title stars a witch named Cereza?",
+      "ja": "プラチナゲームズ製、魔女セレッサが主人公のアクションは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Devil May Cry",
+        "ja": "デビルメイクライ",
+        "ja_typings": [
+          "debirumeikurai"
+        ]
+      },
+      {
+        "en": "Bayonetta",
+        "ja": "ベヨネッタ",
+        "ja_typings": [
+          "beyonetta"
+        ]
+      },
+      {
+        "en": "Onimusha",
+        "ja": "鬼武者",
+        "ja_typings": [
+          "onimusha"
+        ]
+      },
+      {
+        "en": "Dark Souls",
+        "ja": "ダークソウル",
+        "ja_typings": [
+          "da-kusoru",
+          "da-kusouru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01881",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Capcom action series stars demon hunter Dante?",
+      "ja": "カプコン製、悪魔狩人ダンテが主人公のアクションシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Paladins",
+        "ja": "パラディンズ",
+        "ja_typings": [
+          "paradinzu"
+        ]
+      },
+      {
+        "en": "PUBG",
+        "ja": "ピーユービージー",
+        "ja_typings": [
+          "pi-yu-bi-ji-"
+        ]
+      },
+      {
+        "en": "Warzone",
+        "ja": "ウォーゾーン",
+        "ja_typings": [
+          "wo-zo-n"
+        ]
+      },
+      {
+        "en": "Roblox",
+        "ja": "ロブロックス",
+        "ja_typings": [
+          "roburokkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01882",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hi-Rez Studios free-to-play hero shooter features Champions?",
+      "ja": "Hi-Rez Studios 製、チャンピオンが戦う基本無料ヒーローシューターは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mass Effect",
+        "ja": "マスエフェクト",
+        "ja_typings": [
+          "masuefekuto"
+        ]
+      },
+      {
+        "en": "Dragon Age",
+        "ja": "ドラゴンエイジ",
+        "ja_typings": [
+          "doragonneiji"
+        ]
+      },
+      {
+        "en": "Dark Souls",
+        "ja": "ダークソウル",
+        "ja_typings": [
+          "da-kusoru",
+          "da-kusouru"
+        ]
+      },
+      {
+        "en": "Watch Dogs",
+        "ja": "ウォッチドッグス",
+        "ja_typings": [
+          "wotchidoggusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01883",
+    "image_path": null,
+    "question_text": {
+      "en": "Which BioWare sci-fi RPG series stars Commander Shepard?",
+      "ja": "BioWare 製、シェパード司令官が主人公のSF RPGシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dark Souls",
+        "ja": "ダークソウル",
+        "ja_typings": [
+          "da-kusoru",
+          "da-kusouru"
+        ]
+      },
+      {
+        "en": "Nioh",
+        "ja": "仁王",
+        "ja_typings": [
+          "nioh"
+        ]
+      },
+      {
+        "en": "Onimusha",
+        "ja": "鬼武者",
+        "ja_typings": [
+          "onimusha"
+        ]
+      },
+      {
+        "en": "Dragon Age",
+        "ja": "ドラゴンエイジ",
+        "ja_typings": [
+          "doragonneiji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01884",
+    "image_path": null,
+    "question_text": {
+      "en": "Which FromSoftware action RPG series began with Lordran in 2011?",
+      "ja": "2011年にロードランから始まったフロム・ソフトウェアのアクションRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Onimusha",
+        "ja": "鬼武者",
+        "ja_typings": [
+          "onimusha"
+        ]
+      },
+      {
+        "en": "Nioh",
+        "ja": "仁王",
+        "ja_typings": [
+          "nioh"
+        ]
+      },
+      {
+        "en": "Way of the Samurai",
+        "ja": "侍道",
+        "ja_typings": [
+          "samuraidou"
+        ]
+      },
+      {
+        "en": "Bayonetta",
+        "ja": "ベヨネッタ",
+        "ja_typings": [
+          "beyonetta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01885",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Capcom action series is set in Sengoku-era Japan with samurai vs demons?",
+      "ja": "カプコン製、戦国時代を舞台に侍が鬼と戦うアクションシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Way of the Samurai",
+        "ja": "侍道",
+        "ja_typings": [
+          "samuraidou"
+        ]
+      },
+      {
+        "en": "Onimusha",
+        "ja": "鬼武者",
+        "ja_typings": [
+          "onimusha"
+        ]
+      },
+      {
+        "en": "Nioh",
+        "ja": "仁王",
+        "ja_typings": [
+          "nioh"
+        ]
+      },
+      {
+        "en": "Judgment",
+        "ja": "ジャッジアイズ",
+        "ja_typings": [
+          "jajjiaizu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01886",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Acquire-developed series lets you live as a wandering samurai?",
+      "ja": "アクワイア開発、流浪の侍として生きるシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Asteroids",
+        "ja": "アステロイド",
+        "ja_typings": [
+          "asuteroido"
+        ]
+      },
+      {
+        "en": "Contra",
+        "ja": "魂斗羅",
+        "ja_typings": [
+          "kontora"
+        ]
+      },
+      {
+        "en": "TwinBee",
+        "ja": "ツインビー",
+        "ja_typings": [
+          "tsuinbi-"
+        ]
+      },
+      {
+        "en": "Power Drift",
+        "ja": "パワードリフト",
+        "ja_typings": [
+          "pawa-dorifuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01887",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1979 Atari arcade game lets you shoot rocks drifting in space?",
+      "ja": "1979年アタリ製、宇宙の岩を撃つアーケードゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shenmue",
+        "ja": "シェンムー",
+        "ja_typings": [
+          "shenmu-"
+        ]
+      },
+      {
+        "en": "Virtua Fighter",
+        "ja": "バーチャファイター",
+        "ja_typings": [
+          "ba-chafaita-"
+        ]
+      },
+      {
+        "en": "Power Drift",
+        "ja": "パワードリフト",
+        "ja_typings": [
+          "pawa-dorifuto"
+        ]
+      },
+      {
+        "en": "Way of the Samurai",
+        "ja": "侍道",
+        "ja_typings": [
+          "samuraidou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01888",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Sega Yu Suzuki series stars Ryo Hazuki searching for his father's killer?",
+      "ja": "鈴木裕監修、芭月涼が父の仇を追うセガの大作シリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Real-time strategy",
+        "ja": "リアルタイムストラテジー",
+        "ja_typings": [
+          "riarutaimusutorateji-"
+        ]
+      },
+      {
+        "en": "Roblox",
+        "ja": "ロブロックス",
+        "ja_typings": [
+          "roburokkusu"
+        ]
+      },
+      {
+        "en": "Paladins",
+        "ja": "パラディンズ",
+        "ja_typings": [
+          "paradinzu"
+        ]
+      },
+      {
+        "en": "Asteroids",
+        "ja": "アステロイド",
+        "ja_typings": [
+          "asuteroido"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01889",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game genre is exemplified by StarCraft and Age of Empires?",
+      "ja": "『スタークラフト』『エイジ・オブ・エンパイア』に代表されるジャンルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Power Drift",
+        "ja": "パワードリフト",
+        "ja_typings": [
+          "pawa-dorifuto"
+        ]
+      },
+      {
+        "en": "Virtua Fighter",
+        "ja": "バーチャファイター",
+        "ja_typings": [
+          "ba-chafaita-"
+        ]
+      },
+      {
+        "en": "Shenmue",
+        "ja": "シェンムー",
+        "ja_typings": [
+          "shenmu-"
+        ]
+      },
+      {
+        "en": "TwinBee",
+        "ja": "ツインビー",
+        "ja_typings": [
+          "tsuinbi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01890",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1988 Sega arcade racing game features tilting cockpit cabinets?",
+      "ja": "1988年セガのアーケードレース、可動筐体が特徴の作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Contra",
+        "ja": "魂斗羅",
+        "ja_typings": [
+          "kontora"
+        ]
+      },
+      {
+        "en": "TwinBee",
+        "ja": "ツインビー",
+        "ja_typings": [
+          "tsuinbi-"
+        ]
+      },
+      {
+        "en": "Asteroids",
+        "ja": "アステロイド",
+        "ja_typings": [
+          "asuteroido"
+        ]
+      },
+      {
+        "en": "Power Drift",
+        "ja": "パワードリフト",
+        "ja_typings": [
+          "pawa-dorifuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01891",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Konami run-and-gun series began in 1987 with two commandos?",
+      "ja": "1987年に始まったコナミの2人コマンドのラン&ガンシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "TwinBee",
+        "ja": "ツインビー",
+        "ja_typings": [
+          "tsuinbi-"
+        ]
+      },
+      {
+        "en": "Contra",
+        "ja": "魂斗羅",
+        "ja_typings": [
+          "kontora"
+        ]
+      },
+      {
+        "en": "Asteroids",
+        "ja": "アステロイド",
+        "ja_typings": [
+          "asuteroido"
+        ]
+      },
+      {
+        "en": "Power Drift",
+        "ja": "パワードリフト",
+        "ja_typings": [
+          "pawa-dorifuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01892",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Konami cute-em-up features a bell-shooting flying ship?",
+      "ja": "コナミ製、鈴を撃つ可愛い縦シューティングは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Soul Blazer",
+        "ja": "ソウルブレイダー",
+        "ja_typings": [
+          "sorubureida-",
+          "sourubureida-"
+        ]
+      },
+      {
+        "en": "Parasite Eve",
+        "ja": "パラサイト・イヴ",
+        "ja_typings": [
+          "parasaito/ivu"
+        ]
+      },
+      {
+        "en": "Chrono Trigger",
+        "ja": "クロノ・トリガー",
+        "ja_typings": [
+          "kurono/toriga-"
+        ]
+      },
+      {
+        "en": "Xenoblade",
+        "ja": "ゼノブレイド",
+        "ja_typings": [
+          "zenobureido"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01893",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Enix Super Famicom action RPG by Quintet has you reviving the world?",
+      "ja": "クインテット製スーファミの、世界を蘇らせるエニックスのアクションRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Last Blade",
+        "ja": "ラストブレイド",
+        "ja_typings": [
+          "rasutobureido"
+        ]
+      },
+      {
+        "en": "Virtua Fighter",
+        "ja": "バーチャファイター",
+        "ja_typings": [
+          "ba-chafaita-"
+        ]
+      },
+      {
+        "en": "Devil May Cry",
+        "ja": "デビルメイクライ",
+        "ja_typings": [
+          "debirumeikurai"
+        ]
+      },
+      {
+        "en": "Bayonetta",
+        "ja": "ベヨネッタ",
+        "ja_typings": [
+          "beyonetta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01894",
+    "image_path": null,
+    "question_text": {
+      "en": "Which SNK weapon-based fighting game series spun off from Samurai Shodown?",
+      "ja": "『サムライスピリッツ』から派生した武器対戦格闘ゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PC Engine GT",
+        "ja": "PCエンジンGT",
+        "ja_typings": [
+          "pcenjingt"
+        ]
+      },
+      {
+        "en": "Game Gear",
+        "ja": "ゲームギア",
+        "ja_typings": [
+          "ge-mugia"
+        ]
+      },
+      {
+        "en": "Mega Drive",
+        "ja": "メガドライブ",
+        "ja_typings": [
+          "megadoraibu"
+        ]
+      },
+      {
+        "en": "Sega Saturn",
+        "ja": "セガサターン",
+        "ja_typings": [
+          "segasata-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01895",
+    "image_path": null,
+    "question_text": {
+      "en": "Which NEC handheld is a portable PC Engine with a color LCD?",
+      "ja": "PCエンジン互換のNEC製カラー液晶携帯機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Metroid",
+        "ja": "メトロイド",
+        "ja_typings": [
+          "metoroido"
+        ]
+      },
+      {
+        "en": "Kirby",
+        "ja": "カービィ",
+        "ja_typings": [
+          "ka-bii"
+        ]
+      },
+      {
+        "en": "Fire Emblem",
+        "ja": "ファイアーエムブレム",
+        "ja_typings": [
+          "faia-emuburemu"
+        ]
+      },
+      {
+        "en": "Digimon",
+        "ja": "デジモン",
+        "ja_typings": [
+          "dejimon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01896",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nintendo series stars bounty hunter Samus Aran?",
+      "ja": "サムス・アランが活躍する任天堂のシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kirby",
+        "ja": "カービィ",
+        "ja_typings": [
+          "ka-bii"
+        ]
+      },
+      {
+        "en": "Metroid",
+        "ja": "メトロイド",
+        "ja_typings": [
+          "metoroido"
+        ]
+      },
+      {
+        "en": "Fire Emblem",
+        "ja": "ファイアーエムブレム",
+        "ja_typings": [
+          "faia-emuburemu"
+        ]
+      },
+      {
+        "en": "Yo-kai Watch",
+        "ja": "妖怪ウォッチ",
+        "ja_typings": [
+          "youkaiuocchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01897",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HAL Laboratory Nintendo series stars a pink puffball hero?",
+      "ja": "HAL研究所製、ピンクの丸い主人公が活躍する任天堂のシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fire Emblem",
+        "ja": "ファイアーエムブレム",
+        "ja_typings": [
+          "faia-emuburemu"
+        ]
+      },
+      {
+        "en": "Metroid",
+        "ja": "メトロイド",
+        "ja_typings": [
+          "metoroido"
+        ]
+      },
+      {
+        "en": "Kirby",
+        "ja": "カービィ",
+        "ja_typings": [
+          "ka-bii"
+        ]
+      },
+      {
+        "en": "Yo-kai Watch",
+        "ja": "妖怪ウォッチ",
+        "ja_typings": [
+          "youkaiuocchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01898",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Intelligent Systems tactical RPG series began on the Famicom?",
+      "ja": "ファミコンで始まったインテリジェントシステムズのSRPGシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Digimon",
+        "ja": "デジモン",
+        "ja_typings": [
+          "dejimon"
+        ]
+      },
+      {
+        "en": "Yo-kai Watch",
+        "ja": "妖怪ウォッチ",
+        "ja_typings": [
+          "youkaiuocchi"
+        ]
+      },
+      {
+        "en": "Fire Emblem",
+        "ja": "ファイアーエムブレム",
+        "ja_typings": [
+          "faia-emuburemu"
+        ]
+      },
+      {
+        "en": "Kirby",
+        "ja": "カービィ",
+        "ja_typings": [
+          "ka-bii"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01899",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Bandai franchise features creatures hatched from Digivices?",
+      "ja": "デジヴァイスから生まれる生物のバンダイ製シリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yo-kai Watch",
+        "ja": "妖怪ウォッチ",
+        "ja_typings": [
+          "youkaiuocchi"
+        ]
+      },
+      {
+        "en": "Digimon",
+        "ja": "デジモン",
+        "ja_typings": [
+          "dejimon"
+        ]
+      },
+      {
+        "en": "Fire Emblem",
+        "ja": "ファイアーエムブレム",
+        "ja_typings": [
+          "faia-emuburemu"
+        ]
+      },
+      {
+        "en": "Dragon Quest Builders",
+        "ja": "ドラゴンクエストビルダーズ",
+        "ja_typings": [
+          "doragonkuesutobiruda-zu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01900",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Level-5 RPG series features Keita Amano befriending youkai with a watch?",
+      "ja": "レベルファイブ製、ケータくんが時計で妖怪と友達になるシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Final Fantasy X",
+        "ja": "ファイナルファンタジーX",
+        "ja_typings": [
+          "fainarufantaji-x"
+        ]
+      },
+      {
+        "en": "Chrono Trigger",
+        "ja": "クロノ・トリガー",
+        "ja_typings": [
+          "kurono/toriga-"
+        ]
+      },
+      {
+        "en": "Xenoblade",
+        "ja": "ゼノブレイド",
+        "ja_typings": [
+          "zenobureido"
+        ]
+      },
+      {
+        "en": "SaGa Frontier",
+        "ja": "サガ・フロンティア",
+        "ja_typings": [
+          "saga/furontia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01901",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2001 PS2 JRPG features Tidus and the world of Spira?",
+      "ja": "2001年のPS2 JRPGで、ティーダとスピラの世界を描く作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Seiken Densetsu",
+        "ja": "聖剣伝説",
+        "ja_typings": [
+          "seikendensetsu"
+        ]
+      },
+      {
+        "en": "Chrono Trigger",
+        "ja": "クロノ・トリガー",
+        "ja_typings": [
+          "kurono/toriga-"
+        ]
+      },
+      {
+        "en": "SaGa Frontier",
+        "ja": "サガ・フロンティア",
+        "ja_typings": [
+          "saga/furontia"
+        ]
+      },
+      {
+        "en": "Final Fantasy X",
+        "ja": "ファイナルファンタジーX",
+        "ja_typings": [
+          "fainarufantaji-x"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01902",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Square action RPG series began in 1991 as a Final Fantasy spin-off?",
+      "ja": "1991年にFFスピンオフとして始まったスクウェアのアクションRPGシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tales of Series",
+        "ja": "テイルズ オブ シリーズ",
+        "ja_typings": [
+          "teiruzu obu shiri-zu"
+        ]
+      },
+      {
+        "en": "Seiken Densetsu",
+        "ja": "聖剣伝説",
+        "ja_typings": [
+          "seikendensetsu"
+        ]
+      },
+      {
+        "en": "SaGa Frontier",
+        "ja": "サガ・フロンティア",
+        "ja_typings": [
+          "saga/furontia"
+        ]
+      },
+      {
+        "en": "Final Fantasy X",
+        "ja": "ファイナルファンタジーX",
+        "ja_typings": [
+          "fainarufantaji-x"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01903",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Bandai Namco JRPG franchise includes Symphonia and Vesperia?",
+      "ja": "『シンフォニア』『ヴェスペリア』を含むバンダイナムコのJRPGシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SaGa Frontier",
+        "ja": "サガ・フロンティア",
+        "ja_typings": [
+          "saga/furontia"
+        ]
+      },
+      {
+        "en": "Chrono Trigger",
+        "ja": "クロノ・トリガー",
+        "ja_typings": [
+          "kurono/toriga-"
+        ]
+      },
+      {
+        "en": "Seiken Densetsu",
+        "ja": "聖剣伝説",
+        "ja_typings": [
+          "seikendensetsu"
+        ]
+      },
+      {
+        "en": "Final Fantasy X",
+        "ja": "ファイナルファンタジーX",
+        "ja_typings": [
+          "fainarufantaji-x"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01904",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1997 PS1 Square RPG features seven scenarios across Regions?",
+      "ja": "1997年PS1スクウェア製、7つのシナリオを行き来するRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Roblox",
+        "ja": "ロブロックス",
+        "ja_typings": [
+          "roburokkusu"
+        ]
+      },
+      {
+        "en": "PUBG",
+        "ja": "ピーユービージー",
+        "ja_typings": [
+          "pi-yu-bi-ji-"
+        ]
+      },
+      {
+        "en": "Warzone",
+        "ja": "ウォーゾーン",
+        "ja_typings": [
+          "wo-zo-n"
+        ]
+      },
+      {
+        "en": "Paladins",
+        "ja": "パラディンズ",
+        "ja_typings": [
+          "paradinzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01905",
+    "image_path": null,
+    "question_text": {
+      "en": "Which user-generated online platform lets kids create and play 3D worlds?",
+      "ja": "ユーザー作成の3D世界を遊ぶオンラインプラットフォームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dragon Quest Builders",
+        "ja": "ドラゴンクエストビルダーズ",
+        "ja_typings": [
+          "doragonkuesutobiruda-zu"
+        ]
+      },
+      {
+        "en": "Yo-kai Watch",
+        "ja": "妖怪ウォッチ",
+        "ja_typings": [
+          "youkaiuocchi"
+        ]
+      },
+      {
+        "en": "Digimon",
+        "ja": "デジモン",
+        "ja_typings": [
+          "dejimon"
+        ]
+      },
+      {
+        "en": "Saints Row",
+        "ja": "セインツロウ",
+        "ja_typings": [
+          "seintsuro",
+          "seintsurou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01906",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Square Enix Minecraft-like spin-off stars a hero who builds with blocks?",
+      "ja": "スクエニ製、ブロックを積んで世界を作るマイクラ風スピンオフは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Saints Row",
+        "ja": "セインツロウ",
+        "ja_typings": [
+          "seintsuro",
+          "seintsurou"
+        ]
+      },
+      {
+        "en": "Watch Dogs",
+        "ja": "ウォッチドッグス",
+        "ja_typings": [
+          "wotchidoggusu"
+        ]
+      },
+      {
+        "en": "Mafia",
+        "ja": "マフィア",
+        "ja_typings": [
+          "mafia"
+        ]
+      },
+      {
+        "en": "Dragon Quest Builders",
+        "ja": "ドラゴンクエストビルダーズ",
+        "ja_typings": [
+          "doragonkuesutobiruda-zu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01907",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Volition open-world series follows the 3rd Street Saints gang?",
+      "ja": "Volition 製、3rdストリートセインツのギャングを描くオープンワールドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Watch Dogs",
+        "ja": "ウォッチドッグス",
+        "ja_typings": [
+          "wotchidoggusu"
+        ]
+      },
+      {
+        "en": "Saints Row",
+        "ja": "セインツロウ",
+        "ja_typings": [
+          "seintsuro",
+          "seintsurou"
+        ]
+      },
+      {
+        "en": "Mafia",
+        "ja": "マフィア",
+        "ja_typings": [
+          "mafia"
+        ]
+      },
+      {
+        "en": "Roblox",
+        "ja": "ロブロックス",
+        "ja_typings": [
+          "roburokkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01908",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Ubisoft open-world hacker series began in 2014?",
+      "ja": "2014年に始まったユービーアイのハッカー系オープンワールドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mafia",
+        "ja": "マフィア",
+        "ja_typings": [
+          "mafia"
+        ]
+      },
+      {
+        "en": "Watch Dogs",
+        "ja": "ウォッチドッグス",
+        "ja_typings": [
+          "wotchidoggusu"
+        ]
+      },
+      {
+        "en": "Saints Row",
+        "ja": "セインツロウ",
+        "ja_typings": [
+          "seintsuro",
+          "seintsurou"
+        ]
+      },
+      {
+        "en": "Warzone",
+        "ja": "ウォーゾーン",
+        "ja_typings": [
+          "wo-zo-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01909",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2K open-world series began with Tommy Angelo in 1930s Lost Heaven?",
+      "ja": "1930年代ロスト・ヘブンのトミー・アンジェロが主人公の2Kオープンワールドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PUBG",
+        "ja": "ピーユービージー",
+        "ja_typings": [
+          "pi-yu-bi-ji-"
+        ]
+      },
+      {
+        "en": "Warzone",
+        "ja": "ウォーゾーン",
+        "ja_typings": [
+          "wo-zo-n"
+        ]
+      },
+      {
+        "en": "Roblox",
+        "ja": "ロブロックス",
+        "ja_typings": [
+          "roburokkusu"
+        ]
+      },
+      {
+        "en": "Paladins",
+        "ja": "パラディンズ",
+        "ja_typings": [
+          "paradinzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01910",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2017 Krafton battle royale popularized the genre on PC?",
+      "ja": "2017年クラフトン製でバトロワを大流行させたPCゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Warzone",
+        "ja": "ウォーゾーン",
+        "ja_typings": [
+          "wo-zo-n"
+        ]
+      },
+      {
+        "en": "PUBG",
+        "ja": "ピーユービージー",
+        "ja_typings": [
+          "pi-yu-bi-ji-"
+        ]
+      },
+      {
+        "en": "Paladins",
+        "ja": "パラディンズ",
+        "ja_typings": [
+          "paradinzu"
+        ]
+      },
+      {
+        "en": "Roblox",
+        "ja": "ロブロックス",
+        "ja_typings": [
+          "roburokkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01911",
+    "image_path": null,
+    "question_text": {
+      "en": "Which free-to-play battle royale is part of the Call of Duty franchise?",
+      "ja": "CoD シリーズの基本無料バトロワは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Super Famicom",
+        "ja": "スーパーファミコン",
+        "ja_typings": [
+          "su-pa-famikon"
+        ]
+      },
+      {
+        "en": "Game Boy",
+        "ja": "ゲームボーイ",
+        "ja_typings": [
+          "ge-mubo-i"
+        ]
+      },
+      {
+        "en": "Nintendo 64",
+        "ja": "ニンテンドー64",
+        "ja_typings": [
+          "nintendo-64"
+        ]
+      },
+      {
+        "en": "Switch",
+        "ja": "スイッチ",
+        "ja_typings": [
+          "suitchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01912",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1990 Nintendo 16-bit console succeeded the Famicom in Japan?",
+      "ja": "ファミコンの後継として1990年に発売された任天堂の16ビット機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Game Boy",
+        "ja": "ゲームボーイ",
+        "ja_typings": [
+          "ge-mubo-i"
+        ]
+      },
+      {
+        "en": "Super Famicom",
+        "ja": "スーパーファミコン",
+        "ja_typings": [
+          "su-pa-famikon"
+        ]
+      },
+      {
+        "en": "Nintendo 64",
+        "ja": "ニンテンドー64",
+        "ja_typings": [
+          "nintendo-64"
+        ]
+      },
+      {
+        "en": "Switch",
+        "ja": "スイッチ",
+        "ja_typings": [
+          "suitchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01913",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1989 Nintendo handheld popularized portable gaming with Tetris?",
+      "ja": "1989年テトリスで携帯ゲームを普及させた任天堂の携帯機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nintendo 64",
+        "ja": "ニンテンドー64",
+        "ja_typings": [
+          "nintendo-64"
+        ]
+      },
+      {
+        "en": "Super Famicom",
+        "ja": "スーパーファミコン",
+        "ja_typings": [
+          "su-pa-famikon"
+        ]
+      },
+      {
+        "en": "Game Boy",
+        "ja": "ゲームボーイ",
+        "ja_typings": [
+          "ge-mubo-i"
+        ]
+      },
+      {
+        "en": "Sega Saturn",
+        "ja": "セガサターン",
+        "ja_typings": [
+          "segasata-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01914",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1996 Nintendo 64-bit console launched with Super Mario 64?",
+      "ja": "1996年スーパーマリオ64と共に発売された任天堂の64ビット機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sega Saturn",
+        "ja": "セガサターン",
+        "ja_typings": [
+          "segasata-n"
+        ]
+      },
+      {
+        "en": "Mega Drive",
+        "ja": "メガドライブ",
+        "ja_typings": [
+          "megadoraibu"
+        ]
+      },
+      {
+        "en": "PC Engine GT",
+        "ja": "PCエンジンGT",
+        "ja_typings": [
+          "pcenjingt"
+        ]
+      },
+      {
+        "en": "Nintendo 64",
+        "ja": "ニンテンドー64",
+        "ja_typings": [
+          "nintendo-64"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01915",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1994 Sega 32-bit console competed with the PlayStation in Japan?",
+      "ja": "1994年プレイステーションと競った32ビットのセガ家庭用機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Switch",
+        "ja": "スイッチ",
+        "ja_typings": [
+          "suitchi"
+        ]
+      },
+      {
+        "en": "Nintendo 64",
+        "ja": "ニンテンドー64",
+        "ja_typings": [
+          "nintendo-64"
+        ]
+      },
+      {
+        "en": "Game Boy",
+        "ja": "ゲームボーイ",
+        "ja_typings": [
+          "ge-mubo-i"
+        ]
+      },
+      {
+        "en": "Super Famicom",
+        "ja": "スーパーファミコン",
+        "ja_typings": [
+          "su-pa-famikon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01916",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2017 Nintendo hybrid console plays both docked and handheld?",
+      "ja": "2017年発売、据置と携帯を両立する任天堂のハイブリッド機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Inheritance",
+        "ja": "継承",
+        "ja_typings": [
+          "keishou"
+        ]
+      },
+      {
+        "en": "Encapsulation",
+        "ja": "カプセル化",
+        "ja_typings": [
+          "kapuseruka"
+        ]
+      },
+      {
+        "en": "Polymorphism",
+        "ja": "ポリモーフィズム",
+        "ja_typings": [
+          "porimo-fizumu"
+        ]
+      },
+      {
+        "en": "Abstraction",
+        "ja": "抽象化",
+        "ja_typings": [
+          "chuushouka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01917",
+    "image_path": null,
+    "question_text": {
+      "en": "Which OOP concept allows a class to acquire properties from another class?",
+      "ja": "あるクラスが別のクラスのプロパティを受け継ぐオブジェクト指向の概念は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "XML",
+        "ja": "エックスエムエル",
+        "ja_typings": [
+          "ekkusuemueru"
+        ]
+      },
+      {
+        "en": "YAML",
+        "ja": "ヤムル",
+        "ja_typings": [
+          "yamuru"
+        ]
+      },
+      {
+        "en": "TOML",
+        "ja": "トムル",
+        "ja_typings": [
+          "tomuru"
+        ]
+      },
+      {
+        "en": "INI",
+        "ja": "アイエヌアイ",
+        "ja_typings": [
+          "aienuai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01918",
+    "image_path": null,
+    "question_text": {
+      "en": "Which markup language uses customizable tags to describe structured data?",
+      "ja": "ユーザー定義タグで構造化データを記述するマークアップ言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "B-tree",
+        "ja": "ビーツリー",
+        "ja_typings": [
+          "bi-tsuri-"
+        ]
+      },
+      {
+        "en": "Trie",
+        "ja": "トライ木",
+        "ja_typings": [
+          "toraiki",
+          "toraigi"
+        ]
+      },
+      {
+        "en": "Heap",
+        "ja": "ヒープ",
+        "ja_typings": [
+          "hi-pu"
+        ]
+      },
+      {
+        "en": "Splay tree",
+        "ja": "スプレー木",
+        "ja_typings": [
+          "supureeki",
+          "supureegi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01919",
+    "image_path": null,
+    "question_text": {
+      "en": "Which self-balancing tree is widely used in databases and filesystems?",
+      "ja": "データベースやファイルシステムで広く使われる自己平衡木は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cell",
+        "ja": "セル",
+        "ja_typings": [
+          "seru"
+        ]
+      },
+      {
+        "en": "Sheet",
+        "ja": "シート",
+        "ja_typings": [
+          "shi-to"
+        ]
+      },
+      {
+        "en": "Range",
+        "ja": "レンジ",
+        "ja_typings": [
+          "renji"
+        ]
+      },
+      {
+        "en": "Pivot",
+        "ja": "ピボット",
+        "ja_typings": [
+          "pibotto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01920",
+    "image_path": null,
+    "question_text": {
+      "en": "Which spreadsheet term refers to a single unit at the intersection of a row and column?",
+      "ja": "表計算で行と列の交点にある一つの枠を指す用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Scala",
+        "ja": "スカラ",
+        "ja_typings": [
+          "sukara"
+        ]
+      },
+      {
+        "en": "Clojure",
+        "ja": "クロージャ言語",
+        "ja_typings": [
+          "kuroojagengo"
+        ]
+      },
+      {
+        "en": "Kotlin",
+        "ja": "コトリン",
+        "ja_typings": [
+          "kotorin"
+        ]
+      },
+      {
+        "en": "Ceylon",
+        "ja": "セイロン",
+        "ja_typings": [
+          "seiron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01921",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JVM language has functional features and is used at Twitter?",
+      "ja": "JVM 上で動く関数型機能を持つ言語で Twitter でも使われていたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`sub`",
+        "ja": "`sub`",
+        "ja_typings": [
+          "`sub`"
+        ]
+      },
+      {
+        "en": "`def`",
+        "ja": "`def`",
+        "ja_typings": [
+          "`def`"
+        ]
+      },
+      {
+        "en": "`fn`",
+        "ja": "`fn`",
+        "ja_typings": [
+          "`fn`"
+        ]
+      },
+      {
+        "en": "`func`",
+        "ja": "`func`",
+        "ja_typings": [
+          "`func`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01922",
+    "image_path": null,
+    "question_text": {
+      "en": "In Perl, which keyword defines a subroutine?",
+      "ja": "Perl でサブルーチンを定義するキーワードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ken Thompson",
+        "ja": "ケン・トンプソン",
+        "ja_typings": [
+          "ken/tonpuson"
+        ]
+      },
+      {
+        "en": "Brian Kernighan",
+        "ja": "ブライアン・カーニハン",
+        "ja_typings": [
+          "buraian/ka-nihan"
+        ]
+      },
+      {
+        "en": "Bjarne Stroustrup",
+        "ja": "ビャーネ・ストロヴストルップ",
+        "ja_typings": [
+          "bya-ne/sutorovusutoruppu"
+        ]
+      },
+      {
+        "en": "Guido van Rossum",
+        "ja": "グイド・ヴァン・ロッサム",
+        "ja_typings": [
+          "guido/van/rossamu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01923",
+    "image_path": null,
+    "question_text": {
+      "en": "Who co-created Unix and the B programming language at Bell Labs?",
+      "ja": "ベル研で Unix と B 言語を共同開発した人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Apple",
+        "ja": "アップル",
+        "ja_typings": [
+          "appuru"
+        ]
+      },
+      {
+        "en": "Microsoft",
+        "ja": "マイクロソフト",
+        "ja_typings": [
+          "maikurosofuto"
+        ]
+      },
+      {
+        "en": "Mozilla",
+        "ja": "モジラ",
+        "ja_typings": [
+          "mojira"
+        ]
+      },
+      {
+        "en": "JetBrains",
+        "ja": "ジェットブレインズ",
+        "ja_typings": [
+          "jettobureinzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01924",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company created the Swift programming language?",
+      "ja": "プログラミング言語 Swift を開発した企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Delegation",
+        "ja": "委譲",
+        "ja_typings": [
+          "ijou"
+        ]
+      },
+      {
+        "en": "Inheritance",
+        "ja": "継承",
+        "ja_typings": [
+          "keishou"
+        ]
+      },
+      {
+        "en": "Composition",
+        "ja": "コンポジション",
+        "ja_typings": [
+          "konpojishon"
+        ]
+      },
+      {
+        "en": "Aggregation",
+        "ja": "集約",
+        "ja_typings": [
+          "shuuyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01925",
+    "image_path": null,
+    "question_text": {
+      "en": "Which design principle forwards a request from one object to another helper object?",
+      "ja": "あるオブジェクトが処理を別のヘルパーオブジェクトに転送する設計原則は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "npm",
+        "ja": "エヌピーエム",
+        "ja_typings": [
+          "enupi-emu"
+        ]
+      },
+      {
+        "en": "yarn",
+        "ja": "ヤーン",
+        "ja_typings": [
+          "ya-n"
+        ]
+      },
+      {
+        "en": "pnpm",
+        "ja": "ピーエヌピーエム",
+        "ja_typings": [
+          "pi-enupi-emu"
+        ]
+      },
+      {
+        "en": "bun",
+        "ja": "バン",
+        "ja_typings": [
+          "ban"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01926",
+    "image_path": null,
+    "question_text": {
+      "en": "Which package manager is bundled with Node.js by default?",
+      "ja": "Node.js に既定で同梱されるパッケージマネージャは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gradle",
+        "ja": "グレードル",
+        "ja_typings": [
+          "gure-doru"
+        ]
+      },
+      {
+        "en": "Maven",
+        "ja": "メイヴン",
+        "ja_typings": [
+          "meivun"
+        ]
+      },
+      {
+        "en": "Ant",
+        "ja": "アント",
+        "ja_typings": [
+          "anto"
+        ]
+      },
+      {
+        "en": "Bazel",
+        "ja": "バゼル",
+        "ja_typings": [
+          "bazeru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01927",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Groovy-based build automation tool is standard for Android?",
+      "ja": "Android 開発で標準的に使われる Groovy ベースのビルドツールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Make",
+        "ja": "メイク",
+        "ja_typings": [
+          "meiku"
+        ]
+      },
+      {
+        "en": "CMake",
+        "ja": "シーメイク",
+        "ja_typings": [
+          "shi-meiku"
+        ]
+      },
+      {
+        "en": "Ninja",
+        "ja": "ニンジャ",
+        "ja_typings": [
+          "ninja"
+        ]
+      },
+      {
+        "en": "SCons",
+        "ja": "エスコンズ",
+        "ja_typings": [
+          "esukonzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01928",
+    "image_path": null,
+    "question_text": {
+      "en": "Which classic Unix build tool reads a Makefile?",
+      "ja": "Makefile を読み込む古典的な Unix のビルドツールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Groovy",
+        "ja": "グルービー",
+        "ja_typings": [
+          "guru-bi-"
+        ]
+      },
+      {
+        "en": "Scala",
+        "ja": "スカラ",
+        "ja_typings": [
+          "sukara"
+        ]
+      },
+      {
+        "en": "Kotlin",
+        "ja": "コトリン",
+        "ja_typings": [
+          "kotorin"
+        ]
+      },
+      {
+        "en": "Jython",
+        "ja": "ジャイソン",
+        "ja_typings": [
+          "jaison"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01929",
+    "image_path": null,
+    "question_text": {
+      "en": "Which dynamic JVM language is often used with Gradle scripts?",
+      "ja": "Gradle スクリプトで使われる動的な JVM 言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Semaphore",
+        "ja": "セマフォ",
+        "ja_typings": [
+          "semafo"
+        ]
+      },
+      {
+        "en": "Mutex",
+        "ja": "ミューテックス",
+        "ja_typings": [
+          "myu-tekkusu"
+        ]
+      },
+      {
+        "en": "Monitor",
+        "ja": "モニター",
+        "ja_typings": [
+          "monita-"
+        ]
+      },
+      {
+        "en": "Barrier",
+        "ja": "バリア",
+        "ja_typings": [
+          "baria"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01930",
+    "image_path": null,
+    "question_text": {
+      "en": "Which classic synchronization primitive uses a counter to control resource access?",
+      "ja": "カウンタで資源アクセスを制御する古典的な同期プリミティブは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`function`",
+        "ja": "`function`",
+        "ja_typings": [
+          "`function`"
+        ]
+      },
+      {
+        "en": "`def`",
+        "ja": "`def`",
+        "ja_typings": [
+          "`def`"
+        ]
+      },
+      {
+        "en": "`func`",
+        "ja": "`func`",
+        "ja_typings": [
+          "`func`"
+        ]
+      },
+      {
+        "en": "`lambda`",
+        "ja": "`lambda`",
+        "ja_typings": [
+          "`lambda`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01931",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript keyword declares a regular function?",
+      "ja": "JavaScript で通常の関数を宣言するキーワードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "IBM",
+        "ja": "アイビーエム",
+        "ja_typings": [
+          "aibi-emu"
+        ]
+      },
+      {
+        "en": "Compaq",
+        "ja": "コンパック",
+        "ja_typings": [
+          "konpakku"
+        ]
+      },
+      {
+        "en": "Dell",
+        "ja": "デル",
+        "ja_typings": [
+          "deru"
+        ]
+      },
+      {
+        "en": "HP",
+        "ja": "ヒューレットパッカード",
+        "ja_typings": [
+          "hyu-rettopakka-do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01932",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed the original PC compatible architecture and OS/2?",
+      "ja": "PC 互換機と OS/2 を生み出した企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Google",
+        "ja": "グーグル",
+        "ja_typings": [
+          "gu-guru"
+        ]
+      },
+      {
+        "en": "Mozilla",
+        "ja": "モジラ",
+        "ja_typings": [
+          "mojira"
+        ]
+      },
+      {
+        "en": "Oracle",
+        "ja": "オラクル",
+        "ja_typings": [
+          "orakuru"
+        ]
+      },
+      {
+        "en": "Meta",
+        "ja": "メタ社",
+        "ja_typings": [
+          "metasha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01933",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company created the Go programming language?",
+      "ja": "プログラミング言語 Go を生み出した企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Quicksort",
+        "ja": "クイックソート",
+        "ja_typings": [
+          "kuikkuso-to"
+        ]
+      },
+      {
+        "en": "Mergesort",
+        "ja": "マージソート",
+        "ja_typings": [
+          "ma-jiso-to"
+        ]
+      },
+      {
+        "en": "Bubble sort",
+        "ja": "バブルソート",
+        "ja_typings": [
+          "baburuso-to"
+        ]
+      },
+      {
+        "en": "Insertion sort",
+        "ja": "挿入ソート",
+        "ja_typings": [
+          "sounyuusooto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01934",
+    "image_path": null,
+    "question_text": {
+      "en": "Which divide-and-conquer sort uses a pivot to partition the array?",
+      "ja": "ピボットを使って配列を分割する分割統治法のソートは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Heapsort",
+        "ja": "ヒープソート",
+        "ja_typings": [
+          "hi-puso-to"
+        ]
+      },
+      {
+        "en": "Quicksort",
+        "ja": "クイックソート",
+        "ja_typings": [
+          "kuikkuso-to"
+        ]
+      },
+      {
+        "en": "Shellsort",
+        "ja": "シェルソート",
+        "ja_typings": [
+          "sheruso-to"
+        ]
+      },
+      {
+        "en": "Timsort",
+        "ja": "ティムソート",
+        "ja_typings": [
+          "timuso-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01935",
+    "image_path": null,
+    "question_text": {
+      "en": "Which comparison sort builds a binary heap to extract elements in order?",
+      "ja": "二分ヒープを構築して要素を順に取り出す比較ソートは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Iteration",
+        "ja": "反復",
+        "ja_typings": [
+          "hanpuku"
+        ]
+      },
+      {
+        "en": "Recursion",
+        "ja": "再帰",
+        "ja_typings": [
+          "saiki"
+        ]
+      },
+      {
+        "en": "Branching",
+        "ja": "分岐",
+        "ja_typings": [
+          "bunki"
+        ]
+      },
+      {
+        "en": "Continuation",
+        "ja": "継続",
+        "ja_typings": [
+          "keizoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01936",
+    "image_path": null,
+    "question_text": {
+      "en": "Which control-flow concept repeats a block of code using loops?",
+      "ja": "ループを用いてコードブロックを繰り返す制御フローの概念は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JSON",
+        "ja": "ジェイソン",
+        "ja_typings": [
+          "jeison"
+        ]
+      },
+      {
+        "en": "YAML",
+        "ja": "ヤムル",
+        "ja_typings": [
+          "yamuru"
+        ]
+      },
+      {
+        "en": "CSV",
+        "ja": "シーエスブイ",
+        "ja_typings": [
+          "shi-esubui"
+        ]
+      },
+      {
+        "en": "XML",
+        "ja": "エックスエムエル",
+        "ja_typings": [
+          "ekkusuemueru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01937",
+    "image_path": null,
+    "question_text": {
+      "en": "Which lightweight data interchange format is based on JavaScript object syntax?",
+      "ja": "JavaScript のオブジェクト構文に基づく軽量データ交換形式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rollup",
+        "ja": "ロールアップ",
+        "ja_typings": [
+          "ro-ruappu"
+        ]
+      },
+      {
+        "en": "Webpack",
+        "ja": "ウェブパック",
+        "ja_typings": [
+          "webupakku"
+        ]
+      },
+      {
+        "en": "Parcel",
+        "ja": "パーセル",
+        "ja_typings": [
+          "pa-seru"
+        ]
+      },
+      {
+        "en": "esbuild",
+        "ja": "イーエスビルド",
+        "ja_typings": [
+          "i-esubirudo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01938",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript bundler is known for ES module-first design?",
+      "ja": "ES モジュール優先の設計で知られる JavaScript バンドラは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Parcel",
+        "ja": "パーセル",
+        "ja_typings": [
+          "pa-seru"
+        ]
+      },
+      {
+        "en": "Rollup",
+        "ja": "ロールアップ",
+        "ja_typings": [
+          "ro-ruappu"
+        ]
+      },
+      {
+        "en": "Webpack",
+        "ja": "ウェブパック",
+        "ja_typings": [
+          "webupakku"
+        ]
+      },
+      {
+        "en": "Turbopack",
+        "ja": "ターボパック",
+        "ja_typings": [
+          "ta-bopakku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01939",
+    "image_path": null,
+    "question_text": {
+      "en": "Which zero-configuration JavaScript bundler is famous for being beginner-friendly?",
+      "ja": "ゼロ設定で初心者にも優しいことで知られる JavaScript バンドラは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "GET",
+        "ja": "ゲット",
+        "ja_typings": [
+          "getto"
+        ]
+      },
+      {
+        "en": "POST",
+        "ja": "ポスト",
+        "ja_typings": [
+          "posuto"
+        ]
+      },
+      {
+        "en": "PUT",
+        "ja": "プット",
+        "ja_typings": [
+          "putto"
+        ]
+      },
+      {
+        "en": "PATCH",
+        "ja": "パッチ",
+        "ja_typings": [
+          "patchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01940",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP method requests data without modifying the server state?",
+      "ja": "サーバの状態を変えずにデータを取得する HTTP メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Java",
+        "ja": "ジャバ",
+        "ja_typings": [
+          "jaba"
+        ]
+      },
+      {
+        "en": "Kotlin",
+        "ja": "コトリン",
+        "ja_typings": [
+          "kotorin"
+        ]
+      },
+      {
+        "en": "Scala",
+        "ja": "スカラ",
+        "ja_typings": [
+          "sukara"
+        ]
+      },
+      {
+        "en": "Groovy",
+        "ja": "グルービー",
+        "ja_typings": [
+          "guru-bi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01941",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language runs on the JVM and was originally developed by Sun?",
+      "ja": "サンが開発し JVM 上で動作する言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "inline",
+        "ja": "インライン",
+        "ja_typings": [
+          "inrain"
+        ]
+      },
+      {
+        "en": "static",
+        "ja": "スタティック",
+        "ja_typings": [
+          "sutatikku"
+        ]
+      },
+      {
+        "en": "extern",
+        "ja": "エクスターン",
+        "ja_typings": [
+          "ekusuta-n"
+        ]
+      },
+      {
+        "en": "register",
+        "ja": "レジスタ指定",
+        "ja_typings": [
+          "rejisutashitei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01942",
+    "image_path": null,
+    "question_text": {
+      "en": "In C++, which keyword hints the compiler to expand a function at call site?",
+      "ja": "C++ で関数を呼び出し位置に展開するようコンパイラに示唆するキーワードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Node.js",
+        "ja": "ノードジェイエス",
+        "ja_typings": [
+          "no-dojeiesu"
+        ]
+      },
+      {
+        "en": "Deno",
+        "ja": "デノ",
+        "ja_typings": [
+          "deno"
+        ]
+      },
+      {
+        "en": "Bun",
+        "ja": "バン",
+        "ja_typings": [
+          "ban"
+        ]
+      },
+      {
+        "en": "Rhino",
+        "ja": "ライノ",
+        "ja_typings": [
+          "raino"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01943",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript runtime built on V8 enables server-side scripting?",
+      "ja": "V8 上に作られたサーバサイド JavaScript ランタイムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nim",
+        "ja": "ニム",
+        "ja_typings": [
+          "nimu"
+        ]
+      },
+      {
+        "en": "Crystal",
+        "ja": "クリスタル言語",
+        "ja_typings": [
+          "kurisutarugengo"
+        ]
+      },
+      {
+        "en": "Zig",
+        "ja": "ジグ",
+        "ja_typings": [
+          "jigu"
+        ]
+      },
+      {
+        "en": "V",
+        "ja": "ブイ言語",
+        "ja_typings": [
+          "buigengo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01944",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Pascal-like statically typed language compiles to C, JS, and more?",
+      "ja": "Pascal 風の静的型付け言語で C や JS にコンパイル可能なのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Skip list",
+        "ja": "スキップリスト",
+        "ja_typings": [
+          "sukippurisuto"
+        ]
+      },
+      {
+        "en": "Bloom filter",
+        "ja": "ブルームフィルタ",
+        "ja_typings": [
+          "buru-mufiruta"
+        ]
+      },
+      {
+        "en": "Hash table",
+        "ja": "ハッシュテーブル",
+        "ja_typings": [
+          "hasshute-buru"
+        ]
+      },
+      {
+        "en": "AVL tree",
+        "ja": "AVL 木",
+        "ja_typings": [
+          "AVLki",
+          "AVLgi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01945",
+    "image_path": null,
+    "question_text": {
+      "en": "Which probabilistic data structure layers linked lists for fast search?",
+      "ja": "リンクリストを多層化して高速検索を実現する確率的データ構造は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bellman-Ford",
+        "ja": "ベルマン・フォード",
+        "ja_typings": [
+          "beruman/fo-do"
+        ]
+      },
+      {
+        "en": "Dijkstra",
+        "ja": "ダイクストラ",
+        "ja_typings": [
+          "daikusutora"
+        ]
+      },
+      {
+        "en": "Floyd-Warshall",
+        "ja": "フロイド・ワーシャル",
+        "ja_typings": [
+          "furoido/wa-sharu"
+        ]
+      },
+      {
+        "en": "A*",
+        "ja": "エースター",
+        "ja_typings": [
+          "e-suta-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01946",
+    "image_path": null,
+    "question_text": {
+      "en": "Which algorithm finds shortest paths and detects negative-weight cycles?",
+      "ja": "負の重みの閉路も検出できる最短経路アルゴリズムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Imperative",
+        "ja": "命令型",
+        "ja_typings": [
+          "meireigata"
+        ]
+      },
+      {
+        "en": "Declarative",
+        "ja": "宣言型",
+        "ja_typings": [
+          "sengengata"
+        ]
+      },
+      {
+        "en": "Functional",
+        "ja": "関数型",
+        "ja_typings": [
+          "kansuugata"
+        ]
+      },
+      {
+        "en": "Logic",
+        "ja": "論理型",
+        "ja_typings": [
+          "ronrigata"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01947",
+    "image_path": null,
+    "question_text": {
+      "en": "Which programming paradigm focuses on explicit statements that change state?",
+      "ja": "状態を変化させる明示的な命令文を中心とするプログラミングパラダイムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Procedural",
+        "ja": "手続き型",
+        "ja_typings": [
+          "tetsudukigata"
+        ]
+      },
+      {
+        "en": "Object-oriented",
+        "ja": "オブジェクト指向",
+        "ja_typings": [
+          "obujekutoshikou"
+        ]
+      },
+      {
+        "en": "Functional",
+        "ja": "関数型",
+        "ja_typings": [
+          "kansuugata"
+        ]
+      },
+      {
+        "en": "Event-driven",
+        "ja": "イベント駆動",
+        "ja_typings": [
+          "ibentokudou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01948",
+    "image_path": null,
+    "question_text": {
+      "en": "Which paradigm organizes code into reusable procedures or routines?",
+      "ja": "コードを再利用可能な手続きにまとめるパラダイムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Edsger Dijkstra",
+        "ja": "エドガー・ダイクストラ",
+        "ja_typings": [
+          "edoga-/daikusutora"
+        ]
+      },
+      {
+        "en": "Donald Knuth",
+        "ja": "ドナルド・クヌース",
+        "ja_typings": [
+          "donarudo/kunu-su"
+        ]
+      },
+      {
+        "en": "Alan Turing",
+        "ja": "アラン・チューリング",
+        "ja_typings": [
+          "aran/chu-ringu"
+        ]
+      },
+      {
+        "en": "John von Neumann",
+        "ja": "ジョン・フォン・ノイマン",
+        "ja_typings": [
+          "jon/fon/noiman"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01949",
+    "image_path": null,
+    "question_text": {
+      "en": "Who proposed the famous shortest path algorithm in 1956?",
+      "ja": "1956 年に有名な最短経路アルゴリズムを提案した人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "async",
+        "ja": "エイシンク",
+        "ja_typings": [
+          "eishinku"
+        ]
+      },
+      {
+        "en": "await",
+        "ja": "アウェイト",
+        "ja_typings": [
+          "aweito"
+        ]
+      },
+      {
+        "en": "yield",
+        "ja": "イールド",
+        "ja_typings": [
+          "i-rudo"
+        ]
+      },
+      {
+        "en": "defer",
+        "ja": "ディファー",
+        "ja_typings": [
+          "difa-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01950",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript keyword marks a function that returns a Promise?",
+      "ja": "Promise を返す関数を示す JavaScript のキーワードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "zip",
+        "ja": "ジップ関数",
+        "ja_typings": [
+          "jippukansuu"
+        ]
+      },
+      {
+        "en": "map",
+        "ja": "マップ関数",
+        "ja_typings": [
+          "mappukansuu"
+        ]
+      },
+      {
+        "en": "filter",
+        "ja": "フィルタ関数",
+        "ja_typings": [
+          "firutakansuu"
+        ]
+      },
+      {
+        "en": "enumerate",
+        "ja": "エニュメレート",
+        "ja_typings": [
+          "enyumere-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01951",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Python built-in pairs elements from multiple iterables?",
+      "ja": "複数のイテラブルから要素をペアにする Python 組み込み関数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "?:",
+        "ja": "三項演算子",
+        "ja_typings": [
+          "sankouenzanshi"
+        ]
+      },
+      {
+        "en": "&&",
+        "ja": "論理積演算子",
+        "ja_typings": [
+          "ronritekienzanshi"
+        ]
+      },
+      {
+        "en": "||",
+        "ja": "論理和演算子",
+        "ja_typings": [
+          "ronriwaenzanshi"
+        ]
+      },
+      {
+        "en": "==",
+        "ja": "等価演算子",
+        "ja_typings": [
+          "toukaenzanshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01952",
+    "image_path": null,
+    "question_text": {
+      "en": "Which C operator selects between two expressions based on a condition?",
+      "ja": "条件によって 2 つの式を選ぶ C 言語の演算子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "static",
+        "ja": "スタティック",
+        "ja_typings": [
+          "sutatikku"
+        ]
+      },
+      {
+        "en": "extern",
+        "ja": "エクスターン",
+        "ja_typings": [
+          "ekusuta-n"
+        ]
+      },
+      {
+        "en": "auto",
+        "ja": "オート",
+        "ja_typings": [
+          "o-to"
+        ]
+      },
+      {
+        "en": "volatile",
+        "ja": "ボラタイル",
+        "ja_typings": [
+          "boratairu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01953",
+    "image_path": null,
+    "question_text": {
+      "en": "In C, which storage class limits a variable's visibility to its file?",
+      "ja": "C 言語で変数の可視性をファイル内に限定する記憶クラスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Linked List",
+        "ja": "連結リスト",
+        "ja_typings": [
+          "renketsurisuto"
+        ]
+      },
+      {
+        "en": "Array",
+        "ja": "配列",
+        "ja_typings": [
+          "hairetsu"
+        ]
+      },
+      {
+        "en": "Stack",
+        "ja": "スタック",
+        "ja_typings": [
+          "sutakku"
+        ]
+      },
+      {
+        "en": "Queue",
+        "ja": "キュー",
+        "ja_typings": [
+          "kyu-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01954",
+    "image_path": null,
+    "question_text": {
+      "en": "Which linear data structure stores elements with pointers to the next node?",
+      "ja": "次ノードへのポインタで要素を繋ぐ線形データ構造は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Array",
+        "ja": "配列",
+        "ja_typings": [
+          "hairetsu"
+        ]
+      },
+      {
+        "en": "Linked List",
+        "ja": "連結リスト",
+        "ja_typings": [
+          "renketsurisuto"
+        ]
+      },
+      {
+        "en": "Tree",
+        "ja": "木構造",
+        "ja_typings": [
+          "kikouzou"
+        ]
+      },
+      {
+        "en": "Graph",
+        "ja": "グラフ",
+        "ja_typings": [
+          "gurafu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01955",
+    "image_path": null,
+    "question_text": {
+      "en": "Which contiguous-memory data structure offers O(1) index access?",
+      "ja": "添字アクセスが O(1) で可能な連続メモリのデータ構造は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hash",
+        "ja": "ハッシュ関数",
+        "ja_typings": [
+          "hasshukansuu"
+        ]
+      },
+      {
+        "en": "Sort",
+        "ja": "整列",
+        "ja_typings": [
+          "seiretsu"
+        ]
+      },
+      {
+        "en": "Compare",
+        "ja": "比較",
+        "ja_typings": [
+          "hikaku"
+        ]
+      },
+      {
+        "en": "Encode",
+        "ja": "符号化",
+        "ja_typings": [
+          "fugouka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01956",
+    "image_path": null,
+    "question_text": {
+      "en": "Which function maps keys to indices in a hash table?",
+      "ja": "ハッシュテーブルで鍵を添字に変換する関数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ternary Tree",
+        "ja": "三分木",
+        "ja_typings": [
+          "sanbunki",
+          "sanbungi"
+        ]
+      },
+      {
+        "en": "Binary Tree",
+        "ja": "二分木",
+        "ja_typings": [
+          "nibunki",
+          "nibungi"
+        ]
+      },
+      {
+        "en": "Quad Tree",
+        "ja": "四分木",
+        "ja_typings": [
+          "shibunki"
+        ]
+      },
+      {
+        "en": "Octree",
+        "ja": "オクツリー",
+        "ja_typings": [
+          "okutsuri-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01957",
+    "image_path": null,
+    "question_text": {
+      "en": "Which tree variant has at most three children per node?",
+      "ja": "各ノードが最大 3 つの子を持つ木は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Complete Graph",
+        "ja": "完全グラフ",
+        "ja_typings": [
+          "kanzenngurafu"
+        ]
+      },
+      {
+        "en": "Bipartite Graph",
+        "ja": "二部グラフ",
+        "ja_typings": [
+          "nibugurafu"
+        ]
+      },
+      {
+        "en": "Tree",
+        "ja": "木構造",
+        "ja_typings": [
+          "kikouzou"
+        ]
+      },
+      {
+        "en": "DAG",
+        "ja": "有向非巡回グラフ",
+        "ja_typings": [
+          "yuukouhijunkaigurafu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01958",
+    "image_path": null,
+    "question_text": {
+      "en": "Which graph has an edge between every pair of distinct vertices?",
+      "ja": "任意の 2 頂点間に辺がある無向グラフは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Abstraction",
+        "ja": "抽象化",
+        "ja_typings": [
+          "chuushouka"
+        ]
+      },
+      {
+        "en": "Encapsulation",
+        "ja": "カプセル化",
+        "ja_typings": [
+          "kapuseruka"
+        ]
+      },
+      {
+        "en": "Inheritance",
+        "ja": "継承",
+        "ja_typings": [
+          "keishou"
+        ]
+      },
+      {
+        "en": "Polymorphism",
+        "ja": "ポリモーフィズム",
+        "ja_typings": [
+          "porimo-fizumu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01959",
+    "image_path": null,
+    "question_text": {
+      "en": "Which OOP concept hides implementation details behind a simple interface?",
+      "ja": "実装詳細を隠して簡潔なインタフェースを公開する OOP の概念は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Adapter",
+        "ja": "アダプタ",
+        "ja_typings": [
+          "adaputa"
+        ]
+      },
+      {
+        "en": "Facade",
+        "ja": "ファサード",
+        "ja_typings": [
+          "fasa-do"
+        ]
+      },
+      {
+        "en": "Bridge",
+        "ja": "ブリッジ",
+        "ja_typings": [
+          "burijji"
+        ]
+      },
+      {
+        "en": "Proxy",
+        "ja": "プロキシ",
+        "ja_typings": [
+          "purokishi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01960",
+    "image_path": null,
+    "question_text": {
+      "en": "Which structural design pattern bridges incompatible interfaces?",
+      "ja": "互換性のないインタフェースを橋渡しする構造的デザインパターンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Strategy",
+        "ja": "ストラテジー",
+        "ja_typings": [
+          "sutorateji-"
+        ]
+      },
+      {
+        "en": "State",
+        "ja": "ステート",
+        "ja_typings": [
+          "sute-to"
+        ]
+      },
+      {
+        "en": "Command",
+        "ja": "コマンド",
+        "ja_typings": [
+          "komando"
+        ]
+      },
+      {
+        "en": "Template Method",
+        "ja": "テンプレートメソッド",
+        "ja_typings": [
+          "tenpure-tomesoddo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01961",
+    "image_path": null,
+    "question_text": {
+      "en": "Which behavioral pattern lets algorithms vary independently from clients?",
+      "ja": "アルゴリズムをクライアントから独立に切り替えられる振る舞い系パターンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Decorator",
+        "ja": "デコレータ",
+        "ja_typings": [
+          "dekore-ta"
+        ]
+      },
+      {
+        "en": "Adapter",
+        "ja": "アダプタ",
+        "ja_typings": [
+          "adaputa"
+        ]
+      },
+      {
+        "en": "Composite",
+        "ja": "コンポジット",
+        "ja_typings": [
+          "konpojitto"
+        ]
+      },
+      {
+        "en": "Flyweight",
+        "ja": "フライウェイト",
+        "ja_typings": [
+          "furaiweito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01962",
+    "image_path": null,
+    "question_text": {
+      "en": "Which structural pattern wraps an object to add behavior dynamically?",
+      "ja": "オブジェクトを包んで動的に振る舞いを追加する構造パターンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Proxy",
+        "ja": "プロキシ",
+        "ja_typings": [
+          "purokishi"
+        ]
+      },
+      {
+        "en": "Adapter",
+        "ja": "アダプタ",
+        "ja_typings": [
+          "adaputa"
+        ]
+      },
+      {
+        "en": "Decorator",
+        "ja": "デコレータ",
+        "ja_typings": [
+          "dekore-ta"
+        ]
+      },
+      {
+        "en": "Bridge",
+        "ja": "ブリッジ",
+        "ja_typings": [
+          "burijji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01963",
+    "image_path": null,
+    "question_text": {
+      "en": "Which structural pattern provides a surrogate to control access to an object?",
+      "ja": "オブジェクトへのアクセスを制御する代理を提供する構造パターンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Composite",
+        "ja": "コンポジット",
+        "ja_typings": [
+          "konpojitto"
+        ]
+      },
+      {
+        "en": "Decorator",
+        "ja": "デコレータ",
+        "ja_typings": [
+          "dekore-ta"
+        ]
+      },
+      {
+        "en": "Builder",
+        "ja": "ビルダー",
+        "ja_typings": [
+          "biruda-"
+        ]
+      },
+      {
+        "en": "Chain of Responsibility",
+        "ja": "チェーンオブレスポンシビリティ",
+        "ja_typings": [
+          "che-nnoburesuponshibiriti"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01964",
+    "image_path": null,
+    "question_text": {
+      "en": "Which pattern lets clients treat individual objects and compositions uniformly?",
+      "ja": "個々の要素と複合要素を一様に扱える構造パターンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Visitor",
+        "ja": "ビジター",
+        "ja_typings": [
+          "bijita-"
+        ]
+      },
+      {
+        "en": "Mediator",
+        "ja": "メディエータ",
+        "ja_typings": [
+          "medie-ta"
+        ]
+      },
+      {
+        "en": "Iterator",
+        "ja": "イテレータ",
+        "ja_typings": [
+          "itere-ta"
+        ]
+      },
+      {
+        "en": "Observer",
+        "ja": "オブザーバー",
+        "ja_typings": [
+          "obuza-ba-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01965",
+    "image_path": null,
+    "question_text": {
+      "en": "Which behavioral pattern adds operations without changing element classes?",
+      "ja": "要素クラスを変えずに操作を追加できる振る舞いパターンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vec",
+        "ja": "ベック型",
+        "ja_typings": [
+          "bekkugata"
+        ]
+      },
+      {
+        "en": "HashMap",
+        "ja": "ハッシュマップ型",
+        "ja_typings": [
+          "hasshumappugata"
+        ]
+      },
+      {
+        "en": "BTreeMap",
+        "ja": "ビーツリーマップ型",
+        "ja_typings": [
+          "biitsuriimappugata"
+        ]
+      },
+      {
+        "en": "LinkedList",
+        "ja": "リンクトリスト型",
+        "ja_typings": [
+          "rinkutorisutogata"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01966",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Rust standard collection is a growable, heap-allocated array?",
+      "ja": "ヒープ確保で可変長配列を表す Rust の標準コレクションは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Referrer-Policy",
+        "ja": "リファラポリシー",
+        "ja_typings": [
+          "rifaraporishi-"
+        ]
+      },
+      {
+        "en": "Content-Security-Policy",
+        "ja": "コンテンツセキュリティポリシー",
+        "ja_typings": [
+          "kontentsusekyuritiporishi-"
+        ]
+      },
+      {
+        "en": "Strict-Transport-Security",
+        "ja": "ストリクトトランスポートセキュリティ",
+        "ja_typings": [
+          "sutorikutotoransupo-tosekyuriti"
+        ]
+      },
+      {
+        "en": "X-Frame-Options",
+        "ja": "エックスフレームオプションズ",
+        "ja_typings": [
+          "ekkusufure-muopushonzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01967",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP header controls how much referrer information is sent with requests?",
+      "ja": "リクエストに含めるリファラ情報の量を制御する HTTP ヘッダは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FID",
+        "ja": "エフアイディー",
+        "ja_typings": [
+          "efuaidi-"
+        ]
+      },
+      {
+        "en": "LCP",
+        "ja": "エルシーピー",
+        "ja_typings": [
+          "erushi-pi-"
+        ]
+      },
+      {
+        "en": "CLS",
+        "ja": "シーエルエス",
+        "ja_typings": [
+          "shi-eruesu"
+        ]
+      },
+      {
+        "en": "TTFB",
+        "ja": "ティーティーエフビー",
+        "ja_typings": [
+          "ti-ti-efubi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01968",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Web Vitals metric measures the delay until the first user interaction is processed?",
+      "ja": "最初のユーザー操作が処理されるまでの遅延を計る Web Vitals 指標は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PerformanceObserver",
+        "ja": "パフォーマンスオブザーバ",
+        "ja_typings": [
+          "pafo-mansuobuza-ba"
+        ]
+      },
+      {
+        "en": "MutationObserver",
+        "ja": "ミューテーションオブザーバ",
+        "ja_typings": [
+          "myu-te-shonnobuza-ba"
+        ]
+      },
+      {
+        "en": "IntersectionObserver",
+        "ja": "インターセクションオブザーバ",
+        "ja_typings": [
+          "inta-sekushonnobuza-ba"
+        ]
+      },
+      {
+        "en": "ResizeObserver",
+        "ja": "リサイズオブザーバ",
+        "ja_typings": [
+          "risaizuobuza-ba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01969",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Web API observes performance-related events such as paint and longtask?",
+      "ja": "ペイントやロングタスク等のパフォーマンス事象を観測する Web API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bad request",
+        "ja": "バッドリクエスト",
+        "ja_typings": [
+          "baddorikuesuto"
+        ]
+      },
+      {
+        "en": "Unauthorized",
+        "ja": "アンオーソライズド",
+        "ja_typings": [
+          "anno-soraizudo"
+        ]
+      },
+      {
+        "en": "Forbidden",
+        "ja": "フォービドゥン",
+        "ja_typings": [
+          "fo-bidun"
+        ]
+      },
+      {
+        "en": "Not Found",
+        "ja": "ノットファウンド",
+        "ja_typings": [
+          "nottofaundo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01970",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status indicates the server cannot process due to client-side error?",
+      "ja": "クライアント側の誤りで処理できないことを示す HTTP ステータスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "POST",
+        "ja": "ポスト",
+        "ja_typings": [
+          "posuto"
+        ]
+      },
+      {
+        "en": "GET",
+        "ja": "ゲット",
+        "ja_typings": [
+          "getto"
+        ]
+      },
+      {
+        "en": "PUT",
+        "ja": "プット",
+        "ja_typings": [
+          "putto"
+        ]
+      },
+      {
+        "en": "DELETE",
+        "ja": "デリート",
+        "ja_typings": [
+          "deri-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01971",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP method submits data to be processed to a specified resource?",
+      "ja": "指定リソースに処理用データを送信する HTTP メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bulma",
+        "ja": "ブルマ",
+        "ja_typings": [
+          "buruma"
+        ]
+      },
+      {
+        "en": "Bootstrap",
+        "ja": "ブートストラップ",
+        "ja_typings": [
+          "bu-tosutorappu"
+        ]
+      },
+      {
+        "en": "Tailwind CSS",
+        "ja": "テイルウィンドシーエスエス",
+        "ja_typings": [
+          "teiruwindoshi-esuesu"
+        ]
+      },
+      {
+        "en": "Materialize",
+        "ja": "マテリアライズ",
+        "ja_typings": [
+          "materiaraizu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01972",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS framework is built with Sass and based on Flexbox?",
+      "ja": "Sass で作られ Flexbox を基礎にした CSS フレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Foundation",
+        "ja": "ファウンデーション",
+        "ja_typings": [
+          "faunde-shon"
+        ]
+      },
+      {
+        "en": "Bootstrap",
+        "ja": "ブートストラップ",
+        "ja_typings": [
+          "bu-tosutorappu"
+        ]
+      },
+      {
+        "en": "Bulma",
+        "ja": "ブルマ",
+        "ja_typings": [
+          "buruma"
+        ]
+      },
+      {
+        "en": "Skeleton",
+        "ja": "スケルトン",
+        "ja_typings": [
+          "sukeruton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01973",
+    "image_path": null,
+    "question_text": {
+      "en": "Which responsive front-end framework was originally created by ZURB?",
+      "ja": "ZURB が生み出したレスポンシブなフロントエンドフレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Observable",
+        "ja": "オブザーバブル",
+        "ja_typings": [
+          "obuza-baburu"
+        ]
+      },
+      {
+        "en": "Promise",
+        "ja": "プロミス",
+        "ja_typings": [
+          "puromisu"
+        ]
+      },
+      {
+        "en": "Iterator",
+        "ja": "イテレータ",
+        "ja_typings": [
+          "itere-ta"
+        ]
+      },
+      {
+        "en": "Signal",
+        "ja": "シグナル",
+        "ja_typings": [
+          "shigunaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01974",
+    "image_path": null,
+    "question_text": {
+      "en": "Which RxJS primitive represents a push-based stream of values over time?",
+      "ja": "時間経過に伴う値のプッシュ型ストリームを表す RxJS のプリミティブは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`find`",
+        "ja": "`find`",
+        "ja_typings": [
+          "`find`"
+        ]
+      },
+      {
+        "en": "`locate`",
+        "ja": "`locate`",
+        "ja_typings": [
+          "`locate`"
+        ]
+      },
+      {
+        "en": "`which`",
+        "ja": "`which`",
+        "ja_typings": [
+          "`which`"
+        ]
+      },
+      {
+        "en": "`whereis`",
+        "ja": "`whereis`",
+        "ja_typings": [
+          "`whereis`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01975",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Unix-style command in shells locates files by name?",
+      "ja": "シェルで名前からファイルを探す Unix 系コマンドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nuxt.js",
+        "ja": "ナクストジェイエス",
+        "ja_typings": [
+          "nakusutojeiesu"
+        ]
+      },
+      {
+        "en": "Next.js",
+        "ja": "ネクストジェイエス",
+        "ja_typings": [
+          "nekusutojeiesu"
+        ]
+      },
+      {
+        "en": "Remix",
+        "ja": "リミックス",
+        "ja_typings": [
+          "rimikkusu"
+        ]
+      },
+      {
+        "en": "SvelteKit",
+        "ja": "スヴェルトキット",
+        "ja_typings": [
+          "suverutokitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01976",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Vue-based meta-framework supports SSR and static generation?",
+      "ja": "SSR と静的生成に対応する Vue ベースのメタフレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gatsby",
+        "ja": "ギャツビー",
+        "ja_typings": [
+          "gyatsubi-"
+        ]
+      },
+      {
+        "en": "Hugo",
+        "ja": "ヒューゴ",
+        "ja_typings": [
+          "hyu-go"
+        ]
+      },
+      {
+        "en": "Jekyll",
+        "ja": "ジキル",
+        "ja_typings": [
+          "jikiru"
+        ]
+      },
+      {
+        "en": "Eleventy",
+        "ja": "イレブンティ",
+        "ja_typings": [
+          "irebunti"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01977",
+    "image_path": null,
+    "question_text": {
+      "en": "Which React-based static site generator pulls data via GraphQL?",
+      "ja": "GraphQL でデータを取り込む React ベースの静的サイトジェネレータは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Subscription",
+        "ja": "サブスクリプション",
+        "ja_typings": [
+          "sabusukuripushon"
+        ]
+      },
+      {
+        "en": "Query",
+        "ja": "クエリ",
+        "ja_typings": [
+          "kueri"
+        ]
+      },
+      {
+        "en": "Mutation",
+        "ja": "ミューテーション",
+        "ja_typings": [
+          "myu-te-shon"
+        ]
+      },
+      {
+        "en": "Fragment",
+        "ja": "フラグメント",
+        "ja_typings": [
+          "furagumento"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01978",
+    "image_path": null,
+    "question_text": {
+      "en": "Which GraphQL operation type pushes server updates to clients over time?",
+      "ja": "サーバの更新を時系列でクライアントに送る GraphQL の操作型は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SAML",
+        "ja": "サムル",
+        "ja_typings": [
+          "samuru"
+        ]
+      },
+      {
+        "en": "OAuth",
+        "ja": "オーオース",
+        "ja_typings": [
+          "o-o-su"
+        ]
+      },
+      {
+        "en": "OpenID Connect",
+        "ja": "オープンアイディーコネクト",
+        "ja_typings": [
+          "o-punnaidi-konekuto"
+        ]
+      },
+      {
+        "en": "Kerberos",
+        "ja": "ケルベロス",
+        "ja_typings": [
+          "keruberosu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01979",
+    "image_path": null,
+    "question_text": {
+      "en": "Which XML-based open standard exchanges authentication and authorization data?",
+      "ja": "認証認可情報を交換する XML ベースのオープン標準は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ISR",
+        "ja": "アイエスアール",
+        "ja_typings": [
+          "aiesua-ru"
+        ]
+      },
+      {
+        "en": "SSG",
+        "ja": "エスエスジー",
+        "ja_typings": [
+          "esuesuji-"
+        ]
+      },
+      {
+        "en": "SSR",
+        "ja": "エスエスアール",
+        "ja_typings": [
+          "esuesua-ru"
+        ]
+      },
+      {
+        "en": "CSR",
+        "ja": "シーエスアール",
+        "ja_typings": [
+          "shi-esua-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01980",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Next.js rendering mode regenerates static pages on demand after deploy?",
+      "ja": "デプロイ後にオンデマンドで静的ページを再生成する Next.js のレンダリング方式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FCP",
+        "ja": "エフシーピー",
+        "ja_typings": [
+          "efushi-pi-"
+        ]
+      },
+      {
+        "en": "LCP",
+        "ja": "エルシーピー",
+        "ja_typings": [
+          "erushi-pi-"
+        ]
+      },
+      {
+        "en": "FID",
+        "ja": "エフアイディー",
+        "ja_typings": [
+          "efuaidi-"
+        ]
+      },
+      {
+        "en": "TTI",
+        "ja": "ティーティーアイ",
+        "ja_typings": [
+          "ti-ti-ai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01981",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Web Vitals metric measures when the first content is painted on screen?",
+      "ja": "画面に最初のコンテンツが描画されたタイミングを示す Web Vitals 指標は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SSE",
+        "ja": "エスエスイー",
+        "ja_typings": [
+          "esuesui-"
+        ]
+      },
+      {
+        "en": "WebSocket",
+        "ja": "ウェブソケット",
+        "ja_typings": [
+          "webusoketto"
+        ]
+      },
+      {
+        "en": "Long Polling",
+        "ja": "ロングポーリング",
+        "ja_typings": [
+          "rongupo-ringu"
+        ]
+      },
+      {
+        "en": "WebRTC",
+        "ja": "ウェブアールティーシー",
+        "ja_typings": [
+          "webua-ruti-shi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01982",
+    "image_path": null,
+    "question_text": {
+      "en": "Which web technology pushes events from server to browser over a single HTTP connection?",
+      "ja": "単一の HTTP 接続でサーバからブラウザへイベントを送る技術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "localStorage",
+        "ja": "ローカルストレージ",
+        "ja_typings": [
+          "ro-karusutore-ji"
+        ]
+      },
+      {
+        "en": "sessionStorage",
+        "ja": "セッションストレージ",
+        "ja_typings": [
+          "sesshonsutore-ji"
+        ]
+      },
+      {
+        "en": "IndexedDB",
+        "ja": "インデックスドディービー",
+        "ja_typings": [
+          "indekkusudodi-bi-"
+        ]
+      },
+      {
+        "en": "Cookies",
+        "ja": "クッキー",
+        "ja_typings": [
+          "kukki-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01983",
+    "image_path": null,
+    "question_text": {
+      "en": "Which browser storage persists key-value pairs without expiration on the same origin?",
+      "ja": "同一オリジン上でキー値ペアを期限なく保持するブラウザストレージは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<picture>`",
+        "ja": "ピクチャ要素",
+        "ja_typings": [
+          "pikutyayouso"
+        ]
+      },
+      {
+        "en": "`<img>`",
+        "ja": "イメージ要素",
+        "ja_typings": [
+          "imeejiyouso"
+        ]
+      },
+      {
+        "en": "`<figure>`",
+        "ja": "フィギュア要素",
+        "ja_typings": [
+          "figyuayouso"
+        ]
+      },
+      {
+        "en": "`<source>`",
+        "ja": "ソース要素",
+        "ja_typings": [
+          "soosuyouso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01984",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML element lets you supply multiple image sources for different conditions?",
+      "ja": "条件ごとに複数の画像ソースを与える HTML 要素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`@supports`",
+        "ja": "サポート規則",
+        "ja_typings": [
+          "sapootokisoku"
+        ]
+      },
+      {
+        "en": "`@media`",
+        "ja": "メディア規則",
+        "ja_typings": [
+          "mediakisoku"
+        ]
+      },
+      {
+        "en": "`@import`",
+        "ja": "インポート規則",
+        "ja_typings": [
+          "inpootokisoku"
+        ]
+      },
+      {
+        "en": "`@layer`",
+        "ja": "レイヤー規則",
+        "ja_typings": [
+          "reiyaakisoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01985",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS at-rule applies styles only when the browser supports given features?",
+      "ja": "ブラウザが指定機能を支持する場合だけスタイルを適用する CSS の at-rule は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Permissions-Policy",
+        "ja": "パーミッションズポリシー",
+        "ja_typings": [
+          "pa-misshonzuporishi-"
+        ]
+      },
+      {
+        "en": "Feature-Policy",
+        "ja": "フィーチャーポリシー",
+        "ja_typings": [
+          "fi-cha-porishi-"
+        ]
+      },
+      {
+        "en": "Referrer-Policy",
+        "ja": "リファラポリシー",
+        "ja_typings": [
+          "rifaraporishi-"
+        ]
+      },
+      {
+        "en": "Content-Security-Policy",
+        "ja": "コンテンツセキュリティポリシー",
+        "ja_typings": [
+          "kontentsusekyuritiporishi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01986",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP header controls access to browser features like camera and geolocation?",
+      "ja": "カメラや位置情報など端末機能へのアクセスを制御する HTTP ヘッダは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "W3C",
+        "ja": "ダブリュースリーシー",
+        "ja_typings": [
+          "daburyu-suri-shi-"
+        ]
+      },
+      {
+        "en": "WHATWG",
+        "ja": "ワットダブリュージー",
+        "ja_typings": [
+          "wattodaburyu-ji-"
+        ]
+      },
+      {
+        "en": "ISO",
+        "ja": "アイエスオー",
+        "ja_typings": [
+          "aiesuo-"
+        ]
+      },
+      {
+        "en": "ECMA",
+        "ja": "エクマ",
+        "ja_typings": [
+          "ekuma"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01987",
+    "image_path": null,
+    "question_text": {
+      "en": "Which consortium maintains HTML, CSS, and other web standards led by Tim Berners-Lee?",
+      "ja": "ティム・バーナーズ＝リーが率いる HTML や CSS の標準化団体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "IETF",
+        "ja": "アイイーティーエフ",
+        "ja_typings": [
+          "aii-ti-efu"
+        ]
+      },
+      {
+        "en": "W3C",
+        "ja": "ダブリュースリーシー",
+        "ja_typings": [
+          "daburyu-suri-shi-"
+        ]
+      },
+      {
+        "en": "IEEE",
+        "ja": "アイトリプルイー",
+        "ja_typings": [
+          "aitoripurui-"
+        ]
+      },
+      {
+        "en": "ITU",
+        "ja": "アイティーユー",
+        "ja_typings": [
+          "aiti-yu-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01988",
+    "image_path": null,
+    "question_text": {
+      "en": "Which organization standardizes Internet protocols such as HTTP and TLS?",
+      "ja": "HTTP や TLS などインターネットプロトコルを標準化する組織は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Redirect",
+        "ja": "リダイレクト",
+        "ja_typings": [
+          "ridairekuto"
+        ]
+      },
+      {
+        "en": "Rewrite",
+        "ja": "リライト",
+        "ja_typings": [
+          "riraito"
+        ]
+      },
+      {
+        "en": "Forward",
+        "ja": "フォワード",
+        "ja_typings": [
+          "fowa-do"
+        ]
+      },
+      {
+        "en": "Proxy",
+        "ja": "プロキシ",
+        "ja_typings": [
+          "purokishi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01989",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP mechanism instructs the client to fetch a different URL?",
+      "ja": "別の URL を取得するようクライアントに指示する HTTP の仕組みは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Temporary redirect",
+        "ja": "テンポラリリダイレクト",
+        "ja_typings": [
+          "tenporariridairekuto"
+        ]
+      },
+      {
+        "en": "Permanent redirect",
+        "ja": "パーマネントリダイレクト",
+        "ja_typings": [
+          "pa-manentoridairekuto"
+        ]
+      },
+      {
+        "en": "See Other",
+        "ja": "シーアザー",
+        "ja_typings": [
+          "shi-aza-"
+        ]
+      },
+      {
+        "en": "Not Modified",
+        "ja": "ノットモディファイド",
+        "ja_typings": [
+          "nottomodifaido"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01990",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status indicates a temporary redirect that should preserve the method?",
+      "ja": "メソッドを保持したまま一時的にリダイレクトすることを示す HTTP ステータスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Service unavailable",
+        "ja": "サービスアンアベイラブル",
+        "ja_typings": [
+          "sa-bisuannabeiraburu"
+        ]
+      },
+      {
+        "en": "Internal server error",
+        "ja": "インターナルサーバエラー",
+        "ja_typings": [
+          "inta-narusa-baera-"
+        ]
+      },
+      {
+        "en": "Gateway timeout",
+        "ja": "ゲートウェイタイムアウト",
+        "ja_typings": [
+          "ge-toweitaimuauto"
+        ]
+      },
+      {
+        "en": "Bad gateway",
+        "ja": "バッドゲートウェイ",
+        "ja_typings": [
+          "baddoge-towei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01991",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status indicates the server is temporarily unable to handle the request?",
+      "ja": "サーバが一時的にリクエストを処理できないことを示す HTTP ステータスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DELETE",
+        "ja": "デリート",
+        "ja_typings": [
+          "deri-to"
+        ]
+      },
+      {
+        "en": "REMOVE",
+        "ja": "リムーブ",
+        "ja_typings": [
+          "rimu-bu"
+        ]
+      },
+      {
+        "en": "PURGE",
+        "ja": "パージ",
+        "ja_typings": [
+          "pa-ji"
+        ]
+      },
+      {
+        "en": "DROP",
+        "ja": "ドロップ",
+        "ja_typings": [
+          "doroppu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01992",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP method removes the specified resource?",
+      "ja": "指定リソースを削除する HTTP メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HEAD",
+        "ja": "ヘッド",
+        "ja_typings": [
+          "heddo"
+        ]
+      },
+      {
+        "en": "GET",
+        "ja": "ゲット",
+        "ja_typings": [
+          "getto"
+        ]
+      },
+      {
+        "en": "TRACE",
+        "ja": "トレース",
+        "ja_typings": [
+          "tore-su"
+        ]
+      },
+      {
+        "en": "CONNECT",
+        "ja": "コネクト",
+        "ja_typings": [
+          "konekuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01993",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP method returns only headers for a resource?",
+      "ja": "リソースのヘッダだけを返す HTTP メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "OPTIONS",
+        "ja": "オプションズ",
+        "ja_typings": [
+          "opushonzu"
+        ]
+      },
+      {
+        "en": "HEAD",
+        "ja": "ヘッド",
+        "ja_typings": [
+          "heddo"
+        ]
+      },
+      {
+        "en": "TRACE",
+        "ja": "トレース",
+        "ja_typings": [
+          "tore-su"
+        ]
+      },
+      {
+        "en": "CONNECT",
+        "ja": "コネクト",
+        "ja_typings": [
+          "konekuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01994",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP method describes the communication options for the target resource?",
+      "ja": "対象リソースに対する通信オプションを取得する HTTP メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<figure>` tag",
+        "ja": "フィギュアタグ",
+        "ja_typings": [
+          "figyuatagu"
+        ]
+      },
+      {
+        "en": "`<aside>` tag",
+        "ja": "アサイドタグ",
+        "ja_typings": [
+          "asaidotagu"
+        ]
+      },
+      {
+        "en": "`<section>` tag",
+        "ja": "セクションタグ",
+        "ja_typings": [
+          "sekushontagu"
+        ]
+      },
+      {
+        "en": "`<article>` tag",
+        "ja": "アーティクルタグ",
+        "ja_typings": [
+          "aatikurutagu",
+          "aatikulutagu",
+          "a-tikurutagu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01995",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML element represents self-contained content like illustrations?",
+      "ja": "挿絵など自己完結したコンテンツを表す HTML 要素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<canvas>` tag",
+        "ja": "キャンバスタグ",
+        "ja_typings": [
+          "kyanbasutagu"
+        ]
+      },
+      {
+        "en": "`<svg>` tag",
+        "ja": "エスブイジータグ",
+        "ja_typings": [
+          "esubuijiitagu",
+          "esubuiji-tagu"
+        ]
+      },
+      {
+        "en": "`<video>` tag",
+        "ja": "ビデオタグ",
+        "ja_typings": [
+          "bideotagu"
+        ]
+      },
+      {
+        "en": "`<draw>` tag",
+        "ja": "ドロータグ",
+        "ja_typings": [
+          "doroutagu",
+          "doro-tagu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01996",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML element provides a drawable region for graphics via scripting?",
+      "ja": "スクリプトで描画する領域を提供する HTML 要素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`title` attribute",
+        "ja": "タイトル属性",
+        "ja_typings": [
+          "taitorusokusei"
+        ]
+      },
+      {
+        "en": "`alt` attribute",
+        "ja": "オルト属性",
+        "ja_typings": [
+          "orutosokusei"
+        ]
+      },
+      {
+        "en": "`aria-label` attribute",
+        "ja": "エリアラベル属性",
+        "ja_typings": [
+          "ariaraberusokusei"
+        ]
+      },
+      {
+        "en": "`label` attribute",
+        "ja": "ラベル属性",
+        "ja_typings": [
+          "raberusokusei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01997",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML attribute provides advisory text shown as a tooltip on hover?",
+      "ja": "ホバー時にツールチップとして表示される補助テキストの HTML 属性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`src` attribute",
+        "ja": "ソース属性",
+        "ja_typings": [
+          "soosusokusei"
+        ]
+      },
+      {
+        "en": "`href` attribute",
+        "ja": "エイチレフ属性",
+        "ja_typings": [
+          "eichirefusokusei"
+        ]
+      },
+      {
+        "en": "`data` attribute",
+        "ja": "データ属性",
+        "ja_typings": [
+          "deetasokusei"
+        ]
+      },
+      {
+        "en": "`action` attribute",
+        "ja": "アクション属性",
+        "ja_typings": [
+          "akushonsokusei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01998",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML attribute specifies the URL of an external resource like an image?",
+      "ja": "画像など外部リソースの URL を指定する HTML 属性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`name` attribute",
+        "ja": "ネーム属性",
+        "ja_typings": [
+          "neemusokusei"
+        ]
+      },
+      {
+        "en": "`id` attribute",
+        "ja": "アイディー属性",
+        "ja_typings": [
+          "aidiisokusei"
+        ]
+      },
+      {
+        "en": "`for` attribute",
+        "ja": "フォー属性",
+        "ja_typings": [
+          "foosokusei"
+        ]
+      },
+      {
+        "en": "`value` attribute",
+        "ja": "バリュー属性",
+        "ja_typings": [
+          "baryuusokusei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01999",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML attribute identifies a form control when submitted to the server?",
+      "ja": "送信時にサーバへ送られるフォーム部品の識別子を表す HTML 属性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<link>` tag",
+        "ja": "リンクタグ",
+        "ja_typings": [
+          "rinkutagu"
+        ]
+      },
+      {
+        "en": "`<a>` tag",
+        "ja": "エータグ",
+        "ja_typings": [
+          "eetagu",
+          "e-tagu"
+        ]
+      },
+      {
+        "en": "`<meta>` tag",
+        "ja": "メタタグ",
+        "ja_typings": [
+          "metatagu"
+        ]
+      },
+      {
+        "en": "`<script>` tag",
+        "ja": "スクリプトタグ",
+        "ja_typings": [
+          "sukuriputotagu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02000",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML element references external resources such as stylesheets?",
+      "ja": "スタイルシートなど外部リソースを参照する HTML 要素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<nav>` tag",
+        "ja": "ナビタグ",
+        "ja_typings": [
+          "nabitagu"
+        ]
+      },
+      {
+        "en": "`<menu>` tag",
+        "ja": "メニュータグ",
+        "ja_typings": [
+          "menyuutagu",
+          "menyu-tagu"
+        ]
+      },
+      {
+        "en": "`<aside>` tag",
+        "ja": "アサイドタグ",
+        "ja_typings": [
+          "asaidotagu"
+        ]
+      },
+      {
+        "en": "`<header>` tag",
+        "ja": "ヘッダタグ",
+        "ja_typings": [
+          "heddatagu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02001",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML element groups navigation links?",
+      "ja": "ナビゲーション用のリンクをまとめる HTML 要素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<href>` tag",
+        "ja": "エイチレフタグ",
+        "ja_typings": [
+          "eichirefutagu"
+        ]
+      },
+      {
+        "en": "`<a>` tag",
+        "ja": "エータグ",
+        "ja_typings": [
+          "eetagu",
+          "e-tagu"
+        ]
+      },
+      {
+        "en": "`<link>` tag",
+        "ja": "リンクタグ",
+        "ja_typings": [
+          "rinkutagu"
+        ]
+      },
+      {
+        "en": "`<nav>` tag",
+        "ja": "ナビタグ",
+        "ja_typings": [
+          "nabitagu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02002",
+    "image_path": null,
+    "question_text": {
+      "en": "Which of the following is NOT a real HTML element name?",
+      "ja": "実在しない HTML 要素名はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<movie>` tag",
+        "ja": "ムービータグ",
+        "ja_typings": [
+          "muubiitagu",
+          "mu-bi-tagu"
+        ]
+      },
+      {
+        "en": "`<video>` tag",
+        "ja": "ビデオタグ",
+        "ja_typings": [
+          "bideotagu"
+        ]
+      },
+      {
+        "en": "`<audio>` tag",
+        "ja": "オーディオタグ",
+        "ja_typings": [
+          "oodiotagu",
+          "o-diotagu"
+        ]
+      },
+      {
+        "en": "`<source>` tag",
+        "ja": "ソースタグ",
+        "ja_typings": [
+          "soosutagu",
+          "so-sutagu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02003",
+    "image_path": null,
+    "question_text": {
+      "en": "Which of the following is NOT a valid HTML tag?",
+      "ja": "正しい HTML タグでないものはどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<media>` tag",
+        "ja": "メディアタグ",
+        "ja_typings": [
+          "mediatagu"
+        ]
+      },
+      {
+        "en": "`<picture>` tag",
+        "ja": "ピクチャタグ",
+        "ja_typings": [
+          "pikutyatagu"
+        ]
+      },
+      {
+        "en": "`<video>` tag",
+        "ja": "ビデオタグ",
+        "ja_typings": [
+          "bideotagu"
+        ]
+      },
+      {
+        "en": "`<audio>` tag",
+        "ja": "オーディオタグ",
+        "ja_typings": [
+          "oodiotagu",
+          "o-diotagu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02004",
+    "image_path": null,
+    "question_text": {
+      "en": "Which of these tag names does NOT exist in HTML?",
+      "ja": "HTML に存在しないタグ名はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<embed>` tag",
+        "ja": "エンベッドタグ",
+        "ja_typings": [
+          "enbeddotagu"
+        ]
+      },
+      {
+        "en": "`<object>` tag",
+        "ja": "オブジェクトタグ",
+        "ja_typings": [
+          "obujekutotagu"
+        ]
+      },
+      {
+        "en": "`<iframe>` tag",
+        "ja": "アイフレームタグ",
+        "ja_typings": [
+          "aifureemutagu",
+          "aifure-mutagu"
+        ]
+      },
+      {
+        "en": "`<applet>` tag",
+        "ja": "アプレットタグ",
+        "ja_typings": [
+          "aapurettotagu",
+          "apurettotagu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02005",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML element embeds external content such as plugins or media?",
+      "ja": "プラグインやメディアなど外部コンテンツを埋め込む HTML 要素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`display: grid`",
+        "ja": "グリッドディスプレイ",
+        "ja_typings": [
+          "guriddodisupurei"
+        ]
+      },
+      {
+        "en": "`display: flex`",
+        "ja": "フレックスディスプレイ",
+        "ja_typings": [
+          "furekkusudisupurei"
+        ]
+      },
+      {
+        "en": "`display: block`",
+        "ja": "ブロックディスプレイ",
+        "ja_typings": [
+          "burokkudisupurei"
+        ]
+      },
+      {
+        "en": "`display: table`",
+        "ja": "テーブルディスプレイ",
+        "ja_typings": [
+          "teeburudisupurei",
+          "te-burudisupurei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02006",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS display value lays out children in a two-dimensional grid?",
+      "ja": "子要素を 2 次元グリッドに配置する CSS の display 値は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`display: block`",
+        "ja": "ブロックディスプレイ",
+        "ja_typings": [
+          "burokkudisupurei"
+        ]
+      },
+      {
+        "en": "`display: inline`",
+        "ja": "インラインディスプレイ",
+        "ja_typings": [
+          "inraindisupurei"
+        ]
+      },
+      {
+        "en": "`display: flex`",
+        "ja": "フレックスディスプレイ",
+        "ja_typings": [
+          "furekkusudisupurei"
+        ]
+      },
+      {
+        "en": "`display: none`",
+        "ja": "ノンディスプレイ",
+        "ja_typings": [
+          "nondisupurei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02007",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS display value makes the element start on a new line and take full width?",
+      "ja": "要素を改行して横幅いっぱいに広げる CSS の display 値は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`display: inline`",
+        "ja": "インラインディスプレイ",
+        "ja_typings": [
+          "inraindisupurei"
+        ]
+      },
+      {
+        "en": "`display: block`",
+        "ja": "ブロックディスプレイ",
+        "ja_typings": [
+          "burokkudisupurei"
+        ]
+      },
+      {
+        "en": "`display: contents`",
+        "ja": "コンテンツディスプレイ",
+        "ja_typings": [
+          "kontentsudisupurei"
+        ]
+      },
+      {
+        "en": "`display: run-in`",
+        "ja": "ランインディスプレイ",
+        "ja_typings": [
+          "ranindisupurei",
+          "rannindisupurei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02008",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS display value flows the element within text without line breaks?",
+      "ja": "要素を改行せずテキスト中に流す CSS の display 値は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Flexbox",
+        "ja": "フレックスボックス",
+        "ja_typings": [
+          "furekkusubokkusu"
+        ]
+      },
+      {
+        "en": "Grid",
+        "ja": "グリッドレイアウト",
+        "ja_typings": [
+          "guriddoreiauto"
+        ]
+      },
+      {
+        "en": "Table",
+        "ja": "テーブルレイアウト",
+        "ja_typings": [
+          "teebururereiauto",
+          "teebureiauto",
+          "te-burureiauto"
+        ]
+      },
+      {
+        "en": "Multi-column",
+        "ja": "マルチカラム",
+        "ja_typings": [
+          "maruchikaramu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02009",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS layout module arranges items in a single dimension with flexible sizing?",
+      "ja": "アイテムを 1 次元に柔軟なサイズで並べる CSS レイアウトモジュールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Float",
+        "ja": "フロート",
+        "ja_typings": [
+          "furo-to"
+        ]
+      },
+      {
+        "en": "Clear",
+        "ja": "クリア",
+        "ja_typings": [
+          "kuria"
+        ]
+      },
+      {
+        "en": "Position",
+        "ja": "ポジション",
+        "ja_typings": [
+          "pojishon"
+        ]
+      },
+      {
+        "en": "Align",
+        "ja": "アライン",
+        "ja_typings": [
+          "arain"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02010",
+    "image_path": null,
+    "question_text": {
+      "en": "Which legacy CSS property removes an element from normal flow to the side?",
+      "ja": "通常フローから要素を外して横に寄せる古典的な CSS プロパティは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Position",
+        "ja": "ポジション",
+        "ja_typings": [
+          "pojishon"
+        ]
+      },
+      {
+        "en": "Float",
+        "ja": "フロート",
+        "ja_typings": [
+          "furo-to"
+        ]
+      },
+      {
+        "en": "Display",
+        "ja": "ディスプレイ",
+        "ja_typings": [
+          "disupurei"
+        ]
+      },
+      {
+        "en": "Align",
+        "ja": "アライン",
+        "ja_typings": [
+          "arain"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02011",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS property sets how an element is positioned in the document?",
+      "ja": "要素の配置方法を指定する CSS プロパティは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Europe",
+        "ja": "ヨーロッパ",
+        "ja_typings": [
+          "yo-roppa"
+        ]
+      },
+      {
+        "en": "Africa",
+        "ja": "アフリカ",
+        "ja_typings": [
+          "afurika"
+        ]
+      },
+      {
+        "en": "Asia",
+        "ja": "アジア",
+        "ja_typings": [
+          "ajia"
+        ]
+      },
+      {
+        "en": "Oceania",
+        "ja": "オセアニア",
+        "ja_typings": [
+          "oseania"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02012",
+    "image_path": null,
+    "question_text": {
+      "en": "Which continent contains France, Germany, and Italy?",
+      "ja": "フランス・ドイツ・イタリアを含む大陸は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "China",
+        "ja": "中国",
+        "ja_typings": [
+          "chuugoku"
+        ]
+      },
+      {
+        "en": "Russia",
+        "ja": "ロシア",
+        "ja_typings": [
+          "roshia"
+        ]
+      },
+      {
+        "en": "United States",
+        "ja": "アメリカ合衆国",
+        "ja_typings": [
+          "amerika/gasshuukoku"
+        ]
+      },
+      {
+        "en": "Indonesia",
+        "ja": "インドネシア",
+        "ja_typings": [
+          "indoneshia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02013",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has the world's largest population by historical record in 2020?",
+      "ja": "2020年時点で世界最大の人口を持っていた国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gobi Desert",
+        "ja": "ゴビ砂漠",
+        "ja_typings": [
+          "gobi/sabaku"
+        ]
+      },
+      {
+        "en": "Taklamakan",
+        "ja": "タクラマカン砂漠",
+        "ja_typings": [
+          "takuramakan/sabaku"
+        ]
+      },
+      {
+        "en": "Karakum",
+        "ja": "カラクム砂漠",
+        "ja_typings": [
+          "karakumu/sabaku"
+        ]
+      },
+      {
+        "en": "Thar",
+        "ja": "タール砂漠",
+        "ja_typings": [
+          "taaru/sabaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02014",
+    "image_path": null,
+    "question_text": {
+      "en": "Which desert stretches across southern Mongolia and northern China?",
+      "ja": "モンゴル南部と中国北部に広がる砂漠は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lake Tanganyika",
+        "ja": "タンガニーカ湖",
+        "ja_typings": [
+          "tanganiika/ko"
+        ]
+      },
+      {
+        "en": "Lake Victoria",
+        "ja": "ヴィクトリア湖",
+        "ja_typings": [
+          "vikutoria/ko"
+        ]
+      },
+      {
+        "en": "Lake Malawi",
+        "ja": "マラウイ湖",
+        "ja_typings": [
+          "maraui/ko"
+        ]
+      },
+      {
+        "en": "Lake Chad",
+        "ja": "チャド湖",
+        "ja_typings": [
+          "chado/ko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02015",
+    "image_path": null,
+    "question_text": {
+      "en": "Which African lake is the world's second-deepest freshwater lake?",
+      "ja": "世界で2番目に深い淡水湖であるアフリカの湖は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lake Superior",
+        "ja": "スペリオル湖",
+        "ja_typings": [
+          "superioru/ko"
+        ]
+      },
+      {
+        "en": "Lake Huron",
+        "ja": "ヒューロン湖",
+        "ja_typings": [
+          "hyuuron/ko"
+        ]
+      },
+      {
+        "en": "Lake Michigan",
+        "ja": "ミシガン湖",
+        "ja_typings": [
+          "mishigan/ko"
+        ]
+      },
+      {
+        "en": "Lake Erie",
+        "ja": "エリー湖",
+        "ja_typings": [
+          "erii/ko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02016",
+    "image_path": null,
+    "question_text": {
+      "en": "Which of the Great Lakes has the largest surface area?",
+      "ja": "五大湖のうち最も面積が大きい湖は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Alps",
+        "ja": "アルプス山脈",
+        "ja_typings": [
+          "arupusu/sanmyaku"
+        ]
+      },
+      {
+        "en": "Pyrenees",
+        "ja": "ピレネー山脈",
+        "ja_typings": [
+          "pirenee/sanmyaku"
+        ]
+      },
+      {
+        "en": "Carpathians",
+        "ja": "カルパティア山脈",
+        "ja_typings": [
+          "karupatia/sanmyaku"
+        ]
+      },
+      {
+        "en": "Apennines",
+        "ja": "アペニン山脈",
+        "ja_typings": [
+          "apenin/sanmyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02017",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mountain range runs through Switzerland, Austria, and northern Italy?",
+      "ja": "スイス・オーストリア・北イタリアを貫く山脈は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bolivia",
+        "ja": "ボリビア",
+        "ja_typings": [
+          "boribia"
+        ]
+      },
+      {
+        "en": "Peru",
+        "ja": "ペルー",
+        "ja_typings": [
+          "peru-"
+        ]
+      },
+      {
+        "en": "Ecuador",
+        "ja": "エクアドル",
+        "ja_typings": [
+          "ekuadoru"
+        ]
+      },
+      {
+        "en": "Chile",
+        "ja": "チリ",
+        "ja_typings": [
+          "chiri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02018",
+    "image_path": null,
+    "question_text": {
+      "en": "Which South American country has La Paz as one of its capitals?",
+      "ja": "ラパスを首都の一つとする南米の国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sudan",
+        "ja": "スーダン",
+        "ja_typings": [
+          "su-dan"
+        ]
+      },
+      {
+        "en": "Egypt",
+        "ja": "エジプト",
+        "ja_typings": [
+          "ejiputo"
+        ]
+      },
+      {
+        "en": "Ethiopia",
+        "ja": "エチオピア",
+        "ja_typings": [
+          "echiopia"
+        ]
+      },
+      {
+        "en": "Chad",
+        "ja": "チャド",
+        "ja_typings": [
+          "chado"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02019",
+    "image_path": null,
+    "question_text": {
+      "en": "Which African country has Khartoum as its capital?",
+      "ja": "ハルツームを首都とするアフリカの国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "United States",
+        "ja": "アメリカ合衆国",
+        "ja_typings": [
+          "amerika/gasshuukoku"
+        ]
+      },
+      {
+        "en": "Canada",
+        "ja": "カナダ",
+        "ja_typings": [
+          "kanada"
+        ]
+      },
+      {
+        "en": "Mexico",
+        "ja": "メキシコ",
+        "ja_typings": [
+          "mekishiko"
+        ]
+      },
+      {
+        "en": "Brazil",
+        "ja": "ブラジル",
+        "ja_typings": [
+          "burajiru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02020",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Washington D.C. as its capital?",
+      "ja": "ワシントンD.C.を首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Atacama Desert",
+        "ja": "アタカマ砂漠",
+        "ja_typings": [
+          "atakama/sabaku"
+        ]
+      },
+      {
+        "en": "Patagonian Desert",
+        "ja": "パタゴニア砂漠",
+        "ja_typings": [
+          "patagonia/sabaku"
+        ]
+      },
+      {
+        "en": "Sechura Desert",
+        "ja": "セチュラ砂漠",
+        "ja_typings": [
+          "sechura/sabaku"
+        ]
+      },
+      {
+        "en": "Monte Desert",
+        "ja": "モンテ砂漠",
+        "ja_typings": [
+          "monte/sabaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02021",
+    "image_path": null,
+    "question_text": {
+      "en": "Which desert is one of the driest places on Earth, located in Chile?",
+      "ja": "チリにある、地球上で最も乾燥した場所の一つの砂漠は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "North America",
+        "ja": "北アメリカ",
+        "ja_typings": [
+          "kita/amerika"
+        ]
+      },
+      {
+        "en": "South America",
+        "ja": "南アメリカ",
+        "ja_typings": [
+          "minami/amerika"
+        ]
+      },
+      {
+        "en": "Europe",
+        "ja": "ヨーロッパ",
+        "ja_typings": [
+          "yo-roppa"
+        ]
+      },
+      {
+        "en": "Africa",
+        "ja": "アフリカ",
+        "ja_typings": [
+          "afurika"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02022",
+    "image_path": null,
+    "question_text": {
+      "en": "Which continent contains Canada and Mexico?",
+      "ja": "カナダとメキシコを含む大陸は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Antarctica",
+        "ja": "南極大陸",
+        "ja_typings": [
+          "nankyoku/tairiku"
+        ]
+      },
+      {
+        "en": "Australia",
+        "ja": "オーストラリア",
+        "ja_typings": [
+          "o-sutoraria"
+        ]
+      },
+      {
+        "en": "South America",
+        "ja": "南アメリカ",
+        "ja_typings": [
+          "minami/amerika"
+        ]
+      },
+      {
+        "en": "Africa",
+        "ja": "アフリカ",
+        "ja_typings": [
+          "afurika"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02023",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the southernmost continent on Earth?",
+      "ja": "地球上で最も南にある大陸は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mount Kenya",
+        "ja": "ケニア山",
+        "ja_typings": [
+          "kenia/san"
+        ]
+      },
+      {
+        "en": "Mount Kilimanjaro",
+        "ja": "キリマンジャロ山",
+        "ja_typings": [
+          "kirimanjaro/san"
+        ]
+      },
+      {
+        "en": "Mount Stanley",
+        "ja": "スタンレー山",
+        "ja_typings": [
+          "sutanree/san"
+        ]
+      },
+      {
+        "en": "Mount Meru",
+        "ja": "メルー山",
+        "ja_typings": [
+          "meruu/san"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02024",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the second-highest mountain in Africa, located in central Kenya?",
+      "ja": "ケニア中央部にあるアフリカで2番目に高い山は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Istanbul",
+        "ja": "イスタンブール",
+        "ja_typings": [
+          "isutanbu-ru"
+        ]
+      },
+      {
+        "en": "Ankara",
+        "ja": "アンカラ",
+        "ja_typings": [
+          "ankara"
+        ]
+      },
+      {
+        "en": "Izmir",
+        "ja": "イズミル",
+        "ja_typings": [
+          "izumiru"
+        ]
+      },
+      {
+        "en": "Bursa",
+        "ja": "ブルサ",
+        "ja_typings": [
+          "burusa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02025",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the largest city of Turkey, straddling Europe and Asia?",
+      "ja": "ヨーロッパとアジアにまたがるトルコ最大の都市は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pyrenees",
+        "ja": "ピレネー山脈",
+        "ja_typings": [
+          "pirenee/sanmyaku"
+        ]
+      },
+      {
+        "en": "Alps",
+        "ja": "アルプス山脈",
+        "ja_typings": [
+          "arupusu/sanmyaku"
+        ]
+      },
+      {
+        "en": "Apennines",
+        "ja": "アペニン山脈",
+        "ja_typings": [
+          "apenin/sanmyaku"
+        ]
+      },
+      {
+        "en": "Cantabrian Mountains",
+        "ja": "カンタブリア山脈",
+        "ja_typings": [
+          "kantaburia/sanmyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02026",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mountain range forms the border between France and Spain?",
+      "ja": "フランスとスペインの国境を成す山脈は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Denmark",
+        "ja": "デンマーク",
+        "ja_typings": [
+          "denma-ku"
+        ]
+      },
+      {
+        "en": "Sweden",
+        "ja": "スウェーデン",
+        "ja_typings": [
+          "suwe-den"
+        ]
+      },
+      {
+        "en": "Norway",
+        "ja": "ノルウェー",
+        "ja_typings": [
+          "noruwe-"
+        ]
+      },
+      {
+        "en": "Finland",
+        "ja": "フィンランド",
+        "ja_typings": [
+          "finrando"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02027",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Scandinavian country has Copenhagen as its capital?",
+      "ja": "コペンハーゲンを首都とする北欧の国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Iceland",
+        "ja": "アイスランド",
+        "ja_typings": [
+          "aisurando"
+        ]
+      },
+      {
+        "en": "Greenland",
+        "ja": "グリーンランド",
+        "ja_typings": [
+          "guri-nrando"
+        ]
+      },
+      {
+        "en": "Faroe Islands",
+        "ja": "フェロー諸島",
+        "ja_typings": [
+          "feroo/shotou"
+        ]
+      },
+      {
+        "en": "Svalbard",
+        "ja": "スヴァールバル",
+        "ja_typings": [
+          "suva-rubaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02028",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nordic island country has Reykjavik as its capital?",
+      "ja": "レイキャビクを首都とする北欧の島国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mexico",
+        "ja": "メキシコ",
+        "ja_typings": [
+          "mekishiko"
+        ]
+      },
+      {
+        "en": "Guatemala",
+        "ja": "グアテマラ",
+        "ja_typings": [
+          "guatemara"
+        ]
+      },
+      {
+        "en": "Honduras",
+        "ja": "ホンジュラス",
+        "ja_typings": [
+          "honjurasu"
+        ]
+      },
+      {
+        "en": "Belize",
+        "ja": "ベリーズ",
+        "ja_typings": [
+          "beri-zu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02029",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Mexico City as its capital?",
+      "ja": "メキシコシティを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Venezuela",
+        "ja": "ベネズエラ",
+        "ja_typings": [
+          "benezuera"
+        ]
+      },
+      {
+        "en": "Colombia",
+        "ja": "コロンビア",
+        "ja_typings": [
+          "koronbia"
+        ]
+      },
+      {
+        "en": "Guyana",
+        "ja": "ガイアナ",
+        "ja_typings": [
+          "gaiana"
+        ]
+      },
+      {
+        "en": "Suriname",
+        "ja": "スリナム",
+        "ja_typings": [
+          "surinamu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02030",
+    "image_path": null,
+    "question_text": {
+      "en": "Which South American country has Caracas as its capital?",
+      "ja": "カラカスを首都とする南米の国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Laos",
+        "ja": "ラオス",
+        "ja_typings": [
+          "raosu"
+        ]
+      },
+      {
+        "en": "Cambodia",
+        "ja": "カンボジア",
+        "ja_typings": [
+          "kanbojia"
+        ]
+      },
+      {
+        "en": "Vietnam",
+        "ja": "ベトナム",
+        "ja_typings": [
+          "betonamu"
+        ]
+      },
+      {
+        "en": "Thailand",
+        "ja": "タイ",
+        "ja_typings": [
+          "tai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02031",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Southeast Asian country has Vientiane as its capital?",
+      "ja": "ヴィエンチャンを首都とする東南アジアの国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cambodia",
+        "ja": "カンボジア",
+        "ja_typings": [
+          "kanbojia"
+        ]
+      },
+      {
+        "en": "Laos",
+        "ja": "ラオス",
+        "ja_typings": [
+          "raosu"
+        ]
+      },
+      {
+        "en": "Vietnam",
+        "ja": "ベトナム",
+        "ja_typings": [
+          "betonamu"
+        ]
+      },
+      {
+        "en": "Myanmar",
+        "ja": "ミャンマー",
+        "ja_typings": [
+          "myanma-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02032",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Southeast Asian country has Phnom Penh as its capital?",
+      "ja": "プノンペンを首都とする東南アジアの国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Myanmar",
+        "ja": "ミャンマー",
+        "ja_typings": [
+          "myanma-"
+        ]
+      },
+      {
+        "en": "Thailand",
+        "ja": "タイ",
+        "ja_typings": [
+          "tai"
+        ]
+      },
+      {
+        "en": "Bangladesh",
+        "ja": "バングラデシュ",
+        "ja_typings": [
+          "banguradeshu"
+        ]
+      },
+      {
+        "en": "Laos",
+        "ja": "ラオス",
+        "ja_typings": [
+          "raosu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02033",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Southeast Asian country has Naypyidaw as its capital?",
+      "ja": "ネピドーを首都とする東南アジアの国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bulgaria",
+        "ja": "ブルガリア",
+        "ja_typings": [
+          "burugaria"
+        ]
+      },
+      {
+        "en": "Romania",
+        "ja": "ルーマニア",
+        "ja_typings": [
+          "ru-mania"
+        ]
+      },
+      {
+        "en": "Serbia",
+        "ja": "セルビア",
+        "ja_typings": [
+          "serubia"
+        ]
+      },
+      {
+        "en": "Albania",
+        "ja": "アルバニア",
+        "ja_typings": [
+          "arubania"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02034",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Balkan country has Sofia as its capital?",
+      "ja": "ソフィアを首都とするバルカンの国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Romania",
+        "ja": "ルーマニア",
+        "ja_typings": [
+          "ru-mania"
+        ]
+      },
+      {
+        "en": "Bulgaria",
+        "ja": "ブルガリア",
+        "ja_typings": [
+          "burugaria"
+        ]
+      },
+      {
+        "en": "Hungary",
+        "ja": "ハンガリー",
+        "ja_typings": [
+          "hangari-"
+        ]
+      },
+      {
+        "en": "Moldova",
+        "ja": "モルドバ",
+        "ja_typings": [
+          "morudoba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02035",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Eastern European country has Bucharest as its capital?",
+      "ja": "ブカレストを首都とする東欧の国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sweden",
+        "ja": "スウェーデン",
+        "ja_typings": [
+          "suwe-den"
+        ]
+      },
+      {
+        "en": "Norway",
+        "ja": "ノルウェー",
+        "ja_typings": [
+          "noruwe-"
+        ]
+      },
+      {
+        "en": "Denmark",
+        "ja": "デンマーク",
+        "ja_typings": [
+          "denma-ku"
+        ]
+      },
+      {
+        "en": "Finland",
+        "ja": "フィンランド",
+        "ja_typings": [
+          "finrando"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02036",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Scandinavian country has Stockholm as its capital?",
+      "ja": "ストックホルムを首都とする北欧の国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Uruguay",
+        "ja": "ウルグアイ",
+        "ja_typings": [
+          "uruguai"
+        ]
+      },
+      {
+        "en": "Paraguay",
+        "ja": "パラグアイ",
+        "ja_typings": [
+          "paraguai"
+        ]
+      },
+      {
+        "en": "Argentina",
+        "ja": "アルゼンチン",
+        "ja_typings": [
+          "aruzenchin"
+        ]
+      },
+      {
+        "en": "Chile",
+        "ja": "チリ",
+        "ja_typings": [
+          "chiri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02037",
+    "image_path": null,
+    "question_text": {
+      "en": "Which South American country has Montevideo as its capital?",
+      "ja": "モンテビデオを首都とする南米の国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Paraguay",
+        "ja": "パラグアイ",
+        "ja_typings": [
+          "paraguai"
+        ]
+      },
+      {
+        "en": "Uruguay",
+        "ja": "ウルグアイ",
+        "ja_typings": [
+          "uruguai"
+        ]
+      },
+      {
+        "en": "Bolivia",
+        "ja": "ボリビア",
+        "ja_typings": [
+          "boribia"
+        ]
+      },
+      {
+        "en": "Peru",
+        "ja": "ペルー",
+        "ja_typings": [
+          "peru-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02038",
+    "image_path": null,
+    "question_text": {
+      "en": "Which South American country has Asuncion as its capital?",
+      "ja": "アスンシオンを首都とする南米の国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Libya",
+        "ja": "リビア",
+        "ja_typings": [
+          "ribia"
+        ]
+      },
+      {
+        "en": "Tunisia",
+        "ja": "チュニジア",
+        "ja_typings": [
+          "chunijia"
+        ]
+      },
+      {
+        "en": "Algeria",
+        "ja": "アルジェリア",
+        "ja_typings": [
+          "arujeria"
+        ]
+      },
+      {
+        "en": "Egypt",
+        "ja": "エジプト",
+        "ja_typings": [
+          "ejiputo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02039",
+    "image_path": null,
+    "question_text": {
+      "en": "Which North African country has Tripoli as its capital?",
+      "ja": "トリポリを首都とする北アフリカの国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fiji",
+        "ja": "フィジー",
+        "ja_typings": [
+          "fiji-"
+        ]
+      },
+      {
+        "en": "Samoa",
+        "ja": "サモア",
+        "ja_typings": [
+          "samoa"
+        ]
+      },
+      {
+        "en": "Tonga",
+        "ja": "トンガ",
+        "ja_typings": [
+          "tonga"
+        ]
+      },
+      {
+        "en": "Vanuatu",
+        "ja": "バヌアツ",
+        "ja_typings": [
+          "banuatsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02040",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Pacific island country has Suva as its capital?",
+      "ja": "スバを首都とする太平洋の島国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rhine",
+        "ja": "ライン川",
+        "ja_typings": [
+          "rain/gawa"
+        ]
+      },
+      {
+        "en": "Elbe",
+        "ja": "エルベ川",
+        "ja_typings": [
+          "erube/gawa"
+        ]
+      },
+      {
+        "en": "Danube",
+        "ja": "ドナウ川",
+        "ja_typings": [
+          "donau/gawa"
+        ]
+      },
+      {
+        "en": "Seine",
+        "ja": "セーヌ川",
+        "ja_typings": [
+          "seenu/gawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02041",
+    "image_path": null,
+    "question_text": {
+      "en": "Which river flows through Germany and the Netherlands into the North Sea?",
+      "ja": "ドイツとオランダを流れ北海に注ぐ川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Danube",
+        "ja": "ドナウ川",
+        "ja_typings": [
+          "donau/gawa"
+        ]
+      },
+      {
+        "en": "Rhine",
+        "ja": "ライン川",
+        "ja_typings": [
+          "rain/gawa"
+        ]
+      },
+      {
+        "en": "Volga",
+        "ja": "ヴォルガ川",
+        "ja_typings": [
+          "voruga/gawa"
+        ]
+      },
+      {
+        "en": "Dnieper",
+        "ja": "ドニエプル川",
+        "ja_typings": [
+          "doniepuru/gawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02042",
+    "image_path": null,
+    "question_text": {
+      "en": "Which river flows through Vienna, Budapest, and Belgrade into the Black Sea?",
+      "ja": "ウィーン・ブダペスト・ベオグラードを流れ黒海に注ぐ川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Loire",
+        "ja": "ロワール川",
+        "ja_typings": [
+          "rowaaru/gawa"
+        ]
+      },
+      {
+        "en": "Seine",
+        "ja": "セーヌ川",
+        "ja_typings": [
+          "seenu/gawa"
+        ]
+      },
+      {
+        "en": "Rhone",
+        "ja": "ローヌ川",
+        "ja_typings": [
+          "roonu/gawa"
+        ]
+      },
+      {
+        "en": "Garonne",
+        "ja": "ガロンヌ川",
+        "ja_typings": [
+          "garonnu/gawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02043",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the longest river in France?",
+      "ja": "フランスで最も長い川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yellow River",
+        "ja": "黄河",
+        "ja_typings": [
+          "kouga"
+        ]
+      },
+      {
+        "en": "Yangtze",
+        "ja": "長江",
+        "ja_typings": [
+          "choukou"
+        ]
+      },
+      {
+        "en": "Pearl River",
+        "ja": "珠江",
+        "ja_typings": [
+          "shukou"
+        ]
+      },
+      {
+        "en": "Mekong",
+        "ja": "メコン川",
+        "ja_typings": [
+          "mekon/gawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02044",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Chinese river is also known as the Huang He?",
+      "ja": "「黄河」とも呼ばれる中国の川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mekong",
+        "ja": "メコン川",
+        "ja_typings": [
+          "mekon/gawa"
+        ]
+      },
+      {
+        "en": "Yangtze",
+        "ja": "長江",
+        "ja_typings": [
+          "choukou"
+        ]
+      },
+      {
+        "en": "Salween",
+        "ja": "サルウィン川",
+        "ja_typings": [
+          "saruuin/gawa"
+        ]
+      },
+      {
+        "en": "Irrawaddy",
+        "ja": "イラワジ川",
+        "ja_typings": [
+          "irawaji/gawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02045",
+    "image_path": null,
+    "question_text": {
+      "en": "Which river flows from Tibet through Laos and Vietnam into the South China Sea?",
+      "ja": "チベットからラオス・ベトナムを流れ南シナ海に注ぐ川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pearl River",
+        "ja": "珠江",
+        "ja_typings": [
+          "shukou"
+        ]
+      },
+      {
+        "en": "Yellow River",
+        "ja": "黄河",
+        "ja_typings": [
+          "kouga"
+        ]
+      },
+      {
+        "en": "Yangtze",
+        "ja": "長江",
+        "ja_typings": [
+          "choukou"
+        ]
+      },
+      {
+        "en": "Mekong",
+        "ja": "メコン川",
+        "ja_typings": [
+          "mekon/gawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02046",
+    "image_path": null,
+    "question_text": {
+      "en": "Which river flows through Guangzhou into the South China Sea?",
+      "ja": "広州を流れ南シナ海に注ぐ中国の川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Black Sea",
+        "ja": "黒海",
+        "ja_typings": [
+          "kokkai"
+        ]
+      },
+      {
+        "en": "Caspian Sea",
+        "ja": "カスピ海",
+        "ja_typings": [
+          "kasupi/kai"
+        ]
+      },
+      {
+        "en": "Aegean Sea",
+        "ja": "エーゲ海",
+        "ja_typings": [
+          "eege/kai"
+        ]
+      },
+      {
+        "en": "Mediterranean Sea",
+        "ja": "地中海",
+        "ja_typings": [
+          "chichuukai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02047",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sea lies between Turkey and Ukraine?",
+      "ja": "トルコとウクライナの間にある海は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Taklamakan",
+        "ja": "タクラマカン砂漠",
+        "ja_typings": [
+          "takuramakan/sabaku"
+        ]
+      },
+      {
+        "en": "Gobi Desert",
+        "ja": "ゴビ砂漠",
+        "ja_typings": [
+          "gobi/sabaku"
+        ]
+      },
+      {
+        "en": "Karakum",
+        "ja": "カラクム砂漠",
+        "ja_typings": [
+          "karakumu/sabaku"
+        ]
+      },
+      {
+        "en": "Kyzylkum",
+        "ja": "キジルクム砂漠",
+        "ja_typings": [
+          "kijirukumu/sabaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02048",
+    "image_path": null,
+    "question_text": {
+      "en": "Which desert lies in the Tarim Basin of northwest China?",
+      "ja": "中国北西部タリム盆地にある砂漠は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Karakum",
+        "ja": "カラクム砂漠",
+        "ja_typings": [
+          "karakumu/sabaku"
+        ]
+      },
+      {
+        "en": "Kyzylkum",
+        "ja": "キジルクム砂漠",
+        "ja_typings": [
+          "kijirukumu/sabaku"
+        ]
+      },
+      {
+        "en": "Taklamakan",
+        "ja": "タクラマカン砂漠",
+        "ja_typings": [
+          "takuramakan/sabaku"
+        ]
+      },
+      {
+        "en": "Gobi Desert",
+        "ja": "ゴビ砂漠",
+        "ja_typings": [
+          "gobi/sabaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02049",
+    "image_path": null,
+    "question_text": {
+      "en": "Which desert covers most of Turkmenistan?",
+      "ja": "トルクメニスタンの大部分を覆う砂漠は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thar",
+        "ja": "タール砂漠",
+        "ja_typings": [
+          "taaru/sabaku"
+        ]
+      },
+      {
+        "en": "Karakum",
+        "ja": "カラクム砂漠",
+        "ja_typings": [
+          "karakumu/sabaku"
+        ]
+      },
+      {
+        "en": "Gobi Desert",
+        "ja": "ゴビ砂漠",
+        "ja_typings": [
+          "gobi/sabaku"
+        ]
+      },
+      {
+        "en": "Negev",
+        "ja": "ネゲヴ砂漠",
+        "ja_typings": [
+          "negevu/sabaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02050",
+    "image_path": null,
+    "question_text": {
+      "en": "Which desert lies in northwestern India and southeastern Pakistan?",
+      "ja": "インド北西部とパキスタン南東部にある砂漠は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Monaco",
+        "ja": "モナコ",
+        "ja_typings": [
+          "monako"
+        ]
+      },
+      {
+        "en": "Andorra",
+        "ja": "アンドラ",
+        "ja_typings": [
+          "andora"
+        ]
+      },
+      {
+        "en": "San Marino",
+        "ja": "サンマリノ",
+        "ja_typings": [
+          "sanmarino"
+        ]
+      },
+      {
+        "en": "Liechtenstein",
+        "ja": "リヒテンシュタイン",
+        "ja_typings": [
+          "rihitenshutain"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02051",
+    "image_path": null,
+    "question_text": {
+      "en": "Which microstate on the French Riviera is famous for its casino?",
+      "ja": "フレンチリヴィエラにある、カジノで有名な小国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Liechtenstein",
+        "ja": "リヒテンシュタイン",
+        "ja_typings": [
+          "rihitenshutain"
+        ]
+      },
+      {
+        "en": "Monaco",
+        "ja": "モナコ",
+        "ja_typings": [
+          "monako"
+        ]
+      },
+      {
+        "en": "Andorra",
+        "ja": "アンドラ",
+        "ja_typings": [
+          "andora"
+        ]
+      },
+      {
+        "en": "Luxembourg",
+        "ja": "ルクセンブルク",
+        "ja_typings": [
+          "rukusenburuku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02052",
+    "image_path": null,
+    "question_text": {
+      "en": "Which microstate lies between Switzerland and Austria?",
+      "ja": "スイスとオーストリアの間にある小国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Strait of Hormuz",
+        "ja": "ホルムズ海峡",
+        "ja_typings": [
+          "horumuzu/kaikyou"
+        ]
+      },
+      {
+        "en": "Strait of Malacca",
+        "ja": "マラッカ海峡",
+        "ja_typings": [
+          "marakka/kaikyou"
+        ]
+      },
+      {
+        "en": "Bab-el-Mandeb",
+        "ja": "バブ・エル・マンデブ海峡",
+        "ja_typings": [
+          "babu/eru/mandebu/kaikyou"
+        ]
+      },
+      {
+        "en": "Bosphorus",
+        "ja": "ボスポラス海峡",
+        "ja_typings": [
+          "bosuporasu/kaikyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02053",
+    "image_path": null,
+    "question_text": {
+      "en": "Which strait connects the Persian Gulf to the Gulf of Oman?",
+      "ja": "ペルシア湾とオマーン湾を結ぶ海峡は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Strait of Malacca",
+        "ja": "マラッカ海峡",
+        "ja_typings": [
+          "marakka/kaikyou"
+        ]
+      },
+      {
+        "en": "Strait of Hormuz",
+        "ja": "ホルムズ海峡",
+        "ja_typings": [
+          "horumuzu/kaikyou"
+        ]
+      },
+      {
+        "en": "Sunda Strait",
+        "ja": "スンダ海峡",
+        "ja_typings": [
+          "sunda/kaikyou"
+        ]
+      },
+      {
+        "en": "Taiwan Strait",
+        "ja": "台湾海峡",
+        "ja_typings": [
+          "taiwan/kaikyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02054",
+    "image_path": null,
+    "question_text": {
+      "en": "Which strait connects the Indian Ocean and the South China Sea?",
+      "ja": "インド洋と南シナ海を結ぶ海峡は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cyprus",
+        "ja": "キプロス",
+        "ja_typings": [
+          "kipurosu"
+        ]
+      },
+      {
+        "en": "Malta",
+        "ja": "マルタ",
+        "ja_typings": [
+          "maruta"
+        ]
+      },
+      {
+        "en": "Crete",
+        "ja": "クレタ",
+        "ja_typings": [
+          "kureta"
+        ]
+      },
+      {
+        "en": "Rhodes",
+        "ja": "ロドス",
+        "ja_typings": [
+          "rodosu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02055",
+    "image_path": null,
+    "question_text": {
+      "en": "Which island country in the eastern Mediterranean has Nicosia as its capital?",
+      "ja": "東地中海にあるニコシアを首都とする島国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Malta",
+        "ja": "マルタ",
+        "ja_typings": [
+          "maruta"
+        ]
+      },
+      {
+        "en": "Cyprus",
+        "ja": "キプロス",
+        "ja_typings": [
+          "kipurosu"
+        ]
+      },
+      {
+        "en": "Sicily",
+        "ja": "シチリア",
+        "ja_typings": [
+          "shichiria"
+        ]
+      },
+      {
+        "en": "Corsica",
+        "ja": "コルシカ",
+        "ja_typings": [
+          "korushika"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02056",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mediterranean island country has Valletta as its capital?",
+      "ja": "ヴァレッタを首都とする地中海の島国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Brunei",
+        "ja": "ブルネイ",
+        "ja_typings": [
+          "burunei"
+        ]
+      },
+      {
+        "en": "Singapore",
+        "ja": "シンガポール",
+        "ja_typings": [
+          "shingapo-ru"
+        ]
+      },
+      {
+        "en": "Malaysia",
+        "ja": "マレーシア",
+        "ja_typings": [
+          "mare-shia"
+        ]
+      },
+      {
+        "en": "East Timor",
+        "ja": "東ティモール",
+        "ja_typings": [
+          "higashi/timooru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02057",
+    "image_path": null,
+    "question_text": {
+      "en": "Which small Southeast Asian country on Borneo is ruled by a sultan?",
+      "ja": "ボルネオ島にある、スルタンが統治する東南アジアの小国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sydney",
+        "ja": "シドニー",
+        "ja_typings": [
+          "shidoni-"
+        ]
+      },
+      {
+        "en": "Melbourne",
+        "ja": "メルボルン",
+        "ja_typings": [
+          "meruborun"
+        ]
+      },
+      {
+        "en": "Brisbane",
+        "ja": "ブリスベン",
+        "ja_typings": [
+          "burisuben"
+        ]
+      },
+      {
+        "en": "Perth",
+        "ja": "パース",
+        "ja_typings": [
+          "pa-su"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02058",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the most populous city in Australia?",
+      "ja": "オーストラリアで最も人口の多い都市は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Melbourne",
+        "ja": "メルボルン",
+        "ja_typings": [
+          "meruborun"
+        ]
+      },
+      {
+        "en": "Sydney",
+        "ja": "シドニー",
+        "ja_typings": [
+          "shidoni-"
+        ]
+      },
+      {
+        "en": "Adelaide",
+        "ja": "アデレード",
+        "ja_typings": [
+          "adere-do"
+        ]
+      },
+      {
+        "en": "Canberra",
+        "ja": "キャンベラ",
+        "ja_typings": [
+          "kyanbera"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02059",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Australian city hosts the famous Melbourne Cup horse race?",
+      "ja": "メルボルンカップ競馬が開催されるオーストラリアの都市は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Perth",
+        "ja": "パース",
+        "ja_typings": [
+          "pa-su"
+        ]
+      },
+      {
+        "en": "Sydney",
+        "ja": "シドニー",
+        "ja_typings": [
+          "shidoni-"
+        ]
+      },
+      {
+        "en": "Darwin",
+        "ja": "ダーウィン",
+        "ja_typings": [
+          "da-win"
+        ]
+      },
+      {
+        "en": "Hobart",
+        "ja": "ホバート",
+        "ja_typings": [
+          "hoba-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02060",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the capital of Western Australia?",
+      "ja": "西オーストラリア州の州都は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "K2",
+        "ja": "K2",
+        "ja_typings": [
+          "k2"
+        ]
+      },
+      {
+        "en": "Kangchenjunga",
+        "ja": "カンチェンジュンガ",
+        "ja_typings": [
+          "kanchenjunga"
+        ]
+      },
+      {
+        "en": "Lhotse",
+        "ja": "ローツェ",
+        "ja_typings": [
+          "ro-tse"
+        ]
+      },
+      {
+        "en": "Makalu",
+        "ja": "マカルー",
+        "ja_typings": [
+          "makaru-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02061",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the second-highest mountain in the world?",
+      "ja": "世界で2番目に高い山は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kublai Khan",
+        "ja": "フビライ・ハン",
+        "ja_typings": [
+          "fubirai/han"
+        ]
+      },
+      {
+        "en": "Genghis Khan",
+        "ja": "チンギス・ハン",
+        "ja_typings": [
+          "chingisu/han"
+        ]
+      },
+      {
+        "en": "Ogedei Khan",
+        "ja": "オゴデイ・ハン",
+        "ja_typings": [
+          "ogodei/han"
+        ]
+      },
+      {
+        "en": "Mongke Khan",
+        "ja": "モンケ・ハン",
+        "ja_typings": [
+          "monke/han"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02062",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mongol emperor founded the Yuan dynasty?",
+      "ja": "元朝を建てたモンゴル皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Henry IV",
+        "ja": "アンリ4世",
+        "ja_typings": [
+          "anri/4/sei"
+        ]
+      },
+      {
+        "en": "Louis XIII",
+        "ja": "ルイ13世",
+        "ja_typings": [
+          "rui/13/sei"
+        ]
+      },
+      {
+        "en": "Henry III",
+        "ja": "アンリ3世",
+        "ja_typings": [
+          "anri/3/sei"
+        ]
+      },
+      {
+        "en": "Charles IX",
+        "ja": "シャルル9世",
+        "ja_typings": [
+          "sharuru/9/sei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02063",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French king issued the Edict of Nantes in 1598?",
+      "ja": "1598年にナント勅令を発したフランス王は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bose",
+        "ja": "ボース",
+        "ja_typings": [
+          "bo-su"
+        ]
+      },
+      {
+        "en": "Nehru",
+        "ja": "ネルー",
+        "ja_typings": [
+          "neru-"
+        ]
+      },
+      {
+        "en": "Gandhi",
+        "ja": "ガンディー",
+        "ja_typings": [
+          "gandi-"
+        ]
+      },
+      {
+        "en": "Patel",
+        "ja": "パテル",
+        "ja_typings": [
+          "pateru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02064",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Indian revolutionary led the Indian National Army during WWII?",
+      "ja": "第二次大戦中にインド国民軍を率いた独立運動家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Trotsky",
+        "ja": "トロツキー",
+        "ja_typings": [
+          "torotsuki-"
+        ]
+      },
+      {
+        "en": "Lenin",
+        "ja": "レーニン",
+        "ja_typings": [
+          "re-nin"
+        ]
+      },
+      {
+        "en": "Bukharin",
+        "ja": "ブハーリン",
+        "ja_typings": [
+          "buha-rin"
+        ]
+      },
+      {
+        "en": "Kamenev",
+        "ja": "カーメネフ",
+        "ja_typings": [
+          "ka-menefu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02065",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Soviet revolutionary founded the Red Army and was later exiled by Stalin?",
+      "ja": "赤軍を創設し後にスターリンに追放されたソ連の革命家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yuan",
+        "ja": "元",
+        "ja_typings": [
+          "gen"
+        ]
+      },
+      {
+        "en": "Ming",
+        "ja": "明",
+        "ja_typings": [
+          "min"
+        ]
+      },
+      {
+        "en": "Song",
+        "ja": "宋",
+        "ja_typings": [
+          "sou"
+        ]
+      },
+      {
+        "en": "Qing",
+        "ja": "清",
+        "ja_typings": [
+          "shin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02066",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Chinese dynasty was founded by Kublai Khan in 1271?",
+      "ja": "1271年にフビライ・ハンが建てた中国の王朝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Crimean War",
+        "ja": "クリミア戦争",
+        "ja_typings": [
+          "kurimia/sensou"
+        ]
+      },
+      {
+        "en": "Russo-Turkish War",
+        "ja": "露土戦争",
+        "ja_typings": [
+          "roto/sensou"
+        ]
+      },
+      {
+        "en": "Franco-Prussian War",
+        "ja": "普仏戦争",
+        "ja_typings": [
+          "fufutsu/sensou"
+        ]
+      },
+      {
+        "en": "Austro-Prussian War",
+        "ja": "普墺戦争",
+        "ja_typings": [
+          "fuou/sensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02067",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 19th-century war was fought between Russia and an alliance of Britain, France, and the Ottoman Empire?",
+      "ja": "ロシアと英仏オスマン連合の間で起こった19世紀の戦争は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tesla",
+        "ja": "テスラ",
+        "ja_typings": [
+          "tesura"
+        ]
+      },
+      {
+        "en": "Edison",
+        "ja": "エジソン",
+        "ja_typings": [
+          "ejison"
+        ]
+      },
+      {
+        "en": "Marconi",
+        "ja": "マルコーニ",
+        "ja_typings": [
+          "maruko-ni"
+        ]
+      },
+      {
+        "en": "Westinghouse",
+        "ja": "ウェスティングハウス",
+        "ja_typings": [
+          "wesutinguhausu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02068",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Serbian-American inventor pioneered alternating-current electrical systems?",
+      "ja": "交流電力システムを開拓したセルビア系米国人発明家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thermidorian Reaction",
+        "ja": "テルミドールのクーデター",
+        "ja_typings": [
+          "terumidooru/no/kuudetaa",
+          "terumido-runoku-deta-"
+        ]
+      },
+      {
+        "en": "Storming of the Bastille",
+        "ja": "バスティーユ襲撃",
+        "ja_typings": [
+          "bastiyu/shuugeki"
+        ]
+      },
+      {
+        "en": "Night of August 4",
+        "ja": "8月4日の夜",
+        "ja_typings": [
+          "8gatsu/4nichi/no/yoru"
+        ]
+      },
+      {
+        "en": "Brumaire Coup",
+        "ja": "ブリュメールのクーデター",
+        "ja_typings": [
+          "buryumeeru/no/kuudetaa",
+          "buryume-runoku-deta-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02069",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1794 event ended the Reign of Terror in revolutionary France?",
+      "ja": "1794年に恐怖政治を終わらせたフランス革命期の事件は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Battle of Valmy",
+        "ja": "ヴァルミーの戦い",
+        "ja_typings": [
+          "varumii/no/tatakai"
+        ]
+      },
+      {
+        "en": "Battle of Jemappes",
+        "ja": "ジェマップの戦い",
+        "ja_typings": [
+          "jemappu/no/tatakai"
+        ]
+      },
+      {
+        "en": "Battle of Fleurus",
+        "ja": "フルーリュスの戦い",
+        "ja_typings": [
+          "furuuryusu/no/tatakai"
+        ]
+      },
+      {
+        "en": "Battle of Marengo",
+        "ja": "マレンゴの戦い",
+        "ja_typings": [
+          "marengo/no/tatakai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02070",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1792 battle saw French revolutionary forces stop a Prussian invasion?",
+      "ja": "1792年にフランス革命軍がプロイセン軍を阻止した戦いは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Michelangelo",
+        "ja": "ミケランジェロ",
+        "ja_typings": [
+          "mikeranjero"
+        ]
+      },
+      {
+        "en": "Leonardo da Vinci",
+        "ja": "レオナルド・ダ・ヴィンチ",
+        "ja_typings": [
+          "reonarudo/da/vinchi"
+        ]
+      },
+      {
+        "en": "Raphael",
+        "ja": "ラファエロ",
+        "ja_typings": [
+          "rafaero"
+        ]
+      },
+      {
+        "en": "Botticelli",
+        "ja": "ボッティチェリ",
+        "ja_typings": [
+          "botticheri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02071",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Renaissance artist painted the Sistine Chapel ceiling?",
+      "ja": "システィーナ礼拝堂の天井画を描いたルネサンスの芸術家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Raphael",
+        "ja": "ラファエロ",
+        "ja_typings": [
+          "rafaero"
+        ]
+      },
+      {
+        "en": "Michelangelo",
+        "ja": "ミケランジェロ",
+        "ja_typings": [
+          "mikeranjero"
+        ]
+      },
+      {
+        "en": "Botticelli",
+        "ja": "ボッティチェリ",
+        "ja_typings": [
+          "botticheri"
+        ]
+      },
+      {
+        "en": "Titian",
+        "ja": "ティツィアーノ",
+        "ja_typings": [
+          "titsia-no"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02072",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Renaissance painter created 'The School of Athens'?",
+      "ja": "「アテネの学堂」を描いたルネサンスの画家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Botticelli",
+        "ja": "ボッティチェリ",
+        "ja_typings": [
+          "botticheri"
+        ]
+      },
+      {
+        "en": "Raphael",
+        "ja": "ラファエロ",
+        "ja_typings": [
+          "rafaero"
+        ]
+      },
+      {
+        "en": "Michelangelo",
+        "ja": "ミケランジェロ",
+        "ja_typings": [
+          "mikeranjero"
+        ]
+      },
+      {
+        "en": "Donatello",
+        "ja": "ドナテッロ",
+        "ja_typings": [
+          "donaterro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02073",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Renaissance painter created 'The Birth of Venus'?",
+      "ja": "「ヴィーナスの誕生」を描いたルネサンスの画家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jawaharlal Nehru",
+        "ja": "ジャワハルラール・ネルー",
+        "ja_typings": [
+          "jawaharuraaru/neruu",
+          "jawaharura-ru/neru-"
+        ]
+      },
+      {
+        "en": "Mahatma Gandhi",
+        "ja": "マハトマ・ガンディー",
+        "ja_typings": [
+          "mahatoma/gandii",
+          "mahatoma/gandi-"
+        ]
+      },
+      {
+        "en": "Indira Gandhi",
+        "ja": "インディラ・ガンディー",
+        "ja_typings": [
+          "indira/gandii",
+          "indira/gandi-"
+        ]
+      },
+      {
+        "en": "Vallabhbhai Patel",
+        "ja": "ヴァッラブバーイー・パテール",
+        "ja_typings": [
+          "varrabu/baaii/pateeru",
+          "varrabuba-i-/pate-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02074",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first Prime Minister of independent India?",
+      "ja": "独立インドの初代首相は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ogedei Khan",
+        "ja": "オゴデイ・ハン",
+        "ja_typings": [
+          "ogodei/han"
+        ]
+      },
+      {
+        "en": "Kublai Khan",
+        "ja": "フビライ・ハン",
+        "ja_typings": [
+          "fubirai/han"
+        ]
+      },
+      {
+        "en": "Mongke Khan",
+        "ja": "モンケ・ハン",
+        "ja_typings": [
+          "monke/han"
+        ]
+      },
+      {
+        "en": "Guyuk Khan",
+        "ja": "グユク・ハン",
+        "ja_typings": [
+          "guyuku/han"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02075",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mongol Great Khan succeeded Genghis Khan?",
+      "ja": "チンギス・ハンの後を継いだモンゴル帝国の大ハーンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Charles X",
+        "ja": "シャルル10世",
+        "ja_typings": [
+          "sharuru/10/sei"
+        ]
+      },
+      {
+        "en": "Louis XVIII",
+        "ja": "ルイ18世",
+        "ja_typings": [
+          "rui/18/sei"
+        ]
+      },
+      {
+        "en": "Louis Philippe",
+        "ja": "ルイ・フィリップ",
+        "ja_typings": [
+          "rui/firippu"
+        ]
+      },
+      {
+        "en": "Napoleon III",
+        "ja": "ナポレオン3世",
+        "ja_typings": [
+          "naporeon/3/sei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02076",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French king was overthrown in the July Revolution of 1830?",
+      "ja": "1830年7月革命で退位したフランス王は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Caligula",
+        "ja": "カリグラ",
+        "ja_typings": [
+          "karigura"
+        ]
+      },
+      {
+        "en": "Nero",
+        "ja": "ネロ",
+        "ja_typings": [
+          "nero"
+        ]
+      },
+      {
+        "en": "Domitian",
+        "ja": "ドミティアヌス",
+        "ja_typings": [
+          "domitianusu"
+        ]
+      },
+      {
+        "en": "Commodus",
+        "ja": "コンモドゥス",
+        "ja_typings": [
+          "konmodusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02077",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Roman emperor was infamous for cruelty and was assassinated in 41 AD?",
+      "ja": "残虐で知られ41年に暗殺されたローマ皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Battle of Leipzig",
+        "ja": "ライプツィヒの戦い",
+        "ja_typings": [
+          "raiputsuhi/no/tatakai"
+        ]
+      },
+      {
+        "en": "Battle of Waterloo",
+        "ja": "ワーテルローの戦い",
+        "ja_typings": [
+          "wateruroo/no/tatakai"
+        ]
+      },
+      {
+        "en": "Battle of Borodino",
+        "ja": "ボロジノの戦い",
+        "ja_typings": [
+          "borojino/no/tatakai"
+        ]
+      },
+      {
+        "en": "Battle of Austerlitz",
+        "ja": "アウステルリッツの戦い",
+        "ja_typings": [
+          "ausuterurittsu/no/tatakai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02078",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1813 battle saw Napoleon defeated by a coalition of European powers?",
+      "ja": "1813年にナポレオンが欧州連合軍に敗れた戦いは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chamberlain",
+        "ja": "チェンバレン",
+        "ja_typings": [
+          "chenbaren"
+        ]
+      },
+      {
+        "en": "Churchill",
+        "ja": "チャーチル",
+        "ja_typings": [
+          "cha-chiru"
+        ]
+      },
+      {
+        "en": "Baldwin",
+        "ja": "ボールドウィン",
+        "ja_typings": [
+          "bo-rudowin"
+        ]
+      },
+      {
+        "en": "MacDonald",
+        "ja": "マクドナルド",
+        "ja_typings": [
+          "makudonarudo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02079",
+    "image_path": null,
+    "question_text": {
+      "en": "Which British PM is associated with the Munich Agreement appeasing Hitler in 1938?",
+      "ja": "1938年のミュンヘン協定でヒトラーに宥和したイギリス首相は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Attlee",
+        "ja": "アトリー",
+        "ja_typings": [
+          "atori-"
+        ]
+      },
+      {
+        "en": "Wilson",
+        "ja": "ウィルソン",
+        "ja_typings": [
+          "wiruson"
+        ]
+      },
+      {
+        "en": "Callaghan",
+        "ja": "キャラハン",
+        "ja_typings": [
+          "kyarahan"
+        ]
+      },
+      {
+        "en": "Blair",
+        "ja": "ブレア",
+        "ja_typings": [
+          "burea"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02080",
+    "image_path": null,
+    "question_text": {
+      "en": "Which British Labour PM led postwar reforms including the NHS?",
+      "ja": "NHS創設など戦後改革を進めたイギリス労働党の首相は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Eden",
+        "ja": "イーデン",
+        "ja_typings": [
+          "i-den"
+        ]
+      },
+      {
+        "en": "Macmillan",
+        "ja": "マクミラン",
+        "ja_typings": [
+          "makumiran"
+        ]
+      },
+      {
+        "en": "Attlee",
+        "ja": "アトリー",
+        "ja_typings": [
+          "atori-"
+        ]
+      },
+      {
+        "en": "Churchill",
+        "ja": "チャーチル",
+        "ja_typings": [
+          "cha-chiru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02081",
+    "image_path": null,
+    "question_text": {
+      "en": "Which British PM led Britain during the 1956 Suez Crisis?",
+      "ja": "1956年のスエズ危機時のイギリス首相は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Himmler",
+        "ja": "ヒムラー",
+        "ja_typings": [
+          "himura-"
+        ]
+      },
+      {
+        "en": "Goebbels",
+        "ja": "ゲッベルス",
+        "ja_typings": [
+          "gebberusu"
+        ]
+      },
+      {
+        "en": "Goering",
+        "ja": "ゲーリング",
+        "ja_typings": [
+          "ge-ringu"
+        ]
+      },
+      {
+        "en": "Hess",
+        "ja": "ヘス",
+        "ja_typings": [
+          "hesu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02082",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nazi leader headed the SS and organized the Holocaust?",
+      "ja": "親衛隊を率いホロコーストを組織したナチ指導者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Goebbels",
+        "ja": "ゲッベルス",
+        "ja_typings": [
+          "gebberusu"
+        ]
+      },
+      {
+        "en": "Himmler",
+        "ja": "ヒムラー",
+        "ja_typings": [
+          "himura-"
+        ]
+      },
+      {
+        "en": "Goering",
+        "ja": "ゲーリング",
+        "ja_typings": [
+          "ge-ringu"
+        ]
+      },
+      {
+        "en": "Bormann",
+        "ja": "ボルマン",
+        "ja_typings": [
+          "boruman"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02083",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nazi leader served as Minister of Propaganda?",
+      "ja": "ナチス・ドイツの宣伝大臣を務めた人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Goering",
+        "ja": "ゲーリング",
+        "ja_typings": [
+          "ge-ringu"
+        ]
+      },
+      {
+        "en": "Himmler",
+        "ja": "ヒムラー",
+        "ja_typings": [
+          "himura-"
+        ]
+      },
+      {
+        "en": "Goebbels",
+        "ja": "ゲッベルス",
+        "ja_typings": [
+          "gebberusu"
+        ]
+      },
+      {
+        "en": "Heydrich",
+        "ja": "ハイドリヒ",
+        "ja_typings": [
+          "haidorihi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02084",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nazi leader founded the Luftwaffe and the Gestapo?",
+      "ja": "ルフトヴァッフェとゲシュタポを創設したナチ指導者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Khrushchev",
+        "ja": "フルシチョフ",
+        "ja_typings": [
+          "furushichofu"
+        ]
+      },
+      {
+        "en": "Brezhnev",
+        "ja": "ブレジネフ",
+        "ja_typings": [
+          "burejinefu"
+        ]
+      },
+      {
+        "en": "Andropov",
+        "ja": "アンドロポフ",
+        "ja_typings": [
+          "andoropofu"
+        ]
+      },
+      {
+        "en": "Malenkov",
+        "ja": "マレンコフ",
+        "ja_typings": [
+          "marenkofu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02085",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Soviet leader denounced Stalin in 1956 and led during the Cuban Missile Crisis?",
+      "ja": "1956年にスターリン批判を行いキューバ危機を経験したソ連指導者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Eisenhower",
+        "ja": "アイゼンハワー",
+        "ja_typings": [
+          "aizenhawa-"
+        ]
+      },
+      {
+        "en": "Truman",
+        "ja": "トルーマン",
+        "ja_typings": [
+          "toru-man"
+        ]
+      },
+      {
+        "en": "Kennedy",
+        "ja": "ケネディ",
+        "ja_typings": [
+          "kenedi"
+        ]
+      },
+      {
+        "en": "Nixon",
+        "ja": "ニクソン",
+        "ja_typings": [
+          "nikuson"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02086",
+    "image_path": null,
+    "question_text": {
+      "en": "Which US president and WWII general served from 1953 to 1961?",
+      "ja": "1953〜1961年に在任した第二次大戦の将軍出身の米大統領は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Akbar",
+        "ja": "アクバル",
+        "ja_typings": [
+          "akubaru"
+        ]
+      },
+      {
+        "en": "Babur",
+        "ja": "バーブル",
+        "ja_typings": [
+          "ba-buru"
+        ]
+      },
+      {
+        "en": "Humayun",
+        "ja": "フマーユーン",
+        "ja_typings": [
+          "fuma-yu-n"
+        ]
+      },
+      {
+        "en": "Shah Jahan",
+        "ja": "シャー・ジャハーン",
+        "ja_typings": [
+          "shaa/jahaan",
+          "sha-/jaha-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02087",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mughal emperor known for religious tolerance ruled India in the 16th century?",
+      "ja": "宗教的寛容で知られる16世紀インドのムガル皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aurangzeb",
+        "ja": "アウラングゼーブ",
+        "ja_typings": [
+          "auranguze-bu"
+        ]
+      },
+      {
+        "en": "Akbar",
+        "ja": "アクバル",
+        "ja_typings": [
+          "akubaru"
+        ]
+      },
+      {
+        "en": "Shah Jahan",
+        "ja": "シャー・ジャハーン",
+        "ja_typings": [
+          "shaa/jahaan",
+          "sha-/jaha-n"
+        ]
+      },
+      {
+        "en": "Jahangir",
+        "ja": "ジャハーンギール",
+        "ja_typings": [
+          "jaha-ngi-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02088",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mughal emperor was known for orthodox Islamic rule and expansion in the late 17th century?",
+      "ja": "17世紀後半に厳格なイスラム統治と領土拡大を行ったムガル皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Balkan War",
+        "ja": "バルカン戦争",
+        "ja_typings": [
+          "barukan/sensou"
+        ]
+      },
+      {
+        "en": "Crimean War",
+        "ja": "クリミア戦争",
+        "ja_typings": [
+          "kurimia/sensou"
+        ]
+      },
+      {
+        "en": "Russo-Turkish War",
+        "ja": "露土戦争",
+        "ja_typings": [
+          "roto/sensou"
+        ]
+      },
+      {
+        "en": "Greco-Turkish War",
+        "ja": "希土戦争",
+        "ja_typings": [
+          "kido/sensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02089",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1912-1913 war was fought between Balkan states and the Ottoman Empire?",
+      "ja": "1912〜13年にバルカン諸国とオスマン帝国の間で起きた戦争は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Olmec",
+        "ja": "オルメカ",
+        "ja_typings": [
+          "orumeka"
+        ]
+      },
+      {
+        "en": "Maya",
+        "ja": "マヤ",
+        "ja_typings": [
+          "maya"
+        ]
+      },
+      {
+        "en": "Aztec",
+        "ja": "アステカ",
+        "ja_typings": [
+          "asuteka"
+        ]
+      },
+      {
+        "en": "Toltec",
+        "ja": "トルテカ",
+        "ja_typings": [
+          "toruteka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02090",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Mesoamerican civilization is known for colossal stone heads?",
+      "ja": "巨大な石頭像で知られる古代メソアメリカ文明は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Egyptian",
+        "ja": "エジプト",
+        "ja_typings": [
+          "ejiputo"
+        ]
+      },
+      {
+        "en": "Mesopotamian",
+        "ja": "メソポタミア",
+        "ja_typings": [
+          "mesopotamia"
+        ]
+      },
+      {
+        "en": "Greek",
+        "ja": "ギリシア",
+        "ja_typings": [
+          "girishia"
+        ]
+      },
+      {
+        "en": "Roman",
+        "ja": "ローマ",
+        "ja_typings": [
+          "ro-ma"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02091",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient civilization built the pyramids of Giza?",
+      "ja": "ギザのピラミッドを築いた古代文明は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chinese",
+        "ja": "中華",
+        "ja_typings": [
+          "chuuka"
+        ]
+      },
+      {
+        "en": "Indian",
+        "ja": "インド",
+        "ja_typings": [
+          "indo"
+        ]
+      },
+      {
+        "en": "Arab",
+        "ja": "アラブ",
+        "ja_typings": [
+          "arabu"
+        ]
+      },
+      {
+        "en": "Persian",
+        "ja": "ペルシア",
+        "ja_typings": [
+          "perushia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02092",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient civilization invented paper and gunpowder?",
+      "ja": "紙と火薬を発明した古代文明は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Victoria",
+        "ja": "ヴィクトリア",
+        "ja_typings": [
+          "vikutoria"
+        ]
+      },
+      {
+        "en": "Edward VII",
+        "ja": "エドワード7世",
+        "ja_typings": [
+          "edowaado/7/sei"
+        ]
+      },
+      {
+        "en": "George V",
+        "ja": "ジョージ5世",
+        "ja_typings": [
+          "joojii/5/sei"
+        ]
+      },
+      {
+        "en": "William IV",
+        "ja": "ウィリアム4世",
+        "ja_typings": [
+          "wiriamu/4/sei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02093",
+    "image_path": null,
+    "question_text": {
+      "en": "Which British monarch reigned during the height of the British Empire from 1837 to 1901?",
+      "ja": "1837〜1901年に大英帝国の絶頂期に在位した君主は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Heisei",
+        "ja": "平成",
+        "ja_typings": [
+          "heisei"
+        ]
+      },
+      {
+        "en": "Reiwa",
+        "ja": "令和",
+        "ja_typings": [
+          "reiwa"
+        ]
+      },
+      {
+        "en": "Showa",
+        "ja": "昭和",
+        "ja_typings": [
+          "shouwa"
+        ]
+      },
+      {
+        "en": "Taisho",
+        "ja": "大正",
+        "ja_typings": [
+          "taishou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02094",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese era ran from 1989 to 2019?",
+      "ja": "1989年から2019年まで続いた日本の元号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Reiwa",
+        "ja": "令和",
+        "ja_typings": [
+          "reiwa"
+        ]
+      },
+      {
+        "en": "Heisei",
+        "ja": "平成",
+        "ja_typings": [
+          "heisei"
+        ]
+      },
+      {
+        "en": "Showa",
+        "ja": "昭和",
+        "ja_typings": [
+          "shouwa"
+        ]
+      },
+      {
+        "en": "Meiji",
+        "ja": "明治",
+        "ja_typings": [
+          "meiji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02095",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese era began in 2019?",
+      "ja": "2019年に始まった日本の元号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vietnam War",
+        "ja": "ベトナム戦争",
+        "ja_typings": [
+          "betonamu/sensou"
+        ]
+      },
+      {
+        "en": "Korean War",
+        "ja": "朝鮮戦争",
+        "ja_typings": [
+          "chousen/sensou"
+        ]
+      },
+      {
+        "en": "Gulf War",
+        "ja": "湾岸戦争",
+        "ja_typings": [
+          "wangan/sensou"
+        ]
+      },
+      {
+        "en": "Cambodian Civil War",
+        "ja": "カンボジア内戦",
+        "ja_typings": [
+          "kanbojia/naisen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02096",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 20th-century war involved US military intervention in Southeast Asia from 1955 to 1975?",
+      "ja": "1955〜1975年に米軍が東南アジアに介入した20世紀の戦争は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Holy Roman Empire",
+        "ja": "神聖ローマ帝国",
+        "ja_typings": [
+          "shinsei/rooma/teikoku"
+        ]
+      },
+      {
+        "en": "Byzantine Empire",
+        "ja": "ビザンツ帝国",
+        "ja_typings": [
+          "bizantsu/teikoku"
+        ]
+      },
+      {
+        "en": "Carolingian Empire",
+        "ja": "カロリング帝国",
+        "ja_typings": [
+          "karoringu/teikoku"
+        ]
+      },
+      {
+        "en": "Frankish Kingdom",
+        "ja": "フランク王国",
+        "ja_typings": [
+          "furanku/oukoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02097",
+    "image_path": null,
+    "question_text": {
+      "en": "Which European political entity existed from 962 to 1806 in central Europe?",
+      "ja": "962年から1806年まで中欧に存在した政治体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Abu Simbel Temple",
+        "ja": "アブ・シンベル神殿",
+        "ja_typings": [
+          "abu/shinberu/shinden"
+        ]
+      },
+      {
+        "en": "Luxor Temple",
+        "ja": "ルクソール神殿",
+        "ja_typings": [
+          "rukusooru/shinden"
+        ]
+      },
+      {
+        "en": "Karnak Temple",
+        "ja": "カルナック神殿",
+        "ja_typings": [
+          "karunakku/shinden"
+        ]
+      },
+      {
+        "en": "Temple of Hatshepsut",
+        "ja": "ハトシェプスト葬祭殿",
+        "ja_typings": [
+          "hatoshepusuto/sousaiden"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02098",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Egyptian temple complex was relocated due to the Aswan High Dam?",
+      "ja": "アスワンハイダム建設のため移築された古代エジプトの神殿は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Luxor Temple",
+        "ja": "ルクソール神殿",
+        "ja_typings": [
+          "rukusooru/shinden"
+        ]
+      },
+      {
+        "en": "Karnak Temple",
+        "ja": "カルナック神殿",
+        "ja_typings": [
+          "karunakku/shinden"
+        ]
+      },
+      {
+        "en": "Abu Simbel Temple",
+        "ja": "アブ・シンベル神殿",
+        "ja_typings": [
+          "abu/shinberu/shinden"
+        ]
+      },
+      {
+        "en": "Edfu Temple",
+        "ja": "エドフ神殿",
+        "ja_typings": [
+          "edofu/shinden"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02099",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Egyptian temple in modern Luxor was the southern sanctuary of Amun?",
+      "ja": "現在のルクソールにあるアモン神の南方聖域とされた神殿は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Karnak Temple",
+        "ja": "カルナック神殿",
+        "ja_typings": [
+          "karunakku/shinden"
+        ]
+      },
+      {
+        "en": "Luxor Temple",
+        "ja": "ルクソール神殿",
+        "ja_typings": [
+          "rukusooru/shinden"
+        ]
+      },
+      {
+        "en": "Abu Simbel Temple",
+        "ja": "アブ・シンベル神殿",
+        "ja_typings": [
+          "abu/shinberu/shinden"
+        ]
+      },
+      {
+        "en": "Philae Temple",
+        "ja": "フィラエ神殿",
+        "ja_typings": [
+          "firae/shinden"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02100",
+    "image_path": null,
+    "question_text": {
+      "en": "Which vast Egyptian temple complex was dedicated mainly to Amun-Ra?",
+      "ja": "主にアモン・ラー神に捧げられたエジプト最大の神殿群は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Julius Caesar",
+        "ja": "ユリウス・カエサル",
+        "ja_typings": [
+          "uriusu/kaesaru",
+          "yuriusu/kaesaru"
+        ]
+      },
+      {
+        "en": "Pompey",
+        "ja": "ポンペイウス",
+        "ja_typings": [
+          "ponpeiusu"
+        ]
+      },
+      {
+        "en": "Crassus",
+        "ja": "クラッスス",
+        "ja_typings": [
+          "kurassusu"
+        ]
+      },
+      {
+        "en": "Mark Antony",
+        "ja": "アントニウス",
+        "ja_typings": [
+          "antoniusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02101",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Roman general crossed the Rubicon in 49 BC?",
+      "ja": "紀元前49年にルビコン川を渡ったローマの将軍は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tokugawa Iemochi",
+        "ja": "徳川家茂",
+        "ja_typings": [
+          "tokugawa/iemochi"
+        ]
+      },
+      {
+        "en": "Tokugawa Iesada",
+        "ja": "徳川家定",
+        "ja_typings": [
+          "tokugawa/iesada"
+        ]
+      },
+      {
+        "en": "Tokugawa Nariaki",
+        "ja": "徳川斉昭",
+        "ja_typings": [
+          "tokugawa/nariaki"
+        ]
+      },
+      {
+        "en": "Tokugawa Yoshinobu",
+        "ja": "徳川慶喜",
+        "ja_typings": [
+          "tokugawa/yoshinobu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02102",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 14th Tokugawa shogun reigned during the late Bakumatsu period?",
+      "ja": "幕末期に在職した第14代徳川将軍は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tokugawa Iesada",
+        "ja": "徳川家定",
+        "ja_typings": [
+          "tokugawa/iesada"
+        ]
+      },
+      {
+        "en": "Tokugawa Iemochi",
+        "ja": "徳川家茂",
+        "ja_typings": [
+          "tokugawa/iemochi"
+        ]
+      },
+      {
+        "en": "Tokugawa Ieyoshi",
+        "ja": "徳川家慶",
+        "ja_typings": [
+          "tokugawa/ieyoshi"
+        ]
+      },
+      {
+        "en": "Tokugawa Yoshinobu",
+        "ja": "徳川慶喜",
+        "ja_typings": [
+          "tokugawa/yoshinobu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02103",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 13th Tokugawa shogun ruled from 1853 to 1858?",
+      "ja": "1853〜1858年に在職した第13代徳川将軍は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tokugawa Nariaki",
+        "ja": "徳川斉昭",
+        "ja_typings": [
+          "tokugawa/nariaki"
+        ]
+      },
+      {
+        "en": "Tokugawa Iemochi",
+        "ja": "徳川家茂",
+        "ja_typings": [
+          "tokugawa/iemochi"
+        ]
+      },
+      {
+        "en": "Tokugawa Iesada",
+        "ja": "徳川家定",
+        "ja_typings": [
+          "tokugawa/iesada"
+        ]
+      },
+      {
+        "en": "Ii Naosuke",
+        "ja": "井伊直弼",
+        "ja_typings": [
+          "ii/naosuke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02104",
+    "image_path": null,
+    "question_text": {
+      "en": "Which lord of Mito Domain was a major reformist figure in the late Edo period?",
+      "ja": "幕末に活躍した水戸藩主の改革派の人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Emperor Wu of Han",
+        "ja": "漢の武帝",
+        "ja_typings": [
+          "kan/no/butei"
+        ]
+      },
+      {
+        "en": "Emperor Gaozu of Han",
+        "ja": "漢の高祖",
+        "ja_typings": [
+          "kan/no/kouso"
+        ]
+      },
+      {
+        "en": "Emperor Wen of Han",
+        "ja": "漢の文帝",
+        "ja_typings": [
+          "kan/no/buntei"
+        ]
+      },
+      {
+        "en": "Emperor Jing of Han",
+        "ja": "漢の景帝",
+        "ja_typings": [
+          "kan/no/keitei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02105",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Han emperor greatly expanded the empire and reigned 141-87 BC?",
+      "ja": "紀元前141〜87年に在位し領土を大きく拡げた前漢の皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Emperor Taizong of Tang",
+        "ja": "唐の太宗",
+        "ja_typings": [
+          "tou/no/taisou"
+        ]
+      },
+      {
+        "en": "Emperor Gaozu of Tang",
+        "ja": "唐の高祖",
+        "ja_typings": [
+          "tou/no/kouso"
+        ]
+      },
+      {
+        "en": "Emperor Xuanzong of Tang",
+        "ja": "唐の玄宗",
+        "ja_typings": [
+          "tou/no/genso"
+        ]
+      },
+      {
+        "en": "Emperor Gaozong of Tang",
+        "ja": "唐の高宗",
+        "ja_typings": [
+          "tou/no/kousou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02106",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Tang emperor presided over the early Tang golden age?",
+      "ja": "唐初の黄金期を築いた皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Emperor Yang of Sui",
+        "ja": "隋の煬帝",
+        "ja_typings": [
+          "zui/no/youdai"
+        ]
+      },
+      {
+        "en": "Emperor Wen of Sui",
+        "ja": "隋の文帝",
+        "ja_typings": [
+          "zui/no/buntei"
+        ]
+      },
+      {
+        "en": "Emperor Gong of Sui",
+        "ja": "隋の恭帝",
+        "ja_typings": [
+          "zui/no/kyoutei"
+        ]
+      },
+      {
+        "en": "Emperor Taizong of Tang",
+        "ja": "唐の太宗",
+        "ja_typings": [
+          "tou/no/taisou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02107",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Sui emperor built the Grand Canal but lost the throne to rebellion?",
+      "ja": "大運河を建設したが反乱で帝位を失った隋の皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bill of Rights",
+        "ja": "権利章典",
+        "ja_typings": [
+          "kenri/shouten"
+        ]
+      },
+      {
+        "en": "Petition of Right",
+        "ja": "権利の請願",
+        "ja_typings": [
+          "kenri/no/seigan"
+        ]
+      },
+      {
+        "en": "Magna Carta",
+        "ja": "マグナ・カルタ",
+        "ja_typings": [
+          "maguna/karuta"
+        ]
+      },
+      {
+        "en": "Habeas Corpus Act",
+        "ja": "人身保護法",
+        "ja_typings": [
+          "jinshin/hogo/hou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02108",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1689 English document limited royal power and established parliamentary rights?",
+      "ja": "1689年に王権を制限し議会の権利を定めたイギリスの文書は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Petition of Right",
+        "ja": "権利の請願",
+        "ja_typings": [
+          "kenri/no/seigan"
+        ]
+      },
+      {
+        "en": "Bill of Rights",
+        "ja": "権利章典",
+        "ja_typings": [
+          "kenri/shouten"
+        ]
+      },
+      {
+        "en": "Magna Carta",
+        "ja": "マグナ・カルタ",
+        "ja_typings": [
+          "maguna/karuta"
+        ]
+      },
+      {
+        "en": "Act of Settlement",
+        "ja": "王位継承法",
+        "ja_typings": [
+          "oui/keishou/hou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02109",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1628 English document was drafted by Parliament against Charles I?",
+      "ja": "1628年に議会がチャールズ1世に対し起草した文書は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Edict of Nantes",
+        "ja": "ナント勅令",
+        "ja_typings": [
+          "nanto/chokurei"
+        ]
+      },
+      {
+        "en": "Edict of Fontainebleau",
+        "ja": "フォンテーヌブロー勅令",
+        "ja_typings": [
+          "fonteenuburoo/chokurei"
+        ]
+      },
+      {
+        "en": "Bill of Rights",
+        "ja": "権利章典",
+        "ja_typings": [
+          "kenri/shouten"
+        ]
+      },
+      {
+        "en": "Concordat of Bologna",
+        "ja": "ボローニャ政教条約",
+        "ja_typings": [
+          "boroonya/seikyou/jouyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02110",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1598 French royal edict granted religious tolerance to Huguenots?",
+      "ja": "1598年にユグノーに信仰の自由を与えたフランス王令は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Elba",
+        "ja": "エルバ島",
+        "ja_typings": [
+          "eruba/tou"
+        ]
+      },
+      {
+        "en": "Saint Helena",
+        "ja": "セントヘレナ島",
+        "ja_typings": [
+          "sentohelena/tou"
+        ]
+      },
+      {
+        "en": "Corsica",
+        "ja": "コルシカ島",
+        "ja_typings": [
+          "korushika/tou"
+        ]
+      },
+      {
+        "en": "Sardinia",
+        "ja": "サルデーニャ島",
+        "ja_typings": [
+          "sarudeenya/tou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02111",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mediterranean island was Napoleon exiled to in 1814?",
+      "ja": "1814年にナポレオンが流された地中海の島は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bohr",
+        "ja": "ボーア",
+        "ja_typings": [
+          "bo-a"
+        ]
+      },
+      {
+        "en": "Rutherford",
+        "ja": "ラザフォード",
+        "ja_typings": [
+          "razafo-do"
+        ]
+      },
+      {
+        "en": "Thomson",
+        "ja": "トムソン",
+        "ja_typings": [
+          "tomuson"
+        ]
+      },
+      {
+        "en": "Schrodinger",
+        "ja": "シュレディンガー",
+        "ja_typings": [
+          "shuredinga-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02112",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Danish physicist proposed a model of the hydrogen atom with quantized orbits in 1913?",
+      "ja": "1913年に量子化された軌道を持つ水素原子モデルを提唱したデンマークの物理学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Uranus",
+        "ja": "天王星",
+        "ja_typings": [
+          "tennousei"
+        ]
+      },
+      {
+        "en": "Neptune",
+        "ja": "海王星",
+        "ja_typings": [
+          "kaiousei"
+        ]
+      },
+      {
+        "en": "Saturn",
+        "ja": "土星",
+        "ja_typings": [
+          "dosei"
+        ]
+      },
+      {
+        "en": "Jupiter",
+        "ja": "木星",
+        "ja_typings": [
+          "mokusei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02113",
+    "image_path": null,
+    "question_text": {
+      "en": "Which planet is the seventh from the Sun and tilted on its side?",
+      "ja": "太陽から7番目の、横倒しに自転する惑星は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Argon",
+        "ja": "アルゴン",
+        "ja_typings": [
+          "arugon"
+        ]
+      },
+      {
+        "en": "Neon",
+        "ja": "ネオン",
+        "ja_typings": [
+          "neon"
+        ]
+      },
+      {
+        "en": "Helium",
+        "ja": "ヘリウム",
+        "ja_typings": [
+          "heriumu"
+        ]
+      },
+      {
+        "en": "Krypton",
+        "ja": "クリプトン",
+        "ja_typings": [
+          "kuriputon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02114",
+    "image_path": null,
+    "question_text": {
+      "en": "Which noble gas is the third most abundant gas in Earth's atmosphere?",
+      "ja": "地球大気で3番目に多い希ガスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Venus",
+        "ja": "金星",
+        "ja_typings": [
+          "kinsei"
+        ]
+      },
+      {
+        "en": "Mercury",
+        "ja": "水星",
+        "ja_typings": [
+          "suisei"
+        ]
+      },
+      {
+        "en": "Mars",
+        "ja": "火星",
+        "ja_typings": [
+          "kasei"
+        ]
+      },
+      {
+        "en": "Earth",
+        "ja": "地球",
+        "ja_typings": [
+          "chikyuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02115",
+    "image_path": null,
+    "question_text": {
+      "en": "Which planet is the second from the Sun and the hottest in the solar system?",
+      "ja": "太陽から2番目で太陽系で最も高温の惑星は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kidney",
+        "ja": "腎臓",
+        "ja_typings": [
+          "jinzou"
+        ]
+      },
+      {
+        "en": "Liver",
+        "ja": "肝臓",
+        "ja_typings": [
+          "kanzou"
+        ]
+      },
+      {
+        "en": "Spleen",
+        "ja": "脾臓",
+        "ja_typings": [
+          "hizou"
+        ]
+      },
+      {
+        "en": "Pancreas",
+        "ja": "膵臓",
+        "ja_typings": [
+          "suizou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02116",
+    "image_path": null,
+    "question_text": {
+      "en": "Which human organ filters blood and produces urine?",
+      "ja": "血液を濾過し尿を生成する人体の臓器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Spleen",
+        "ja": "脾臓",
+        "ja_typings": [
+          "hizou"
+        ]
+      },
+      {
+        "en": "Kidney",
+        "ja": "腎臓",
+        "ja_typings": [
+          "jinzou"
+        ]
+      },
+      {
+        "en": "Liver",
+        "ja": "肝臓",
+        "ja_typings": [
+          "kanzou"
+        ]
+      },
+      {
+        "en": "Pancreas",
+        "ja": "膵臓",
+        "ja_typings": [
+          "suizou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02117",
+    "image_path": null,
+    "question_text": {
+      "en": "Which organ stores white blood cells and recycles old red blood cells?",
+      "ja": "白血球を蓄え古い赤血球を分解する臓器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lamarck",
+        "ja": "ラマルク",
+        "ja_typings": [
+          "ramaruku"
+        ]
+      },
+      {
+        "en": "Darwin",
+        "ja": "ダーウィン",
+        "ja_typings": [
+          "da-win"
+        ]
+      },
+      {
+        "en": "Linnaeus",
+        "ja": "リンネ",
+        "ja_typings": [
+          "rinnne"
+        ]
+      },
+      {
+        "en": "Cuvier",
+        "ja": "キュヴィエ",
+        "ja_typings": [
+          "kyuvie"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02118",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French naturalist proposed an early theory of inheritance of acquired characteristics?",
+      "ja": "獲得形質の遺伝説を提唱したフランスの博物学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Curie",
+        "ja": "キュリー",
+        "ja_typings": [
+          "kyuri-"
+        ]
+      },
+      {
+        "en": "Becquerel",
+        "ja": "ベクレル",
+        "ja_typings": [
+          "bekureru"
+        ]
+      },
+      {
+        "en": "Rutherford",
+        "ja": "ラザフォード",
+        "ja_typings": [
+          "razafo-do"
+        ]
+      },
+      {
+        "en": "Roentgen",
+        "ja": "レントゲン",
+        "ja_typings": [
+          "rentogen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02119",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Polish-French scientist discovered polonium and radium?",
+      "ja": "ポロニウムとラジウムを発見したポーランド系フランス人科学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Reflection",
+        "ja": "反射",
+        "ja_typings": [
+          "hansha"
+        ]
+      },
+      {
+        "en": "Refraction",
+        "ja": "屈折",
+        "ja_typings": [
+          "kussetsu"
+        ]
+      },
+      {
+        "en": "Diffraction",
+        "ja": "回折",
+        "ja_typings": [
+          "kaisetsu"
+        ]
+      },
+      {
+        "en": "Absorption",
+        "ja": "吸収",
+        "ja_typings": [
+          "kyuushuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02120",
+    "image_path": null,
+    "question_text": {
+      "en": "Which optical phenomenon describes light bouncing off a surface?",
+      "ja": "光が表面で跳ね返る光学現象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Diffraction",
+        "ja": "回折",
+        "ja_typings": [
+          "kaisetsu"
+        ]
+      },
+      {
+        "en": "Reflection",
+        "ja": "反射",
+        "ja_typings": [
+          "hansha"
+        ]
+      },
+      {
+        "en": "Refraction",
+        "ja": "屈折",
+        "ja_typings": [
+          "kussetsu"
+        ]
+      },
+      {
+        "en": "Interference",
+        "ja": "干渉",
+        "ja_typings": [
+          "kanshou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02121",
+    "image_path": null,
+    "question_text": {
+      "en": "Which wave phenomenon describes bending around obstacles or through narrow slits?",
+      "ja": "障害物や狭い隙間で波が回り込む現象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Brahe",
+        "ja": "ブラーエ",
+        "ja_typings": [
+          "bura-e"
+        ]
+      },
+      {
+        "en": "Kepler",
+        "ja": "ケプラー",
+        "ja_typings": [
+          "kepura-"
+        ]
+      },
+      {
+        "en": "Galileo",
+        "ja": "ガリレオ",
+        "ja_typings": [
+          "garireo"
+        ]
+      },
+      {
+        "en": "Copernicus",
+        "ja": "コペルニクス",
+        "ja_typings": [
+          "koperunikusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02122",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Danish astronomer made precise pre-telescope observations used by Kepler?",
+      "ja": "ケプラーが利用した精密な肉眼観測を残したデンマークの天文学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bar",
+        "ja": "バール",
+        "ja_typings": [
+          "ba-ru"
+        ]
+      },
+      {
+        "en": "Pascal",
+        "ja": "パスカル",
+        "ja_typings": [
+          "pasukaru"
+        ]
+      },
+      {
+        "en": "Atmosphere",
+        "ja": "気圧",
+        "ja_typings": [
+          "kiatsu"
+        ]
+      },
+      {
+        "en": "Torr",
+        "ja": "トル",
+        "ja_typings": [
+          "toru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02123",
+    "image_path": null,
+    "question_text": {
+      "en": "Which unit of pressure equals 100,000 pascals?",
+      "ja": "10万パスカルに相当する圧力の単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Methane",
+        "ja": "メタン",
+        "ja_typings": [
+          "metan"
+        ]
+      },
+      {
+        "en": "Ethane",
+        "ja": "エタン",
+        "ja_typings": [
+          "etan"
+        ]
+      },
+      {
+        "en": "Propane",
+        "ja": "プロパン",
+        "ja_typings": [
+          "puropan"
+        ]
+      },
+      {
+        "en": "Butane",
+        "ja": "ブタン",
+        "ja_typings": [
+          "butan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02124",
+    "image_path": null,
+    "question_text": {
+      "en": "Which gas, CH4, is the main component of natural gas?",
+      "ja": "化学式CH4で天然ガスの主成分である気体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ozone",
+        "ja": "オゾン",
+        "ja_typings": [
+          "ozon"
+        ]
+      },
+      {
+        "en": "Methane",
+        "ja": "メタン",
+        "ja_typings": [
+          "metan"
+        ]
+      },
+      {
+        "en": "Argon",
+        "ja": "アルゴン",
+        "ja_typings": [
+          "arugon"
+        ]
+      },
+      {
+        "en": "Nitrous oxide",
+        "ja": "亜酸化窒素",
+        "ja_typings": [
+          "asankachisso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02125",
+    "image_path": null,
+    "question_text": {
+      "en": "Which atmospheric gas, O3, forms a protective layer in the stratosphere?",
+      "ja": "化学式O3で成層圏に保護層を形成する気体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hooke's law",
+        "ja": "フックの法則",
+        "ja_typings": [
+          "fukku/no/housoku"
+        ]
+      },
+      {
+        "en": "Newton's law",
+        "ja": "ニュートンの法則",
+        "ja_typings": [
+          "nyuuton/no/housoku"
+        ]
+      },
+      {
+        "en": "Boyle's law",
+        "ja": "ボイルの法則",
+        "ja_typings": [
+          "boiru/no/housoku"
+        ]
+      },
+      {
+        "en": "Ohm's law",
+        "ja": "オームの法則",
+        "ja_typings": [
+          "oomu/no/housoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02126",
+    "image_path": null,
+    "question_text": {
+      "en": "Which physical law states that the force exerted by a spring is proportional to its extension?",
+      "ja": "ばねの力が伸びに比例するという物理法則は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Beaufort scale",
+        "ja": "ビューフォート風力階級",
+        "ja_typings": [
+          "byuufooto/fuuryoku/kaikyuu"
+        ]
+      },
+      {
+        "en": "Richter scale",
+        "ja": "リヒター・スケール",
+        "ja_typings": [
+          "rihitaa/sukeeru",
+          "rihita-/suke-ru"
+        ]
+      },
+      {
+        "en": "Fujita scale",
+        "ja": "藤田スケール",
+        "ja_typings": [
+          "fujita/sukeeru"
+        ]
+      },
+      {
+        "en": "Mercalli scale",
+        "ja": "メルカリ震度階級",
+        "ja_typings": [
+          "merukari/shindo/kaikyuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02127",
+    "image_path": null,
+    "question_text": {
+      "en": "Which empirical scale measures wind force from 0 to 12?",
+      "ja": "0から12までで風力を表す経験的尺度は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pluto",
+        "ja": "冥王星",
+        "ja_typings": [
+          "meiousei"
+        ]
+      },
+      {
+        "en": "Ceres",
+        "ja": "ケレス",
+        "ja_typings": [
+          "keresu"
+        ]
+      },
+      {
+        "en": "Eris",
+        "ja": "エリス",
+        "ja_typings": [
+          "erisu"
+        ]
+      },
+      {
+        "en": "Haumea",
+        "ja": "ハウメア",
+        "ja_typings": [
+          "haumea"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02128",
+    "image_path": null,
+    "question_text": {
+      "en": "Which dwarf planet was reclassified from full planet status in 2006?",
+      "ja": "2006年に惑星から準惑星に再分類された天体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CO2",
+        "ja": "二酸化炭素",
+        "ja_typings": [
+          "nisanka/tanso"
+        ]
+      },
+      {
+        "en": "SO2",
+        "ja": "二酸化硫黄",
+        "ja_typings": [
+          "nisanka/iou"
+        ]
+      },
+      {
+        "en": "O2",
+        "ja": "酸素",
+        "ja_typings": [
+          "sanso"
+        ]
+      },
+      {
+        "en": "NH3",
+        "ja": "アンモニア",
+        "ja_typings": [
+          "anmonia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02129",
+    "image_path": null,
+    "question_text": {
+      "en": "Which gas with formula CO2 is a major greenhouse gas exhaled by humans?",
+      "ja": "化学式CO2で人間が呼吸で排出する主要な温室効果ガスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "O2",
+        "ja": "酸素",
+        "ja_typings": [
+          "sanso"
+        ]
+      },
+      {
+        "en": "N2",
+        "ja": "窒素",
+        "ja_typings": [
+          "chisso"
+        ]
+      },
+      {
+        "en": "CO2",
+        "ja": "二酸化炭素",
+        "ja_typings": [
+          "nisanka/tanso"
+        ]
+      },
+      {
+        "en": "H2",
+        "ja": "水素",
+        "ja_typings": [
+          "suiso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02130",
+    "image_path": null,
+    "question_text": {
+      "en": "Which molecule with formula O2 is essential for human respiration?",
+      "ja": "化学式O2で人間の呼吸に不可欠な分子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NH3",
+        "ja": "アンモニア",
+        "ja_typings": [
+          "anmonia"
+        ]
+      },
+      {
+        "en": "CO2",
+        "ja": "二酸化炭素",
+        "ja_typings": [
+          "nisanka/tanso"
+        ]
+      },
+      {
+        "en": "SO2",
+        "ja": "二酸化硫黄",
+        "ja_typings": [
+          "nisanka/iou"
+        ]
+      },
+      {
+        "en": "CH4",
+        "ja": "メタン",
+        "ja_typings": [
+          "metan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02131",
+    "image_path": null,
+    "question_text": {
+      "en": "Which pungent gas with formula NH3 is widely used in fertilizers?",
+      "ja": "化学式NH3で肥料に広く用いられる刺激臭の気体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cu",
+        "ja": "銅",
+        "ja_typings": [
+          "dou"
+        ]
+      },
+      {
+        "en": "Fe",
+        "ja": "鉄",
+        "ja_typings": [
+          "tetsu"
+        ]
+      },
+      {
+        "en": "Au",
+        "ja": "金",
+        "ja_typings": [
+          "kin"
+        ]
+      },
+      {
+        "en": "Ag",
+        "ja": "銀",
+        "ja_typings": [
+          "gin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02132",
+    "image_path": null,
+    "question_text": {
+      "en": "Which element has the chemical symbol Cu?",
+      "ja": "化学記号Cuで表される元素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pb",
+        "ja": "鉛",
+        "ja_typings": [
+          "namari"
+        ]
+      },
+      {
+        "en": "Sn",
+        "ja": "錫",
+        "ja_typings": [
+          "suzu"
+        ]
+      },
+      {
+        "en": "Zn",
+        "ja": "亜鉛",
+        "ja_typings": [
+          "aen"
+        ]
+      },
+      {
+        "en": "Cu",
+        "ja": "銅",
+        "ja_typings": [
+          "dou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02133",
+    "image_path": null,
+    "question_text": {
+      "en": "Which element has the chemical symbol Pb?",
+      "ja": "化学記号Pbで表される元素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "30,000 km",
+        "ja": "40,000 km",
+        "ja_typings": [
+          "40,000 km"
+        ]
+      },
+      {
+        "en": "3,000,000 km",
+        "ja": "3,000,000 km",
+        "ja_typings": [
+          "3,000,000 km"
+        ]
+      },
+      {
+        "en": "3,000 km",
+        "ja": "3,000 km",
+        "ja_typings": [
+          "3,000 km"
+        ]
+      },
+      {
+        "en": "300 km",
+        "ja": "300 km",
+        "ja_typings": [
+          "300 km"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02134",
+    "image_path": null,
+    "question_text": {
+      "en": "Approximately what is the circumference of the Earth at the equator?",
+      "ja": "地球の赤道周長は約何kmか?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "3,000,000 km",
+        "ja": "380,000 km",
+        "ja_typings": [
+          "380,000 km"
+        ]
+      },
+      {
+        "en": "30,000 km",
+        "ja": "30,000 km",
+        "ja_typings": [
+          "30,000 km"
+        ]
+      },
+      {
+        "en": "3,000 km",
+        "ja": "3,000 km",
+        "ja_typings": [
+          "3,000 km"
+        ]
+      },
+      {
+        "en": "300,000,000 km",
+        "ja": "300,000,000 km",
+        "ja_typings": [
+          "300,000,000 km"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02135",
+    "image_path": null,
+    "question_text": {
+      "en": "Approximately what is the distance from the Earth to the Moon?",
+      "ja": "地球から月までの距離は約何kmか?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "3,000 km",
+        "ja": "3,500 km",
+        "ja_typings": [
+          "3,500 km"
+        ]
+      },
+      {
+        "en": "30,000 km",
+        "ja": "30,000 km",
+        "ja_typings": [
+          "30,000 km"
+        ]
+      },
+      {
+        "en": "300 km",
+        "ja": "300 km",
+        "ja_typings": [
+          "300 km"
+        ]
+      },
+      {
+        "en": "300,000 km",
+        "ja": "300,000 km",
+        "ja_typings": [
+          "300,000 km"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02136",
+    "image_path": null,
+    "question_text": {
+      "en": "Approximately what is the diameter of the Moon?",
+      "ja": "月の直径は約何kmか?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hawking",
+        "ja": "ホーキング",
+        "ja_typings": [
+          "ho-kingu"
+        ]
+      },
+      {
+        "en": "Penrose",
+        "ja": "ペンローズ",
+        "ja_typings": [
+          "penro-zu"
+        ]
+      },
+      {
+        "en": "Dirac",
+        "ja": "ディラック",
+        "ja_typings": [
+          "dirakku"
+        ]
+      },
+      {
+        "en": "Eddington",
+        "ja": "エディントン",
+        "ja_typings": [
+          "edinton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02137",
+    "image_path": null,
+    "question_text": {
+      "en": "Which British physicist proposed that black holes emit radiation?",
+      "ja": "ブラックホールが放射を発するという理論を提唱したイギリスの物理学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Earth",
+        "ja": "地球",
+        "ja_typings": [
+          "chikyuu"
+        ]
+      },
+      {
+        "en": "Venus",
+        "ja": "金星",
+        "ja_typings": [
+          "kinsei"
+        ]
+      },
+      {
+        "en": "Mars",
+        "ja": "火星",
+        "ja_typings": [
+          "kasei"
+        ]
+      },
+      {
+        "en": "Mercury",
+        "ja": "水星",
+        "ja_typings": [
+          "suisei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02138",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the third planet from the Sun?",
+      "ja": "太陽から3番目の惑星は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "N",
+        "ja": "窒素",
+        "ja_typings": [
+          "chisso"
+        ]
+      },
+      {
+        "en": "C",
+        "ja": "炭素",
+        "ja_typings": [
+          "tanso"
+        ]
+      },
+      {
+        "en": "H",
+        "ja": "水素",
+        "ja_typings": [
+          "suiso"
+        ]
+      },
+      {
+        "en": "O",
+        "ja": "酸素",
+        "ja_typings": [
+          "sanso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02139",
+    "image_path": null,
+    "question_text": {
+      "en": "Which element has the chemical symbol N?",
+      "ja": "化学記号Nで表される元素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "C",
+        "ja": "炭素",
+        "ja_typings": [
+          "tanso"
+        ]
+      },
+      {
+        "en": "N",
+        "ja": "窒素",
+        "ja_typings": [
+          "chisso"
+        ]
+      },
+      {
+        "en": "H",
+        "ja": "水素",
+        "ja_typings": [
+          "suiso"
+        ]
+      },
+      {
+        "en": "O",
+        "ja": "酸素",
+        "ja_typings": [
+          "sanso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02140",
+    "image_path": null,
+    "question_text": {
+      "en": "Which element has the chemical symbol C and is the basis of organic chemistry?",
+      "ja": "化学記号Cで有機化学の基礎をなす元素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "H",
+        "ja": "水素",
+        "ja_typings": [
+          "suiso"
+        ]
+      },
+      {
+        "en": "Li",
+        "ja": "リチウム",
+        "ja_typings": [
+          "richiumu"
+        ]
+      },
+      {
+        "en": "K",
+        "ja": "カリウム",
+        "ja_typings": [
+          "kariumu"
+        ]
+      },
+      {
+        "en": "O",
+        "ja": "酸素",
+        "ja_typings": [
+          "sanso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02141",
+    "image_path": null,
+    "question_text": {
+      "en": "Which element has the chemical symbol H and is the lightest element?",
+      "ja": "化学記号Hで最も軽い元素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mendel and Darwin",
+        "ja": "メンデルとダーウィン",
+        "ja_typings": [
+          "menderu/to/daawin",
+          "menderutoda-win"
+        ]
+      },
+      {
+        "en": "Pasteur and Koch",
+        "ja": "パスツールとコッホ",
+        "ja_typings": [
+          "pasutsuuru/to/kohho",
+          "pasutsu-rutokohho"
+        ]
+      },
+      {
+        "en": "Lamarck and Linnaeus",
+        "ja": "ラマルクとリンネ",
+        "ja_typings": [
+          "ramaruku/to/rinne",
+          "ramarukutorinnne"
+        ]
+      },
+      {
+        "en": "Watson and Crick",
+        "ja": "ワトソンとクリック",
+        "ja_typings": [
+          "watoson/to/kurikku",
+          "watosontokurikku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02142",
+    "image_path": null,
+    "question_text": {
+      "en": "Who are the two 19th-century scientists most often cited as founders of evolution and modern genetics?",
+      "ja": "進化論と近代遺伝学の創始者としてよく挙げられる19世紀の2人の科学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pasteur and Koch",
+        "ja": "パスツールとコッホ",
+        "ja_typings": [
+          "pasutsuuru/to/kohho",
+          "pasutsu-rutokohho"
+        ]
+      },
+      {
+        "en": "Mendel and Darwin",
+        "ja": "メンデルとダーウィン",
+        "ja_typings": [
+          "menderu/to/daawin",
+          "menderutoda-win"
+        ]
+      },
+      {
+        "en": "Lamarck and Linnaeus",
+        "ja": "ラマルクとリンネ",
+        "ja_typings": [
+          "ramaruku/to/rinne",
+          "ramarukutorinnne"
+        ]
+      },
+      {
+        "en": "Watson and Crick",
+        "ja": "ワトソンとクリック",
+        "ja_typings": [
+          "watoson/to/kurikku",
+          "watosontokurikku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02143",
+    "image_path": null,
+    "question_text": {
+      "en": "Who are the two 19th-century scientists most associated with the founding of microbiology?",
+      "ja": "微生物学の創始に深く関わった19世紀の2人の科学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lamarck and Linnaeus",
+        "ja": "ラマルクとリンネ",
+        "ja_typings": [
+          "ramaruku/to/rinne",
+          "ramarukutorinnne"
+        ]
+      },
+      {
+        "en": "Mendel and Darwin",
+        "ja": "メンデルとダーウィン",
+        "ja_typings": [
+          "menderu/to/daawin",
+          "menderutoda-win"
+        ]
+      },
+      {
+        "en": "Pasteur and Koch",
+        "ja": "パスツールとコッホ",
+        "ja_typings": [
+          "pasutsuuru/to/kohho",
+          "pasutsu-rutokohho"
+        ]
+      },
+      {
+        "en": "Watson and Crick",
+        "ja": "ワトソンとクリック",
+        "ja_typings": [
+          "watoson/to/kurikku",
+          "watosontokurikku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02144",
+    "image_path": null,
+    "question_text": {
+      "en": "Who are the two pre-Darwinian naturalists associated with early classification and inheritance theory?",
+      "ja": "ダーウィン以前の分類学・進化思想に関わった2人の博物学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Linnaeus",
+        "ja": "リンネ",
+        "ja_typings": [
+          "rinnne"
+        ]
+      },
+      {
+        "en": "Lamarck",
+        "ja": "ラマルク",
+        "ja_typings": [
+          "ramaruku"
+        ]
+      },
+      {
+        "en": "Darwin",
+        "ja": "ダーウィン",
+        "ja_typings": [
+          "da-win"
+        ]
+      },
+      {
+        "en": "Cuvier",
+        "ja": "キュヴィエ",
+        "ja_typings": [
+          "kyuvie"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02145",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 18th-century Swedish naturalist established the modern binomial nomenclature?",
+      "ja": "二名法を確立した18世紀スウェーデンの博物学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "90 degrees",
+        "ja": "180 degrees",
+        "ja_typings": [
+          "180 degrees"
+        ]
+      },
+      {
+        "en": "80 degrees",
+        "ja": "80 degrees",
+        "ja_typings": [
+          "80 degrees"
+        ]
+      },
+      {
+        "en": "120 degrees",
+        "ja": "120 degrees",
+        "ja_typings": [
+          "120 degrees"
+        ]
+      },
+      {
+        "en": "360 degrees",
+        "ja": "360 degrees",
+        "ja_typings": [
+          "360 degrees"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02146",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the sum of the interior angles of a triangle in Euclidean geometry?",
+      "ja": "ユークリッド幾何で三角形の内角の和は何度か?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "80 degrees",
+        "ja": "80 degrees",
+        "ja_typings": [
+          "80 degrees"
+        ]
+      },
+      {
+        "en": "90 degrees",
+        "ja": "90 degrees",
+        "ja_typings": [
+          "90 degrees"
+        ]
+      },
+      {
+        "en": "120 degrees",
+        "ja": "120 degrees",
+        "ja_typings": [
+          "120 degrees"
+        ]
+      },
+      {
+        "en": "100 degrees",
+        "ja": "100 degrees",
+        "ja_typings": [
+          "100 degrees"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02147",
+    "image_path": null,
+    "question_text": {
+      "en": "If an isoceles triangle has a vertex angle of 20 degrees, each base angle measures how many degrees?",
+      "ja": "頂角20度の二等辺三角形の底角はそれぞれ何度か?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "120 degrees",
+        "ja": "120 degrees",
+        "ja_typings": [
+          "120 degrees"
+        ]
+      },
+      {
+        "en": "90 degrees",
+        "ja": "90 degrees",
+        "ja_typings": [
+          "90 degrees"
+        ]
+      },
+      {
+        "en": "80 degrees",
+        "ja": "80 degrees",
+        "ja_typings": [
+          "80 degrees"
+        ]
+      },
+      {
+        "en": "100 degrees",
+        "ja": "100 degrees",
+        "ja_typings": [
+          "100 degrees"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02148",
+    "image_path": null,
+    "question_text": {
+      "en": "Each interior angle of a regular hexagon measures how many degrees?",
+      "ja": "正六角形の1つの内角は何度か?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "100 m",
+        "ja": "100 m",
+        "ja_typings": [
+          "100 m"
+        ]
+      },
+      {
+        "en": "1000 m",
+        "ja": "1000 m",
+        "ja_typings": [
+          "1000 m"
+        ]
+      },
+      {
+        "en": "3000 m",
+        "ja": "3000 m",
+        "ja_typings": [
+          "3000 m"
+        ]
+      },
+      {
+        "en": "10 m",
+        "ja": "10 m",
+        "ja_typings": [
+          "10 m"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02149",
+    "image_path": null,
+    "question_text": {
+      "en": "Approximately how long is a standard Olympic sprint track in meters for the 100m dash?",
+      "ja": "オリンピックの100m走の距離は何mか?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1000 m",
+        "ja": "1000 m",
+        "ja_typings": [
+          "1000 m"
+        ]
+      },
+      {
+        "en": "100 m",
+        "ja": "100 m",
+        "ja_typings": [
+          "100 m"
+        ]
+      },
+      {
+        "en": "3000 m",
+        "ja": "3000 m",
+        "ja_typings": [
+          "3000 m"
+        ]
+      },
+      {
+        "en": "10000 m",
+        "ja": "10000 m",
+        "ja_typings": [
+          "10000 m"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02150",
+    "image_path": null,
+    "question_text": {
+      "en": "How long is a standard track distance for the 1km run in meters?",
+      "ja": "1km走の距離はメートル換算で何mか?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "3000 m",
+        "ja": "3000 m",
+        "ja_typings": [
+          "3000 m"
+        ]
+      },
+      {
+        "en": "100 m",
+        "ja": "100 m",
+        "ja_typings": [
+          "100 m"
+        ]
+      },
+      {
+        "en": "1000 m",
+        "ja": "1000 m",
+        "ja_typings": [
+          "1000 m"
+        ]
+      },
+      {
+        "en": "300 m",
+        "ja": "300 m",
+        "ja_typings": [
+          "300 m"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02151",
+    "image_path": null,
+    "question_text": {
+      "en": "How many meters is a 3km running event?",
+      "ja": "3km走は何mか?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "23",
+        "ja": "23対",
+        "ja_typings": [
+          "23/tsui"
+        ]
+      },
+      {
+        "en": "48",
+        "ja": "48対",
+        "ja_typings": [
+          "48/tsui"
+        ]
+      },
+      {
+        "en": "24",
+        "ja": "24対",
+        "ja_typings": [
+          "24/tsui"
+        ]
+      },
+      {
+        "en": "46",
+        "ja": "46対",
+        "ja_typings": [
+          "46/tsui"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02152",
+    "image_path": null,
+    "question_text": {
+      "en": "How many pairs of chromosomes do humans normally have?",
+      "ja": "ヒトの染色体は通常何対あるか?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "48",
+        "ja": "48本",
+        "ja_typings": [
+          "48/hon"
+        ]
+      },
+      {
+        "en": "23",
+        "ja": "23本",
+        "ja_typings": [
+          "23/hon"
+        ]
+      },
+      {
+        "en": "24",
+        "ja": "24本",
+        "ja_typings": [
+          "24/hon"
+        ]
+      },
+      {
+        "en": "46",
+        "ja": "46本",
+        "ja_typings": [
+          "46/hon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02153",
+    "image_path": null,
+    "question_text": {
+      "en": "How many chromosomes do chimpanzees have in total?",
+      "ja": "チンパンジーの染色体は全部で何本あるか?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "24",
+        "ja": "24時間",
+        "ja_typings": [
+          "24/jikan"
+        ]
+      },
+      {
+        "en": "23",
+        "ja": "23時間",
+        "ja_typings": [
+          "23/jikan"
+        ]
+      },
+      {
+        "en": "48",
+        "ja": "48時間",
+        "ja_typings": [
+          "48/jikan"
+        ]
+      },
+      {
+        "en": "12",
+        "ja": "12時間",
+        "ja_typings": [
+          "12/jikan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02154",
+    "image_path": null,
+    "question_text": {
+      "en": "How many hours are in one day?",
+      "ja": "1日は何時間か?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lungs",
+        "ja": "肺",
+        "ja_typings": [
+          "hai"
+        ]
+      },
+      {
+        "en": "Heart",
+        "ja": "心臓",
+        "ja_typings": [
+          "shinzou"
+        ]
+      },
+      {
+        "en": "Liver",
+        "ja": "肝臓",
+        "ja_typings": [
+          "kanzou"
+        ]
+      },
+      {
+        "en": "Kidney",
+        "ja": "腎臓",
+        "ja_typings": [
+          "jinzou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02155",
+    "image_path": null,
+    "question_text": {
+      "en": "Which organ enables breathing by exchanging oxygen and carbon dioxide?",
+      "ja": "酸素と二酸化炭素を交換し呼吸を担う臓器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Brain",
+        "ja": "脳",
+        "ja_typings": [
+          "nou"
+        ]
+      },
+      {
+        "en": "Heart",
+        "ja": "心臓",
+        "ja_typings": [
+          "shinzou"
+        ]
+      },
+      {
+        "en": "Spinal cord",
+        "ja": "脊髄",
+        "ja_typings": [
+          "sekizui"
+        ]
+      },
+      {
+        "en": "Liver",
+        "ja": "肝臓",
+        "ja_typings": [
+          "kanzou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02156",
+    "image_path": null,
+    "question_text": {
+      "en": "Which organ is the control center of the human nervous system?",
+      "ja": "人間の神経系の中枢を担う臓器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Polaris",
+        "ja": "ポラリス",
+        "ja_typings": [
+          "porarisu"
+        ]
+      },
+      {
+        "en": "Sirius",
+        "ja": "シリウス",
+        "ja_typings": [
+          "shiriusu"
+        ]
+      },
+      {
+        "en": "Betelgeuse",
+        "ja": "ベテルギウス",
+        "ja_typings": [
+          "beterugiusu"
+        ]
+      },
+      {
+        "en": "Vega",
+        "ja": "ベガ",
+        "ja_typings": [
+          "bega"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02157",
+    "image_path": null,
+    "question_text": {
+      "en": "Which star, near the celestial north pole, is used for navigation?",
+      "ja": "天の北極付近にあり航法に使われる恒星は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Betelgeuse",
+        "ja": "ベテルギウス",
+        "ja_typings": [
+          "beterugiusu"
+        ]
+      },
+      {
+        "en": "Sirius",
+        "ja": "シリウス",
+        "ja_typings": [
+          "shiriusu"
+        ]
+      },
+      {
+        "en": "Polaris",
+        "ja": "ポラリス",
+        "ja_typings": [
+          "porarisu"
+        ]
+      },
+      {
+        "en": "Rigel",
+        "ja": "リゲル",
+        "ja_typings": [
+          "rigeru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02158",
+    "image_path": null,
+    "question_text": {
+      "en": "Which red supergiant star marks the shoulder of Orion?",
+      "ja": "オリオン座の肩を成す赤色超巨星は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "KCl",
+        "ja": "塩化カリウム",
+        "ja_typings": [
+          "enka/kariumu"
+        ]
+      },
+      {
+        "en": "NaCl",
+        "ja": "塩化ナトリウム",
+        "ja_typings": [
+          "enka/natoriumu"
+        ]
+      },
+      {
+        "en": "CaCl2",
+        "ja": "塩化カルシウム",
+        "ja_typings": [
+          "enka/karushiumu"
+        ]
+      },
+      {
+        "en": "MgCl2",
+        "ja": "塩化マグネシウム",
+        "ja_typings": [
+          "enka/maguneshiumu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02159",
+    "image_path": null,
+    "question_text": {
+      "en": "Which chemical compound with formula KCl is commonly used as a salt substitute?",
+      "ja": "化学式KClで塩の代替として使われる化合物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CaCO3",
+        "ja": "炭酸カルシウム",
+        "ja_typings": [
+          "tansan/karushiumu"
+        ]
+      },
+      {
+        "en": "CaO",
+        "ja": "酸化カルシウム",
+        "ja_typings": [
+          "sanka/karushiumu"
+        ]
+      },
+      {
+        "en": "Ca(OH)2",
+        "ja": "水酸化カルシウム",
+        "ja_typings": [
+          "suisanka/karushiumu"
+        ]
+      },
+      {
+        "en": "CaSO4",
+        "ja": "硫酸カルシウム",
+        "ja_typings": [
+          "ryuusan/karushiumu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02160",
+    "image_path": null,
+    "question_text": {
+      "en": "Which compound with formula CaCO3 is the main component of limestone?",
+      "ja": "化学式CaCO3で石灰岩の主成分である化合物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Central limit theorem",
+        "ja": "中心極限定理",
+        "ja_typings": [
+          "chuushinkyokugenteiri"
+        ]
+      },
+      {
+        "en": "Law of large numbers",
+        "ja": "大数の法則",
+        "ja_typings": [
+          "taisuunohousoku"
+        ]
+      },
+      {
+        "en": "Bayes theorem",
+        "ja": "ベイズの定理",
+        "ja_typings": [
+          "beizunoteiri"
+        ]
+      },
+      {
+        "en": "Chebyshev inequality",
+        "ja": "チェビシェフの不等式",
+        "ja_typings": [
+          "chebishefunofutoushiki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02161",
+    "image_path": null,
+    "question_text": {
+      "en": "Which theorem states that large samples' means tend toward a normal distribution?",
+      "ja": "大規模標本の平均が正規分布に近づくとする定理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hilbert",
+        "ja": "ヒルベルト",
+        "ja_typings": [
+          "hiruberuto"
+        ]
+      },
+      {
+        "en": "Gauss",
+        "ja": "ガウス",
+        "ja_typings": [
+          "gausu"
+        ]
+      },
+      {
+        "en": "Euler",
+        "ja": "オイラー",
+        "ja_typings": [
+          "oira-"
+        ]
+      },
+      {
+        "en": "Cantor",
+        "ja": "カントール",
+        "ja_typings": [
+          "kanto-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02162",
+    "image_path": null,
+    "question_text": {
+      "en": "Who proposed 23 famous unsolved problems in 1900?",
+      "ja": "1900年に23の未解決問題を提示した数学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cauchy",
+        "ja": "コーシー",
+        "ja_typings": [
+          "ko-shi-"
+        ]
+      },
+      {
+        "en": "Weierstrass",
+        "ja": "ワイエルシュトラス",
+        "ja_typings": [
+          "waierushutorasu"
+        ]
+      },
+      {
+        "en": "Jacobi",
+        "ja": "ヤコビ",
+        "ja_typings": [
+          "yakobi"
+        ]
+      },
+      {
+        "en": "Liouville",
+        "ja": "リウヴィル",
+        "ja_typings": [
+          "riuviru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02163",
+    "image_path": null,
+    "question_text": {
+      "en": "Whose name is associated with the integral formula for analytic functions on a closed contour?",
+      "ja": "閉曲線上の解析関数の積分公式に名を残す数学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Riemann",
+        "ja": "リーマン",
+        "ja_typings": [
+          "ri-man"
+        ]
+      },
+      {
+        "en": "Hilbert",
+        "ja": "ヒルベルト",
+        "ja_typings": [
+          "hiruberuto"
+        ]
+      },
+      {
+        "en": "Poincare",
+        "ja": "ポアンカレ",
+        "ja_typings": [
+          "poankare"
+        ]
+      },
+      {
+        "en": "Dedekind",
+        "ja": "デデキント",
+        "ja_typings": [
+          "dedekinto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02164",
+    "image_path": null,
+    "question_text": {
+      "en": "Whose hypothesis about the zeros of the zeta function is a Millennium Prize problem?",
+      "ja": "ゼータ関数の零点に関する仮説で知られミレニアム懸賞問題となっている数学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Abel",
+        "ja": "アーベル",
+        "ja_typings": [
+          "a-beru"
+        ]
+      },
+      {
+        "en": "Galois",
+        "ja": "ガロア",
+        "ja_typings": [
+          "garoa"
+        ]
+      },
+      {
+        "en": "Lagrange",
+        "ja": "ラグランジュ",
+        "ja_typings": [
+          "raguranju"
+        ]
+      },
+      {
+        "en": "Ruffini",
+        "ja": "ルフィニ",
+        "ja_typings": [
+          "rufini"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02165",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Norwegian mathematician proved the impossibility of solving the general quintic by radicals?",
+      "ja": "一般5次方程式が代数的に解けないことを示したノルウェーの数学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rational number",
+        "ja": "有理数",
+        "ja_typings": [
+          "yuurisuu"
+        ]
+      },
+      {
+        "en": "Irrational number",
+        "ja": "無理数",
+        "ja_typings": [
+          "murisuu"
+        ]
+      },
+      {
+        "en": "Imaginary number",
+        "ja": "虚数",
+        "ja_typings": [
+          "kyosuu"
+        ]
+      },
+      {
+        "en": "Transcendental number",
+        "ja": "超越数",
+        "ja_typings": [
+          "chouetsusuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02166",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call a number that can be expressed as a ratio of two integers?",
+      "ja": "2つの整数の比で表せる数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "270 degrees",
+        "ja": "270度",
+        "ja_typings": [
+          "270do"
+        ]
+      },
+      {
+        "en": "180 degrees",
+        "ja": "180度",
+        "ja_typings": [
+          "180do"
+        ]
+      },
+      {
+        "en": "90 degrees",
+        "ja": "90度",
+        "ja_typings": [
+          "90do"
+        ]
+      },
+      {
+        "en": "360 degrees",
+        "ja": "360度",
+        "ja_typings": [
+          "360do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02167",
+    "image_path": null,
+    "question_text": {
+      "en": "If you rotate three-quarters of a full turn, how many degrees is that?",
+      "ja": "1回転の4分の3を角度で表すと?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1/3",
+        "ja": "3分の1",
+        "ja_typings": [
+          "3bunno1"
+        ]
+      },
+      {
+        "en": "2/6",
+        "ja": "6分の2",
+        "ja_typings": [
+          "6bunno2"
+        ]
+      },
+      {
+        "en": "1/2",
+        "ja": "2分の1",
+        "ja_typings": [
+          "2bunno1"
+        ]
+      },
+      {
+        "en": "1/6",
+        "ja": "6分の1",
+        "ja_typings": [
+          "6bunno1"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02168",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the value of 2 divided by 6 as a fraction in lowest terms?",
+      "ja": "2÷6を既約分数にすると?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "100",
+        "ja": "100",
+        "ja_typings": [
+          "100"
+        ]
+      },
+      {
+        "en": "1000",
+        "ja": "1000",
+        "ja_typings": [
+          "1000"
+        ]
+      },
+      {
+        "en": "20",
+        "ja": "20",
+        "ja_typings": [
+          "20"
+        ]
+      },
+      {
+        "en": "200",
+        "ja": "200",
+        "ja_typings": [
+          "200"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02169",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 10 squared?",
+      "ja": "10の2乗は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "21",
+        "ja": "21",
+        "ja_typings": [
+          "21"
+        ]
+      },
+      {
+        "en": "24",
+        "ja": "24",
+        "ja_typings": [
+          "24"
+        ]
+      },
+      {
+        "en": "18",
+        "ja": "18",
+        "ja_typings": [
+          "18"
+        ]
+      },
+      {
+        "en": "27",
+        "ja": "27",
+        "ja_typings": [
+          "27"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02170",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 3 multiplied by 7?",
+      "ja": "3×7はいくつ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "8",
+        "ja": "8",
+        "ja_typings": [
+          "8"
+        ]
+      },
+      {
+        "en": "6",
+        "ja": "6",
+        "ja_typings": [
+          "6"
+        ]
+      },
+      {
+        "en": "9",
+        "ja": "9",
+        "ja_typings": [
+          "9"
+        ]
+      },
+      {
+        "en": "16",
+        "ja": "16",
+        "ja_typings": [
+          "16"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02171",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 2 to the third power?",
+      "ja": "2の3乗は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sphere",
+        "ja": "球",
+        "ja_typings": [
+          "tama",
+          "kyuu"
+        ]
+      },
+      {
+        "en": "cube",
+        "ja": "立方体",
+        "ja_typings": [
+          "rippoutai"
+        ]
+      },
+      {
+        "en": "cylinder",
+        "ja": "円柱",
+        "ja_typings": [
+          "enchuu"
+        ]
+      },
+      {
+        "en": "cone",
+        "ja": "円錐",
+        "ja_typings": [
+          "ensui"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02172",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the name of a perfectly round 3D figure where all surface points are equidistant from the center?",
+      "ja": "中心から表面までの距離がすべて等しい立体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "2",
+        "ja": "2",
+        "ja_typings": [
+          "2"
+        ]
+      },
+      {
+        "en": "4",
+        "ja": "4",
+        "ja_typings": [
+          "4"
+        ]
+      },
+      {
+        "en": "6",
+        "ja": "6",
+        "ja_typings": [
+          "6"
+        ]
+      },
+      {
+        "en": "8",
+        "ja": "8",
+        "ja_typings": [
+          "8"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02173",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the only even prime number?",
+      "ja": "唯一の偶数の素数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "4",
+        "ja": "4",
+        "ja_typings": [
+          "4"
+        ]
+      },
+      {
+        "en": "8",
+        "ja": "8",
+        "ja_typings": [
+          "8"
+        ]
+      },
+      {
+        "en": "16",
+        "ja": "16",
+        "ja_typings": [
+          "16"
+        ]
+      },
+      {
+        "en": "6",
+        "ja": "6",
+        "ja_typings": [
+          "6"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02174",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 2 squared?",
+      "ja": "2の2乗は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Goldbach",
+        "ja": "ゴールドバッハ",
+        "ja_typings": [
+          "go-rudobahha"
+        ]
+      },
+      {
+        "en": "Euler",
+        "ja": "オイラー",
+        "ja_typings": [
+          "oira-"
+        ]
+      },
+      {
+        "en": "Fermat",
+        "ja": "フェルマー",
+        "ja_typings": [
+          "feruma-"
+        ]
+      },
+      {
+        "en": "Riemann",
+        "ja": "リーマン",
+        "ja_typings": [
+          "ri-man"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02175",
+    "image_path": null,
+    "question_text": {
+      "en": "Whose conjecture says every even integer greater than 2 is the sum of two primes?",
+      "ja": "2より大きい偶数はすべて2つの素数の和で表せるという予想を提唱したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fermat's Last Theorem",
+        "ja": "フェルマーの最終定理",
+        "ja_typings": [
+          "ferumaanosaishuuteiri"
+        ]
+      },
+      {
+        "en": "Goldbach conjecture",
+        "ja": "ゴールドバッハ予想",
+        "ja_typings": [
+          "goorudobahhayosou"
+        ]
+      },
+      {
+        "en": "Riemann hypothesis",
+        "ja": "リーマン予想",
+        "ja_typings": [
+          "riimanyosou"
+        ]
+      },
+      {
+        "en": "Twin prime conjecture",
+        "ja": "双子素数予想",
+        "ja_typings": [
+          "futagososuuyosou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02176",
+    "image_path": null,
+    "question_text": {
+      "en": "Which theorem proven by Andrew Wiles in 1995 says x^n + y^n = z^n has no positive integer solutions for n > 2?",
+      "ja": "1995年にワイルズが証明した、n>2でx^n+y^n=z^nが正整数解を持たないとする定理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Binomial theorem",
+        "ja": "二項定理",
+        "ja_typings": [
+          "nikouteiri"
+        ]
+      },
+      {
+        "en": "Multinomial theorem",
+        "ja": "多項定理",
+        "ja_typings": [
+          "takouteiri"
+        ]
+      },
+      {
+        "en": "Taylor theorem",
+        "ja": "テイラーの定理",
+        "ja_typings": [
+          "teiraanoteiri"
+        ]
+      },
+      {
+        "en": "Mean value theorem",
+        "ja": "平均値の定理",
+        "ja_typings": [
+          "heikinchinoteiri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02177",
+    "image_path": null,
+    "question_text": {
+      "en": "Which theorem expands (a+b)^n using combinations?",
+      "ja": "(a+b)^nを組合せを使って展開する定理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Phi",
+        "ja": "ファイ",
+        "ja_typings": [
+          "fai"
+        ]
+      },
+      {
+        "en": "Psi",
+        "ja": "プサイ",
+        "ja_typings": [
+          "pusai"
+        ]
+      },
+      {
+        "en": "Chi",
+        "ja": "カイ",
+        "ja_typings": [
+          "kai"
+        ]
+      },
+      {
+        "en": "Omega",
+        "ja": "オメガ",
+        "ja_typings": [
+          "omega"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02178",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Greek letter is often used to denote the golden ratio?",
+      "ja": "黄金比を表すのによく使われるギリシャ文字は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Theta",
+        "ja": "シータ",
+        "ja_typings": [
+          "shi-ta"
+        ]
+      },
+      {
+        "en": "Phi",
+        "ja": "ファイ",
+        "ja_typings": [
+          "fai"
+        ]
+      },
+      {
+        "en": "Lambda",
+        "ja": "ラムダ",
+        "ja_typings": [
+          "ramuda"
+        ]
+      },
+      {
+        "en": "Sigma",
+        "ja": "シグマ",
+        "ja_typings": [
+          "shiguma"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02179",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Greek letter is commonly used to denote an angle?",
+      "ja": "角度を表すのによく使われるギリシャ文字は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bernoulli",
+        "ja": "ベルヌーイ",
+        "ja_typings": [
+          "berunu-i"
+        ]
+      },
+      {
+        "en": "Euler",
+        "ja": "オイラー",
+        "ja_typings": [
+          "oira-"
+        ]
+      },
+      {
+        "en": "Cauchy",
+        "ja": "コーシー",
+        "ja_typings": [
+          "ko-shi-"
+        ]
+      },
+      {
+        "en": "Lagrange",
+        "ja": "ラグランジュ",
+        "ja_typings": [
+          "raguranju"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02180",
+    "image_path": null,
+    "question_text": {
+      "en": "Whose family produced multiple Swiss mathematicians known for probability and fluid dynamics?",
+      "ja": "確率や流体力学で知られるスイスの数学者一族の名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dedekind",
+        "ja": "デデキント",
+        "ja_typings": [
+          "dedekinto"
+        ]
+      },
+      {
+        "en": "Cantor",
+        "ja": "カントール",
+        "ja_typings": [
+          "kanto-ru"
+        ]
+      },
+      {
+        "en": "Weierstrass",
+        "ja": "ワイエルシュトラス",
+        "ja_typings": [
+          "waierushutorasu"
+        ]
+      },
+      {
+        "en": "Riemann",
+        "ja": "リーマン",
+        "ja_typings": [
+          "ri-man"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02181",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is known for the construction of real numbers via cuts of rationals?",
+      "ja": "有理数の切断で実数を構成したことで知られる数学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Poincare",
+        "ja": "ポアンカレ",
+        "ja_typings": [
+          "poankare"
+        ]
+      },
+      {
+        "en": "Cauchy",
+        "ja": "コーシー",
+        "ja_typings": [
+          "ko-shi-"
+        ]
+      },
+      {
+        "en": "Lagrange",
+        "ja": "ラグランジュ",
+        "ja_typings": [
+          "raguranju"
+        ]
+      },
+      {
+        "en": "Galois",
+        "ja": "ガロア",
+        "ja_typings": [
+          "garoa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02182",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French mathematician's conjecture on 3-manifolds was solved by Perelman?",
+      "ja": "3次元多様体に関する予想がペレルマンに解かれたフランスの数学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lagrange",
+        "ja": "ラグランジュ",
+        "ja_typings": [
+          "raguranju"
+        ]
+      },
+      {
+        "en": "Laplace",
+        "ja": "ラプラス",
+        "ja_typings": [
+          "rapurasu"
+        ]
+      },
+      {
+        "en": "Legendre",
+        "ja": "ルジャンドル",
+        "ja_typings": [
+          "rujandoru"
+        ]
+      },
+      {
+        "en": "Fermat",
+        "ja": "フェルマー",
+        "ja_typings": [
+          "feruma-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02183",
+    "image_path": null,
+    "question_text": {
+      "en": "Who developed the calculus of variations and a theorem on subgroup order in group theory?",
+      "ja": "変分法を発展させ群論で部分群の位数の定理にも名を残す数学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Composite number",
+        "ja": "合成数",
+        "ja_typings": [
+          "gouseisuu"
+        ]
+      },
+      {
+        "en": "Prime number",
+        "ja": "素数",
+        "ja_typings": [
+          "sosuu"
+        ]
+      },
+      {
+        "en": "Perfect number",
+        "ja": "完全数",
+        "ja_typings": [
+          "kanzensuu"
+        ]
+      },
+      {
+        "en": "Natural number",
+        "ja": "自然数",
+        "ja_typings": [
+          "shizensuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02184",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call a positive integer with more than two divisors?",
+      "ja": "約数を3つ以上もつ正の整数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Perfect number",
+        "ja": "完全数",
+        "ja_typings": [
+          "kanzensuu"
+        ]
+      },
+      {
+        "en": "Amicable number",
+        "ja": "友愛数",
+        "ja_typings": [
+          "yuuaisuu"
+        ]
+      },
+      {
+        "en": "Composite number",
+        "ja": "合成数",
+        "ja_typings": [
+          "gouseisuu"
+        ]
+      },
+      {
+        "en": "Triangular number",
+        "ja": "三角数",
+        "ja_typings": [
+          "sankakusuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02185",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call a positive integer equal to the sum of its proper divisors, like 6 or 28?",
+      "ja": "自分自身を除く約数の和が自分自身に等しい数(6や28)は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Natural number",
+        "ja": "自然数",
+        "ja_typings": [
+          "shizensuu"
+        ]
+      },
+      {
+        "en": "Integer",
+        "ja": "整数",
+        "ja_typings": [
+          "seisuu"
+        ]
+      },
+      {
+        "en": "Rational number",
+        "ja": "有理数",
+        "ja_typings": [
+          "yuurisuu"
+        ]
+      },
+      {
+        "en": "Real number",
+        "ja": "実数",
+        "ja_typings": [
+          "jissuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02186",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call the counting numbers 1, 2, 3, ...?",
+      "ja": "1, 2, 3, ... のような数え上げの数を何という?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Integer",
+        "ja": "整数",
+        "ja_typings": [
+          "seisuu"
+        ]
+      },
+      {
+        "en": "Natural number",
+        "ja": "自然数",
+        "ja_typings": [
+          "shizensuu"
+        ]
+      },
+      {
+        "en": "Rational number",
+        "ja": "有理数",
+        "ja_typings": [
+          "yuurisuu"
+        ]
+      },
+      {
+        "en": "Whole number",
+        "ja": "全数",
+        "ja_typings": [
+          "zensuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02187",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call the set including negative whole numbers, zero, and positive whole numbers?",
+      "ja": "負・0・正の整数すべてをまとめた数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Napier's number e",
+        "ja": "ネイピア数e",
+        "ja_typings": [
+          "neipiasuue"
+        ]
+      },
+      {
+        "en": "Pi",
+        "ja": "円周率",
+        "ja_typings": [
+          "enshuuritsu"
+        ]
+      },
+      {
+        "en": "Golden ratio",
+        "ja": "黄金比",
+        "ja_typings": [
+          "ougonhi"
+        ]
+      },
+      {
+        "en": "Euler-Mascheroni constant",
+        "ja": "オイラーマスケローニ定数",
+        "ja_typings": [
+          "oiraamasukerooniteisuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02188",
+    "image_path": null,
+    "question_text": {
+      "en": "Which constant approximately 2.71828 is the base of the natural logarithm?",
+      "ja": "自然対数の底となる約2.71828の定数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Golden ratio phi",
+        "ja": "黄金比φ",
+        "ja_typings": [
+          "ougonhi"
+        ]
+      },
+      {
+        "en": "Silver ratio",
+        "ja": "白銀比",
+        "ja_typings": [
+          "hakuginhi"
+        ]
+      },
+      {
+        "en": "Napier's number e",
+        "ja": "ネイピア数e",
+        "ja_typings": [
+          "neipiasuue"
+        ]
+      },
+      {
+        "en": "Bronze ratio",
+        "ja": "青銅比",
+        "ja_typings": [
+          "seidouhi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02189",
+    "image_path": null,
+    "question_text": {
+      "en": "Which constant approximately 1.618 is often denoted by the Greek letter phi?",
+      "ja": "ギリシャ文字ファイで表される約1.618の定数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pi",
+        "ja": "円周率π",
+        "ja_typings": [
+          "enshuuritsu"
+        ]
+      },
+      {
+        "en": "Napier's number e",
+        "ja": "ネイピア数e",
+        "ja_typings": [
+          "neipiasuue"
+        ]
+      },
+      {
+        "en": "Golden ratio",
+        "ja": "黄金比",
+        "ja_typings": [
+          "ougonhi"
+        ]
+      },
+      {
+        "en": "Square root of 2",
+        "ja": "ルート2",
+        "ja_typings": [
+          "ruuto2",
+          "ru-to2"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02190",
+    "image_path": null,
+    "question_text": {
+      "en": "Which constant approximately equals 3.14159?",
+      "ja": "約3.14159となる定数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Euler-Mascheroni constant",
+        "ja": "オイラーマスケローニ定数",
+        "ja_typings": [
+          "oiraamasukerooniteisuu"
+        ]
+      },
+      {
+        "en": "Napier's number e",
+        "ja": "ネイピア数e",
+        "ja_typings": [
+          "neipiasuue"
+        ]
+      },
+      {
+        "en": "Catalan constant",
+        "ja": "カタラン定数",
+        "ja_typings": [
+          "kataranteisuu"
+        ]
+      },
+      {
+        "en": "Apery's constant",
+        "ja": "アペリーの定数",
+        "ja_typings": [
+          "aperiinoteisuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02191",
+    "image_path": null,
+    "question_text": {
+      "en": "Which constant approximately 0.5772 appears as the limit difference between harmonic sums and the natural log?",
+      "ja": "調和数と自然対数の差の極限として現れる約0.5772の定数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Silver ratio",
+        "ja": "白銀比",
+        "ja_typings": [
+          "hakuginhi"
+        ]
+      },
+      {
+        "en": "Golden ratio",
+        "ja": "黄金比",
+        "ja_typings": [
+          "ougonhi"
+        ]
+      },
+      {
+        "en": "Bronze ratio",
+        "ja": "青銅比",
+        "ja_typings": [
+          "seidouhi"
+        ]
+      },
+      {
+        "en": "Harmonic ratio",
+        "ja": "調和比",
+        "ja_typings": [
+          "chouwahi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02192",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ratio approximately 1:1.414 appears in A4 paper sizes?",
+      "ja": "A4などのコピー用紙に現れる約1:1.414の比は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bronze ratio",
+        "ja": "青銅比",
+        "ja_typings": [
+          "seidouhi"
+        ]
+      },
+      {
+        "en": "Copper ratio",
+        "ja": "銅比",
+        "ja_typings": [
+          "douhi"
+        ]
+      },
+      {
+        "en": "Iron ratio",
+        "ja": "鉄比",
+        "ja_typings": [
+          "tetsuhi"
+        ]
+      },
+      {
+        "en": "Platinum ratio",
+        "ja": "白金比",
+        "ja_typings": [
+          "hakkinhi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02193",
+    "image_path": null,
+    "question_text": {
+      "en": "Which metallic ratio is the third in the series after golden and silver?",
+      "ja": "黄金比、白銀比に続く第3の金属比は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Harmonic ratio",
+        "ja": "調和比",
+        "ja_typings": [
+          "chouwahi"
+        ]
+      },
+      {
+        "en": "Golden ratio",
+        "ja": "黄金比",
+        "ja_typings": [
+          "ougonhi"
+        ]
+      },
+      {
+        "en": "Silver ratio",
+        "ja": "白銀比",
+        "ja_typings": [
+          "hakuginhi"
+        ]
+      },
+      {
+        "en": "Geometric ratio",
+        "ja": "幾何比",
+        "ja_typings": [
+          "kikahi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02194",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call a ratio related to harmonic means used in music and projective geometry?",
+      "ja": "音楽や射影幾何で現れる調和平均に関わる比を何という?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Arithmetic sequence",
+        "ja": "等差数列",
+        "ja_typings": [
+          "touasuuretsu"
+        ]
+      },
+      {
+        "en": "Geometric sequence",
+        "ja": "等比数列",
+        "ja_typings": [
+          "touhisuuretsu"
+        ]
+      },
+      {
+        "en": "Harmonic sequence",
+        "ja": "調和数列",
+        "ja_typings": [
+          "chouwasuuretsu"
+        ]
+      },
+      {
+        "en": "Fibonacci sequence",
+        "ja": "フィボナッチ数列",
+        "ja_typings": [
+          "fibonacchisuuretsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02195",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call a sequence where each term differs from the previous by a constant?",
+      "ja": "隣り合う項の差が一定の数列は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Geometric sequence",
+        "ja": "等比数列",
+        "ja_typings": [
+          "touhisuuretsu"
+        ]
+      },
+      {
+        "en": "Arithmetic sequence",
+        "ja": "等差数列",
+        "ja_typings": [
+          "touasuuretsu"
+        ]
+      },
+      {
+        "en": "Harmonic sequence",
+        "ja": "調和数列",
+        "ja_typings": [
+          "chouwasuuretsu"
+        ]
+      },
+      {
+        "en": "Constant sequence",
+        "ja": "定数数列",
+        "ja_typings": [
+          "teisuusuuretsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02196",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call a sequence where each term is a constant multiple of the previous one?",
+      "ja": "隣り合う項の比が一定の数列は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Harmonic sequence",
+        "ja": "調和数列",
+        "ja_typings": [
+          "chouwasuuretsu"
+        ]
+      },
+      {
+        "en": "Arithmetic sequence",
+        "ja": "等差数列",
+        "ja_typings": [
+          "touasuuretsu"
+        ]
+      },
+      {
+        "en": "Geometric sequence",
+        "ja": "等比数列",
+        "ja_typings": [
+          "touhisuuretsu"
+        ]
+      },
+      {
+        "en": "Reciprocal sequence",
+        "ja": "逆数列",
+        "ja_typings": [
+          "gyakusuuretsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02197",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call a sequence whose reciprocals form an arithmetic progression?",
+      "ja": "逆数を取ると等差数列になる数列は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "90 degrees",
+        "ja": "90度",
+        "ja_typings": [
+          "90do"
+        ]
+      },
+      {
+        "en": "45 degrees",
+        "ja": "45度",
+        "ja_typings": [
+          "45do"
+        ]
+      },
+      {
+        "en": "180 degrees",
+        "ja": "180度",
+        "ja_typings": [
+          "180do"
+        ]
+      },
+      {
+        "en": "60 degrees",
+        "ja": "60度",
+        "ja_typings": [
+          "60do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02198",
+    "image_path": null,
+    "question_text": {
+      "en": "How many degrees is a right angle?",
+      "ja": "直角は何度?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "2/3",
+        "ja": "3分の2",
+        "ja_typings": [
+          "3bunno2"
+        ]
+      },
+      {
+        "en": "4/6",
+        "ja": "6分の4",
+        "ja_typings": [
+          "6bunno4"
+        ]
+      },
+      {
+        "en": "3/4",
+        "ja": "4分の3",
+        "ja_typings": [
+          "4bunno3"
+        ]
+      },
+      {
+        "en": "1/2",
+        "ja": "2分の1",
+        "ja_typings": [
+          "2bunno1"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02199",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 4 divided by 6 as a fraction in lowest terms?",
+      "ja": "4÷6を既約分数で表すと?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cup",
+        "ja": "カップ",
+        "ja_typings": [
+          "kappu"
+        ]
+      },
+      {
+        "en": "Cap",
+        "ja": "キャップ",
+        "ja_typings": [
+          "kyappu"
+        ]
+      },
+      {
+        "en": "Subset",
+        "ja": "サブセット",
+        "ja_typings": [
+          "sabusetto"
+        ]
+      },
+      {
+        "en": "Element of",
+        "ja": "属する",
+        "ja_typings": [
+          "zokusuru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02200",
+    "image_path": null,
+    "question_text": {
+      "en": "Which set operation symbol represents the union of two sets?",
+      "ja": "2つの集合の和集合を表す記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Subset",
+        "ja": "部分集合",
+        "ja_typings": [
+          "bubunshuugou"
+        ]
+      },
+      {
+        "en": "Superset",
+        "ja": "上位集合",
+        "ja_typings": [
+          "jouishuugou"
+        ]
+      },
+      {
+        "en": "Power set",
+        "ja": "ベキ集合",
+        "ja_typings": [
+          "bekishuugou"
+        ]
+      },
+      {
+        "en": "Empty set",
+        "ja": "空集合",
+        "ja_typings": [
+          "kuushuugou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02201",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call set A when every element of A is also in set B?",
+      "ja": "Aの要素すべてがBに含まれているとき、AはBの何?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Element of",
+        "ja": "属する",
+        "ja_typings": [
+          "zokusuru"
+        ]
+      },
+      {
+        "en": "Subset",
+        "ja": "部分集合",
+        "ja_typings": [
+          "bubunshuugou"
+        ]
+      },
+      {
+        "en": "Union",
+        "ja": "和集合",
+        "ja_typings": [
+          "washuugou"
+        ]
+      },
+      {
+        "en": "Intersection",
+        "ja": "共通部分",
+        "ja_typings": [
+          "kyoutsuububun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02202",
+    "image_path": null,
+    "question_text": {
+      "en": "Which symbol means 'is an element of'?",
+      "ja": "「要素として属する」を表す記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Scalar",
+        "ja": "スカラー",
+        "ja_typings": [
+          "sukara-"
+        ]
+      },
+      {
+        "en": "Vector",
+        "ja": "ベクトル",
+        "ja_typings": [
+          "bekutoru"
+        ]
+      },
+      {
+        "en": "Tensor",
+        "ja": "テンソル",
+        "ja_typings": [
+          "tensoru"
+        ]
+      },
+      {
+        "en": "Matrix",
+        "ja": "行列",
+        "ja_typings": [
+          "gyouretsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02203",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call a single number quantity without direction?",
+      "ja": "向きを持たず大きさのみの量は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tensor",
+        "ja": "テンソル",
+        "ja_typings": [
+          "tensoru"
+        ]
+      },
+      {
+        "en": "Scalar",
+        "ja": "スカラー",
+        "ja_typings": [
+          "sukara-"
+        ]
+      },
+      {
+        "en": "Vector",
+        "ja": "ベクトル",
+        "ja_typings": [
+          "bekutoru"
+        ]
+      },
+      {
+        "en": "Spinor",
+        "ja": "スピノル",
+        "ja_typings": [
+          "supinoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02204",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call a multi-dimensional generalization of vectors and matrices?",
+      "ja": "ベクトルや行列を多次元に一般化した量は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sequence",
+        "ja": "数列",
+        "ja_typings": [
+          "suuretsu"
+        ]
+      },
+      {
+        "en": "Series",
+        "ja": "級数",
+        "ja_typings": [
+          "kyuusuu"
+        ]
+      },
+      {
+        "en": "Set",
+        "ja": "集合",
+        "ja_typings": [
+          "shuugou"
+        ]
+      },
+      {
+        "en": "Function",
+        "ja": "関数",
+        "ja_typings": [
+          "kansuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02205",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call an ordered list of numbers indexed by natural numbers?",
+      "ja": "自然数で順序付けられた数の並びは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Set",
+        "ja": "集合",
+        "ja_typings": [
+          "shuugou"
+        ]
+      },
+      {
+        "en": "Sequence",
+        "ja": "数列",
+        "ja_typings": [
+          "suuretsu"
+        ]
+      },
+      {
+        "en": "Group",
+        "ja": "群",
+        "ja_typings": [
+          "gun"
+        ]
+      },
+      {
+        "en": "Ring",
+        "ja": "環",
+        "ja_typings": [
+          "kan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02206",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call an unordered collection of distinct objects?",
+      "ja": "順序を考えない異なるものの集まりを何という?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pascal",
+        "ja": "パスカル",
+        "ja_typings": [
+          "pasukaru"
+        ]
+      },
+      {
+        "en": "Fermat",
+        "ja": "フェルマー",
+        "ja_typings": [
+          "feruma-"
+        ]
+      },
+      {
+        "en": "Descartes",
+        "ja": "デカルト",
+        "ja_typings": [
+          "dekaruto"
+        ]
+      },
+      {
+        "en": "Laplace",
+        "ja": "ラプラス",
+        "ja_typings": [
+          "rapurasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02207",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French mathematician's triangle gives binomial coefficients?",
+      "ja": "二項係数を並べた三角形に名を残すフランスの数学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pythagoras",
+        "ja": "ピタゴラス",
+        "ja_typings": [
+          "pitagorasu"
+        ]
+      },
+      {
+        "en": "Euclid",
+        "ja": "ユークリッド",
+        "ja_typings": [
+          "yu-kuriddo"
+        ]
+      },
+      {
+        "en": "Archimedes",
+        "ja": "アルキメデス",
+        "ja_typings": [
+          "arukimedesu"
+        ]
+      },
+      {
+        "en": "Thales",
+        "ja": "タレス",
+        "ja_typings": [
+          "taresu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02208",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Greek mathematician's theorem relates the sides of a right triangle?",
+      "ja": "直角三角形の辺の関係に名を残す古代ギリシャの数学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thales",
+        "ja": "タレス",
+        "ja_typings": [
+          "taresu"
+        ]
+      },
+      {
+        "en": "Pythagoras",
+        "ja": "ピタゴラス",
+        "ja_typings": [
+          "pitagorasu"
+        ]
+      },
+      {
+        "en": "Euclid",
+        "ja": "ユークリッド",
+        "ja_typings": [
+          "yu-kuriddo"
+        ]
+      },
+      {
+        "en": "Plato",
+        "ja": "プラトン",
+        "ja_typings": [
+          "puraton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02209",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Greek philosopher is credited with one of the first geometric theorems about angles in a semicircle?",
+      "ja": "半円に内接する角に関する定理で知られる古代ギリシャの哲学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Plato",
+        "ja": "プラトン",
+        "ja_typings": [
+          "puraton"
+        ]
+      },
+      {
+        "en": "Aristotle",
+        "ja": "アリストテレス",
+        "ja_typings": [
+          "arisutoteresu"
+        ]
+      },
+      {
+        "en": "Socrates",
+        "ja": "ソクラテス",
+        "ja_typings": [
+          "sokuratesu"
+        ]
+      },
+      {
+        "en": "Euclid",
+        "ja": "ユークリッド",
+        "ja_typings": [
+          "yu-kuriddo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02210",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Greek philosopher is associated with five regular polyhedra called the 'solids'?",
+      "ja": "5種類の正多面体に名を残すギリシャの哲学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "France",
+        "ja": "フランス",
+        "ja_typings": [
+          "furansu"
+        ]
+      },
+      {
+        "en": "Italy",
+        "ja": "イタリア",
+        "ja_typings": [
+          "itaria"
+        ]
+      },
+      {
+        "en": "Spain",
+        "ja": "スペイン",
+        "ja_typings": [
+          "supein"
+        ]
+      },
+      {
+        "en": "Germany",
+        "ja": "ドイツ",
+        "ja_typings": [
+          "doitsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02211",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country is the Eiffel Tower located in?",
+      "ja": "エッフェル塔がある国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Guglielmo Marconi",
+        "ja": "グリエルモ マルコーニ",
+        "ja_typings": [
+          "gurierumo maruko-ni"
+        ]
+      },
+      {
+        "en": "Nikola Tesla",
+        "ja": "ニコラ テスラ",
+        "ja_typings": [
+          "nikora tesura"
+        ]
+      },
+      {
+        "en": "Alexander Bell",
+        "ja": "アレクサンダー ベル",
+        "ja_typings": [
+          "arekusanda- beru"
+        ]
+      },
+      {
+        "en": "Thomas Edison",
+        "ja": "トーマス エジソン",
+        "ja_typings": [
+          "to-masu ejison"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02212",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the Italian inventor credited with the first long-distance radio transmission?",
+      "ja": "長距離無線通信を初めて成功させたイタリアの発明家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "United Kingdom",
+        "ja": "イギリス",
+        "ja_typings": [
+          "igirisu"
+        ]
+      },
+      {
+        "en": "Ireland",
+        "ja": "アイルランド",
+        "ja_typings": [
+          "airurando"
+        ]
+      },
+      {
+        "en": "France",
+        "ja": "フランス",
+        "ja_typings": [
+          "furansu"
+        ]
+      },
+      {
+        "en": "Netherlands",
+        "ja": "オランダ",
+        "ja_typings": [
+          "oranda"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02213",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has London as its capital?",
+      "ja": "ロンドンを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "fish",
+        "ja": "魚",
+        "ja_typings": [
+          "sakana"
+        ]
+      },
+      {
+        "en": "amphibian",
+        "ja": "両生類",
+        "ja_typings": [
+          "ryouseirui"
+        ]
+      },
+      {
+        "en": "reptile",
+        "ja": "爬虫類",
+        "ja_typings": [
+          "hachuurui"
+        ]
+      },
+      {
+        "en": "mammal",
+        "ja": "哺乳類",
+        "ja_typings": [
+          "honyuurui"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02214",
+    "image_path": null,
+    "question_text": {
+      "en": "Which animal group includes salmon, tuna, and trout?",
+      "ja": "サケ・マグロ・マスを含む生き物のグループは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Italy",
+        "ja": "イタリア",
+        "ja_typings": [
+          "itaria"
+        ]
+      },
+      {
+        "en": "Spain",
+        "ja": "スペイン",
+        "ja_typings": [
+          "supein"
+        ]
+      },
+      {
+        "en": "Greece",
+        "ja": "ギリシャ",
+        "ja_typings": [
+          "girisha"
+        ]
+      },
+      {
+        "en": "Portugal",
+        "ja": "ポルトガル",
+        "ja_typings": [
+          "porutogaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02215",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country is shaped like a boot and known for pasta and pizza?",
+      "ja": "長靴の形をしておりパスタやピザで有名な国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "German",
+        "ja": "ドイツ語",
+        "ja_typings": [
+          "doitsugo"
+        ]
+      },
+      {
+        "en": "Dutch",
+        "ja": "オランダ語",
+        "ja_typings": [
+          "orandago"
+        ]
+      },
+      {
+        "en": "Austrian",
+        "ja": "オーストリア語",
+        "ja_typings": [
+          "oosutoriago"
+        ]
+      },
+      {
+        "en": "Swiss",
+        "ja": "スイス語",
+        "ja_typings": [
+          "suisugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02216",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language is spoken as the official language of Germany?",
+      "ja": "ドイツの公用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "hertz",
+        "ja": "ヘルツ",
+        "ja_typings": [
+          "herutsu"
+        ]
+      },
+      {
+        "en": "joule",
+        "ja": "ジュール",
+        "ja_typings": [
+          "ju-ru"
+        ]
+      },
+      {
+        "en": "newton",
+        "ja": "ニュートン",
+        "ja_typings": [
+          "nyu-ton"
+        ]
+      },
+      {
+        "en": "watt",
+        "ja": "ワット",
+        "ja_typings": [
+          "watto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02217",
+    "image_path": null,
+    "question_text": {
+      "en": "Which SI unit measures frequency, in cycles per second?",
+      "ja": "周波数のSI単位(毎秒の振動回数)は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "home base",
+        "ja": "ホームベース",
+        "ja_typings": [
+          "ho-mube-su"
+        ]
+      },
+      {
+        "en": "first base",
+        "ja": "一塁",
+        "ja_typings": [
+          "ichirui"
+        ]
+      },
+      {
+        "en": "second base",
+        "ja": "二塁",
+        "ja_typings": [
+          "nirui"
+        ]
+      },
+      {
+        "en": "third base",
+        "ja": "三塁",
+        "ja_typings": [
+          "sanrui"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02218",
+    "image_path": null,
+    "question_text": {
+      "en": "In baseball, what is the name of the base that batters aim to return to score?",
+      "ja": "野球で打者が戻ってきて得点となるベースは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "hit",
+        "ja": "ヒット",
+        "ja_typings": [
+          "hitto"
+        ]
+      },
+      {
+        "en": "foul",
+        "ja": "ファウル",
+        "ja_typings": [
+          "fauru"
+        ]
+      },
+      {
+        "en": "strike",
+        "ja": "ストライク",
+        "ja_typings": [
+          "sutoraiku"
+        ]
+      },
+      {
+        "en": "ball",
+        "ja": "ボール",
+        "ja_typings": [
+          "bo-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02219",
+    "image_path": null,
+    "question_text": {
+      "en": "In baseball, what term means a successful safe hit on the ball into fair territory?",
+      "ja": "野球で打球がフェア地域に飛び出塁できた打撃を何という?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "foul",
+        "ja": "ファウル",
+        "ja_typings": [
+          "fauru"
+        ]
+      },
+      {
+        "en": "hit",
+        "ja": "ヒット",
+        "ja_typings": [
+          "hitto"
+        ]
+      },
+      {
+        "en": "strike",
+        "ja": "ストライク",
+        "ja_typings": [
+          "sutoraiku"
+        ]
+      },
+      {
+        "en": "homerun",
+        "ja": "ホームラン",
+        "ja_typings": [
+          "ho-muran"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02220",
+    "image_path": null,
+    "question_text": {
+      "en": "In baseball, what term means the ball was hit outside the fair territory lines?",
+      "ja": "野球で打球がフェア地域の外に飛ぶことを何という?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "45 minutes",
+        "ja": "45分",
+        "ja_typings": [
+          "45fun"
+        ]
+      },
+      {
+        "en": "30 minutes",
+        "ja": "30分",
+        "ja_typings": [
+          "30pun"
+        ]
+      },
+      {
+        "en": "60 minutes",
+        "ja": "60分",
+        "ja_typings": [
+          "60pun"
+        ]
+      },
+      {
+        "en": "40 minutes",
+        "ja": "40分",
+        "ja_typings": [
+          "40pun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02221",
+    "image_path": null,
+    "question_text": {
+      "en": "How long is one half in a standard soccer match?",
+      "ja": "サッカーの前半・後半は1つあたり何分?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "12 minutes",
+        "ja": "12分",
+        "ja_typings": [
+          "12fun"
+        ]
+      },
+      {
+        "en": "30 minutes",
+        "ja": "30分",
+        "ja_typings": [
+          "30pun"
+        ]
+      },
+      {
+        "en": "60 minutes",
+        "ja": "60分",
+        "ja_typings": [
+          "60pun"
+        ]
+      },
+      {
+        "en": "40 minutes",
+        "ja": "40分",
+        "ja_typings": [
+          "40pun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02222",
+    "image_path": null,
+    "question_text": {
+      "en": "How long is one quarter in standard NBA basketball?",
+      "ja": "NBAの1クォーターは何分?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "20 minutes",
+        "ja": "20分",
+        "ja_typings": [
+          "20pun"
+        ]
+      },
+      {
+        "en": "30 minutes",
+        "ja": "30分",
+        "ja_typings": [
+          "30pun"
+        ]
+      },
+      {
+        "en": "40 minutes",
+        "ja": "40分",
+        "ja_typings": [
+          "40pun"
+        ]
+      },
+      {
+        "en": "60 minutes",
+        "ja": "60分",
+        "ja_typings": [
+          "60pun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02223",
+    "image_path": null,
+    "question_text": {
+      "en": "How long is one period in standard ice hockey?",
+      "ja": "アイスホッケーの1ピリオドは何分?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Juan Antonio Samaranch",
+        "ja": "フアン アントニオ サマランチ",
+        "ja_typings": [
+          "fuan antonio samaranchi"
+        ]
+      },
+      {
+        "en": "Jacques Rogge",
+        "ja": "ジャック ロゲ",
+        "ja_typings": [
+          "jakku roge"
+        ]
+      },
+      {
+        "en": "Thomas Bach",
+        "ja": "トーマス バッハ",
+        "ja_typings": [
+          "to-masu bahha"
+        ]
+      },
+      {
+        "en": "Avery Brundage",
+        "ja": "アベリー ブランデージ",
+        "ja_typings": [
+          "aberi- burande-ji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02224",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the 7th president of the International Olympic Committee, serving 1980-2001?",
+      "ja": "1980年から2001年までIOC会長を務めたスペイン人は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jacques Rogge",
+        "ja": "ジャック ロゲ",
+        "ja_typings": [
+          "jakku roge"
+        ]
+      },
+      {
+        "en": "Juan Antonio Samaranch",
+        "ja": "フアン アントニオ サマランチ",
+        "ja_typings": [
+          "fuan antonio samaranchi"
+        ]
+      },
+      {
+        "en": "Thomas Bach",
+        "ja": "トーマス バッハ",
+        "ja_typings": [
+          "to-masu bahha"
+        ]
+      },
+      {
+        "en": "Pierre de Coubertin",
+        "ja": "ピエール ド クーベルタン",
+        "ja_typings": [
+          "pie-ru do ku-berutan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02225",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the 8th president of the IOC, serving 2001-2013?",
+      "ja": "2001年から2013年までIOC会長を務めたベルギー人は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thomas Bach",
+        "ja": "トーマス バッハ",
+        "ja_typings": [
+          "to-masu bahha"
+        ]
+      },
+      {
+        "en": "Jacques Rogge",
+        "ja": "ジャック ロゲ",
+        "ja_typings": [
+          "jakku roge"
+        ]
+      },
+      {
+        "en": "Juan Antonio Samaranch",
+        "ja": "フアン アントニオ サマランチ",
+        "ja_typings": [
+          "fuan antonio samaranchi"
+        ]
+      },
+      {
+        "en": "Sebastian Coe",
+        "ja": "セバスチャン コー",
+        "ja_typings": [
+          "sebasuchan ko-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02226",
+    "image_path": null,
+    "question_text": {
+      "en": "Who became the 9th president of the IOC in 2013?",
+      "ja": "2013年にIOC会長となったドイツ人は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nikola Tesla",
+        "ja": "ニコラ テスラ",
+        "ja_typings": [
+          "nikora tesura"
+        ]
+      },
+      {
+        "en": "Thomas Edison",
+        "ja": "トーマス エジソン",
+        "ja_typings": [
+          "to-masu ejison"
+        ]
+      },
+      {
+        "en": "Guglielmo Marconi",
+        "ja": "グリエルモ マルコーニ",
+        "ja_typings": [
+          "gurierumo maruko-ni"
+        ]
+      },
+      {
+        "en": "Alexander Bell",
+        "ja": "アレクサンダー ベル",
+        "ja_typings": [
+          "arekusanda- beru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02227",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Serbian-American inventor is known for AC electrical systems?",
+      "ja": "交流送電で知られるセルビア系アメリカ人の発明家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Marie Curie",
+        "ja": "マリー キュリー",
+        "ja_typings": [
+          "mari- kyuri-"
+        ]
+      },
+      {
+        "en": "Albert Einstein",
+        "ja": "アルベルト アインシュタイン",
+        "ja_typings": [
+          "aruberuto ainshutain"
+        ]
+      },
+      {
+        "en": "Lise Meitner",
+        "ja": "リーゼ マイトナー",
+        "ja_typings": [
+          "ri-ze maitona-"
+        ]
+      },
+      {
+        "en": "Rosalind Franklin",
+        "ja": "ロザリンド フランクリン",
+        "ja_typings": [
+          "rozarindo furankurin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02228",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Polish-French physicist who won Nobel Prizes in both physics and chemistry for work on radioactivity?",
+      "ja": "放射線の研究で物理学賞と化学賞の両方を受賞したポーランド系フランス人の物理学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1956",
+        "ja": "1956",
+        "ja_typings": [
+          "1956"
+        ]
+      },
+      {
+        "en": "1968",
+        "ja": "1968",
+        "ja_typings": [
+          "1968"
+        ]
+      },
+      {
+        "en": "1972",
+        "ja": "1972",
+        "ja_typings": [
+          "1972"
+        ]
+      },
+      {
+        "en": "1960",
+        "ja": "1960",
+        "ja_typings": [
+          "1960"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02229",
+    "image_path": null,
+    "question_text": {
+      "en": "In which year did Melbourne host the Summer Olympics?",
+      "ja": "メルボルン夏季オリンピックが開催された年は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1968",
+        "ja": "1968",
+        "ja_typings": [
+          "1968"
+        ]
+      },
+      {
+        "en": "1956",
+        "ja": "1956",
+        "ja_typings": [
+          "1956"
+        ]
+      },
+      {
+        "en": "1972",
+        "ja": "1972",
+        "ja_typings": [
+          "1972"
+        ]
+      },
+      {
+        "en": "1964",
+        "ja": "1964",
+        "ja_typings": [
+          "1964"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02230",
+    "image_path": null,
+    "question_text": {
+      "en": "In which year did Mexico City host the Summer Olympics?",
+      "ja": "メキシコシティ夏季オリンピックが開催された年は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1972",
+        "ja": "1972",
+        "ja_typings": [
+          "1972"
+        ]
+      },
+      {
+        "en": "1968",
+        "ja": "1968",
+        "ja_typings": [
+          "1968"
+        ]
+      },
+      {
+        "en": "1956",
+        "ja": "1956",
+        "ja_typings": [
+          "1956"
+        ]
+      },
+      {
+        "en": "1976",
+        "ja": "1976",
+        "ja_typings": [
+          "1976"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02231",
+    "image_path": null,
+    "question_text": {
+      "en": "In which year did Munich host the Summer Olympics?",
+      "ja": "ミュンヘン夏季オリンピックが開催された年は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Japan Trench",
+        "ja": "日本海溝",
+        "ja_typings": [
+          "nihonkaikou"
+        ]
+      },
+      {
+        "en": "Puerto Rico Trench",
+        "ja": "プエルトリコ海溝",
+        "ja_typings": [
+          "puerutorikokaikou"
+        ]
+      },
+      {
+        "en": "Tonga Trench",
+        "ja": "トンガ海溝",
+        "ja_typings": [
+          "tongakaikou"
+        ]
+      },
+      {
+        "en": "Mariana Trench",
+        "ja": "マリアナ海溝",
+        "ja_typings": [
+          "marianakaikou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02232",
+    "image_path": null,
+    "question_text": {
+      "en": "Which trench off the Pacific coast of Tohoku is famous for deep-focus earthquakes?",
+      "ja": "東北沖の太平洋にある深発地震で有名な海溝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Puerto Rico Trench",
+        "ja": "プエルトリコ海溝",
+        "ja_typings": [
+          "puerutorikokaikou"
+        ]
+      },
+      {
+        "en": "Japan Trench",
+        "ja": "日本海溝",
+        "ja_typings": [
+          "nihonkaikou"
+        ]
+      },
+      {
+        "en": "Tonga Trench",
+        "ja": "トンガ海溝",
+        "ja_typings": [
+          "tongakaikou"
+        ]
+      },
+      {
+        "en": "Sunda Trench",
+        "ja": "スンダ海溝",
+        "ja_typings": [
+          "sundakaikou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02233",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the deepest trench in the Atlantic Ocean?",
+      "ja": "大西洋で最も深い海溝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tonga Trench",
+        "ja": "トンガ海溝",
+        "ja_typings": [
+          "tongakaikou"
+        ]
+      },
+      {
+        "en": "Japan Trench",
+        "ja": "日本海溝",
+        "ja_typings": [
+          "nihonkaikou"
+        ]
+      },
+      {
+        "en": "Puerto Rico Trench",
+        "ja": "プエルトリコ海溝",
+        "ja_typings": [
+          "puerutorikokaikou"
+        ]
+      },
+      {
+        "en": "Kermadec Trench",
+        "ja": "ケルマデック海溝",
+        "ja_typings": [
+          "kerumadekkukaikou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02234",
+    "image_path": null,
+    "question_text": {
+      "en": "Which trench in the South Pacific is the second deepest in the world?",
+      "ja": "世界で2番目に深い南太平洋の海溝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "John Steinbeck",
+        "ja": "ジョン スタインベック",
+        "ja_typings": [
+          "jon sutainbekku"
+        ]
+      },
+      {
+        "en": "William Faulkner",
+        "ja": "ウィリアム フォークナー",
+        "ja_typings": [
+          "wiriamu fo-kuna-"
+        ]
+      },
+      {
+        "en": "Ernest Hemingway",
+        "ja": "アーネスト ヘミングウェイ",
+        "ja_typings": [
+          "a-nesuto heminguwei"
+        ]
+      },
+      {
+        "en": "F. Scott Fitzgerald",
+        "ja": "F スコット フィッツジェラルド",
+        "ja_typings": [
+          "f sukotto fittsujerarudo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02235",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote 'The Grapes of Wrath' and won the Nobel Prize in Literature in 1962?",
+      "ja": "「怒りの葡萄」を書き1962年にノーベル文学賞を受賞した米国人作家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "William Faulkner",
+        "ja": "ウィリアム フォークナー",
+        "ja_typings": [
+          "wiriamu fo-kuna-"
+        ]
+      },
+      {
+        "en": "John Steinbeck",
+        "ja": "ジョン スタインベック",
+        "ja_typings": [
+          "jon sutainbekku"
+        ]
+      },
+      {
+        "en": "Ernest Hemingway",
+        "ja": "アーネスト ヘミングウェイ",
+        "ja_typings": [
+          "a-nesuto heminguwei"
+        ]
+      },
+      {
+        "en": "F. Scott Fitzgerald",
+        "ja": "F スコット フィッツジェラルド",
+        "ja_typings": [
+          "f sukotto fittsujerarudo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02236",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote 'The Sound and the Fury' and won the Nobel Prize in Literature in 1949?",
+      "ja": "「響きと怒り」を書き1949年にノーベル文学賞を受賞した米国人作家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "F. Scott Fitzgerald",
+        "ja": "F スコット フィッツジェラルド",
+        "ja_typings": [
+          "f sukotto fittsujerarudo"
+        ]
+      },
+      {
+        "en": "John Steinbeck",
+        "ja": "ジョン スタインベック",
+        "ja_typings": [
+          "jon sutainbekku"
+        ]
+      },
+      {
+        "en": "William Faulkner",
+        "ja": "ウィリアム フォークナー",
+        "ja_typings": [
+          "wiriamu fo-kuna-"
+        ]
+      },
+      {
+        "en": "Ernest Hemingway",
+        "ja": "アーネスト ヘミングウェイ",
+        "ja_typings": [
+          "a-nesuto heminguwei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02237",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote 'The Great Gatsby'?",
+      "ja": "「グレート ギャツビー」の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Steven Spielberg",
+        "ja": "スティーブン スピルバーグ",
+        "ja_typings": [
+          "suti-bun supiruba-gu"
+        ]
+      },
+      {
+        "en": "Martin Scorsese",
+        "ja": "マーティン スコセッシ",
+        "ja_typings": [
+          "ma-tin sukosesshi"
+        ]
+      },
+      {
+        "en": "Ridley Scott",
+        "ja": "リドリー スコット",
+        "ja_typings": [
+          "ridori- sukotto"
+        ]
+      },
+      {
+        "en": "Francis Coppola",
+        "ja": "フランシス コッポラ",
+        "ja_typings": [
+          "furanshisu koppora"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02238",
+    "image_path": null,
+    "question_text": {
+      "en": "Who directed 'Jaws', 'E.T.', and 'Jurassic Park'?",
+      "ja": "「ジョーズ」「E.T.」「ジュラシック パーク」を監督した米国人は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Martin Scorsese",
+        "ja": "マーティン スコセッシ",
+        "ja_typings": [
+          "ma-tin sukosesshi"
+        ]
+      },
+      {
+        "en": "Steven Spielberg",
+        "ja": "スティーブン スピルバーグ",
+        "ja_typings": [
+          "suti-bun supiruba-gu"
+        ]
+      },
+      {
+        "en": "Ridley Scott",
+        "ja": "リドリー スコット",
+        "ja_typings": [
+          "ridori- sukotto"
+        ]
+      },
+      {
+        "en": "Francis Coppola",
+        "ja": "フランシス コッポラ",
+        "ja_typings": [
+          "furanshisu koppora"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02239",
+    "image_path": null,
+    "question_text": {
+      "en": "Who directed 'Taxi Driver' and 'Goodfellas'?",
+      "ja": "「タクシードライバー」「グッドフェローズ」を監督した米国人は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ridley Scott",
+        "ja": "リドリー スコット",
+        "ja_typings": [
+          "ridori- sukotto"
+        ]
+      },
+      {
+        "en": "Steven Spielberg",
+        "ja": "スティーブン スピルバーグ",
+        "ja_typings": [
+          "suti-bun supiruba-gu"
+        ]
+      },
+      {
+        "en": "Martin Scorsese",
+        "ja": "マーティン スコセッシ",
+        "ja_typings": [
+          "ma-tin sukosesshi"
+        ]
+      },
+      {
+        "en": "James Cameron",
+        "ja": "ジェームズ キャメロン",
+        "ja_typings": [
+          "je-muzu kyameron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02240",
+    "image_path": null,
+    "question_text": {
+      "en": "Who directed 'Alien', 'Blade Runner', and 'Gladiator'?",
+      "ja": "「エイリアン」「ブレードランナー」「グラディエーター」を監督した英国人は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tomato",
+        "ja": "トマト",
+        "ja_typings": [
+          "tomato"
+        ]
+      },
+      {
+        "en": "Red cabbage",
+        "ja": "紫キャベツ",
+        "ja_typings": [
+          "murasakikyabetsu"
+        ]
+      },
+      {
+        "en": "Red radish",
+        "ja": "赤大根",
+        "ja_typings": [
+          "akadaikon"
+        ]
+      },
+      {
+        "en": "Red bell pepper",
+        "ja": "赤パプリカ",
+        "ja_typings": [
+          "akapapurika"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02241",
+    "image_path": null,
+    "question_text": {
+      "en": "Botanically classified as a fruit but commonly used as a vegetable, what red ingredient is essential to ketchup?",
+      "ja": "植物学的には果実だが料理では野菜扱いされケチャップの主原料となる赤い食材は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "lion",
+        "ja": "ライオン",
+        "ja_typings": [
+          "raion"
+        ]
+      },
+      {
+        "en": "leopard",
+        "ja": "ヒョウ",
+        "ja_typings": [
+          "hyo",
+          "hyou"
+        ]
+      },
+      {
+        "en": "cheetah",
+        "ja": "チーター",
+        "ja_typings": [
+          "chi-ta-"
+        ]
+      },
+      {
+        "en": "tiger",
+        "ja": "トラ",
+        "ja_typings": [
+          "tora"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02242",
+    "image_path": null,
+    "question_text": {
+      "en": "Which large cat is known as the 'king of the savannah' and lives in prides?",
+      "ja": "サバンナの王者と呼ばれ群れを作る大型のネコ科動物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "gazelle",
+        "ja": "ガゼル",
+        "ja_typings": [
+          "gazeru"
+        ]
+      },
+      {
+        "en": "lion",
+        "ja": "ライオン",
+        "ja_typings": [
+          "raion"
+        ]
+      },
+      {
+        "en": "zebra",
+        "ja": "シマウマ",
+        "ja_typings": [
+          "shimauma"
+        ]
+      },
+      {
+        "en": "giraffe",
+        "ja": "キリン",
+        "ja_typings": [
+          "kirin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02243",
+    "image_path": null,
+    "question_text": {
+      "en": "Which slender African antelope is famous for its leaping bounds?",
+      "ja": "跳躍で有名なアフリカの細身の動物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "leopard",
+        "ja": "ヒョウ",
+        "ja_typings": [
+          "hyo",
+          "hyou"
+        ]
+      },
+      {
+        "en": "cheetah",
+        "ja": "チーター",
+        "ja_typings": [
+          "chi-ta-"
+        ]
+      },
+      {
+        "en": "lion",
+        "ja": "ライオン",
+        "ja_typings": [
+          "raion"
+        ]
+      },
+      {
+        "en": "jaguar",
+        "ja": "ジャガー",
+        "ja_typings": [
+          "jaga-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02244",
+    "image_path": null,
+    "question_text": {
+      "en": "Which spotted big cat is known for dragging prey up into trees?",
+      "ja": "獲物を木の上に運ぶことで知られる斑点模様の大型ネコ科動物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wimbledon",
+        "ja": "ウィンブルドン",
+        "ja_typings": [
+          "winburudon"
+        ]
+      },
+      {
+        "en": "French Open",
+        "ja": "全仏オープン",
+        "ja_typings": [
+          "zenbutsuoopun"
+        ]
+      },
+      {
+        "en": "Australian Open",
+        "ja": "全豪オープン",
+        "ja_typings": [
+          "zengouoopun"
+        ]
+      },
+      {
+        "en": "US Open",
+        "ja": "全米オープン",
+        "ja_typings": [
+          "zenbeioopun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02245",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Grand Slam tennis tournament is played on grass in London?",
+      "ja": "ロンドンの芝コートで開催されるテニスのグランドスラム大会は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "French Open",
+        "ja": "全仏オープン",
+        "ja_typings": [
+          "zenbutsuoopun"
+        ]
+      },
+      {
+        "en": "Wimbledon",
+        "ja": "ウィンブルドン",
+        "ja_typings": [
+          "winburudon"
+        ]
+      },
+      {
+        "en": "Australian Open",
+        "ja": "全豪オープン",
+        "ja_typings": [
+          "zengouoopun"
+        ]
+      },
+      {
+        "en": "US Open",
+        "ja": "全米オープン",
+        "ja_typings": [
+          "zenbeioopun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02246",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Grand Slam tennis tournament is played on clay courts in Paris?",
+      "ja": "パリのクレーコートで開催されるテニスのグランドスラム大会は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Australian Open",
+        "ja": "全豪オープン",
+        "ja_typings": [
+          "zengouoopun"
+        ]
+      },
+      {
+        "en": "French Open",
+        "ja": "全仏オープン",
+        "ja_typings": [
+          "zenbutsuoopun"
+        ]
+      },
+      {
+        "en": "Wimbledon",
+        "ja": "ウィンブルドン",
+        "ja_typings": [
+          "winburudon"
+        ]
+      },
+      {
+        "en": "US Open",
+        "ja": "全米オープン",
+        "ja_typings": [
+          "zenbeioopun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02247",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Grand Slam tennis tournament is held in Melbourne in January?",
+      "ja": "1月にメルボルンで開催されるテニスのグランドスラム大会は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thomas Newcomen",
+        "ja": "トーマス ニューコメン",
+        "ja_typings": [
+          "to-masu nyu-komen"
+        ]
+      },
+      {
+        "en": "James Watt",
+        "ja": "ジェームズ ワット",
+        "ja_typings": [
+          "je-muzu watto"
+        ]
+      },
+      {
+        "en": "George Stephenson",
+        "ja": "ジョージ スチーブンソン",
+        "ja_typings": [
+          "jo-ji suchi-bunson"
+        ]
+      },
+      {
+        "en": "Robert Fulton",
+        "ja": "ロバート フルトン",
+        "ja_typings": [
+          "roba-to furuton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02248",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the English inventor of the early atmospheric steam engine in 1712?",
+      "ja": "1712年に大気圧蒸気機関を実用化した英国の発明家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "George Stephenson",
+        "ja": "ジョージ スチーブンソン",
+        "ja_typings": [
+          "jo-ji suchi-bunson"
+        ]
+      },
+      {
+        "en": "Thomas Newcomen",
+        "ja": "トーマス ニューコメン",
+        "ja_typings": [
+          "to-masu nyu-komen"
+        ]
+      },
+      {
+        "en": "James Watt",
+        "ja": "ジェームズ ワット",
+        "ja_typings": [
+          "je-muzu watto"
+        ]
+      },
+      {
+        "en": "Robert Fulton",
+        "ja": "ロバート フルトン",
+        "ja_typings": [
+          "roba-to furuton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02249",
+    "image_path": null,
+    "question_text": {
+      "en": "Who built the early steam locomotive 'Rocket' in England?",
+      "ja": "英国で蒸気機関車「ロケット号」を製作した技術者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Robert Fulton",
+        "ja": "ロバート フルトン",
+        "ja_typings": [
+          "roba-to furuton"
+        ]
+      },
+      {
+        "en": "Thomas Newcomen",
+        "ja": "トーマス ニューコメン",
+        "ja_typings": [
+          "to-masu nyu-komen"
+        ]
+      },
+      {
+        "en": "George Stephenson",
+        "ja": "ジョージ スチーブンソン",
+        "ja_typings": [
+          "jo-ji suchi-bunson"
+        ]
+      },
+      {
+        "en": "James Watt",
+        "ja": "ジェームズ ワット",
+        "ja_typings": [
+          "je-muzu watto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02250",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the American engineer who developed the first commercially successful steamboat?",
+      "ja": "商業的に成功した最初の蒸気船を開発した米国人は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "hornet",
+        "ja": "スズメバチ",
+        "ja_typings": [
+          "suzumebachi"
+        ]
+      },
+      {
+        "en": "paper wasp",
+        "ja": "アシナガバチ",
+        "ja_typings": [
+          "ashinagabachi"
+        ]
+      },
+      {
+        "en": "carpenter bee",
+        "ja": "クマバチ",
+        "ja_typings": [
+          "kumabachi"
+        ]
+      },
+      {
+        "en": "honeybee",
+        "ja": "ミツバチ",
+        "ja_typings": [
+          "mitsubachi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02251",
+    "image_path": null,
+    "question_text": {
+      "en": "Which large stinging insect builds papery nests and is more aggressive than honeybees?",
+      "ja": "ミツバチより攻撃的で紙状の巣を作る大型の刺す昆虫は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "paper wasp",
+        "ja": "アシナガバチ",
+        "ja_typings": [
+          "ashinagabachi"
+        ]
+      },
+      {
+        "en": "hornet",
+        "ja": "スズメバチ",
+        "ja_typings": [
+          "suzumebachi"
+        ]
+      },
+      {
+        "en": "carpenter bee",
+        "ja": "クマバチ",
+        "ja_typings": [
+          "kumabachi"
+        ]
+      },
+      {
+        "en": "honeybee",
+        "ja": "ミツバチ",
+        "ja_typings": [
+          "mitsubachi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02252",
+    "image_path": null,
+    "question_text": {
+      "en": "Which slender wasp builds open umbrella-shaped nests?",
+      "ja": "細身で傘状の巣を作るハチは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "carpenter bee",
+        "ja": "クマバチ",
+        "ja_typings": [
+          "kumabachi"
+        ]
+      },
+      {
+        "en": "hornet",
+        "ja": "スズメバチ",
+        "ja_typings": [
+          "suzumebachi"
+        ]
+      },
+      {
+        "en": "paper wasp",
+        "ja": "アシナガバチ",
+        "ja_typings": [
+          "ashinagabachi"
+        ]
+      },
+      {
+        "en": "bumblebee",
+        "ja": "マルハナバチ",
+        "ja_typings": [
+          "maruhanabachi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02253",
+    "image_path": null,
+    "question_text": {
+      "en": "Which large solitary black bee bores into wood to make nests?",
+      "ja": "木に穴を開けて巣を作る大きな黒い単独行動の蜂は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mirai Akari",
+        "ja": "ミライアカリ",
+        "ja_typings": [
+          "miraiakari"
+        ]
+      },
+      {
+        "en": "Kaguya Luna",
+        "ja": "輝夜月",
+        "ja_typings": [
+          "kaguyaruna"
+        ]
+      },
+      {
+        "en": "Kizuna AI",
+        "ja": "キズナアイ",
+        "ja_typings": [
+          "kizunaai"
+        ]
+      },
+      {
+        "en": "Nekomasu",
+        "ja": "ねこます",
+        "ja_typings": [
+          "nekomasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02254",
+    "image_path": null,
+    "question_text": {
+      "en": "Which early Japanese VTuber was known as the cheerful 'school idol' alongside the original four?",
+      "ja": "初期4大VTuberの一人で「未来の学園アイドル」として人気を博したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kaguya Luna",
+        "ja": "輝夜月",
+        "ja_typings": [
+          "kaguyaruna"
+        ]
+      },
+      {
+        "en": "Mirai Akari",
+        "ja": "ミライアカリ",
+        "ja_typings": [
+          "miraiakari"
+        ]
+      },
+      {
+        "en": "Kizuna AI",
+        "ja": "キズナアイ",
+        "ja_typings": [
+          "kizunaai"
+        ]
+      },
+      {
+        "en": "Siro",
+        "ja": "シロ",
+        "ja_typings": [
+          "shiro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02255",
+    "image_path": null,
+    "question_text": {
+      "en": "Which early Japanese VTuber is famous for an energetic Princess Kaguya themed persona?",
+      "ja": "かぐや姫をモチーフにした奔放なキャラで知られる初期VTuberは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Houshou Marine",
+        "ja": "宝鐘マリン",
+        "ja_typings": [
+          "houshoumarin"
+        ]
+      },
+      {
+        "en": "Usada Pekora",
+        "ja": "兎田ぺこら",
+        "ja_typings": [
+          "usadapekora"
+        ]
+      },
+      {
+        "en": "Shirakami Fubuki",
+        "ja": "白上フブキ",
+        "ja_typings": [
+          "shirakamifubuki"
+        ]
+      },
+      {
+        "en": "Minato Aqua",
+        "ja": "湊あくあ",
+        "ja_typings": [
+          "minatoakua"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02256",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive VTuber is a pirate captain known for the catchphrase 'ahoy'?",
+      "ja": "「あほーい」で知られるホロライブの海賊船長は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "anger",
+        "ja": "怒り",
+        "ja_typings": [
+          "ikari"
+        ]
+      },
+      {
+        "en": "sadness",
+        "ja": "悲しみ",
+        "ja_typings": [
+          "kanashimi"
+        ]
+      },
+      {
+        "en": "joy",
+        "ja": "喜び",
+        "ja_typings": [
+          "yorokobi"
+        ]
+      },
+      {
+        "en": "fear",
+        "ja": "恐れ",
+        "ja_typings": [
+          "osore"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02257",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Plutchik emotion is conveyed by the red angry-face emoji?",
+      "ja": "赤い怒り顔の絵文字が表すプルチック基本感情は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Noripro",
+        "ja": "のりプロ",
+        "ja_typings": [
+          "noripuro"
+        ]
+      },
+      {
+        "en": "VShojo",
+        "ja": "ブイショウジョ",
+        "ja_typings": [
+          "buishojo",
+          "buishoujo"
+        ]
+      },
+      {
+        "en": "Nijisanji",
+        "ja": "にじさんじ",
+        "ja_typings": [
+          "nijisanji"
+        ]
+      },
+      {
+        "en": "Hololive",
+        "ja": "ホロライブ",
+        "ja_typings": [
+          "hororaibu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02258",
+    "image_path": null,
+    "question_text": {
+      "en": "Which VTuber agency manages stylish 'Noripro' talents in Japan?",
+      "ja": "ののかみらいなど「のりプロ」の所属タレントを抱える事務所は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "VShojo",
+        "ja": "ブイショウジョ",
+        "ja_typings": [
+          "buishojo",
+          "buishoujo"
+        ]
+      },
+      {
+        "en": "Noripro",
+        "ja": "のりプロ",
+        "ja_typings": [
+          "noripuro"
+        ]
+      },
+      {
+        "en": "Hololive EN",
+        "ja": "ホロライブEN",
+        "ja_typings": [
+          "hororaibuen"
+        ]
+      },
+      {
+        "en": "Nijisanji EN",
+        "ja": "にじさんじEN",
+        "ja_typings": [
+          "nijisanjien"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02259",
+    "image_path": null,
+    "question_text": {
+      "en": "Which English-language VTuber agency includes Ironmouse and Projekt Melody?",
+      "ja": "アイアンマウスやプロジェクトメロディなどが所属する英語圏VTuber事務所は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dennou Shoujo Siro",
+        "ja": "電脳少女シロ",
+        "ja_typings": [
+          "dennoushoujoshiro"
+        ]
+      },
+      {
+        "en": "Mirai Akari",
+        "ja": "ミライアカリ",
+        "ja_typings": [
+          "miraiakari"
+        ]
+      },
+      {
+        "en": "Kaguya Luna",
+        "ja": "輝夜月",
+        "ja_typings": [
+          "kaguyaruna"
+        ]
+      },
+      {
+        "en": "Kizuna AI",
+        "ja": "キズナアイ",
+        "ja_typings": [
+          "kizunaai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02260",
+    "image_path": null,
+    "question_text": {
+      "en": "Which early VTuber's full name is 'Dennou Shoujo Siro'?",
+      "ja": "「電脳少女シロ」のフルネームで知られる初期VTuberは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CyberAgent",
+        "ja": "サイバーエージェント",
+        "ja_typings": [
+          "saiba-e-jento"
+        ]
+      },
+      {
+        "en": "Sony",
+        "ja": "ソニー",
+        "ja_typings": [
+          "soni-"
+        ]
+      },
+      {
+        "en": "Bushiroad",
+        "ja": "ブシロード",
+        "ja_typings": [
+          "bushiro-do"
+        ]
+      },
+      {
+        "en": "DeNA",
+        "ja": "ディー エヌ エー",
+        "ja_typings": [
+          "di- enu e-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02261",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese internet company is the parent of Nijisanji's operator Anycolor's predecessor relationships and also runs AbemaTV?",
+      "ja": "AbemaTVを運営する日本のインターネット企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chato",
+        "ja": "ちゃと",
+        "ja_typings": [
+          "chato"
+        ]
+      },
+      {
+        "en": "Nekomasu",
+        "ja": "ねこます",
+        "ja_typings": [
+          "nekomasu"
+        ]
+      },
+      {
+        "en": "Siro",
+        "ja": "シロ",
+        "ja_typings": [
+          "shiro"
+        ]
+      },
+      {
+        "en": "Mikoto",
+        "ja": "ミコト",
+        "ja_typings": [
+          "mikoto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02262",
+    "image_path": null,
+    "question_text": {
+      "en": "What live streaming community term refers to the meme cat 'chato' that became iconic in early Japanese VTuber chats?",
+      "ja": "初期VTuber配信のコメント文化で象徴的になった猫「ちゃと」を指す言葉は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Watson Amelia",
+        "ja": "ワトソン アメリア",
+        "ja_typings": [
+          "watoson ameria"
+        ]
+      },
+      {
+        "en": "Gawr Gura",
+        "ja": "がうる ぐら",
+        "ja_typings": [
+          "gauru gura"
+        ]
+      },
+      {
+        "en": "Ninomae Inanis",
+        "ja": "一伊那尓栖",
+        "ja_typings": [
+          "ninomaeinanisu"
+        ]
+      },
+      {
+        "en": "Mori Calliope",
+        "ja": "森カリオペ",
+        "ja_typings": [
+          "morikariope"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02263",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive English Myth member is the detective with the catchphrase 'Watson'?",
+      "ja": "ホロライブEN Mythの「探偵」キャラのメンバーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sadness",
+        "ja": "悲しみ",
+        "ja_typings": [
+          "kanashimi"
+        ]
+      },
+      {
+        "en": "anger",
+        "ja": "怒り",
+        "ja_typings": [
+          "ikari"
+        ]
+      },
+      {
+        "en": "joy",
+        "ja": "喜び",
+        "ja_typings": [
+          "yorokobi"
+        ]
+      },
+      {
+        "en": "fear",
+        "ja": "恐れ",
+        "ja_typings": [
+          "osore"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02264",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Plutchik emotion is conveyed by the crying-face emoji?",
+      "ja": "泣き顔の絵文字が表すプルチック基本感情は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "VSPO!",
+        "ja": "ブイスポ",
+        "ja_typings": [
+          "buisupo"
+        ]
+      },
+      {
+        "en": "VShojo",
+        "ja": "ブイショウジョ",
+        "ja_typings": [
+          "buishojo",
+          "buishoujo"
+        ]
+      },
+      {
+        "en": "Noripro",
+        "ja": "のりプロ",
+        "ja_typings": [
+          "noripuro"
+        ]
+      },
+      {
+        "en": "Nijisanji",
+        "ja": "にじさんじ",
+        "ja_typings": [
+          "nijisanji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02265",
+    "image_path": null,
+    "question_text": {
+      "en": "Which VTuber group focuses on competitive FPS and esports under Brave Group?",
+      "ja": "ブレイブグループ傘下でFPS・eスポーツを中心とするVTuberグループは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": ".LIVE",
+        "ja": "どっとライブ",
+        "ja_typings": [
+          "dottoraibu"
+        ]
+      },
+      {
+        "en": "Hololive",
+        "ja": "ホロライブ",
+        "ja_typings": [
+          "hororaibu"
+        ]
+      },
+      {
+        "en": "Nijisanji",
+        "ja": "にじさんじ",
+        "ja_typings": [
+          "nijisanji"
+        ]
+      },
+      {
+        "en": "VShojo",
+        "ja": "ブイショウジョ",
+        "ja_typings": [
+          "buishojo",
+          "buishoujo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02266",
+    "image_path": null,
+    "question_text": {
+      "en": "Which early Japanese VTuber group included Dennou Shoujo Siro and Mononobe no Alice?",
+      "ja": "電脳少女シロや物述有栖が所属していた初期VTuberグループは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bushiroad",
+        "ja": "ブシロード",
+        "ja_typings": [
+          "bushiro-do"
+        ]
+      },
+      {
+        "en": "CyberAgent",
+        "ja": "サイバーエージェント",
+        "ja_typings": [
+          "saiba-e-jento"
+        ]
+      },
+      {
+        "en": "Sony",
+        "ja": "ソニー",
+        "ja_typings": [
+          "soni-"
+        ]
+      },
+      {
+        "en": "Bandai",
+        "ja": "バンダイ",
+        "ja_typings": [
+          "bandai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02267",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese company is famous for Weiss Schwarz card games and pro wrestling promotion?",
+      "ja": "ヴァイスシュヴァルツやプロレス興行で知られる日本企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sony",
+        "ja": "ソニー",
+        "ja_typings": [
+          "soni-"
+        ]
+      },
+      {
+        "en": "Bushiroad",
+        "ja": "ブシロード",
+        "ja_typings": [
+          "bushiro-do"
+        ]
+      },
+      {
+        "en": "CyberAgent",
+        "ja": "サイバーエージェント",
+        "ja_typings": [
+          "saiba-e-jento"
+        ]
+      },
+      {
+        "en": "Panasonic",
+        "ja": "パナソニック",
+        "ja_typings": [
+          "panasonikku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02268",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese electronics company makes the PlayStation?",
+      "ja": "プレイステーションを製造する日本企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "wwwww",
+        "ja": "大爆笑",
+        "ja_typings": [
+          "daibakushou"
+        ]
+      },
+      {
+        "en": "XD",
+        "ja": "笑顔",
+        "ja_typings": [
+          "egao"
+        ]
+      },
+      {
+        "en": "kusa haeru",
+        "ja": "ありがとう",
+        "ja_typings": [
+          "arigatou",
+          "arigato"
+        ]
+      },
+      {
+        "en": "nya",
+        "ja": "怒っている",
+        "ja_typings": [
+          "okotteiru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02269",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese chat slang of multiple 'w' characters means laughing hard?",
+      "ja": "wを連ねた「wwwww」というネットスラングの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "XD",
+        "ja": "エックスディー",
+        "ja_typings": [
+          "ekkusudi-"
+        ]
+      },
+      {
+        "en": "wwwww",
+        "ja": "ダブリュー連打",
+        "ja_typings": [
+          "daburyuurenda"
+        ]
+      },
+      {
+        "en": "nya",
+        "ja": "ニャー",
+        "ja_typings": [
+          "nya-"
+        ]
+      },
+      {
+        "en": "dazo",
+        "ja": "だぞ",
+        "ja_typings": [
+          "dazo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02270",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Western internet slang means laughing, written as an emoticon with squinted eyes?",
+      "ja": "目をつぶった顔文字で笑いを表す英語圏のネットスラングは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "kusa haeru",
+        "ja": "草生える",
+        "ja_typings": [
+          "kusahaeru"
+        ]
+      },
+      {
+        "en": "wwwww",
+        "ja": "ダブリュー連打",
+        "ja_typings": [
+          "daburyuurenda"
+        ]
+      },
+      {
+        "en": "XD",
+        "ja": "エックスディー",
+        "ja_typings": [
+          "ekkusudi-"
+        ]
+      },
+      {
+        "en": "nya",
+        "ja": "ニャー",
+        "ja_typings": [
+          "nya-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02271",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese internet phrase literally meaning 'grass grows' is used to indicate laughter?",
+      "ja": "「草が生える」という言葉でネット上の笑いを表す表現は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Membership",
+        "ja": "メンバーシップ",
+        "ja_typings": [
+          "menba-shippu"
+        ]
+      },
+      {
+        "en": "Donation",
+        "ja": "投げ銭",
+        "ja_typings": [
+          "nagesen"
+        ]
+      },
+      {
+        "en": "Subsc",
+        "ja": "サブスク",
+        "ja_typings": [
+          "sabusuku"
+        ]
+      },
+      {
+        "en": "Coin",
+        "ja": "コイン",
+        "ja_typings": [
+          "koin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02272",
+    "image_path": null,
+    "question_text": {
+      "en": "Which YouTube monetization feature provides paid subscribers with badges and exclusive perks?",
+      "ja": "YouTubeで有料会員にバッジや限定特典を付与する仕組みは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Donation",
+        "ja": "投げ銭",
+        "ja_typings": [
+          "nagesen"
+        ]
+      },
+      {
+        "en": "Membership",
+        "ja": "メンバーシップ",
+        "ja_typings": [
+          "menba-shippu"
+        ]
+      },
+      {
+        "en": "Subsc",
+        "ja": "サブスク",
+        "ja_typings": [
+          "sabusuku"
+        ]
+      },
+      {
+        "en": "Gem",
+        "ja": "ジェム",
+        "ja_typings": [
+          "jemu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02273",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the general term for sending money to a streamer?",
+      "ja": "配信者にお金を送る一般用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sucha",
+        "ja": "スパチャ",
+        "ja_typings": [
+          "supacha"
+        ]
+      },
+      {
+        "en": "Done",
+        "ja": "投げ銭",
+        "ja_typings": [
+          "nagesen"
+        ]
+      },
+      {
+        "en": "Menshi",
+        "ja": "メン限",
+        "ja_typings": [
+          "mengen"
+        ]
+      },
+      {
+        "en": "Gentei",
+        "ja": "限定",
+        "ja_typings": [
+          "gentei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02274",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese slang word for 'Super Chat' on YouTube is used in VTuber chats?",
+      "ja": "YouTubeのスーパーチャットをVTuber視聴者が略して呼ぶ言葉は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Done",
+        "ja": "ドネ",
+        "ja_typings": [
+          "done"
+        ]
+      },
+      {
+        "en": "Sucha",
+        "ja": "スパチャ",
+        "ja_typings": [
+          "supacha"
+        ]
+      },
+      {
+        "en": "Menshi",
+        "ja": "メン限",
+        "ja_typings": [
+          "mengen"
+        ]
+      },
+      {
+        "en": "Subsc",
+        "ja": "サブスク",
+        "ja_typings": [
+          "sabusuku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02275",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese chat slang abbreviates 'donation/tip'?",
+      "ja": "「投げ銭」を意味するチャットスラングは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Menshi",
+        "ja": "メン限",
+        "ja_typings": [
+          "mengen"
+        ]
+      },
+      {
+        "en": "Sucha",
+        "ja": "スパチャ",
+        "ja_typings": [
+          "supacha"
+        ]
+      },
+      {
+        "en": "Gentei",
+        "ja": "限定",
+        "ja_typings": [
+          "gentei"
+        ]
+      },
+      {
+        "en": "Subsc",
+        "ja": "サブスク",
+        "ja_typings": [
+          "sabusuku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02276",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese fan slang abbreviates 'members-only stream'?",
+      "ja": "「メンバー限定配信」をファンが略す言い方は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gentei",
+        "ja": "限定",
+        "ja_typings": [
+          "gentei"
+        ]
+      },
+      {
+        "en": "Menshi",
+        "ja": "メン限",
+        "ja_typings": [
+          "mengen"
+        ]
+      },
+      {
+        "en": "Sucha",
+        "ja": "スパチャ",
+        "ja_typings": [
+          "supacha"
+        ]
+      },
+      {
+        "en": "Done",
+        "ja": "ドネ",
+        "ja_typings": [
+          "done"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02277",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese word meaning 'limited' is used for members-only or time-limited content?",
+      "ja": "メン限や期間限定で使われる「限定」の日本語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Subsc",
+        "ja": "サブスク",
+        "ja_typings": [
+          "sabusuku"
+        ]
+      },
+      {
+        "en": "Menshi",
+        "ja": "メン限",
+        "ja_typings": [
+          "mengen"
+        ]
+      },
+      {
+        "en": "Sucha",
+        "ja": "スパチャ",
+        "ja_typings": [
+          "supacha"
+        ]
+      },
+      {
+        "en": "Gentei",
+        "ja": "限定",
+        "ja_typings": [
+          "gentei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02278",
+    "image_path": null,
+    "question_text": {
+      "en": "Which English abbreviation refers to a recurring paid subscription service?",
+      "ja": "月額課金サービスの英語略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Coin",
+        "ja": "コイン",
+        "ja_typings": [
+          "koin"
+        ]
+      },
+      {
+        "en": "Gem",
+        "ja": "ジェム",
+        "ja_typings": [
+          "jemu"
+        ]
+      },
+      {
+        "en": "Stone",
+        "ja": "石",
+        "ja_typings": [
+          "ishi"
+        ]
+      },
+      {
+        "en": "Ticket",
+        "ja": "チケット",
+        "ja_typings": [
+          "chiketto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02279",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the in-app currency name commonly used in mobile games and streaming apps?",
+      "ja": "モバイルゲームや配信アプリの基本的なアプリ内通貨の呼び名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gem",
+        "ja": "ジェム",
+        "ja_typings": [
+          "jemu"
+        ]
+      },
+      {
+        "en": "Coin",
+        "ja": "コイン",
+        "ja_typings": [
+          "koin"
+        ]
+      },
+      {
+        "en": "Token",
+        "ja": "トークン",
+        "ja_typings": [
+          "to-kun"
+        ]
+      },
+      {
+        "en": "Ticket",
+        "ja": "チケット",
+        "ja_typings": [
+          "chiketto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02280",
+    "image_path": null,
+    "question_text": {
+      "en": "Which premium in-app currency is often represented as a shining stone?",
+      "ja": "光る宝石として描かれる高価なアプリ内通貨は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Comment Cannon",
+        "ja": "コメント砲",
+        "ja_typings": [
+          "komentohou"
+        ]
+      },
+      {
+        "en": "Flow Comment",
+        "ja": "流れコメント",
+        "ja_typings": [
+          "nagarekomento"
+        ]
+      },
+      {
+        "en": "Chat",
+        "ja": "チャット",
+        "ja_typings": [
+          "chatto"
+        ]
+      },
+      {
+        "en": "Sucha",
+        "ja": "スパチャ",
+        "ja_typings": [
+          "supacha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02281",
+    "image_path": null,
+    "question_text": {
+      "en": "Which niconico feature lets viewers shoot a barrage of comments at once?",
+      "ja": "ニコニコ動画でコメントを一斉に大量に流す機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Flow Comment",
+        "ja": "流れコメント",
+        "ja_typings": [
+          "nagarekomento"
+        ]
+      },
+      {
+        "en": "Comment Cannon",
+        "ja": "コメント砲",
+        "ja_typings": [
+          "komentohou"
+        ]
+      },
+      {
+        "en": "Chat",
+        "ja": "チャット",
+        "ja_typings": [
+          "chatto"
+        ]
+      },
+      {
+        "en": "Sucha",
+        "ja": "スパチャ",
+        "ja_typings": [
+          "supacha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02282",
+    "image_path": null,
+    "question_text": {
+      "en": "Which niconico video commenting style scrolls comments from right to left?",
+      "ja": "ニコニコ動画でコメントが右から左へ流れる方式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chat",
+        "ja": "チャット",
+        "ja_typings": [
+          "chatto"
+        ]
+      },
+      {
+        "en": "Comment Cannon",
+        "ja": "コメント砲",
+        "ja_typings": [
+          "komentohou"
+        ]
+      },
+      {
+        "en": "Flow Comment",
+        "ja": "流れコメント",
+        "ja_typings": [
+          "nagarekomento"
+        ]
+      },
+      {
+        "en": "Sucha",
+        "ja": "スパチャ",
+        "ja_typings": [
+          "supacha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02283",
+    "image_path": null,
+    "question_text": {
+      "en": "Which general English term refers to live text conversation in a stream?",
+      "ja": "ライブ配信で文字会話を行う一般的な英語の名称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kaichou",
+        "ja": "会長",
+        "ja_typings": [
+          "kaichou"
+        ]
+      },
+      {
+        "en": "Danchou",
+        "ja": "団長",
+        "ja_typings": [
+          "danchou"
+        ]
+      },
+      {
+        "en": "Shachou",
+        "ja": "社長",
+        "ja_typings": [
+          "shachou"
+        ]
+      },
+      {
+        "en": "Senpai",
+        "ja": "先輩",
+        "ja_typings": [
+          "senpai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02284",
+    "image_path": null,
+    "question_text": {
+      "en": "Which VTuber title refers to the head of a student council, used by Shirogane Noel?",
+      "ja": "白銀ノエルが使う「会長」を意味するVTuber呼称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Danchou",
+        "ja": "団長",
+        "ja_typings": [
+          "danchou"
+        ]
+      },
+      {
+        "en": "Kaichou",
+        "ja": "会長",
+        "ja_typings": [
+          "kaichou"
+        ]
+      },
+      {
+        "en": "Shachou",
+        "ja": "社長",
+        "ja_typings": [
+          "shachou"
+        ]
+      },
+      {
+        "en": "Buchou",
+        "ja": "部長",
+        "ja_typings": [
+          "buchou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02285",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese title meaning 'group leader' is used as a nickname for Shirogane Noel?",
+      "ja": "白銀ノエルの愛称として使われる「団長」を意味する呼称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shachou",
+        "ja": "社長",
+        "ja_typings": [
+          "shachou"
+        ]
+      },
+      {
+        "en": "Kaichou",
+        "ja": "会長",
+        "ja_typings": [
+          "kaichou"
+        ]
+      },
+      {
+        "en": "Danchou",
+        "ja": "団長",
+        "ja_typings": [
+          "danchou"
+        ]
+      },
+      {
+        "en": "Buchou",
+        "ja": "部長",
+        "ja_typings": [
+          "buchou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02286",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese title meaning 'company president' is used as a nickname for Houshou Marine?",
+      "ja": "宝鐘マリンの愛称として使われる「社長」を意味する呼称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "nya",
+        "ja": "ニャ",
+        "ja_typings": [
+          "nya"
+        ]
+      },
+      {
+        "en": "dazo",
+        "ja": "ダゾ",
+        "ja_typings": [
+          "dazo"
+        ]
+      },
+      {
+        "en": "nanoda",
+        "ja": "ナノダ",
+        "ja_typings": [
+          "nanoda"
+        ]
+      },
+      {
+        "en": "desu",
+        "ja": "デス",
+        "ja_typings": [
+          "desu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02287",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese character ending sound is associated with cute cat-like speech?",
+      "ja": "猫っぽい可愛い語尾としてキャラに使われるのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "dazo",
+        "ja": "ダゾ",
+        "ja_typings": [
+          "dazo"
+        ]
+      },
+      {
+        "en": "nanoda",
+        "ja": "ナノダ",
+        "ja_typings": [
+          "nanoda"
+        ]
+      },
+      {
+        "en": "nya",
+        "ja": "ニャ",
+        "ja_typings": [
+          "nya"
+        ]
+      },
+      {
+        "en": "desu",
+        "ja": "デス",
+        "ja_typings": [
+          "desu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02288",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese sentence-ending emphasis word means roughly 'you know'?",
+      "ja": "強調や念押しで使う「ぞ」を含む語尾は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "nanoda",
+        "ja": "ナノダ",
+        "ja_typings": [
+          "nanoda"
+        ]
+      },
+      {
+        "en": "dazo",
+        "ja": "ダゾ",
+        "ja_typings": [
+          "dazo"
+        ]
+      },
+      {
+        "en": "nya",
+        "ja": "ニャ",
+        "ja_typings": [
+          "nya"
+        ]
+      },
+      {
+        "en": "desu",
+        "ja": "デス",
+        "ja_typings": [
+          "desu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02289",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese assertive sentence-ending phrase often used by anime characters means roughly 'it is so'?",
+      "ja": "アニメキャラがよく使う「断定」の語尾で「のだ」となるのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hololive ID",
+        "ja": "ホロライブID",
+        "ja_typings": [
+          "hororaibuid"
+        ]
+      },
+      {
+        "en": "Hololive JP",
+        "ja": "ホロライブJP",
+        "ja_typings": [
+          "hororaibujp"
+        ]
+      },
+      {
+        "en": "Hololive CN",
+        "ja": "ホロライブCN",
+        "ja_typings": [
+          "hororaibucn"
+        ]
+      },
+      {
+        "en": "Hololive EN",
+        "ja": "ホロライブEN",
+        "ja_typings": [
+          "hororaibuen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02290",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive branch is based in Indonesia?",
+      "ja": "ホロライブのインドネシア拠点支部は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hololive JP",
+        "ja": "ホロライブJP",
+        "ja_typings": [
+          "hororaibujp"
+        ]
+      },
+      {
+        "en": "Hololive ID",
+        "ja": "ホロライブID",
+        "ja_typings": [
+          "hororaibuid"
+        ]
+      },
+      {
+        "en": "Hololive CN",
+        "ja": "ホロライブCN",
+        "ja_typings": [
+          "hororaibucn"
+        ]
+      },
+      {
+        "en": "Hololive EN",
+        "ja": "ホロライブEN",
+        "ja_typings": [
+          "hororaibuen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02291",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive branch is the original Japanese division?",
+      "ja": "ホロライブの本家日本支部は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hololive CN",
+        "ja": "ホロライブCN",
+        "ja_typings": [
+          "hororaibucn"
+        ]
+      },
+      {
+        "en": "Hololive JP",
+        "ja": "ホロライブJP",
+        "ja_typings": [
+          "hororaibujp"
+        ]
+      },
+      {
+        "en": "Hololive ID",
+        "ja": "ホロライブID",
+        "ja_typings": [
+          "hororaibuid"
+        ]
+      },
+      {
+        "en": "Hololive EN",
+        "ja": "ホロライブEN",
+        "ja_typings": [
+          "hororaibuen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02292",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive branch operated in mainland China before its 2020 closure?",
+      "ja": "2020年に活動終了したホロライブの中国大陸支部は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Takanashi Kiara",
+        "ja": "小鳥遊キアラ",
+        "ja_typings": [
+          "takanashikiara"
+        ]
+      },
+      {
+        "en": "Watson Amelia",
+        "ja": "ワトソン アメリア",
+        "ja_typings": [
+          "watoson ameria"
+        ]
+      },
+      {
+        "en": "Gawr Gura",
+        "ja": "がうる ぐら",
+        "ja_typings": [
+          "gauru gura"
+        ]
+      },
+      {
+        "en": "Mori Calliope",
+        "ja": "森カリオペ",
+        "ja_typings": [
+          "morikariope"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02293",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive English Myth member is themed after a phoenix and known as KFP?",
+      "ja": "不死鳥がモチーフでKFPのファン名でも知られるホロライブEN Mythのメンバーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tsukino Mito",
+        "ja": "月ノ美兎",
+        "ja_typings": [
+          "tsukinomito"
+        ]
+      },
+      {
+        "en": "Sasaki Saku",
+        "ja": "笹木咲",
+        "ja_typings": [
+          "sasakisaku"
+        ]
+      },
+      {
+        "en": "Honma Himawari",
+        "ja": "本間ひまわり",
+        "ja_typings": [
+          "honmahimawari"
+        ]
+      },
+      {
+        "en": "Shizuka Rin",
+        "ja": "静凛",
+        "ja_typings": [
+          "shizukarin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02294",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nijisanji VTuber is famous as one of the original gen 1 members and was known as 'Mito-chan'?",
+      "ja": "にじさんじ1期生で「ミトちゃん」として親しまれてきたメンバーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sasaki Saku",
+        "ja": "笹木咲",
+        "ja_typings": [
+          "sasakisaku"
+        ]
+      },
+      {
+        "en": "Tsukino Mito",
+        "ja": "月ノ美兎",
+        "ja_typings": [
+          "tsukinomito"
+        ]
+      },
+      {
+        "en": "Honma Himawari",
+        "ja": "本間ひまわり",
+        "ja_typings": [
+          "honmahimawari"
+        ]
+      },
+      {
+        "en": "Lize Helesta",
+        "ja": "リゼ ヘルエスタ",
+        "ja_typings": [
+          "rize heruesuta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02295",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nijisanji female VTuber is known for collabs with Honma Himawari as a duo?",
+      "ja": "本間ひまわりとのコンビでも知られるにじさんじの女性ライバーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Honma Himawari",
+        "ja": "本間ひまわり",
+        "ja_typings": [
+          "honmahimawari"
+        ]
+      },
+      {
+        "en": "Sasaki Saku",
+        "ja": "笹木咲",
+        "ja_typings": [
+          "sasakisaku"
+        ]
+      },
+      {
+        "en": "Tsukino Mito",
+        "ja": "月ノ美兎",
+        "ja_typings": [
+          "tsukinomito"
+        ]
+      },
+      {
+        "en": "Kanae",
+        "ja": "叶",
+        "ja_typings": [
+          "kanae"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02296",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nijisanji VTuber pairs with Sasaki Saku in the 'Saku and Hima' duo?",
+      "ja": "「咲ひま」コンビで笹木咲とペアになるにじさんじのメンバーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kuzuha and Kanae",
+        "ja": "葛葉と叶",
+        "ja_typings": [
+          "kuzuhatokanae"
+        ]
+      },
+      {
+        "en": "Kuzuha and Kenmochi",
+        "ja": "葛葉と剣持",
+        "ja_typings": [
+          "kuzuhatokenmochi"
+        ]
+      },
+      {
+        "en": "Kanae and Kenmochi",
+        "ja": "叶と剣持",
+        "ja_typings": [
+          "kanaetokenmochi"
+        ]
+      },
+      {
+        "en": "Kuzuha and Tsukino Mito",
+        "ja": "葛葉と月ノ美兎",
+        "ja_typings": [
+          "kuzuhatotsukinomito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02297",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nijisanji male duo consists of two top streamers known as 'ChroNoiR'?",
+      "ja": "「ChroNoiR」として知られるにじさんじのトップ配信者2人組は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kanae and Kenmochi",
+        "ja": "叶と剣持",
+        "ja_typings": [
+          "kanaetokenmochi"
+        ]
+      },
+      {
+        "en": "Kuzuha and Kanae",
+        "ja": "葛葉と叶",
+        "ja_typings": [
+          "kuzuhatokanae"
+        ]
+      },
+      {
+        "en": "Kuzuha and Kenmochi",
+        "ja": "葛葉と剣持",
+        "ja_typings": [
+          "kuzuhatokenmochi"
+        ]
+      },
+      {
+        "en": "Kuzuha and Tsukino Mito",
+        "ja": "葛葉と月ノ美兎",
+        "ja_typings": [
+          "kuzuhatotsukinomito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02298",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nijisanji male duo combines 'Kanae' with the lawyer-themed VTuber?",
+      "ja": "叶と弁護士キャラのVTuberが組むにじさんじのコンビは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kuzuha and Tsukino Mito",
+        "ja": "葛葉と月ノ美兎",
+        "ja_typings": [
+          "kuzuhatotsukinomito"
+        ]
+      },
+      {
+        "en": "Kanae and Kenmochi",
+        "ja": "叶と剣持",
+        "ja_typings": [
+          "kanaetokenmochi"
+        ]
+      },
+      {
+        "en": "Kuzuha and Kanae",
+        "ja": "葛葉と叶",
+        "ja_typings": [
+          "kuzuhatokanae"
+        ]
+      },
+      {
+        "en": "Kuzuha and Kenmochi",
+        "ja": "葛葉と剣持",
+        "ja_typings": [
+          "kuzuhatokenmochi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02299",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nijisanji collab pair brings together the vampire-themed Kuzuha and the gen 1 chairperson?",
+      "ja": "吸血鬼キャラの葛葉と1期生委員長によるコラボペアは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Attack on Titan",
+        "ja": "進撃の巨人",
+        "ja_typings": [
+          "shingekinokyojin"
+        ]
+      },
+      {
+        "en": "One Piece",
+        "ja": "ワンピース",
+        "ja_typings": [
+          "wanpi-su"
+        ]
+      },
+      {
+        "en": "Demon Slayer",
+        "ja": "鬼滅の刃",
+        "ja_typings": [
+          "kimetsunoyaiba"
+        ]
+      },
+      {
+        "en": "Jujutsu Kaisen",
+        "ja": "呪術廻戦",
+        "ja_typings": [
+          "jujutsukaisen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02300",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga and anime by Hajime Isayama features humans fighting giant humanoids?",
+      "ja": "諫山創による人類と巨人の戦いを描いた漫画・アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "One Piece",
+        "ja": "ワンピース",
+        "ja_typings": [
+          "wanpi-su"
+        ]
+      },
+      {
+        "en": "Attack on Titan",
+        "ja": "進撃の巨人",
+        "ja_typings": [
+          "shingekinokyojin"
+        ]
+      },
+      {
+        "en": "Demon Slayer",
+        "ja": "鬼滅の刃",
+        "ja_typings": [
+          "kimetsunoyaiba"
+        ]
+      },
+      {
+        "en": "Naruto",
+        "ja": "ナルト",
+        "ja_typings": [
+          "naruto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02301",
+    "image_path": null,
+    "question_text": {
+      "en": "Which long-running Shonen Jump manga features pirates searching for the ultimate treasure?",
+      "ja": "海賊たちが究極の財宝を探す週刊少年ジャンプの長編漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Demon Slayer",
+        "ja": "鬼滅の刃",
+        "ja_typings": [
+          "kimetsunoyaiba"
+        ]
+      },
+      {
+        "en": "Attack on Titan",
+        "ja": "進撃の巨人",
+        "ja_typings": [
+          "shingekinokyojin"
+        ]
+      },
+      {
+        "en": "One Piece",
+        "ja": "ワンピース",
+        "ja_typings": [
+          "wanpi-su"
+        ]
+      },
+      {
+        "en": "Jujutsu Kaisen",
+        "ja": "呪術廻戦",
+        "ja_typings": [
+          "jujutsukaisen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02302",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga by Koyoharu Gotouge features a boy who joins a corps to slay demons after his family is attacked?",
+      "ja": "家族を襲われた少年が鬼を狩る隊に入る、吾峠呼世晴の漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Got it",
+        "ja": "了解",
+        "ja_typings": [
+          "ryoukai"
+        ]
+      },
+      {
+        "en": "Done",
+        "ja": "完了",
+        "ja_typings": [
+          "kanryou"
+        ]
+      },
+      {
+        "en": "XD",
+        "ja": "笑い",
+        "ja_typings": [
+          "warai"
+        ]
+      },
+      {
+        "en": "nya",
+        "ja": "ニャー",
+        "ja_typings": [
+          "nya-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02303",
+    "image_path": null,
+    "question_text": {
+      "en": "Which English chat phrase means 'understood' or 'I see'?",
+      "ja": "「了解」「わかった」を意味する英語チャットフレーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Katakana",
+        "ja": "カタカナ",
+        "ja_typings": [
+          "katakana"
+        ]
+      },
+      {
+        "en": "Hiragana",
+        "ja": "ひらがな",
+        "ja_typings": [
+          "hiragana"
+        ]
+      },
+      {
+        "en": "Kanji",
+        "ja": "漢字",
+        "ja_typings": [
+          "kanji"
+        ]
+      },
+      {
+        "en": "Romaji",
+        "ja": "ローマ字",
+        "ja_typings": [
+          "ro-maji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02304",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese script is used mainly for foreign loanwords?",
+      "ja": "外来語を表すのに主に使われる日本語の文字は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Altaic",
+        "ja": "アルタイ諸語",
+        "ja_typings": [
+          "arutaishogo"
+        ]
+      },
+      {
+        "en": "Uralic",
+        "ja": "ウラル諸語",
+        "ja_typings": [
+          "urarushogo"
+        ]
+      },
+      {
+        "en": "Sino-Tibetan",
+        "ja": "シナ・チベット諸語",
+        "ja_typings": [
+          "sinachibettoshogo"
+        ]
+      },
+      {
+        "en": "Dravidian",
+        "ja": "ドラヴィダ諸語",
+        "ja_typings": [
+          "dorabidashogo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02305",
+    "image_path": null,
+    "question_text": {
+      "en": "Which controversial language family groups Turkic, Mongolic, and Tungusic?",
+      "ja": "テュルク・モンゴル・ツングース諸語をまとめる仮説的な語族は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "English",
+        "ja": "英語",
+        "ja_typings": [
+          "eigo"
+        ]
+      },
+      {
+        "en": "French",
+        "ja": "フランス語",
+        "ja_typings": [
+          "furansugo"
+        ]
+      },
+      {
+        "en": "Spanish",
+        "ja": "スペイン語",
+        "ja_typings": [
+          "supeingo"
+        ]
+      },
+      {
+        "en": "Mandarin",
+        "ja": "中国語",
+        "ja_typings": [
+          "chuugokugo",
+          "chugokugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02306",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language has the most native speakers as a global lingua franca?",
+      "ja": "世界共通語として最も広く使われている言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Conjunction",
+        "ja": "接続詞",
+        "ja_typings": [
+          "setsuzokushi"
+        ]
+      },
+      {
+        "en": "Preposition",
+        "ja": "前置詞",
+        "ja_typings": [
+          "zenchishi"
+        ]
+      },
+      {
+        "en": "Interjection",
+        "ja": "感動詞",
+        "ja_typings": [
+          "kandoushi",
+          "kandoshi"
+        ]
+      },
+      {
+        "en": "Adverb",
+        "ja": "副詞",
+        "ja_typings": [
+          "fukushi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02307",
+    "image_path": null,
+    "question_text": {
+      "en": "Which part of speech connects words or clauses, like 'and' or 'but'?",
+      "ja": "「そして」「しかし」のように語句や節をつなぐ品詞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Middle voice",
+        "ja": "中動態",
+        "ja_typings": [
+          "chuudoutai",
+          "chudotai"
+        ]
+      },
+      {
+        "en": "Active voice",
+        "ja": "能動態",
+        "ja_typings": [
+          "nodoutai",
+          "nodotai"
+        ]
+      },
+      {
+        "en": "Passive voice",
+        "ja": "受動態",
+        "ja_typings": [
+          "judoutai",
+          "judotai"
+        ]
+      },
+      {
+        "en": "Causative voice",
+        "ja": "使役態",
+        "ja_typings": [
+          "shiekitai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02308",
+    "image_path": null,
+    "question_text": {
+      "en": "Which grammatical voice is neither active nor passive (e.g., Ancient Greek)?",
+      "ja": "能動でも受動でもない、古典ギリシャ語などにある態は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Italian",
+        "ja": "イタリア語",
+        "ja_typings": [
+          "itariago"
+        ]
+      },
+      {
+        "en": "Spanish",
+        "ja": "スペイン語",
+        "ja_typings": [
+          "supeingo"
+        ]
+      },
+      {
+        "en": "Portuguese",
+        "ja": "ポルトガル語",
+        "ja_typings": [
+          "porutogarugo"
+        ]
+      },
+      {
+        "en": "Romanian",
+        "ja": "ルーマニア語",
+        "ja_typings": [
+          "ru-maniago"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02309",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Romance language is the official language of Italy?",
+      "ja": "イタリアの公用語であるロマンス諸語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wade-Giles",
+        "ja": "ウェード式",
+        "ja_typings": [
+          "we-doshiki"
+        ]
+      },
+      {
+        "en": "Pinyin",
+        "ja": "ピンイン",
+        "ja_typings": [
+          "pinnin"
+        ]
+      },
+      {
+        "en": "Yale",
+        "ja": "イェール式",
+        "ja_typings": [
+          "ie-rushiki"
+        ]
+      },
+      {
+        "en": "Zhuyin",
+        "ja": "注音符号",
+        "ja_typings": [
+          "chuuonfugou",
+          "chuonfugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02310",
+    "image_path": null,
+    "question_text": {
+      "en": "Which romanization system for Mandarin was widely used before Pinyin?",
+      "ja": "ピンイン以前に広く使われた中国語ローマ字表記は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Antithesis",
+        "ja": "対句法",
+        "ja_typings": [
+          "taikuhou",
+          "taikuho"
+        ]
+      },
+      {
+        "en": "Metaphor",
+        "ja": "隠喩",
+        "ja_typings": [
+          "inyu"
+        ]
+      },
+      {
+        "en": "Simile",
+        "ja": "直喩",
+        "ja_typings": [
+          "chokuyu"
+        ]
+      },
+      {
+        "en": "Hyperbole",
+        "ja": "誇張法",
+        "ja_typings": [
+          "kochouhou",
+          "kochoho"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02311",
+    "image_path": null,
+    "question_text": {
+      "en": "Which rhetorical device juxtaposes contrasting ideas in parallel structure?",
+      "ja": "対立する語句を並列に置く修辞技法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kan-on",
+        "ja": "漢音",
+        "ja_typings": [
+          "kan'on",
+          "kannon"
+        ]
+      },
+      {
+        "en": "Go-on",
+        "ja": "呉音",
+        "ja_typings": [
+          "goon"
+        ]
+      },
+      {
+        "en": "To-on",
+        "ja": "唐音",
+        "ja_typings": [
+          "touon",
+          "toon"
+        ]
+      },
+      {
+        "en": "Kun-yomi",
+        "ja": "訓読み",
+        "ja_typings": [
+          "kunyomi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02312",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Sino-Japanese reading reflects the pronunciation of Tang-era China?",
+      "ja": "唐代の中国音を伝える漢字の音読みは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Phoenician",
+        "ja": "フェニキア文字",
+        "ja_typings": [
+          "fenikiamoji"
+        ]
+      },
+      {
+        "en": "Cuneiform",
+        "ja": "楔形文字",
+        "ja_typings": [
+          "kusabigatamoji"
+        ]
+      },
+      {
+        "en": "Hieroglyphs",
+        "ja": "ヒエログリフ",
+        "ja_typings": [
+          "hierogurifu"
+        ]
+      },
+      {
+        "en": "Linear B",
+        "ja": "線文字B",
+        "ja_typings": [
+          "senmojibi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02313",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Semitic script is the ancestor of most modern alphabets?",
+      "ja": "現代のアルファベットの祖となった古代セム系文字は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Catalan",
+        "ja": "カタルーニャ語",
+        "ja_typings": [
+          "kataru-nyago"
+        ]
+      },
+      {
+        "en": "Basque",
+        "ja": "バスク語",
+        "ja_typings": [
+          "basukugo"
+        ]
+      },
+      {
+        "en": "Galician",
+        "ja": "ガリシア語",
+        "ja_typings": [
+          "garishiago"
+        ]
+      },
+      {
+        "en": "Occitan",
+        "ja": "オック語",
+        "ja_typings": [
+          "okkugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02314",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Romance language is co-official in Andorra and parts of Spain?",
+      "ja": "アンドラとスペインの一部で公用語となるロマンス語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hanja",
+        "ja": "漢字 (韓国)",
+        "ja_typings": [
+          "kanji"
+        ]
+      },
+      {
+        "en": "Hanzi",
+        "ja": "漢字 (中国)",
+        "ja_typings": [
+          "kanji"
+        ]
+      },
+      {
+        "en": "Kanji",
+        "ja": "漢字 (日本)",
+        "ja_typings": [
+          "kanji"
+        ]
+      },
+      {
+        "en": "Chu Nom",
+        "ja": "チュノム",
+        "ja_typings": [
+          "chunomu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02315",
+    "image_path": null,
+    "question_text": {
+      "en": "What name is used for Chinese characters when used in Korean?",
+      "ja": "韓国語で使われる漢字の呼称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dravidian",
+        "ja": "ドラヴィダ語族",
+        "ja_typings": [
+          "doravu~idagozoku"
+        ]
+      },
+      {
+        "en": "Indo-Aryan",
+        "ja": "インド・アーリア語族",
+        "ja_typings": [
+          "indo a-riagozoku"
+        ]
+      },
+      {
+        "en": "Austroasiatic",
+        "ja": "オーストロアジア語族",
+        "ja_typings": [
+          "o-sutoroajiagozoku"
+        ]
+      },
+      {
+        "en": "Sino-Tibetan",
+        "ja": "シナ・チベット語族",
+        "ja_typings": [
+          "shinachibettogozoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02316",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language family includes Tamil, Telugu, and Malayalam?",
+      "ja": "タミル語・テルグ語・マラヤーラム語を含む語族は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "alphabet",
+        "ja": "アルファベット",
+        "ja_typings": [
+          "arufabetto"
+        ]
+      },
+      {
+        "en": "syllabary",
+        "ja": "音節文字",
+        "ja_typings": [
+          "onsetsumoji"
+        ]
+      },
+      {
+        "en": "logogram",
+        "ja": "表語文字",
+        "ja_typings": [
+          "hyougomoji",
+          "hyogomoji"
+        ]
+      },
+      {
+        "en": "abjad",
+        "ja": "アブジャド",
+        "ja_typings": [
+          "abujado"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02317",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a standardized set of letters used to write a language?",
+      "ja": "言語を表記するために標準化された文字の集合は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "vowel harmony",
+        "ja": "母音調和",
+        "ja_typings": [
+          "boinchouwa",
+          "boinchowa"
+        ]
+      },
+      {
+        "en": "consonant cluster",
+        "ja": "子音連結",
+        "ja_typings": [
+          "shi'inrenketsu"
+        ]
+      },
+      {
+        "en": "vowel reduction",
+        "ja": "母音弱化",
+        "ja_typings": [
+          "boinjakka"
+        ]
+      },
+      {
+        "en": "vowel shift",
+        "ja": "母音推移",
+        "ja_typings": [
+          "boinsuii"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02318",
+    "image_path": null,
+    "question_text": {
+      "en": "Which phonological phenomenon (e.g., in Turkish) requires vowels in a word to share features?",
+      "ja": "トルコ語などで語内の母音が同じ特徴を持つ現象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Morphology",
+        "ja": "形態論",
+        "ja_typings": [
+          "keitairon"
+        ]
+      },
+      {
+        "en": "Phonology",
+        "ja": "音韻論",
+        "ja_typings": [
+          "on'inron",
+          "oninron"
+        ]
+      },
+      {
+        "en": "Syntax",
+        "ja": "統語論",
+        "ja_typings": [
+          "tougoron",
+          "togoron"
+        ]
+      },
+      {
+        "en": "Semantics",
+        "ja": "意味論",
+        "ja_typings": [
+          "imiron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02319",
+    "image_path": null,
+    "question_text": {
+      "en": "Which branch of linguistics studies word formation?",
+      "ja": "語の形成を研究する言語学の分野は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Phoneme",
+        "ja": "音素",
+        "ja_typings": [
+          "onso"
+        ]
+      },
+      {
+        "en": "Morpheme",
+        "ja": "形態素",
+        "ja_typings": [
+          "keitaiso"
+        ]
+      },
+      {
+        "en": "Grapheme",
+        "ja": "書記素",
+        "ja_typings": [
+          "shokiso"
+        ]
+      },
+      {
+        "en": "Lexeme",
+        "ja": "語彙素",
+        "ja_typings": [
+          "goiso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02320",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the smallest unit of sound that distinguishes meaning?",
+      "ja": "意味を区別する音声の最小単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Syllable",
+        "ja": "音節",
+        "ja_typings": [
+          "onsetsu"
+        ]
+      },
+      {
+        "en": "Mora",
+        "ja": "モーラ",
+        "ja_typings": [
+          "mo-ra"
+        ]
+      },
+      {
+        "en": "Foot",
+        "ja": "韻脚",
+        "ja_typings": [
+          "inkyaku"
+        ]
+      },
+      {
+        "en": "Phrase",
+        "ja": "句",
+        "ja_typings": [
+          "ku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02321",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a unit of pronunciation having one vowel sound?",
+      "ja": "母音を1つ含む発音の単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Phonetics",
+        "ja": "音声学",
+        "ja_typings": [
+          "onseigaku"
+        ]
+      },
+      {
+        "en": "Phonology",
+        "ja": "音韻論",
+        "ja_typings": [
+          "on'inron",
+          "oninron"
+        ]
+      },
+      {
+        "en": "Pragmatics",
+        "ja": "語用論",
+        "ja_typings": [
+          "goyouron",
+          "goyoron"
+        ]
+      },
+      {
+        "en": "Etymology",
+        "ja": "語源学",
+        "ja_typings": [
+          "gogengaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02322",
+    "image_path": null,
+    "question_text": {
+      "en": "Which field studies the physical sounds of human speech?",
+      "ja": "人間の言語音の物理的性質を扱う分野は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Graphemics",
+        "ja": "書記素論",
+        "ja_typings": [
+          "shokisoron"
+        ]
+      },
+      {
+        "en": "Calligraphy",
+        "ja": "書道",
+        "ja_typings": [
+          "shodou",
+          "shodo"
+        ]
+      },
+      {
+        "en": "Orthography",
+        "ja": "正書法",
+        "ja_typings": [
+          "seishohou",
+          "seishoho"
+        ]
+      },
+      {
+        "en": "Typography",
+        "ja": "活字術",
+        "ja_typings": [
+          "katsujijutsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02323",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the study of writing systems and their units?",
+      "ja": "文字体系とその単位を研究する分野は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Arabic script",
+        "ja": "アラビア文字",
+        "ja_typings": [
+          "arabiamoji"
+        ]
+      },
+      {
+        "en": "Hebrew script",
+        "ja": "ヘブライ文字",
+        "ja_typings": [
+          "heburaimoji"
+        ]
+      },
+      {
+        "en": "Latin script",
+        "ja": "ラテン文字",
+        "ja_typings": [
+          "ratenmoji"
+        ]
+      },
+      {
+        "en": "Cyrillic script",
+        "ja": "キリル文字",
+        "ja_typings": [
+          "kirirumoji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02324",
+    "image_path": null,
+    "question_text": {
+      "en": "Which script is used to write modern Standard Arabic?",
+      "ja": "現代標準アラビア語を書くための文字は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Greek alphabet",
+        "ja": "ギリシャ文字",
+        "ja_typings": [
+          "girishamoji"
+        ]
+      },
+      {
+        "en": "Cyrillic alphabet",
+        "ja": "キリル文字",
+        "ja_typings": [
+          "kirirumoji"
+        ]
+      },
+      {
+        "en": "Latin alphabet",
+        "ja": "ラテン文字",
+        "ja_typings": [
+          "ratenmoji"
+        ]
+      },
+      {
+        "en": "Armenian alphabet",
+        "ja": "アルメニア文字",
+        "ja_typings": [
+          "arumeniamoji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02325",
+    "image_path": null,
+    "question_text": {
+      "en": "Which alphabet is used to write modern Greek?",
+      "ja": "現代ギリシャ語を書くアルファベットは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hebrew script",
+        "ja": "ヘブライ文字",
+        "ja_typings": [
+          "heburaimoji"
+        ]
+      },
+      {
+        "en": "Arabic script",
+        "ja": "アラビア文字",
+        "ja_typings": [
+          "arabiamoji"
+        ]
+      },
+      {
+        "en": "Syriac script",
+        "ja": "シリア文字",
+        "ja_typings": [
+          "shiriamoji"
+        ]
+      },
+      {
+        "en": "Greek script",
+        "ja": "ギリシャ文字",
+        "ja_typings": [
+          "girishamoji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02326",
+    "image_path": null,
+    "question_text": {
+      "en": "Which script is used to write modern Hebrew?",
+      "ja": "現代ヘブライ語を書く文字は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Left to right",
+        "ja": "左から右",
+        "ja_typings": [
+          "hidarikaramigi"
+        ]
+      },
+      {
+        "en": "Right to left",
+        "ja": "右から左",
+        "ja_typings": [
+          "migikarahidari"
+        ]
+      },
+      {
+        "en": "Top to bottom",
+        "ja": "上から下",
+        "ja_typings": [
+          "uekarashita"
+        ]
+      },
+      {
+        "en": "Bottom to top",
+        "ja": "下から上",
+        "ja_typings": [
+          "shitakaraue"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02327",
+    "image_path": null,
+    "question_text": {
+      "en": "In which direction is English written?",
+      "ja": "英語の文字を書く方向は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Top to bottom",
+        "ja": "上から下",
+        "ja_typings": [
+          "uekarashita"
+        ]
+      },
+      {
+        "en": "Bottom to top",
+        "ja": "下から上",
+        "ja_typings": [
+          "shitakaraue"
+        ]
+      },
+      {
+        "en": "Left to right",
+        "ja": "左から右",
+        "ja_typings": [
+          "hidarikaramigi"
+        ]
+      },
+      {
+        "en": "Right to left",
+        "ja": "右から左",
+        "ja_typings": [
+          "migikarahidari"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02328",
+    "image_path": null,
+    "question_text": {
+      "en": "In which direction is traditional vertical Japanese text read?",
+      "ja": "日本語の伝統的な縦書きの読む方向は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Top to bottom",
+        "ja": "上から下",
+        "ja_typings": [
+          "uekarashita"
+        ]
+      },
+      {
+        "en": "Bottom to top",
+        "ja": "下から上",
+        "ja_typings": [
+          "shitakaraue"
+        ]
+      },
+      {
+        "en": "Right to left",
+        "ja": "右から左",
+        "ja_typings": [
+          "migikarahidari"
+        ]
+      },
+      {
+        "en": "Left to right",
+        "ja": "左から右",
+        "ja_typings": [
+          "hidarikaramigi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02329",
+    "image_path": null,
+    "question_text": {
+      "en": "Which writing direction is used by Mongolian traditional script?",
+      "ja": "モンゴル伝統文字の書字方向は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Adjective",
+        "ja": "形容詞",
+        "ja_typings": [
+          "keiyoushi",
+          "keiyoshi"
+        ]
+      },
+      {
+        "en": "Adverb",
+        "ja": "副詞",
+        "ja_typings": [
+          "fukushi"
+        ]
+      },
+      {
+        "en": "Verb",
+        "ja": "動詞",
+        "ja_typings": [
+          "doushi",
+          "doshi"
+        ]
+      },
+      {
+        "en": "Noun",
+        "ja": "名詞",
+        "ja_typings": [
+          "meishi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02330",
+    "image_path": null,
+    "question_text": {
+      "en": "Which part of speech modifies a noun, like 'red' or 'tall'?",
+      "ja": "「赤い」「高い」のように名詞を修飾する品詞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Adnominal",
+        "ja": "連体詞",
+        "ja_typings": [
+          "rentaishi"
+        ]
+      },
+      {
+        "en": "Adjective",
+        "ja": "形容詞",
+        "ja_typings": [
+          "keiyoushi",
+          "keiyoshi"
+        ]
+      },
+      {
+        "en": "Adverb",
+        "ja": "副詞",
+        "ja_typings": [
+          "fukushi"
+        ]
+      },
+      {
+        "en": "Particle",
+        "ja": "助詞",
+        "ja_typings": [
+          "joshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02331",
+    "image_path": null,
+    "question_text": {
+      "en": "In Japanese grammar, what part of speech only modifies nouns (e.g., kono, sono)?",
+      "ja": "「この」「その」のように名詞だけを修飾する日本語の品詞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Interjection",
+        "ja": "感動詞",
+        "ja_typings": [
+          "kandoushi",
+          "kandoshi"
+        ]
+      },
+      {
+        "en": "Conjunction",
+        "ja": "接続詞",
+        "ja_typings": [
+          "setsuzokushi"
+        ]
+      },
+      {
+        "en": "Adverb",
+        "ja": "副詞",
+        "ja_typings": [
+          "fukushi"
+        ]
+      },
+      {
+        "en": "Particle",
+        "ja": "助詞",
+        "ja_typings": [
+          "joshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02332",
+    "image_path": null,
+    "question_text": {
+      "en": "Which part of speech expresses emotion (e.g., 'oh!', 'wow!')?",
+      "ja": "「あっ」「おお」のように感動を表す品詞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pronoun",
+        "ja": "代名詞",
+        "ja_typings": [
+          "daimeishi"
+        ]
+      },
+      {
+        "en": "Noun",
+        "ja": "名詞",
+        "ja_typings": [
+          "meishi"
+        ]
+      },
+      {
+        "en": "Adjective",
+        "ja": "形容詞",
+        "ja_typings": [
+          "keiyoushi",
+          "keiyoshi"
+        ]
+      },
+      {
+        "en": "Adverb",
+        "ja": "副詞",
+        "ja_typings": [
+          "fukushi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02333",
+    "image_path": null,
+    "question_text": {
+      "en": "Which part of speech replaces a noun (e.g., 'he', 'she', 'it')?",
+      "ja": "名詞の代わりに使われる品詞 (例: 彼、それ) は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Beautifying language",
+        "ja": "美化語",
+        "ja_typings": [
+          "bikago"
+        ]
+      },
+      {
+        "en": "Respectful language",
+        "ja": "尊敬語",
+        "ja_typings": [
+          "sonkeigo"
+        ]
+      },
+      {
+        "en": "Humble language",
+        "ja": "謙譲語",
+        "ja_typings": [
+          "kenjougo",
+          "kenjogo"
+        ]
+      },
+      {
+        "en": "Polite language",
+        "ja": "丁寧語",
+        "ja_typings": [
+          "teineigo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02334",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Japanese honorific 'o-' / 'go-' prefix style called?",
+      "ja": "日本語で「お」「ご」を付けて言葉を整える表現の名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Colloquial",
+        "ja": "口語",
+        "ja_typings": [
+          "kougo",
+          "kogo"
+        ]
+      },
+      {
+        "en": "Formal",
+        "ja": "文語",
+        "ja_typings": [
+          "bungo"
+        ]
+      },
+      {
+        "en": "Archaic",
+        "ja": "古語",
+        "ja_typings": [
+          "kogo"
+        ]
+      },
+      {
+        "en": "Slang",
+        "ja": "俗語",
+        "ja_typings": [
+          "zokugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02335",
+    "image_path": null,
+    "question_text": {
+      "en": "Which register of speech is used in informal conversation?",
+      "ja": "日常会話で用いられる、くだけた言葉遣いは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Formal style",
+        "ja": "文語体",
+        "ja_typings": [
+          "bungotai"
+        ]
+      },
+      {
+        "en": "Colloquial style",
+        "ja": "口語体",
+        "ja_typings": [
+          "kougotai",
+          "kogotai"
+        ]
+      },
+      {
+        "en": "Honorific style",
+        "ja": "敬体",
+        "ja_typings": [
+          "keitai"
+        ]
+      },
+      {
+        "en": "Plain style",
+        "ja": "常体",
+        "ja_typings": [
+          "joutai",
+          "jotai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02336",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese style is used in official documents and speeches?",
+      "ja": "公的な文書や演説で用いられる日本語の文体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Derivation",
+        "ja": "派生",
+        "ja_typings": [
+          "hasei"
+        ]
+      },
+      {
+        "en": "Inflection",
+        "ja": "屈折",
+        "ja_typings": [
+          "kussetsu"
+        ]
+      },
+      {
+        "en": "Compounding",
+        "ja": "複合",
+        "ja_typings": [
+          "fukugou",
+          "fukugo"
+        ]
+      },
+      {
+        "en": "Borrowing",
+        "ja": "借用",
+        "ja_typings": [
+          "shakuyou",
+          "shakuyo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02337",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the process of forming a new word by adding affixes?",
+      "ja": "接辞を付けて新しい語を作る過程は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Inflection",
+        "ja": "屈折",
+        "ja_typings": [
+          "kussetsu"
+        ]
+      },
+      {
+        "en": "Derivation",
+        "ja": "派生",
+        "ja_typings": [
+          "hasei"
+        ]
+      },
+      {
+        "en": "Conjugation",
+        "ja": "活用",
+        "ja_typings": [
+          "katsuyou",
+          "katsuyo"
+        ]
+      },
+      {
+        "en": "Declension",
+        "ja": "曲用",
+        "ja_typings": [
+          "kyokuyou",
+          "kyokuyo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02338",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the modification of a word to express grammatical features?",
+      "ja": "語の文法的特徴を表すための変化は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sound change",
+        "ja": "音変化",
+        "ja_typings": [
+          "onhenka"
+        ]
+      },
+      {
+        "en": "Spelling reform",
+        "ja": "綴り改革",
+        "ja_typings": [
+          "tsuzurikaikaku"
+        ]
+      },
+      {
+        "en": "Loanword",
+        "ja": "借用語",
+        "ja_typings": [
+          "shakuyougo",
+          "shakuyogo"
+        ]
+      },
+      {
+        "en": "Neologism",
+        "ja": "新語",
+        "ja_typings": [
+          "shingo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02339",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a diachronic change in pronunciation of a language called?",
+      "ja": "時間とともに起こる言語の発音変化は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gemination",
+        "ja": "促音化",
+        "ja_typings": [
+          "sokuonka"
+        ]
+      },
+      {
+        "en": "Elision",
+        "ja": "脱落",
+        "ja_typings": [
+          "datsuraku"
+        ]
+      },
+      {
+        "en": "Assimilation",
+        "ja": "同化",
+        "ja_typings": [
+          "douka",
+          "doka"
+        ]
+      },
+      {
+        "en": "Lenition",
+        "ja": "弱化",
+        "ja_typings": [
+          "jakka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02340",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the doubling of a consonant sound called (e.g., Japanese sokuon)?",
+      "ja": "促音のように子音が重なる現象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vowel alternation",
+        "ja": "母音交替",
+        "ja_typings": [
+          "boinkoutai",
+          "boinkotai"
+        ]
+      },
+      {
+        "en": "Vowel harmony",
+        "ja": "母音調和",
+        "ja_typings": [
+          "boinchouwa",
+          "boinchowa"
+        ]
+      },
+      {
+        "en": "Vowel reduction",
+        "ja": "母音弱化",
+        "ja_typings": [
+          "boinjakka"
+        ]
+      },
+      {
+        "en": "Vowel lengthening",
+        "ja": "母音長音化",
+        "ja_typings": [
+          "boinchouonka",
+          "boinchoonka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02341",
+    "image_path": null,
+    "question_text": {
+      "en": "What term refers to a vowel changing across related forms (e.g., sing/sang)?",
+      "ja": "関連する語形で母音が変化する現象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Onbin",
+        "ja": "音便",
+        "ja_typings": [
+          "onbin"
+        ]
+      },
+      {
+        "en": "Rendaku",
+        "ja": "連濁",
+        "ja_typings": [
+          "rendaku"
+        ]
+      },
+      {
+        "en": "Renjo",
+        "ja": "連声",
+        "ja_typings": [
+          "renjou",
+          "renjo"
+        ]
+      },
+      {
+        "en": "Yotsugana",
+        "ja": "四つ仮名",
+        "ja_typings": [
+          "yotsugana"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02342",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the historical sound change in Japanese where word-internal sounds change for ease?",
+      "ja": "日本語で発音が変化する音便現象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nasal sound change",
+        "ja": "撥音便",
+        "ja_typings": [
+          "hatsuonbin"
+        ]
+      },
+      {
+        "en": "I-onbin",
+        "ja": "イ音便",
+        "ja_typings": [
+          "i-onbin"
+        ]
+      },
+      {
+        "en": "U-onbin",
+        "ja": "ウ音便",
+        "ja_typings": [
+          "u-onbin"
+        ]
+      },
+      {
+        "en": "Sokuonbin",
+        "ja": "促音便",
+        "ja_typings": [
+          "sokuonbin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02343",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese sound change turns a consonant into a nasal (e.g., 'shinde')?",
+      "ja": "日本語で子音が撥音に変化する音便は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Renjo",
+        "ja": "連声",
+        "ja_typings": [
+          "renjou",
+          "renjo"
+        ]
+      },
+      {
+        "en": "Rendaku",
+        "ja": "連濁",
+        "ja_typings": [
+          "rendaku"
+        ]
+      },
+      {
+        "en": "Onbin",
+        "ja": "音便",
+        "ja_typings": [
+          "onbin"
+        ]
+      },
+      {
+        "en": "Gemination",
+        "ja": "促音化",
+        "ja_typings": [
+          "sokuonka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02344",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese sandhi merges a final n with a following vowel (e.g., han'nou)?",
+      "ja": "撥音が後続母音と結びついて生じる日本語の連音現象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Perfect aspect",
+        "ja": "完了相",
+        "ja_typings": [
+          "kanryousou",
+          "kanryoso"
+        ]
+      },
+      {
+        "en": "Progressive aspect",
+        "ja": "進行相",
+        "ja_typings": [
+          "shinkousou",
+          "shinkoso"
+        ]
+      },
+      {
+        "en": "Habitual aspect",
+        "ja": "習慣相",
+        "ja_typings": [
+          "shuukansou",
+          "shukanso"
+        ]
+      },
+      {
+        "en": "Perfective aspect",
+        "ja": "完結相",
+        "ja_typings": [
+          "kanketsusou",
+          "kanketsuso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02345",
+    "image_path": null,
+    "question_text": {
+      "en": "Which grammatical aspect expresses completed action with present relevance?",
+      "ja": "完了して現在に影響が残ることを示す相は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Past tense",
+        "ja": "過去時制",
+        "ja_typings": [
+          "kakojisei"
+        ]
+      },
+      {
+        "en": "Present tense",
+        "ja": "現在時制",
+        "ja_typings": [
+          "genzaijisei"
+        ]
+      },
+      {
+        "en": "Future tense",
+        "ja": "未来時制",
+        "ja_typings": [
+          "miraijisei"
+        ]
+      },
+      {
+        "en": "Perfect tense",
+        "ja": "完了時制",
+        "ja_typings": [
+          "kanryoujisei",
+          "kanryojisei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02346",
+    "image_path": null,
+    "question_text": {
+      "en": "Which tense refers to actions that already happened?",
+      "ja": "すでに起こった出来事を示す時制は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Future tense",
+        "ja": "未来時制",
+        "ja_typings": [
+          "miraijisei"
+        ]
+      },
+      {
+        "en": "Past tense",
+        "ja": "過去時制",
+        "ja_typings": [
+          "kakojisei"
+        ]
+      },
+      {
+        "en": "Present tense",
+        "ja": "現在時制",
+        "ja_typings": [
+          "genzaijisei"
+        ]
+      },
+      {
+        "en": "Perfect tense",
+        "ja": "完了時制",
+        "ja_typings": [
+          "kanryoujisei",
+          "kanryojisei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02347",
+    "image_path": null,
+    "question_text": {
+      "en": "Which tense refers to actions yet to happen?",
+      "ja": "これから起こる出来事を示す時制は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aspect",
+        "ja": "相",
+        "ja_typings": [
+          "sou",
+          "so"
+        ]
+      },
+      {
+        "en": "Tense",
+        "ja": "時制",
+        "ja_typings": [
+          "jisei"
+        ]
+      },
+      {
+        "en": "Mood",
+        "ja": "法",
+        "ja_typings": [
+          "hou",
+          "ho"
+        ]
+      },
+      {
+        "en": "Voice",
+        "ja": "態",
+        "ja_typings": [
+          "tai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02348",
+    "image_path": null,
+    "question_text": {
+      "en": "Which grammatical category describes the flow of time within an action?",
+      "ja": "動作の時間的な流れ方を表す文法カテゴリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Voice",
+        "ja": "態",
+        "ja_typings": [
+          "tai"
+        ]
+      },
+      {
+        "en": "Aspect",
+        "ja": "相",
+        "ja_typings": [
+          "sou",
+          "so"
+        ]
+      },
+      {
+        "en": "Tense",
+        "ja": "時制",
+        "ja_typings": [
+          "jisei"
+        ]
+      },
+      {
+        "en": "Mood",
+        "ja": "法",
+        "ja_typings": [
+          "hou",
+          "ho"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02349",
+    "image_path": null,
+    "question_text": {
+      "en": "Which grammatical category distinguishes active and passive?",
+      "ja": "能動と受動を区別する文法カテゴリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mood",
+        "ja": "法",
+        "ja_typings": [
+          "hou",
+          "ho"
+        ]
+      },
+      {
+        "en": "Voice",
+        "ja": "態",
+        "ja_typings": [
+          "tai"
+        ]
+      },
+      {
+        "en": "Tense",
+        "ja": "時制",
+        "ja_typings": [
+          "jisei"
+        ]
+      },
+      {
+        "en": "Aspect",
+        "ja": "相",
+        "ja_typings": [
+          "sou",
+          "so"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02350",
+    "image_path": null,
+    "question_text": {
+      "en": "Which grammatical category expresses attitude (e.g., command, wish)?",
+      "ja": "話者の心的態度 (命令・願望など) を表す文法カテゴリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Potential form",
+        "ja": "可能形",
+        "ja_typings": [
+          "kanoukei",
+          "kanokei"
+        ]
+      },
+      {
+        "en": "Passive form",
+        "ja": "受身形",
+        "ja_typings": [
+          "ukemikei"
+        ]
+      },
+      {
+        "en": "Causative form",
+        "ja": "使役形",
+        "ja_typings": [
+          "shiekikei"
+        ]
+      },
+      {
+        "en": "Imperative form",
+        "ja": "命令形",
+        "ja_typings": [
+          "meireikei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02351",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese verb form expresses 'can do' (e.g., yomeru)?",
+      "ja": "「読める」のように「〜できる」を表す日本語の動詞形は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "French",
+        "ja": "フランス語",
+        "ja_typings": [
+          "furansugo"
+        ]
+      },
+      {
+        "en": "Italian",
+        "ja": "イタリア語",
+        "ja_typings": [
+          "itariago"
+        ]
+      },
+      {
+        "en": "Spanish",
+        "ja": "スペイン語",
+        "ja_typings": [
+          "supeingo"
+        ]
+      },
+      {
+        "en": "German",
+        "ja": "ドイツ語",
+        "ja_typings": [
+          "doitsugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02352",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language is the official language of France?",
+      "ja": "フランスの公用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dutch",
+        "ja": "オランダ語",
+        "ja_typings": [
+          "orandago"
+        ]
+      },
+      {
+        "en": "German",
+        "ja": "ドイツ語",
+        "ja_typings": [
+          "doitsugo"
+        ]
+      },
+      {
+        "en": "Danish",
+        "ja": "デンマーク語",
+        "ja_typings": [
+          "denma-kugo"
+        ]
+      },
+      {
+        "en": "Swedish",
+        "ja": "スウェーデン語",
+        "ja_typings": [
+          "suwe-dengo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02353",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language is the official language of the Netherlands?",
+      "ja": "オランダの公用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Las Fallas",
+        "ja": "ラス・ファリャス",
+        "ja_typings": [
+          "rasu/faryasu"
+        ]
+      },
+      {
+        "en": "La Tomatina",
+        "ja": "ラ・トマティーナ",
+        "ja_typings": [
+          "ra/tomati-na"
+        ]
+      },
+      {
+        "en": "San Fermin",
+        "ja": "サン・フェルミン",
+        "ja_typings": [
+          "san/ferumin"
+        ]
+      },
+      {
+        "en": "Feria de Abril",
+        "ja": "フェリア・デ・アブリル",
+        "ja_typings": [
+          "feria/de/aburiru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02354",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Valencia festival burns giant satirical figures in March?",
+      "ja": "3月にバレンシアで巨大な人形を焼くスペインの祭りは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Las Posadas",
+        "ja": "ラス・ポサダス",
+        "ja_typings": [
+          "rasu/posadasu"
+        ]
+      },
+      {
+        "en": "Dia de los Muertos",
+        "ja": "死者の日",
+        "ja_typings": [
+          "shishanohi"
+        ]
+      },
+      {
+        "en": "Las Fallas",
+        "ja": "ラス・ファリャス",
+        "ja_typings": [
+          "rasu/faryasu"
+        ]
+      },
+      {
+        "en": "Cinco de Mayo",
+        "ja": "シンコ・デ・マヨ",
+        "ja_typings": [
+          "shinko/de/mayo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02355",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mexican Christmas tradition reenacts Mary and Joseph seeking lodging?",
+      "ja": "メキシコでマリアとヨセフの宿探しを再現するクリスマス行事は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Navratri",
+        "ja": "ナヴラトリ",
+        "ja_typings": [
+          "navuratori"
+        ]
+      },
+      {
+        "en": "Diwali",
+        "ja": "ディーワーリー",
+        "ja_typings": [
+          "di-wa-ri-"
+        ]
+      },
+      {
+        "en": "Holi",
+        "ja": "ホーリー",
+        "ja_typings": [
+          "ho-ri-"
+        ]
+      },
+      {
+        "en": "Pongal",
+        "ja": "ポンガル",
+        "ja_typings": [
+          "pongaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02356",
+    "image_path": null,
+    "question_text": {
+      "en": "Which nine-night Hindu festival worships the goddess Durga?",
+      "ja": "ドゥルガー女神を祀る9夜にわたるヒンドゥー教の祭は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pongal",
+        "ja": "ポンガル",
+        "ja_typings": [
+          "pongaru"
+        ]
+      },
+      {
+        "en": "Onam",
+        "ja": "オーナム",
+        "ja_typings": [
+          "o-namu"
+        ]
+      },
+      {
+        "en": "Navratri",
+        "ja": "ナヴラトリ",
+        "ja_typings": [
+          "navuratori"
+        ]
+      },
+      {
+        "en": "Holi",
+        "ja": "ホーリー",
+        "ja_typings": [
+          "ho-ri-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02357",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Tamil harvest festival celebrates the sun in January?",
+      "ja": "1月に太陽神を祝うタミル人の収穫祭は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dhoti",
+        "ja": "ドーティー",
+        "ja_typings": [
+          "do-ti-"
+        ]
+      },
+      {
+        "en": "Sari",
+        "ja": "サリー",
+        "ja_typings": [
+          "sari-"
+        ]
+      },
+      {
+        "en": "Kurta",
+        "ja": "クルター",
+        "ja_typings": [
+          "kuruta-"
+        ]
+      },
+      {
+        "en": "Lungi",
+        "ja": "ルンギー",
+        "ja_typings": [
+          "rungi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02358",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the traditional Indian male garment wrapped around the waist?",
+      "ja": "腰に巻くインドの伝統的な男性用の衣装は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bachata",
+        "ja": "バチャータ",
+        "ja_typings": [
+          "bacha-ta"
+        ]
+      },
+      {
+        "en": "Merengue",
+        "ja": "メレンゲ",
+        "ja_typings": [
+          "merenge"
+        ]
+      },
+      {
+        "en": "Salsa",
+        "ja": "サルサ",
+        "ja_typings": [
+          "sarusa"
+        ]
+      },
+      {
+        "en": "Reggaeton",
+        "ja": "レゲトン",
+        "ja_typings": [
+          "regeton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02359",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Dominican music and dance style features romantic guitar?",
+      "ja": "ロマンチックなギターが特徴のドミニカ共和国の音楽は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Feria de Abril",
+        "ja": "フェリア・デ・アブリル",
+        "ja_typings": [
+          "feria/de/aburiru"
+        ]
+      },
+      {
+        "en": "Las Fallas",
+        "ja": "ラス・ファリャス",
+        "ja_typings": [
+          "rasu/faryasu"
+        ]
+      },
+      {
+        "en": "Semana Santa",
+        "ja": "セマナ・サンタ",
+        "ja_typings": [
+          "semana/santa"
+        ]
+      },
+      {
+        "en": "La Tomatina",
+        "ja": "ラ・トマティーナ",
+        "ja_typings": [
+          "ra/tomati-na"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02360",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Seville festival features flamenco and casetas after Holy Week?",
+      "ja": "聖週間後にセビリアで開かれるフラメンコの祭りは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "longhouse",
+        "ja": "ロングハウス",
+        "ja_typings": [
+          "ronguhausu"
+        ]
+      },
+      {
+        "en": "teepee",
+        "ja": "ティピー",
+        "ja_typings": [
+          "tipi-"
+        ]
+      },
+      {
+        "en": "igloo",
+        "ja": "イグルー",
+        "ja_typings": [
+          "iguru-"
+        ]
+      },
+      {
+        "en": "hogan",
+        "ja": "ホーガン",
+        "ja_typings": [
+          "ho-gan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02361",
+    "image_path": null,
+    "question_text": {
+      "en": "Which large communal dwelling housed several families in Native American cultures?",
+      "ja": "複数の家族が暮らした北米先住民の細長い共同住居は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Zeami",
+        "ja": "世阿弥",
+        "ja_typings": [
+          "zeami"
+        ]
+      },
+      {
+        "en": "Kan'ami",
+        "ja": "観阿弥",
+        "ja_typings": [
+          "kan'ami",
+          "kannami"
+        ]
+      },
+      {
+        "en": "Chikamatsu",
+        "ja": "近松門左衛門",
+        "ja_typings": [
+          "chikamatsumonzaemon"
+        ]
+      },
+      {
+        "en": "Izumi Kyoka",
+        "ja": "泉鏡花",
+        "ja_typings": [
+          "izumikyouka",
+          "izumikyoka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02362",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the most important playwright and theorist of Noh theatre?",
+      "ja": "能の大成者として最も知られる劇作家・理論家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Matsuo Basho",
+        "ja": "松尾芭蕉",
+        "ja_typings": [
+          "matsuobashou",
+          "matsuobasho"
+        ]
+      },
+      {
+        "en": "Yosa Buson",
+        "ja": "与謝蕪村",
+        "ja_typings": [
+          "yosabuson"
+        ]
+      },
+      {
+        "en": "Kobayashi Issa",
+        "ja": "小林一茶",
+        "ja_typings": [
+          "kobayashiissa"
+        ]
+      },
+      {
+        "en": "Masaoka Shiki",
+        "ja": "正岡子規",
+        "ja_typings": [
+          "masaokashiki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02363",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the master of haiku famous for 'Oku no Hosomichi'?",
+      "ja": "『奥の細道』で知られる俳諧の巨匠は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sesshu",
+        "ja": "雪舟",
+        "ja_typings": [
+          "sesshuu",
+          "sesshu"
+        ]
+      },
+      {
+        "en": "Kano Eitoku",
+        "ja": "狩野永徳",
+        "ja_typings": [
+          "kanoueitoku",
+          "kanoeitoku"
+        ]
+      },
+      {
+        "en": "Tawaraya Sotatsu",
+        "ja": "俵屋宗達",
+        "ja_typings": [
+          "tawarayasoutatsu",
+          "tawarayasotatsu"
+        ]
+      },
+      {
+        "en": "Ogata Korin",
+        "ja": "尾形光琳",
+        "ja_typings": [
+          "ogatakourin",
+          "ogatakorin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02364",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Muromachi-era ink painter is known for landscapes like 'Long Landscape Scroll'?",
+      "ja": "『山水長巻』で知られる室町時代の水墨画家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sao Paulo",
+        "ja": "サンパウロ",
+        "ja_typings": [
+          "sanpauro"
+        ]
+      },
+      {
+        "en": "Rio de Janeiro",
+        "ja": "リオデジャネイロ",
+        "ja_typings": [
+          "riodejaneiro"
+        ]
+      },
+      {
+        "en": "Brasilia",
+        "ja": "ブラジリア",
+        "ja_typings": [
+          "burajiria"
+        ]
+      },
+      {
+        "en": "Salvador",
+        "ja": "サルヴァドール",
+        "ja_typings": [
+          "saruvado-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02365",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the largest city in Brazil?",
+      "ja": "ブラジル最大の都市は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Salvador",
+        "ja": "サルヴァドール",
+        "ja_typings": [
+          "saruvado-ru"
+        ]
+      },
+      {
+        "en": "Brasilia",
+        "ja": "ブラジリア",
+        "ja_typings": [
+          "burajiria"
+        ]
+      },
+      {
+        "en": "Sao Paulo",
+        "ja": "サンパウロ",
+        "ja_typings": [
+          "sanpauro"
+        ]
+      },
+      {
+        "en": "Recife",
+        "ja": "レシフェ",
+        "ja_typings": [
+          "reshife"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02366",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Brazilian city was the country's first capital and is known for Afro-Brazilian culture?",
+      "ja": "ブラジル最初の首都で、アフロ・ブラジル文化の中心地は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cannes Film Festival",
+        "ja": "カンヌ国際映画祭",
+        "ja_typings": [
+          "kannukokusaieigasai"
+        ]
+      },
+      {
+        "en": "Venice Film Festival",
+        "ja": "ヴェネツィア国際映画祭",
+        "ja_typings": [
+          "vu~enetsiakokusaieigasai"
+        ]
+      },
+      {
+        "en": "Berlin Film Festival",
+        "ja": "ベルリン国際映画祭",
+        "ja_typings": [
+          "berurinkokusaieigasai"
+        ]
+      },
+      {
+        "en": "Toronto Film Festival",
+        "ja": "トロント国際映画祭",
+        "ja_typings": [
+          "torontokokusaieigasai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02367",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French film festival awards the Palme d'Or?",
+      "ja": "パルム・ドールを授与するフランスの映画祭は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Venice Carnival",
+        "ja": "ヴェネツィア・カーニバル",
+        "ja_typings": [
+          "venetsia/ka-nibaru"
+        ]
+      },
+      {
+        "en": "Rio Carnival",
+        "ja": "リオのカーニバル",
+        "ja_typings": [
+          "riono ka-nibaru",
+          "rionoka-nibaru"
+        ]
+      },
+      {
+        "en": "Las Fallas",
+        "ja": "ラス・ファリャス",
+        "ja_typings": [
+          "rasu/faryasu"
+        ]
+      },
+      {
+        "en": "Mardi Gras",
+        "ja": "マルディグラ",
+        "ja_typings": [
+          "marudigura"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02368",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian carnival is famous for elaborate masks?",
+      "ja": "華やかな仮面で知られるイタリアの謝肉祭は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rock in Rio",
+        "ja": "ロック・イン・リオ",
+        "ja_typings": [
+          "rokku/in/rio"
+        ]
+      },
+      {
+        "en": "Tomorrowland",
+        "ja": "トゥモローランド",
+        "ja_typings": [
+          "tumoro-rando"
+        ]
+      },
+      {
+        "en": "Coachella",
+        "ja": "コーチェラ",
+        "ja_typings": [
+          "ko-chera"
+        ]
+      },
+      {
+        "en": "Glastonbury",
+        "ja": "グラストンベリー",
+        "ja_typings": [
+          "gurasutonberi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02369",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Brazilian music festival is one of the largest in the world?",
+      "ja": "ブラジルで開かれる世界最大級の音楽フェスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Noh",
+        "ja": "能",
+        "ja_typings": [
+          "nou",
+          "no"
+        ]
+      },
+      {
+        "en": "Kabuki",
+        "ja": "歌舞伎",
+        "ja_typings": [
+          "kabuki"
+        ]
+      },
+      {
+        "en": "Bunraku",
+        "ja": "文楽",
+        "ja_typings": [
+          "bunraku"
+        ]
+      },
+      {
+        "en": "Kyogen",
+        "ja": "狂言",
+        "ja_typings": [
+          "kyougen",
+          "kyogen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02370",
+    "image_path": null,
+    "question_text": {
+      "en": "Which masked Japanese musical drama dates from the 14th century?",
+      "ja": "14世紀から続く面を着けた日本の歌舞演劇は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bunraku",
+        "ja": "文楽",
+        "ja_typings": [
+          "bunraku"
+        ]
+      },
+      {
+        "en": "Noh",
+        "ja": "能",
+        "ja_typings": [
+          "nou",
+          "no"
+        ]
+      },
+      {
+        "en": "Kabuki",
+        "ja": "歌舞伎",
+        "ja_typings": [
+          "kabuki"
+        ]
+      },
+      {
+        "en": "Kyogen",
+        "ja": "狂言",
+        "ja_typings": [
+          "kyougen",
+          "kyogen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02371",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese traditional puppet theatre uses three puppeteers per puppet?",
+      "ja": "1体の人形を3人で操る日本の伝統人形劇は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kyogen",
+        "ja": "狂言",
+        "ja_typings": [
+          "kyougen",
+          "kyogen"
+        ]
+      },
+      {
+        "en": "Bunraku",
+        "ja": "文楽",
+        "ja_typings": [
+          "bunraku"
+        ]
+      },
+      {
+        "en": "Kabuki",
+        "ja": "歌舞伎",
+        "ja_typings": [
+          "kabuki"
+        ]
+      },
+      {
+        "en": "Rakugo",
+        "ja": "落語",
+        "ja_typings": [
+          "rakugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02372",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese comic theatre is performed between Noh plays?",
+      "ja": "能の演目の合間に上演される滑稽な日本の演劇は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Muharram",
+        "ja": "ムハッラム",
+        "ja_typings": [
+          "muharramu"
+        ]
+      },
+      {
+        "en": "Ramadan",
+        "ja": "ラマダーン",
+        "ja_typings": [
+          "ramada-n"
+        ]
+      },
+      {
+        "en": "Shawwal",
+        "ja": "シャウワール",
+        "ja_typings": [
+          "shauwa-ru"
+        ]
+      },
+      {
+        "en": "Rajab",
+        "ja": "ラジャブ",
+        "ja_typings": [
+          "rajabu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02373",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Islamic month commemorates the martyrdom of Husayn ibn Ali?",
+      "ja": "フサイン・イブン・アリーの殉教を悼むイスラム暦の月は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shawwal",
+        "ja": "シャウワール",
+        "ja_typings": [
+          "shauwa-ru"
+        ]
+      },
+      {
+        "en": "Muharram",
+        "ja": "ムハッラム",
+        "ja_typings": [
+          "muharramu"
+        ]
+      },
+      {
+        "en": "Rajab",
+        "ja": "ラジャブ",
+        "ja_typings": [
+          "rajabu"
+        ]
+      },
+      {
+        "en": "Safar",
+        "ja": "サファル",
+        "ja_typings": [
+          "safaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02374",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Islamic month follows Ramadan and starts with Eid al-Fitr?",
+      "ja": "ラマダーン明けでイード・アル＝フィトルから始まるイスラム暦の月は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rajab",
+        "ja": "ラジャブ",
+        "ja_typings": [
+          "rajabu"
+        ]
+      },
+      {
+        "en": "Shawwal",
+        "ja": "シャウワール",
+        "ja_typings": [
+          "shauwa-ru"
+        ]
+      },
+      {
+        "en": "Muharram",
+        "ja": "ムハッラム",
+        "ja_typings": [
+          "muharramu"
+        ]
+      },
+      {
+        "en": "Ramadan",
+        "ja": "ラマダーン",
+        "ja_typings": [
+          "ramada-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02375",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the seventh month of the Islamic calendar, considered sacred?",
+      "ja": "イスラム暦の第7月で神聖月とされるのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cappuccino",
+        "ja": "カプチーノ",
+        "ja_typings": [
+          "kapuchi-no"
+        ]
+      },
+      {
+        "en": "Macchiato",
+        "ja": "マキアート",
+        "ja_typings": [
+          "makia-to"
+        ]
+      },
+      {
+        "en": "Americano",
+        "ja": "アメリカーノ",
+        "ja_typings": [
+          "amerika-no"
+        ]
+      },
+      {
+        "en": "Latte",
+        "ja": "カフェラテ",
+        "ja_typings": [
+          "kaferate"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02376",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian coffee drink tops espresso with foamed milk in equal layers?",
+      "ja": "エスプレッソに泡立てミルクを等量に重ねるイタリアのコーヒーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Macchiato",
+        "ja": "マキアート",
+        "ja_typings": [
+          "makia-to"
+        ]
+      },
+      {
+        "en": "Cappuccino",
+        "ja": "カプチーノ",
+        "ja_typings": [
+          "kapuchi-no"
+        ]
+      },
+      {
+        "en": "Americano",
+        "ja": "アメリカーノ",
+        "ja_typings": [
+          "amerika-no"
+        ]
+      },
+      {
+        "en": "Mocha",
+        "ja": "モカ",
+        "ja_typings": [
+          "moka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02377",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian coffee is espresso 'stained' with a small amount of milk?",
+      "ja": "エスプレッソに少量のミルクを加えたイタリアのコーヒーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Americano",
+        "ja": "アメリカーノ",
+        "ja_typings": [
+          "amerika-no"
+        ]
+      },
+      {
+        "en": "Cappuccino",
+        "ja": "カプチーノ",
+        "ja_typings": [
+          "kapuchi-no"
+        ]
+      },
+      {
+        "en": "Macchiato",
+        "ja": "マキアート",
+        "ja_typings": [
+          "makia-to"
+        ]
+      },
+      {
+        "en": "Espresso",
+        "ja": "エスプレッソ",
+        "ja_typings": [
+          "esupuresso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02378",
+    "image_path": null,
+    "question_text": {
+      "en": "Which coffee is espresso diluted with hot water?",
+      "ja": "エスプレッソをお湯で薄めたコーヒーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Semana Santa",
+        "ja": "セマナ・サンタ",
+        "ja_typings": [
+          "semana/santa"
+        ]
+      },
+      {
+        "en": "Feria de Abril",
+        "ja": "フェリア・デ・アブリル",
+        "ja_typings": [
+          "feria/de/aburiru"
+        ]
+      },
+      {
+        "en": "Las Fallas",
+        "ja": "ラス・ファリャス",
+        "ja_typings": [
+          "rasu/faryasu"
+        ]
+      },
+      {
+        "en": "San Fermin",
+        "ja": "サン・フェルミン",
+        "ja_typings": [
+          "san/ferumin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02379",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Spanish Holy Week celebration features hooded processions?",
+      "ja": "とんがり頭巾の行列が特徴のスペイン聖週間の祝祭は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mid-Autumn Festival",
+        "ja": "中秋節",
+        "ja_typings": [
+          "chuushuusetsu",
+          "chushusetsu"
+        ]
+      },
+      {
+        "en": "Dragon Boat Festival",
+        "ja": "端午節",
+        "ja_typings": [
+          "tangosetsu"
+        ]
+      },
+      {
+        "en": "Qingming Festival",
+        "ja": "清明節",
+        "ja_typings": [
+          "seimeisetsu"
+        ]
+      },
+      {
+        "en": "Lantern Festival",
+        "ja": "元宵節",
+        "ja_typings": [
+          "genshousetsu",
+          "genshosetsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02380",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Chinese festival celebrates the harvest with mooncakes?",
+      "ja": "月餅を食べて収穫を祝う中国の祭りは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dragon Boat Festival",
+        "ja": "端午節",
+        "ja_typings": [
+          "tangosetsu"
+        ]
+      },
+      {
+        "en": "Mid-Autumn Festival",
+        "ja": "中秋節",
+        "ja_typings": [
+          "chuushuusetsu",
+          "chushusetsu"
+        ]
+      },
+      {
+        "en": "Qingming Festival",
+        "ja": "清明節",
+        "ja_typings": [
+          "seimeisetsu"
+        ]
+      },
+      {
+        "en": "Lantern Festival",
+        "ja": "元宵節",
+        "ja_typings": [
+          "genshousetsu",
+          "genshosetsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02381",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Chinese festival features dragon boat races and zongzi?",
+      "ja": "ドラゴンボートレースと粽が伝統の中国の祭りは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Qingming Festival",
+        "ja": "清明節",
+        "ja_typings": [
+          "seimeisetsu"
+        ]
+      },
+      {
+        "en": "Mid-Autumn Festival",
+        "ja": "中秋節",
+        "ja_typings": [
+          "chuushuusetsu",
+          "chushusetsu"
+        ]
+      },
+      {
+        "en": "Dragon Boat Festival",
+        "ja": "端午節",
+        "ja_typings": [
+          "tangosetsu"
+        ]
+      },
+      {
+        "en": "Lantern Festival",
+        "ja": "元宵節",
+        "ja_typings": [
+          "genshousetsu",
+          "genshosetsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02382",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Chinese festival is the tomb-sweeping day in early April?",
+      "ja": "4月初旬に行われる墓参りの中国の祭りは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bouillabaisse",
+        "ja": "ブイヤベース",
+        "ja_typings": [
+          "buiyabe-su"
+        ]
+      },
+      {
+        "en": "Cassoulet",
+        "ja": "カスレ",
+        "ja_typings": [
+          "kasure"
+        ]
+      },
+      {
+        "en": "Pot-au-feu",
+        "ja": "ポトフ",
+        "ja_typings": [
+          "potofu"
+        ]
+      },
+      {
+        "en": "Ratatouille",
+        "ja": "ラタトゥイユ",
+        "ja_typings": [
+          "ratatuiyu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02383",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Provencal fish stew is from Marseille?",
+      "ja": "マルセイユ発祥のプロヴァンス風魚介スープは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cassoulet",
+        "ja": "カスレ",
+        "ja_typings": [
+          "kasure"
+        ]
+      },
+      {
+        "en": "Bouillabaisse",
+        "ja": "ブイヤベース",
+        "ja_typings": [
+          "buiyabe-su"
+        ]
+      },
+      {
+        "en": "Pot-au-feu",
+        "ja": "ポトフ",
+        "ja_typings": [
+          "potofu"
+        ]
+      },
+      {
+        "en": "Coq au vin",
+        "ja": "コック・オ・ヴァン",
+        "ja_typings": [
+          "kokku/o/van"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02384",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French slow-cooked stew of beans and meat is from Languedoc?",
+      "ja": "ラングドック地方の豆と肉の煮込み料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pot-au-feu",
+        "ja": "ポトフ",
+        "ja_typings": [
+          "potofu"
+        ]
+      },
+      {
+        "en": "Bouillabaisse",
+        "ja": "ブイヤベース",
+        "ja_typings": [
+          "buiyabe-su"
+        ]
+      },
+      {
+        "en": "Cassoulet",
+        "ja": "カスレ",
+        "ja_typings": [
+          "kasure"
+        ]
+      },
+      {
+        "en": "Ratatouille",
+        "ja": "ラタトゥイユ",
+        "ja_typings": [
+          "ratatuiyu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02385",
+    "image_path": null,
+    "question_text": {
+      "en": "Which classic French dish is a boiled beef and vegetable stew?",
+      "ja": "牛肉と野菜を煮込んだフランスの伝統料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kurta",
+        "ja": "クルター",
+        "ja_typings": [
+          "kuruta-"
+        ]
+      },
+      {
+        "en": "Dhoti",
+        "ja": "ドーティー",
+        "ja_typings": [
+          "do-ti-"
+        ]
+      },
+      {
+        "en": "Sherwani",
+        "ja": "シェルワーニー",
+        "ja_typings": [
+          "sheruwa-ni-"
+        ]
+      },
+      {
+        "en": "Lungi",
+        "ja": "ルンギー",
+        "ja_typings": [
+          "rungi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02386",
+    "image_path": null,
+    "question_text": {
+      "en": "Which long collarless shirt is worn across South Asia?",
+      "ja": "南アジアで広く着用される襟なしの長いシャツは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shalwar",
+        "ja": "シャルワール",
+        "ja_typings": [
+          "sharuwa-ru"
+        ]
+      },
+      {
+        "en": "Dhoti",
+        "ja": "ドーティー",
+        "ja_typings": [
+          "do-ti-"
+        ]
+      },
+      {
+        "en": "Kurta",
+        "ja": "クルター",
+        "ja_typings": [
+          "kuruta-"
+        ]
+      },
+      {
+        "en": "Lungi",
+        "ja": "ルンギー",
+        "ja_typings": [
+          "rungi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02387",
+    "image_path": null,
+    "question_text": {
+      "en": "Which loose trousers are paired with a kameez in South Asia?",
+      "ja": "南アジアでカミーズと合わせる、ゆったりしたズボンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Umrah",
+        "ja": "ウムラ",
+        "ja_typings": [
+          "umura"
+        ]
+      },
+      {
+        "en": "Hajj",
+        "ja": "ハッジ",
+        "ja_typings": [
+          "hajji"
+        ]
+      },
+      {
+        "en": "Salat",
+        "ja": "サラート",
+        "ja_typings": [
+          "sara-to"
+        ]
+      },
+      {
+        "en": "Zakat",
+        "ja": "ザカート",
+        "ja_typings": [
+          "zaka-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02388",
+    "image_path": null,
+    "question_text": {
+      "en": "Which non-mandatory Islamic pilgrimage to Mecca can be performed any time of year?",
+      "ja": "メッカへの随時可能な小巡礼は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Salat",
+        "ja": "サラート",
+        "ja_typings": [
+          "sara-to"
+        ]
+      },
+      {
+        "en": "Zakat",
+        "ja": "ザカート",
+        "ja_typings": [
+          "zaka-to"
+        ]
+      },
+      {
+        "en": "Hajj",
+        "ja": "ハッジ",
+        "ja_typings": [
+          "hajji"
+        ]
+      },
+      {
+        "en": "Umrah",
+        "ja": "ウムラ",
+        "ja_typings": [
+          "umura"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02389",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the Islamic ritual prayer performed five times a day?",
+      "ja": "1日5回行うイスラム教の礼拝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Zakat",
+        "ja": "ザカート",
+        "ja_typings": [
+          "zaka-to"
+        ]
+      },
+      {
+        "en": "Salat",
+        "ja": "サラート",
+        "ja_typings": [
+          "sara-to"
+        ]
+      },
+      {
+        "en": "Hajj",
+        "ja": "ハッジ",
+        "ja_typings": [
+          "hajji"
+        ]
+      },
+      {
+        "en": "Umrah",
+        "ja": "ウムラ",
+        "ja_typings": [
+          "umura"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02390",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Islamic pillar is the obligatory almsgiving?",
+      "ja": "イスラム教における義務的な喜捨は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Babushka",
+        "ja": "バブーシュカ",
+        "ja_typings": [
+          "babu-shuka"
+        ]
+      },
+      {
+        "en": "Matryoshka",
+        "ja": "マトリョーシカ",
+        "ja_typings": [
+          "matoryo-shika"
+        ]
+      },
+      {
+        "en": "Pirozhki",
+        "ja": "ピロシキ",
+        "ja_typings": [
+          "piroshiki"
+        ]
+      },
+      {
+        "en": "Sarafan",
+        "ja": "サラファン",
+        "ja_typings": [
+          "sarafan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02391",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Russian word names the traditional grandmother's headscarf or nesting doll?",
+      "ja": "ロシアの伝統的なおばあさんの頭巾や入れ子人形を指す語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pirozhki",
+        "ja": "ピロシキ",
+        "ja_typings": [
+          "piroshiki"
+        ]
+      },
+      {
+        "en": "Babushka",
+        "ja": "バブーシュカ",
+        "ja_typings": [
+          "babu-shuka"
+        ]
+      },
+      {
+        "en": "Blini",
+        "ja": "ブリヌイ",
+        "ja_typings": [
+          "burinui"
+        ]
+      },
+      {
+        "en": "Pelmeni",
+        "ja": "ペリメニ",
+        "ja_typings": [
+          "perimeni"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02392",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Russian small baked or fried bun is filled with meat or potatoes?",
+      "ja": "肉や芋を詰めて焼くロシアの小さなパンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Khokhloma",
+        "ja": "ホフロマ",
+        "ja_typings": [
+          "hofuroma"
+        ]
+      },
+      {
+        "en": "Gzhel",
+        "ja": "グジェリ",
+        "ja_typings": [
+          "gujeri"
+        ]
+      },
+      {
+        "en": "Palekh",
+        "ja": "パレフ",
+        "ja_typings": [
+          "parefu"
+        ]
+      },
+      {
+        "en": "Matryoshka",
+        "ja": "マトリョーシカ",
+        "ja_typings": [
+          "matoryo-shika"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02393",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Russian folk painting uses red, black and gold on wooden tableware?",
+      "ja": "赤・黒・金で木製食器を彩るロシアの民芸絵付けは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Notre-Dame Cathedral",
+        "ja": "ノートルダム大聖堂",
+        "ja_typings": [
+          "no-torudamudaiseidou",
+          "no-torudamudaiseido"
+        ]
+      },
+      {
+        "en": "Cologne Cathedral",
+        "ja": "ケルン大聖堂",
+        "ja_typings": [
+          "kerundaiseidou",
+          "kerundaiseido"
+        ]
+      },
+      {
+        "en": "Milan Cathedral",
+        "ja": "ミラノ大聖堂",
+        "ja_typings": [
+          "miranodaiseidou",
+          "miranodaiseido"
+        ]
+      },
+      {
+        "en": "Reims Cathedral",
+        "ja": "ランス大聖堂",
+        "ja_typings": [
+          "ransudaiseidou",
+          "ransudaiseido"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02394",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Paris Gothic cathedral has flying buttresses and famous gargoyles?",
+      "ja": "フライング・バットレスとガーゴイルで有名なパリのゴシック大聖堂は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cologne Cathedral",
+        "ja": "ケルン大聖堂",
+        "ja_typings": [
+          "kerundaiseidou",
+          "kerundaiseido"
+        ]
+      },
+      {
+        "en": "Notre-Dame Cathedral",
+        "ja": "ノートルダム大聖堂",
+        "ja_typings": [
+          "no-torudamudaiseidou",
+          "no-torudamudaiseido"
+        ]
+      },
+      {
+        "en": "Milan Cathedral",
+        "ja": "ミラノ大聖堂",
+        "ja_typings": [
+          "miranodaiseidou",
+          "miranodaiseido"
+        ]
+      },
+      {
+        "en": "St. Peter's Basilica",
+        "ja": "サン・ピエトロ大聖堂",
+        "ja_typings": [
+          "sanpietorodaiseidou",
+          "sanpietorodaiseido"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02395",
+    "image_path": null,
+    "question_text": {
+      "en": "Which German Gothic cathedral is the largest in northern Europe?",
+      "ja": "北ヨーロッパ最大のゴシック大聖堂であるドイツの教会は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Milan Cathedral",
+        "ja": "ミラノ大聖堂",
+        "ja_typings": [
+          "miranodaiseidou",
+          "miranodaiseido"
+        ]
+      },
+      {
+        "en": "Notre-Dame Cathedral",
+        "ja": "ノートルダム大聖堂",
+        "ja_typings": [
+          "no-torudamudaiseidou",
+          "no-torudamudaiseido"
+        ]
+      },
+      {
+        "en": "Cologne Cathedral",
+        "ja": "ケルン大聖堂",
+        "ja_typings": [
+          "kerundaiseidou",
+          "kerundaiseido"
+        ]
+      },
+      {
+        "en": "Florence Cathedral",
+        "ja": "フィレンツェ大聖堂",
+        "ja_typings": [
+          "firentsedaiseidou",
+          "firentsedaiseido"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02396",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian Gothic cathedral has more than 3,000 statues on its facade?",
+      "ja": "3000体以上の彫像が並ぶイタリアのゴシック大聖堂は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sogetsu",
+        "ja": "草月流",
+        "ja_typings": [
+          "sougetsuryuu",
+          "sogetsuryu"
+        ]
+      },
+      {
+        "en": "Ohara",
+        "ja": "小原流",
+        "ja_typings": [
+          "oharaRyuu",
+          "oharaRyu"
+        ]
+      },
+      {
+        "en": "Ikenobo",
+        "ja": "池坊",
+        "ja_typings": [
+          "ikenobou",
+          "ikenobo"
+        ]
+      },
+      {
+        "en": "Saga Goryu",
+        "ja": "嵯峨御流",
+        "ja_typings": [
+          "sagagoryuu",
+          "sagagoryu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02397",
+    "image_path": null,
+    "question_text": {
+      "en": "Which avant-garde school of ikebana was founded in 1927 by Teshigahara?",
+      "ja": "1927年に勅使河原蒼風が創始したいけばなの流派は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ohara",
+        "ja": "小原流",
+        "ja_typings": [
+          "ohararyuu",
+          "ohararyu"
+        ]
+      },
+      {
+        "en": "Sogetsu",
+        "ja": "草月流",
+        "ja_typings": [
+          "sougetsuryuu",
+          "sogetsuryu"
+        ]
+      },
+      {
+        "en": "Ikenobo",
+        "ja": "池坊",
+        "ja_typings": [
+          "ikenobou",
+          "ikenobo"
+        ]
+      },
+      {
+        "en": "Saga Goryu",
+        "ja": "嵯峨御流",
+        "ja_typings": [
+          "sagagoryuu",
+          "sagagoryu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02398",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ikebana school pioneered the moribana shallow-container style?",
+      "ja": "盛花を考案したいけばなの流派は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Saga Goryu",
+        "ja": "嵯峨御流",
+        "ja_typings": [
+          "sagagoryuu",
+          "sagagoryu"
+        ]
+      },
+      {
+        "en": "Sogetsu",
+        "ja": "草月流",
+        "ja_typings": [
+          "sougetsuryuu",
+          "sogetsuryu"
+        ]
+      },
+      {
+        "en": "Ohara",
+        "ja": "小原流",
+        "ja_typings": [
+          "ohararyuu",
+          "ohararyu"
+        ]
+      },
+      {
+        "en": "Ikenobo",
+        "ja": "池坊",
+        "ja_typings": [
+          "ikenobou",
+          "ikenobo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02399",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ikebana school traces its origin to Emperor Saga at Daikaku-ji?",
+      "ja": "嵯峨天皇と大覚寺に由来するいけばなの流派は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Barong Tagalog",
+        "ja": "バロン・タガログ",
+        "ja_typings": [
+          "baron/tagarogu"
+        ]
+      },
+      {
+        "en": "Kurta",
+        "ja": "クルター",
+        "ja_typings": [
+          "kuruta-"
+        ]
+      },
+      {
+        "en": "Dhoti",
+        "ja": "ドーティー",
+        "ja_typings": [
+          "do-ti-"
+        ]
+      },
+      {
+        "en": "Sherwani",
+        "ja": "シェルワーニー",
+        "ja_typings": [
+          "sheruwa-ni-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02400",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the national embroidered formal shirt of the Philippines for men?",
+      "ja": "フィリピンの男性正装である刺繍シャツは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yom Kippur",
+        "ja": "ヨム・キプール",
+        "ja_typings": [
+          "yomu/kipu-ru"
+        ]
+      },
+      {
+        "en": "Hanukkah",
+        "ja": "ハヌカー",
+        "ja_typings": [
+          "hanuka-"
+        ]
+      },
+      {
+        "en": "Passover",
+        "ja": "過越祭",
+        "ja_typings": [
+          "sugikoshisai"
+        ]
+      },
+      {
+        "en": "Rosh Hashanah",
+        "ja": "ローシュ・ハッシャーナー",
+        "ja_typings": [
+          "ro-shu/hassha-na-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02401",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the holiest day of the Jewish year, the Day of Atonement?",
+      "ja": "ユダヤ教で最も神聖な「贖罪の日」は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hanukkah",
+        "ja": "ハヌカー",
+        "ja_typings": [
+          "hanuka-"
+        ]
+      },
+      {
+        "en": "Yom Kippur",
+        "ja": "ヨム・キプール",
+        "ja_typings": [
+          "yomu/kipu-ru"
+        ]
+      },
+      {
+        "en": "Passover",
+        "ja": "過越祭",
+        "ja_typings": [
+          "sugikoshisai"
+        ]
+      },
+      {
+        "en": "Sukkot",
+        "ja": "スコット",
+        "ja_typings": [
+          "sukotto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02402",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Jewish festival of lights lasts eight nights?",
+      "ja": "8日間ろうそくを灯すユダヤ教の光の祭は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ECS",
+        "ja": "ECS",
+        "ja_typings": [
+          "i-shi-esu",
+          "ecs"
+        ]
+      },
+      {
+        "en": "EKS",
+        "ja": "EKS",
+        "ja_typings": [
+          "i-kei-esu",
+          "eks"
+        ]
+      },
+      {
+        "en": "Lambda",
+        "ja": "Lambda",
+        "ja_typings": [
+          "lambda"
+        ]
+      },
+      {
+        "en": "Fargate",
+        "ja": "Fargate",
+        "ja_typings": [
+          "fargate"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02403",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS service runs Docker containers without Kubernetes?",
+      "ja": "Kubernetes を使わず Docker コンテナを動かす AWS のサービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "EKS",
+        "ja": "EKS",
+        "ja_typings": [
+          "i-kei-esu",
+          "eks"
+        ]
+      },
+      {
+        "en": "ECS",
+        "ja": "ECS",
+        "ja_typings": [
+          "i-shi-esu",
+          "ecs"
+        ]
+      },
+      {
+        "en": "AKS",
+        "ja": "AKS",
+        "ja_typings": [
+          "e-kei-esu",
+          "aks"
+        ]
+      },
+      {
+        "en": "GKE",
+        "ja": "GKE",
+        "ja_typings": [
+          "ji-kei-i-",
+          "gke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02404",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is AWS's managed Kubernetes service?",
+      "ja": "AWS が提供するマネージド Kubernetes は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "QA",
+        "ja": "QA",
+        "ja_typings": [
+          "kyu-e-",
+          "qa"
+        ]
+      },
+      {
+        "en": "UA",
+        "ja": "UA",
+        "ja_typings": [
+          "yu-e-",
+          "ua"
+        ]
+      },
+      {
+        "en": "DA",
+        "ja": "DA",
+        "ja_typings": [
+          "di-e-",
+          "da"
+        ]
+      },
+      {
+        "en": "PA",
+        "ja": "PA",
+        "ja_typings": [
+          "pi-e-",
+          "pa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02405",
+    "image_path": null,
+    "question_text": {
+      "en": "Which abbreviation refers to quality assurance in software?",
+      "ja": "ソフトウェアの品質保証を意味する略語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "OCI",
+        "ja": "OCI",
+        "ja_typings": [
+          "o-shi-ai",
+          "oci"
+        ]
+      },
+      {
+        "en": "CRI",
+        "ja": "CRI",
+        "ja_typings": [
+          "shi-a-ru-ai",
+          "cri"
+        ]
+      },
+      {
+        "en": "CNI",
+        "ja": "CNI",
+        "ja_typings": [
+          "shi-enu-ai",
+          "cni"
+        ]
+      },
+      {
+        "en": "OPA",
+        "ja": "OPA",
+        "ja_typings": [
+          "o-pi-e-",
+          "opa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02406",
+    "image_path": null,
+    "question_text": {
+      "en": "Which open standard defines container runtimes and image format?",
+      "ja": "コンテナランタイムとイメージ形式のオープン標準は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Availability",
+        "ja": "可用性",
+        "ja_typings": [
+          "kayousei",
+          "kayosei"
+        ]
+      },
+      {
+        "en": "Reliability",
+        "ja": "信頼性",
+        "ja_typings": [
+          "shinraisei"
+        ]
+      },
+      {
+        "en": "Scalability",
+        "ja": "拡張性",
+        "ja_typings": [
+          "kakuchousei",
+          "kakuchosei"
+        ]
+      },
+      {
+        "en": "Maintainability",
+        "ja": "保守性",
+        "ja_typings": [
+          "hoshusei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02407",
+    "image_path": null,
+    "question_text": {
+      "en": "Which non-functional requirement measures uptime of a system?",
+      "ja": "システムの稼働率を示す非機能要件は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "AKS",
+        "ja": "AKS",
+        "ja_typings": [
+          "e-kei-esu",
+          "aks"
+        ]
+      },
+      {
+        "en": "EKS",
+        "ja": "EKS",
+        "ja_typings": [
+          "i-kei-esu",
+          "eks"
+        ]
+      },
+      {
+        "en": "GKE",
+        "ja": "GKE",
+        "ja_typings": [
+          "ji-kei-i-",
+          "gke"
+        ]
+      },
+      {
+        "en": "OKE",
+        "ja": "OKE",
+        "ja_typings": [
+          "o-kei-i-",
+          "oke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02408",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is Microsoft Azure's managed Kubernetes service?",
+      "ja": "Microsoft Azure のマネージド Kubernetes は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "OKE",
+        "ja": "OKE",
+        "ja_typings": [
+          "o-kei-i-",
+          "oke"
+        ]
+      },
+      {
+        "en": "AKS",
+        "ja": "AKS",
+        "ja_typings": [
+          "e-kei-esu",
+          "aks"
+        ]
+      },
+      {
+        "en": "EKS",
+        "ja": "EKS",
+        "ja_typings": [
+          "i-kei-esu",
+          "eks"
+        ]
+      },
+      {
+        "en": "GKE",
+        "ja": "GKE",
+        "ja_typings": [
+          "ji-kei-i-",
+          "gke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02409",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is Oracle Cloud's managed Kubernetes service?",
+      "ja": "Oracle Cloud のマネージド Kubernetes は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ITIL",
+        "ja": "ITIL",
+        "ja_typings": [
+          "aitiru",
+          "itil"
+        ]
+      },
+      {
+        "en": "COBIT",
+        "ja": "COBIT",
+        "ja_typings": [
+          "kobitto",
+          "cobit"
+        ]
+      },
+      {
+        "en": "TOGAF",
+        "ja": "TOGAF",
+        "ja_typings": [
+          "to-gafu",
+          "togaf"
+        ]
+      },
+      {
+        "en": "PMBOK",
+        "ja": "PMBOK",
+        "ja_typings": [
+          "pinbokku",
+          "pmbok"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02410",
+    "image_path": null,
+    "question_text": {
+      "en": "Which framework standardizes IT service management practices?",
+      "ja": "IT サービスマネジメントのベストプラクティス集は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sprint Planning",
+        "ja": "スプリントプランニング",
+        "ja_typings": [
+          "supurintopurannningu"
+        ]
+      },
+      {
+        "en": "Sprint Review",
+        "ja": "スプリントレビュー",
+        "ja_typings": [
+          "supurintorebyu-"
+        ]
+      },
+      {
+        "en": "Sprint Retrospective",
+        "ja": "スプリントレトロスペクティブ",
+        "ja_typings": [
+          "supurintoretorosupekutibu"
+        ]
+      },
+      {
+        "en": "Daily Scrum",
+        "ja": "デイリースクラム",
+        "ja_typings": [
+          "deiri-sukuramu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02411",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Scrum event begins a sprint by selecting backlog items?",
+      "ja": "バックログを選んでスプリントを開始する Scrum のイベントは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chef",
+        "ja": "Chef",
+        "ja_typings": [
+          "chef"
+        ]
+      },
+      {
+        "en": "Puppet",
+        "ja": "Puppet",
+        "ja_typings": [
+          "puppet"
+        ]
+      },
+      {
+        "en": "Ansible",
+        "ja": "Ansible",
+        "ja_typings": [
+          "ansible"
+        ]
+      },
+      {
+        "en": "Salt",
+        "ja": "Salt",
+        "ja_typings": [
+          "salt"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02412",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Ruby-based configuration management tool defines infrastructure as recipes?",
+      "ja": "Ruby ベースでレシピを書く構成管理ツールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Puppet",
+        "ja": "Puppet",
+        "ja_typings": [
+          "puppet"
+        ]
+      },
+      {
+        "en": "Chef",
+        "ja": "Chef",
+        "ja_typings": [
+          "chef"
+        ]
+      },
+      {
+        "en": "Ansible",
+        "ja": "Ansible",
+        "ja_typings": [
+          "ansible"
+        ]
+      },
+      {
+        "en": "Terraform",
+        "ja": "Terraform",
+        "ja_typings": [
+          "terraform"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02413",
+    "image_path": null,
+    "question_text": {
+      "en": "Which configuration management tool uses a declarative DSL and a pull model?",
+      "ja": "宣言的 DSL とプル型を採用する構成管理ツールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CD",
+        "ja": "CD (継続的デリバリ)",
+        "ja_typings": [
+          "shi-di-"
+        ]
+      },
+      {
+        "en": "CI",
+        "ja": "CI (継続的インテグレーション)",
+        "ja_typings": [
+          "shi-ai"
+        ]
+      },
+      {
+        "en": "QA",
+        "ja": "QA",
+        "ja_typings": [
+          "kyu-e-",
+          "qa"
+        ]
+      },
+      {
+        "en": "BA",
+        "ja": "BA",
+        "ja_typings": [
+          "bi-e-",
+          "ba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02414",
+    "image_path": null,
+    "question_text": {
+      "en": "Which DevOps practice automatically delivers code to production?",
+      "ja": "コードを自動で本番にデリバリする DevOps プラクティスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vagrant",
+        "ja": "Vagrant",
+        "ja_typings": [
+          "vagrant"
+        ]
+      },
+      {
+        "en": "Packer",
+        "ja": "Packer",
+        "ja_typings": [
+          "packer"
+        ]
+      },
+      {
+        "en": "Terraform",
+        "ja": "Terraform",
+        "ja_typings": [
+          "terraform"
+        ]
+      },
+      {
+        "en": "Consul",
+        "ja": "Consul",
+        "ja_typings": [
+          "consul"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02415",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HashiCorp tool manages reproducible developer VMs?",
+      "ja": "再現可能な開発用 VM を管理する HashiCorp のツールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "EBS",
+        "ja": "EBS",
+        "ja_typings": [
+          "i-bi-esu",
+          "ebs"
+        ]
+      },
+      {
+        "en": "EFS",
+        "ja": "EFS",
+        "ja_typings": [
+          "i-efu-esu",
+          "efs"
+        ]
+      },
+      {
+        "en": "S3",
+        "ja": "S3",
+        "ja_typings": [
+          "esu-su-ri-",
+          "s3"
+        ]
+      },
+      {
+        "en": "Glacier",
+        "ja": "Glacier",
+        "ja_typings": [
+          "glacier"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02416",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS service provides block storage volumes for EC2?",
+      "ja": "EC2 にブロックストレージボリュームを提供する AWS のサービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "EFS",
+        "ja": "EFS",
+        "ja_typings": [
+          "i-efu-esu",
+          "efs"
+        ]
+      },
+      {
+        "en": "EBS",
+        "ja": "EBS",
+        "ja_typings": [
+          "i-bi-esu",
+          "ebs"
+        ]
+      },
+      {
+        "en": "S3",
+        "ja": "S3",
+        "ja_typings": [
+          "esu-su-ri-",
+          "s3"
+        ]
+      },
+      {
+        "en": "FSx",
+        "ja": "FSx",
+        "ja_typings": [
+          "efu-esu-ekkusu",
+          "fsx"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02417",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS service provides scalable shared file storage (NFS)?",
+      "ja": "AWS で NFS 互換の共有ファイルストレージを提供するサービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Beanstalk",
+        "ja": "Beanstalk",
+        "ja_typings": [
+          "beanstalk"
+        ]
+      },
+      {
+        "en": "Lambda",
+        "ja": "Lambda",
+        "ja_typings": [
+          "lambda"
+        ]
+      },
+      {
+        "en": "Amplify",
+        "ja": "Amplify",
+        "ja_typings": [
+          "amplify"
+        ]
+      },
+      {
+        "en": "AppRunner",
+        "ja": "AppRunner",
+        "ja_typings": [
+          "apprunner"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02418",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS PaaS deploys apps and handles capacity, load balancing, scaling?",
+      "ja": "AWS でアプリ展開と負荷分散・スケーリングを自動化する PaaS は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Accuracy",
+        "ja": "正解率",
+        "ja_typings": [
+          "seikairitsu"
+        ]
+      },
+      {
+        "en": "Precision",
+        "ja": "適合率",
+        "ja_typings": [
+          "tekigouritsu",
+          "tekigoritsu"
+        ]
+      },
+      {
+        "en": "Recall",
+        "ja": "再現率",
+        "ja_typings": [
+          "saigenritsu"
+        ]
+      },
+      {
+        "en": "F1 score",
+        "ja": "F1スコア",
+        "ja_typings": [
+          "efuwansukoa",
+          "f1sukoa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02419",
+    "image_path": null,
+    "question_text": {
+      "en": "Which metric measures how often predictions are correct?",
+      "ja": "予測の正答率を表す指標は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Authentication",
+        "ja": "認証",
+        "ja_typings": [
+          "ninshou",
+          "nintsho"
+        ]
+      },
+      {
+        "en": "Authorization",
+        "ja": "認可",
+        "ja_typings": [
+          "ninka"
+        ]
+      },
+      {
+        "en": "Auditing",
+        "ja": "監査",
+        "ja_typings": [
+          "kansa"
+        ]
+      },
+      {
+        "en": "Accounting",
+        "ja": "課金",
+        "ja_typings": [
+          "kakin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02420",
+    "image_path": null,
+    "question_text": {
+      "en": "Which security concept verifies the identity of a user?",
+      "ja": "ユーザーの本人確認を行うセキュリティ概念は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Persistence",
+        "ja": "永続性",
+        "ja_typings": [
+          "eizokusei"
+        ]
+      },
+      {
+        "en": "Volatility",
+        "ja": "揮発性",
+        "ja_typings": [
+          "kihatsusei"
+        ]
+      },
+      {
+        "en": "Idempotency",
+        "ja": "冪等性",
+        "ja_typings": [
+          "bekitousei",
+          "bekitosei"
+        ]
+      },
+      {
+        "en": "Consistency",
+        "ja": "整合性",
+        "ja_typings": [
+          "seigousei",
+          "seigosei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02421",
+    "image_path": null,
+    "question_text": {
+      "en": "Which data property describes data surviving after the program ends?",
+      "ja": "プログラム終了後もデータが保持される性質は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Performance",
+        "ja": "性能",
+        "ja_typings": [
+          "seinou",
+          "seino"
+        ]
+      },
+      {
+        "en": "Availability",
+        "ja": "可用性",
+        "ja_typings": [
+          "kayousei",
+          "kayosei"
+        ]
+      },
+      {
+        "en": "Security",
+        "ja": "セキュリティ",
+        "ja_typings": [
+          "sekyuriti"
+        ]
+      },
+      {
+        "en": "Usability",
+        "ja": "使い勝手",
+        "ja_typings": [
+          "tsukaigatte"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02422",
+    "image_path": null,
+    "question_text": {
+      "en": "Which non-functional requirement is about response time and throughput?",
+      "ja": "応答時間やスループットを評価する非機能要件は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Privacy",
+        "ja": "プライバシー",
+        "ja_typings": [
+          "puraibashi-"
+        ]
+      },
+      {
+        "en": "Performance",
+        "ja": "性能",
+        "ja_typings": [
+          "seinou",
+          "seino"
+        ]
+      },
+      {
+        "en": "Reliability",
+        "ja": "信頼性",
+        "ja_typings": [
+          "shinraisei"
+        ]
+      },
+      {
+        "en": "Portability",
+        "ja": "移植性",
+        "ja_typings": [
+          "ishokusei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02423",
+    "image_path": null,
+    "question_text": {
+      "en": "Which non-functional requirement protects personal information?",
+      "ja": "個人情報の保護に関する非機能要件は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DaaS",
+        "ja": "DaaS",
+        "ja_typings": [
+          "da-su",
+          "daas"
+        ]
+      },
+      {
+        "en": "IaaS",
+        "ja": "IaaS",
+        "ja_typings": [
+          "aia-su",
+          "iaas"
+        ]
+      },
+      {
+        "en": "PaaS",
+        "ja": "PaaS",
+        "ja_typings": [
+          "pa-su",
+          "paas"
+        ]
+      },
+      {
+        "en": "SaaS",
+        "ja": "SaaS",
+        "ja_typings": [
+          "sa-su",
+          "saas"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02424",
+    "image_path": null,
+    "question_text": {
+      "en": "Which cloud delivery model provides virtual desktops?",
+      "ja": "仮想デスクトップを提供するクラウドモデルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Iteration",
+        "ja": "イテレーション",
+        "ja_typings": [
+          "itere-shon"
+        ]
+      },
+      {
+        "en": "Sprint Planning",
+        "ja": "スプリントプランニング",
+        "ja_typings": [
+          "supurintopurannningu"
+        ]
+      },
+      {
+        "en": "Standup",
+        "ja": "スタンドアップ",
+        "ja_typings": [
+          "sutandoappu"
+        ]
+      },
+      {
+        "en": "Backlog",
+        "ja": "バックログ",
+        "ja_typings": [
+          "bakkurogu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02425",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Agile term refers to one timeboxed cycle of work?",
+      "ja": "アジャイルで時間枠を区切った1サイクルの作業を指すのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Milestone",
+        "ja": "マイルストーン",
+        "ja_typings": [
+          "mairusuto-n"
+        ]
+      },
+      {
+        "en": "Deliverable",
+        "ja": "成果物",
+        "ja_typings": [
+          "seikabutsu"
+        ]
+      },
+      {
+        "en": "Iteration",
+        "ja": "イテレーション",
+        "ja_typings": [
+          "itere-shon"
+        ]
+      },
+      {
+        "en": "Backlog",
+        "ja": "バックログ",
+        "ja_typings": [
+          "bakkurogu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02426",
+    "image_path": null,
+    "question_text": {
+      "en": "Which project term marks a significant scheduled checkpoint?",
+      "ja": "プロジェクトの重要な節目を示す用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Release",
+        "ja": "リリース",
+        "ja_typings": [
+          "riri-su"
+        ]
+      },
+      {
+        "en": "Build",
+        "ja": "ビルド",
+        "ja_typings": [
+          "birudo"
+        ]
+      },
+      {
+        "en": "Patch",
+        "ja": "パッチ",
+        "ja_typings": [
+          "patchi"
+        ]
+      },
+      {
+        "en": "Snapshot",
+        "ja": "スナップショット",
+        "ja_typings": [
+          "sunappushotto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02427",
+    "image_path": null,
+    "question_text": {
+      "en": "Which event makes a new version of software available to users?",
+      "ja": "ソフトウェアの新版を利用者へ提供することを指すのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Product Owner",
+        "ja": "プロダクトオーナー",
+        "ja_typings": [
+          "purodakuto-na-",
+          "purodakutoo-na-"
+        ]
+      },
+      {
+        "en": "Scrum Master",
+        "ja": "スクラムマスター",
+        "ja_typings": [
+          "sukuramumasuta-"
+        ]
+      },
+      {
+        "en": "Tech Lead",
+        "ja": "テックリード",
+        "ja_typings": [
+          "tekkuri-do"
+        ]
+      },
+      {
+        "en": "Project Manager",
+        "ja": "プロジェクトマネージャー",
+        "ja_typings": [
+          "purojekutomane-ja-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02428",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Scrum role owns the product backlog and prioritization?",
+      "ja": "プロダクトバックログと優先順位を所有する Scrum の役割は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tech Lead",
+        "ja": "テックリード",
+        "ja_typings": [
+          "tekkuri-do"
+        ]
+      },
+      {
+        "en": "Product Owner",
+        "ja": "プロダクトオーナー",
+        "ja_typings": [
+          "purodakuto-na-",
+          "purodakutoo-na-"
+        ]
+      },
+      {
+        "en": "Scrum Master",
+        "ja": "スクラムマスター",
+        "ja_typings": [
+          "sukuramumasuta-"
+        ]
+      },
+      {
+        "en": "Project Manager",
+        "ja": "プロジェクトマネージャー",
+        "ja_typings": [
+          "purojekutomane-ja-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02429",
+    "image_path": null,
+    "question_text": {
+      "en": "Which engineering role leads technical decisions in a team?",
+      "ja": "チームの技術的意思決定を主導するエンジニアの役職は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Project Manager",
+        "ja": "プロジェクトマネージャー",
+        "ja_typings": [
+          "purojekutomane-ja-"
+        ]
+      },
+      {
+        "en": "Product Owner",
+        "ja": "プロダクトオーナー",
+        "ja_typings": [
+          "purodakuto-na-",
+          "purodakutoo-na-"
+        ]
+      },
+      {
+        "en": "Scrum Master",
+        "ja": "スクラムマスター",
+        "ja_typings": [
+          "sukuramumasuta-"
+        ]
+      },
+      {
+        "en": "Tech Lead",
+        "ja": "テックリード",
+        "ja_typings": [
+          "tekkuri-do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02430",
+    "image_path": null,
+    "question_text": {
+      "en": "Which role manages scope, schedule, and budget of a project?",
+      "ja": "プロジェクトの範囲・予定・予算を管理する役割は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MIT",
+        "ja": "MITライセンス",
+        "ja_typings": [
+          "emuaiti-raisensu",
+          "mitraisensu"
+        ]
+      },
+      {
+        "en": "BSD",
+        "ja": "BSDライセンス",
+        "ja_typings": [
+          "bi-esudi-raisensu",
+          "bsdraisensu"
+        ]
+      },
+      {
+        "en": "Apache",
+        "ja": "Apacheライセンス",
+        "ja_typings": [
+          "apatchiraisensu",
+          "apacheraisensu"
+        ]
+      },
+      {
+        "en": "GPL",
+        "ja": "GPL",
+        "ja_typings": [
+          "ji-pi-eru",
+          "gpl"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02431",
+    "image_path": null,
+    "question_text": {
+      "en": "Which permissive open source license is associated with the X Window System?",
+      "ja": "X Window System に由来する寛容なオープンソースライセンスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "BSD",
+        "ja": "BSDライセンス",
+        "ja_typings": [
+          "bi-esudi-raisensu",
+          "bsdraisensu"
+        ]
+      },
+      {
+        "en": "MIT",
+        "ja": "MITライセンス",
+        "ja_typings": [
+          "emuaiti-raisensu",
+          "mitraisensu"
+        ]
+      },
+      {
+        "en": "Apache",
+        "ja": "Apacheライセンス",
+        "ja_typings": [
+          "apatchiraisensu",
+          "apacheraisensu"
+        ]
+      },
+      {
+        "en": "MPL",
+        "ja": "MPL",
+        "ja_typings": [
+          "emupi-eru",
+          "mpl"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02432",
+    "image_path": null,
+    "question_text": {
+      "en": "Which open source license originated with the Berkeley Unix distribution?",
+      "ja": "Berkeley Unix 由来のオープンソースライセンスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Apache",
+        "ja": "Apacheライセンス",
+        "ja_typings": [
+          "apatchiraisensu",
+          "apacheraisensu"
+        ]
+      },
+      {
+        "en": "MIT",
+        "ja": "MITライセンス",
+        "ja_typings": [
+          "emuaiti-raisensu",
+          "mitraisensu"
+        ]
+      },
+      {
+        "en": "BSD",
+        "ja": "BSDライセンス",
+        "ja_typings": [
+          "bi-esudi-raisensu",
+          "bsdraisensu"
+        ]
+      },
+      {
+        "en": "GPL",
+        "ja": "GPL",
+        "ja_typings": [
+          "ji-pi-eru",
+          "gpl"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02433",
+    "image_path": null,
+    "question_text": {
+      "en": "Which open source license version 2.0 has an explicit patent grant?",
+      "ja": "明示的な特許許諾条項を含むオープンソースライセンス2.0は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "AWS",
+        "ja": "AWS",
+        "ja_typings": [
+          "e-daburyu-esu",
+          "aws"
+        ]
+      },
+      {
+        "en": "GCP",
+        "ja": "GCP",
+        "ja_typings": [
+          "ji-shi-pi-",
+          "gcp"
+        ]
+      },
+      {
+        "en": "Azure",
+        "ja": "Azure",
+        "ja_typings": [
+          "azure"
+        ]
+      },
+      {
+        "en": "OCI",
+        "ja": "OCI",
+        "ja_typings": [
+          "o-shi-ai",
+          "oci"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02434",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the largest public cloud provider, run by Amazon?",
+      "ja": "Amazon が運営する最大手のパブリッククラウドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "GCP",
+        "ja": "GCP",
+        "ja_typings": [
+          "ji-shi-pi-",
+          "gcp"
+        ]
+      },
+      {
+        "en": "AWS",
+        "ja": "AWS",
+        "ja_typings": [
+          "e-daburyu-esu",
+          "aws"
+        ]
+      },
+      {
+        "en": "Azure",
+        "ja": "Azure",
+        "ja_typings": [
+          "azure"
+        ]
+      },
+      {
+        "en": "OCI",
+        "ja": "OCI",
+        "ja_typings": [
+          "o-shi-ai",
+          "oci"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02435",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Google public cloud platform competes with AWS and Azure?",
+      "ja": "AWS や Azure と競合する Google のパブリッククラウドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Batch",
+        "ja": "バッチ処理",
+        "ja_typings": [
+          "batchishori"
+        ]
+      },
+      {
+        "en": "Online",
+        "ja": "オンライン処理",
+        "ja_typings": [
+          "onrainshori"
+        ]
+      },
+      {
+        "en": "Stream",
+        "ja": "ストリーム処理",
+        "ja_typings": [
+          "sutori-mushori"
+        ]
+      },
+      {
+        "en": "Realtime",
+        "ja": "リアルタイム処理",
+        "ja_typings": [
+          "riarutaimushori"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02436",
+    "image_path": null,
+    "question_text": {
+      "en": "Which processing mode runs a job collectively at scheduled times?",
+      "ja": "決まった時刻にまとめて処理する方式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NDA",
+        "ja": "NDA",
+        "ja_typings": [
+          "enudi-e-",
+          "nda"
+        ]
+      },
+      {
+        "en": "MOU",
+        "ja": "MOU",
+        "ja_typings": [
+          "emuo-yu-",
+          "mou"
+        ]
+      },
+      {
+        "en": "EULA",
+        "ja": "EULA",
+        "ja_typings": [
+          "yu-ra",
+          "eula"
+        ]
+      },
+      {
+        "en": "SLA",
+        "ja": "SLA",
+        "ja_typings": [
+          "esueruE-",
+          "sla"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02437",
+    "image_path": null,
+    "question_text": {
+      "en": "Which legal agreement prevents disclosure of confidential info?",
+      "ja": "機密情報の開示を禁じる契約は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MOU",
+        "ja": "MOU",
+        "ja_typings": [
+          "emuo-yu-",
+          "mou"
+        ]
+      },
+      {
+        "en": "NDA",
+        "ja": "NDA",
+        "ja_typings": [
+          "enudi-e-",
+          "nda"
+        ]
+      },
+      {
+        "en": "EULA",
+        "ja": "EULA",
+        "ja_typings": [
+          "yu-ra",
+          "eula"
+        ]
+      },
+      {
+        "en": "SLA",
+        "ja": "SLA",
+        "ja_typings": [
+          "esueruE-",
+          "sla"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02438",
+    "image_path": null,
+    "question_text": {
+      "en": "Which non-binding agreement outlines mutual intent between parties?",
+      "ja": "当事者間の意思を確認するための法的拘束力のない覚書は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "EULA",
+        "ja": "EULA",
+        "ja_typings": [
+          "yu-ra",
+          "eula"
+        ]
+      },
+      {
+        "en": "MOU",
+        "ja": "MOU",
+        "ja_typings": [
+          "emuo-yu-",
+          "mou"
+        ]
+      },
+      {
+        "en": "NDA",
+        "ja": "NDA",
+        "ja_typings": [
+          "enudi-e-",
+          "nda"
+        ]
+      },
+      {
+        "en": "SLA",
+        "ja": "SLA",
+        "ja_typings": [
+          "esueruE-",
+          "sla"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02439",
+    "image_path": null,
+    "question_text": {
+      "en": "Which contract is presented to end users for software use?",
+      "ja": "ソフトウェア使用にあたりエンドユーザーに提示される契約は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DevOps",
+        "ja": "DevOps",
+        "ja_typings": [
+          "devops"
+        ]
+      },
+      {
+        "en": "Agile",
+        "ja": "Agile",
+        "ja_typings": [
+          "agile"
+        ]
+      },
+      {
+        "en": "Waterfall",
+        "ja": "Waterfall",
+        "ja_typings": [
+          "waterfall"
+        ]
+      },
+      {
+        "en": "Lean",
+        "ja": "Lean",
+        "ja_typings": [
+          "lean"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02440",
+    "image_path": null,
+    "question_text": {
+      "en": "Which culture unites development and operations teams?",
+      "ja": "開発と運用を統合する文化・運動は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CaC",
+        "ja": "CaC",
+        "ja_typings": [
+          "shi-e-shi-",
+          "cac"
+        ]
+      },
+      {
+        "en": "PaC",
+        "ja": "PaC",
+        "ja_typings": [
+          "pi-e-shi-",
+          "pac"
+        ]
+      },
+      {
+        "en": "DaC",
+        "ja": "DaC",
+        "ja_typings": [
+          "di-e-shi-",
+          "dac"
+        ]
+      },
+      {
+        "en": "IaC",
+        "ja": "IaC",
+        "ja_typings": [
+          "aia-shi-",
+          "iac"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02441",
+    "image_path": null,
+    "question_text": {
+      "en": "Which practice manages configurations declaratively as code?",
+      "ja": "構成情報をコードとして宣言的に管理する手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PaC",
+        "ja": "PaC",
+        "ja_typings": [
+          "pi-e-shi-",
+          "pac"
+        ]
+      },
+      {
+        "en": "CaC",
+        "ja": "CaC",
+        "ja_typings": [
+          "shi-e-shi-",
+          "cac"
+        ]
+      },
+      {
+        "en": "DaC",
+        "ja": "DaC",
+        "ja_typings": [
+          "di-e-shi-",
+          "dac"
+        ]
+      },
+      {
+        "en": "IaC",
+        "ja": "IaC",
+        "ja_typings": [
+          "aia-shi-",
+          "iac"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02442",
+    "image_path": null,
+    "question_text": {
+      "en": "Which practice expresses security policies as code (e.g., OPA)?",
+      "ja": "OPA 等でポリシーをコードとして書く手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DaC",
+        "ja": "DaC",
+        "ja_typings": [
+          "di-e-shi-",
+          "dac"
+        ]
+      },
+      {
+        "en": "CaC",
+        "ja": "CaC",
+        "ja_typings": [
+          "shi-e-shi-",
+          "cac"
+        ]
+      },
+      {
+        "en": "PaC",
+        "ja": "PaC",
+        "ja_typings": [
+          "pi-e-shi-",
+          "pac"
+        ]
+      },
+      {
+        "en": "IaC",
+        "ja": "IaC",
+        "ja_typings": [
+          "aia-shi-",
+          "iac"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02443",
+    "image_path": null,
+    "question_text": {
+      "en": "Which practice manages documentation as code in repositories?",
+      "ja": "ドキュメントをコードのようにリポジトリ管理する手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Trigger",
+        "ja": "トリガー",
+        "ja_typings": [
+          "toriga-"
+        ]
+      },
+      {
+        "en": "View",
+        "ja": "ビュー",
+        "ja_typings": [
+          "byu-"
+        ]
+      },
+      {
+        "en": "Schema",
+        "ja": "スキーマ",
+        "ja_typings": [
+          "suki-ma"
+        ]
+      },
+      {
+        "en": "Index",
+        "ja": "インデックス",
+        "ja_typings": [
+          "indekkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02444",
+    "image_path": null,
+    "question_text": {
+      "en": "Which DB object executes a procedure when a table changes?",
+      "ja": "テーブル変更時に処理を実行する DB オブジェクトは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "View",
+        "ja": "ビュー",
+        "ja_typings": [
+          "byu-"
+        ]
+      },
+      {
+        "en": "Trigger",
+        "ja": "トリガー",
+        "ja_typings": [
+          "toriga-"
+        ]
+      },
+      {
+        "en": "Schema",
+        "ja": "スキーマ",
+        "ja_typings": [
+          "suki-ma"
+        ]
+      },
+      {
+        "en": "Sequence",
+        "ja": "シーケンス",
+        "ja_typings": [
+          "shi-kensu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02445",
+    "image_path": null,
+    "question_text": {
+      "en": "Which DB object is a virtual table from a stored query?",
+      "ja": "クエリから生成される仮想表である DB オブジェクトは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Schema",
+        "ja": "スキーマ",
+        "ja_typings": [
+          "suki-ma"
+        ]
+      },
+      {
+        "en": "View",
+        "ja": "ビュー",
+        "ja_typings": [
+          "byu-"
+        ]
+      },
+      {
+        "en": "Trigger",
+        "ja": "トリガー",
+        "ja_typings": [
+          "toriga-"
+        ]
+      },
+      {
+        "en": "Index",
+        "ja": "インデックス",
+        "ja_typings": [
+          "indekkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02446",
+    "image_path": null,
+    "question_text": {
+      "en": "Which DB term names the overall structure of tables and relations?",
+      "ja": "テーブルと関係の全体構造を示す DB 用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NewSQL",
+        "ja": "NewSQL",
+        "ja_typings": [
+          "nyu-esukyu-eru",
+          "newsql"
+        ]
+      },
+      {
+        "en": "NoSQL",
+        "ja": "NoSQL",
+        "ja_typings": [
+          "no-esukyu-eru",
+          "nosql"
+        ]
+      },
+      {
+        "en": "OLAP",
+        "ja": "OLAP",
+        "ja_typings": [
+          "o-rappu",
+          "olap"
+        ]
+      },
+      {
+        "en": "OLTP",
+        "ja": "OLTP",
+        "ja_typings": [
+          "o-rutipi-",
+          "oltp"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02447",
+    "image_path": null,
+    "question_text": {
+      "en": "Which class of databases combines SQL with horizontal scalability?",
+      "ja": "SQL と水平スケールを両立させる新世代 DB は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "OLAP",
+        "ja": "OLAP",
+        "ja_typings": [
+          "o-rappu",
+          "olap"
+        ]
+      },
+      {
+        "en": "OLTP",
+        "ja": "OLTP",
+        "ja_typings": [
+          "o-rutipi-",
+          "oltp"
+        ]
+      },
+      {
+        "en": "NewSQL",
+        "ja": "NewSQL",
+        "ja_typings": [
+          "nyu-esukyu-eru",
+          "newsql"
+        ]
+      },
+      {
+        "en": "NoSQL",
+        "ja": "NoSQL",
+        "ja_typings": [
+          "no-esukyu-eru",
+          "nosql"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02448",
+    "image_path": null,
+    "question_text": {
+      "en": "Which workload type emphasizes analytical multi-dimensional queries?",
+      "ja": "多次元分析クエリ向けのワークロード種別は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "OLTP",
+        "ja": "OLTP",
+        "ja_typings": [
+          "o-rutipi-",
+          "oltp"
+        ]
+      },
+      {
+        "en": "OLAP",
+        "ja": "OLAP",
+        "ja_typings": [
+          "o-rappu",
+          "olap"
+        ]
+      },
+      {
+        "en": "NewSQL",
+        "ja": "NewSQL",
+        "ja_typings": [
+          "nyu-esukyu-eru",
+          "newsql"
+        ]
+      },
+      {
+        "en": "NoSQL",
+        "ja": "NoSQL",
+        "ja_typings": [
+          "no-esukyu-eru",
+          "nosql"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02449",
+    "image_path": null,
+    "question_text": {
+      "en": "Which workload type handles many short, transactional operations?",
+      "ja": "短時間のトランザクション処理を多数こなすワークロードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HIPAA",
+        "ja": "HIPAA",
+        "ja_typings": [
+          "hipa-",
+          "hipaa"
+        ]
+      },
+      {
+        "en": "CCPA",
+        "ja": "CCPA",
+        "ja_typings": [
+          "shi-shi-pi-e-",
+          "ccpa"
+        ]
+      },
+      {
+        "en": "SOX",
+        "ja": "SOX",
+        "ja_typings": [
+          "sokkusu",
+          "sox"
+        ]
+      },
+      {
+        "en": "GDPR",
+        "ja": "GDPR",
+        "ja_typings": [
+          "ji-di-pi-a-ru",
+          "gdpr"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02450",
+    "image_path": null,
+    "question_text": {
+      "en": "Which US law protects health information privacy?",
+      "ja": "アメリカで医療情報のプライバシーを守る法律は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CCPA",
+        "ja": "CCPA",
+        "ja_typings": [
+          "shi-shi-pi-e-",
+          "ccpa"
+        ]
+      },
+      {
+        "en": "HIPAA",
+        "ja": "HIPAA",
+        "ja_typings": [
+          "hipa-",
+          "hipaa"
+        ]
+      },
+      {
+        "en": "SOX",
+        "ja": "SOX",
+        "ja_typings": [
+          "sokkusu",
+          "sox"
+        ]
+      },
+      {
+        "en": "GDPR",
+        "ja": "GDPR",
+        "ja_typings": [
+          "ji-di-pi-a-ru",
+          "gdpr"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02451",
+    "image_path": null,
+    "question_text": {
+      "en": "Which California law protects consumer data rights?",
+      "ja": "カリフォルニア州の消費者データ保護法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SOX",
+        "ja": "SOX",
+        "ja_typings": [
+          "sokkusu",
+          "sox"
+        ]
+      },
+      {
+        "en": "HIPAA",
+        "ja": "HIPAA",
+        "ja_typings": [
+          "hipa-",
+          "hipaa"
+        ]
+      },
+      {
+        "en": "CCPA",
+        "ja": "CCPA",
+        "ja_typings": [
+          "shi-shi-pi-e-",
+          "ccpa"
+        ]
+      },
+      {
+        "en": "GDPR",
+        "ja": "GDPR",
+        "ja_typings": [
+          "ji-di-pi-a-ru",
+          "gdpr"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02452",
+    "image_path": null,
+    "question_text": {
+      "en": "Which US law tightens corporate financial reporting after Enron?",
+      "ja": "エンロン事件後に施行されたアメリカの企業会計改革法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FTP",
+        "ja": "FTP",
+        "ja_typings": [
+          "efuti-pi-",
+          "ftp"
+        ]
+      },
+      {
+        "en": "SFTP",
+        "ja": "SFTP",
+        "ja_typings": [
+          "esuefuti-pi-",
+          "sftp"
+        ]
+      },
+      {
+        "en": "FTPS",
+        "ja": "FTPS",
+        "ja_typings": [
+          "efuti-pi-esu",
+          "ftps"
+        ]
+      },
+      {
+        "en": "TFTP",
+        "ja": "TFTP",
+        "ja_typings": [
+          "ti-efuti-pi-",
+          "tftp"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02453",
+    "image_path": null,
+    "question_text": {
+      "en": "Which file transfer protocol uses plain text and ports 20/21?",
+      "ja": "ポート20/21を使う平文ファイル転送プロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "16 bits",
+        "ja": "16ビット",
+        "ja_typings": [
+          "ju-rokubitto",
+          "16bitto"
+        ]
+      },
+      {
+        "en": "8 bits",
+        "ja": "8ビット",
+        "ja_typings": [
+          "hachibitto",
+          "8bitto"
+        ]
+      },
+      {
+        "en": "32 bits",
+        "ja": "32ビット",
+        "ja_typings": [
+          "sanju-nibitto",
+          "32bitto"
+        ]
+      },
+      {
+        "en": "64 bits",
+        "ja": "64ビット",
+        "ja_typings": [
+          "rokuju-yonbitto",
+          "64bitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02454",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CPU register width was standard for Intel 8086?",
+      "ja": "Intel 8086 の標準的なレジスタ幅は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "64 bits",
+        "ja": "64ビット",
+        "ja_typings": [
+          "rokuju-yonbitto",
+          "64bitto"
+        ]
+      },
+      {
+        "en": "32 bits",
+        "ja": "32ビット",
+        "ja_typings": [
+          "sanju-nibitto",
+          "32bitto"
+        ]
+      },
+      {
+        "en": "16 bits",
+        "ja": "16ビット",
+        "ja_typings": [
+          "ju-rokubitto",
+          "16bitto"
+        ]
+      },
+      {
+        "en": "128 bits",
+        "ja": "128ビット",
+        "ja_typings": [
+          "hyakunijuhachibitto",
+          "128bitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02455",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CPU register width is standard for modern x86_64 / ARM64?",
+      "ja": "現代の x86_64 や ARM64 で標準のレジスタ幅は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MD5",
+        "ja": "MD5",
+        "ja_typings": [
+          "emudi-go",
+          "md5"
+        ]
+      },
+      {
+        "en": "SHA-1",
+        "ja": "SHA-1",
+        "ja_typings": [
+          "esuetchie-ichi",
+          "sha-1"
+        ]
+      },
+      {
+        "en": "SHA-256",
+        "ja": "SHA-256",
+        "ja_typings": [
+          "esuetchie-nigorokuju-roku",
+          "sha-256"
+        ]
+      },
+      {
+        "en": "CRC32",
+        "ja": "CRC32",
+        "ja_typings": [
+          "shi-a-ru-shi-sanjuni",
+          "crc32"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02456",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 128-bit hash function is now considered broken?",
+      "ja": "現在では衝突攻撃に弱い128ビットのハッシュ関数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "POP3",
+        "ja": "POP3",
+        "ja_typings": [
+          "popputsuri-",
+          "pop3"
+        ]
+      },
+      {
+        "en": "IMAP",
+        "ja": "IMAP",
+        "ja_typings": [
+          "aimappu",
+          "imap"
+        ]
+      },
+      {
+        "en": "SMTP",
+        "ja": "SMTP",
+        "ja_typings": [
+          "esuemuti-pi-",
+          "smtp"
+        ]
+      },
+      {
+        "en": "MAPI",
+        "ja": "MAPI",
+        "ja_typings": [
+          "mapi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02457",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol retrieves email by downloading from server (legacy)?",
+      "ja": "メールをダウンロードして取得する旧来の受信プロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SATA",
+        "ja": "SATA",
+        "ja_typings": [
+          "sata"
+        ]
+      },
+      {
+        "en": "SCSI",
+        "ja": "SCSI",
+        "ja_typings": [
+          "sukajii",
+          "scsi"
+        ]
+      },
+      {
+        "en": "PATA",
+        "ja": "PATA",
+        "ja_typings": [
+          "pata"
+        ]
+      },
+      {
+        "en": "eSATA",
+        "ja": "eSATA",
+        "ja_typings": [
+          "i-sata",
+          "esata"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02458",
+    "image_path": null,
+    "question_text": {
+      "en": "Which serial interface connects hard drives in PCs?",
+      "ja": "PC で HDD を接続する内蔵シリアルインタフェースは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "22",
+        "ja": "ポート22",
+        "ja_typings": [
+          "po-toniju-ni",
+          "po-to22"
+        ]
+      },
+      {
+        "en": "21",
+        "ja": "ポート21",
+        "ja_typings": [
+          "po-tonijuichi",
+          "po-to21"
+        ]
+      },
+      {
+        "en": "23",
+        "ja": "ポート23",
+        "ja_typings": [
+          "po-toniju-san",
+          "po-to23"
+        ]
+      },
+      {
+        "en": "25",
+        "ja": "ポート25",
+        "ja_typings": [
+          "po-tonijugo",
+          "po-to25"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02459",
+    "image_path": null,
+    "question_text": {
+      "en": "Which TCP port does SSH use by default?",
+      "ja": "SSH が既定で使う TCP ポートは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ROM",
+        "ja": "ROM",
+        "ja_typings": [
+          "romu",
+          "rom"
+        ]
+      },
+      {
+        "en": "RAM",
+        "ja": "RAM",
+        "ja_typings": [
+          "ramu",
+          "ram"
+        ]
+      },
+      {
+        "en": "Cache",
+        "ja": "キャッシュ",
+        "ja_typings": [
+          "kyasshu"
+        ]
+      },
+      {
+        "en": "Register",
+        "ja": "レジスタ",
+        "ja_typings": [
+          "rejisuta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02460",
+    "image_path": null,
+    "question_text": {
+      "en": "Which memory type can only be read, not modified at runtime?",
+      "ja": "実行時に書き換えできず読み出し専用のメモリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shell",
+        "ja": "シェル",
+        "ja_typings": [
+          "sheru"
+        ]
+      },
+      {
+        "en": "Kernel",
+        "ja": "カーネル",
+        "ja_typings": [
+          "ka-neru"
+        ]
+      },
+      {
+        "en": "Driver",
+        "ja": "ドライバ",
+        "ja_typings": [
+          "doraiba"
+        ]
+      },
+      {
+        "en": "Daemon",
+        "ja": "デーモン",
+        "ja_typings": [
+          "de-mon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02461",
+    "image_path": null,
+    "question_text": {
+      "en": "Which OS component provides a command-line interface?",
+      "ja": "コマンドライン操作を提供する OS の構成要素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "VPN",
+        "ja": "VPN",
+        "ja_typings": [
+          "bui-pi-enu",
+          "vpn"
+        ]
+      },
+      {
+        "en": "DNS",
+        "ja": "DNS",
+        "ja_typings": [
+          "di-enu-esu",
+          "dns"
+        ]
+      },
+      {
+        "en": "VLAN",
+        "ja": "VLAN",
+        "ja_typings": [
+          "buiran",
+          "vlan"
+        ]
+      },
+      {
+        "en": "NAT",
+        "ja": "NAT",
+        "ja_typings": [
+          "natto",
+          "nat"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02462",
+    "image_path": null,
+    "question_text": {
+      "en": "Which technology creates an encrypted tunnel over a public network?",
+      "ja": "公衆網上に暗号化トンネルを作る技術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SNMP",
+        "ja": "SNMP",
+        "ja_typings": [
+          "esuenuemupi-",
+          "snmp"
+        ]
+      },
+      {
+        "en": "SMTP",
+        "ja": "SMTP",
+        "ja_typings": [
+          "esuemuti-pi-",
+          "smtp"
+        ]
+      },
+      {
+        "en": "ICMP",
+        "ja": "ICMP",
+        "ja_typings": [
+          "aishi-emupi-",
+          "icmp"
+        ]
+      },
+      {
+        "en": "NTP",
+        "ja": "NTP",
+        "ja_typings": [
+          "enuti-pi-",
+          "ntp"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02463",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol monitors and manages network devices?",
+      "ja": "ネットワーク機器の監視・管理に使うプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ECC",
+        "ja": "ECCメモリ",
+        "ja_typings": [
+          "i-shi-shi-memori",
+          "eccmemori"
+        ]
+      },
+      {
+        "en": "DDR",
+        "ja": "DDRメモリ",
+        "ja_typings": [
+          "di-di-a-rumemori",
+          "ddrmemori"
+        ]
+      },
+      {
+        "en": "SRAM",
+        "ja": "SRAM",
+        "ja_typings": [
+          "esuramu",
+          "sram"
+        ]
+      },
+      {
+        "en": "Flash",
+        "ja": "Flashメモリ",
+        "ja_typings": [
+          "furasshumemori",
+          "flashmemori"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02464",
+    "image_path": null,
+    "question_text": {
+      "en": "Which memory technology detects and corrects single-bit errors?",
+      "ja": "1ビット誤りを検出・訂正できるメモリ技術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ZFS",
+        "ja": "ZFS",
+        "ja_typings": [
+          "zetto-efu-esu",
+          "zfs"
+        ]
+      },
+      {
+        "en": "Btrfs",
+        "ja": "Btrfs",
+        "ja_typings": [
+          "bata-efu-esu",
+          "btrfs"
+        ]
+      },
+      {
+        "en": "XFS",
+        "ja": "XFS",
+        "ja_typings": [
+          "ekkusu-efu-esu",
+          "xfs"
+        ]
+      },
+      {
+        "en": "ext4",
+        "ja": "ext4",
+        "ja_typings": [
+          "ikusutoyon",
+          "ext4"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02465",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Sun-originated filesystem features copy-on-write and snapshots?",
+      "ja": "Sun 発のコピーオンライトとスナップショットを持つファイルシステムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "exFAT",
+        "ja": "exFAT",
+        "ja_typings": [
+          "ekkusufatto",
+          "exfat"
+        ]
+      },
+      {
+        "en": "FAT32",
+        "ja": "FAT32",
+        "ja_typings": [
+          "fattosanjuni",
+          "fat32"
+        ]
+      },
+      {
+        "en": "NTFS",
+        "ja": "NTFS",
+        "ja_typings": [
+          "enuti-efu-esu",
+          "ntfs"
+        ]
+      },
+      {
+        "en": "ext4",
+        "ja": "ext4",
+        "ja_typings": [
+          "ikusutoyon",
+          "ext4"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02466",
+    "image_path": null,
+    "question_text": {
+      "en": "Which filesystem extends FAT for large flash drives beyond 32GB?",
+      "ja": "32GB を超える大型フラッシュ向けに FAT を拡張したファイルシステムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Intel",
+        "ja": "Intel",
+        "ja_typings": [
+          "interu",
+          "intel"
+        ]
+      },
+      {
+        "en": "AMD",
+        "ja": "AMD",
+        "ja_typings": [
+          "e-emudi-",
+          "amd"
+        ]
+      },
+      {
+        "en": "VIA",
+        "ja": "VIA",
+        "ja_typings": [
+          "bia",
+          "via"
+        ]
+      },
+      {
+        "en": "Cyrix",
+        "ja": "Cyrix",
+        "ja_typings": [
+          "sairikkusu",
+          "cyrix"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02467",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the largest x86 CPU vendor with brands like Core and Xeon?",
+      "ja": "Core や Xeon を擁する最大の x86 CPU メーカーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "x86",
+        "ja": "x86",
+        "ja_typings": [
+          "ekkusuhachiroku",
+          "x86"
+        ]
+      },
+      {
+        "en": "ARM",
+        "ja": "ARM",
+        "ja_typings": [
+          "a-mu",
+          "arm"
+        ]
+      },
+      {
+        "en": "MIPS",
+        "ja": "MIPS",
+        "ja_typings": [
+          "mippusu",
+          "mips"
+        ]
+      },
+      {
+        "en": "RISC-V",
+        "ja": "RISC-V",
+        "ja_typings": [
+          "risukubu~i",
+          "risukubui-",
+          "risc-v"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02468",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CISC instruction set architecture is used by Intel and AMD?",
+      "ja": "Intel や AMD が採用する CISC 命令セットアーキテクチャは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MIPS",
+        "ja": "MIPS",
+        "ja_typings": [
+          "mippusu",
+          "mips"
+        ]
+      },
+      {
+        "en": "SPARC",
+        "ja": "SPARC",
+        "ja_typings": [
+          "supa-ku",
+          "sparc"
+        ]
+      },
+      {
+        "en": "PowerPC",
+        "ja": "PowerPC",
+        "ja_typings": [
+          "pawa-pi-shi-",
+          "powerpc"
+        ]
+      },
+      {
+        "en": "Alpha",
+        "ja": "Alpha",
+        "ja_typings": [
+          "arufa",
+          "alpha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02469",
+    "image_path": null,
+    "question_text": {
+      "en": "Which RISC architecture originated at Stanford in the 1980s?",
+      "ja": "1980年代にスタンフォードで生まれた RISC アーキテクチャは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SPARC",
+        "ja": "SPARC",
+        "ja_typings": [
+          "supa-ku",
+          "sparc"
+        ]
+      },
+      {
+        "en": "MIPS",
+        "ja": "MIPS",
+        "ja_typings": [
+          "mippusu",
+          "mips"
+        ]
+      },
+      {
+        "en": "PowerPC",
+        "ja": "PowerPC",
+        "ja_typings": [
+          "pawa-pi-shi-",
+          "powerpc"
+        ]
+      },
+      {
+        "en": "Alpha",
+        "ja": "Alpha",
+        "ja_typings": [
+          "arufa",
+          "alpha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02470",
+    "image_path": null,
+    "question_text": {
+      "en": "Which RISC architecture was developed by Sun Microsystems?",
+      "ja": "Sun Microsystems が開発した RISC アーキテクチャは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "VGA",
+        "ja": "VGA",
+        "ja_typings": [
+          "bui-ji-e-",
+          "vga"
+        ]
+      },
+      {
+        "en": "XGA",
+        "ja": "XGA",
+        "ja_typings": [
+          "ekkusuji-e-",
+          "xga"
+        ]
+      },
+      {
+        "en": "SVGA",
+        "ja": "SVGA",
+        "ja_typings": [
+          "esubui-ji-e-",
+          "svga"
+        ]
+      },
+      {
+        "en": "CGA",
+        "ja": "CGA",
+        "ja_typings": [
+          "shi-ji-e-",
+          "cga"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02471",
+    "image_path": null,
+    "question_text": {
+      "en": "Which video display standard introduced 640x480 resolution on PCs?",
+      "ja": "PC で 640x480 解像度を一般化したビデオ規格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wi-Fi",
+        "ja": "Wi-Fi",
+        "ja_typings": [
+          "waifai",
+          "wi-fi"
+        ]
+      },
+      {
+        "en": "Bluetooth",
+        "ja": "Bluetooth",
+        "ja_typings": [
+          "buru-tu-su",
+          "bluetooth"
+        ]
+      },
+      {
+        "en": "Zigbee",
+        "ja": "Zigbee",
+        "ja_typings": [
+          "jigubi-",
+          "zigbee"
+        ]
+      },
+      {
+        "en": "LTE",
+        "ja": "LTE",
+        "ja_typings": [
+          "eruti-i-",
+          "lte"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02472",
+    "image_path": null,
+    "question_text": {
+      "en": "Which wireless standard is based on IEEE 802.11?",
+      "ja": "IEEE 802.11 を基にした無線 LAN 規格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "IMAP",
+        "ja": "IMAP",
+        "ja_typings": [
+          "aimappu",
+          "imap"
+        ]
+      },
+      {
+        "en": "POP3",
+        "ja": "POP3",
+        "ja_typings": [
+          "popputsuri-",
+          "pop3"
+        ]
+      },
+      {
+        "en": "SMTP",
+        "ja": "SMTP",
+        "ja_typings": [
+          "esuemuti-pi-",
+          "smtp"
+        ]
+      },
+      {
+        "en": "MAPI",
+        "ja": "MAPI",
+        "ja_typings": [
+          "mapi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02473",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mail protocol synchronizes messages across multiple devices?",
+      "ja": "複数端末でメッセージを同期するメール受信プロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SCSI",
+        "ja": "SCSI",
+        "ja_typings": [
+          "sukajii",
+          "scsi"
+        ]
+      },
+      {
+        "en": "SATA",
+        "ja": "SATA",
+        "ja_typings": [
+          "sata"
+        ]
+      },
+      {
+        "en": "PATA",
+        "ja": "PATA",
+        "ja_typings": [
+          "pata"
+        ]
+      },
+      {
+        "en": "PCIe",
+        "ja": "PCIe",
+        "ja_typings": [
+          "pi-shi-ai-i-",
+          "pcie"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02474",
+    "image_path": null,
+    "question_text": {
+      "en": "Which parallel interface historically connected enterprise disks and scanners?",
+      "ja": "業務用ディスクやスキャナを接続したパラレルインタフェースは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "port 21",
+        "ja": "ポート21",
+        "ja_typings": [
+          "po-tonijuichi",
+          "po-to21"
+        ]
+      },
+      {
+        "en": "port 22",
+        "ja": "ポート22",
+        "ja_typings": [
+          "po-toniju-ni",
+          "po-to22"
+        ]
+      },
+      {
+        "en": "port 23",
+        "ja": "ポート23",
+        "ja_typings": [
+          "po-toniju-san",
+          "po-to23"
+        ]
+      },
+      {
+        "en": "port 25",
+        "ja": "ポート25",
+        "ja_typings": [
+          "po-tonijugo",
+          "po-to25"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02475",
+    "image_path": null,
+    "question_text": {
+      "en": "Which TCP port is used for the FTP control connection?",
+      "ja": "FTP の制御コネクションに使われる TCP ポートは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "23",
+        "ja": "ポート23",
+        "ja_typings": [
+          "po-toniju-san",
+          "po-to23"
+        ]
+      },
+      {
+        "en": "22",
+        "ja": "ポート22",
+        "ja_typings": [
+          "po-toniju-ni",
+          "po-to22"
+        ]
+      },
+      {
+        "en": "21",
+        "ja": "ポート21",
+        "ja_typings": [
+          "po-tonijuichi",
+          "po-to21"
+        ]
+      },
+      {
+        "en": "25",
+        "ja": "ポート25",
+        "ja_typings": [
+          "po-tonijugo",
+          "po-to25"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02476",
+    "image_path": null,
+    "question_text": {
+      "en": "Which TCP port does Telnet use by default?",
+      "ja": "Telnet が既定で使う TCP ポートは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "WebSocket",
+        "ja": "WebSocket",
+        "ja_typings": [
+          "websocket"
+        ]
+      },
+      {
+        "en": "HTTP",
+        "ja": "HTTP",
+        "ja_typings": [
+          "etchi-ti-ti-pi-",
+          "http"
+        ]
+      },
+      {
+        "en": "gRPC",
+        "ja": "gRPC",
+        "ja_typings": [
+          "ji-a-ru-pi-shi-",
+          "grpc"
+        ]
+      },
+      {
+        "en": "MQTT",
+        "ja": "MQTT",
+        "ja_typings": [
+          "emukyu-ti-ti-",
+          "mqtt"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02477",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol enables full-duplex communication over a single TCP connection?",
+      "ja": "単一の TCP 接続で全二重通信を行うプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "TPU",
+        "ja": "TPU",
+        "ja_typings": [
+          "ti-pi-yu-",
+          "tpu"
+        ]
+      },
+      {
+        "en": "GPU",
+        "ja": "GPU",
+        "ja_typings": [
+          "ji-pi-yu-",
+          "gpu"
+        ]
+      },
+      {
+        "en": "CPU",
+        "ja": "CPU",
+        "ja_typings": [
+          "shi-pi-yu-",
+          "cpu"
+        ]
+      },
+      {
+        "en": "FPGA",
+        "ja": "FPGA",
+        "ja_typings": [
+          "efupi-ji-e-",
+          "fpga"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02478",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Google chip accelerates tensor computations for ML?",
+      "ja": "Google が機械学習用に開発したテンソル演算アクセラレータは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DSP",
+        "ja": "DSP",
+        "ja_typings": [
+          "di-esu-pi-",
+          "dsp"
+        ]
+      },
+      {
+        "en": "GPU",
+        "ja": "GPU",
+        "ja_typings": [
+          "ji-pi-yu-",
+          "gpu"
+        ]
+      },
+      {
+        "en": "CPU",
+        "ja": "CPU",
+        "ja_typings": [
+          "shi-pi-yu-",
+          "cpu"
+        ]
+      },
+      {
+        "en": "MCU",
+        "ja": "MCU",
+        "ja_typings": [
+          "emu-shi-yu-",
+          "mcu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02479",
+    "image_path": null,
+    "question_text": {
+      "en": "Which specialized processor handles signal processing tasks?",
+      "ja": "信号処理に特化した専用プロセッサは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "USB flash drive",
+        "ja": "USBメモリ",
+        "ja_typings": [
+          "yu-esubi-memori",
+          "usbmemori"
+        ]
+      },
+      {
+        "en": "Optical disc",
+        "ja": "光ディスク",
+        "ja_typings": [
+          "hikaridisuku"
+        ]
+      },
+      {
+        "en": "FDD",
+        "ja": "FDD",
+        "ja_typings": [
+          "efu-di-di-",
+          "fdd"
+        ]
+      },
+      {
+        "en": "MO",
+        "ja": "MO",
+        "ja_typings": [
+          "emu-o-",
+          "mo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02480",
+    "image_path": null,
+    "question_text": {
+      "en": "Which portable storage device uses NAND flash and USB?",
+      "ja": "NAND フラッシュと USB を使う携帯型ストレージは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Optical disc",
+        "ja": "光ディスク",
+        "ja_typings": [
+          "hikaridisuku"
+        ]
+      },
+      {
+        "en": "USB flash drive",
+        "ja": "USBメモリ",
+        "ja_typings": [
+          "yu-esubi-memori",
+          "usbmemori"
+        ]
+      },
+      {
+        "en": "FDD",
+        "ja": "FDD",
+        "ja_typings": [
+          "efu-di-di-",
+          "fdd"
+        ]
+      },
+      {
+        "en": "HDD",
+        "ja": "HDD",
+        "ja_typings": [
+          "etchi-di-di-",
+          "hdd"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02481",
+    "image_path": null,
+    "question_text": {
+      "en": "Which storage uses lasers to read pits (e.g., CD, DVD)?",
+      "ja": "レーザーでピットを読み取る光学記憶媒体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FDD",
+        "ja": "FDD",
+        "ja_typings": [
+          "efu-di-di-",
+          "fdd"
+        ]
+      },
+      {
+        "en": "HDD",
+        "ja": "HDD",
+        "ja_typings": [
+          "etchi-di-di-",
+          "hdd"
+        ]
+      },
+      {
+        "en": "MO",
+        "ja": "MO",
+        "ja_typings": [
+          "emu-o-",
+          "mo"
+        ]
+      },
+      {
+        "en": "ZIP",
+        "ja": "ZIP",
+        "ja_typings": [
+          "jippu",
+          "zip"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02482",
+    "image_path": null,
+    "question_text": {
+      "en": "Which legacy 3.5-inch removable magnetic storage was common in the 90s?",
+      "ja": "90年代に普及した3.5インチの磁気フロッピーディスク装置は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MO",
+        "ja": "MO",
+        "ja_typings": [
+          "emu-o-",
+          "mo"
+        ]
+      },
+      {
+        "en": "FDD",
+        "ja": "FDD",
+        "ja_typings": [
+          "efu-di-di-",
+          "fdd"
+        ]
+      },
+      {
+        "en": "ZIP",
+        "ja": "ZIP",
+        "ja_typings": [
+          "jippu",
+          "zip"
+        ]
+      },
+      {
+        "en": "DAT",
+        "ja": "DAT",
+        "ja_typings": [
+          "datto",
+          "dat"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02483",
+    "image_path": null,
+    "question_text": {
+      "en": "Which magneto-optical removable disc was popular in Japan in the 90s?",
+      "ja": "90年代の日本で普及した光磁気ディスクは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Driver",
+        "ja": "ドライバ",
+        "ja_typings": [
+          "doraiba"
+        ]
+      },
+      {
+        "en": "Compiler",
+        "ja": "コンパイラ",
+        "ja_typings": [
+          "konpaira"
+        ]
+      },
+      {
+        "en": "Daemon",
+        "ja": "デーモン",
+        "ja_typings": [
+          "de-mon"
+        ]
+      },
+      {
+        "en": "Shell",
+        "ja": "シェル",
+        "ja_typings": [
+          "sheru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02484",
+    "image_path": null,
+    "question_text": {
+      "en": "Which software lets the OS communicate with hardware devices?",
+      "ja": "OS がハードウェアと通信するためのソフトウェアは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Library",
+        "ja": "ライブラリ",
+        "ja_typings": [
+          "raiburari"
+        ]
+      },
+      {
+        "en": "Framework",
+        "ja": "フレームワーク",
+        "ja_typings": [
+          "fure-muwa-ku"
+        ]
+      },
+      {
+        "en": "Module",
+        "ja": "モジュール",
+        "ja_typings": [
+          "moju-ru"
+        ]
+      },
+      {
+        "en": "Plugin",
+        "ja": "プラグイン",
+        "ja_typings": [
+          "puraguin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02485",
+    "image_path": null,
+    "question_text": {
+      "en": "Which reusable code collection can be linked into programs?",
+      "ja": "プログラムにリンクして再利用するコードの集合は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Daemon",
+        "ja": "デーモン",
+        "ja_typings": [
+          "de-mon"
+        ]
+      },
+      {
+        "en": "Driver",
+        "ja": "ドライバ",
+        "ja_typings": [
+          "doraiba"
+        ]
+      },
+      {
+        "en": "Shell",
+        "ja": "シェル",
+        "ja_typings": [
+          "sheru"
+        ]
+      },
+      {
+        "en": "Service",
+        "ja": "サービス",
+        "ja_typings": [
+          "sa-bisu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02486",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Unix term names a background service process?",
+      "ja": "Unix でバックグラウンドサービスを指す用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Compiler",
+        "ja": "コンパイラ",
+        "ja_typings": [
+          "konpaira"
+        ]
+      },
+      {
+        "en": "Interpreter",
+        "ja": "インタプリタ",
+        "ja_typings": [
+          "intapurita"
+        ]
+      },
+      {
+        "en": "Linker",
+        "ja": "リンカ",
+        "ja_typings": [
+          "rinka"
+        ]
+      },
+      {
+        "en": "Assembler",
+        "ja": "アセンブラ",
+        "ja_typings": [
+          "asenbura"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02487",
+    "image_path": null,
+    "question_text": {
+      "en": "Which tool translates source code into machine code?",
+      "ja": "ソースコードを機械語に変換するツールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Repository",
+        "ja": "リポジトリ",
+        "ja_typings": [
+          "ripojitori"
+        ]
+      },
+      {
+        "en": "Branch",
+        "ja": "ブランチ",
+        "ja_typings": [
+          "buranchi"
+        ]
+      },
+      {
+        "en": "Tag",
+        "ja": "タグ",
+        "ja_typings": [
+          "tagu"
+        ]
+      },
+      {
+        "en": "Commit",
+        "ja": "コミット",
+        "ja_typings": [
+          "komitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02488",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Git term names a storage location for project history?",
+      "ja": "Git でプロジェクト履歴を格納する場所を指す用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Debugger",
+        "ja": "デバッガ",
+        "ja_typings": [
+          "debagga"
+        ]
+      },
+      {
+        "en": "Compiler",
+        "ja": "コンパイラ",
+        "ja_typings": [
+          "konpaira"
+        ]
+      },
+      {
+        "en": "Profiler",
+        "ja": "プロファイラ",
+        "ja_typings": [
+          "purofaira"
+        ]
+      },
+      {
+        "en": "Linker",
+        "ja": "リンカ",
+        "ja_typings": [
+          "rinka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02489",
+    "image_path": null,
+    "question_text": {
+      "en": "Which tool steps through code to find bugs?",
+      "ja": "プログラムを段階実行してバグを見つけるツールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fiber",
+        "ja": "光ファイバ",
+        "ja_typings": [
+          "hikarifaiba"
+        ]
+      },
+      {
+        "en": "Coaxial cable",
+        "ja": "同軸ケーブル",
+        "ja_typings": [
+          "doujikuke-buru",
+          "dojikuke-buru"
+        ]
+      },
+      {
+        "en": "Twisted pair",
+        "ja": "ツイストペア",
+        "ja_typings": [
+          "tsuisutopea"
+        ]
+      },
+      {
+        "en": "Wireless",
+        "ja": "無線",
+        "ja_typings": [
+          "musen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02490",
+    "image_path": null,
+    "question_text": {
+      "en": "Which medium carries data as light pulses through glass strands?",
+      "ja": "ガラス繊維を通る光パルスでデータを伝える媒体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Container",
+        "ja": "コンテナ",
+        "ja_typings": [
+          "kontena"
+        ]
+      },
+      {
+        "en": "VM",
+        "ja": "VM",
+        "ja_typings": [
+          "bui-emu",
+          "vm"
+        ]
+      },
+      {
+        "en": "Jail",
+        "ja": "Jail",
+        "ja_typings": [
+          "jail"
+        ]
+      },
+      {
+        "en": "Sandbox",
+        "ja": "サンドボックス",
+        "ja_typings": [
+          "sandobokkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02491",
+    "image_path": null,
+    "question_text": {
+      "en": "Which OS-level virtualization unit packages an app with its deps?",
+      "ja": "アプリと依存関係をまとめる OS レベル仮想化の単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Switch",
+        "ja": "スイッチ",
+        "ja_typings": [
+          "suitchi"
+        ]
+      },
+      {
+        "en": "Hub",
+        "ja": "ハブ",
+        "ja_typings": [
+          "habu"
+        ]
+      },
+      {
+        "en": "Router",
+        "ja": "ルーター",
+        "ja_typings": [
+          "ru-ta-"
+        ]
+      },
+      {
+        "en": "Repeater",
+        "ja": "リピータ",
+        "ja_typings": [
+          "ripi-ta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02492",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Ethernet device forwards frames using MAC addresses?",
+      "ja": "MAC アドレスでフレームを転送するイーサネット機器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hub",
+        "ja": "ハブ",
+        "ja_typings": [
+          "habu"
+        ]
+      },
+      {
+        "en": "Switch",
+        "ja": "スイッチ",
+        "ja_typings": [
+          "suitchi"
+        ]
+      },
+      {
+        "en": "Router",
+        "ja": "ルーター",
+        "ja_typings": [
+          "ru-ta-"
+        ]
+      },
+      {
+        "en": "Bridge",
+        "ja": "ブリッジ",
+        "ja_typings": [
+          "burijji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02493",
+    "image_path": null,
+    "question_text": {
+      "en": "Which legacy device broadcasts all incoming traffic to every port?",
+      "ja": "受信した信号を全ポートに送出する旧式の機器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Repeater",
+        "ja": "リピータ",
+        "ja_typings": [
+          "ripi-ta"
+        ]
+      },
+      {
+        "en": "Switch",
+        "ja": "スイッチ",
+        "ja_typings": [
+          "suitchi"
+        ]
+      },
+      {
+        "en": "Hub",
+        "ja": "ハブ",
+        "ja_typings": [
+          "habu"
+        ]
+      },
+      {
+        "en": "Modem",
+        "ja": "モデム",
+        "ja_typings": [
+          "modemu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02494",
+    "image_path": null,
+    "question_text": {
+      "en": "Which device regenerates signals to extend a network's reach?",
+      "ja": "信号を増幅・整形してネットワーク到達距離を伸ばす機器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "256 bits",
+        "ja": "256ビット",
+        "ja_typings": [
+          "nigorokuju-rokubitto",
+          "256bitto"
+        ]
+      },
+      {
+        "en": "128 bits",
+        "ja": "128ビット",
+        "ja_typings": [
+          "hyakunijuhachibitto",
+          "128bitto"
+        ]
+      },
+      {
+        "en": "192 bits",
+        "ja": "192ビット",
+        "ja_typings": [
+          "hyakukyuju-nibitto",
+          "192bitto"
+        ]
+      },
+      {
+        "en": "512 bits",
+        "ja": "512ビット",
+        "ja_typings": [
+          "gohyakuju-nibitto",
+          "512bitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02495",
+    "image_path": null,
+    "question_text": {
+      "en": "Which key length is standard for AES-256?",
+      "ja": "AES-256 で使われる鍵長は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Symmetric-key cryptography",
+        "ja": "共通鍵暗号",
+        "ja_typings": [
+          "kyoutsuukagiangou",
+          "kyotsukagiango"
+        ]
+      },
+      {
+        "en": "Public-key cryptography",
+        "ja": "公開鍵暗号",
+        "ja_typings": [
+          "koukaikagiangou",
+          "kokaikagiango"
+        ]
+      },
+      {
+        "en": "Hash function",
+        "ja": "ハッシュ関数",
+        "ja_typings": [
+          "hasshukansu-"
+        ]
+      },
+      {
+        "en": "Quantum cryptography",
+        "ja": "量子暗号",
+        "ja_typings": [
+          "ryoushiangou",
+          "ryoshiango"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02496",
+    "image_path": null,
+    "question_text": {
+      "en": "Which class of cryptography uses one shared key for encrypt and decrypt?",
+      "ja": "暗号化と復号に同じ鍵を使う暗号方式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Steganography",
+        "ja": "ステガノグラフィー",
+        "ja_typings": [
+          "suteganogurafi-"
+        ]
+      },
+      {
+        "en": "Cryptography",
+        "ja": "暗号",
+        "ja_typings": [
+          "angou",
+          "ango"
+        ]
+      },
+      {
+        "en": "Hashing",
+        "ja": "ハッシュ",
+        "ja_typings": [
+          "hasshu"
+        ]
+      },
+      {
+        "en": "Encoding",
+        "ja": "エンコーディング",
+        "ja_typings": [
+          "enko-dingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02497",
+    "image_path": null,
+    "question_text": {
+      "en": "Which technique hides messages inside other media (e.g., images)?",
+      "ja": "画像などに情報を隠す技術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DES",
+        "ja": "DES",
+        "ja_typings": [
+          "di-i-esu",
+          "des"
+        ]
+      },
+      {
+        "en": "AES",
+        "ja": "AES",
+        "ja_typings": [
+          "e-i-esu",
+          "aes"
+        ]
+      },
+      {
+        "en": "RSA",
+        "ja": "RSA",
+        "ja_typings": [
+          "a-ru-esu-e-",
+          "rsa"
+        ]
+      },
+      {
+        "en": "Blowfish",
+        "ja": "Blowfish",
+        "ja_typings": [
+          "blowfish"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02498",
+    "image_path": null,
+    "question_text": {
+      "en": "Which now-deprecated symmetric block cipher uses a 56-bit key?",
+      "ja": "56ビット鍵を使う旧式の対称ブロック暗号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SHA",
+        "ja": "SHA",
+        "ja_typings": [
+          "esuetchie-",
+          "sha"
+        ]
+      },
+      {
+        "en": "MD5",
+        "ja": "MD5",
+        "ja_typings": [
+          "emudi-go",
+          "md5"
+        ]
+      },
+      {
+        "en": "CRC",
+        "ja": "CRC",
+        "ja_typings": [
+          "shi-a-ru-shi-",
+          "crc"
+        ]
+      },
+      {
+        "en": "HMAC",
+        "ja": "HMAC",
+        "ja_typings": [
+          "etchi-makku",
+          "hmac"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02499",
+    "image_path": null,
+    "question_text": {
+      "en": "Which family of cryptographic hash functions includes -1, -256, -512?",
+      "ja": "-1 や -256 などのバリアントを持つ暗号ハッシュ関数群は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Compression algorithm",
+        "ja": "圧縮アルゴリズム",
+        "ja_typings": [
+          "asshukuarugorizumu"
+        ]
+      },
+      {
+        "en": "Encryption algorithm",
+        "ja": "暗号化アルゴリズム",
+        "ja_typings": [
+          "angoukaarugorizumu",
+          "angokaarugorizumu"
+        ]
+      },
+      {
+        "en": "Hash function",
+        "ja": "ハッシュ関数",
+        "ja_typings": [
+          "hasshukansu-"
+        ]
+      },
+      {
+        "en": "Sorting algorithm",
+        "ja": "ソートアルゴリズム",
+        "ja_typings": [
+          "so-toarugorizumu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02500",
+    "image_path": null,
+    "question_text": {
+      "en": "Which kind of algorithm reduces data size for storage or transmission?",
+      "ja": "保存や伝送のためにデータサイズを小さくするアルゴリズムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Digital signature",
+        "ja": "デジタル署名",
+        "ja_typings": [
+          "dejitarushomei"
+        ]
+      },
+      {
+        "en": "Hash function",
+        "ja": "ハッシュ関数",
+        "ja_typings": [
+          "hasshukansu-"
+        ]
+      },
+      {
+        "en": "Symmetric cipher",
+        "ja": "対称暗号",
+        "ja_typings": [
+          "taishouangou",
+          "taishoango"
+        ]
+      },
+      {
+        "en": "Checksum",
+        "ja": "チェックサム",
+        "ja_typings": [
+          "chekkusamu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02501",
+    "image_path": null,
+    "question_text": {
+      "en": "Which cryptographic technique proves message authenticity using a key pair?",
+      "ja": "鍵ペアを用いてメッセージの真正性を証明する技術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Random number generator",
+        "ja": "乱数生成器",
+        "ja_typings": [
+          "ransuuseiseiki",
+          "ransuseiseiki"
+        ]
+      },
+      {
+        "en": "Hash function",
+        "ja": "ハッシュ関数",
+        "ja_typings": [
+          "hasshukansu-"
+        ]
+      },
+      {
+        "en": "Cipher",
+        "ja": "暗号",
+        "ja_typings": [
+          "angou",
+          "ango"
+        ]
+      },
+      {
+        "en": "Counter",
+        "ja": "カウンタ",
+        "ja_typings": [
+          "kaunta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02502",
+    "image_path": null,
+    "question_text": {
+      "en": "Which component produces sequences for cryptography and simulations?",
+      "ja": "暗号やシミュレーションに使う列を生成する装置は?"
+    }
   }
 ]

--- a/data/questions_ja.json
+++ b/data/questions_ja.json
@@ -71708,10 +71708,9 @@
       },
       {
         "en": "Yuki Kaji",
-        "ja": "梶裕介",
+        "ja": "梶裕貴",
         "ja_typings": [
-          "kajiyuuki",
-          "kajiyuusuke"
+          "kajiyuuki"
         ]
       }
     ],
@@ -75317,7 +75316,7 @@
       }
     ],
     "correct_answer_index": 0,
-    "genre": "manga",
+    "genre": "general_knowledge",
     "id": "q01860",
     "image_path": null,
     "question_text": {
@@ -75357,7 +75356,7 @@
       }
     ],
     "correct_answer_index": 0,
-    "genre": "manga",
+    "genre": "general_knowledge",
     "id": "q01861",
     "image_path": null,
     "question_text": {
@@ -75397,7 +75396,7 @@
       }
     ],
     "correct_answer_index": 0,
-    "genre": "manga",
+    "genre": "general_knowledge",
     "id": "q01862",
     "image_path": null,
     "question_text": {
@@ -75437,7 +75436,7 @@
       }
     ],
     "correct_answer_index": 0,
-    "genre": "manga",
+    "genre": "general_knowledge",
     "id": "q01863",
     "image_path": null,
     "question_text": {
@@ -91660,7 +91659,7 @@
       }
     ],
     "correct_answer_index": 0,
-    "genre": "vtuber_net_culture",
+    "genre": "general_knowledge",
     "id": "q02267",
     "image_path": null,
     "question_text": {
@@ -91700,7 +91699,7 @@
       }
     ],
     "correct_answer_index": 0,
-    "genre": "vtuber_net_culture",
+    "genre": "general_knowledge",
     "id": "q02268",
     "image_path": null,
     "question_text": {

--- a/data/questions_ja.json
+++ b/data/questions_ja.json
@@ -71642,5 +71642,29774 @@
       "en": "Which Vietnamese soup is broth-based with herbs?",
       "ja": "ハーブを使うベトナム麺スープは?"
     }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fumiko Orikasa",
+        "ja": "折笠富美子",
+        "ja_typings": [
+          "orikasafumiko"
+        ]
+      },
+      {
+        "en": "Aya Hirano",
+        "ja": "平野綾",
+        "ja_typings": [
+          "hiranoaya"
+        ]
+      },
+      {
+        "en": "Maaya Sakamoto",
+        "ja": "坂本真綾",
+        "ja_typings": [
+          "sakamotomaaya"
+        ]
+      },
+      {
+        "en": "Rie Kugimiya",
+        "ja": "釘宮理恵",
+        "ja_typings": [
+          "kugimiyarie"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01769",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actress voices Rukia Kuchiki in Bleach?",
+      "ja": "『BLEACH』で朽木ルキアを演じる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hiroshi Kamiya",
+        "ja": "神谷浩史",
+        "ja_typings": [
+          "kamiyahiroshi"
+        ]
+      },
+      {
+        "en": "Tomokazu Sugita",
+        "ja": "杉田智和",
+        "ja_typings": [
+          "sugitatomokazu"
+        ]
+      },
+      {
+        "en": "Daisuke Ono",
+        "ja": "小野大輔",
+        "ja_typings": [
+          "onodaisuke"
+        ]
+      },
+      {
+        "en": "Yuki Kaji",
+        "ja": "梶裕介",
+        "ja_typings": [
+          "kajiyuuki",
+          "kajiyuusuke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01770",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actor voices Izaya Orihara in Durarara!!?",
+      "ja": "『デュラララ!!』で折原臨也を演じる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tomokazu Sugita",
+        "ja": "杉田智和",
+        "ja_typings": [
+          "sugitatomokazu"
+        ]
+      },
+      {
+        "en": "Hiroshi Kamiya",
+        "ja": "神谷浩史",
+        "ja_typings": [
+          "kamiyahiroshi"
+        ]
+      },
+      {
+        "en": "Takahiro Sakurai",
+        "ja": "桜井孝宏",
+        "ja_typings": [
+          "sakuraitakahiro"
+        ]
+      },
+      {
+        "en": "Kensho Ono",
+        "ja": "小野賢章",
+        "ja_typings": [
+          "onokenshou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01771",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actor voices Gintoki Sakata in Gintama?",
+      "ja": "『銀魂』で坂田銀時を演じる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yuki Kaji",
+        "ja": "梶裕貴",
+        "ja_typings": [
+          "kajiyuuki"
+        ]
+      },
+      {
+        "en": "Yuma Uchida",
+        "ja": "内田雄馬",
+        "ja_typings": [
+          "uchidayuuma"
+        ]
+      },
+      {
+        "en": "Yoshitsugu Matsuoka",
+        "ja": "松岡禎丞",
+        "ja_typings": [
+          "matsuokayoshitsugu"
+        ]
+      },
+      {
+        "en": "Takahiro Sakurai",
+        "ja": "桜井孝宏",
+        "ja_typings": [
+          "sakuraitakahiro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01772",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actor voices Eren Yeager in Attack on Titan?",
+      "ja": "『進撃の巨人』でエレン・イェーガーを演じる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Daisuke Ono",
+        "ja": "小野大輔",
+        "ja_typings": [
+          "onodaisuke"
+        ]
+      },
+      {
+        "en": "Hiroshi Kamiya",
+        "ja": "神谷浩史",
+        "ja_typings": [
+          "kamiyahiroshi"
+        ]
+      },
+      {
+        "en": "Tomokazu Sugita",
+        "ja": "杉田智和",
+        "ja_typings": [
+          "sugitatomokazu"
+        ]
+      },
+      {
+        "en": "Kazuhiko Inoue",
+        "ja": "井上和彦",
+        "ja_typings": [
+          "inouekazuhiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01773",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actor voices Sebastian Michaelis in Black Butler?",
+      "ja": "『黒執事』でセバスチャン・ミカエリスを演じる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rie Kugimiya",
+        "ja": "釘宮理恵",
+        "ja_typings": [
+          "kugimiyarie"
+        ]
+      },
+      {
+        "en": "Aya Hirano",
+        "ja": "平野綾",
+        "ja_typings": [
+          "hiranoaya"
+        ]
+      },
+      {
+        "en": "Saori Hayami",
+        "ja": "早見沙織",
+        "ja_typings": [
+          "hayamisaori"
+        ]
+      },
+      {
+        "en": "Maaya Sakamoto",
+        "ja": "坂本真綾",
+        "ja_typings": [
+          "sakamotomaaya"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01774",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actress is well known for tsundere roles like Shana and Louise?",
+      "ja": "シャナやルイズなどツンデレ役で知られる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yoshitsugu Matsuoka",
+        "ja": "松岡禎丞",
+        "ja_typings": [
+          "matsuokayoshitsugu"
+        ]
+      },
+      {
+        "en": "Yuki Kaji",
+        "ja": "梶裕貴",
+        "ja_typings": [
+          "kajiyuuki"
+        ]
+      },
+      {
+        "en": "Yuma Uchida",
+        "ja": "内田雄馬",
+        "ja_typings": [
+          "uchidayuuma"
+        ]
+      },
+      {
+        "en": "Daisuke Ono",
+        "ja": "小野大輔",
+        "ja_typings": [
+          "onodaisuke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01775",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actor voices Kirito in Sword Art Online?",
+      "ja": "『ソードアート・オンライン』でキリトを演じる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yuma Uchida",
+        "ja": "内田雄馬",
+        "ja_typings": [
+          "uchidayuuma"
+        ]
+      },
+      {
+        "en": "Yuki Kaji",
+        "ja": "梶裕貴",
+        "ja_typings": [
+          "kajiyuuki"
+        ]
+      },
+      {
+        "en": "Yoshitsugu Matsuoka",
+        "ja": "松岡禎丞",
+        "ja_typings": [
+          "matsuokayoshitsugu"
+        ]
+      },
+      {
+        "en": "Hiroshi Kamiya",
+        "ja": "神谷浩史",
+        "ja_typings": [
+          "kamiyahiroshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01776",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actor voices Iida Tenya in My Hero Academia?",
+      "ja": "『僕のヒーローアカデミア』で飯田天哉を演じる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Takahiro Sakurai",
+        "ja": "桜井孝宏",
+        "ja_typings": [
+          "sakuraitakahiro"
+        ]
+      },
+      {
+        "en": "Daisuke Ono",
+        "ja": "小野大輔",
+        "ja_typings": [
+          "onodaisuke"
+        ]
+      },
+      {
+        "en": "Tomokazu Sugita",
+        "ja": "杉田智和",
+        "ja_typings": [
+          "sugitatomokazu"
+        ]
+      },
+      {
+        "en": "Kazuhiko Inoue",
+        "ja": "井上和彦",
+        "ja_typings": [
+          "inouekazuhiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01777",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actor is widely known for roles like Cloud Strife and Suzaku Kururugi?",
+      "ja": "クラウド・ストライフや枢木スザクなどで知られる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kensho Ono",
+        "ja": "小野賢章",
+        "ja_typings": [
+          "onokenshou"
+        ]
+      },
+      {
+        "en": "Yuki Kaji",
+        "ja": "梶裕貴",
+        "ja_typings": [
+          "kajiyuuki"
+        ]
+      },
+      {
+        "en": "Yuma Uchida",
+        "ja": "内田雄馬",
+        "ja_typings": [
+          "uchidayuuma"
+        ]
+      },
+      {
+        "en": "Yoshitsugu Matsuoka",
+        "ja": "松岡禎丞",
+        "ja_typings": [
+          "matsuokayoshitsugu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01778",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actor voices Tetsuya Kuroko in Kuroko's Basketball?",
+      "ja": "『黒子のバスケ』で黒子テツヤを演じる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kenichi Matsuyama",
+        "ja": "松山ケンイチ",
+        "ja_typings": [
+          "matsuyamakennichi"
+        ]
+      },
+      {
+        "en": "Takahiro Sakurai",
+        "ja": "桜井孝宏",
+        "ja_typings": [
+          "sakuraitakahiro"
+        ]
+      },
+      {
+        "en": "Daisuke Ono",
+        "ja": "小野大輔",
+        "ja_typings": [
+          "onodaisuke"
+        ]
+      },
+      {
+        "en": "Tomokazu Sugita",
+        "ja": "杉田智和",
+        "ja_typings": [
+          "sugitatomokazu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01779",
+    "image_path": null,
+    "question_text": {
+      "en": "Which actor voices L in the live-action Death Note films?",
+      "ja": "実写映画『デスノート』でLを演じた俳優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Maaya Sakamoto",
+        "ja": "坂本真綾",
+        "ja_typings": [
+          "sakamotomaaya"
+        ]
+      },
+      {
+        "en": "Aya Hirano",
+        "ja": "平野綾",
+        "ja_typings": [
+          "hiranoaya"
+        ]
+      },
+      {
+        "en": "Saori Hayami",
+        "ja": "早見沙織",
+        "ja_typings": [
+          "hayamisaori"
+        ]
+      },
+      {
+        "en": "Aya Hisakawa",
+        "ja": "久川綾",
+        "ja_typings": [
+          "hisakawaaya"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01780",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actress voices Hitagi Senjogahara in the Monogatari series?",
+      "ja": "『〈物語〉シリーズ』で戦場ヶ原ひたぎを演じる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kotono Mitsuishi",
+        "ja": "三石琴乃",
+        "ja_typings": [
+          "mitsuishikotono"
+        ]
+      },
+      {
+        "en": "Aya Hisakawa",
+        "ja": "久川綾",
+        "ja_typings": [
+          "hisakawaaya"
+        ]
+      },
+      {
+        "en": "Maaya Sakamoto",
+        "ja": "坂本真綾",
+        "ja_typings": [
+          "sakamotomaaya"
+        ]
+      },
+      {
+        "en": "Fumiko Orikasa",
+        "ja": "折笠富美子",
+        "ja_typings": [
+          "orikasafumiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01781",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actress voices Usagi Tsukino in the original Sailor Moon anime?",
+      "ja": "初代『美少女戦士セーラームーン』アニメで月野うさぎを演じた声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aya Hisakawa",
+        "ja": "久川綾",
+        "ja_typings": [
+          "hisakawaaya"
+        ]
+      },
+      {
+        "en": "Kotono Mitsuishi",
+        "ja": "三石琴乃",
+        "ja_typings": [
+          "mitsuishikotono"
+        ]
+      },
+      {
+        "en": "Maaya Sakamoto",
+        "ja": "坂本真綾",
+        "ja_typings": [
+          "sakamotomaaya"
+        ]
+      },
+      {
+        "en": "Aya Hirano",
+        "ja": "平野綾",
+        "ja_typings": [
+          "hiranoaya"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01782",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actress voices Sailor Mercury / Ami Mizuno in the original Sailor Moon anime?",
+      "ja": "初代『セーラームーン』アニメで水野亜美/セーラーマーキュリーを演じた声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shuichi Ikeda",
+        "ja": "池田秀一",
+        "ja_typings": [
+          "ikedashuuichi"
+        ]
+      },
+      {
+        "en": "Kazuhiko Inoue",
+        "ja": "井上和彦",
+        "ja_typings": [
+          "inouekazuhiko"
+        ]
+      },
+      {
+        "en": "Tomokazu Sugita",
+        "ja": "杉田智和",
+        "ja_typings": [
+          "sugitatomokazu"
+        ]
+      },
+      {
+        "en": "Hiroshi Kamiya",
+        "ja": "神谷浩史",
+        "ja_typings": [
+          "kamiyahiroshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01783",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actor voices Char Aznable in Mobile Suit Gundam?",
+      "ja": "『機動戦士ガンダム』でシャア・アズナブルを演じる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kazuhiko Inoue",
+        "ja": "井上和彦",
+        "ja_typings": [
+          "inouekazuhiko"
+        ]
+      },
+      {
+        "en": "Shuichi Ikeda",
+        "ja": "池田秀一",
+        "ja_typings": [
+          "ikedashuuichi"
+        ]
+      },
+      {
+        "en": "Takahiro Sakurai",
+        "ja": "桜井孝宏",
+        "ja_typings": [
+          "sakuraitakahiro"
+        ]
+      },
+      {
+        "en": "Daisuke Ono",
+        "ja": "小野大輔",
+        "ja_typings": [
+          "onodaisuke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01784",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actor is famous for playing Kakashi Hatake in Naruto?",
+      "ja": "『NARUTO』ではたけカカシを演じる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Saori Hayami",
+        "ja": "早見沙織",
+        "ja_typings": [
+          "hayamisaori"
+        ]
+      },
+      {
+        "en": "Maaya Sakamoto",
+        "ja": "坂本真綾",
+        "ja_typings": [
+          "sakamotomaaya"
+        ]
+      },
+      {
+        "en": "Aya Hirano",
+        "ja": "平野綾",
+        "ja_typings": [
+          "hiranoaya"
+        ]
+      },
+      {
+        "en": "Fumiko Orikasa",
+        "ja": "折笠富美子",
+        "ja_typings": [
+          "orikasafumiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01785",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actress voices Yor Forger in Spy x Family?",
+      "ja": "『SPY×FAMILY』でヨル・フォージャーを演じる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aya Hirano",
+        "ja": "平野綾",
+        "ja_typings": [
+          "hiranoaya"
+        ]
+      },
+      {
+        "en": "Maaya Sakamoto",
+        "ja": "坂本真綾",
+        "ja_typings": [
+          "sakamotomaaya"
+        ]
+      },
+      {
+        "en": "Saori Hayami",
+        "ja": "早見沙織",
+        "ja_typings": [
+          "hayamisaori"
+        ]
+      },
+      {
+        "en": "Rie Kugimiya",
+        "ja": "釘宮理恵",
+        "ja_typings": [
+          "kugimiyarie"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01786",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actress voices Haruhi Suzumiya in The Melancholy of Haruhi Suzumiya?",
+      "ja": "『涼宮ハルヒの憂鬱』で涼宮ハルヒを演じる声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Production I.G",
+        "ja": "プロダクション・アイジー",
+        "ja_typings": [
+          "purodakushon/aiji-"
+        ]
+      },
+      {
+        "en": "Madhouse",
+        "ja": "マッドハウス",
+        "ja_typings": [
+          "maddohausu"
+        ]
+      },
+      {
+        "en": "Wit Studio",
+        "ja": "ウィットスタジオ",
+        "ja_typings": [
+          "wittosutajio"
+        ]
+      },
+      {
+        "en": "A-1 Pictures",
+        "ja": "エーワン・ピクチャーズ",
+        "ja_typings": [
+          "e-wan/pikucha-zu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01787",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio produced Ghost in the Shell: Stand Alone Complex?",
+      "ja": "『攻殻機動隊 STAND ALONE COMPLEX』を制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Madhouse",
+        "ja": "マッドハウス",
+        "ja_typings": [
+          "maddohausu"
+        ]
+      },
+      {
+        "en": "Production I.G",
+        "ja": "プロダクション・アイジー",
+        "ja_typings": [
+          "purodakushon/aiji-"
+        ]
+      },
+      {
+        "en": "Wit Studio",
+        "ja": "ウィットスタジオ",
+        "ja_typings": [
+          "wittosutajio"
+        ]
+      },
+      {
+        "en": "Pierrot",
+        "ja": "ぴえろ",
+        "ja_typings": [
+          "piero"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01788",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio produced Death Note and One-Punch Man (Season 1)?",
+      "ja": "『デスノート』『ワンパンマン』(1期) を制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wit Studio",
+        "ja": "ウィットスタジオ",
+        "ja_typings": [
+          "wittosutajio"
+        ]
+      },
+      {
+        "en": "Madhouse",
+        "ja": "マッドハウス",
+        "ja_typings": [
+          "maddohausu"
+        ]
+      },
+      {
+        "en": "Production I.G",
+        "ja": "プロダクション・アイジー",
+        "ja_typings": [
+          "purodakushon/aiji-"
+        ]
+      },
+      {
+        "en": "A-1 Pictures",
+        "ja": "エーワン・ピクチャーズ",
+        "ja_typings": [
+          "e-wan/pikucha-zu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01789",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio produced Attack on Titan (Seasons 1-3)?",
+      "ja": "『進撃の巨人』(1-3期) を制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "A-1 Pictures",
+        "ja": "エーワン・ピクチャーズ",
+        "ja_typings": [
+          "e-wan/pikucha-zu"
+        ]
+      },
+      {
+        "en": "Wit Studio",
+        "ja": "ウィットスタジオ",
+        "ja_typings": [
+          "wittosutajio"
+        ]
+      },
+      {
+        "en": "Madhouse",
+        "ja": "マッドハウス",
+        "ja_typings": [
+          "maddohausu"
+        ]
+      },
+      {
+        "en": "Pierrot",
+        "ja": "ぴえろ",
+        "ja_typings": [
+          "piero"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01790",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio produced Sword Art Online and Fairy Tail?",
+      "ja": "『ソードアート・オンライン』『フェアリーテイル』を制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pierrot",
+        "ja": "ぴえろ",
+        "ja_typings": [
+          "piero"
+        ]
+      },
+      {
+        "en": "Madhouse",
+        "ja": "マッドハウス",
+        "ja_typings": [
+          "maddohausu"
+        ]
+      },
+      {
+        "en": "A-1 Pictures",
+        "ja": "エーワン・ピクチャーズ",
+        "ja_typings": [
+          "e-wan/pikucha-zu"
+        ]
+      },
+      {
+        "en": "Wit Studio",
+        "ja": "ウィットスタジオ",
+        "ja_typings": [
+          "wittosutajio"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01791",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio produced Naruto and Bleach?",
+      "ja": "『NARUTO』『BLEACH』を制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": [
+          "magi"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "フェアリーテイル",
+        "ja_typings": [
+          "feari-teiru"
+        ]
+      },
+      {
+        "en": "D.Gray-man",
+        "ja": "ディーグレイマン",
+        "ja_typings": [
+          "di-gureiman"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01792",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime follows Aladdin and Alibaba exploring mysterious dungeons?",
+      "ja": "アラジンとアリババがダンジョンに挑む冒険アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yu Yu Hakusho",
+        "ja": "幽☆遊☆白書",
+        "ja_typings": [
+          "yuuyuuhakusho"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "フェアリーテイル",
+        "ja_typings": [
+          "feari-teiru"
+        ]
+      },
+      {
+        "en": "Hell's Paradise",
+        "ja": "地獄楽",
+        "ja_typings": [
+          "jigokuraku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01793",
+    "image_path": null,
+    "question_text": {
+      "en": "Which classic anime features Yusuke Urameshi as a Spirit Detective?",
+      "ja": "浦飯幽助が霊界探偵を務める名作アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Outlaw Star",
+        "ja": "アウトロースター",
+        "ja_typings": [
+          "autoro-suta-"
+        ]
+      },
+      {
+        "en": "Galaxy Express 999",
+        "ja": "銀河鉄道999",
+        "ja_typings": [
+          "gingatetsudou999"
+        ]
+      },
+      {
+        "en": "Log Horizon",
+        "ja": "ログ・ホライズン",
+        "ja_typings": [
+          "rogu/horaizun"
+        ]
+      },
+      {
+        "en": "Black Lagoon",
+        "ja": "ブラック・ラグーン",
+        "ja_typings": [
+          "burakku/ragu-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01794",
+    "image_path": null,
+    "question_text": {
+      "en": "Which space western anime features Gene Starwind and his ship the Outlaw?",
+      "ja": "ジーン・スターウィンドが主人公の宇宙ウェスタンアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ranma 1/2",
+        "ja": "らんま1/2",
+        "ja_typings": [
+          "ranma1/2"
+        ]
+      },
+      {
+        "en": "Urusei Yatsura",
+        "ja": "うる星やつら",
+        "ja_typings": [
+          "uruseiyatsura"
+        ]
+      },
+      {
+        "en": "Galaxy Express 999",
+        "ja": "銀河鉄道999",
+        "ja_typings": [
+          "gingatetsudou999"
+        ]
+      },
+      {
+        "en": "Dororo",
+        "ja": "どろろ",
+        "ja_typings": [
+          "dororo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01795",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Rumiko Takahashi work follows a boy who turns into a girl when splashed with cold water?",
+      "ja": "高橋留美子作で水をかぶると女になる少年の物語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Urusei Yatsura",
+        "ja": "うる星やつら",
+        "ja_typings": [
+          "uruseiyatsura"
+        ]
+      },
+      {
+        "en": "Ranma 1/2",
+        "ja": "らんま1/2",
+        "ja_typings": [
+          "ranma1/2"
+        ]
+      },
+      {
+        "en": "Galaxy Express 999",
+        "ja": "銀河鉄道999",
+        "ja_typings": [
+          "gingatetsudou999"
+        ]
+      },
+      {
+        "en": "Heidi",
+        "ja": "アルプスの少女ハイジ",
+        "ja_typings": [
+          "arupusunoshoujohaiji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01796",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Rumiko Takahashi work features the alien Lum and Ataru Moroboshi?",
+      "ja": "高橋留美子作でラムちゃんと諸星あたるが登場する作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Log Horizon",
+        "ja": "ログ・ホライズン",
+        "ja_typings": [
+          "rogu/horaizun"
+        ]
+      },
+      {
+        "en": "Outlaw Star",
+        "ja": "アウトロースター",
+        "ja_typings": [
+          "autoro-suta-"
+        ]
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": [
+          "magi"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01797",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime, based on Mamare Touno's novels, traps players inside an MMORPG world?",
+      "ja": "橙乃ままれ原作で MMO 世界に閉じ込められる作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "フェアリーテイル",
+        "ja_typings": [
+          "feari-teiru"
+        ]
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": [
+          "magi"
+        ]
+      },
+      {
+        "en": "D.Gray-man",
+        "ja": "ディーグレイマン",
+        "ja_typings": [
+          "di-gureiman"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01798",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Shonen Jump anime follows Asta, a magicless boy in a magical kingdom?",
+      "ja": "魔法が使えない少年アスタを描くジャンプアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fairy Tail",
+        "ja": "フェアリーテイル",
+        "ja_typings": [
+          "feari-teiru"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": [
+          "magi"
+        ]
+      },
+      {
+        "en": "Hell's Paradise",
+        "ja": "地獄楽",
+        "ja_typings": [
+          "jigokuraku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01799",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hiro Mashima anime follows Natsu and his guild of mages?",
+      "ja": "真島ヒロ原作、ナツが所属する魔導士ギルドの物語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "D.Gray-man",
+        "ja": "ディーグレイマン",
+        "ja_typings": [
+          "di-gureiman"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
+      },
+      {
+        "en": "Fairy Tail",
+        "ja": "フェアリーテイル",
+        "ja_typings": [
+          "feari-teiru"
+        ]
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": [
+          "magi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01800",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Katsura Hoshino anime follows exorcists fighting Akuma with Innocence?",
+      "ja": "星野桂原作、イノセンスでアクマと戦うエクソシストたちの物語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ace of Diamond",
+        "ja": "ダイヤのエース",
+        "ja_typings": [
+          "daiyanoe-su"
+        ]
+      },
+      {
+        "en": "Hell's Paradise",
+        "ja": "地獄楽",
+        "ja_typings": [
+          "jigokuraku"
+        ]
+      },
+      {
+        "en": "MASHLE",
+        "ja": "マッシュル",
+        "ja_typings": [
+          "masshuru"
+        ]
+      },
+      {
+        "en": "Dororo",
+        "ja": "どろろ",
+        "ja_typings": [
+          "dororo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01801",
+    "image_path": null,
+    "question_text": {
+      "en": "Which baseball anime follows the Seido High pitching ace Eijun Sawamura?",
+      "ja": "沢村栄純が主人公の高校野球アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dororo",
+        "ja": "どろろ",
+        "ja_typings": [
+          "dororo"
+        ]
+      },
+      {
+        "en": "Hell's Paradise",
+        "ja": "地獄楽",
+        "ja_typings": [
+          "jigokuraku"
+        ]
+      },
+      {
+        "en": "MASHLE",
+        "ja": "マッシュル",
+        "ja_typings": [
+          "masshuru"
+        ]
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": [
+          "magi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01802",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Osamu Tezuka work features a boy reclaiming his body parts from demons?",
+      "ja": "手塚治虫原作、体の部位を魔物から取り戻す少年の物語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Black Lagoon",
+        "ja": "ブラック・ラグーン",
+        "ja_typings": [
+          "burakku/ragu-n"
+        ]
+      },
+      {
+        "en": "Outlaw Star",
+        "ja": "アウトロースター",
+        "ja_typings": [
+          "autoro-suta-"
+        ]
+      },
+      {
+        "en": "Hell's Paradise",
+        "ja": "地獄楽",
+        "ja_typings": [
+          "jigokuraku"
+        ]
+      },
+      {
+        "en": "Log Horizon",
+        "ja": "ログ・ホライズン",
+        "ja_typings": [
+          "rogu/horaizun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01803",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Rei Hiroe anime follows the mercenary crew of the Black Lagoon Company?",
+      "ja": "広江礼威原作、傭兵チーム『ブラック・ラグーン商会』の物語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wolf Children",
+        "ja": "おおかみこどもの雨と雪",
+        "ja_typings": [
+          "ookamikodomonoametoyuki"
+        ]
+      },
+      {
+        "en": "Summer Wars",
+        "ja": "サマーウォーズ",
+        "ja_typings": [
+          "sama-wo-zu"
+        ]
+      },
+      {
+        "en": "Tokyo Godfathers",
+        "ja": "東京ゴッドファーザーズ",
+        "ja_typings": [
+          "toukyougoddofa-za-zu"
+        ]
+      },
+      {
+        "en": "Heidi",
+        "ja": "アルプスの少女ハイジ",
+        "ja_typings": [
+          "arupusunoshoujohaiji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01804",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mamoru Hosoda film features a single mother raising two half-wolf children?",
+      "ja": "細田守監督、狼男との間に生まれた姉弟を描く映画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Summer Wars",
+        "ja": "サマーウォーズ",
+        "ja_typings": [
+          "sama-wo-zu"
+        ]
+      },
+      {
+        "en": "Wolf Children",
+        "ja": "おおかみこどもの雨と雪",
+        "ja_typings": [
+          "ookamikodomonoametoyuki"
+        ]
+      },
+      {
+        "en": "Tokyo Godfathers",
+        "ja": "東京ゴッドファーザーズ",
+        "ja_typings": [
+          "toukyougoddofa-za-zu"
+        ]
+      },
+      {
+        "en": "Galaxy Express 999",
+        "ja": "銀河鉄道999",
+        "ja_typings": [
+          "gingatetsudou999"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01805",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mamoru Hosoda film centers on a virtual world called OZ?",
+      "ja": "細田守監督、仮想空間 OZ を舞台にした映画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tokyo Godfathers",
+        "ja": "東京ゴッドファーザーズ",
+        "ja_typings": [
+          "toukyougoddofa-za-zu"
+        ]
+      },
+      {
+        "en": "Summer Wars",
+        "ja": "サマーウォーズ",
+        "ja_typings": [
+          "sama-wo-zu"
+        ]
+      },
+      {
+        "en": "Wolf Children",
+        "ja": "おおかみこどもの雨と雪",
+        "ja_typings": [
+          "ookamikodomonoametoyuki"
+        ]
+      },
+      {
+        "en": "Heidi",
+        "ja": "アルプスの少女ハイジ",
+        "ja_typings": [
+          "arupusunoshoujohaiji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01806",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Satoshi Kon film follows three homeless people who find an abandoned baby?",
+      "ja": "今敏監督、ホームレス3人が捨て子を拾う物語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hell's Paradise",
+        "ja": "地獄楽",
+        "ja_typings": [
+          "jigokuraku"
+        ]
+      },
+      {
+        "en": "Dororo",
+        "ja": "どろろ",
+        "ja_typings": [
+          "dororo"
+        ]
+      },
+      {
+        "en": "MASHLE",
+        "ja": "マッシュル",
+        "ja_typings": [
+          "masshuru"
+        ]
+      },
+      {
+        "en": "Wonder Egg Priority",
+        "ja": "ワンダーエッグ・プライオリティ",
+        "ja_typings": [
+          "wanda-eggu/puraioriti"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01807",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Yutaka Yamamoto-directed anime follows an Edo-period executioner sent to a flower island?",
+      "ja": "江戸時代の処刑人が花の島に派遣される死刑囚との物語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Galaxy Express 999",
+        "ja": "銀河鉄道999",
+        "ja_typings": [
+          "gingatetsudou999"
+        ]
+      },
+      {
+        "en": "Outlaw Star",
+        "ja": "アウトロースター",
+        "ja_typings": [
+          "autoro-suta-"
+        ]
+      },
+      {
+        "en": "Heidi",
+        "ja": "アルプスの少女ハイジ",
+        "ja_typings": [
+          "arupusunoshoujohaiji"
+        ]
+      },
+      {
+        "en": "Urusei Yatsura",
+        "ja": "うる星やつら",
+        "ja_typings": [
+          "uruseiyatsura"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01808",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Leiji Matsumoto work features a steam locomotive traveling through space?",
+      "ja": "松本零士原作で宇宙を走る蒸気機関車を描く作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Heidi",
+        "ja": "アルプスの少女ハイジ",
+        "ja_typings": [
+          "arupusunoshoujohaiji"
+        ]
+      },
+      {
+        "en": "Galaxy Express 999",
+        "ja": "銀河鉄道999",
+        "ja_typings": [
+          "gingatetsudou999"
+        ]
+      },
+      {
+        "en": "Wolf Children",
+        "ja": "おおかみこどもの雨と雪",
+        "ja_typings": [
+          "ookamikodomonoametoyuki"
+        ]
+      },
+      {
+        "en": "Summer Wars",
+        "ja": "サマーウォーズ",
+        "ja_typings": [
+          "sama-wo-zu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01809",
+    "image_path": null,
+    "question_text": {
+      "en": "Which World Masterpiece Theater anime is set in the Swiss Alps?",
+      "ja": "世界名作劇場でスイスアルプスを舞台にした作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wonder Egg Priority",
+        "ja": "ワンダーエッグ・プライオリティ",
+        "ja_typings": [
+          "wanda-eggu/puraioriti"
+        ]
+      },
+      {
+        "en": "Hell's Paradise",
+        "ja": "地獄楽",
+        "ja_typings": [
+          "jigokuraku"
+        ]
+      },
+      {
+        "en": "MASHLE",
+        "ja": "マッシュル",
+        "ja_typings": [
+          "masshuru"
+        ]
+      },
+      {
+        "en": "Dororo",
+        "ja": "どろろ",
+        "ja_typings": [
+          "dororo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01810",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2021 original anime by CloverWorks features girls fighting in dream worlds to bring back the dead?",
+      "ja": "2021年クローバーワークス制作、夢の世界で戦う少女たちのオリジナルアニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MASHLE",
+        "ja": "マッシュル",
+        "ja_typings": [
+          "masshuru"
+        ]
+      },
+      {
+        "en": "Hell's Paradise",
+        "ja": "地獄楽",
+        "ja_typings": [
+          "jigokuraku"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": [
+          "magi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01811",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hajime Komoto anime follows Mash Burnedead, a magicless boy attending magic school?",
+      "ja": "甲本一原作、魔法が使えない少年マッシュが魔法学校に通う作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Katsuhiro Otomo",
+        "ja": "大友克洋",
+        "ja_typings": [
+          "ootomokatsuhiro"
+        ]
+      },
+      {
+        "en": "Goro Miyazaki",
+        "ja": "宮崎吾朗",
+        "ja_typings": [
+          "miyazakigorou"
+        ]
+      },
+      {
+        "en": "Yoshiyuki Sadamoto",
+        "ja": "貞本義行",
+        "ja_typings": [
+          "sadamotoyoshiyuki"
+        ]
+      },
+      {
+        "en": "Tatsuki Fujimoto",
+        "ja": "藤本タツキ",
+        "ja_typings": [
+          "fujimototatsuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01812",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Akira and directed its 1988 film adaptation?",
+      "ja": "『AKIRA』の原作者で1988年映画版の監督も務めたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Goro Miyazaki",
+        "ja": "宮崎吾朗",
+        "ja_typings": [
+          "miyazakigorou"
+        ]
+      },
+      {
+        "en": "Katsuhiro Otomo",
+        "ja": "大友克洋",
+        "ja_typings": [
+          "ootomokatsuhiro"
+        ]
+      },
+      {
+        "en": "Yoshiyuki Sadamoto",
+        "ja": "貞本義行",
+        "ja_typings": [
+          "sadamotoyoshiyuki"
+        ]
+      },
+      {
+        "en": "Tatsuki Fujimoto",
+        "ja": "藤本タツキ",
+        "ja_typings": [
+          "fujimototatsuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01813",
+    "image_path": null,
+    "question_text": {
+      "en": "Who directed Tales from Earthsea and From Up on Poppy Hill at Studio Ghibli?",
+      "ja": "ジブリで『ゲド戦記』『コクリコ坂から』を監督したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yoshiyuki Sadamoto",
+        "ja": "貞本義行",
+        "ja_typings": [
+          "sadamotoyoshiyuki"
+        ]
+      },
+      {
+        "en": "Katsuhiro Otomo",
+        "ja": "大友克洋",
+        "ja_typings": [
+          "ootomokatsuhiro"
+        ]
+      },
+      {
+        "en": "Goro Miyazaki",
+        "ja": "宮崎吾朗",
+        "ja_typings": [
+          "miyazakigorou"
+        ]
+      },
+      {
+        "en": "Tatsuki Fujimoto",
+        "ja": "藤本タツキ",
+        "ja_typings": [
+          "fujimototatsuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01814",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the character designer for Neon Genesis Evangelion?",
+      "ja": "『新世紀エヴァンゲリオン』のキャラクターデザイナーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jiraiya",
+        "ja": "ジライヤ",
+        "ja_typings": [
+          "jiraiya"
+        ]
+      },
+      {
+        "en": "Chimera Shadow Garden",
+        "ja": "キメラ・シャドウガーデン",
+        "ja_typings": [
+          "kimera/shadoga-den",
+          "kimera/shadouga-den"
+        ]
+      },
+      {
+        "en": "Log Horizon",
+        "ja": "ログ・ホライズン",
+        "ja_typings": [
+          "rogu/horaizun"
+        ]
+      },
+      {
+        "en": "Outlaw Star",
+        "ja": "アウトロースター",
+        "ja_typings": [
+          "autoro-suta-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q01815",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the name of Saitama's S-Class hero disciple in One-Punch Man?",
+      "ja": "『ワンパンマン』でサイタマの弟子となる S級ヒーローの名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Weekly Shonen Magazine",
+        "ja": "週刊少年マガジン",
+        "ja_typings": [
+          "shuukanshounenmagajin"
+        ]
+      },
+      {
+        "en": "Weekly Shonen Champion",
+        "ja": "週刊少年チャンピオン",
+        "ja_typings": [
+          "shuukanshounenchanpion"
+        ]
+      },
+      {
+        "en": "Shonen Jump",
+        "ja": "少年ジャンプ",
+        "ja_typings": [
+          "shounenjanpu"
+        ]
+      },
+      {
+        "en": "Big Comic",
+        "ja": "ビッグコミック",
+        "ja_typings": [
+          "biggukomikku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01816",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Kodansha weekly serializes Fairy Tail and Hajime no Ippo?",
+      "ja": "『フェアリーテイル』『はじめの一歩』を連載する講談社の週刊誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Morning",
+        "ja": "モーニング",
+        "ja_typings": [
+          "mo-ningu"
+        ]
+      },
+      {
+        "en": "Monthly Afternoon",
+        "ja": "月刊アフタヌーン",
+        "ja_typings": [
+          "gekkanafutanu-n"
+        ]
+      },
+      {
+        "en": "Big Comic Original",
+        "ja": "ビッグコミックオリジナル",
+        "ja_typings": [
+          "biggukomikkuorijinaru"
+        ]
+      },
+      {
+        "en": "Weekly Shonen Champion",
+        "ja": "週刊少年チャンピオン",
+        "ja_typings": [
+          "shuukanshounenchanpion"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01817",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Kodansha seinen magazine serializes Vagabond and Vinland Saga?",
+      "ja": "『バガボンド』『ヴィンランド・サガ』を連載する講談社の青年誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Monthly Afternoon",
+        "ja": "月刊アフタヌーン",
+        "ja_typings": [
+          "gekkanafutanu-n"
+        ]
+      },
+      {
+        "en": "Morning",
+        "ja": "モーニング",
+        "ja_typings": [
+          "mo-ningu"
+        ]
+      },
+      {
+        "en": "Big Comic",
+        "ja": "ビッグコミック",
+        "ja_typings": [
+          "biggukomikku"
+        ]
+      },
+      {
+        "en": "Weekly Shonen Magazine",
+        "ja": "週刊少年マガジン",
+        "ja_typings": [
+          "shuukanshounenmagajin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01818",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Kodansha monthly serialized Blame! and Mushishi?",
+      "ja": "『BLAME!』『蟲師』を連載した講談社の月刊誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Big Comic",
+        "ja": "ビッグコミック",
+        "ja_typings": [
+          "biggukomikku"
+        ]
+      },
+      {
+        "en": "Morning",
+        "ja": "モーニング",
+        "ja_typings": [
+          "mo-ningu"
+        ]
+      },
+      {
+        "en": "Monthly Afternoon",
+        "ja": "月刊アフタヌーン",
+        "ja_typings": [
+          "gekkanafutanu-n"
+        ]
+      },
+      {
+        "en": "Weekly Shonen Magazine",
+        "ja": "週刊少年マガジン",
+        "ja_typings": [
+          "shuukanshounenmagajin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01819",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Shogakukan biweekly serializes Golgo 13?",
+      "ja": "『ゴルゴ13』を連載する小学館の隔週誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Big Comic Original",
+        "ja": "ビッグコミックオリジナル",
+        "ja_typings": [
+          "biggukomikkuorijinaru"
+        ]
+      },
+      {
+        "en": "Morning",
+        "ja": "モーニング",
+        "ja_typings": [
+          "mo-ningu"
+        ]
+      },
+      {
+        "en": "Monthly Afternoon",
+        "ja": "月刊アフタヌーン",
+        "ja_typings": [
+          "gekkanafutanu-n"
+        ]
+      },
+      {
+        "en": "Weekly Shonen Champion",
+        "ja": "週刊少年チャンピオン",
+        "ja_typings": [
+          "shuukanshounenchanpion"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01820",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Shogakukan biweekly serialized Sanctuary and 3-gatsu no Lion?",
+      "ja": "『サンクチュアリ』『3月のライオン』を連載した小学館の隔週誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Weekly Shonen Champion",
+        "ja": "週刊少年チャンピオン",
+        "ja_typings": [
+          "shuukanshounenchanpion"
+        ]
+      },
+      {
+        "en": "Weekly Shonen Magazine",
+        "ja": "週刊少年マガジン",
+        "ja_typings": [
+          "shuukanshounenmagajin"
+        ]
+      },
+      {
+        "en": "Shonen Jump",
+        "ja": "少年ジャンプ",
+        "ja_typings": [
+          "shounenjanpu"
+        ]
+      },
+      {
+        "en": "Morning",
+        "ja": "モーニング",
+        "ja_typings": [
+          "mo-ningu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01821",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Akita Shoten weekly serializes Baki and serialized Grappler Baki?",
+      "ja": "『バキ』を連載する秋田書店の週刊誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shonen Jump",
+        "ja": "少年ジャンプ",
+        "ja_typings": [
+          "shounenjanpu"
+        ]
+      },
+      {
+        "en": "Weekly Shonen Magazine",
+        "ja": "週刊少年マガジン",
+        "ja_typings": [
+          "shuukanshounenmagajin"
+        ]
+      },
+      {
+        "en": "Weekly Shonen Champion",
+        "ja": "週刊少年チャンピオン",
+        "ja_typings": [
+          "shuukanshounenchanpion"
+        ]
+      },
+      {
+        "en": "Morning",
+        "ja": "モーニング",
+        "ja_typings": [
+          "mo-ningu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01822",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Shueisha magazine serializes One Piece and Jujutsu Kaisen?",
+      "ja": "『ONE PIECE』『呪術廻戦』を連載する集英社の雑誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": [
+          "magi"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
+      },
+      {
+        "en": "Bakuman",
+        "ja": "バクマン。",
+        "ja_typings": [
+          "bakuman."
+        ]
+      },
+      {
+        "en": "Platinum End",
+        "ja": "プラチナエンド",
+        "ja_typings": [
+          "purachinaendo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01823",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga features Akira Yuki training under his master in Edo-era Japan?",
+      "ja": "アスタが魔法の国で修行する少年漫画は? (誤) — 正: アラジンとアリババがダンジョンに挑む小学館連載作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": [
+          "magi"
+        ]
+      },
+      {
+        "en": "Bakuman",
+        "ja": "バクマン。",
+        "ja_typings": [
+          "bakuman."
+        ]
+      },
+      {
+        "en": "Platinum End",
+        "ja": "プラチナエンド",
+        "ja_typings": [
+          "purachinaendo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01824",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Yuki Tabata manga follows Asta in the Clover Kingdom?",
+      "ja": "田畠裕基の漫画で、アスタがクローバー王国で活躍する作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bakuman",
+        "ja": "バクマン。",
+        "ja_typings": [
+          "bakuman."
+        ]
+      },
+      {
+        "en": "Platinum End",
+        "ja": "プラチナエンド",
+        "ja_typings": [
+          "purachinaendo"
+        ]
+      },
+      {
+        "en": "Liar Game",
+        "ja": "ライアーゲーム",
+        "ja_typings": [
+          "raia-ge-mu"
+        ]
+      },
+      {
+        "en": "Black Clover",
+        "ja": "ブラッククローバー",
+        "ja_typings": [
+          "burakkukuro-ba-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01825",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Tsugumi Ohba & Takeshi Obata manga follows two boys aiming to become manga artists?",
+      "ja": "大場つぐみ・小畑健で、漫画家を目指す二人の少年の物語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Platinum End",
+        "ja": "プラチナエンド",
+        "ja_typings": [
+          "purachinaendo"
+        ]
+      },
+      {
+        "en": "Bakuman",
+        "ja": "バクマン。",
+        "ja_typings": [
+          "bakuman."
+        ]
+      },
+      {
+        "en": "Liar Game",
+        "ja": "ライアーゲーム",
+        "ja_typings": [
+          "raia-ge-mu"
+        ]
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": [
+          "magi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01826",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Ohba & Obata manga features a boy chosen by an angel competing to become god?",
+      "ja": "大場つぐみ・小畑健で、天使に選ばれた少年が神を目指す作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Liar Game",
+        "ja": "ライアーゲーム",
+        "ja_typings": [
+          "raia-ge-mu"
+        ]
+      },
+      {
+        "en": "Bakuman",
+        "ja": "バクマン。",
+        "ja_typings": [
+          "bakuman."
+        ]
+      },
+      {
+        "en": "Platinum End",
+        "ja": "プラチナエンド",
+        "ja_typings": [
+          "purachinaendo"
+        ]
+      },
+      {
+        "en": "Mister Ajikko",
+        "ja": "ミスター味っ子",
+        "ja_typings": [
+          "misuta-ajikko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01827",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Shinobu Kaitani manga revolves around a deception tournament with huge debts?",
+      "ja": "甲斐谷忍の漫画で、巨額の借金を賭けた騙し合いトーナメントを描く作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mister Ajikko",
+        "ja": "ミスター味っ子",
+        "ja_typings": [
+          "misuta-ajikko"
+        ]
+      },
+      {
+        "en": "Liar Game",
+        "ja": "ライアーゲーム",
+        "ja_typings": [
+          "raia-ge-mu"
+        ]
+      },
+      {
+        "en": "Bakuman",
+        "ja": "バクマン。",
+        "ja_typings": [
+          "bakuman."
+        ]
+      },
+      {
+        "en": "Platinum End",
+        "ja": "プラチナエンド",
+        "ja_typings": [
+          "purachinaendo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01828",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Daisuke Hashimoto cooking manga follows young chef Yoichi Ajiyoshi?",
+      "ja": "味吉陽一を主人公とする料理漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Maoyu",
+        "ja": "まおゆう魔王勇者",
+        "ja_typings": [
+          "maoyuumaouyuusha"
+        ]
+      },
+      {
+        "en": "Magi",
+        "ja": "マギ",
+        "ja_typings": [
+          "magi"
+        ]
+      },
+      {
+        "en": "Platinum End",
+        "ja": "プラチナエンド",
+        "ja_typings": [
+          "purachinaendo"
+        ]
+      },
+      {
+        "en": "Bakuman",
+        "ja": "バクマン。",
+        "ja_typings": [
+          "bakuman."
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01829",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mamare Touno light-novel-based manga is set in a dark fantasy of demon-human peace?",
+      "ja": "魔王と勇者の和平を描く橙乃ままれ原作のダーク・ファンタジー漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Masakazu Katsura",
+        "ja": "桂正和",
+        "ja_typings": [
+          "katsuramasakazu"
+        ]
+      },
+      {
+        "en": "Masanori Morita",
+        "ja": "森田まさのり",
+        "ja_typings": [
+          "moritamasanori"
+        ]
+      },
+      {
+        "en": "Yusuke Murata",
+        "ja": "村田雄介",
+        "ja_typings": [
+          "muratayuusuke"
+        ]
+      },
+      {
+        "en": "Buronson",
+        "ja": "武論尊",
+        "ja_typings": [
+          "buronson"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01830",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Video Girl Ai and I\"s?",
+      "ja": "『電影少女』『I\"s』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Masanori Morita",
+        "ja": "森田まさのり",
+        "ja_typings": [
+          "moritamasanori"
+        ]
+      },
+      {
+        "en": "Masakazu Katsura",
+        "ja": "桂正和",
+        "ja_typings": [
+          "katsuramasakazu"
+        ]
+      },
+      {
+        "en": "Yusuke Murata",
+        "ja": "村田雄介",
+        "ja_typings": [
+          "muratayuusuke"
+        ]
+      },
+      {
+        "en": "Buronson",
+        "ja": "武論尊",
+        "ja_typings": [
+          "buronson"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01831",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Rookies and Rokudenashi Blues?",
+      "ja": "『ROOKIES』『ろくでなしBLUES』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Keiko Takemiya",
+        "ja": "竹宮惠子",
+        "ja_typings": [
+          "takemiyakeiko"
+        ]
+      },
+      {
+        "en": "Yumiko Oshima",
+        "ja": "大島弓子",
+        "ja_typings": [
+          "ooshimayumiko"
+        ]
+      },
+      {
+        "en": "Yumi Tamura",
+        "ja": "田村由美",
+        "ja_typings": [
+          "tamurayumi"
+        ]
+      },
+      {
+        "en": "Akimi Yoshida",
+        "ja": "吉田秋生",
+        "ja_typings": [
+          "yoshidaakimi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01832",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the Year 24 Group member behind Kaze to Ki no Uta and Toward the Terra?",
+      "ja": "『風と木の詩』『地球へ…』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yumi Tamura",
+        "ja": "田村由美",
+        "ja_typings": [
+          "tamurayumi"
+        ]
+      },
+      {
+        "en": "Keiko Takemiya",
+        "ja": "竹宮惠子",
+        "ja_typings": [
+          "takemiyakeiko"
+        ]
+      },
+      {
+        "en": "Yumiko Oshima",
+        "ja": "大島弓子",
+        "ja_typings": [
+          "ooshimayumiko"
+        ]
+      },
+      {
+        "en": "Akimi Yoshida",
+        "ja": "吉田秋生",
+        "ja_typings": [
+          "yoshidaakimi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01833",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Basara and 7 Seeds?",
+      "ja": "『BASARA』『7SEEDS』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Masami Kurumada",
+        "ja": "車田正美",
+        "ja_typings": [
+          "kurumadamasami"
+        ]
+      },
+      {
+        "en": "Masakazu Katsura",
+        "ja": "桂正和",
+        "ja_typings": [
+          "katsuramasakazu"
+        ]
+      },
+      {
+        "en": "Buronson",
+        "ja": "武論尊",
+        "ja_typings": [
+          "buronson"
+        ]
+      },
+      {
+        "en": "Yusuke Murata",
+        "ja": "村田雄介",
+        "ja_typings": [
+          "muratayuusuke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01834",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Saint Seiya?",
+      "ja": "『聖闘士星矢』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fujio Akatsuka",
+        "ja": "赤塚不二夫",
+        "ja_typings": [
+          "akatsukafujio"
+        ]
+      },
+      {
+        "en": "Fujiko Fujio A",
+        "ja": "藤子不二雄A",
+        "ja_typings": [
+          "fujikofujioe-"
+        ]
+      },
+      {
+        "en": "Kazuo Umezu",
+        "ja": "楳図かずお",
+        "ja_typings": [
+          "umezukazuo"
+        ]
+      },
+      {
+        "en": "Shinji Mizushima",
+        "ja": "水島新司",
+        "ja_typings": [
+          "mizushimashinji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01835",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Tensai Bakabon and Osomatsu-kun?",
+      "ja": "『天才バカボン』『おそ松くん』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CLAMP",
+        "ja": "クランプ",
+        "ja_typings": [
+          "kuranpu"
+        ]
+      },
+      {
+        "en": "Yudetamago",
+        "ja": "ゆでたまご",
+        "ja_typings": [
+          "yudetamago"
+        ]
+      },
+      {
+        "en": "Buronson",
+        "ja": "武論尊",
+        "ja_typings": [
+          "buronson"
+        ]
+      },
+      {
+        "en": "Yusuke Murata",
+        "ja": "村田雄介",
+        "ja_typings": [
+          "muratayuusuke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01836",
+    "image_path": null,
+    "question_text": {
+      "en": "Which all-female group created Cardcaptor Sakura and X/1999?",
+      "ja": "『カードキャプターさくら』『X』を生み出した女性作家グループは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Buronson",
+        "ja": "武論尊",
+        "ja_typings": [
+          "buronson"
+        ]
+      },
+      {
+        "en": "Masakazu Katsura",
+        "ja": "桂正和",
+        "ja_typings": [
+          "katsuramasakazu"
+        ]
+      },
+      {
+        "en": "Masanori Morita",
+        "ja": "森田まさのり",
+        "ja_typings": [
+          "moritamasanori"
+        ]
+      },
+      {
+        "en": "Ikki Kajiwara",
+        "ja": "梶原一騎",
+        "ja_typings": [
+          "kajiwaraikki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01837",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote the original story for Fist of the North Star?",
+      "ja": "『北斗の拳』の原作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ikki Kajiwara",
+        "ja": "梶原一騎",
+        "ja_typings": [
+          "kajiwaraikki"
+        ]
+      },
+      {
+        "en": "Buronson",
+        "ja": "武論尊",
+        "ja_typings": [
+          "buronson"
+        ]
+      },
+      {
+        "en": "Masanori Morita",
+        "ja": "森田まさのり",
+        "ja_typings": [
+          "moritamasanori"
+        ]
+      },
+      {
+        "en": "Masakazu Katsura",
+        "ja": "桂正和",
+        "ja_typings": [
+          "katsuramasakazu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01838",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote the original story for Star of the Giants and Tomorrow's Joe?",
+      "ja": "『巨人の星』『あしたのジョー』の原作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yudetamago",
+        "ja": "ゆでたまご",
+        "ja_typings": [
+          "yudetamago"
+        ]
+      },
+      {
+        "en": "CLAMP",
+        "ja": "クランプ",
+        "ja_typings": [
+          "kuranpu"
+        ]
+      },
+      {
+        "en": "Buronson",
+        "ja": "武論尊",
+        "ja_typings": [
+          "buronson"
+        ]
+      },
+      {
+        "en": "Yusuke Murata",
+        "ja": "村田雄介",
+        "ja_typings": [
+          "muratayuusuke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01839",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the duo behind Kinnikuman?",
+      "ja": "『キン肉マン』の作者コンビは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yusuke Murata",
+        "ja": "村田雄介",
+        "ja_typings": [
+          "muratayuusuke"
+        ]
+      },
+      {
+        "en": "Masakazu Katsura",
+        "ja": "桂正和",
+        "ja_typings": [
+          "katsuramasakazu"
+        ]
+      },
+      {
+        "en": "Masanori Morita",
+        "ja": "森田まさのり",
+        "ja_typings": [
+          "moritamasanori"
+        ]
+      },
+      {
+        "en": "Buronson",
+        "ja": "武論尊",
+        "ja_typings": [
+          "buronson"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01840",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the artist behind the One-Punch Man remake and Eyeshield 21?",
+      "ja": "ワンパンマン作画版や『アイシールド21』作画の漫画家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yoko Kamio",
+        "ja": "神尾葉子",
+        "ja_typings": [
+          "kamiyouko"
+        ]
+      },
+      {
+        "en": "Yumi Tamura",
+        "ja": "田村由美",
+        "ja_typings": [
+          "tamurayumi"
+        ]
+      },
+      {
+        "en": "Karuho Shiina",
+        "ja": "椎名軽穂",
+        "ja_typings": [
+          "shiinakaruho"
+        ]
+      },
+      {
+        "en": "Akimi Yoshida",
+        "ja": "吉田秋生",
+        "ja_typings": [
+          "yoshidaakimi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01841",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Boys Over Flowers (Hana Yori Dango)?",
+      "ja": "『花より男子』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yumiko Oshima",
+        "ja": "大島弓子",
+        "ja_typings": [
+          "ooshimayumiko"
+        ]
+      },
+      {
+        "en": "Keiko Takemiya",
+        "ja": "竹宮惠子",
+        "ja_typings": [
+          "takemiyakeiko"
+        ]
+      },
+      {
+        "en": "Yumi Tamura",
+        "ja": "田村由美",
+        "ja_typings": [
+          "tamurayumi"
+        ]
+      },
+      {
+        "en": "Machiko Satonaka",
+        "ja": "里中満智子",
+        "ja_typings": [
+          "satonakamachiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01842",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of The Star of Cottonland?",
+      "ja": "『綿の国星』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fujiko Fujio A",
+        "ja": "藤子不二雄A",
+        "ja_typings": [
+          "fujikofujioe-"
+        ]
+      },
+      {
+        "en": "Fujio Akatsuka",
+        "ja": "赤塚不二夫",
+        "ja_typings": [
+          "akatsukafujio"
+        ]
+      },
+      {
+        "en": "Kazuo Umezu",
+        "ja": "楳図かずお",
+        "ja_typings": [
+          "umezukazuo"
+        ]
+      },
+      {
+        "en": "Hiroshi Motomiya",
+        "ja": "本宮ひろ志",
+        "ja_typings": [
+          "motomiyahiroshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01843",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Doraemon as one half of the duo, and later worked solo on Laughing Salesman?",
+      "ja": "藤子不二雄コンビの片割れで『笑ゥせぇるすまん』も手がけたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kenshi Hirokane",
+        "ja": "弘兼憲史",
+        "ja_typings": [
+          "hirokanekenshi"
+        ]
+      },
+      {
+        "en": "Fujio Akatsuka",
+        "ja": "赤塚不二夫",
+        "ja_typings": [
+          "akatsukafujio"
+        ]
+      },
+      {
+        "en": "Kazuo Umezu",
+        "ja": "楳図かずお",
+        "ja_typings": [
+          "umezukazuo"
+        ]
+      },
+      {
+        "en": "Hiroshi Motomiya",
+        "ja": "本宮ひろ志",
+        "ja_typings": [
+          "motomiyahiroshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01844",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Section Chief Kosaku Shima?",
+      "ja": "『課長島耕作』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kazuo Umezu",
+        "ja": "楳図かずお",
+        "ja_typings": [
+          "umezukazuo"
+        ]
+      },
+      {
+        "en": "Fujio Akatsuka",
+        "ja": "赤塚不二夫",
+        "ja_typings": [
+          "akatsukafujio"
+        ]
+      },
+      {
+        "en": "Hiroshi Motomiya",
+        "ja": "本宮ひろ志",
+        "ja_typings": [
+          "motomiyahiroshi"
+        ]
+      },
+      {
+        "en": "Kenshi Hirokane",
+        "ja": "弘兼憲史",
+        "ja_typings": [
+          "hirokanekenshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01845",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the horror manga master behind The Drifting Classroom?",
+      "ja": "『漂流教室』の作者であるホラー漫画の巨匠は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hiroshi Motomiya",
+        "ja": "本宮ひろ志",
+        "ja_typings": [
+          "motomiyahiroshi"
+        ]
+      },
+      {
+        "en": "Kenshi Hirokane",
+        "ja": "弘兼憲史",
+        "ja_typings": [
+          "hirokanekenshi"
+        ]
+      },
+      {
+        "en": "Fujio Akatsuka",
+        "ja": "赤塚不二夫",
+        "ja_typings": [
+          "akatsukafujio"
+        ]
+      },
+      {
+        "en": "Kazuo Umezu",
+        "ja": "楳図かずお",
+        "ja_typings": [
+          "umezukazuo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01846",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Otoko Oidon and Salaryman Kintaro?",
+      "ja": "『男一匹ガキ大将』『サラリーマン金太郎』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yoshihiro Takahashi",
+        "ja": "高橋よしひろ",
+        "ja_typings": [
+          "takahashiyoshihiro"
+        ]
+      },
+      {
+        "en": "Akio Chiba",
+        "ja": "ちばあきお",
+        "ja_typings": [
+          "chibaakio"
+        ]
+      },
+      {
+        "en": "Shinji Mizushima",
+        "ja": "水島新司",
+        "ja_typings": [
+          "mizushimashinji"
+        ]
+      },
+      {
+        "en": "Fujihiko Hosono",
+        "ja": "細野不二彦",
+        "ja_typings": [
+          "hosonofujihiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01847",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created the dog adventure manga Silver Fang?",
+      "ja": "犬の冒険漫画『銀牙 -流れ星 銀-』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fujihiko Hosono",
+        "ja": "細野不二彦",
+        "ja_typings": [
+          "hosonofujihiko"
+        ]
+      },
+      {
+        "en": "Akio Chiba",
+        "ja": "ちばあきお",
+        "ja_typings": [
+          "chibaakio"
+        ]
+      },
+      {
+        "en": "Shinji Mizushima",
+        "ja": "水島新司",
+        "ja_typings": [
+          "mizushimashinji"
+        ]
+      },
+      {
+        "en": "Yoshihiro Takahashi",
+        "ja": "高橋よしひろ",
+        "ja_typings": [
+          "takahashiyoshihiro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01848",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Gallery Fake and Gaki Deka counterpart Yawara!? — namely the author of Gallery Fake?",
+      "ja": "『ギャラリーフェイク』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Akio Chiba",
+        "ja": "ちばあきお",
+        "ja_typings": [
+          "chibaakio"
+        ]
+      },
+      {
+        "en": "Shinji Mizushima",
+        "ja": "水島新司",
+        "ja_typings": [
+          "mizushimashinji"
+        ]
+      },
+      {
+        "en": "Yoshihiro Takahashi",
+        "ja": "高橋よしひろ",
+        "ja_typings": [
+          "takahashiyoshihiro"
+        ]
+      },
+      {
+        "en": "Fujihiko Hosono",
+        "ja": "細野不二彦",
+        "ja_typings": [
+          "hosonofujihiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01849",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Captain and Play Ball?",
+      "ja": "『キャプテン』『プレイボール』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shinji Mizushima",
+        "ja": "水島新司",
+        "ja_typings": [
+          "mizushimashinji"
+        ]
+      },
+      {
+        "en": "Akio Chiba",
+        "ja": "ちばあきお",
+        "ja_typings": [
+          "chibaakio"
+        ]
+      },
+      {
+        "en": "Yoshihiro Takahashi",
+        "ja": "高橋よしひろ",
+        "ja_typings": [
+          "takahashiyoshihiro"
+        ]
+      },
+      {
+        "en": "Fujihiko Hosono",
+        "ja": "細野不二彦",
+        "ja_typings": [
+          "hosonofujihiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01850",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the baseball manga master behind Dokaben?",
+      "ja": "『ドカベン』の作者である野球漫画の巨匠は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Masami Yuki",
+        "ja": "ゆうきまさみ",
+        "ja_typings": [
+          "yuukimasami"
+        ]
+      },
+      {
+        "en": "Mamoru Nagano",
+        "ja": "永野護",
+        "ja_typings": [
+          "naganomamoru"
+        ]
+      },
+      {
+        "en": "Akimi Yoshida",
+        "ja": "吉田秋生",
+        "ja_typings": [
+          "yoshidaakimi"
+        ]
+      },
+      {
+        "en": "Karuho Shiina",
+        "ja": "椎名軽穂",
+        "ja_typings": [
+          "shiinakaruho"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01851",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Patlabor (manga)?",
+      "ja": "漫画版『機動警察パトレイバー』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mamoru Nagano",
+        "ja": "永野護",
+        "ja_typings": [
+          "naganomamoru"
+        ]
+      },
+      {
+        "en": "Masami Yuki",
+        "ja": "ゆうきまさみ",
+        "ja_typings": [
+          "yuukimasami"
+        ]
+      },
+      {
+        "en": "Akimi Yoshida",
+        "ja": "吉田秋生",
+        "ja_typings": [
+          "yoshidaakimi"
+        ]
+      },
+      {
+        "en": "Karuho Shiina",
+        "ja": "椎名軽穂",
+        "ja_typings": [
+          "shiinakaruho"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01852",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of The Five Star Stories?",
+      "ja": "『ファイブスター物語』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kazuhiro Fujita",
+        "ja": "藤田和日郎",
+        "ja_typings": [
+          "fujitakazuhiro"
+        ]
+      },
+      {
+        "en": "Masami Yuki",
+        "ja": "ゆうきまさみ",
+        "ja_typings": [
+          "yuukimasami"
+        ]
+      },
+      {
+        "en": "Koji Kumeta",
+        "ja": "久米田康治",
+        "ja_typings": [
+          "kumetakouji"
+        ]
+      },
+      {
+        "en": "Mamoru Nagano",
+        "ja": "永野護",
+        "ja_typings": [
+          "naganomamoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01853",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Ushio and Tora?",
+      "ja": "『うしおととら』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Satoru Makimura",
+        "ja": "室山まゆみ",
+        "ja_typings": [
+          "muroyamamayumi"
+        ]
+      },
+      {
+        "en": "Machiko Satonaka",
+        "ja": "里中満智子",
+        "ja_typings": [
+          "satonakamachiko"
+        ]
+      },
+      {
+        "en": "Fusako Kuramochi",
+        "ja": "倉持房子",
+        "ja_typings": [
+          "kuramochifusako"
+        ]
+      },
+      {
+        "en": "Karuho Shiina",
+        "ja": "椎名軽穂",
+        "ja_typings": [
+          "shiinakaruho"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01854",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Asari-chan?",
+      "ja": "『あさりちゃん』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fusako Kuramochi",
+        "ja": "倉持房子",
+        "ja_typings": [
+          "kuramochifusako"
+        ]
+      },
+      {
+        "en": "Machiko Satonaka",
+        "ja": "里中満智子",
+        "ja_typings": [
+          "satonakamachiko"
+        ]
+      },
+      {
+        "en": "Karuho Shiina",
+        "ja": "椎名軽穂",
+        "ja_typings": [
+          "shiinakaruho"
+        ]
+      },
+      {
+        "en": "Yoko Kamio",
+        "ja": "神尾葉子",
+        "ja_typings": [
+          "kamiyouko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01855",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Tenshi nanka ja nai?",
+      "ja": "『天使なんかじゃない』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Akimi Yoshida",
+        "ja": "吉田秋生",
+        "ja_typings": [
+          "yoshidaakimi"
+        ]
+      },
+      {
+        "en": "Yumi Tamura",
+        "ja": "田村由美",
+        "ja_typings": [
+          "tamurayumi"
+        ]
+      },
+      {
+        "en": "Fusako Kuramochi",
+        "ja": "倉持房子",
+        "ja_typings": [
+          "kuramochifusako"
+        ]
+      },
+      {
+        "en": "Machiko Satonaka",
+        "ja": "里中満智子",
+        "ja_typings": [
+          "satonakamachiko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01856",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Banana Fish?",
+      "ja": "『BANANA FISH』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Karuho Shiina",
+        "ja": "椎名軽穂",
+        "ja_typings": [
+          "shiinakaruho"
+        ]
+      },
+      {
+        "en": "Yoko Kamio",
+        "ja": "神尾葉子",
+        "ja_typings": [
+          "kamiyouko"
+        ]
+      },
+      {
+        "en": "Akimi Yoshida",
+        "ja": "吉田秋生",
+        "ja_typings": [
+          "yoshidaakimi"
+        ]
+      },
+      {
+        "en": "Fusako Kuramochi",
+        "ja": "倉持房子",
+        "ja_typings": [
+          "kuramochifusako"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01857",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Kimi ni Todoke?",
+      "ja": "『君に届け』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Koji Kumeta",
+        "ja": "久米田康治",
+        "ja_typings": [
+          "kumetakouji"
+        ]
+      },
+      {
+        "en": "Kazuhiro Fujita",
+        "ja": "藤田和日郎",
+        "ja_typings": [
+          "fujitakazuhiro"
+        ]
+      },
+      {
+        "en": "Masami Yuki",
+        "ja": "ゆうきまさみ",
+        "ja_typings": [
+          "yuukimasami"
+        ]
+      },
+      {
+        "en": "Mamoru Nagano",
+        "ja": "永野護",
+        "ja_typings": [
+          "naganomamoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01858",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the author of Sayonara, Zetsubou-Sensei?",
+      "ja": "『さよなら絶望先生』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Machiko Satonaka",
+        "ja": "里中満智子",
+        "ja_typings": [
+          "satonakamachiko"
+        ]
+      },
+      {
+        "en": "Fusako Kuramochi",
+        "ja": "倉持房子",
+        "ja_typings": [
+          "kuramochifusako"
+        ]
+      },
+      {
+        "en": "Yumi Tamura",
+        "ja": "田村由美",
+        "ja_typings": [
+          "tamurayumi"
+        ]
+      },
+      {
+        "en": "Akimi Yoshida",
+        "ja": "吉田秋生",
+        "ja_typings": [
+          "yoshidaakimi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01859",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the historical-josei master behind Tenjo no Niji?",
+      "ja": "『天上の虹』を描いた歴史少女漫画の巨匠は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kadokawa Shoten",
+        "ja": "角川書店",
+        "ja_typings": [
+          "kadokawashoten"
+        ]
+      },
+      {
+        "en": "The Yomiuri Shimbun",
+        "ja": "読売新聞",
+        "ja_typings": [
+          "yomiurishinbun"
+        ]
+      },
+      {
+        "en": "The Mainichi Shimbun",
+        "ja": "毎日新聞",
+        "ja_typings": [
+          "mainichishinbun"
+        ]
+      },
+      {
+        "en": "Nikkei",
+        "ja": "日本経済新聞",
+        "ja_typings": [
+          "nihonkeizaishinbun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01860",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese publisher releases Kadokawa Bunko and many light novels?",
+      "ja": "角川文庫やライトノベルを多数出す日本の出版社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Yomiuri Shimbun",
+        "ja": "読売新聞",
+        "ja_typings": [
+          "yomiurishinbun"
+        ]
+      },
+      {
+        "en": "The Mainichi Shimbun",
+        "ja": "毎日新聞",
+        "ja_typings": [
+          "mainichishinbun"
+        ]
+      },
+      {
+        "en": "Nikkei",
+        "ja": "日本経済新聞",
+        "ja_typings": [
+          "nihonkeizaishinbun"
+        ]
+      },
+      {
+        "en": "Kadokawa Shoten",
+        "ja": "角川書店",
+        "ja_typings": [
+          "kadokawashoten"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01861",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese newspaper has the largest circulation and sponsors the Giants?",
+      "ja": "発行部数最大、巨人を所有する日本の新聞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Mainichi Shimbun",
+        "ja": "毎日新聞",
+        "ja_typings": [
+          "mainichishinbun"
+        ]
+      },
+      {
+        "en": "The Yomiuri Shimbun",
+        "ja": "読売新聞",
+        "ja_typings": [
+          "yomiurishinbun"
+        ]
+      },
+      {
+        "en": "Nikkei",
+        "ja": "日本経済新聞",
+        "ja_typings": [
+          "nihonkeizaishinbun"
+        ]
+      },
+      {
+        "en": "Kadokawa Shoten",
+        "ja": "角川書店",
+        "ja_typings": [
+          "kadokawashoten"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01862",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese newspaper sponsors the high school baseball Summer Koshien?",
+      "ja": "夏の甲子園を主催する日本の新聞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nikkei",
+        "ja": "日本経済新聞",
+        "ja_typings": [
+          "nihonkeizaishinbun"
+        ]
+      },
+      {
+        "en": "The Yomiuri Shimbun",
+        "ja": "読売新聞",
+        "ja_typings": [
+          "yomiurishinbun"
+        ]
+      },
+      {
+        "en": "The Mainichi Shimbun",
+        "ja": "毎日新聞",
+        "ja_typings": [
+          "mainichishinbun"
+        ]
+      },
+      {
+        "en": "Kadokawa Shoten",
+        "ja": "角川書店",
+        "ja_typings": [
+          "kadokawashoten"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01863",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese newspaper focuses on business and economics?",
+      "ja": "経済を専門に扱う日本の新聞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ayumi Himekawa",
+        "ja": "姫川亜弓",
+        "ja_typings": [
+          "himekawaayumi"
+        ]
+      },
+      {
+        "en": "Chigusa Tsukikage",
+        "ja": "月影千草",
+        "ja_typings": [
+          "tsukikagechigusa"
+        ]
+      },
+      {
+        "en": "Fusako Kuramochi",
+        "ja": "倉持房子",
+        "ja_typings": [
+          "kuramochifusako"
+        ]
+      },
+      {
+        "en": "Karuho Shiina",
+        "ja": "椎名軽穂",
+        "ja_typings": [
+          "shiinakaruho"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01864",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the heir to Hanagumi at the Imperial Theatre in Sakura Wars?",
+      "ja": "『サクラ大戦』で帝国華撃団・花組の隊員は神崎すみれと誰? (新人の少女の名)"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ayumi Himekawa",
+        "ja": "姫川亜弓",
+        "ja_typings": [
+          "himekawaayumi"
+        ]
+      },
+      {
+        "en": "Chigusa Tsukikage",
+        "ja": "月影千草",
+        "ja_typings": [
+          "tsukikagechigusa"
+        ]
+      },
+      {
+        "en": "Machiko Satonaka",
+        "ja": "里中満智子",
+        "ja_typings": [
+          "satonakamachiko"
+        ]
+      },
+      {
+        "en": "Fusako Kuramochi",
+        "ja": "倉持房子",
+        "ja_typings": [
+          "kuramochifusako"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01865",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the rival actress in Glass Mask (Garasu no Kamen)?",
+      "ja": "『ガラスの仮面』で北島マヤのライバルとなる天才女優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chigusa Tsukikage",
+        "ja": "月影千草",
+        "ja_typings": [
+          "tsukikagechigusa"
+        ]
+      },
+      {
+        "en": "Ayumi Himekawa",
+        "ja": "姫川亜弓",
+        "ja_typings": [
+          "himekawaayumi"
+        ]
+      },
+      {
+        "en": "Machiko Satonaka",
+        "ja": "里中満智子",
+        "ja_typings": [
+          "satonakamachiko"
+        ]
+      },
+      {
+        "en": "Fusako Kuramochi",
+        "ja": "倉持房子",
+        "ja_typings": [
+          "kuramochifusako"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q01866",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the legendary actress and mentor in Glass Mask?",
+      "ja": "『ガラスの仮面』で月影先生として知られる伝説の女優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Konami",
+        "ja": "コナミ",
+        "ja_typings": [
+          "konami"
+        ]
+      },
+      {
+        "en": "Tri-Ace",
+        "ja": "トライエース",
+        "ja_typings": [
+          "toraie-su"
+        ]
+      },
+      {
+        "en": "Capcom",
+        "ja": "カプコン",
+        "ja_typings": [
+          "kapukon"
+        ]
+      },
+      {
+        "en": "Sega",
+        "ja": "セガ",
+        "ja_typings": [
+          "sega"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01867",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese game company developed the Metal Gear and Castlevania series?",
+      "ja": "『メタルギア』『悪魔城ドラキュラ』を開発した日本のゲーム会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yu Suzuki",
+        "ja": "鈴木裕",
+        "ja_typings": [
+          "suzukiyuu"
+        ]
+      },
+      {
+        "en": "Tri-Ace",
+        "ja": "トライエース",
+        "ja_typings": [
+          "toraie-su"
+        ]
+      },
+      {
+        "en": "Konami",
+        "ja": "コナミ",
+        "ja_typings": [
+          "konami"
+        ]
+      },
+      {
+        "en": "Onimusha",
+        "ja": "鬼武者",
+        "ja_typings": [
+          "onimusha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01868",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the creator of Virtua Fighter and Shenmue at Sega?",
+      "ja": "セガで『バーチャファイター』『シェンムー』を生み出したクリエイターは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tri-Ace",
+        "ja": "トライエース",
+        "ja_typings": [
+          "toraie-su"
+        ]
+      },
+      {
+        "en": "Konami",
+        "ja": "コナミ",
+        "ja_typings": [
+          "konami"
+        ]
+      },
+      {
+        "en": "Capcom",
+        "ja": "カプコン",
+        "ja_typings": [
+          "kapukon"
+        ]
+      },
+      {
+        "en": "Sega",
+        "ja": "セガ",
+        "ja_typings": [
+          "sega"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01869",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese developer is known for Star Ocean and Valkyrie Profile?",
+      "ja": "『スターオーシャン』『ヴァルキリープロファイル』で知られるデベロッパーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chrono Trigger",
+        "ja": "クロノ・トリガー",
+        "ja_typings": [
+          "kurono/toriga-"
+        ]
+      },
+      {
+        "en": "Final Fantasy",
+        "ja": "ファイナルファンタジー",
+        "ja_typings": [
+          "fainarufantaji-"
+        ]
+      },
+      {
+        "en": "Xenoblade",
+        "ja": "ゼノブレイド",
+        "ja_typings": [
+          "zenobureido"
+        ]
+      },
+      {
+        "en": "Seiken Densetsu",
+        "ja": "聖剣伝説",
+        "ja_typings": [
+          "seikendensetsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01870",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1995 Square JRPG features Crono and time-traveling adventures?",
+      "ja": "1995年スクウェアのRPGで、クロノが時を超える物語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Final Fantasy",
+        "ja": "ファイナルファンタジー",
+        "ja_typings": [
+          "fainarufantaji-"
+        ]
+      },
+      {
+        "en": "Chrono Trigger",
+        "ja": "クロノ・トリガー",
+        "ja_typings": [
+          "kurono/toriga-"
+        ]
+      },
+      {
+        "en": "Seiken Densetsu",
+        "ja": "聖剣伝説",
+        "ja_typings": [
+          "seikendensetsu"
+        ]
+      },
+      {
+        "en": "SaGa Frontier",
+        "ja": "サガ・フロンティア",
+        "ja_typings": [
+          "saga/furontia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01871",
+    "image_path": null,
+    "question_text": {
+      "en": "Which long-running Square Enix JRPG series began on the Famicom in 1987?",
+      "ja": "1987年ファミコンで始まったスクウェアの長寿RPGシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Virtua Fighter",
+        "ja": "バーチャファイター",
+        "ja_typings": [
+          "ba-chafaita-"
+        ]
+      },
+      {
+        "en": "Last Blade",
+        "ja": "ラストブレイド",
+        "ja_typings": [
+          "rasutobureido"
+        ]
+      },
+      {
+        "en": "Devil May Cry",
+        "ja": "デビルメイクライ",
+        "ja_typings": [
+          "debirumeikurai"
+        ]
+      },
+      {
+        "en": "Bayonetta",
+        "ja": "ベヨネッタ",
+        "ja_typings": [
+          "beyonetta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01872",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Sega 3D fighting series began in 1993 starring Akira Yuki?",
+      "ja": "1993年に始まったセガの3D格闘ゲームシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dragon Age",
+        "ja": "ドラゴンエイジ",
+        "ja_typings": [
+          "doragonneiji"
+        ]
+      },
+      {
+        "en": "Mass Effect",
+        "ja": "マスエフェクト",
+        "ja_typings": [
+          "masuefekuto"
+        ]
+      },
+      {
+        "en": "Dark Souls",
+        "ja": "ダークソウル",
+        "ja_typings": [
+          "da-kusoru",
+          "da-kusouru"
+        ]
+      },
+      {
+        "en": "Dragon Quest Builders",
+        "ja": "ドラゴンクエストビルダーズ",
+        "ja_typings": [
+          "doragonkuesutobiruda-zu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01873",
+    "image_path": null,
+    "question_text": {
+      "en": "Which BioWare RPG series features Grey Wardens fighting darkspawn?",
+      "ja": "BioWare 製、灰色の守人がダークスポーンと戦うRPGシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nioh",
+        "ja": "仁王",
+        "ja_typings": [
+          "nioh"
+        ]
+      },
+      {
+        "en": "Onimusha",
+        "ja": "鬼武者",
+        "ja_typings": [
+          "onimusha"
+        ]
+      },
+      {
+        "en": "Way of the Samurai",
+        "ja": "侍道",
+        "ja_typings": [
+          "samuraidou"
+        ]
+      },
+      {
+        "en": "Dark Souls",
+        "ja": "ダークソウル",
+        "ja_typings": [
+          "da-kusoru",
+          "da-kusouru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01874",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Team Ninja action RPG is set in Sengoku Japan starring William Adams?",
+      "ja": "コーエーテクモ製、戦国時代を舞台にウィリアムが戦うアクションRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Judgment",
+        "ja": "ジャッジアイズ",
+        "ja_typings": [
+          "jajjiaizu"
+        ]
+      },
+      {
+        "en": "Nioh",
+        "ja": "仁王",
+        "ja_typings": [
+          "nioh"
+        ]
+      },
+      {
+        "en": "Onimusha",
+        "ja": "鬼武者",
+        "ja_typings": [
+          "onimusha"
+        ]
+      },
+      {
+        "en": "Shenmue",
+        "ja": "シェンムー",
+        "ja_typings": [
+          "shenmu-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01875",
+    "image_path": null,
+    "question_text": {
+      "en": "Which RGG Studio spin-off stars lawyer-turned-detective Takayuki Yagami?",
+      "ja": "龍が如くスタジオのスピンオフで、八神隆之が主人公の作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mega Drive",
+        "ja": "メガドライブ",
+        "ja_typings": [
+          "megadoraibu"
+        ]
+      },
+      {
+        "en": "Game Gear",
+        "ja": "ゲームギア",
+        "ja_typings": [
+          "ge-mugia"
+        ]
+      },
+      {
+        "en": "Sega Saturn",
+        "ja": "セガサターン",
+        "ja_typings": [
+          "segasata-n"
+        ]
+      },
+      {
+        "en": "PC Engine GT",
+        "ja": "PCエンジンGT",
+        "ja_typings": [
+          "pcenjingt"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01876",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Sega 16-bit home console competed with the Super Famicom in the early 1990s?",
+      "ja": "1990年代初頭にスーパーファミコンと競合したセガの16ビット家庭用機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Game Gear",
+        "ja": "ゲームギア",
+        "ja_typings": [
+          "ge-mugia"
+        ]
+      },
+      {
+        "en": "Mega Drive",
+        "ja": "メガドライブ",
+        "ja_typings": [
+          "megadoraibu"
+        ]
+      },
+      {
+        "en": "Sega Saturn",
+        "ja": "セガサターン",
+        "ja_typings": [
+          "segasata-n"
+        ]
+      },
+      {
+        "en": "PC Engine GT",
+        "ja": "PCエンジンGT",
+        "ja_typings": [
+          "pcenjingt"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01877",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Sega handheld competed with the Game Boy?",
+      "ja": "ゲームボーイと競合したセガの携帯ゲーム機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Parasite Eve",
+        "ja": "パラサイト・イヴ",
+        "ja_typings": [
+          "parasaito/ivu"
+        ]
+      },
+      {
+        "en": "Chrono Trigger",
+        "ja": "クロノ・トリガー",
+        "ja_typings": [
+          "kurono/toriga-"
+        ]
+      },
+      {
+        "en": "Onimusha",
+        "ja": "鬼武者",
+        "ja_typings": [
+          "onimusha"
+        ]
+      },
+      {
+        "en": "Soul Blazer",
+        "ja": "ソウルブレイダー",
+        "ja_typings": [
+          "sorubureida-",
+          "sourubureida-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01878",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Square horror RPG is set in NYC starring Aya Brea?",
+      "ja": "ニューヨークを舞台にアヤ・ブレアが活躍するスクウェアのホラーRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Xenoblade",
+        "ja": "ゼノブレイド",
+        "ja_typings": [
+          "zenobureido"
+        ]
+      },
+      {
+        "en": "Chrono Trigger",
+        "ja": "クロノ・トリガー",
+        "ja_typings": [
+          "kurono/toriga-"
+        ]
+      },
+      {
+        "en": "Seiken Densetsu",
+        "ja": "聖剣伝説",
+        "ja_typings": [
+          "seikendensetsu"
+        ]
+      },
+      {
+        "en": "SaGa Frontier",
+        "ja": "サガ・フロンティア",
+        "ja_typings": [
+          "saga/furontia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01879",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Monolith Soft JRPG series features giant Titans and the Monado?",
+      "ja": "モノリスソフトの巨神とモナドが登場するJRPGシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bayonetta",
+        "ja": "ベヨネッタ",
+        "ja_typings": [
+          "beyonetta"
+        ]
+      },
+      {
+        "en": "Devil May Cry",
+        "ja": "デビルメイクライ",
+        "ja_typings": [
+          "debirumeikurai"
+        ]
+      },
+      {
+        "en": "Nioh",
+        "ja": "仁王",
+        "ja_typings": [
+          "nioh"
+        ]
+      },
+      {
+        "en": "Onimusha",
+        "ja": "鬼武者",
+        "ja_typings": [
+          "onimusha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01880",
+    "image_path": null,
+    "question_text": {
+      "en": "Which PlatinumGames action title stars a witch named Cereza?",
+      "ja": "プラチナゲームズ製、魔女セレッサが主人公のアクションは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Devil May Cry",
+        "ja": "デビルメイクライ",
+        "ja_typings": [
+          "debirumeikurai"
+        ]
+      },
+      {
+        "en": "Bayonetta",
+        "ja": "ベヨネッタ",
+        "ja_typings": [
+          "beyonetta"
+        ]
+      },
+      {
+        "en": "Onimusha",
+        "ja": "鬼武者",
+        "ja_typings": [
+          "onimusha"
+        ]
+      },
+      {
+        "en": "Dark Souls",
+        "ja": "ダークソウル",
+        "ja_typings": [
+          "da-kusoru",
+          "da-kusouru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01881",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Capcom action series stars demon hunter Dante?",
+      "ja": "カプコン製、悪魔狩人ダンテが主人公のアクションシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Paladins",
+        "ja": "パラディンズ",
+        "ja_typings": [
+          "paradinzu"
+        ]
+      },
+      {
+        "en": "PUBG",
+        "ja": "ピーユービージー",
+        "ja_typings": [
+          "pi-yu-bi-ji-"
+        ]
+      },
+      {
+        "en": "Warzone",
+        "ja": "ウォーゾーン",
+        "ja_typings": [
+          "wo-zo-n"
+        ]
+      },
+      {
+        "en": "Roblox",
+        "ja": "ロブロックス",
+        "ja_typings": [
+          "roburokkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01882",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hi-Rez Studios free-to-play hero shooter features Champions?",
+      "ja": "Hi-Rez Studios 製、チャンピオンが戦う基本無料ヒーローシューターは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mass Effect",
+        "ja": "マスエフェクト",
+        "ja_typings": [
+          "masuefekuto"
+        ]
+      },
+      {
+        "en": "Dragon Age",
+        "ja": "ドラゴンエイジ",
+        "ja_typings": [
+          "doragonneiji"
+        ]
+      },
+      {
+        "en": "Dark Souls",
+        "ja": "ダークソウル",
+        "ja_typings": [
+          "da-kusoru",
+          "da-kusouru"
+        ]
+      },
+      {
+        "en": "Watch Dogs",
+        "ja": "ウォッチドッグス",
+        "ja_typings": [
+          "wotchidoggusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01883",
+    "image_path": null,
+    "question_text": {
+      "en": "Which BioWare sci-fi RPG series stars Commander Shepard?",
+      "ja": "BioWare 製、シェパード司令官が主人公のSF RPGシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dark Souls",
+        "ja": "ダークソウル",
+        "ja_typings": [
+          "da-kusoru",
+          "da-kusouru"
+        ]
+      },
+      {
+        "en": "Nioh",
+        "ja": "仁王",
+        "ja_typings": [
+          "nioh"
+        ]
+      },
+      {
+        "en": "Onimusha",
+        "ja": "鬼武者",
+        "ja_typings": [
+          "onimusha"
+        ]
+      },
+      {
+        "en": "Dragon Age",
+        "ja": "ドラゴンエイジ",
+        "ja_typings": [
+          "doragonneiji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01884",
+    "image_path": null,
+    "question_text": {
+      "en": "Which FromSoftware action RPG series began with Lordran in 2011?",
+      "ja": "2011年にロードランから始まったフロム・ソフトウェアのアクションRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Onimusha",
+        "ja": "鬼武者",
+        "ja_typings": [
+          "onimusha"
+        ]
+      },
+      {
+        "en": "Nioh",
+        "ja": "仁王",
+        "ja_typings": [
+          "nioh"
+        ]
+      },
+      {
+        "en": "Way of the Samurai",
+        "ja": "侍道",
+        "ja_typings": [
+          "samuraidou"
+        ]
+      },
+      {
+        "en": "Bayonetta",
+        "ja": "ベヨネッタ",
+        "ja_typings": [
+          "beyonetta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01885",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Capcom action series is set in Sengoku-era Japan with samurai vs demons?",
+      "ja": "カプコン製、戦国時代を舞台に侍が鬼と戦うアクションシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Way of the Samurai",
+        "ja": "侍道",
+        "ja_typings": [
+          "samuraidou"
+        ]
+      },
+      {
+        "en": "Onimusha",
+        "ja": "鬼武者",
+        "ja_typings": [
+          "onimusha"
+        ]
+      },
+      {
+        "en": "Nioh",
+        "ja": "仁王",
+        "ja_typings": [
+          "nioh"
+        ]
+      },
+      {
+        "en": "Judgment",
+        "ja": "ジャッジアイズ",
+        "ja_typings": [
+          "jajjiaizu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01886",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Acquire-developed series lets you live as a wandering samurai?",
+      "ja": "アクワイア開発、流浪の侍として生きるシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Asteroids",
+        "ja": "アステロイド",
+        "ja_typings": [
+          "asuteroido"
+        ]
+      },
+      {
+        "en": "Contra",
+        "ja": "魂斗羅",
+        "ja_typings": [
+          "kontora"
+        ]
+      },
+      {
+        "en": "TwinBee",
+        "ja": "ツインビー",
+        "ja_typings": [
+          "tsuinbi-"
+        ]
+      },
+      {
+        "en": "Power Drift",
+        "ja": "パワードリフト",
+        "ja_typings": [
+          "pawa-dorifuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01887",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1979 Atari arcade game lets you shoot rocks drifting in space?",
+      "ja": "1979年アタリ製、宇宙の岩を撃つアーケードゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shenmue",
+        "ja": "シェンムー",
+        "ja_typings": [
+          "shenmu-"
+        ]
+      },
+      {
+        "en": "Virtua Fighter",
+        "ja": "バーチャファイター",
+        "ja_typings": [
+          "ba-chafaita-"
+        ]
+      },
+      {
+        "en": "Power Drift",
+        "ja": "パワードリフト",
+        "ja_typings": [
+          "pawa-dorifuto"
+        ]
+      },
+      {
+        "en": "Way of the Samurai",
+        "ja": "侍道",
+        "ja_typings": [
+          "samuraidou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01888",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Sega Yu Suzuki series stars Ryo Hazuki searching for his father's killer?",
+      "ja": "鈴木裕監修、芭月涼が父の仇を追うセガの大作シリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Real-time strategy",
+        "ja": "リアルタイムストラテジー",
+        "ja_typings": [
+          "riarutaimusutorateji-"
+        ]
+      },
+      {
+        "en": "Roblox",
+        "ja": "ロブロックス",
+        "ja_typings": [
+          "roburokkusu"
+        ]
+      },
+      {
+        "en": "Paladins",
+        "ja": "パラディンズ",
+        "ja_typings": [
+          "paradinzu"
+        ]
+      },
+      {
+        "en": "Asteroids",
+        "ja": "アステロイド",
+        "ja_typings": [
+          "asuteroido"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01889",
+    "image_path": null,
+    "question_text": {
+      "en": "Which game genre is exemplified by StarCraft and Age of Empires?",
+      "ja": "『スタークラフト』『エイジ・オブ・エンパイア』に代表されるジャンルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Power Drift",
+        "ja": "パワードリフト",
+        "ja_typings": [
+          "pawa-dorifuto"
+        ]
+      },
+      {
+        "en": "Virtua Fighter",
+        "ja": "バーチャファイター",
+        "ja_typings": [
+          "ba-chafaita-"
+        ]
+      },
+      {
+        "en": "Shenmue",
+        "ja": "シェンムー",
+        "ja_typings": [
+          "shenmu-"
+        ]
+      },
+      {
+        "en": "TwinBee",
+        "ja": "ツインビー",
+        "ja_typings": [
+          "tsuinbi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01890",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1988 Sega arcade racing game features tilting cockpit cabinets?",
+      "ja": "1988年セガのアーケードレース、可動筐体が特徴の作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Contra",
+        "ja": "魂斗羅",
+        "ja_typings": [
+          "kontora"
+        ]
+      },
+      {
+        "en": "TwinBee",
+        "ja": "ツインビー",
+        "ja_typings": [
+          "tsuinbi-"
+        ]
+      },
+      {
+        "en": "Asteroids",
+        "ja": "アステロイド",
+        "ja_typings": [
+          "asuteroido"
+        ]
+      },
+      {
+        "en": "Power Drift",
+        "ja": "パワードリフト",
+        "ja_typings": [
+          "pawa-dorifuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01891",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Konami run-and-gun series began in 1987 with two commandos?",
+      "ja": "1987年に始まったコナミの2人コマンドのラン&ガンシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "TwinBee",
+        "ja": "ツインビー",
+        "ja_typings": [
+          "tsuinbi-"
+        ]
+      },
+      {
+        "en": "Contra",
+        "ja": "魂斗羅",
+        "ja_typings": [
+          "kontora"
+        ]
+      },
+      {
+        "en": "Asteroids",
+        "ja": "アステロイド",
+        "ja_typings": [
+          "asuteroido"
+        ]
+      },
+      {
+        "en": "Power Drift",
+        "ja": "パワードリフト",
+        "ja_typings": [
+          "pawa-dorifuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01892",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Konami cute-em-up features a bell-shooting flying ship?",
+      "ja": "コナミ製、鈴を撃つ可愛い縦シューティングは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Soul Blazer",
+        "ja": "ソウルブレイダー",
+        "ja_typings": [
+          "sorubureida-",
+          "sourubureida-"
+        ]
+      },
+      {
+        "en": "Parasite Eve",
+        "ja": "パラサイト・イヴ",
+        "ja_typings": [
+          "parasaito/ivu"
+        ]
+      },
+      {
+        "en": "Chrono Trigger",
+        "ja": "クロノ・トリガー",
+        "ja_typings": [
+          "kurono/toriga-"
+        ]
+      },
+      {
+        "en": "Xenoblade",
+        "ja": "ゼノブレイド",
+        "ja_typings": [
+          "zenobureido"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01893",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Enix Super Famicom action RPG by Quintet has you reviving the world?",
+      "ja": "クインテット製スーファミの、世界を蘇らせるエニックスのアクションRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Last Blade",
+        "ja": "ラストブレイド",
+        "ja_typings": [
+          "rasutobureido"
+        ]
+      },
+      {
+        "en": "Virtua Fighter",
+        "ja": "バーチャファイター",
+        "ja_typings": [
+          "ba-chafaita-"
+        ]
+      },
+      {
+        "en": "Devil May Cry",
+        "ja": "デビルメイクライ",
+        "ja_typings": [
+          "debirumeikurai"
+        ]
+      },
+      {
+        "en": "Bayonetta",
+        "ja": "ベヨネッタ",
+        "ja_typings": [
+          "beyonetta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01894",
+    "image_path": null,
+    "question_text": {
+      "en": "Which SNK weapon-based fighting game series spun off from Samurai Shodown?",
+      "ja": "『サムライスピリッツ』から派生した武器対戦格闘ゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PC Engine GT",
+        "ja": "PCエンジンGT",
+        "ja_typings": [
+          "pcenjingt"
+        ]
+      },
+      {
+        "en": "Game Gear",
+        "ja": "ゲームギア",
+        "ja_typings": [
+          "ge-mugia"
+        ]
+      },
+      {
+        "en": "Mega Drive",
+        "ja": "メガドライブ",
+        "ja_typings": [
+          "megadoraibu"
+        ]
+      },
+      {
+        "en": "Sega Saturn",
+        "ja": "セガサターン",
+        "ja_typings": [
+          "segasata-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01895",
+    "image_path": null,
+    "question_text": {
+      "en": "Which NEC handheld is a portable PC Engine with a color LCD?",
+      "ja": "PCエンジン互換のNEC製カラー液晶携帯機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Metroid",
+        "ja": "メトロイド",
+        "ja_typings": [
+          "metoroido"
+        ]
+      },
+      {
+        "en": "Kirby",
+        "ja": "カービィ",
+        "ja_typings": [
+          "ka-bii"
+        ]
+      },
+      {
+        "en": "Fire Emblem",
+        "ja": "ファイアーエムブレム",
+        "ja_typings": [
+          "faia-emuburemu"
+        ]
+      },
+      {
+        "en": "Digimon",
+        "ja": "デジモン",
+        "ja_typings": [
+          "dejimon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01896",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nintendo series stars bounty hunter Samus Aran?",
+      "ja": "サムス・アランが活躍する任天堂のシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kirby",
+        "ja": "カービィ",
+        "ja_typings": [
+          "ka-bii"
+        ]
+      },
+      {
+        "en": "Metroid",
+        "ja": "メトロイド",
+        "ja_typings": [
+          "metoroido"
+        ]
+      },
+      {
+        "en": "Fire Emblem",
+        "ja": "ファイアーエムブレム",
+        "ja_typings": [
+          "faia-emuburemu"
+        ]
+      },
+      {
+        "en": "Yo-kai Watch",
+        "ja": "妖怪ウォッチ",
+        "ja_typings": [
+          "youkaiuocchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01897",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HAL Laboratory Nintendo series stars a pink puffball hero?",
+      "ja": "HAL研究所製、ピンクの丸い主人公が活躍する任天堂のシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fire Emblem",
+        "ja": "ファイアーエムブレム",
+        "ja_typings": [
+          "faia-emuburemu"
+        ]
+      },
+      {
+        "en": "Metroid",
+        "ja": "メトロイド",
+        "ja_typings": [
+          "metoroido"
+        ]
+      },
+      {
+        "en": "Kirby",
+        "ja": "カービィ",
+        "ja_typings": [
+          "ka-bii"
+        ]
+      },
+      {
+        "en": "Yo-kai Watch",
+        "ja": "妖怪ウォッチ",
+        "ja_typings": [
+          "youkaiuocchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01898",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Intelligent Systems tactical RPG series began on the Famicom?",
+      "ja": "ファミコンで始まったインテリジェントシステムズのSRPGシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Digimon",
+        "ja": "デジモン",
+        "ja_typings": [
+          "dejimon"
+        ]
+      },
+      {
+        "en": "Yo-kai Watch",
+        "ja": "妖怪ウォッチ",
+        "ja_typings": [
+          "youkaiuocchi"
+        ]
+      },
+      {
+        "en": "Fire Emblem",
+        "ja": "ファイアーエムブレム",
+        "ja_typings": [
+          "faia-emuburemu"
+        ]
+      },
+      {
+        "en": "Kirby",
+        "ja": "カービィ",
+        "ja_typings": [
+          "ka-bii"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01899",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Bandai franchise features creatures hatched from Digivices?",
+      "ja": "デジヴァイスから生まれる生物のバンダイ製シリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yo-kai Watch",
+        "ja": "妖怪ウォッチ",
+        "ja_typings": [
+          "youkaiuocchi"
+        ]
+      },
+      {
+        "en": "Digimon",
+        "ja": "デジモン",
+        "ja_typings": [
+          "dejimon"
+        ]
+      },
+      {
+        "en": "Fire Emblem",
+        "ja": "ファイアーエムブレム",
+        "ja_typings": [
+          "faia-emuburemu"
+        ]
+      },
+      {
+        "en": "Dragon Quest Builders",
+        "ja": "ドラゴンクエストビルダーズ",
+        "ja_typings": [
+          "doragonkuesutobiruda-zu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01900",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Level-5 RPG series features Keita Amano befriending youkai with a watch?",
+      "ja": "レベルファイブ製、ケータくんが時計で妖怪と友達になるシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Final Fantasy X",
+        "ja": "ファイナルファンタジーX",
+        "ja_typings": [
+          "fainarufantaji-x"
+        ]
+      },
+      {
+        "en": "Chrono Trigger",
+        "ja": "クロノ・トリガー",
+        "ja_typings": [
+          "kurono/toriga-"
+        ]
+      },
+      {
+        "en": "Xenoblade",
+        "ja": "ゼノブレイド",
+        "ja_typings": [
+          "zenobureido"
+        ]
+      },
+      {
+        "en": "SaGa Frontier",
+        "ja": "サガ・フロンティア",
+        "ja_typings": [
+          "saga/furontia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01901",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2001 PS2 JRPG features Tidus and the world of Spira?",
+      "ja": "2001年のPS2 JRPGで、ティーダとスピラの世界を描く作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Seiken Densetsu",
+        "ja": "聖剣伝説",
+        "ja_typings": [
+          "seikendensetsu"
+        ]
+      },
+      {
+        "en": "Chrono Trigger",
+        "ja": "クロノ・トリガー",
+        "ja_typings": [
+          "kurono/toriga-"
+        ]
+      },
+      {
+        "en": "SaGa Frontier",
+        "ja": "サガ・フロンティア",
+        "ja_typings": [
+          "saga/furontia"
+        ]
+      },
+      {
+        "en": "Final Fantasy X",
+        "ja": "ファイナルファンタジーX",
+        "ja_typings": [
+          "fainarufantaji-x"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01902",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Square action RPG series began in 1991 as a Final Fantasy spin-off?",
+      "ja": "1991年にFFスピンオフとして始まったスクウェアのアクションRPGシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tales of Series",
+        "ja": "テイルズ オブ シリーズ",
+        "ja_typings": [
+          "teiruzu obu shiri-zu"
+        ]
+      },
+      {
+        "en": "Seiken Densetsu",
+        "ja": "聖剣伝説",
+        "ja_typings": [
+          "seikendensetsu"
+        ]
+      },
+      {
+        "en": "SaGa Frontier",
+        "ja": "サガ・フロンティア",
+        "ja_typings": [
+          "saga/furontia"
+        ]
+      },
+      {
+        "en": "Final Fantasy X",
+        "ja": "ファイナルファンタジーX",
+        "ja_typings": [
+          "fainarufantaji-x"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01903",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Bandai Namco JRPG franchise includes Symphonia and Vesperia?",
+      "ja": "『シンフォニア』『ヴェスペリア』を含むバンダイナムコのJRPGシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SaGa Frontier",
+        "ja": "サガ・フロンティア",
+        "ja_typings": [
+          "saga/furontia"
+        ]
+      },
+      {
+        "en": "Chrono Trigger",
+        "ja": "クロノ・トリガー",
+        "ja_typings": [
+          "kurono/toriga-"
+        ]
+      },
+      {
+        "en": "Seiken Densetsu",
+        "ja": "聖剣伝説",
+        "ja_typings": [
+          "seikendensetsu"
+        ]
+      },
+      {
+        "en": "Final Fantasy X",
+        "ja": "ファイナルファンタジーX",
+        "ja_typings": [
+          "fainarufantaji-x"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01904",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1997 PS1 Square RPG features seven scenarios across Regions?",
+      "ja": "1997年PS1スクウェア製、7つのシナリオを行き来するRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Roblox",
+        "ja": "ロブロックス",
+        "ja_typings": [
+          "roburokkusu"
+        ]
+      },
+      {
+        "en": "PUBG",
+        "ja": "ピーユービージー",
+        "ja_typings": [
+          "pi-yu-bi-ji-"
+        ]
+      },
+      {
+        "en": "Warzone",
+        "ja": "ウォーゾーン",
+        "ja_typings": [
+          "wo-zo-n"
+        ]
+      },
+      {
+        "en": "Paladins",
+        "ja": "パラディンズ",
+        "ja_typings": [
+          "paradinzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01905",
+    "image_path": null,
+    "question_text": {
+      "en": "Which user-generated online platform lets kids create and play 3D worlds?",
+      "ja": "ユーザー作成の3D世界を遊ぶオンラインプラットフォームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dragon Quest Builders",
+        "ja": "ドラゴンクエストビルダーズ",
+        "ja_typings": [
+          "doragonkuesutobiruda-zu"
+        ]
+      },
+      {
+        "en": "Yo-kai Watch",
+        "ja": "妖怪ウォッチ",
+        "ja_typings": [
+          "youkaiuocchi"
+        ]
+      },
+      {
+        "en": "Digimon",
+        "ja": "デジモン",
+        "ja_typings": [
+          "dejimon"
+        ]
+      },
+      {
+        "en": "Saints Row",
+        "ja": "セインツロウ",
+        "ja_typings": [
+          "seintsuro",
+          "seintsurou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01906",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Square Enix Minecraft-like spin-off stars a hero who builds with blocks?",
+      "ja": "スクエニ製、ブロックを積んで世界を作るマイクラ風スピンオフは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Saints Row",
+        "ja": "セインツロウ",
+        "ja_typings": [
+          "seintsuro",
+          "seintsurou"
+        ]
+      },
+      {
+        "en": "Watch Dogs",
+        "ja": "ウォッチドッグス",
+        "ja_typings": [
+          "wotchidoggusu"
+        ]
+      },
+      {
+        "en": "Mafia",
+        "ja": "マフィア",
+        "ja_typings": [
+          "mafia"
+        ]
+      },
+      {
+        "en": "Dragon Quest Builders",
+        "ja": "ドラゴンクエストビルダーズ",
+        "ja_typings": [
+          "doragonkuesutobiruda-zu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01907",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Volition open-world series follows the 3rd Street Saints gang?",
+      "ja": "Volition 製、3rdストリートセインツのギャングを描くオープンワールドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Watch Dogs",
+        "ja": "ウォッチドッグス",
+        "ja_typings": [
+          "wotchidoggusu"
+        ]
+      },
+      {
+        "en": "Saints Row",
+        "ja": "セインツロウ",
+        "ja_typings": [
+          "seintsuro",
+          "seintsurou"
+        ]
+      },
+      {
+        "en": "Mafia",
+        "ja": "マフィア",
+        "ja_typings": [
+          "mafia"
+        ]
+      },
+      {
+        "en": "Roblox",
+        "ja": "ロブロックス",
+        "ja_typings": [
+          "roburokkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01908",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Ubisoft open-world hacker series began in 2014?",
+      "ja": "2014年に始まったユービーアイのハッカー系オープンワールドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mafia",
+        "ja": "マフィア",
+        "ja_typings": [
+          "mafia"
+        ]
+      },
+      {
+        "en": "Watch Dogs",
+        "ja": "ウォッチドッグス",
+        "ja_typings": [
+          "wotchidoggusu"
+        ]
+      },
+      {
+        "en": "Saints Row",
+        "ja": "セインツロウ",
+        "ja_typings": [
+          "seintsuro",
+          "seintsurou"
+        ]
+      },
+      {
+        "en": "Warzone",
+        "ja": "ウォーゾーン",
+        "ja_typings": [
+          "wo-zo-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01909",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2K open-world series began with Tommy Angelo in 1930s Lost Heaven?",
+      "ja": "1930年代ロスト・ヘブンのトミー・アンジェロが主人公の2Kオープンワールドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PUBG",
+        "ja": "ピーユービージー",
+        "ja_typings": [
+          "pi-yu-bi-ji-"
+        ]
+      },
+      {
+        "en": "Warzone",
+        "ja": "ウォーゾーン",
+        "ja_typings": [
+          "wo-zo-n"
+        ]
+      },
+      {
+        "en": "Roblox",
+        "ja": "ロブロックス",
+        "ja_typings": [
+          "roburokkusu"
+        ]
+      },
+      {
+        "en": "Paladins",
+        "ja": "パラディンズ",
+        "ja_typings": [
+          "paradinzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01910",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2017 Krafton battle royale popularized the genre on PC?",
+      "ja": "2017年クラフトン製でバトロワを大流行させたPCゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Warzone",
+        "ja": "ウォーゾーン",
+        "ja_typings": [
+          "wo-zo-n"
+        ]
+      },
+      {
+        "en": "PUBG",
+        "ja": "ピーユービージー",
+        "ja_typings": [
+          "pi-yu-bi-ji-"
+        ]
+      },
+      {
+        "en": "Paladins",
+        "ja": "パラディンズ",
+        "ja_typings": [
+          "paradinzu"
+        ]
+      },
+      {
+        "en": "Roblox",
+        "ja": "ロブロックス",
+        "ja_typings": [
+          "roburokkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01911",
+    "image_path": null,
+    "question_text": {
+      "en": "Which free-to-play battle royale is part of the Call of Duty franchise?",
+      "ja": "CoD シリーズの基本無料バトロワは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Super Famicom",
+        "ja": "スーパーファミコン",
+        "ja_typings": [
+          "su-pa-famikon"
+        ]
+      },
+      {
+        "en": "Game Boy",
+        "ja": "ゲームボーイ",
+        "ja_typings": [
+          "ge-mubo-i"
+        ]
+      },
+      {
+        "en": "Nintendo 64",
+        "ja": "ニンテンドー64",
+        "ja_typings": [
+          "nintendo-64"
+        ]
+      },
+      {
+        "en": "Switch",
+        "ja": "スイッチ",
+        "ja_typings": [
+          "suitchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01912",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1990 Nintendo 16-bit console succeeded the Famicom in Japan?",
+      "ja": "ファミコンの後継として1990年に発売された任天堂の16ビット機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Game Boy",
+        "ja": "ゲームボーイ",
+        "ja_typings": [
+          "ge-mubo-i"
+        ]
+      },
+      {
+        "en": "Super Famicom",
+        "ja": "スーパーファミコン",
+        "ja_typings": [
+          "su-pa-famikon"
+        ]
+      },
+      {
+        "en": "Nintendo 64",
+        "ja": "ニンテンドー64",
+        "ja_typings": [
+          "nintendo-64"
+        ]
+      },
+      {
+        "en": "Switch",
+        "ja": "スイッチ",
+        "ja_typings": [
+          "suitchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01913",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1989 Nintendo handheld popularized portable gaming with Tetris?",
+      "ja": "1989年テトリスで携帯ゲームを普及させた任天堂の携帯機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nintendo 64",
+        "ja": "ニンテンドー64",
+        "ja_typings": [
+          "nintendo-64"
+        ]
+      },
+      {
+        "en": "Super Famicom",
+        "ja": "スーパーファミコン",
+        "ja_typings": [
+          "su-pa-famikon"
+        ]
+      },
+      {
+        "en": "Game Boy",
+        "ja": "ゲームボーイ",
+        "ja_typings": [
+          "ge-mubo-i"
+        ]
+      },
+      {
+        "en": "Sega Saturn",
+        "ja": "セガサターン",
+        "ja_typings": [
+          "segasata-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01914",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1996 Nintendo 64-bit console launched with Super Mario 64?",
+      "ja": "1996年スーパーマリオ64と共に発売された任天堂の64ビット機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sega Saturn",
+        "ja": "セガサターン",
+        "ja_typings": [
+          "segasata-n"
+        ]
+      },
+      {
+        "en": "Mega Drive",
+        "ja": "メガドライブ",
+        "ja_typings": [
+          "megadoraibu"
+        ]
+      },
+      {
+        "en": "PC Engine GT",
+        "ja": "PCエンジンGT",
+        "ja_typings": [
+          "pcenjingt"
+        ]
+      },
+      {
+        "en": "Nintendo 64",
+        "ja": "ニンテンドー64",
+        "ja_typings": [
+          "nintendo-64"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01915",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1994 Sega 32-bit console competed with the PlayStation in Japan?",
+      "ja": "1994年プレイステーションと競った32ビットのセガ家庭用機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Switch",
+        "ja": "スイッチ",
+        "ja_typings": [
+          "suitchi"
+        ]
+      },
+      {
+        "en": "Nintendo 64",
+        "ja": "ニンテンドー64",
+        "ja_typings": [
+          "nintendo-64"
+        ]
+      },
+      {
+        "en": "Game Boy",
+        "ja": "ゲームボーイ",
+        "ja_typings": [
+          "ge-mubo-i"
+        ]
+      },
+      {
+        "en": "Super Famicom",
+        "ja": "スーパーファミコン",
+        "ja_typings": [
+          "su-pa-famikon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q01916",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2017 Nintendo hybrid console plays both docked and handheld?",
+      "ja": "2017年発売、据置と携帯を両立する任天堂のハイブリッド機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Inheritance",
+        "ja": "継承",
+        "ja_typings": [
+          "keishou"
+        ]
+      },
+      {
+        "en": "Encapsulation",
+        "ja": "カプセル化",
+        "ja_typings": [
+          "kapuseruka"
+        ]
+      },
+      {
+        "en": "Polymorphism",
+        "ja": "ポリモーフィズム",
+        "ja_typings": [
+          "porimo-fizumu"
+        ]
+      },
+      {
+        "en": "Abstraction",
+        "ja": "抽象化",
+        "ja_typings": [
+          "chuushouka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01917",
+    "image_path": null,
+    "question_text": {
+      "en": "Which OOP concept allows a class to acquire properties from another class?",
+      "ja": "あるクラスが別のクラスのプロパティを受け継ぐオブジェクト指向の概念は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "XML",
+        "ja": "エックスエムエル",
+        "ja_typings": [
+          "ekkusuemueru"
+        ]
+      },
+      {
+        "en": "YAML",
+        "ja": "ヤムル",
+        "ja_typings": [
+          "yamuru"
+        ]
+      },
+      {
+        "en": "TOML",
+        "ja": "トムル",
+        "ja_typings": [
+          "tomuru"
+        ]
+      },
+      {
+        "en": "INI",
+        "ja": "アイエヌアイ",
+        "ja_typings": [
+          "aienuai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01918",
+    "image_path": null,
+    "question_text": {
+      "en": "Which markup language uses customizable tags to describe structured data?",
+      "ja": "ユーザー定義タグで構造化データを記述するマークアップ言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "B-tree",
+        "ja": "ビーツリー",
+        "ja_typings": [
+          "bi-tsuri-"
+        ]
+      },
+      {
+        "en": "Trie",
+        "ja": "トライ木",
+        "ja_typings": [
+          "toraiki",
+          "toraigi"
+        ]
+      },
+      {
+        "en": "Heap",
+        "ja": "ヒープ",
+        "ja_typings": [
+          "hi-pu"
+        ]
+      },
+      {
+        "en": "Splay tree",
+        "ja": "スプレー木",
+        "ja_typings": [
+          "supureeki",
+          "supureegi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01919",
+    "image_path": null,
+    "question_text": {
+      "en": "Which self-balancing tree is widely used in databases and filesystems?",
+      "ja": "データベースやファイルシステムで広く使われる自己平衡木は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cell",
+        "ja": "セル",
+        "ja_typings": [
+          "seru"
+        ]
+      },
+      {
+        "en": "Sheet",
+        "ja": "シート",
+        "ja_typings": [
+          "shi-to"
+        ]
+      },
+      {
+        "en": "Range",
+        "ja": "レンジ",
+        "ja_typings": [
+          "renji"
+        ]
+      },
+      {
+        "en": "Pivot",
+        "ja": "ピボット",
+        "ja_typings": [
+          "pibotto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01920",
+    "image_path": null,
+    "question_text": {
+      "en": "Which spreadsheet term refers to a single unit at the intersection of a row and column?",
+      "ja": "表計算で行と列の交点にある一つの枠を指す用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Scala",
+        "ja": "スカラ",
+        "ja_typings": [
+          "sukara"
+        ]
+      },
+      {
+        "en": "Clojure",
+        "ja": "クロージャ言語",
+        "ja_typings": [
+          "kuroojagengo"
+        ]
+      },
+      {
+        "en": "Kotlin",
+        "ja": "コトリン",
+        "ja_typings": [
+          "kotorin"
+        ]
+      },
+      {
+        "en": "Ceylon",
+        "ja": "セイロン",
+        "ja_typings": [
+          "seiron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01921",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JVM language has functional features and is used at Twitter?",
+      "ja": "JVM 上で動く関数型機能を持つ言語で Twitter でも使われていたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`sub`",
+        "ja": "`sub`",
+        "ja_typings": [
+          "`sub`"
+        ]
+      },
+      {
+        "en": "`def`",
+        "ja": "`def`",
+        "ja_typings": [
+          "`def`"
+        ]
+      },
+      {
+        "en": "`fn`",
+        "ja": "`fn`",
+        "ja_typings": [
+          "`fn`"
+        ]
+      },
+      {
+        "en": "`func`",
+        "ja": "`func`",
+        "ja_typings": [
+          "`func`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01922",
+    "image_path": null,
+    "question_text": {
+      "en": "In Perl, which keyword defines a subroutine?",
+      "ja": "Perl でサブルーチンを定義するキーワードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ken Thompson",
+        "ja": "ケン・トンプソン",
+        "ja_typings": [
+          "ken/tonpuson"
+        ]
+      },
+      {
+        "en": "Brian Kernighan",
+        "ja": "ブライアン・カーニハン",
+        "ja_typings": [
+          "buraian/ka-nihan"
+        ]
+      },
+      {
+        "en": "Bjarne Stroustrup",
+        "ja": "ビャーネ・ストロヴストルップ",
+        "ja_typings": [
+          "bya-ne/sutorovusutoruppu"
+        ]
+      },
+      {
+        "en": "Guido van Rossum",
+        "ja": "グイド・ヴァン・ロッサム",
+        "ja_typings": [
+          "guido/van/rossamu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01923",
+    "image_path": null,
+    "question_text": {
+      "en": "Who co-created Unix and the B programming language at Bell Labs?",
+      "ja": "ベル研で Unix と B 言語を共同開発した人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Apple",
+        "ja": "アップル",
+        "ja_typings": [
+          "appuru"
+        ]
+      },
+      {
+        "en": "Microsoft",
+        "ja": "マイクロソフト",
+        "ja_typings": [
+          "maikurosofuto"
+        ]
+      },
+      {
+        "en": "Mozilla",
+        "ja": "モジラ",
+        "ja_typings": [
+          "mojira"
+        ]
+      },
+      {
+        "en": "JetBrains",
+        "ja": "ジェットブレインズ",
+        "ja_typings": [
+          "jettobureinzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01924",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company created the Swift programming language?",
+      "ja": "プログラミング言語 Swift を開発した企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Delegation",
+        "ja": "委譲",
+        "ja_typings": [
+          "ijou"
+        ]
+      },
+      {
+        "en": "Inheritance",
+        "ja": "継承",
+        "ja_typings": [
+          "keishou"
+        ]
+      },
+      {
+        "en": "Composition",
+        "ja": "コンポジション",
+        "ja_typings": [
+          "konpojishon"
+        ]
+      },
+      {
+        "en": "Aggregation",
+        "ja": "集約",
+        "ja_typings": [
+          "shuuyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01925",
+    "image_path": null,
+    "question_text": {
+      "en": "Which design principle forwards a request from one object to another helper object?",
+      "ja": "あるオブジェクトが処理を別のヘルパーオブジェクトに転送する設計原則は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "npm",
+        "ja": "エヌピーエム",
+        "ja_typings": [
+          "enupi-emu"
+        ]
+      },
+      {
+        "en": "yarn",
+        "ja": "ヤーン",
+        "ja_typings": [
+          "ya-n"
+        ]
+      },
+      {
+        "en": "pnpm",
+        "ja": "ピーエヌピーエム",
+        "ja_typings": [
+          "pi-enupi-emu"
+        ]
+      },
+      {
+        "en": "bun",
+        "ja": "バン",
+        "ja_typings": [
+          "ban"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01926",
+    "image_path": null,
+    "question_text": {
+      "en": "Which package manager is bundled with Node.js by default?",
+      "ja": "Node.js に既定で同梱されるパッケージマネージャは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gradle",
+        "ja": "グレードル",
+        "ja_typings": [
+          "gure-doru"
+        ]
+      },
+      {
+        "en": "Maven",
+        "ja": "メイヴン",
+        "ja_typings": [
+          "meivun"
+        ]
+      },
+      {
+        "en": "Ant",
+        "ja": "アント",
+        "ja_typings": [
+          "anto"
+        ]
+      },
+      {
+        "en": "Bazel",
+        "ja": "バゼル",
+        "ja_typings": [
+          "bazeru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01927",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Groovy-based build automation tool is standard for Android?",
+      "ja": "Android 開発で標準的に使われる Groovy ベースのビルドツールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Make",
+        "ja": "メイク",
+        "ja_typings": [
+          "meiku"
+        ]
+      },
+      {
+        "en": "CMake",
+        "ja": "シーメイク",
+        "ja_typings": [
+          "shi-meiku"
+        ]
+      },
+      {
+        "en": "Ninja",
+        "ja": "ニンジャ",
+        "ja_typings": [
+          "ninja"
+        ]
+      },
+      {
+        "en": "SCons",
+        "ja": "エスコンズ",
+        "ja_typings": [
+          "esukonzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01928",
+    "image_path": null,
+    "question_text": {
+      "en": "Which classic Unix build tool reads a Makefile?",
+      "ja": "Makefile を読み込む古典的な Unix のビルドツールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Groovy",
+        "ja": "グルービー",
+        "ja_typings": [
+          "guru-bi-"
+        ]
+      },
+      {
+        "en": "Scala",
+        "ja": "スカラ",
+        "ja_typings": [
+          "sukara"
+        ]
+      },
+      {
+        "en": "Kotlin",
+        "ja": "コトリン",
+        "ja_typings": [
+          "kotorin"
+        ]
+      },
+      {
+        "en": "Jython",
+        "ja": "ジャイソン",
+        "ja_typings": [
+          "jaison"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01929",
+    "image_path": null,
+    "question_text": {
+      "en": "Which dynamic JVM language is often used with Gradle scripts?",
+      "ja": "Gradle スクリプトで使われる動的な JVM 言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Semaphore",
+        "ja": "セマフォ",
+        "ja_typings": [
+          "semafo"
+        ]
+      },
+      {
+        "en": "Mutex",
+        "ja": "ミューテックス",
+        "ja_typings": [
+          "myu-tekkusu"
+        ]
+      },
+      {
+        "en": "Monitor",
+        "ja": "モニター",
+        "ja_typings": [
+          "monita-"
+        ]
+      },
+      {
+        "en": "Barrier",
+        "ja": "バリア",
+        "ja_typings": [
+          "baria"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01930",
+    "image_path": null,
+    "question_text": {
+      "en": "Which classic synchronization primitive uses a counter to control resource access?",
+      "ja": "カウンタで資源アクセスを制御する古典的な同期プリミティブは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`function`",
+        "ja": "`function`",
+        "ja_typings": [
+          "`function`"
+        ]
+      },
+      {
+        "en": "`def`",
+        "ja": "`def`",
+        "ja_typings": [
+          "`def`"
+        ]
+      },
+      {
+        "en": "`func`",
+        "ja": "`func`",
+        "ja_typings": [
+          "`func`"
+        ]
+      },
+      {
+        "en": "`lambda`",
+        "ja": "`lambda`",
+        "ja_typings": [
+          "`lambda`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01931",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript keyword declares a regular function?",
+      "ja": "JavaScript で通常の関数を宣言するキーワードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "IBM",
+        "ja": "アイビーエム",
+        "ja_typings": [
+          "aibi-emu"
+        ]
+      },
+      {
+        "en": "Compaq",
+        "ja": "コンパック",
+        "ja_typings": [
+          "konpakku"
+        ]
+      },
+      {
+        "en": "Dell",
+        "ja": "デル",
+        "ja_typings": [
+          "deru"
+        ]
+      },
+      {
+        "en": "HP",
+        "ja": "ヒューレットパッカード",
+        "ja_typings": [
+          "hyu-rettopakka-do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01932",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed the original PC compatible architecture and OS/2?",
+      "ja": "PC 互換機と OS/2 を生み出した企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Google",
+        "ja": "グーグル",
+        "ja_typings": [
+          "gu-guru"
+        ]
+      },
+      {
+        "en": "Mozilla",
+        "ja": "モジラ",
+        "ja_typings": [
+          "mojira"
+        ]
+      },
+      {
+        "en": "Oracle",
+        "ja": "オラクル",
+        "ja_typings": [
+          "orakuru"
+        ]
+      },
+      {
+        "en": "Meta",
+        "ja": "メタ社",
+        "ja_typings": [
+          "metasha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01933",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company created the Go programming language?",
+      "ja": "プログラミング言語 Go を生み出した企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Quicksort",
+        "ja": "クイックソート",
+        "ja_typings": [
+          "kuikkuso-to"
+        ]
+      },
+      {
+        "en": "Mergesort",
+        "ja": "マージソート",
+        "ja_typings": [
+          "ma-jiso-to"
+        ]
+      },
+      {
+        "en": "Bubble sort",
+        "ja": "バブルソート",
+        "ja_typings": [
+          "baburuso-to"
+        ]
+      },
+      {
+        "en": "Insertion sort",
+        "ja": "挿入ソート",
+        "ja_typings": [
+          "sounyuusooto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01934",
+    "image_path": null,
+    "question_text": {
+      "en": "Which divide-and-conquer sort uses a pivot to partition the array?",
+      "ja": "ピボットを使って配列を分割する分割統治法のソートは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Heapsort",
+        "ja": "ヒープソート",
+        "ja_typings": [
+          "hi-puso-to"
+        ]
+      },
+      {
+        "en": "Quicksort",
+        "ja": "クイックソート",
+        "ja_typings": [
+          "kuikkuso-to"
+        ]
+      },
+      {
+        "en": "Shellsort",
+        "ja": "シェルソート",
+        "ja_typings": [
+          "sheruso-to"
+        ]
+      },
+      {
+        "en": "Timsort",
+        "ja": "ティムソート",
+        "ja_typings": [
+          "timuso-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01935",
+    "image_path": null,
+    "question_text": {
+      "en": "Which comparison sort builds a binary heap to extract elements in order?",
+      "ja": "二分ヒープを構築して要素を順に取り出す比較ソートは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Iteration",
+        "ja": "反復",
+        "ja_typings": [
+          "hanpuku"
+        ]
+      },
+      {
+        "en": "Recursion",
+        "ja": "再帰",
+        "ja_typings": [
+          "saiki"
+        ]
+      },
+      {
+        "en": "Branching",
+        "ja": "分岐",
+        "ja_typings": [
+          "bunki"
+        ]
+      },
+      {
+        "en": "Continuation",
+        "ja": "継続",
+        "ja_typings": [
+          "keizoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01936",
+    "image_path": null,
+    "question_text": {
+      "en": "Which control-flow concept repeats a block of code using loops?",
+      "ja": "ループを用いてコードブロックを繰り返す制御フローの概念は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JSON",
+        "ja": "ジェイソン",
+        "ja_typings": [
+          "jeison"
+        ]
+      },
+      {
+        "en": "YAML",
+        "ja": "ヤムル",
+        "ja_typings": [
+          "yamuru"
+        ]
+      },
+      {
+        "en": "CSV",
+        "ja": "シーエスブイ",
+        "ja_typings": [
+          "shi-esubui"
+        ]
+      },
+      {
+        "en": "XML",
+        "ja": "エックスエムエル",
+        "ja_typings": [
+          "ekkusuemueru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01937",
+    "image_path": null,
+    "question_text": {
+      "en": "Which lightweight data interchange format is based on JavaScript object syntax?",
+      "ja": "JavaScript のオブジェクト構文に基づく軽量データ交換形式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rollup",
+        "ja": "ロールアップ",
+        "ja_typings": [
+          "ro-ruappu"
+        ]
+      },
+      {
+        "en": "Webpack",
+        "ja": "ウェブパック",
+        "ja_typings": [
+          "webupakku"
+        ]
+      },
+      {
+        "en": "Parcel",
+        "ja": "パーセル",
+        "ja_typings": [
+          "pa-seru"
+        ]
+      },
+      {
+        "en": "esbuild",
+        "ja": "イーエスビルド",
+        "ja_typings": [
+          "i-esubirudo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01938",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript bundler is known for ES module-first design?",
+      "ja": "ES モジュール優先の設計で知られる JavaScript バンドラは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Parcel",
+        "ja": "パーセル",
+        "ja_typings": [
+          "pa-seru"
+        ]
+      },
+      {
+        "en": "Rollup",
+        "ja": "ロールアップ",
+        "ja_typings": [
+          "ro-ruappu"
+        ]
+      },
+      {
+        "en": "Webpack",
+        "ja": "ウェブパック",
+        "ja_typings": [
+          "webupakku"
+        ]
+      },
+      {
+        "en": "Turbopack",
+        "ja": "ターボパック",
+        "ja_typings": [
+          "ta-bopakku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01939",
+    "image_path": null,
+    "question_text": {
+      "en": "Which zero-configuration JavaScript bundler is famous for being beginner-friendly?",
+      "ja": "ゼロ設定で初心者にも優しいことで知られる JavaScript バンドラは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "GET",
+        "ja": "ゲット",
+        "ja_typings": [
+          "getto"
+        ]
+      },
+      {
+        "en": "POST",
+        "ja": "ポスト",
+        "ja_typings": [
+          "posuto"
+        ]
+      },
+      {
+        "en": "PUT",
+        "ja": "プット",
+        "ja_typings": [
+          "putto"
+        ]
+      },
+      {
+        "en": "PATCH",
+        "ja": "パッチ",
+        "ja_typings": [
+          "patchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01940",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP method requests data without modifying the server state?",
+      "ja": "サーバの状態を変えずにデータを取得する HTTP メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Java",
+        "ja": "ジャバ",
+        "ja_typings": [
+          "jaba"
+        ]
+      },
+      {
+        "en": "Kotlin",
+        "ja": "コトリン",
+        "ja_typings": [
+          "kotorin"
+        ]
+      },
+      {
+        "en": "Scala",
+        "ja": "スカラ",
+        "ja_typings": [
+          "sukara"
+        ]
+      },
+      {
+        "en": "Groovy",
+        "ja": "グルービー",
+        "ja_typings": [
+          "guru-bi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01941",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language runs on the JVM and was originally developed by Sun?",
+      "ja": "サンが開発し JVM 上で動作する言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "inline",
+        "ja": "インライン",
+        "ja_typings": [
+          "inrain"
+        ]
+      },
+      {
+        "en": "static",
+        "ja": "スタティック",
+        "ja_typings": [
+          "sutatikku"
+        ]
+      },
+      {
+        "en": "extern",
+        "ja": "エクスターン",
+        "ja_typings": [
+          "ekusuta-n"
+        ]
+      },
+      {
+        "en": "register",
+        "ja": "レジスタ指定",
+        "ja_typings": [
+          "rejisutashitei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01942",
+    "image_path": null,
+    "question_text": {
+      "en": "In C++, which keyword hints the compiler to expand a function at call site?",
+      "ja": "C++ で関数を呼び出し位置に展開するようコンパイラに示唆するキーワードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Node.js",
+        "ja": "ノードジェイエス",
+        "ja_typings": [
+          "no-dojeiesu"
+        ]
+      },
+      {
+        "en": "Deno",
+        "ja": "デノ",
+        "ja_typings": [
+          "deno"
+        ]
+      },
+      {
+        "en": "Bun",
+        "ja": "バン",
+        "ja_typings": [
+          "ban"
+        ]
+      },
+      {
+        "en": "Rhino",
+        "ja": "ライノ",
+        "ja_typings": [
+          "raino"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01943",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript runtime built on V8 enables server-side scripting?",
+      "ja": "V8 上に作られたサーバサイド JavaScript ランタイムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nim",
+        "ja": "ニム",
+        "ja_typings": [
+          "nimu"
+        ]
+      },
+      {
+        "en": "Crystal",
+        "ja": "クリスタル言語",
+        "ja_typings": [
+          "kurisutarugengo"
+        ]
+      },
+      {
+        "en": "Zig",
+        "ja": "ジグ",
+        "ja_typings": [
+          "jigu"
+        ]
+      },
+      {
+        "en": "V",
+        "ja": "ブイ言語",
+        "ja_typings": [
+          "buigengo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01944",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Pascal-like statically typed language compiles to C, JS, and more?",
+      "ja": "Pascal 風の静的型付け言語で C や JS にコンパイル可能なのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Skip list",
+        "ja": "スキップリスト",
+        "ja_typings": [
+          "sukippurisuto"
+        ]
+      },
+      {
+        "en": "Bloom filter",
+        "ja": "ブルームフィルタ",
+        "ja_typings": [
+          "buru-mufiruta"
+        ]
+      },
+      {
+        "en": "Hash table",
+        "ja": "ハッシュテーブル",
+        "ja_typings": [
+          "hasshute-buru"
+        ]
+      },
+      {
+        "en": "AVL tree",
+        "ja": "AVL 木",
+        "ja_typings": [
+          "AVLki",
+          "AVLgi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01945",
+    "image_path": null,
+    "question_text": {
+      "en": "Which probabilistic data structure layers linked lists for fast search?",
+      "ja": "リンクリストを多層化して高速検索を実現する確率的データ構造は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bellman-Ford",
+        "ja": "ベルマン・フォード",
+        "ja_typings": [
+          "beruman/fo-do"
+        ]
+      },
+      {
+        "en": "Dijkstra",
+        "ja": "ダイクストラ",
+        "ja_typings": [
+          "daikusutora"
+        ]
+      },
+      {
+        "en": "Floyd-Warshall",
+        "ja": "フロイド・ワーシャル",
+        "ja_typings": [
+          "furoido/wa-sharu"
+        ]
+      },
+      {
+        "en": "A*",
+        "ja": "エースター",
+        "ja_typings": [
+          "e-suta-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01946",
+    "image_path": null,
+    "question_text": {
+      "en": "Which algorithm finds shortest paths and detects negative-weight cycles?",
+      "ja": "負の重みの閉路も検出できる最短経路アルゴリズムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Imperative",
+        "ja": "命令型",
+        "ja_typings": [
+          "meireigata"
+        ]
+      },
+      {
+        "en": "Declarative",
+        "ja": "宣言型",
+        "ja_typings": [
+          "sengengata"
+        ]
+      },
+      {
+        "en": "Functional",
+        "ja": "関数型",
+        "ja_typings": [
+          "kansuugata"
+        ]
+      },
+      {
+        "en": "Logic",
+        "ja": "論理型",
+        "ja_typings": [
+          "ronrigata"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01947",
+    "image_path": null,
+    "question_text": {
+      "en": "Which programming paradigm focuses on explicit statements that change state?",
+      "ja": "状態を変化させる明示的な命令文を中心とするプログラミングパラダイムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Procedural",
+        "ja": "手続き型",
+        "ja_typings": [
+          "tetsudukigata"
+        ]
+      },
+      {
+        "en": "Object-oriented",
+        "ja": "オブジェクト指向",
+        "ja_typings": [
+          "obujekutoshikou"
+        ]
+      },
+      {
+        "en": "Functional",
+        "ja": "関数型",
+        "ja_typings": [
+          "kansuugata"
+        ]
+      },
+      {
+        "en": "Event-driven",
+        "ja": "イベント駆動",
+        "ja_typings": [
+          "ibentokudou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01948",
+    "image_path": null,
+    "question_text": {
+      "en": "Which paradigm organizes code into reusable procedures or routines?",
+      "ja": "コードを再利用可能な手続きにまとめるパラダイムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Edsger Dijkstra",
+        "ja": "エドガー・ダイクストラ",
+        "ja_typings": [
+          "edoga-/daikusutora"
+        ]
+      },
+      {
+        "en": "Donald Knuth",
+        "ja": "ドナルド・クヌース",
+        "ja_typings": [
+          "donarudo/kunu-su"
+        ]
+      },
+      {
+        "en": "Alan Turing",
+        "ja": "アラン・チューリング",
+        "ja_typings": [
+          "aran/chu-ringu"
+        ]
+      },
+      {
+        "en": "John von Neumann",
+        "ja": "ジョン・フォン・ノイマン",
+        "ja_typings": [
+          "jon/fon/noiman"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01949",
+    "image_path": null,
+    "question_text": {
+      "en": "Who proposed the famous shortest path algorithm in 1956?",
+      "ja": "1956 年に有名な最短経路アルゴリズムを提案した人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "async",
+        "ja": "エイシンク",
+        "ja_typings": [
+          "eishinku"
+        ]
+      },
+      {
+        "en": "await",
+        "ja": "アウェイト",
+        "ja_typings": [
+          "aweito"
+        ]
+      },
+      {
+        "en": "yield",
+        "ja": "イールド",
+        "ja_typings": [
+          "i-rudo"
+        ]
+      },
+      {
+        "en": "defer",
+        "ja": "ディファー",
+        "ja_typings": [
+          "difa-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01950",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript keyword marks a function that returns a Promise?",
+      "ja": "Promise を返す関数を示す JavaScript のキーワードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "zip",
+        "ja": "ジップ関数",
+        "ja_typings": [
+          "jippukansuu"
+        ]
+      },
+      {
+        "en": "map",
+        "ja": "マップ関数",
+        "ja_typings": [
+          "mappukansuu"
+        ]
+      },
+      {
+        "en": "filter",
+        "ja": "フィルタ関数",
+        "ja_typings": [
+          "firutakansuu"
+        ]
+      },
+      {
+        "en": "enumerate",
+        "ja": "エニュメレート",
+        "ja_typings": [
+          "enyumere-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01951",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Python built-in pairs elements from multiple iterables?",
+      "ja": "複数のイテラブルから要素をペアにする Python 組み込み関数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "?:",
+        "ja": "三項演算子",
+        "ja_typings": [
+          "sankouenzanshi"
+        ]
+      },
+      {
+        "en": "&&",
+        "ja": "論理積演算子",
+        "ja_typings": [
+          "ronritekienzanshi"
+        ]
+      },
+      {
+        "en": "||",
+        "ja": "論理和演算子",
+        "ja_typings": [
+          "ronriwaenzanshi"
+        ]
+      },
+      {
+        "en": "==",
+        "ja": "等価演算子",
+        "ja_typings": [
+          "toukaenzanshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01952",
+    "image_path": null,
+    "question_text": {
+      "en": "Which C operator selects between two expressions based on a condition?",
+      "ja": "条件によって 2 つの式を選ぶ C 言語の演算子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "static",
+        "ja": "スタティック",
+        "ja_typings": [
+          "sutatikku"
+        ]
+      },
+      {
+        "en": "extern",
+        "ja": "エクスターン",
+        "ja_typings": [
+          "ekusuta-n"
+        ]
+      },
+      {
+        "en": "auto",
+        "ja": "オート",
+        "ja_typings": [
+          "o-to"
+        ]
+      },
+      {
+        "en": "volatile",
+        "ja": "ボラタイル",
+        "ja_typings": [
+          "boratairu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01953",
+    "image_path": null,
+    "question_text": {
+      "en": "In C, which storage class limits a variable's visibility to its file?",
+      "ja": "C 言語で変数の可視性をファイル内に限定する記憶クラスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Linked List",
+        "ja": "連結リスト",
+        "ja_typings": [
+          "renketsurisuto"
+        ]
+      },
+      {
+        "en": "Array",
+        "ja": "配列",
+        "ja_typings": [
+          "hairetsu"
+        ]
+      },
+      {
+        "en": "Stack",
+        "ja": "スタック",
+        "ja_typings": [
+          "sutakku"
+        ]
+      },
+      {
+        "en": "Queue",
+        "ja": "キュー",
+        "ja_typings": [
+          "kyu-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01954",
+    "image_path": null,
+    "question_text": {
+      "en": "Which linear data structure stores elements with pointers to the next node?",
+      "ja": "次ノードへのポインタで要素を繋ぐ線形データ構造は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Array",
+        "ja": "配列",
+        "ja_typings": [
+          "hairetsu"
+        ]
+      },
+      {
+        "en": "Linked List",
+        "ja": "連結リスト",
+        "ja_typings": [
+          "renketsurisuto"
+        ]
+      },
+      {
+        "en": "Tree",
+        "ja": "木構造",
+        "ja_typings": [
+          "kikouzou"
+        ]
+      },
+      {
+        "en": "Graph",
+        "ja": "グラフ",
+        "ja_typings": [
+          "gurafu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01955",
+    "image_path": null,
+    "question_text": {
+      "en": "Which contiguous-memory data structure offers O(1) index access?",
+      "ja": "添字アクセスが O(1) で可能な連続メモリのデータ構造は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hash",
+        "ja": "ハッシュ関数",
+        "ja_typings": [
+          "hasshukansuu"
+        ]
+      },
+      {
+        "en": "Sort",
+        "ja": "整列",
+        "ja_typings": [
+          "seiretsu"
+        ]
+      },
+      {
+        "en": "Compare",
+        "ja": "比較",
+        "ja_typings": [
+          "hikaku"
+        ]
+      },
+      {
+        "en": "Encode",
+        "ja": "符号化",
+        "ja_typings": [
+          "fugouka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01956",
+    "image_path": null,
+    "question_text": {
+      "en": "Which function maps keys to indices in a hash table?",
+      "ja": "ハッシュテーブルで鍵を添字に変換する関数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ternary Tree",
+        "ja": "三分木",
+        "ja_typings": [
+          "sanbunki",
+          "sanbungi"
+        ]
+      },
+      {
+        "en": "Binary Tree",
+        "ja": "二分木",
+        "ja_typings": [
+          "nibunki",
+          "nibungi"
+        ]
+      },
+      {
+        "en": "Quad Tree",
+        "ja": "四分木",
+        "ja_typings": [
+          "shibunki"
+        ]
+      },
+      {
+        "en": "Octree",
+        "ja": "オクツリー",
+        "ja_typings": [
+          "okutsuri-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01957",
+    "image_path": null,
+    "question_text": {
+      "en": "Which tree variant has at most three children per node?",
+      "ja": "各ノードが最大 3 つの子を持つ木は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Complete Graph",
+        "ja": "完全グラフ",
+        "ja_typings": [
+          "kanzenngurafu"
+        ]
+      },
+      {
+        "en": "Bipartite Graph",
+        "ja": "二部グラフ",
+        "ja_typings": [
+          "nibugurafu"
+        ]
+      },
+      {
+        "en": "Tree",
+        "ja": "木構造",
+        "ja_typings": [
+          "kikouzou"
+        ]
+      },
+      {
+        "en": "DAG",
+        "ja": "有向非巡回グラフ",
+        "ja_typings": [
+          "yuukouhijunkaigurafu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01958",
+    "image_path": null,
+    "question_text": {
+      "en": "Which graph has an edge between every pair of distinct vertices?",
+      "ja": "任意の 2 頂点間に辺がある無向グラフは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Abstraction",
+        "ja": "抽象化",
+        "ja_typings": [
+          "chuushouka"
+        ]
+      },
+      {
+        "en": "Encapsulation",
+        "ja": "カプセル化",
+        "ja_typings": [
+          "kapuseruka"
+        ]
+      },
+      {
+        "en": "Inheritance",
+        "ja": "継承",
+        "ja_typings": [
+          "keishou"
+        ]
+      },
+      {
+        "en": "Polymorphism",
+        "ja": "ポリモーフィズム",
+        "ja_typings": [
+          "porimo-fizumu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01959",
+    "image_path": null,
+    "question_text": {
+      "en": "Which OOP concept hides implementation details behind a simple interface?",
+      "ja": "実装詳細を隠して簡潔なインタフェースを公開する OOP の概念は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Adapter",
+        "ja": "アダプタ",
+        "ja_typings": [
+          "adaputa"
+        ]
+      },
+      {
+        "en": "Facade",
+        "ja": "ファサード",
+        "ja_typings": [
+          "fasa-do"
+        ]
+      },
+      {
+        "en": "Bridge",
+        "ja": "ブリッジ",
+        "ja_typings": [
+          "burijji"
+        ]
+      },
+      {
+        "en": "Proxy",
+        "ja": "プロキシ",
+        "ja_typings": [
+          "purokishi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01960",
+    "image_path": null,
+    "question_text": {
+      "en": "Which structural design pattern bridges incompatible interfaces?",
+      "ja": "互換性のないインタフェースを橋渡しする構造的デザインパターンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Strategy",
+        "ja": "ストラテジー",
+        "ja_typings": [
+          "sutorateji-"
+        ]
+      },
+      {
+        "en": "State",
+        "ja": "ステート",
+        "ja_typings": [
+          "sute-to"
+        ]
+      },
+      {
+        "en": "Command",
+        "ja": "コマンド",
+        "ja_typings": [
+          "komando"
+        ]
+      },
+      {
+        "en": "Template Method",
+        "ja": "テンプレートメソッド",
+        "ja_typings": [
+          "tenpure-tomesoddo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01961",
+    "image_path": null,
+    "question_text": {
+      "en": "Which behavioral pattern lets algorithms vary independently from clients?",
+      "ja": "アルゴリズムをクライアントから独立に切り替えられる振る舞い系パターンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Decorator",
+        "ja": "デコレータ",
+        "ja_typings": [
+          "dekore-ta"
+        ]
+      },
+      {
+        "en": "Adapter",
+        "ja": "アダプタ",
+        "ja_typings": [
+          "adaputa"
+        ]
+      },
+      {
+        "en": "Composite",
+        "ja": "コンポジット",
+        "ja_typings": [
+          "konpojitto"
+        ]
+      },
+      {
+        "en": "Flyweight",
+        "ja": "フライウェイト",
+        "ja_typings": [
+          "furaiweito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01962",
+    "image_path": null,
+    "question_text": {
+      "en": "Which structural pattern wraps an object to add behavior dynamically?",
+      "ja": "オブジェクトを包んで動的に振る舞いを追加する構造パターンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Proxy",
+        "ja": "プロキシ",
+        "ja_typings": [
+          "purokishi"
+        ]
+      },
+      {
+        "en": "Adapter",
+        "ja": "アダプタ",
+        "ja_typings": [
+          "adaputa"
+        ]
+      },
+      {
+        "en": "Decorator",
+        "ja": "デコレータ",
+        "ja_typings": [
+          "dekore-ta"
+        ]
+      },
+      {
+        "en": "Bridge",
+        "ja": "ブリッジ",
+        "ja_typings": [
+          "burijji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01963",
+    "image_path": null,
+    "question_text": {
+      "en": "Which structural pattern provides a surrogate to control access to an object?",
+      "ja": "オブジェクトへのアクセスを制御する代理を提供する構造パターンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Composite",
+        "ja": "コンポジット",
+        "ja_typings": [
+          "konpojitto"
+        ]
+      },
+      {
+        "en": "Decorator",
+        "ja": "デコレータ",
+        "ja_typings": [
+          "dekore-ta"
+        ]
+      },
+      {
+        "en": "Builder",
+        "ja": "ビルダー",
+        "ja_typings": [
+          "biruda-"
+        ]
+      },
+      {
+        "en": "Chain of Responsibility",
+        "ja": "チェーンオブレスポンシビリティ",
+        "ja_typings": [
+          "che-nnoburesuponshibiriti"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01964",
+    "image_path": null,
+    "question_text": {
+      "en": "Which pattern lets clients treat individual objects and compositions uniformly?",
+      "ja": "個々の要素と複合要素を一様に扱える構造パターンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Visitor",
+        "ja": "ビジター",
+        "ja_typings": [
+          "bijita-"
+        ]
+      },
+      {
+        "en": "Mediator",
+        "ja": "メディエータ",
+        "ja_typings": [
+          "medie-ta"
+        ]
+      },
+      {
+        "en": "Iterator",
+        "ja": "イテレータ",
+        "ja_typings": [
+          "itere-ta"
+        ]
+      },
+      {
+        "en": "Observer",
+        "ja": "オブザーバー",
+        "ja_typings": [
+          "obuza-ba-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01965",
+    "image_path": null,
+    "question_text": {
+      "en": "Which behavioral pattern adds operations without changing element classes?",
+      "ja": "要素クラスを変えずに操作を追加できる振る舞いパターンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vec",
+        "ja": "ベック型",
+        "ja_typings": [
+          "bekkugata"
+        ]
+      },
+      {
+        "en": "HashMap",
+        "ja": "ハッシュマップ型",
+        "ja_typings": [
+          "hasshumappugata"
+        ]
+      },
+      {
+        "en": "BTreeMap",
+        "ja": "ビーツリーマップ型",
+        "ja_typings": [
+          "biitsuriimappugata"
+        ]
+      },
+      {
+        "en": "LinkedList",
+        "ja": "リンクトリスト型",
+        "ja_typings": [
+          "rinkutorisutogata"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q01966",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Rust standard collection is a growable, heap-allocated array?",
+      "ja": "ヒープ確保で可変長配列を表す Rust の標準コレクションは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Referrer-Policy",
+        "ja": "リファラポリシー",
+        "ja_typings": [
+          "rifaraporishi-"
+        ]
+      },
+      {
+        "en": "Content-Security-Policy",
+        "ja": "コンテンツセキュリティポリシー",
+        "ja_typings": [
+          "kontentsusekyuritiporishi-"
+        ]
+      },
+      {
+        "en": "Strict-Transport-Security",
+        "ja": "ストリクトトランスポートセキュリティ",
+        "ja_typings": [
+          "sutorikutotoransupo-tosekyuriti"
+        ]
+      },
+      {
+        "en": "X-Frame-Options",
+        "ja": "エックスフレームオプションズ",
+        "ja_typings": [
+          "ekkusufure-muopushonzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01967",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP header controls how much referrer information is sent with requests?",
+      "ja": "リクエストに含めるリファラ情報の量を制御する HTTP ヘッダは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FID",
+        "ja": "エフアイディー",
+        "ja_typings": [
+          "efuaidi-"
+        ]
+      },
+      {
+        "en": "LCP",
+        "ja": "エルシーピー",
+        "ja_typings": [
+          "erushi-pi-"
+        ]
+      },
+      {
+        "en": "CLS",
+        "ja": "シーエルエス",
+        "ja_typings": [
+          "shi-eruesu"
+        ]
+      },
+      {
+        "en": "TTFB",
+        "ja": "ティーティーエフビー",
+        "ja_typings": [
+          "ti-ti-efubi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01968",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Web Vitals metric measures the delay until the first user interaction is processed?",
+      "ja": "最初のユーザー操作が処理されるまでの遅延を計る Web Vitals 指標は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PerformanceObserver",
+        "ja": "パフォーマンスオブザーバ",
+        "ja_typings": [
+          "pafo-mansuobuza-ba"
+        ]
+      },
+      {
+        "en": "MutationObserver",
+        "ja": "ミューテーションオブザーバ",
+        "ja_typings": [
+          "myu-te-shonnobuza-ba"
+        ]
+      },
+      {
+        "en": "IntersectionObserver",
+        "ja": "インターセクションオブザーバ",
+        "ja_typings": [
+          "inta-sekushonnobuza-ba"
+        ]
+      },
+      {
+        "en": "ResizeObserver",
+        "ja": "リサイズオブザーバ",
+        "ja_typings": [
+          "risaizuobuza-ba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01969",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Web API observes performance-related events such as paint and longtask?",
+      "ja": "ペイントやロングタスク等のパフォーマンス事象を観測する Web API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bad request",
+        "ja": "バッドリクエスト",
+        "ja_typings": [
+          "baddorikuesuto"
+        ]
+      },
+      {
+        "en": "Unauthorized",
+        "ja": "アンオーソライズド",
+        "ja_typings": [
+          "anno-soraizudo"
+        ]
+      },
+      {
+        "en": "Forbidden",
+        "ja": "フォービドゥン",
+        "ja_typings": [
+          "fo-bidun"
+        ]
+      },
+      {
+        "en": "Not Found",
+        "ja": "ノットファウンド",
+        "ja_typings": [
+          "nottofaundo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01970",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status indicates the server cannot process due to client-side error?",
+      "ja": "クライアント側の誤りで処理できないことを示す HTTP ステータスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "POST",
+        "ja": "ポスト",
+        "ja_typings": [
+          "posuto"
+        ]
+      },
+      {
+        "en": "GET",
+        "ja": "ゲット",
+        "ja_typings": [
+          "getto"
+        ]
+      },
+      {
+        "en": "PUT",
+        "ja": "プット",
+        "ja_typings": [
+          "putto"
+        ]
+      },
+      {
+        "en": "DELETE",
+        "ja": "デリート",
+        "ja_typings": [
+          "deri-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01971",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP method submits data to be processed to a specified resource?",
+      "ja": "指定リソースに処理用データを送信する HTTP メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bulma",
+        "ja": "ブルマ",
+        "ja_typings": [
+          "buruma"
+        ]
+      },
+      {
+        "en": "Bootstrap",
+        "ja": "ブートストラップ",
+        "ja_typings": [
+          "bu-tosutorappu"
+        ]
+      },
+      {
+        "en": "Tailwind CSS",
+        "ja": "テイルウィンドシーエスエス",
+        "ja_typings": [
+          "teiruwindoshi-esuesu"
+        ]
+      },
+      {
+        "en": "Materialize",
+        "ja": "マテリアライズ",
+        "ja_typings": [
+          "materiaraizu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01972",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS framework is built with Sass and based on Flexbox?",
+      "ja": "Sass で作られ Flexbox を基礎にした CSS フレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Foundation",
+        "ja": "ファウンデーション",
+        "ja_typings": [
+          "faunde-shon"
+        ]
+      },
+      {
+        "en": "Bootstrap",
+        "ja": "ブートストラップ",
+        "ja_typings": [
+          "bu-tosutorappu"
+        ]
+      },
+      {
+        "en": "Bulma",
+        "ja": "ブルマ",
+        "ja_typings": [
+          "buruma"
+        ]
+      },
+      {
+        "en": "Skeleton",
+        "ja": "スケルトン",
+        "ja_typings": [
+          "sukeruton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01973",
+    "image_path": null,
+    "question_text": {
+      "en": "Which responsive front-end framework was originally created by ZURB?",
+      "ja": "ZURB が生み出したレスポンシブなフロントエンドフレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Observable",
+        "ja": "オブザーバブル",
+        "ja_typings": [
+          "obuza-baburu"
+        ]
+      },
+      {
+        "en": "Promise",
+        "ja": "プロミス",
+        "ja_typings": [
+          "puromisu"
+        ]
+      },
+      {
+        "en": "Iterator",
+        "ja": "イテレータ",
+        "ja_typings": [
+          "itere-ta"
+        ]
+      },
+      {
+        "en": "Signal",
+        "ja": "シグナル",
+        "ja_typings": [
+          "shigunaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01974",
+    "image_path": null,
+    "question_text": {
+      "en": "Which RxJS primitive represents a push-based stream of values over time?",
+      "ja": "時間経過に伴う値のプッシュ型ストリームを表す RxJS のプリミティブは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`find`",
+        "ja": "`find`",
+        "ja_typings": [
+          "`find`"
+        ]
+      },
+      {
+        "en": "`locate`",
+        "ja": "`locate`",
+        "ja_typings": [
+          "`locate`"
+        ]
+      },
+      {
+        "en": "`which`",
+        "ja": "`which`",
+        "ja_typings": [
+          "`which`"
+        ]
+      },
+      {
+        "en": "`whereis`",
+        "ja": "`whereis`",
+        "ja_typings": [
+          "`whereis`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01975",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Unix-style command in shells locates files by name?",
+      "ja": "シェルで名前からファイルを探す Unix 系コマンドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nuxt.js",
+        "ja": "ナクストジェイエス",
+        "ja_typings": [
+          "nakusutojeiesu"
+        ]
+      },
+      {
+        "en": "Next.js",
+        "ja": "ネクストジェイエス",
+        "ja_typings": [
+          "nekusutojeiesu"
+        ]
+      },
+      {
+        "en": "Remix",
+        "ja": "リミックス",
+        "ja_typings": [
+          "rimikkusu"
+        ]
+      },
+      {
+        "en": "SvelteKit",
+        "ja": "スヴェルトキット",
+        "ja_typings": [
+          "suverutokitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01976",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Vue-based meta-framework supports SSR and static generation?",
+      "ja": "SSR と静的生成に対応する Vue ベースのメタフレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gatsby",
+        "ja": "ギャツビー",
+        "ja_typings": [
+          "gyatsubi-"
+        ]
+      },
+      {
+        "en": "Hugo",
+        "ja": "ヒューゴ",
+        "ja_typings": [
+          "hyu-go"
+        ]
+      },
+      {
+        "en": "Jekyll",
+        "ja": "ジキル",
+        "ja_typings": [
+          "jikiru"
+        ]
+      },
+      {
+        "en": "Eleventy",
+        "ja": "イレブンティ",
+        "ja_typings": [
+          "irebunti"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01977",
+    "image_path": null,
+    "question_text": {
+      "en": "Which React-based static site generator pulls data via GraphQL?",
+      "ja": "GraphQL でデータを取り込む React ベースの静的サイトジェネレータは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Subscription",
+        "ja": "サブスクリプション",
+        "ja_typings": [
+          "sabusukuripushon"
+        ]
+      },
+      {
+        "en": "Query",
+        "ja": "クエリ",
+        "ja_typings": [
+          "kueri"
+        ]
+      },
+      {
+        "en": "Mutation",
+        "ja": "ミューテーション",
+        "ja_typings": [
+          "myu-te-shon"
+        ]
+      },
+      {
+        "en": "Fragment",
+        "ja": "フラグメント",
+        "ja_typings": [
+          "furagumento"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01978",
+    "image_path": null,
+    "question_text": {
+      "en": "Which GraphQL operation type pushes server updates to clients over time?",
+      "ja": "サーバの更新を時系列でクライアントに送る GraphQL の操作型は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SAML",
+        "ja": "サムル",
+        "ja_typings": [
+          "samuru"
+        ]
+      },
+      {
+        "en": "OAuth",
+        "ja": "オーオース",
+        "ja_typings": [
+          "o-o-su"
+        ]
+      },
+      {
+        "en": "OpenID Connect",
+        "ja": "オープンアイディーコネクト",
+        "ja_typings": [
+          "o-punnaidi-konekuto"
+        ]
+      },
+      {
+        "en": "Kerberos",
+        "ja": "ケルベロス",
+        "ja_typings": [
+          "keruberosu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01979",
+    "image_path": null,
+    "question_text": {
+      "en": "Which XML-based open standard exchanges authentication and authorization data?",
+      "ja": "認証認可情報を交換する XML ベースのオープン標準は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ISR",
+        "ja": "アイエスアール",
+        "ja_typings": [
+          "aiesua-ru"
+        ]
+      },
+      {
+        "en": "SSG",
+        "ja": "エスエスジー",
+        "ja_typings": [
+          "esuesuji-"
+        ]
+      },
+      {
+        "en": "SSR",
+        "ja": "エスエスアール",
+        "ja_typings": [
+          "esuesua-ru"
+        ]
+      },
+      {
+        "en": "CSR",
+        "ja": "シーエスアール",
+        "ja_typings": [
+          "shi-esua-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01980",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Next.js rendering mode regenerates static pages on demand after deploy?",
+      "ja": "デプロイ後にオンデマンドで静的ページを再生成する Next.js のレンダリング方式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FCP",
+        "ja": "エフシーピー",
+        "ja_typings": [
+          "efushi-pi-"
+        ]
+      },
+      {
+        "en": "LCP",
+        "ja": "エルシーピー",
+        "ja_typings": [
+          "erushi-pi-"
+        ]
+      },
+      {
+        "en": "FID",
+        "ja": "エフアイディー",
+        "ja_typings": [
+          "efuaidi-"
+        ]
+      },
+      {
+        "en": "TTI",
+        "ja": "ティーティーアイ",
+        "ja_typings": [
+          "ti-ti-ai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01981",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Web Vitals metric measures when the first content is painted on screen?",
+      "ja": "画面に最初のコンテンツが描画されたタイミングを示す Web Vitals 指標は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SSE",
+        "ja": "エスエスイー",
+        "ja_typings": [
+          "esuesui-"
+        ]
+      },
+      {
+        "en": "WebSocket",
+        "ja": "ウェブソケット",
+        "ja_typings": [
+          "webusoketto"
+        ]
+      },
+      {
+        "en": "Long Polling",
+        "ja": "ロングポーリング",
+        "ja_typings": [
+          "rongupo-ringu"
+        ]
+      },
+      {
+        "en": "WebRTC",
+        "ja": "ウェブアールティーシー",
+        "ja_typings": [
+          "webua-ruti-shi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01982",
+    "image_path": null,
+    "question_text": {
+      "en": "Which web technology pushes events from server to browser over a single HTTP connection?",
+      "ja": "単一の HTTP 接続でサーバからブラウザへイベントを送る技術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "localStorage",
+        "ja": "ローカルストレージ",
+        "ja_typings": [
+          "ro-karusutore-ji"
+        ]
+      },
+      {
+        "en": "sessionStorage",
+        "ja": "セッションストレージ",
+        "ja_typings": [
+          "sesshonsutore-ji"
+        ]
+      },
+      {
+        "en": "IndexedDB",
+        "ja": "インデックスドディービー",
+        "ja_typings": [
+          "indekkusudodi-bi-"
+        ]
+      },
+      {
+        "en": "Cookies",
+        "ja": "クッキー",
+        "ja_typings": [
+          "kukki-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01983",
+    "image_path": null,
+    "question_text": {
+      "en": "Which browser storage persists key-value pairs without expiration on the same origin?",
+      "ja": "同一オリジン上でキー値ペアを期限なく保持するブラウザストレージは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<picture>`",
+        "ja": "ピクチャ要素",
+        "ja_typings": [
+          "pikutyayouso"
+        ]
+      },
+      {
+        "en": "`<img>`",
+        "ja": "イメージ要素",
+        "ja_typings": [
+          "imeejiyouso"
+        ]
+      },
+      {
+        "en": "`<figure>`",
+        "ja": "フィギュア要素",
+        "ja_typings": [
+          "figyuayouso"
+        ]
+      },
+      {
+        "en": "`<source>`",
+        "ja": "ソース要素",
+        "ja_typings": [
+          "soosuyouso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01984",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML element lets you supply multiple image sources for different conditions?",
+      "ja": "条件ごとに複数の画像ソースを与える HTML 要素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`@supports`",
+        "ja": "サポート規則",
+        "ja_typings": [
+          "sapootokisoku"
+        ]
+      },
+      {
+        "en": "`@media`",
+        "ja": "メディア規則",
+        "ja_typings": [
+          "mediakisoku"
+        ]
+      },
+      {
+        "en": "`@import`",
+        "ja": "インポート規則",
+        "ja_typings": [
+          "inpootokisoku"
+        ]
+      },
+      {
+        "en": "`@layer`",
+        "ja": "レイヤー規則",
+        "ja_typings": [
+          "reiyaakisoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01985",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS at-rule applies styles only when the browser supports given features?",
+      "ja": "ブラウザが指定機能を支持する場合だけスタイルを適用する CSS の at-rule は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Permissions-Policy",
+        "ja": "パーミッションズポリシー",
+        "ja_typings": [
+          "pa-misshonzuporishi-"
+        ]
+      },
+      {
+        "en": "Feature-Policy",
+        "ja": "フィーチャーポリシー",
+        "ja_typings": [
+          "fi-cha-porishi-"
+        ]
+      },
+      {
+        "en": "Referrer-Policy",
+        "ja": "リファラポリシー",
+        "ja_typings": [
+          "rifaraporishi-"
+        ]
+      },
+      {
+        "en": "Content-Security-Policy",
+        "ja": "コンテンツセキュリティポリシー",
+        "ja_typings": [
+          "kontentsusekyuritiporishi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01986",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP header controls access to browser features like camera and geolocation?",
+      "ja": "カメラや位置情報など端末機能へのアクセスを制御する HTTP ヘッダは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "W3C",
+        "ja": "ダブリュースリーシー",
+        "ja_typings": [
+          "daburyu-suri-shi-"
+        ]
+      },
+      {
+        "en": "WHATWG",
+        "ja": "ワットダブリュージー",
+        "ja_typings": [
+          "wattodaburyu-ji-"
+        ]
+      },
+      {
+        "en": "ISO",
+        "ja": "アイエスオー",
+        "ja_typings": [
+          "aiesuo-"
+        ]
+      },
+      {
+        "en": "ECMA",
+        "ja": "エクマ",
+        "ja_typings": [
+          "ekuma"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01987",
+    "image_path": null,
+    "question_text": {
+      "en": "Which consortium maintains HTML, CSS, and other web standards led by Tim Berners-Lee?",
+      "ja": "ティム・バーナーズ＝リーが率いる HTML や CSS の標準化団体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "IETF",
+        "ja": "アイイーティーエフ",
+        "ja_typings": [
+          "aii-ti-efu"
+        ]
+      },
+      {
+        "en": "W3C",
+        "ja": "ダブリュースリーシー",
+        "ja_typings": [
+          "daburyu-suri-shi-"
+        ]
+      },
+      {
+        "en": "IEEE",
+        "ja": "アイトリプルイー",
+        "ja_typings": [
+          "aitoripurui-"
+        ]
+      },
+      {
+        "en": "ITU",
+        "ja": "アイティーユー",
+        "ja_typings": [
+          "aiti-yu-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01988",
+    "image_path": null,
+    "question_text": {
+      "en": "Which organization standardizes Internet protocols such as HTTP and TLS?",
+      "ja": "HTTP や TLS などインターネットプロトコルを標準化する組織は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Redirect",
+        "ja": "リダイレクト",
+        "ja_typings": [
+          "ridairekuto"
+        ]
+      },
+      {
+        "en": "Rewrite",
+        "ja": "リライト",
+        "ja_typings": [
+          "riraito"
+        ]
+      },
+      {
+        "en": "Forward",
+        "ja": "フォワード",
+        "ja_typings": [
+          "fowa-do"
+        ]
+      },
+      {
+        "en": "Proxy",
+        "ja": "プロキシ",
+        "ja_typings": [
+          "purokishi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01989",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP mechanism instructs the client to fetch a different URL?",
+      "ja": "別の URL を取得するようクライアントに指示する HTTP の仕組みは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Temporary redirect",
+        "ja": "テンポラリリダイレクト",
+        "ja_typings": [
+          "tenporariridairekuto"
+        ]
+      },
+      {
+        "en": "Permanent redirect",
+        "ja": "パーマネントリダイレクト",
+        "ja_typings": [
+          "pa-manentoridairekuto"
+        ]
+      },
+      {
+        "en": "See Other",
+        "ja": "シーアザー",
+        "ja_typings": [
+          "shi-aza-"
+        ]
+      },
+      {
+        "en": "Not Modified",
+        "ja": "ノットモディファイド",
+        "ja_typings": [
+          "nottomodifaido"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01990",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status indicates a temporary redirect that should preserve the method?",
+      "ja": "メソッドを保持したまま一時的にリダイレクトすることを示す HTTP ステータスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Service unavailable",
+        "ja": "サービスアンアベイラブル",
+        "ja_typings": [
+          "sa-bisuannabeiraburu"
+        ]
+      },
+      {
+        "en": "Internal server error",
+        "ja": "インターナルサーバエラー",
+        "ja_typings": [
+          "inta-narusa-baera-"
+        ]
+      },
+      {
+        "en": "Gateway timeout",
+        "ja": "ゲートウェイタイムアウト",
+        "ja_typings": [
+          "ge-toweitaimuauto"
+        ]
+      },
+      {
+        "en": "Bad gateway",
+        "ja": "バッドゲートウェイ",
+        "ja_typings": [
+          "baddoge-towei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01991",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status indicates the server is temporarily unable to handle the request?",
+      "ja": "サーバが一時的にリクエストを処理できないことを示す HTTP ステータスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DELETE",
+        "ja": "デリート",
+        "ja_typings": [
+          "deri-to"
+        ]
+      },
+      {
+        "en": "REMOVE",
+        "ja": "リムーブ",
+        "ja_typings": [
+          "rimu-bu"
+        ]
+      },
+      {
+        "en": "PURGE",
+        "ja": "パージ",
+        "ja_typings": [
+          "pa-ji"
+        ]
+      },
+      {
+        "en": "DROP",
+        "ja": "ドロップ",
+        "ja_typings": [
+          "doroppu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01992",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP method removes the specified resource?",
+      "ja": "指定リソースを削除する HTTP メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HEAD",
+        "ja": "ヘッド",
+        "ja_typings": [
+          "heddo"
+        ]
+      },
+      {
+        "en": "GET",
+        "ja": "ゲット",
+        "ja_typings": [
+          "getto"
+        ]
+      },
+      {
+        "en": "TRACE",
+        "ja": "トレース",
+        "ja_typings": [
+          "tore-su"
+        ]
+      },
+      {
+        "en": "CONNECT",
+        "ja": "コネクト",
+        "ja_typings": [
+          "konekuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01993",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP method returns only headers for a resource?",
+      "ja": "リソースのヘッダだけを返す HTTP メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "OPTIONS",
+        "ja": "オプションズ",
+        "ja_typings": [
+          "opushonzu"
+        ]
+      },
+      {
+        "en": "HEAD",
+        "ja": "ヘッド",
+        "ja_typings": [
+          "heddo"
+        ]
+      },
+      {
+        "en": "TRACE",
+        "ja": "トレース",
+        "ja_typings": [
+          "tore-su"
+        ]
+      },
+      {
+        "en": "CONNECT",
+        "ja": "コネクト",
+        "ja_typings": [
+          "konekuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01994",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP method describes the communication options for the target resource?",
+      "ja": "対象リソースに対する通信オプションを取得する HTTP メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<figure>` tag",
+        "ja": "フィギュアタグ",
+        "ja_typings": [
+          "figyuatagu"
+        ]
+      },
+      {
+        "en": "`<aside>` tag",
+        "ja": "アサイドタグ",
+        "ja_typings": [
+          "asaidotagu"
+        ]
+      },
+      {
+        "en": "`<section>` tag",
+        "ja": "セクションタグ",
+        "ja_typings": [
+          "sekushontagu"
+        ]
+      },
+      {
+        "en": "`<article>` tag",
+        "ja": "アーティクルタグ",
+        "ja_typings": [
+          "aatikurutagu",
+          "aatikulutagu",
+          "a-tikurutagu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01995",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML element represents self-contained content like illustrations?",
+      "ja": "挿絵など自己完結したコンテンツを表す HTML 要素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<canvas>` tag",
+        "ja": "キャンバスタグ",
+        "ja_typings": [
+          "kyanbasutagu"
+        ]
+      },
+      {
+        "en": "`<svg>` tag",
+        "ja": "エスブイジータグ",
+        "ja_typings": [
+          "esubuijiitagu",
+          "esubuiji-tagu"
+        ]
+      },
+      {
+        "en": "`<video>` tag",
+        "ja": "ビデオタグ",
+        "ja_typings": [
+          "bideotagu"
+        ]
+      },
+      {
+        "en": "`<draw>` tag",
+        "ja": "ドロータグ",
+        "ja_typings": [
+          "doroutagu",
+          "doro-tagu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01996",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML element provides a drawable region for graphics via scripting?",
+      "ja": "スクリプトで描画する領域を提供する HTML 要素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`title` attribute",
+        "ja": "タイトル属性",
+        "ja_typings": [
+          "taitorusokusei"
+        ]
+      },
+      {
+        "en": "`alt` attribute",
+        "ja": "オルト属性",
+        "ja_typings": [
+          "orutosokusei"
+        ]
+      },
+      {
+        "en": "`aria-label` attribute",
+        "ja": "エリアラベル属性",
+        "ja_typings": [
+          "ariaraberusokusei"
+        ]
+      },
+      {
+        "en": "`label` attribute",
+        "ja": "ラベル属性",
+        "ja_typings": [
+          "raberusokusei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01997",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML attribute provides advisory text shown as a tooltip on hover?",
+      "ja": "ホバー時にツールチップとして表示される補助テキストの HTML 属性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`src` attribute",
+        "ja": "ソース属性",
+        "ja_typings": [
+          "soosusokusei"
+        ]
+      },
+      {
+        "en": "`href` attribute",
+        "ja": "エイチレフ属性",
+        "ja_typings": [
+          "eichirefusokusei"
+        ]
+      },
+      {
+        "en": "`data` attribute",
+        "ja": "データ属性",
+        "ja_typings": [
+          "deetasokusei"
+        ]
+      },
+      {
+        "en": "`action` attribute",
+        "ja": "アクション属性",
+        "ja_typings": [
+          "akushonsokusei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01998",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML attribute specifies the URL of an external resource like an image?",
+      "ja": "画像など外部リソースの URL を指定する HTML 属性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`name` attribute",
+        "ja": "ネーム属性",
+        "ja_typings": [
+          "neemusokusei"
+        ]
+      },
+      {
+        "en": "`id` attribute",
+        "ja": "アイディー属性",
+        "ja_typings": [
+          "aidiisokusei"
+        ]
+      },
+      {
+        "en": "`for` attribute",
+        "ja": "フォー属性",
+        "ja_typings": [
+          "foosokusei"
+        ]
+      },
+      {
+        "en": "`value` attribute",
+        "ja": "バリュー属性",
+        "ja_typings": [
+          "baryuusokusei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q01999",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML attribute identifies a form control when submitted to the server?",
+      "ja": "送信時にサーバへ送られるフォーム部品の識別子を表す HTML 属性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<link>` tag",
+        "ja": "リンクタグ",
+        "ja_typings": [
+          "rinkutagu"
+        ]
+      },
+      {
+        "en": "`<a>` tag",
+        "ja": "エータグ",
+        "ja_typings": [
+          "eetagu",
+          "e-tagu"
+        ]
+      },
+      {
+        "en": "`<meta>` tag",
+        "ja": "メタタグ",
+        "ja_typings": [
+          "metatagu"
+        ]
+      },
+      {
+        "en": "`<script>` tag",
+        "ja": "スクリプトタグ",
+        "ja_typings": [
+          "sukuriputotagu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02000",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML element references external resources such as stylesheets?",
+      "ja": "スタイルシートなど外部リソースを参照する HTML 要素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<nav>` tag",
+        "ja": "ナビタグ",
+        "ja_typings": [
+          "nabitagu"
+        ]
+      },
+      {
+        "en": "`<menu>` tag",
+        "ja": "メニュータグ",
+        "ja_typings": [
+          "menyuutagu",
+          "menyu-tagu"
+        ]
+      },
+      {
+        "en": "`<aside>` tag",
+        "ja": "アサイドタグ",
+        "ja_typings": [
+          "asaidotagu"
+        ]
+      },
+      {
+        "en": "`<header>` tag",
+        "ja": "ヘッダタグ",
+        "ja_typings": [
+          "heddatagu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02001",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML element groups navigation links?",
+      "ja": "ナビゲーション用のリンクをまとめる HTML 要素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<href>` tag",
+        "ja": "エイチレフタグ",
+        "ja_typings": [
+          "eichirefutagu"
+        ]
+      },
+      {
+        "en": "`<a>` tag",
+        "ja": "エータグ",
+        "ja_typings": [
+          "eetagu",
+          "e-tagu"
+        ]
+      },
+      {
+        "en": "`<link>` tag",
+        "ja": "リンクタグ",
+        "ja_typings": [
+          "rinkutagu"
+        ]
+      },
+      {
+        "en": "`<nav>` tag",
+        "ja": "ナビタグ",
+        "ja_typings": [
+          "nabitagu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02002",
+    "image_path": null,
+    "question_text": {
+      "en": "Which of the following is NOT a real HTML element name?",
+      "ja": "実在しない HTML 要素名はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<movie>` tag",
+        "ja": "ムービータグ",
+        "ja_typings": [
+          "muubiitagu",
+          "mu-bi-tagu"
+        ]
+      },
+      {
+        "en": "`<video>` tag",
+        "ja": "ビデオタグ",
+        "ja_typings": [
+          "bideotagu"
+        ]
+      },
+      {
+        "en": "`<audio>` tag",
+        "ja": "オーディオタグ",
+        "ja_typings": [
+          "oodiotagu",
+          "o-diotagu"
+        ]
+      },
+      {
+        "en": "`<source>` tag",
+        "ja": "ソースタグ",
+        "ja_typings": [
+          "soosutagu",
+          "so-sutagu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02003",
+    "image_path": null,
+    "question_text": {
+      "en": "Which of the following is NOT a valid HTML tag?",
+      "ja": "正しい HTML タグでないものはどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<media>` tag",
+        "ja": "メディアタグ",
+        "ja_typings": [
+          "mediatagu"
+        ]
+      },
+      {
+        "en": "`<picture>` tag",
+        "ja": "ピクチャタグ",
+        "ja_typings": [
+          "pikutyatagu"
+        ]
+      },
+      {
+        "en": "`<video>` tag",
+        "ja": "ビデオタグ",
+        "ja_typings": [
+          "bideotagu"
+        ]
+      },
+      {
+        "en": "`<audio>` tag",
+        "ja": "オーディオタグ",
+        "ja_typings": [
+          "oodiotagu",
+          "o-diotagu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02004",
+    "image_path": null,
+    "question_text": {
+      "en": "Which of these tag names does NOT exist in HTML?",
+      "ja": "HTML に存在しないタグ名はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<embed>` tag",
+        "ja": "エンベッドタグ",
+        "ja_typings": [
+          "enbeddotagu"
+        ]
+      },
+      {
+        "en": "`<object>` tag",
+        "ja": "オブジェクトタグ",
+        "ja_typings": [
+          "obujekutotagu"
+        ]
+      },
+      {
+        "en": "`<iframe>` tag",
+        "ja": "アイフレームタグ",
+        "ja_typings": [
+          "aifureemutagu",
+          "aifure-mutagu"
+        ]
+      },
+      {
+        "en": "`<applet>` tag",
+        "ja": "アプレットタグ",
+        "ja_typings": [
+          "aapurettotagu",
+          "apurettotagu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02005",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML element embeds external content such as plugins or media?",
+      "ja": "プラグインやメディアなど外部コンテンツを埋め込む HTML 要素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`display: grid`",
+        "ja": "グリッドディスプレイ",
+        "ja_typings": [
+          "guriddodisupurei"
+        ]
+      },
+      {
+        "en": "`display: flex`",
+        "ja": "フレックスディスプレイ",
+        "ja_typings": [
+          "furekkusudisupurei"
+        ]
+      },
+      {
+        "en": "`display: block`",
+        "ja": "ブロックディスプレイ",
+        "ja_typings": [
+          "burokkudisupurei"
+        ]
+      },
+      {
+        "en": "`display: table`",
+        "ja": "テーブルディスプレイ",
+        "ja_typings": [
+          "teeburudisupurei",
+          "te-burudisupurei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02006",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS display value lays out children in a two-dimensional grid?",
+      "ja": "子要素を 2 次元グリッドに配置する CSS の display 値は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`display: block`",
+        "ja": "ブロックディスプレイ",
+        "ja_typings": [
+          "burokkudisupurei"
+        ]
+      },
+      {
+        "en": "`display: inline`",
+        "ja": "インラインディスプレイ",
+        "ja_typings": [
+          "inraindisupurei"
+        ]
+      },
+      {
+        "en": "`display: flex`",
+        "ja": "フレックスディスプレイ",
+        "ja_typings": [
+          "furekkusudisupurei"
+        ]
+      },
+      {
+        "en": "`display: none`",
+        "ja": "ノンディスプレイ",
+        "ja_typings": [
+          "nondisupurei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02007",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS display value makes the element start on a new line and take full width?",
+      "ja": "要素を改行して横幅いっぱいに広げる CSS の display 値は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`display: inline`",
+        "ja": "インラインディスプレイ",
+        "ja_typings": [
+          "inraindisupurei"
+        ]
+      },
+      {
+        "en": "`display: block`",
+        "ja": "ブロックディスプレイ",
+        "ja_typings": [
+          "burokkudisupurei"
+        ]
+      },
+      {
+        "en": "`display: contents`",
+        "ja": "コンテンツディスプレイ",
+        "ja_typings": [
+          "kontentsudisupurei"
+        ]
+      },
+      {
+        "en": "`display: run-in`",
+        "ja": "ランインディスプレイ",
+        "ja_typings": [
+          "ranindisupurei",
+          "rannindisupurei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02008",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS display value flows the element within text without line breaks?",
+      "ja": "要素を改行せずテキスト中に流す CSS の display 値は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Flexbox",
+        "ja": "フレックスボックス",
+        "ja_typings": [
+          "furekkusubokkusu"
+        ]
+      },
+      {
+        "en": "Grid",
+        "ja": "グリッドレイアウト",
+        "ja_typings": [
+          "guriddoreiauto"
+        ]
+      },
+      {
+        "en": "Table",
+        "ja": "テーブルレイアウト",
+        "ja_typings": [
+          "teebururereiauto",
+          "teebureiauto",
+          "te-burureiauto"
+        ]
+      },
+      {
+        "en": "Multi-column",
+        "ja": "マルチカラム",
+        "ja_typings": [
+          "maruchikaramu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02009",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS layout module arranges items in a single dimension with flexible sizing?",
+      "ja": "アイテムを 1 次元に柔軟なサイズで並べる CSS レイアウトモジュールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Float",
+        "ja": "フロート",
+        "ja_typings": [
+          "furo-to"
+        ]
+      },
+      {
+        "en": "Clear",
+        "ja": "クリア",
+        "ja_typings": [
+          "kuria"
+        ]
+      },
+      {
+        "en": "Position",
+        "ja": "ポジション",
+        "ja_typings": [
+          "pojishon"
+        ]
+      },
+      {
+        "en": "Align",
+        "ja": "アライン",
+        "ja_typings": [
+          "arain"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02010",
+    "image_path": null,
+    "question_text": {
+      "en": "Which legacy CSS property removes an element from normal flow to the side?",
+      "ja": "通常フローから要素を外して横に寄せる古典的な CSS プロパティは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Position",
+        "ja": "ポジション",
+        "ja_typings": [
+          "pojishon"
+        ]
+      },
+      {
+        "en": "Float",
+        "ja": "フロート",
+        "ja_typings": [
+          "furo-to"
+        ]
+      },
+      {
+        "en": "Display",
+        "ja": "ディスプレイ",
+        "ja_typings": [
+          "disupurei"
+        ]
+      },
+      {
+        "en": "Align",
+        "ja": "アライン",
+        "ja_typings": [
+          "arain"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02011",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS property sets how an element is positioned in the document?",
+      "ja": "要素の配置方法を指定する CSS プロパティは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Europe",
+        "ja": "ヨーロッパ",
+        "ja_typings": [
+          "yo-roppa"
+        ]
+      },
+      {
+        "en": "Africa",
+        "ja": "アフリカ",
+        "ja_typings": [
+          "afurika"
+        ]
+      },
+      {
+        "en": "Asia",
+        "ja": "アジア",
+        "ja_typings": [
+          "ajia"
+        ]
+      },
+      {
+        "en": "Oceania",
+        "ja": "オセアニア",
+        "ja_typings": [
+          "oseania"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02012",
+    "image_path": null,
+    "question_text": {
+      "en": "Which continent contains France, Germany, and Italy?",
+      "ja": "フランス・ドイツ・イタリアを含む大陸は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "China",
+        "ja": "中国",
+        "ja_typings": [
+          "chuugoku"
+        ]
+      },
+      {
+        "en": "Russia",
+        "ja": "ロシア",
+        "ja_typings": [
+          "roshia"
+        ]
+      },
+      {
+        "en": "United States",
+        "ja": "アメリカ合衆国",
+        "ja_typings": [
+          "amerika/gasshuukoku"
+        ]
+      },
+      {
+        "en": "Indonesia",
+        "ja": "インドネシア",
+        "ja_typings": [
+          "indoneshia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02013",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has the world's largest population by historical record in 2020?",
+      "ja": "2020年時点で世界最大の人口を持っていた国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gobi Desert",
+        "ja": "ゴビ砂漠",
+        "ja_typings": [
+          "gobi/sabaku"
+        ]
+      },
+      {
+        "en": "Taklamakan",
+        "ja": "タクラマカン砂漠",
+        "ja_typings": [
+          "takuramakan/sabaku"
+        ]
+      },
+      {
+        "en": "Karakum",
+        "ja": "カラクム砂漠",
+        "ja_typings": [
+          "karakumu/sabaku"
+        ]
+      },
+      {
+        "en": "Thar",
+        "ja": "タール砂漠",
+        "ja_typings": [
+          "taaru/sabaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02014",
+    "image_path": null,
+    "question_text": {
+      "en": "Which desert stretches across southern Mongolia and northern China?",
+      "ja": "モンゴル南部と中国北部に広がる砂漠は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lake Tanganyika",
+        "ja": "タンガニーカ湖",
+        "ja_typings": [
+          "tanganiika/ko"
+        ]
+      },
+      {
+        "en": "Lake Victoria",
+        "ja": "ヴィクトリア湖",
+        "ja_typings": [
+          "vikutoria/ko"
+        ]
+      },
+      {
+        "en": "Lake Malawi",
+        "ja": "マラウイ湖",
+        "ja_typings": [
+          "maraui/ko"
+        ]
+      },
+      {
+        "en": "Lake Chad",
+        "ja": "チャド湖",
+        "ja_typings": [
+          "chado/ko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02015",
+    "image_path": null,
+    "question_text": {
+      "en": "Which African lake is the world's second-deepest freshwater lake?",
+      "ja": "世界で2番目に深い淡水湖であるアフリカの湖は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lake Superior",
+        "ja": "スペリオル湖",
+        "ja_typings": [
+          "superioru/ko"
+        ]
+      },
+      {
+        "en": "Lake Huron",
+        "ja": "ヒューロン湖",
+        "ja_typings": [
+          "hyuuron/ko"
+        ]
+      },
+      {
+        "en": "Lake Michigan",
+        "ja": "ミシガン湖",
+        "ja_typings": [
+          "mishigan/ko"
+        ]
+      },
+      {
+        "en": "Lake Erie",
+        "ja": "エリー湖",
+        "ja_typings": [
+          "erii/ko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02016",
+    "image_path": null,
+    "question_text": {
+      "en": "Which of the Great Lakes has the largest surface area?",
+      "ja": "五大湖のうち最も面積が大きい湖は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Alps",
+        "ja": "アルプス山脈",
+        "ja_typings": [
+          "arupusu/sanmyaku"
+        ]
+      },
+      {
+        "en": "Pyrenees",
+        "ja": "ピレネー山脈",
+        "ja_typings": [
+          "pirenee/sanmyaku"
+        ]
+      },
+      {
+        "en": "Carpathians",
+        "ja": "カルパティア山脈",
+        "ja_typings": [
+          "karupatia/sanmyaku"
+        ]
+      },
+      {
+        "en": "Apennines",
+        "ja": "アペニン山脈",
+        "ja_typings": [
+          "apenin/sanmyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02017",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mountain range runs through Switzerland, Austria, and northern Italy?",
+      "ja": "スイス・オーストリア・北イタリアを貫く山脈は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bolivia",
+        "ja": "ボリビア",
+        "ja_typings": [
+          "boribia"
+        ]
+      },
+      {
+        "en": "Peru",
+        "ja": "ペルー",
+        "ja_typings": [
+          "peru-"
+        ]
+      },
+      {
+        "en": "Ecuador",
+        "ja": "エクアドル",
+        "ja_typings": [
+          "ekuadoru"
+        ]
+      },
+      {
+        "en": "Chile",
+        "ja": "チリ",
+        "ja_typings": [
+          "chiri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02018",
+    "image_path": null,
+    "question_text": {
+      "en": "Which South American country has La Paz as one of its capitals?",
+      "ja": "ラパスを首都の一つとする南米の国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sudan",
+        "ja": "スーダン",
+        "ja_typings": [
+          "su-dan"
+        ]
+      },
+      {
+        "en": "Egypt",
+        "ja": "エジプト",
+        "ja_typings": [
+          "ejiputo"
+        ]
+      },
+      {
+        "en": "Ethiopia",
+        "ja": "エチオピア",
+        "ja_typings": [
+          "echiopia"
+        ]
+      },
+      {
+        "en": "Chad",
+        "ja": "チャド",
+        "ja_typings": [
+          "chado"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02019",
+    "image_path": null,
+    "question_text": {
+      "en": "Which African country has Khartoum as its capital?",
+      "ja": "ハルツームを首都とするアフリカの国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "United States",
+        "ja": "アメリカ合衆国",
+        "ja_typings": [
+          "amerika/gasshuukoku"
+        ]
+      },
+      {
+        "en": "Canada",
+        "ja": "カナダ",
+        "ja_typings": [
+          "kanada"
+        ]
+      },
+      {
+        "en": "Mexico",
+        "ja": "メキシコ",
+        "ja_typings": [
+          "mekishiko"
+        ]
+      },
+      {
+        "en": "Brazil",
+        "ja": "ブラジル",
+        "ja_typings": [
+          "burajiru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02020",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Washington D.C. as its capital?",
+      "ja": "ワシントンD.C.を首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Atacama Desert",
+        "ja": "アタカマ砂漠",
+        "ja_typings": [
+          "atakama/sabaku"
+        ]
+      },
+      {
+        "en": "Patagonian Desert",
+        "ja": "パタゴニア砂漠",
+        "ja_typings": [
+          "patagonia/sabaku"
+        ]
+      },
+      {
+        "en": "Sechura Desert",
+        "ja": "セチュラ砂漠",
+        "ja_typings": [
+          "sechura/sabaku"
+        ]
+      },
+      {
+        "en": "Monte Desert",
+        "ja": "モンテ砂漠",
+        "ja_typings": [
+          "monte/sabaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02021",
+    "image_path": null,
+    "question_text": {
+      "en": "Which desert is one of the driest places on Earth, located in Chile?",
+      "ja": "チリにある、地球上で最も乾燥した場所の一つの砂漠は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "North America",
+        "ja": "北アメリカ",
+        "ja_typings": [
+          "kita/amerika"
+        ]
+      },
+      {
+        "en": "South America",
+        "ja": "南アメリカ",
+        "ja_typings": [
+          "minami/amerika"
+        ]
+      },
+      {
+        "en": "Europe",
+        "ja": "ヨーロッパ",
+        "ja_typings": [
+          "yo-roppa"
+        ]
+      },
+      {
+        "en": "Africa",
+        "ja": "アフリカ",
+        "ja_typings": [
+          "afurika"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02022",
+    "image_path": null,
+    "question_text": {
+      "en": "Which continent contains Canada and Mexico?",
+      "ja": "カナダとメキシコを含む大陸は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Antarctica",
+        "ja": "南極大陸",
+        "ja_typings": [
+          "nankyoku/tairiku"
+        ]
+      },
+      {
+        "en": "Australia",
+        "ja": "オーストラリア",
+        "ja_typings": [
+          "o-sutoraria"
+        ]
+      },
+      {
+        "en": "South America",
+        "ja": "南アメリカ",
+        "ja_typings": [
+          "minami/amerika"
+        ]
+      },
+      {
+        "en": "Africa",
+        "ja": "アフリカ",
+        "ja_typings": [
+          "afurika"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02023",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the southernmost continent on Earth?",
+      "ja": "地球上で最も南にある大陸は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mount Kenya",
+        "ja": "ケニア山",
+        "ja_typings": [
+          "kenia/san"
+        ]
+      },
+      {
+        "en": "Mount Kilimanjaro",
+        "ja": "キリマンジャロ山",
+        "ja_typings": [
+          "kirimanjaro/san"
+        ]
+      },
+      {
+        "en": "Mount Stanley",
+        "ja": "スタンレー山",
+        "ja_typings": [
+          "sutanree/san"
+        ]
+      },
+      {
+        "en": "Mount Meru",
+        "ja": "メルー山",
+        "ja_typings": [
+          "meruu/san"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02024",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the second-highest mountain in Africa, located in central Kenya?",
+      "ja": "ケニア中央部にあるアフリカで2番目に高い山は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Istanbul",
+        "ja": "イスタンブール",
+        "ja_typings": [
+          "isutanbu-ru"
+        ]
+      },
+      {
+        "en": "Ankara",
+        "ja": "アンカラ",
+        "ja_typings": [
+          "ankara"
+        ]
+      },
+      {
+        "en": "Izmir",
+        "ja": "イズミル",
+        "ja_typings": [
+          "izumiru"
+        ]
+      },
+      {
+        "en": "Bursa",
+        "ja": "ブルサ",
+        "ja_typings": [
+          "burusa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02025",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the largest city of Turkey, straddling Europe and Asia?",
+      "ja": "ヨーロッパとアジアにまたがるトルコ最大の都市は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pyrenees",
+        "ja": "ピレネー山脈",
+        "ja_typings": [
+          "pirenee/sanmyaku"
+        ]
+      },
+      {
+        "en": "Alps",
+        "ja": "アルプス山脈",
+        "ja_typings": [
+          "arupusu/sanmyaku"
+        ]
+      },
+      {
+        "en": "Apennines",
+        "ja": "アペニン山脈",
+        "ja_typings": [
+          "apenin/sanmyaku"
+        ]
+      },
+      {
+        "en": "Cantabrian Mountains",
+        "ja": "カンタブリア山脈",
+        "ja_typings": [
+          "kantaburia/sanmyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02026",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mountain range forms the border between France and Spain?",
+      "ja": "フランスとスペインの国境を成す山脈は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Denmark",
+        "ja": "デンマーク",
+        "ja_typings": [
+          "denma-ku"
+        ]
+      },
+      {
+        "en": "Sweden",
+        "ja": "スウェーデン",
+        "ja_typings": [
+          "suwe-den"
+        ]
+      },
+      {
+        "en": "Norway",
+        "ja": "ノルウェー",
+        "ja_typings": [
+          "noruwe-"
+        ]
+      },
+      {
+        "en": "Finland",
+        "ja": "フィンランド",
+        "ja_typings": [
+          "finrando"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02027",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Scandinavian country has Copenhagen as its capital?",
+      "ja": "コペンハーゲンを首都とする北欧の国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Iceland",
+        "ja": "アイスランド",
+        "ja_typings": [
+          "aisurando"
+        ]
+      },
+      {
+        "en": "Greenland",
+        "ja": "グリーンランド",
+        "ja_typings": [
+          "guri-nrando"
+        ]
+      },
+      {
+        "en": "Faroe Islands",
+        "ja": "フェロー諸島",
+        "ja_typings": [
+          "feroo/shotou"
+        ]
+      },
+      {
+        "en": "Svalbard",
+        "ja": "スヴァールバル",
+        "ja_typings": [
+          "suva-rubaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02028",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nordic island country has Reykjavik as its capital?",
+      "ja": "レイキャビクを首都とする北欧の島国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mexico",
+        "ja": "メキシコ",
+        "ja_typings": [
+          "mekishiko"
+        ]
+      },
+      {
+        "en": "Guatemala",
+        "ja": "グアテマラ",
+        "ja_typings": [
+          "guatemara"
+        ]
+      },
+      {
+        "en": "Honduras",
+        "ja": "ホンジュラス",
+        "ja_typings": [
+          "honjurasu"
+        ]
+      },
+      {
+        "en": "Belize",
+        "ja": "ベリーズ",
+        "ja_typings": [
+          "beri-zu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02029",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has Mexico City as its capital?",
+      "ja": "メキシコシティを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Venezuela",
+        "ja": "ベネズエラ",
+        "ja_typings": [
+          "benezuera"
+        ]
+      },
+      {
+        "en": "Colombia",
+        "ja": "コロンビア",
+        "ja_typings": [
+          "koronbia"
+        ]
+      },
+      {
+        "en": "Guyana",
+        "ja": "ガイアナ",
+        "ja_typings": [
+          "gaiana"
+        ]
+      },
+      {
+        "en": "Suriname",
+        "ja": "スリナム",
+        "ja_typings": [
+          "surinamu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02030",
+    "image_path": null,
+    "question_text": {
+      "en": "Which South American country has Caracas as its capital?",
+      "ja": "カラカスを首都とする南米の国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Laos",
+        "ja": "ラオス",
+        "ja_typings": [
+          "raosu"
+        ]
+      },
+      {
+        "en": "Cambodia",
+        "ja": "カンボジア",
+        "ja_typings": [
+          "kanbojia"
+        ]
+      },
+      {
+        "en": "Vietnam",
+        "ja": "ベトナム",
+        "ja_typings": [
+          "betonamu"
+        ]
+      },
+      {
+        "en": "Thailand",
+        "ja": "タイ",
+        "ja_typings": [
+          "tai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02031",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Southeast Asian country has Vientiane as its capital?",
+      "ja": "ヴィエンチャンを首都とする東南アジアの国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cambodia",
+        "ja": "カンボジア",
+        "ja_typings": [
+          "kanbojia"
+        ]
+      },
+      {
+        "en": "Laos",
+        "ja": "ラオス",
+        "ja_typings": [
+          "raosu"
+        ]
+      },
+      {
+        "en": "Vietnam",
+        "ja": "ベトナム",
+        "ja_typings": [
+          "betonamu"
+        ]
+      },
+      {
+        "en": "Myanmar",
+        "ja": "ミャンマー",
+        "ja_typings": [
+          "myanma-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02032",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Southeast Asian country has Phnom Penh as its capital?",
+      "ja": "プノンペンを首都とする東南アジアの国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Myanmar",
+        "ja": "ミャンマー",
+        "ja_typings": [
+          "myanma-"
+        ]
+      },
+      {
+        "en": "Thailand",
+        "ja": "タイ",
+        "ja_typings": [
+          "tai"
+        ]
+      },
+      {
+        "en": "Bangladesh",
+        "ja": "バングラデシュ",
+        "ja_typings": [
+          "banguradeshu"
+        ]
+      },
+      {
+        "en": "Laos",
+        "ja": "ラオス",
+        "ja_typings": [
+          "raosu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02033",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Southeast Asian country has Naypyidaw as its capital?",
+      "ja": "ネピドーを首都とする東南アジアの国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bulgaria",
+        "ja": "ブルガリア",
+        "ja_typings": [
+          "burugaria"
+        ]
+      },
+      {
+        "en": "Romania",
+        "ja": "ルーマニア",
+        "ja_typings": [
+          "ru-mania"
+        ]
+      },
+      {
+        "en": "Serbia",
+        "ja": "セルビア",
+        "ja_typings": [
+          "serubia"
+        ]
+      },
+      {
+        "en": "Albania",
+        "ja": "アルバニア",
+        "ja_typings": [
+          "arubania"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02034",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Balkan country has Sofia as its capital?",
+      "ja": "ソフィアを首都とするバルカンの国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Romania",
+        "ja": "ルーマニア",
+        "ja_typings": [
+          "ru-mania"
+        ]
+      },
+      {
+        "en": "Bulgaria",
+        "ja": "ブルガリア",
+        "ja_typings": [
+          "burugaria"
+        ]
+      },
+      {
+        "en": "Hungary",
+        "ja": "ハンガリー",
+        "ja_typings": [
+          "hangari-"
+        ]
+      },
+      {
+        "en": "Moldova",
+        "ja": "モルドバ",
+        "ja_typings": [
+          "morudoba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02035",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Eastern European country has Bucharest as its capital?",
+      "ja": "ブカレストを首都とする東欧の国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sweden",
+        "ja": "スウェーデン",
+        "ja_typings": [
+          "suwe-den"
+        ]
+      },
+      {
+        "en": "Norway",
+        "ja": "ノルウェー",
+        "ja_typings": [
+          "noruwe-"
+        ]
+      },
+      {
+        "en": "Denmark",
+        "ja": "デンマーク",
+        "ja_typings": [
+          "denma-ku"
+        ]
+      },
+      {
+        "en": "Finland",
+        "ja": "フィンランド",
+        "ja_typings": [
+          "finrando"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02036",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Scandinavian country has Stockholm as its capital?",
+      "ja": "ストックホルムを首都とする北欧の国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Uruguay",
+        "ja": "ウルグアイ",
+        "ja_typings": [
+          "uruguai"
+        ]
+      },
+      {
+        "en": "Paraguay",
+        "ja": "パラグアイ",
+        "ja_typings": [
+          "paraguai"
+        ]
+      },
+      {
+        "en": "Argentina",
+        "ja": "アルゼンチン",
+        "ja_typings": [
+          "aruzenchin"
+        ]
+      },
+      {
+        "en": "Chile",
+        "ja": "チリ",
+        "ja_typings": [
+          "chiri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02037",
+    "image_path": null,
+    "question_text": {
+      "en": "Which South American country has Montevideo as its capital?",
+      "ja": "モンテビデオを首都とする南米の国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Paraguay",
+        "ja": "パラグアイ",
+        "ja_typings": [
+          "paraguai"
+        ]
+      },
+      {
+        "en": "Uruguay",
+        "ja": "ウルグアイ",
+        "ja_typings": [
+          "uruguai"
+        ]
+      },
+      {
+        "en": "Bolivia",
+        "ja": "ボリビア",
+        "ja_typings": [
+          "boribia"
+        ]
+      },
+      {
+        "en": "Peru",
+        "ja": "ペルー",
+        "ja_typings": [
+          "peru-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02038",
+    "image_path": null,
+    "question_text": {
+      "en": "Which South American country has Asuncion as its capital?",
+      "ja": "アスンシオンを首都とする南米の国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Libya",
+        "ja": "リビア",
+        "ja_typings": [
+          "ribia"
+        ]
+      },
+      {
+        "en": "Tunisia",
+        "ja": "チュニジア",
+        "ja_typings": [
+          "chunijia"
+        ]
+      },
+      {
+        "en": "Algeria",
+        "ja": "アルジェリア",
+        "ja_typings": [
+          "arujeria"
+        ]
+      },
+      {
+        "en": "Egypt",
+        "ja": "エジプト",
+        "ja_typings": [
+          "ejiputo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02039",
+    "image_path": null,
+    "question_text": {
+      "en": "Which North African country has Tripoli as its capital?",
+      "ja": "トリポリを首都とする北アフリカの国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fiji",
+        "ja": "フィジー",
+        "ja_typings": [
+          "fiji-"
+        ]
+      },
+      {
+        "en": "Samoa",
+        "ja": "サモア",
+        "ja_typings": [
+          "samoa"
+        ]
+      },
+      {
+        "en": "Tonga",
+        "ja": "トンガ",
+        "ja_typings": [
+          "tonga"
+        ]
+      },
+      {
+        "en": "Vanuatu",
+        "ja": "バヌアツ",
+        "ja_typings": [
+          "banuatsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02040",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Pacific island country has Suva as its capital?",
+      "ja": "スバを首都とする太平洋の島国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rhine",
+        "ja": "ライン川",
+        "ja_typings": [
+          "rain/gawa"
+        ]
+      },
+      {
+        "en": "Elbe",
+        "ja": "エルベ川",
+        "ja_typings": [
+          "erube/gawa"
+        ]
+      },
+      {
+        "en": "Danube",
+        "ja": "ドナウ川",
+        "ja_typings": [
+          "donau/gawa"
+        ]
+      },
+      {
+        "en": "Seine",
+        "ja": "セーヌ川",
+        "ja_typings": [
+          "seenu/gawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02041",
+    "image_path": null,
+    "question_text": {
+      "en": "Which river flows through Germany and the Netherlands into the North Sea?",
+      "ja": "ドイツとオランダを流れ北海に注ぐ川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Danube",
+        "ja": "ドナウ川",
+        "ja_typings": [
+          "donau/gawa"
+        ]
+      },
+      {
+        "en": "Rhine",
+        "ja": "ライン川",
+        "ja_typings": [
+          "rain/gawa"
+        ]
+      },
+      {
+        "en": "Volga",
+        "ja": "ヴォルガ川",
+        "ja_typings": [
+          "voruga/gawa"
+        ]
+      },
+      {
+        "en": "Dnieper",
+        "ja": "ドニエプル川",
+        "ja_typings": [
+          "doniepuru/gawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02042",
+    "image_path": null,
+    "question_text": {
+      "en": "Which river flows through Vienna, Budapest, and Belgrade into the Black Sea?",
+      "ja": "ウィーン・ブダペスト・ベオグラードを流れ黒海に注ぐ川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Loire",
+        "ja": "ロワール川",
+        "ja_typings": [
+          "rowaaru/gawa"
+        ]
+      },
+      {
+        "en": "Seine",
+        "ja": "セーヌ川",
+        "ja_typings": [
+          "seenu/gawa"
+        ]
+      },
+      {
+        "en": "Rhone",
+        "ja": "ローヌ川",
+        "ja_typings": [
+          "roonu/gawa"
+        ]
+      },
+      {
+        "en": "Garonne",
+        "ja": "ガロンヌ川",
+        "ja_typings": [
+          "garonnu/gawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02043",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the longest river in France?",
+      "ja": "フランスで最も長い川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yellow River",
+        "ja": "黄河",
+        "ja_typings": [
+          "kouga"
+        ]
+      },
+      {
+        "en": "Yangtze",
+        "ja": "長江",
+        "ja_typings": [
+          "choukou"
+        ]
+      },
+      {
+        "en": "Pearl River",
+        "ja": "珠江",
+        "ja_typings": [
+          "shukou"
+        ]
+      },
+      {
+        "en": "Mekong",
+        "ja": "メコン川",
+        "ja_typings": [
+          "mekon/gawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02044",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Chinese river is also known as the Huang He?",
+      "ja": "「黄河」とも呼ばれる中国の川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mekong",
+        "ja": "メコン川",
+        "ja_typings": [
+          "mekon/gawa"
+        ]
+      },
+      {
+        "en": "Yangtze",
+        "ja": "長江",
+        "ja_typings": [
+          "choukou"
+        ]
+      },
+      {
+        "en": "Salween",
+        "ja": "サルウィン川",
+        "ja_typings": [
+          "saruuin/gawa"
+        ]
+      },
+      {
+        "en": "Irrawaddy",
+        "ja": "イラワジ川",
+        "ja_typings": [
+          "irawaji/gawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02045",
+    "image_path": null,
+    "question_text": {
+      "en": "Which river flows from Tibet through Laos and Vietnam into the South China Sea?",
+      "ja": "チベットからラオス・ベトナムを流れ南シナ海に注ぐ川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pearl River",
+        "ja": "珠江",
+        "ja_typings": [
+          "shukou"
+        ]
+      },
+      {
+        "en": "Yellow River",
+        "ja": "黄河",
+        "ja_typings": [
+          "kouga"
+        ]
+      },
+      {
+        "en": "Yangtze",
+        "ja": "長江",
+        "ja_typings": [
+          "choukou"
+        ]
+      },
+      {
+        "en": "Mekong",
+        "ja": "メコン川",
+        "ja_typings": [
+          "mekon/gawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02046",
+    "image_path": null,
+    "question_text": {
+      "en": "Which river flows through Guangzhou into the South China Sea?",
+      "ja": "広州を流れ南シナ海に注ぐ中国の川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Black Sea",
+        "ja": "黒海",
+        "ja_typings": [
+          "kokkai"
+        ]
+      },
+      {
+        "en": "Caspian Sea",
+        "ja": "カスピ海",
+        "ja_typings": [
+          "kasupi/kai"
+        ]
+      },
+      {
+        "en": "Aegean Sea",
+        "ja": "エーゲ海",
+        "ja_typings": [
+          "eege/kai"
+        ]
+      },
+      {
+        "en": "Mediterranean Sea",
+        "ja": "地中海",
+        "ja_typings": [
+          "chichuukai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02047",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sea lies between Turkey and Ukraine?",
+      "ja": "トルコとウクライナの間にある海は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Taklamakan",
+        "ja": "タクラマカン砂漠",
+        "ja_typings": [
+          "takuramakan/sabaku"
+        ]
+      },
+      {
+        "en": "Gobi Desert",
+        "ja": "ゴビ砂漠",
+        "ja_typings": [
+          "gobi/sabaku"
+        ]
+      },
+      {
+        "en": "Karakum",
+        "ja": "カラクム砂漠",
+        "ja_typings": [
+          "karakumu/sabaku"
+        ]
+      },
+      {
+        "en": "Kyzylkum",
+        "ja": "キジルクム砂漠",
+        "ja_typings": [
+          "kijirukumu/sabaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02048",
+    "image_path": null,
+    "question_text": {
+      "en": "Which desert lies in the Tarim Basin of northwest China?",
+      "ja": "中国北西部タリム盆地にある砂漠は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Karakum",
+        "ja": "カラクム砂漠",
+        "ja_typings": [
+          "karakumu/sabaku"
+        ]
+      },
+      {
+        "en": "Kyzylkum",
+        "ja": "キジルクム砂漠",
+        "ja_typings": [
+          "kijirukumu/sabaku"
+        ]
+      },
+      {
+        "en": "Taklamakan",
+        "ja": "タクラマカン砂漠",
+        "ja_typings": [
+          "takuramakan/sabaku"
+        ]
+      },
+      {
+        "en": "Gobi Desert",
+        "ja": "ゴビ砂漠",
+        "ja_typings": [
+          "gobi/sabaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02049",
+    "image_path": null,
+    "question_text": {
+      "en": "Which desert covers most of Turkmenistan?",
+      "ja": "トルクメニスタンの大部分を覆う砂漠は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thar",
+        "ja": "タール砂漠",
+        "ja_typings": [
+          "taaru/sabaku"
+        ]
+      },
+      {
+        "en": "Karakum",
+        "ja": "カラクム砂漠",
+        "ja_typings": [
+          "karakumu/sabaku"
+        ]
+      },
+      {
+        "en": "Gobi Desert",
+        "ja": "ゴビ砂漠",
+        "ja_typings": [
+          "gobi/sabaku"
+        ]
+      },
+      {
+        "en": "Negev",
+        "ja": "ネゲヴ砂漠",
+        "ja_typings": [
+          "negevu/sabaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02050",
+    "image_path": null,
+    "question_text": {
+      "en": "Which desert lies in northwestern India and southeastern Pakistan?",
+      "ja": "インド北西部とパキスタン南東部にある砂漠は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Monaco",
+        "ja": "モナコ",
+        "ja_typings": [
+          "monako"
+        ]
+      },
+      {
+        "en": "Andorra",
+        "ja": "アンドラ",
+        "ja_typings": [
+          "andora"
+        ]
+      },
+      {
+        "en": "San Marino",
+        "ja": "サンマリノ",
+        "ja_typings": [
+          "sanmarino"
+        ]
+      },
+      {
+        "en": "Liechtenstein",
+        "ja": "リヒテンシュタイン",
+        "ja_typings": [
+          "rihitenshutain"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02051",
+    "image_path": null,
+    "question_text": {
+      "en": "Which microstate on the French Riviera is famous for its casino?",
+      "ja": "フレンチリヴィエラにある、カジノで有名な小国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Liechtenstein",
+        "ja": "リヒテンシュタイン",
+        "ja_typings": [
+          "rihitenshutain"
+        ]
+      },
+      {
+        "en": "Monaco",
+        "ja": "モナコ",
+        "ja_typings": [
+          "monako"
+        ]
+      },
+      {
+        "en": "Andorra",
+        "ja": "アンドラ",
+        "ja_typings": [
+          "andora"
+        ]
+      },
+      {
+        "en": "Luxembourg",
+        "ja": "ルクセンブルク",
+        "ja_typings": [
+          "rukusenburuku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02052",
+    "image_path": null,
+    "question_text": {
+      "en": "Which microstate lies between Switzerland and Austria?",
+      "ja": "スイスとオーストリアの間にある小国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Strait of Hormuz",
+        "ja": "ホルムズ海峡",
+        "ja_typings": [
+          "horumuzu/kaikyou"
+        ]
+      },
+      {
+        "en": "Strait of Malacca",
+        "ja": "マラッカ海峡",
+        "ja_typings": [
+          "marakka/kaikyou"
+        ]
+      },
+      {
+        "en": "Bab-el-Mandeb",
+        "ja": "バブ・エル・マンデブ海峡",
+        "ja_typings": [
+          "babu/eru/mandebu/kaikyou"
+        ]
+      },
+      {
+        "en": "Bosphorus",
+        "ja": "ボスポラス海峡",
+        "ja_typings": [
+          "bosuporasu/kaikyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02053",
+    "image_path": null,
+    "question_text": {
+      "en": "Which strait connects the Persian Gulf to the Gulf of Oman?",
+      "ja": "ペルシア湾とオマーン湾を結ぶ海峡は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Strait of Malacca",
+        "ja": "マラッカ海峡",
+        "ja_typings": [
+          "marakka/kaikyou"
+        ]
+      },
+      {
+        "en": "Strait of Hormuz",
+        "ja": "ホルムズ海峡",
+        "ja_typings": [
+          "horumuzu/kaikyou"
+        ]
+      },
+      {
+        "en": "Sunda Strait",
+        "ja": "スンダ海峡",
+        "ja_typings": [
+          "sunda/kaikyou"
+        ]
+      },
+      {
+        "en": "Taiwan Strait",
+        "ja": "台湾海峡",
+        "ja_typings": [
+          "taiwan/kaikyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02054",
+    "image_path": null,
+    "question_text": {
+      "en": "Which strait connects the Indian Ocean and the South China Sea?",
+      "ja": "インド洋と南シナ海を結ぶ海峡は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cyprus",
+        "ja": "キプロス",
+        "ja_typings": [
+          "kipurosu"
+        ]
+      },
+      {
+        "en": "Malta",
+        "ja": "マルタ",
+        "ja_typings": [
+          "maruta"
+        ]
+      },
+      {
+        "en": "Crete",
+        "ja": "クレタ",
+        "ja_typings": [
+          "kureta"
+        ]
+      },
+      {
+        "en": "Rhodes",
+        "ja": "ロドス",
+        "ja_typings": [
+          "rodosu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02055",
+    "image_path": null,
+    "question_text": {
+      "en": "Which island country in the eastern Mediterranean has Nicosia as its capital?",
+      "ja": "東地中海にあるニコシアを首都とする島国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Malta",
+        "ja": "マルタ",
+        "ja_typings": [
+          "maruta"
+        ]
+      },
+      {
+        "en": "Cyprus",
+        "ja": "キプロス",
+        "ja_typings": [
+          "kipurosu"
+        ]
+      },
+      {
+        "en": "Sicily",
+        "ja": "シチリア",
+        "ja_typings": [
+          "shichiria"
+        ]
+      },
+      {
+        "en": "Corsica",
+        "ja": "コルシカ",
+        "ja_typings": [
+          "korushika"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02056",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mediterranean island country has Valletta as its capital?",
+      "ja": "ヴァレッタを首都とする地中海の島国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Brunei",
+        "ja": "ブルネイ",
+        "ja_typings": [
+          "burunei"
+        ]
+      },
+      {
+        "en": "Singapore",
+        "ja": "シンガポール",
+        "ja_typings": [
+          "shingapo-ru"
+        ]
+      },
+      {
+        "en": "Malaysia",
+        "ja": "マレーシア",
+        "ja_typings": [
+          "mare-shia"
+        ]
+      },
+      {
+        "en": "East Timor",
+        "ja": "東ティモール",
+        "ja_typings": [
+          "higashi/timooru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02057",
+    "image_path": null,
+    "question_text": {
+      "en": "Which small Southeast Asian country on Borneo is ruled by a sultan?",
+      "ja": "ボルネオ島にある、スルタンが統治する東南アジアの小国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sydney",
+        "ja": "シドニー",
+        "ja_typings": [
+          "shidoni-"
+        ]
+      },
+      {
+        "en": "Melbourne",
+        "ja": "メルボルン",
+        "ja_typings": [
+          "meruborun"
+        ]
+      },
+      {
+        "en": "Brisbane",
+        "ja": "ブリスベン",
+        "ja_typings": [
+          "burisuben"
+        ]
+      },
+      {
+        "en": "Perth",
+        "ja": "パース",
+        "ja_typings": [
+          "pa-su"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02058",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the most populous city in Australia?",
+      "ja": "オーストラリアで最も人口の多い都市は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Melbourne",
+        "ja": "メルボルン",
+        "ja_typings": [
+          "meruborun"
+        ]
+      },
+      {
+        "en": "Sydney",
+        "ja": "シドニー",
+        "ja_typings": [
+          "shidoni-"
+        ]
+      },
+      {
+        "en": "Adelaide",
+        "ja": "アデレード",
+        "ja_typings": [
+          "adere-do"
+        ]
+      },
+      {
+        "en": "Canberra",
+        "ja": "キャンベラ",
+        "ja_typings": [
+          "kyanbera"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02059",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Australian city hosts the famous Melbourne Cup horse race?",
+      "ja": "メルボルンカップ競馬が開催されるオーストラリアの都市は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Perth",
+        "ja": "パース",
+        "ja_typings": [
+          "pa-su"
+        ]
+      },
+      {
+        "en": "Sydney",
+        "ja": "シドニー",
+        "ja_typings": [
+          "shidoni-"
+        ]
+      },
+      {
+        "en": "Darwin",
+        "ja": "ダーウィン",
+        "ja_typings": [
+          "da-win"
+        ]
+      },
+      {
+        "en": "Hobart",
+        "ja": "ホバート",
+        "ja_typings": [
+          "hoba-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02060",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the capital of Western Australia?",
+      "ja": "西オーストラリア州の州都は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "K2",
+        "ja": "K2",
+        "ja_typings": [
+          "k2"
+        ]
+      },
+      {
+        "en": "Kangchenjunga",
+        "ja": "カンチェンジュンガ",
+        "ja_typings": [
+          "kanchenjunga"
+        ]
+      },
+      {
+        "en": "Lhotse",
+        "ja": "ローツェ",
+        "ja_typings": [
+          "ro-tse"
+        ]
+      },
+      {
+        "en": "Makalu",
+        "ja": "マカルー",
+        "ja_typings": [
+          "makaru-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02061",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the second-highest mountain in the world?",
+      "ja": "世界で2番目に高い山は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kublai Khan",
+        "ja": "フビライ・ハン",
+        "ja_typings": [
+          "fubirai/han"
+        ]
+      },
+      {
+        "en": "Genghis Khan",
+        "ja": "チンギス・ハン",
+        "ja_typings": [
+          "chingisu/han"
+        ]
+      },
+      {
+        "en": "Ogedei Khan",
+        "ja": "オゴデイ・ハン",
+        "ja_typings": [
+          "ogodei/han"
+        ]
+      },
+      {
+        "en": "Mongke Khan",
+        "ja": "モンケ・ハン",
+        "ja_typings": [
+          "monke/han"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02062",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mongol emperor founded the Yuan dynasty?",
+      "ja": "元朝を建てたモンゴル皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Henry IV",
+        "ja": "アンリ4世",
+        "ja_typings": [
+          "anri/4/sei"
+        ]
+      },
+      {
+        "en": "Louis XIII",
+        "ja": "ルイ13世",
+        "ja_typings": [
+          "rui/13/sei"
+        ]
+      },
+      {
+        "en": "Henry III",
+        "ja": "アンリ3世",
+        "ja_typings": [
+          "anri/3/sei"
+        ]
+      },
+      {
+        "en": "Charles IX",
+        "ja": "シャルル9世",
+        "ja_typings": [
+          "sharuru/9/sei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02063",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French king issued the Edict of Nantes in 1598?",
+      "ja": "1598年にナント勅令を発したフランス王は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bose",
+        "ja": "ボース",
+        "ja_typings": [
+          "bo-su"
+        ]
+      },
+      {
+        "en": "Nehru",
+        "ja": "ネルー",
+        "ja_typings": [
+          "neru-"
+        ]
+      },
+      {
+        "en": "Gandhi",
+        "ja": "ガンディー",
+        "ja_typings": [
+          "gandi-"
+        ]
+      },
+      {
+        "en": "Patel",
+        "ja": "パテル",
+        "ja_typings": [
+          "pateru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02064",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Indian revolutionary led the Indian National Army during WWII?",
+      "ja": "第二次大戦中にインド国民軍を率いた独立運動家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Trotsky",
+        "ja": "トロツキー",
+        "ja_typings": [
+          "torotsuki-"
+        ]
+      },
+      {
+        "en": "Lenin",
+        "ja": "レーニン",
+        "ja_typings": [
+          "re-nin"
+        ]
+      },
+      {
+        "en": "Bukharin",
+        "ja": "ブハーリン",
+        "ja_typings": [
+          "buha-rin"
+        ]
+      },
+      {
+        "en": "Kamenev",
+        "ja": "カーメネフ",
+        "ja_typings": [
+          "ka-menefu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02065",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Soviet revolutionary founded the Red Army and was later exiled by Stalin?",
+      "ja": "赤軍を創設し後にスターリンに追放されたソ連の革命家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yuan",
+        "ja": "元",
+        "ja_typings": [
+          "gen"
+        ]
+      },
+      {
+        "en": "Ming",
+        "ja": "明",
+        "ja_typings": [
+          "min"
+        ]
+      },
+      {
+        "en": "Song",
+        "ja": "宋",
+        "ja_typings": [
+          "sou"
+        ]
+      },
+      {
+        "en": "Qing",
+        "ja": "清",
+        "ja_typings": [
+          "shin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02066",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Chinese dynasty was founded by Kublai Khan in 1271?",
+      "ja": "1271年にフビライ・ハンが建てた中国の王朝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Crimean War",
+        "ja": "クリミア戦争",
+        "ja_typings": [
+          "kurimia/sensou"
+        ]
+      },
+      {
+        "en": "Russo-Turkish War",
+        "ja": "露土戦争",
+        "ja_typings": [
+          "roto/sensou"
+        ]
+      },
+      {
+        "en": "Franco-Prussian War",
+        "ja": "普仏戦争",
+        "ja_typings": [
+          "fufutsu/sensou"
+        ]
+      },
+      {
+        "en": "Austro-Prussian War",
+        "ja": "普墺戦争",
+        "ja_typings": [
+          "fuou/sensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02067",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 19th-century war was fought between Russia and an alliance of Britain, France, and the Ottoman Empire?",
+      "ja": "ロシアと英仏オスマン連合の間で起こった19世紀の戦争は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tesla",
+        "ja": "テスラ",
+        "ja_typings": [
+          "tesura"
+        ]
+      },
+      {
+        "en": "Edison",
+        "ja": "エジソン",
+        "ja_typings": [
+          "ejison"
+        ]
+      },
+      {
+        "en": "Marconi",
+        "ja": "マルコーニ",
+        "ja_typings": [
+          "maruko-ni"
+        ]
+      },
+      {
+        "en": "Westinghouse",
+        "ja": "ウェスティングハウス",
+        "ja_typings": [
+          "wesutinguhausu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02068",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Serbian-American inventor pioneered alternating-current electrical systems?",
+      "ja": "交流電力システムを開拓したセルビア系米国人発明家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thermidorian Reaction",
+        "ja": "テルミドールのクーデター",
+        "ja_typings": [
+          "terumidooru/no/kuudetaa",
+          "terumido-runoku-deta-"
+        ]
+      },
+      {
+        "en": "Storming of the Bastille",
+        "ja": "バスティーユ襲撃",
+        "ja_typings": [
+          "bastiyu/shuugeki"
+        ]
+      },
+      {
+        "en": "Night of August 4",
+        "ja": "8月4日の夜",
+        "ja_typings": [
+          "8gatsu/4nichi/no/yoru"
+        ]
+      },
+      {
+        "en": "Brumaire Coup",
+        "ja": "ブリュメールのクーデター",
+        "ja_typings": [
+          "buryumeeru/no/kuudetaa",
+          "buryume-runoku-deta-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02069",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1794 event ended the Reign of Terror in revolutionary France?",
+      "ja": "1794年に恐怖政治を終わらせたフランス革命期の事件は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Battle of Valmy",
+        "ja": "ヴァルミーの戦い",
+        "ja_typings": [
+          "varumii/no/tatakai"
+        ]
+      },
+      {
+        "en": "Battle of Jemappes",
+        "ja": "ジェマップの戦い",
+        "ja_typings": [
+          "jemappu/no/tatakai"
+        ]
+      },
+      {
+        "en": "Battle of Fleurus",
+        "ja": "フルーリュスの戦い",
+        "ja_typings": [
+          "furuuryusu/no/tatakai"
+        ]
+      },
+      {
+        "en": "Battle of Marengo",
+        "ja": "マレンゴの戦い",
+        "ja_typings": [
+          "marengo/no/tatakai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02070",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1792 battle saw French revolutionary forces stop a Prussian invasion?",
+      "ja": "1792年にフランス革命軍がプロイセン軍を阻止した戦いは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Michelangelo",
+        "ja": "ミケランジェロ",
+        "ja_typings": [
+          "mikeranjero"
+        ]
+      },
+      {
+        "en": "Leonardo da Vinci",
+        "ja": "レオナルド・ダ・ヴィンチ",
+        "ja_typings": [
+          "reonarudo/da/vinchi"
+        ]
+      },
+      {
+        "en": "Raphael",
+        "ja": "ラファエロ",
+        "ja_typings": [
+          "rafaero"
+        ]
+      },
+      {
+        "en": "Botticelli",
+        "ja": "ボッティチェリ",
+        "ja_typings": [
+          "botticheri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02071",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Renaissance artist painted the Sistine Chapel ceiling?",
+      "ja": "システィーナ礼拝堂の天井画を描いたルネサンスの芸術家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Raphael",
+        "ja": "ラファエロ",
+        "ja_typings": [
+          "rafaero"
+        ]
+      },
+      {
+        "en": "Michelangelo",
+        "ja": "ミケランジェロ",
+        "ja_typings": [
+          "mikeranjero"
+        ]
+      },
+      {
+        "en": "Botticelli",
+        "ja": "ボッティチェリ",
+        "ja_typings": [
+          "botticheri"
+        ]
+      },
+      {
+        "en": "Titian",
+        "ja": "ティツィアーノ",
+        "ja_typings": [
+          "titsia-no"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02072",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Renaissance painter created 'The School of Athens'?",
+      "ja": "「アテネの学堂」を描いたルネサンスの画家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Botticelli",
+        "ja": "ボッティチェリ",
+        "ja_typings": [
+          "botticheri"
+        ]
+      },
+      {
+        "en": "Raphael",
+        "ja": "ラファエロ",
+        "ja_typings": [
+          "rafaero"
+        ]
+      },
+      {
+        "en": "Michelangelo",
+        "ja": "ミケランジェロ",
+        "ja_typings": [
+          "mikeranjero"
+        ]
+      },
+      {
+        "en": "Donatello",
+        "ja": "ドナテッロ",
+        "ja_typings": [
+          "donaterro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02073",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Renaissance painter created 'The Birth of Venus'?",
+      "ja": "「ヴィーナスの誕生」を描いたルネサンスの画家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jawaharlal Nehru",
+        "ja": "ジャワハルラール・ネルー",
+        "ja_typings": [
+          "jawaharuraaru/neruu",
+          "jawaharura-ru/neru-"
+        ]
+      },
+      {
+        "en": "Mahatma Gandhi",
+        "ja": "マハトマ・ガンディー",
+        "ja_typings": [
+          "mahatoma/gandii",
+          "mahatoma/gandi-"
+        ]
+      },
+      {
+        "en": "Indira Gandhi",
+        "ja": "インディラ・ガンディー",
+        "ja_typings": [
+          "indira/gandii",
+          "indira/gandi-"
+        ]
+      },
+      {
+        "en": "Vallabhbhai Patel",
+        "ja": "ヴァッラブバーイー・パテール",
+        "ja_typings": [
+          "varrabu/baaii/pateeru",
+          "varrabuba-i-/pate-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02074",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first Prime Minister of independent India?",
+      "ja": "独立インドの初代首相は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ogedei Khan",
+        "ja": "オゴデイ・ハン",
+        "ja_typings": [
+          "ogodei/han"
+        ]
+      },
+      {
+        "en": "Kublai Khan",
+        "ja": "フビライ・ハン",
+        "ja_typings": [
+          "fubirai/han"
+        ]
+      },
+      {
+        "en": "Mongke Khan",
+        "ja": "モンケ・ハン",
+        "ja_typings": [
+          "monke/han"
+        ]
+      },
+      {
+        "en": "Guyuk Khan",
+        "ja": "グユク・ハン",
+        "ja_typings": [
+          "guyuku/han"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02075",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mongol Great Khan succeeded Genghis Khan?",
+      "ja": "チンギス・ハンの後を継いだモンゴル帝国の大ハーンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Charles X",
+        "ja": "シャルル10世",
+        "ja_typings": [
+          "sharuru/10/sei"
+        ]
+      },
+      {
+        "en": "Louis XVIII",
+        "ja": "ルイ18世",
+        "ja_typings": [
+          "rui/18/sei"
+        ]
+      },
+      {
+        "en": "Louis Philippe",
+        "ja": "ルイ・フィリップ",
+        "ja_typings": [
+          "rui/firippu"
+        ]
+      },
+      {
+        "en": "Napoleon III",
+        "ja": "ナポレオン3世",
+        "ja_typings": [
+          "naporeon/3/sei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02076",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French king was overthrown in the July Revolution of 1830?",
+      "ja": "1830年7月革命で退位したフランス王は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Caligula",
+        "ja": "カリグラ",
+        "ja_typings": [
+          "karigura"
+        ]
+      },
+      {
+        "en": "Nero",
+        "ja": "ネロ",
+        "ja_typings": [
+          "nero"
+        ]
+      },
+      {
+        "en": "Domitian",
+        "ja": "ドミティアヌス",
+        "ja_typings": [
+          "domitianusu"
+        ]
+      },
+      {
+        "en": "Commodus",
+        "ja": "コンモドゥス",
+        "ja_typings": [
+          "konmodusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02077",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Roman emperor was infamous for cruelty and was assassinated in 41 AD?",
+      "ja": "残虐で知られ41年に暗殺されたローマ皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Battle of Leipzig",
+        "ja": "ライプツィヒの戦い",
+        "ja_typings": [
+          "raiputsuhi/no/tatakai"
+        ]
+      },
+      {
+        "en": "Battle of Waterloo",
+        "ja": "ワーテルローの戦い",
+        "ja_typings": [
+          "wateruroo/no/tatakai"
+        ]
+      },
+      {
+        "en": "Battle of Borodino",
+        "ja": "ボロジノの戦い",
+        "ja_typings": [
+          "borojino/no/tatakai"
+        ]
+      },
+      {
+        "en": "Battle of Austerlitz",
+        "ja": "アウステルリッツの戦い",
+        "ja_typings": [
+          "ausuterurittsu/no/tatakai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02078",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1813 battle saw Napoleon defeated by a coalition of European powers?",
+      "ja": "1813年にナポレオンが欧州連合軍に敗れた戦いは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chamberlain",
+        "ja": "チェンバレン",
+        "ja_typings": [
+          "chenbaren"
+        ]
+      },
+      {
+        "en": "Churchill",
+        "ja": "チャーチル",
+        "ja_typings": [
+          "cha-chiru"
+        ]
+      },
+      {
+        "en": "Baldwin",
+        "ja": "ボールドウィン",
+        "ja_typings": [
+          "bo-rudowin"
+        ]
+      },
+      {
+        "en": "MacDonald",
+        "ja": "マクドナルド",
+        "ja_typings": [
+          "makudonarudo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02079",
+    "image_path": null,
+    "question_text": {
+      "en": "Which British PM is associated with the Munich Agreement appeasing Hitler in 1938?",
+      "ja": "1938年のミュンヘン協定でヒトラーに宥和したイギリス首相は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Attlee",
+        "ja": "アトリー",
+        "ja_typings": [
+          "atori-"
+        ]
+      },
+      {
+        "en": "Wilson",
+        "ja": "ウィルソン",
+        "ja_typings": [
+          "wiruson"
+        ]
+      },
+      {
+        "en": "Callaghan",
+        "ja": "キャラハン",
+        "ja_typings": [
+          "kyarahan"
+        ]
+      },
+      {
+        "en": "Blair",
+        "ja": "ブレア",
+        "ja_typings": [
+          "burea"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02080",
+    "image_path": null,
+    "question_text": {
+      "en": "Which British Labour PM led postwar reforms including the NHS?",
+      "ja": "NHS創設など戦後改革を進めたイギリス労働党の首相は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Eden",
+        "ja": "イーデン",
+        "ja_typings": [
+          "i-den"
+        ]
+      },
+      {
+        "en": "Macmillan",
+        "ja": "マクミラン",
+        "ja_typings": [
+          "makumiran"
+        ]
+      },
+      {
+        "en": "Attlee",
+        "ja": "アトリー",
+        "ja_typings": [
+          "atori-"
+        ]
+      },
+      {
+        "en": "Churchill",
+        "ja": "チャーチル",
+        "ja_typings": [
+          "cha-chiru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02081",
+    "image_path": null,
+    "question_text": {
+      "en": "Which British PM led Britain during the 1956 Suez Crisis?",
+      "ja": "1956年のスエズ危機時のイギリス首相は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Himmler",
+        "ja": "ヒムラー",
+        "ja_typings": [
+          "himura-"
+        ]
+      },
+      {
+        "en": "Goebbels",
+        "ja": "ゲッベルス",
+        "ja_typings": [
+          "gebberusu"
+        ]
+      },
+      {
+        "en": "Goering",
+        "ja": "ゲーリング",
+        "ja_typings": [
+          "ge-ringu"
+        ]
+      },
+      {
+        "en": "Hess",
+        "ja": "ヘス",
+        "ja_typings": [
+          "hesu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02082",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nazi leader headed the SS and organized the Holocaust?",
+      "ja": "親衛隊を率いホロコーストを組織したナチ指導者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Goebbels",
+        "ja": "ゲッベルス",
+        "ja_typings": [
+          "gebberusu"
+        ]
+      },
+      {
+        "en": "Himmler",
+        "ja": "ヒムラー",
+        "ja_typings": [
+          "himura-"
+        ]
+      },
+      {
+        "en": "Goering",
+        "ja": "ゲーリング",
+        "ja_typings": [
+          "ge-ringu"
+        ]
+      },
+      {
+        "en": "Bormann",
+        "ja": "ボルマン",
+        "ja_typings": [
+          "boruman"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02083",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nazi leader served as Minister of Propaganda?",
+      "ja": "ナチス・ドイツの宣伝大臣を務めた人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Goering",
+        "ja": "ゲーリング",
+        "ja_typings": [
+          "ge-ringu"
+        ]
+      },
+      {
+        "en": "Himmler",
+        "ja": "ヒムラー",
+        "ja_typings": [
+          "himura-"
+        ]
+      },
+      {
+        "en": "Goebbels",
+        "ja": "ゲッベルス",
+        "ja_typings": [
+          "gebberusu"
+        ]
+      },
+      {
+        "en": "Heydrich",
+        "ja": "ハイドリヒ",
+        "ja_typings": [
+          "haidorihi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02084",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nazi leader founded the Luftwaffe and the Gestapo?",
+      "ja": "ルフトヴァッフェとゲシュタポを創設したナチ指導者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Khrushchev",
+        "ja": "フルシチョフ",
+        "ja_typings": [
+          "furushichofu"
+        ]
+      },
+      {
+        "en": "Brezhnev",
+        "ja": "ブレジネフ",
+        "ja_typings": [
+          "burejinefu"
+        ]
+      },
+      {
+        "en": "Andropov",
+        "ja": "アンドロポフ",
+        "ja_typings": [
+          "andoropofu"
+        ]
+      },
+      {
+        "en": "Malenkov",
+        "ja": "マレンコフ",
+        "ja_typings": [
+          "marenkofu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02085",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Soviet leader denounced Stalin in 1956 and led during the Cuban Missile Crisis?",
+      "ja": "1956年にスターリン批判を行いキューバ危機を経験したソ連指導者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Eisenhower",
+        "ja": "アイゼンハワー",
+        "ja_typings": [
+          "aizenhawa-"
+        ]
+      },
+      {
+        "en": "Truman",
+        "ja": "トルーマン",
+        "ja_typings": [
+          "toru-man"
+        ]
+      },
+      {
+        "en": "Kennedy",
+        "ja": "ケネディ",
+        "ja_typings": [
+          "kenedi"
+        ]
+      },
+      {
+        "en": "Nixon",
+        "ja": "ニクソン",
+        "ja_typings": [
+          "nikuson"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02086",
+    "image_path": null,
+    "question_text": {
+      "en": "Which US president and WWII general served from 1953 to 1961?",
+      "ja": "1953〜1961年に在任した第二次大戦の将軍出身の米大統領は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Akbar",
+        "ja": "アクバル",
+        "ja_typings": [
+          "akubaru"
+        ]
+      },
+      {
+        "en": "Babur",
+        "ja": "バーブル",
+        "ja_typings": [
+          "ba-buru"
+        ]
+      },
+      {
+        "en": "Humayun",
+        "ja": "フマーユーン",
+        "ja_typings": [
+          "fuma-yu-n"
+        ]
+      },
+      {
+        "en": "Shah Jahan",
+        "ja": "シャー・ジャハーン",
+        "ja_typings": [
+          "shaa/jahaan",
+          "sha-/jaha-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02087",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mughal emperor known for religious tolerance ruled India in the 16th century?",
+      "ja": "宗教的寛容で知られる16世紀インドのムガル皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aurangzeb",
+        "ja": "アウラングゼーブ",
+        "ja_typings": [
+          "auranguze-bu"
+        ]
+      },
+      {
+        "en": "Akbar",
+        "ja": "アクバル",
+        "ja_typings": [
+          "akubaru"
+        ]
+      },
+      {
+        "en": "Shah Jahan",
+        "ja": "シャー・ジャハーン",
+        "ja_typings": [
+          "shaa/jahaan",
+          "sha-/jaha-n"
+        ]
+      },
+      {
+        "en": "Jahangir",
+        "ja": "ジャハーンギール",
+        "ja_typings": [
+          "jaha-ngi-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02088",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mughal emperor was known for orthodox Islamic rule and expansion in the late 17th century?",
+      "ja": "17世紀後半に厳格なイスラム統治と領土拡大を行ったムガル皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Balkan War",
+        "ja": "バルカン戦争",
+        "ja_typings": [
+          "barukan/sensou"
+        ]
+      },
+      {
+        "en": "Crimean War",
+        "ja": "クリミア戦争",
+        "ja_typings": [
+          "kurimia/sensou"
+        ]
+      },
+      {
+        "en": "Russo-Turkish War",
+        "ja": "露土戦争",
+        "ja_typings": [
+          "roto/sensou"
+        ]
+      },
+      {
+        "en": "Greco-Turkish War",
+        "ja": "希土戦争",
+        "ja_typings": [
+          "kido/sensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02089",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1912-1913 war was fought between Balkan states and the Ottoman Empire?",
+      "ja": "1912〜13年にバルカン諸国とオスマン帝国の間で起きた戦争は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Olmec",
+        "ja": "オルメカ",
+        "ja_typings": [
+          "orumeka"
+        ]
+      },
+      {
+        "en": "Maya",
+        "ja": "マヤ",
+        "ja_typings": [
+          "maya"
+        ]
+      },
+      {
+        "en": "Aztec",
+        "ja": "アステカ",
+        "ja_typings": [
+          "asuteka"
+        ]
+      },
+      {
+        "en": "Toltec",
+        "ja": "トルテカ",
+        "ja_typings": [
+          "toruteka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02090",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Mesoamerican civilization is known for colossal stone heads?",
+      "ja": "巨大な石頭像で知られる古代メソアメリカ文明は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Egyptian",
+        "ja": "エジプト",
+        "ja_typings": [
+          "ejiputo"
+        ]
+      },
+      {
+        "en": "Mesopotamian",
+        "ja": "メソポタミア",
+        "ja_typings": [
+          "mesopotamia"
+        ]
+      },
+      {
+        "en": "Greek",
+        "ja": "ギリシア",
+        "ja_typings": [
+          "girishia"
+        ]
+      },
+      {
+        "en": "Roman",
+        "ja": "ローマ",
+        "ja_typings": [
+          "ro-ma"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02091",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient civilization built the pyramids of Giza?",
+      "ja": "ギザのピラミッドを築いた古代文明は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chinese",
+        "ja": "中華",
+        "ja_typings": [
+          "chuuka"
+        ]
+      },
+      {
+        "en": "Indian",
+        "ja": "インド",
+        "ja_typings": [
+          "indo"
+        ]
+      },
+      {
+        "en": "Arab",
+        "ja": "アラブ",
+        "ja_typings": [
+          "arabu"
+        ]
+      },
+      {
+        "en": "Persian",
+        "ja": "ペルシア",
+        "ja_typings": [
+          "perushia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02092",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient civilization invented paper and gunpowder?",
+      "ja": "紙と火薬を発明した古代文明は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Victoria",
+        "ja": "ヴィクトリア",
+        "ja_typings": [
+          "vikutoria"
+        ]
+      },
+      {
+        "en": "Edward VII",
+        "ja": "エドワード7世",
+        "ja_typings": [
+          "edowaado/7/sei"
+        ]
+      },
+      {
+        "en": "George V",
+        "ja": "ジョージ5世",
+        "ja_typings": [
+          "joojii/5/sei"
+        ]
+      },
+      {
+        "en": "William IV",
+        "ja": "ウィリアム4世",
+        "ja_typings": [
+          "wiriamu/4/sei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02093",
+    "image_path": null,
+    "question_text": {
+      "en": "Which British monarch reigned during the height of the British Empire from 1837 to 1901?",
+      "ja": "1837〜1901年に大英帝国の絶頂期に在位した君主は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Heisei",
+        "ja": "平成",
+        "ja_typings": [
+          "heisei"
+        ]
+      },
+      {
+        "en": "Reiwa",
+        "ja": "令和",
+        "ja_typings": [
+          "reiwa"
+        ]
+      },
+      {
+        "en": "Showa",
+        "ja": "昭和",
+        "ja_typings": [
+          "shouwa"
+        ]
+      },
+      {
+        "en": "Taisho",
+        "ja": "大正",
+        "ja_typings": [
+          "taishou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02094",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese era ran from 1989 to 2019?",
+      "ja": "1989年から2019年まで続いた日本の元号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Reiwa",
+        "ja": "令和",
+        "ja_typings": [
+          "reiwa"
+        ]
+      },
+      {
+        "en": "Heisei",
+        "ja": "平成",
+        "ja_typings": [
+          "heisei"
+        ]
+      },
+      {
+        "en": "Showa",
+        "ja": "昭和",
+        "ja_typings": [
+          "shouwa"
+        ]
+      },
+      {
+        "en": "Meiji",
+        "ja": "明治",
+        "ja_typings": [
+          "meiji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02095",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese era began in 2019?",
+      "ja": "2019年に始まった日本の元号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vietnam War",
+        "ja": "ベトナム戦争",
+        "ja_typings": [
+          "betonamu/sensou"
+        ]
+      },
+      {
+        "en": "Korean War",
+        "ja": "朝鮮戦争",
+        "ja_typings": [
+          "chousen/sensou"
+        ]
+      },
+      {
+        "en": "Gulf War",
+        "ja": "湾岸戦争",
+        "ja_typings": [
+          "wangan/sensou"
+        ]
+      },
+      {
+        "en": "Cambodian Civil War",
+        "ja": "カンボジア内戦",
+        "ja_typings": [
+          "kanbojia/naisen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02096",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 20th-century war involved US military intervention in Southeast Asia from 1955 to 1975?",
+      "ja": "1955〜1975年に米軍が東南アジアに介入した20世紀の戦争は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Holy Roman Empire",
+        "ja": "神聖ローマ帝国",
+        "ja_typings": [
+          "shinsei/rooma/teikoku"
+        ]
+      },
+      {
+        "en": "Byzantine Empire",
+        "ja": "ビザンツ帝国",
+        "ja_typings": [
+          "bizantsu/teikoku"
+        ]
+      },
+      {
+        "en": "Carolingian Empire",
+        "ja": "カロリング帝国",
+        "ja_typings": [
+          "karoringu/teikoku"
+        ]
+      },
+      {
+        "en": "Frankish Kingdom",
+        "ja": "フランク王国",
+        "ja_typings": [
+          "furanku/oukoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02097",
+    "image_path": null,
+    "question_text": {
+      "en": "Which European political entity existed from 962 to 1806 in central Europe?",
+      "ja": "962年から1806年まで中欧に存在した政治体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Abu Simbel Temple",
+        "ja": "アブ・シンベル神殿",
+        "ja_typings": [
+          "abu/shinberu/shinden"
+        ]
+      },
+      {
+        "en": "Luxor Temple",
+        "ja": "ルクソール神殿",
+        "ja_typings": [
+          "rukusooru/shinden"
+        ]
+      },
+      {
+        "en": "Karnak Temple",
+        "ja": "カルナック神殿",
+        "ja_typings": [
+          "karunakku/shinden"
+        ]
+      },
+      {
+        "en": "Temple of Hatshepsut",
+        "ja": "ハトシェプスト葬祭殿",
+        "ja_typings": [
+          "hatoshepusuto/sousaiden"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02098",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Egyptian temple complex was relocated due to the Aswan High Dam?",
+      "ja": "アスワンハイダム建設のため移築された古代エジプトの神殿は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Luxor Temple",
+        "ja": "ルクソール神殿",
+        "ja_typings": [
+          "rukusooru/shinden"
+        ]
+      },
+      {
+        "en": "Karnak Temple",
+        "ja": "カルナック神殿",
+        "ja_typings": [
+          "karunakku/shinden"
+        ]
+      },
+      {
+        "en": "Abu Simbel Temple",
+        "ja": "アブ・シンベル神殿",
+        "ja_typings": [
+          "abu/shinberu/shinden"
+        ]
+      },
+      {
+        "en": "Edfu Temple",
+        "ja": "エドフ神殿",
+        "ja_typings": [
+          "edofu/shinden"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02099",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Egyptian temple in modern Luxor was the southern sanctuary of Amun?",
+      "ja": "現在のルクソールにあるアモン神の南方聖域とされた神殿は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Karnak Temple",
+        "ja": "カルナック神殿",
+        "ja_typings": [
+          "karunakku/shinden"
+        ]
+      },
+      {
+        "en": "Luxor Temple",
+        "ja": "ルクソール神殿",
+        "ja_typings": [
+          "rukusooru/shinden"
+        ]
+      },
+      {
+        "en": "Abu Simbel Temple",
+        "ja": "アブ・シンベル神殿",
+        "ja_typings": [
+          "abu/shinberu/shinden"
+        ]
+      },
+      {
+        "en": "Philae Temple",
+        "ja": "フィラエ神殿",
+        "ja_typings": [
+          "firae/shinden"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02100",
+    "image_path": null,
+    "question_text": {
+      "en": "Which vast Egyptian temple complex was dedicated mainly to Amun-Ra?",
+      "ja": "主にアモン・ラー神に捧げられたエジプト最大の神殿群は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Julius Caesar",
+        "ja": "ユリウス・カエサル",
+        "ja_typings": [
+          "uriusu/kaesaru",
+          "yuriusu/kaesaru"
+        ]
+      },
+      {
+        "en": "Pompey",
+        "ja": "ポンペイウス",
+        "ja_typings": [
+          "ponpeiusu"
+        ]
+      },
+      {
+        "en": "Crassus",
+        "ja": "クラッスス",
+        "ja_typings": [
+          "kurassusu"
+        ]
+      },
+      {
+        "en": "Mark Antony",
+        "ja": "アントニウス",
+        "ja_typings": [
+          "antoniusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02101",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Roman general crossed the Rubicon in 49 BC?",
+      "ja": "紀元前49年にルビコン川を渡ったローマの将軍は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tokugawa Iemochi",
+        "ja": "徳川家茂",
+        "ja_typings": [
+          "tokugawa/iemochi"
+        ]
+      },
+      {
+        "en": "Tokugawa Iesada",
+        "ja": "徳川家定",
+        "ja_typings": [
+          "tokugawa/iesada"
+        ]
+      },
+      {
+        "en": "Tokugawa Nariaki",
+        "ja": "徳川斉昭",
+        "ja_typings": [
+          "tokugawa/nariaki"
+        ]
+      },
+      {
+        "en": "Tokugawa Yoshinobu",
+        "ja": "徳川慶喜",
+        "ja_typings": [
+          "tokugawa/yoshinobu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02102",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 14th Tokugawa shogun reigned during the late Bakumatsu period?",
+      "ja": "幕末期に在職した第14代徳川将軍は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tokugawa Iesada",
+        "ja": "徳川家定",
+        "ja_typings": [
+          "tokugawa/iesada"
+        ]
+      },
+      {
+        "en": "Tokugawa Iemochi",
+        "ja": "徳川家茂",
+        "ja_typings": [
+          "tokugawa/iemochi"
+        ]
+      },
+      {
+        "en": "Tokugawa Ieyoshi",
+        "ja": "徳川家慶",
+        "ja_typings": [
+          "tokugawa/ieyoshi"
+        ]
+      },
+      {
+        "en": "Tokugawa Yoshinobu",
+        "ja": "徳川慶喜",
+        "ja_typings": [
+          "tokugawa/yoshinobu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02103",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 13th Tokugawa shogun ruled from 1853 to 1858?",
+      "ja": "1853〜1858年に在職した第13代徳川将軍は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tokugawa Nariaki",
+        "ja": "徳川斉昭",
+        "ja_typings": [
+          "tokugawa/nariaki"
+        ]
+      },
+      {
+        "en": "Tokugawa Iemochi",
+        "ja": "徳川家茂",
+        "ja_typings": [
+          "tokugawa/iemochi"
+        ]
+      },
+      {
+        "en": "Tokugawa Iesada",
+        "ja": "徳川家定",
+        "ja_typings": [
+          "tokugawa/iesada"
+        ]
+      },
+      {
+        "en": "Ii Naosuke",
+        "ja": "井伊直弼",
+        "ja_typings": [
+          "ii/naosuke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02104",
+    "image_path": null,
+    "question_text": {
+      "en": "Which lord of Mito Domain was a major reformist figure in the late Edo period?",
+      "ja": "幕末に活躍した水戸藩主の改革派の人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Emperor Wu of Han",
+        "ja": "漢の武帝",
+        "ja_typings": [
+          "kan/no/butei"
+        ]
+      },
+      {
+        "en": "Emperor Gaozu of Han",
+        "ja": "漢の高祖",
+        "ja_typings": [
+          "kan/no/kouso"
+        ]
+      },
+      {
+        "en": "Emperor Wen of Han",
+        "ja": "漢の文帝",
+        "ja_typings": [
+          "kan/no/buntei"
+        ]
+      },
+      {
+        "en": "Emperor Jing of Han",
+        "ja": "漢の景帝",
+        "ja_typings": [
+          "kan/no/keitei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02105",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Han emperor greatly expanded the empire and reigned 141-87 BC?",
+      "ja": "紀元前141〜87年に在位し領土を大きく拡げた前漢の皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Emperor Taizong of Tang",
+        "ja": "唐の太宗",
+        "ja_typings": [
+          "tou/no/taisou"
+        ]
+      },
+      {
+        "en": "Emperor Gaozu of Tang",
+        "ja": "唐の高祖",
+        "ja_typings": [
+          "tou/no/kouso"
+        ]
+      },
+      {
+        "en": "Emperor Xuanzong of Tang",
+        "ja": "唐の玄宗",
+        "ja_typings": [
+          "tou/no/genso"
+        ]
+      },
+      {
+        "en": "Emperor Gaozong of Tang",
+        "ja": "唐の高宗",
+        "ja_typings": [
+          "tou/no/kousou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02106",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Tang emperor presided over the early Tang golden age?",
+      "ja": "唐初の黄金期を築いた皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Emperor Yang of Sui",
+        "ja": "隋の煬帝",
+        "ja_typings": [
+          "zui/no/youdai"
+        ]
+      },
+      {
+        "en": "Emperor Wen of Sui",
+        "ja": "隋の文帝",
+        "ja_typings": [
+          "zui/no/buntei"
+        ]
+      },
+      {
+        "en": "Emperor Gong of Sui",
+        "ja": "隋の恭帝",
+        "ja_typings": [
+          "zui/no/kyoutei"
+        ]
+      },
+      {
+        "en": "Emperor Taizong of Tang",
+        "ja": "唐の太宗",
+        "ja_typings": [
+          "tou/no/taisou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02107",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Sui emperor built the Grand Canal but lost the throne to rebellion?",
+      "ja": "大運河を建設したが反乱で帝位を失った隋の皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bill of Rights",
+        "ja": "権利章典",
+        "ja_typings": [
+          "kenri/shouten"
+        ]
+      },
+      {
+        "en": "Petition of Right",
+        "ja": "権利の請願",
+        "ja_typings": [
+          "kenri/no/seigan"
+        ]
+      },
+      {
+        "en": "Magna Carta",
+        "ja": "マグナ・カルタ",
+        "ja_typings": [
+          "maguna/karuta"
+        ]
+      },
+      {
+        "en": "Habeas Corpus Act",
+        "ja": "人身保護法",
+        "ja_typings": [
+          "jinshin/hogo/hou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02108",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1689 English document limited royal power and established parliamentary rights?",
+      "ja": "1689年に王権を制限し議会の権利を定めたイギリスの文書は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Petition of Right",
+        "ja": "権利の請願",
+        "ja_typings": [
+          "kenri/no/seigan"
+        ]
+      },
+      {
+        "en": "Bill of Rights",
+        "ja": "権利章典",
+        "ja_typings": [
+          "kenri/shouten"
+        ]
+      },
+      {
+        "en": "Magna Carta",
+        "ja": "マグナ・カルタ",
+        "ja_typings": [
+          "maguna/karuta"
+        ]
+      },
+      {
+        "en": "Act of Settlement",
+        "ja": "王位継承法",
+        "ja_typings": [
+          "oui/keishou/hou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02109",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1628 English document was drafted by Parliament against Charles I?",
+      "ja": "1628年に議会がチャールズ1世に対し起草した文書は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Edict of Nantes",
+        "ja": "ナント勅令",
+        "ja_typings": [
+          "nanto/chokurei"
+        ]
+      },
+      {
+        "en": "Edict of Fontainebleau",
+        "ja": "フォンテーヌブロー勅令",
+        "ja_typings": [
+          "fonteenuburoo/chokurei"
+        ]
+      },
+      {
+        "en": "Bill of Rights",
+        "ja": "権利章典",
+        "ja_typings": [
+          "kenri/shouten"
+        ]
+      },
+      {
+        "en": "Concordat of Bologna",
+        "ja": "ボローニャ政教条約",
+        "ja_typings": [
+          "boroonya/seikyou/jouyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02110",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1598 French royal edict granted religious tolerance to Huguenots?",
+      "ja": "1598年にユグノーに信仰の自由を与えたフランス王令は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Elba",
+        "ja": "エルバ島",
+        "ja_typings": [
+          "eruba/tou"
+        ]
+      },
+      {
+        "en": "Saint Helena",
+        "ja": "セントヘレナ島",
+        "ja_typings": [
+          "sentohelena/tou"
+        ]
+      },
+      {
+        "en": "Corsica",
+        "ja": "コルシカ島",
+        "ja_typings": [
+          "korushika/tou"
+        ]
+      },
+      {
+        "en": "Sardinia",
+        "ja": "サルデーニャ島",
+        "ja_typings": [
+          "sarudeenya/tou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q02111",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mediterranean island was Napoleon exiled to in 1814?",
+      "ja": "1814年にナポレオンが流された地中海の島は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bohr",
+        "ja": "ボーア",
+        "ja_typings": [
+          "bo-a"
+        ]
+      },
+      {
+        "en": "Rutherford",
+        "ja": "ラザフォード",
+        "ja_typings": [
+          "razafo-do"
+        ]
+      },
+      {
+        "en": "Thomson",
+        "ja": "トムソン",
+        "ja_typings": [
+          "tomuson"
+        ]
+      },
+      {
+        "en": "Schrodinger",
+        "ja": "シュレディンガー",
+        "ja_typings": [
+          "shuredinga-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02112",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Danish physicist proposed a model of the hydrogen atom with quantized orbits in 1913?",
+      "ja": "1913年に量子化された軌道を持つ水素原子モデルを提唱したデンマークの物理学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Uranus",
+        "ja": "天王星",
+        "ja_typings": [
+          "tennousei"
+        ]
+      },
+      {
+        "en": "Neptune",
+        "ja": "海王星",
+        "ja_typings": [
+          "kaiousei"
+        ]
+      },
+      {
+        "en": "Saturn",
+        "ja": "土星",
+        "ja_typings": [
+          "dosei"
+        ]
+      },
+      {
+        "en": "Jupiter",
+        "ja": "木星",
+        "ja_typings": [
+          "mokusei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02113",
+    "image_path": null,
+    "question_text": {
+      "en": "Which planet is the seventh from the Sun and tilted on its side?",
+      "ja": "太陽から7番目の、横倒しに自転する惑星は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Argon",
+        "ja": "アルゴン",
+        "ja_typings": [
+          "arugon"
+        ]
+      },
+      {
+        "en": "Neon",
+        "ja": "ネオン",
+        "ja_typings": [
+          "neon"
+        ]
+      },
+      {
+        "en": "Helium",
+        "ja": "ヘリウム",
+        "ja_typings": [
+          "heriumu"
+        ]
+      },
+      {
+        "en": "Krypton",
+        "ja": "クリプトン",
+        "ja_typings": [
+          "kuriputon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02114",
+    "image_path": null,
+    "question_text": {
+      "en": "Which noble gas is the third most abundant gas in Earth's atmosphere?",
+      "ja": "地球大気で3番目に多い希ガスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Venus",
+        "ja": "金星",
+        "ja_typings": [
+          "kinsei"
+        ]
+      },
+      {
+        "en": "Mercury",
+        "ja": "水星",
+        "ja_typings": [
+          "suisei"
+        ]
+      },
+      {
+        "en": "Mars",
+        "ja": "火星",
+        "ja_typings": [
+          "kasei"
+        ]
+      },
+      {
+        "en": "Earth",
+        "ja": "地球",
+        "ja_typings": [
+          "chikyuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02115",
+    "image_path": null,
+    "question_text": {
+      "en": "Which planet is the second from the Sun and the hottest in the solar system?",
+      "ja": "太陽から2番目で太陽系で最も高温の惑星は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kidney",
+        "ja": "腎臓",
+        "ja_typings": [
+          "jinzou"
+        ]
+      },
+      {
+        "en": "Liver",
+        "ja": "肝臓",
+        "ja_typings": [
+          "kanzou"
+        ]
+      },
+      {
+        "en": "Spleen",
+        "ja": "脾臓",
+        "ja_typings": [
+          "hizou"
+        ]
+      },
+      {
+        "en": "Pancreas",
+        "ja": "膵臓",
+        "ja_typings": [
+          "suizou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02116",
+    "image_path": null,
+    "question_text": {
+      "en": "Which human organ filters blood and produces urine?",
+      "ja": "血液を濾過し尿を生成する人体の臓器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Spleen",
+        "ja": "脾臓",
+        "ja_typings": [
+          "hizou"
+        ]
+      },
+      {
+        "en": "Kidney",
+        "ja": "腎臓",
+        "ja_typings": [
+          "jinzou"
+        ]
+      },
+      {
+        "en": "Liver",
+        "ja": "肝臓",
+        "ja_typings": [
+          "kanzou"
+        ]
+      },
+      {
+        "en": "Pancreas",
+        "ja": "膵臓",
+        "ja_typings": [
+          "suizou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02117",
+    "image_path": null,
+    "question_text": {
+      "en": "Which organ stores white blood cells and recycles old red blood cells?",
+      "ja": "白血球を蓄え古い赤血球を分解する臓器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lamarck",
+        "ja": "ラマルク",
+        "ja_typings": [
+          "ramaruku"
+        ]
+      },
+      {
+        "en": "Darwin",
+        "ja": "ダーウィン",
+        "ja_typings": [
+          "da-win"
+        ]
+      },
+      {
+        "en": "Linnaeus",
+        "ja": "リンネ",
+        "ja_typings": [
+          "rinnne"
+        ]
+      },
+      {
+        "en": "Cuvier",
+        "ja": "キュヴィエ",
+        "ja_typings": [
+          "kyuvie"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02118",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French naturalist proposed an early theory of inheritance of acquired characteristics?",
+      "ja": "獲得形質の遺伝説を提唱したフランスの博物学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Curie",
+        "ja": "キュリー",
+        "ja_typings": [
+          "kyuri-"
+        ]
+      },
+      {
+        "en": "Becquerel",
+        "ja": "ベクレル",
+        "ja_typings": [
+          "bekureru"
+        ]
+      },
+      {
+        "en": "Rutherford",
+        "ja": "ラザフォード",
+        "ja_typings": [
+          "razafo-do"
+        ]
+      },
+      {
+        "en": "Roentgen",
+        "ja": "レントゲン",
+        "ja_typings": [
+          "rentogen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02119",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Polish-French scientist discovered polonium and radium?",
+      "ja": "ポロニウムとラジウムを発見したポーランド系フランス人科学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Reflection",
+        "ja": "反射",
+        "ja_typings": [
+          "hansha"
+        ]
+      },
+      {
+        "en": "Refraction",
+        "ja": "屈折",
+        "ja_typings": [
+          "kussetsu"
+        ]
+      },
+      {
+        "en": "Diffraction",
+        "ja": "回折",
+        "ja_typings": [
+          "kaisetsu"
+        ]
+      },
+      {
+        "en": "Absorption",
+        "ja": "吸収",
+        "ja_typings": [
+          "kyuushuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02120",
+    "image_path": null,
+    "question_text": {
+      "en": "Which optical phenomenon describes light bouncing off a surface?",
+      "ja": "光が表面で跳ね返る光学現象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Diffraction",
+        "ja": "回折",
+        "ja_typings": [
+          "kaisetsu"
+        ]
+      },
+      {
+        "en": "Reflection",
+        "ja": "反射",
+        "ja_typings": [
+          "hansha"
+        ]
+      },
+      {
+        "en": "Refraction",
+        "ja": "屈折",
+        "ja_typings": [
+          "kussetsu"
+        ]
+      },
+      {
+        "en": "Interference",
+        "ja": "干渉",
+        "ja_typings": [
+          "kanshou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02121",
+    "image_path": null,
+    "question_text": {
+      "en": "Which wave phenomenon describes bending around obstacles or through narrow slits?",
+      "ja": "障害物や狭い隙間で波が回り込む現象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Brahe",
+        "ja": "ブラーエ",
+        "ja_typings": [
+          "bura-e"
+        ]
+      },
+      {
+        "en": "Kepler",
+        "ja": "ケプラー",
+        "ja_typings": [
+          "kepura-"
+        ]
+      },
+      {
+        "en": "Galileo",
+        "ja": "ガリレオ",
+        "ja_typings": [
+          "garireo"
+        ]
+      },
+      {
+        "en": "Copernicus",
+        "ja": "コペルニクス",
+        "ja_typings": [
+          "koperunikusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02122",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Danish astronomer made precise pre-telescope observations used by Kepler?",
+      "ja": "ケプラーが利用した精密な肉眼観測を残したデンマークの天文学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bar",
+        "ja": "バール",
+        "ja_typings": [
+          "ba-ru"
+        ]
+      },
+      {
+        "en": "Pascal",
+        "ja": "パスカル",
+        "ja_typings": [
+          "pasukaru"
+        ]
+      },
+      {
+        "en": "Atmosphere",
+        "ja": "気圧",
+        "ja_typings": [
+          "kiatsu"
+        ]
+      },
+      {
+        "en": "Torr",
+        "ja": "トル",
+        "ja_typings": [
+          "toru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02123",
+    "image_path": null,
+    "question_text": {
+      "en": "Which unit of pressure equals 100,000 pascals?",
+      "ja": "10万パスカルに相当する圧力の単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Methane",
+        "ja": "メタン",
+        "ja_typings": [
+          "metan"
+        ]
+      },
+      {
+        "en": "Ethane",
+        "ja": "エタン",
+        "ja_typings": [
+          "etan"
+        ]
+      },
+      {
+        "en": "Propane",
+        "ja": "プロパン",
+        "ja_typings": [
+          "puropan"
+        ]
+      },
+      {
+        "en": "Butane",
+        "ja": "ブタン",
+        "ja_typings": [
+          "butan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02124",
+    "image_path": null,
+    "question_text": {
+      "en": "Which gas, CH4, is the main component of natural gas?",
+      "ja": "化学式CH4で天然ガスの主成分である気体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ozone",
+        "ja": "オゾン",
+        "ja_typings": [
+          "ozon"
+        ]
+      },
+      {
+        "en": "Methane",
+        "ja": "メタン",
+        "ja_typings": [
+          "metan"
+        ]
+      },
+      {
+        "en": "Argon",
+        "ja": "アルゴン",
+        "ja_typings": [
+          "arugon"
+        ]
+      },
+      {
+        "en": "Nitrous oxide",
+        "ja": "亜酸化窒素",
+        "ja_typings": [
+          "asankachisso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02125",
+    "image_path": null,
+    "question_text": {
+      "en": "Which atmospheric gas, O3, forms a protective layer in the stratosphere?",
+      "ja": "化学式O3で成層圏に保護層を形成する気体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hooke's law",
+        "ja": "フックの法則",
+        "ja_typings": [
+          "fukku/no/housoku"
+        ]
+      },
+      {
+        "en": "Newton's law",
+        "ja": "ニュートンの法則",
+        "ja_typings": [
+          "nyuuton/no/housoku"
+        ]
+      },
+      {
+        "en": "Boyle's law",
+        "ja": "ボイルの法則",
+        "ja_typings": [
+          "boiru/no/housoku"
+        ]
+      },
+      {
+        "en": "Ohm's law",
+        "ja": "オームの法則",
+        "ja_typings": [
+          "oomu/no/housoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02126",
+    "image_path": null,
+    "question_text": {
+      "en": "Which physical law states that the force exerted by a spring is proportional to its extension?",
+      "ja": "ばねの力が伸びに比例するという物理法則は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Beaufort scale",
+        "ja": "ビューフォート風力階級",
+        "ja_typings": [
+          "byuufooto/fuuryoku/kaikyuu"
+        ]
+      },
+      {
+        "en": "Richter scale",
+        "ja": "リヒター・スケール",
+        "ja_typings": [
+          "rihitaa/sukeeru",
+          "rihita-/suke-ru"
+        ]
+      },
+      {
+        "en": "Fujita scale",
+        "ja": "藤田スケール",
+        "ja_typings": [
+          "fujita/sukeeru"
+        ]
+      },
+      {
+        "en": "Mercalli scale",
+        "ja": "メルカリ震度階級",
+        "ja_typings": [
+          "merukari/shindo/kaikyuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02127",
+    "image_path": null,
+    "question_text": {
+      "en": "Which empirical scale measures wind force from 0 to 12?",
+      "ja": "0から12までで風力を表す経験的尺度は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pluto",
+        "ja": "冥王星",
+        "ja_typings": [
+          "meiousei"
+        ]
+      },
+      {
+        "en": "Ceres",
+        "ja": "ケレス",
+        "ja_typings": [
+          "keresu"
+        ]
+      },
+      {
+        "en": "Eris",
+        "ja": "エリス",
+        "ja_typings": [
+          "erisu"
+        ]
+      },
+      {
+        "en": "Haumea",
+        "ja": "ハウメア",
+        "ja_typings": [
+          "haumea"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02128",
+    "image_path": null,
+    "question_text": {
+      "en": "Which dwarf planet was reclassified from full planet status in 2006?",
+      "ja": "2006年に惑星から準惑星に再分類された天体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CO2",
+        "ja": "二酸化炭素",
+        "ja_typings": [
+          "nisanka/tanso"
+        ]
+      },
+      {
+        "en": "SO2",
+        "ja": "二酸化硫黄",
+        "ja_typings": [
+          "nisanka/iou"
+        ]
+      },
+      {
+        "en": "O2",
+        "ja": "酸素",
+        "ja_typings": [
+          "sanso"
+        ]
+      },
+      {
+        "en": "NH3",
+        "ja": "アンモニア",
+        "ja_typings": [
+          "anmonia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02129",
+    "image_path": null,
+    "question_text": {
+      "en": "Which gas with formula CO2 is a major greenhouse gas exhaled by humans?",
+      "ja": "化学式CO2で人間が呼吸で排出する主要な温室効果ガスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "O2",
+        "ja": "酸素",
+        "ja_typings": [
+          "sanso"
+        ]
+      },
+      {
+        "en": "N2",
+        "ja": "窒素",
+        "ja_typings": [
+          "chisso"
+        ]
+      },
+      {
+        "en": "CO2",
+        "ja": "二酸化炭素",
+        "ja_typings": [
+          "nisanka/tanso"
+        ]
+      },
+      {
+        "en": "H2",
+        "ja": "水素",
+        "ja_typings": [
+          "suiso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02130",
+    "image_path": null,
+    "question_text": {
+      "en": "Which molecule with formula O2 is essential for human respiration?",
+      "ja": "化学式O2で人間の呼吸に不可欠な分子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NH3",
+        "ja": "アンモニア",
+        "ja_typings": [
+          "anmonia"
+        ]
+      },
+      {
+        "en": "CO2",
+        "ja": "二酸化炭素",
+        "ja_typings": [
+          "nisanka/tanso"
+        ]
+      },
+      {
+        "en": "SO2",
+        "ja": "二酸化硫黄",
+        "ja_typings": [
+          "nisanka/iou"
+        ]
+      },
+      {
+        "en": "CH4",
+        "ja": "メタン",
+        "ja_typings": [
+          "metan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02131",
+    "image_path": null,
+    "question_text": {
+      "en": "Which pungent gas with formula NH3 is widely used in fertilizers?",
+      "ja": "化学式NH3で肥料に広く用いられる刺激臭の気体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cu",
+        "ja": "銅",
+        "ja_typings": [
+          "dou"
+        ]
+      },
+      {
+        "en": "Fe",
+        "ja": "鉄",
+        "ja_typings": [
+          "tetsu"
+        ]
+      },
+      {
+        "en": "Au",
+        "ja": "金",
+        "ja_typings": [
+          "kin"
+        ]
+      },
+      {
+        "en": "Ag",
+        "ja": "銀",
+        "ja_typings": [
+          "gin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02132",
+    "image_path": null,
+    "question_text": {
+      "en": "Which element has the chemical symbol Cu?",
+      "ja": "化学記号Cuで表される元素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pb",
+        "ja": "鉛",
+        "ja_typings": [
+          "namari"
+        ]
+      },
+      {
+        "en": "Sn",
+        "ja": "錫",
+        "ja_typings": [
+          "suzu"
+        ]
+      },
+      {
+        "en": "Zn",
+        "ja": "亜鉛",
+        "ja_typings": [
+          "aen"
+        ]
+      },
+      {
+        "en": "Cu",
+        "ja": "銅",
+        "ja_typings": [
+          "dou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02133",
+    "image_path": null,
+    "question_text": {
+      "en": "Which element has the chemical symbol Pb?",
+      "ja": "化学記号Pbで表される元素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "30,000 km",
+        "ja": "40,000 km",
+        "ja_typings": [
+          "40,000 km"
+        ]
+      },
+      {
+        "en": "3,000,000 km",
+        "ja": "3,000,000 km",
+        "ja_typings": [
+          "3,000,000 km"
+        ]
+      },
+      {
+        "en": "3,000 km",
+        "ja": "3,000 km",
+        "ja_typings": [
+          "3,000 km"
+        ]
+      },
+      {
+        "en": "300 km",
+        "ja": "300 km",
+        "ja_typings": [
+          "300 km"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02134",
+    "image_path": null,
+    "question_text": {
+      "en": "Approximately what is the circumference of the Earth at the equator?",
+      "ja": "地球の赤道周長は約何kmか?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "3,000,000 km",
+        "ja": "380,000 km",
+        "ja_typings": [
+          "380,000 km"
+        ]
+      },
+      {
+        "en": "30,000 km",
+        "ja": "30,000 km",
+        "ja_typings": [
+          "30,000 km"
+        ]
+      },
+      {
+        "en": "3,000 km",
+        "ja": "3,000 km",
+        "ja_typings": [
+          "3,000 km"
+        ]
+      },
+      {
+        "en": "300,000,000 km",
+        "ja": "300,000,000 km",
+        "ja_typings": [
+          "300,000,000 km"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02135",
+    "image_path": null,
+    "question_text": {
+      "en": "Approximately what is the distance from the Earth to the Moon?",
+      "ja": "地球から月までの距離は約何kmか?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "3,000 km",
+        "ja": "3,500 km",
+        "ja_typings": [
+          "3,500 km"
+        ]
+      },
+      {
+        "en": "30,000 km",
+        "ja": "30,000 km",
+        "ja_typings": [
+          "30,000 km"
+        ]
+      },
+      {
+        "en": "300 km",
+        "ja": "300 km",
+        "ja_typings": [
+          "300 km"
+        ]
+      },
+      {
+        "en": "300,000 km",
+        "ja": "300,000 km",
+        "ja_typings": [
+          "300,000 km"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02136",
+    "image_path": null,
+    "question_text": {
+      "en": "Approximately what is the diameter of the Moon?",
+      "ja": "月の直径は約何kmか?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hawking",
+        "ja": "ホーキング",
+        "ja_typings": [
+          "ho-kingu"
+        ]
+      },
+      {
+        "en": "Penrose",
+        "ja": "ペンローズ",
+        "ja_typings": [
+          "penro-zu"
+        ]
+      },
+      {
+        "en": "Dirac",
+        "ja": "ディラック",
+        "ja_typings": [
+          "dirakku"
+        ]
+      },
+      {
+        "en": "Eddington",
+        "ja": "エディントン",
+        "ja_typings": [
+          "edinton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02137",
+    "image_path": null,
+    "question_text": {
+      "en": "Which British physicist proposed that black holes emit radiation?",
+      "ja": "ブラックホールが放射を発するという理論を提唱したイギリスの物理学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Earth",
+        "ja": "地球",
+        "ja_typings": [
+          "chikyuu"
+        ]
+      },
+      {
+        "en": "Venus",
+        "ja": "金星",
+        "ja_typings": [
+          "kinsei"
+        ]
+      },
+      {
+        "en": "Mars",
+        "ja": "火星",
+        "ja_typings": [
+          "kasei"
+        ]
+      },
+      {
+        "en": "Mercury",
+        "ja": "水星",
+        "ja_typings": [
+          "suisei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02138",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the third planet from the Sun?",
+      "ja": "太陽から3番目の惑星は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "N",
+        "ja": "窒素",
+        "ja_typings": [
+          "chisso"
+        ]
+      },
+      {
+        "en": "C",
+        "ja": "炭素",
+        "ja_typings": [
+          "tanso"
+        ]
+      },
+      {
+        "en": "H",
+        "ja": "水素",
+        "ja_typings": [
+          "suiso"
+        ]
+      },
+      {
+        "en": "O",
+        "ja": "酸素",
+        "ja_typings": [
+          "sanso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02139",
+    "image_path": null,
+    "question_text": {
+      "en": "Which element has the chemical symbol N?",
+      "ja": "化学記号Nで表される元素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "C",
+        "ja": "炭素",
+        "ja_typings": [
+          "tanso"
+        ]
+      },
+      {
+        "en": "N",
+        "ja": "窒素",
+        "ja_typings": [
+          "chisso"
+        ]
+      },
+      {
+        "en": "H",
+        "ja": "水素",
+        "ja_typings": [
+          "suiso"
+        ]
+      },
+      {
+        "en": "O",
+        "ja": "酸素",
+        "ja_typings": [
+          "sanso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02140",
+    "image_path": null,
+    "question_text": {
+      "en": "Which element has the chemical symbol C and is the basis of organic chemistry?",
+      "ja": "化学記号Cで有機化学の基礎をなす元素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "H",
+        "ja": "水素",
+        "ja_typings": [
+          "suiso"
+        ]
+      },
+      {
+        "en": "Li",
+        "ja": "リチウム",
+        "ja_typings": [
+          "richiumu"
+        ]
+      },
+      {
+        "en": "K",
+        "ja": "カリウム",
+        "ja_typings": [
+          "kariumu"
+        ]
+      },
+      {
+        "en": "O",
+        "ja": "酸素",
+        "ja_typings": [
+          "sanso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02141",
+    "image_path": null,
+    "question_text": {
+      "en": "Which element has the chemical symbol H and is the lightest element?",
+      "ja": "化学記号Hで最も軽い元素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mendel and Darwin",
+        "ja": "メンデルとダーウィン",
+        "ja_typings": [
+          "menderu/to/daawin",
+          "menderutoda-win"
+        ]
+      },
+      {
+        "en": "Pasteur and Koch",
+        "ja": "パスツールとコッホ",
+        "ja_typings": [
+          "pasutsuuru/to/kohho",
+          "pasutsu-rutokohho"
+        ]
+      },
+      {
+        "en": "Lamarck and Linnaeus",
+        "ja": "ラマルクとリンネ",
+        "ja_typings": [
+          "ramaruku/to/rinne",
+          "ramarukutorinnne"
+        ]
+      },
+      {
+        "en": "Watson and Crick",
+        "ja": "ワトソンとクリック",
+        "ja_typings": [
+          "watoson/to/kurikku",
+          "watosontokurikku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02142",
+    "image_path": null,
+    "question_text": {
+      "en": "Who are the two 19th-century scientists most often cited as founders of evolution and modern genetics?",
+      "ja": "進化論と近代遺伝学の創始者としてよく挙げられる19世紀の2人の科学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pasteur and Koch",
+        "ja": "パスツールとコッホ",
+        "ja_typings": [
+          "pasutsuuru/to/kohho",
+          "pasutsu-rutokohho"
+        ]
+      },
+      {
+        "en": "Mendel and Darwin",
+        "ja": "メンデルとダーウィン",
+        "ja_typings": [
+          "menderu/to/daawin",
+          "menderutoda-win"
+        ]
+      },
+      {
+        "en": "Lamarck and Linnaeus",
+        "ja": "ラマルクとリンネ",
+        "ja_typings": [
+          "ramaruku/to/rinne",
+          "ramarukutorinnne"
+        ]
+      },
+      {
+        "en": "Watson and Crick",
+        "ja": "ワトソンとクリック",
+        "ja_typings": [
+          "watoson/to/kurikku",
+          "watosontokurikku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02143",
+    "image_path": null,
+    "question_text": {
+      "en": "Who are the two 19th-century scientists most associated with the founding of microbiology?",
+      "ja": "微生物学の創始に深く関わった19世紀の2人の科学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lamarck and Linnaeus",
+        "ja": "ラマルクとリンネ",
+        "ja_typings": [
+          "ramaruku/to/rinne",
+          "ramarukutorinnne"
+        ]
+      },
+      {
+        "en": "Mendel and Darwin",
+        "ja": "メンデルとダーウィン",
+        "ja_typings": [
+          "menderu/to/daawin",
+          "menderutoda-win"
+        ]
+      },
+      {
+        "en": "Pasteur and Koch",
+        "ja": "パスツールとコッホ",
+        "ja_typings": [
+          "pasutsuuru/to/kohho",
+          "pasutsu-rutokohho"
+        ]
+      },
+      {
+        "en": "Watson and Crick",
+        "ja": "ワトソンとクリック",
+        "ja_typings": [
+          "watoson/to/kurikku",
+          "watosontokurikku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02144",
+    "image_path": null,
+    "question_text": {
+      "en": "Who are the two pre-Darwinian naturalists associated with early classification and inheritance theory?",
+      "ja": "ダーウィン以前の分類学・進化思想に関わった2人の博物学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Linnaeus",
+        "ja": "リンネ",
+        "ja_typings": [
+          "rinnne"
+        ]
+      },
+      {
+        "en": "Lamarck",
+        "ja": "ラマルク",
+        "ja_typings": [
+          "ramaruku"
+        ]
+      },
+      {
+        "en": "Darwin",
+        "ja": "ダーウィン",
+        "ja_typings": [
+          "da-win"
+        ]
+      },
+      {
+        "en": "Cuvier",
+        "ja": "キュヴィエ",
+        "ja_typings": [
+          "kyuvie"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02145",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 18th-century Swedish naturalist established the modern binomial nomenclature?",
+      "ja": "二名法を確立した18世紀スウェーデンの博物学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "90 degrees",
+        "ja": "180 degrees",
+        "ja_typings": [
+          "180 degrees"
+        ]
+      },
+      {
+        "en": "80 degrees",
+        "ja": "80 degrees",
+        "ja_typings": [
+          "80 degrees"
+        ]
+      },
+      {
+        "en": "120 degrees",
+        "ja": "120 degrees",
+        "ja_typings": [
+          "120 degrees"
+        ]
+      },
+      {
+        "en": "360 degrees",
+        "ja": "360 degrees",
+        "ja_typings": [
+          "360 degrees"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02146",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the sum of the interior angles of a triangle in Euclidean geometry?",
+      "ja": "ユークリッド幾何で三角形の内角の和は何度か?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "80 degrees",
+        "ja": "80 degrees",
+        "ja_typings": [
+          "80 degrees"
+        ]
+      },
+      {
+        "en": "90 degrees",
+        "ja": "90 degrees",
+        "ja_typings": [
+          "90 degrees"
+        ]
+      },
+      {
+        "en": "120 degrees",
+        "ja": "120 degrees",
+        "ja_typings": [
+          "120 degrees"
+        ]
+      },
+      {
+        "en": "100 degrees",
+        "ja": "100 degrees",
+        "ja_typings": [
+          "100 degrees"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02147",
+    "image_path": null,
+    "question_text": {
+      "en": "If an isoceles triangle has a vertex angle of 20 degrees, each base angle measures how many degrees?",
+      "ja": "頂角20度の二等辺三角形の底角はそれぞれ何度か?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "120 degrees",
+        "ja": "120 degrees",
+        "ja_typings": [
+          "120 degrees"
+        ]
+      },
+      {
+        "en": "90 degrees",
+        "ja": "90 degrees",
+        "ja_typings": [
+          "90 degrees"
+        ]
+      },
+      {
+        "en": "80 degrees",
+        "ja": "80 degrees",
+        "ja_typings": [
+          "80 degrees"
+        ]
+      },
+      {
+        "en": "100 degrees",
+        "ja": "100 degrees",
+        "ja_typings": [
+          "100 degrees"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02148",
+    "image_path": null,
+    "question_text": {
+      "en": "Each interior angle of a regular hexagon measures how many degrees?",
+      "ja": "正六角形の1つの内角は何度か?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "100 m",
+        "ja": "100 m",
+        "ja_typings": [
+          "100 m"
+        ]
+      },
+      {
+        "en": "1000 m",
+        "ja": "1000 m",
+        "ja_typings": [
+          "1000 m"
+        ]
+      },
+      {
+        "en": "3000 m",
+        "ja": "3000 m",
+        "ja_typings": [
+          "3000 m"
+        ]
+      },
+      {
+        "en": "10 m",
+        "ja": "10 m",
+        "ja_typings": [
+          "10 m"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02149",
+    "image_path": null,
+    "question_text": {
+      "en": "Approximately how long is a standard Olympic sprint track in meters for the 100m dash?",
+      "ja": "オリンピックの100m走の距離は何mか?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1000 m",
+        "ja": "1000 m",
+        "ja_typings": [
+          "1000 m"
+        ]
+      },
+      {
+        "en": "100 m",
+        "ja": "100 m",
+        "ja_typings": [
+          "100 m"
+        ]
+      },
+      {
+        "en": "3000 m",
+        "ja": "3000 m",
+        "ja_typings": [
+          "3000 m"
+        ]
+      },
+      {
+        "en": "10000 m",
+        "ja": "10000 m",
+        "ja_typings": [
+          "10000 m"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02150",
+    "image_path": null,
+    "question_text": {
+      "en": "How long is a standard track distance for the 1km run in meters?",
+      "ja": "1km走の距離はメートル換算で何mか?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "3000 m",
+        "ja": "3000 m",
+        "ja_typings": [
+          "3000 m"
+        ]
+      },
+      {
+        "en": "100 m",
+        "ja": "100 m",
+        "ja_typings": [
+          "100 m"
+        ]
+      },
+      {
+        "en": "1000 m",
+        "ja": "1000 m",
+        "ja_typings": [
+          "1000 m"
+        ]
+      },
+      {
+        "en": "300 m",
+        "ja": "300 m",
+        "ja_typings": [
+          "300 m"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02151",
+    "image_path": null,
+    "question_text": {
+      "en": "How many meters is a 3km running event?",
+      "ja": "3km走は何mか?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "23",
+        "ja": "23対",
+        "ja_typings": [
+          "23/tsui"
+        ]
+      },
+      {
+        "en": "48",
+        "ja": "48対",
+        "ja_typings": [
+          "48/tsui"
+        ]
+      },
+      {
+        "en": "24",
+        "ja": "24対",
+        "ja_typings": [
+          "24/tsui"
+        ]
+      },
+      {
+        "en": "46",
+        "ja": "46対",
+        "ja_typings": [
+          "46/tsui"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02152",
+    "image_path": null,
+    "question_text": {
+      "en": "How many pairs of chromosomes do humans normally have?",
+      "ja": "ヒトの染色体は通常何対あるか?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "48",
+        "ja": "48本",
+        "ja_typings": [
+          "48/hon"
+        ]
+      },
+      {
+        "en": "23",
+        "ja": "23本",
+        "ja_typings": [
+          "23/hon"
+        ]
+      },
+      {
+        "en": "24",
+        "ja": "24本",
+        "ja_typings": [
+          "24/hon"
+        ]
+      },
+      {
+        "en": "46",
+        "ja": "46本",
+        "ja_typings": [
+          "46/hon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02153",
+    "image_path": null,
+    "question_text": {
+      "en": "How many chromosomes do chimpanzees have in total?",
+      "ja": "チンパンジーの染色体は全部で何本あるか?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "24",
+        "ja": "24時間",
+        "ja_typings": [
+          "24/jikan"
+        ]
+      },
+      {
+        "en": "23",
+        "ja": "23時間",
+        "ja_typings": [
+          "23/jikan"
+        ]
+      },
+      {
+        "en": "48",
+        "ja": "48時間",
+        "ja_typings": [
+          "48/jikan"
+        ]
+      },
+      {
+        "en": "12",
+        "ja": "12時間",
+        "ja_typings": [
+          "12/jikan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02154",
+    "image_path": null,
+    "question_text": {
+      "en": "How many hours are in one day?",
+      "ja": "1日は何時間か?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lungs",
+        "ja": "肺",
+        "ja_typings": [
+          "hai"
+        ]
+      },
+      {
+        "en": "Heart",
+        "ja": "心臓",
+        "ja_typings": [
+          "shinzou"
+        ]
+      },
+      {
+        "en": "Liver",
+        "ja": "肝臓",
+        "ja_typings": [
+          "kanzou"
+        ]
+      },
+      {
+        "en": "Kidney",
+        "ja": "腎臓",
+        "ja_typings": [
+          "jinzou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02155",
+    "image_path": null,
+    "question_text": {
+      "en": "Which organ enables breathing by exchanging oxygen and carbon dioxide?",
+      "ja": "酸素と二酸化炭素を交換し呼吸を担う臓器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Brain",
+        "ja": "脳",
+        "ja_typings": [
+          "nou"
+        ]
+      },
+      {
+        "en": "Heart",
+        "ja": "心臓",
+        "ja_typings": [
+          "shinzou"
+        ]
+      },
+      {
+        "en": "Spinal cord",
+        "ja": "脊髄",
+        "ja_typings": [
+          "sekizui"
+        ]
+      },
+      {
+        "en": "Liver",
+        "ja": "肝臓",
+        "ja_typings": [
+          "kanzou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02156",
+    "image_path": null,
+    "question_text": {
+      "en": "Which organ is the control center of the human nervous system?",
+      "ja": "人間の神経系の中枢を担う臓器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Polaris",
+        "ja": "ポラリス",
+        "ja_typings": [
+          "porarisu"
+        ]
+      },
+      {
+        "en": "Sirius",
+        "ja": "シリウス",
+        "ja_typings": [
+          "shiriusu"
+        ]
+      },
+      {
+        "en": "Betelgeuse",
+        "ja": "ベテルギウス",
+        "ja_typings": [
+          "beterugiusu"
+        ]
+      },
+      {
+        "en": "Vega",
+        "ja": "ベガ",
+        "ja_typings": [
+          "bega"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02157",
+    "image_path": null,
+    "question_text": {
+      "en": "Which star, near the celestial north pole, is used for navigation?",
+      "ja": "天の北極付近にあり航法に使われる恒星は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Betelgeuse",
+        "ja": "ベテルギウス",
+        "ja_typings": [
+          "beterugiusu"
+        ]
+      },
+      {
+        "en": "Sirius",
+        "ja": "シリウス",
+        "ja_typings": [
+          "shiriusu"
+        ]
+      },
+      {
+        "en": "Polaris",
+        "ja": "ポラリス",
+        "ja_typings": [
+          "porarisu"
+        ]
+      },
+      {
+        "en": "Rigel",
+        "ja": "リゲル",
+        "ja_typings": [
+          "rigeru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02158",
+    "image_path": null,
+    "question_text": {
+      "en": "Which red supergiant star marks the shoulder of Orion?",
+      "ja": "オリオン座の肩を成す赤色超巨星は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "KCl",
+        "ja": "塩化カリウム",
+        "ja_typings": [
+          "enka/kariumu"
+        ]
+      },
+      {
+        "en": "NaCl",
+        "ja": "塩化ナトリウム",
+        "ja_typings": [
+          "enka/natoriumu"
+        ]
+      },
+      {
+        "en": "CaCl2",
+        "ja": "塩化カルシウム",
+        "ja_typings": [
+          "enka/karushiumu"
+        ]
+      },
+      {
+        "en": "MgCl2",
+        "ja": "塩化マグネシウム",
+        "ja_typings": [
+          "enka/maguneshiumu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02159",
+    "image_path": null,
+    "question_text": {
+      "en": "Which chemical compound with formula KCl is commonly used as a salt substitute?",
+      "ja": "化学式KClで塩の代替として使われる化合物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CaCO3",
+        "ja": "炭酸カルシウム",
+        "ja_typings": [
+          "tansan/karushiumu"
+        ]
+      },
+      {
+        "en": "CaO",
+        "ja": "酸化カルシウム",
+        "ja_typings": [
+          "sanka/karushiumu"
+        ]
+      },
+      {
+        "en": "Ca(OH)2",
+        "ja": "水酸化カルシウム",
+        "ja_typings": [
+          "suisanka/karushiumu"
+        ]
+      },
+      {
+        "en": "CaSO4",
+        "ja": "硫酸カルシウム",
+        "ja_typings": [
+          "ryuusan/karushiumu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q02160",
+    "image_path": null,
+    "question_text": {
+      "en": "Which compound with formula CaCO3 is the main component of limestone?",
+      "ja": "化学式CaCO3で石灰岩の主成分である化合物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Central limit theorem",
+        "ja": "中心極限定理",
+        "ja_typings": [
+          "chuushinkyokugenteiri"
+        ]
+      },
+      {
+        "en": "Law of large numbers",
+        "ja": "大数の法則",
+        "ja_typings": [
+          "taisuunohousoku"
+        ]
+      },
+      {
+        "en": "Bayes theorem",
+        "ja": "ベイズの定理",
+        "ja_typings": [
+          "beizunoteiri"
+        ]
+      },
+      {
+        "en": "Chebyshev inequality",
+        "ja": "チェビシェフの不等式",
+        "ja_typings": [
+          "chebishefunofutoushiki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02161",
+    "image_path": null,
+    "question_text": {
+      "en": "Which theorem states that large samples' means tend toward a normal distribution?",
+      "ja": "大規模標本の平均が正規分布に近づくとする定理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hilbert",
+        "ja": "ヒルベルト",
+        "ja_typings": [
+          "hiruberuto"
+        ]
+      },
+      {
+        "en": "Gauss",
+        "ja": "ガウス",
+        "ja_typings": [
+          "gausu"
+        ]
+      },
+      {
+        "en": "Euler",
+        "ja": "オイラー",
+        "ja_typings": [
+          "oira-"
+        ]
+      },
+      {
+        "en": "Cantor",
+        "ja": "カントール",
+        "ja_typings": [
+          "kanto-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02162",
+    "image_path": null,
+    "question_text": {
+      "en": "Who proposed 23 famous unsolved problems in 1900?",
+      "ja": "1900年に23の未解決問題を提示した数学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cauchy",
+        "ja": "コーシー",
+        "ja_typings": [
+          "ko-shi-"
+        ]
+      },
+      {
+        "en": "Weierstrass",
+        "ja": "ワイエルシュトラス",
+        "ja_typings": [
+          "waierushutorasu"
+        ]
+      },
+      {
+        "en": "Jacobi",
+        "ja": "ヤコビ",
+        "ja_typings": [
+          "yakobi"
+        ]
+      },
+      {
+        "en": "Liouville",
+        "ja": "リウヴィル",
+        "ja_typings": [
+          "riuviru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02163",
+    "image_path": null,
+    "question_text": {
+      "en": "Whose name is associated with the integral formula for analytic functions on a closed contour?",
+      "ja": "閉曲線上の解析関数の積分公式に名を残す数学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Riemann",
+        "ja": "リーマン",
+        "ja_typings": [
+          "ri-man"
+        ]
+      },
+      {
+        "en": "Hilbert",
+        "ja": "ヒルベルト",
+        "ja_typings": [
+          "hiruberuto"
+        ]
+      },
+      {
+        "en": "Poincare",
+        "ja": "ポアンカレ",
+        "ja_typings": [
+          "poankare"
+        ]
+      },
+      {
+        "en": "Dedekind",
+        "ja": "デデキント",
+        "ja_typings": [
+          "dedekinto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02164",
+    "image_path": null,
+    "question_text": {
+      "en": "Whose hypothesis about the zeros of the zeta function is a Millennium Prize problem?",
+      "ja": "ゼータ関数の零点に関する仮説で知られミレニアム懸賞問題となっている数学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Abel",
+        "ja": "アーベル",
+        "ja_typings": [
+          "a-beru"
+        ]
+      },
+      {
+        "en": "Galois",
+        "ja": "ガロア",
+        "ja_typings": [
+          "garoa"
+        ]
+      },
+      {
+        "en": "Lagrange",
+        "ja": "ラグランジュ",
+        "ja_typings": [
+          "raguranju"
+        ]
+      },
+      {
+        "en": "Ruffini",
+        "ja": "ルフィニ",
+        "ja_typings": [
+          "rufini"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02165",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Norwegian mathematician proved the impossibility of solving the general quintic by radicals?",
+      "ja": "一般5次方程式が代数的に解けないことを示したノルウェーの数学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rational number",
+        "ja": "有理数",
+        "ja_typings": [
+          "yuurisuu"
+        ]
+      },
+      {
+        "en": "Irrational number",
+        "ja": "無理数",
+        "ja_typings": [
+          "murisuu"
+        ]
+      },
+      {
+        "en": "Imaginary number",
+        "ja": "虚数",
+        "ja_typings": [
+          "kyosuu"
+        ]
+      },
+      {
+        "en": "Transcendental number",
+        "ja": "超越数",
+        "ja_typings": [
+          "chouetsusuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02166",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call a number that can be expressed as a ratio of two integers?",
+      "ja": "2つの整数の比で表せる数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "270 degrees",
+        "ja": "270度",
+        "ja_typings": [
+          "270do"
+        ]
+      },
+      {
+        "en": "180 degrees",
+        "ja": "180度",
+        "ja_typings": [
+          "180do"
+        ]
+      },
+      {
+        "en": "90 degrees",
+        "ja": "90度",
+        "ja_typings": [
+          "90do"
+        ]
+      },
+      {
+        "en": "360 degrees",
+        "ja": "360度",
+        "ja_typings": [
+          "360do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02167",
+    "image_path": null,
+    "question_text": {
+      "en": "If you rotate three-quarters of a full turn, how many degrees is that?",
+      "ja": "1回転の4分の3を角度で表すと?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1/3",
+        "ja": "3分の1",
+        "ja_typings": [
+          "3bunno1"
+        ]
+      },
+      {
+        "en": "2/6",
+        "ja": "6分の2",
+        "ja_typings": [
+          "6bunno2"
+        ]
+      },
+      {
+        "en": "1/2",
+        "ja": "2分の1",
+        "ja_typings": [
+          "2bunno1"
+        ]
+      },
+      {
+        "en": "1/6",
+        "ja": "6分の1",
+        "ja_typings": [
+          "6bunno1"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02168",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the value of 2 divided by 6 as a fraction in lowest terms?",
+      "ja": "2÷6を既約分数にすると?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "100",
+        "ja": "100",
+        "ja_typings": [
+          "100"
+        ]
+      },
+      {
+        "en": "1000",
+        "ja": "1000",
+        "ja_typings": [
+          "1000"
+        ]
+      },
+      {
+        "en": "20",
+        "ja": "20",
+        "ja_typings": [
+          "20"
+        ]
+      },
+      {
+        "en": "200",
+        "ja": "200",
+        "ja_typings": [
+          "200"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02169",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 10 squared?",
+      "ja": "10の2乗は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "21",
+        "ja": "21",
+        "ja_typings": [
+          "21"
+        ]
+      },
+      {
+        "en": "24",
+        "ja": "24",
+        "ja_typings": [
+          "24"
+        ]
+      },
+      {
+        "en": "18",
+        "ja": "18",
+        "ja_typings": [
+          "18"
+        ]
+      },
+      {
+        "en": "27",
+        "ja": "27",
+        "ja_typings": [
+          "27"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02170",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 3 multiplied by 7?",
+      "ja": "3×7はいくつ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "8",
+        "ja": "8",
+        "ja_typings": [
+          "8"
+        ]
+      },
+      {
+        "en": "6",
+        "ja": "6",
+        "ja_typings": [
+          "6"
+        ]
+      },
+      {
+        "en": "9",
+        "ja": "9",
+        "ja_typings": [
+          "9"
+        ]
+      },
+      {
+        "en": "16",
+        "ja": "16",
+        "ja_typings": [
+          "16"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02171",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 2 to the third power?",
+      "ja": "2の3乗は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sphere",
+        "ja": "球",
+        "ja_typings": [
+          "tama",
+          "kyuu"
+        ]
+      },
+      {
+        "en": "cube",
+        "ja": "立方体",
+        "ja_typings": [
+          "rippoutai"
+        ]
+      },
+      {
+        "en": "cylinder",
+        "ja": "円柱",
+        "ja_typings": [
+          "enchuu"
+        ]
+      },
+      {
+        "en": "cone",
+        "ja": "円錐",
+        "ja_typings": [
+          "ensui"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02172",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the name of a perfectly round 3D figure where all surface points are equidistant from the center?",
+      "ja": "中心から表面までの距離がすべて等しい立体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "2",
+        "ja": "2",
+        "ja_typings": [
+          "2"
+        ]
+      },
+      {
+        "en": "4",
+        "ja": "4",
+        "ja_typings": [
+          "4"
+        ]
+      },
+      {
+        "en": "6",
+        "ja": "6",
+        "ja_typings": [
+          "6"
+        ]
+      },
+      {
+        "en": "8",
+        "ja": "8",
+        "ja_typings": [
+          "8"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02173",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the only even prime number?",
+      "ja": "唯一の偶数の素数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "4",
+        "ja": "4",
+        "ja_typings": [
+          "4"
+        ]
+      },
+      {
+        "en": "8",
+        "ja": "8",
+        "ja_typings": [
+          "8"
+        ]
+      },
+      {
+        "en": "16",
+        "ja": "16",
+        "ja_typings": [
+          "16"
+        ]
+      },
+      {
+        "en": "6",
+        "ja": "6",
+        "ja_typings": [
+          "6"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02174",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 2 squared?",
+      "ja": "2の2乗は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Goldbach",
+        "ja": "ゴールドバッハ",
+        "ja_typings": [
+          "go-rudobahha"
+        ]
+      },
+      {
+        "en": "Euler",
+        "ja": "オイラー",
+        "ja_typings": [
+          "oira-"
+        ]
+      },
+      {
+        "en": "Fermat",
+        "ja": "フェルマー",
+        "ja_typings": [
+          "feruma-"
+        ]
+      },
+      {
+        "en": "Riemann",
+        "ja": "リーマン",
+        "ja_typings": [
+          "ri-man"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02175",
+    "image_path": null,
+    "question_text": {
+      "en": "Whose conjecture says every even integer greater than 2 is the sum of two primes?",
+      "ja": "2より大きい偶数はすべて2つの素数の和で表せるという予想を提唱したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fermat's Last Theorem",
+        "ja": "フェルマーの最終定理",
+        "ja_typings": [
+          "ferumaanosaishuuteiri"
+        ]
+      },
+      {
+        "en": "Goldbach conjecture",
+        "ja": "ゴールドバッハ予想",
+        "ja_typings": [
+          "goorudobahhayosou"
+        ]
+      },
+      {
+        "en": "Riemann hypothesis",
+        "ja": "リーマン予想",
+        "ja_typings": [
+          "riimanyosou"
+        ]
+      },
+      {
+        "en": "Twin prime conjecture",
+        "ja": "双子素数予想",
+        "ja_typings": [
+          "futagososuuyosou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02176",
+    "image_path": null,
+    "question_text": {
+      "en": "Which theorem proven by Andrew Wiles in 1995 says x^n + y^n = z^n has no positive integer solutions for n > 2?",
+      "ja": "1995年にワイルズが証明した、n>2でx^n+y^n=z^nが正整数解を持たないとする定理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Binomial theorem",
+        "ja": "二項定理",
+        "ja_typings": [
+          "nikouteiri"
+        ]
+      },
+      {
+        "en": "Multinomial theorem",
+        "ja": "多項定理",
+        "ja_typings": [
+          "takouteiri"
+        ]
+      },
+      {
+        "en": "Taylor theorem",
+        "ja": "テイラーの定理",
+        "ja_typings": [
+          "teiraanoteiri"
+        ]
+      },
+      {
+        "en": "Mean value theorem",
+        "ja": "平均値の定理",
+        "ja_typings": [
+          "heikinchinoteiri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02177",
+    "image_path": null,
+    "question_text": {
+      "en": "Which theorem expands (a+b)^n using combinations?",
+      "ja": "(a+b)^nを組合せを使って展開する定理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Phi",
+        "ja": "ファイ",
+        "ja_typings": [
+          "fai"
+        ]
+      },
+      {
+        "en": "Psi",
+        "ja": "プサイ",
+        "ja_typings": [
+          "pusai"
+        ]
+      },
+      {
+        "en": "Chi",
+        "ja": "カイ",
+        "ja_typings": [
+          "kai"
+        ]
+      },
+      {
+        "en": "Omega",
+        "ja": "オメガ",
+        "ja_typings": [
+          "omega"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02178",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Greek letter is often used to denote the golden ratio?",
+      "ja": "黄金比を表すのによく使われるギリシャ文字は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Theta",
+        "ja": "シータ",
+        "ja_typings": [
+          "shi-ta"
+        ]
+      },
+      {
+        "en": "Phi",
+        "ja": "ファイ",
+        "ja_typings": [
+          "fai"
+        ]
+      },
+      {
+        "en": "Lambda",
+        "ja": "ラムダ",
+        "ja_typings": [
+          "ramuda"
+        ]
+      },
+      {
+        "en": "Sigma",
+        "ja": "シグマ",
+        "ja_typings": [
+          "shiguma"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02179",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Greek letter is commonly used to denote an angle?",
+      "ja": "角度を表すのによく使われるギリシャ文字は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bernoulli",
+        "ja": "ベルヌーイ",
+        "ja_typings": [
+          "berunu-i"
+        ]
+      },
+      {
+        "en": "Euler",
+        "ja": "オイラー",
+        "ja_typings": [
+          "oira-"
+        ]
+      },
+      {
+        "en": "Cauchy",
+        "ja": "コーシー",
+        "ja_typings": [
+          "ko-shi-"
+        ]
+      },
+      {
+        "en": "Lagrange",
+        "ja": "ラグランジュ",
+        "ja_typings": [
+          "raguranju"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02180",
+    "image_path": null,
+    "question_text": {
+      "en": "Whose family produced multiple Swiss mathematicians known for probability and fluid dynamics?",
+      "ja": "確率や流体力学で知られるスイスの数学者一族の名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dedekind",
+        "ja": "デデキント",
+        "ja_typings": [
+          "dedekinto"
+        ]
+      },
+      {
+        "en": "Cantor",
+        "ja": "カントール",
+        "ja_typings": [
+          "kanto-ru"
+        ]
+      },
+      {
+        "en": "Weierstrass",
+        "ja": "ワイエルシュトラス",
+        "ja_typings": [
+          "waierushutorasu"
+        ]
+      },
+      {
+        "en": "Riemann",
+        "ja": "リーマン",
+        "ja_typings": [
+          "ri-man"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02181",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is known for the construction of real numbers via cuts of rationals?",
+      "ja": "有理数の切断で実数を構成したことで知られる数学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Poincare",
+        "ja": "ポアンカレ",
+        "ja_typings": [
+          "poankare"
+        ]
+      },
+      {
+        "en": "Cauchy",
+        "ja": "コーシー",
+        "ja_typings": [
+          "ko-shi-"
+        ]
+      },
+      {
+        "en": "Lagrange",
+        "ja": "ラグランジュ",
+        "ja_typings": [
+          "raguranju"
+        ]
+      },
+      {
+        "en": "Galois",
+        "ja": "ガロア",
+        "ja_typings": [
+          "garoa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02182",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French mathematician's conjecture on 3-manifolds was solved by Perelman?",
+      "ja": "3次元多様体に関する予想がペレルマンに解かれたフランスの数学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lagrange",
+        "ja": "ラグランジュ",
+        "ja_typings": [
+          "raguranju"
+        ]
+      },
+      {
+        "en": "Laplace",
+        "ja": "ラプラス",
+        "ja_typings": [
+          "rapurasu"
+        ]
+      },
+      {
+        "en": "Legendre",
+        "ja": "ルジャンドル",
+        "ja_typings": [
+          "rujandoru"
+        ]
+      },
+      {
+        "en": "Fermat",
+        "ja": "フェルマー",
+        "ja_typings": [
+          "feruma-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02183",
+    "image_path": null,
+    "question_text": {
+      "en": "Who developed the calculus of variations and a theorem on subgroup order in group theory?",
+      "ja": "変分法を発展させ群論で部分群の位数の定理にも名を残す数学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Composite number",
+        "ja": "合成数",
+        "ja_typings": [
+          "gouseisuu"
+        ]
+      },
+      {
+        "en": "Prime number",
+        "ja": "素数",
+        "ja_typings": [
+          "sosuu"
+        ]
+      },
+      {
+        "en": "Perfect number",
+        "ja": "完全数",
+        "ja_typings": [
+          "kanzensuu"
+        ]
+      },
+      {
+        "en": "Natural number",
+        "ja": "自然数",
+        "ja_typings": [
+          "shizensuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02184",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call a positive integer with more than two divisors?",
+      "ja": "約数を3つ以上もつ正の整数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Perfect number",
+        "ja": "完全数",
+        "ja_typings": [
+          "kanzensuu"
+        ]
+      },
+      {
+        "en": "Amicable number",
+        "ja": "友愛数",
+        "ja_typings": [
+          "yuuaisuu"
+        ]
+      },
+      {
+        "en": "Composite number",
+        "ja": "合成数",
+        "ja_typings": [
+          "gouseisuu"
+        ]
+      },
+      {
+        "en": "Triangular number",
+        "ja": "三角数",
+        "ja_typings": [
+          "sankakusuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02185",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call a positive integer equal to the sum of its proper divisors, like 6 or 28?",
+      "ja": "自分自身を除く約数の和が自分自身に等しい数(6や28)は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Natural number",
+        "ja": "自然数",
+        "ja_typings": [
+          "shizensuu"
+        ]
+      },
+      {
+        "en": "Integer",
+        "ja": "整数",
+        "ja_typings": [
+          "seisuu"
+        ]
+      },
+      {
+        "en": "Rational number",
+        "ja": "有理数",
+        "ja_typings": [
+          "yuurisuu"
+        ]
+      },
+      {
+        "en": "Real number",
+        "ja": "実数",
+        "ja_typings": [
+          "jissuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02186",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call the counting numbers 1, 2, 3, ...?",
+      "ja": "1, 2, 3, ... のような数え上げの数を何という?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Integer",
+        "ja": "整数",
+        "ja_typings": [
+          "seisuu"
+        ]
+      },
+      {
+        "en": "Natural number",
+        "ja": "自然数",
+        "ja_typings": [
+          "shizensuu"
+        ]
+      },
+      {
+        "en": "Rational number",
+        "ja": "有理数",
+        "ja_typings": [
+          "yuurisuu"
+        ]
+      },
+      {
+        "en": "Whole number",
+        "ja": "全数",
+        "ja_typings": [
+          "zensuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02187",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call the set including negative whole numbers, zero, and positive whole numbers?",
+      "ja": "負・0・正の整数すべてをまとめた数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Napier's number e",
+        "ja": "ネイピア数e",
+        "ja_typings": [
+          "neipiasuue"
+        ]
+      },
+      {
+        "en": "Pi",
+        "ja": "円周率",
+        "ja_typings": [
+          "enshuuritsu"
+        ]
+      },
+      {
+        "en": "Golden ratio",
+        "ja": "黄金比",
+        "ja_typings": [
+          "ougonhi"
+        ]
+      },
+      {
+        "en": "Euler-Mascheroni constant",
+        "ja": "オイラーマスケローニ定数",
+        "ja_typings": [
+          "oiraamasukerooniteisuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02188",
+    "image_path": null,
+    "question_text": {
+      "en": "Which constant approximately 2.71828 is the base of the natural logarithm?",
+      "ja": "自然対数の底となる約2.71828の定数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Golden ratio phi",
+        "ja": "黄金比φ",
+        "ja_typings": [
+          "ougonhi"
+        ]
+      },
+      {
+        "en": "Silver ratio",
+        "ja": "白銀比",
+        "ja_typings": [
+          "hakuginhi"
+        ]
+      },
+      {
+        "en": "Napier's number e",
+        "ja": "ネイピア数e",
+        "ja_typings": [
+          "neipiasuue"
+        ]
+      },
+      {
+        "en": "Bronze ratio",
+        "ja": "青銅比",
+        "ja_typings": [
+          "seidouhi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02189",
+    "image_path": null,
+    "question_text": {
+      "en": "Which constant approximately 1.618 is often denoted by the Greek letter phi?",
+      "ja": "ギリシャ文字ファイで表される約1.618の定数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pi",
+        "ja": "円周率π",
+        "ja_typings": [
+          "enshuuritsu"
+        ]
+      },
+      {
+        "en": "Napier's number e",
+        "ja": "ネイピア数e",
+        "ja_typings": [
+          "neipiasuue"
+        ]
+      },
+      {
+        "en": "Golden ratio",
+        "ja": "黄金比",
+        "ja_typings": [
+          "ougonhi"
+        ]
+      },
+      {
+        "en": "Square root of 2",
+        "ja": "ルート2",
+        "ja_typings": [
+          "ruuto2",
+          "ru-to2"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02190",
+    "image_path": null,
+    "question_text": {
+      "en": "Which constant approximately equals 3.14159?",
+      "ja": "約3.14159となる定数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Euler-Mascheroni constant",
+        "ja": "オイラーマスケローニ定数",
+        "ja_typings": [
+          "oiraamasukerooniteisuu"
+        ]
+      },
+      {
+        "en": "Napier's number e",
+        "ja": "ネイピア数e",
+        "ja_typings": [
+          "neipiasuue"
+        ]
+      },
+      {
+        "en": "Catalan constant",
+        "ja": "カタラン定数",
+        "ja_typings": [
+          "kataranteisuu"
+        ]
+      },
+      {
+        "en": "Apery's constant",
+        "ja": "アペリーの定数",
+        "ja_typings": [
+          "aperiinoteisuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02191",
+    "image_path": null,
+    "question_text": {
+      "en": "Which constant approximately 0.5772 appears as the limit difference between harmonic sums and the natural log?",
+      "ja": "調和数と自然対数の差の極限として現れる約0.5772の定数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Silver ratio",
+        "ja": "白銀比",
+        "ja_typings": [
+          "hakuginhi"
+        ]
+      },
+      {
+        "en": "Golden ratio",
+        "ja": "黄金比",
+        "ja_typings": [
+          "ougonhi"
+        ]
+      },
+      {
+        "en": "Bronze ratio",
+        "ja": "青銅比",
+        "ja_typings": [
+          "seidouhi"
+        ]
+      },
+      {
+        "en": "Harmonic ratio",
+        "ja": "調和比",
+        "ja_typings": [
+          "chouwahi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02192",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ratio approximately 1:1.414 appears in A4 paper sizes?",
+      "ja": "A4などのコピー用紙に現れる約1:1.414の比は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bronze ratio",
+        "ja": "青銅比",
+        "ja_typings": [
+          "seidouhi"
+        ]
+      },
+      {
+        "en": "Copper ratio",
+        "ja": "銅比",
+        "ja_typings": [
+          "douhi"
+        ]
+      },
+      {
+        "en": "Iron ratio",
+        "ja": "鉄比",
+        "ja_typings": [
+          "tetsuhi"
+        ]
+      },
+      {
+        "en": "Platinum ratio",
+        "ja": "白金比",
+        "ja_typings": [
+          "hakkinhi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02193",
+    "image_path": null,
+    "question_text": {
+      "en": "Which metallic ratio is the third in the series after golden and silver?",
+      "ja": "黄金比、白銀比に続く第3の金属比は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Harmonic ratio",
+        "ja": "調和比",
+        "ja_typings": [
+          "chouwahi"
+        ]
+      },
+      {
+        "en": "Golden ratio",
+        "ja": "黄金比",
+        "ja_typings": [
+          "ougonhi"
+        ]
+      },
+      {
+        "en": "Silver ratio",
+        "ja": "白銀比",
+        "ja_typings": [
+          "hakuginhi"
+        ]
+      },
+      {
+        "en": "Geometric ratio",
+        "ja": "幾何比",
+        "ja_typings": [
+          "kikahi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02194",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call a ratio related to harmonic means used in music and projective geometry?",
+      "ja": "音楽や射影幾何で現れる調和平均に関わる比を何という?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Arithmetic sequence",
+        "ja": "等差数列",
+        "ja_typings": [
+          "touasuuretsu"
+        ]
+      },
+      {
+        "en": "Geometric sequence",
+        "ja": "等比数列",
+        "ja_typings": [
+          "touhisuuretsu"
+        ]
+      },
+      {
+        "en": "Harmonic sequence",
+        "ja": "調和数列",
+        "ja_typings": [
+          "chouwasuuretsu"
+        ]
+      },
+      {
+        "en": "Fibonacci sequence",
+        "ja": "フィボナッチ数列",
+        "ja_typings": [
+          "fibonacchisuuretsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02195",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call a sequence where each term differs from the previous by a constant?",
+      "ja": "隣り合う項の差が一定の数列は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Geometric sequence",
+        "ja": "等比数列",
+        "ja_typings": [
+          "touhisuuretsu"
+        ]
+      },
+      {
+        "en": "Arithmetic sequence",
+        "ja": "等差数列",
+        "ja_typings": [
+          "touasuuretsu"
+        ]
+      },
+      {
+        "en": "Harmonic sequence",
+        "ja": "調和数列",
+        "ja_typings": [
+          "chouwasuuretsu"
+        ]
+      },
+      {
+        "en": "Constant sequence",
+        "ja": "定数数列",
+        "ja_typings": [
+          "teisuusuuretsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02196",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call a sequence where each term is a constant multiple of the previous one?",
+      "ja": "隣り合う項の比が一定の数列は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Harmonic sequence",
+        "ja": "調和数列",
+        "ja_typings": [
+          "chouwasuuretsu"
+        ]
+      },
+      {
+        "en": "Arithmetic sequence",
+        "ja": "等差数列",
+        "ja_typings": [
+          "touasuuretsu"
+        ]
+      },
+      {
+        "en": "Geometric sequence",
+        "ja": "等比数列",
+        "ja_typings": [
+          "touhisuuretsu"
+        ]
+      },
+      {
+        "en": "Reciprocal sequence",
+        "ja": "逆数列",
+        "ja_typings": [
+          "gyakusuuretsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02197",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call a sequence whose reciprocals form an arithmetic progression?",
+      "ja": "逆数を取ると等差数列になる数列は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "90 degrees",
+        "ja": "90度",
+        "ja_typings": [
+          "90do"
+        ]
+      },
+      {
+        "en": "45 degrees",
+        "ja": "45度",
+        "ja_typings": [
+          "45do"
+        ]
+      },
+      {
+        "en": "180 degrees",
+        "ja": "180度",
+        "ja_typings": [
+          "180do"
+        ]
+      },
+      {
+        "en": "60 degrees",
+        "ja": "60度",
+        "ja_typings": [
+          "60do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02198",
+    "image_path": null,
+    "question_text": {
+      "en": "How many degrees is a right angle?",
+      "ja": "直角は何度?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "2/3",
+        "ja": "3分の2",
+        "ja_typings": [
+          "3bunno2"
+        ]
+      },
+      {
+        "en": "4/6",
+        "ja": "6分の4",
+        "ja_typings": [
+          "6bunno4"
+        ]
+      },
+      {
+        "en": "3/4",
+        "ja": "4分の3",
+        "ja_typings": [
+          "4bunno3"
+        ]
+      },
+      {
+        "en": "1/2",
+        "ja": "2分の1",
+        "ja_typings": [
+          "2bunno1"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02199",
+    "image_path": null,
+    "question_text": {
+      "en": "What is 4 divided by 6 as a fraction in lowest terms?",
+      "ja": "4÷6を既約分数で表すと?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cup",
+        "ja": "カップ",
+        "ja_typings": [
+          "kappu"
+        ]
+      },
+      {
+        "en": "Cap",
+        "ja": "キャップ",
+        "ja_typings": [
+          "kyappu"
+        ]
+      },
+      {
+        "en": "Subset",
+        "ja": "サブセット",
+        "ja_typings": [
+          "sabusetto"
+        ]
+      },
+      {
+        "en": "Element of",
+        "ja": "属する",
+        "ja_typings": [
+          "zokusuru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02200",
+    "image_path": null,
+    "question_text": {
+      "en": "Which set operation symbol represents the union of two sets?",
+      "ja": "2つの集合の和集合を表す記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Subset",
+        "ja": "部分集合",
+        "ja_typings": [
+          "bubunshuugou"
+        ]
+      },
+      {
+        "en": "Superset",
+        "ja": "上位集合",
+        "ja_typings": [
+          "jouishuugou"
+        ]
+      },
+      {
+        "en": "Power set",
+        "ja": "ベキ集合",
+        "ja_typings": [
+          "bekishuugou"
+        ]
+      },
+      {
+        "en": "Empty set",
+        "ja": "空集合",
+        "ja_typings": [
+          "kuushuugou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02201",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call set A when every element of A is also in set B?",
+      "ja": "Aの要素すべてがBに含まれているとき、AはBの何?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Element of",
+        "ja": "属する",
+        "ja_typings": [
+          "zokusuru"
+        ]
+      },
+      {
+        "en": "Subset",
+        "ja": "部分集合",
+        "ja_typings": [
+          "bubunshuugou"
+        ]
+      },
+      {
+        "en": "Union",
+        "ja": "和集合",
+        "ja_typings": [
+          "washuugou"
+        ]
+      },
+      {
+        "en": "Intersection",
+        "ja": "共通部分",
+        "ja_typings": [
+          "kyoutsuububun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02202",
+    "image_path": null,
+    "question_text": {
+      "en": "Which symbol means 'is an element of'?",
+      "ja": "「要素として属する」を表す記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Scalar",
+        "ja": "スカラー",
+        "ja_typings": [
+          "sukara-"
+        ]
+      },
+      {
+        "en": "Vector",
+        "ja": "ベクトル",
+        "ja_typings": [
+          "bekutoru"
+        ]
+      },
+      {
+        "en": "Tensor",
+        "ja": "テンソル",
+        "ja_typings": [
+          "tensoru"
+        ]
+      },
+      {
+        "en": "Matrix",
+        "ja": "行列",
+        "ja_typings": [
+          "gyouretsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02203",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call a single number quantity without direction?",
+      "ja": "向きを持たず大きさのみの量は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tensor",
+        "ja": "テンソル",
+        "ja_typings": [
+          "tensoru"
+        ]
+      },
+      {
+        "en": "Scalar",
+        "ja": "スカラー",
+        "ja_typings": [
+          "sukara-"
+        ]
+      },
+      {
+        "en": "Vector",
+        "ja": "ベクトル",
+        "ja_typings": [
+          "bekutoru"
+        ]
+      },
+      {
+        "en": "Spinor",
+        "ja": "スピノル",
+        "ja_typings": [
+          "supinoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02204",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call a multi-dimensional generalization of vectors and matrices?",
+      "ja": "ベクトルや行列を多次元に一般化した量は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sequence",
+        "ja": "数列",
+        "ja_typings": [
+          "suuretsu"
+        ]
+      },
+      {
+        "en": "Series",
+        "ja": "級数",
+        "ja_typings": [
+          "kyuusuu"
+        ]
+      },
+      {
+        "en": "Set",
+        "ja": "集合",
+        "ja_typings": [
+          "shuugou"
+        ]
+      },
+      {
+        "en": "Function",
+        "ja": "関数",
+        "ja_typings": [
+          "kansuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02205",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call an ordered list of numbers indexed by natural numbers?",
+      "ja": "自然数で順序付けられた数の並びは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Set",
+        "ja": "集合",
+        "ja_typings": [
+          "shuugou"
+        ]
+      },
+      {
+        "en": "Sequence",
+        "ja": "数列",
+        "ja_typings": [
+          "suuretsu"
+        ]
+      },
+      {
+        "en": "Group",
+        "ja": "群",
+        "ja_typings": [
+          "gun"
+        ]
+      },
+      {
+        "en": "Ring",
+        "ja": "環",
+        "ja_typings": [
+          "kan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02206",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call an unordered collection of distinct objects?",
+      "ja": "順序を考えない異なるものの集まりを何という?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pascal",
+        "ja": "パスカル",
+        "ja_typings": [
+          "pasukaru"
+        ]
+      },
+      {
+        "en": "Fermat",
+        "ja": "フェルマー",
+        "ja_typings": [
+          "feruma-"
+        ]
+      },
+      {
+        "en": "Descartes",
+        "ja": "デカルト",
+        "ja_typings": [
+          "dekaruto"
+        ]
+      },
+      {
+        "en": "Laplace",
+        "ja": "ラプラス",
+        "ja_typings": [
+          "rapurasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02207",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French mathematician's triangle gives binomial coefficients?",
+      "ja": "二項係数を並べた三角形に名を残すフランスの数学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pythagoras",
+        "ja": "ピタゴラス",
+        "ja_typings": [
+          "pitagorasu"
+        ]
+      },
+      {
+        "en": "Euclid",
+        "ja": "ユークリッド",
+        "ja_typings": [
+          "yu-kuriddo"
+        ]
+      },
+      {
+        "en": "Archimedes",
+        "ja": "アルキメデス",
+        "ja_typings": [
+          "arukimedesu"
+        ]
+      },
+      {
+        "en": "Thales",
+        "ja": "タレス",
+        "ja_typings": [
+          "taresu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02208",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Greek mathematician's theorem relates the sides of a right triangle?",
+      "ja": "直角三角形の辺の関係に名を残す古代ギリシャの数学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thales",
+        "ja": "タレス",
+        "ja_typings": [
+          "taresu"
+        ]
+      },
+      {
+        "en": "Pythagoras",
+        "ja": "ピタゴラス",
+        "ja_typings": [
+          "pitagorasu"
+        ]
+      },
+      {
+        "en": "Euclid",
+        "ja": "ユークリッド",
+        "ja_typings": [
+          "yu-kuriddo"
+        ]
+      },
+      {
+        "en": "Plato",
+        "ja": "プラトン",
+        "ja_typings": [
+          "puraton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02209",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Greek philosopher is credited with one of the first geometric theorems about angles in a semicircle?",
+      "ja": "半円に内接する角に関する定理で知られる古代ギリシャの哲学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Plato",
+        "ja": "プラトン",
+        "ja_typings": [
+          "puraton"
+        ]
+      },
+      {
+        "en": "Aristotle",
+        "ja": "アリストテレス",
+        "ja_typings": [
+          "arisutoteresu"
+        ]
+      },
+      {
+        "en": "Socrates",
+        "ja": "ソクラテス",
+        "ja_typings": [
+          "sokuratesu"
+        ]
+      },
+      {
+        "en": "Euclid",
+        "ja": "ユークリッド",
+        "ja_typings": [
+          "yu-kuriddo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q02210",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Greek philosopher is associated with five regular polyhedra called the 'solids'?",
+      "ja": "5種類の正多面体に名を残すギリシャの哲学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "France",
+        "ja": "フランス",
+        "ja_typings": [
+          "furansu"
+        ]
+      },
+      {
+        "en": "Italy",
+        "ja": "イタリア",
+        "ja_typings": [
+          "itaria"
+        ]
+      },
+      {
+        "en": "Spain",
+        "ja": "スペイン",
+        "ja_typings": [
+          "supein"
+        ]
+      },
+      {
+        "en": "Germany",
+        "ja": "ドイツ",
+        "ja_typings": [
+          "doitsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02211",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country is the Eiffel Tower located in?",
+      "ja": "エッフェル塔がある国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Guglielmo Marconi",
+        "ja": "グリエルモ マルコーニ",
+        "ja_typings": [
+          "gurierumo maruko-ni"
+        ]
+      },
+      {
+        "en": "Nikola Tesla",
+        "ja": "ニコラ テスラ",
+        "ja_typings": [
+          "nikora tesura"
+        ]
+      },
+      {
+        "en": "Alexander Bell",
+        "ja": "アレクサンダー ベル",
+        "ja_typings": [
+          "arekusanda- beru"
+        ]
+      },
+      {
+        "en": "Thomas Edison",
+        "ja": "トーマス エジソン",
+        "ja_typings": [
+          "to-masu ejison"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02212",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the Italian inventor credited with the first long-distance radio transmission?",
+      "ja": "長距離無線通信を初めて成功させたイタリアの発明家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "United Kingdom",
+        "ja": "イギリス",
+        "ja_typings": [
+          "igirisu"
+        ]
+      },
+      {
+        "en": "Ireland",
+        "ja": "アイルランド",
+        "ja_typings": [
+          "airurando"
+        ]
+      },
+      {
+        "en": "France",
+        "ja": "フランス",
+        "ja_typings": [
+          "furansu"
+        ]
+      },
+      {
+        "en": "Netherlands",
+        "ja": "オランダ",
+        "ja_typings": [
+          "oranda"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02213",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has London as its capital?",
+      "ja": "ロンドンを首都とする国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "fish",
+        "ja": "魚",
+        "ja_typings": [
+          "sakana"
+        ]
+      },
+      {
+        "en": "amphibian",
+        "ja": "両生類",
+        "ja_typings": [
+          "ryouseirui"
+        ]
+      },
+      {
+        "en": "reptile",
+        "ja": "爬虫類",
+        "ja_typings": [
+          "hachuurui"
+        ]
+      },
+      {
+        "en": "mammal",
+        "ja": "哺乳類",
+        "ja_typings": [
+          "honyuurui"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02214",
+    "image_path": null,
+    "question_text": {
+      "en": "Which animal group includes salmon, tuna, and trout?",
+      "ja": "サケ・マグロ・マスを含む生き物のグループは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Italy",
+        "ja": "イタリア",
+        "ja_typings": [
+          "itaria"
+        ]
+      },
+      {
+        "en": "Spain",
+        "ja": "スペイン",
+        "ja_typings": [
+          "supein"
+        ]
+      },
+      {
+        "en": "Greece",
+        "ja": "ギリシャ",
+        "ja_typings": [
+          "girisha"
+        ]
+      },
+      {
+        "en": "Portugal",
+        "ja": "ポルトガル",
+        "ja_typings": [
+          "porutogaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02215",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country is shaped like a boot and known for pasta and pizza?",
+      "ja": "長靴の形をしておりパスタやピザで有名な国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "German",
+        "ja": "ドイツ語",
+        "ja_typings": [
+          "doitsugo"
+        ]
+      },
+      {
+        "en": "Dutch",
+        "ja": "オランダ語",
+        "ja_typings": [
+          "orandago"
+        ]
+      },
+      {
+        "en": "Austrian",
+        "ja": "オーストリア語",
+        "ja_typings": [
+          "oosutoriago"
+        ]
+      },
+      {
+        "en": "Swiss",
+        "ja": "スイス語",
+        "ja_typings": [
+          "suisugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02216",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language is spoken as the official language of Germany?",
+      "ja": "ドイツの公用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "hertz",
+        "ja": "ヘルツ",
+        "ja_typings": [
+          "herutsu"
+        ]
+      },
+      {
+        "en": "joule",
+        "ja": "ジュール",
+        "ja_typings": [
+          "ju-ru"
+        ]
+      },
+      {
+        "en": "newton",
+        "ja": "ニュートン",
+        "ja_typings": [
+          "nyu-ton"
+        ]
+      },
+      {
+        "en": "watt",
+        "ja": "ワット",
+        "ja_typings": [
+          "watto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02217",
+    "image_path": null,
+    "question_text": {
+      "en": "Which SI unit measures frequency, in cycles per second?",
+      "ja": "周波数のSI単位(毎秒の振動回数)は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "home base",
+        "ja": "ホームベース",
+        "ja_typings": [
+          "ho-mube-su"
+        ]
+      },
+      {
+        "en": "first base",
+        "ja": "一塁",
+        "ja_typings": [
+          "ichirui"
+        ]
+      },
+      {
+        "en": "second base",
+        "ja": "二塁",
+        "ja_typings": [
+          "nirui"
+        ]
+      },
+      {
+        "en": "third base",
+        "ja": "三塁",
+        "ja_typings": [
+          "sanrui"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02218",
+    "image_path": null,
+    "question_text": {
+      "en": "In baseball, what is the name of the base that batters aim to return to score?",
+      "ja": "野球で打者が戻ってきて得点となるベースは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "hit",
+        "ja": "ヒット",
+        "ja_typings": [
+          "hitto"
+        ]
+      },
+      {
+        "en": "foul",
+        "ja": "ファウル",
+        "ja_typings": [
+          "fauru"
+        ]
+      },
+      {
+        "en": "strike",
+        "ja": "ストライク",
+        "ja_typings": [
+          "sutoraiku"
+        ]
+      },
+      {
+        "en": "ball",
+        "ja": "ボール",
+        "ja_typings": [
+          "bo-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02219",
+    "image_path": null,
+    "question_text": {
+      "en": "In baseball, what term means a successful safe hit on the ball into fair territory?",
+      "ja": "野球で打球がフェア地域に飛び出塁できた打撃を何という?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "foul",
+        "ja": "ファウル",
+        "ja_typings": [
+          "fauru"
+        ]
+      },
+      {
+        "en": "hit",
+        "ja": "ヒット",
+        "ja_typings": [
+          "hitto"
+        ]
+      },
+      {
+        "en": "strike",
+        "ja": "ストライク",
+        "ja_typings": [
+          "sutoraiku"
+        ]
+      },
+      {
+        "en": "homerun",
+        "ja": "ホームラン",
+        "ja_typings": [
+          "ho-muran"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02220",
+    "image_path": null,
+    "question_text": {
+      "en": "In baseball, what term means the ball was hit outside the fair territory lines?",
+      "ja": "野球で打球がフェア地域の外に飛ぶことを何という?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "45 minutes",
+        "ja": "45分",
+        "ja_typings": [
+          "45fun"
+        ]
+      },
+      {
+        "en": "30 minutes",
+        "ja": "30分",
+        "ja_typings": [
+          "30pun"
+        ]
+      },
+      {
+        "en": "60 minutes",
+        "ja": "60分",
+        "ja_typings": [
+          "60pun"
+        ]
+      },
+      {
+        "en": "40 minutes",
+        "ja": "40分",
+        "ja_typings": [
+          "40pun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02221",
+    "image_path": null,
+    "question_text": {
+      "en": "How long is one half in a standard soccer match?",
+      "ja": "サッカーの前半・後半は1つあたり何分?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "12 minutes",
+        "ja": "12分",
+        "ja_typings": [
+          "12fun"
+        ]
+      },
+      {
+        "en": "30 minutes",
+        "ja": "30分",
+        "ja_typings": [
+          "30pun"
+        ]
+      },
+      {
+        "en": "60 minutes",
+        "ja": "60分",
+        "ja_typings": [
+          "60pun"
+        ]
+      },
+      {
+        "en": "40 minutes",
+        "ja": "40分",
+        "ja_typings": [
+          "40pun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02222",
+    "image_path": null,
+    "question_text": {
+      "en": "How long is one quarter in standard NBA basketball?",
+      "ja": "NBAの1クォーターは何分?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "20 minutes",
+        "ja": "20分",
+        "ja_typings": [
+          "20pun"
+        ]
+      },
+      {
+        "en": "30 minutes",
+        "ja": "30分",
+        "ja_typings": [
+          "30pun"
+        ]
+      },
+      {
+        "en": "40 minutes",
+        "ja": "40分",
+        "ja_typings": [
+          "40pun"
+        ]
+      },
+      {
+        "en": "60 minutes",
+        "ja": "60分",
+        "ja_typings": [
+          "60pun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02223",
+    "image_path": null,
+    "question_text": {
+      "en": "How long is one period in standard ice hockey?",
+      "ja": "アイスホッケーの1ピリオドは何分?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Juan Antonio Samaranch",
+        "ja": "フアン アントニオ サマランチ",
+        "ja_typings": [
+          "fuan antonio samaranchi"
+        ]
+      },
+      {
+        "en": "Jacques Rogge",
+        "ja": "ジャック ロゲ",
+        "ja_typings": [
+          "jakku roge"
+        ]
+      },
+      {
+        "en": "Thomas Bach",
+        "ja": "トーマス バッハ",
+        "ja_typings": [
+          "to-masu bahha"
+        ]
+      },
+      {
+        "en": "Avery Brundage",
+        "ja": "アベリー ブランデージ",
+        "ja_typings": [
+          "aberi- burande-ji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02224",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the 7th president of the International Olympic Committee, serving 1980-2001?",
+      "ja": "1980年から2001年までIOC会長を務めたスペイン人は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jacques Rogge",
+        "ja": "ジャック ロゲ",
+        "ja_typings": [
+          "jakku roge"
+        ]
+      },
+      {
+        "en": "Juan Antonio Samaranch",
+        "ja": "フアン アントニオ サマランチ",
+        "ja_typings": [
+          "fuan antonio samaranchi"
+        ]
+      },
+      {
+        "en": "Thomas Bach",
+        "ja": "トーマス バッハ",
+        "ja_typings": [
+          "to-masu bahha"
+        ]
+      },
+      {
+        "en": "Pierre de Coubertin",
+        "ja": "ピエール ド クーベルタン",
+        "ja_typings": [
+          "pie-ru do ku-berutan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02225",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the 8th president of the IOC, serving 2001-2013?",
+      "ja": "2001年から2013年までIOC会長を務めたベルギー人は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thomas Bach",
+        "ja": "トーマス バッハ",
+        "ja_typings": [
+          "to-masu bahha"
+        ]
+      },
+      {
+        "en": "Jacques Rogge",
+        "ja": "ジャック ロゲ",
+        "ja_typings": [
+          "jakku roge"
+        ]
+      },
+      {
+        "en": "Juan Antonio Samaranch",
+        "ja": "フアン アントニオ サマランチ",
+        "ja_typings": [
+          "fuan antonio samaranchi"
+        ]
+      },
+      {
+        "en": "Sebastian Coe",
+        "ja": "セバスチャン コー",
+        "ja_typings": [
+          "sebasuchan ko-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02226",
+    "image_path": null,
+    "question_text": {
+      "en": "Who became the 9th president of the IOC in 2013?",
+      "ja": "2013年にIOC会長となったドイツ人は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nikola Tesla",
+        "ja": "ニコラ テスラ",
+        "ja_typings": [
+          "nikora tesura"
+        ]
+      },
+      {
+        "en": "Thomas Edison",
+        "ja": "トーマス エジソン",
+        "ja_typings": [
+          "to-masu ejison"
+        ]
+      },
+      {
+        "en": "Guglielmo Marconi",
+        "ja": "グリエルモ マルコーニ",
+        "ja_typings": [
+          "gurierumo maruko-ni"
+        ]
+      },
+      {
+        "en": "Alexander Bell",
+        "ja": "アレクサンダー ベル",
+        "ja_typings": [
+          "arekusanda- beru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02227",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Serbian-American inventor is known for AC electrical systems?",
+      "ja": "交流送電で知られるセルビア系アメリカ人の発明家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Marie Curie",
+        "ja": "マリー キュリー",
+        "ja_typings": [
+          "mari- kyuri-"
+        ]
+      },
+      {
+        "en": "Albert Einstein",
+        "ja": "アルベルト アインシュタイン",
+        "ja_typings": [
+          "aruberuto ainshutain"
+        ]
+      },
+      {
+        "en": "Lise Meitner",
+        "ja": "リーゼ マイトナー",
+        "ja_typings": [
+          "ri-ze maitona-"
+        ]
+      },
+      {
+        "en": "Rosalind Franklin",
+        "ja": "ロザリンド フランクリン",
+        "ja_typings": [
+          "rozarindo furankurin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02228",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Polish-French physicist who won Nobel Prizes in both physics and chemistry for work on radioactivity?",
+      "ja": "放射線の研究で物理学賞と化学賞の両方を受賞したポーランド系フランス人の物理学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1956",
+        "ja": "1956",
+        "ja_typings": [
+          "1956"
+        ]
+      },
+      {
+        "en": "1968",
+        "ja": "1968",
+        "ja_typings": [
+          "1968"
+        ]
+      },
+      {
+        "en": "1972",
+        "ja": "1972",
+        "ja_typings": [
+          "1972"
+        ]
+      },
+      {
+        "en": "1960",
+        "ja": "1960",
+        "ja_typings": [
+          "1960"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02229",
+    "image_path": null,
+    "question_text": {
+      "en": "In which year did Melbourne host the Summer Olympics?",
+      "ja": "メルボルン夏季オリンピックが開催された年は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1968",
+        "ja": "1968",
+        "ja_typings": [
+          "1968"
+        ]
+      },
+      {
+        "en": "1956",
+        "ja": "1956",
+        "ja_typings": [
+          "1956"
+        ]
+      },
+      {
+        "en": "1972",
+        "ja": "1972",
+        "ja_typings": [
+          "1972"
+        ]
+      },
+      {
+        "en": "1964",
+        "ja": "1964",
+        "ja_typings": [
+          "1964"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02230",
+    "image_path": null,
+    "question_text": {
+      "en": "In which year did Mexico City host the Summer Olympics?",
+      "ja": "メキシコシティ夏季オリンピックが開催された年は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1972",
+        "ja": "1972",
+        "ja_typings": [
+          "1972"
+        ]
+      },
+      {
+        "en": "1968",
+        "ja": "1968",
+        "ja_typings": [
+          "1968"
+        ]
+      },
+      {
+        "en": "1956",
+        "ja": "1956",
+        "ja_typings": [
+          "1956"
+        ]
+      },
+      {
+        "en": "1976",
+        "ja": "1976",
+        "ja_typings": [
+          "1976"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02231",
+    "image_path": null,
+    "question_text": {
+      "en": "In which year did Munich host the Summer Olympics?",
+      "ja": "ミュンヘン夏季オリンピックが開催された年は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Japan Trench",
+        "ja": "日本海溝",
+        "ja_typings": [
+          "nihonkaikou"
+        ]
+      },
+      {
+        "en": "Puerto Rico Trench",
+        "ja": "プエルトリコ海溝",
+        "ja_typings": [
+          "puerutorikokaikou"
+        ]
+      },
+      {
+        "en": "Tonga Trench",
+        "ja": "トンガ海溝",
+        "ja_typings": [
+          "tongakaikou"
+        ]
+      },
+      {
+        "en": "Mariana Trench",
+        "ja": "マリアナ海溝",
+        "ja_typings": [
+          "marianakaikou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02232",
+    "image_path": null,
+    "question_text": {
+      "en": "Which trench off the Pacific coast of Tohoku is famous for deep-focus earthquakes?",
+      "ja": "東北沖の太平洋にある深発地震で有名な海溝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Puerto Rico Trench",
+        "ja": "プエルトリコ海溝",
+        "ja_typings": [
+          "puerutorikokaikou"
+        ]
+      },
+      {
+        "en": "Japan Trench",
+        "ja": "日本海溝",
+        "ja_typings": [
+          "nihonkaikou"
+        ]
+      },
+      {
+        "en": "Tonga Trench",
+        "ja": "トンガ海溝",
+        "ja_typings": [
+          "tongakaikou"
+        ]
+      },
+      {
+        "en": "Sunda Trench",
+        "ja": "スンダ海溝",
+        "ja_typings": [
+          "sundakaikou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02233",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the deepest trench in the Atlantic Ocean?",
+      "ja": "大西洋で最も深い海溝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tonga Trench",
+        "ja": "トンガ海溝",
+        "ja_typings": [
+          "tongakaikou"
+        ]
+      },
+      {
+        "en": "Japan Trench",
+        "ja": "日本海溝",
+        "ja_typings": [
+          "nihonkaikou"
+        ]
+      },
+      {
+        "en": "Puerto Rico Trench",
+        "ja": "プエルトリコ海溝",
+        "ja_typings": [
+          "puerutorikokaikou"
+        ]
+      },
+      {
+        "en": "Kermadec Trench",
+        "ja": "ケルマデック海溝",
+        "ja_typings": [
+          "kerumadekkukaikou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02234",
+    "image_path": null,
+    "question_text": {
+      "en": "Which trench in the South Pacific is the second deepest in the world?",
+      "ja": "世界で2番目に深い南太平洋の海溝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "John Steinbeck",
+        "ja": "ジョン スタインベック",
+        "ja_typings": [
+          "jon sutainbekku"
+        ]
+      },
+      {
+        "en": "William Faulkner",
+        "ja": "ウィリアム フォークナー",
+        "ja_typings": [
+          "wiriamu fo-kuna-"
+        ]
+      },
+      {
+        "en": "Ernest Hemingway",
+        "ja": "アーネスト ヘミングウェイ",
+        "ja_typings": [
+          "a-nesuto heminguwei"
+        ]
+      },
+      {
+        "en": "F. Scott Fitzgerald",
+        "ja": "F スコット フィッツジェラルド",
+        "ja_typings": [
+          "f sukotto fittsujerarudo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02235",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote 'The Grapes of Wrath' and won the Nobel Prize in Literature in 1962?",
+      "ja": "「怒りの葡萄」を書き1962年にノーベル文学賞を受賞した米国人作家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "William Faulkner",
+        "ja": "ウィリアム フォークナー",
+        "ja_typings": [
+          "wiriamu fo-kuna-"
+        ]
+      },
+      {
+        "en": "John Steinbeck",
+        "ja": "ジョン スタインベック",
+        "ja_typings": [
+          "jon sutainbekku"
+        ]
+      },
+      {
+        "en": "Ernest Hemingway",
+        "ja": "アーネスト ヘミングウェイ",
+        "ja_typings": [
+          "a-nesuto heminguwei"
+        ]
+      },
+      {
+        "en": "F. Scott Fitzgerald",
+        "ja": "F スコット フィッツジェラルド",
+        "ja_typings": [
+          "f sukotto fittsujerarudo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02236",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote 'The Sound and the Fury' and won the Nobel Prize in Literature in 1949?",
+      "ja": "「響きと怒り」を書き1949年にノーベル文学賞を受賞した米国人作家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "F. Scott Fitzgerald",
+        "ja": "F スコット フィッツジェラルド",
+        "ja_typings": [
+          "f sukotto fittsujerarudo"
+        ]
+      },
+      {
+        "en": "John Steinbeck",
+        "ja": "ジョン スタインベック",
+        "ja_typings": [
+          "jon sutainbekku"
+        ]
+      },
+      {
+        "en": "William Faulkner",
+        "ja": "ウィリアム フォークナー",
+        "ja_typings": [
+          "wiriamu fo-kuna-"
+        ]
+      },
+      {
+        "en": "Ernest Hemingway",
+        "ja": "アーネスト ヘミングウェイ",
+        "ja_typings": [
+          "a-nesuto heminguwei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02237",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote 'The Great Gatsby'?",
+      "ja": "「グレート ギャツビー」の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Steven Spielberg",
+        "ja": "スティーブン スピルバーグ",
+        "ja_typings": [
+          "suti-bun supiruba-gu"
+        ]
+      },
+      {
+        "en": "Martin Scorsese",
+        "ja": "マーティン スコセッシ",
+        "ja_typings": [
+          "ma-tin sukosesshi"
+        ]
+      },
+      {
+        "en": "Ridley Scott",
+        "ja": "リドリー スコット",
+        "ja_typings": [
+          "ridori- sukotto"
+        ]
+      },
+      {
+        "en": "Francis Coppola",
+        "ja": "フランシス コッポラ",
+        "ja_typings": [
+          "furanshisu koppora"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02238",
+    "image_path": null,
+    "question_text": {
+      "en": "Who directed 'Jaws', 'E.T.', and 'Jurassic Park'?",
+      "ja": "「ジョーズ」「E.T.」「ジュラシック パーク」を監督した米国人は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Martin Scorsese",
+        "ja": "マーティン スコセッシ",
+        "ja_typings": [
+          "ma-tin sukosesshi"
+        ]
+      },
+      {
+        "en": "Steven Spielberg",
+        "ja": "スティーブン スピルバーグ",
+        "ja_typings": [
+          "suti-bun supiruba-gu"
+        ]
+      },
+      {
+        "en": "Ridley Scott",
+        "ja": "リドリー スコット",
+        "ja_typings": [
+          "ridori- sukotto"
+        ]
+      },
+      {
+        "en": "Francis Coppola",
+        "ja": "フランシス コッポラ",
+        "ja_typings": [
+          "furanshisu koppora"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02239",
+    "image_path": null,
+    "question_text": {
+      "en": "Who directed 'Taxi Driver' and 'Goodfellas'?",
+      "ja": "「タクシードライバー」「グッドフェローズ」を監督した米国人は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ridley Scott",
+        "ja": "リドリー スコット",
+        "ja_typings": [
+          "ridori- sukotto"
+        ]
+      },
+      {
+        "en": "Steven Spielberg",
+        "ja": "スティーブン スピルバーグ",
+        "ja_typings": [
+          "suti-bun supiruba-gu"
+        ]
+      },
+      {
+        "en": "Martin Scorsese",
+        "ja": "マーティン スコセッシ",
+        "ja_typings": [
+          "ma-tin sukosesshi"
+        ]
+      },
+      {
+        "en": "James Cameron",
+        "ja": "ジェームズ キャメロン",
+        "ja_typings": [
+          "je-muzu kyameron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02240",
+    "image_path": null,
+    "question_text": {
+      "en": "Who directed 'Alien', 'Blade Runner', and 'Gladiator'?",
+      "ja": "「エイリアン」「ブレードランナー」「グラディエーター」を監督した英国人は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tomato",
+        "ja": "トマト",
+        "ja_typings": [
+          "tomato"
+        ]
+      },
+      {
+        "en": "Red cabbage",
+        "ja": "紫キャベツ",
+        "ja_typings": [
+          "murasakikyabetsu"
+        ]
+      },
+      {
+        "en": "Red radish",
+        "ja": "赤大根",
+        "ja_typings": [
+          "akadaikon"
+        ]
+      },
+      {
+        "en": "Red bell pepper",
+        "ja": "赤パプリカ",
+        "ja_typings": [
+          "akapapurika"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02241",
+    "image_path": null,
+    "question_text": {
+      "en": "Botanically classified as a fruit but commonly used as a vegetable, what red ingredient is essential to ketchup?",
+      "ja": "植物学的には果実だが料理では野菜扱いされケチャップの主原料となる赤い食材は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "lion",
+        "ja": "ライオン",
+        "ja_typings": [
+          "raion"
+        ]
+      },
+      {
+        "en": "leopard",
+        "ja": "ヒョウ",
+        "ja_typings": [
+          "hyo",
+          "hyou"
+        ]
+      },
+      {
+        "en": "cheetah",
+        "ja": "チーター",
+        "ja_typings": [
+          "chi-ta-"
+        ]
+      },
+      {
+        "en": "tiger",
+        "ja": "トラ",
+        "ja_typings": [
+          "tora"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02242",
+    "image_path": null,
+    "question_text": {
+      "en": "Which large cat is known as the 'king of the savannah' and lives in prides?",
+      "ja": "サバンナの王者と呼ばれ群れを作る大型のネコ科動物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "gazelle",
+        "ja": "ガゼル",
+        "ja_typings": [
+          "gazeru"
+        ]
+      },
+      {
+        "en": "lion",
+        "ja": "ライオン",
+        "ja_typings": [
+          "raion"
+        ]
+      },
+      {
+        "en": "zebra",
+        "ja": "シマウマ",
+        "ja_typings": [
+          "shimauma"
+        ]
+      },
+      {
+        "en": "giraffe",
+        "ja": "キリン",
+        "ja_typings": [
+          "kirin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02243",
+    "image_path": null,
+    "question_text": {
+      "en": "Which slender African antelope is famous for its leaping bounds?",
+      "ja": "跳躍で有名なアフリカの細身の動物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "leopard",
+        "ja": "ヒョウ",
+        "ja_typings": [
+          "hyo",
+          "hyou"
+        ]
+      },
+      {
+        "en": "cheetah",
+        "ja": "チーター",
+        "ja_typings": [
+          "chi-ta-"
+        ]
+      },
+      {
+        "en": "lion",
+        "ja": "ライオン",
+        "ja_typings": [
+          "raion"
+        ]
+      },
+      {
+        "en": "jaguar",
+        "ja": "ジャガー",
+        "ja_typings": [
+          "jaga-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02244",
+    "image_path": null,
+    "question_text": {
+      "en": "Which spotted big cat is known for dragging prey up into trees?",
+      "ja": "獲物を木の上に運ぶことで知られる斑点模様の大型ネコ科動物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wimbledon",
+        "ja": "ウィンブルドン",
+        "ja_typings": [
+          "winburudon"
+        ]
+      },
+      {
+        "en": "French Open",
+        "ja": "全仏オープン",
+        "ja_typings": [
+          "zenbutsuoopun"
+        ]
+      },
+      {
+        "en": "Australian Open",
+        "ja": "全豪オープン",
+        "ja_typings": [
+          "zengouoopun"
+        ]
+      },
+      {
+        "en": "US Open",
+        "ja": "全米オープン",
+        "ja_typings": [
+          "zenbeioopun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02245",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Grand Slam tennis tournament is played on grass in London?",
+      "ja": "ロンドンの芝コートで開催されるテニスのグランドスラム大会は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "French Open",
+        "ja": "全仏オープン",
+        "ja_typings": [
+          "zenbutsuoopun"
+        ]
+      },
+      {
+        "en": "Wimbledon",
+        "ja": "ウィンブルドン",
+        "ja_typings": [
+          "winburudon"
+        ]
+      },
+      {
+        "en": "Australian Open",
+        "ja": "全豪オープン",
+        "ja_typings": [
+          "zengouoopun"
+        ]
+      },
+      {
+        "en": "US Open",
+        "ja": "全米オープン",
+        "ja_typings": [
+          "zenbeioopun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02246",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Grand Slam tennis tournament is played on clay courts in Paris?",
+      "ja": "パリのクレーコートで開催されるテニスのグランドスラム大会は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Australian Open",
+        "ja": "全豪オープン",
+        "ja_typings": [
+          "zengouoopun"
+        ]
+      },
+      {
+        "en": "French Open",
+        "ja": "全仏オープン",
+        "ja_typings": [
+          "zenbutsuoopun"
+        ]
+      },
+      {
+        "en": "Wimbledon",
+        "ja": "ウィンブルドン",
+        "ja_typings": [
+          "winburudon"
+        ]
+      },
+      {
+        "en": "US Open",
+        "ja": "全米オープン",
+        "ja_typings": [
+          "zenbeioopun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02247",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Grand Slam tennis tournament is held in Melbourne in January?",
+      "ja": "1月にメルボルンで開催されるテニスのグランドスラム大会は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thomas Newcomen",
+        "ja": "トーマス ニューコメン",
+        "ja_typings": [
+          "to-masu nyu-komen"
+        ]
+      },
+      {
+        "en": "James Watt",
+        "ja": "ジェームズ ワット",
+        "ja_typings": [
+          "je-muzu watto"
+        ]
+      },
+      {
+        "en": "George Stephenson",
+        "ja": "ジョージ スチーブンソン",
+        "ja_typings": [
+          "jo-ji suchi-bunson"
+        ]
+      },
+      {
+        "en": "Robert Fulton",
+        "ja": "ロバート フルトン",
+        "ja_typings": [
+          "roba-to furuton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02248",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the English inventor of the early atmospheric steam engine in 1712?",
+      "ja": "1712年に大気圧蒸気機関を実用化した英国の発明家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "George Stephenson",
+        "ja": "ジョージ スチーブンソン",
+        "ja_typings": [
+          "jo-ji suchi-bunson"
+        ]
+      },
+      {
+        "en": "Thomas Newcomen",
+        "ja": "トーマス ニューコメン",
+        "ja_typings": [
+          "to-masu nyu-komen"
+        ]
+      },
+      {
+        "en": "James Watt",
+        "ja": "ジェームズ ワット",
+        "ja_typings": [
+          "je-muzu watto"
+        ]
+      },
+      {
+        "en": "Robert Fulton",
+        "ja": "ロバート フルトン",
+        "ja_typings": [
+          "roba-to furuton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02249",
+    "image_path": null,
+    "question_text": {
+      "en": "Who built the early steam locomotive 'Rocket' in England?",
+      "ja": "英国で蒸気機関車「ロケット号」を製作した技術者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Robert Fulton",
+        "ja": "ロバート フルトン",
+        "ja_typings": [
+          "roba-to furuton"
+        ]
+      },
+      {
+        "en": "Thomas Newcomen",
+        "ja": "トーマス ニューコメン",
+        "ja_typings": [
+          "to-masu nyu-komen"
+        ]
+      },
+      {
+        "en": "George Stephenson",
+        "ja": "ジョージ スチーブンソン",
+        "ja_typings": [
+          "jo-ji suchi-bunson"
+        ]
+      },
+      {
+        "en": "James Watt",
+        "ja": "ジェームズ ワット",
+        "ja_typings": [
+          "je-muzu watto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02250",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the American engineer who developed the first commercially successful steamboat?",
+      "ja": "商業的に成功した最初の蒸気船を開発した米国人は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "hornet",
+        "ja": "スズメバチ",
+        "ja_typings": [
+          "suzumebachi"
+        ]
+      },
+      {
+        "en": "paper wasp",
+        "ja": "アシナガバチ",
+        "ja_typings": [
+          "ashinagabachi"
+        ]
+      },
+      {
+        "en": "carpenter bee",
+        "ja": "クマバチ",
+        "ja_typings": [
+          "kumabachi"
+        ]
+      },
+      {
+        "en": "honeybee",
+        "ja": "ミツバチ",
+        "ja_typings": [
+          "mitsubachi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02251",
+    "image_path": null,
+    "question_text": {
+      "en": "Which large stinging insect builds papery nests and is more aggressive than honeybees?",
+      "ja": "ミツバチより攻撃的で紙状の巣を作る大型の刺す昆虫は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "paper wasp",
+        "ja": "アシナガバチ",
+        "ja_typings": [
+          "ashinagabachi"
+        ]
+      },
+      {
+        "en": "hornet",
+        "ja": "スズメバチ",
+        "ja_typings": [
+          "suzumebachi"
+        ]
+      },
+      {
+        "en": "carpenter bee",
+        "ja": "クマバチ",
+        "ja_typings": [
+          "kumabachi"
+        ]
+      },
+      {
+        "en": "honeybee",
+        "ja": "ミツバチ",
+        "ja_typings": [
+          "mitsubachi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02252",
+    "image_path": null,
+    "question_text": {
+      "en": "Which slender wasp builds open umbrella-shaped nests?",
+      "ja": "細身で傘状の巣を作るハチは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "carpenter bee",
+        "ja": "クマバチ",
+        "ja_typings": [
+          "kumabachi"
+        ]
+      },
+      {
+        "en": "hornet",
+        "ja": "スズメバチ",
+        "ja_typings": [
+          "suzumebachi"
+        ]
+      },
+      {
+        "en": "paper wasp",
+        "ja": "アシナガバチ",
+        "ja_typings": [
+          "ashinagabachi"
+        ]
+      },
+      {
+        "en": "bumblebee",
+        "ja": "マルハナバチ",
+        "ja_typings": [
+          "maruhanabachi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q02253",
+    "image_path": null,
+    "question_text": {
+      "en": "Which large solitary black bee bores into wood to make nests?",
+      "ja": "木に穴を開けて巣を作る大きな黒い単独行動の蜂は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mirai Akari",
+        "ja": "ミライアカリ",
+        "ja_typings": [
+          "miraiakari"
+        ]
+      },
+      {
+        "en": "Kaguya Luna",
+        "ja": "輝夜月",
+        "ja_typings": [
+          "kaguyaruna"
+        ]
+      },
+      {
+        "en": "Kizuna AI",
+        "ja": "キズナアイ",
+        "ja_typings": [
+          "kizunaai"
+        ]
+      },
+      {
+        "en": "Nekomasu",
+        "ja": "ねこます",
+        "ja_typings": [
+          "nekomasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02254",
+    "image_path": null,
+    "question_text": {
+      "en": "Which early Japanese VTuber was known as the cheerful 'school idol' alongside the original four?",
+      "ja": "初期4大VTuberの一人で「未来の学園アイドル」として人気を博したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kaguya Luna",
+        "ja": "輝夜月",
+        "ja_typings": [
+          "kaguyaruna"
+        ]
+      },
+      {
+        "en": "Mirai Akari",
+        "ja": "ミライアカリ",
+        "ja_typings": [
+          "miraiakari"
+        ]
+      },
+      {
+        "en": "Kizuna AI",
+        "ja": "キズナアイ",
+        "ja_typings": [
+          "kizunaai"
+        ]
+      },
+      {
+        "en": "Siro",
+        "ja": "シロ",
+        "ja_typings": [
+          "shiro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02255",
+    "image_path": null,
+    "question_text": {
+      "en": "Which early Japanese VTuber is famous for an energetic Princess Kaguya themed persona?",
+      "ja": "かぐや姫をモチーフにした奔放なキャラで知られる初期VTuberは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Houshou Marine",
+        "ja": "宝鐘マリン",
+        "ja_typings": [
+          "houshoumarin"
+        ]
+      },
+      {
+        "en": "Usada Pekora",
+        "ja": "兎田ぺこら",
+        "ja_typings": [
+          "usadapekora"
+        ]
+      },
+      {
+        "en": "Shirakami Fubuki",
+        "ja": "白上フブキ",
+        "ja_typings": [
+          "shirakamifubuki"
+        ]
+      },
+      {
+        "en": "Minato Aqua",
+        "ja": "湊あくあ",
+        "ja_typings": [
+          "minatoakua"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02256",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive VTuber is a pirate captain known for the catchphrase 'ahoy'?",
+      "ja": "「あほーい」で知られるホロライブの海賊船長は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "anger",
+        "ja": "怒り",
+        "ja_typings": [
+          "ikari"
+        ]
+      },
+      {
+        "en": "sadness",
+        "ja": "悲しみ",
+        "ja_typings": [
+          "kanashimi"
+        ]
+      },
+      {
+        "en": "joy",
+        "ja": "喜び",
+        "ja_typings": [
+          "yorokobi"
+        ]
+      },
+      {
+        "en": "fear",
+        "ja": "恐れ",
+        "ja_typings": [
+          "osore"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02257",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Plutchik emotion is conveyed by the red angry-face emoji?",
+      "ja": "赤い怒り顔の絵文字が表すプルチック基本感情は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Noripro",
+        "ja": "のりプロ",
+        "ja_typings": [
+          "noripuro"
+        ]
+      },
+      {
+        "en": "VShojo",
+        "ja": "ブイショウジョ",
+        "ja_typings": [
+          "buishojo",
+          "buishoujo"
+        ]
+      },
+      {
+        "en": "Nijisanji",
+        "ja": "にじさんじ",
+        "ja_typings": [
+          "nijisanji"
+        ]
+      },
+      {
+        "en": "Hololive",
+        "ja": "ホロライブ",
+        "ja_typings": [
+          "hororaibu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02258",
+    "image_path": null,
+    "question_text": {
+      "en": "Which VTuber agency manages stylish 'Noripro' talents in Japan?",
+      "ja": "ののかみらいなど「のりプロ」の所属タレントを抱える事務所は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "VShojo",
+        "ja": "ブイショウジョ",
+        "ja_typings": [
+          "buishojo",
+          "buishoujo"
+        ]
+      },
+      {
+        "en": "Noripro",
+        "ja": "のりプロ",
+        "ja_typings": [
+          "noripuro"
+        ]
+      },
+      {
+        "en": "Hololive EN",
+        "ja": "ホロライブEN",
+        "ja_typings": [
+          "hororaibuen"
+        ]
+      },
+      {
+        "en": "Nijisanji EN",
+        "ja": "にじさんじEN",
+        "ja_typings": [
+          "nijisanjien"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02259",
+    "image_path": null,
+    "question_text": {
+      "en": "Which English-language VTuber agency includes Ironmouse and Projekt Melody?",
+      "ja": "アイアンマウスやプロジェクトメロディなどが所属する英語圏VTuber事務所は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dennou Shoujo Siro",
+        "ja": "電脳少女シロ",
+        "ja_typings": [
+          "dennoushoujoshiro"
+        ]
+      },
+      {
+        "en": "Mirai Akari",
+        "ja": "ミライアカリ",
+        "ja_typings": [
+          "miraiakari"
+        ]
+      },
+      {
+        "en": "Kaguya Luna",
+        "ja": "輝夜月",
+        "ja_typings": [
+          "kaguyaruna"
+        ]
+      },
+      {
+        "en": "Kizuna AI",
+        "ja": "キズナアイ",
+        "ja_typings": [
+          "kizunaai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02260",
+    "image_path": null,
+    "question_text": {
+      "en": "Which early VTuber's full name is 'Dennou Shoujo Siro'?",
+      "ja": "「電脳少女シロ」のフルネームで知られる初期VTuberは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CyberAgent",
+        "ja": "サイバーエージェント",
+        "ja_typings": [
+          "saiba-e-jento"
+        ]
+      },
+      {
+        "en": "Sony",
+        "ja": "ソニー",
+        "ja_typings": [
+          "soni-"
+        ]
+      },
+      {
+        "en": "Bushiroad",
+        "ja": "ブシロード",
+        "ja_typings": [
+          "bushiro-do"
+        ]
+      },
+      {
+        "en": "DeNA",
+        "ja": "ディー エヌ エー",
+        "ja_typings": [
+          "di- enu e-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02261",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese internet company is the parent of Nijisanji's operator Anycolor's predecessor relationships and also runs AbemaTV?",
+      "ja": "AbemaTVを運営する日本のインターネット企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chato",
+        "ja": "ちゃと",
+        "ja_typings": [
+          "chato"
+        ]
+      },
+      {
+        "en": "Nekomasu",
+        "ja": "ねこます",
+        "ja_typings": [
+          "nekomasu"
+        ]
+      },
+      {
+        "en": "Siro",
+        "ja": "シロ",
+        "ja_typings": [
+          "shiro"
+        ]
+      },
+      {
+        "en": "Mikoto",
+        "ja": "ミコト",
+        "ja_typings": [
+          "mikoto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02262",
+    "image_path": null,
+    "question_text": {
+      "en": "What live streaming community term refers to the meme cat 'chato' that became iconic in early Japanese VTuber chats?",
+      "ja": "初期VTuber配信のコメント文化で象徴的になった猫「ちゃと」を指す言葉は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Watson Amelia",
+        "ja": "ワトソン アメリア",
+        "ja_typings": [
+          "watoson ameria"
+        ]
+      },
+      {
+        "en": "Gawr Gura",
+        "ja": "がうる ぐら",
+        "ja_typings": [
+          "gauru gura"
+        ]
+      },
+      {
+        "en": "Ninomae Inanis",
+        "ja": "一伊那尓栖",
+        "ja_typings": [
+          "ninomaeinanisu"
+        ]
+      },
+      {
+        "en": "Mori Calliope",
+        "ja": "森カリオペ",
+        "ja_typings": [
+          "morikariope"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02263",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive English Myth member is the detective with the catchphrase 'Watson'?",
+      "ja": "ホロライブEN Mythの「探偵」キャラのメンバーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sadness",
+        "ja": "悲しみ",
+        "ja_typings": [
+          "kanashimi"
+        ]
+      },
+      {
+        "en": "anger",
+        "ja": "怒り",
+        "ja_typings": [
+          "ikari"
+        ]
+      },
+      {
+        "en": "joy",
+        "ja": "喜び",
+        "ja_typings": [
+          "yorokobi"
+        ]
+      },
+      {
+        "en": "fear",
+        "ja": "恐れ",
+        "ja_typings": [
+          "osore"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02264",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Plutchik emotion is conveyed by the crying-face emoji?",
+      "ja": "泣き顔の絵文字が表すプルチック基本感情は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "VSPO!",
+        "ja": "ブイスポ",
+        "ja_typings": [
+          "buisupo"
+        ]
+      },
+      {
+        "en": "VShojo",
+        "ja": "ブイショウジョ",
+        "ja_typings": [
+          "buishojo",
+          "buishoujo"
+        ]
+      },
+      {
+        "en": "Noripro",
+        "ja": "のりプロ",
+        "ja_typings": [
+          "noripuro"
+        ]
+      },
+      {
+        "en": "Nijisanji",
+        "ja": "にじさんじ",
+        "ja_typings": [
+          "nijisanji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02265",
+    "image_path": null,
+    "question_text": {
+      "en": "Which VTuber group focuses on competitive FPS and esports under Brave Group?",
+      "ja": "ブレイブグループ傘下でFPS・eスポーツを中心とするVTuberグループは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": ".LIVE",
+        "ja": "どっとライブ",
+        "ja_typings": [
+          "dottoraibu"
+        ]
+      },
+      {
+        "en": "Hololive",
+        "ja": "ホロライブ",
+        "ja_typings": [
+          "hororaibu"
+        ]
+      },
+      {
+        "en": "Nijisanji",
+        "ja": "にじさんじ",
+        "ja_typings": [
+          "nijisanji"
+        ]
+      },
+      {
+        "en": "VShojo",
+        "ja": "ブイショウジョ",
+        "ja_typings": [
+          "buishojo",
+          "buishoujo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02266",
+    "image_path": null,
+    "question_text": {
+      "en": "Which early Japanese VTuber group included Dennou Shoujo Siro and Mononobe no Alice?",
+      "ja": "電脳少女シロや物述有栖が所属していた初期VTuberグループは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bushiroad",
+        "ja": "ブシロード",
+        "ja_typings": [
+          "bushiro-do"
+        ]
+      },
+      {
+        "en": "CyberAgent",
+        "ja": "サイバーエージェント",
+        "ja_typings": [
+          "saiba-e-jento"
+        ]
+      },
+      {
+        "en": "Sony",
+        "ja": "ソニー",
+        "ja_typings": [
+          "soni-"
+        ]
+      },
+      {
+        "en": "Bandai",
+        "ja": "バンダイ",
+        "ja_typings": [
+          "bandai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02267",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese company is famous for Weiss Schwarz card games and pro wrestling promotion?",
+      "ja": "ヴァイスシュヴァルツやプロレス興行で知られる日本企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sony",
+        "ja": "ソニー",
+        "ja_typings": [
+          "soni-"
+        ]
+      },
+      {
+        "en": "Bushiroad",
+        "ja": "ブシロード",
+        "ja_typings": [
+          "bushiro-do"
+        ]
+      },
+      {
+        "en": "CyberAgent",
+        "ja": "サイバーエージェント",
+        "ja_typings": [
+          "saiba-e-jento"
+        ]
+      },
+      {
+        "en": "Panasonic",
+        "ja": "パナソニック",
+        "ja_typings": [
+          "panasonikku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02268",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese electronics company makes the PlayStation?",
+      "ja": "プレイステーションを製造する日本企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "wwwww",
+        "ja": "大爆笑",
+        "ja_typings": [
+          "daibakushou"
+        ]
+      },
+      {
+        "en": "XD",
+        "ja": "笑顔",
+        "ja_typings": [
+          "egao"
+        ]
+      },
+      {
+        "en": "kusa haeru",
+        "ja": "ありがとう",
+        "ja_typings": [
+          "arigatou",
+          "arigato"
+        ]
+      },
+      {
+        "en": "nya",
+        "ja": "怒っている",
+        "ja_typings": [
+          "okotteiru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02269",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese chat slang of multiple 'w' characters means laughing hard?",
+      "ja": "wを連ねた「wwwww」というネットスラングの意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "XD",
+        "ja": "エックスディー",
+        "ja_typings": [
+          "ekkusudi-"
+        ]
+      },
+      {
+        "en": "wwwww",
+        "ja": "ダブリュー連打",
+        "ja_typings": [
+          "daburyuurenda"
+        ]
+      },
+      {
+        "en": "nya",
+        "ja": "ニャー",
+        "ja_typings": [
+          "nya-"
+        ]
+      },
+      {
+        "en": "dazo",
+        "ja": "だぞ",
+        "ja_typings": [
+          "dazo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02270",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Western internet slang means laughing, written as an emoticon with squinted eyes?",
+      "ja": "目をつぶった顔文字で笑いを表す英語圏のネットスラングは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "kusa haeru",
+        "ja": "草生える",
+        "ja_typings": [
+          "kusahaeru"
+        ]
+      },
+      {
+        "en": "wwwww",
+        "ja": "ダブリュー連打",
+        "ja_typings": [
+          "daburyuurenda"
+        ]
+      },
+      {
+        "en": "XD",
+        "ja": "エックスディー",
+        "ja_typings": [
+          "ekkusudi-"
+        ]
+      },
+      {
+        "en": "nya",
+        "ja": "ニャー",
+        "ja_typings": [
+          "nya-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02271",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese internet phrase literally meaning 'grass grows' is used to indicate laughter?",
+      "ja": "「草が生える」という言葉でネット上の笑いを表す表現は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Membership",
+        "ja": "メンバーシップ",
+        "ja_typings": [
+          "menba-shippu"
+        ]
+      },
+      {
+        "en": "Donation",
+        "ja": "投げ銭",
+        "ja_typings": [
+          "nagesen"
+        ]
+      },
+      {
+        "en": "Subsc",
+        "ja": "サブスク",
+        "ja_typings": [
+          "sabusuku"
+        ]
+      },
+      {
+        "en": "Coin",
+        "ja": "コイン",
+        "ja_typings": [
+          "koin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02272",
+    "image_path": null,
+    "question_text": {
+      "en": "Which YouTube monetization feature provides paid subscribers with badges and exclusive perks?",
+      "ja": "YouTubeで有料会員にバッジや限定特典を付与する仕組みは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Donation",
+        "ja": "投げ銭",
+        "ja_typings": [
+          "nagesen"
+        ]
+      },
+      {
+        "en": "Membership",
+        "ja": "メンバーシップ",
+        "ja_typings": [
+          "menba-shippu"
+        ]
+      },
+      {
+        "en": "Subsc",
+        "ja": "サブスク",
+        "ja_typings": [
+          "sabusuku"
+        ]
+      },
+      {
+        "en": "Gem",
+        "ja": "ジェム",
+        "ja_typings": [
+          "jemu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02273",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the general term for sending money to a streamer?",
+      "ja": "配信者にお金を送る一般用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sucha",
+        "ja": "スパチャ",
+        "ja_typings": [
+          "supacha"
+        ]
+      },
+      {
+        "en": "Done",
+        "ja": "投げ銭",
+        "ja_typings": [
+          "nagesen"
+        ]
+      },
+      {
+        "en": "Menshi",
+        "ja": "メン限",
+        "ja_typings": [
+          "mengen"
+        ]
+      },
+      {
+        "en": "Gentei",
+        "ja": "限定",
+        "ja_typings": [
+          "gentei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02274",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese slang word for 'Super Chat' on YouTube is used in VTuber chats?",
+      "ja": "YouTubeのスーパーチャットをVTuber視聴者が略して呼ぶ言葉は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Done",
+        "ja": "ドネ",
+        "ja_typings": [
+          "done"
+        ]
+      },
+      {
+        "en": "Sucha",
+        "ja": "スパチャ",
+        "ja_typings": [
+          "supacha"
+        ]
+      },
+      {
+        "en": "Menshi",
+        "ja": "メン限",
+        "ja_typings": [
+          "mengen"
+        ]
+      },
+      {
+        "en": "Subsc",
+        "ja": "サブスク",
+        "ja_typings": [
+          "sabusuku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02275",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese chat slang abbreviates 'donation/tip'?",
+      "ja": "「投げ銭」を意味するチャットスラングは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Menshi",
+        "ja": "メン限",
+        "ja_typings": [
+          "mengen"
+        ]
+      },
+      {
+        "en": "Sucha",
+        "ja": "スパチャ",
+        "ja_typings": [
+          "supacha"
+        ]
+      },
+      {
+        "en": "Gentei",
+        "ja": "限定",
+        "ja_typings": [
+          "gentei"
+        ]
+      },
+      {
+        "en": "Subsc",
+        "ja": "サブスク",
+        "ja_typings": [
+          "sabusuku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02276",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese fan slang abbreviates 'members-only stream'?",
+      "ja": "「メンバー限定配信」をファンが略す言い方は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gentei",
+        "ja": "限定",
+        "ja_typings": [
+          "gentei"
+        ]
+      },
+      {
+        "en": "Menshi",
+        "ja": "メン限",
+        "ja_typings": [
+          "mengen"
+        ]
+      },
+      {
+        "en": "Sucha",
+        "ja": "スパチャ",
+        "ja_typings": [
+          "supacha"
+        ]
+      },
+      {
+        "en": "Done",
+        "ja": "ドネ",
+        "ja_typings": [
+          "done"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02277",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese word meaning 'limited' is used for members-only or time-limited content?",
+      "ja": "メン限や期間限定で使われる「限定」の日本語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Subsc",
+        "ja": "サブスク",
+        "ja_typings": [
+          "sabusuku"
+        ]
+      },
+      {
+        "en": "Menshi",
+        "ja": "メン限",
+        "ja_typings": [
+          "mengen"
+        ]
+      },
+      {
+        "en": "Sucha",
+        "ja": "スパチャ",
+        "ja_typings": [
+          "supacha"
+        ]
+      },
+      {
+        "en": "Gentei",
+        "ja": "限定",
+        "ja_typings": [
+          "gentei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02278",
+    "image_path": null,
+    "question_text": {
+      "en": "Which English abbreviation refers to a recurring paid subscription service?",
+      "ja": "月額課金サービスの英語略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Coin",
+        "ja": "コイン",
+        "ja_typings": [
+          "koin"
+        ]
+      },
+      {
+        "en": "Gem",
+        "ja": "ジェム",
+        "ja_typings": [
+          "jemu"
+        ]
+      },
+      {
+        "en": "Stone",
+        "ja": "石",
+        "ja_typings": [
+          "ishi"
+        ]
+      },
+      {
+        "en": "Ticket",
+        "ja": "チケット",
+        "ja_typings": [
+          "chiketto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02279",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the in-app currency name commonly used in mobile games and streaming apps?",
+      "ja": "モバイルゲームや配信アプリの基本的なアプリ内通貨の呼び名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gem",
+        "ja": "ジェム",
+        "ja_typings": [
+          "jemu"
+        ]
+      },
+      {
+        "en": "Coin",
+        "ja": "コイン",
+        "ja_typings": [
+          "koin"
+        ]
+      },
+      {
+        "en": "Token",
+        "ja": "トークン",
+        "ja_typings": [
+          "to-kun"
+        ]
+      },
+      {
+        "en": "Ticket",
+        "ja": "チケット",
+        "ja_typings": [
+          "chiketto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02280",
+    "image_path": null,
+    "question_text": {
+      "en": "Which premium in-app currency is often represented as a shining stone?",
+      "ja": "光る宝石として描かれる高価なアプリ内通貨は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Comment Cannon",
+        "ja": "コメント砲",
+        "ja_typings": [
+          "komentohou"
+        ]
+      },
+      {
+        "en": "Flow Comment",
+        "ja": "流れコメント",
+        "ja_typings": [
+          "nagarekomento"
+        ]
+      },
+      {
+        "en": "Chat",
+        "ja": "チャット",
+        "ja_typings": [
+          "chatto"
+        ]
+      },
+      {
+        "en": "Sucha",
+        "ja": "スパチャ",
+        "ja_typings": [
+          "supacha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02281",
+    "image_path": null,
+    "question_text": {
+      "en": "Which niconico feature lets viewers shoot a barrage of comments at once?",
+      "ja": "ニコニコ動画でコメントを一斉に大量に流す機能は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Flow Comment",
+        "ja": "流れコメント",
+        "ja_typings": [
+          "nagarekomento"
+        ]
+      },
+      {
+        "en": "Comment Cannon",
+        "ja": "コメント砲",
+        "ja_typings": [
+          "komentohou"
+        ]
+      },
+      {
+        "en": "Chat",
+        "ja": "チャット",
+        "ja_typings": [
+          "chatto"
+        ]
+      },
+      {
+        "en": "Sucha",
+        "ja": "スパチャ",
+        "ja_typings": [
+          "supacha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02282",
+    "image_path": null,
+    "question_text": {
+      "en": "Which niconico video commenting style scrolls comments from right to left?",
+      "ja": "ニコニコ動画でコメントが右から左へ流れる方式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chat",
+        "ja": "チャット",
+        "ja_typings": [
+          "chatto"
+        ]
+      },
+      {
+        "en": "Comment Cannon",
+        "ja": "コメント砲",
+        "ja_typings": [
+          "komentohou"
+        ]
+      },
+      {
+        "en": "Flow Comment",
+        "ja": "流れコメント",
+        "ja_typings": [
+          "nagarekomento"
+        ]
+      },
+      {
+        "en": "Sucha",
+        "ja": "スパチャ",
+        "ja_typings": [
+          "supacha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02283",
+    "image_path": null,
+    "question_text": {
+      "en": "Which general English term refers to live text conversation in a stream?",
+      "ja": "ライブ配信で文字会話を行う一般的な英語の名称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kaichou",
+        "ja": "会長",
+        "ja_typings": [
+          "kaichou"
+        ]
+      },
+      {
+        "en": "Danchou",
+        "ja": "団長",
+        "ja_typings": [
+          "danchou"
+        ]
+      },
+      {
+        "en": "Shachou",
+        "ja": "社長",
+        "ja_typings": [
+          "shachou"
+        ]
+      },
+      {
+        "en": "Senpai",
+        "ja": "先輩",
+        "ja_typings": [
+          "senpai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02284",
+    "image_path": null,
+    "question_text": {
+      "en": "Which VTuber title refers to the head of a student council, used by Shirogane Noel?",
+      "ja": "白銀ノエルが使う「会長」を意味するVTuber呼称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Danchou",
+        "ja": "団長",
+        "ja_typings": [
+          "danchou"
+        ]
+      },
+      {
+        "en": "Kaichou",
+        "ja": "会長",
+        "ja_typings": [
+          "kaichou"
+        ]
+      },
+      {
+        "en": "Shachou",
+        "ja": "社長",
+        "ja_typings": [
+          "shachou"
+        ]
+      },
+      {
+        "en": "Buchou",
+        "ja": "部長",
+        "ja_typings": [
+          "buchou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02285",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese title meaning 'group leader' is used as a nickname for Shirogane Noel?",
+      "ja": "白銀ノエルの愛称として使われる「団長」を意味する呼称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shachou",
+        "ja": "社長",
+        "ja_typings": [
+          "shachou"
+        ]
+      },
+      {
+        "en": "Kaichou",
+        "ja": "会長",
+        "ja_typings": [
+          "kaichou"
+        ]
+      },
+      {
+        "en": "Danchou",
+        "ja": "団長",
+        "ja_typings": [
+          "danchou"
+        ]
+      },
+      {
+        "en": "Buchou",
+        "ja": "部長",
+        "ja_typings": [
+          "buchou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02286",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese title meaning 'company president' is used as a nickname for Houshou Marine?",
+      "ja": "宝鐘マリンの愛称として使われる「社長」を意味する呼称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "nya",
+        "ja": "ニャ",
+        "ja_typings": [
+          "nya"
+        ]
+      },
+      {
+        "en": "dazo",
+        "ja": "ダゾ",
+        "ja_typings": [
+          "dazo"
+        ]
+      },
+      {
+        "en": "nanoda",
+        "ja": "ナノダ",
+        "ja_typings": [
+          "nanoda"
+        ]
+      },
+      {
+        "en": "desu",
+        "ja": "デス",
+        "ja_typings": [
+          "desu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02287",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese character ending sound is associated with cute cat-like speech?",
+      "ja": "猫っぽい可愛い語尾としてキャラに使われるのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "dazo",
+        "ja": "ダゾ",
+        "ja_typings": [
+          "dazo"
+        ]
+      },
+      {
+        "en": "nanoda",
+        "ja": "ナノダ",
+        "ja_typings": [
+          "nanoda"
+        ]
+      },
+      {
+        "en": "nya",
+        "ja": "ニャ",
+        "ja_typings": [
+          "nya"
+        ]
+      },
+      {
+        "en": "desu",
+        "ja": "デス",
+        "ja_typings": [
+          "desu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02288",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese sentence-ending emphasis word means roughly 'you know'?",
+      "ja": "強調や念押しで使う「ぞ」を含む語尾は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "nanoda",
+        "ja": "ナノダ",
+        "ja_typings": [
+          "nanoda"
+        ]
+      },
+      {
+        "en": "dazo",
+        "ja": "ダゾ",
+        "ja_typings": [
+          "dazo"
+        ]
+      },
+      {
+        "en": "nya",
+        "ja": "ニャ",
+        "ja_typings": [
+          "nya"
+        ]
+      },
+      {
+        "en": "desu",
+        "ja": "デス",
+        "ja_typings": [
+          "desu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02289",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese assertive sentence-ending phrase often used by anime characters means roughly 'it is so'?",
+      "ja": "アニメキャラがよく使う「断定」の語尾で「のだ」となるのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hololive ID",
+        "ja": "ホロライブID",
+        "ja_typings": [
+          "hororaibuid"
+        ]
+      },
+      {
+        "en": "Hololive JP",
+        "ja": "ホロライブJP",
+        "ja_typings": [
+          "hororaibujp"
+        ]
+      },
+      {
+        "en": "Hololive CN",
+        "ja": "ホロライブCN",
+        "ja_typings": [
+          "hororaibucn"
+        ]
+      },
+      {
+        "en": "Hololive EN",
+        "ja": "ホロライブEN",
+        "ja_typings": [
+          "hororaibuen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02290",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive branch is based in Indonesia?",
+      "ja": "ホロライブのインドネシア拠点支部は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hololive JP",
+        "ja": "ホロライブJP",
+        "ja_typings": [
+          "hororaibujp"
+        ]
+      },
+      {
+        "en": "Hololive ID",
+        "ja": "ホロライブID",
+        "ja_typings": [
+          "hororaibuid"
+        ]
+      },
+      {
+        "en": "Hololive CN",
+        "ja": "ホロライブCN",
+        "ja_typings": [
+          "hororaibucn"
+        ]
+      },
+      {
+        "en": "Hololive EN",
+        "ja": "ホロライブEN",
+        "ja_typings": [
+          "hororaibuen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02291",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive branch is the original Japanese division?",
+      "ja": "ホロライブの本家日本支部は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hololive CN",
+        "ja": "ホロライブCN",
+        "ja_typings": [
+          "hororaibucn"
+        ]
+      },
+      {
+        "en": "Hololive JP",
+        "ja": "ホロライブJP",
+        "ja_typings": [
+          "hororaibujp"
+        ]
+      },
+      {
+        "en": "Hololive ID",
+        "ja": "ホロライブID",
+        "ja_typings": [
+          "hororaibuid"
+        ]
+      },
+      {
+        "en": "Hololive EN",
+        "ja": "ホロライブEN",
+        "ja_typings": [
+          "hororaibuen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02292",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive branch operated in mainland China before its 2020 closure?",
+      "ja": "2020年に活動終了したホロライブの中国大陸支部は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Takanashi Kiara",
+        "ja": "小鳥遊キアラ",
+        "ja_typings": [
+          "takanashikiara"
+        ]
+      },
+      {
+        "en": "Watson Amelia",
+        "ja": "ワトソン アメリア",
+        "ja_typings": [
+          "watoson ameria"
+        ]
+      },
+      {
+        "en": "Gawr Gura",
+        "ja": "がうる ぐら",
+        "ja_typings": [
+          "gauru gura"
+        ]
+      },
+      {
+        "en": "Mori Calliope",
+        "ja": "森カリオペ",
+        "ja_typings": [
+          "morikariope"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02293",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive English Myth member is themed after a phoenix and known as KFP?",
+      "ja": "不死鳥がモチーフでKFPのファン名でも知られるホロライブEN Mythのメンバーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tsukino Mito",
+        "ja": "月ノ美兎",
+        "ja_typings": [
+          "tsukinomito"
+        ]
+      },
+      {
+        "en": "Sasaki Saku",
+        "ja": "笹木咲",
+        "ja_typings": [
+          "sasakisaku"
+        ]
+      },
+      {
+        "en": "Honma Himawari",
+        "ja": "本間ひまわり",
+        "ja_typings": [
+          "honmahimawari"
+        ]
+      },
+      {
+        "en": "Shizuka Rin",
+        "ja": "静凛",
+        "ja_typings": [
+          "shizukarin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02294",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nijisanji VTuber is famous as one of the original gen 1 members and was known as 'Mito-chan'?",
+      "ja": "にじさんじ1期生で「ミトちゃん」として親しまれてきたメンバーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sasaki Saku",
+        "ja": "笹木咲",
+        "ja_typings": [
+          "sasakisaku"
+        ]
+      },
+      {
+        "en": "Tsukino Mito",
+        "ja": "月ノ美兎",
+        "ja_typings": [
+          "tsukinomito"
+        ]
+      },
+      {
+        "en": "Honma Himawari",
+        "ja": "本間ひまわり",
+        "ja_typings": [
+          "honmahimawari"
+        ]
+      },
+      {
+        "en": "Lize Helesta",
+        "ja": "リゼ ヘルエスタ",
+        "ja_typings": [
+          "rize heruesuta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02295",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nijisanji female VTuber is known for collabs with Honma Himawari as a duo?",
+      "ja": "本間ひまわりとのコンビでも知られるにじさんじの女性ライバーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Honma Himawari",
+        "ja": "本間ひまわり",
+        "ja_typings": [
+          "honmahimawari"
+        ]
+      },
+      {
+        "en": "Sasaki Saku",
+        "ja": "笹木咲",
+        "ja_typings": [
+          "sasakisaku"
+        ]
+      },
+      {
+        "en": "Tsukino Mito",
+        "ja": "月ノ美兎",
+        "ja_typings": [
+          "tsukinomito"
+        ]
+      },
+      {
+        "en": "Kanae",
+        "ja": "叶",
+        "ja_typings": [
+          "kanae"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02296",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nijisanji VTuber pairs with Sasaki Saku in the 'Saku and Hima' duo?",
+      "ja": "「咲ひま」コンビで笹木咲とペアになるにじさんじのメンバーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kuzuha and Kanae",
+        "ja": "葛葉と叶",
+        "ja_typings": [
+          "kuzuhatokanae"
+        ]
+      },
+      {
+        "en": "Kuzuha and Kenmochi",
+        "ja": "葛葉と剣持",
+        "ja_typings": [
+          "kuzuhatokenmochi"
+        ]
+      },
+      {
+        "en": "Kanae and Kenmochi",
+        "ja": "叶と剣持",
+        "ja_typings": [
+          "kanaetokenmochi"
+        ]
+      },
+      {
+        "en": "Kuzuha and Tsukino Mito",
+        "ja": "葛葉と月ノ美兎",
+        "ja_typings": [
+          "kuzuhatotsukinomito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02297",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nijisanji male duo consists of two top streamers known as 'ChroNoiR'?",
+      "ja": "「ChroNoiR」として知られるにじさんじのトップ配信者2人組は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kanae and Kenmochi",
+        "ja": "叶と剣持",
+        "ja_typings": [
+          "kanaetokenmochi"
+        ]
+      },
+      {
+        "en": "Kuzuha and Kanae",
+        "ja": "葛葉と叶",
+        "ja_typings": [
+          "kuzuhatokanae"
+        ]
+      },
+      {
+        "en": "Kuzuha and Kenmochi",
+        "ja": "葛葉と剣持",
+        "ja_typings": [
+          "kuzuhatokenmochi"
+        ]
+      },
+      {
+        "en": "Kuzuha and Tsukino Mito",
+        "ja": "葛葉と月ノ美兎",
+        "ja_typings": [
+          "kuzuhatotsukinomito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02298",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nijisanji male duo combines 'Kanae' with the lawyer-themed VTuber?",
+      "ja": "叶と弁護士キャラのVTuberが組むにじさんじのコンビは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kuzuha and Tsukino Mito",
+        "ja": "葛葉と月ノ美兎",
+        "ja_typings": [
+          "kuzuhatotsukinomito"
+        ]
+      },
+      {
+        "en": "Kanae and Kenmochi",
+        "ja": "叶と剣持",
+        "ja_typings": [
+          "kanaetokenmochi"
+        ]
+      },
+      {
+        "en": "Kuzuha and Kanae",
+        "ja": "葛葉と叶",
+        "ja_typings": [
+          "kuzuhatokanae"
+        ]
+      },
+      {
+        "en": "Kuzuha and Kenmochi",
+        "ja": "葛葉と剣持",
+        "ja_typings": [
+          "kuzuhatokenmochi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02299",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nijisanji collab pair brings together the vampire-themed Kuzuha and the gen 1 chairperson?",
+      "ja": "吸血鬼キャラの葛葉と1期生委員長によるコラボペアは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Attack on Titan",
+        "ja": "進撃の巨人",
+        "ja_typings": [
+          "shingekinokyojin"
+        ]
+      },
+      {
+        "en": "One Piece",
+        "ja": "ワンピース",
+        "ja_typings": [
+          "wanpi-su"
+        ]
+      },
+      {
+        "en": "Demon Slayer",
+        "ja": "鬼滅の刃",
+        "ja_typings": [
+          "kimetsunoyaiba"
+        ]
+      },
+      {
+        "en": "Jujutsu Kaisen",
+        "ja": "呪術廻戦",
+        "ja_typings": [
+          "jujutsukaisen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02300",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga and anime by Hajime Isayama features humans fighting giant humanoids?",
+      "ja": "諫山創による人類と巨人の戦いを描いた漫画・アニメは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "One Piece",
+        "ja": "ワンピース",
+        "ja_typings": [
+          "wanpi-su"
+        ]
+      },
+      {
+        "en": "Attack on Titan",
+        "ja": "進撃の巨人",
+        "ja_typings": [
+          "shingekinokyojin"
+        ]
+      },
+      {
+        "en": "Demon Slayer",
+        "ja": "鬼滅の刃",
+        "ja_typings": [
+          "kimetsunoyaiba"
+        ]
+      },
+      {
+        "en": "Naruto",
+        "ja": "ナルト",
+        "ja_typings": [
+          "naruto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02301",
+    "image_path": null,
+    "question_text": {
+      "en": "Which long-running Shonen Jump manga features pirates searching for the ultimate treasure?",
+      "ja": "海賊たちが究極の財宝を探す週刊少年ジャンプの長編漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Demon Slayer",
+        "ja": "鬼滅の刃",
+        "ja_typings": [
+          "kimetsunoyaiba"
+        ]
+      },
+      {
+        "en": "Attack on Titan",
+        "ja": "進撃の巨人",
+        "ja_typings": [
+          "shingekinokyojin"
+        ]
+      },
+      {
+        "en": "One Piece",
+        "ja": "ワンピース",
+        "ja_typings": [
+          "wanpi-su"
+        ]
+      },
+      {
+        "en": "Jujutsu Kaisen",
+        "ja": "呪術廻戦",
+        "ja_typings": [
+          "jujutsukaisen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02302",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga by Koyoharu Gotouge features a boy who joins a corps to slay demons after his family is attacked?",
+      "ja": "家族を襲われた少年が鬼を狩る隊に入る、吾峠呼世晴の漫画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Got it",
+        "ja": "了解",
+        "ja_typings": [
+          "ryoukai"
+        ]
+      },
+      {
+        "en": "Done",
+        "ja": "完了",
+        "ja_typings": [
+          "kanryou"
+        ]
+      },
+      {
+        "en": "XD",
+        "ja": "笑い",
+        "ja_typings": [
+          "warai"
+        ]
+      },
+      {
+        "en": "nya",
+        "ja": "ニャー",
+        "ja_typings": [
+          "nya-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q02303",
+    "image_path": null,
+    "question_text": {
+      "en": "Which English chat phrase means 'understood' or 'I see'?",
+      "ja": "「了解」「わかった」を意味する英語チャットフレーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Katakana",
+        "ja": "カタカナ",
+        "ja_typings": [
+          "katakana"
+        ]
+      },
+      {
+        "en": "Hiragana",
+        "ja": "ひらがな",
+        "ja_typings": [
+          "hiragana"
+        ]
+      },
+      {
+        "en": "Kanji",
+        "ja": "漢字",
+        "ja_typings": [
+          "kanji"
+        ]
+      },
+      {
+        "en": "Romaji",
+        "ja": "ローマ字",
+        "ja_typings": [
+          "ro-maji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02304",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese script is used mainly for foreign loanwords?",
+      "ja": "外来語を表すのに主に使われる日本語の文字は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Altaic",
+        "ja": "アルタイ諸語",
+        "ja_typings": [
+          "arutaishogo"
+        ]
+      },
+      {
+        "en": "Uralic",
+        "ja": "ウラル諸語",
+        "ja_typings": [
+          "urarushogo"
+        ]
+      },
+      {
+        "en": "Sino-Tibetan",
+        "ja": "シナ・チベット諸語",
+        "ja_typings": [
+          "sinachibettoshogo"
+        ]
+      },
+      {
+        "en": "Dravidian",
+        "ja": "ドラヴィダ諸語",
+        "ja_typings": [
+          "dorabidashogo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02305",
+    "image_path": null,
+    "question_text": {
+      "en": "Which controversial language family groups Turkic, Mongolic, and Tungusic?",
+      "ja": "テュルク・モンゴル・ツングース諸語をまとめる仮説的な語族は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "English",
+        "ja": "英語",
+        "ja_typings": [
+          "eigo"
+        ]
+      },
+      {
+        "en": "French",
+        "ja": "フランス語",
+        "ja_typings": [
+          "furansugo"
+        ]
+      },
+      {
+        "en": "Spanish",
+        "ja": "スペイン語",
+        "ja_typings": [
+          "supeingo"
+        ]
+      },
+      {
+        "en": "Mandarin",
+        "ja": "中国語",
+        "ja_typings": [
+          "chuugokugo",
+          "chugokugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02306",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language has the most native speakers as a global lingua franca?",
+      "ja": "世界共通語として最も広く使われている言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Conjunction",
+        "ja": "接続詞",
+        "ja_typings": [
+          "setsuzokushi"
+        ]
+      },
+      {
+        "en": "Preposition",
+        "ja": "前置詞",
+        "ja_typings": [
+          "zenchishi"
+        ]
+      },
+      {
+        "en": "Interjection",
+        "ja": "感動詞",
+        "ja_typings": [
+          "kandoushi",
+          "kandoshi"
+        ]
+      },
+      {
+        "en": "Adverb",
+        "ja": "副詞",
+        "ja_typings": [
+          "fukushi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02307",
+    "image_path": null,
+    "question_text": {
+      "en": "Which part of speech connects words or clauses, like 'and' or 'but'?",
+      "ja": "「そして」「しかし」のように語句や節をつなぐ品詞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Middle voice",
+        "ja": "中動態",
+        "ja_typings": [
+          "chuudoutai",
+          "chudotai"
+        ]
+      },
+      {
+        "en": "Active voice",
+        "ja": "能動態",
+        "ja_typings": [
+          "nodoutai",
+          "nodotai"
+        ]
+      },
+      {
+        "en": "Passive voice",
+        "ja": "受動態",
+        "ja_typings": [
+          "judoutai",
+          "judotai"
+        ]
+      },
+      {
+        "en": "Causative voice",
+        "ja": "使役態",
+        "ja_typings": [
+          "shiekitai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02308",
+    "image_path": null,
+    "question_text": {
+      "en": "Which grammatical voice is neither active nor passive (e.g., Ancient Greek)?",
+      "ja": "能動でも受動でもない、古典ギリシャ語などにある態は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Italian",
+        "ja": "イタリア語",
+        "ja_typings": [
+          "itariago"
+        ]
+      },
+      {
+        "en": "Spanish",
+        "ja": "スペイン語",
+        "ja_typings": [
+          "supeingo"
+        ]
+      },
+      {
+        "en": "Portuguese",
+        "ja": "ポルトガル語",
+        "ja_typings": [
+          "porutogarugo"
+        ]
+      },
+      {
+        "en": "Romanian",
+        "ja": "ルーマニア語",
+        "ja_typings": [
+          "ru-maniago"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02309",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Romance language is the official language of Italy?",
+      "ja": "イタリアの公用語であるロマンス諸語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wade-Giles",
+        "ja": "ウェード式",
+        "ja_typings": [
+          "we-doshiki"
+        ]
+      },
+      {
+        "en": "Pinyin",
+        "ja": "ピンイン",
+        "ja_typings": [
+          "pinnin"
+        ]
+      },
+      {
+        "en": "Yale",
+        "ja": "イェール式",
+        "ja_typings": [
+          "ie-rushiki"
+        ]
+      },
+      {
+        "en": "Zhuyin",
+        "ja": "注音符号",
+        "ja_typings": [
+          "chuuonfugou",
+          "chuonfugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02310",
+    "image_path": null,
+    "question_text": {
+      "en": "Which romanization system for Mandarin was widely used before Pinyin?",
+      "ja": "ピンイン以前に広く使われた中国語ローマ字表記は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Antithesis",
+        "ja": "対句法",
+        "ja_typings": [
+          "taikuhou",
+          "taikuho"
+        ]
+      },
+      {
+        "en": "Metaphor",
+        "ja": "隠喩",
+        "ja_typings": [
+          "inyu"
+        ]
+      },
+      {
+        "en": "Simile",
+        "ja": "直喩",
+        "ja_typings": [
+          "chokuyu"
+        ]
+      },
+      {
+        "en": "Hyperbole",
+        "ja": "誇張法",
+        "ja_typings": [
+          "kochouhou",
+          "kochoho"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02311",
+    "image_path": null,
+    "question_text": {
+      "en": "Which rhetorical device juxtaposes contrasting ideas in parallel structure?",
+      "ja": "対立する語句を並列に置く修辞技法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kan-on",
+        "ja": "漢音",
+        "ja_typings": [
+          "kan'on",
+          "kannon"
+        ]
+      },
+      {
+        "en": "Go-on",
+        "ja": "呉音",
+        "ja_typings": [
+          "goon"
+        ]
+      },
+      {
+        "en": "To-on",
+        "ja": "唐音",
+        "ja_typings": [
+          "touon",
+          "toon"
+        ]
+      },
+      {
+        "en": "Kun-yomi",
+        "ja": "訓読み",
+        "ja_typings": [
+          "kunyomi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02312",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Sino-Japanese reading reflects the pronunciation of Tang-era China?",
+      "ja": "唐代の中国音を伝える漢字の音読みは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Phoenician",
+        "ja": "フェニキア文字",
+        "ja_typings": [
+          "fenikiamoji"
+        ]
+      },
+      {
+        "en": "Cuneiform",
+        "ja": "楔形文字",
+        "ja_typings": [
+          "kusabigatamoji"
+        ]
+      },
+      {
+        "en": "Hieroglyphs",
+        "ja": "ヒエログリフ",
+        "ja_typings": [
+          "hierogurifu"
+        ]
+      },
+      {
+        "en": "Linear B",
+        "ja": "線文字B",
+        "ja_typings": [
+          "senmojibi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02313",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Semitic script is the ancestor of most modern alphabets?",
+      "ja": "現代のアルファベットの祖となった古代セム系文字は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Catalan",
+        "ja": "カタルーニャ語",
+        "ja_typings": [
+          "kataru-nyago"
+        ]
+      },
+      {
+        "en": "Basque",
+        "ja": "バスク語",
+        "ja_typings": [
+          "basukugo"
+        ]
+      },
+      {
+        "en": "Galician",
+        "ja": "ガリシア語",
+        "ja_typings": [
+          "garishiago"
+        ]
+      },
+      {
+        "en": "Occitan",
+        "ja": "オック語",
+        "ja_typings": [
+          "okkugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02314",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Romance language is co-official in Andorra and parts of Spain?",
+      "ja": "アンドラとスペインの一部で公用語となるロマンス語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hanja",
+        "ja": "漢字 (韓国)",
+        "ja_typings": [
+          "kanji"
+        ]
+      },
+      {
+        "en": "Hanzi",
+        "ja": "漢字 (中国)",
+        "ja_typings": [
+          "kanji"
+        ]
+      },
+      {
+        "en": "Kanji",
+        "ja": "漢字 (日本)",
+        "ja_typings": [
+          "kanji"
+        ]
+      },
+      {
+        "en": "Chu Nom",
+        "ja": "チュノム",
+        "ja_typings": [
+          "chunomu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02315",
+    "image_path": null,
+    "question_text": {
+      "en": "What name is used for Chinese characters when used in Korean?",
+      "ja": "韓国語で使われる漢字の呼称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dravidian",
+        "ja": "ドラヴィダ語族",
+        "ja_typings": [
+          "doravu~idagozoku"
+        ]
+      },
+      {
+        "en": "Indo-Aryan",
+        "ja": "インド・アーリア語族",
+        "ja_typings": [
+          "indo a-riagozoku"
+        ]
+      },
+      {
+        "en": "Austroasiatic",
+        "ja": "オーストロアジア語族",
+        "ja_typings": [
+          "o-sutoroajiagozoku"
+        ]
+      },
+      {
+        "en": "Sino-Tibetan",
+        "ja": "シナ・チベット語族",
+        "ja_typings": [
+          "shinachibettogozoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02316",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language family includes Tamil, Telugu, and Malayalam?",
+      "ja": "タミル語・テルグ語・マラヤーラム語を含む語族は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "alphabet",
+        "ja": "アルファベット",
+        "ja_typings": [
+          "arufabetto"
+        ]
+      },
+      {
+        "en": "syllabary",
+        "ja": "音節文字",
+        "ja_typings": [
+          "onsetsumoji"
+        ]
+      },
+      {
+        "en": "logogram",
+        "ja": "表語文字",
+        "ja_typings": [
+          "hyougomoji",
+          "hyogomoji"
+        ]
+      },
+      {
+        "en": "abjad",
+        "ja": "アブジャド",
+        "ja_typings": [
+          "abujado"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02317",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a standardized set of letters used to write a language?",
+      "ja": "言語を表記するために標準化された文字の集合は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "vowel harmony",
+        "ja": "母音調和",
+        "ja_typings": [
+          "boinchouwa",
+          "boinchowa"
+        ]
+      },
+      {
+        "en": "consonant cluster",
+        "ja": "子音連結",
+        "ja_typings": [
+          "shi'inrenketsu"
+        ]
+      },
+      {
+        "en": "vowel reduction",
+        "ja": "母音弱化",
+        "ja_typings": [
+          "boinjakka"
+        ]
+      },
+      {
+        "en": "vowel shift",
+        "ja": "母音推移",
+        "ja_typings": [
+          "boinsuii"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02318",
+    "image_path": null,
+    "question_text": {
+      "en": "Which phonological phenomenon (e.g., in Turkish) requires vowels in a word to share features?",
+      "ja": "トルコ語などで語内の母音が同じ特徴を持つ現象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Morphology",
+        "ja": "形態論",
+        "ja_typings": [
+          "keitairon"
+        ]
+      },
+      {
+        "en": "Phonology",
+        "ja": "音韻論",
+        "ja_typings": [
+          "on'inron",
+          "oninron"
+        ]
+      },
+      {
+        "en": "Syntax",
+        "ja": "統語論",
+        "ja_typings": [
+          "tougoron",
+          "togoron"
+        ]
+      },
+      {
+        "en": "Semantics",
+        "ja": "意味論",
+        "ja_typings": [
+          "imiron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02319",
+    "image_path": null,
+    "question_text": {
+      "en": "Which branch of linguistics studies word formation?",
+      "ja": "語の形成を研究する言語学の分野は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Phoneme",
+        "ja": "音素",
+        "ja_typings": [
+          "onso"
+        ]
+      },
+      {
+        "en": "Morpheme",
+        "ja": "形態素",
+        "ja_typings": [
+          "keitaiso"
+        ]
+      },
+      {
+        "en": "Grapheme",
+        "ja": "書記素",
+        "ja_typings": [
+          "shokiso"
+        ]
+      },
+      {
+        "en": "Lexeme",
+        "ja": "語彙素",
+        "ja_typings": [
+          "goiso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02320",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the smallest unit of sound that distinguishes meaning?",
+      "ja": "意味を区別する音声の最小単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Syllable",
+        "ja": "音節",
+        "ja_typings": [
+          "onsetsu"
+        ]
+      },
+      {
+        "en": "Mora",
+        "ja": "モーラ",
+        "ja_typings": [
+          "mo-ra"
+        ]
+      },
+      {
+        "en": "Foot",
+        "ja": "韻脚",
+        "ja_typings": [
+          "inkyaku"
+        ]
+      },
+      {
+        "en": "Phrase",
+        "ja": "句",
+        "ja_typings": [
+          "ku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02321",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a unit of pronunciation having one vowel sound?",
+      "ja": "母音を1つ含む発音の単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Phonetics",
+        "ja": "音声学",
+        "ja_typings": [
+          "onseigaku"
+        ]
+      },
+      {
+        "en": "Phonology",
+        "ja": "音韻論",
+        "ja_typings": [
+          "on'inron",
+          "oninron"
+        ]
+      },
+      {
+        "en": "Pragmatics",
+        "ja": "語用論",
+        "ja_typings": [
+          "goyouron",
+          "goyoron"
+        ]
+      },
+      {
+        "en": "Etymology",
+        "ja": "語源学",
+        "ja_typings": [
+          "gogengaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02322",
+    "image_path": null,
+    "question_text": {
+      "en": "Which field studies the physical sounds of human speech?",
+      "ja": "人間の言語音の物理的性質を扱う分野は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Graphemics",
+        "ja": "書記素論",
+        "ja_typings": [
+          "shokisoron"
+        ]
+      },
+      {
+        "en": "Calligraphy",
+        "ja": "書道",
+        "ja_typings": [
+          "shodou",
+          "shodo"
+        ]
+      },
+      {
+        "en": "Orthography",
+        "ja": "正書法",
+        "ja_typings": [
+          "seishohou",
+          "seishoho"
+        ]
+      },
+      {
+        "en": "Typography",
+        "ja": "活字術",
+        "ja_typings": [
+          "katsujijutsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02323",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the study of writing systems and their units?",
+      "ja": "文字体系とその単位を研究する分野は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Arabic script",
+        "ja": "アラビア文字",
+        "ja_typings": [
+          "arabiamoji"
+        ]
+      },
+      {
+        "en": "Hebrew script",
+        "ja": "ヘブライ文字",
+        "ja_typings": [
+          "heburaimoji"
+        ]
+      },
+      {
+        "en": "Latin script",
+        "ja": "ラテン文字",
+        "ja_typings": [
+          "ratenmoji"
+        ]
+      },
+      {
+        "en": "Cyrillic script",
+        "ja": "キリル文字",
+        "ja_typings": [
+          "kirirumoji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02324",
+    "image_path": null,
+    "question_text": {
+      "en": "Which script is used to write modern Standard Arabic?",
+      "ja": "現代標準アラビア語を書くための文字は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Greek alphabet",
+        "ja": "ギリシャ文字",
+        "ja_typings": [
+          "girishamoji"
+        ]
+      },
+      {
+        "en": "Cyrillic alphabet",
+        "ja": "キリル文字",
+        "ja_typings": [
+          "kirirumoji"
+        ]
+      },
+      {
+        "en": "Latin alphabet",
+        "ja": "ラテン文字",
+        "ja_typings": [
+          "ratenmoji"
+        ]
+      },
+      {
+        "en": "Armenian alphabet",
+        "ja": "アルメニア文字",
+        "ja_typings": [
+          "arumeniamoji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02325",
+    "image_path": null,
+    "question_text": {
+      "en": "Which alphabet is used to write modern Greek?",
+      "ja": "現代ギリシャ語を書くアルファベットは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hebrew script",
+        "ja": "ヘブライ文字",
+        "ja_typings": [
+          "heburaimoji"
+        ]
+      },
+      {
+        "en": "Arabic script",
+        "ja": "アラビア文字",
+        "ja_typings": [
+          "arabiamoji"
+        ]
+      },
+      {
+        "en": "Syriac script",
+        "ja": "シリア文字",
+        "ja_typings": [
+          "shiriamoji"
+        ]
+      },
+      {
+        "en": "Greek script",
+        "ja": "ギリシャ文字",
+        "ja_typings": [
+          "girishamoji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02326",
+    "image_path": null,
+    "question_text": {
+      "en": "Which script is used to write modern Hebrew?",
+      "ja": "現代ヘブライ語を書く文字は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Left to right",
+        "ja": "左から右",
+        "ja_typings": [
+          "hidarikaramigi"
+        ]
+      },
+      {
+        "en": "Right to left",
+        "ja": "右から左",
+        "ja_typings": [
+          "migikarahidari"
+        ]
+      },
+      {
+        "en": "Top to bottom",
+        "ja": "上から下",
+        "ja_typings": [
+          "uekarashita"
+        ]
+      },
+      {
+        "en": "Bottom to top",
+        "ja": "下から上",
+        "ja_typings": [
+          "shitakaraue"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02327",
+    "image_path": null,
+    "question_text": {
+      "en": "In which direction is English written?",
+      "ja": "英語の文字を書く方向は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Top to bottom",
+        "ja": "上から下",
+        "ja_typings": [
+          "uekarashita"
+        ]
+      },
+      {
+        "en": "Bottom to top",
+        "ja": "下から上",
+        "ja_typings": [
+          "shitakaraue"
+        ]
+      },
+      {
+        "en": "Left to right",
+        "ja": "左から右",
+        "ja_typings": [
+          "hidarikaramigi"
+        ]
+      },
+      {
+        "en": "Right to left",
+        "ja": "右から左",
+        "ja_typings": [
+          "migikarahidari"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02328",
+    "image_path": null,
+    "question_text": {
+      "en": "In which direction is traditional vertical Japanese text read?",
+      "ja": "日本語の伝統的な縦書きの読む方向は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Top to bottom",
+        "ja": "上から下",
+        "ja_typings": [
+          "uekarashita"
+        ]
+      },
+      {
+        "en": "Bottom to top",
+        "ja": "下から上",
+        "ja_typings": [
+          "shitakaraue"
+        ]
+      },
+      {
+        "en": "Right to left",
+        "ja": "右から左",
+        "ja_typings": [
+          "migikarahidari"
+        ]
+      },
+      {
+        "en": "Left to right",
+        "ja": "左から右",
+        "ja_typings": [
+          "hidarikaramigi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02329",
+    "image_path": null,
+    "question_text": {
+      "en": "Which writing direction is used by Mongolian traditional script?",
+      "ja": "モンゴル伝統文字の書字方向は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Adjective",
+        "ja": "形容詞",
+        "ja_typings": [
+          "keiyoushi",
+          "keiyoshi"
+        ]
+      },
+      {
+        "en": "Adverb",
+        "ja": "副詞",
+        "ja_typings": [
+          "fukushi"
+        ]
+      },
+      {
+        "en": "Verb",
+        "ja": "動詞",
+        "ja_typings": [
+          "doushi",
+          "doshi"
+        ]
+      },
+      {
+        "en": "Noun",
+        "ja": "名詞",
+        "ja_typings": [
+          "meishi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02330",
+    "image_path": null,
+    "question_text": {
+      "en": "Which part of speech modifies a noun, like 'red' or 'tall'?",
+      "ja": "「赤い」「高い」のように名詞を修飾する品詞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Adnominal",
+        "ja": "連体詞",
+        "ja_typings": [
+          "rentaishi"
+        ]
+      },
+      {
+        "en": "Adjective",
+        "ja": "形容詞",
+        "ja_typings": [
+          "keiyoushi",
+          "keiyoshi"
+        ]
+      },
+      {
+        "en": "Adverb",
+        "ja": "副詞",
+        "ja_typings": [
+          "fukushi"
+        ]
+      },
+      {
+        "en": "Particle",
+        "ja": "助詞",
+        "ja_typings": [
+          "joshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02331",
+    "image_path": null,
+    "question_text": {
+      "en": "In Japanese grammar, what part of speech only modifies nouns (e.g., kono, sono)?",
+      "ja": "「この」「その」のように名詞だけを修飾する日本語の品詞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Interjection",
+        "ja": "感動詞",
+        "ja_typings": [
+          "kandoushi",
+          "kandoshi"
+        ]
+      },
+      {
+        "en": "Conjunction",
+        "ja": "接続詞",
+        "ja_typings": [
+          "setsuzokushi"
+        ]
+      },
+      {
+        "en": "Adverb",
+        "ja": "副詞",
+        "ja_typings": [
+          "fukushi"
+        ]
+      },
+      {
+        "en": "Particle",
+        "ja": "助詞",
+        "ja_typings": [
+          "joshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02332",
+    "image_path": null,
+    "question_text": {
+      "en": "Which part of speech expresses emotion (e.g., 'oh!', 'wow!')?",
+      "ja": "「あっ」「おお」のように感動を表す品詞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pronoun",
+        "ja": "代名詞",
+        "ja_typings": [
+          "daimeishi"
+        ]
+      },
+      {
+        "en": "Noun",
+        "ja": "名詞",
+        "ja_typings": [
+          "meishi"
+        ]
+      },
+      {
+        "en": "Adjective",
+        "ja": "形容詞",
+        "ja_typings": [
+          "keiyoushi",
+          "keiyoshi"
+        ]
+      },
+      {
+        "en": "Adverb",
+        "ja": "副詞",
+        "ja_typings": [
+          "fukushi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02333",
+    "image_path": null,
+    "question_text": {
+      "en": "Which part of speech replaces a noun (e.g., 'he', 'she', 'it')?",
+      "ja": "名詞の代わりに使われる品詞 (例: 彼、それ) は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Beautifying language",
+        "ja": "美化語",
+        "ja_typings": [
+          "bikago"
+        ]
+      },
+      {
+        "en": "Respectful language",
+        "ja": "尊敬語",
+        "ja_typings": [
+          "sonkeigo"
+        ]
+      },
+      {
+        "en": "Humble language",
+        "ja": "謙譲語",
+        "ja_typings": [
+          "kenjougo",
+          "kenjogo"
+        ]
+      },
+      {
+        "en": "Polite language",
+        "ja": "丁寧語",
+        "ja_typings": [
+          "teineigo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02334",
+    "image_path": null,
+    "question_text": {
+      "en": "What is Japanese honorific 'o-' / 'go-' prefix style called?",
+      "ja": "日本語で「お」「ご」を付けて言葉を整える表現の名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Colloquial",
+        "ja": "口語",
+        "ja_typings": [
+          "kougo",
+          "kogo"
+        ]
+      },
+      {
+        "en": "Formal",
+        "ja": "文語",
+        "ja_typings": [
+          "bungo"
+        ]
+      },
+      {
+        "en": "Archaic",
+        "ja": "古語",
+        "ja_typings": [
+          "kogo"
+        ]
+      },
+      {
+        "en": "Slang",
+        "ja": "俗語",
+        "ja_typings": [
+          "zokugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02335",
+    "image_path": null,
+    "question_text": {
+      "en": "Which register of speech is used in informal conversation?",
+      "ja": "日常会話で用いられる、くだけた言葉遣いは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Formal style",
+        "ja": "文語体",
+        "ja_typings": [
+          "bungotai"
+        ]
+      },
+      {
+        "en": "Colloquial style",
+        "ja": "口語体",
+        "ja_typings": [
+          "kougotai",
+          "kogotai"
+        ]
+      },
+      {
+        "en": "Honorific style",
+        "ja": "敬体",
+        "ja_typings": [
+          "keitai"
+        ]
+      },
+      {
+        "en": "Plain style",
+        "ja": "常体",
+        "ja_typings": [
+          "joutai",
+          "jotai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02336",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese style is used in official documents and speeches?",
+      "ja": "公的な文書や演説で用いられる日本語の文体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Derivation",
+        "ja": "派生",
+        "ja_typings": [
+          "hasei"
+        ]
+      },
+      {
+        "en": "Inflection",
+        "ja": "屈折",
+        "ja_typings": [
+          "kussetsu"
+        ]
+      },
+      {
+        "en": "Compounding",
+        "ja": "複合",
+        "ja_typings": [
+          "fukugou",
+          "fukugo"
+        ]
+      },
+      {
+        "en": "Borrowing",
+        "ja": "借用",
+        "ja_typings": [
+          "shakuyou",
+          "shakuyo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02337",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the process of forming a new word by adding affixes?",
+      "ja": "接辞を付けて新しい語を作る過程は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Inflection",
+        "ja": "屈折",
+        "ja_typings": [
+          "kussetsu"
+        ]
+      },
+      {
+        "en": "Derivation",
+        "ja": "派生",
+        "ja_typings": [
+          "hasei"
+        ]
+      },
+      {
+        "en": "Conjugation",
+        "ja": "活用",
+        "ja_typings": [
+          "katsuyou",
+          "katsuyo"
+        ]
+      },
+      {
+        "en": "Declension",
+        "ja": "曲用",
+        "ja_typings": [
+          "kyokuyou",
+          "kyokuyo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02338",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the modification of a word to express grammatical features?",
+      "ja": "語の文法的特徴を表すための変化は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sound change",
+        "ja": "音変化",
+        "ja_typings": [
+          "onhenka"
+        ]
+      },
+      {
+        "en": "Spelling reform",
+        "ja": "綴り改革",
+        "ja_typings": [
+          "tsuzurikaikaku"
+        ]
+      },
+      {
+        "en": "Loanword",
+        "ja": "借用語",
+        "ja_typings": [
+          "shakuyougo",
+          "shakuyogo"
+        ]
+      },
+      {
+        "en": "Neologism",
+        "ja": "新語",
+        "ja_typings": [
+          "shingo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02339",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a diachronic change in pronunciation of a language called?",
+      "ja": "時間とともに起こる言語の発音変化は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gemination",
+        "ja": "促音化",
+        "ja_typings": [
+          "sokuonka"
+        ]
+      },
+      {
+        "en": "Elision",
+        "ja": "脱落",
+        "ja_typings": [
+          "datsuraku"
+        ]
+      },
+      {
+        "en": "Assimilation",
+        "ja": "同化",
+        "ja_typings": [
+          "douka",
+          "doka"
+        ]
+      },
+      {
+        "en": "Lenition",
+        "ja": "弱化",
+        "ja_typings": [
+          "jakka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02340",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the doubling of a consonant sound called (e.g., Japanese sokuon)?",
+      "ja": "促音のように子音が重なる現象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vowel alternation",
+        "ja": "母音交替",
+        "ja_typings": [
+          "boinkoutai",
+          "boinkotai"
+        ]
+      },
+      {
+        "en": "Vowel harmony",
+        "ja": "母音調和",
+        "ja_typings": [
+          "boinchouwa",
+          "boinchowa"
+        ]
+      },
+      {
+        "en": "Vowel reduction",
+        "ja": "母音弱化",
+        "ja_typings": [
+          "boinjakka"
+        ]
+      },
+      {
+        "en": "Vowel lengthening",
+        "ja": "母音長音化",
+        "ja_typings": [
+          "boinchouonka",
+          "boinchoonka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02341",
+    "image_path": null,
+    "question_text": {
+      "en": "What term refers to a vowel changing across related forms (e.g., sing/sang)?",
+      "ja": "関連する語形で母音が変化する現象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Onbin",
+        "ja": "音便",
+        "ja_typings": [
+          "onbin"
+        ]
+      },
+      {
+        "en": "Rendaku",
+        "ja": "連濁",
+        "ja_typings": [
+          "rendaku"
+        ]
+      },
+      {
+        "en": "Renjo",
+        "ja": "連声",
+        "ja_typings": [
+          "renjou",
+          "renjo"
+        ]
+      },
+      {
+        "en": "Yotsugana",
+        "ja": "四つ仮名",
+        "ja_typings": [
+          "yotsugana"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02342",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the historical sound change in Japanese where word-internal sounds change for ease?",
+      "ja": "日本語で発音が変化する音便現象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nasal sound change",
+        "ja": "撥音便",
+        "ja_typings": [
+          "hatsuonbin"
+        ]
+      },
+      {
+        "en": "I-onbin",
+        "ja": "イ音便",
+        "ja_typings": [
+          "i-onbin"
+        ]
+      },
+      {
+        "en": "U-onbin",
+        "ja": "ウ音便",
+        "ja_typings": [
+          "u-onbin"
+        ]
+      },
+      {
+        "en": "Sokuonbin",
+        "ja": "促音便",
+        "ja_typings": [
+          "sokuonbin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02343",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese sound change turns a consonant into a nasal (e.g., 'shinde')?",
+      "ja": "日本語で子音が撥音に変化する音便は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Renjo",
+        "ja": "連声",
+        "ja_typings": [
+          "renjou",
+          "renjo"
+        ]
+      },
+      {
+        "en": "Rendaku",
+        "ja": "連濁",
+        "ja_typings": [
+          "rendaku"
+        ]
+      },
+      {
+        "en": "Onbin",
+        "ja": "音便",
+        "ja_typings": [
+          "onbin"
+        ]
+      },
+      {
+        "en": "Gemination",
+        "ja": "促音化",
+        "ja_typings": [
+          "sokuonka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02344",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese sandhi merges a final n with a following vowel (e.g., han'nou)?",
+      "ja": "撥音が後続母音と結びついて生じる日本語の連音現象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Perfect aspect",
+        "ja": "完了相",
+        "ja_typings": [
+          "kanryousou",
+          "kanryoso"
+        ]
+      },
+      {
+        "en": "Progressive aspect",
+        "ja": "進行相",
+        "ja_typings": [
+          "shinkousou",
+          "shinkoso"
+        ]
+      },
+      {
+        "en": "Habitual aspect",
+        "ja": "習慣相",
+        "ja_typings": [
+          "shuukansou",
+          "shukanso"
+        ]
+      },
+      {
+        "en": "Perfective aspect",
+        "ja": "完結相",
+        "ja_typings": [
+          "kanketsusou",
+          "kanketsuso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02345",
+    "image_path": null,
+    "question_text": {
+      "en": "Which grammatical aspect expresses completed action with present relevance?",
+      "ja": "完了して現在に影響が残ることを示す相は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Past tense",
+        "ja": "過去時制",
+        "ja_typings": [
+          "kakojisei"
+        ]
+      },
+      {
+        "en": "Present tense",
+        "ja": "現在時制",
+        "ja_typings": [
+          "genzaijisei"
+        ]
+      },
+      {
+        "en": "Future tense",
+        "ja": "未来時制",
+        "ja_typings": [
+          "miraijisei"
+        ]
+      },
+      {
+        "en": "Perfect tense",
+        "ja": "完了時制",
+        "ja_typings": [
+          "kanryoujisei",
+          "kanryojisei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02346",
+    "image_path": null,
+    "question_text": {
+      "en": "Which tense refers to actions that already happened?",
+      "ja": "すでに起こった出来事を示す時制は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Future tense",
+        "ja": "未来時制",
+        "ja_typings": [
+          "miraijisei"
+        ]
+      },
+      {
+        "en": "Past tense",
+        "ja": "過去時制",
+        "ja_typings": [
+          "kakojisei"
+        ]
+      },
+      {
+        "en": "Present tense",
+        "ja": "現在時制",
+        "ja_typings": [
+          "genzaijisei"
+        ]
+      },
+      {
+        "en": "Perfect tense",
+        "ja": "完了時制",
+        "ja_typings": [
+          "kanryoujisei",
+          "kanryojisei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02347",
+    "image_path": null,
+    "question_text": {
+      "en": "Which tense refers to actions yet to happen?",
+      "ja": "これから起こる出来事を示す時制は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aspect",
+        "ja": "相",
+        "ja_typings": [
+          "sou",
+          "so"
+        ]
+      },
+      {
+        "en": "Tense",
+        "ja": "時制",
+        "ja_typings": [
+          "jisei"
+        ]
+      },
+      {
+        "en": "Mood",
+        "ja": "法",
+        "ja_typings": [
+          "hou",
+          "ho"
+        ]
+      },
+      {
+        "en": "Voice",
+        "ja": "態",
+        "ja_typings": [
+          "tai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02348",
+    "image_path": null,
+    "question_text": {
+      "en": "Which grammatical category describes the flow of time within an action?",
+      "ja": "動作の時間的な流れ方を表す文法カテゴリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Voice",
+        "ja": "態",
+        "ja_typings": [
+          "tai"
+        ]
+      },
+      {
+        "en": "Aspect",
+        "ja": "相",
+        "ja_typings": [
+          "sou",
+          "so"
+        ]
+      },
+      {
+        "en": "Tense",
+        "ja": "時制",
+        "ja_typings": [
+          "jisei"
+        ]
+      },
+      {
+        "en": "Mood",
+        "ja": "法",
+        "ja_typings": [
+          "hou",
+          "ho"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02349",
+    "image_path": null,
+    "question_text": {
+      "en": "Which grammatical category distinguishes active and passive?",
+      "ja": "能動と受動を区別する文法カテゴリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mood",
+        "ja": "法",
+        "ja_typings": [
+          "hou",
+          "ho"
+        ]
+      },
+      {
+        "en": "Voice",
+        "ja": "態",
+        "ja_typings": [
+          "tai"
+        ]
+      },
+      {
+        "en": "Tense",
+        "ja": "時制",
+        "ja_typings": [
+          "jisei"
+        ]
+      },
+      {
+        "en": "Aspect",
+        "ja": "相",
+        "ja_typings": [
+          "sou",
+          "so"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02350",
+    "image_path": null,
+    "question_text": {
+      "en": "Which grammatical category expresses attitude (e.g., command, wish)?",
+      "ja": "話者の心的態度 (命令・願望など) を表す文法カテゴリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Potential form",
+        "ja": "可能形",
+        "ja_typings": [
+          "kanoukei",
+          "kanokei"
+        ]
+      },
+      {
+        "en": "Passive form",
+        "ja": "受身形",
+        "ja_typings": [
+          "ukemikei"
+        ]
+      },
+      {
+        "en": "Causative form",
+        "ja": "使役形",
+        "ja_typings": [
+          "shiekikei"
+        ]
+      },
+      {
+        "en": "Imperative form",
+        "ja": "命令形",
+        "ja_typings": [
+          "meireikei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02351",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese verb form expresses 'can do' (e.g., yomeru)?",
+      "ja": "「読める」のように「〜できる」を表す日本語の動詞形は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "French",
+        "ja": "フランス語",
+        "ja_typings": [
+          "furansugo"
+        ]
+      },
+      {
+        "en": "Italian",
+        "ja": "イタリア語",
+        "ja_typings": [
+          "itariago"
+        ]
+      },
+      {
+        "en": "Spanish",
+        "ja": "スペイン語",
+        "ja_typings": [
+          "supeingo"
+        ]
+      },
+      {
+        "en": "German",
+        "ja": "ドイツ語",
+        "ja_typings": [
+          "doitsugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02352",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language is the official language of France?",
+      "ja": "フランスの公用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dutch",
+        "ja": "オランダ語",
+        "ja_typings": [
+          "orandago"
+        ]
+      },
+      {
+        "en": "German",
+        "ja": "ドイツ語",
+        "ja_typings": [
+          "doitsugo"
+        ]
+      },
+      {
+        "en": "Danish",
+        "ja": "デンマーク語",
+        "ja_typings": [
+          "denma-kugo"
+        ]
+      },
+      {
+        "en": "Swedish",
+        "ja": "スウェーデン語",
+        "ja_typings": [
+          "suwe-dengo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q02353",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language is the official language of the Netherlands?",
+      "ja": "オランダの公用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Las Fallas",
+        "ja": "ラス・ファリャス",
+        "ja_typings": [
+          "rasu/faryasu"
+        ]
+      },
+      {
+        "en": "La Tomatina",
+        "ja": "ラ・トマティーナ",
+        "ja_typings": [
+          "ra/tomati-na"
+        ]
+      },
+      {
+        "en": "San Fermin",
+        "ja": "サン・フェルミン",
+        "ja_typings": [
+          "san/ferumin"
+        ]
+      },
+      {
+        "en": "Feria de Abril",
+        "ja": "フェリア・デ・アブリル",
+        "ja_typings": [
+          "feria/de/aburiru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02354",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Valencia festival burns giant satirical figures in March?",
+      "ja": "3月にバレンシアで巨大な人形を焼くスペインの祭りは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Las Posadas",
+        "ja": "ラス・ポサダス",
+        "ja_typings": [
+          "rasu/posadasu"
+        ]
+      },
+      {
+        "en": "Dia de los Muertos",
+        "ja": "死者の日",
+        "ja_typings": [
+          "shishanohi"
+        ]
+      },
+      {
+        "en": "Las Fallas",
+        "ja": "ラス・ファリャス",
+        "ja_typings": [
+          "rasu/faryasu"
+        ]
+      },
+      {
+        "en": "Cinco de Mayo",
+        "ja": "シンコ・デ・マヨ",
+        "ja_typings": [
+          "shinko/de/mayo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02355",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mexican Christmas tradition reenacts Mary and Joseph seeking lodging?",
+      "ja": "メキシコでマリアとヨセフの宿探しを再現するクリスマス行事は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Navratri",
+        "ja": "ナヴラトリ",
+        "ja_typings": [
+          "navuratori"
+        ]
+      },
+      {
+        "en": "Diwali",
+        "ja": "ディーワーリー",
+        "ja_typings": [
+          "di-wa-ri-"
+        ]
+      },
+      {
+        "en": "Holi",
+        "ja": "ホーリー",
+        "ja_typings": [
+          "ho-ri-"
+        ]
+      },
+      {
+        "en": "Pongal",
+        "ja": "ポンガル",
+        "ja_typings": [
+          "pongaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02356",
+    "image_path": null,
+    "question_text": {
+      "en": "Which nine-night Hindu festival worships the goddess Durga?",
+      "ja": "ドゥルガー女神を祀る9夜にわたるヒンドゥー教の祭は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pongal",
+        "ja": "ポンガル",
+        "ja_typings": [
+          "pongaru"
+        ]
+      },
+      {
+        "en": "Onam",
+        "ja": "オーナム",
+        "ja_typings": [
+          "o-namu"
+        ]
+      },
+      {
+        "en": "Navratri",
+        "ja": "ナヴラトリ",
+        "ja_typings": [
+          "navuratori"
+        ]
+      },
+      {
+        "en": "Holi",
+        "ja": "ホーリー",
+        "ja_typings": [
+          "ho-ri-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02357",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Tamil harvest festival celebrates the sun in January?",
+      "ja": "1月に太陽神を祝うタミル人の収穫祭は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dhoti",
+        "ja": "ドーティー",
+        "ja_typings": [
+          "do-ti-"
+        ]
+      },
+      {
+        "en": "Sari",
+        "ja": "サリー",
+        "ja_typings": [
+          "sari-"
+        ]
+      },
+      {
+        "en": "Kurta",
+        "ja": "クルター",
+        "ja_typings": [
+          "kuruta-"
+        ]
+      },
+      {
+        "en": "Lungi",
+        "ja": "ルンギー",
+        "ja_typings": [
+          "rungi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02358",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the traditional Indian male garment wrapped around the waist?",
+      "ja": "腰に巻くインドの伝統的な男性用の衣装は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bachata",
+        "ja": "バチャータ",
+        "ja_typings": [
+          "bacha-ta"
+        ]
+      },
+      {
+        "en": "Merengue",
+        "ja": "メレンゲ",
+        "ja_typings": [
+          "merenge"
+        ]
+      },
+      {
+        "en": "Salsa",
+        "ja": "サルサ",
+        "ja_typings": [
+          "sarusa"
+        ]
+      },
+      {
+        "en": "Reggaeton",
+        "ja": "レゲトン",
+        "ja_typings": [
+          "regeton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02359",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Dominican music and dance style features romantic guitar?",
+      "ja": "ロマンチックなギターが特徴のドミニカ共和国の音楽は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Feria de Abril",
+        "ja": "フェリア・デ・アブリル",
+        "ja_typings": [
+          "feria/de/aburiru"
+        ]
+      },
+      {
+        "en": "Las Fallas",
+        "ja": "ラス・ファリャス",
+        "ja_typings": [
+          "rasu/faryasu"
+        ]
+      },
+      {
+        "en": "Semana Santa",
+        "ja": "セマナ・サンタ",
+        "ja_typings": [
+          "semana/santa"
+        ]
+      },
+      {
+        "en": "La Tomatina",
+        "ja": "ラ・トマティーナ",
+        "ja_typings": [
+          "ra/tomati-na"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02360",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Seville festival features flamenco and casetas after Holy Week?",
+      "ja": "聖週間後にセビリアで開かれるフラメンコの祭りは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "longhouse",
+        "ja": "ロングハウス",
+        "ja_typings": [
+          "ronguhausu"
+        ]
+      },
+      {
+        "en": "teepee",
+        "ja": "ティピー",
+        "ja_typings": [
+          "tipi-"
+        ]
+      },
+      {
+        "en": "igloo",
+        "ja": "イグルー",
+        "ja_typings": [
+          "iguru-"
+        ]
+      },
+      {
+        "en": "hogan",
+        "ja": "ホーガン",
+        "ja_typings": [
+          "ho-gan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02361",
+    "image_path": null,
+    "question_text": {
+      "en": "Which large communal dwelling housed several families in Native American cultures?",
+      "ja": "複数の家族が暮らした北米先住民の細長い共同住居は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Zeami",
+        "ja": "世阿弥",
+        "ja_typings": [
+          "zeami"
+        ]
+      },
+      {
+        "en": "Kan'ami",
+        "ja": "観阿弥",
+        "ja_typings": [
+          "kan'ami",
+          "kannami"
+        ]
+      },
+      {
+        "en": "Chikamatsu",
+        "ja": "近松門左衛門",
+        "ja_typings": [
+          "chikamatsumonzaemon"
+        ]
+      },
+      {
+        "en": "Izumi Kyoka",
+        "ja": "泉鏡花",
+        "ja_typings": [
+          "izumikyouka",
+          "izumikyoka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02362",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the most important playwright and theorist of Noh theatre?",
+      "ja": "能の大成者として最も知られる劇作家・理論家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Matsuo Basho",
+        "ja": "松尾芭蕉",
+        "ja_typings": [
+          "matsuobashou",
+          "matsuobasho"
+        ]
+      },
+      {
+        "en": "Yosa Buson",
+        "ja": "与謝蕪村",
+        "ja_typings": [
+          "yosabuson"
+        ]
+      },
+      {
+        "en": "Kobayashi Issa",
+        "ja": "小林一茶",
+        "ja_typings": [
+          "kobayashiissa"
+        ]
+      },
+      {
+        "en": "Masaoka Shiki",
+        "ja": "正岡子規",
+        "ja_typings": [
+          "masaokashiki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02363",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the master of haiku famous for 'Oku no Hosomichi'?",
+      "ja": "『奥の細道』で知られる俳諧の巨匠は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sesshu",
+        "ja": "雪舟",
+        "ja_typings": [
+          "sesshuu",
+          "sesshu"
+        ]
+      },
+      {
+        "en": "Kano Eitoku",
+        "ja": "狩野永徳",
+        "ja_typings": [
+          "kanoueitoku",
+          "kanoeitoku"
+        ]
+      },
+      {
+        "en": "Tawaraya Sotatsu",
+        "ja": "俵屋宗達",
+        "ja_typings": [
+          "tawarayasoutatsu",
+          "tawarayasotatsu"
+        ]
+      },
+      {
+        "en": "Ogata Korin",
+        "ja": "尾形光琳",
+        "ja_typings": [
+          "ogatakourin",
+          "ogatakorin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02364",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Muromachi-era ink painter is known for landscapes like 'Long Landscape Scroll'?",
+      "ja": "『山水長巻』で知られる室町時代の水墨画家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sao Paulo",
+        "ja": "サンパウロ",
+        "ja_typings": [
+          "sanpauro"
+        ]
+      },
+      {
+        "en": "Rio de Janeiro",
+        "ja": "リオデジャネイロ",
+        "ja_typings": [
+          "riodejaneiro"
+        ]
+      },
+      {
+        "en": "Brasilia",
+        "ja": "ブラジリア",
+        "ja_typings": [
+          "burajiria"
+        ]
+      },
+      {
+        "en": "Salvador",
+        "ja": "サルヴァドール",
+        "ja_typings": [
+          "saruvado-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02365",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the largest city in Brazil?",
+      "ja": "ブラジル最大の都市は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Salvador",
+        "ja": "サルヴァドール",
+        "ja_typings": [
+          "saruvado-ru"
+        ]
+      },
+      {
+        "en": "Brasilia",
+        "ja": "ブラジリア",
+        "ja_typings": [
+          "burajiria"
+        ]
+      },
+      {
+        "en": "Sao Paulo",
+        "ja": "サンパウロ",
+        "ja_typings": [
+          "sanpauro"
+        ]
+      },
+      {
+        "en": "Recife",
+        "ja": "レシフェ",
+        "ja_typings": [
+          "reshife"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02366",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Brazilian city was the country's first capital and is known for Afro-Brazilian culture?",
+      "ja": "ブラジル最初の首都で、アフロ・ブラジル文化の中心地は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cannes Film Festival",
+        "ja": "カンヌ国際映画祭",
+        "ja_typings": [
+          "kannukokusaieigasai"
+        ]
+      },
+      {
+        "en": "Venice Film Festival",
+        "ja": "ヴェネツィア国際映画祭",
+        "ja_typings": [
+          "vu~enetsiakokusaieigasai"
+        ]
+      },
+      {
+        "en": "Berlin Film Festival",
+        "ja": "ベルリン国際映画祭",
+        "ja_typings": [
+          "berurinkokusaieigasai"
+        ]
+      },
+      {
+        "en": "Toronto Film Festival",
+        "ja": "トロント国際映画祭",
+        "ja_typings": [
+          "torontokokusaieigasai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02367",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French film festival awards the Palme d'Or?",
+      "ja": "パルム・ドールを授与するフランスの映画祭は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Venice Carnival",
+        "ja": "ヴェネツィア・カーニバル",
+        "ja_typings": [
+          "venetsia/ka-nibaru"
+        ]
+      },
+      {
+        "en": "Rio Carnival",
+        "ja": "リオのカーニバル",
+        "ja_typings": [
+          "riono ka-nibaru",
+          "rionoka-nibaru"
+        ]
+      },
+      {
+        "en": "Las Fallas",
+        "ja": "ラス・ファリャス",
+        "ja_typings": [
+          "rasu/faryasu"
+        ]
+      },
+      {
+        "en": "Mardi Gras",
+        "ja": "マルディグラ",
+        "ja_typings": [
+          "marudigura"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02368",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian carnival is famous for elaborate masks?",
+      "ja": "華やかな仮面で知られるイタリアの謝肉祭は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rock in Rio",
+        "ja": "ロック・イン・リオ",
+        "ja_typings": [
+          "rokku/in/rio"
+        ]
+      },
+      {
+        "en": "Tomorrowland",
+        "ja": "トゥモローランド",
+        "ja_typings": [
+          "tumoro-rando"
+        ]
+      },
+      {
+        "en": "Coachella",
+        "ja": "コーチェラ",
+        "ja_typings": [
+          "ko-chera"
+        ]
+      },
+      {
+        "en": "Glastonbury",
+        "ja": "グラストンベリー",
+        "ja_typings": [
+          "gurasutonberi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02369",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Brazilian music festival is one of the largest in the world?",
+      "ja": "ブラジルで開かれる世界最大級の音楽フェスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Noh",
+        "ja": "能",
+        "ja_typings": [
+          "nou",
+          "no"
+        ]
+      },
+      {
+        "en": "Kabuki",
+        "ja": "歌舞伎",
+        "ja_typings": [
+          "kabuki"
+        ]
+      },
+      {
+        "en": "Bunraku",
+        "ja": "文楽",
+        "ja_typings": [
+          "bunraku"
+        ]
+      },
+      {
+        "en": "Kyogen",
+        "ja": "狂言",
+        "ja_typings": [
+          "kyougen",
+          "kyogen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02370",
+    "image_path": null,
+    "question_text": {
+      "en": "Which masked Japanese musical drama dates from the 14th century?",
+      "ja": "14世紀から続く面を着けた日本の歌舞演劇は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bunraku",
+        "ja": "文楽",
+        "ja_typings": [
+          "bunraku"
+        ]
+      },
+      {
+        "en": "Noh",
+        "ja": "能",
+        "ja_typings": [
+          "nou",
+          "no"
+        ]
+      },
+      {
+        "en": "Kabuki",
+        "ja": "歌舞伎",
+        "ja_typings": [
+          "kabuki"
+        ]
+      },
+      {
+        "en": "Kyogen",
+        "ja": "狂言",
+        "ja_typings": [
+          "kyougen",
+          "kyogen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02371",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese traditional puppet theatre uses three puppeteers per puppet?",
+      "ja": "1体の人形を3人で操る日本の伝統人形劇は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kyogen",
+        "ja": "狂言",
+        "ja_typings": [
+          "kyougen",
+          "kyogen"
+        ]
+      },
+      {
+        "en": "Bunraku",
+        "ja": "文楽",
+        "ja_typings": [
+          "bunraku"
+        ]
+      },
+      {
+        "en": "Kabuki",
+        "ja": "歌舞伎",
+        "ja_typings": [
+          "kabuki"
+        ]
+      },
+      {
+        "en": "Rakugo",
+        "ja": "落語",
+        "ja_typings": [
+          "rakugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02372",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese comic theatre is performed between Noh plays?",
+      "ja": "能の演目の合間に上演される滑稽な日本の演劇は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Muharram",
+        "ja": "ムハッラム",
+        "ja_typings": [
+          "muharramu"
+        ]
+      },
+      {
+        "en": "Ramadan",
+        "ja": "ラマダーン",
+        "ja_typings": [
+          "ramada-n"
+        ]
+      },
+      {
+        "en": "Shawwal",
+        "ja": "シャウワール",
+        "ja_typings": [
+          "shauwa-ru"
+        ]
+      },
+      {
+        "en": "Rajab",
+        "ja": "ラジャブ",
+        "ja_typings": [
+          "rajabu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02373",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Islamic month commemorates the martyrdom of Husayn ibn Ali?",
+      "ja": "フサイン・イブン・アリーの殉教を悼むイスラム暦の月は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shawwal",
+        "ja": "シャウワール",
+        "ja_typings": [
+          "shauwa-ru"
+        ]
+      },
+      {
+        "en": "Muharram",
+        "ja": "ムハッラム",
+        "ja_typings": [
+          "muharramu"
+        ]
+      },
+      {
+        "en": "Rajab",
+        "ja": "ラジャブ",
+        "ja_typings": [
+          "rajabu"
+        ]
+      },
+      {
+        "en": "Safar",
+        "ja": "サファル",
+        "ja_typings": [
+          "safaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02374",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Islamic month follows Ramadan and starts with Eid al-Fitr?",
+      "ja": "ラマダーン明けでイード・アル＝フィトルから始まるイスラム暦の月は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rajab",
+        "ja": "ラジャブ",
+        "ja_typings": [
+          "rajabu"
+        ]
+      },
+      {
+        "en": "Shawwal",
+        "ja": "シャウワール",
+        "ja_typings": [
+          "shauwa-ru"
+        ]
+      },
+      {
+        "en": "Muharram",
+        "ja": "ムハッラム",
+        "ja_typings": [
+          "muharramu"
+        ]
+      },
+      {
+        "en": "Ramadan",
+        "ja": "ラマダーン",
+        "ja_typings": [
+          "ramada-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02375",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the seventh month of the Islamic calendar, considered sacred?",
+      "ja": "イスラム暦の第7月で神聖月とされるのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cappuccino",
+        "ja": "カプチーノ",
+        "ja_typings": [
+          "kapuchi-no"
+        ]
+      },
+      {
+        "en": "Macchiato",
+        "ja": "マキアート",
+        "ja_typings": [
+          "makia-to"
+        ]
+      },
+      {
+        "en": "Americano",
+        "ja": "アメリカーノ",
+        "ja_typings": [
+          "amerika-no"
+        ]
+      },
+      {
+        "en": "Latte",
+        "ja": "カフェラテ",
+        "ja_typings": [
+          "kaferate"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02376",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian coffee drink tops espresso with foamed milk in equal layers?",
+      "ja": "エスプレッソに泡立てミルクを等量に重ねるイタリアのコーヒーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Macchiato",
+        "ja": "マキアート",
+        "ja_typings": [
+          "makia-to"
+        ]
+      },
+      {
+        "en": "Cappuccino",
+        "ja": "カプチーノ",
+        "ja_typings": [
+          "kapuchi-no"
+        ]
+      },
+      {
+        "en": "Americano",
+        "ja": "アメリカーノ",
+        "ja_typings": [
+          "amerika-no"
+        ]
+      },
+      {
+        "en": "Mocha",
+        "ja": "モカ",
+        "ja_typings": [
+          "moka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02377",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian coffee is espresso 'stained' with a small amount of milk?",
+      "ja": "エスプレッソに少量のミルクを加えたイタリアのコーヒーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Americano",
+        "ja": "アメリカーノ",
+        "ja_typings": [
+          "amerika-no"
+        ]
+      },
+      {
+        "en": "Cappuccino",
+        "ja": "カプチーノ",
+        "ja_typings": [
+          "kapuchi-no"
+        ]
+      },
+      {
+        "en": "Macchiato",
+        "ja": "マキアート",
+        "ja_typings": [
+          "makia-to"
+        ]
+      },
+      {
+        "en": "Espresso",
+        "ja": "エスプレッソ",
+        "ja_typings": [
+          "esupuresso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02378",
+    "image_path": null,
+    "question_text": {
+      "en": "Which coffee is espresso diluted with hot water?",
+      "ja": "エスプレッソをお湯で薄めたコーヒーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Semana Santa",
+        "ja": "セマナ・サンタ",
+        "ja_typings": [
+          "semana/santa"
+        ]
+      },
+      {
+        "en": "Feria de Abril",
+        "ja": "フェリア・デ・アブリル",
+        "ja_typings": [
+          "feria/de/aburiru"
+        ]
+      },
+      {
+        "en": "Las Fallas",
+        "ja": "ラス・ファリャス",
+        "ja_typings": [
+          "rasu/faryasu"
+        ]
+      },
+      {
+        "en": "San Fermin",
+        "ja": "サン・フェルミン",
+        "ja_typings": [
+          "san/ferumin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02379",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Spanish Holy Week celebration features hooded processions?",
+      "ja": "とんがり頭巾の行列が特徴のスペイン聖週間の祝祭は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mid-Autumn Festival",
+        "ja": "中秋節",
+        "ja_typings": [
+          "chuushuusetsu",
+          "chushusetsu"
+        ]
+      },
+      {
+        "en": "Dragon Boat Festival",
+        "ja": "端午節",
+        "ja_typings": [
+          "tangosetsu"
+        ]
+      },
+      {
+        "en": "Qingming Festival",
+        "ja": "清明節",
+        "ja_typings": [
+          "seimeisetsu"
+        ]
+      },
+      {
+        "en": "Lantern Festival",
+        "ja": "元宵節",
+        "ja_typings": [
+          "genshousetsu",
+          "genshosetsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02380",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Chinese festival celebrates the harvest with mooncakes?",
+      "ja": "月餅を食べて収穫を祝う中国の祭りは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dragon Boat Festival",
+        "ja": "端午節",
+        "ja_typings": [
+          "tangosetsu"
+        ]
+      },
+      {
+        "en": "Mid-Autumn Festival",
+        "ja": "中秋節",
+        "ja_typings": [
+          "chuushuusetsu",
+          "chushusetsu"
+        ]
+      },
+      {
+        "en": "Qingming Festival",
+        "ja": "清明節",
+        "ja_typings": [
+          "seimeisetsu"
+        ]
+      },
+      {
+        "en": "Lantern Festival",
+        "ja": "元宵節",
+        "ja_typings": [
+          "genshousetsu",
+          "genshosetsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02381",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Chinese festival features dragon boat races and zongzi?",
+      "ja": "ドラゴンボートレースと粽が伝統の中国の祭りは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Qingming Festival",
+        "ja": "清明節",
+        "ja_typings": [
+          "seimeisetsu"
+        ]
+      },
+      {
+        "en": "Mid-Autumn Festival",
+        "ja": "中秋節",
+        "ja_typings": [
+          "chuushuusetsu",
+          "chushusetsu"
+        ]
+      },
+      {
+        "en": "Dragon Boat Festival",
+        "ja": "端午節",
+        "ja_typings": [
+          "tangosetsu"
+        ]
+      },
+      {
+        "en": "Lantern Festival",
+        "ja": "元宵節",
+        "ja_typings": [
+          "genshousetsu",
+          "genshosetsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02382",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Chinese festival is the tomb-sweeping day in early April?",
+      "ja": "4月初旬に行われる墓参りの中国の祭りは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bouillabaisse",
+        "ja": "ブイヤベース",
+        "ja_typings": [
+          "buiyabe-su"
+        ]
+      },
+      {
+        "en": "Cassoulet",
+        "ja": "カスレ",
+        "ja_typings": [
+          "kasure"
+        ]
+      },
+      {
+        "en": "Pot-au-feu",
+        "ja": "ポトフ",
+        "ja_typings": [
+          "potofu"
+        ]
+      },
+      {
+        "en": "Ratatouille",
+        "ja": "ラタトゥイユ",
+        "ja_typings": [
+          "ratatuiyu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02383",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Provencal fish stew is from Marseille?",
+      "ja": "マルセイユ発祥のプロヴァンス風魚介スープは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cassoulet",
+        "ja": "カスレ",
+        "ja_typings": [
+          "kasure"
+        ]
+      },
+      {
+        "en": "Bouillabaisse",
+        "ja": "ブイヤベース",
+        "ja_typings": [
+          "buiyabe-su"
+        ]
+      },
+      {
+        "en": "Pot-au-feu",
+        "ja": "ポトフ",
+        "ja_typings": [
+          "potofu"
+        ]
+      },
+      {
+        "en": "Coq au vin",
+        "ja": "コック・オ・ヴァン",
+        "ja_typings": [
+          "kokku/o/van"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02384",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French slow-cooked stew of beans and meat is from Languedoc?",
+      "ja": "ラングドック地方の豆と肉の煮込み料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pot-au-feu",
+        "ja": "ポトフ",
+        "ja_typings": [
+          "potofu"
+        ]
+      },
+      {
+        "en": "Bouillabaisse",
+        "ja": "ブイヤベース",
+        "ja_typings": [
+          "buiyabe-su"
+        ]
+      },
+      {
+        "en": "Cassoulet",
+        "ja": "カスレ",
+        "ja_typings": [
+          "kasure"
+        ]
+      },
+      {
+        "en": "Ratatouille",
+        "ja": "ラタトゥイユ",
+        "ja_typings": [
+          "ratatuiyu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02385",
+    "image_path": null,
+    "question_text": {
+      "en": "Which classic French dish is a boiled beef and vegetable stew?",
+      "ja": "牛肉と野菜を煮込んだフランスの伝統料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kurta",
+        "ja": "クルター",
+        "ja_typings": [
+          "kuruta-"
+        ]
+      },
+      {
+        "en": "Dhoti",
+        "ja": "ドーティー",
+        "ja_typings": [
+          "do-ti-"
+        ]
+      },
+      {
+        "en": "Sherwani",
+        "ja": "シェルワーニー",
+        "ja_typings": [
+          "sheruwa-ni-"
+        ]
+      },
+      {
+        "en": "Lungi",
+        "ja": "ルンギー",
+        "ja_typings": [
+          "rungi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02386",
+    "image_path": null,
+    "question_text": {
+      "en": "Which long collarless shirt is worn across South Asia?",
+      "ja": "南アジアで広く着用される襟なしの長いシャツは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shalwar",
+        "ja": "シャルワール",
+        "ja_typings": [
+          "sharuwa-ru"
+        ]
+      },
+      {
+        "en": "Dhoti",
+        "ja": "ドーティー",
+        "ja_typings": [
+          "do-ti-"
+        ]
+      },
+      {
+        "en": "Kurta",
+        "ja": "クルター",
+        "ja_typings": [
+          "kuruta-"
+        ]
+      },
+      {
+        "en": "Lungi",
+        "ja": "ルンギー",
+        "ja_typings": [
+          "rungi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02387",
+    "image_path": null,
+    "question_text": {
+      "en": "Which loose trousers are paired with a kameez in South Asia?",
+      "ja": "南アジアでカミーズと合わせる、ゆったりしたズボンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Umrah",
+        "ja": "ウムラ",
+        "ja_typings": [
+          "umura"
+        ]
+      },
+      {
+        "en": "Hajj",
+        "ja": "ハッジ",
+        "ja_typings": [
+          "hajji"
+        ]
+      },
+      {
+        "en": "Salat",
+        "ja": "サラート",
+        "ja_typings": [
+          "sara-to"
+        ]
+      },
+      {
+        "en": "Zakat",
+        "ja": "ザカート",
+        "ja_typings": [
+          "zaka-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02388",
+    "image_path": null,
+    "question_text": {
+      "en": "Which non-mandatory Islamic pilgrimage to Mecca can be performed any time of year?",
+      "ja": "メッカへの随時可能な小巡礼は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Salat",
+        "ja": "サラート",
+        "ja_typings": [
+          "sara-to"
+        ]
+      },
+      {
+        "en": "Zakat",
+        "ja": "ザカート",
+        "ja_typings": [
+          "zaka-to"
+        ]
+      },
+      {
+        "en": "Hajj",
+        "ja": "ハッジ",
+        "ja_typings": [
+          "hajji"
+        ]
+      },
+      {
+        "en": "Umrah",
+        "ja": "ウムラ",
+        "ja_typings": [
+          "umura"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02389",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the Islamic ritual prayer performed five times a day?",
+      "ja": "1日5回行うイスラム教の礼拝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Zakat",
+        "ja": "ザカート",
+        "ja_typings": [
+          "zaka-to"
+        ]
+      },
+      {
+        "en": "Salat",
+        "ja": "サラート",
+        "ja_typings": [
+          "sara-to"
+        ]
+      },
+      {
+        "en": "Hajj",
+        "ja": "ハッジ",
+        "ja_typings": [
+          "hajji"
+        ]
+      },
+      {
+        "en": "Umrah",
+        "ja": "ウムラ",
+        "ja_typings": [
+          "umura"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02390",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Islamic pillar is the obligatory almsgiving?",
+      "ja": "イスラム教における義務的な喜捨は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Babushka",
+        "ja": "バブーシュカ",
+        "ja_typings": [
+          "babu-shuka"
+        ]
+      },
+      {
+        "en": "Matryoshka",
+        "ja": "マトリョーシカ",
+        "ja_typings": [
+          "matoryo-shika"
+        ]
+      },
+      {
+        "en": "Pirozhki",
+        "ja": "ピロシキ",
+        "ja_typings": [
+          "piroshiki"
+        ]
+      },
+      {
+        "en": "Sarafan",
+        "ja": "サラファン",
+        "ja_typings": [
+          "sarafan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02391",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Russian word names the traditional grandmother's headscarf or nesting doll?",
+      "ja": "ロシアの伝統的なおばあさんの頭巾や入れ子人形を指す語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pirozhki",
+        "ja": "ピロシキ",
+        "ja_typings": [
+          "piroshiki"
+        ]
+      },
+      {
+        "en": "Babushka",
+        "ja": "バブーシュカ",
+        "ja_typings": [
+          "babu-shuka"
+        ]
+      },
+      {
+        "en": "Blini",
+        "ja": "ブリヌイ",
+        "ja_typings": [
+          "burinui"
+        ]
+      },
+      {
+        "en": "Pelmeni",
+        "ja": "ペリメニ",
+        "ja_typings": [
+          "perimeni"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02392",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Russian small baked or fried bun is filled with meat or potatoes?",
+      "ja": "肉や芋を詰めて焼くロシアの小さなパンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Khokhloma",
+        "ja": "ホフロマ",
+        "ja_typings": [
+          "hofuroma"
+        ]
+      },
+      {
+        "en": "Gzhel",
+        "ja": "グジェリ",
+        "ja_typings": [
+          "gujeri"
+        ]
+      },
+      {
+        "en": "Palekh",
+        "ja": "パレフ",
+        "ja_typings": [
+          "parefu"
+        ]
+      },
+      {
+        "en": "Matryoshka",
+        "ja": "マトリョーシカ",
+        "ja_typings": [
+          "matoryo-shika"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02393",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Russian folk painting uses red, black and gold on wooden tableware?",
+      "ja": "赤・黒・金で木製食器を彩るロシアの民芸絵付けは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Notre-Dame Cathedral",
+        "ja": "ノートルダム大聖堂",
+        "ja_typings": [
+          "no-torudamudaiseidou",
+          "no-torudamudaiseido"
+        ]
+      },
+      {
+        "en": "Cologne Cathedral",
+        "ja": "ケルン大聖堂",
+        "ja_typings": [
+          "kerundaiseidou",
+          "kerundaiseido"
+        ]
+      },
+      {
+        "en": "Milan Cathedral",
+        "ja": "ミラノ大聖堂",
+        "ja_typings": [
+          "miranodaiseidou",
+          "miranodaiseido"
+        ]
+      },
+      {
+        "en": "Reims Cathedral",
+        "ja": "ランス大聖堂",
+        "ja_typings": [
+          "ransudaiseidou",
+          "ransudaiseido"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02394",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Paris Gothic cathedral has flying buttresses and famous gargoyles?",
+      "ja": "フライング・バットレスとガーゴイルで有名なパリのゴシック大聖堂は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cologne Cathedral",
+        "ja": "ケルン大聖堂",
+        "ja_typings": [
+          "kerundaiseidou",
+          "kerundaiseido"
+        ]
+      },
+      {
+        "en": "Notre-Dame Cathedral",
+        "ja": "ノートルダム大聖堂",
+        "ja_typings": [
+          "no-torudamudaiseidou",
+          "no-torudamudaiseido"
+        ]
+      },
+      {
+        "en": "Milan Cathedral",
+        "ja": "ミラノ大聖堂",
+        "ja_typings": [
+          "miranodaiseidou",
+          "miranodaiseido"
+        ]
+      },
+      {
+        "en": "St. Peter's Basilica",
+        "ja": "サン・ピエトロ大聖堂",
+        "ja_typings": [
+          "sanpietorodaiseidou",
+          "sanpietorodaiseido"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02395",
+    "image_path": null,
+    "question_text": {
+      "en": "Which German Gothic cathedral is the largest in northern Europe?",
+      "ja": "北ヨーロッパ最大のゴシック大聖堂であるドイツの教会は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Milan Cathedral",
+        "ja": "ミラノ大聖堂",
+        "ja_typings": [
+          "miranodaiseidou",
+          "miranodaiseido"
+        ]
+      },
+      {
+        "en": "Notre-Dame Cathedral",
+        "ja": "ノートルダム大聖堂",
+        "ja_typings": [
+          "no-torudamudaiseidou",
+          "no-torudamudaiseido"
+        ]
+      },
+      {
+        "en": "Cologne Cathedral",
+        "ja": "ケルン大聖堂",
+        "ja_typings": [
+          "kerundaiseidou",
+          "kerundaiseido"
+        ]
+      },
+      {
+        "en": "Florence Cathedral",
+        "ja": "フィレンツェ大聖堂",
+        "ja_typings": [
+          "firentsedaiseidou",
+          "firentsedaiseido"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02396",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian Gothic cathedral has more than 3,000 statues on its facade?",
+      "ja": "3000体以上の彫像が並ぶイタリアのゴシック大聖堂は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sogetsu",
+        "ja": "草月流",
+        "ja_typings": [
+          "sougetsuryuu",
+          "sogetsuryu"
+        ]
+      },
+      {
+        "en": "Ohara",
+        "ja": "小原流",
+        "ja_typings": [
+          "oharaRyuu",
+          "oharaRyu"
+        ]
+      },
+      {
+        "en": "Ikenobo",
+        "ja": "池坊",
+        "ja_typings": [
+          "ikenobou",
+          "ikenobo"
+        ]
+      },
+      {
+        "en": "Saga Goryu",
+        "ja": "嵯峨御流",
+        "ja_typings": [
+          "sagagoryuu",
+          "sagagoryu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02397",
+    "image_path": null,
+    "question_text": {
+      "en": "Which avant-garde school of ikebana was founded in 1927 by Teshigahara?",
+      "ja": "1927年に勅使河原蒼風が創始したいけばなの流派は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ohara",
+        "ja": "小原流",
+        "ja_typings": [
+          "ohararyuu",
+          "ohararyu"
+        ]
+      },
+      {
+        "en": "Sogetsu",
+        "ja": "草月流",
+        "ja_typings": [
+          "sougetsuryuu",
+          "sogetsuryu"
+        ]
+      },
+      {
+        "en": "Ikenobo",
+        "ja": "池坊",
+        "ja_typings": [
+          "ikenobou",
+          "ikenobo"
+        ]
+      },
+      {
+        "en": "Saga Goryu",
+        "ja": "嵯峨御流",
+        "ja_typings": [
+          "sagagoryuu",
+          "sagagoryu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02398",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ikebana school pioneered the moribana shallow-container style?",
+      "ja": "盛花を考案したいけばなの流派は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Saga Goryu",
+        "ja": "嵯峨御流",
+        "ja_typings": [
+          "sagagoryuu",
+          "sagagoryu"
+        ]
+      },
+      {
+        "en": "Sogetsu",
+        "ja": "草月流",
+        "ja_typings": [
+          "sougetsuryuu",
+          "sogetsuryu"
+        ]
+      },
+      {
+        "en": "Ohara",
+        "ja": "小原流",
+        "ja_typings": [
+          "ohararyuu",
+          "ohararyu"
+        ]
+      },
+      {
+        "en": "Ikenobo",
+        "ja": "池坊",
+        "ja_typings": [
+          "ikenobou",
+          "ikenobo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02399",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ikebana school traces its origin to Emperor Saga at Daikaku-ji?",
+      "ja": "嵯峨天皇と大覚寺に由来するいけばなの流派は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Barong Tagalog",
+        "ja": "バロン・タガログ",
+        "ja_typings": [
+          "baron/tagarogu"
+        ]
+      },
+      {
+        "en": "Kurta",
+        "ja": "クルター",
+        "ja_typings": [
+          "kuruta-"
+        ]
+      },
+      {
+        "en": "Dhoti",
+        "ja": "ドーティー",
+        "ja_typings": [
+          "do-ti-"
+        ]
+      },
+      {
+        "en": "Sherwani",
+        "ja": "シェルワーニー",
+        "ja_typings": [
+          "sheruwa-ni-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02400",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the national embroidered formal shirt of the Philippines for men?",
+      "ja": "フィリピンの男性正装である刺繍シャツは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yom Kippur",
+        "ja": "ヨム・キプール",
+        "ja_typings": [
+          "yomu/kipu-ru"
+        ]
+      },
+      {
+        "en": "Hanukkah",
+        "ja": "ハヌカー",
+        "ja_typings": [
+          "hanuka-"
+        ]
+      },
+      {
+        "en": "Passover",
+        "ja": "過越祭",
+        "ja_typings": [
+          "sugikoshisai"
+        ]
+      },
+      {
+        "en": "Rosh Hashanah",
+        "ja": "ローシュ・ハッシャーナー",
+        "ja_typings": [
+          "ro-shu/hassha-na-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02401",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the holiest day of the Jewish year, the Day of Atonement?",
+      "ja": "ユダヤ教で最も神聖な「贖罪の日」は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hanukkah",
+        "ja": "ハヌカー",
+        "ja_typings": [
+          "hanuka-"
+        ]
+      },
+      {
+        "en": "Yom Kippur",
+        "ja": "ヨム・キプール",
+        "ja_typings": [
+          "yomu/kipu-ru"
+        ]
+      },
+      {
+        "en": "Passover",
+        "ja": "過越祭",
+        "ja_typings": [
+          "sugikoshisai"
+        ]
+      },
+      {
+        "en": "Sukkot",
+        "ja": "スコット",
+        "ja_typings": [
+          "sukotto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q02402",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Jewish festival of lights lasts eight nights?",
+      "ja": "8日間ろうそくを灯すユダヤ教の光の祭は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ECS",
+        "ja": "ECS",
+        "ja_typings": [
+          "i-shi-esu",
+          "ecs"
+        ]
+      },
+      {
+        "en": "EKS",
+        "ja": "EKS",
+        "ja_typings": [
+          "i-kei-esu",
+          "eks"
+        ]
+      },
+      {
+        "en": "Lambda",
+        "ja": "Lambda",
+        "ja_typings": [
+          "lambda"
+        ]
+      },
+      {
+        "en": "Fargate",
+        "ja": "Fargate",
+        "ja_typings": [
+          "fargate"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02403",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS service runs Docker containers without Kubernetes?",
+      "ja": "Kubernetes を使わず Docker コンテナを動かす AWS のサービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "EKS",
+        "ja": "EKS",
+        "ja_typings": [
+          "i-kei-esu",
+          "eks"
+        ]
+      },
+      {
+        "en": "ECS",
+        "ja": "ECS",
+        "ja_typings": [
+          "i-shi-esu",
+          "ecs"
+        ]
+      },
+      {
+        "en": "AKS",
+        "ja": "AKS",
+        "ja_typings": [
+          "e-kei-esu",
+          "aks"
+        ]
+      },
+      {
+        "en": "GKE",
+        "ja": "GKE",
+        "ja_typings": [
+          "ji-kei-i-",
+          "gke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02404",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is AWS's managed Kubernetes service?",
+      "ja": "AWS が提供するマネージド Kubernetes は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "QA",
+        "ja": "QA",
+        "ja_typings": [
+          "kyu-e-",
+          "qa"
+        ]
+      },
+      {
+        "en": "UA",
+        "ja": "UA",
+        "ja_typings": [
+          "yu-e-",
+          "ua"
+        ]
+      },
+      {
+        "en": "DA",
+        "ja": "DA",
+        "ja_typings": [
+          "di-e-",
+          "da"
+        ]
+      },
+      {
+        "en": "PA",
+        "ja": "PA",
+        "ja_typings": [
+          "pi-e-",
+          "pa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02405",
+    "image_path": null,
+    "question_text": {
+      "en": "Which abbreviation refers to quality assurance in software?",
+      "ja": "ソフトウェアの品質保証を意味する略語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "OCI",
+        "ja": "OCI",
+        "ja_typings": [
+          "o-shi-ai",
+          "oci"
+        ]
+      },
+      {
+        "en": "CRI",
+        "ja": "CRI",
+        "ja_typings": [
+          "shi-a-ru-ai",
+          "cri"
+        ]
+      },
+      {
+        "en": "CNI",
+        "ja": "CNI",
+        "ja_typings": [
+          "shi-enu-ai",
+          "cni"
+        ]
+      },
+      {
+        "en": "OPA",
+        "ja": "OPA",
+        "ja_typings": [
+          "o-pi-e-",
+          "opa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02406",
+    "image_path": null,
+    "question_text": {
+      "en": "Which open standard defines container runtimes and image format?",
+      "ja": "コンテナランタイムとイメージ形式のオープン標準は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Availability",
+        "ja": "可用性",
+        "ja_typings": [
+          "kayousei",
+          "kayosei"
+        ]
+      },
+      {
+        "en": "Reliability",
+        "ja": "信頼性",
+        "ja_typings": [
+          "shinraisei"
+        ]
+      },
+      {
+        "en": "Scalability",
+        "ja": "拡張性",
+        "ja_typings": [
+          "kakuchousei",
+          "kakuchosei"
+        ]
+      },
+      {
+        "en": "Maintainability",
+        "ja": "保守性",
+        "ja_typings": [
+          "hoshusei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02407",
+    "image_path": null,
+    "question_text": {
+      "en": "Which non-functional requirement measures uptime of a system?",
+      "ja": "システムの稼働率を示す非機能要件は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "AKS",
+        "ja": "AKS",
+        "ja_typings": [
+          "e-kei-esu",
+          "aks"
+        ]
+      },
+      {
+        "en": "EKS",
+        "ja": "EKS",
+        "ja_typings": [
+          "i-kei-esu",
+          "eks"
+        ]
+      },
+      {
+        "en": "GKE",
+        "ja": "GKE",
+        "ja_typings": [
+          "ji-kei-i-",
+          "gke"
+        ]
+      },
+      {
+        "en": "OKE",
+        "ja": "OKE",
+        "ja_typings": [
+          "o-kei-i-",
+          "oke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02408",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is Microsoft Azure's managed Kubernetes service?",
+      "ja": "Microsoft Azure のマネージド Kubernetes は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "OKE",
+        "ja": "OKE",
+        "ja_typings": [
+          "o-kei-i-",
+          "oke"
+        ]
+      },
+      {
+        "en": "AKS",
+        "ja": "AKS",
+        "ja_typings": [
+          "e-kei-esu",
+          "aks"
+        ]
+      },
+      {
+        "en": "EKS",
+        "ja": "EKS",
+        "ja_typings": [
+          "i-kei-esu",
+          "eks"
+        ]
+      },
+      {
+        "en": "GKE",
+        "ja": "GKE",
+        "ja_typings": [
+          "ji-kei-i-",
+          "gke"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02409",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is Oracle Cloud's managed Kubernetes service?",
+      "ja": "Oracle Cloud のマネージド Kubernetes は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ITIL",
+        "ja": "ITIL",
+        "ja_typings": [
+          "aitiru",
+          "itil"
+        ]
+      },
+      {
+        "en": "COBIT",
+        "ja": "COBIT",
+        "ja_typings": [
+          "kobitto",
+          "cobit"
+        ]
+      },
+      {
+        "en": "TOGAF",
+        "ja": "TOGAF",
+        "ja_typings": [
+          "to-gafu",
+          "togaf"
+        ]
+      },
+      {
+        "en": "PMBOK",
+        "ja": "PMBOK",
+        "ja_typings": [
+          "pinbokku",
+          "pmbok"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02410",
+    "image_path": null,
+    "question_text": {
+      "en": "Which framework standardizes IT service management practices?",
+      "ja": "IT サービスマネジメントのベストプラクティス集は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sprint Planning",
+        "ja": "スプリントプランニング",
+        "ja_typings": [
+          "supurintopurannningu"
+        ]
+      },
+      {
+        "en": "Sprint Review",
+        "ja": "スプリントレビュー",
+        "ja_typings": [
+          "supurintorebyu-"
+        ]
+      },
+      {
+        "en": "Sprint Retrospective",
+        "ja": "スプリントレトロスペクティブ",
+        "ja_typings": [
+          "supurintoretorosupekutibu"
+        ]
+      },
+      {
+        "en": "Daily Scrum",
+        "ja": "デイリースクラム",
+        "ja_typings": [
+          "deiri-sukuramu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02411",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Scrum event begins a sprint by selecting backlog items?",
+      "ja": "バックログを選んでスプリントを開始する Scrum のイベントは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chef",
+        "ja": "Chef",
+        "ja_typings": [
+          "chef"
+        ]
+      },
+      {
+        "en": "Puppet",
+        "ja": "Puppet",
+        "ja_typings": [
+          "puppet"
+        ]
+      },
+      {
+        "en": "Ansible",
+        "ja": "Ansible",
+        "ja_typings": [
+          "ansible"
+        ]
+      },
+      {
+        "en": "Salt",
+        "ja": "Salt",
+        "ja_typings": [
+          "salt"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02412",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Ruby-based configuration management tool defines infrastructure as recipes?",
+      "ja": "Ruby ベースでレシピを書く構成管理ツールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Puppet",
+        "ja": "Puppet",
+        "ja_typings": [
+          "puppet"
+        ]
+      },
+      {
+        "en": "Chef",
+        "ja": "Chef",
+        "ja_typings": [
+          "chef"
+        ]
+      },
+      {
+        "en": "Ansible",
+        "ja": "Ansible",
+        "ja_typings": [
+          "ansible"
+        ]
+      },
+      {
+        "en": "Terraform",
+        "ja": "Terraform",
+        "ja_typings": [
+          "terraform"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02413",
+    "image_path": null,
+    "question_text": {
+      "en": "Which configuration management tool uses a declarative DSL and a pull model?",
+      "ja": "宣言的 DSL とプル型を採用する構成管理ツールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CD",
+        "ja": "CD (継続的デリバリ)",
+        "ja_typings": [
+          "shi-di-"
+        ]
+      },
+      {
+        "en": "CI",
+        "ja": "CI (継続的インテグレーション)",
+        "ja_typings": [
+          "shi-ai"
+        ]
+      },
+      {
+        "en": "QA",
+        "ja": "QA",
+        "ja_typings": [
+          "kyu-e-",
+          "qa"
+        ]
+      },
+      {
+        "en": "BA",
+        "ja": "BA",
+        "ja_typings": [
+          "bi-e-",
+          "ba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02414",
+    "image_path": null,
+    "question_text": {
+      "en": "Which DevOps practice automatically delivers code to production?",
+      "ja": "コードを自動で本番にデリバリする DevOps プラクティスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vagrant",
+        "ja": "Vagrant",
+        "ja_typings": [
+          "vagrant"
+        ]
+      },
+      {
+        "en": "Packer",
+        "ja": "Packer",
+        "ja_typings": [
+          "packer"
+        ]
+      },
+      {
+        "en": "Terraform",
+        "ja": "Terraform",
+        "ja_typings": [
+          "terraform"
+        ]
+      },
+      {
+        "en": "Consul",
+        "ja": "Consul",
+        "ja_typings": [
+          "consul"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02415",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HashiCorp tool manages reproducible developer VMs?",
+      "ja": "再現可能な開発用 VM を管理する HashiCorp のツールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "EBS",
+        "ja": "EBS",
+        "ja_typings": [
+          "i-bi-esu",
+          "ebs"
+        ]
+      },
+      {
+        "en": "EFS",
+        "ja": "EFS",
+        "ja_typings": [
+          "i-efu-esu",
+          "efs"
+        ]
+      },
+      {
+        "en": "S3",
+        "ja": "S3",
+        "ja_typings": [
+          "esu-su-ri-",
+          "s3"
+        ]
+      },
+      {
+        "en": "Glacier",
+        "ja": "Glacier",
+        "ja_typings": [
+          "glacier"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02416",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS service provides block storage volumes for EC2?",
+      "ja": "EC2 にブロックストレージボリュームを提供する AWS のサービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "EFS",
+        "ja": "EFS",
+        "ja_typings": [
+          "i-efu-esu",
+          "efs"
+        ]
+      },
+      {
+        "en": "EBS",
+        "ja": "EBS",
+        "ja_typings": [
+          "i-bi-esu",
+          "ebs"
+        ]
+      },
+      {
+        "en": "S3",
+        "ja": "S3",
+        "ja_typings": [
+          "esu-su-ri-",
+          "s3"
+        ]
+      },
+      {
+        "en": "FSx",
+        "ja": "FSx",
+        "ja_typings": [
+          "efu-esu-ekkusu",
+          "fsx"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02417",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS service provides scalable shared file storage (NFS)?",
+      "ja": "AWS で NFS 互換の共有ファイルストレージを提供するサービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Beanstalk",
+        "ja": "Beanstalk",
+        "ja_typings": [
+          "beanstalk"
+        ]
+      },
+      {
+        "en": "Lambda",
+        "ja": "Lambda",
+        "ja_typings": [
+          "lambda"
+        ]
+      },
+      {
+        "en": "Amplify",
+        "ja": "Amplify",
+        "ja_typings": [
+          "amplify"
+        ]
+      },
+      {
+        "en": "AppRunner",
+        "ja": "AppRunner",
+        "ja_typings": [
+          "apprunner"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02418",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS PaaS deploys apps and handles capacity, load balancing, scaling?",
+      "ja": "AWS でアプリ展開と負荷分散・スケーリングを自動化する PaaS は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Accuracy",
+        "ja": "正解率",
+        "ja_typings": [
+          "seikairitsu"
+        ]
+      },
+      {
+        "en": "Precision",
+        "ja": "適合率",
+        "ja_typings": [
+          "tekigouritsu",
+          "tekigoritsu"
+        ]
+      },
+      {
+        "en": "Recall",
+        "ja": "再現率",
+        "ja_typings": [
+          "saigenritsu"
+        ]
+      },
+      {
+        "en": "F1 score",
+        "ja": "F1スコア",
+        "ja_typings": [
+          "efuwansukoa",
+          "f1sukoa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02419",
+    "image_path": null,
+    "question_text": {
+      "en": "Which metric measures how often predictions are correct?",
+      "ja": "予測の正答率を表す指標は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Authentication",
+        "ja": "認証",
+        "ja_typings": [
+          "ninshou",
+          "nintsho"
+        ]
+      },
+      {
+        "en": "Authorization",
+        "ja": "認可",
+        "ja_typings": [
+          "ninka"
+        ]
+      },
+      {
+        "en": "Auditing",
+        "ja": "監査",
+        "ja_typings": [
+          "kansa"
+        ]
+      },
+      {
+        "en": "Accounting",
+        "ja": "課金",
+        "ja_typings": [
+          "kakin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02420",
+    "image_path": null,
+    "question_text": {
+      "en": "Which security concept verifies the identity of a user?",
+      "ja": "ユーザーの本人確認を行うセキュリティ概念は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Persistence",
+        "ja": "永続性",
+        "ja_typings": [
+          "eizokusei"
+        ]
+      },
+      {
+        "en": "Volatility",
+        "ja": "揮発性",
+        "ja_typings": [
+          "kihatsusei"
+        ]
+      },
+      {
+        "en": "Idempotency",
+        "ja": "冪等性",
+        "ja_typings": [
+          "bekitousei",
+          "bekitosei"
+        ]
+      },
+      {
+        "en": "Consistency",
+        "ja": "整合性",
+        "ja_typings": [
+          "seigousei",
+          "seigosei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02421",
+    "image_path": null,
+    "question_text": {
+      "en": "Which data property describes data surviving after the program ends?",
+      "ja": "プログラム終了後もデータが保持される性質は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Performance",
+        "ja": "性能",
+        "ja_typings": [
+          "seinou",
+          "seino"
+        ]
+      },
+      {
+        "en": "Availability",
+        "ja": "可用性",
+        "ja_typings": [
+          "kayousei",
+          "kayosei"
+        ]
+      },
+      {
+        "en": "Security",
+        "ja": "セキュリティ",
+        "ja_typings": [
+          "sekyuriti"
+        ]
+      },
+      {
+        "en": "Usability",
+        "ja": "使い勝手",
+        "ja_typings": [
+          "tsukaigatte"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02422",
+    "image_path": null,
+    "question_text": {
+      "en": "Which non-functional requirement is about response time and throughput?",
+      "ja": "応答時間やスループットを評価する非機能要件は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Privacy",
+        "ja": "プライバシー",
+        "ja_typings": [
+          "puraibashi-"
+        ]
+      },
+      {
+        "en": "Performance",
+        "ja": "性能",
+        "ja_typings": [
+          "seinou",
+          "seino"
+        ]
+      },
+      {
+        "en": "Reliability",
+        "ja": "信頼性",
+        "ja_typings": [
+          "shinraisei"
+        ]
+      },
+      {
+        "en": "Portability",
+        "ja": "移植性",
+        "ja_typings": [
+          "ishokusei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02423",
+    "image_path": null,
+    "question_text": {
+      "en": "Which non-functional requirement protects personal information?",
+      "ja": "個人情報の保護に関する非機能要件は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DaaS",
+        "ja": "DaaS",
+        "ja_typings": [
+          "da-su",
+          "daas"
+        ]
+      },
+      {
+        "en": "IaaS",
+        "ja": "IaaS",
+        "ja_typings": [
+          "aia-su",
+          "iaas"
+        ]
+      },
+      {
+        "en": "PaaS",
+        "ja": "PaaS",
+        "ja_typings": [
+          "pa-su",
+          "paas"
+        ]
+      },
+      {
+        "en": "SaaS",
+        "ja": "SaaS",
+        "ja_typings": [
+          "sa-su",
+          "saas"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02424",
+    "image_path": null,
+    "question_text": {
+      "en": "Which cloud delivery model provides virtual desktops?",
+      "ja": "仮想デスクトップを提供するクラウドモデルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Iteration",
+        "ja": "イテレーション",
+        "ja_typings": [
+          "itere-shon"
+        ]
+      },
+      {
+        "en": "Sprint Planning",
+        "ja": "スプリントプランニング",
+        "ja_typings": [
+          "supurintopurannningu"
+        ]
+      },
+      {
+        "en": "Standup",
+        "ja": "スタンドアップ",
+        "ja_typings": [
+          "sutandoappu"
+        ]
+      },
+      {
+        "en": "Backlog",
+        "ja": "バックログ",
+        "ja_typings": [
+          "bakkurogu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02425",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Agile term refers to one timeboxed cycle of work?",
+      "ja": "アジャイルで時間枠を区切った1サイクルの作業を指すのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Milestone",
+        "ja": "マイルストーン",
+        "ja_typings": [
+          "mairusuto-n"
+        ]
+      },
+      {
+        "en": "Deliverable",
+        "ja": "成果物",
+        "ja_typings": [
+          "seikabutsu"
+        ]
+      },
+      {
+        "en": "Iteration",
+        "ja": "イテレーション",
+        "ja_typings": [
+          "itere-shon"
+        ]
+      },
+      {
+        "en": "Backlog",
+        "ja": "バックログ",
+        "ja_typings": [
+          "bakkurogu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02426",
+    "image_path": null,
+    "question_text": {
+      "en": "Which project term marks a significant scheduled checkpoint?",
+      "ja": "プロジェクトの重要な節目を示す用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Release",
+        "ja": "リリース",
+        "ja_typings": [
+          "riri-su"
+        ]
+      },
+      {
+        "en": "Build",
+        "ja": "ビルド",
+        "ja_typings": [
+          "birudo"
+        ]
+      },
+      {
+        "en": "Patch",
+        "ja": "パッチ",
+        "ja_typings": [
+          "patchi"
+        ]
+      },
+      {
+        "en": "Snapshot",
+        "ja": "スナップショット",
+        "ja_typings": [
+          "sunappushotto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02427",
+    "image_path": null,
+    "question_text": {
+      "en": "Which event makes a new version of software available to users?",
+      "ja": "ソフトウェアの新版を利用者へ提供することを指すのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Product Owner",
+        "ja": "プロダクトオーナー",
+        "ja_typings": [
+          "purodakuto-na-",
+          "purodakutoo-na-"
+        ]
+      },
+      {
+        "en": "Scrum Master",
+        "ja": "スクラムマスター",
+        "ja_typings": [
+          "sukuramumasuta-"
+        ]
+      },
+      {
+        "en": "Tech Lead",
+        "ja": "テックリード",
+        "ja_typings": [
+          "tekkuri-do"
+        ]
+      },
+      {
+        "en": "Project Manager",
+        "ja": "プロジェクトマネージャー",
+        "ja_typings": [
+          "purojekutomane-ja-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02428",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Scrum role owns the product backlog and prioritization?",
+      "ja": "プロダクトバックログと優先順位を所有する Scrum の役割は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tech Lead",
+        "ja": "テックリード",
+        "ja_typings": [
+          "tekkuri-do"
+        ]
+      },
+      {
+        "en": "Product Owner",
+        "ja": "プロダクトオーナー",
+        "ja_typings": [
+          "purodakuto-na-",
+          "purodakutoo-na-"
+        ]
+      },
+      {
+        "en": "Scrum Master",
+        "ja": "スクラムマスター",
+        "ja_typings": [
+          "sukuramumasuta-"
+        ]
+      },
+      {
+        "en": "Project Manager",
+        "ja": "プロジェクトマネージャー",
+        "ja_typings": [
+          "purojekutomane-ja-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02429",
+    "image_path": null,
+    "question_text": {
+      "en": "Which engineering role leads technical decisions in a team?",
+      "ja": "チームの技術的意思決定を主導するエンジニアの役職は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Project Manager",
+        "ja": "プロジェクトマネージャー",
+        "ja_typings": [
+          "purojekutomane-ja-"
+        ]
+      },
+      {
+        "en": "Product Owner",
+        "ja": "プロダクトオーナー",
+        "ja_typings": [
+          "purodakuto-na-",
+          "purodakutoo-na-"
+        ]
+      },
+      {
+        "en": "Scrum Master",
+        "ja": "スクラムマスター",
+        "ja_typings": [
+          "sukuramumasuta-"
+        ]
+      },
+      {
+        "en": "Tech Lead",
+        "ja": "テックリード",
+        "ja_typings": [
+          "tekkuri-do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02430",
+    "image_path": null,
+    "question_text": {
+      "en": "Which role manages scope, schedule, and budget of a project?",
+      "ja": "プロジェクトの範囲・予定・予算を管理する役割は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MIT",
+        "ja": "MITライセンス",
+        "ja_typings": [
+          "emuaiti-raisensu",
+          "mitraisensu"
+        ]
+      },
+      {
+        "en": "BSD",
+        "ja": "BSDライセンス",
+        "ja_typings": [
+          "bi-esudi-raisensu",
+          "bsdraisensu"
+        ]
+      },
+      {
+        "en": "Apache",
+        "ja": "Apacheライセンス",
+        "ja_typings": [
+          "apatchiraisensu",
+          "apacheraisensu"
+        ]
+      },
+      {
+        "en": "GPL",
+        "ja": "GPL",
+        "ja_typings": [
+          "ji-pi-eru",
+          "gpl"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02431",
+    "image_path": null,
+    "question_text": {
+      "en": "Which permissive open source license is associated with the X Window System?",
+      "ja": "X Window System に由来する寛容なオープンソースライセンスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "BSD",
+        "ja": "BSDライセンス",
+        "ja_typings": [
+          "bi-esudi-raisensu",
+          "bsdraisensu"
+        ]
+      },
+      {
+        "en": "MIT",
+        "ja": "MITライセンス",
+        "ja_typings": [
+          "emuaiti-raisensu",
+          "mitraisensu"
+        ]
+      },
+      {
+        "en": "Apache",
+        "ja": "Apacheライセンス",
+        "ja_typings": [
+          "apatchiraisensu",
+          "apacheraisensu"
+        ]
+      },
+      {
+        "en": "MPL",
+        "ja": "MPL",
+        "ja_typings": [
+          "emupi-eru",
+          "mpl"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02432",
+    "image_path": null,
+    "question_text": {
+      "en": "Which open source license originated with the Berkeley Unix distribution?",
+      "ja": "Berkeley Unix 由来のオープンソースライセンスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Apache",
+        "ja": "Apacheライセンス",
+        "ja_typings": [
+          "apatchiraisensu",
+          "apacheraisensu"
+        ]
+      },
+      {
+        "en": "MIT",
+        "ja": "MITライセンス",
+        "ja_typings": [
+          "emuaiti-raisensu",
+          "mitraisensu"
+        ]
+      },
+      {
+        "en": "BSD",
+        "ja": "BSDライセンス",
+        "ja_typings": [
+          "bi-esudi-raisensu",
+          "bsdraisensu"
+        ]
+      },
+      {
+        "en": "GPL",
+        "ja": "GPL",
+        "ja_typings": [
+          "ji-pi-eru",
+          "gpl"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02433",
+    "image_path": null,
+    "question_text": {
+      "en": "Which open source license version 2.0 has an explicit patent grant?",
+      "ja": "明示的な特許許諾条項を含むオープンソースライセンス2.0は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "AWS",
+        "ja": "AWS",
+        "ja_typings": [
+          "e-daburyu-esu",
+          "aws"
+        ]
+      },
+      {
+        "en": "GCP",
+        "ja": "GCP",
+        "ja_typings": [
+          "ji-shi-pi-",
+          "gcp"
+        ]
+      },
+      {
+        "en": "Azure",
+        "ja": "Azure",
+        "ja_typings": [
+          "azure"
+        ]
+      },
+      {
+        "en": "OCI",
+        "ja": "OCI",
+        "ja_typings": [
+          "o-shi-ai",
+          "oci"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02434",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the largest public cloud provider, run by Amazon?",
+      "ja": "Amazon が運営する最大手のパブリッククラウドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "GCP",
+        "ja": "GCP",
+        "ja_typings": [
+          "ji-shi-pi-",
+          "gcp"
+        ]
+      },
+      {
+        "en": "AWS",
+        "ja": "AWS",
+        "ja_typings": [
+          "e-daburyu-esu",
+          "aws"
+        ]
+      },
+      {
+        "en": "Azure",
+        "ja": "Azure",
+        "ja_typings": [
+          "azure"
+        ]
+      },
+      {
+        "en": "OCI",
+        "ja": "OCI",
+        "ja_typings": [
+          "o-shi-ai",
+          "oci"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02435",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Google public cloud platform competes with AWS and Azure?",
+      "ja": "AWS や Azure と競合する Google のパブリッククラウドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Batch",
+        "ja": "バッチ処理",
+        "ja_typings": [
+          "batchishori"
+        ]
+      },
+      {
+        "en": "Online",
+        "ja": "オンライン処理",
+        "ja_typings": [
+          "onrainshori"
+        ]
+      },
+      {
+        "en": "Stream",
+        "ja": "ストリーム処理",
+        "ja_typings": [
+          "sutori-mushori"
+        ]
+      },
+      {
+        "en": "Realtime",
+        "ja": "リアルタイム処理",
+        "ja_typings": [
+          "riarutaimushori"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02436",
+    "image_path": null,
+    "question_text": {
+      "en": "Which processing mode runs a job collectively at scheduled times?",
+      "ja": "決まった時刻にまとめて処理する方式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NDA",
+        "ja": "NDA",
+        "ja_typings": [
+          "enudi-e-",
+          "nda"
+        ]
+      },
+      {
+        "en": "MOU",
+        "ja": "MOU",
+        "ja_typings": [
+          "emuo-yu-",
+          "mou"
+        ]
+      },
+      {
+        "en": "EULA",
+        "ja": "EULA",
+        "ja_typings": [
+          "yu-ra",
+          "eula"
+        ]
+      },
+      {
+        "en": "SLA",
+        "ja": "SLA",
+        "ja_typings": [
+          "esueruE-",
+          "sla"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02437",
+    "image_path": null,
+    "question_text": {
+      "en": "Which legal agreement prevents disclosure of confidential info?",
+      "ja": "機密情報の開示を禁じる契約は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MOU",
+        "ja": "MOU",
+        "ja_typings": [
+          "emuo-yu-",
+          "mou"
+        ]
+      },
+      {
+        "en": "NDA",
+        "ja": "NDA",
+        "ja_typings": [
+          "enudi-e-",
+          "nda"
+        ]
+      },
+      {
+        "en": "EULA",
+        "ja": "EULA",
+        "ja_typings": [
+          "yu-ra",
+          "eula"
+        ]
+      },
+      {
+        "en": "SLA",
+        "ja": "SLA",
+        "ja_typings": [
+          "esueruE-",
+          "sla"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02438",
+    "image_path": null,
+    "question_text": {
+      "en": "Which non-binding agreement outlines mutual intent between parties?",
+      "ja": "当事者間の意思を確認するための法的拘束力のない覚書は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "EULA",
+        "ja": "EULA",
+        "ja_typings": [
+          "yu-ra",
+          "eula"
+        ]
+      },
+      {
+        "en": "MOU",
+        "ja": "MOU",
+        "ja_typings": [
+          "emuo-yu-",
+          "mou"
+        ]
+      },
+      {
+        "en": "NDA",
+        "ja": "NDA",
+        "ja_typings": [
+          "enudi-e-",
+          "nda"
+        ]
+      },
+      {
+        "en": "SLA",
+        "ja": "SLA",
+        "ja_typings": [
+          "esueruE-",
+          "sla"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02439",
+    "image_path": null,
+    "question_text": {
+      "en": "Which contract is presented to end users for software use?",
+      "ja": "ソフトウェア使用にあたりエンドユーザーに提示される契約は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DevOps",
+        "ja": "DevOps",
+        "ja_typings": [
+          "devops"
+        ]
+      },
+      {
+        "en": "Agile",
+        "ja": "Agile",
+        "ja_typings": [
+          "agile"
+        ]
+      },
+      {
+        "en": "Waterfall",
+        "ja": "Waterfall",
+        "ja_typings": [
+          "waterfall"
+        ]
+      },
+      {
+        "en": "Lean",
+        "ja": "Lean",
+        "ja_typings": [
+          "lean"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02440",
+    "image_path": null,
+    "question_text": {
+      "en": "Which culture unites development and operations teams?",
+      "ja": "開発と運用を統合する文化・運動は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CaC",
+        "ja": "CaC",
+        "ja_typings": [
+          "shi-e-shi-",
+          "cac"
+        ]
+      },
+      {
+        "en": "PaC",
+        "ja": "PaC",
+        "ja_typings": [
+          "pi-e-shi-",
+          "pac"
+        ]
+      },
+      {
+        "en": "DaC",
+        "ja": "DaC",
+        "ja_typings": [
+          "di-e-shi-",
+          "dac"
+        ]
+      },
+      {
+        "en": "IaC",
+        "ja": "IaC",
+        "ja_typings": [
+          "aia-shi-",
+          "iac"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02441",
+    "image_path": null,
+    "question_text": {
+      "en": "Which practice manages configurations declaratively as code?",
+      "ja": "構成情報をコードとして宣言的に管理する手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PaC",
+        "ja": "PaC",
+        "ja_typings": [
+          "pi-e-shi-",
+          "pac"
+        ]
+      },
+      {
+        "en": "CaC",
+        "ja": "CaC",
+        "ja_typings": [
+          "shi-e-shi-",
+          "cac"
+        ]
+      },
+      {
+        "en": "DaC",
+        "ja": "DaC",
+        "ja_typings": [
+          "di-e-shi-",
+          "dac"
+        ]
+      },
+      {
+        "en": "IaC",
+        "ja": "IaC",
+        "ja_typings": [
+          "aia-shi-",
+          "iac"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02442",
+    "image_path": null,
+    "question_text": {
+      "en": "Which practice expresses security policies as code (e.g., OPA)?",
+      "ja": "OPA 等でポリシーをコードとして書く手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DaC",
+        "ja": "DaC",
+        "ja_typings": [
+          "di-e-shi-",
+          "dac"
+        ]
+      },
+      {
+        "en": "CaC",
+        "ja": "CaC",
+        "ja_typings": [
+          "shi-e-shi-",
+          "cac"
+        ]
+      },
+      {
+        "en": "PaC",
+        "ja": "PaC",
+        "ja_typings": [
+          "pi-e-shi-",
+          "pac"
+        ]
+      },
+      {
+        "en": "IaC",
+        "ja": "IaC",
+        "ja_typings": [
+          "aia-shi-",
+          "iac"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02443",
+    "image_path": null,
+    "question_text": {
+      "en": "Which practice manages documentation as code in repositories?",
+      "ja": "ドキュメントをコードのようにリポジトリ管理する手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Trigger",
+        "ja": "トリガー",
+        "ja_typings": [
+          "toriga-"
+        ]
+      },
+      {
+        "en": "View",
+        "ja": "ビュー",
+        "ja_typings": [
+          "byu-"
+        ]
+      },
+      {
+        "en": "Schema",
+        "ja": "スキーマ",
+        "ja_typings": [
+          "suki-ma"
+        ]
+      },
+      {
+        "en": "Index",
+        "ja": "インデックス",
+        "ja_typings": [
+          "indekkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02444",
+    "image_path": null,
+    "question_text": {
+      "en": "Which DB object executes a procedure when a table changes?",
+      "ja": "テーブル変更時に処理を実行する DB オブジェクトは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "View",
+        "ja": "ビュー",
+        "ja_typings": [
+          "byu-"
+        ]
+      },
+      {
+        "en": "Trigger",
+        "ja": "トリガー",
+        "ja_typings": [
+          "toriga-"
+        ]
+      },
+      {
+        "en": "Schema",
+        "ja": "スキーマ",
+        "ja_typings": [
+          "suki-ma"
+        ]
+      },
+      {
+        "en": "Sequence",
+        "ja": "シーケンス",
+        "ja_typings": [
+          "shi-kensu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02445",
+    "image_path": null,
+    "question_text": {
+      "en": "Which DB object is a virtual table from a stored query?",
+      "ja": "クエリから生成される仮想表である DB オブジェクトは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Schema",
+        "ja": "スキーマ",
+        "ja_typings": [
+          "suki-ma"
+        ]
+      },
+      {
+        "en": "View",
+        "ja": "ビュー",
+        "ja_typings": [
+          "byu-"
+        ]
+      },
+      {
+        "en": "Trigger",
+        "ja": "トリガー",
+        "ja_typings": [
+          "toriga-"
+        ]
+      },
+      {
+        "en": "Index",
+        "ja": "インデックス",
+        "ja_typings": [
+          "indekkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02446",
+    "image_path": null,
+    "question_text": {
+      "en": "Which DB term names the overall structure of tables and relations?",
+      "ja": "テーブルと関係の全体構造を示す DB 用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NewSQL",
+        "ja": "NewSQL",
+        "ja_typings": [
+          "nyu-esukyu-eru",
+          "newsql"
+        ]
+      },
+      {
+        "en": "NoSQL",
+        "ja": "NoSQL",
+        "ja_typings": [
+          "no-esukyu-eru",
+          "nosql"
+        ]
+      },
+      {
+        "en": "OLAP",
+        "ja": "OLAP",
+        "ja_typings": [
+          "o-rappu",
+          "olap"
+        ]
+      },
+      {
+        "en": "OLTP",
+        "ja": "OLTP",
+        "ja_typings": [
+          "o-rutipi-",
+          "oltp"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02447",
+    "image_path": null,
+    "question_text": {
+      "en": "Which class of databases combines SQL with horizontal scalability?",
+      "ja": "SQL と水平スケールを両立させる新世代 DB は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "OLAP",
+        "ja": "OLAP",
+        "ja_typings": [
+          "o-rappu",
+          "olap"
+        ]
+      },
+      {
+        "en": "OLTP",
+        "ja": "OLTP",
+        "ja_typings": [
+          "o-rutipi-",
+          "oltp"
+        ]
+      },
+      {
+        "en": "NewSQL",
+        "ja": "NewSQL",
+        "ja_typings": [
+          "nyu-esukyu-eru",
+          "newsql"
+        ]
+      },
+      {
+        "en": "NoSQL",
+        "ja": "NoSQL",
+        "ja_typings": [
+          "no-esukyu-eru",
+          "nosql"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02448",
+    "image_path": null,
+    "question_text": {
+      "en": "Which workload type emphasizes analytical multi-dimensional queries?",
+      "ja": "多次元分析クエリ向けのワークロード種別は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "OLTP",
+        "ja": "OLTP",
+        "ja_typings": [
+          "o-rutipi-",
+          "oltp"
+        ]
+      },
+      {
+        "en": "OLAP",
+        "ja": "OLAP",
+        "ja_typings": [
+          "o-rappu",
+          "olap"
+        ]
+      },
+      {
+        "en": "NewSQL",
+        "ja": "NewSQL",
+        "ja_typings": [
+          "nyu-esukyu-eru",
+          "newsql"
+        ]
+      },
+      {
+        "en": "NoSQL",
+        "ja": "NoSQL",
+        "ja_typings": [
+          "no-esukyu-eru",
+          "nosql"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02449",
+    "image_path": null,
+    "question_text": {
+      "en": "Which workload type handles many short, transactional operations?",
+      "ja": "短時間のトランザクション処理を多数こなすワークロードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HIPAA",
+        "ja": "HIPAA",
+        "ja_typings": [
+          "hipa-",
+          "hipaa"
+        ]
+      },
+      {
+        "en": "CCPA",
+        "ja": "CCPA",
+        "ja_typings": [
+          "shi-shi-pi-e-",
+          "ccpa"
+        ]
+      },
+      {
+        "en": "SOX",
+        "ja": "SOX",
+        "ja_typings": [
+          "sokkusu",
+          "sox"
+        ]
+      },
+      {
+        "en": "GDPR",
+        "ja": "GDPR",
+        "ja_typings": [
+          "ji-di-pi-a-ru",
+          "gdpr"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02450",
+    "image_path": null,
+    "question_text": {
+      "en": "Which US law protects health information privacy?",
+      "ja": "アメリカで医療情報のプライバシーを守る法律は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CCPA",
+        "ja": "CCPA",
+        "ja_typings": [
+          "shi-shi-pi-e-",
+          "ccpa"
+        ]
+      },
+      {
+        "en": "HIPAA",
+        "ja": "HIPAA",
+        "ja_typings": [
+          "hipa-",
+          "hipaa"
+        ]
+      },
+      {
+        "en": "SOX",
+        "ja": "SOX",
+        "ja_typings": [
+          "sokkusu",
+          "sox"
+        ]
+      },
+      {
+        "en": "GDPR",
+        "ja": "GDPR",
+        "ja_typings": [
+          "ji-di-pi-a-ru",
+          "gdpr"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02451",
+    "image_path": null,
+    "question_text": {
+      "en": "Which California law protects consumer data rights?",
+      "ja": "カリフォルニア州の消費者データ保護法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SOX",
+        "ja": "SOX",
+        "ja_typings": [
+          "sokkusu",
+          "sox"
+        ]
+      },
+      {
+        "en": "HIPAA",
+        "ja": "HIPAA",
+        "ja_typings": [
+          "hipa-",
+          "hipaa"
+        ]
+      },
+      {
+        "en": "CCPA",
+        "ja": "CCPA",
+        "ja_typings": [
+          "shi-shi-pi-e-",
+          "ccpa"
+        ]
+      },
+      {
+        "en": "GDPR",
+        "ja": "GDPR",
+        "ja_typings": [
+          "ji-di-pi-a-ru",
+          "gdpr"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q02452",
+    "image_path": null,
+    "question_text": {
+      "en": "Which US law tightens corporate financial reporting after Enron?",
+      "ja": "エンロン事件後に施行されたアメリカの企業会計改革法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FTP",
+        "ja": "FTP",
+        "ja_typings": [
+          "efuti-pi-",
+          "ftp"
+        ]
+      },
+      {
+        "en": "SFTP",
+        "ja": "SFTP",
+        "ja_typings": [
+          "esuefuti-pi-",
+          "sftp"
+        ]
+      },
+      {
+        "en": "FTPS",
+        "ja": "FTPS",
+        "ja_typings": [
+          "efuti-pi-esu",
+          "ftps"
+        ]
+      },
+      {
+        "en": "TFTP",
+        "ja": "TFTP",
+        "ja_typings": [
+          "ti-efuti-pi-",
+          "tftp"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02453",
+    "image_path": null,
+    "question_text": {
+      "en": "Which file transfer protocol uses plain text and ports 20/21?",
+      "ja": "ポート20/21を使う平文ファイル転送プロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "16 bits",
+        "ja": "16ビット",
+        "ja_typings": [
+          "ju-rokubitto",
+          "16bitto"
+        ]
+      },
+      {
+        "en": "8 bits",
+        "ja": "8ビット",
+        "ja_typings": [
+          "hachibitto",
+          "8bitto"
+        ]
+      },
+      {
+        "en": "32 bits",
+        "ja": "32ビット",
+        "ja_typings": [
+          "sanju-nibitto",
+          "32bitto"
+        ]
+      },
+      {
+        "en": "64 bits",
+        "ja": "64ビット",
+        "ja_typings": [
+          "rokuju-yonbitto",
+          "64bitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02454",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CPU register width was standard for Intel 8086?",
+      "ja": "Intel 8086 の標準的なレジスタ幅は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "64 bits",
+        "ja": "64ビット",
+        "ja_typings": [
+          "rokuju-yonbitto",
+          "64bitto"
+        ]
+      },
+      {
+        "en": "32 bits",
+        "ja": "32ビット",
+        "ja_typings": [
+          "sanju-nibitto",
+          "32bitto"
+        ]
+      },
+      {
+        "en": "16 bits",
+        "ja": "16ビット",
+        "ja_typings": [
+          "ju-rokubitto",
+          "16bitto"
+        ]
+      },
+      {
+        "en": "128 bits",
+        "ja": "128ビット",
+        "ja_typings": [
+          "hyakunijuhachibitto",
+          "128bitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02455",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CPU register width is standard for modern x86_64 / ARM64?",
+      "ja": "現代の x86_64 や ARM64 で標準のレジスタ幅は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MD5",
+        "ja": "MD5",
+        "ja_typings": [
+          "emudi-go",
+          "md5"
+        ]
+      },
+      {
+        "en": "SHA-1",
+        "ja": "SHA-1",
+        "ja_typings": [
+          "esuetchie-ichi",
+          "sha-1"
+        ]
+      },
+      {
+        "en": "SHA-256",
+        "ja": "SHA-256",
+        "ja_typings": [
+          "esuetchie-nigorokuju-roku",
+          "sha-256"
+        ]
+      },
+      {
+        "en": "CRC32",
+        "ja": "CRC32",
+        "ja_typings": [
+          "shi-a-ru-shi-sanjuni",
+          "crc32"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02456",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 128-bit hash function is now considered broken?",
+      "ja": "現在では衝突攻撃に弱い128ビットのハッシュ関数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "POP3",
+        "ja": "POP3",
+        "ja_typings": [
+          "popputsuri-",
+          "pop3"
+        ]
+      },
+      {
+        "en": "IMAP",
+        "ja": "IMAP",
+        "ja_typings": [
+          "aimappu",
+          "imap"
+        ]
+      },
+      {
+        "en": "SMTP",
+        "ja": "SMTP",
+        "ja_typings": [
+          "esuemuti-pi-",
+          "smtp"
+        ]
+      },
+      {
+        "en": "MAPI",
+        "ja": "MAPI",
+        "ja_typings": [
+          "mapi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02457",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol retrieves email by downloading from server (legacy)?",
+      "ja": "メールをダウンロードして取得する旧来の受信プロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SATA",
+        "ja": "SATA",
+        "ja_typings": [
+          "sata"
+        ]
+      },
+      {
+        "en": "SCSI",
+        "ja": "SCSI",
+        "ja_typings": [
+          "sukajii",
+          "scsi"
+        ]
+      },
+      {
+        "en": "PATA",
+        "ja": "PATA",
+        "ja_typings": [
+          "pata"
+        ]
+      },
+      {
+        "en": "eSATA",
+        "ja": "eSATA",
+        "ja_typings": [
+          "i-sata",
+          "esata"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02458",
+    "image_path": null,
+    "question_text": {
+      "en": "Which serial interface connects hard drives in PCs?",
+      "ja": "PC で HDD を接続する内蔵シリアルインタフェースは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "22",
+        "ja": "ポート22",
+        "ja_typings": [
+          "po-toniju-ni",
+          "po-to22"
+        ]
+      },
+      {
+        "en": "21",
+        "ja": "ポート21",
+        "ja_typings": [
+          "po-tonijuichi",
+          "po-to21"
+        ]
+      },
+      {
+        "en": "23",
+        "ja": "ポート23",
+        "ja_typings": [
+          "po-toniju-san",
+          "po-to23"
+        ]
+      },
+      {
+        "en": "25",
+        "ja": "ポート25",
+        "ja_typings": [
+          "po-tonijugo",
+          "po-to25"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02459",
+    "image_path": null,
+    "question_text": {
+      "en": "Which TCP port does SSH use by default?",
+      "ja": "SSH が既定で使う TCP ポートは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ROM",
+        "ja": "ROM",
+        "ja_typings": [
+          "romu",
+          "rom"
+        ]
+      },
+      {
+        "en": "RAM",
+        "ja": "RAM",
+        "ja_typings": [
+          "ramu",
+          "ram"
+        ]
+      },
+      {
+        "en": "Cache",
+        "ja": "キャッシュ",
+        "ja_typings": [
+          "kyasshu"
+        ]
+      },
+      {
+        "en": "Register",
+        "ja": "レジスタ",
+        "ja_typings": [
+          "rejisuta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02460",
+    "image_path": null,
+    "question_text": {
+      "en": "Which memory type can only be read, not modified at runtime?",
+      "ja": "実行時に書き換えできず読み出し専用のメモリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shell",
+        "ja": "シェル",
+        "ja_typings": [
+          "sheru"
+        ]
+      },
+      {
+        "en": "Kernel",
+        "ja": "カーネル",
+        "ja_typings": [
+          "ka-neru"
+        ]
+      },
+      {
+        "en": "Driver",
+        "ja": "ドライバ",
+        "ja_typings": [
+          "doraiba"
+        ]
+      },
+      {
+        "en": "Daemon",
+        "ja": "デーモン",
+        "ja_typings": [
+          "de-mon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02461",
+    "image_path": null,
+    "question_text": {
+      "en": "Which OS component provides a command-line interface?",
+      "ja": "コマンドライン操作を提供する OS の構成要素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "VPN",
+        "ja": "VPN",
+        "ja_typings": [
+          "bui-pi-enu",
+          "vpn"
+        ]
+      },
+      {
+        "en": "DNS",
+        "ja": "DNS",
+        "ja_typings": [
+          "di-enu-esu",
+          "dns"
+        ]
+      },
+      {
+        "en": "VLAN",
+        "ja": "VLAN",
+        "ja_typings": [
+          "buiran",
+          "vlan"
+        ]
+      },
+      {
+        "en": "NAT",
+        "ja": "NAT",
+        "ja_typings": [
+          "natto",
+          "nat"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02462",
+    "image_path": null,
+    "question_text": {
+      "en": "Which technology creates an encrypted tunnel over a public network?",
+      "ja": "公衆網上に暗号化トンネルを作る技術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SNMP",
+        "ja": "SNMP",
+        "ja_typings": [
+          "esuenuemupi-",
+          "snmp"
+        ]
+      },
+      {
+        "en": "SMTP",
+        "ja": "SMTP",
+        "ja_typings": [
+          "esuemuti-pi-",
+          "smtp"
+        ]
+      },
+      {
+        "en": "ICMP",
+        "ja": "ICMP",
+        "ja_typings": [
+          "aishi-emupi-",
+          "icmp"
+        ]
+      },
+      {
+        "en": "NTP",
+        "ja": "NTP",
+        "ja_typings": [
+          "enuti-pi-",
+          "ntp"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02463",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol monitors and manages network devices?",
+      "ja": "ネットワーク機器の監視・管理に使うプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ECC",
+        "ja": "ECCメモリ",
+        "ja_typings": [
+          "i-shi-shi-memori",
+          "eccmemori"
+        ]
+      },
+      {
+        "en": "DDR",
+        "ja": "DDRメモリ",
+        "ja_typings": [
+          "di-di-a-rumemori",
+          "ddrmemori"
+        ]
+      },
+      {
+        "en": "SRAM",
+        "ja": "SRAM",
+        "ja_typings": [
+          "esuramu",
+          "sram"
+        ]
+      },
+      {
+        "en": "Flash",
+        "ja": "Flashメモリ",
+        "ja_typings": [
+          "furasshumemori",
+          "flashmemori"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02464",
+    "image_path": null,
+    "question_text": {
+      "en": "Which memory technology detects and corrects single-bit errors?",
+      "ja": "1ビット誤りを検出・訂正できるメモリ技術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ZFS",
+        "ja": "ZFS",
+        "ja_typings": [
+          "zetto-efu-esu",
+          "zfs"
+        ]
+      },
+      {
+        "en": "Btrfs",
+        "ja": "Btrfs",
+        "ja_typings": [
+          "bata-efu-esu",
+          "btrfs"
+        ]
+      },
+      {
+        "en": "XFS",
+        "ja": "XFS",
+        "ja_typings": [
+          "ekkusu-efu-esu",
+          "xfs"
+        ]
+      },
+      {
+        "en": "ext4",
+        "ja": "ext4",
+        "ja_typings": [
+          "ikusutoyon",
+          "ext4"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02465",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Sun-originated filesystem features copy-on-write and snapshots?",
+      "ja": "Sun 発のコピーオンライトとスナップショットを持つファイルシステムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "exFAT",
+        "ja": "exFAT",
+        "ja_typings": [
+          "ekkusufatto",
+          "exfat"
+        ]
+      },
+      {
+        "en": "FAT32",
+        "ja": "FAT32",
+        "ja_typings": [
+          "fattosanjuni",
+          "fat32"
+        ]
+      },
+      {
+        "en": "NTFS",
+        "ja": "NTFS",
+        "ja_typings": [
+          "enuti-efu-esu",
+          "ntfs"
+        ]
+      },
+      {
+        "en": "ext4",
+        "ja": "ext4",
+        "ja_typings": [
+          "ikusutoyon",
+          "ext4"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02466",
+    "image_path": null,
+    "question_text": {
+      "en": "Which filesystem extends FAT for large flash drives beyond 32GB?",
+      "ja": "32GB を超える大型フラッシュ向けに FAT を拡張したファイルシステムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Intel",
+        "ja": "Intel",
+        "ja_typings": [
+          "interu",
+          "intel"
+        ]
+      },
+      {
+        "en": "AMD",
+        "ja": "AMD",
+        "ja_typings": [
+          "e-emudi-",
+          "amd"
+        ]
+      },
+      {
+        "en": "VIA",
+        "ja": "VIA",
+        "ja_typings": [
+          "bia",
+          "via"
+        ]
+      },
+      {
+        "en": "Cyrix",
+        "ja": "Cyrix",
+        "ja_typings": [
+          "sairikkusu",
+          "cyrix"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02467",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the largest x86 CPU vendor with brands like Core and Xeon?",
+      "ja": "Core や Xeon を擁する最大の x86 CPU メーカーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "x86",
+        "ja": "x86",
+        "ja_typings": [
+          "ekkusuhachiroku",
+          "x86"
+        ]
+      },
+      {
+        "en": "ARM",
+        "ja": "ARM",
+        "ja_typings": [
+          "a-mu",
+          "arm"
+        ]
+      },
+      {
+        "en": "MIPS",
+        "ja": "MIPS",
+        "ja_typings": [
+          "mippusu",
+          "mips"
+        ]
+      },
+      {
+        "en": "RISC-V",
+        "ja": "RISC-V",
+        "ja_typings": [
+          "risukubu~i",
+          "risukubui-",
+          "risc-v"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02468",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CISC instruction set architecture is used by Intel and AMD?",
+      "ja": "Intel や AMD が採用する CISC 命令セットアーキテクチャは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MIPS",
+        "ja": "MIPS",
+        "ja_typings": [
+          "mippusu",
+          "mips"
+        ]
+      },
+      {
+        "en": "SPARC",
+        "ja": "SPARC",
+        "ja_typings": [
+          "supa-ku",
+          "sparc"
+        ]
+      },
+      {
+        "en": "PowerPC",
+        "ja": "PowerPC",
+        "ja_typings": [
+          "pawa-pi-shi-",
+          "powerpc"
+        ]
+      },
+      {
+        "en": "Alpha",
+        "ja": "Alpha",
+        "ja_typings": [
+          "arufa",
+          "alpha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02469",
+    "image_path": null,
+    "question_text": {
+      "en": "Which RISC architecture originated at Stanford in the 1980s?",
+      "ja": "1980年代にスタンフォードで生まれた RISC アーキテクチャは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SPARC",
+        "ja": "SPARC",
+        "ja_typings": [
+          "supa-ku",
+          "sparc"
+        ]
+      },
+      {
+        "en": "MIPS",
+        "ja": "MIPS",
+        "ja_typings": [
+          "mippusu",
+          "mips"
+        ]
+      },
+      {
+        "en": "PowerPC",
+        "ja": "PowerPC",
+        "ja_typings": [
+          "pawa-pi-shi-",
+          "powerpc"
+        ]
+      },
+      {
+        "en": "Alpha",
+        "ja": "Alpha",
+        "ja_typings": [
+          "arufa",
+          "alpha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02470",
+    "image_path": null,
+    "question_text": {
+      "en": "Which RISC architecture was developed by Sun Microsystems?",
+      "ja": "Sun Microsystems が開発した RISC アーキテクチャは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "VGA",
+        "ja": "VGA",
+        "ja_typings": [
+          "bui-ji-e-",
+          "vga"
+        ]
+      },
+      {
+        "en": "XGA",
+        "ja": "XGA",
+        "ja_typings": [
+          "ekkusuji-e-",
+          "xga"
+        ]
+      },
+      {
+        "en": "SVGA",
+        "ja": "SVGA",
+        "ja_typings": [
+          "esubui-ji-e-",
+          "svga"
+        ]
+      },
+      {
+        "en": "CGA",
+        "ja": "CGA",
+        "ja_typings": [
+          "shi-ji-e-",
+          "cga"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02471",
+    "image_path": null,
+    "question_text": {
+      "en": "Which video display standard introduced 640x480 resolution on PCs?",
+      "ja": "PC で 640x480 解像度を一般化したビデオ規格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wi-Fi",
+        "ja": "Wi-Fi",
+        "ja_typings": [
+          "waifai",
+          "wi-fi"
+        ]
+      },
+      {
+        "en": "Bluetooth",
+        "ja": "Bluetooth",
+        "ja_typings": [
+          "buru-tu-su",
+          "bluetooth"
+        ]
+      },
+      {
+        "en": "Zigbee",
+        "ja": "Zigbee",
+        "ja_typings": [
+          "jigubi-",
+          "zigbee"
+        ]
+      },
+      {
+        "en": "LTE",
+        "ja": "LTE",
+        "ja_typings": [
+          "eruti-i-",
+          "lte"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02472",
+    "image_path": null,
+    "question_text": {
+      "en": "Which wireless standard is based on IEEE 802.11?",
+      "ja": "IEEE 802.11 を基にした無線 LAN 規格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "IMAP",
+        "ja": "IMAP",
+        "ja_typings": [
+          "aimappu",
+          "imap"
+        ]
+      },
+      {
+        "en": "POP3",
+        "ja": "POP3",
+        "ja_typings": [
+          "popputsuri-",
+          "pop3"
+        ]
+      },
+      {
+        "en": "SMTP",
+        "ja": "SMTP",
+        "ja_typings": [
+          "esuemuti-pi-",
+          "smtp"
+        ]
+      },
+      {
+        "en": "MAPI",
+        "ja": "MAPI",
+        "ja_typings": [
+          "mapi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02473",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mail protocol synchronizes messages across multiple devices?",
+      "ja": "複数端末でメッセージを同期するメール受信プロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SCSI",
+        "ja": "SCSI",
+        "ja_typings": [
+          "sukajii",
+          "scsi"
+        ]
+      },
+      {
+        "en": "SATA",
+        "ja": "SATA",
+        "ja_typings": [
+          "sata"
+        ]
+      },
+      {
+        "en": "PATA",
+        "ja": "PATA",
+        "ja_typings": [
+          "pata"
+        ]
+      },
+      {
+        "en": "PCIe",
+        "ja": "PCIe",
+        "ja_typings": [
+          "pi-shi-ai-i-",
+          "pcie"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02474",
+    "image_path": null,
+    "question_text": {
+      "en": "Which parallel interface historically connected enterprise disks and scanners?",
+      "ja": "業務用ディスクやスキャナを接続したパラレルインタフェースは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "port 21",
+        "ja": "ポート21",
+        "ja_typings": [
+          "po-tonijuichi",
+          "po-to21"
+        ]
+      },
+      {
+        "en": "port 22",
+        "ja": "ポート22",
+        "ja_typings": [
+          "po-toniju-ni",
+          "po-to22"
+        ]
+      },
+      {
+        "en": "port 23",
+        "ja": "ポート23",
+        "ja_typings": [
+          "po-toniju-san",
+          "po-to23"
+        ]
+      },
+      {
+        "en": "port 25",
+        "ja": "ポート25",
+        "ja_typings": [
+          "po-tonijugo",
+          "po-to25"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02475",
+    "image_path": null,
+    "question_text": {
+      "en": "Which TCP port is used for the FTP control connection?",
+      "ja": "FTP の制御コネクションに使われる TCP ポートは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "23",
+        "ja": "ポート23",
+        "ja_typings": [
+          "po-toniju-san",
+          "po-to23"
+        ]
+      },
+      {
+        "en": "22",
+        "ja": "ポート22",
+        "ja_typings": [
+          "po-toniju-ni",
+          "po-to22"
+        ]
+      },
+      {
+        "en": "21",
+        "ja": "ポート21",
+        "ja_typings": [
+          "po-tonijuichi",
+          "po-to21"
+        ]
+      },
+      {
+        "en": "25",
+        "ja": "ポート25",
+        "ja_typings": [
+          "po-tonijugo",
+          "po-to25"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02476",
+    "image_path": null,
+    "question_text": {
+      "en": "Which TCP port does Telnet use by default?",
+      "ja": "Telnet が既定で使う TCP ポートは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "WebSocket",
+        "ja": "WebSocket",
+        "ja_typings": [
+          "websocket"
+        ]
+      },
+      {
+        "en": "HTTP",
+        "ja": "HTTP",
+        "ja_typings": [
+          "etchi-ti-ti-pi-",
+          "http"
+        ]
+      },
+      {
+        "en": "gRPC",
+        "ja": "gRPC",
+        "ja_typings": [
+          "ji-a-ru-pi-shi-",
+          "grpc"
+        ]
+      },
+      {
+        "en": "MQTT",
+        "ja": "MQTT",
+        "ja_typings": [
+          "emukyu-ti-ti-",
+          "mqtt"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02477",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol enables full-duplex communication over a single TCP connection?",
+      "ja": "単一の TCP 接続で全二重通信を行うプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "TPU",
+        "ja": "TPU",
+        "ja_typings": [
+          "ti-pi-yu-",
+          "tpu"
+        ]
+      },
+      {
+        "en": "GPU",
+        "ja": "GPU",
+        "ja_typings": [
+          "ji-pi-yu-",
+          "gpu"
+        ]
+      },
+      {
+        "en": "CPU",
+        "ja": "CPU",
+        "ja_typings": [
+          "shi-pi-yu-",
+          "cpu"
+        ]
+      },
+      {
+        "en": "FPGA",
+        "ja": "FPGA",
+        "ja_typings": [
+          "efupi-ji-e-",
+          "fpga"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02478",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Google chip accelerates tensor computations for ML?",
+      "ja": "Google が機械学習用に開発したテンソル演算アクセラレータは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DSP",
+        "ja": "DSP",
+        "ja_typings": [
+          "di-esu-pi-",
+          "dsp"
+        ]
+      },
+      {
+        "en": "GPU",
+        "ja": "GPU",
+        "ja_typings": [
+          "ji-pi-yu-",
+          "gpu"
+        ]
+      },
+      {
+        "en": "CPU",
+        "ja": "CPU",
+        "ja_typings": [
+          "shi-pi-yu-",
+          "cpu"
+        ]
+      },
+      {
+        "en": "MCU",
+        "ja": "MCU",
+        "ja_typings": [
+          "emu-shi-yu-",
+          "mcu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02479",
+    "image_path": null,
+    "question_text": {
+      "en": "Which specialized processor handles signal processing tasks?",
+      "ja": "信号処理に特化した専用プロセッサは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "USB flash drive",
+        "ja": "USBメモリ",
+        "ja_typings": [
+          "yu-esubi-memori",
+          "usbmemori"
+        ]
+      },
+      {
+        "en": "Optical disc",
+        "ja": "光ディスク",
+        "ja_typings": [
+          "hikaridisuku"
+        ]
+      },
+      {
+        "en": "FDD",
+        "ja": "FDD",
+        "ja_typings": [
+          "efu-di-di-",
+          "fdd"
+        ]
+      },
+      {
+        "en": "MO",
+        "ja": "MO",
+        "ja_typings": [
+          "emu-o-",
+          "mo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02480",
+    "image_path": null,
+    "question_text": {
+      "en": "Which portable storage device uses NAND flash and USB?",
+      "ja": "NAND フラッシュと USB を使う携帯型ストレージは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Optical disc",
+        "ja": "光ディスク",
+        "ja_typings": [
+          "hikaridisuku"
+        ]
+      },
+      {
+        "en": "USB flash drive",
+        "ja": "USBメモリ",
+        "ja_typings": [
+          "yu-esubi-memori",
+          "usbmemori"
+        ]
+      },
+      {
+        "en": "FDD",
+        "ja": "FDD",
+        "ja_typings": [
+          "efu-di-di-",
+          "fdd"
+        ]
+      },
+      {
+        "en": "HDD",
+        "ja": "HDD",
+        "ja_typings": [
+          "etchi-di-di-",
+          "hdd"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02481",
+    "image_path": null,
+    "question_text": {
+      "en": "Which storage uses lasers to read pits (e.g., CD, DVD)?",
+      "ja": "レーザーでピットを読み取る光学記憶媒体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FDD",
+        "ja": "FDD",
+        "ja_typings": [
+          "efu-di-di-",
+          "fdd"
+        ]
+      },
+      {
+        "en": "HDD",
+        "ja": "HDD",
+        "ja_typings": [
+          "etchi-di-di-",
+          "hdd"
+        ]
+      },
+      {
+        "en": "MO",
+        "ja": "MO",
+        "ja_typings": [
+          "emu-o-",
+          "mo"
+        ]
+      },
+      {
+        "en": "ZIP",
+        "ja": "ZIP",
+        "ja_typings": [
+          "jippu",
+          "zip"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02482",
+    "image_path": null,
+    "question_text": {
+      "en": "Which legacy 3.5-inch removable magnetic storage was common in the 90s?",
+      "ja": "90年代に普及した3.5インチの磁気フロッピーディスク装置は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MO",
+        "ja": "MO",
+        "ja_typings": [
+          "emu-o-",
+          "mo"
+        ]
+      },
+      {
+        "en": "FDD",
+        "ja": "FDD",
+        "ja_typings": [
+          "efu-di-di-",
+          "fdd"
+        ]
+      },
+      {
+        "en": "ZIP",
+        "ja": "ZIP",
+        "ja_typings": [
+          "jippu",
+          "zip"
+        ]
+      },
+      {
+        "en": "DAT",
+        "ja": "DAT",
+        "ja_typings": [
+          "datto",
+          "dat"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02483",
+    "image_path": null,
+    "question_text": {
+      "en": "Which magneto-optical removable disc was popular in Japan in the 90s?",
+      "ja": "90年代の日本で普及した光磁気ディスクは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Driver",
+        "ja": "ドライバ",
+        "ja_typings": [
+          "doraiba"
+        ]
+      },
+      {
+        "en": "Compiler",
+        "ja": "コンパイラ",
+        "ja_typings": [
+          "konpaira"
+        ]
+      },
+      {
+        "en": "Daemon",
+        "ja": "デーモン",
+        "ja_typings": [
+          "de-mon"
+        ]
+      },
+      {
+        "en": "Shell",
+        "ja": "シェル",
+        "ja_typings": [
+          "sheru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02484",
+    "image_path": null,
+    "question_text": {
+      "en": "Which software lets the OS communicate with hardware devices?",
+      "ja": "OS がハードウェアと通信するためのソフトウェアは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Library",
+        "ja": "ライブラリ",
+        "ja_typings": [
+          "raiburari"
+        ]
+      },
+      {
+        "en": "Framework",
+        "ja": "フレームワーク",
+        "ja_typings": [
+          "fure-muwa-ku"
+        ]
+      },
+      {
+        "en": "Module",
+        "ja": "モジュール",
+        "ja_typings": [
+          "moju-ru"
+        ]
+      },
+      {
+        "en": "Plugin",
+        "ja": "プラグイン",
+        "ja_typings": [
+          "puraguin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02485",
+    "image_path": null,
+    "question_text": {
+      "en": "Which reusable code collection can be linked into programs?",
+      "ja": "プログラムにリンクして再利用するコードの集合は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Daemon",
+        "ja": "デーモン",
+        "ja_typings": [
+          "de-mon"
+        ]
+      },
+      {
+        "en": "Driver",
+        "ja": "ドライバ",
+        "ja_typings": [
+          "doraiba"
+        ]
+      },
+      {
+        "en": "Shell",
+        "ja": "シェル",
+        "ja_typings": [
+          "sheru"
+        ]
+      },
+      {
+        "en": "Service",
+        "ja": "サービス",
+        "ja_typings": [
+          "sa-bisu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02486",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Unix term names a background service process?",
+      "ja": "Unix でバックグラウンドサービスを指す用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Compiler",
+        "ja": "コンパイラ",
+        "ja_typings": [
+          "konpaira"
+        ]
+      },
+      {
+        "en": "Interpreter",
+        "ja": "インタプリタ",
+        "ja_typings": [
+          "intapurita"
+        ]
+      },
+      {
+        "en": "Linker",
+        "ja": "リンカ",
+        "ja_typings": [
+          "rinka"
+        ]
+      },
+      {
+        "en": "Assembler",
+        "ja": "アセンブラ",
+        "ja_typings": [
+          "asenbura"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02487",
+    "image_path": null,
+    "question_text": {
+      "en": "Which tool translates source code into machine code?",
+      "ja": "ソースコードを機械語に変換するツールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Repository",
+        "ja": "リポジトリ",
+        "ja_typings": [
+          "ripojitori"
+        ]
+      },
+      {
+        "en": "Branch",
+        "ja": "ブランチ",
+        "ja_typings": [
+          "buranchi"
+        ]
+      },
+      {
+        "en": "Tag",
+        "ja": "タグ",
+        "ja_typings": [
+          "tagu"
+        ]
+      },
+      {
+        "en": "Commit",
+        "ja": "コミット",
+        "ja_typings": [
+          "komitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02488",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Git term names a storage location for project history?",
+      "ja": "Git でプロジェクト履歴を格納する場所を指す用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Debugger",
+        "ja": "デバッガ",
+        "ja_typings": [
+          "debagga"
+        ]
+      },
+      {
+        "en": "Compiler",
+        "ja": "コンパイラ",
+        "ja_typings": [
+          "konpaira"
+        ]
+      },
+      {
+        "en": "Profiler",
+        "ja": "プロファイラ",
+        "ja_typings": [
+          "purofaira"
+        ]
+      },
+      {
+        "en": "Linker",
+        "ja": "リンカ",
+        "ja_typings": [
+          "rinka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02489",
+    "image_path": null,
+    "question_text": {
+      "en": "Which tool steps through code to find bugs?",
+      "ja": "プログラムを段階実行してバグを見つけるツールは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fiber",
+        "ja": "光ファイバ",
+        "ja_typings": [
+          "hikarifaiba"
+        ]
+      },
+      {
+        "en": "Coaxial cable",
+        "ja": "同軸ケーブル",
+        "ja_typings": [
+          "doujikuke-buru",
+          "dojikuke-buru"
+        ]
+      },
+      {
+        "en": "Twisted pair",
+        "ja": "ツイストペア",
+        "ja_typings": [
+          "tsuisutopea"
+        ]
+      },
+      {
+        "en": "Wireless",
+        "ja": "無線",
+        "ja_typings": [
+          "musen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02490",
+    "image_path": null,
+    "question_text": {
+      "en": "Which medium carries data as light pulses through glass strands?",
+      "ja": "ガラス繊維を通る光パルスでデータを伝える媒体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Container",
+        "ja": "コンテナ",
+        "ja_typings": [
+          "kontena"
+        ]
+      },
+      {
+        "en": "VM",
+        "ja": "VM",
+        "ja_typings": [
+          "bui-emu",
+          "vm"
+        ]
+      },
+      {
+        "en": "Jail",
+        "ja": "Jail",
+        "ja_typings": [
+          "jail"
+        ]
+      },
+      {
+        "en": "Sandbox",
+        "ja": "サンドボックス",
+        "ja_typings": [
+          "sandobokkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02491",
+    "image_path": null,
+    "question_text": {
+      "en": "Which OS-level virtualization unit packages an app with its deps?",
+      "ja": "アプリと依存関係をまとめる OS レベル仮想化の単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Switch",
+        "ja": "スイッチ",
+        "ja_typings": [
+          "suitchi"
+        ]
+      },
+      {
+        "en": "Hub",
+        "ja": "ハブ",
+        "ja_typings": [
+          "habu"
+        ]
+      },
+      {
+        "en": "Router",
+        "ja": "ルーター",
+        "ja_typings": [
+          "ru-ta-"
+        ]
+      },
+      {
+        "en": "Repeater",
+        "ja": "リピータ",
+        "ja_typings": [
+          "ripi-ta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02492",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Ethernet device forwards frames using MAC addresses?",
+      "ja": "MAC アドレスでフレームを転送するイーサネット機器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hub",
+        "ja": "ハブ",
+        "ja_typings": [
+          "habu"
+        ]
+      },
+      {
+        "en": "Switch",
+        "ja": "スイッチ",
+        "ja_typings": [
+          "suitchi"
+        ]
+      },
+      {
+        "en": "Router",
+        "ja": "ルーター",
+        "ja_typings": [
+          "ru-ta-"
+        ]
+      },
+      {
+        "en": "Bridge",
+        "ja": "ブリッジ",
+        "ja_typings": [
+          "burijji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02493",
+    "image_path": null,
+    "question_text": {
+      "en": "Which legacy device broadcasts all incoming traffic to every port?",
+      "ja": "受信した信号を全ポートに送出する旧式の機器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Repeater",
+        "ja": "リピータ",
+        "ja_typings": [
+          "ripi-ta"
+        ]
+      },
+      {
+        "en": "Switch",
+        "ja": "スイッチ",
+        "ja_typings": [
+          "suitchi"
+        ]
+      },
+      {
+        "en": "Hub",
+        "ja": "ハブ",
+        "ja_typings": [
+          "habu"
+        ]
+      },
+      {
+        "en": "Modem",
+        "ja": "モデム",
+        "ja_typings": [
+          "modemu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02494",
+    "image_path": null,
+    "question_text": {
+      "en": "Which device regenerates signals to extend a network's reach?",
+      "ja": "信号を増幅・整形してネットワーク到達距離を伸ばす機器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "256 bits",
+        "ja": "256ビット",
+        "ja_typings": [
+          "nigorokuju-rokubitto",
+          "256bitto"
+        ]
+      },
+      {
+        "en": "128 bits",
+        "ja": "128ビット",
+        "ja_typings": [
+          "hyakunijuhachibitto",
+          "128bitto"
+        ]
+      },
+      {
+        "en": "192 bits",
+        "ja": "192ビット",
+        "ja_typings": [
+          "hyakukyuju-nibitto",
+          "192bitto"
+        ]
+      },
+      {
+        "en": "512 bits",
+        "ja": "512ビット",
+        "ja_typings": [
+          "gohyakuju-nibitto",
+          "512bitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02495",
+    "image_path": null,
+    "question_text": {
+      "en": "Which key length is standard for AES-256?",
+      "ja": "AES-256 で使われる鍵長は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Symmetric-key cryptography",
+        "ja": "共通鍵暗号",
+        "ja_typings": [
+          "kyoutsuukagiangou",
+          "kyotsukagiango"
+        ]
+      },
+      {
+        "en": "Public-key cryptography",
+        "ja": "公開鍵暗号",
+        "ja_typings": [
+          "koukaikagiangou",
+          "kokaikagiango"
+        ]
+      },
+      {
+        "en": "Hash function",
+        "ja": "ハッシュ関数",
+        "ja_typings": [
+          "hasshukansu-"
+        ]
+      },
+      {
+        "en": "Quantum cryptography",
+        "ja": "量子暗号",
+        "ja_typings": [
+          "ryoushiangou",
+          "ryoshiango"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02496",
+    "image_path": null,
+    "question_text": {
+      "en": "Which class of cryptography uses one shared key for encrypt and decrypt?",
+      "ja": "暗号化と復号に同じ鍵を使う暗号方式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Steganography",
+        "ja": "ステガノグラフィー",
+        "ja_typings": [
+          "suteganogurafi-"
+        ]
+      },
+      {
+        "en": "Cryptography",
+        "ja": "暗号",
+        "ja_typings": [
+          "angou",
+          "ango"
+        ]
+      },
+      {
+        "en": "Hashing",
+        "ja": "ハッシュ",
+        "ja_typings": [
+          "hasshu"
+        ]
+      },
+      {
+        "en": "Encoding",
+        "ja": "エンコーディング",
+        "ja_typings": [
+          "enko-dingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02497",
+    "image_path": null,
+    "question_text": {
+      "en": "Which technique hides messages inside other media (e.g., images)?",
+      "ja": "画像などに情報を隠す技術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DES",
+        "ja": "DES",
+        "ja_typings": [
+          "di-i-esu",
+          "des"
+        ]
+      },
+      {
+        "en": "AES",
+        "ja": "AES",
+        "ja_typings": [
+          "e-i-esu",
+          "aes"
+        ]
+      },
+      {
+        "en": "RSA",
+        "ja": "RSA",
+        "ja_typings": [
+          "a-ru-esu-e-",
+          "rsa"
+        ]
+      },
+      {
+        "en": "Blowfish",
+        "ja": "Blowfish",
+        "ja_typings": [
+          "blowfish"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02498",
+    "image_path": null,
+    "question_text": {
+      "en": "Which now-deprecated symmetric block cipher uses a 56-bit key?",
+      "ja": "56ビット鍵を使う旧式の対称ブロック暗号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SHA",
+        "ja": "SHA",
+        "ja_typings": [
+          "esuetchie-",
+          "sha"
+        ]
+      },
+      {
+        "en": "MD5",
+        "ja": "MD5",
+        "ja_typings": [
+          "emudi-go",
+          "md5"
+        ]
+      },
+      {
+        "en": "CRC",
+        "ja": "CRC",
+        "ja_typings": [
+          "shi-a-ru-shi-",
+          "crc"
+        ]
+      },
+      {
+        "en": "HMAC",
+        "ja": "HMAC",
+        "ja_typings": [
+          "etchi-makku",
+          "hmac"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02499",
+    "image_path": null,
+    "question_text": {
+      "en": "Which family of cryptographic hash functions includes -1, -256, -512?",
+      "ja": "-1 や -256 などのバリアントを持つ暗号ハッシュ関数群は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Compression algorithm",
+        "ja": "圧縮アルゴリズム",
+        "ja_typings": [
+          "asshukuarugorizumu"
+        ]
+      },
+      {
+        "en": "Encryption algorithm",
+        "ja": "暗号化アルゴリズム",
+        "ja_typings": [
+          "angoukaarugorizumu",
+          "angokaarugorizumu"
+        ]
+      },
+      {
+        "en": "Hash function",
+        "ja": "ハッシュ関数",
+        "ja_typings": [
+          "hasshukansu-"
+        ]
+      },
+      {
+        "en": "Sorting algorithm",
+        "ja": "ソートアルゴリズム",
+        "ja_typings": [
+          "so-toarugorizumu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02500",
+    "image_path": null,
+    "question_text": {
+      "en": "Which kind of algorithm reduces data size for storage or transmission?",
+      "ja": "保存や伝送のためにデータサイズを小さくするアルゴリズムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Digital signature",
+        "ja": "デジタル署名",
+        "ja_typings": [
+          "dejitarushomei"
+        ]
+      },
+      {
+        "en": "Hash function",
+        "ja": "ハッシュ関数",
+        "ja_typings": [
+          "hasshukansu-"
+        ]
+      },
+      {
+        "en": "Symmetric cipher",
+        "ja": "対称暗号",
+        "ja_typings": [
+          "taishouangou",
+          "taishoango"
+        ]
+      },
+      {
+        "en": "Checksum",
+        "ja": "チェックサム",
+        "ja_typings": [
+          "chekkusamu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02501",
+    "image_path": null,
+    "question_text": {
+      "en": "Which cryptographic technique proves message authenticity using a key pair?",
+      "ja": "鍵ペアを用いてメッセージの真正性を証明する技術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Random number generator",
+        "ja": "乱数生成器",
+        "ja_typings": [
+          "ransuuseiseiki",
+          "ransuseiseiki"
+        ]
+      },
+      {
+        "en": "Hash function",
+        "ja": "ハッシュ関数",
+        "ja_typings": [
+          "hasshukansu-"
+        ]
+      },
+      {
+        "en": "Cipher",
+        "ja": "暗号",
+        "ja_typings": [
+          "angou",
+          "ango"
+        ]
+      },
+      {
+        "en": "Counter",
+        "ja": "カウンタ",
+        "ja_typings": [
+          "kaunta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q02502",
+    "image_path": null,
+    "question_text": {
+      "en": "Which component produces sequences for cryptography and simulations?",
+      "ja": "暗号やシミュレーションに使う列を生成する装置は?"
+    }
   }
 ]


### PR DESCRIPTION
## Summary
Issue #116 の本来目的「誤答単語を正解とする問題を作って暗記戦略を防ぐ」に特化したラウンド。

## カバレッジ
元の 735 問の誤答ユニーク 1891 件のうち、新規問題で正解化されたもの:

| | before round3 | after round3 |
|---|---|---|
| 全体 | 151/1891 (8%) | **719/1891 (38%)** |

ジャンル別:
| genre | covered |
|---|---|
| manga | 68% |
| language | 61% |
| it_terminology | 59% |
| culture | 54% |
| science | 51% |
| vtuber_net_culture | 45% |
| technology | 43% |
| math | 40% |
| general_knowledge | 35% |
| web_development | 33% |
| programming | 27% |
| anime | 26% |
| game | 25% |
| geography | 25% |
| history | 21% |

## 問題数推移
735 → 1768 (PR #117) → **2502** (本PR、+734問)

## Test plan
- [x] lint-questions: 0 conflicts, 0 errors
- [x] cargo test --release: 236 passed
- [x] backfill-ja-typing 通過

## 関連
- Issue #116 の本来目的に向けた継続作業
- PR #117 の続編