### PR TITLE
feat: Round 4 — 低カバレッジ8ジャンル特化 (+819問、2502→3321)

### DIFF
--- a/data/questions_en.json
+++ b/data/questions_en.json
@@ -30989,7 +30989,7 @@
         "en": "Linear A",
         "ja": "線文字A",
         "ja_typings": [
-          "senmojiA"
+          "senmojia"
         ]
       },
       {
@@ -45905,7 +45905,7 @@
         "ja": "咲-Saki-",
         "ja_typings": [
           "saki",
-          "saki-Saki-"
+          "saki-saki-"
         ]
       },
       {
@@ -50304,7 +50304,7 @@
         "en": "C++20",
         "ja": "シープラプラニジュウ",
         "ja_typings": [
-          "C++20",
+          "c++20",
           "shi-purapuranijuu"
         ]
       },
@@ -50312,7 +50312,7 @@
         "en": "C++17",
         "ja": "シープラプラジュウナナ",
         "ja_typings": [
-          "C++17",
+          "c++17",
           "shi-purapurajuunana"
         ]
       },
@@ -50320,7 +50320,7 @@
         "en": "C++14",
         "ja": "シープラプラジュウヨン",
         "ja_typings": [
-          "C++14",
+          "c++14",
           "shi-purapurajuuyon"
         ]
       },
@@ -50328,7 +50328,7 @@
         "en": "C++11",
         "ja": "シープラプラジュウイチ",
         "ja_typings": [
-          "C++11",
+          "c++11",
           "shi-purapurajuuichi"
         ]
       }
@@ -50588,7 +50588,7 @@
         "en": "O(n^2)",
         "ja": "オーエヌジジョウ",
         "ja_typings": [
-          "O(n^2)",
+          "o(n^2)",
           "o-enujijo",
           "o-enujijou"
         ]
@@ -50597,7 +50597,7 @@
         "en": "O(n log n)",
         "ja": "オーエヌログエヌ",
         "ja_typings": [
-          "O(n log n)",
+          "o(n log n)",
           "o-enuroguenu"
         ]
       },
@@ -50605,7 +50605,7 @@
         "en": "O(1)",
         "ja": "オーイチ",
         "ja_typings": [
-          "O(1)",
+          "o(1)",
           "o-ichi"
         ]
       },
@@ -50613,7 +50613,7 @@
         "en": "O(log n)",
         "ja": "オーログエヌ",
         "ja_typings": [
-          "O(log n)",
+          "o(log n)",
           "o-roguenu"
         ]
       }
@@ -53975,7 +53975,7 @@
         "en": "RFC 3986 strict",
         "ja": "アールエフシーサンキュウハチロクストリクト",
         "ja_typings": [
-          "RFC 3986 strict",
+          "rfc 3986 strict",
           "a-ruefushi-sankyuuhachirokusutorikuto"
         ]
       },
@@ -54433,7 +54433,7 @@
         "en": "Layzner",
         "ja": "蒼き流星SPTレイズナー",
         "ja_typings": [
-          "aokiryuuseiSPTreizunaa"
+          "aokiryuuseisptreizunaa"
         ]
       }
     ],
@@ -54452,7 +54452,7 @@
         "en": "Patlabor: The Movie",
         "ja": "機動警察パトレイバー the Movie",
         "ja_typings": [
-          "kidoukeisatsupatoreibaatheMovie"
+          "kidoukeisatsupatoreibaathemovie"
         ]
       },
       {
@@ -54553,7 +54553,7 @@
         "en": "Lensman",
         "ja": "SF新世紀レンズマン",
         "ja_typings": [
-          "SFshinseikirenzuman"
+          "sfshinseikirenzuman"
         ]
       }
     ],
@@ -54701,7 +54701,7 @@
         "en": "Lupin III Part 2",
         "ja": "ルパン三世 PART2",
         "ja_typings": [
-          "rupansansei PART2"
+          "rupansansei part2"
         ]
       },
       {
@@ -55142,7 +55142,7 @@
         "en": "Wolf Children",
         "ja": "おおかみこどもの雨と雪",
         "ja_typings": [
-          "ookamikodomonoameToyuki"
+          "ookamikodomonoametoyuki"
         ]
       },
       {
@@ -55455,7 +55455,7 @@
         "en": "Kyoto Animation",
         "ja": "京都アニメーション",
         "ja_typings": [
-          "kyouToanimeeshon"
+          "kyoutoanimeeshon"
         ]
       },
       {
@@ -55502,7 +55502,7 @@
         "en": "Kyoto Animation",
         "ja": "京都アニメーション",
         "ja_typings": [
-          "kyouToanimeeshon"
+          "kyoutoanimeeshon"
         ]
       },
       {
@@ -63524,7 +63524,7 @@
         "en": "P vs NP",
         "ja": "P対NP問題",
         "ja_typings": [
-          "P tai NP mondai"
+          "p tai np mondai"
         ]
       },
       {
@@ -63725,7 +63725,7 @@
         "en": "A4",
         "ja": "A4群",
         "ja_typings": [
-          "A4gun"
+          "a4gun"
         ]
       },
       {
@@ -65926,7 +65926,7 @@
         "en": "a derpy Pepe emote",
         "ja": "間抜けなPepeエモート",
         "ja_typings": [
-          "manukenaPepeemo-to"
+          "manukenapepeemo-to"
         ]
       },
       {
@@ -78724,8 +78724,8 @@
         "en": "AVL tree",
         "ja": "AVL 木",
         "ja_typings": [
-          "AVLki",
-          "AVLgi"
+          "avlki",
+          "avlgi"
         ]
       }
     ],
@@ -96924,8 +96924,8 @@
         "en": "Ohara",
         "ja": "小原流",
         "ja_typings": [
-          "oharaRyuu",
-          "oharaRyu"
+          "ohararyuu",
+          "ohararyu"
         ]
       },
       {
@@ -98622,7 +98622,7 @@
         "en": "SLA",
         "ja": "SLA",
         "ja_typings": [
-          "esueruE-",
+          "esuerue-",
           "sla"
         ]
       }
@@ -98666,7 +98666,7 @@
         "en": "SLA",
         "ja": "SLA",
         "ja_typings": [
-          "esueruE-",
+          "esuerue-",
           "sla"
         ]
       }
@@ -98710,7 +98710,7 @@
         "en": "SLA",
         "ja": "SLA",
         "ja_typings": [
-          "esueruE-",
+          "esuerue-",
           "sla"
         ]
       }
@@ -101409,6 +101409,33663 @@
     "question_text": {
       "en": "Which component produces sequences for cryptography and simulations?",
       "ja": "暗号やシミュレーションに使う列を生成する装置は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Alexandria",
+        "ja": "アレクサンドリア",
+        "ja_typings": [
+          "arekusandoria"
+        ]
+      },
+      {
+        "en": "Cairo",
+        "ja": "カイロ",
+        "ja_typings": [
+          "kairo"
+        ]
+      },
+      {
+        "en": "Luxor",
+        "ja": "ルクソール",
+        "ja_typings": [
+          "rukuso-ru"
+        ]
+      },
+      {
+        "en": "Aswan",
+        "ja": "アスワン",
+        "ja_typings": [
+          "asuwan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02503",
+    "image_path": null,
+    "question_text": {
+      "en": "エジプトの地中海沿岸に位置し、古代に大図書館があった都市は?",
+      "ja": "Which Egyptian city on the Mediterranean coast was home to a famous ancient library?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Amazon River",
+        "ja": "アマゾン川",
+        "ja_typings": [
+          "amazongawa",
+          "amazonkawa"
+        ]
+      },
+      {
+        "en": "Nile River",
+        "ja": "ナイル川",
+        "ja_typings": [
+          "nairugawa",
+          "nairukawa"
+        ]
+      },
+      {
+        "en": "Mississippi River",
+        "ja": "ミシシッピ川",
+        "ja_typings": [
+          "mishishippigawa",
+          "mishishippikawa"
+        ]
+      },
+      {
+        "en": "Yangtze River",
+        "ja": "長江",
+        "ja_typings": [
+          "chouko",
+          "choukou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02504",
+    "image_path": null,
+    "question_text": {
+      "en": "南米大陸を流れる世界最大級の流域面積を持つ川は?",
+      "ja": "Which river in South America has one of the largest drainage basins in the world?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Arctic Ocean",
+        "ja": "北極海",
+        "ja_typings": [
+          "hokkyokukai"
+        ]
+      },
+      {
+        "en": "Atlantic Ocean",
+        "ja": "大西洋",
+        "ja_typings": [
+          "taiseiyou"
+        ]
+      },
+      {
+        "en": "Indian Ocean",
+        "ja": "インド洋",
+        "ja_typings": [
+          "indoyou"
+        ]
+      },
+      {
+        "en": "Pacific Ocean",
+        "ja": "太平洋",
+        "ja_typings": [
+          "taiheiyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02505",
+    "image_path": null,
+    "question_text": {
+      "en": "地球で最も北に位置する海洋は?",
+      "ja": "Which is the northernmost ocean on Earth?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Asahikawa",
+        "ja": "旭川",
+        "ja_typings": [
+          "asahikawa"
+        ]
+      },
+      {
+        "en": "Sapporo",
+        "ja": "札幌",
+        "ja_typings": [
+          "sapporo"
+        ]
+      },
+      {
+        "en": "Hakodate",
+        "ja": "函館",
+        "ja_typings": [
+          "hakodate"
+        ]
+      },
+      {
+        "en": "Kushiro",
+        "ja": "釧路",
+        "ja_typings": [
+          "kushiro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02506",
+    "image_path": null,
+    "question_text": {
+      "en": "北海道のほぼ中央にあり、上川盆地に位置する都市は?",
+      "ja": "Which Hokkaido city is located in the Kamikawa Basin near the center of the island?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Asia",
+        "ja": "アジア",
+        "ja_typings": [
+          "ajia"
+        ]
+      },
+      {
+        "en": "Africa",
+        "ja": "アフリカ",
+        "ja_typings": [
+          "afurika"
+        ]
+      },
+      {
+        "en": "Europe",
+        "ja": "ヨーロッパ",
+        "ja_typings": [
+          "yo-roppa"
+        ]
+      },
+      {
+        "en": "Oceania",
+        "ja": "オセアニア",
+        "ja_typings": [
+          "oseania"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02507",
+    "image_path": null,
+    "question_text": {
+      "en": "世界で最も広い大陸は?",
+      "ja": "Which is the largest continent in the world?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Asuncion",
+        "ja": "アスンシオン",
+        "ja_typings": [
+          "asunshion"
+        ]
+      },
+      {
+        "en": "Montevideo",
+        "ja": "モンテビデオ",
+        "ja_typings": [
+          "montebideo"
+        ]
+      },
+      {
+        "en": "La Paz",
+        "ja": "ラパス",
+        "ja_typings": [
+          "rapasu"
+        ]
+      },
+      {
+        "en": "Lima",
+        "ja": "リマ",
+        "ja_typings": [
+          "rima"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02508",
+    "image_path": null,
+    "question_text": {
+      "en": "パラグアイの首都は?",
+      "ja": "What is the capital of Paraguay?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Atlantic Ocean",
+        "ja": "大西洋",
+        "ja_typings": [
+          "taiseiyou"
+        ]
+      },
+      {
+        "en": "Pacific Ocean",
+        "ja": "太平洋",
+        "ja_typings": [
+          "taiheiyou"
+        ]
+      },
+      {
+        "en": "Indian Ocean",
+        "ja": "インド洋",
+        "ja_typings": [
+          "indoyou"
+        ]
+      },
+      {
+        "en": "Arctic Ocean",
+        "ja": "北極海",
+        "ja_typings": [
+          "hokkyokukai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02509",
+    "image_path": null,
+    "question_text": {
+      "en": "ヨーロッパとアメリカ大陸の間に広がる海洋は?",
+      "ja": "Which ocean lies between Europe and the Americas?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Atlas Mountains",
+        "ja": "アトラス山脈",
+        "ja_typings": [
+          "atorasusanmyaku"
+        ]
+      },
+      {
+        "en": "Alps",
+        "ja": "アルプス山脈",
+        "ja_typings": [
+          "arupususanmyaku"
+        ]
+      },
+      {
+        "en": "Andes",
+        "ja": "アンデス山脈",
+        "ja_typings": [
+          "andesusanmyaku"
+        ]
+      },
+      {
+        "en": "Caucasus Mountains",
+        "ja": "コーカサス山脈",
+        "ja_typings": [
+          "ko-kasasusanmyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02510",
+    "image_path": null,
+    "question_text": {
+      "en": "北アフリカを横断する大山脈は?",
+      "ja": "Which mountain range stretches across North Africa?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bangalore",
+        "ja": "バンガロール",
+        "ja_typings": [
+          "bangaro-ru"
+        ]
+      },
+      {
+        "en": "Mumbai",
+        "ja": "ムンバイ",
+        "ja_typings": [
+          "munbai"
+        ]
+      },
+      {
+        "en": "Kolkata",
+        "ja": "コルカタ",
+        "ja_typings": [
+          "korukata"
+        ]
+      },
+      {
+        "en": "Delhi",
+        "ja": "デリー",
+        "ja_typings": [
+          "deri-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02511",
+    "image_path": null,
+    "question_text": {
+      "en": "インドのIT産業の中心地として知られる都市は?",
+      "ja": "Which Indian city is known as the center of the IT industry?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Barcelona",
+        "ja": "バルセロナ",
+        "ja_typings": [
+          "baruserona"
+        ]
+      },
+      {
+        "en": "Madrid",
+        "ja": "マドリード",
+        "ja_typings": [
+          "madori-do"
+        ]
+      },
+      {
+        "en": "Seville",
+        "ja": "セビリア",
+        "ja_typings": [
+          "sebiria"
+        ]
+      },
+      {
+        "en": "Valencia",
+        "ja": "バレンシア",
+        "ja_typings": [
+          "barenshia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02512",
+    "image_path": null,
+    "question_text": {
+      "en": "サグラダ・ファミリアがあるスペイン東部の都市は?",
+      "ja": "Which city in eastern Spain is home to the Sagrada Familia?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Berlin",
+        "ja": "ベルリン",
+        "ja_typings": [
+          "berurin"
+        ]
+      },
+      {
+        "en": "Munich",
+        "ja": "ミュンヘン",
+        "ja_typings": [
+          "myunhen"
+        ]
+      },
+      {
+        "en": "Hamburg",
+        "ja": "ハンブルク",
+        "ja_typings": [
+          "hanburuku"
+        ]
+      },
+      {
+        "en": "Frankfurt",
+        "ja": "フランクフルト",
+        "ja_typings": [
+          "furankufuruto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02513",
+    "image_path": null,
+    "question_text": {
+      "en": "ドイツの首都は?",
+      "ja": "What is the capital of Germany?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bhutan",
+        "ja": "ブータン",
+        "ja_typings": [
+          "bu-tan"
+        ]
+      },
+      {
+        "en": "Nepal",
+        "ja": "ネパール",
+        "ja_typings": [
+          "nepa-ru"
+        ]
+      },
+      {
+        "en": "India",
+        "ja": "インド",
+        "ja_typings": [
+          "indo"
+        ]
+      },
+      {
+        "en": "Bangladesh",
+        "ja": "バングラデシュ",
+        "ja_typings": [
+          "banguradeshu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02514",
+    "image_path": null,
+    "question_text": {
+      "en": "ヒマラヤ山脈にある「幸福度」で知られる国は?",
+      "ja": "Which Himalayan country is known for its focus on Gross National Happiness?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Borneo",
+        "ja": "ボルネオ島",
+        "ja_typings": [
+          "boruneotou",
+          "boruneoshima"
+        ]
+      },
+      {
+        "en": "Sumatra",
+        "ja": "スマトラ島",
+        "ja_typings": [
+          "sumatoratou",
+          "sumatorashima"
+        ]
+      },
+      {
+        "en": "Java",
+        "ja": "ジャワ島",
+        "ja_typings": [
+          "jawatou",
+          "jawashima"
+        ]
+      },
+      {
+        "en": "New Guinea",
+        "ja": "ニューギニア島",
+        "ja_typings": [
+          "nyu-gineatou",
+          "nyu-gineashima"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02515",
+    "image_path": null,
+    "question_text": {
+      "en": "東南アジアにある世界で3番目に大きい島は?",
+      "ja": "Which is the third largest island in the world, located in Southeast Asia?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Brazil and Argentina",
+        "ja": "ブラジルとアルゼンチン",
+        "ja_typings": [
+          "burajirutoaruzenchin"
+        ]
+      },
+      {
+        "en": "Chile and Peru",
+        "ja": "チリとペルー",
+        "ja_typings": [
+          "chiritoperu-"
+        ]
+      },
+      {
+        "en": "Colombia and Venezuela",
+        "ja": "コロンビアとベネズエラ",
+        "ja_typings": [
+          "koronbiatobenezuera"
+        ]
+      },
+      {
+        "en": "Bolivia and Paraguay",
+        "ja": "ボリビアとパラグアイ",
+        "ja_typings": [
+          "boribiatoparaguai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02516",
+    "image_path": null,
+    "question_text": {
+      "en": "イグアスの滝が国境にある国の組み合わせは?",
+      "ja": "Iguazu Falls lies on the border between which two countries?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Buenos Aires",
+        "ja": "ブエノスアイレス",
+        "ja_typings": [
+          "buenosuairesu"
+        ]
+      },
+      {
+        "en": "Santiago",
+        "ja": "サンティアゴ",
+        "ja_typings": [
+          "santiago"
+        ]
+      },
+      {
+        "en": "Montevideo",
+        "ja": "モンテビデオ",
+        "ja_typings": [
+          "montebideo"
+        ]
+      },
+      {
+        "en": "Asuncion",
+        "ja": "アスンシオン",
+        "ja_typings": [
+          "asunshion"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02517",
+    "image_path": null,
+    "question_text": {
+      "en": "アルゼンチンの首都は?",
+      "ja": "What is the capital of Argentina?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bursa",
+        "ja": "ブルサ",
+        "ja_typings": [
+          "burusa"
+        ]
+      },
+      {
+        "en": "Izmir",
+        "ja": "イズミル",
+        "ja_typings": [
+          "izumiru"
+        ]
+      },
+      {
+        "en": "Ankara",
+        "ja": "アンカラ",
+        "ja_typings": [
+          "ankara"
+        ]
+      },
+      {
+        "en": "Konya",
+        "ja": "コンヤ",
+        "ja_typings": [
+          "konnya"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02518",
+    "image_path": null,
+    "question_text": {
+      "en": "トルコ北西部の旧オスマン帝国首都として知られる都市は?",
+      "ja": "Which northwestern Turkish city was a former capital of the Ottoman Empire?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Busan",
+        "ja": "プサン",
+        "ja_typings": [
+          "pusan"
+        ]
+      },
+      {
+        "en": "Incheon",
+        "ja": "インチョン",
+        "ja_typings": [
+          "inchon"
+        ]
+      },
+      {
+        "en": "Daegu",
+        "ja": "テグ",
+        "ja_typings": [
+          "tegu"
+        ]
+      },
+      {
+        "en": "Gwangju",
+        "ja": "クァンジュ",
+        "ja_typings": [
+          "kuanju"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02519",
+    "image_path": null,
+    "question_text": {
+      "en": "韓国第2の都市で南東部の主要港湾都市は?",
+      "ja": "Which is South Korea's second largest city and a major southeastern port?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cancun",
+        "ja": "カンクン",
+        "ja_typings": [
+          "kankun"
+        ]
+      },
+      {
+        "en": "Acapulco",
+        "ja": "アカプルコ",
+        "ja_typings": [
+          "akapuruko"
+        ]
+      },
+      {
+        "en": "Tijuana",
+        "ja": "ティフアナ",
+        "ja_typings": [
+          "tifuana"
+        ]
+      },
+      {
+        "en": "Veracruz",
+        "ja": "ベラクルス",
+        "ja_typings": [
+          "berakurusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02520",
+    "image_path": null,
+    "question_text": {
+      "en": "メキシコ・ユカタン半島のリゾート都市は?",
+      "ja": "Which resort city is on Mexico's Yucatan Peninsula?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Caspian Sea shore",
+        "ja": "カスピ海沿岸",
+        "ja_typings": [
+          "kasupikaiengan"
+        ]
+      },
+      {
+        "en": "Black Sea shore",
+        "ja": "黒海沿岸",
+        "ja_typings": [
+          "kokkaiengan"
+        ]
+      },
+      {
+        "en": "Mediterranean coast",
+        "ja": "地中海沿岸",
+        "ja_typings": [
+          "chichuukaiengan"
+        ]
+      },
+      {
+        "en": "Red Sea shore",
+        "ja": "紅海沿岸",
+        "ja_typings": [
+          "koukaiengan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02521",
+    "image_path": null,
+    "question_text": {
+      "en": "アゼルバイジャンのバクーがあるのは?",
+      "ja": "Baku, the capital of Azerbaijan, is located on which shore?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Caucasus Mountains",
+        "ja": "コーカサス山脈",
+        "ja_typings": [
+          "ko-kasasusanmyaku"
+        ]
+      },
+      {
+        "en": "Ural Mountains",
+        "ja": "ウラル山脈",
+        "ja_typings": [
+          "ururusanmyaku"
+        ]
+      },
+      {
+        "en": "Atlas Mountains",
+        "ja": "アトラス山脈",
+        "ja_typings": [
+          "atorasusanmyaku"
+        ]
+      },
+      {
+        "en": "Pyrenees",
+        "ja": "ピレネー山脈",
+        "ja_typings": [
+          "pirene-sanmyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02522",
+    "image_path": null,
+    "question_text": {
+      "en": "黒海とカスピ海の間に広がる山脈は?",
+      "ja": "Which mountain range lies between the Black Sea and the Caspian Sea?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chicago",
+        "ja": "シカゴ",
+        "ja_typings": [
+          "shikago"
+        ]
+      },
+      {
+        "en": "Detroit",
+        "ja": "デトロイト",
+        "ja_typings": [
+          "detoroito"
+        ]
+      },
+      {
+        "en": "Cleveland",
+        "ja": "クリーブランド",
+        "ja_typings": [
+          "kuri-burando"
+        ]
+      },
+      {
+        "en": "Milwaukee",
+        "ja": "ミルウォーキー",
+        "ja_typings": [
+          "miruwo-ki-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02523",
+    "image_path": null,
+    "question_text": {
+      "en": "アメリカ五大湖のミシガン湖畔に位置する都市は?",
+      "ja": "Which U.S. city is located on the shore of Lake Michigan?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Corinth",
+        "ja": "コリント",
+        "ja_typings": [
+          "korinto"
+        ]
+      },
+      {
+        "en": "Sparta",
+        "ja": "スパルタ",
+        "ja_typings": [
+          "suparuta"
+        ]
+      },
+      {
+        "en": "Thebes",
+        "ja": "テーベ",
+        "ja_typings": [
+          "te-be"
+        ]
+      },
+      {
+        "en": "Athens",
+        "ja": "アテネ",
+        "ja_typings": [
+          "atene"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02524",
+    "image_path": null,
+    "question_text": {
+      "en": "ペロポネソス半島の付け根にある古代ギリシャの都市は?",
+      "ja": "Which ancient Greek city stood at the isthmus of the Peloponnese?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Da Nang",
+        "ja": "ダナン",
+        "ja_typings": [
+          "danan"
+        ]
+      },
+      {
+        "en": "Hue",
+        "ja": "フエ",
+        "ja_typings": [
+          "fue"
+        ]
+      },
+      {
+        "en": "Hanoi",
+        "ja": "ハノイ",
+        "ja_typings": [
+          "hanoi"
+        ]
+      },
+      {
+        "en": "Ho Chi Minh City",
+        "ja": "ホーチミン",
+        "ja_typings": [
+          "ho-chimin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02525",
+    "image_path": null,
+    "question_text": {
+      "en": "ベトナム中部の主要港湾都市は?",
+      "ja": "Which city is a major port in central Vietnam?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dublin",
+        "ja": "ダブリン",
+        "ja_typings": [
+          "daburin"
+        ]
+      },
+      {
+        "en": "Belfast",
+        "ja": "ベルファスト",
+        "ja_typings": [
+          "berufasuto"
+        ]
+      },
+      {
+        "en": "Cork",
+        "ja": "コーク",
+        "ja_typings": [
+          "ko-ku"
+        ]
+      },
+      {
+        "en": "Galway",
+        "ja": "ゴールウェイ",
+        "ja_typings": [
+          "go-ruwei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02526",
+    "image_path": null,
+    "question_text": {
+      "en": "アイルランドの首都は?",
+      "ja": "What is the capital of Ireland?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Edinburgh",
+        "ja": "エディンバラ",
+        "ja_typings": [
+          "edinbara"
+        ]
+      },
+      {
+        "en": "Glasgow",
+        "ja": "グラスゴー",
+        "ja_typings": [
+          "gurasugo-"
+        ]
+      },
+      {
+        "en": "Aberdeen",
+        "ja": "アバディーン",
+        "ja_typings": [
+          "abadi-n"
+        ]
+      },
+      {
+        "en": "Dundee",
+        "ja": "ダンディー",
+        "ja_typings": [
+          "dandi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02527",
+    "image_path": null,
+    "question_text": {
+      "en": "スコットランドの首都は?",
+      "ja": "What is the capital of Scotland?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Florence",
+        "ja": "フィレンツェ",
+        "ja_typings": [
+          "firentse"
+        ]
+      },
+      {
+        "en": "Rome",
+        "ja": "ローマ",
+        "ja_typings": [
+          "ro-ma"
+        ]
+      },
+      {
+        "en": "Milan",
+        "ja": "ミラノ",
+        "ja_typings": [
+          "mirano"
+        ]
+      },
+      {
+        "en": "Venice",
+        "ja": "ベネチア",
+        "ja_typings": [
+          "benechia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02528",
+    "image_path": null,
+    "question_text": {
+      "en": "イタリアのトスカーナ州の州都でルネサンス発祥の地は?",
+      "ja": "Which Tuscan city is known as the birthplace of the Renaissance?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Frankfurt",
+        "ja": "フランクフルト",
+        "ja_typings": [
+          "furankufuruto"
+        ]
+      },
+      {
+        "en": "Berlin",
+        "ja": "ベルリン",
+        "ja_typings": [
+          "berurin"
+        ]
+      },
+      {
+        "en": "Hamburg",
+        "ja": "ハンブルク",
+        "ja_typings": [
+          "hanburuku"
+        ]
+      },
+      {
+        "en": "Munich",
+        "ja": "ミュンヘン",
+        "ja_typings": [
+          "myunhen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02529",
+    "image_path": null,
+    "question_text": {
+      "en": "ドイツの金融の中心地として知られる都市は?",
+      "ja": "Which German city is the country's financial center?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ginowan",
+        "ja": "宜野湾",
+        "ja_typings": [
+          "ginowan"
+        ]
+      },
+      {
+        "en": "Naha",
+        "ja": "那覇",
+        "ja_typings": [
+          "naha"
+        ]
+      },
+      {
+        "en": "Nago",
+        "ja": "名護",
+        "ja_typings": [
+          "nago"
+        ]
+      },
+      {
+        "en": "Uruma",
+        "ja": "うるま",
+        "ja_typings": [
+          "uruma"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02530",
+    "image_path": null,
+    "question_text": {
+      "en": "沖縄本島中部の都市で米軍基地が多いことで知られるのは?",
+      "ja": "Which Okinawan city is known for hosting many U.S. military bases?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Giza",
+        "ja": "ギザ",
+        "ja_typings": [
+          "giza"
+        ]
+      },
+      {
+        "en": "Luxor",
+        "ja": "ルクソール",
+        "ja_typings": [
+          "rukuso-ru"
+        ]
+      },
+      {
+        "en": "Alexandria",
+        "ja": "アレクサンドリア",
+        "ja_typings": [
+          "arekusandoria"
+        ]
+      },
+      {
+        "en": "Cairo",
+        "ja": "カイロ",
+        "ja_typings": [
+          "kairo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02531",
+    "image_path": null,
+    "question_text": {
+      "en": "ピラミッドとスフィンクスがあるエジプトの都市は?",
+      "ja": "Which Egyptian city is home to the pyramids and the Sphinx?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Greenland",
+        "ja": "グリーンランド",
+        "ja_typings": [
+          "guri-nrando"
+        ]
+      },
+      {
+        "en": "New Guinea",
+        "ja": "ニューギニア島",
+        "ja_typings": [
+          "nyu-gineatou",
+          "nyu-gineashima"
+        ]
+      },
+      {
+        "en": "Borneo",
+        "ja": "ボルネオ島",
+        "ja_typings": [
+          "boruneotou",
+          "boruneoshima"
+        ]
+      },
+      {
+        "en": "Madagascar",
+        "ja": "マダガスカル",
+        "ja_typings": [
+          "madagasukaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02532",
+    "image_path": null,
+    "question_text": {
+      "en": "世界最大の島でデンマーク自治領なのは?",
+      "ja": "Which is the world's largest island, an autonomous territory of Denmark?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Guadalajara",
+        "ja": "グアダラハラ",
+        "ja_typings": [
+          "guadarahara"
+        ]
+      },
+      {
+        "en": "Monterrey",
+        "ja": "モンテレイ",
+        "ja_typings": [
+          "monterei"
+        ]
+      },
+      {
+        "en": "Puebla",
+        "ja": "プエブラ",
+        "ja_typings": [
+          "puebura"
+        ]
+      },
+      {
+        "en": "Tijuana",
+        "ja": "ティフアナ",
+        "ja_typings": [
+          "tifuana"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02533",
+    "image_path": null,
+    "question_text": {
+      "en": "メキシコ第2の都市でテキーラの産地として有名な都市は?",
+      "ja": "Which Mexican city is famous as the home of tequila?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hakodate",
+        "ja": "函館",
+        "ja_typings": [
+          "hakodate"
+        ]
+      },
+      {
+        "en": "Otaru",
+        "ja": "小樽",
+        "ja_typings": [
+          "otaru"
+        ]
+      },
+      {
+        "en": "Muroran",
+        "ja": "室蘭",
+        "ja_typings": [
+          "muroran"
+        ]
+      },
+      {
+        "en": "Kushiro",
+        "ja": "釧路",
+        "ja_typings": [
+          "kushiro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02534",
+    "image_path": null,
+    "question_text": {
+      "en": "北海道南部にある夜景が有名な港町は?",
+      "ja": "Which Hokkaido port town is famous for its night view?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hamburg",
+        "ja": "ハンブルク",
+        "ja_typings": [
+          "hanburuku"
+        ]
+      },
+      {
+        "en": "Bremen",
+        "ja": "ブレーメン",
+        "ja_typings": [
+          "bure-men"
+        ]
+      },
+      {
+        "en": "Kiel",
+        "ja": "キール",
+        "ja_typings": [
+          "ki-ru"
+        ]
+      },
+      {
+        "en": "Rostock",
+        "ja": "ロストック",
+        "ja_typings": [
+          "rosutokku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02535",
+    "image_path": null,
+    "question_text": {
+      "en": "ドイツ北部の主要港湾都市は?",
+      "ja": "Which city is a major northern German port?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hanoi",
+        "ja": "ハノイ",
+        "ja_typings": [
+          "hanoi"
+        ]
+      },
+      {
+        "en": "Ho Chi Minh City",
+        "ja": "ホーチミン",
+        "ja_typings": [
+          "ho-chimin"
+        ]
+      },
+      {
+        "en": "Da Nang",
+        "ja": "ダナン",
+        "ja_typings": [
+          "danan"
+        ]
+      },
+      {
+        "en": "Hue",
+        "ja": "フエ",
+        "ja_typings": [
+          "fue"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02536",
+    "image_path": null,
+    "question_text": {
+      "en": "ベトナムの首都は?",
+      "ja": "What is the capital of Vietnam?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ho Chi Minh City",
+        "ja": "ホーチミン",
+        "ja_typings": [
+          "ho-chimin"
+        ]
+      },
+      {
+        "en": "Hanoi",
+        "ja": "ハノイ",
+        "ja_typings": [
+          "hanoi"
+        ]
+      },
+      {
+        "en": "Hue",
+        "ja": "フエ",
+        "ja_typings": [
+          "fue"
+        ]
+      },
+      {
+        "en": "Da Nang",
+        "ja": "ダナン",
+        "ja_typings": [
+          "danan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02537",
+    "image_path": null,
+    "question_text": {
+      "en": "ベトナム南部最大の都市は?",
+      "ja": "Which is the largest city in southern Vietnam?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hong Kong",
+        "ja": "香港",
+        "ja_typings": [
+          "honkon"
+        ]
+      },
+      {
+        "en": "Macao",
+        "ja": "マカオ",
+        "ja_typings": [
+          "makao"
+        ]
+      },
+      {
+        "en": "Shenzhen",
+        "ja": "深圳",
+        "ja_typings": [
+          "shinsen"
+        ]
+      },
+      {
+        "en": "Guangzhou",
+        "ja": "広州",
+        "ja_typings": [
+          "koushuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02538",
+    "image_path": null,
+    "question_text": {
+      "en": "中国南部にある特別行政区で金融センターとして知られる都市は?",
+      "ja": "Which Special Administrative Region of southern China is a major financial hub?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hue",
+        "ja": "フエ",
+        "ja_typings": [
+          "fue"
+        ]
+      },
+      {
+        "en": "Hanoi",
+        "ja": "ハノイ",
+        "ja_typings": [
+          "hanoi"
+        ]
+      },
+      {
+        "en": "Da Nang",
+        "ja": "ダナン",
+        "ja_typings": [
+          "danan"
+        ]
+      },
+      {
+        "en": "Ho Chi Minh City",
+        "ja": "ホーチミン",
+        "ja_typings": [
+          "ho-chimin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02539",
+    "image_path": null,
+    "question_text": {
+      "en": "ベトナム中部の旧王朝の都は?",
+      "ja": "Which central Vietnamese city was the imperial capital under the Nguyen dynasty?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Incheon",
+        "ja": "インチョン",
+        "ja_typings": [
+          "inchon"
+        ]
+      },
+      {
+        "en": "Busan",
+        "ja": "プサン",
+        "ja_typings": [
+          "pusan"
+        ]
+      },
+      {
+        "en": "Daegu",
+        "ja": "テグ",
+        "ja_typings": [
+          "tegu"
+        ]
+      },
+      {
+        "en": "Ulsan",
+        "ja": "ウルサン",
+        "ja_typings": [
+          "urusan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02540",
+    "image_path": null,
+    "question_text": {
+      "en": "韓国の国際空港があるソウル近郊の港湾都市は?",
+      "ja": "Which port city near Seoul hosts South Korea's main international airport?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "India",
+        "ja": "インド",
+        "ja_typings": [
+          "indo"
+        ]
+      },
+      {
+        "en": "Pakistan",
+        "ja": "パキスタン",
+        "ja_typings": [
+          "pakisutan"
+        ]
+      },
+      {
+        "en": "Bangladesh",
+        "ja": "バングラデシュ",
+        "ja_typings": [
+          "banguradeshu"
+        ]
+      },
+      {
+        "en": "Sri Lanka",
+        "ja": "スリランカ",
+        "ja_typings": [
+          "suriranka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02541",
+    "image_path": null,
+    "question_text": {
+      "en": "南アジアで人口最多の国は?",
+      "ja": "Which is the most populous country in South Asia?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Indian Ocean",
+        "ja": "インド洋",
+        "ja_typings": [
+          "indoyou"
+        ]
+      },
+      {
+        "en": "Pacific Ocean",
+        "ja": "太平洋",
+        "ja_typings": [
+          "taiheiyou"
+        ]
+      },
+      {
+        "en": "Atlantic Ocean",
+        "ja": "大西洋",
+        "ja_typings": [
+          "taiseiyou"
+        ]
+      },
+      {
+        "en": "Arctic Ocean",
+        "ja": "北極海",
+        "ja_typings": [
+          "hokkyokukai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02542",
+    "image_path": null,
+    "question_text": {
+      "en": "アフリカとオーストラリアの間に広がる海洋は?",
+      "ja": "Which ocean lies between Africa and Australia?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ishigaki",
+        "ja": "石垣島",
+        "ja_typings": [
+          "ishigakijima",
+          "ishigakitou"
+        ]
+      },
+      {
+        "en": "Iriomote",
+        "ja": "西表島",
+        "ja_typings": [
+          "iriomotejima"
+        ]
+      },
+      {
+        "en": "Yonaguni",
+        "ja": "与那国島",
+        "ja_typings": [
+          "yonagunijima"
+        ]
+      },
+      {
+        "en": "Miyako",
+        "ja": "宮古島",
+        "ja_typings": [
+          "miyakojima"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02543",
+    "image_path": null,
+    "question_text": {
+      "en": "八重山諸島の中心の島は?",
+      "ja": "Which is the main island of the Yaeyama Islands?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ishikari River",
+        "ja": "石狩川",
+        "ja_typings": [
+          "ishikarigawa",
+          "ishikarikawa"
+        ]
+      },
+      {
+        "en": "Tone River",
+        "ja": "利根川",
+        "ja_typings": [
+          "tonegawa",
+          "tonekawa"
+        ]
+      },
+      {
+        "en": "Tenryu River",
+        "ja": "天竜川",
+        "ja_typings": [
+          "tenryuugawa",
+          "tenryuukawa"
+        ]
+      },
+      {
+        "en": "Yodo River",
+        "ja": "淀川",
+        "ja_typings": [
+          "yodogawa",
+          "yodokawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02544",
+    "image_path": null,
+    "question_text": {
+      "en": "北海道で最長の川は?",
+      "ja": "Which is the longest river in Hokkaido?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Izmir",
+        "ja": "イズミル",
+        "ja_typings": [
+          "izumiru"
+        ]
+      },
+      {
+        "en": "Bursa",
+        "ja": "ブルサ",
+        "ja_typings": [
+          "burusa"
+        ]
+      },
+      {
+        "en": "Antalya",
+        "ja": "アンタルヤ",
+        "ja_typings": [
+          "antaruya"
+        ]
+      },
+      {
+        "en": "Adana",
+        "ja": "アダナ",
+        "ja_typings": [
+          "adana"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02545",
+    "image_path": null,
+    "question_text": {
+      "en": "トルコ第3の都市でエーゲ海沿岸の港湾都市は?",
+      "ja": "Which is Turkey's third largest city, a port on the Aegean coast?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jeddah",
+        "ja": "ジッダ",
+        "ja_typings": [
+          "jidda"
+        ]
+      },
+      {
+        "en": "Mecca",
+        "ja": "メッカ",
+        "ja_typings": [
+          "mekka"
+        ]
+      },
+      {
+        "en": "Medina",
+        "ja": "メディナ",
+        "ja_typings": [
+          "medina"
+        ]
+      },
+      {
+        "en": "Riyadh",
+        "ja": "リヤド",
+        "ja_typings": [
+          "riyado"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02546",
+    "image_path": null,
+    "question_text": {
+      "en": "サウジアラビアの紅海沿岸の主要都市は?",
+      "ja": "Which is Saudi Arabia's main city on the Red Sea coast?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kalahari Desert",
+        "ja": "カラハリ砂漠",
+        "ja_typings": [
+          "karaharisabaku"
+        ]
+      },
+      {
+        "en": "Sahara Desert",
+        "ja": "サハラ砂漠",
+        "ja_typings": [
+          "saharasabaku"
+        ]
+      },
+      {
+        "en": "Namib Desert",
+        "ja": "ナミブ砂漠",
+        "ja_typings": [
+          "namibusabaku"
+        ]
+      },
+      {
+        "en": "Gobi Desert",
+        "ja": "ゴビ砂漠",
+        "ja_typings": [
+          "gobisabaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02547",
+    "image_path": null,
+    "question_text": {
+      "en": "南部アフリカに広がる砂漠は?",
+      "ja": "Which desert covers much of southern Africa?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kanmon Bridge",
+        "ja": "関門橋",
+        "ja_typings": [
+          "kanmonkyou",
+          "kanmonbashi"
+        ]
+      },
+      {
+        "en": "Akashi Kaikyo Bridge",
+        "ja": "明石海峡大橋",
+        "ja_typings": [
+          "akashikaikyouoohashi"
+        ]
+      },
+      {
+        "en": "Seto Ohashi",
+        "ja": "瀬戸大橋",
+        "ja_typings": [
+          "setoohashi"
+        ]
+      },
+      {
+        "en": "Rainbow Bridge",
+        "ja": "レインボーブリッジ",
+        "ja_typings": [
+          "reinbo-burijji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02548",
+    "image_path": null,
+    "question_text": {
+      "en": "本州と九州を結ぶ関門海峡にかかる橋は?",
+      "ja": "Which bridge spans the Kanmon Strait between Honshu and Kyushu?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kolkata",
+        "ja": "コルカタ",
+        "ja_typings": [
+          "korukata"
+        ]
+      },
+      {
+        "en": "Mumbai",
+        "ja": "ムンバイ",
+        "ja_typings": [
+          "munbai"
+        ]
+      },
+      {
+        "en": "Chennai",
+        "ja": "チェンナイ",
+        "ja_typings": [
+          "chennnai"
+        ]
+      },
+      {
+        "en": "Bangalore",
+        "ja": "バンガロール",
+        "ja_typings": [
+          "bangaro-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02549",
+    "image_path": null,
+    "question_text": {
+      "en": "インド東部の大都市で旧称カルカッタの都市は?",
+      "ja": "Which large eastern Indian city was formerly called Calcutta?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kushiro",
+        "ja": "釧路",
+        "ja_typings": [
+          "kushiro"
+        ]
+      },
+      {
+        "en": "Nemuro",
+        "ja": "根室",
+        "ja_typings": [
+          "nemuro"
+        ]
+      },
+      {
+        "en": "Abashiri",
+        "ja": "網走",
+        "ja_typings": [
+          "abashiri"
+        ]
+      },
+      {
+        "en": "Obihiro",
+        "ja": "帯広",
+        "ja_typings": [
+          "obihiro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02550",
+    "image_path": null,
+    "question_text": {
+      "en": "北海道道東にある霧で有名な港町は?",
+      "ja": "Which port town in eastern Hokkaido is famous for its fog?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lake Assal",
+        "ja": "アッサル湖",
+        "ja_typings": [
+          "assaruko"
+        ]
+      },
+      {
+        "en": "Dead Sea",
+        "ja": "死海",
+        "ja_typings": [
+          "shikai"
+        ]
+      },
+      {
+        "en": "Caspian Sea",
+        "ja": "カスピ海",
+        "ja_typings": [
+          "kasupikai"
+        ]
+      },
+      {
+        "en": "Lake Eyre",
+        "ja": "エア湖",
+        "ja_typings": [
+          "eako"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02551",
+    "image_path": null,
+    "question_text": {
+      "en": "ジブチにある世界で最も標高の低い湖は?",
+      "ja": "Which lake in Djibouti is the lowest point on land?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lake Inawashiro",
+        "ja": "猪苗代湖",
+        "ja_typings": [
+          "inawashiroko"
+        ]
+      },
+      {
+        "en": "Lake Biwa",
+        "ja": "琵琶湖",
+        "ja_typings": [
+          "biwako"
+        ]
+      },
+      {
+        "en": "Lake Kasumigaura",
+        "ja": "霞ヶ浦",
+        "ja_typings": [
+          "kasumigaura"
+        ]
+      },
+      {
+        "en": "Lake Towada",
+        "ja": "十和田湖",
+        "ja_typings": [
+          "towadako"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02552",
+    "image_path": null,
+    "question_text": {
+      "en": "福島県にある日本で4番目に大きい湖は?",
+      "ja": "Which Fukushima lake is the fourth largest in Japan?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lake Kasumigaura",
+        "ja": "霞ヶ浦",
+        "ja_typings": [
+          "kasumigaura"
+        ]
+      },
+      {
+        "en": "Lake Biwa",
+        "ja": "琵琶湖",
+        "ja_typings": [
+          "biwako"
+        ]
+      },
+      {
+        "en": "Lake Inawashiro",
+        "ja": "猪苗代湖",
+        "ja_typings": [
+          "inawashiroko"
+        ]
+      },
+      {
+        "en": "Lake Suwa",
+        "ja": "諏訪湖",
+        "ja_typings": [
+          "suwako"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02553",
+    "image_path": null,
+    "question_text": {
+      "en": "茨城県にある日本で2番目に大きい湖は?",
+      "ja": "Which Ibaraki lake is the second largest in Japan?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lake Saroma",
+        "ja": "サロマ湖",
+        "ja_typings": [
+          "saromako"
+        ]
+      },
+      {
+        "en": "Lake Akan",
+        "ja": "阿寒湖",
+        "ja_typings": [
+          "akanko"
+        ]
+      },
+      {
+        "en": "Lake Mashu",
+        "ja": "摩周湖",
+        "ja_typings": [
+          "mashuuko"
+        ]
+      },
+      {
+        "en": "Lake Kussharo",
+        "ja": "屈斜路湖",
+        "ja_typings": [
+          "kussharoko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02554",
+    "image_path": null,
+    "question_text": {
+      "en": "北海道東部のオホーツク海に面した日本最大の汽水湖は?",
+      "ja": "Which is Japan's largest brackish lake, on Hokkaido's Sea of Okhotsk coast?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Los Angeles",
+        "ja": "ロサンゼルス",
+        "ja_typings": [
+          "rosanzerusu"
+        ]
+      },
+      {
+        "en": "San Diego",
+        "ja": "サンディエゴ",
+        "ja_typings": [
+          "sandiego"
+        ]
+      },
+      {
+        "en": "San Francisco",
+        "ja": "サンフランシスコ",
+        "ja_typings": [
+          "sanfuranshisuko"
+        ]
+      },
+      {
+        "en": "Sacramento",
+        "ja": "サクラメント",
+        "ja_typings": [
+          "sakuramento"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02555",
+    "image_path": null,
+    "question_text": {
+      "en": "アメリカ・カリフォルニア州南部の大都市は?",
+      "ja": "Which is the largest city in Southern California?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Luxor",
+        "ja": "ルクソール",
+        "ja_typings": [
+          "rukuso-ru"
+        ]
+      },
+      {
+        "en": "Alexandria",
+        "ja": "アレクサンドリア",
+        "ja_typings": [
+          "arekusandoria"
+        ]
+      },
+      {
+        "en": "Giza",
+        "ja": "ギザ",
+        "ja_typings": [
+          "giza"
+        ]
+      },
+      {
+        "en": "Aswan",
+        "ja": "アスワン",
+        "ja_typings": [
+          "asuwan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02556",
+    "image_path": null,
+    "question_text": {
+      "en": "エジプト南部にあるカルナック神殿で有名な都市は?",
+      "ja": "Which southern Egyptian city is famous for the Karnak Temple?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Madagascar",
+        "ja": "マダガスカル",
+        "ja_typings": [
+          "madagasukaru"
+        ]
+      },
+      {
+        "en": "Greenland",
+        "ja": "グリーンランド",
+        "ja_typings": [
+          "guri-nrando"
+        ]
+      },
+      {
+        "en": "Borneo",
+        "ja": "ボルネオ島",
+        "ja_typings": [
+          "boruneotou",
+          "boruneoshima"
+        ]
+      },
+      {
+        "en": "New Guinea",
+        "ja": "ニューギニア島",
+        "ja_typings": [
+          "nyu-gineatou",
+          "nyu-gineashima"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02557",
+    "image_path": null,
+    "question_text": {
+      "en": "アフリカ南東沖にある世界で4番目に大きい島は?",
+      "ja": "Which is the fourth largest island in the world, off southeastern Africa?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Madrid",
+        "ja": "マドリード",
+        "ja_typings": [
+          "madori-do"
+        ]
+      },
+      {
+        "en": "Barcelona",
+        "ja": "バルセロナ",
+        "ja_typings": [
+          "baruserona"
+        ]
+      },
+      {
+        "en": "Seville",
+        "ja": "セビリア",
+        "ja_typings": [
+          "sebiria"
+        ]
+      },
+      {
+        "en": "Valencia",
+        "ja": "バレンシア",
+        "ja_typings": [
+          "barenshia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02558",
+    "image_path": null,
+    "question_text": {
+      "en": "スペインの首都は?",
+      "ja": "What is the capital of Spain?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Manchester",
+        "ja": "マンチェスター",
+        "ja_typings": [
+          "manchesuta-"
+        ]
+      },
+      {
+        "en": "Liverpool",
+        "ja": "リバプール",
+        "ja_typings": [
+          "ribapu-ru"
+        ]
+      },
+      {
+        "en": "Leeds",
+        "ja": "リーズ",
+        "ja_typings": [
+          "ri-zu"
+        ]
+      },
+      {
+        "en": "Birmingham",
+        "ja": "バーミンガム",
+        "ja_typings": [
+          "ba-mingamu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02559",
+    "image_path": null,
+    "question_text": {
+      "en": "イギリス北西部の工業都市でサッカーが盛んな都市は?",
+      "ja": "Which northwestern English industrial city is famous for football?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mecca",
+        "ja": "メッカ",
+        "ja_typings": [
+          "mekka"
+        ]
+      },
+      {
+        "en": "Medina",
+        "ja": "メディナ",
+        "ja_typings": [
+          "medina"
+        ]
+      },
+      {
+        "en": "Jeddah",
+        "ja": "ジッダ",
+        "ja_typings": [
+          "jidda"
+        ]
+      },
+      {
+        "en": "Riyadh",
+        "ja": "リヤド",
+        "ja_typings": [
+          "riyado"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02560",
+    "image_path": null,
+    "question_text": {
+      "en": "イスラム教最大の聖地はサウジアラビアの?",
+      "ja": "Which Saudi Arabian city is Islam's holiest site?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Medina",
+        "ja": "メディナ",
+        "ja_typings": [
+          "medina"
+        ]
+      },
+      {
+        "en": "Mecca",
+        "ja": "メッカ",
+        "ja_typings": [
+          "mekka"
+        ]
+      },
+      {
+        "en": "Jeddah",
+        "ja": "ジッダ",
+        "ja_typings": [
+          "jidda"
+        ]
+      },
+      {
+        "en": "Riyadh",
+        "ja": "リヤド",
+        "ja_typings": [
+          "riyado"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02561",
+    "image_path": null,
+    "question_text": {
+      "en": "イスラム教第2の聖地で預言者ムハンマドの墓がある都市は?",
+      "ja": "Which city is Islam's second holiest, home to the Prophet Muhammad's tomb?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mediterranean coast",
+        "ja": "地中海沿岸",
+        "ja_typings": [
+          "chichuukaiengan"
+        ]
+      },
+      {
+        "en": "Red Sea shore",
+        "ja": "紅海沿岸",
+        "ja_typings": [
+          "koukaiengan"
+        ]
+      },
+      {
+        "en": "Caspian Sea shore",
+        "ja": "カスピ海沿岸",
+        "ja_typings": [
+          "kasupikaiengan"
+        ]
+      },
+      {
+        "en": "Black Sea shore",
+        "ja": "黒海沿岸",
+        "ja_typings": [
+          "kokkaiengan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02562",
+    "image_path": null,
+    "question_text": {
+      "en": "イスラエルのテルアビブやレバノンのベイルートが面しているのは?",
+      "ja": "Tel Aviv and Beirut both face which coastal region?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Milan",
+        "ja": "ミラノ",
+        "ja_typings": [
+          "mirano"
+        ]
+      },
+      {
+        "en": "Rome",
+        "ja": "ローマ",
+        "ja_typings": [
+          "ro-ma"
+        ]
+      },
+      {
+        "en": "Florence",
+        "ja": "フィレンツェ",
+        "ja_typings": [
+          "firentse"
+        ]
+      },
+      {
+        "en": "Turin",
+        "ja": "トリノ",
+        "ja_typings": [
+          "torino"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02563",
+    "image_path": null,
+    "question_text": {
+      "en": "イタリア北部の経済の中心地でファッションの都は?",
+      "ja": "Which northern Italian city is its economic and fashion capital?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mississippi River",
+        "ja": "ミシシッピ川",
+        "ja_typings": [
+          "mishishippigawa",
+          "mishishippikawa"
+        ]
+      },
+      {
+        "en": "Missouri River",
+        "ja": "ミズーリ川",
+        "ja_typings": [
+          "mizu-rigawa",
+          "mizu-rikawa"
+        ]
+      },
+      {
+        "en": "Colorado River",
+        "ja": "コロラド川",
+        "ja_typings": [
+          "kororadogawa",
+          "kororadokawa"
+        ]
+      },
+      {
+        "en": "Rio Grande",
+        "ja": "リオグランデ川",
+        "ja_typings": [
+          "riogurandegawa",
+          "riogurandekawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02564",
+    "image_path": null,
+    "question_text": {
+      "en": "アメリカ中部を南北に貫く大河は?",
+      "ja": "Which great river runs north-south through the central United States?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Monterrey",
+        "ja": "モンテレイ",
+        "ja_typings": [
+          "monterei"
+        ]
+      },
+      {
+        "en": "Guadalajara",
+        "ja": "グアダラハラ",
+        "ja_typings": [
+          "guadarahara"
+        ]
+      },
+      {
+        "en": "Tijuana",
+        "ja": "ティフアナ",
+        "ja_typings": [
+          "tifuana"
+        ]
+      },
+      {
+        "en": "Puebla",
+        "ja": "プエブラ",
+        "ja_typings": [
+          "puebura"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02565",
+    "image_path": null,
+    "question_text": {
+      "en": "メキシコ北部の工業都市は?",
+      "ja": "Which northern Mexican city is a major industrial center?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Montevideo",
+        "ja": "モンテビデオ",
+        "ja_typings": [
+          "montebideo"
+        ]
+      },
+      {
+        "en": "Buenos Aires",
+        "ja": "ブエノスアイレス",
+        "ja_typings": [
+          "buenosuairesu"
+        ]
+      },
+      {
+        "en": "Asuncion",
+        "ja": "アスンシオン",
+        "ja_typings": [
+          "asunshion"
+        ]
+      },
+      {
+        "en": "Santiago",
+        "ja": "サンティアゴ",
+        "ja_typings": [
+          "santiago"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02566",
+    "image_path": null,
+    "question_text": {
+      "en": "ウルグアイの首都は?",
+      "ja": "What is the capital of Uruguay?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Montreal",
+        "ja": "モントリオール",
+        "ja_typings": [
+          "montorio-ru"
+        ]
+      },
+      {
+        "en": "Toronto",
+        "ja": "トロント",
+        "ja_typings": [
+          "toronto"
+        ]
+      },
+      {
+        "en": "Vancouver",
+        "ja": "バンクーバー",
+        "ja_typings": [
+          "banku-ba-"
+        ]
+      },
+      {
+        "en": "Ottawa",
+        "ja": "オタワ",
+        "ja_typings": [
+          "otawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02567",
+    "image_path": null,
+    "question_text": {
+      "en": "カナダ・ケベック州の最大都市は?",
+      "ja": "Which is the largest city in Quebec, Canada?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mount Hotaka",
+        "ja": "穂高岳",
+        "ja_typings": [
+          "hotakadake"
+        ]
+      },
+      {
+        "en": "Mount Yari",
+        "ja": "槍ヶ岳",
+        "ja_typings": [
+          "yarigatake"
+        ]
+      },
+      {
+        "en": "Mount Tate",
+        "ja": "立山",
+        "ja_typings": [
+          "tateyama"
+        ]
+      },
+      {
+        "en": "Mount Norikura",
+        "ja": "乗鞍岳",
+        "ja_typings": [
+          "norikuradake"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02568",
+    "image_path": null,
+    "question_text": {
+      "en": "北アルプスにある標高3190mの山は?",
+      "ja": "Which Northern Japan Alps peak rises to 3190 meters?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mount Kilimanjaro",
+        "ja": "キリマンジャロ",
+        "ja_typings": [
+          "kirimanjaro"
+        ]
+      },
+      {
+        "en": "Mount Kenya",
+        "ja": "ケニア山",
+        "ja_typings": [
+          "keniasan"
+        ]
+      },
+      {
+        "en": "Mount Rwenzori",
+        "ja": "ルウェンゾリ山",
+        "ja_typings": [
+          "ruwenzorisan"
+        ]
+      },
+      {
+        "en": "Mount Meru",
+        "ja": "メルー山",
+        "ja_typings": [
+          "meru-san"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02569",
+    "image_path": null,
+    "question_text": {
+      "en": "タンザニアにあるアフリカ最高峰は?",
+      "ja": "Which is Africa's highest mountain, located in Tanzania?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mount Kita",
+        "ja": "北岳",
+        "ja_typings": [
+          "kitadake"
+        ]
+      },
+      {
+        "en": "Mount Fuji",
+        "ja": "富士山",
+        "ja_typings": [
+          "fujisan"
+        ]
+      },
+      {
+        "en": "Mount Hotaka",
+        "ja": "穂高岳",
+        "ja_typings": [
+          "hotakadake"
+        ]
+      },
+      {
+        "en": "Mount Yari",
+        "ja": "槍ヶ岳",
+        "ja_typings": [
+          "yarigatake"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02570",
+    "image_path": null,
+    "question_text": {
+      "en": "南アルプスにある標高3193mで日本第2位の高峰は?",
+      "ja": "Which Southern Japan Alps peak is Japan's second highest at 3193 meters?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mount McKinley",
+        "ja": "マッキンリー",
+        "ja_typings": [
+          "makkinri-"
+        ]
+      },
+      {
+        "en": "Mount Logan",
+        "ja": "ローガン山",
+        "ja_typings": [
+          "ro-gansan"
+        ]
+      },
+      {
+        "en": "Mount Saint Elias",
+        "ja": "セントエライアス山",
+        "ja_typings": [
+          "sentoeraiasusan"
+        ]
+      },
+      {
+        "en": "Mount Foraker",
+        "ja": "フォレイカー山",
+        "ja_typings": [
+          "foreika-san"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02571",
+    "image_path": null,
+    "question_text": {
+      "en": "アラスカにある北米最高峰の旧称は?",
+      "ja": "Which is the former name of North America's highest peak in Alaska?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mount Rwenzori",
+        "ja": "ルウェンゾリ山",
+        "ja_typings": [
+          "ruwenzorisan"
+        ]
+      },
+      {
+        "en": "Mount Kilimanjaro",
+        "ja": "キリマンジャロ",
+        "ja_typings": [
+          "kirimanjaro"
+        ]
+      },
+      {
+        "en": "Mount Kenya",
+        "ja": "ケニア山",
+        "ja_typings": [
+          "keniasan"
+        ]
+      },
+      {
+        "en": "Mount Elgon",
+        "ja": "エルゴン山",
+        "ja_typings": [
+          "erugonsan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02572",
+    "image_path": null,
+    "question_text": {
+      "en": "ウガンダとコンゴ民主共和国の国境にある山は?",
+      "ja": "Which mountain range lies on the border between Uganda and DR Congo?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mount Yari",
+        "ja": "槍ヶ岳",
+        "ja_typings": [
+          "yarigatake"
+        ]
+      },
+      {
+        "en": "Mount Hotaka",
+        "ja": "穂高岳",
+        "ja_typings": [
+          "hotakadake"
+        ]
+      },
+      {
+        "en": "Mount Tate",
+        "ja": "立山",
+        "ja_typings": [
+          "tateyama"
+        ]
+      },
+      {
+        "en": "Mount Kita",
+        "ja": "北岳",
+        "ja_typings": [
+          "kitadake"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02573",
+    "image_path": null,
+    "question_text": {
+      "en": "北アルプスの槍状の山頂で知られる山は?",
+      "ja": "Which Northern Japan Alps peak is famous for its spear-like summit?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mumbai",
+        "ja": "ムンバイ",
+        "ja_typings": [
+          "munbai"
+        ]
+      },
+      {
+        "en": "Delhi",
+        "ja": "デリー",
+        "ja_typings": [
+          "deri-"
+        ]
+      },
+      {
+        "en": "Kolkata",
+        "ja": "コルカタ",
+        "ja_typings": [
+          "korukata"
+        ]
+      },
+      {
+        "en": "Chennai",
+        "ja": "チェンナイ",
+        "ja_typings": [
+          "chennnai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02574",
+    "image_path": null,
+    "question_text": {
+      "en": "インド最大の都市で旧称ボンベイは?",
+      "ja": "Which is India's largest city, formerly known as Bombay?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Munich",
+        "ja": "ミュンヘン",
+        "ja_typings": [
+          "myunhen"
+        ]
+      },
+      {
+        "en": "Berlin",
+        "ja": "ベルリン",
+        "ja_typings": [
+          "berurin"
+        ]
+      },
+      {
+        "en": "Hamburg",
+        "ja": "ハンブルク",
+        "ja_typings": [
+          "hanburuku"
+        ]
+      },
+      {
+        "en": "Frankfurt",
+        "ja": "フランクフルト",
+        "ja_typings": [
+          "furankufuruto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02575",
+    "image_path": null,
+    "question_text": {
+      "en": "ドイツ・バイエルン州の州都は?",
+      "ja": "What is the capital of Bavaria, Germany?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nago",
+        "ja": "名護",
+        "ja_typings": [
+          "nago"
+        ]
+      },
+      {
+        "en": "Naha",
+        "ja": "那覇",
+        "ja_typings": [
+          "naha"
+        ]
+      },
+      {
+        "en": "Ginowan",
+        "ja": "宜野湾",
+        "ja_typings": [
+          "ginowan"
+        ]
+      },
+      {
+        "en": "Uruma",
+        "ja": "うるま",
+        "ja_typings": [
+          "uruma"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02576",
+    "image_path": null,
+    "question_text": {
+      "en": "沖縄本島北部の中心都市は?",
+      "ja": "Which is the central city of northern Okinawa Island?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nanjing",
+        "ja": "南京",
+        "ja_typings": [
+          "nankin"
+        ]
+      },
+      {
+        "en": "Beijing",
+        "ja": "北京",
+        "ja_typings": [
+          "pekin"
+        ]
+      },
+      {
+        "en": "Shanghai",
+        "ja": "上海",
+        "ja_typings": [
+          "shanhai"
+        ]
+      },
+      {
+        "en": "Hangzhou",
+        "ja": "杭州",
+        "ja_typings": [
+          "koushuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02577",
+    "image_path": null,
+    "question_text": {
+      "en": "中国の旧首都で長江下流域にある都市は?",
+      "ja": "Which former Chinese capital lies on the lower Yangtze River?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nepal",
+        "ja": "ネパール",
+        "ja_typings": [
+          "nepa-ru"
+        ]
+      },
+      {
+        "en": "Bhutan",
+        "ja": "ブータン",
+        "ja_typings": [
+          "bu-tan"
+        ]
+      },
+      {
+        "en": "Tibet",
+        "ja": "チベット",
+        "ja_typings": [
+          "chibetto"
+        ]
+      },
+      {
+        "en": "Sikkim",
+        "ja": "シッキム",
+        "ja_typings": [
+          "shikkimu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02578",
+    "image_path": null,
+    "question_text": {
+      "en": "エベレストがある南アジアの内陸国は?",
+      "ja": "Which landlocked South Asian country is home to Mount Everest?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Netherlands",
+        "ja": "オランダ",
+        "ja_typings": [
+          "oranda"
+        ]
+      },
+      {
+        "en": "Belgium",
+        "ja": "ベルギー",
+        "ja_typings": [
+          "berugi-"
+        ]
+      },
+      {
+        "en": "Denmark",
+        "ja": "デンマーク",
+        "ja_typings": [
+          "denma-ku"
+        ]
+      },
+      {
+        "en": "Luxembourg",
+        "ja": "ルクセンブルク",
+        "ja_typings": [
+          "rukusenburuku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02579",
+    "image_path": null,
+    "question_text": {
+      "en": "アムステルダムを首都とするヨーロッパの国は?",
+      "ja": "Which European country has Amsterdam as its capital?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "New Guinea",
+        "ja": "ニューギニア島",
+        "ja_typings": [
+          "nyu-gineatou",
+          "nyu-gineashima"
+        ]
+      },
+      {
+        "en": "Borneo",
+        "ja": "ボルネオ島",
+        "ja_typings": [
+          "boruneotou",
+          "boruneoshima"
+        ]
+      },
+      {
+        "en": "Madagascar",
+        "ja": "マダガスカル",
+        "ja_typings": [
+          "madagasukaru"
+        ]
+      },
+      {
+        "en": "Sumatra",
+        "ja": "スマトラ島",
+        "ja_typings": [
+          "sumatoratou",
+          "sumatorashima"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02580",
+    "image_path": null,
+    "question_text": {
+      "en": "世界第2位の大きさを持つ島でインドネシアとパプアニューギニアに分かれているのは?",
+      "ja": "Which is the world's second largest island, split between Indonesia and Papua New Guinea?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "New York",
+        "ja": "ニューヨーク",
+        "ja_typings": [
+          "nyu-yo-ku"
+        ]
+      },
+      {
+        "en": "Boston",
+        "ja": "ボストン",
+        "ja_typings": [
+          "bosuton"
+        ]
+      },
+      {
+        "en": "Philadelphia",
+        "ja": "フィラデルフィア",
+        "ja_typings": [
+          "firaderufia"
+        ]
+      },
+      {
+        "en": "Washington",
+        "ja": "ワシントン",
+        "ja_typings": [
+          "washinton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02581",
+    "image_path": null,
+    "question_text": {
+      "en": "アメリカ東海岸の世界都市は?",
+      "ja": "Which is the U.S. east coast's global city?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Novosibirsk",
+        "ja": "ノボシビルスク",
+        "ja_typings": [
+          "noboshibirusuku"
+        ]
+      },
+      {
+        "en": "Vladivostok",
+        "ja": "ウラジオストク",
+        "ja_typings": [
+          "urajiosutoku"
+        ]
+      },
+      {
+        "en": "Irkutsk",
+        "ja": "イルクーツク",
+        "ja_typings": [
+          "iruku-tsuku"
+        ]
+      },
+      {
+        "en": "Krasnoyarsk",
+        "ja": "クラスノヤルスク",
+        "ja_typings": [
+          "kurasunoyarusuku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02582",
+    "image_path": null,
+    "question_text": {
+      "en": "シベリア最大の都市は?",
+      "ja": "Which is the largest city in Siberia?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Phnom Penh",
+        "ja": "プノンペン",
+        "ja_typings": [
+          "punonpen"
+        ]
+      },
+      {
+        "en": "Siem Reap",
+        "ja": "シェムリアップ",
+        "ja_typings": [
+          "shemuriappu"
+        ]
+      },
+      {
+        "en": "Vientiane",
+        "ja": "ビエンチャン",
+        "ja_typings": [
+          "bienchan"
+        ]
+      },
+      {
+        "en": "Hanoi",
+        "ja": "ハノイ",
+        "ja_typings": [
+          "hanoi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02583",
+    "image_path": null,
+    "question_text": {
+      "en": "カンボジアの首都は?",
+      "ja": "What is the capital of Cambodia?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pyongyang",
+        "ja": "ピョンヤン",
+        "ja_typings": [
+          "pyonnyan"
+        ]
+      },
+      {
+        "en": "Seoul",
+        "ja": "ソウル",
+        "ja_typings": [
+          "soru",
+          "souru"
+        ]
+      },
+      {
+        "en": "Kaesong",
+        "ja": "ケソン",
+        "ja_typings": [
+          "keson"
+        ]
+      },
+      {
+        "en": "Wonsan",
+        "ja": "ウォンサン",
+        "ja_typings": [
+          "wonsan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02584",
+    "image_path": null,
+    "question_text": {
+      "en": "北朝鮮の首都は?",
+      "ja": "What is the capital of North Korea?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rainbow Bridge",
+        "ja": "レインボーブリッジ",
+        "ja_typings": [
+          "reinbo-burijji"
+        ]
+      },
+      {
+        "en": "Tokyo Bay Aqua-Line",
+        "ja": "東京湾アクアライン",
+        "ja_typings": [
+          "toukyouwanakurarain"
+        ]
+      },
+      {
+        "en": "Kanmon Bridge",
+        "ja": "関門橋",
+        "ja_typings": [
+          "kanmonkyou",
+          "kanmonbashi"
+        ]
+      },
+      {
+        "en": "Seto Ohashi",
+        "ja": "瀬戸大橋",
+        "ja_typings": [
+          "setoohashi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02585",
+    "image_path": null,
+    "question_text": {
+      "en": "東京湾のお台場と芝浦を結ぶ橋は?",
+      "ja": "Which bridge connects Odaiba and Shibaura over Tokyo Bay?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rio de Janeiro",
+        "ja": "リオデジャネイロ",
+        "ja_typings": [
+          "riodejaneiro"
+        ]
+      },
+      {
+        "en": "Sao Paulo",
+        "ja": "サンパウロ",
+        "ja_typings": [
+          "sanpauro"
+        ]
+      },
+      {
+        "en": "Brasilia",
+        "ja": "ブラジリア",
+        "ja_typings": [
+          "burajiria"
+        ]
+      },
+      {
+        "en": "Salvador",
+        "ja": "サルバドール",
+        "ja_typings": [
+          "sarubado-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02586",
+    "image_path": null,
+    "question_text": {
+      "en": "ブラジルでコルコバードのキリスト像で有名な都市は?",
+      "ja": "Which Brazilian city is famous for the Christ the Redeemer statue?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rotterdam",
+        "ja": "ロッテルダム",
+        "ja_typings": [
+          "rotterudamu"
+        ]
+      },
+      {
+        "en": "Amsterdam",
+        "ja": "アムステルダム",
+        "ja_typings": [
+          "amusuterudamu"
+        ]
+      },
+      {
+        "en": "The Hague",
+        "ja": "ハーグ",
+        "ja_typings": [
+          "ha-gu"
+        ]
+      },
+      {
+        "en": "Utrecht",
+        "ja": "ユトレヒト",
+        "ja_typings": [
+          "yutorehito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02587",
+    "image_path": null,
+    "question_text": {
+      "en": "オランダの主要港湾都市でユーロポートを擁するのは?",
+      "ja": "Which Dutch port city houses Europoort, one of Europe's largest ports?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Saint Petersburg",
+        "ja": "サンクトペテルブルク",
+        "ja_typings": [
+          "sankutopeteruburuku"
+        ]
+      },
+      {
+        "en": "Moscow",
+        "ja": "モスクワ",
+        "ja_typings": [
+          "mosukuwa"
+        ]
+      },
+      {
+        "en": "Kazan",
+        "ja": "カザン",
+        "ja_typings": [
+          "kazan"
+        ]
+      },
+      {
+        "en": "Yekaterinburg",
+        "ja": "エカテリンブルク",
+        "ja_typings": [
+          "ekaterinburuku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02588",
+    "image_path": null,
+    "question_text": {
+      "en": "ロシアの旧首都でバルト海沿岸の都市は?",
+      "ja": "Which is Russia's former capital on the Baltic coast?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Santiago",
+        "ja": "サンティアゴ",
+        "ja_typings": [
+          "santiago"
+        ]
+      },
+      {
+        "en": "Buenos Aires",
+        "ja": "ブエノスアイレス",
+        "ja_typings": [
+          "buenosuairesu"
+        ]
+      },
+      {
+        "en": "Lima",
+        "ja": "リマ",
+        "ja_typings": [
+          "rima"
+        ]
+      },
+      {
+        "en": "La Paz",
+        "ja": "ラパス",
+        "ja_typings": [
+          "rapasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02589",
+    "image_path": null,
+    "question_text": {
+      "en": "チリの首都は?",
+      "ja": "What is the capital of Chile?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sao Paulo",
+        "ja": "サンパウロ",
+        "ja_typings": [
+          "sanpauro"
+        ]
+      },
+      {
+        "en": "Rio de Janeiro",
+        "ja": "リオデジャネイロ",
+        "ja_typings": [
+          "riodejaneiro"
+        ]
+      },
+      {
+        "en": "Brasilia",
+        "ja": "ブラジリア",
+        "ja_typings": [
+          "burajiria"
+        ]
+      },
+      {
+        "en": "Salvador",
+        "ja": "サルバドール",
+        "ja_typings": [
+          "sarubado-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02590",
+    "image_path": null,
+    "question_text": {
+      "en": "ブラジル最大の都市は?",
+      "ja": "Which is the largest city in Brazil?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Seville",
+        "ja": "セビリア",
+        "ja_typings": [
+          "sebiria"
+        ]
+      },
+      {
+        "en": "Cordoba",
+        "ja": "コルドバ",
+        "ja_typings": [
+          "korudoba"
+        ]
+      },
+      {
+        "en": "Granada",
+        "ja": "グラナダ",
+        "ja_typings": [
+          "guranada"
+        ]
+      },
+      {
+        "en": "Malaga",
+        "ja": "マラガ",
+        "ja_typings": [
+          "maraga"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02591",
+    "image_path": null,
+    "question_text": {
+      "en": "スペイン南部アンダルシア州の州都は?",
+      "ja": "What is the capital of Andalusia in southern Spain?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shanghai",
+        "ja": "上海",
+        "ja_typings": [
+          "shanhai"
+        ]
+      },
+      {
+        "en": "Beijing",
+        "ja": "北京",
+        "ja_typings": [
+          "pekin"
+        ]
+      },
+      {
+        "en": "Guangzhou",
+        "ja": "広州",
+        "ja_typings": [
+          "koushuu"
+        ]
+      },
+      {
+        "en": "Shenzhen",
+        "ja": "深圳",
+        "ja_typings": [
+          "shinsen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02592",
+    "image_path": null,
+    "question_text": {
+      "en": "中国最大の都市で長江河口の港湾都市は?",
+      "ja": "Which is China's largest city, located at the mouth of the Yangtze?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Siberia",
+        "ja": "シベリア",
+        "ja_typings": [
+          "shiberia"
+        ]
+      },
+      {
+        "en": "Mongolia",
+        "ja": "モンゴル",
+        "ja_typings": [
+          "mongoru"
+        ]
+      },
+      {
+        "en": "Manchuria",
+        "ja": "満州",
+        "ja_typings": [
+          "manshuu"
+        ]
+      },
+      {
+        "en": "Caucasus",
+        "ja": "コーカサス",
+        "ja_typings": [
+          "ko-kasasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02593",
+    "image_path": null,
+    "question_text": {
+      "en": "ロシア東部に広がる広大な地域は?",
+      "ja": "Which vast region covers eastern Russia?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "South Africa",
+        "ja": "南アフリカ",
+        "ja_typings": [
+          "minamiafurika"
+        ]
+      },
+      {
+        "en": "Namibia",
+        "ja": "ナミビア",
+        "ja_typings": [
+          "namibia"
+        ]
+      },
+      {
+        "en": "Botswana",
+        "ja": "ボツワナ",
+        "ja_typings": [
+          "botsuwana"
+        ]
+      },
+      {
+        "en": "Zimbabwe",
+        "ja": "ジンバブエ",
+        "ja_typings": [
+          "jinbabue"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02594",
+    "image_path": null,
+    "question_text": {
+      "en": "ケープタウンを擁するアフリカ大陸南端の国は?",
+      "ja": "Which country at Africa's southern tip is home to Cape Town?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "South America",
+        "ja": "南アメリカ",
+        "ja_typings": [
+          "minamiamerika"
+        ]
+      },
+      {
+        "en": "North America",
+        "ja": "北アメリカ",
+        "ja_typings": [
+          "kitaamerika"
+        ]
+      },
+      {
+        "en": "Africa",
+        "ja": "アフリカ",
+        "ja_typings": [
+          "afurika"
+        ]
+      },
+      {
+        "en": "Asia",
+        "ja": "アジア",
+        "ja_typings": [
+          "ajia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02595",
+    "image_path": null,
+    "question_text": {
+      "en": "ブラジルやアルゼンチンを含む大陸は?",
+      "ja": "Which continent includes Brazil and Argentina?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sparta",
+        "ja": "スパルタ",
+        "ja_typings": [
+          "suparuta"
+        ]
+      },
+      {
+        "en": "Athens",
+        "ja": "アテネ",
+        "ja_typings": [
+          "atene"
+        ]
+      },
+      {
+        "en": "Corinth",
+        "ja": "コリント",
+        "ja_typings": [
+          "korinto"
+        ]
+      },
+      {
+        "en": "Thebes",
+        "ja": "テーベ",
+        "ja_typings": [
+          "te-be"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02596",
+    "image_path": null,
+    "question_text": {
+      "en": "古代ギリシャの軍事都市国家は?",
+      "ja": "Which ancient Greek city-state was famous for its military?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tenryu River",
+        "ja": "天竜川",
+        "ja_typings": [
+          "tenryuugawa",
+          "tenryuukawa"
+        ]
+      },
+      {
+        "en": "Tone River",
+        "ja": "利根川",
+        "ja_typings": [
+          "tonegawa",
+          "tonekawa"
+        ]
+      },
+      {
+        "en": "Ishikari River",
+        "ja": "石狩川",
+        "ja_typings": [
+          "ishikarigawa",
+          "ishikarikawa"
+        ]
+      },
+      {
+        "en": "Shinano River",
+        "ja": "信濃川",
+        "ja_typings": [
+          "shinanogawa",
+          "shinanokawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02597",
+    "image_path": null,
+    "question_text": {
+      "en": "長野県・静岡県を流れて遠州灘に注ぐ川は?",
+      "ja": "Which river flows from Nagano through Shizuoka into Enshu-nada Sea?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Hague",
+        "ja": "ハーグ",
+        "ja_typings": [
+          "ha-gu"
+        ]
+      },
+      {
+        "en": "Amsterdam",
+        "ja": "アムステルダム",
+        "ja_typings": [
+          "amusuterudamu"
+        ]
+      },
+      {
+        "en": "Rotterdam",
+        "ja": "ロッテルダム",
+        "ja_typings": [
+          "rotterudamu"
+        ]
+      },
+      {
+        "en": "Utrecht",
+        "ja": "ユトレヒト",
+        "ja_typings": [
+          "yutorehito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02598",
+    "image_path": null,
+    "question_text": {
+      "en": "国際司法裁判所が置かれるオランダの都市は?",
+      "ja": "Which Dutch city is home to the International Court of Justice?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thessaloniki",
+        "ja": "テッサロニキ",
+        "ja_typings": [
+          "tessaroniki"
+        ]
+      },
+      {
+        "en": "Athens",
+        "ja": "アテネ",
+        "ja_typings": [
+          "atene"
+        ]
+      },
+      {
+        "en": "Patras",
+        "ja": "パトラ",
+        "ja_typings": [
+          "patora"
+        ]
+      },
+      {
+        "en": "Heraklion",
+        "ja": "イラクリオン",
+        "ja_typings": [
+          "irakurion"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02599",
+    "image_path": null,
+    "question_text": {
+      "en": "ギリシャ第2の都市は?",
+      "ja": "Which is Greece's second largest city?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tokyo Bay Aqua-Line",
+        "ja": "東京湾アクアライン",
+        "ja_typings": [
+          "toukyouwanakurarain"
+        ]
+      },
+      {
+        "en": "Rainbow Bridge",
+        "ja": "レインボーブリッジ",
+        "ja_typings": [
+          "reinbo-burijji"
+        ]
+      },
+      {
+        "en": "Kanmon Bridge",
+        "ja": "関門橋",
+        "ja_typings": [
+          "kanmonkyou",
+          "kanmonbashi"
+        ]
+      },
+      {
+        "en": "Seto Ohashi",
+        "ja": "瀬戸大橋",
+        "ja_typings": [
+          "setoohashi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02600",
+    "image_path": null,
+    "question_text": {
+      "en": "東京と神奈川を結ぶ東京湾を横断する道路は?",
+      "ja": "Which highway crosses Tokyo Bay between Tokyo area and Kanagawa?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tone River",
+        "ja": "利根川",
+        "ja_typings": [
+          "tonegawa",
+          "tonekawa"
+        ]
+      },
+      {
+        "en": "Shinano River",
+        "ja": "信濃川",
+        "ja_typings": [
+          "shinanogawa",
+          "shinanokawa"
+        ]
+      },
+      {
+        "en": "Ishikari River",
+        "ja": "石狩川",
+        "ja_typings": [
+          "ishikarigawa",
+          "ishikarikawa"
+        ]
+      },
+      {
+        "en": "Kitakami River",
+        "ja": "北上川",
+        "ja_typings": [
+          "kitakamigawa",
+          "kitakamikawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02601",
+    "image_path": null,
+    "question_text": {
+      "en": "関東平野を流れる日本最大の流域面積を持つ川は?",
+      "ja": "Which Kanto Plain river has Japan's largest drainage basin?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Toronto",
+        "ja": "トロント",
+        "ja_typings": [
+          "toronto"
+        ]
+      },
+      {
+        "en": "Montreal",
+        "ja": "モントリオール",
+        "ja_typings": [
+          "montorio-ru"
+        ]
+      },
+      {
+        "en": "Vancouver",
+        "ja": "バンクーバー",
+        "ja_typings": [
+          "banku-ba-"
+        ]
+      },
+      {
+        "en": "Ottawa",
+        "ja": "オタワ",
+        "ja_typings": [
+          "otawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02602",
+    "image_path": null,
+    "question_text": {
+      "en": "カナダ最大の都市は?",
+      "ja": "Which is the largest city in Canada?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Turpan Depression",
+        "ja": "トルファン盆地",
+        "ja_typings": [
+          "torufanbonchi"
+        ]
+      },
+      {
+        "en": "Tarim Basin",
+        "ja": "タリム盆地",
+        "ja_typings": [
+          "tarimubonchi"
+        ]
+      },
+      {
+        "en": "Junggar Basin",
+        "ja": "ジュンガル盆地",
+        "ja_typings": [
+          "junngarubonchi"
+        ]
+      },
+      {
+        "en": "Qaidam Basin",
+        "ja": "ツァイダム盆地",
+        "ja_typings": [
+          "tsuaidamubonchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02603",
+    "image_path": null,
+    "question_text": {
+      "en": "中国新疆ウイグル自治区にある中国で最も低い場所は?",
+      "ja": "Which depression in China's Xinjiang region is the country's lowest point?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "USA and Mexico",
+        "ja": "アメリカとメキシコ",
+        "ja_typings": [
+          "amerikatomekishiko"
+        ]
+      },
+      {
+        "en": "Brazil and Argentina",
+        "ja": "ブラジルとアルゼンチン",
+        "ja_typings": [
+          "burajirutoaruzenchin"
+        ]
+      },
+      {
+        "en": "Canada and USA",
+        "ja": "カナダとアメリカ",
+        "ja_typings": [
+          "kanadatoamerika"
+        ]
+      },
+      {
+        "en": "Chile and Peru",
+        "ja": "チリとペルー",
+        "ja_typings": [
+          "chiritoperu-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02604",
+    "image_path": null,
+    "question_text": {
+      "en": "リオ・グランデ川が国境を流れている国の組み合わせは?",
+      "ja": "The Rio Grande forms the border between which two countries?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Utrecht",
+        "ja": "ユトレヒト",
+        "ja_typings": [
+          "yutorehito"
+        ]
+      },
+      {
+        "en": "Amsterdam",
+        "ja": "アムステルダム",
+        "ja_typings": [
+          "amusuterudamu"
+        ]
+      },
+      {
+        "en": "Rotterdam",
+        "ja": "ロッテルダム",
+        "ja_typings": [
+          "rotterudamu"
+        ]
+      },
+      {
+        "en": "The Hague",
+        "ja": "ハーグ",
+        "ja_typings": [
+          "ha-gu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02605",
+    "image_path": null,
+    "question_text": {
+      "en": "オランダ中央部の大学都市は?",
+      "ja": "Which Dutch central city is a major university town?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Valencia",
+        "ja": "バレンシア",
+        "ja_typings": [
+          "barenshia"
+        ]
+      },
+      {
+        "en": "Barcelona",
+        "ja": "バルセロナ",
+        "ja_typings": [
+          "baruserona"
+        ]
+      },
+      {
+        "en": "Madrid",
+        "ja": "マドリード",
+        "ja_typings": [
+          "madori-do"
+        ]
+      },
+      {
+        "en": "Seville",
+        "ja": "セビリア",
+        "ja_typings": [
+          "sebiria"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02606",
+    "image_path": null,
+    "question_text": {
+      "en": "スペイン東部地中海沿岸の都市でパエリア発祥地は?",
+      "ja": "Which eastern Spanish city on the Mediterranean is the birthplace of paella?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vancouver",
+        "ja": "バンクーバー",
+        "ja_typings": [
+          "banku-ba-"
+        ]
+      },
+      {
+        "en": "Toronto",
+        "ja": "トロント",
+        "ja_typings": [
+          "toronto"
+        ]
+      },
+      {
+        "en": "Montreal",
+        "ja": "モントリオール",
+        "ja_typings": [
+          "montorio-ru"
+        ]
+      },
+      {
+        "en": "Calgary",
+        "ja": "カルガリー",
+        "ja_typings": [
+          "karugari-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02607",
+    "image_path": null,
+    "question_text": {
+      "en": "カナダ西海岸の港湾都市は?",
+      "ja": "Which is Canada's main west coast port city?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Venice",
+        "ja": "ベネチア",
+        "ja_typings": [
+          "benechia"
+        ]
+      },
+      {
+        "en": "Florence",
+        "ja": "フィレンツェ",
+        "ja_typings": [
+          "firentse"
+        ]
+      },
+      {
+        "en": "Milan",
+        "ja": "ミラノ",
+        "ja_typings": [
+          "mirano"
+        ]
+      },
+      {
+        "en": "Verona",
+        "ja": "ベローナ",
+        "ja_typings": [
+          "bero-na"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02608",
+    "image_path": null,
+    "question_text": {
+      "en": "イタリア北東部の運河の街は?",
+      "ja": "Which northeastern Italian city is famous for its canals?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vientiane",
+        "ja": "ビエンチャン",
+        "ja_typings": [
+          "bienchan"
+        ]
+      },
+      {
+        "en": "Phnom Penh",
+        "ja": "プノンペン",
+        "ja_typings": [
+          "punonpen"
+        ]
+      },
+      {
+        "en": "Hanoi",
+        "ja": "ハノイ",
+        "ja_typings": [
+          "hanoi"
+        ]
+      },
+      {
+        "en": "Yangon",
+        "ja": "ヤンゴン",
+        "ja_typings": [
+          "yangon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02609",
+    "image_path": null,
+    "question_text": {
+      "en": "ラオスの首都は?",
+      "ja": "What is the capital of Laos?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vladivostok",
+        "ja": "ウラジオストク",
+        "ja_typings": [
+          "urajiosutoku"
+        ]
+      },
+      {
+        "en": "Khabarovsk",
+        "ja": "ハバロフスク",
+        "ja_typings": [
+          "habarofusuku"
+        ]
+      },
+      {
+        "en": "Novosibirsk",
+        "ja": "ノボシビルスク",
+        "ja_typings": [
+          "noboshibirusuku"
+        ]
+      },
+      {
+        "en": "Irkutsk",
+        "ja": "イルクーツク",
+        "ja_typings": [
+          "iruku-tsuku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02610",
+    "image_path": null,
+    "question_text": {
+      "en": "ロシア極東の最大都市は?",
+      "ja": "Which is the largest city in the Russian Far East?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yangtze River",
+        "ja": "長江",
+        "ja_typings": [
+          "chouko",
+          "choukou"
+        ]
+      },
+      {
+        "en": "Yellow River",
+        "ja": "黄河",
+        "ja_typings": [
+          "kouga"
+        ]
+      },
+      {
+        "en": "Mekong River",
+        "ja": "メコン川",
+        "ja_typings": [
+          "mekongawa",
+          "mekonkawa"
+        ]
+      },
+      {
+        "en": "Amur River",
+        "ja": "アムール川",
+        "ja_typings": [
+          "amu-rugawa",
+          "amu-rukawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02611",
+    "image_path": null,
+    "question_text": {
+      "en": "中国を流れるアジア最長の川は?",
+      "ja": "Which is Asia's longest river, flowing through China?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Zambia and Zimbabwe",
+        "ja": "ザンビアとジンバブエ",
+        "ja_typings": [
+          "zanbiatojinbabue"
+        ]
+      },
+      {
+        "en": "Brazil and Argentina",
+        "ja": "ブラジルとアルゼンチン",
+        "ja_typings": [
+          "burajirutoaruzenchin"
+        ]
+      },
+      {
+        "en": "USA and Mexico",
+        "ja": "アメリカとメキシコ",
+        "ja_typings": [
+          "amerikatomekishiko"
+        ]
+      },
+      {
+        "en": "Tanzania and Kenya",
+        "ja": "タンザニアとケニア",
+        "ja_typings": [
+          "tanzaniatokenia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02612",
+    "image_path": null,
+    "question_text": {
+      "en": "ビクトリアの滝が国境にある国の組み合わせは?",
+      "ja": "Victoria Falls lies on the border between which two countries?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "127",
+        "ja": "127",
+        "ja_typings": [
+          "127"
+        ]
+      },
+      {
+        "en": "64",
+        "ja": "64",
+        "ja_typings": [
+          "64"
+        ]
+      },
+      {
+        "en": "32",
+        "ja": "32",
+        "ja_typings": [
+          "32"
+        ]
+      },
+      {
+        "en": "255",
+        "ja": "255",
+        "ja_typings": [
+          "255"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02613",
+    "image_path": null,
+    "question_text": {
+      "en": "IPv4でルータが特別な用途で予約しているTTLのデフォルト最大値の1つは?",
+      "ja": "Which is one of the typical default maximum TTL values used in IPv4?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "128",
+        "ja": "128",
+        "ja_typings": [
+          "128"
+        ]
+      },
+      {
+        "en": "256",
+        "ja": "256",
+        "ja_typings": [
+          "256"
+        ]
+      },
+      {
+        "en": "64",
+        "ja": "64",
+        "ja_typings": [
+          "64"
+        ]
+      },
+      {
+        "en": "127",
+        "ja": "127",
+        "ja_typings": [
+          "127"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02614",
+    "image_path": null,
+    "question_text": {
+      "en": "8ビット符号なし整数で表せる最大値は?",
+      "ja": "What is the maximum value of an 8-bit unsigned integer?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "16",
+        "ja": "16ビット",
+        "ja_typings": [
+          "16bitto"
+        ]
+      },
+      {
+        "en": "32",
+        "ja": "32ビット",
+        "ja_typings": [
+          "32bitto"
+        ]
+      },
+      {
+        "en": "8",
+        "ja": "8ビット",
+        "ja_typings": [
+          "8bitto"
+        ]
+      },
+      {
+        "en": "64",
+        "ja": "64ビット",
+        "ja_typings": [
+          "64bitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02615",
+    "image_path": null,
+    "question_text": {
+      "en": "C言語のshort型で多くの環境におけるビット数は?",
+      "ja": "How many bits does C's short type typically have?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "256",
+        "ja": "256通り",
+        "ja_typings": [
+          "256toori"
+        ]
+      },
+      {
+        "en": "128",
+        "ja": "128通り",
+        "ja_typings": [
+          "128toori"
+        ]
+      },
+      {
+        "en": "512",
+        "ja": "512通り",
+        "ja_typings": [
+          "512toori"
+        ]
+      },
+      {
+        "en": "64",
+        "ja": "64通り",
+        "ja_typings": [
+          "64toori"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02616",
+    "image_path": null,
+    "question_text": {
+      "en": "8ビット整数で表現できる値の総数は?",
+      "ja": "How many distinct values can be represented with 8 bits?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "64",
+        "ja": "64ビット",
+        "ja_typings": [
+          "64bitto"
+        ]
+      },
+      {
+        "en": "32",
+        "ja": "32ビット",
+        "ja_typings": [
+          "32bitto"
+        ]
+      },
+      {
+        "en": "16",
+        "ja": "16ビット",
+        "ja_typings": [
+          "16bitto"
+        ]
+      },
+      {
+        "en": "128",
+        "ja": "128ビット",
+        "ja_typings": [
+          "128bitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02617",
+    "image_path": null,
+    "question_text": {
+      "en": "x86_64アーキテクチャでの汎用レジスタの幅は何ビット?",
+      "ja": "How many bits wide is a general purpose register in x86_64?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "8",
+        "ja": "8ビット",
+        "ja_typings": [
+          "8bitto"
+        ]
+      },
+      {
+        "en": "4",
+        "ja": "4ビット",
+        "ja_typings": [
+          "4bitto"
+        ]
+      },
+      {
+        "en": "16",
+        "ja": "16ビット",
+        "ja_typings": [
+          "16bitto"
+        ]
+      },
+      {
+        "en": "32",
+        "ja": "32ビット",
+        "ja_typings": [
+          "32bitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02618",
+    "image_path": null,
+    "question_text": {
+      "en": "IPv4の1オクテットは何ビット?",
+      "ja": "How many bits is one octet in IPv4?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ARP",
+        "ja": "ARP",
+        "ja_typings": [
+          "arp"
+        ]
+      },
+      {
+        "en": "DNS",
+        "ja": "DNS",
+        "ja_typings": [
+          "dns"
+        ]
+      },
+      {
+        "en": "DHCP",
+        "ja": "DHCP",
+        "ja_typings": [
+          "dhcp"
+        ]
+      },
+      {
+        "en": "ICMP",
+        "ja": "ICMP",
+        "ja_typings": [
+          "icmp"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02619",
+    "image_path": null,
+    "question_text": {
+      "en": "IPアドレスからMACアドレスを解決するプロトコルは?",
+      "ja": "Which protocol resolves IP addresses to MAC addresses?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ansible",
+        "ja": "Ansible",
+        "ja_typings": [
+          "ansible"
+        ]
+      },
+      {
+        "en": "Terraform",
+        "ja": "Terraform",
+        "ja_typings": [
+          "terraform"
+        ]
+      },
+      {
+        "en": "Chef",
+        "ja": "Chef",
+        "ja_typings": [
+          "chef"
+        ]
+      },
+      {
+        "en": "Puppet",
+        "ja": "Puppet",
+        "ja_typings": [
+          "puppet"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02620",
+    "image_path": null,
+    "question_text": {
+      "en": "サーバ構成管理ツールでYAMLで定義しエージェントレスで動作するのは?",
+      "ja": "Which agentless configuration management tool uses YAML playbooks?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ant",
+        "ja": "Ant",
+        "ja_typings": [
+          "ant"
+        ]
+      },
+      {
+        "en": "Maven",
+        "ja": "Maven",
+        "ja_typings": [
+          "maven"
+        ]
+      },
+      {
+        "en": "Gradle",
+        "ja": "Gradle",
+        "ja_typings": [
+          "gradle"
+        ]
+      },
+      {
+        "en": "Cargo",
+        "ja": "Cargo",
+        "ja_typings": [
+          "cargo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02621",
+    "image_path": null,
+    "question_text": {
+      "en": "Javaのビルドツールで古くから使われているXMLベースのものは?",
+      "ja": "Which old XML-based build tool is used for Java projects?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Arc",
+        "ja": "Arc",
+        "ja_typings": [
+          "arc"
+        ]
+      },
+      {
+        "en": "Brave",
+        "ja": "Brave",
+        "ja_typings": [
+          "brave"
+        ]
+      },
+      {
+        "en": "Vivaldi",
+        "ja": "Vivaldi",
+        "ja_typings": [
+          "vivaldi"
+        ]
+      },
+      {
+        "en": "Opera",
+        "ja": "Opera",
+        "ja_typings": [
+          "opera"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02622",
+    "image_path": null,
+    "question_text": {
+      "en": "Mozillaが開発したJavaScriptランタイム向けの新ブラウザは?",
+      "ja": "Which browser was made by The Browser Company with a focus on tabs and workflows?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Assembler",
+        "ja": "アセンブラ",
+        "ja_typings": [
+          "asenbura"
+        ]
+      },
+      {
+        "en": "Compiler",
+        "ja": "コンパイラ",
+        "ja_typings": [
+          "konpaira"
+        ]
+      },
+      {
+        "en": "Interpreter",
+        "ja": "インタプリタ",
+        "ja_typings": [
+          "intapurita"
+        ]
+      },
+      {
+        "en": "Linker",
+        "ja": "リンカ",
+        "ja_typings": [
+          "rinka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02623",
+    "image_path": null,
+    "question_text": {
+      "en": "アセンブリ言語を機械語に変換するプログラムは?",
+      "ja": "Which program translates assembly language into machine code?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Assembly",
+        "ja": "アセンブリ言語",
+        "ja_typings": [
+          "asenburigengo"
+        ]
+      },
+      {
+        "en": "Machine Code",
+        "ja": "機械語",
+        "ja_typings": [
+          "kikaigo"
+        ]
+      },
+      {
+        "en": "C",
+        "ja": "C言語",
+        "ja_typings": [
+          "cgengo"
+        ]
+      },
+      {
+        "en": "Fortran",
+        "ja": "Fortran",
+        "ja_typings": [
+          "fortran"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02624",
+    "image_path": null,
+    "question_text": {
+      "en": "CPUの命令を直接表現する低水準言語は?",
+      "ja": "Which low-level language directly represents CPU instructions?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Assignment",
+        "ja": "代入",
+        "ja_typings": [
+          "dainyuu"
+        ]
+      },
+      {
+        "en": "Declaration",
+        "ja": "宣言",
+        "ja_typings": [
+          "sengen"
+        ]
+      },
+      {
+        "en": "Initialization",
+        "ja": "初期化",
+        "ja_typings": [
+          "shokika"
+        ]
+      },
+      {
+        "en": "Reference",
+        "ja": "参照",
+        "ja_typings": [
+          "sanshou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02625",
+    "image_path": null,
+    "question_text": {
+      "en": "プログラミングで変数に値を入れる操作は?",
+      "ja": "What is the operation of setting a value into a variable called?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Average run count",
+        "ja": "平均実行回数",
+        "ja_typings": [
+          "heikinjikkoukaisuu"
+        ]
+      },
+      {
+        "en": "Memory usage",
+        "ja": "メモリ使用量",
+        "ja_typings": [
+          "memorishiyouryou"
+        ]
+      },
+      {
+        "en": "Source Map",
+        "ja": "ソースマップ",
+        "ja_typings": [
+          "so-sumappu"
+        ]
+      },
+      {
+        "en": "Stack Overflow",
+        "ja": "スタックオーバーフロー",
+        "ja_typings": [
+          "sutakkuo-ba-furo-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02626",
+    "image_path": null,
+    "question_text": {
+      "en": "プロファイラで関数の平均実行回数を示す指標は?",
+      "ja": "Which profiling metric shows the average number of times a function ran?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "BFS",
+        "ja": "幅優先探索",
+        "ja_typings": [
+          "habayuusentansaku"
+        ]
+      },
+      {
+        "en": "DFS",
+        "ja": "深さ優先探索",
+        "ja_typings": [
+          "fukasayuusentansaku"
+        ]
+      },
+      {
+        "en": "Mergesort",
+        "ja": "マージソート",
+        "ja_typings": [
+          "ma-jiso-to"
+        ]
+      },
+      {
+        "en": "Quicksort",
+        "ja": "クイックソート",
+        "ja_typings": [
+          "kuikkuso-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02627",
+    "image_path": null,
+    "question_text": {
+      "en": "グラフ探索で全方向に広く探索する手法は?",
+      "ja": "Which graph traversal explores all neighbors level by level?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "BPS",
+        "ja": "BPS",
+        "ja_typings": [
+          "bps"
+        ]
+      },
+      {
+        "en": "FPS",
+        "ja": "FPS",
+        "ja_typings": [
+          "fps"
+        ]
+      },
+      {
+        "en": "DPS",
+        "ja": "DPS",
+        "ja_typings": [
+          "dps"
+        ]
+      },
+      {
+        "en": "FFS",
+        "ja": "FFS",
+        "ja_typings": [
+          "ffs"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02628",
+    "image_path": null,
+    "question_text": {
+      "en": "ビットレートの単位で1秒間のビット数を表すのは?",
+      "ja": "Which unit represents bits transferred per second?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bad Request",
+        "ja": "Bad Request",
+        "ja_typings": [
+          "bad request",
+          "badrequest"
+        ]
+      },
+      {
+        "en": "Not Found",
+        "ja": "Not Found",
+        "ja_typings": [
+          "not found",
+          "notfound"
+        ]
+      },
+      {
+        "en": "Forbidden",
+        "ja": "Forbidden",
+        "ja_typings": [
+          "forbidden"
+        ]
+      },
+      {
+        "en": "Unauthorized",
+        "ja": "Unauthorized",
+        "ja_typings": [
+          "unauthorized"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02629",
+    "image_path": null,
+    "question_text": {
+      "en": "HTTPステータスコード400が示すのは?",
+      "ja": "What does HTTP status code 400 indicate?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bash",
+        "ja": "Bash",
+        "ja_typings": [
+          "bash"
+        ]
+      },
+      {
+        "en": "Zsh",
+        "ja": "Zsh",
+        "ja_typings": [
+          "zsh"
+        ]
+      },
+      {
+        "en": "Fish",
+        "ja": "Fish",
+        "ja_typings": [
+          "fish"
+        ]
+      },
+      {
+        "en": "Tcsh",
+        "ja": "Tcsh",
+        "ja_typings": [
+          "tcsh"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02630",
+    "image_path": null,
+    "question_text": {
+      "en": "Linuxで標準的に使われるシェルは?",
+      "ja": "Which is the standard shell on most Linux distributions?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bill Joy",
+        "ja": "Bill Joy",
+        "ja_typings": [
+          "bill joy",
+          "billjoy"
+        ]
+      },
+      {
+        "en": "Bjarne Stroustrup",
+        "ja": "Bjarne Stroustrup",
+        "ja_typings": [
+          "bjarne stroustrup",
+          "bjarnestroustrup"
+        ]
+      },
+      {
+        "en": "Linus Torvalds",
+        "ja": "Linus Torvalds",
+        "ja_typings": [
+          "linus torvalds",
+          "linustorvalds"
+        ]
+      },
+      {
+        "en": "Richard Stallman",
+        "ja": "Richard Stallman",
+        "ja_typings": [
+          "richard stallman",
+          "richardstallman"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02631",
+    "image_path": null,
+    "question_text": {
+      "en": "viエディタを開発した人物は?",
+      "ja": "Who is the author of the vi editor?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bitwise OR",
+        "ja": "ビット論理和",
+        "ja_typings": [
+          "bittoronriwa"
+        ]
+      },
+      {
+        "en": "Logical AND",
+        "ja": "論理積",
+        "ja_typings": [
+          "ronriseki"
+        ]
+      },
+      {
+        "en": "Bitwise XOR",
+        "ja": "ビット排他的論理和",
+        "ja_typings": [
+          "bittohaitatekironriwa"
+        ]
+      },
+      {
+        "en": "Bitwise AND",
+        "ja": "ビット論理積",
+        "ja_typings": [
+          "bittoronriseki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02632",
+    "image_path": null,
+    "question_text": {
+      "en": "ビット単位で「どちらかが1なら1」を取る演算は?",
+      "ja": "Which bitwise operation returns 1 if either bit is 1?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bjarne Stroustrup",
+        "ja": "Bjarne Stroustrup",
+        "ja_typings": [
+          "bjarne stroustrup",
+          "bjarnestroustrup"
+        ]
+      },
+      {
+        "en": "Dennis Ritchie",
+        "ja": "Dennis Ritchie",
+        "ja_typings": [
+          "dennis ritchie",
+          "dennisritchie"
+        ]
+      },
+      {
+        "en": "Bill Joy",
+        "ja": "Bill Joy",
+        "ja_typings": [
+          "bill joy",
+          "billjoy"
+        ]
+      },
+      {
+        "en": "Brian Kernighan",
+        "ja": "Brian Kernighan",
+        "ja_typings": [
+          "brian kernighan",
+          "briankernighan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02633",
+    "image_path": null,
+    "question_text": {
+      "en": "C++を設計した人物は?",
+      "ja": "Who designed the C++ programming language?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Box",
+        "ja": "Box",
+        "ja_typings": [
+          "box"
+        ]
+      },
+      {
+        "en": "Rc",
+        "ja": "Rc",
+        "ja_typings": [
+          "rc"
+        ]
+      },
+      {
+        "en": "Arc",
+        "ja": "Arc",
+        "ja_typings": [
+          "arc"
+        ]
+      },
+      {
+        "en": "RefCell",
+        "ja": "RefCell",
+        "ja_typings": [
+          "refcell"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02634",
+    "image_path": null,
+    "question_text": {
+      "en": "Rustのヒープに値を1つ置くスマートポインタ型は?",
+      "ja": "Which Rust smart pointer places a single value on the heap?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Brendan Eich",
+        "ja": "Brendan Eich",
+        "ja_typings": [
+          "brendan eich",
+          "brendaneich"
+        ]
+      },
+      {
+        "en": "Guido van Rossum",
+        "ja": "Guido van Rossum",
+        "ja_typings": [
+          "guido van rossum",
+          "guidovanrossum"
+        ]
+      },
+      {
+        "en": "Larry Wall",
+        "ja": "Larry Wall",
+        "ja_typings": [
+          "larry wall",
+          "larrywall"
+        ]
+      },
+      {
+        "en": "Yukihiro Matsumoto",
+        "ja": "Yukihiro Matsumoto",
+        "ja_typings": [
+          "yukihiro matsumoto",
+          "yukihiromatsumoto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02635",
+    "image_path": null,
+    "question_text": {
+      "en": "JavaScriptを設計した人物は?",
+      "ja": "Who designed JavaScript?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Brian Kernighan",
+        "ja": "Brian Kernighan",
+        "ja_typings": [
+          "brian kernighan",
+          "briankernighan"
+        ]
+      },
+      {
+        "en": "Dennis Ritchie",
+        "ja": "Dennis Ritchie",
+        "ja_typings": [
+          "dennis ritchie",
+          "dennisritchie"
+        ]
+      },
+      {
+        "en": "Bjarne Stroustrup",
+        "ja": "Bjarne Stroustrup",
+        "ja_typings": [
+          "bjarne stroustrup",
+          "bjarnestroustrup"
+        ]
+      },
+      {
+        "en": "Bill Joy",
+        "ja": "Bill Joy",
+        "ja_typings": [
+          "bill joy",
+          "billjoy"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02636",
+    "image_path": null,
+    "question_text": {
+      "en": "AWKの開発者の1人で『プログラミング言語C』の共著者は?",
+      "ja": "Who co-authored 'The C Programming Language' and co-created AWK?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "C",
+        "ja": "C言語",
+        "ja_typings": [
+          "cgengo"
+        ]
+      },
+      {
+        "en": "Pascal",
+        "ja": "Pascal",
+        "ja_typings": [
+          "pascal"
+        ]
+      },
+      {
+        "en": "Fortran",
+        "ja": "Fortran",
+        "ja_typings": [
+          "fortran"
+        ]
+      },
+      {
+        "en": "COBOL",
+        "ja": "COBOL",
+        "ja_typings": [
+          "cobol"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02637",
+    "image_path": null,
+    "question_text": {
+      "en": "UNIX上で生まれた構造化プログラミング言語は?",
+      "ja": "Which structured language was developed on UNIX in the 1970s?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CLR",
+        "ja": "CLR",
+        "ja_typings": [
+          "clr"
+        ]
+      },
+      {
+        "en": "JVM",
+        "ja": "JVM",
+        "ja_typings": [
+          "jvm"
+        ]
+      },
+      {
+        "en": "LLVM",
+        "ja": "LLVM",
+        "ja_typings": [
+          "llvm"
+        ]
+      },
+      {
+        "en": "V8",
+        "ja": "V8",
+        "ja_typings": [
+          "v8"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02638",
+    "image_path": null,
+    "question_text": {
+      "en": ".NETの共通言語ランタイムの略称は?",
+      "ja": "What is the abbreviation for .NET's common language runtime?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "COBOL",
+        "ja": "COBOL",
+        "ja_typings": [
+          "cobol"
+        ]
+      },
+      {
+        "en": "Fortran",
+        "ja": "Fortran",
+        "ja_typings": [
+          "fortran"
+        ]
+      },
+      {
+        "en": "Pascal",
+        "ja": "Pascal",
+        "ja_typings": [
+          "pascal"
+        ]
+      },
+      {
+        "en": "Assembly",
+        "ja": "アセンブリ言語",
+        "ja_typings": [
+          "asenburigengo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02639",
+    "image_path": null,
+    "question_text": {
+      "en": "事務処理用に1959年に作られた言語は?",
+      "ja": "Which programming language was designed in 1959 for business processing?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CSS",
+        "ja": "CSS",
+        "ja_typings": [
+          "css"
+        ]
+      },
+      {
+        "en": "HTML",
+        "ja": "HTML",
+        "ja_typings": [
+          "html"
+        ]
+      },
+      {
+        "en": "JavaScript",
+        "ja": "JavaScript",
+        "ja_typings": [
+          "javascript"
+        ]
+      },
+      {
+        "en": "XML",
+        "ja": "XML",
+        "ja_typings": [
+          "xml"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02640",
+    "image_path": null,
+    "question_text": {
+      "en": "HTMLの見た目を装飾する言語は?",
+      "ja": "Which language styles HTML documents?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cargo",
+        "ja": "Cargo",
+        "ja_typings": [
+          "cargo"
+        ]
+      },
+      {
+        "en": "Maven",
+        "ja": "Maven",
+        "ja_typings": [
+          "maven"
+        ]
+      },
+      {
+        "en": "Ant",
+        "ja": "Ant",
+        "ja_typings": [
+          "ant"
+        ]
+      },
+      {
+        "en": "pip",
+        "ja": "pip",
+        "ja_typings": [
+          "pip"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02641",
+    "image_path": null,
+    "question_text": {
+      "en": "Rustのパッケージマネージャ兼ビルドツールは?",
+      "ja": "What is Rust's package manager and build tool called?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cassandra",
+        "ja": "Cassandra",
+        "ja_typings": [
+          "cassandra"
+        ]
+      },
+      {
+        "en": "MongoDB",
+        "ja": "MongoDB",
+        "ja_typings": [
+          "mongodb"
+        ]
+      },
+      {
+        "en": "Neo4j",
+        "ja": "Neo4j",
+        "ja_typings": [
+          "neo4j"
+        ]
+      },
+      {
+        "en": "SQLite",
+        "ja": "SQLite",
+        "ja_typings": [
+          "sqlite"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02642",
+    "image_path": null,
+    "question_text": {
+      "en": "分散NoSQLデータベースの1つで列指向ストアなのは?",
+      "ja": "Which distributed NoSQL database uses a column-family store?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Client Error",
+        "ja": "クライアントエラー",
+        "ja_typings": [
+          "kuraiantoera-"
+        ]
+      },
+      {
+        "en": "Server Error",
+        "ja": "サーバーエラー",
+        "ja_typings": [
+          "sa-ba-era-"
+        ]
+      },
+      {
+        "en": "Redirect",
+        "ja": "リダイレクト",
+        "ja_typings": [
+          "ridairekuto"
+        ]
+      },
+      {
+        "en": "Success",
+        "ja": "成功",
+        "ja_typings": [
+          "seikou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02643",
+    "image_path": null,
+    "question_text": {
+      "en": "HTTPの4xx系ステータスコードが意味するのは?",
+      "ja": "What category does HTTP 4xx status code belong to?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Compiler",
+        "ja": "コンパイラ",
+        "ja_typings": [
+          "konpaira"
+        ]
+      },
+      {
+        "en": "Interpreter",
+        "ja": "インタプリタ",
+        "ja_typings": [
+          "intapurita"
+        ]
+      },
+      {
+        "en": "Assembler",
+        "ja": "アセンブラ",
+        "ja_typings": [
+          "asenbura"
+        ]
+      },
+      {
+        "en": "Linker",
+        "ja": "リンカ",
+        "ja_typings": [
+          "rinka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02644",
+    "image_path": null,
+    "question_text": {
+      "en": "ソースコードを機械語などに翻訳するソフトウェアは?",
+      "ja": "Which software translates source code into machine code?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DFS",
+        "ja": "深さ優先探索",
+        "ja_typings": [
+          "fukasayuusentansaku"
+        ]
+      },
+      {
+        "en": "BFS",
+        "ja": "幅優先探索",
+        "ja_typings": [
+          "habayuusentansaku"
+        ]
+      },
+      {
+        "en": "Quicksort",
+        "ja": "クイックソート",
+        "ja_typings": [
+          "kuikkuso-to"
+        ]
+      },
+      {
+        "en": "Mergesort",
+        "ja": "マージソート",
+        "ja_typings": [
+          "ma-jiso-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02645",
+    "image_path": null,
+    "question_text": {
+      "en": "グラフ探索でできるだけ深く進むのは?",
+      "ja": "Which graph traversal explores as deep as possible first?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DPS",
+        "ja": "DPS",
+        "ja_typings": [
+          "dps"
+        ]
+      },
+      {
+        "en": "BPS",
+        "ja": "BPS",
+        "ja_typings": [
+          "bps"
+        ]
+      },
+      {
+        "en": "FPS",
+        "ja": "FPS",
+        "ja_typings": [
+          "fps"
+        ]
+      },
+      {
+        "en": "FFS",
+        "ja": "FFS",
+        "ja_typings": [
+          "ffs"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02646",
+    "image_path": null,
+    "question_text": {
+      "en": "1秒間に与えるダメージ量の指標は?",
+      "ja": "Which gaming metric measures damage dealt per second?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Debugger",
+        "ja": "デバッガ",
+        "ja_typings": [
+          "debagga"
+        ]
+      },
+      {
+        "en": "Profiler",
+        "ja": "プロファイラ",
+        "ja_typings": [
+          "purofaira"
+        ]
+      },
+      {
+        "en": "Compiler",
+        "ja": "コンパイラ",
+        "ja_typings": [
+          "konpaira"
+        ]
+      },
+      {
+        "en": "Linker",
+        "ja": "リンカ",
+        "ja_typings": [
+          "rinka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02647",
+    "image_path": null,
+    "question_text": {
+      "en": "プログラムをステップ実行・変数監視できるツールは?",
+      "ja": "Which tool lets you step through code and inspect variables?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Decimal",
+        "ja": "10進数",
+        "ja_typings": [
+          "10shinsuu",
+          "juushinsuu"
+        ]
+      },
+      {
+        "en": "Hexadecimal",
+        "ja": "16進数",
+        "ja_typings": [
+          "16shinsuu",
+          "juurokushinsuu"
+        ]
+      },
+      {
+        "en": "Octal",
+        "ja": "8進数",
+        "ja_typings": [
+          "8shinsuu",
+          "hasshinsuu"
+        ]
+      },
+      {
+        "en": "Binary",
+        "ja": "2進数",
+        "ja_typings": [
+          "2shinsuu",
+          "nishinsuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02648",
+    "image_path": null,
+    "question_text": {
+      "en": "0から9までの記号を使う数値表現は?",
+      "ja": "Which numeral system uses digits 0 through 9?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dennis Ritchie",
+        "ja": "Dennis Ritchie",
+        "ja_typings": [
+          "dennis ritchie",
+          "dennisritchie"
+        ]
+      },
+      {
+        "en": "Brian Kernighan",
+        "ja": "Brian Kernighan",
+        "ja_typings": [
+          "brian kernighan",
+          "briankernighan"
+        ]
+      },
+      {
+        "en": "Bjarne Stroustrup",
+        "ja": "Bjarne Stroustrup",
+        "ja_typings": [
+          "bjarne stroustrup",
+          "bjarnestroustrup"
+        ]
+      },
+      {
+        "en": "Bill Joy",
+        "ja": "Bill Joy",
+        "ja_typings": [
+          "bill joy",
+          "billjoy"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02649",
+    "image_path": null,
+    "question_text": {
+      "en": "C言語を開発した人物は?",
+      "ja": "Who developed the C programming language?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Docker Compose",
+        "ja": "Docker Compose",
+        "ja_typings": [
+          "docker compose",
+          "dockercompose"
+        ]
+      },
+      {
+        "en": "Terraform",
+        "ja": "Terraform",
+        "ja_typings": [
+          "terraform"
+        ]
+      },
+      {
+        "en": "Ansible",
+        "ja": "Ansible",
+        "ja_typings": [
+          "ansible"
+        ]
+      },
+      {
+        "en": "Kubernetes",
+        "ja": "Kubernetes",
+        "ja_typings": [
+          "kubernetes"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02650",
+    "image_path": null,
+    "question_text": {
+      "en": "複数のコンテナをまとめて定義・起動するツールは?",
+      "ja": "Which tool runs multi-container Docker applications via YAML?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dynamic",
+        "ja": "動的",
+        "ja_typings": [
+          "douteki"
+        ]
+      },
+      {
+        "en": "Static",
+        "ja": "静的",
+        "ja_typings": [
+          "seiteki"
+        ]
+      },
+      {
+        "en": "Immutable",
+        "ja": "イミュータブル",
+        "ja_typings": [
+          "imyu-taburu"
+        ]
+      },
+      {
+        "en": "Compiled",
+        "ja": "コンパイル型",
+        "ja_typings": [
+          "konpairugata"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02651",
+    "image_path": null,
+    "question_text": {
+      "en": "実行時に型が決まる言語の性質を表す語は?",
+      "ja": "Which term describes a language whose types are determined at runtime?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Encapsulation",
+        "ja": "カプセル化",
+        "ja_typings": [
+          "kapuseruka"
+        ]
+      },
+      {
+        "en": "Polymorphism",
+        "ja": "ポリモーフィズム",
+        "ja_typings": [
+          "porimo-fizumu"
+        ]
+      },
+      {
+        "en": "Inheritance",
+        "ja": "継承",
+        "ja_typings": [
+          "keishou"
+        ]
+      },
+      {
+        "en": "Abstraction",
+        "ja": "抽象化",
+        "ja_typings": [
+          "chuushouka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02652",
+    "image_path": null,
+    "question_text": {
+      "en": "オブジェクト指向で内部状態を隠す概念は?",
+      "ja": "Which OOP concept hides internal state and exposes a public interface?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FETCH",
+        "ja": "FETCH",
+        "ja_typings": [
+          "fetch"
+        ]
+      },
+      {
+        "en": "MERGE",
+        "ja": "MERGE",
+        "ja_typings": [
+          "merge"
+        ]
+      },
+      {
+        "en": "GROUP",
+        "ja": "GROUP",
+        "ja_typings": [
+          "group"
+        ]
+      },
+      {
+        "en": "HEAD",
+        "ja": "HEAD",
+        "ja_typings": [
+          "head"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02653",
+    "image_path": null,
+    "question_text": {
+      "en": "SQLでデータを取得するために使われるカーソル操作の文は?",
+      "ja": "Which SQL statement retrieves rows from a cursor?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FFS",
+        "ja": "FFS",
+        "ja_typings": [
+          "ffs"
+        ]
+      },
+      {
+        "en": "WFS",
+        "ja": "WFS",
+        "ja_typings": [
+          "wfs"
+        ]
+      },
+      {
+        "en": "FTP",
+        "ja": "FTP",
+        "ja_typings": [
+          "ftp"
+        ]
+      },
+      {
+        "en": "BPS",
+        "ja": "BPS",
+        "ja_typings": [
+          "bps"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02654",
+    "image_path": null,
+    "question_text": {
+      "en": "BSD系UNIXで使われた高速ファイルシステムは?",
+      "ja": "Which fast file system was developed for BSD UNIX?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FTP",
+        "ja": "FTP",
+        "ja_typings": [
+          "ftp"
+        ]
+      },
+      {
+        "en": "SMTP",
+        "ja": "SMTP",
+        "ja_typings": [
+          "smtp"
+        ]
+      },
+      {
+        "en": "Telnet",
+        "ja": "Telnet",
+        "ja_typings": [
+          "telnet"
+        ]
+      },
+      {
+        "en": "ICMP",
+        "ja": "ICMP",
+        "ja_typings": [
+          "icmp"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02655",
+    "image_path": null,
+    "question_text": {
+      "en": "ファイルを転送する古典的なプロトコルは?",
+      "ja": "Which classic protocol is used to transfer files?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Factory",
+        "ja": "ファクトリー",
+        "ja_typings": [
+          "fakutori-"
+        ]
+      },
+      {
+        "en": "Singleton",
+        "ja": "シングルトン",
+        "ja_typings": [
+          "shingoruton",
+          "shinguruton"
+        ]
+      },
+      {
+        "en": "Observer",
+        "ja": "オブザーバー",
+        "ja_typings": [
+          "obuza-ba-"
+        ]
+      },
+      {
+        "en": "Mergesort",
+        "ja": "マージソート",
+        "ja_typings": [
+          "ma-jiso-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02656",
+    "image_path": null,
+    "question_text": {
+      "en": "GoFのデザインパターンで生成系の1つは?",
+      "ja": "Which is one of the GoF creational design patterns?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fiber",
+        "ja": "ファイバー",
+        "ja_typings": [
+          "faiba-"
+        ]
+      },
+      {
+        "en": "Thread",
+        "ja": "スレッド",
+        "ja_typings": [
+          "sureddo"
+        ]
+      },
+      {
+        "en": "Process",
+        "ja": "プロセス",
+        "ja_typings": [
+          "purosesu"
+        ]
+      },
+      {
+        "en": "Mutex",
+        "ja": "ミューテックス",
+        "ja_typings": [
+          "myu-tekkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02657",
+    "image_path": null,
+    "question_text": {
+      "en": "軽量スレッドのことを指す概念は?",
+      "ja": "Which term refers to lightweight threads scheduled by a runtime?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Forbidden",
+        "ja": "Forbidden",
+        "ja_typings": [
+          "forbidden"
+        ]
+      },
+      {
+        "en": "Unauthorized",
+        "ja": "Unauthorized",
+        "ja_typings": [
+          "unauthorized"
+        ]
+      },
+      {
+        "en": "Not Found",
+        "ja": "Not Found",
+        "ja_typings": [
+          "not found",
+          "notfound"
+        ]
+      },
+      {
+        "en": "Bad Request",
+        "ja": "Bad Request",
+        "ja_typings": [
+          "bad request",
+          "badrequest"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02658",
+    "image_path": null,
+    "question_text": {
+      "en": "HTTPステータスコード403が示すのは?",
+      "ja": "What does HTTP status code 403 indicate?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fortran",
+        "ja": "Fortran",
+        "ja_typings": [
+          "fortran"
+        ]
+      },
+      {
+        "en": "COBOL",
+        "ja": "COBOL",
+        "ja_typings": [
+          "cobol"
+        ]
+      },
+      {
+        "en": "Pascal",
+        "ja": "Pascal",
+        "ja_typings": [
+          "pascal"
+        ]
+      },
+      {
+        "en": "Lisp",
+        "ja": "Lisp",
+        "ja_typings": [
+          "lisp"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02659",
+    "image_path": null,
+    "question_text": {
+      "en": "科学計算用に1957年に作られた言語は?",
+      "ja": "Which language was created in 1957 for scientific computation?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "GROUP",
+        "ja": "GROUP",
+        "ja_typings": [
+          "group"
+        ]
+      },
+      {
+        "en": "MERGE",
+        "ja": "MERGE",
+        "ja_typings": [
+          "merge"
+        ]
+      },
+      {
+        "en": "FETCH",
+        "ja": "FETCH",
+        "ja_typings": [
+          "fetch"
+        ]
+      },
+      {
+        "en": "HEAD",
+        "ja": "HEAD",
+        "ja_typings": [
+          "head"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02660",
+    "image_path": null,
+    "question_text": {
+      "en": "SQLで列ごとに集計するための句は?",
+      "ja": "Which SQL clause aggregates rows by column values?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Go",
+        "ja": "Go",
+        "ja_typings": [
+          "go"
+        ]
+      },
+      {
+        "en": "Rust",
+        "ja": "Rust",
+        "ja_typings": [
+          "rust"
+        ]
+      },
+      {
+        "en": "Java",
+        "ja": "Java",
+        "ja_typings": [
+          "java"
+        ]
+      },
+      {
+        "en": "Python",
+        "ja": "Python",
+        "ja_typings": [
+          "python"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02661",
+    "image_path": null,
+    "question_text": {
+      "en": "Googleが開発した静的型付きの並行処理向け言語は?",
+      "ja": "Which Google-designed statically typed language emphasizes concurrency?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Graph",
+        "ja": "グラフ",
+        "ja_typings": [
+          "gurafu"
+        ]
+      },
+      {
+        "en": "Tree",
+        "ja": "木",
+        "ja_typings": [
+          "ki"
+        ]
+      },
+      {
+        "en": "Stack",
+        "ja": "スタック",
+        "ja_typings": [
+          "sutakku"
+        ]
+      },
+      {
+        "en": "Queue",
+        "ja": "キュー",
+        "ja_typings": [
+          "kyu-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02662",
+    "image_path": null,
+    "question_text": {
+      "en": "ノードとエッジで関係を表すデータ構造は?",
+      "ja": "Which data structure represents relations with nodes and edges?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Guido van Rossum",
+        "ja": "Guido van Rossum",
+        "ja_typings": [
+          "guido van rossum",
+          "guidovanrossum"
+        ]
+      },
+      {
+        "en": "Brendan Eich",
+        "ja": "Brendan Eich",
+        "ja_typings": [
+          "brendan eich",
+          "brendaneich"
+        ]
+      },
+      {
+        "en": "Larry Wall",
+        "ja": "Larry Wall",
+        "ja_typings": [
+          "larry wall",
+          "larrywall"
+        ]
+      },
+      {
+        "en": "Yukihiro Matsumoto",
+        "ja": "Yukihiro Matsumoto",
+        "ja_typings": [
+          "yukihiro matsumoto",
+          "yukihiromatsumoto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02663",
+    "image_path": null,
+    "question_text": {
+      "en": "Pythonを設計した人物は?",
+      "ja": "Who designed the Python programming language?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HEAD",
+        "ja": "HEAD",
+        "ja_typings": [
+          "head"
+        ]
+      },
+      {
+        "en": "GET",
+        "ja": "GET",
+        "ja_typings": [
+          "get"
+        ]
+      },
+      {
+        "en": "POST",
+        "ja": "POST",
+        "ja_typings": [
+          "post"
+        ]
+      },
+      {
+        "en": "PUT",
+        "ja": "PUT",
+        "ja_typings": [
+          "put"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02664",
+    "image_path": null,
+    "question_text": {
+      "en": "HTTPでヘッダだけ取得するメソッドは?",
+      "ja": "Which HTTP method fetches only headers without a body?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HTML",
+        "ja": "HTML",
+        "ja_typings": [
+          "html"
+        ]
+      },
+      {
+        "en": "CSS",
+        "ja": "CSS",
+        "ja_typings": [
+          "css"
+        ]
+      },
+      {
+        "en": "XML",
+        "ja": "XML",
+        "ja_typings": [
+          "xml"
+        ]
+      },
+      {
+        "en": "JSON",
+        "ja": "JSON",
+        "ja_typings": [
+          "json"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02665",
+    "image_path": null,
+    "question_text": {
+      "en": "Webページの構造を記述するマークアップ言語は?",
+      "ja": "Which markup language describes the structure of a web page?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hexadecimal",
+        "ja": "16進数",
+        "ja_typings": [
+          "16shinsuu",
+          "juurokushinsuu"
+        ]
+      },
+      {
+        "en": "Decimal",
+        "ja": "10進数",
+        "ja_typings": [
+          "10shinsuu",
+          "juushinsuu"
+        ]
+      },
+      {
+        "en": "Octal",
+        "ja": "8進数",
+        "ja_typings": [
+          "8shinsuu",
+          "hasshinsuu"
+        ]
+      },
+      {
+        "en": "Binary",
+        "ja": "2進数",
+        "ja_typings": [
+          "2shinsuu",
+          "nishinsuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02666",
+    "image_path": null,
+    "question_text": {
+      "en": "0からF までの記号を使う数値表現は?",
+      "ja": "Which numeral system uses digits 0-9 and A-F?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ICMP",
+        "ja": "ICMP",
+        "ja_typings": [
+          "icmp"
+        ]
+      },
+      {
+        "en": "ARP",
+        "ja": "ARP",
+        "ja_typings": [
+          "arp"
+        ]
+      },
+      {
+        "en": "UDP",
+        "ja": "UDP",
+        "ja_typings": [
+          "udp"
+        ]
+      },
+      {
+        "en": "SMTP",
+        "ja": "SMTP",
+        "ja_typings": [
+          "smtp"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02667",
+    "image_path": null,
+    "question_text": {
+      "en": "pingで使われるIP制御メッセージプロトコルは?",
+      "ja": "Which IP control message protocol does ping use?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Immutable",
+        "ja": "イミュータブル",
+        "ja_typings": [
+          "imyu-taburu"
+        ]
+      },
+      {
+        "en": "Dynamic",
+        "ja": "動的",
+        "ja_typings": [
+          "douteki"
+        ]
+      },
+      {
+        "en": "Static",
+        "ja": "静的",
+        "ja_typings": [
+          "seiteki"
+        ]
+      },
+      {
+        "en": "Mutable",
+        "ja": "ミュータブル",
+        "ja_typings": [
+          "myu-taburu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02668",
+    "image_path": null,
+    "question_text": {
+      "en": "一度作ったら変更できない性質を表す語は?",
+      "ja": "Which term describes objects that cannot be modified after creation?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Internal Server Error",
+        "ja": "Internal Server Error",
+        "ja_typings": [
+          "internal server error",
+          "internalservererror"
+        ]
+      },
+      {
+        "en": "Bad Request",
+        "ja": "Bad Request",
+        "ja_typings": [
+          "bad request",
+          "badrequest"
+        ]
+      },
+      {
+        "en": "Not Found",
+        "ja": "Not Found",
+        "ja_typings": [
+          "not found",
+          "notfound"
+        ]
+      },
+      {
+        "en": "Forbidden",
+        "ja": "Forbidden",
+        "ja_typings": [
+          "forbidden"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02669",
+    "image_path": null,
+    "question_text": {
+      "en": "HTTPステータスコード500が示すのは?",
+      "ja": "What does HTTP status code 500 indicate?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Interpreter",
+        "ja": "インタプリタ",
+        "ja_typings": [
+          "intapurita"
+        ]
+      },
+      {
+        "en": "Compiler",
+        "ja": "コンパイラ",
+        "ja_typings": [
+          "konpaira"
+        ]
+      },
+      {
+        "en": "Assembler",
+        "ja": "アセンブラ",
+        "ja_typings": [
+          "asenbura"
+        ]
+      },
+      {
+        "en": "Linker",
+        "ja": "リンカ",
+        "ja_typings": [
+          "rinka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02670",
+    "image_path": null,
+    "question_text": {
+      "en": "ソースコードを逐次解釈実行するソフトウェアは?",
+      "ja": "Which software executes source code line by line?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "It indicates comments",
+        "ja": "コメントを表す",
+        "ja_typings": [
+          "komentowohyousu"
+        ]
+      },
+      {
+        "en": "It indicates return values",
+        "ja": "戻り値を表す",
+        "ja_typings": [
+          "modoriatewohyousu"
+        ]
+      },
+      {
+        "en": "It indicates types",
+        "ja": "型を表す",
+        "ja_typings": [
+          "katawohyousu"
+        ]
+      },
+      {
+        "en": "It indicates assignments",
+        "ja": "代入を表す",
+        "ja_typings": [
+          "dainyuuwohyousu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02671",
+    "image_path": null,
+    "question_text": {
+      "en": "Pythonで `#` 記号の役割は?",
+      "ja": "What does the `#` symbol indicate in Python?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "It indicates return values",
+        "ja": "戻り値を表す",
+        "ja_typings": [
+          "modoriatewohyousu"
+        ]
+      },
+      {
+        "en": "It indicates comments",
+        "ja": "コメントを表す",
+        "ja_typings": [
+          "komentowohyousu"
+        ]
+      },
+      {
+        "en": "It indicates types",
+        "ja": "型を表す",
+        "ja_typings": [
+          "katawohyousu"
+        ]
+      },
+      {
+        "en": "It indicates assignments",
+        "ja": "代入を表す",
+        "ja_typings": [
+          "dainyuuwohyousu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02672",
+    "image_path": null,
+    "question_text": {
+      "en": "関数定義で `->` 記号が示すのは?",
+      "ja": "What does the `->` arrow indicate in a function signature?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "It indicates types",
+        "ja": "型を表す",
+        "ja_typings": [
+          "katawohyousu"
+        ]
+      },
+      {
+        "en": "It indicates comments",
+        "ja": "コメントを表す",
+        "ja_typings": [
+          "komentowohyousu"
+        ]
+      },
+      {
+        "en": "It indicates return values",
+        "ja": "戻り値を表す",
+        "ja_typings": [
+          "modoriatewohyousu"
+        ]
+      },
+      {
+        "en": "It indicates assignments",
+        "ja": "代入を表す",
+        "ja_typings": [
+          "dainyuuwohyousu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02673",
+    "image_path": null,
+    "question_text": {
+      "en": "TypeScriptで `: number` のように書く記号 `:` の役割は?",
+      "ja": "What does the `:` colon indicate in TypeScript annotations like `: number`?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Java Source Object Network",
+        "ja": "Java Source Object Network",
+        "ja_typings": [
+          "java source object network"
+        ]
+      },
+      {
+        "en": "JavaScript Object Notation",
+        "ja": "JavaScript Object Notation",
+        "ja_typings": [
+          "javascript object notation"
+        ]
+      },
+      {
+        "en": "Joint Standard Object Notation",
+        "ja": "Joint Standard Object Notation",
+        "ja_typings": [
+          "joint standard object notation"
+        ]
+      },
+      {
+        "en": "JavaScript Open Network",
+        "ja": "JavaScript Open Network",
+        "ja_typings": [
+          "javascript open network"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02674",
+    "image_path": null,
+    "question_text": {
+      "en": "JSONのフルネームの誤った候補として混同されがちなのは?",
+      "ja": "Which is a common (incorrect) fake expansion of JSON?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JavaScript",
+        "ja": "JavaScript",
+        "ja_typings": [
+          "javascript"
+        ]
+      },
+      {
+        "en": "TypeScript",
+        "ja": "TypeScript",
+        "ja_typings": [
+          "typescript"
+        ]
+      },
+      {
+        "en": "Python",
+        "ja": "Python",
+        "ja_typings": [
+          "python"
+        ]
+      },
+      {
+        "en": "Ruby",
+        "ja": "Ruby",
+        "ja_typings": [
+          "ruby"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02675",
+    "image_path": null,
+    "question_text": {
+      "en": "ブラウザで動く動的言語は?",
+      "ja": "Which dynamic language runs in web browsers?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JavaScript Open Network",
+        "ja": "JavaScript Open Network",
+        "ja_typings": [
+          "javascript open network"
+        ]
+      },
+      {
+        "en": "JavaScript Object Notation",
+        "ja": "JavaScript Object Notation",
+        "ja_typings": [
+          "javascript object notation"
+        ]
+      },
+      {
+        "en": "Java Source Object Network",
+        "ja": "Java Source Object Network",
+        "ja_typings": [
+          "java source object network"
+        ]
+      },
+      {
+        "en": "Joint Standard Object Notation",
+        "ja": "Joint Standard Object Notation",
+        "ja_typings": [
+          "joint standard object notation"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02676",
+    "image_path": null,
+    "question_text": {
+      "en": "JSONの正式名称として誤って語られがちなのは?",
+      "ja": "Which is another common false expansion of JSON?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Joint Standard Object Notation",
+        "ja": "Joint Standard Object Notation",
+        "ja_typings": [
+          "joint standard object notation"
+        ]
+      },
+      {
+        "en": "JavaScript Object Notation",
+        "ja": "JavaScript Object Notation",
+        "ja_typings": [
+          "javascript object notation"
+        ]
+      },
+      {
+        "en": "Java Source Object Network",
+        "ja": "Java Source Object Network",
+        "ja_typings": [
+          "java source object network"
+        ]
+      },
+      {
+        "en": "JavaScript Open Network",
+        "ja": "JavaScript Open Network",
+        "ja_typings": [
+          "javascript open network"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02677",
+    "image_path": null,
+    "question_text": {
+      "en": "JSONの誤った命名候補としてしばしば挙げられるのは?",
+      "ja": "Which is another false expansion sometimes given for JSON?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Junio Hamano",
+        "ja": "Junio Hamano",
+        "ja_typings": [
+          "junio hamano",
+          "juniohamano"
+        ]
+      },
+      {
+        "en": "Yukihiro Matsumoto",
+        "ja": "Yukihiro Matsumoto",
+        "ja_typings": [
+          "yukihiro matsumoto",
+          "yukihiromatsumoto"
+        ]
+      },
+      {
+        "en": "Linus Torvalds",
+        "ja": "Linus Torvalds",
+        "ja_typings": [
+          "linus torvalds",
+          "linustorvalds"
+        ]
+      },
+      {
+        "en": "Brian Kernighan",
+        "ja": "Brian Kernighan",
+        "ja_typings": [
+          "brian kernighan",
+          "briankernighan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02678",
+    "image_path": null,
+    "question_text": {
+      "en": "Gitの現在のメンテナを務める日本人開発者は?",
+      "ja": "Which Japanese developer maintains Git?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "LLVM",
+        "ja": "LLVM",
+        "ja_typings": [
+          "llvm"
+        ]
+      },
+      {
+        "en": "CLR",
+        "ja": "CLR",
+        "ja_typings": [
+          "clr"
+        ]
+      },
+      {
+        "en": "JVM",
+        "ja": "JVM",
+        "ja_typings": [
+          "jvm"
+        ]
+      },
+      {
+        "en": "V8",
+        "ja": "V8",
+        "ja_typings": [
+          "v8"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02679",
+    "image_path": null,
+    "question_text": {
+      "en": "Clang/Swiftなどが利用するコンパイラ基盤は?",
+      "ja": "Which compiler infrastructure is used by Clang and Swift?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Larry Wall",
+        "ja": "Larry Wall",
+        "ja_typings": [
+          "larry wall",
+          "larrywall"
+        ]
+      },
+      {
+        "en": "Guido van Rossum",
+        "ja": "Guido van Rossum",
+        "ja_typings": [
+          "guido van rossum",
+          "guidovanrossum"
+        ]
+      },
+      {
+        "en": "Brendan Eich",
+        "ja": "Brendan Eich",
+        "ja_typings": [
+          "brendan eich",
+          "brendaneich"
+        ]
+      },
+      {
+        "en": "Yukihiro Matsumoto",
+        "ja": "Yukihiro Matsumoto",
+        "ja_typings": [
+          "yukihiro matsumoto",
+          "yukihiromatsumoto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02680",
+    "image_path": null,
+    "question_text": {
+      "en": "Perlを設計した人物は?",
+      "ja": "Who designed the Perl programming language?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Linker",
+        "ja": "リンカ",
+        "ja_typings": [
+          "rinka"
+        ]
+      },
+      {
+        "en": "Compiler",
+        "ja": "コンパイラ",
+        "ja_typings": [
+          "konpaira"
+        ]
+      },
+      {
+        "en": "Assembler",
+        "ja": "アセンブラ",
+        "ja_typings": [
+          "asenbura"
+        ]
+      },
+      {
+        "en": "Loader",
+        "ja": "ローダー",
+        "ja_typings": [
+          "ro-da-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02681",
+    "image_path": null,
+    "question_text": {
+      "en": "オブジェクトファイルをまとめて実行ファイルを作るのは?",
+      "ja": "Which tool combines object files into an executable?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Linus Torvalds",
+        "ja": "Linus Torvalds",
+        "ja_typings": [
+          "linus torvalds",
+          "linustorvalds"
+        ]
+      },
+      {
+        "en": "Richard Stallman",
+        "ja": "Richard Stallman",
+        "ja_typings": [
+          "richard stallman",
+          "richardstallman"
+        ]
+      },
+      {
+        "en": "Dennis Ritchie",
+        "ja": "Dennis Ritchie",
+        "ja_typings": [
+          "dennis ritchie",
+          "dennisritchie"
+        ]
+      },
+      {
+        "en": "Brian Kernighan",
+        "ja": "Brian Kernighan",
+        "ja_typings": [
+          "brian kernighan",
+          "briankernighan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02682",
+    "image_path": null,
+    "question_text": {
+      "en": "Linuxカーネルを最初に開発した人物は?",
+      "ja": "Who originally developed the Linux kernel?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Logical AND",
+        "ja": "論理積",
+        "ja_typings": [
+          "ronriseki"
+        ]
+      },
+      {
+        "en": "Bitwise OR",
+        "ja": "ビット論理和",
+        "ja_typings": [
+          "bittoronriwa"
+        ]
+      },
+      {
+        "en": "Logical OR",
+        "ja": "論理和",
+        "ja_typings": [
+          "ronriwa"
+        ]
+      },
+      {
+        "en": "Bitwise XOR",
+        "ja": "ビット排他的論理和",
+        "ja_typings": [
+          "bittohaitatekironriwa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02683",
+    "image_path": null,
+    "question_text": {
+      "en": "ビット単位で「両方1のときだけ1」を取る演算の論理版は?",
+      "ja": "Which logical operation returns true only when both operands are true?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lower bound of complexity",
+        "ja": "計算量の下限",
+        "ja_typings": [
+          "keisanryounokagen"
+        ]
+      },
+      {
+        "en": "Upper bound of complexity",
+        "ja": "計算量の上限",
+        "ja_typings": [
+          "keisanryounokougen"
+        ]
+      },
+      {
+        "en": "Average run count",
+        "ja": "平均実行回数",
+        "ja_typings": [
+          "heikinjikkoukaisuu"
+        ]
+      },
+      {
+        "en": "Memory usage",
+        "ja": "メモリ使用量",
+        "ja_typings": [
+          "memorishiyouryou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02684",
+    "image_path": null,
+    "question_text": {
+      "en": "比較ソートで証明されている計算量の下限は?",
+      "ja": "What is the proven lower bound of complexity for comparison sorting?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MERGE",
+        "ja": "MERGE",
+        "ja_typings": [
+          "merge"
+        ]
+      },
+      {
+        "en": "FETCH",
+        "ja": "FETCH",
+        "ja_typings": [
+          "fetch"
+        ]
+      },
+      {
+        "en": "GROUP",
+        "ja": "GROUP",
+        "ja_typings": [
+          "group"
+        ]
+      },
+      {
+        "en": "HEAD",
+        "ja": "HEAD",
+        "ja_typings": [
+          "head"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02685",
+    "image_path": null,
+    "question_text": {
+      "en": "SQLでINSERT/UPDATEを一度に行う命令は?",
+      "ja": "Which SQL statement combines INSERT and UPDATE in one operation?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Machine Code",
+        "ja": "機械語",
+        "ja_typings": [
+          "kikaigo"
+        ]
+      },
+      {
+        "en": "Assembly",
+        "ja": "アセンブリ言語",
+        "ja_typings": [
+          "asenburigengo"
+        ]
+      },
+      {
+        "en": "Source Map",
+        "ja": "ソースマップ",
+        "ja_typings": [
+          "so-sumappu"
+        ]
+      },
+      {
+        "en": "Bytecode",
+        "ja": "バイトコード",
+        "ja_typings": [
+          "baitoko-do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02686",
+    "image_path": null,
+    "question_text": {
+      "en": "CPUが直接実行できるバイナリ表現の命令は?",
+      "ja": "Which form of instructions is directly executed by the CPU?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Maven",
+        "ja": "Maven",
+        "ja_typings": [
+          "maven"
+        ]
+      },
+      {
+        "en": "Ant",
+        "ja": "Ant",
+        "ja_typings": [
+          "ant"
+        ]
+      },
+      {
+        "en": "Gradle",
+        "ja": "Gradle",
+        "ja_typings": [
+          "gradle"
+        ]
+      },
+      {
+        "en": "Cargo",
+        "ja": "Cargo",
+        "ja_typings": [
+          "cargo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02687",
+    "image_path": null,
+    "question_text": {
+      "en": "JavaのXMLベースのビルドツールでpom.xmlを使うのは?",
+      "ja": "Which Java build tool uses pom.xml configuration?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Memory Leak",
+        "ja": "メモリリーク",
+        "ja_typings": [
+          "memori-ri-ku",
+          "memoriri-ku"
+        ]
+      },
+      {
+        "en": "Segmentation Fault",
+        "ja": "セグメンテーション違反",
+        "ja_typings": [
+          "segumente-shonihan"
+        ]
+      },
+      {
+        "en": "Stack Overflow",
+        "ja": "スタックオーバーフロー",
+        "ja_typings": [
+          "sutakkuo-ba-furo-"
+        ]
+      },
+      {
+        "en": "Mutex",
+        "ja": "ミューテックス",
+        "ja_typings": [
+          "myu-tekkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02688",
+    "image_path": null,
+    "question_text": {
+      "en": "解放されないメモリが蓄積する不具合は?",
+      "ja": "Which bug refers to memory that is never released?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Memory usage",
+        "ja": "メモリ使用量",
+        "ja_typings": [
+          "memorishiyouryou"
+        ]
+      },
+      {
+        "en": "Average run count",
+        "ja": "平均実行回数",
+        "ja_typings": [
+          "heikinjikkoukaisuu"
+        ]
+      },
+      {
+        "en": "Stack Overflow",
+        "ja": "スタックオーバーフロー",
+        "ja_typings": [
+          "sutakkuo-ba-furo-"
+        ]
+      },
+      {
+        "en": "Source Map",
+        "ja": "ソースマップ",
+        "ja_typings": [
+          "so-sumappu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02689",
+    "image_path": null,
+    "question_text": {
+      "en": "プロファイラで「メモリの使用量」を示す指標は?",
+      "ja": "Which profiling metric shows how much memory the program uses?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mergesort",
+        "ja": "マージソート",
+        "ja_typings": [
+          "ma-jiso-to"
+        ]
+      },
+      {
+        "en": "Quicksort",
+        "ja": "クイックソート",
+        "ja_typings": [
+          "kuikkuso-to"
+        ]
+      },
+      {
+        "en": "Bubble Sort",
+        "ja": "バブルソート",
+        "ja_typings": [
+          "baburuso-to"
+        ]
+      },
+      {
+        "en": "Insertion Sort",
+        "ja": "挿入ソート",
+        "ja_typings": [
+          "sounyuuso-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02690",
+    "image_path": null,
+    "question_text": {
+      "en": "分割統治法による安定ソートでO(n log n)を保証するのは?",
+      "ja": "Which divide-and-conquer stable sort guarantees O(n log n)?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MongoDB",
+        "ja": "MongoDB",
+        "ja_typings": [
+          "mongodb"
+        ]
+      },
+      {
+        "en": "Cassandra",
+        "ja": "Cassandra",
+        "ja_typings": [
+          "cassandra"
+        ]
+      },
+      {
+        "en": "Neo4j",
+        "ja": "Neo4j",
+        "ja_typings": [
+          "neo4j"
+        ]
+      },
+      {
+        "en": "PostgreSQL",
+        "ja": "PostgreSQL",
+        "ja_typings": [
+          "postgresql"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02691",
+    "image_path": null,
+    "question_text": {
+      "en": "ドキュメント指向NoSQLの代表例は?",
+      "ja": "Which is a leading document-oriented NoSQL database?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mutex",
+        "ja": "ミューテックス",
+        "ja_typings": [
+          "myu-tekkusu"
+        ]
+      },
+      {
+        "en": "Thread",
+        "ja": "スレッド",
+        "ja_typings": [
+          "sureddo"
+        ]
+      },
+      {
+        "en": "Fiber",
+        "ja": "ファイバー",
+        "ja_typings": [
+          "faiba-"
+        ]
+      },
+      {
+        "en": "Signal",
+        "ja": "シグナル",
+        "ja_typings": [
+          "shigunaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02692",
+    "image_path": null,
+    "question_text": {
+      "en": "複数スレッドが同時にアクセスしないよう制御する仕組みは?",
+      "ja": "Which primitive ensures only one thread accesses a resource at a time?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MySQL",
+        "ja": "MySQL",
+        "ja_typings": [
+          "mysql"
+        ]
+      },
+      {
+        "en": "PostgreSQL",
+        "ja": "PostgreSQL",
+        "ja_typings": [
+          "postgresql"
+        ]
+      },
+      {
+        "en": "SQLite",
+        "ja": "SQLite",
+        "ja_typings": [
+          "sqlite"
+        ]
+      },
+      {
+        "en": "MongoDB",
+        "ja": "MongoDB",
+        "ja_typings": [
+          "mongodb"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02693",
+    "image_path": null,
+    "question_text": {
+      "en": "オープンソースの代表的なリレーショナルDBで「m」で始まるのは?",
+      "ja": "Which popular open-source relational database starts with 'M'?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Neo4j",
+        "ja": "Neo4j",
+        "ja_typings": [
+          "neo4j"
+        ]
+      },
+      {
+        "en": "MongoDB",
+        "ja": "MongoDB",
+        "ja_typings": [
+          "mongodb"
+        ]
+      },
+      {
+        "en": "Cassandra",
+        "ja": "Cassandra",
+        "ja_typings": [
+          "cassandra"
+        ]
+      },
+      {
+        "en": "MySQL",
+        "ja": "MySQL",
+        "ja_typings": [
+          "mysql"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02694",
+    "image_path": null,
+    "question_text": {
+      "en": "グラフ型データベースの代表は?",
+      "ja": "Which is a leading graph database?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Not Found",
+        "ja": "Not Found",
+        "ja_typings": [
+          "not found",
+          "notfound"
+        ]
+      },
+      {
+        "en": "Forbidden",
+        "ja": "Forbidden",
+        "ja_typings": [
+          "forbidden"
+        ]
+      },
+      {
+        "en": "Bad Request",
+        "ja": "Bad Request",
+        "ja_typings": [
+          "bad request",
+          "badrequest"
+        ]
+      },
+      {
+        "en": "Unauthorized",
+        "ja": "Unauthorized",
+        "ja_typings": [
+          "unauthorized"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02695",
+    "image_path": null,
+    "question_text": {
+      "en": "HTTPステータスコード404が示すのは?",
+      "ja": "What does HTTP status code 404 indicate?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "O(1)",
+        "ja": "O(1)",
+        "ja_typings": [
+          "o(1)"
+        ]
+      },
+      {
+        "en": "O(log n)",
+        "ja": "O(log n)",
+        "ja_typings": [
+          "o(log n)"
+        ]
+      },
+      {
+        "en": "O(n)",
+        "ja": "O(n)",
+        "ja_typings": [
+          "o(n)"
+        ]
+      },
+      {
+        "en": "O(n log n)",
+        "ja": "O(n log n)",
+        "ja_typings": [
+          "o(n log n)"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02696",
+    "image_path": null,
+    "question_text": {
+      "en": "ハッシュテーブルの平均的な検索計算量は?",
+      "ja": "What is the average-case lookup complexity of a hash table?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "O(log n)",
+        "ja": "O(log n)",
+        "ja_typings": [
+          "o(log n)"
+        ]
+      },
+      {
+        "en": "O(1)",
+        "ja": "O(1)",
+        "ja_typings": [
+          "o(1)"
+        ]
+      },
+      {
+        "en": "O(n)",
+        "ja": "O(n)",
+        "ja_typings": [
+          "o(n)"
+        ]
+      },
+      {
+        "en": "O(n log n)",
+        "ja": "O(n log n)",
+        "ja_typings": [
+          "o(n log n)"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02697",
+    "image_path": null,
+    "question_text": {
+      "en": "二分探索の計算量は?",
+      "ja": "What is the time complexity of binary search?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "O(n log n)",
+        "ja": "O(n log n)",
+        "ja_typings": [
+          "o(n log n)"
+        ]
+      },
+      {
+        "en": "O(log n)",
+        "ja": "O(log n)",
+        "ja_typings": [
+          "o(log n)"
+        ]
+      },
+      {
+        "en": "O(n)",
+        "ja": "O(n)",
+        "ja_typings": [
+          "o(n)"
+        ]
+      },
+      {
+        "en": "O(1)",
+        "ja": "O(1)",
+        "ja_typings": [
+          "o(1)"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02698",
+    "image_path": null,
+    "question_text": {
+      "en": "比較ソートの最良計算量は?",
+      "ja": "What is the best achievable complexity for comparison sorting?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "O(n)",
+        "ja": "O(n)",
+        "ja_typings": [
+          "o(n)"
+        ]
+      },
+      {
+        "en": "O(1)",
+        "ja": "O(1)",
+        "ja_typings": [
+          "o(1)"
+        ]
+      },
+      {
+        "en": "O(log n)",
+        "ja": "O(log n)",
+        "ja_typings": [
+          "o(log n)"
+        ]
+      },
+      {
+        "en": "O(n log n)",
+        "ja": "O(n log n)",
+        "ja_typings": [
+          "o(n log n)"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02699",
+    "image_path": null,
+    "question_text": {
+      "en": "配列を1度走査する線形探索の計算量は?",
+      "ja": "What is the time complexity of a single-pass linear search?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "OK",
+        "ja": "OK",
+        "ja_typings": [
+          "ok"
+        ]
+      },
+      {
+        "en": "Bad Request",
+        "ja": "Bad Request",
+        "ja_typings": [
+          "bad request",
+          "badrequest"
+        ]
+      },
+      {
+        "en": "Not Found",
+        "ja": "Not Found",
+        "ja_typings": [
+          "not found",
+          "notfound"
+        ]
+      },
+      {
+        "en": "Forbidden",
+        "ja": "Forbidden",
+        "ja_typings": [
+          "forbidden"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02700",
+    "image_path": null,
+    "question_text": {
+      "en": "HTTPステータスコード200が示すのは?",
+      "ja": "What does HTTP status code 200 indicate?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Observer",
+        "ja": "オブザーバー",
+        "ja_typings": [
+          "obuza-ba-"
+        ]
+      },
+      {
+        "en": "Singleton",
+        "ja": "シングルトン",
+        "ja_typings": [
+          "shingoruton",
+          "shinguruton"
+        ]
+      },
+      {
+        "en": "Factory",
+        "ja": "ファクトリー",
+        "ja_typings": [
+          "fakutori-"
+        ]
+      },
+      {
+        "en": "Decorator",
+        "ja": "デコレーター",
+        "ja_typings": [
+          "dekore-ta-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02701",
+    "image_path": null,
+    "question_text": {
+      "en": "GoFパターンで状態変化を購読者に通知するのは?",
+      "ja": "Which GoF pattern notifies subscribers of state changes?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Octal",
+        "ja": "8進数",
+        "ja_typings": [
+          "8shinsuu",
+          "hasshinsuu"
+        ]
+      },
+      {
+        "en": "Hexadecimal",
+        "ja": "16進数",
+        "ja_typings": [
+          "16shinsuu",
+          "juurokushinsuu"
+        ]
+      },
+      {
+        "en": "Binary",
+        "ja": "2進数",
+        "ja_typings": [
+          "2shinsuu",
+          "nishinsuu"
+        ]
+      },
+      {
+        "en": "Decimal",
+        "ja": "10進数",
+        "ja_typings": [
+          "10shinsuu",
+          "juushinsuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02702",
+    "image_path": null,
+    "question_text": {
+      "en": "0から7までの数字で表す進数は?",
+      "ja": "Which numeral system uses digits 0-7?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PATCH",
+        "ja": "PATCH",
+        "ja_typings": [
+          "patch"
+        ]
+      },
+      {
+        "en": "PUT",
+        "ja": "PUT",
+        "ja_typings": [
+          "put"
+        ]
+      },
+      {
+        "en": "POST",
+        "ja": "POST",
+        "ja_typings": [
+          "post"
+        ]
+      },
+      {
+        "en": "HEAD",
+        "ja": "HEAD",
+        "ja_typings": [
+          "head"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02703",
+    "image_path": null,
+    "question_text": {
+      "en": "HTTPでリソースの一部更新を表すメソッドは?",
+      "ja": "Which HTTP method represents a partial update of a resource?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PHP",
+        "ja": "PHP",
+        "ja_typings": [
+          "php"
+        ]
+      },
+      {
+        "en": "Perl",
+        "ja": "Perl",
+        "ja_typings": [
+          "perl"
+        ]
+      },
+      {
+        "en": "Ruby",
+        "ja": "Ruby",
+        "ja_typings": [
+          "ruby"
+        ]
+      },
+      {
+        "en": "Python",
+        "ja": "Python",
+        "ja_typings": [
+          "python"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02704",
+    "image_path": null,
+    "question_text": {
+      "en": "サーバサイドで動的Webページを生成する人気言語は?",
+      "ja": "Which server-side language is widely used for generating dynamic web pages?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "POST",
+        "ja": "POST",
+        "ja_typings": [
+          "post"
+        ]
+      },
+      {
+        "en": "GET",
+        "ja": "GET",
+        "ja_typings": [
+          "get"
+        ]
+      },
+      {
+        "en": "PUT",
+        "ja": "PUT",
+        "ja_typings": [
+          "put"
+        ]
+      },
+      {
+        "en": "HEAD",
+        "ja": "HEAD",
+        "ja_typings": [
+          "head"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02705",
+    "image_path": null,
+    "question_text": {
+      "en": "HTTPでデータをサーバに送信する代表的なメソッドは?",
+      "ja": "Which HTTP method commonly submits data to the server?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PUT",
+        "ja": "PUT",
+        "ja_typings": [
+          "put"
+        ]
+      },
+      {
+        "en": "PATCH",
+        "ja": "PATCH",
+        "ja_typings": [
+          "patch"
+        ]
+      },
+      {
+        "en": "POST",
+        "ja": "POST",
+        "ja_typings": [
+          "post"
+        ]
+      },
+      {
+        "en": "HEAD",
+        "ja": "HEAD",
+        "ja_typings": [
+          "head"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02706",
+    "image_path": null,
+    "question_text": {
+      "en": "HTTPでリソース全体を置き換えるメソッドは?",
+      "ja": "Which HTTP method replaces a resource entirely?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pascal",
+        "ja": "Pascal",
+        "ja_typings": [
+          "pascal"
+        ]
+      },
+      {
+        "en": "Fortran",
+        "ja": "Fortran",
+        "ja_typings": [
+          "fortran"
+        ]
+      },
+      {
+        "en": "COBOL",
+        "ja": "COBOL",
+        "ja_typings": [
+          "cobol"
+        ]
+      },
+      {
+        "en": "Ada",
+        "ja": "Ada",
+        "ja_typings": [
+          "ada"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02707",
+    "image_path": null,
+    "question_text": {
+      "en": "Niklaus Wirthが設計した教育用言語は?",
+      "ja": "Which educational language was designed by Niklaus Wirth?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Polymorphism",
+        "ja": "ポリモーフィズム",
+        "ja_typings": [
+          "porimo-fizumu"
+        ]
+      },
+      {
+        "en": "Encapsulation",
+        "ja": "カプセル化",
+        "ja_typings": [
+          "kapuseruka"
+        ]
+      },
+      {
+        "en": "Inheritance",
+        "ja": "継承",
+        "ja_typings": [
+          "keishou"
+        ]
+      },
+      {
+        "en": "Abstraction",
+        "ja": "抽象化",
+        "ja_typings": [
+          "chuushouka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02708",
+    "image_path": null,
+    "question_text": {
+      "en": "オブジェクト指向で同じインタフェースで多様な振る舞いをする概念は?",
+      "ja": "Which OOP concept lets one interface serve many implementations?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PostgreSQL",
+        "ja": "PostgreSQL",
+        "ja_typings": [
+          "postgresql"
+        ]
+      },
+      {
+        "en": "MySQL",
+        "ja": "MySQL",
+        "ja_typings": [
+          "mysql"
+        ]
+      },
+      {
+        "en": "SQLite",
+        "ja": "SQLite",
+        "ja_typings": [
+          "sqlite"
+        ]
+      },
+      {
+        "en": "MongoDB",
+        "ja": "MongoDB",
+        "ja_typings": [
+          "mongodb"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02709",
+    "image_path": null,
+    "question_text": {
+      "en": "高機能で拡張性に優れたオープンソースRDBは?",
+      "ja": "Which is a feature-rich, extensible open-source RDBMS?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Process",
+        "ja": "プロセス",
+        "ja_typings": [
+          "purosesu"
+        ]
+      },
+      {
+        "en": "Thread",
+        "ja": "スレッド",
+        "ja_typings": [
+          "sureddo"
+        ]
+      },
+      {
+        "en": "Fiber",
+        "ja": "ファイバー",
+        "ja_typings": [
+          "faiba-"
+        ]
+      },
+      {
+        "en": "Mutex",
+        "ja": "ミューテックス",
+        "ja_typings": [
+          "myu-tekkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02710",
+    "image_path": null,
+    "question_text": {
+      "en": "OSが管理する実行単位でメモリ空間を独立して持つのは?",
+      "ja": "Which OS-managed execution unit has its own memory space?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Profiler",
+        "ja": "プロファイラ",
+        "ja_typings": [
+          "purofaira"
+        ]
+      },
+      {
+        "en": "Debugger",
+        "ja": "デバッガ",
+        "ja_typings": [
+          "debagga"
+        ]
+      },
+      {
+        "en": "Compiler",
+        "ja": "コンパイラ",
+        "ja_typings": [
+          "konpaira"
+        ]
+      },
+      {
+        "en": "Linker",
+        "ja": "リンカ",
+        "ja_typings": [
+          "rinka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02711",
+    "image_path": null,
+    "question_text": {
+      "en": "プログラムの性能を測定し分析するツールは?",
+      "ja": "Which tool measures and analyzes a program's performance?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Queue",
+        "ja": "キュー",
+        "ja_typings": [
+          "kyu-"
+        ]
+      },
+      {
+        "en": "Stack",
+        "ja": "スタック",
+        "ja_typings": [
+          "sutakku"
+        ]
+      },
+      {
+        "en": "Tree",
+        "ja": "木",
+        "ja_typings": [
+          "ki"
+        ]
+      },
+      {
+        "en": "Graph",
+        "ja": "グラフ",
+        "ja_typings": [
+          "gurafu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02712",
+    "image_path": null,
+    "question_text": {
+      "en": "FIFO方式で出し入れするデータ構造は?",
+      "ja": "Which data structure follows FIFO (first-in, first-out)?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rc",
+        "ja": "Rc",
+        "ja_typings": [
+          "rc"
+        ]
+      },
+      {
+        "en": "Arc",
+        "ja": "Arc",
+        "ja_typings": [
+          "arc"
+        ]
+      },
+      {
+        "en": "Box",
+        "ja": "Box",
+        "ja_typings": [
+          "box"
+        ]
+      },
+      {
+        "en": "RefCell",
+        "ja": "RefCell",
+        "ja_typings": [
+          "refcell"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02713",
+    "image_path": null,
+    "question_text": {
+      "en": "Rustのシングルスレッド向け参照カウントスマートポインタは?",
+      "ja": "Which Rust smart pointer is a single-threaded reference counter?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Redirect",
+        "ja": "リダイレクト",
+        "ja_typings": [
+          "ridairekuto"
+        ]
+      },
+      {
+        "en": "Client Error",
+        "ja": "クライアントエラー",
+        "ja_typings": [
+          "kuraiantoera-"
+        ]
+      },
+      {
+        "en": "Server Error",
+        "ja": "サーバーエラー",
+        "ja_typings": [
+          "sa-ba-era-"
+        ]
+      },
+      {
+        "en": "Success",
+        "ja": "成功",
+        "ja_typings": [
+          "seikou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02714",
+    "image_path": null,
+    "question_text": {
+      "en": "HTTPで別URLに転送することを表す3xx系の意味は?",
+      "ja": "What is the meaning of the HTTP 3xx status family?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Richard Stallman",
+        "ja": "Richard Stallman",
+        "ja_typings": [
+          "richard stallman",
+          "richardstallman"
+        ]
+      },
+      {
+        "en": "Linus Torvalds",
+        "ja": "Linus Torvalds",
+        "ja_typings": [
+          "linus torvalds",
+          "linustorvalds"
+        ]
+      },
+      {
+        "en": "Bill Joy",
+        "ja": "Bill Joy",
+        "ja_typings": [
+          "bill joy",
+          "billjoy"
+        ]
+      },
+      {
+        "en": "Dennis Ritchie",
+        "ja": "Dennis Ritchie",
+        "ja_typings": [
+          "dennis ritchie",
+          "dennisritchie"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02715",
+    "image_path": null,
+    "question_text": {
+      "en": "GNUプロジェクトを創設した人物は?",
+      "ja": "Who founded the GNU Project?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SMTP",
+        "ja": "SMTP",
+        "ja_typings": [
+          "smtp"
+        ]
+      },
+      {
+        "en": "FTP",
+        "ja": "FTP",
+        "ja_typings": [
+          "ftp"
+        ]
+      },
+      {
+        "en": "ICMP",
+        "ja": "ICMP",
+        "ja_typings": [
+          "icmp"
+        ]
+      },
+      {
+        "en": "Telnet",
+        "ja": "Telnet",
+        "ja_typings": [
+          "telnet"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02716",
+    "image_path": null,
+    "question_text": {
+      "en": "メール送信に使われるプロトコルは?",
+      "ja": "Which protocol is used to send emails?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SQL",
+        "ja": "SQL",
+        "ja_typings": [
+          "sql"
+        ]
+      },
+      {
+        "en": "CSS",
+        "ja": "CSS",
+        "ja_typings": [
+          "css"
+        ]
+      },
+      {
+        "en": "HTML",
+        "ja": "HTML",
+        "ja_typings": [
+          "html"
+        ]
+      },
+      {
+        "en": "XML",
+        "ja": "XML",
+        "ja_typings": [
+          "xml"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02717",
+    "image_path": null,
+    "question_text": {
+      "en": "リレーショナルDBを操作する標準言語は?",
+      "ja": "Which standard language manipulates relational databases?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SQLite",
+        "ja": "SQLite",
+        "ja_typings": [
+          "sqlite"
+        ]
+      },
+      {
+        "en": "MySQL",
+        "ja": "MySQL",
+        "ja_typings": [
+          "mysql"
+        ]
+      },
+      {
+        "en": "PostgreSQL",
+        "ja": "PostgreSQL",
+        "ja_typings": [
+          "postgresql"
+        ]
+      },
+      {
+        "en": "MongoDB",
+        "ja": "MongoDB",
+        "ja_typings": [
+          "mongodb"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02718",
+    "image_path": null,
+    "question_text": {
+      "en": "ファイル1つで動く軽量な組み込みRDBは?",
+      "ja": "Which lightweight embedded RDBMS stores data in a single file?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Segmentation Fault",
+        "ja": "セグメンテーション違反",
+        "ja_typings": [
+          "segumente-shonihan"
+        ]
+      },
+      {
+        "en": "Memory Leak",
+        "ja": "メモリリーク",
+        "ja_typings": [
+          "memori-ri-ku",
+          "memoriri-ku"
+        ]
+      },
+      {
+        "en": "Stack Overflow",
+        "ja": "スタックオーバーフロー",
+        "ja_typings": [
+          "sutakkuo-ba-furo-"
+        ]
+      },
+      {
+        "en": "Bad Request",
+        "ja": "Bad Request",
+        "ja_typings": [
+          "bad request",
+          "badrequest"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02719",
+    "image_path": null,
+    "question_text": {
+      "en": "不正なメモリアクセスで発生する典型的なエラーは?",
+      "ja": "Which error is typically caused by invalid memory access?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Signal",
+        "ja": "シグナル",
+        "ja_typings": [
+          "shigunaru"
+        ]
+      },
+      {
+        "en": "Mutex",
+        "ja": "ミューテックス",
+        "ja_typings": [
+          "myu-tekkusu"
+        ]
+      },
+      {
+        "en": "Thread",
+        "ja": "スレッド",
+        "ja_typings": [
+          "sureddo"
+        ]
+      },
+      {
+        "en": "Fiber",
+        "ja": "ファイバー",
+        "ja_typings": [
+          "faiba-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02720",
+    "image_path": null,
+    "question_text": {
+      "en": "Unixでプロセスに送る通知の仕組みは?",
+      "ja": "Which Unix mechanism sends notifications to processes?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Singleton",
+        "ja": "シングルトン",
+        "ja_typings": [
+          "shingoruton",
+          "shinguruton"
+        ]
+      },
+      {
+        "en": "Factory",
+        "ja": "ファクトリー",
+        "ja_typings": [
+          "fakutori-"
+        ]
+      },
+      {
+        "en": "Observer",
+        "ja": "オブザーバー",
+        "ja_typings": [
+          "obuza-ba-"
+        ]
+      },
+      {
+        "en": "Decorator",
+        "ja": "デコレーター",
+        "ja_typings": [
+          "dekore-ta-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02721",
+    "image_path": null,
+    "question_text": {
+      "en": "GoFパターンでインスタンスを1つに制限するのは?",
+      "ja": "Which GoF pattern restricts a class to a single instance?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Source Map",
+        "ja": "ソースマップ",
+        "ja_typings": [
+          "so-sumappu"
+        ]
+      },
+      {
+        "en": "Memory Leak",
+        "ja": "メモリリーク",
+        "ja_typings": [
+          "memori-ri-ku",
+          "memoriri-ku"
+        ]
+      },
+      {
+        "en": "Stack Overflow",
+        "ja": "スタックオーバーフロー",
+        "ja_typings": [
+          "sutakkuo-ba-furo-"
+        ]
+      },
+      {
+        "en": "Average run count",
+        "ja": "平均実行回数",
+        "ja_typings": [
+          "heikinjikkoukaisuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02722",
+    "image_path": null,
+    "question_text": {
+      "en": "ミニファイされたコードと元のコードを対応付けるファイルは?",
+      "ja": "Which file maps minified code back to the original source?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Stack",
+        "ja": "スタック",
+        "ja_typings": [
+          "sutakku"
+        ]
+      },
+      {
+        "en": "Queue",
+        "ja": "キュー",
+        "ja_typings": [
+          "kyu-"
+        ]
+      },
+      {
+        "en": "Tree",
+        "ja": "木",
+        "ja_typings": [
+          "ki"
+        ]
+      },
+      {
+        "en": "Graph",
+        "ja": "グラフ",
+        "ja_typings": [
+          "gurafu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02723",
+    "image_path": null,
+    "question_text": {
+      "en": "LIFO方式で出し入れするデータ構造は?",
+      "ja": "Which data structure follows LIFO (last-in, first-out)?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Stack Overflow",
+        "ja": "スタックオーバーフロー",
+        "ja_typings": [
+          "sutakkuo-ba-furo-"
+        ]
+      },
+      {
+        "en": "Memory Leak",
+        "ja": "メモリリーク",
+        "ja_typings": [
+          "memori-ri-ku",
+          "memoriri-ku"
+        ]
+      },
+      {
+        "en": "Segmentation Fault",
+        "ja": "セグメンテーション違反",
+        "ja_typings": [
+          "segumente-shonihan"
+        ]
+      },
+      {
+        "en": "Source Map",
+        "ja": "ソースマップ",
+        "ja_typings": [
+          "so-sumappu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02724",
+    "image_path": null,
+    "question_text": {
+      "en": "スタック領域が溢れたときに起きるエラーは?",
+      "ja": "Which error occurs when the call stack exceeds its limit?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Static",
+        "ja": "静的",
+        "ja_typings": [
+          "seiteki"
+        ]
+      },
+      {
+        "en": "Dynamic",
+        "ja": "動的",
+        "ja_typings": [
+          "douteki"
+        ]
+      },
+      {
+        "en": "Immutable",
+        "ja": "イミュータブル",
+        "ja_typings": [
+          "imyu-taburu"
+        ]
+      },
+      {
+        "en": "Interpreted",
+        "ja": "インタプリタ型",
+        "ja_typings": [
+          "intapuritagata"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02725",
+    "image_path": null,
+    "question_text": {
+      "en": "コンパイル時に型が決まる言語の性質を表す語は?",
+      "ja": "Which term describes a language whose types are checked at compile time?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Success",
+        "ja": "成功",
+        "ja_typings": [
+          "seikou"
+        ]
+      },
+      {
+        "en": "Redirect",
+        "ja": "リダイレクト",
+        "ja_typings": [
+          "ridairekuto"
+        ]
+      },
+      {
+        "en": "Client Error",
+        "ja": "クライアントエラー",
+        "ja_typings": [
+          "kuraiantoera-"
+        ]
+      },
+      {
+        "en": "Server Error",
+        "ja": "サーバーエラー",
+        "ja_typings": [
+          "sa-ba-era-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02726",
+    "image_path": null,
+    "question_text": {
+      "en": "HTTPの2xx系ステータスコードのカテゴリ名は?",
+      "ja": "What is the meaning of the HTTP 2xx status family?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Telnet",
+        "ja": "Telnet",
+        "ja_typings": [
+          "telnet"
+        ]
+      },
+      {
+        "en": "FTP",
+        "ja": "FTP",
+        "ja_typings": [
+          "ftp"
+        ]
+      },
+      {
+        "en": "SMTP",
+        "ja": "SMTP",
+        "ja_typings": [
+          "smtp"
+        ]
+      },
+      {
+        "en": "ARP",
+        "ja": "ARP",
+        "ja_typings": [
+          "arp"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02727",
+    "image_path": null,
+    "question_text": {
+      "en": "古くからある暗号化されないリモートログインプロトコルは?",
+      "ja": "Which old remote-login protocol transmits data unencrypted?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Terraform",
+        "ja": "Terraform",
+        "ja_typings": [
+          "terraform"
+        ]
+      },
+      {
+        "en": "Ansible",
+        "ja": "Ansible",
+        "ja_typings": [
+          "ansible"
+        ]
+      },
+      {
+        "en": "Docker Compose",
+        "ja": "Docker Compose",
+        "ja_typings": [
+          "docker compose",
+          "dockercompose"
+        ]
+      },
+      {
+        "en": "Maven",
+        "ja": "Maven",
+        "ja_typings": [
+          "maven"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02728",
+    "image_path": null,
+    "question_text": {
+      "en": "HashiCorpが開発するインフラ宣言型ツールは?",
+      "ja": "Which HashiCorp tool provisions infrastructure declaratively?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thread",
+        "ja": "スレッド",
+        "ja_typings": [
+          "sureddo"
+        ]
+      },
+      {
+        "en": "Process",
+        "ja": "プロセス",
+        "ja_typings": [
+          "purosesu"
+        ]
+      },
+      {
+        "en": "Fiber",
+        "ja": "ファイバー",
+        "ja_typings": [
+          "faiba-"
+        ]
+      },
+      {
+        "en": "Mutex",
+        "ja": "ミューテックス",
+        "ja_typings": [
+          "myu-tekkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02729",
+    "image_path": null,
+    "question_text": {
+      "en": "プロセス内で並行実行されメモリ空間を共有する単位は?",
+      "ja": "Which execution unit runs in a process and shares its memory?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tim Berners-Lee",
+        "ja": "Tim Berners-Lee",
+        "ja_typings": [
+          "tim berners-lee",
+          "timberners-lee"
+        ]
+      },
+      {
+        "en": "Linus Torvalds",
+        "ja": "Linus Torvalds",
+        "ja_typings": [
+          "linus torvalds",
+          "linustorvalds"
+        ]
+      },
+      {
+        "en": "Brendan Eich",
+        "ja": "Brendan Eich",
+        "ja_typings": [
+          "brendan eich",
+          "brendaneich"
+        ]
+      },
+      {
+        "en": "Dennis Ritchie",
+        "ja": "Dennis Ritchie",
+        "ja_typings": [
+          "dennis ritchie",
+          "dennisritchie"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02730",
+    "image_path": null,
+    "question_text": {
+      "en": "World Wide Webを発明した人物は?",
+      "ja": "Who invented the World Wide Web?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tree",
+        "ja": "木",
+        "ja_typings": [
+          "ki"
+        ]
+      },
+      {
+        "en": "Graph",
+        "ja": "グラフ",
+        "ja_typings": [
+          "gurafu"
+        ]
+      },
+      {
+        "en": "Stack",
+        "ja": "スタック",
+        "ja_typings": [
+          "sutakku"
+        ]
+      },
+      {
+        "en": "Queue",
+        "ja": "キュー",
+        "ja_typings": [
+          "kyu-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02731",
+    "image_path": null,
+    "question_text": {
+      "en": "節点と枝で階層構造を表すデータ構造は?",
+      "ja": "Which data structure represents hierarchical relations with nodes and branches?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "UDP",
+        "ja": "UDP",
+        "ja_typings": [
+          "udp"
+        ]
+      },
+      {
+        "en": "TCP",
+        "ja": "TCP",
+        "ja_typings": [
+          "tcp"
+        ]
+      },
+      {
+        "en": "ICMP",
+        "ja": "ICMP",
+        "ja_typings": [
+          "icmp"
+        ]
+      },
+      {
+        "en": "ARP",
+        "ja": "ARP",
+        "ja_typings": [
+          "arp"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02732",
+    "image_path": null,
+    "question_text": {
+      "en": "コネクションレスで信頼性を保証しないトランスポート層プロトコルは?",
+      "ja": "Which transport protocol is connectionless and unreliable?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Unauthorized",
+        "ja": "Unauthorized",
+        "ja_typings": [
+          "unauthorized"
+        ]
+      },
+      {
+        "en": "Forbidden",
+        "ja": "Forbidden",
+        "ja_typings": [
+          "forbidden"
+        ]
+      },
+      {
+        "en": "Bad Request",
+        "ja": "Bad Request",
+        "ja_typings": [
+          "bad request",
+          "badrequest"
+        ]
+      },
+      {
+        "en": "Not Found",
+        "ja": "Not Found",
+        "ja_typings": [
+          "not found",
+          "notfound"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02733",
+    "image_path": null,
+    "question_text": {
+      "en": "HTTPステータスコード401が示すのは?",
+      "ja": "What does HTTP status code 401 indicate?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "V8",
+        "ja": "V8",
+        "ja_typings": [
+          "v8"
+        ]
+      },
+      {
+        "en": "LLVM",
+        "ja": "LLVM",
+        "ja_typings": [
+          "llvm"
+        ]
+      },
+      {
+        "en": "CLR",
+        "ja": "CLR",
+        "ja_typings": [
+          "clr"
+        ]
+      },
+      {
+        "en": "JVM",
+        "ja": "JVM",
+        "ja_typings": [
+          "jvm"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02734",
+    "image_path": null,
+    "question_text": {
+      "en": "GoogleのChromeなどで動くJavaScriptエンジンは?",
+      "ja": "Which JavaScript engine powers Google Chrome?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vim",
+        "ja": "Vim",
+        "ja_typings": [
+          "vim"
+        ]
+      },
+      {
+        "en": "Emacs",
+        "ja": "Emacs",
+        "ja_typings": [
+          "emacs"
+        ]
+      },
+      {
+        "en": "Nano",
+        "ja": "Nano",
+        "ja_typings": [
+          "nano"
+        ]
+      },
+      {
+        "en": "Bash",
+        "ja": "Bash",
+        "ja_typings": [
+          "bash"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02735",
+    "image_path": null,
+    "question_text": {
+      "en": "Linuxユーザに愛される高機能テキストエディタは?",
+      "ja": "Which highly extensible terminal text editor is beloved by Linux users?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "WFS",
+        "ja": "WFS",
+        "ja_typings": [
+          "wfs"
+        ]
+      },
+      {
+        "en": "FFS",
+        "ja": "FFS",
+        "ja_typings": [
+          "ffs"
+        ]
+      },
+      {
+        "en": "FTP",
+        "ja": "FTP",
+        "ja_typings": [
+          "ftp"
+        ]
+      },
+      {
+        "en": "BPS",
+        "ja": "BPS",
+        "ja_typings": [
+          "bps"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02736",
+    "image_path": null,
+    "question_text": {
+      "en": "OGC仕様の地理空間ベクタフィーチャ取得サービスは?",
+      "ja": "Which OGC service provides geospatial vector features over the web?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yukihiro Matsumoto",
+        "ja": "Yukihiro Matsumoto",
+        "ja_typings": [
+          "yukihiro matsumoto",
+          "yukihiromatsumoto"
+        ]
+      },
+      {
+        "en": "Guido van Rossum",
+        "ja": "Guido van Rossum",
+        "ja_typings": [
+          "guido van rossum",
+          "guidovanrossum"
+        ]
+      },
+      {
+        "en": "Brendan Eich",
+        "ja": "Brendan Eich",
+        "ja_typings": [
+          "brendan eich",
+          "brendaneich"
+        ]
+      },
+      {
+        "en": "Larry Wall",
+        "ja": "Larry Wall",
+        "ja_typings": [
+          "larry wall",
+          "larrywall"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02737",
+    "image_path": null,
+    "question_text": {
+      "en": "Rubyを設計した人物は?",
+      "ja": "Who designed the Ruby programming language?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`#`",
+        "ja": "`#`",
+        "ja_typings": [
+          "#",
+          "`#`"
+        ]
+      },
+      {
+        "en": "`$`",
+        "ja": "`$`",
+        "ja_typings": [
+          "$",
+          "`$`"
+        ]
+      },
+      {
+        "en": "`%`",
+        "ja": "`%`",
+        "ja_typings": [
+          "%",
+          "`%`"
+        ]
+      },
+      {
+        "en": "`@`",
+        "ja": "`@`",
+        "ja_typings": [
+          "@",
+          "`@`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02738",
+    "image_path": null,
+    "question_text": {
+      "en": "多くの言語でコメント開始を表す記号は?",
+      "ja": "Which character commonly starts a line comment in many languages?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`$`",
+        "ja": "`$`",
+        "ja_typings": [
+          "$",
+          "`$`"
+        ]
+      },
+      {
+        "en": "`#`",
+        "ja": "`#`",
+        "ja_typings": [
+          "#",
+          "`#`"
+        ]
+      },
+      {
+        "en": "`%`",
+        "ja": "`%`",
+        "ja_typings": [
+          "%",
+          "`%`"
+        ]
+      },
+      {
+        "en": "`&`",
+        "ja": "`&`",
+        "ja_typings": [
+          "&",
+          "`&`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02739",
+    "image_path": null,
+    "question_text": {
+      "en": "シェルで変数を参照するときに使う記号は?",
+      "ja": "Which character is used to reference shell variables?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`%`",
+        "ja": "`%`",
+        "ja_typings": [
+          "%",
+          "`%`"
+        ]
+      },
+      {
+        "en": "`*`",
+        "ja": "`*`",
+        "ja_typings": [
+          "*",
+          "`*`"
+        ]
+      },
+      {
+        "en": "`#`",
+        "ja": "`#`",
+        "ja_typings": [
+          "#",
+          "`#`"
+        ]
+      },
+      {
+        "en": "`$`",
+        "ja": "`$`",
+        "ja_typings": [
+          "$",
+          "`$`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02740",
+    "image_path": null,
+    "question_text": {
+      "en": "C系言語で剰余演算を表す記号は?",
+      "ja": "Which operator represents modulo in C-like languages?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`&`",
+        "ja": "`&`",
+        "ja_typings": [
+          "&",
+          "`&`"
+        ]
+      },
+      {
+        "en": "`*`",
+        "ja": "`*`",
+        "ja_typings": [
+          "*",
+          "`*`"
+        ]
+      },
+      {
+        "en": "`@`",
+        "ja": "`@`",
+        "ja_typings": [
+          "@",
+          "`@`"
+        ]
+      },
+      {
+        "en": "`#`",
+        "ja": "`#`",
+        "ja_typings": [
+          "#",
+          "`#`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02741",
+    "image_path": null,
+    "question_text": {
+      "en": "シェルでコマンドをバックグラウンド実行する記号は?",
+      "ja": "Which shell character runs a command in the background?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`*`",
+        "ja": "`*`",
+        "ja_typings": [
+          "*",
+          "`*`"
+        ]
+      },
+      {
+        "en": "`&`",
+        "ja": "`&`",
+        "ja_typings": [
+          "&",
+          "`&`"
+        ]
+      },
+      {
+        "en": "`%`",
+        "ja": "`%`",
+        "ja_typings": [
+          "%",
+          "`%`"
+        ]
+      },
+      {
+        "en": "`#`",
+        "ja": "`#`",
+        "ja_typings": [
+          "#",
+          "`#`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02742",
+    "image_path": null,
+    "question_text": {
+      "en": "C系言語でポインタの参照外しや乗算を表す記号は?",
+      "ja": "Which operator dereferences pointers or denotes multiplication in C?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`@`",
+        "ja": "`@`",
+        "ja_typings": [
+          "@",
+          "`@`"
+        ]
+      },
+      {
+        "en": "`#`",
+        "ja": "`#`",
+        "ja_typings": [
+          "#",
+          "`#`"
+        ]
+      },
+      {
+        "en": "`$`",
+        "ja": "`$`",
+        "ja_typings": [
+          "$",
+          "`$`"
+        ]
+      },
+      {
+        "en": "`&`",
+        "ja": "`&`",
+        "ja_typings": [
+          "&",
+          "`&`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02743",
+    "image_path": null,
+    "question_text": {
+      "en": "Pythonでデコレータを表す記号は?",
+      "ja": "Which character marks a decorator in Python?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`await`",
+        "ja": "`await`",
+        "ja_typings": [
+          "await",
+          "`await`"
+        ]
+      },
+      {
+        "en": "`yield`",
+        "ja": "`yield`",
+        "ja_typings": [
+          "yield",
+          "`yield`"
+        ]
+      },
+      {
+        "en": "`return`",
+        "ja": "`return`",
+        "ja_typings": [
+          "return",
+          "`return`"
+        ]
+      },
+      {
+        "en": "`defer`",
+        "ja": "`defer`",
+        "ja_typings": [
+          "defer",
+          "`defer`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02744",
+    "image_path": null,
+    "question_text": {
+      "en": "非同期関数の完了を待つPython/JSのキーワードは?",
+      "ja": "Which keyword in Python and JS waits for an async result?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`def`",
+        "ja": "`def`",
+        "ja_typings": [
+          "def",
+          "`def`"
+        ]
+      },
+      {
+        "en": "`fn`",
+        "ja": "`fn`",
+        "ja_typings": [
+          "fn",
+          "`fn`"
+        ]
+      },
+      {
+        "en": "`return`",
+        "ja": "`return`",
+        "ja_typings": [
+          "return",
+          "`return`"
+        ]
+      },
+      {
+        "en": "`yield`",
+        "ja": "`yield`",
+        "ja_typings": [
+          "yield",
+          "`yield`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02745",
+    "image_path": null,
+    "question_text": {
+      "en": "Pythonで関数を定義するキーワードは?",
+      "ja": "Which Python keyword defines a function?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`defer`",
+        "ja": "`defer`",
+        "ja_typings": [
+          "defer",
+          "`defer`"
+        ]
+      },
+      {
+        "en": "`await`",
+        "ja": "`await`",
+        "ja_typings": [
+          "await",
+          "`await`"
+        ]
+      },
+      {
+        "en": "`yield`",
+        "ja": "`yield`",
+        "ja_typings": [
+          "yield",
+          "`yield`"
+        ]
+      },
+      {
+        "en": "`return`",
+        "ja": "`return`",
+        "ja_typings": [
+          "return",
+          "`return`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02746",
+    "image_path": null,
+    "question_text": {
+      "en": "Goで関数終了時に処理を予約するキーワードは?",
+      "ja": "Which Go keyword schedules a call to run when the function returns?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`fn`",
+        "ja": "`fn`",
+        "ja_typings": [
+          "fn",
+          "`fn`"
+        ]
+      },
+      {
+        "en": "`def`",
+        "ja": "`def`",
+        "ja_typings": [
+          "def",
+          "`def`"
+        ]
+      },
+      {
+        "en": "`return`",
+        "ja": "`return`",
+        "ja_typings": [
+          "return",
+          "`return`"
+        ]
+      },
+      {
+        "en": "`yield`",
+        "ja": "`yield`",
+        "ja_typings": [
+          "yield",
+          "`yield`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02747",
+    "image_path": null,
+    "question_text": {
+      "en": "Rustで関数を定義するキーワードは?",
+      "ja": "Which Rust keyword defines a function?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`return`",
+        "ja": "`return`",
+        "ja_typings": [
+          "return",
+          "`return`"
+        ]
+      },
+      {
+        "en": "`yield`",
+        "ja": "`yield`",
+        "ja_typings": [
+          "yield",
+          "`yield`"
+        ]
+      },
+      {
+        "en": "`await`",
+        "ja": "`await`",
+        "ja_typings": [
+          "await",
+          "`await`"
+        ]
+      },
+      {
+        "en": "`defer`",
+        "ja": "`defer`",
+        "ja_typings": [
+          "defer",
+          "`defer`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02748",
+    "image_path": null,
+    "question_text": {
+      "en": "関数から値を返すための多くの言語で共通のキーワードは?",
+      "ja": "Which keyword returns a value from a function in most languages?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`yield`",
+        "ja": "`yield`",
+        "ja_typings": [
+          "yield",
+          "`yield`"
+        ]
+      },
+      {
+        "en": "`return`",
+        "ja": "`return`",
+        "ja_typings": [
+          "return",
+          "`return`"
+        ]
+      },
+      {
+        "en": "`await`",
+        "ja": "`await`",
+        "ja_typings": [
+          "await",
+          "`await`"
+        ]
+      },
+      {
+        "en": "`defer`",
+        "ja": "`defer`",
+        "ja_typings": [
+          "defer",
+          "`defer`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02749",
+    "image_path": null,
+    "question_text": {
+      "en": "ジェネレータで値を1つずつ生成するキーワードは?",
+      "ja": "Which keyword produces values one at a time from a generator?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "pip",
+        "ja": "pip",
+        "ja_typings": [
+          "pip"
+        ]
+      },
+      {
+        "en": "Cargo",
+        "ja": "Cargo",
+        "ja_typings": [
+          "cargo"
+        ]
+      },
+      {
+        "en": "Maven",
+        "ja": "Maven",
+        "ja_typings": [
+          "maven"
+        ]
+      },
+      {
+        "en": "Ant",
+        "ja": "Ant",
+        "ja_typings": [
+          "ant"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02750",
+    "image_path": null,
+    "question_text": {
+      "en": "Pythonのパッケージインストーラは?",
+      "ja": "Which is the standard package installer for Python?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "API Key",
+        "ja": "APIキー",
+        "ja_typings": [
+          "apiki-"
+        ]
+      },
+      {
+        "en": "Session ID",
+        "ja": "セッションID",
+        "ja_typings": [
+          "sesshonid"
+        ]
+      },
+      {
+        "en": "CSRF Token",
+        "ja": "CSRFトークン",
+        "ja_typings": [
+          "csrfto-kun"
+        ]
+      },
+      {
+        "en": "Refresh Token",
+        "ja": "リフレッシュトークン",
+        "ja_typings": [
+          "rifuresshuto-kun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02751",
+    "image_path": null,
+    "question_text": {
+      "en": "Which credential string identifies a client to a web API?",
+      "ja": "Web API でクライアントを識別する資格情報文字列は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Angular",
+        "ja": "アンギュラー",
+        "ja_typings": [
+          "angyura-"
+        ]
+      },
+      {
+        "en": "React",
+        "ja": "リアクト",
+        "ja_typings": [
+          "riakuto"
+        ]
+      },
+      {
+        "en": "Vue",
+        "ja": "ビュー",
+        "ja_typings": [
+          "byu-"
+        ]
+      },
+      {
+        "en": "Svelte",
+        "ja": "スベルト",
+        "ja_typings": [
+          "suberuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02752",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Google-backed SPA framework uses TypeScript and decorators?",
+      "ja": "Google が開発した TypeScript ベースの SPA フレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Authentication required",
+        "ja": "認証が必要",
+        "ja_typings": [
+          "ninshougahitsuyou"
+        ]
+      },
+      {
+        "en": "Forbidden access",
+        "ja": "アクセス禁止",
+        "ja_typings": [
+          "akusesukinshi"
+        ]
+      },
+      {
+        "en": "Resource not found",
+        "ja": "リソースが見つからない",
+        "ja_typings": [
+          "risoosugamitsukaranai"
+        ]
+      },
+      {
+        "en": "Internal server error",
+        "ja": "内部サーバエラー",
+        "ja_typings": [
+          "naibusaabaeraa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02753",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status family message says credentials are required?",
+      "ja": "認証情報が必要であることを示す HTTP メッセージは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Backbone",
+        "ja": "バックボーン",
+        "ja_typings": [
+          "bakkubo-n"
+        ]
+      },
+      {
+        "en": "Ember",
+        "ja": "エンバー",
+        "ja_typings": [
+          "enba-"
+        ]
+      },
+      {
+        "en": "Knockout",
+        "ja": "ノックアウト",
+        "ja_typings": [
+          "nokkuauto"
+        ]
+      },
+      {
+        "en": "Meteor",
+        "ja": "メテオ",
+        "ja_typings": [
+          "meteo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02754",
+    "image_path": null,
+    "question_text": {
+      "en": "Which early MVC JavaScript framework popularized models and collections?",
+      "ja": "モデルとコレクションで知られた初期の MVC 系 JS フレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Basic authentication",
+        "ja": "ベーシック認証",
+        "ja_typings": [
+          "beeshikkuninshou"
+        ]
+      },
+      {
+        "en": "Digest authentication",
+        "ja": "ダイジェスト認証",
+        "ja_typings": [
+          "daijesutoninshou"
+        ]
+      },
+      {
+        "en": "Bearer authentication",
+        "ja": "ベアラー認証",
+        "ja_typings": [
+          "bearaaninshou"
+        ]
+      },
+      {
+        "en": "Kerberos authentication",
+        "ja": "ケルベロス認証",
+        "ja_typings": [
+          "keruberosuninshou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02755",
+    "image_path": null,
+    "question_text": {
+      "en": "Which scheme sends username:password Base64-encoded in HTTP headers?",
+      "ja": "ユーザー名とパスワードを Base64 で送る HTTP 認証方式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bootstrap",
+        "ja": "ブートストラップ",
+        "ja_typings": [
+          "bu-tosutorappu"
+        ]
+      },
+      {
+        "en": "Tailwind CSS",
+        "ja": "テイルウィンドCSS",
+        "ja_typings": [
+          "teiruwindocss"
+        ]
+      },
+      {
+        "en": "Bulma",
+        "ja": "ブルマ",
+        "ja_typings": [
+          "buruma"
+        ]
+      },
+      {
+        "en": "Foundation",
+        "ja": "ファウンデーション",
+        "ja_typings": [
+          "faunde-shon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02756",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS framework popularized grid systems and component classes from Twitter?",
+      "ja": "Twitter 発のグリッドとコンポーネントクラスを広めた CSS フレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Built on UDP",
+        "ja": "UDP上に構築",
+        "ja_typings": [
+          "udpjounikoutiku"
+        ]
+      },
+      {
+        "en": "Built on TCP",
+        "ja": "TCP上に構築",
+        "ja_typings": [
+          "tcpjounikoutiku"
+        ]
+      },
+      {
+        "en": "Text-based protocol",
+        "ja": "テキストベースプロトコル",
+        "ja_typings": [
+          "tekisutobe-supurotokoru"
+        ]
+      },
+      {
+        "en": "Mandatory encryption only",
+        "ja": "暗号化必須",
+        "ja_typings": [
+          "angoukahissu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02757",
+    "image_path": null,
+    "question_text": {
+      "en": "Which phrase describes the QUIC protocol's transport choice?",
+      "ja": "QUIC プロトコルのトランスポート選択を表す表現は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bundlers",
+        "ja": "バンドラー",
+        "ja_typings": [
+          "bandora-"
+        ]
+      },
+      {
+        "en": "Linters",
+        "ja": "リンター",
+        "ja_typings": [
+          "rinta-"
+        ]
+      },
+      {
+        "en": "Transpilers",
+        "ja": "トランスパイラ",
+        "ja_typings": [
+          "toransupaira"
+        ]
+      },
+      {
+        "en": "Polyfills",
+        "ja": "ポリフィル",
+        "ja_typings": [
+          "porifiru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02758",
+    "image_path": null,
+    "question_text": {
+      "en": "What collective name covers tools like webpack, Rollup, and Vite?",
+      "ja": "webpack や Rollup、Vite などをまとめて指す呼称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CSP",
+        "ja": "シーエスピー",
+        "ja_typings": [
+          "shi-esupi-"
+        ]
+      },
+      {
+        "en": "CORS",
+        "ja": "コルス",
+        "ja_typings": [
+          "korusu"
+        ]
+      },
+      {
+        "en": "HSTS",
+        "ja": "エイチエスティーエス",
+        "ja_typings": [
+          "eichiesuti-esu"
+        ]
+      },
+      {
+        "en": "SRI",
+        "ja": "エスアールアイ",
+        "ja_typings": [
+          "esua-ruai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02759",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP header lets a server declare allowed script sources?",
+      "ja": "許可するスクリプト配信元をサーバーが宣言するための HTTP ヘッダの略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CSR",
+        "ja": "シーエスアール",
+        "ja_typings": [
+          "shi-esua-ru"
+        ]
+      },
+      {
+        "en": "SSR",
+        "ja": "エスエスアール",
+        "ja_typings": [
+          "esuesua-ru"
+        ]
+      },
+      {
+        "en": "SSG",
+        "ja": "エスエスジー",
+        "ja_typings": [
+          "esuesuji-"
+        ]
+      },
+      {
+        "en": "ISR",
+        "ja": "アイエスアール",
+        "ja_typings": [
+          "aiesua-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02760",
+    "image_path": null,
+    "question_text": {
+      "en": "Which rendering strategy generates HTML on the server per request?",
+      "ja": "リクエストごとにサーバーで HTML を生成する描画方式の略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CSRF",
+        "ja": "シーエスアールエフ",
+        "ja_typings": [
+          "shi-esua-ruefu"
+        ]
+      },
+      {
+        "en": "XSS",
+        "ja": "クロスサイトスクリプティング",
+        "ja_typings": [
+          "kurosusaitosukuriputingu"
+        ]
+      },
+      {
+        "en": "SSRF",
+        "ja": "エスエスアールエフ",
+        "ja_typings": [
+          "esuesua-ruefu"
+        ]
+      },
+      {
+        "en": "Clickjacking",
+        "ja": "クリックジャッキング",
+        "ja_typings": [
+          "kurikkujakkingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02761",
+    "image_path": null,
+    "question_text": {
+      "en": "Which attack tricks a logged-in user into submitting unwanted requests?",
+      "ja": "ログイン中のユーザーに意図しないリクエストを送らせる攻撃の略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CSS frameworks",
+        "ja": "CSSフレームワーク",
+        "ja_typings": [
+          "cssfure-muwa-ku"
+        ]
+      },
+      {
+        "en": "JS frameworks",
+        "ja": "JSフレームワーク",
+        "ja_typings": [
+          "jsfure-muwa-ku"
+        ]
+      },
+      {
+        "en": "Template engines",
+        "ja": "テンプレートエンジン",
+        "ja_typings": [
+          "tenpure-toenjin"
+        ]
+      },
+      {
+        "en": "Static site generators",
+        "ja": "静的サイトジェネレータ",
+        "ja_typings": [
+          "seitekisaitojenereeta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02762",
+    "image_path": null,
+    "question_text": {
+      "en": "What collective name describes libraries like Bootstrap and Tailwind?",
+      "ja": "Bootstrap や Tailwind のようなライブラリ群の総称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cache Storage",
+        "ja": "キャッシュストレージ",
+        "ja_typings": [
+          "kyasshusutore-ji"
+        ]
+      },
+      {
+        "en": "IndexedDB",
+        "ja": "インデックスドDB",
+        "ja_typings": [
+          "indekkusudodb"
+        ]
+      },
+      {
+        "en": "Local Storage",
+        "ja": "ローカルストレージ",
+        "ja_typings": [
+          "ro-karusutore-ji"
+        ]
+      },
+      {
+        "en": "Session Storage",
+        "ja": "セッションストレージ",
+        "ja_typings": [
+          "sesshonsutore-ji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02763",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Service Worker API caches HTTP request/response pairs?",
+      "ja": "Service Worker でリクエストとレスポンスのペアをキャッシュする API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Callback",
+        "ja": "コールバック",
+        "ja_typings": [
+          "ko-rubakku"
+        ]
+      },
+      {
+        "en": "Promise",
+        "ja": "プロミス",
+        "ja_typings": [
+          "puromisu"
+        ]
+      },
+      {
+        "en": "Generator",
+        "ja": "ジェネレータ",
+        "ja_typings": [
+          "jenere-ta"
+        ]
+      },
+      {
+        "en": "Iterator",
+        "ja": "イテレータ",
+        "ja_typings": [
+          "itere-ta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02764",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript pattern passes a function to be executed later?",
+      "ja": "後で実行される関数を引数として渡す JS のパターンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cookie",
+        "ja": "クッキー",
+        "ja_typings": [
+          "kukki-"
+        ]
+      },
+      {
+        "en": "Session",
+        "ja": "セッション",
+        "ja_typings": [
+          "sesshon"
+        ]
+      },
+      {
+        "en": "Token",
+        "ja": "トークン",
+        "ja_typings": [
+          "to-kun"
+        ]
+      },
+      {
+        "en": "Header",
+        "ja": "ヘッダ",
+        "ja_typings": [
+          "hedda"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02765",
+    "image_path": null,
+    "question_text": {
+      "en": "Which small piece of data does a server store in the user's browser?",
+      "ja": "サーバーがユーザーのブラウザに保存する小さなデータは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DDoS",
+        "ja": "ディードス",
+        "ja_typings": [
+          "di-dosu"
+        ]
+      },
+      {
+        "en": "XSS",
+        "ja": "クロスサイトスクリプティング",
+        "ja_typings": [
+          "kurosusaitosukuriputingu"
+        ]
+      },
+      {
+        "en": "CSRF",
+        "ja": "シーエスアールエフ",
+        "ja_typings": [
+          "shi-esua-ruefu"
+        ]
+      },
+      {
+        "en": "SQLi",
+        "ja": "エスキューエルアイ",
+        "ja_typings": [
+          "esukyu-eruai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02766",
+    "image_path": null,
+    "question_text": {
+      "en": "Which attack floods a service with traffic from many sources?",
+      "ja": "多数のソースから大量のトラフィックでサービスを麻痺させる攻撃の略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DNS Lookup",
+        "ja": "DNSルックアップ",
+        "ja_typings": [
+          "dnsrukkuappu"
+        ]
+      },
+      {
+        "en": "TCP Handshake",
+        "ja": "TCPハンドシェイク",
+        "ja_typings": [
+          "tcphandosheiku"
+        ]
+      },
+      {
+        "en": "TLS Handshake",
+        "ja": "TLSハンドシェイク",
+        "ja_typings": [
+          "tlshandosheiku"
+        ]
+      },
+      {
+        "en": "HTTP Request",
+        "ja": "HTTPリクエスト",
+        "ja_typings": [
+          "httprikuesuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02767",
+    "image_path": null,
+    "question_text": {
+      "en": "Which step resolves a domain name into an IP address?",
+      "ja": "ドメイン名を IP アドレスに解決する手順は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Data Object Model",
+        "ja": "データオブジェクトモデル",
+        "ja_typings": [
+          "de-taobujekutomoderu"
+        ]
+      },
+      {
+        "en": "Document Object Model",
+        "ja": "ドキュメントオブジェクトモデル",
+        "ja_typings": [
+          "dokyumentobujekutomoderu",
+          "dokyumentoobujekutomoderu"
+        ]
+      },
+      {
+        "en": "Display Object Model",
+        "ja": "ディスプレイオブジェクトモデル",
+        "ja_typings": [
+          "disupureiobujekutomoderu"
+        ]
+      },
+      {
+        "en": "Dynamic Object Module",
+        "ja": "ダイナミックオブジェクトモジュール",
+        "ja_typings": [
+          "dainamikkuobujekutomoju-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02768",
+    "image_path": null,
+    "question_text": {
+      "en": "Which option is a decoy expansion sometimes confused with DOM?",
+      "ja": "DOM と紛らわしいダミーの展開語はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Digest authentication",
+        "ja": "ダイジェスト認証",
+        "ja_typings": [
+          "daijesutoninshou"
+        ]
+      },
+      {
+        "en": "Basic authentication",
+        "ja": "ベーシック認証",
+        "ja_typings": [
+          "beeshikkuninshou"
+        ]
+      },
+      {
+        "en": "Bearer authentication",
+        "ja": "ベアラー認証",
+        "ja_typings": [
+          "bearaaninshou"
+        ]
+      },
+      {
+        "en": "Form authentication",
+        "ja": "フォーム認証",
+        "ja_typings": [
+          "foomuninshou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02769",
+    "image_path": null,
+    "question_text": {
+      "en": "Which authentication scheme hashes credentials with a server nonce?",
+      "ja": "サーバーのノンスで資格情報をハッシュ化する認証方式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Display Object Model",
+        "ja": "ディスプレイオブジェクトモデル",
+        "ja_typings": [
+          "disupureiobujekutomoderu"
+        ]
+      },
+      {
+        "en": "Document Object Model",
+        "ja": "ドキュメントオブジェクトモデル",
+        "ja_typings": [
+          "dokyumentobujekutomoderu",
+          "dokyumentoobujekutomoderu"
+        ]
+      },
+      {
+        "en": "Data Object Model",
+        "ja": "データオブジェクトモデル",
+        "ja_typings": [
+          "de-taobujekutomoderu"
+        ]
+      },
+      {
+        "en": "Dynamic Object Module",
+        "ja": "ダイナミックオブジェクトモジュール",
+        "ja_typings": [
+          "dainamikkuobujekutomoju-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02770",
+    "image_path": null,
+    "question_text": {
+      "en": "Which DOM expansion is also a decoy display-oriented term?",
+      "ja": "DOM に似せたディスプレイ系の誤答候補はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dynamic Object Module",
+        "ja": "ダイナミックオブジェクトモジュール",
+        "ja_typings": [
+          "dainamikkuobujekutomoju-ru"
+        ]
+      },
+      {
+        "en": "Data Object Model",
+        "ja": "データオブジェクトモデル",
+        "ja_typings": [
+          "de-taobujekutomoderu"
+        ]
+      },
+      {
+        "en": "Display Object Model",
+        "ja": "ディスプレイオブジェクトモデル",
+        "ja_typings": [
+          "disupureiobujekutomoderu"
+        ]
+      },
+      {
+        "en": "Document Object Model",
+        "ja": "ドキュメントオブジェクトモデル",
+        "ja_typings": [
+          "dokyumentobujekutomoderu",
+          "dokyumentoobujekutomoderu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02771",
+    "image_path": null,
+    "question_text": {
+      "en": "Which DOM-like decoy uses the word 'Module' instead of 'Model'?",
+      "ja": "Model ではなく Module を使った DOM 風の誤答候補は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Elements",
+        "ja": "エレメンツ",
+        "ja_typings": [
+          "erementsu"
+        ]
+      },
+      {
+        "en": "Sources",
+        "ja": "ソース",
+        "ja_typings": [
+          "so-su"
+        ]
+      },
+      {
+        "en": "Network",
+        "ja": "ネットワーク",
+        "ja_typings": [
+          "nettowa-ku"
+        ]
+      },
+      {
+        "en": "Console",
+        "ja": "コンソール",
+        "ja_typings": [
+          "konso-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02772",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Chrome DevTools tab shows the live DOM tree of a page?",
+      "ja": "Chrome DevTools でページの DOM ツリーを表示するタブは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ember",
+        "ja": "エンバー",
+        "ja_typings": [
+          "enba-"
+        ]
+      },
+      {
+        "en": "Backbone",
+        "ja": "バックボーン",
+        "ja_typings": [
+          "bakkubo-n"
+        ]
+      },
+      {
+        "en": "Knockout",
+        "ja": "ノックアウト",
+        "ja_typings": [
+          "nokkuauto"
+        ]
+      },
+      {
+        "en": "Meteor",
+        "ja": "メテオ",
+        "ja_typings": [
+          "meteo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02773",
+    "image_path": null,
+    "question_text": {
+      "en": "Which early MVC framework was built on top of Handlebars?",
+      "ja": "Handlebars を採用した初期の MVC 系 JS フレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Forbidden access",
+        "ja": "アクセス禁止",
+        "ja_typings": [
+          "akusesukinshi"
+        ]
+      },
+      {
+        "en": "Authentication required",
+        "ja": "認証が必要",
+        "ja_typings": [
+          "ninshougahitsuyou"
+        ]
+      },
+      {
+        "en": "Resource not found",
+        "ja": "リソースが見つからない",
+        "ja_typings": [
+          "risoosugamitsukaranai"
+        ]
+      },
+      {
+        "en": "Internal server error",
+        "ja": "内部サーバエラー",
+        "ja_typings": [
+          "naibusaabaeraa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02774",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status message says the server refuses to authorize the request?",
+      "ja": "サーバーが認可を拒否することを示す HTTP メッセージは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fragment",
+        "ja": "フラグメント",
+        "ja_typings": [
+          "furagumento"
+        ]
+      },
+      {
+        "en": "Query",
+        "ja": "クエリ",
+        "ja_typings": [
+          "kueri"
+        ]
+      },
+      {
+        "en": "Path",
+        "ja": "パス",
+        "ja_typings": [
+          "pasu"
+        ]
+      },
+      {
+        "en": "Host",
+        "ja": "ホスト",
+        "ja_typings": [
+          "hosuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02775",
+    "image_path": null,
+    "question_text": {
+      "en": "Which URL part follows a `#` and is not sent to the server?",
+      "ja": "URL の `#` 以降にあたり、サーバーに送られない部分は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "GET",
+        "ja": "ゲット",
+        "ja_typings": [
+          "getto"
+        ]
+      },
+      {
+        "en": "POST",
+        "ja": "ポスト",
+        "ja_typings": [
+          "posuto"
+        ]
+      },
+      {
+        "en": "PUT",
+        "ja": "プット",
+        "ja_typings": [
+          "putto"
+        ]
+      },
+      {
+        "en": "DELETE",
+        "ja": "デリート",
+        "ja_typings": [
+          "deri-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02776",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP method retrieves a resource without modifying it?",
+      "ja": "リソースを変更せず取得する HTTP メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HTML",
+        "ja": "エイチティーエムエル",
+        "ja_typings": [
+          "eichiti-emueru"
+        ]
+      },
+      {
+        "en": "CSS",
+        "ja": "シーエスエス",
+        "ja_typings": [
+          "shi-esuesu"
+        ]
+      },
+      {
+        "en": "XML",
+        "ja": "エックスエムエル",
+        "ja_typings": [
+          "ekkusuemueru"
+        ]
+      },
+      {
+        "en": "SVG",
+        "ja": "エスブイジー",
+        "ja_typings": [
+          "esubuiji-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02777",
+    "image_path": null,
+    "question_text": {
+      "en": "Which markup language describes the structure of a web page?",
+      "ja": "Web ページの構造を記述するマークアップ言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HTTP/1.1",
+        "ja": "HTTP1.1",
+        "ja_typings": [
+          "http1.1"
+        ]
+      },
+      {
+        "en": "HTTP/1.0",
+        "ja": "HTTP1.0",
+        "ja_typings": [
+          "http1.0"
+        ]
+      },
+      {
+        "en": "HTTP/2",
+        "ja": "HTTP2",
+        "ja_typings": [
+          "http2"
+        ]
+      },
+      {
+        "en": "HTTP/3",
+        "ja": "HTTP3",
+        "ja_typings": [
+          "http3"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02778",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP version introduced persistent connections by default?",
+      "ja": "持続的接続を既定で導入した HTTP のバージョンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "IndexedDB",
+        "ja": "インデックスドDB",
+        "ja_typings": [
+          "indekkusudodb"
+        ]
+      },
+      {
+        "en": "Local Storage",
+        "ja": "ローカルストレージ",
+        "ja_typings": [
+          "ro-karusutore-ji"
+        ]
+      },
+      {
+        "en": "Cache Storage",
+        "ja": "キャッシュストレージ",
+        "ja_typings": [
+          "kyasshusutore-ji"
+        ]
+      },
+      {
+        "en": "Cookie",
+        "ja": "クッキー",
+        "ja_typings": [
+          "kukki-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02779",
+    "image_path": null,
+    "question_text": {
+      "en": "Which browser API stores large structured data with key-based access?",
+      "ja": "キーで大きな構造化データを保存するブラウザ API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Internal server error",
+        "ja": "内部サーバエラー",
+        "ja_typings": [
+          "naibusaabaeraa"
+        ]
+      },
+      {
+        "en": "Forbidden access",
+        "ja": "アクセス禁止",
+        "ja_typings": [
+          "akusesukinshi"
+        ]
+      },
+      {
+        "en": "Authentication required",
+        "ja": "認証が必要",
+        "ja_typings": [
+          "ninshougahitsuyou"
+        ]
+      },
+      {
+        "en": "Resource not found",
+        "ja": "リソースが見つからない",
+        "ja_typings": [
+          "risoosugamitsukaranai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02780",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status message indicates an unexpected server-side failure?",
+      "ja": "サーバー側で予期しない失敗が起きたことを示す HTTP メッセージは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JSON",
+        "ja": "ジェイソン",
+        "ja_typings": [
+          "jeison"
+        ]
+      },
+      {
+        "en": "XML",
+        "ja": "エックスエムエル",
+        "ja_typings": [
+          "ekkusuemueru"
+        ]
+      },
+      {
+        "en": "YAML",
+        "ja": "ヤムル",
+        "ja_typings": [
+          "yamuru"
+        ]
+      },
+      {
+        "en": "CSV",
+        "ja": "シーエスブイ",
+        "ja_typings": [
+          "shi-esubui"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02781",
+    "image_path": null,
+    "question_text": {
+      "en": "Which lightweight text format is widely used for web APIs?",
+      "ja": "Web API で広く使われる軽量テキスト形式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JavaScript runtimes",
+        "ja": "JavaScriptランタイム",
+        "ja_typings": [
+          "javascriptrantaimu"
+        ]
+      },
+      {
+        "en": "Web browsers",
+        "ja": "Webブラウザ",
+        "ja_typings": [
+          "webburauza"
+        ]
+      },
+      {
+        "en": "Package managers",
+        "ja": "パッケージマネージャ",
+        "ja_typings": [
+          "pakke-jimane-ja"
+        ]
+      },
+      {
+        "en": "Bundlers",
+        "ja": "バンドラー",
+        "ja_typings": [
+          "bandora-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02782",
+    "image_path": null,
+    "question_text": {
+      "en": "What collective term covers Node.js, Deno, and Bun?",
+      "ja": "Node.js や Deno、Bun の総称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kerberos",
+        "ja": "ケルベロス",
+        "ja_typings": [
+          "keruberosu"
+        ]
+      },
+      {
+        "en": "LDAP",
+        "ja": "エルダップ",
+        "ja_typings": [
+          "erudappu"
+        ]
+      },
+      {
+        "en": "OAuth",
+        "ja": "オーオース",
+        "ja_typings": [
+          "o-o-su"
+        ]
+      },
+      {
+        "en": "SAML",
+        "ja": "サムル",
+        "ja_typings": [
+          "samuru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02783",
+    "image_path": null,
+    "question_text": {
+      "en": "Which network authentication protocol uses tickets and a KDC?",
+      "ja": "チケットと KDC を使うネットワーク認証プロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "LCP",
+        "ja": "エルシーピー",
+        "ja_typings": [
+          "erushi-pi-"
+        ]
+      },
+      {
+        "en": "FID",
+        "ja": "エフアイディー",
+        "ja_typings": [
+          "efuaidi-"
+        ]
+      },
+      {
+        "en": "CLS",
+        "ja": "シーエルエス",
+        "ja_typings": [
+          "shi-eruesu"
+        ]
+      },
+      {
+        "en": "TTFB",
+        "ja": "ティーティーエフビー",
+        "ja_typings": [
+          "ti-ti-efubi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02784",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Core Web Vitals metric measures the largest visible content paint time?",
+      "ja": "最大の可視コンテンツ描画時間を測る Core Web Vitals 指標の略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "LDAP",
+        "ja": "エルダップ",
+        "ja_typings": [
+          "erudappu"
+        ]
+      },
+      {
+        "en": "Kerberos",
+        "ja": "ケルベロス",
+        "ja_typings": [
+          "keruberosu"
+        ]
+      },
+      {
+        "en": "OAuth",
+        "ja": "オーオース",
+        "ja_typings": [
+          "o-o-su"
+        ]
+      },
+      {
+        "en": "SAML",
+        "ja": "サムル",
+        "ja_typings": [
+          "samuru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02785",
+    "image_path": null,
+    "question_text": {
+      "en": "Which directory access protocol underpins many enterprise auth systems?",
+      "ja": "多くの企業認証の基盤になるディレクトリアクセスプロトコルの略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Long Polling",
+        "ja": "ロングポーリング",
+        "ja_typings": [
+          "rongupo-ringu"
+        ]
+      },
+      {
+        "en": "Short Polling",
+        "ja": "ショートポーリング",
+        "ja_typings": [
+          "sho-topo-ringu"
+        ]
+      },
+      {
+        "en": "Server-Sent Events",
+        "ja": "サーバー送信イベント",
+        "ja_typings": [
+          "saabaasoushinibento"
+        ]
+      },
+      {
+        "en": "WebSocket",
+        "ja": "ウェブソケット",
+        "ja_typings": [
+          "webusoketto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02786",
+    "image_path": null,
+    "question_text": {
+      "en": "Which technique keeps an HTTP request open until the server has data?",
+      "ja": "サーバーにデータが届くまで HTTP リクエストを開いたままにする手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MIME",
+        "ja": "マイム",
+        "ja_typings": [
+          "maimu"
+        ]
+      },
+      {
+        "en": "URI",
+        "ja": "ユーアールアイ",
+        "ja_typings": [
+          "yu-a-ruai"
+        ]
+      },
+      {
+        "en": "URL",
+        "ja": "ユーアールエル",
+        "ja_typings": [
+          "yu-a-rueru"
+        ]
+      },
+      {
+        "en": "URN",
+        "ja": "ユーアールエヌ",
+        "ja_typings": [
+          "yu-a-ruenu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02787",
+    "image_path": null,
+    "question_text": {
+      "en": "Which standard labels content types like text/html and image/png?",
+      "ja": "text/html や image/png のようにコンテンツ種別を表す標準は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mandatory encryption only",
+        "ja": "暗号化必須",
+        "ja_typings": [
+          "angoukahissu"
+        ]
+      },
+      {
+        "en": "Optional encryption",
+        "ja": "暗号化任意",
+        "ja_typings": [
+          "angoukanin'i"
+        ]
+      },
+      {
+        "en": "Built on UDP",
+        "ja": "UDP上に構築",
+        "ja_typings": [
+          "udpjounikoutiku"
+        ]
+      },
+      {
+        "en": "Text-based protocol",
+        "ja": "テキストベースプロトコル",
+        "ja_typings": [
+          "tekisutobe-supurotokoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02788",
+    "image_path": null,
+    "question_text": {
+      "en": "Which phrase describes HTTPS being required with no plaintext fallback?",
+      "ja": "平文へのフォールバックなしに HTTPS を必須とする方針を表す表現は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mutation",
+        "ja": "ミューテーション",
+        "ja_typings": [
+          "myu-te-shon"
+        ]
+      },
+      {
+        "en": "Query",
+        "ja": "クエリ",
+        "ja_typings": [
+          "kueri"
+        ]
+      },
+      {
+        "en": "Subscription",
+        "ja": "サブスクリプション",
+        "ja_typings": [
+          "sabusukuripushon"
+        ]
+      },
+      {
+        "en": "Fragment",
+        "ja": "フラグメント",
+        "ja_typings": [
+          "furagumento"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02789",
+    "image_path": null,
+    "question_text": {
+      "en": "In GraphQL, which root operation type changes server-side data?",
+      "ja": "GraphQL でサーバーのデータを変更するルート操作タイプは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Network",
+        "ja": "ネットワーク",
+        "ja_typings": [
+          "nettowa-ku"
+        ]
+      },
+      {
+        "en": "Sources",
+        "ja": "ソース",
+        "ja_typings": [
+          "so-su"
+        ]
+      },
+      {
+        "en": "Elements",
+        "ja": "エレメンツ",
+        "ja_typings": [
+          "erementsu"
+        ]
+      },
+      {
+        "en": "Performance",
+        "ja": "パフォーマンス",
+        "ja_typings": [
+          "pafo-mansu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02790",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Chrome DevTools tab shows HTTP requests made by the page?",
+      "ja": "ページが行った HTTP リクエストを表示する DevTools のタブは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Next",
+        "ja": "ネクスト",
+        "ja_typings": [
+          "nekusuto"
+        ]
+      },
+      {
+        "en": "Nuxt",
+        "ja": "ナクスト",
+        "ja_typings": [
+          "nakusuto"
+        ]
+      },
+      {
+        "en": "Remix",
+        "ja": "リミックス",
+        "ja_typings": [
+          "rimikkusu"
+        ]
+      },
+      {
+        "en": "Astro",
+        "ja": "アストロ",
+        "ja_typings": [
+          "asutoro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02791",
+    "image_path": null,
+    "question_text": {
+      "en": "Which one-syllable word names the React-based meta-framework by Vercel?",
+      "ja": "Vercel が作る React ベースのメタフレームワークの省略形は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Next.js",
+        "ja": "ネクストJS",
+        "ja_typings": [
+          "nekusutojs"
+        ]
+      },
+      {
+        "en": "Nuxt.js",
+        "ja": "ナクストJS",
+        "ja_typings": [
+          "nakusutojs"
+        ]
+      },
+      {
+        "en": "Node.js",
+        "ja": "ノードJS",
+        "ja_typings": [
+          "no-dojs"
+        ]
+      },
+      {
+        "en": "Nest.js",
+        "ja": "ネストJS",
+        "ja_typings": [
+          "nesutojs"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02792",
+    "image_path": null,
+    "question_text": {
+      "en": "Which framework's full name pairs Next with the `.js` suffix?",
+      "ja": "Next にファイル拡張子 `.js` を付けた正式名のフレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PATCH",
+        "ja": "パッチ",
+        "ja_typings": [
+          "patchi"
+        ]
+      },
+      {
+        "en": "PUT",
+        "ja": "プット",
+        "ja_typings": [
+          "putto"
+        ]
+      },
+      {
+        "en": "POST",
+        "ja": "ポスト",
+        "ja_typings": [
+          "posuto"
+        ]
+      },
+      {
+        "en": "DELETE",
+        "ja": "デリート",
+        "ja_typings": [
+          "deri-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02793",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP method applies a partial update to a resource?",
+      "ja": "リソースに部分的な更新を適用する HTTP メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PUT",
+        "ja": "プット",
+        "ja_typings": [
+          "putto"
+        ]
+      },
+      {
+        "en": "PATCH",
+        "ja": "パッチ",
+        "ja_typings": [
+          "patchi"
+        ]
+      },
+      {
+        "en": "POST",
+        "ja": "ポスト",
+        "ja_typings": [
+          "posuto"
+        ]
+      },
+      {
+        "en": "GET",
+        "ja": "ゲット",
+        "ja_typings": [
+          "getto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02794",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP method replaces a resource at a given URL?",
+      "ja": "指定 URL のリソースを丸ごと置き換える HTTP メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PWA",
+        "ja": "ピーダブリューエー",
+        "ja_typings": [
+          "pi-daburyu-e-"
+        ]
+      },
+      {
+        "en": "SPA",
+        "ja": "エスピーエー",
+        "ja_typings": [
+          "esupi-e-"
+        ]
+      },
+      {
+        "en": "SSG",
+        "ja": "エスエスジー",
+        "ja_typings": [
+          "esuesuji-"
+        ]
+      },
+      {
+        "en": "CSR",
+        "ja": "シーエスアール",
+        "ja_typings": [
+          "shi-esua-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02795",
+    "image_path": null,
+    "question_text": {
+      "en": "Which acronym describes installable, offline-capable web apps?",
+      "ja": "インストール可能でオフライン対応の Web アプリの略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Query",
+        "ja": "クエリ",
+        "ja_typings": [
+          "kueri"
+        ]
+      },
+      {
+        "en": "Mutation",
+        "ja": "ミューテーション",
+        "ja_typings": [
+          "myu-te-shon"
+        ]
+      },
+      {
+        "en": "Subscription",
+        "ja": "サブスクリプション",
+        "ja_typings": [
+          "sabusukuripushon"
+        ]
+      },
+      {
+        "en": "Fragment",
+        "ja": "フラグメント",
+        "ja_typings": [
+          "furagumento"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02796",
+    "image_path": null,
+    "question_text": {
+      "en": "In GraphQL, which root operation type reads data without changing it?",
+      "ja": "GraphQL でデータを変更せず読み取るルート操作タイプは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "REST",
+        "ja": "レスト",
+        "ja_typings": [
+          "resuto"
+        ]
+      },
+      {
+        "en": "SOAP",
+        "ja": "ソープ",
+        "ja_typings": [
+          "so-pu"
+        ]
+      },
+      {
+        "en": "gRPC",
+        "ja": "ジーアールピーシー",
+        "ja_typings": [
+          "ji-a-rupi-shi-"
+        ]
+      },
+      {
+        "en": "GraphQL",
+        "ja": "グラフQL",
+        "ja_typings": [
+          "gurafuql"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02797",
+    "image_path": null,
+    "question_text": {
+      "en": "Which architectural style uses URIs, verbs, and stateless servers?",
+      "ja": "URI と HTTP 動詞、ステートレスサーバを用いる API アーキテクチャは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "React",
+        "ja": "リアクト",
+        "ja_typings": [
+          "riakuto"
+        ]
+      },
+      {
+        "en": "Vue",
+        "ja": "ビュー",
+        "ja_typings": [
+          "byu-"
+        ]
+      },
+      {
+        "en": "Angular",
+        "ja": "アンギュラー",
+        "ja_typings": [
+          "angyura-"
+        ]
+      },
+      {
+        "en": "Svelte",
+        "ja": "スベルト",
+        "ja_typings": [
+          "suberuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02798",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Meta-developed UI library popularized the virtual DOM?",
+      "ja": "仮想 DOM を広めた Meta 製の UI ライブラリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Request succeeded",
+        "ja": "リクエスト成功",
+        "ja_typings": [
+          "rikuesutoseikou"
+        ]
+      },
+      {
+        "en": "Resource not found",
+        "ja": "リソースが見つからない",
+        "ja_typings": [
+          "risoosugamitsukaranai"
+        ]
+      },
+      {
+        "en": "Forbidden access",
+        "ja": "アクセス禁止",
+        "ja_typings": [
+          "akusesukinshi"
+        ]
+      },
+      {
+        "en": "Internal server error",
+        "ja": "内部サーバエラー",
+        "ja_typings": [
+          "naibusaabaeraa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02799",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status message says the request was processed successfully?",
+      "ja": "リクエストが正常に処理されたことを示す HTTP メッセージは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Resource not found",
+        "ja": "リソースが見つからない",
+        "ja_typings": [
+          "risoosugamitsukaranai"
+        ]
+      },
+      {
+        "en": "Forbidden access",
+        "ja": "アクセス禁止",
+        "ja_typings": [
+          "akusesukinshi"
+        ]
+      },
+      {
+        "en": "Authentication required",
+        "ja": "認証が必要",
+        "ja_typings": [
+          "ninshougahitsuyou"
+        ]
+      },
+      {
+        "en": "Internal server error",
+        "ja": "内部サーバエラー",
+        "ja_typings": [
+          "naibusaabaeraa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02800",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status message indicates the URL has no matching resource?",
+      "ja": "URL に該当するリソースが無いことを示す HTTP メッセージは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SCTP",
+        "ja": "エスシーティーピー",
+        "ja_typings": [
+          "esushi-ti-pi-"
+        ]
+      },
+      {
+        "en": "TCP",
+        "ja": "ティーシーピー",
+        "ja_typings": [
+          "ti-shi-pi-"
+        ]
+      },
+      {
+        "en": "UDP",
+        "ja": "ユーディーピー",
+        "ja_typings": [
+          "yu-di-pi-"
+        ]
+      },
+      {
+        "en": "QUIC",
+        "ja": "クイック",
+        "ja_typings": [
+          "kuikku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02801",
+    "image_path": null,
+    "question_text": {
+      "en": "Which IETF transport protocol provides message-oriented streams?",
+      "ja": "メッセージ指向のストリームを提供する IETF のトランスポートプロトコルの略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SOAP",
+        "ja": "ソープ",
+        "ja_typings": [
+          "so-pu"
+        ]
+      },
+      {
+        "en": "REST",
+        "ja": "レスト",
+        "ja_typings": [
+          "resuto"
+        ]
+      },
+      {
+        "en": "gRPC",
+        "ja": "ジーアールピーシー",
+        "ja_typings": [
+          "ji-a-rupi-shi-"
+        ]
+      },
+      {
+        "en": "GraphQL",
+        "ja": "グラフQL",
+        "ja_typings": [
+          "gurafuql"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02802",
+    "image_path": null,
+    "question_text": {
+      "en": "Which XML-based RPC protocol pre-dates REST in enterprise services?",
+      "ja": "企業向けで REST 以前に広まった XML ベースの RPC プロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SOP",
+        "ja": "エスオーピー",
+        "ja_typings": [
+          "esuo-pi-"
+        ]
+      },
+      {
+        "en": "CORS",
+        "ja": "コルス",
+        "ja_typings": [
+          "korusu"
+        ]
+      },
+      {
+        "en": "CSP",
+        "ja": "シーエスピー",
+        "ja_typings": [
+          "shi-esupi-"
+        ]
+      },
+      {
+        "en": "CSRF",
+        "ja": "シーエスアールエフ",
+        "ja_typings": [
+          "shi-esua-ruefu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02803",
+    "image_path": null,
+    "question_text": {
+      "en": "Which browser policy restricts cross-origin scripting access by default?",
+      "ja": "クロスオリジンのスクリプトアクセスを既定で制限するブラウザの方針の略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SPA",
+        "ja": "エスピーエー",
+        "ja_typings": [
+          "esupi-e-"
+        ]
+      },
+      {
+        "en": "PWA",
+        "ja": "ピーダブリューエー",
+        "ja_typings": [
+          "pi-daburyu-e-"
+        ]
+      },
+      {
+        "en": "MPA",
+        "ja": "エムピーエー",
+        "ja_typings": [
+          "emupi-e-"
+        ]
+      },
+      {
+        "en": "SSR",
+        "ja": "エスエスアール",
+        "ja_typings": [
+          "esuesua-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02804",
+    "image_path": null,
+    "question_text": {
+      "en": "Which acronym describes a client-side app that updates one HTML shell?",
+      "ja": "1 枚の HTML を更新し続けるクライアント側アプリの略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SSG",
+        "ja": "エスエスジー",
+        "ja_typings": [
+          "esuesuji-"
+        ]
+      },
+      {
+        "en": "SSR",
+        "ja": "エスエスアール",
+        "ja_typings": [
+          "esuesua-ru"
+        ]
+      },
+      {
+        "en": "CSR",
+        "ja": "シーエスアール",
+        "ja_typings": [
+          "shi-esua-ru"
+        ]
+      },
+      {
+        "en": "ISR",
+        "ja": "アイエスアール",
+        "ja_typings": [
+          "aiesua-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02805",
+    "image_path": null,
+    "question_text": {
+      "en": "Which rendering strategy builds all pages at build time?",
+      "ja": "ビルド時にすべてのページを生成する描画方式の略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Schema",
+        "ja": "スキーマ",
+        "ja_typings": [
+          "suki-ma"
+        ]
+      },
+      {
+        "en": "Query",
+        "ja": "クエリ",
+        "ja_typings": [
+          "kueri"
+        ]
+      },
+      {
+        "en": "Mutation",
+        "ja": "ミューテーション",
+        "ja_typings": [
+          "myu-te-shon"
+        ]
+      },
+      {
+        "en": "Fragment",
+        "ja": "フラグメント",
+        "ja_typings": [
+          "furagumento"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02806",
+    "image_path": null,
+    "question_text": {
+      "en": "In GraphQL, which document defines the available types and fields?",
+      "ja": "GraphQL で利用可能な型とフィールドを定義する文書は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Session ID",
+        "ja": "セッションID",
+        "ja_typings": [
+          "sesshonid"
+        ]
+      },
+      {
+        "en": "API Key",
+        "ja": "APIキー",
+        "ja_typings": [
+          "apiki-"
+        ]
+      },
+      {
+        "en": "CSRF Token",
+        "ja": "CSRFトークン",
+        "ja_typings": [
+          "csrfto-kun"
+        ]
+      },
+      {
+        "en": "Nonce",
+        "ja": "ノンス",
+        "ja_typings": [
+          "nonsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02807",
+    "image_path": null,
+    "question_text": {
+      "en": "Which identifier ties subsequent HTTP requests to one user session?",
+      "ja": "後続の HTTP リクエストを 1 つのユーザーセッションに紐づける識別子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Session hijacking",
+        "ja": "セッションハイジャック",
+        "ja_typings": [
+          "sesshonhaijakku"
+        ]
+      },
+      {
+        "en": "Session fixation",
+        "ja": "セッション固定化",
+        "ja_typings": [
+          "sesyonkoteika",
+          "sesshonkoteika"
+        ]
+      },
+      {
+        "en": "CSRF",
+        "ja": "シーエスアールエフ",
+        "ja_typings": [
+          "shi-esua-ruefu"
+        ]
+      },
+      {
+        "en": "XSS",
+        "ja": "クロスサイトスクリプティング",
+        "ja_typings": [
+          "kurosusaitosukuriputingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02808",
+    "image_path": null,
+    "question_text": {
+      "en": "Which attack steals or reuses a valid user session token?",
+      "ja": "正規のセッショントークンを盗んだり再利用する攻撃は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shared Worker",
+        "ja": "シェアードワーカー",
+        "ja_typings": [
+          "shea-dowa-ka-"
+        ]
+      },
+      {
+        "en": "Service Worker",
+        "ja": "サービスワーカー",
+        "ja_typings": [
+          "sa-bisuwa-ka-"
+        ]
+      },
+      {
+        "en": "Web Worker",
+        "ja": "ウェブワーカー",
+        "ja_typings": [
+          "webuwa-ka-"
+        ]
+      },
+      {
+        "en": "Dedicated Worker",
+        "ja": "デディケーテッドワーカー",
+        "ja_typings": [
+          "dedike-teddowa-ka-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02809",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Web Worker variant can be reached from multiple browsing contexts?",
+      "ja": "複数のブラウジングコンテキストから利用できる Web Worker は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sources",
+        "ja": "ソース",
+        "ja_typings": [
+          "so-su"
+        ]
+      },
+      {
+        "en": "Elements",
+        "ja": "エレメンツ",
+        "ja_typings": [
+          "erementsu"
+        ]
+      },
+      {
+        "en": "Network",
+        "ja": "ネットワーク",
+        "ja_typings": [
+          "nettowa-ku"
+        ]
+      },
+      {
+        "en": "Performance",
+        "ja": "パフォーマンス",
+        "ja_typings": [
+          "pafo-mansu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02810",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Chrome DevTools tab shows the original JavaScript sources?",
+      "ja": "オリジナルの JavaScript ソースを表示する DevTools のタブは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Svelte",
+        "ja": "スベルト",
+        "ja_typings": [
+          "suberuto"
+        ]
+      },
+      {
+        "en": "React",
+        "ja": "リアクト",
+        "ja_typings": [
+          "riakuto"
+        ]
+      },
+      {
+        "en": "Vue",
+        "ja": "ビュー",
+        "ja_typings": [
+          "byu-"
+        ]
+      },
+      {
+        "en": "Angular",
+        "ja": "アンギュラー",
+        "ja_typings": [
+          "angyura-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02811",
+    "image_path": null,
+    "question_text": {
+      "en": "Which framework compiles components to plain JS at build time?",
+      "ja": "コンポーネントをビルド時に素の JS にコンパイルするフレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "TCP",
+        "ja": "ティーシーピー",
+        "ja_typings": [
+          "ti-shi-pi-"
+        ]
+      },
+      {
+        "en": "UDP",
+        "ja": "ユーディーピー",
+        "ja_typings": [
+          "yu-di-pi-"
+        ]
+      },
+      {
+        "en": "SCTP",
+        "ja": "エスシーティーピー",
+        "ja_typings": [
+          "esushi-ti-pi-"
+        ]
+      },
+      {
+        "en": "QUIC",
+        "ja": "クイック",
+        "ja_typings": [
+          "kuikku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02812",
+    "image_path": null,
+    "question_text": {
+      "en": "Which transport protocol provides reliable, ordered byte streams?",
+      "ja": "信頼性のある順序付きバイトストリームを提供するトランスポートは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "TLS",
+        "ja": "ティーエルエス",
+        "ja_typings": [
+          "ti-eruesu"
+        ]
+      },
+      {
+        "en": "SSL",
+        "ja": "エスエスエル",
+        "ja_typings": [
+          "esuesueru"
+        ]
+      },
+      {
+        "en": "SSH",
+        "ja": "エスエスエイチ",
+        "ja_typings": [
+          "esuesueichi"
+        ]
+      },
+      {
+        "en": "IPsec",
+        "ja": "アイピーセック",
+        "ja_typings": [
+          "aipi-sekku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02813",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol encrypts HTTP between browser and server?",
+      "ja": "ブラウザとサーバ間の HTTP を暗号化するプロトコルの略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "TTFB",
+        "ja": "ティーティーエフビー",
+        "ja_typings": [
+          "ti-ti-efubi-"
+        ]
+      },
+      {
+        "en": "LCP",
+        "ja": "エルシーピー",
+        "ja_typings": [
+          "erushi-pi-"
+        ]
+      },
+      {
+        "en": "FID",
+        "ja": "エフアイディー",
+        "ja_typings": [
+          "efuaidi-"
+        ]
+      },
+      {
+        "en": "CLS",
+        "ja": "シーエルエス",
+        "ja_typings": [
+          "shi-eruesu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02814",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Web Vitals metric measures the time to the first response byte?",
+      "ja": "最初のレスポンスバイトまでの時間を測る Web Vitals 指標の略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tailwind CSS",
+        "ja": "テイルウィンドCSS",
+        "ja_typings": [
+          "teiruwindocss"
+        ]
+      },
+      {
+        "en": "Bootstrap",
+        "ja": "ブートストラップ",
+        "ja_typings": [
+          "bu-tosutorappu"
+        ]
+      },
+      {
+        "en": "Bulma",
+        "ja": "ブルマ",
+        "ja_typings": [
+          "buruma"
+        ]
+      },
+      {
+        "en": "Foundation",
+        "ja": "ファウンデーション",
+        "ja_typings": [
+          "faunde-shon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02815",
+    "image_path": null,
+    "question_text": {
+      "en": "Which utility-first CSS framework uses class names like `flex` and `gap-4`?",
+      "ja": "`flex` や `gap-4` のようなユーティリティクラス中心の CSS フレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Text-based protocol",
+        "ja": "テキストベースプロトコル",
+        "ja_typings": [
+          "tekisutobe-supurotokoru"
+        ]
+      },
+      {
+        "en": "Binary protocol",
+        "ja": "バイナリプロトコル",
+        "ja_typings": [
+          "bainaripurotokoru"
+        ]
+      },
+      {
+        "en": "Built on UDP",
+        "ja": "UDP上に構築",
+        "ja_typings": [
+          "udpjounikoutiku"
+        ]
+      },
+      {
+        "en": "Mandatory encryption only",
+        "ja": "暗号化必須",
+        "ja_typings": [
+          "angoukahissu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02816",
+    "image_path": null,
+    "question_text": {
+      "en": "Which phrase describes HTTP/1.1 as human-readable on the wire?",
+      "ja": "HTTP/1.1 が人間可読な形式で送られることを表す表現は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thread",
+        "ja": "スレッド",
+        "ja_typings": [
+          "sureddo"
+        ]
+      },
+      {
+        "en": "Process",
+        "ja": "プロセス",
+        "ja_typings": [
+          "purosesu"
+        ]
+      },
+      {
+        "en": "Fiber",
+        "ja": "ファイバー",
+        "ja_typings": [
+          "faiba-"
+        ]
+      },
+      {
+        "en": "Coroutine",
+        "ja": "コルーチン",
+        "ja_typings": [
+          "koru-chin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02817",
+    "image_path": null,
+    "question_text": {
+      "en": "Which unit of execution is scheduled by the OS within a process?",
+      "ja": "プロセス内で OS がスケジュールする実行単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vue",
+        "ja": "ビュー",
+        "ja_typings": [
+          "byu-"
+        ]
+      },
+      {
+        "en": "React",
+        "ja": "リアクト",
+        "ja_typings": [
+          "riakuto"
+        ]
+      },
+      {
+        "en": "Angular",
+        "ja": "アンギュラー",
+        "ja_typings": [
+          "angyura-"
+        ]
+      },
+      {
+        "en": "Svelte",
+        "ja": "スベルト",
+        "ja_typings": [
+          "suberuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02818",
+    "image_path": null,
+    "question_text": {
+      "en": "Which progressive JS framework was created by Evan You?",
+      "ja": "Evan You が作った漸進的に採用できる JS フレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Web Worker",
+        "ja": "ウェブワーカー",
+        "ja_typings": [
+          "webuwa-ka-"
+        ]
+      },
+      {
+        "en": "Service Worker",
+        "ja": "サービスワーカー",
+        "ja_typings": [
+          "sa-bisuwa-ka-"
+        ]
+      },
+      {
+        "en": "Shared Worker",
+        "ja": "シェアードワーカー",
+        "ja_typings": [
+          "shea-dowa-ka-"
+        ]
+      },
+      {
+        "en": "Worklet",
+        "ja": "ワークレット",
+        "ja_typings": [
+          "wa-kuretto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02819",
+    "image_path": null,
+    "question_text": {
+      "en": "Which worker type lets web pages run scripts off the main thread?",
+      "ja": "メインスレッド外でスクリプトを実行できるワーカーの基本形は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "WebSocket",
+        "ja": "ウェブソケット",
+        "ja_typings": [
+          "webusoketto"
+        ]
+      },
+      {
+        "en": "HTTP",
+        "ja": "エイチティーティーピー",
+        "ja_typings": [
+          "eichiti-ti-pi-"
+        ]
+      },
+      {
+        "en": "gRPC",
+        "ja": "ジーアールピーシー",
+        "ja_typings": [
+          "ji-a-rupi-shi-"
+        ]
+      },
+      {
+        "en": "Long Polling",
+        "ja": "ロングポーリング",
+        "ja_typings": [
+          "rongupo-ringu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02820",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol gives full-duplex communication over a single TCP connection?",
+      "ja": "1 本の TCP 接続で全二重通信を提供するプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "XSS",
+        "ja": "クロスサイトスクリプティング",
+        "ja_typings": [
+          "kurosusaitosukuriputingu"
+        ]
+      },
+      {
+        "en": "CSRF",
+        "ja": "シーエスアールエフ",
+        "ja_typings": [
+          "shi-esua-ruefu"
+        ]
+      },
+      {
+        "en": "SSRF",
+        "ja": "エスエスアールエフ",
+        "ja_typings": [
+          "esuesua-ruefu"
+        ]
+      },
+      {
+        "en": "Clickjacking",
+        "ja": "クリックジャッキング",
+        "ja_typings": [
+          "kurikkujakkingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02821",
+    "image_path": null,
+    "question_text": {
+      "en": "Which attack injects malicious scripts that run in other users' browsers?",
+      "ja": "他ユーザーのブラウザで悪意あるスクリプトを実行させる攻撃の略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`!=`",
+        "ja": "イコールでない",
+        "ja_typings": [
+          "ikoorudenai",
+          "iko-rudenai"
+        ]
+      },
+      {
+        "en": "`==`",
+        "ja": "イコール2つ",
+        "ja_typings": [
+          "ikooru2tsu"
+        ]
+      },
+      {
+        "en": "`===`",
+        "ja": "イコール3つ",
+        "ja_typings": [
+          "ikooru3tsu"
+        ]
+      },
+      {
+        "en": "`=`",
+        "ja": "イコール1つ",
+        "ja_typings": [
+          "ikooru1tsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02822",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript operator tests for strict inequality?",
+      "ja": "厳密な不等価を判定する JavaScript 演算子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`#`",
+        "ja": "シャープ",
+        "ja_typings": [
+          "sha-pu"
+        ]
+      },
+      {
+        "en": "`?`",
+        "ja": "クエスチョン",
+        "ja_typings": [
+          "kuesuchon"
+        ]
+      },
+      {
+        "en": "`&`",
+        "ja": "アンパサンド",
+        "ja_typings": [
+          "anpasando"
+        ]
+      },
+      {
+        "en": "`@`",
+        "ja": "アットマーク",
+        "ja_typings": [
+          "attoma-ku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02823",
+    "image_path": null,
+    "question_text": {
+      "en": "Which symbol starts a URL fragment identifier?",
+      "ja": "URL のフラグメント識別子の先頭に来る記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`&`",
+        "ja": "アンパサンド",
+        "ja_typings": [
+          "anpasando"
+        ]
+      },
+      {
+        "en": "`?`",
+        "ja": "クエスチョン",
+        "ja_typings": [
+          "kuesuchon"
+        ]
+      },
+      {
+        "en": "`#`",
+        "ja": "シャープ",
+        "ja_typings": [
+          "sha-pu"
+        ]
+      },
+      {
+        "en": "`=`",
+        "ja": "イコール",
+        "ja_typings": [
+          "iko-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02824",
+    "image_path": null,
+    "question_text": {
+      "en": "Which symbol separates query parameters in a URL?",
+      "ja": "URL のクエリパラメータを区切る記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`*`",
+        "ja": "アスタリスク",
+        "ja_typings": [
+          "asutarisuku"
+        ]
+      },
+      {
+        "en": "`.`",
+        "ja": "ドット",
+        "ja_typings": [
+          "dotto"
+        ]
+      },
+      {
+        "en": "`#`",
+        "ja": "シャープ",
+        "ja_typings": [
+          "sha-pu"
+        ]
+      },
+      {
+        "en": "`:`",
+        "ja": "コロン",
+        "ja_typings": [
+          "koron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02825",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS selector matches any element?",
+      "ja": "任意の要素にマッチする CSS セレクタ記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`.`",
+        "ja": "ドット",
+        "ja_typings": [
+          "dotto"
+        ]
+      },
+      {
+        "en": "`#`",
+        "ja": "シャープ",
+        "ja_typings": [
+          "sha-pu"
+        ]
+      },
+      {
+        "en": "`*`",
+        "ja": "アスタリスク",
+        "ja_typings": [
+          "asutarisuku"
+        ]
+      },
+      {
+        "en": "`:`",
+        "ja": "コロン",
+        "ja_typings": [
+          "koron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02826",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS selector prefix matches by class name?",
+      "ja": "クラス名で一致させる CSS セレクタの先頭記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`:`",
+        "ja": "コロン",
+        "ja_typings": [
+          "koron"
+        ]
+      },
+      {
+        "en": "`.`",
+        "ja": "ドット",
+        "ja_typings": [
+          "dotto"
+        ]
+      },
+      {
+        "en": "`#`",
+        "ja": "シャープ",
+        "ja_typings": [
+          "sha-pu"
+        ]
+      },
+      {
+        "en": "`*`",
+        "ja": "アスタリスク",
+        "ja_typings": [
+          "asutarisuku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02827",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS character prefixes a pseudo-class like `:hover`?",
+      "ja": "`:hover` のような擬似クラスの先頭に置かれる CSS の文字は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<picture>` tag",
+        "ja": "ピクチャタグ",
+        "ja_typings": [
+          "pikuchatagu"
+        ]
+      },
+      {
+        "en": "`<img>` tag",
+        "ja": "イメージタグ",
+        "ja_typings": [
+          "ime-jitagu"
+        ]
+      },
+      {
+        "en": "`<figure>` tag",
+        "ja": "フィギュアタグ",
+        "ja_typings": [
+          "figyuatagu"
+        ]
+      },
+      {
+        "en": "`<svg>` tag",
+        "ja": "エスブイジータグ",
+        "ja_typings": [
+          "esubuiji-tagu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02828",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML element serves responsive images via multiple `<source>` children?",
+      "ja": "複数の `<source>` でレスポンシブ画像を提供する HTML 要素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`==`",
+        "ja": "イコール2つ",
+        "ja_typings": [
+          "ikooru2tsu"
+        ]
+      },
+      {
+        "en": "`===`",
+        "ja": "イコール3つ",
+        "ja_typings": [
+          "ikooru3tsu"
+        ]
+      },
+      {
+        "en": "`!=`",
+        "ja": "イコールでない",
+        "ja_typings": [
+          "ikoorudenai",
+          "iko-rudenai"
+        ]
+      },
+      {
+        "en": "`=`",
+        "ja": "イコール1つ",
+        "ja_typings": [
+          "ikooru1tsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02829",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript operator tests for loose equality with type coercion?",
+      "ja": "型変換ありで等価を判定する JavaScript 演算子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`=`",
+        "ja": "イコール1つ",
+        "ja_typings": [
+          "ikooru1tsu"
+        ]
+      },
+      {
+        "en": "`==`",
+        "ja": "イコール2つ",
+        "ja_typings": [
+          "ikooru2tsu"
+        ]
+      },
+      {
+        "en": "`===`",
+        "ja": "イコール3つ",
+        "ja_typings": [
+          "ikooru3tsu"
+        ]
+      },
+      {
+        "en": "`!=`",
+        "ja": "イコールでない",
+        "ja_typings": [
+          "ikoorudenai",
+          "iko-rudenai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02830",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript operator assigns a value to a variable?",
+      "ja": "JavaScript で変数に値を代入する演算子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`@`",
+        "ja": "アットマーク",
+        "ja_typings": [
+          "attoma-ku"
+        ]
+      },
+      {
+        "en": "`#`",
+        "ja": "シャープ",
+        "ja_typings": [
+          "sha-pu"
+        ]
+      },
+      {
+        "en": "`&`",
+        "ja": "アンパサンド",
+        "ja_typings": [
+          "anpasando"
+        ]
+      },
+      {
+        "en": "`.`",
+        "ja": "ドット",
+        "ja_typings": [
+          "dotto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02831",
+    "image_path": null,
+    "question_text": {
+      "en": "Which symbol separates a user name from a host in an email address?",
+      "ja": "メールアドレスでユーザー名とホストを区切る記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`border`",
+        "ja": "ボーダー",
+        "ja_typings": [
+          "bo-da-"
+        ]
+      },
+      {
+        "en": "`outline`",
+        "ja": "アウトライン",
+        "ja_typings": [
+          "autorain"
+        ]
+      },
+      {
+        "en": "`margin`",
+        "ja": "マージン",
+        "ja_typings": [
+          "ma-jin"
+        ]
+      },
+      {
+        "en": "`padding`",
+        "ja": "パディング",
+        "ja_typings": [
+          "padingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02832",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS shorthand property sets all four borders at once?",
+      "ja": "4 辺のボーダーを一括で指定する CSS のショートハンドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`final`",
+        "ja": "ファイナル",
+        "ja_typings": [
+          "fainaru"
+        ]
+      },
+      {
+        "en": "`const`",
+        "ja": "コンスト",
+        "ja_typings": [
+          "konsuto"
+        ]
+      },
+      {
+        "en": "`var`",
+        "ja": "バー",
+        "ja_typings": [
+          "ba-"
+        ]
+      },
+      {
+        "en": "`let`",
+        "ja": "レット",
+        "ja_typings": [
+          "retto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02833",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Java/Dart keyword prevents reassignment of a variable?",
+      "ja": "Java や Dart で再代入を禁じる変数宣言キーワードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`forEach`",
+        "ja": "フォーイーチ",
+        "ja_typings": [
+          "fo-i-chi"
+        ]
+      },
+      {
+        "en": "`map`",
+        "ja": "マップ",
+        "ja_typings": [
+          "mappu"
+        ]
+      },
+      {
+        "en": "`reduce`",
+        "ja": "リデュース",
+        "ja_typings": [
+          "rideyu-su"
+        ]
+      },
+      {
+        "en": "`some`",
+        "ja": "サム",
+        "ja_typings": [
+          "samu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02834",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript array method executes a callback for each element without returning a new array?",
+      "ja": "新しい配列を返さず各要素にコールバックを実行する JS の配列メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`gap`",
+        "ja": "ギャップ",
+        "ja_typings": [
+          "gyappu"
+        ]
+      },
+      {
+        "en": "`margin`",
+        "ja": "マージン",
+        "ja_typings": [
+          "ma-jin"
+        ]
+      },
+      {
+        "en": "`padding`",
+        "ja": "パディング",
+        "ja_typings": [
+          "padingu"
+        ]
+      },
+      {
+        "en": "`spacing`",
+        "ja": "スペーシング",
+        "ja_typings": [
+          "supe-shingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02835",
+    "image_path": null,
+    "question_text": {
+      "en": "Which modern CSS property sets spacing between flex or grid items?",
+      "ja": "Flex/Grid 項目間の間隔を指定する現代的な CSS プロパティは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`inset`",
+        "ja": "インセット",
+        "ja_typings": [
+          "insetto"
+        ]
+      },
+      {
+        "en": "`offset`",
+        "ja": "オフセット",
+        "ja_typings": [
+          "ofusetto"
+        ]
+      },
+      {
+        "en": "`margin`",
+        "ja": "マージン",
+        "ja_typings": [
+          "ma-jin"
+        ]
+      },
+      {
+        "en": "`padding`",
+        "ja": "パディング",
+        "ja_typings": [
+          "padingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02836",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS shorthand sets top/right/bottom/left for positioned elements?",
+      "ja": "配置済み要素の上下左右オフセットを一括指定する CSS プロパティは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`let`",
+        "ja": "レット",
+        "ja_typings": [
+          "retto"
+        ]
+      },
+      {
+        "en": "`const`",
+        "ja": "コンスト",
+        "ja_typings": [
+          "konsuto"
+        ]
+      },
+      {
+        "en": "`var`",
+        "ja": "バー",
+        "ja_typings": [
+          "ba-"
+        ]
+      },
+      {
+        "en": "`final`",
+        "ja": "ファイナル",
+        "ja_typings": [
+          "fainaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02837",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript keyword declares a block-scoped mutable variable?",
+      "ja": "ブロックスコープで可変な変数を宣言する JS キーワードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`map`",
+        "ja": "マップ",
+        "ja_typings": [
+          "mappu"
+        ]
+      },
+      {
+        "en": "`forEach`",
+        "ja": "フォーイーチ",
+        "ja_typings": [
+          "fo-i-chi"
+        ]
+      },
+      {
+        "en": "`filter`",
+        "ja": "フィルター",
+        "ja_typings": [
+          "firuta-"
+        ]
+      },
+      {
+        "en": "`reduce`",
+        "ja": "リデュース",
+        "ja_typings": [
+          "rideyu-su"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02838",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript array method returns a new array with each element transformed?",
+      "ja": "各要素を変換した新しい配列を返す JS の配列メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`margin`",
+        "ja": "マージン",
+        "ja_typings": [
+          "ma-jin"
+        ]
+      },
+      {
+        "en": "`padding`",
+        "ja": "パディング",
+        "ja_typings": [
+          "padingu"
+        ]
+      },
+      {
+        "en": "`border`",
+        "ja": "ボーダー",
+        "ja_typings": [
+          "bo-da-"
+        ]
+      },
+      {
+        "en": "`gap`",
+        "ja": "ギャップ",
+        "ja_typings": [
+          "gyappu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02839",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS shorthand sets the outer space around an element?",
+      "ja": "要素の外側の余白を一括指定する CSS のショートハンドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`padding`",
+        "ja": "パディング",
+        "ja_typings": [
+          "padingu"
+        ]
+      },
+      {
+        "en": "`margin`",
+        "ja": "マージン",
+        "ja_typings": [
+          "ma-jin"
+        ]
+      },
+      {
+        "en": "`border`",
+        "ja": "ボーダー",
+        "ja_typings": [
+          "bo-da-"
+        ]
+      },
+      {
+        "en": "`gap`",
+        "ja": "ギャップ",
+        "ja_typings": [
+          "gyappu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02840",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS shorthand sets the inner space inside an element's border?",
+      "ja": "要素の内側の余白を一括指定する CSS のショートハンドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`reduce`",
+        "ja": "リデュース",
+        "ja_typings": [
+          "rideyu-su"
+        ]
+      },
+      {
+        "en": "`map`",
+        "ja": "マップ",
+        "ja_typings": [
+          "mappu"
+        ]
+      },
+      {
+        "en": "`forEach`",
+        "ja": "フォーイーチ",
+        "ja_typings": [
+          "fo-i-chi"
+        ]
+      },
+      {
+        "en": "`filter`",
+        "ja": "フィルター",
+        "ja_typings": [
+          "firuta-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02841",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript array method reduces values to a single accumulated result?",
+      "ja": "配列の値を 1 つの累積値にまとめる JS の配列メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`some`",
+        "ja": "サム",
+        "ja_typings": [
+          "samu"
+        ]
+      },
+      {
+        "en": "`every`",
+        "ja": "エブリ",
+        "ja_typings": [
+          "eburi"
+        ]
+      },
+      {
+        "en": "`map`",
+        "ja": "マップ",
+        "ja_typings": [
+          "mappu"
+        ]
+      },
+      {
+        "en": "`reduce`",
+        "ja": "リデュース",
+        "ja_typings": [
+          "rideyu-su"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02842",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript array method checks whether at least one element passes a test?",
+      "ja": "少なくとも 1 要素が条件を満たすかを判定する JS の配列メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`spacing`",
+        "ja": "スペーシング",
+        "ja_typings": [
+          "supe-shingu"
+        ]
+      },
+      {
+        "en": "`gap`",
+        "ja": "ギャップ",
+        "ja_typings": [
+          "gyappu"
+        ]
+      },
+      {
+        "en": "`margin`",
+        "ja": "マージン",
+        "ja_typings": [
+          "ma-jin"
+        ]
+      },
+      {
+        "en": "`padding`",
+        "ja": "パディング",
+        "ja_typings": [
+          "padingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02843",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Tailwind-style class word is used for inter-item gap utilities?",
+      "ja": "Tailwind 系で要素間の間隔ユーティリティに使われる語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`var`",
+        "ja": "バー",
+        "ja_typings": [
+          "ba-"
+        ]
+      },
+      {
+        "en": "`let`",
+        "ja": "レット",
+        "ja_typings": [
+          "retto"
+        ]
+      },
+      {
+        "en": "`const`",
+        "ja": "コンスト",
+        "ja_typings": [
+          "konsuto"
+        ]
+      },
+      {
+        "en": "`final`",
+        "ja": "ファイナル",
+        "ja_typings": [
+          "fainaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02844",
+    "image_path": null,
+    "question_text": {
+      "en": "Which legacy JavaScript keyword declares a function-scoped variable?",
+      "ja": "関数スコープで変数を宣言する従来からの JS キーワードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "bun",
+        "ja": "バン",
+        "ja_typings": [
+          "ban"
+        ]
+      },
+      {
+        "en": "yarn",
+        "ja": "ヤーン",
+        "ja_typings": [
+          "ya-n"
+        ]
+      },
+      {
+        "en": "pnpm",
+        "ja": "ピーエヌピーエム",
+        "ja_typings": [
+          "pi-enupi-emu"
+        ]
+      },
+      {
+        "en": "npm",
+        "ja": "エヌピーエム",
+        "ja_typings": [
+          "enupi-emu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02845",
+    "image_path": null,
+    "question_text": {
+      "en": "Which all-in-one JavaScript runtime by Jarred Sumner ships its own bundler?",
+      "ja": "Jarred Sumner が作るバンドラ同梱の JS ランタイムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "gRPC",
+        "ja": "ジーアールピーシー",
+        "ja_typings": [
+          "ji-a-rupi-shi-"
+        ]
+      },
+      {
+        "en": "REST",
+        "ja": "レスト",
+        "ja_typings": [
+          "resuto"
+        ]
+      },
+      {
+        "en": "SOAP",
+        "ja": "ソープ",
+        "ja_typings": [
+          "so-pu"
+        ]
+      },
+      {
+        "en": "GraphQL",
+        "ja": "グラフQL",
+        "ja_typings": [
+          "gurafuql"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02846",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Google-made high-performance RPC framework uses HTTP/2 and protobuf?",
+      "ja": "HTTP/2 と Protocol Buffers を使う Google 製の高性能 RPC は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "pnpm",
+        "ja": "ピーエヌピーエム",
+        "ja_typings": [
+          "pi-enupi-emu"
+        ]
+      },
+      {
+        "en": "npm",
+        "ja": "エヌピーエム",
+        "ja_typings": [
+          "enupi-emu"
+        ]
+      },
+      {
+        "en": "yarn",
+        "ja": "ヤーン",
+        "ja_typings": [
+          "ya-n"
+        ]
+      },
+      {
+        "en": "bun",
+        "ja": "バン",
+        "ja_typings": [
+          "ban"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02847",
+    "image_path": null,
+    "question_text": {
+      "en": "Which package manager stores dependencies in a content-addressable store with hard links?",
+      "ja": "コンテンツアドレス指定のストアとハードリンクで依存を管理する Node のパッケージマネージャは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sessionStorage",
+        "ja": "セッションストレージ",
+        "ja_typings": [
+          "sesshonsutore-ji"
+        ]
+      },
+      {
+        "en": "localStorage",
+        "ja": "ローカルストレージ",
+        "ja_typings": [
+          "ro-karusutore-ji"
+        ]
+      },
+      {
+        "en": "Cache Storage",
+        "ja": "キャッシュストレージ",
+        "ja_typings": [
+          "kyasshusutore-ji"
+        ]
+      },
+      {
+        "en": "IndexedDB",
+        "ja": "インデックスドDB",
+        "ja_typings": [
+          "indekkusudodb"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02848",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Web Storage API persists key/value pairs only until the tab closes?",
+      "ja": "タブを閉じるまでキー/値を保持する Web Storage API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "yarn",
+        "ja": "ヤーン",
+        "ja_typings": [
+          "ya-n"
+        ]
+      },
+      {
+        "en": "npm",
+        "ja": "エヌピーエム",
+        "ja_typings": [
+          "enupi-emu"
+        ]
+      },
+      {
+        "en": "pnpm",
+        "ja": "ピーエヌピーエム",
+        "ja_typings": [
+          "pi-enupi-emu"
+        ]
+      },
+      {
+        "en": "bun",
+        "ja": "バン",
+        "ja_typings": [
+          "ban"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02849",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Node package manager was originally created by Facebook?",
+      "ja": "Facebook が最初に作った Node のパッケージマネージャは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aki Hayakawa",
+        "ja": "早川アキ",
+        "ja_typings": [
+          "hayakawaaki"
+        ]
+      },
+      {
+        "en": "Denji",
+        "ja": "デンジ",
+        "ja_typings": [
+          "denji"
+        ]
+      },
+      {
+        "en": "Kobeni",
+        "ja": "コベニ",
+        "ja_typings": [
+          "kobeni"
+        ]
+      },
+      {
+        "en": "Himeno",
+        "ja": "ヒメノ",
+        "ja_typings": [
+          "himeno"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02850",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Public Safety Devil Hunter partners with Denji in Chainsaw Man?",
+      "ja": "チェンソーマンでデンジと組む公安のデビルハンターは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Akira Kamiya",
+        "ja": "神谷明",
+        "ja_typings": [
+          "kamiyaakira"
+        ]
+      },
+      {
+        "en": "Toru Furuya",
+        "ja": "古谷徹",
+        "ja_typings": [
+          "furuyatooru"
+        ]
+      },
+      {
+        "en": "Banjo Ginga",
+        "ja": "銀河万丈",
+        "ja_typings": [
+          "gingabanjou"
+        ]
+      },
+      {
+        "en": "Kenji Utsumi",
+        "ja": "内海賢二",
+        "ja_typings": [
+          "utsumikenji",
+          "uchiumikenji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02851",
+    "image_path": null,
+    "question_text": {
+      "en": "Which veteran voice actor is known for Ryo Saeba in City Hunter?",
+      "ja": "シティーハンターの冴羽獠を演じたベテラン声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "All Might",
+        "ja": "オールマイト",
+        "ja_typings": [
+          "o-rumaito"
+        ]
+      },
+      {
+        "en": "Endeavor",
+        "ja": "エンデヴァー",
+        "ja_typings": [
+          "endeva-"
+        ]
+      },
+      {
+        "en": "Hawks",
+        "ja": "ホークス",
+        "ja_typings": [
+          "ho-kusu"
+        ]
+      },
+      {
+        "en": "Best Jeanist",
+        "ja": "ベストジーニスト",
+        "ja_typings": [
+          "besutoji-nisuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02852",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Symbol of Peace is the No.1 hero in My Hero Academia?",
+      "ja": "ヒロアカで「平和の象徴」と呼ばれる No.1 ヒーローは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Alphonse Elric",
+        "ja": "アルフォンス・エルリック",
+        "ja_typings": [
+          "arufonsu/erurikku"
+        ]
+      },
+      {
+        "en": "Edward Elric",
+        "ja": "エドワード・エルリック",
+        "ja_typings": [
+          "edowa-do/erurikku"
+        ]
+      },
+      {
+        "en": "Roy Mustang",
+        "ja": "ロイ・マスタング",
+        "ja_typings": [
+          "roi/masutangu"
+        ]
+      },
+      {
+        "en": "Winry Rockbell",
+        "ja": "ウィンリィ・ロックベル",
+        "ja_typings": [
+          "winrii/rokkuberu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02853",
+    "image_path": null,
+    "question_text": {
+      "en": "Which younger Elric brother has his soul bound to a suit of armor?",
+      "ja": "魂を鎧に定着させた弟のエルリック兄弟は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Anya Forger",
+        "ja": "アーニャ・フォージャー",
+        "ja_typings": [
+          "a-nya/fo-ja-"
+        ]
+      },
+      {
+        "en": "Yor Forger",
+        "ja": "ヨル・フォージャー",
+        "ja_typings": [
+          "yoru/fo-ja-"
+        ]
+      },
+      {
+        "en": "Loid Forger",
+        "ja": "ロイド・フォージャー",
+        "ja_typings": [
+          "roido/fo-ja-"
+        ]
+      },
+      {
+        "en": "Becky Blackbell",
+        "ja": "ベッキー・ブラックベル",
+        "ja_typings": [
+          "bekki-/burakkuberu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02854",
+    "image_path": null,
+    "question_text": {
+      "en": "Which pink-haired telepath is the daughter in the Forger family?",
+      "ja": "フォージャー家のピンク髪の超能力少女は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Armin Arlert",
+        "ja": "アルミン・アルレルト",
+        "ja_typings": [
+          "arumin/arureruto"
+        ]
+      },
+      {
+        "en": "Eren Yeager",
+        "ja": "エレン・イェーガー",
+        "ja_typings": [
+          "eren/ye-ga-"
+        ]
+      },
+      {
+        "en": "Jean Kirstein",
+        "ja": "ジャン・キルシュタイン",
+        "ja_typings": [
+          "jan/kirushutain"
+        ]
+      },
+      {
+        "en": "Connie Springer",
+        "ja": "コニー・スプリンガー",
+        "ja_typings": [
+          "koni-/supuringa-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02855",
+    "image_path": null,
+    "question_text": {
+      "en": "Which short blond strategist of the Survey Corps is Eren's friend?",
+      "ja": "調査兵団でエレンの友人にあたる金髪の戦略家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Asuka Langley Soryu",
+        "ja": "惣流・アスカ・ラングレー",
+        "ja_typings": [
+          "souryuuasukaranguree",
+          "souryuuasukarangure"
+        ]
+      },
+      {
+        "en": "Rei Ayanami",
+        "ja": "綾波レイ",
+        "ja_typings": [
+          "ayanamirei"
+        ]
+      },
+      {
+        "en": "Mari Makinami",
+        "ja": "真希波・マリ",
+        "ja_typings": [
+          "makinamimari"
+        ]
+      },
+      {
+        "en": "Kaworu Nagisa",
+        "ja": "渚カヲル",
+        "ja_typings": [
+          "nagisakaworu",
+          "nagisakaoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02856",
+    "image_path": null,
+    "question_text": {
+      "en": "Which redheaded Eva pilot is designated the Second Child?",
+      "ja": "セカンドチルドレンに指定された赤毛のエヴァパイロットは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Banjo Ginga",
+        "ja": "銀河万丈",
+        "ja_typings": [
+          "gingabanjou"
+        ]
+      },
+      {
+        "en": "Akira Kamiya",
+        "ja": "神谷明",
+        "ja_typings": [
+          "kamiyaakira"
+        ]
+      },
+      {
+        "en": "Kenji Utsumi",
+        "ja": "内海賢二",
+        "ja_typings": [
+          "utsumikenji",
+          "uchiumikenji"
+        ]
+      },
+      {
+        "en": "Toru Furuya",
+        "ja": "古谷徹",
+        "ja_typings": [
+          "furuyatooru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02857",
+    "image_path": null,
+    "question_text": {
+      "en": "Which deep-voiced veteran voice actor is associated with characters like Dorf and General Revil?",
+      "ja": "ドルフやレビル将軍などで知られる重低音のベテラン声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Char Aznable",
+        "ja": "シャア・アズナブル",
+        "ja_typings": [
+          "shaa/azunaburu"
+        ]
+      },
+      {
+        "en": "Amuro Ray",
+        "ja": "アムロ・レイ",
+        "ja_typings": [
+          "amuro/rei"
+        ]
+      },
+      {
+        "en": "Kamille Bidan",
+        "ja": "カミーユ・ビダン",
+        "ja_typings": [
+          "kami-yu/bidan"
+        ]
+      },
+      {
+        "en": "Judau Ashta",
+        "ja": "ジュドー・アーシタ",
+        "ja_typings": [
+          "judo-/a-shita"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02858",
+    "image_path": null,
+    "question_text": {
+      "en": "Which masked blond Zeon ace is also known as 'the Red Comet'?",
+      "ja": "「赤い彗星」と呼ばれる仮面のジオンのエースは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chimera Shadow Garden",
+        "ja": "嵌合暗翳庭",
+        "ja_typings": [
+          "kangouan'eitei"
+        ]
+      },
+      {
+        "en": "Malevolent Shrine",
+        "ja": "伏魔御厨子",
+        "ja_typings": [
+          "fukumamizushi"
+        ]
+      },
+      {
+        "en": "Unlimited Void",
+        "ja": "無量空処",
+        "ja_typings": [
+          "muryoukuusho"
+        ]
+      },
+      {
+        "en": "Time Prison",
+        "ja": "時胞月宮殿",
+        "ja_typings": [
+          "jihougetsukyuuden"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02859",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Domain Expansion belongs to Megumi Fushiguro in Jujutsu Kaisen?",
+      "ja": "呪術廻戦で伏黒恵が使う領域展開の名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Coffin of the Iron Mountain",
+        "ja": "鉄山の柩",
+        "ja_typings": [
+          "tetsuzannohitsugi"
+        ]
+      },
+      {
+        "en": "Malevolent Shrine",
+        "ja": "伏魔御厨子",
+        "ja_typings": [
+          "fukumamizushi"
+        ]
+      },
+      {
+        "en": "Unlimited Void",
+        "ja": "無量空処",
+        "ja_typings": [
+          "muryoukuusho"
+        ]
+      },
+      {
+        "en": "Chimera Shadow Garden",
+        "ja": "嵌合暗翳庭",
+        "ja_typings": [
+          "kangouan'eitei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02860",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hashira's Domain Expansion name belongs to Muzan-adjacent foe Akaza? (decoy set: which name from JJK's signature domains is *not* in JJK?)",
+      "ja": "呪術廻戦の代表的領域展開のうち、上弦ぽいけど実在しない名前はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fujiko F. Fujio",
+        "ja": "藤子・F・不二雄",
+        "ja_typings": [
+          "hujikofhujio"
+        ]
+      },
+      {
+        "en": "Osamu Tezuka",
+        "ja": "手塚治虫",
+        "ja_typings": [
+          "tezukaosamu"
+        ]
+      },
+      {
+        "en": "Shotaro Ishinomori",
+        "ja": "石ノ森章太郎",
+        "ja_typings": [
+          "ishinomorishoutarou"
+        ]
+      },
+      {
+        "en": "Hideaki Anno",
+        "ja": "庵野秀明",
+        "ja_typings": [
+          "annohideaki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02861",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga artist created Doraemon as one half of his duo pen name?",
+      "ja": "コンビ筆名の片割れとしてドラえもんを描いた漫画家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gainax",
+        "ja": "ガイナックス",
+        "ja_typings": [
+          "gainakkusu"
+        ]
+      },
+      {
+        "en": "Studio Khara",
+        "ja": "スタジオカラー",
+        "ja_typings": [
+          "sutajiokara-"
+        ]
+      },
+      {
+        "en": "Studio Ghibli",
+        "ja": "スタジオジブリ",
+        "ja_typings": [
+          "sutajiojiburi"
+        ]
+      },
+      {
+        "en": "Toei Animation",
+        "ja": "東映アニメーション",
+        "ja_typings": [
+          "toueianimeeshon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02862",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio produced Neon Genesis Evangelion in the 1990s?",
+      "ja": "1990 年代に新世紀エヴァンゲリオンを制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gege Akutami",
+        "ja": "芥見下々",
+        "ja_typings": [
+          "akutamigege"
+        ]
+      },
+      {
+        "en": "Kohei Horikoshi",
+        "ja": "堀越耕平",
+        "ja_typings": [
+          "horikoshikouhei"
+        ]
+      },
+      {
+        "en": "Tatsuki Fujimoto",
+        "ja": "藤本タツキ",
+        "ja_typings": [
+          "fujimototatsuki"
+        ]
+      },
+      {
+        "en": "Hajime Isayama",
+        "ja": "諫山創",
+        "ja_typings": [
+          "isayamahajime"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02863",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga author created Jujutsu Kaisen?",
+      "ja": "呪術廻戦の原作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Giorno Giovanna",
+        "ja": "ジョルノ・ジョバァーナ",
+        "ja_typings": [
+          "joruno/jobaa-na"
+        ]
+      },
+      {
+        "en": "Jonathan Joestar",
+        "ja": "ジョナサン・ジョースター",
+        "ja_typings": [
+          "jonasan/jo-suta-"
+        ]
+      },
+      {
+        "en": "Josuke Higashikata",
+        "ja": "東方仗助",
+        "ja_typings": [
+          "higasikatajousuke"
+        ]
+      },
+      {
+        "en": "Jotaro Kujo",
+        "ja": "空条承太郎",
+        "ja_typings": [
+          "kujoujoutarou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02864",
+    "image_path": null,
+    "question_text": {
+      "en": "Which blond protagonist of JoJo Part 5 wants to become a Gang-Star?",
+      "ja": "ジョジョ第5部でギャングのトップを目指す金髪の主人公は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hajime Isayama",
+        "ja": "諫山創",
+        "ja_typings": [
+          "isayamahajime"
+        ]
+      },
+      {
+        "en": "Gege Akutami",
+        "ja": "芥見下々",
+        "ja_typings": [
+          "akutamigege"
+        ]
+      },
+      {
+        "en": "Kohei Horikoshi",
+        "ja": "堀越耕平",
+        "ja_typings": [
+          "horikoshikouhei"
+        ]
+      },
+      {
+        "en": "Tatsuki Fujimoto",
+        "ja": "藤本タツキ",
+        "ja_typings": [
+          "fujimototatsuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02865",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga author created Attack on Titan?",
+      "ja": "進撃の巨人の原作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hideaki Anno",
+        "ja": "庵野秀明",
+        "ja_typings": [
+          "annohideaki"
+        ]
+      },
+      {
+        "en": "Mamoru Oshii",
+        "ja": "押井守",
+        "ja_typings": [
+          "oshiimamoru"
+        ]
+      },
+      {
+        "en": "Isao Takahata",
+        "ja": "高畑勲",
+        "ja_typings": [
+          "takahataisao"
+        ]
+      },
+      {
+        "en": "Mamoru Hosoda",
+        "ja": "細田守",
+        "ja_typings": [
+          "hosodamamoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02866",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Gainax co-founder directed the original Neon Genesis Evangelion?",
+      "ja": "新世紀エヴァンゲリオンを監督した Gainax の共同創業者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Inosuke Hashibira",
+        "ja": "嘴平伊之助",
+        "ja_typings": [
+          "hashibirainosuke"
+        ]
+      },
+      {
+        "en": "Zenitsu Agatsuma",
+        "ja": "我妻善逸",
+        "ja_typings": [
+          "agatsumazenitsu"
+        ]
+      },
+      {
+        "en": "Tanjiro Kamado",
+        "ja": "竈門炭治郎",
+        "ja_typings": [
+          "kamadotanjirou"
+        ]
+      },
+      {
+        "en": "Giyu Tomioka",
+        "ja": "冨岡義勇",
+        "ja_typings": [
+          "tomiokagiyuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02867",
+    "image_path": null,
+    "question_text": {
+      "en": "Which wild boar-headed Demon Slayer fights with twin nichirin blades?",
+      "ja": "猪の頭をかぶり、二刀流で戦う鬼殺隊士は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Isao Takahata",
+        "ja": "高畑勲",
+        "ja_typings": [
+          "takahataisao"
+        ]
+      },
+      {
+        "en": "Hayao Miyazaki",
+        "ja": "宮崎駿",
+        "ja_typings": [
+          "miyazakihayao"
+        ]
+      },
+      {
+        "en": "Mamoru Hosoda",
+        "ja": "細田守",
+        "ja_typings": [
+          "hosodamamoru"
+        ]
+      },
+      {
+        "en": "Hideaki Anno",
+        "ja": "庵野秀明",
+        "ja_typings": [
+          "annohideaki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02868",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Ghibli co-founder directed Grave of the Fireflies?",
+      "ja": "火垂るの墓を監督したジブリの共同創業者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jonathan Joestar",
+        "ja": "ジョナサン・ジョースター",
+        "ja_typings": [
+          "jonasan/jo-suta-"
+        ]
+      },
+      {
+        "en": "Joseph Joestar",
+        "ja": "ジョセフ・ジョースター",
+        "ja_typings": [
+          "josefu/jo-suta-"
+        ]
+      },
+      {
+        "en": "Jotaro Kujo",
+        "ja": "空条承太郎",
+        "ja_typings": [
+          "kujoujoutarou"
+        ]
+      },
+      {
+        "en": "Giorno Giovanna",
+        "ja": "ジョルノ・ジョバァーナ",
+        "ja_typings": [
+          "joruno/jobaa-na"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02869",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 19th-century English gentleman is the first JoJo of Part 1?",
+      "ja": "第1部の主人公にあたる 19 世紀イギリス紳士のジョジョは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Josuke Higashikata",
+        "ja": "東方仗助",
+        "ja_typings": [
+          "higasikatajousuke"
+        ]
+      },
+      {
+        "en": "Giorno Giovanna",
+        "ja": "ジョルノ・ジョバァーナ",
+        "ja_typings": [
+          "joruno/jobaa-na"
+        ]
+      },
+      {
+        "en": "Jonathan Joestar",
+        "ja": "ジョナサン・ジョースター",
+        "ja_typings": [
+          "jonasan/jo-suta-"
+        ]
+      },
+      {
+        "en": "Jotaro Kujo",
+        "ja": "空条承太郎",
+        "ja_typings": [
+          "kujoujoutarou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02870",
+    "image_path": null,
+    "question_text": {
+      "en": "Which pompadour-haired Part 4 hero protects Morioh from Stand users?",
+      "ja": "杜王町を守るリーゼント髪のジョジョ第4部の主人公は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Judau Ashta",
+        "ja": "ジュドー・アーシタ",
+        "ja_typings": [
+          "judo-/a-shita"
+        ]
+      },
+      {
+        "en": "Kamille Bidan",
+        "ja": "カミーユ・ビダン",
+        "ja_typings": [
+          "kami-yu/bidan"
+        ]
+      },
+      {
+        "en": "Amuro Ray",
+        "ja": "アムロ・レイ",
+        "ja_typings": [
+          "amuro/rei"
+        ]
+      },
+      {
+        "en": "Char Aznable",
+        "ja": "シャア・アズナブル",
+        "ja_typings": [
+          "shaa/azunaburu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02871",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protagonist of Zeta Gundam's sequel ZZ pilots the Double Zeta Gundam?",
+      "ja": "機動戦士ガンダムZZでΖΖガンダムに乗る主人公は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kaito Ishikawa",
+        "ja": "石川界人",
+        "ja_typings": [
+          "ishikawakaito"
+        ]
+      },
+      {
+        "en": "Koki Uchiyama",
+        "ja": "内山昂輝",
+        "ja_typings": [
+          "uchiyamakouki"
+        ]
+      },
+      {
+        "en": "Toru Furuya",
+        "ja": "古谷徹",
+        "ja_typings": [
+          "furuyatooru"
+        ]
+      },
+      {
+        "en": "Akira Kamiya",
+        "ja": "神谷明",
+        "ja_typings": [
+          "kamiyaakira"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02872",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actor for Tobio Kageyama in Haikyu!! also voices many shōnen leads?",
+      "ja": "ハイキュー!! の影山飛雄役を演じた声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kakashi Hatake",
+        "ja": "はたけカカシ",
+        "ja_typings": [
+          "hatakekakashi"
+        ]
+      },
+      {
+        "en": "Sasuke Uchiha",
+        "ja": "うちはサスケ",
+        "ja_typings": [
+          "uchihasasuke"
+        ]
+      },
+      {
+        "en": "Yashamaru",
+        "ja": "夜叉丸",
+        "ja_typings": [
+          "yashamaru"
+        ]
+      },
+      {
+        "en": "Tsunade",
+        "ja": "綱手",
+        "ja_typings": [
+          "tsunade"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02873",
+    "image_path": null,
+    "question_text": {
+      "en": "Which silver-haired ninja with a Sharingan eye leads Team 7 in Naruto?",
+      "ja": "ナルトで第七班を率いる写輪眼を持つ銀髪の忍は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kamille Bidan",
+        "ja": "カミーユ・ビダン",
+        "ja_typings": [
+          "kami-yu/bidan"
+        ]
+      },
+      {
+        "en": "Judau Ashta",
+        "ja": "ジュドー・アーシタ",
+        "ja_typings": [
+          "judo-/a-shita"
+        ]
+      },
+      {
+        "en": "Amuro Ray",
+        "ja": "アムロ・レイ",
+        "ja_typings": [
+          "amuro/rei"
+        ]
+      },
+      {
+        "en": "Char Aznable",
+        "ja": "シャア・アズナブル",
+        "ja_typings": [
+          "shaa/azunaburu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02874",
+    "image_path": null,
+    "question_text": {
+      "en": "Which moody Newtype pilots the Zeta Gundam in its title series?",
+      "ja": "機動戦士Ζガンダムで Ζガンダムに乗るニュータイプは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kanao Tsuyuri",
+        "ja": "栗花落カナヲ",
+        "ja_typings": [
+          "turiyurikanawo",
+          "tsuyurikanawo"
+        ]
+      },
+      {
+        "en": "Shinobu Kocho",
+        "ja": "胡蝶しのぶ",
+        "ja_typings": [
+          "kochoushinobu"
+        ]
+      },
+      {
+        "en": "Mitsuri Kanroji",
+        "ja": "甘露寺蜜璃",
+        "ja_typings": [
+          "kanrojimitsuri"
+        ]
+      },
+      {
+        "en": "Nezuko Kamado",
+        "ja": "竈門禰豆子",
+        "ja_typings": [
+          "kamadonezuko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02875",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Tsuguko of the Insect Hashira wields a sword with two crescent blades?",
+      "ja": "蟲柱の継子で二日月型の刀を使う鬼殺隊士は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Katsuki Bakugo",
+        "ja": "爆豪勝己",
+        "ja_typings": [
+          "bakugoukatsuki"
+        ]
+      },
+      {
+        "en": "Shoto Todoroki",
+        "ja": "轟焦凍",
+        "ja_typings": [
+          "todorokishouto"
+        ]
+      },
+      {
+        "en": "All Might",
+        "ja": "オールマイト",
+        "ja_typings": [
+          "o-rumaito"
+        ]
+      },
+      {
+        "en": "Tenya Iida",
+        "ja": "飯田天哉",
+        "ja_typings": [
+          "iidatenya"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02876",
+    "image_path": null,
+    "question_text": {
+      "en": "Which explosive-quirk classmate of Deku calls himself the future No.1 hero?",
+      "ja": "デクの同級生で爆破個性を持ち、未来の No.1 を自称するのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kaworu Nagisa",
+        "ja": "渚カヲル",
+        "ja_typings": [
+          "nagisakaworu",
+          "nagisakaoru"
+        ]
+      },
+      {
+        "en": "Rei Ayanami",
+        "ja": "綾波レイ",
+        "ja_typings": [
+          "ayanamirei"
+        ]
+      },
+      {
+        "en": "Asuka Langley Soryu",
+        "ja": "惣流・アスカ・ラングレー",
+        "ja_typings": [
+          "souryuuasukaranguree",
+          "souryuuasukarangure"
+        ]
+      },
+      {
+        "en": "Shinji Ikari",
+        "ja": "碇シンジ",
+        "ja_typings": [
+          "ikarishinji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02877",
+    "image_path": null,
+    "question_text": {
+      "en": "Which gray-haired Evangelion pilot is designated the Fifth Child?",
+      "ja": "フィフスチルドレンに指定された灰色の髪のエヴァパイロットは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kenji Utsumi",
+        "ja": "内海賢二",
+        "ja_typings": [
+          "utsumikenji",
+          "uchiumikenji"
+        ]
+      },
+      {
+        "en": "Banjo Ginga",
+        "ja": "銀河万丈",
+        "ja_typings": [
+          "gingabanjou"
+        ]
+      },
+      {
+        "en": "Akira Kamiya",
+        "ja": "神谷明",
+        "ja_typings": [
+          "kamiyaakira"
+        ]
+      },
+      {
+        "en": "Toru Furuya",
+        "ja": "古谷徹",
+        "ja_typings": [
+          "furuyatooru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02878",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actor was famous for booming villains like Raoh in Fist of the North Star?",
+      "ja": "北斗の拳のラオウ等の威厳ある悪役で知られた声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kohei Horikoshi",
+        "ja": "堀越耕平",
+        "ja_typings": [
+          "horikoshikouhei"
+        ]
+      },
+      {
+        "en": "Gege Akutami",
+        "ja": "芥見下々",
+        "ja_typings": [
+          "akutamigege"
+        ]
+      },
+      {
+        "en": "Hajime Isayama",
+        "ja": "諫山創",
+        "ja_typings": [
+          "isayamahajime"
+        ]
+      },
+      {
+        "en": "Tatsuki Fujimoto",
+        "ja": "藤本タツキ",
+        "ja_typings": [
+          "fujimototatsuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02879",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga author created My Hero Academia?",
+      "ja": "僕のヒーローアカデミアの原作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Koki Uchiyama",
+        "ja": "内山昂輝",
+        "ja_typings": [
+          "uchiyamakouki"
+        ]
+      },
+      {
+        "en": "Kaito Ishikawa",
+        "ja": "石川界人",
+        "ja_typings": [
+          "ishikawakaito"
+        ]
+      },
+      {
+        "en": "Megumi Ogata",
+        "ja": "緒方恵美",
+        "ja_typings": [
+          "ogatamegumi"
+        ]
+      },
+      {
+        "en": "Toru Furuya",
+        "ja": "古谷徹",
+        "ja_typings": [
+          "furuyatooru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02880",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actor for L (Death Note) is also known for Echizen in Prince of Tennis?",
+      "ja": "デスノートのＬや越前リョーマを演じた声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Krillin",
+        "ja": "クリリン",
+        "ja_typings": [
+          "kuririn"
+        ]
+      },
+      {
+        "en": "Piccolo",
+        "ja": "ピッコロ",
+        "ja_typings": [
+          "pikkoro"
+        ]
+      },
+      {
+        "en": "Vegeta",
+        "ja": "ベジータ",
+        "ja_typings": [
+          "beji-ta"
+        ]
+      },
+      {
+        "en": "Yamcha",
+        "ja": "ヤムチャ",
+        "ja_typings": [
+          "yamucha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02881",
+    "image_path": null,
+    "question_text": {
+      "en": "Which short, bald Z-Fighter is one of Goku's oldest friends?",
+      "ja": "悟空の最古参の親友にあたる坊主頭の Z 戦士は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lawliet",
+        "ja": "ローライト",
+        "ja_typings": [
+          "ro-raito"
+        ]
+      },
+      {
+        "en": "Ryuk",
+        "ja": "リューク",
+        "ja_typings": [
+          "ryu-ku"
+        ]
+      },
+      {
+        "en": "Misa Amane",
+        "ja": "弥海砂",
+        "ja_typings": [
+          "amanemisa"
+        ]
+      },
+      {
+        "en": "Yagami",
+        "ja": "夜神",
+        "ja_typings": [
+          "yagami"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02882",
+    "image_path": null,
+    "question_text": {
+      "en": "Which white-haired detective in Death Note uses the alias 'L'?",
+      "ja": "デスノートで L を名乗る白髪交じりの探偵の本名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Levi Ackerman",
+        "ja": "リヴァイ・アッカーマン",
+        "ja_typings": [
+          "rivai/akka-man"
+        ]
+      },
+      {
+        "en": "Mikasa Ackerman",
+        "ja": "ミカサ・アッカーマン",
+        "ja_typings": [
+          "mikasa/akka-man"
+        ]
+      },
+      {
+        "en": "Erwin Smith",
+        "ja": "エルヴィン・スミス",
+        "ja_typings": [
+          "eruvin/sumisu"
+        ]
+      },
+      {
+        "en": "Armin Arlert",
+        "ja": "アルミン・アルレルト",
+        "ja_typings": [
+          "arumin/arureruto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02883",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Survey Corps captain is humanity's strongest soldier?",
+      "ja": "人類最強の兵士と呼ばれる調査兵団の兵長は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Makima",
+        "ja": "マキマ",
+        "ja_typings": [
+          "makima"
+        ]
+      },
+      {
+        "en": "Power",
+        "ja": "パワー",
+        "ja_typings": [
+          "pawa-"
+        ]
+      },
+      {
+        "en": "Reze",
+        "ja": "レゼ",
+        "ja_typings": [
+          "reze"
+        ]
+      },
+      {
+        "en": "Kobeni",
+        "ja": "コベニ",
+        "ja_typings": [
+          "kobeni"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02884",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Chainsaw Man character is a control devil who recruits Denji?",
+      "ja": "チェンソーマンでデンジを勧誘する支配の悪魔の姿の女性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Malevolent Shrine",
+        "ja": "伏魔御厨子",
+        "ja_typings": [
+          "fukumamizushi"
+        ]
+      },
+      {
+        "en": "Chimera Shadow Garden",
+        "ja": "嵌合暗翳庭",
+        "ja_typings": [
+          "kangouan'eitei"
+        ]
+      },
+      {
+        "en": "Unlimited Void",
+        "ja": "無量空処",
+        "ja_typings": [
+          "muryoukuusho"
+        ]
+      },
+      {
+        "en": "Time Prison",
+        "ja": "時胞月宮殿",
+        "ja_typings": [
+          "jihougetsukyuuden"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02885",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Domain Expansion belongs to Ryomen Sukuna in Jujutsu Kaisen?",
+      "ja": "呪術廻戦で両面宿儺が使う領域展開の名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mamoru Hosoda",
+        "ja": "細田守",
+        "ja_typings": [
+          "hosodamamoru"
+        ]
+      },
+      {
+        "en": "Hayao Miyazaki",
+        "ja": "宮崎駿",
+        "ja_typings": [
+          "miyazakihayao"
+        ]
+      },
+      {
+        "en": "Isao Takahata",
+        "ja": "高畑勲",
+        "ja_typings": [
+          "takahataisao"
+        ]
+      },
+      {
+        "en": "Mamoru Oshii",
+        "ja": "押井守",
+        "ja_typings": [
+          "oshiimamoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02886",
+    "image_path": null,
+    "question_text": {
+      "en": "Which director helmed Summer Wars and Mirai (Mirai no Mirai)?",
+      "ja": "サマーウォーズや未来のミライを監督したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mamoru Oshii",
+        "ja": "押井守",
+        "ja_typings": [
+          "oshiimamoru"
+        ]
+      },
+      {
+        "en": "Mamoru Hosoda",
+        "ja": "細田守",
+        "ja_typings": [
+          "hosodamamoru"
+        ]
+      },
+      {
+        "en": "Hideaki Anno",
+        "ja": "庵野秀明",
+        "ja_typings": [
+          "annohideaki"
+        ]
+      },
+      {
+        "en": "Satoshi Kon",
+        "ja": "今敏",
+        "ja_typings": [
+          "konsatoshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02887",
+    "image_path": null,
+    "question_text": {
+      "en": "Which director helmed Ghost in the Shell (1995)?",
+      "ja": "1995 年の劇場版『攻殻機動隊』を監督したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mayumi Tanaka",
+        "ja": "田中真弓",
+        "ja_typings": [
+          "tanakamayumi"
+        ]
+      },
+      {
+        "en": "Megumi Hayashibara",
+        "ja": "林原めぐみ",
+        "ja_typings": [
+          "hayashibaramegumi"
+        ]
+      },
+      {
+        "en": "Minami Takayama",
+        "ja": "高山みなみ",
+        "ja_typings": [
+          "takayamaminami"
+        ]
+      },
+      {
+        "en": "Nobuyo Oyama",
+        "ja": "大山のぶ代",
+        "ja_typings": [
+          "ooyamanobuyo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02888",
+    "image_path": null,
+    "question_text": {
+      "en": "Which longtime Japanese voice actress played Krillin and Luffy?",
+      "ja": "クリリンやルフィを演じた長年の女性声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Megumi Fushiguro",
+        "ja": "伏黒恵",
+        "ja_typings": [
+          "fukuromegumi"
+        ]
+      },
+      {
+        "en": "Yuji Itadori",
+        "ja": "虎杖悠仁",
+        "ja_typings": [
+          "itadoriyuuji"
+        ]
+      },
+      {
+        "en": "Nobara Kugisaki",
+        "ja": "釘崎野薔薇",
+        "ja_typings": [
+          "kugisakinobara"
+        ]
+      },
+      {
+        "en": "Satoru Gojo",
+        "ja": "五条悟",
+        "ja_typings": [
+          "gojousatoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02889",
+    "image_path": null,
+    "question_text": {
+      "en": "Which shadow-summoning sorcerer is the Ten Shadows user in JJK?",
+      "ja": "呪術廻戦で十種影法術を使う影使いの呪術師は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Megumi Hayashibara",
+        "ja": "林原めぐみ",
+        "ja_typings": [
+          "hayashibaramegumi"
+        ]
+      },
+      {
+        "en": "Megumi Ogata",
+        "ja": "緒方恵美",
+        "ja_typings": [
+          "ogatamegumi"
+        ]
+      },
+      {
+        "en": "Megumi Toyoguchi",
+        "ja": "豊口めぐみ",
+        "ja_typings": [
+          "toyoguchimegumi"
+        ]
+      },
+      {
+        "en": "Mayumi Tanaka",
+        "ja": "田中真弓",
+        "ja_typings": [
+          "tanakamayumi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02890",
+    "image_path": null,
+    "question_text": {
+      "en": "Which prolific voice actress played Rei Ayanami and Faye Valentine?",
+      "ja": "綾波レイやフェイ・バレンタインを演じた女性声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Megumi Ogata",
+        "ja": "緒方恵美",
+        "ja_typings": [
+          "ogatamegumi"
+        ]
+      },
+      {
+        "en": "Megumi Hayashibara",
+        "ja": "林原めぐみ",
+        "ja_typings": [
+          "hayashibaramegumi"
+        ]
+      },
+      {
+        "en": "Megumi Toyoguchi",
+        "ja": "豊口めぐみ",
+        "ja_typings": [
+          "toyoguchimegumi"
+        ]
+      },
+      {
+        "en": "Minami Takayama",
+        "ja": "高山みなみ",
+        "ja_typings": [
+          "takayamaminami"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02891",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actress is associated with Shinji Ikari and Sailor Uranus?",
+      "ja": "碇シンジや天王はるかを演じた女性声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Megumi Toyoguchi",
+        "ja": "豊口めぐみ",
+        "ja_typings": [
+          "toyoguchimegumi"
+        ]
+      },
+      {
+        "en": "Megumi Hayashibara",
+        "ja": "林原めぐみ",
+        "ja_typings": [
+          "hayashibaramegumi"
+        ]
+      },
+      {
+        "en": "Megumi Ogata",
+        "ja": "緒方恵美",
+        "ja_typings": [
+          "ogatamegumi"
+        ]
+      },
+      {
+        "en": "Mayumi Tanaka",
+        "ja": "田中真弓",
+        "ja_typings": [
+          "tanakamayumi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02892",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actress played Revy in Black Lagoon and Winry in FMA?",
+      "ja": "ブラックラグーンのレヴィや FMA のウィンリィを演じた女性声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mikasa Ackerman",
+        "ja": "ミカサ・アッカーマン",
+        "ja_typings": [
+          "mikasa/akka-man"
+        ]
+      },
+      {
+        "en": "Levi Ackerman",
+        "ja": "リヴァイ・アッカーマン",
+        "ja_typings": [
+          "rivai/akka-man"
+        ]
+      },
+      {
+        "en": "Annie Leonhart",
+        "ja": "アニ・レオンハート",
+        "ja_typings": [
+          "ani/reonha-to"
+        ]
+      },
+      {
+        "en": "Historia Reiss",
+        "ja": "ヒストリア・レイス",
+        "ja_typings": [
+          "hisutoria/reisu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02893",
+    "image_path": null,
+    "question_text": {
+      "en": "Which black-haired Ackerman is Eren's adoptive sister and a top soldier?",
+      "ja": "エレンの義妹で最強クラスの兵士、アッカーマン家の黒髪少女は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Minami Takayama",
+        "ja": "高山みなみ",
+        "ja_typings": [
+          "takayamaminami"
+        ]
+      },
+      {
+        "en": "Megumi Hayashibara",
+        "ja": "林原めぐみ",
+        "ja_typings": [
+          "hayashibaramegumi"
+        ]
+      },
+      {
+        "en": "Mayumi Tanaka",
+        "ja": "田中真弓",
+        "ja_typings": [
+          "tanakamayumi"
+        ]
+      },
+      {
+        "en": "Nobuyo Oyama",
+        "ja": "大山のぶ代",
+        "ja_typings": [
+          "ooyamanobuyo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02894",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actress plays Conan Edogawa in Detective Conan?",
+      "ja": "名探偵コナンで江戸川コナンを演じる女性声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Misa Amane",
+        "ja": "弥海砂",
+        "ja_typings": [
+          "amanemisa"
+        ]
+      },
+      {
+        "en": "Sayu Yagami",
+        "ja": "夜神粧裕",
+        "ja_typings": [
+          "yagamisayu"
+        ]
+      },
+      {
+        "en": "Naomi Misora",
+        "ja": "南空ナオミ",
+        "ja_typings": [
+          "misoranaomi"
+        ]
+      },
+      {
+        "en": "Kiyomi Takada",
+        "ja": "高田清美",
+        "ja_typings": [
+          "takadakiyomi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02895",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Death Note heroine becomes the second Kira out of love for Light?",
+      "ja": "デスノートでライトへの愛から第二のキラになるヒロインは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mitsuri Kanroji",
+        "ja": "甘露寺蜜璃",
+        "ja_typings": [
+          "kanrojimitsuri"
+        ]
+      },
+      {
+        "en": "Shinobu Kocho",
+        "ja": "胡蝶しのぶ",
+        "ja_typings": [
+          "kochoushinobu"
+        ]
+      },
+      {
+        "en": "Kanao Tsuyuri",
+        "ja": "栗花落カナヲ",
+        "ja_typings": [
+          "turiyurikanawo",
+          "tsuyurikanawo"
+        ]
+      },
+      {
+        "en": "Nezuko Kamado",
+        "ja": "竈門禰豆子",
+        "ja_typings": [
+          "kamadonezuko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02896",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Demon Slayer Love Hashira fights with a uniquely flexible katana?",
+      "ja": "鬼殺隊の恋柱で柔軟な刀を扱うのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nami",
+        "ja": "ナミ",
+        "ja_typings": [
+          "nami"
+        ]
+      },
+      {
+        "en": "Robin",
+        "ja": "ロビン",
+        "ja_typings": [
+          "robin"
+        ]
+      },
+      {
+        "en": "Vivi",
+        "ja": "ビビ",
+        "ja_typings": [
+          "bibi"
+        ]
+      },
+      {
+        "en": "Hancock",
+        "ja": "ハンコック",
+        "ja_typings": [
+          "hankokku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02897",
+    "image_path": null,
+    "question_text": {
+      "en": "Which orange-haired navigator of the Straw Hat Pirates loves money?",
+      "ja": "麦わら海賊団の航海士で金が大好きなオレンジ髪の女性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nezuko Kamado",
+        "ja": "竈門禰豆子",
+        "ja_typings": [
+          "kamadonezuko"
+        ]
+      },
+      {
+        "en": "Mitsuri Kanroji",
+        "ja": "甘露寺蜜璃",
+        "ja_typings": [
+          "kanrojimitsuri"
+        ]
+      },
+      {
+        "en": "Shinobu Kocho",
+        "ja": "胡蝶しのぶ",
+        "ja_typings": [
+          "kochoushinobu"
+        ]
+      },
+      {
+        "en": "Kanao Tsuyuri",
+        "ja": "栗花落カナヲ",
+        "ja_typings": [
+          "turiyurikanawo",
+          "tsuyurikanawo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02898",
+    "image_path": null,
+    "question_text": {
+      "en": "Which pink-clad demon-girl in a box is Tanjiro's younger sister?",
+      "ja": "炭治郎の妹で、箱に入った桃色の鬼の少女は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nobara Kugisaki",
+        "ja": "釘崎野薔薇",
+        "ja_typings": [
+          "kugisakinobara"
+        ]
+      },
+      {
+        "en": "Megumi Fushiguro",
+        "ja": "伏黒恵",
+        "ja_typings": [
+          "fukuromegumi"
+        ]
+      },
+      {
+        "en": "Yuji Itadori",
+        "ja": "虎杖悠仁",
+        "ja_typings": [
+          "itadoriyuuji"
+        ]
+      },
+      {
+        "en": "Maki Zenin",
+        "ja": "禪院真希",
+        "ja_typings": [
+          "zen'inmaki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02899",
+    "image_path": null,
+    "question_text": {
+      "en": "Which hammer-wielding female student of Tokyo Jujutsu High wears short hair?",
+      "ja": "東京呪術高専所属で金槌を扱うショートヘアの女子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nobuyo Oyama",
+        "ja": "大山のぶ代",
+        "ja_typings": [
+          "ooyamanobuyo"
+        ]
+      },
+      {
+        "en": "Minami Takayama",
+        "ja": "高山みなみ",
+        "ja_typings": [
+          "takayamaminami"
+        ]
+      },
+      {
+        "en": "Mayumi Tanaka",
+        "ja": "田中真弓",
+        "ja_typings": [
+          "tanakamayumi"
+        ]
+      },
+      {
+        "en": "Megumi Hayashibara",
+        "ja": "林原めぐみ",
+        "ja_typings": [
+          "hayashibaramegumi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02900",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actress is the original Doraemon (1979–2005)?",
+      "ja": "1979 年版のオリジナル・ドラえもんを演じた声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Orihime Inoue",
+        "ja": "井上織姫",
+        "ja_typings": [
+          "inoueorihime"
+        ]
+      },
+      {
+        "en": "Rukia Kuchiki",
+        "ja": "朽木ルキア",
+        "ja_typings": [
+          "kuchikirukia"
+        ]
+      },
+      {
+        "en": "Yoruichi Shihouin",
+        "ja": "四楓院夜一",
+        "ja_typings": [
+          "shihouinyoruichi"
+        ]
+      },
+      {
+        "en": "Rangiku Matsumoto",
+        "ja": "松本乱菊",
+        "ja_typings": [
+          "matsumotorangiku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02901",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Bleach heroine is Ichigo's longtime crush with healing powers?",
+      "ja": "BLEACH で一護の幼馴染にあたる治癒能力者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Osamu Tezuka",
+        "ja": "手塚治虫",
+        "ja_typings": [
+          "tezukaosamu"
+        ]
+      },
+      {
+        "en": "Shotaro Ishinomori",
+        "ja": "石ノ森章太郎",
+        "ja_typings": [
+          "ishinomorishoutarou"
+        ]
+      },
+      {
+        "en": "Fujiko F. Fujio",
+        "ja": "藤子・F・不二雄",
+        "ja_typings": [
+          "hujikofhujio"
+        ]
+      },
+      {
+        "en": "Hideaki Anno",
+        "ja": "庵野秀明",
+        "ja_typings": [
+          "annohideaki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02902",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga artist is called 'the God of Manga' for works like Astro Boy?",
+      "ja": "鉄腕アトムなどで「漫画の神様」と呼ばれる漫画家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Piccolo",
+        "ja": "ピッコロ",
+        "ja_typings": [
+          "pikkoro"
+        ]
+      },
+      {
+        "en": "Vegeta",
+        "ja": "ベジータ",
+        "ja_typings": [
+          "beji-ta"
+        ]
+      },
+      {
+        "en": "Krillin",
+        "ja": "クリリン",
+        "ja_typings": [
+          "kuririn"
+        ]
+      },
+      {
+        "en": "Frieza",
+        "ja": "フリーザ",
+        "ja_typings": [
+          "furi-za"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02903",
+    "image_path": null,
+    "question_text": {
+      "en": "Which green-skinned Namekian is Goku's former rival turned ally?",
+      "ja": "悟空の元ライバルで仲間になった緑の肌のナメック星人は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Power",
+        "ja": "パワー",
+        "ja_typings": [
+          "pawa-"
+        ]
+      },
+      {
+        "en": "Makima",
+        "ja": "マキマ",
+        "ja_typings": [
+          "makima"
+        ]
+      },
+      {
+        "en": "Denji",
+        "ja": "デンジ",
+        "ja_typings": [
+          "denji"
+        ]
+      },
+      {
+        "en": "Reze",
+        "ja": "レゼ",
+        "ja_typings": [
+          "reze"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02904",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Chainsaw Man devil is Aki Hayakawa's blood-loving partner?",
+      "ja": "チェンソーマンで早川アキの相棒となる血を好む悪魔は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rei Ayanami",
+        "ja": "綾波レイ",
+        "ja_typings": [
+          "ayanamirei"
+        ]
+      },
+      {
+        "en": "Asuka Langley Soryu",
+        "ja": "惣流・アスカ・ラングレー",
+        "ja_typings": [
+          "souryuuasukaranguree",
+          "souryuuasukarangure"
+        ]
+      },
+      {
+        "en": "Kaworu Nagisa",
+        "ja": "渚カヲル",
+        "ja_typings": [
+          "nagisakaworu",
+          "nagisakaoru"
+        ]
+      },
+      {
+        "en": "Mari Makinami",
+        "ja": "真希波・マリ",
+        "ja_typings": [
+          "makinamimari"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02905",
+    "image_path": null,
+    "question_text": {
+      "en": "Which blue-haired Eva pilot is designated the First Child?",
+      "ja": "ファーストチルドレンに指定された青髪のエヴァパイロットは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Romantic comedy",
+        "ja": "ラブコメ",
+        "ja_typings": [
+          "rabukome"
+        ]
+      },
+      {
+        "en": "Slice of life",
+        "ja": "日常系",
+        "ja_typings": [
+          "nitijoukei"
+        ]
+      },
+      {
+        "en": "Sports",
+        "ja": "スポーツ",
+        "ja_typings": [
+          "supo-tsu"
+        ]
+      },
+      {
+        "en": "Mecha",
+        "ja": "メカ",
+        "ja_typings": [
+          "meka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02906",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime genre is the term for love-comedy series?",
+      "ja": "恋愛コメディ系のアニメジャンルを指す英語表現は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Roronoa Zoro",
+        "ja": "ロロノア・ゾロ",
+        "ja_typings": [
+          "roronoa/zoro"
+        ]
+      },
+      {
+        "en": "Sanji",
+        "ja": "サンジ",
+        "ja_typings": [
+          "sanji"
+        ]
+      },
+      {
+        "en": "Nami",
+        "ja": "ナミ",
+        "ja_typings": [
+          "nami"
+        ]
+      },
+      {
+        "en": "Luffy",
+        "ja": "ルフィ",
+        "ja_typings": [
+          "rufi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02907",
+    "image_path": null,
+    "question_text": {
+      "en": "Which green-haired swordsman of the Straw Hats uses three swords at once?",
+      "ja": "麦わら海賊団で三刀流を使う緑髪の剣士は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Roy Mustang",
+        "ja": "ロイ・マスタング",
+        "ja_typings": [
+          "roi/masutangu"
+        ]
+      },
+      {
+        "en": "Alphonse Elric",
+        "ja": "アルフォンス・エルリック",
+        "ja_typings": [
+          "arufonsu/erurikku"
+        ]
+      },
+      {
+        "en": "Edward Elric",
+        "ja": "エドワード・エルリック",
+        "ja_typings": [
+          "edowa-do/erurikku"
+        ]
+      },
+      {
+        "en": "Winry Rockbell",
+        "ja": "ウィンリィ・ロックベル",
+        "ja_typings": [
+          "winrii/rokkuberu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02908",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Flame Alchemist colonel in FMA can snap fire from his fingers?",
+      "ja": "鋼の錬金術師で指を鳴らして炎を操る大佐は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rukia Kuchiki",
+        "ja": "朽木ルキア",
+        "ja_typings": [
+          "kuchikirukia"
+        ]
+      },
+      {
+        "en": "Orihime Inoue",
+        "ja": "井上織姫",
+        "ja_typings": [
+          "inoueorihime"
+        ]
+      },
+      {
+        "en": "Yoruichi Shihouin",
+        "ja": "四楓院夜一",
+        "ja_typings": [
+          "shihouinyoruichi"
+        ]
+      },
+      {
+        "en": "Rangiku Matsumoto",
+        "ja": "松本乱菊",
+        "ja_typings": [
+          "matsumotorangiku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02909",
+    "image_path": null,
+    "question_text": {
+      "en": "Which black-haired shinigami lieutenant lent her powers to Ichigo in Bleach?",
+      "ja": "BLEACH で一護に死神の力を貸した黒髪の死神は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ryuk",
+        "ja": "リューク",
+        "ja_typings": [
+          "ryu-ku"
+        ]
+      },
+      {
+        "en": "Lawliet",
+        "ja": "ローライト",
+        "ja_typings": [
+          "ro-raito"
+        ]
+      },
+      {
+        "en": "Misa Amane",
+        "ja": "弥海砂",
+        "ja_typings": [
+          "amanemisa"
+        ]
+      },
+      {
+        "en": "Rem",
+        "ja": "レム",
+        "ja_typings": [
+          "remu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02910",
+    "image_path": null,
+    "question_text": {
+      "en": "Which apple-loving shinigami drops the Death Note in the human world?",
+      "ja": "リンゴ好きで人間界にデスノートを落とした死神は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sanji",
+        "ja": "サンジ",
+        "ja_typings": [
+          "sanji"
+        ]
+      },
+      {
+        "en": "Roronoa Zoro",
+        "ja": "ロロノア・ゾロ",
+        "ja_typings": [
+          "roronoa/zoro"
+        ]
+      },
+      {
+        "en": "Luffy",
+        "ja": "ルフィ",
+        "ja_typings": [
+          "rufi"
+        ]
+      },
+      {
+        "en": "Usopp",
+        "ja": "ウソップ",
+        "ja_typings": [
+          "usoppu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02911",
+    "image_path": null,
+    "question_text": {
+      "en": "Which chivalrous, kicking-only chef of the Straw Hats has a curly eyebrow?",
+      "ja": "麦わら海賊団で蹴り技専門のコック、ぐるぐる眉毛のキャラは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sasuke Uchiha",
+        "ja": "うちはサスケ",
+        "ja_typings": [
+          "uchihasasuke"
+        ]
+      },
+      {
+        "en": "Kakashi Hatake",
+        "ja": "はたけカカシ",
+        "ja_typings": [
+          "hatakekakashi"
+        ]
+      },
+      {
+        "en": "Naruto Uzumaki",
+        "ja": "うずまきナルト",
+        "ja_typings": [
+          "uzumakinaruto"
+        ]
+      },
+      {
+        "en": "Tsunade",
+        "ja": "綱手",
+        "ja_typings": [
+          "tsunade"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02912",
+    "image_path": null,
+    "question_text": {
+      "en": "Which raven-haired prodigy rival to Naruto wields the Sharingan?",
+      "ja": "ナルトのライバルで写輪眼を持つ黒髪の天才忍者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Satoru Gojo",
+        "ja": "五条悟",
+        "ja_typings": [
+          "gojousatoru"
+        ]
+      },
+      {
+        "en": "Megumi Fushiguro",
+        "ja": "伏黒恵",
+        "ja_typings": [
+          "fukuromegumi"
+        ]
+      },
+      {
+        "en": "Yuji Itadori",
+        "ja": "虎杖悠仁",
+        "ja_typings": [
+          "itadoriyuuji"
+        ]
+      },
+      {
+        "en": "Suguru Geto",
+        "ja": "夏油傑",
+        "ja_typings": [
+          "getousuguru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02913",
+    "image_path": null,
+    "question_text": {
+      "en": "Which white-haired strongest jujutsu sorcerer wears a blindfold?",
+      "ja": "目隠しを巻いた最強の呪術師は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Satoshi Kon",
+        "ja": "今敏",
+        "ja_typings": [
+          "konsatoshi"
+        ]
+      },
+      {
+        "en": "Mamoru Oshii",
+        "ja": "押井守",
+        "ja_typings": [
+          "oshiimamoru"
+        ]
+      },
+      {
+        "en": "Mamoru Hosoda",
+        "ja": "細田守",
+        "ja_typings": [
+          "hosodamamoru"
+        ]
+      },
+      {
+        "en": "Hideaki Anno",
+        "ja": "庵野秀明",
+        "ja_typings": [
+          "annohideaki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02914",
+    "image_path": null,
+    "question_text": {
+      "en": "Which director helmed Perfect Blue and Paprika before his early death?",
+      "ja": "パーフェクトブルーやパプリカを監督した、夭折のアニメ監督は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shaft",
+        "ja": "シャフト",
+        "ja_typings": [
+          "shafuto"
+        ]
+      },
+      {
+        "en": "Gainax",
+        "ja": "ガイナックス",
+        "ja_typings": [
+          "gainakkusu"
+        ]
+      },
+      {
+        "en": "ufotable",
+        "ja": "ユーフォーテーブル",
+        "ja_typings": [
+          "yu-fo-te-buru"
+        ]
+      },
+      {
+        "en": "WIT STUDIO",
+        "ja": "WITスタジオ",
+        "ja_typings": [
+          "witsutajio"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02915",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio is known for Bakemonogatari and the Monogatari series?",
+      "ja": "化物語など〈物語〉シリーズで知られる制作スタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shinobu Kocho",
+        "ja": "胡蝶しのぶ",
+        "ja_typings": [
+          "kochoushinobu"
+        ]
+      },
+      {
+        "en": "Mitsuri Kanroji",
+        "ja": "甘露寺蜜璃",
+        "ja_typings": [
+          "kanrojimitsuri"
+        ]
+      },
+      {
+        "en": "Kanao Tsuyuri",
+        "ja": "栗花落カナヲ",
+        "ja_typings": [
+          "turiyurikanawo",
+          "tsuyurikanawo"
+        ]
+      },
+      {
+        "en": "Nezuko Kamado",
+        "ja": "竈門禰豆子",
+        "ja_typings": [
+          "kamadonezuko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02916",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Insect Hashira fights with poison-laced thrust attacks?",
+      "ja": "毒を仕込んだ突き技で戦う蟲柱は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shotaro Ishinomori",
+        "ja": "石ノ森章太郎",
+        "ja_typings": [
+          "ishinomorishoutarou"
+        ]
+      },
+      {
+        "en": "Osamu Tezuka",
+        "ja": "手塚治虫",
+        "ja_typings": [
+          "tezukaosamu"
+        ]
+      },
+      {
+        "en": "Fujiko F. Fujio",
+        "ja": "藤子・F・不二雄",
+        "ja_typings": [
+          "hujikofhujio"
+        ]
+      },
+      {
+        "en": "Hideaki Anno",
+        "ja": "庵野秀明",
+        "ja_typings": [
+          "annohideaki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02917",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga artist created Kamen Rider and Cyborg 009?",
+      "ja": "仮面ライダーやサイボーグ009を創造した漫画家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shoto Todoroki",
+        "ja": "轟焦凍",
+        "ja_typings": [
+          "todorokishouto"
+        ]
+      },
+      {
+        "en": "Katsuki Bakugo",
+        "ja": "爆豪勝己",
+        "ja_typings": [
+          "bakugoukatsuki"
+        ]
+      },
+      {
+        "en": "All Might",
+        "ja": "オールマイト",
+        "ja_typings": [
+          "o-rumaito"
+        ]
+      },
+      {
+        "en": "Tenya Iida",
+        "ja": "飯田天哉",
+        "ja_typings": [
+          "iidatenya"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02918",
+    "image_path": null,
+    "question_text": {
+      "en": "Which half-and-half-haired classmate of Deku has both fire and ice quirks?",
+      "ja": "デクの同級生で炎と氷の両方の個性を持つハーフカラー髪のヒーローは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Slice of life",
+        "ja": "日常系",
+        "ja_typings": [
+          "nitijoukei"
+        ]
+      },
+      {
+        "en": "Romantic comedy",
+        "ja": "ラブコメ",
+        "ja_typings": [
+          "rabukome"
+        ]
+      },
+      {
+        "en": "Sports",
+        "ja": "スポーツ",
+        "ja_typings": [
+          "supo-tsu"
+        ]
+      },
+      {
+        "en": "Mecha",
+        "ja": "メカ",
+        "ja_typings": [
+          "meka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02919",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime genre label describes laid-back everyday-life shows?",
+      "ja": "日々の生活をのんびり描くアニメのジャンル英語表記は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sports",
+        "ja": "スポーツ",
+        "ja_typings": [
+          "supo-tsu"
+        ]
+      },
+      {
+        "en": "Slice of life",
+        "ja": "日常系",
+        "ja_typings": [
+          "nitijoukei"
+        ]
+      },
+      {
+        "en": "Romantic comedy",
+        "ja": "ラブコメ",
+        "ja_typings": [
+          "rabukome"
+        ]
+      },
+      {
+        "en": "Mecha",
+        "ja": "メカ",
+        "ja_typings": [
+          "meka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02920",
+    "image_path": null,
+    "question_text": {
+      "en": "Which broad anime genre covers Haikyu!!, Slam Dunk, and Captain Tsubasa?",
+      "ja": "ハイキュー!! や SLAM DUNK、キャプテン翼を含む広いジャンルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Studio Ghibli",
+        "ja": "スタジオジブリ",
+        "ja_typings": [
+          "sutajiojiburi"
+        ]
+      },
+      {
+        "en": "Studio Khara",
+        "ja": "スタジオカラー",
+        "ja_typings": [
+          "sutajiokara-"
+        ]
+      },
+      {
+        "en": "Gainax",
+        "ja": "ガイナックス",
+        "ja_typings": [
+          "gainakkusu"
+        ]
+      },
+      {
+        "en": "Toei Animation",
+        "ja": "東映アニメーション",
+        "ja_typings": [
+          "toueianimeeshon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02921",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Tokyo-based studio produced Spirited Away and Princess Mononoke?",
+      "ja": "千と千尋の神隠しやもののけ姫を制作した東京のスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Studio Khara",
+        "ja": "スタジオカラー",
+        "ja_typings": [
+          "sutajiokara-"
+        ]
+      },
+      {
+        "en": "Gainax",
+        "ja": "ガイナックス",
+        "ja_typings": [
+          "gainakkusu"
+        ]
+      },
+      {
+        "en": "Studio Ghibli",
+        "ja": "スタジオジブリ",
+        "ja_typings": [
+          "sutajiojiburi"
+        ]
+      },
+      {
+        "en": "WIT STUDIO",
+        "ja": "WITスタジオ",
+        "ja_typings": [
+          "witsutajio"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02922",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio is led by Hideaki Anno and produced the Rebuild of Evangelion films?",
+      "ja": "庵野秀明が率い、新劇場版エヴァンゲリオンを制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sunrise",
+        "ja": "サンライズ",
+        "ja_typings": [
+          "sanraizu"
+        ]
+      },
+      {
+        "en": "Gainax",
+        "ja": "ガイナックス",
+        "ja_typings": [
+          "gainakkusu"
+        ]
+      },
+      {
+        "en": "Toei Animation",
+        "ja": "東映アニメーション",
+        "ja_typings": [
+          "toueianimeeshon"
+        ]
+      },
+      {
+        "en": "Studio Ghibli",
+        "ja": "スタジオジブリ",
+        "ja_typings": [
+          "sutajiojiburi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02923",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio is the historical home of Gundam, Cowboy Bebop, and Code Geass?",
+      "ja": "ガンダム、カウボーイビバップ、コードギアスの伝統的な制作スタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tatsuki Fujimoto",
+        "ja": "藤本タツキ",
+        "ja_typings": [
+          "fujimototatsuki"
+        ]
+      },
+      {
+        "en": "Gege Akutami",
+        "ja": "芥見下々",
+        "ja_typings": [
+          "akutamigege"
+        ]
+      },
+      {
+        "en": "Kohei Horikoshi",
+        "ja": "堀越耕平",
+        "ja_typings": [
+          "horikoshikouhei"
+        ]
+      },
+      {
+        "en": "Hajime Isayama",
+        "ja": "諫山創",
+        "ja_typings": [
+          "isayamahajime"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02924",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga author created Chainsaw Man and Fire Punch?",
+      "ja": "チェンソーマンとファイアパンチの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tetsuro Kuroo",
+        "ja": "黒尾鉄朗",
+        "ja_typings": [
+          "kurootetsurou"
+        ]
+      },
+      {
+        "en": "Tobio Kageyama",
+        "ja": "影山飛雄",
+        "ja_typings": [
+          "kageyamatobio"
+        ]
+      },
+      {
+        "en": "Toru Oikawa",
+        "ja": "及川徹",
+        "ja_typings": [
+          "oikawatooru"
+        ]
+      },
+      {
+        "en": "Shoyo Hinata",
+        "ja": "日向翔陽",
+        "ja_typings": [
+          "hinatashouyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02925",
+    "image_path": null,
+    "question_text": {
+      "en": "Which black-haired Nekoma captain in Haikyu!! tangles with Karasuno?",
+      "ja": "ハイキュー!! で烏野と戦う音駒高校の黒髪キャプテンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Time Prison",
+        "ja": "時胞月宮殿",
+        "ja_typings": [
+          "jihougetsukyuuden"
+        ]
+      },
+      {
+        "en": "Malevolent Shrine",
+        "ja": "伏魔御厨子",
+        "ja_typings": [
+          "fukumamizushi"
+        ]
+      },
+      {
+        "en": "Unlimited Void",
+        "ja": "無量空処",
+        "ja_typings": [
+          "muryoukuusho"
+        ]
+      },
+      {
+        "en": "Chimera Shadow Garden",
+        "ja": "嵌合暗翳庭",
+        "ja_typings": [
+          "kangouan'eitei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02926",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Jujutsu Kaisen domain belongs to Kenjaku and traps targets in time?",
+      "ja": "呪術廻戦で羂索が用いる時間制圧の領域展開は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tobio Kageyama",
+        "ja": "影山飛雄",
+        "ja_typings": [
+          "kageyamatobio"
+        ]
+      },
+      {
+        "en": "Tetsuro Kuroo",
+        "ja": "黒尾鉄朗",
+        "ja_typings": [
+          "kurootetsurou"
+        ]
+      },
+      {
+        "en": "Toru Oikawa",
+        "ja": "及川徹",
+        "ja_typings": [
+          "oikawatooru"
+        ]
+      },
+      {
+        "en": "Shoyo Hinata",
+        "ja": "日向翔陽",
+        "ja_typings": [
+          "hinatashouyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02927",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Karasuno setter has prodigious aim and a fierce temper in Haikyu!!?",
+      "ja": "ハイキュー!! の烏野のセッターで気性の荒い天才は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Toei Animation",
+        "ja": "東映アニメーション",
+        "ja_typings": [
+          "toueianimeeshon"
+        ]
+      },
+      {
+        "en": "Sunrise",
+        "ja": "サンライズ",
+        "ja_typings": [
+          "sanraizu"
+        ]
+      },
+      {
+        "en": "Gainax",
+        "ja": "ガイナックス",
+        "ja_typings": [
+          "gainakkusu"
+        ]
+      },
+      {
+        "en": "Studio Ghibli",
+        "ja": "スタジオジブリ",
+        "ja_typings": [
+          "sutajiojiburi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02928",
+    "image_path": null,
+    "question_text": {
+      "en": "Which classic anime studio is famous for Dragon Ball, Sailor Moon, and One Piece?",
+      "ja": "ドラゴンボール、セーラームーン、ワンピースを制作した老舗スタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Toru Furuya",
+        "ja": "古谷徹",
+        "ja_typings": [
+          "furuyatooru"
+        ]
+      },
+      {
+        "en": "Banjo Ginga",
+        "ja": "銀河万丈",
+        "ja_typings": [
+          "gingabanjou"
+        ]
+      },
+      {
+        "en": "Kenji Utsumi",
+        "ja": "内海賢二",
+        "ja_typings": [
+          "utsumikenji",
+          "uchiumikenji"
+        ]
+      },
+      {
+        "en": "Akira Kamiya",
+        "ja": "神谷明",
+        "ja_typings": [
+          "kamiyaakira"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02929",
+    "image_path": null,
+    "question_text": {
+      "en": "Which iconic voice actor played Amuro Ray and Tuxedo Mask?",
+      "ja": "アムロ・レイやタキシード仮面を演じた往年の男性声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Toru Oikawa",
+        "ja": "及川徹",
+        "ja_typings": [
+          "oikawatooru"
+        ]
+      },
+      {
+        "en": "Tobio Kageyama",
+        "ja": "影山飛雄",
+        "ja_typings": [
+          "kageyamatobio"
+        ]
+      },
+      {
+        "en": "Tetsuro Kuroo",
+        "ja": "黒尾鉄朗",
+        "ja_typings": [
+          "kurootetsurou"
+        ]
+      },
+      {
+        "en": "Shoyo Hinata",
+        "ja": "日向翔陽",
+        "ja_typings": [
+          "hinatashouyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02930",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Aoba Johsai setter rivals Kageyama as 'the Grand King' in Haikyu!!?",
+      "ja": "ハイキュー!! で影山のライバル、青葉城西の「大王様」と呼ばれるセッターは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tsunade",
+        "ja": "綱手",
+        "ja_typings": [
+          "tsunade"
+        ]
+      },
+      {
+        "en": "Jiraiya",
+        "ja": "自来也",
+        "ja_typings": [
+          "jiraiya"
+        ]
+      },
+      {
+        "en": "Orochimaru",
+        "ja": "大蛇丸",
+        "ja_typings": [
+          "orochimaru"
+        ]
+      },
+      {
+        "en": "Kakashi Hatake",
+        "ja": "はたけカカシ",
+        "ja_typings": [
+          "hatakekakashi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02931",
+    "image_path": null,
+    "question_text": {
+      "en": "Which busty blonde Sannin becomes the Fifth Hokage in Naruto?",
+      "ja": "ナルトで五代目火影に就任する金髪・巨乳の伝説の三忍は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Unlimited Void",
+        "ja": "無量空処",
+        "ja_typings": [
+          "muryoukuusho"
+        ]
+      },
+      {
+        "en": "Malevolent Shrine",
+        "ja": "伏魔御厨子",
+        "ja_typings": [
+          "fukumamizushi"
+        ]
+      },
+      {
+        "en": "Chimera Shadow Garden",
+        "ja": "嵌合暗翳庭",
+        "ja_typings": [
+          "kangouan'eitei"
+        ]
+      },
+      {
+        "en": "Time Prison",
+        "ja": "時胞月宮殿",
+        "ja_typings": [
+          "jihougetsukyuuden"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02932",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Gojo domain forces total sensory input on everyone inside it?",
+      "ja": "五条悟の領域展開で内部の全員に膨大な情報を流し込むのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Uryu Ishida",
+        "ja": "石田雨竜",
+        "ja_typings": [
+          "ishidauryuu"
+        ]
+      },
+      {
+        "en": "Orihime Inoue",
+        "ja": "井上織姫",
+        "ja_typings": [
+          "inoueorihime"
+        ]
+      },
+      {
+        "en": "Rukia Kuchiki",
+        "ja": "朽木ルキア",
+        "ja_typings": [
+          "kuchikirukia"
+        ]
+      },
+      {
+        "en": "Yasutora Sado",
+        "ja": "茶渡泰虎",
+        "ja_typings": [
+          "sadoyasutora"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02933",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Bleach Quincy archer is one of Ichigo's school friends?",
+      "ja": "BLEACH で一護のクラスメイトの滅却師の弓使いは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vegeta",
+        "ja": "ベジータ",
+        "ja_typings": [
+          "beji-ta"
+        ]
+      },
+      {
+        "en": "Piccolo",
+        "ja": "ピッコロ",
+        "ja_typings": [
+          "pikkoro"
+        ]
+      },
+      {
+        "en": "Krillin",
+        "ja": "クリリン",
+        "ja_typings": [
+          "kuririn"
+        ]
+      },
+      {
+        "en": "Frieza",
+        "ja": "フリーザ",
+        "ja_typings": [
+          "furi-za"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02934",
+    "image_path": null,
+    "question_text": {
+      "en": "Which proud Saiyan prince is Goku's longtime rival and ally?",
+      "ja": "悟空のライバルにして仲間となる誇り高きサイヤ人の王子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "WIT STUDIO",
+        "ja": "WITスタジオ",
+        "ja_typings": [
+          "witsutajio"
+        ]
+      },
+      {
+        "en": "ufotable",
+        "ja": "ユーフォーテーブル",
+        "ja_typings": [
+          "yu-fo-te-buru"
+        ]
+      },
+      {
+        "en": "Toei Animation",
+        "ja": "東映アニメーション",
+        "ja_typings": [
+          "toueianimeeshon"
+        ]
+      },
+      {
+        "en": "Sunrise",
+        "ja": "サンライズ",
+        "ja_typings": [
+          "sanraizu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02935",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio produced Attack on Titan seasons 1–3?",
+      "ja": "進撃の巨人 シーズン1～3を制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Winry Rockbell",
+        "ja": "ウィンリィ・ロックベル",
+        "ja_typings": [
+          "winrii/rokkuberu"
+        ]
+      },
+      {
+        "en": "Alphonse Elric",
+        "ja": "アルフォンス・エルリック",
+        "ja_typings": [
+          "arufonsu/erurikku"
+        ]
+      },
+      {
+        "en": "Edward Elric",
+        "ja": "エドワード・エルリック",
+        "ja_typings": [
+          "edowa-do/erurikku"
+        ]
+      },
+      {
+        "en": "Roy Mustang",
+        "ja": "ロイ・マスタング",
+        "ja_typings": [
+          "roi/masutangu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02936",
+    "image_path": null,
+    "question_text": {
+      "en": "Which blonde automail mechanic in FMA grew up with the Elric brothers?",
+      "ja": "鋼の錬金術師でエルリック兄弟と幼馴染の機械鎧技師は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yashamaru",
+        "ja": "夜叉丸",
+        "ja_typings": [
+          "yashamaru"
+        ]
+      },
+      {
+        "en": "Kakashi Hatake",
+        "ja": "はたけカカシ",
+        "ja_typings": [
+          "hatakekakashi"
+        ]
+      },
+      {
+        "en": "Sasuke Uchiha",
+        "ja": "うちはサスケ",
+        "ja_typings": [
+          "uchihasasuke"
+        ]
+      },
+      {
+        "en": "Tsunade",
+        "ja": "綱手",
+        "ja_typings": [
+          "tsunade"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02937",
+    "image_path": null,
+    "question_text": {
+      "en": "Which masked maternal-uncle bodyguard of young Gaara dies in early Naruto?",
+      "ja": "ナルト初期で幼少の我愛羅の世話役だった仮面の母方の叔父は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yor Forger",
+        "ja": "ヨル・フォージャー",
+        "ja_typings": [
+          "yoru/fo-ja-"
+        ]
+      },
+      {
+        "en": "Anya Forger",
+        "ja": "アーニャ・フォージャー",
+        "ja_typings": [
+          "a-nya/fo-ja-"
+        ]
+      },
+      {
+        "en": "Loid Forger",
+        "ja": "ロイド・フォージャー",
+        "ja_typings": [
+          "roido/fo-ja-"
+        ]
+      },
+      {
+        "en": "Yuri Briar",
+        "ja": "ユーリ・ブライア",
+        "ja_typings": [
+          "yu-ri/buraia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02938",
+    "image_path": null,
+    "question_text": {
+      "en": "Which dark-haired Spy x Family mother is secretly the assassin 'Thorn Princess'?",
+      "ja": "スパイファミリーの母親で正体が殺し屋「いばら姫」の女性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yoshiyuki Tomino",
+        "ja": "富野由悠季",
+        "ja_typings": [
+          "tominoyoshiyuki"
+        ]
+      },
+      {
+        "en": "Hideaki Anno",
+        "ja": "庵野秀明",
+        "ja_typings": [
+          "annohideaki"
+        ]
+      },
+      {
+        "en": "Mamoru Oshii",
+        "ja": "押井守",
+        "ja_typings": [
+          "oshiimamoru"
+        ]
+      },
+      {
+        "en": "Mamoru Hosoda",
+        "ja": "細田守",
+        "ja_typings": [
+          "hosodamamoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02939",
+    "image_path": null,
+    "question_text": {
+      "en": "Which veteran director created Mobile Suit Gundam and is called the 'father of Gundam'?",
+      "ja": "機動戦士ガンダムを生み「ガンダムの父」と呼ばれる監督は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yuri Briar",
+        "ja": "ユーリ・ブライア",
+        "ja_typings": [
+          "yu-ri/buraia"
+        ]
+      },
+      {
+        "en": "Yor Forger",
+        "ja": "ヨル・フォージャー",
+        "ja_typings": [
+          "yoru/fo-ja-"
+        ]
+      },
+      {
+        "en": "Loid Forger",
+        "ja": "ロイド・フォージャー",
+        "ja_typings": [
+          "roido/fo-ja-"
+        ]
+      },
+      {
+        "en": "Anya Forger",
+        "ja": "アーニャ・フォージャー",
+        "ja_typings": [
+          "a-nya/fo-ja-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02940",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sister-obsessed State Security officer is Yor's younger brother?",
+      "ja": "スパイファミリーでヨルを溺愛する弟・国家保安局員は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Zenitsu Agatsuma",
+        "ja": "我妻善逸",
+        "ja_typings": [
+          "agatsumazenitsu"
+        ]
+      },
+      {
+        "en": "Inosuke Hashibira",
+        "ja": "嘴平伊之助",
+        "ja_typings": [
+          "hashibirainosuke"
+        ]
+      },
+      {
+        "en": "Tanjiro Kamado",
+        "ja": "竈門炭治郎",
+        "ja_typings": [
+          "kamadotanjirou"
+        ]
+      },
+      {
+        "en": "Giyu Tomioka",
+        "ja": "冨岡義勇",
+        "ja_typings": [
+          "tomiokagiyuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02941",
+    "image_path": null,
+    "question_text": {
+      "en": "Which cowardly thunder-breathing Demon Slayer is in love with Nezuko?",
+      "ja": "禰豆子に惚れている雷の呼吸の臆病な鬼殺隊士は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ufotable",
+        "ja": "ユーフォーテーブル",
+        "ja_typings": [
+          "yu-fo-te-buru"
+        ]
+      },
+      {
+        "en": "WIT STUDIO",
+        "ja": "WITスタジオ",
+        "ja_typings": [
+          "witsutajio"
+        ]
+      },
+      {
+        "en": "Shaft",
+        "ja": "シャフト",
+        "ja_typings": [
+          "shafuto"
+        ]
+      },
+      {
+        "en": "Sunrise",
+        "ja": "サンライズ",
+        "ja_typings": [
+          "sanraizu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02942",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio is known for high-quality battle animation in Demon Slayer and Fate/Zero?",
+      "ja": "鬼滅の刃や Fate/Zero の戦闘作画で知られるスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ARMS",
+        "ja": "アームズ",
+        "ja_typings": [
+          "a-muzu"
+        ]
+      },
+      {
+        "en": "Splatoon",
+        "ja": "スプラトゥーン",
+        "ja_typings": [
+          "supuratu-n"
+        ]
+      },
+      {
+        "en": "Pikmin",
+        "ja": "ピクミン",
+        "ja_typings": [
+          "pikumin"
+        ]
+      },
+      {
+        "en": "Star Fox",
+        "ja": "スターフォックス",
+        "ja_typings": [
+          "suta-fokkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02943",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nintendo Switch fighting game uses extendable arms?",
+      "ja": "ニンテンドースイッチで腕が伸びる格闘ゲームはどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Activision",
+        "ja": "アクティビジョン",
+        "ja_typings": [
+          "akutibijon"
+        ]
+      },
+      {
+        "en": "Bungie",
+        "ja": "バンジー",
+        "ja_typings": [
+          "banji-"
+        ]
+      },
+      {
+        "en": "Bethesda",
+        "ja": "ベセスダ",
+        "ja_typings": [
+          "besesuda"
+        ]
+      },
+      {
+        "en": "Ubisoft",
+        "ja": "ユービーアイソフト",
+        "ja_typings": [
+          "yu-bi-aisofuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02944",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company publishes Call of Duty?",
+      "ja": "コール オブ デューティを発売している会社はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Agent 47",
+        "ja": "エージェント47",
+        "ja_typings": [
+          "e-jento47"
+        ]
+      },
+      {
+        "en": "Sam Fisher",
+        "ja": "サム・フィッシャー",
+        "ja_typings": [
+          "samu/fissha-"
+        ]
+      },
+      {
+        "en": "Jason Bourne",
+        "ja": "ジェイソン・ボーン",
+        "ja_typings": [
+          "jeison/bo-n"
+        ]
+      },
+      {
+        "en": "Goro Majima",
+        "ja": "真島吾朗",
+        "ja_typings": [
+          "majima goro",
+          "majimagorou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02945",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the bald assassin protagonist of the Hitman series?",
+      "ja": "ヒットマンシリーズの主人公である禿頭の暗殺者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Akira Nishikiyama",
+        "ja": "錦山彰",
+        "ja_typings": [
+          "nishikiyama akira",
+          "nishikiyamaakira"
+        ]
+      },
+      {
+        "en": "Goro Majima",
+        "ja": "真島吾朗",
+        "ja_typings": [
+          "majima goro",
+          "majimagorou"
+        ]
+      },
+      {
+        "en": "Ichiban Kasuga",
+        "ja": "春日一番",
+        "ja_typings": [
+          "kasuga ichiban",
+          "kasugaichiban"
+        ]
+      },
+      {
+        "en": "Goichi Suda",
+        "ja": "須田剛一",
+        "ja_typings": [
+          "suda goichi",
+          "sudagouichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02946",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the Tojo Clan captain who Kiryu fought in Yakuza?",
+      "ja": "龍が如くで桐生が戦う東城会の若頭は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Apex Legends",
+        "ja": "エーペックスレジェンズ",
+        "ja_typings": [
+          "e-pekkusurejenzu"
+        ]
+      },
+      {
+        "en": "Valorant",
+        "ja": "ヴァロラント",
+        "ja_typings": [
+          "varoranto"
+        ]
+      },
+      {
+        "en": "Overwatch",
+        "ja": "オーバーウォッチ",
+        "ja_typings": [
+          "o-ba-wotchi"
+        ]
+      },
+      {
+        "en": "Fortnite",
+        "ja": "フォートナイト",
+        "ja_typings": [
+          "fo-tonaito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02947",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Respawn battle royale features Legends with unique abilities?",
+      "ja": "リスポーンのバトルロイヤルでレジェンドが登場する作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Azur Lane",
+        "ja": "アズールレーン",
+        "ja_typings": [
+          "azu-rure-n"
+        ]
+      },
+      {
+        "en": "Granblue Fantasy",
+        "ja": "グランブルーファンタジー",
+        "ja_typings": [
+          "guranburu-fantaji-"
+        ]
+      },
+      {
+        "en": "Princess Connect",
+        "ja": "プリンセスコネクト",
+        "ja_typings": [
+          "purinsesukonekuto"
+        ]
+      },
+      {
+        "en": "Shadowverse",
+        "ja": "シャドウバース",
+        "ja_typings": [
+          "shadoba-su",
+          "shadouba-su"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02948",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mobile game features anthropomorphized warship girls?",
+      "ja": "艦船を擬人化したモバイルゲームはどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Battlefield",
+        "ja": "バトルフィールド",
+        "ja_typings": [
+          "batorufi-rudo"
+        ]
+      },
+      {
+        "en": "Medal of Honor",
+        "ja": "メダル・オブ・オナー",
+        "ja_typings": [
+          "medaru/obu/ona-"
+        ]
+      },
+      {
+        "en": "Rainbow Six",
+        "ja": "レインボーシックス",
+        "ja_typings": [
+          "reinbo-shikkusu"
+        ]
+      },
+      {
+        "en": "Team Fortress",
+        "ja": "チームフォートレス",
+        "ja_typings": [
+          "chi-mufo-toresu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02949",
+    "image_path": null,
+    "question_text": {
+      "en": "Which EA first-person shooter series competes with Call of Duty?",
+      "ja": "EAが出すCoDのライバルとなるFPSシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bethesda",
+        "ja": "ベセスダ",
+        "ja_typings": [
+          "besesuda"
+        ]
+      },
+      {
+        "en": "Bungie",
+        "ja": "バンジー",
+        "ja_typings": [
+          "banji-"
+        ]
+      },
+      {
+        "en": "Activision",
+        "ja": "アクティビジョン",
+        "ja_typings": [
+          "akutibijon"
+        ]
+      },
+      {
+        "en": "Epic Games",
+        "ja": "エピックゲームズ",
+        "ja_typings": [
+          "epikkuge-muzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02950",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio makes The Elder Scrolls and Fallout?",
+      "ja": "エルダースクロールズやフォールアウトを作る会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Black Desert",
+        "ja": "黒い砂漠",
+        "ja_typings": [
+          "kuroi sabaku",
+          "kuroisabaku"
+        ]
+      },
+      {
+        "en": "Lost Ark",
+        "ja": "ロストアーク",
+        "ja_typings": [
+          "rosutoa-ku"
+        ]
+      },
+      {
+        "en": "Guild Wars 2",
+        "ja": "ギルドウォーズ2",
+        "ja_typings": [
+          "girudouo-zu2",
+          "girudouo-zutsu-",
+          "girudowo-zu2"
+        ]
+      },
+      {
+        "en": "EverQuest",
+        "ja": "エバークエスト",
+        "ja_typings": [
+          "eba-kuesuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02951",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Korean MMORPG known for graphics was made by Pearl Abyss?",
+      "ja": "パールアビスが開発した韓国産MMORPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bomberman",
+        "ja": "ボンバーマン",
+        "ja_typings": [
+          "bonba-man"
+        ]
+      },
+      {
+        "en": "Dig Dug",
+        "ja": "ディグダグ",
+        "ja_typings": [
+          "digudagu"
+        ]
+      },
+      {
+        "en": "Galaga",
+        "ja": "ギャラガ",
+        "ja_typings": [
+          "gyaraga"
+        ]
+      },
+      {
+        "en": "Xevious",
+        "ja": "ゼビウス",
+        "ja_typings": [
+          "zebiusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02952",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hudson classic features a character planting bombs in a maze?",
+      "ja": "ハドソンの爆弾を置く迷路ゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Boom Beach",
+        "ja": "ブームビーチ",
+        "ja_typings": [
+          "bu-mubi-chi"
+        ]
+      },
+      {
+        "en": "Hay Day",
+        "ja": "ヘイデイ",
+        "ja_typings": [
+          "heidei"
+        ]
+      },
+      {
+        "en": "Brawl Stars",
+        "ja": "ブロスタ",
+        "ja_typings": [
+          "burosuta"
+        ]
+      },
+      {
+        "en": "Ingress",
+        "ja": "イングレス",
+        "ja_typings": [
+          "inguresu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02953",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Supercell game has players raiding tropical beaches?",
+      "ja": "スーパーセル社の南の島を攻略するゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Borderlands",
+        "ja": "ボーダーランズ",
+        "ja_typings": [
+          "bo-da-ranzu"
+        ]
+      },
+      {
+        "en": "Doom",
+        "ja": "ドゥーム",
+        "ja_typings": [
+          "du-mu"
+        ]
+      },
+      {
+        "en": "Quake",
+        "ja": "クエイク",
+        "ja_typings": [
+          "kueiku"
+        ]
+      },
+      {
+        "en": "Deus Ex",
+        "ja": "デウスエクス",
+        "ja_typings": [
+          "deusuekusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02954",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2K loot-shooter series features cel-shaded graphics on Pandora?",
+      "ja": "2Kのトゥーン調FPSでパンドラ星を舞台にする作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Brawl Stars",
+        "ja": "ブロスタ",
+        "ja_typings": [
+          "burosuta"
+        ]
+      },
+      {
+        "en": "Boom Beach",
+        "ja": "ブームビーチ",
+        "ja_typings": [
+          "bu-mubi-chi"
+        ]
+      },
+      {
+        "en": "Hay Day",
+        "ja": "ヘイデイ",
+        "ja_typings": [
+          "heidei"
+        ]
+      },
+      {
+        "en": "Pikmin Bloom",
+        "ja": "ピクミンブルーム",
+        "ja_typings": [
+          "pikuminburu-mu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02955",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Supercell mobile game features 3v3 team brawls?",
+      "ja": "スーパーセルの3対3のチーム対戦モバイルゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Breakout",
+        "ja": "ブレイクアウト",
+        "ja_typings": [
+          "bureikuauto"
+        ]
+      },
+      {
+        "en": "Columns",
+        "ja": "コラムス",
+        "ja_typings": [
+          "koramusu"
+        ]
+      },
+      {
+        "en": "Galaxian",
+        "ja": "ギャラクシアン",
+        "ja_typings": [
+          "gyarakushian"
+        ]
+      },
+      {
+        "en": "Moon Cresta",
+        "ja": "ムーンクレスタ",
+        "ja_typings": [
+          "mu-nkuresuta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02956",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Atari classic involves bouncing a ball to break bricks?",
+      "ja": "ボールでブロックを崩すアタリのゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bungie",
+        "ja": "バンジー",
+        "ja_typings": [
+          "banji-"
+        ]
+      },
+      {
+        "en": "Bethesda",
+        "ja": "ベセスダ",
+        "ja_typings": [
+          "besesuda"
+        ]
+      },
+      {
+        "en": "Activision",
+        "ja": "アクティビジョン",
+        "ja_typings": [
+          "akutibijon"
+        ]
+      },
+      {
+        "en": "Take-Two Interactive",
+        "ja": "テイクツー",
+        "ja_typings": [
+          "teikutsu-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02957",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio created Destiny and Halo?",
+      "ja": "ヘイローやデスティニーを作ったスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CS:GO",
+        "ja": "シーエスゴー",
+        "ja_typings": [
+          "shi-esugo-"
+        ]
+      },
+      {
+        "en": "Valorant",
+        "ja": "ヴァロラント",
+        "ja_typings": [
+          "varoranto"
+        ]
+      },
+      {
+        "en": "Quake",
+        "ja": "クエイク",
+        "ja_typings": [
+          "kueiku"
+        ]
+      },
+      {
+        "en": "Apex Legends",
+        "ja": "エーペックスレジェンズ",
+        "ja_typings": [
+          "e-pekkusurejenzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02958",
+    "image_path": null,
+    "question_text": {
+      "en": "Which competitive FPS is short for Counter-Strike: Global Offensive?",
+      "ja": "カウンターストライクの略称で語られる対戦FPSは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Call of Duty",
+        "ja": "コール オブ デューティ",
+        "ja_typings": [
+          "ko-ru obu deyu-ti"
+        ]
+      },
+      {
+        "en": "Battlefield",
+        "ja": "バトルフィールド",
+        "ja_typings": [
+          "batorufi-rudo"
+        ]
+      },
+      {
+        "en": "Medal of Honor",
+        "ja": "メダル・オブ・オナー",
+        "ja_typings": [
+          "medaru/obu/ona-"
+        ]
+      },
+      {
+        "en": "Doom",
+        "ja": "ドゥーム",
+        "ja_typings": [
+          "du-mu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02959",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Activision FPS series has Modern Warfare entries?",
+      "ja": "モダンウォーフェアを含むアクティビジョンのFPSは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Columns",
+        "ja": "コラムス",
+        "ja_typings": [
+          "koramusu"
+        ]
+      },
+      {
+        "en": "Puyo Puyo",
+        "ja": "ぷよぷよ",
+        "ja_typings": [
+          "puyopuyo"
+        ]
+      },
+      {
+        "en": "Dr. Mario",
+        "ja": "ドクターマリオ",
+        "ja_typings": [
+          "dokuta-mario"
+        ]
+      },
+      {
+        "en": "Tetris",
+        "ja": "テトリス",
+        "ja_typings": [
+          "tetorisu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02960",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Sega puzzle game involves matching colored stones in columns?",
+      "ja": "セガの落ちもの宝石パズルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cyberpunk 2077",
+        "ja": "サイバーパンク2077",
+        "ja_typings": [
+          "saiba-panku2077"
+        ]
+      },
+      {
+        "en": "Witcher",
+        "ja": "ウィッチャー",
+        "ja_typings": [
+          "witcha-"
+        ]
+      },
+      {
+        "en": "Fallout",
+        "ja": "フォールアウト",
+        "ja_typings": [
+          "fo-ruauto"
+        ]
+      },
+      {
+        "en": "Deus Ex",
+        "ja": "デウスエクス",
+        "ja_typings": [
+          "deusuekusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02961",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CD Projekt RED dystopian RPG was released in 2020?",
+      "ja": "CDプロジェクト製の2020年発売SF RPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Days Gone",
+        "ja": "デイズ ゴーン",
+        "ja_typings": [
+          "deizu go-n"
+        ]
+      },
+      {
+        "en": "Death Stranding",
+        "ja": "デス・ストランディング",
+        "ja_typings": [
+          "desu/sutorandingu"
+        ]
+      },
+      {
+        "en": "Detroit: Become Human",
+        "ja": "デトロイト ビカム ヒューマン",
+        "ja_typings": [
+          "detoroito bikamu hyu-man"
+        ]
+      },
+      {
+        "en": "Ghost of Tsushima",
+        "ja": "ゴースト・オブ・ツシマ",
+        "ja_typings": [
+          "go-suto/obu/tsushima"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02962",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Sony post-apocalyptic biker game features Deacon St. John?",
+      "ja": "ディーコンが主人公のソニーのバイクゾンビゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Death Stranding",
+        "ja": "デス・ストランディング",
+        "ja_typings": [
+          "desu/sutorandingu"
+        ]
+      },
+      {
+        "en": "Days Gone",
+        "ja": "デイズ ゴーン",
+        "ja_typings": [
+          "deizu go-n"
+        ]
+      },
+      {
+        "en": "Sekiro",
+        "ja": "隻狼",
+        "ja_typings": [
+          "sekiro",
+          "sekirou"
+        ]
+      },
+      {
+        "en": "Cyberpunk 2077",
+        "ja": "サイバーパンク2077",
+        "ja_typings": [
+          "saiba-panku2077"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02963",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Kojima Productions delivery game features Sam Bridges?",
+      "ja": "サム・ブリッジズが配達するコジマプロの作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Detroit: Become Human",
+        "ja": "デトロイト ビカム ヒューマン",
+        "ja_typings": [
+          "detoroito bikamu hyu-man"
+        ]
+      },
+      {
+        "en": "Death Stranding",
+        "ja": "デス・ストランディング",
+        "ja_typings": [
+          "desu/sutorandingu"
+        ]
+      },
+      {
+        "en": "Days Gone",
+        "ja": "デイズ ゴーン",
+        "ja_typings": [
+          "deizu go-n"
+        ]
+      },
+      {
+        "en": "Doom",
+        "ja": "ドゥーム",
+        "ja_typings": [
+          "du-mu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02964",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Quantic Dream game depicts a society of sentient androids?",
+      "ja": "クアンティック・ドリームのアンドロイドが主役の作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Deus Ex",
+        "ja": "デウスエクス",
+        "ja_typings": [
+          "deusuekusu"
+        ]
+      },
+      {
+        "en": "Cyberpunk 2077",
+        "ja": "サイバーパンク2077",
+        "ja_typings": [
+          "saiba-panku2077"
+        ]
+      },
+      {
+        "en": "Shadowrun",
+        "ja": "シャドウラン",
+        "ja_typings": [
+          "shadoran",
+          "shadouran"
+        ]
+      },
+      {
+        "en": "Fallout",
+        "ja": "フォールアウト",
+        "ja_typings": [
+          "fo-ruauto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02965",
+    "image_path": null,
+    "question_text": {
+      "en": "Which cyberpunk RPG series features augmented agent Adam Jensen?",
+      "ja": "アダム・ジェンセンが主人公のサイバーパンクRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dig Dug",
+        "ja": "ディグダグ",
+        "ja_typings": [
+          "digudagu"
+        ]
+      },
+      {
+        "en": "Galaga",
+        "ja": "ギャラガ",
+        "ja_typings": [
+          "gyaraga"
+        ]
+      },
+      {
+        "en": "Xevious",
+        "ja": "ゼビウス",
+        "ja_typings": [
+          "zebiusu"
+        ]
+      },
+      {
+        "en": "Galaxian",
+        "ja": "ギャラクシアン",
+        "ja_typings": [
+          "gyarakushian"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02966",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Namco classic involves a character pumping up underground monsters?",
+      "ja": "地中の敵を膨らませて倒すナムコのゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Doom",
+        "ja": "ドゥーム",
+        "ja_typings": [
+          "du-mu"
+        ]
+      },
+      {
+        "en": "Quake",
+        "ja": "クエイク",
+        "ja_typings": [
+          "kueiku"
+        ]
+      },
+      {
+        "en": "Wolfenstein",
+        "ja": "ウルフェンシュタイン",
+        "ja_typings": [
+          "urufenshutain"
+        ]
+      },
+      {
+        "en": "Half-Life",
+        "ja": "ハーフライフ",
+        "ja_typings": [
+          "ha-furaifu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02967",
+    "image_path": null,
+    "question_text": {
+      "en": "Which id Software FPS features a Space Marine fighting demons?",
+      "ja": "id Softwareの悪魔を倒す宇宙海兵FPSは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dota 2",
+        "ja": "ドータ2",
+        "ja_typings": [
+          "do-ta2",
+          "do-tatsu-"
+        ]
+      },
+      {
+        "en": "Smite",
+        "ja": "スマイト",
+        "ja_typings": [
+          "sumaito"
+        ]
+      },
+      {
+        "en": "Heroes of the Storm",
+        "ja": "ヒーローズ・オブ・ザ・ストーム",
+        "ja_typings": [
+          "hi-ro-zu/obu/za/suto-mu"
+        ]
+      },
+      {
+        "en": "Rocket League",
+        "ja": "ロケットリーグ",
+        "ja_typings": [
+          "rokettori-gu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02968",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Valve MOBA features heroes battling for ancients?",
+      "ja": "Valveのエンシェントを破壊するMOBAは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dr. Mario",
+        "ja": "ドクターマリオ",
+        "ja_typings": [
+          "dokuta-mario"
+        ]
+      },
+      {
+        "en": "Paper Mario",
+        "ja": "ペーパーマリオ",
+        "ja_typings": [
+          "pe-pa-mario"
+        ]
+      },
+      {
+        "en": "Mario Party",
+        "ja": "マリオパーティ",
+        "ja_typings": [
+          "mariopa-ti"
+        ]
+      },
+      {
+        "en": "Mario Kart",
+        "ja": "マリオカート",
+        "ja_typings": [
+          "marioka-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02969",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Game Boy puzzle game has Mario throwing pills at viruses?",
+      "ja": "マリオがウイルスを薬で倒すゲームボーイのパズルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dragon Quest X",
+        "ja": "ドラゴンクエストX",
+        "ja_typings": [
+          "doragonkuesutox",
+          "doragonkuesutoten"
+        ]
+      },
+      {
+        "en": "Dragon Quest IX",
+        "ja": "ドラゴンクエストIX",
+        "ja_typings": [
+          "doragonkuesutoix",
+          "doragonkuesutonain"
+        ]
+      },
+      {
+        "en": "Dragon Quest XI",
+        "ja": "ドラゴンクエストXI",
+        "ja_typings": [
+          "doragonkuesutoxi",
+          "doragonkuesutoirebun"
+        ]
+      },
+      {
+        "en": "Dragon Quest VIII",
+        "ja": "ドラゴンクエストVIII",
+        "ja_typings": [
+          "doragonkuesutoviii",
+          "doragonkuesutoeito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02970",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Dragon Quest entry is the MMORPG numbered ten?",
+      "ja": "ドラクエシリーズで唯一のMMORPGの番号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Epic Games",
+        "ja": "エピックゲームズ",
+        "ja_typings": [
+          "epikkuge-muzu"
+        ]
+      },
+      {
+        "en": "Ubisoft",
+        "ja": "ユービーアイソフト",
+        "ja_typings": [
+          "yu-bi-aisofuto"
+        ]
+      },
+      {
+        "en": "Activision",
+        "ja": "アクティビジョン",
+        "ja_typings": [
+          "akutibijon"
+        ]
+      },
+      {
+        "en": "Take-Two Interactive",
+        "ja": "テイクツー",
+        "ja_typings": [
+          "teikutsu-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02971",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company makes Unreal Engine and Fortnite?",
+      "ja": "アンリアルエンジンとフォートナイトの会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "EverQuest",
+        "ja": "エバークエスト",
+        "ja_typings": [
+          "eba-kuesuto"
+        ]
+      },
+      {
+        "en": "Lost Ark",
+        "ja": "ロストアーク",
+        "ja_typings": [
+          "rosutoa-ku"
+        ]
+      },
+      {
+        "en": "Guild Wars 2",
+        "ja": "ギルドウォーズ2",
+        "ja_typings": [
+          "girudouo-zu2",
+          "girudouo-zutsu-",
+          "girudowo-zu2"
+        ]
+      },
+      {
+        "en": "Black Desert",
+        "ja": "黒い砂漠",
+        "ja_typings": [
+          "kuroi sabaku",
+          "kuroisabaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02972",
+    "image_path": null,
+    "question_text": {
+      "en": "Which classic Sony Online MMORPG predated World of Warcraft?",
+      "ja": "WoW登場以前のソニー製代表的MMORPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fallout",
+        "ja": "フォールアウト",
+        "ja_typings": [
+          "fo-ruauto"
+        ]
+      },
+      {
+        "en": "The Elder Scrolls",
+        "ja": "エルダースクロールズ",
+        "ja_typings": [
+          "eruda-sukuro-ruzu"
+        ]
+      },
+      {
+        "en": "Borderlands",
+        "ja": "ボーダーランズ",
+        "ja_typings": [
+          "bo-da-ranzu"
+        ]
+      },
+      {
+        "en": "Witcher",
+        "ja": "ウィッチャー",
+        "ja_typings": [
+          "witcha-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02973",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Bethesda post-apocalyptic RPG features Vault Boy?",
+      "ja": "ベセスダのVault Boyが象徴のポストアポカリプスRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Football Manager",
+        "ja": "フットボールマネージャー",
+        "ja_typings": [
+          "futtobo-rumane-ja-"
+        ]
+      },
+      {
+        "en": "Winning Eleven",
+        "ja": "ウイニングイレブン",
+        "ja_typings": [
+          "uininguirebun"
+        ]
+      },
+      {
+        "en": "Pro Spirits",
+        "ja": "プロスピ",
+        "ja_typings": [
+          "purosupi"
+        ]
+      },
+      {
+        "en": "Pro Yakyu Spirits",
+        "ja": "プロ野球スピリッツ",
+        "ja_typings": [
+          "pro yakyu spirits",
+          "puroyakyuusupirittsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02974",
+    "image_path": null,
+    "question_text": {
+      "en": "Which SEGA Sports Interactive series simulates soccer team management?",
+      "ja": "セガが出すサッカークラブ経営シミュは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Galaga",
+        "ja": "ギャラガ",
+        "ja_typings": [
+          "gyaraga"
+        ]
+      },
+      {
+        "en": "Galaxian",
+        "ja": "ギャラクシアン",
+        "ja_typings": [
+          "gyarakushian"
+        ]
+      },
+      {
+        "en": "Xevious",
+        "ja": "ゼビウス",
+        "ja_typings": [
+          "zebiusu"
+        ]
+      },
+      {
+        "en": "Moon Cresta",
+        "ja": "ムーンクレスタ",
+        "ja_typings": [
+          "mu-nkuresuta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02975",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Namco shooter has insects forming attack formations?",
+      "ja": "編隊で攻撃してくるナムコのシューティングは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Galaxian",
+        "ja": "ギャラクシアン",
+        "ja_typings": [
+          "gyarakushian"
+        ]
+      },
+      {
+        "en": "Galaga",
+        "ja": "ギャラガ",
+        "ja_typings": [
+          "gyaraga"
+        ]
+      },
+      {
+        "en": "Xevious",
+        "ja": "ゼビウス",
+        "ja_typings": [
+          "zebiusu"
+        ]
+      },
+      {
+        "en": "Space Invaders",
+        "ja": "スペースインベーダー",
+        "ja_typings": [
+          "supe-suinbe-da-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02976",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Namco shooter from 1979 preceded Galaga?",
+      "ja": "ギャラガの前作にあたる1979年のナムコ作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ghost of Tsushima",
+        "ja": "ゴースト・オブ・ツシマ",
+        "ja_typings": [
+          "go-suto/obu/tsushima"
+        ]
+      },
+      {
+        "en": "Sekiro",
+        "ja": "隻狼",
+        "ja_typings": [
+          "sekiro",
+          "sekirou"
+        ]
+      },
+      {
+        "en": "Days Gone",
+        "ja": "デイズ ゴーン",
+        "ja_typings": [
+          "deizu go-n"
+        ]
+      },
+      {
+        "en": "Death Stranding",
+        "ja": "デス・ストランディング",
+        "ja_typings": [
+          "desu/sutorandingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02977",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Sucker Punch samurai game is set on a Mongol-invaded island?",
+      "ja": "サッカーパンチ社の蒙古襲来を舞台にしたサムライ作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Goichi Suda",
+        "ja": "須田剛一",
+        "ja_typings": [
+          "suda goichi",
+          "sudagouichi"
+        ]
+      },
+      {
+        "en": "Hideki Kamiya",
+        "ja": "神谷英樹",
+        "ja_typings": [
+          "kamiya hideki",
+          "kamiyahideki"
+        ]
+      },
+      {
+        "en": "Shinji Mikami",
+        "ja": "三上真司",
+        "ja_typings": [
+          "mikami shinji",
+          "mikamishinji"
+        ]
+      },
+      {
+        "en": "Tomonobu Itagaki",
+        "ja": "板垣伴信",
+        "ja_typings": [
+          "itagaki tomonobu",
+          "itagakitomonobu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02978",
+    "image_path": null,
+    "question_text": {
+      "en": "Who founded Grasshopper Manufacture and directed No More Heroes?",
+      "ja": "ノーモア★ヒーローズを生んだグラスホッパー創業者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Goro Majima",
+        "ja": "真島吾朗",
+        "ja_typings": [
+          "majima goro",
+          "majimagorou"
+        ]
+      },
+      {
+        "en": "Akira Nishikiyama",
+        "ja": "錦山彰",
+        "ja_typings": [
+          "nishikiyama akira",
+          "nishikiyamaakira"
+        ]
+      },
+      {
+        "en": "Ichiban Kasuga",
+        "ja": "春日一番",
+        "ja_typings": [
+          "kasuga ichiban",
+          "kasugaichiban"
+        ]
+      },
+      {
+        "en": "Kazuma Kiryu",
+        "ja": "桐生一馬",
+        "ja_typings": [
+          "kiryu kazuma",
+          "kiryuukazuma"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02979",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the eyepatch-wearing Mad Dog of Shimano in Yakuza?",
+      "ja": "龍が如くで眼帯姿の嶋野の狂犬は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Granblue Fantasy",
+        "ja": "グランブルーファンタジー",
+        "ja_typings": [
+          "guranburu-fantaji-"
+        ]
+      },
+      {
+        "en": "Princess Connect",
+        "ja": "プリンセスコネクト",
+        "ja_typings": [
+          "purinsesukonekuto"
+        ]
+      },
+      {
+        "en": "Shadowverse",
+        "ja": "シャドウバース",
+        "ja_typings": [
+          "shadoba-su",
+          "shadouba-su"
+        ]
+      },
+      {
+        "en": "Azur Lane",
+        "ja": "アズールレーン",
+        "ja_typings": [
+          "azu-rure-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02980",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Cygames fantasy mobile RPG features sky-faring adventurers?",
+      "ja": "サイゲームスの空の旅を描くファンタジーRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Guild Wars 2",
+        "ja": "ギルドウォーズ2",
+        "ja_typings": [
+          "girudouo-zu2",
+          "girudouo-zutsu-",
+          "girudowo-zu2"
+        ]
+      },
+      {
+        "en": "EverQuest",
+        "ja": "エバークエスト",
+        "ja_typings": [
+          "eba-kuesuto"
+        ]
+      },
+      {
+        "en": "Lost Ark",
+        "ja": "ロストアーク",
+        "ja_typings": [
+          "rosutoa-ku"
+        ]
+      },
+      {
+        "en": "World of Warcraft",
+        "ja": "ワールド オブ ウォークラフト",
+        "ja_typings": [
+          "wa-rudo obu wo-kurafuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02981",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ArenaNet MMORPG sequel released in 2012 has no monthly fee?",
+      "ja": "アリーナネットの月額無料MMORPG続編は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gunpei Yokoi",
+        "ja": "横井軍平",
+        "ja_typings": [
+          "yokoi gunpei",
+          "yokoigunpei"
+        ]
+      },
+      {
+        "en": "Satoru Iwata",
+        "ja": "岩田聡",
+        "ja_typings": [
+          "iwata satoru",
+          "iwatasatoru"
+        ]
+      },
+      {
+        "en": "Satoshi Tajiri",
+        "ja": "田尻智",
+        "ja_typings": [
+          "tajiri satoshi",
+          "tajirisatoshi"
+        ]
+      },
+      {
+        "en": "Yuji Naka",
+        "ja": "中裕司",
+        "ja_typings": [
+          "naka yuji",
+          "nakayuuji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02982",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created the Game & Watch and Game Boy at Nintendo?",
+      "ja": "ゲーム&ウオッチとゲームボーイの生みの親は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hack and Slash",
+        "ja": "ハックアンドスラッシュ",
+        "ja_typings": [
+          "hakkuandosurasshu"
+        ]
+      },
+      {
+        "en": "Turn-based Strategy",
+        "ja": "ターン制ストラテジー",
+        "ja_typings": [
+          "ta-nseisutorateji-"
+        ]
+      },
+      {
+        "en": "MOBA",
+        "ja": "モバ",
+        "ja_typings": [
+          "moba"
+        ]
+      },
+      {
+        "en": "RTS",
+        "ja": "リアルタイムストラテジー",
+        "ja_typings": [
+          "riarutaimusutorateji-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02983",
+    "image_path": null,
+    "question_text": {
+      "en": "Which action game genre is abbreviated H&S?",
+      "ja": "ハクスラとも呼ばれるアクションゲームのジャンルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Harry Potter: Wizards Unite",
+        "ja": "ハリーポッター 魔法同盟",
+        "ja_typings": [
+          "mahou doumei",
+          "mahoudoumei"
+        ]
+      },
+      {
+        "en": "Pikmin Bloom",
+        "ja": "ピクミンブルーム",
+        "ja_typings": [
+          "pikuminburu-mu"
+        ]
+      },
+      {
+        "en": "Ingress",
+        "ja": "イングレス",
+        "ja_typings": [
+          "inguresu"
+        ]
+      },
+      {
+        "en": "Pokemon GO",
+        "ja": "ポケモンGO",
+        "ja_typings": [
+          "pokemongo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02984",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Niantic AR game uses the Harry Potter universe?",
+      "ja": "ナイアンティックのハリーポッターAR位置情報ゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hay Day",
+        "ja": "ヘイデイ",
+        "ja_typings": [
+          "heidei"
+        ]
+      },
+      {
+        "en": "Boom Beach",
+        "ja": "ブームビーチ",
+        "ja_typings": [
+          "bu-mubi-chi"
+        ]
+      },
+      {
+        "en": "Brawl Stars",
+        "ja": "ブロスタ",
+        "ja_typings": [
+          "burosuta"
+        ]
+      },
+      {
+        "en": "Story of Seasons",
+        "ja": "牧場物語",
+        "ja_typings": [
+          "bokujou monogatari",
+          "bokujoumonogatari"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02985",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Supercell game has players running a small farm?",
+      "ja": "スーパーセル製の農場経営モバイルゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Heroes of the Storm",
+        "ja": "ヒーローズ・オブ・ザ・ストーム",
+        "ja_typings": [
+          "hi-ro-zu/obu/za/suto-mu"
+        ]
+      },
+      {
+        "en": "Dota 2",
+        "ja": "ドータ2",
+        "ja_typings": [
+          "do-ta2",
+          "do-tatsu-"
+        ]
+      },
+      {
+        "en": "Smite",
+        "ja": "スマイト",
+        "ja_typings": [
+          "sumaito"
+        ]
+      },
+      {
+        "en": "Overwatch",
+        "ja": "オーバーウォッチ",
+        "ja_typings": [
+          "o-ba-wotchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02986",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Blizzard MOBA features characters from across its franchises?",
+      "ja": "ブリザード全作品のキャラが集うMOBAは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hideki Kamiya",
+        "ja": "神谷英樹",
+        "ja_typings": [
+          "kamiya hideki",
+          "kamiyahideki"
+        ]
+      },
+      {
+        "en": "Shinji Mikami",
+        "ja": "三上真司",
+        "ja_typings": [
+          "mikami shinji",
+          "mikamishinji"
+        ]
+      },
+      {
+        "en": "Goichi Suda",
+        "ja": "須田剛一",
+        "ja_typings": [
+          "suda goichi",
+          "sudagouichi"
+        ]
+      },
+      {
+        "en": "Hideo Kojima",
+        "ja": "小島秀夫",
+        "ja_typings": [
+          "kojima hideo",
+          "kojimahideo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02987",
+    "image_path": null,
+    "question_text": {
+      "en": "Who directed Bayonetta and founded PlatinumGames?",
+      "ja": "ベヨネッタの監督でプラチナゲームズ創業者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hideo Kojima",
+        "ja": "小島秀夫",
+        "ja_typings": [
+          "kojima hideo",
+          "kojimahideo"
+        ]
+      },
+      {
+        "en": "Hideki Kamiya",
+        "ja": "神谷英樹",
+        "ja_typings": [
+          "kamiya hideki",
+          "kamiyahideki"
+        ]
+      },
+      {
+        "en": "Shinji Mikami",
+        "ja": "三上真司",
+        "ja_typings": [
+          "mikami shinji",
+          "mikamishinji"
+        ]
+      },
+      {
+        "en": "Tetsuya Nomura",
+        "ja": "野村哲也",
+        "ja_typings": [
+          "nomura tetsuya",
+          "nomuratetsuya"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02988",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Metal Gear Solid and Death Stranding?",
+      "ja": "メタルギアやデス・ストランディングの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hironobu Sakaguchi",
+        "ja": "坂口博信",
+        "ja_typings": [
+          "sakaguchi hironobu",
+          "sakaguchihironobu"
+        ]
+      },
+      {
+        "en": "Yuji Horii",
+        "ja": "堀井雄二",
+        "ja_typings": [
+          "horii yuji",
+          "horiiyuuji"
+        ]
+      },
+      {
+        "en": "Tetsuya Nomura",
+        "ja": "野村哲也",
+        "ja_typings": [
+          "nomura tetsuya",
+          "nomuratetsuya"
+        ]
+      },
+      {
+        "en": "Motomu Toriyama",
+        "ja": "鳥山求",
+        "ja_typings": [
+          "toriyama motomu",
+          "toriyamamotomu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02989",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created the Final Fantasy series at Square?",
+      "ja": "ファイナルファンタジーシリーズの生みの親は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Honkai Star Rail",
+        "ja": "崩壊スターレイル",
+        "ja_typings": [
+          "houkai sutareiru",
+          "houkaisutareiru"
+        ]
+      },
+      {
+        "en": "Tower of Fantasy",
+        "ja": "幻塔",
+        "ja_typings": [
+          "gentou"
+        ]
+      },
+      {
+        "en": "Granblue Fantasy",
+        "ja": "グランブルーファンタジー",
+        "ja_typings": [
+          "guranburu-fantaji-"
+        ]
+      },
+      {
+        "en": "Azur Lane",
+        "ja": "アズールレーン",
+        "ja_typings": [
+          "azu-rure-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02990",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HoYoverse space-themed turn-based RPG launched in 2023?",
+      "ja": "ホヨバースの2023年宇宙ターン制RPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ichiban Kasuga",
+        "ja": "春日一番",
+        "ja_typings": [
+          "kasuga ichiban",
+          "kasugaichiban"
+        ]
+      },
+      {
+        "en": "Goro Majima",
+        "ja": "真島吾朗",
+        "ja_typings": [
+          "majima goro",
+          "majimagorou"
+        ]
+      },
+      {
+        "en": "Akira Nishikiyama",
+        "ja": "錦山彰",
+        "ja_typings": [
+          "nishikiyama akira",
+          "nishikiyamaakira"
+        ]
+      },
+      {
+        "en": "Kazuma Kiryu",
+        "ja": "桐生一馬",
+        "ja_typings": [
+          "kiryu kazuma",
+          "kiryuukazuma"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02991",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the protagonist of Yakuza: Like a Dragon?",
+      "ja": "龍が如く7の主人公は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ingress",
+        "ja": "イングレス",
+        "ja_typings": [
+          "inguresu"
+        ]
+      },
+      {
+        "en": "Pikmin Bloom",
+        "ja": "ピクミンブルーム",
+        "ja_typings": [
+          "pikuminburu-mu"
+        ]
+      },
+      {
+        "en": "Harry Potter: Wizards Unite",
+        "ja": "ハリーポッター 魔法同盟",
+        "ja_typings": [
+          "mahou doumei",
+          "mahoudoumei"
+        ]
+      },
+      {
+        "en": "Hay Day",
+        "ja": "ヘイデイ",
+        "ja_typings": [
+          "heidei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02992",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Niantic AR game predated Pokemon GO?",
+      "ja": "ナイアンティックがポケモンGOより前に出した位置情報ARゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Itadaki Street",
+        "ja": "いただきストリート",
+        "ja_typings": [
+          "itadakisutori-to"
+        ]
+      },
+      {
+        "en": "Mario Party",
+        "ja": "マリオパーティ",
+        "ja_typings": [
+          "mariopa-ti"
+        ]
+      },
+      {
+        "en": "The Game of Life",
+        "ja": "人生ゲーム",
+        "ja_typings": [
+          "jinsei game",
+          "jinseigeemu"
+        ]
+      },
+      {
+        "en": "Mario Kart",
+        "ja": "マリオカート",
+        "ja_typings": [
+          "marioka-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02993",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Square board-game series features Dragon Quest characters?",
+      "ja": "ドラクエキャラが登場するスクウェアの双六ゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jak and Daxter",
+        "ja": "ジャック×ダクスター",
+        "ja_typings": [
+          "jakkudakusuta-"
+        ]
+      },
+      {
+        "en": "Ratchet & Clank",
+        "ja": "ラチェット&クランク",
+        "ja_typings": [
+          "rachettokuranku"
+        ]
+      },
+      {
+        "en": "Uncharted",
+        "ja": "アンチャーテッド",
+        "ja_typings": [
+          "ancha-teddo"
+        ]
+      },
+      {
+        "en": "Sly Cooper",
+        "ja": "怪盗スライ",
+        "ja_typings": [
+          "kaitou suraikuupaa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02994",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Naughty Dog PS2 platformer pairs a boy with a furry sidekick?",
+      "ja": "ノーティードッグのPS2ジャンプアクションは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Keiji Inafune",
+        "ja": "稲船敬二",
+        "ja_typings": [
+          "inafune keiji",
+          "inafunekeiji"
+        ]
+      },
+      {
+        "en": "Shinji Mikami",
+        "ja": "三上真司",
+        "ja_typings": [
+          "mikami shinji",
+          "mikamishinji"
+        ]
+      },
+      {
+        "en": "Yoshiki Okamoto",
+        "ja": "岡本吉起",
+        "ja_typings": [
+          "okamoto yoshiki",
+          "okamotoyoshiki"
+        ]
+      },
+      {
+        "en": "Hideki Kamiya",
+        "ja": "神谷英樹",
+        "ja_typings": [
+          "kamiya hideki",
+          "kamiyahideki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02995",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Mega Man at Capcom?",
+      "ja": "カプコンでロックマンを生んだ人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Koichi Nakamura",
+        "ja": "中村光一",
+        "ja_typings": [
+          "nakamura koichi",
+          "nakamurakouichi"
+        ]
+      },
+      {
+        "en": "Yuji Horii",
+        "ja": "堀井雄二",
+        "ja_typings": [
+          "horii yuji",
+          "horiiyuuji"
+        ]
+      },
+      {
+        "en": "Yuji Naka",
+        "ja": "中裕司",
+        "ja_typings": [
+          "naka yuji",
+          "nakayuuji"
+        ]
+      },
+      {
+        "en": "Satoshi Tajiri",
+        "ja": "田尻智",
+        "ja_typings": [
+          "tajiri satoshi",
+          "tajirisatoshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02996",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created the original Dragon Quest game system at Chunsoft?",
+      "ja": "ドラクエ初代のプログラマでチュンソフト創業者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lost Ark",
+        "ja": "ロストアーク",
+        "ja_typings": [
+          "rosutoa-ku"
+        ]
+      },
+      {
+        "en": "Black Desert",
+        "ja": "黒い砂漠",
+        "ja_typings": [
+          "kuroi sabaku",
+          "kuroisabaku"
+        ]
+      },
+      {
+        "en": "EverQuest",
+        "ja": "エバークエスト",
+        "ja_typings": [
+          "eba-kuesuto"
+        ]
+      },
+      {
+        "en": "Guild Wars 2",
+        "ja": "ギルドウォーズ2",
+        "ja_typings": [
+          "girudouo-zu2",
+          "girudouo-zutsu-",
+          "girudowo-zu2"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02997",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Smilegate MMORPG with isometric view launched globally in 2022?",
+      "ja": "スマイルゲートの2022年世界配信トップダウンMMORPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MOBA",
+        "ja": "モバ",
+        "ja_typings": [
+          "moba"
+        ]
+      },
+      {
+        "en": "RTS",
+        "ja": "リアルタイムストラテジー",
+        "ja_typings": [
+          "riarutaimusutorateji-"
+        ]
+      },
+      {
+        "en": "RPG",
+        "ja": "ロールプレイングゲーム",
+        "ja_typings": [
+          "ro-rupureinguge-mu"
+        ]
+      },
+      {
+        "en": "Hack and Slash",
+        "ja": "ハックアンドスラッシュ",
+        "ja_typings": [
+          "hakkuandosurasshu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02998",
+    "image_path": null,
+    "question_text": {
+      "en": "Which genre includes League of Legends and Dota 2?",
+      "ja": "LoLやDota 2のジャンル名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mario Kart",
+        "ja": "マリオカート",
+        "ja_typings": [
+          "marioka-to"
+        ]
+      },
+      {
+        "en": "Mario Party",
+        "ja": "マリオパーティ",
+        "ja_typings": [
+          "mariopa-ti"
+        ]
+      },
+      {
+        "en": "Rocket League",
+        "ja": "ロケットリーグ",
+        "ja_typings": [
+          "rokettori-gu"
+        ]
+      },
+      {
+        "en": "Star Fox",
+        "ja": "スターフォックス",
+        "ja_typings": [
+          "suta-fokkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02999",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nintendo racing series features banana peels and shells?",
+      "ja": "甲羅やバナナを投げる任天堂レースゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mario Party",
+        "ja": "マリオパーティ",
+        "ja_typings": [
+          "mariopa-ti"
+        ]
+      },
+      {
+        "en": "Mario Kart",
+        "ja": "マリオカート",
+        "ja_typings": [
+          "marioka-to"
+        ]
+      },
+      {
+        "en": "Itadaki Street",
+        "ja": "いただきストリート",
+        "ja_typings": [
+          "itadakisutori-to"
+        ]
+      },
+      {
+        "en": "The Game of Life",
+        "ja": "人生ゲーム",
+        "ja_typings": [
+          "jinsei game",
+          "jinseigeemu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03000",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nintendo party game series features minigame board play?",
+      "ja": "ミニゲーム集の任天堂パーティーゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Masahiro Sakurai",
+        "ja": "桜井政博",
+        "ja_typings": [
+          "sakurai masahiro",
+          "sakuraimasahiro"
+        ]
+      },
+      {
+        "en": "Satoru Iwata",
+        "ja": "岩田聡",
+        "ja_typings": [
+          "iwata satoru",
+          "iwatasatoru"
+        ]
+      },
+      {
+        "en": "Gunpei Yokoi",
+        "ja": "横井軍平",
+        "ja_typings": [
+          "yokoi gunpei",
+          "yokoigunpei"
+        ]
+      },
+      {
+        "en": "Hideki Kamiya",
+        "ja": "神谷英樹",
+        "ja_typings": [
+          "kamiya hideki",
+          "kamiyahideki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03001",
+    "image_path": null,
+    "question_text": {
+      "en": "Who directed Super Smash Bros. and Kirby?",
+      "ja": "スマブラやカービィの生みの親は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Medal of Honor",
+        "ja": "メダル・オブ・オナー",
+        "ja_typings": [
+          "medaru/obu/ona-"
+        ]
+      },
+      {
+        "en": "Battlefield",
+        "ja": "バトルフィールド",
+        "ja_typings": [
+          "batorufi-rudo"
+        ]
+      },
+      {
+        "en": "Doom",
+        "ja": "ドゥーム",
+        "ja_typings": [
+          "du-mu"
+        ]
+      },
+      {
+        "en": "Team Fortress",
+        "ja": "チームフォートレス",
+        "ja_typings": [
+          "chi-mufo-toresu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03002",
+    "image_path": null,
+    "question_text": {
+      "en": "Which EA WWII FPS series competed with early Call of Duty?",
+      "ja": "EAの第二次大戦FPSで初期CoDの競合は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mega Man",
+        "ja": "ロックマン",
+        "ja_typings": [
+          "rokkuman"
+        ]
+      },
+      {
+        "en": "Sengoku Basara",
+        "ja": "戦国BASARA",
+        "ja_typings": [
+          "sengoku basara"
+        ]
+      },
+      {
+        "en": "Monster Hunter",
+        "ja": "モンスターハンター",
+        "ja_typings": [
+          "monsuta-hanta-"
+        ]
+      },
+      {
+        "en": "Tomb Raider",
+        "ja": "トゥームレイダー",
+        "ja_typings": [
+          "tu-mureida-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03003",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Capcom blue-armored robot hero series began in 1987?",
+      "ja": "1987年に始まった青い鎧のカプコンロボットは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Moero Pro Yakyu",
+        "ja": "燃えろ!!プロ野球",
+        "ja_typings": [
+          "moero pro yakyu",
+          "moeropuroyakyuu"
+        ]
+      },
+      {
+        "en": "Pro Spirits",
+        "ja": "プロスピ",
+        "ja_typings": [
+          "purosupi"
+        ]
+      },
+      {
+        "en": "Pro Yakyu Spirits",
+        "ja": "プロ野球スピリッツ",
+        "ja_typings": [
+          "pro yakyu spirits",
+          "puroyakyuusupirittsu"
+        ]
+      },
+      {
+        "en": "Winning Eleven",
+        "ja": "ウイニングイレブン",
+        "ja_typings": [
+          "uininguirebun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03004",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Konami baseball series features pixel-style players?",
+      "ja": "燃えろプロ野球の二頭身プロ野球ゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Monster Hunter",
+        "ja": "モンスターハンター",
+        "ja_typings": [
+          "monsuta-hanta-"
+        ]
+      },
+      {
+        "en": "Mega Man",
+        "ja": "ロックマン",
+        "ja_typings": [
+          "rokkuman"
+        ]
+      },
+      {
+        "en": "Sengoku Basara",
+        "ja": "戦国BASARA",
+        "ja_typings": [
+          "sengoku basara"
+        ]
+      },
+      {
+        "en": "Sekiro",
+        "ja": "隻狼",
+        "ja_typings": [
+          "sekiro",
+          "sekirou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03005",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Capcom action series has hunters slaying giant beasts?",
+      "ja": "巨大モンスターを狩るカプコン代表作は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Moon Cresta",
+        "ja": "ムーンクレスタ",
+        "ja_typings": [
+          "mu-nkuresuta"
+        ]
+      },
+      {
+        "en": "Galaxian",
+        "ja": "ギャラクシアン",
+        "ja_typings": [
+          "gyarakushian"
+        ]
+      },
+      {
+        "en": "Xevious",
+        "ja": "ゼビウス",
+        "ja_typings": [
+          "zebiusu"
+        ]
+      },
+      {
+        "en": "Space Invaders",
+        "ja": "スペースインベーダー",
+        "ja_typings": [
+          "supe-suinbe-da-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03006",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1980 Nichibutsu shooter sequel to Cosmos features docking?",
+      "ja": "三段ロケットがドッキングする日物のシューティングは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Motomu Toriyama",
+        "ja": "鳥山求",
+        "ja_typings": [
+          "toriyama motomu",
+          "toriyamamotomu"
+        ]
+      },
+      {
+        "en": "Tetsuya Nomura",
+        "ja": "野村哲也",
+        "ja_typings": [
+          "nomura tetsuya",
+          "nomuratetsuya"
+        ]
+      },
+      {
+        "en": "Hironobu Sakaguchi",
+        "ja": "坂口博信",
+        "ja_typings": [
+          "sakaguchi hironobu",
+          "sakaguchihironobu"
+        ]
+      },
+      {
+        "en": "Yuji Horii",
+        "ja": "堀井雄二",
+        "ja_typings": [
+          "horii yuji",
+          "horiiyuuji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03007",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the Final Fantasy XIII director at Square Enix?",
+      "ja": "FF13シリーズの監督を務めたスクエニ社員は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nintendo 3DS",
+        "ja": "ニンテンドー3DS",
+        "ja_typings": [
+          "nintendo-3ds",
+          "nintendo-suri-dei-esu"
+        ]
+      },
+      {
+        "en": "Nintendo DS",
+        "ja": "ニンテンドーDS",
+        "ja_typings": [
+          "nintendo-ds",
+          "nintendo-dei-esu"
+        ]
+      },
+      {
+        "en": "Nintendo Switch",
+        "ja": "ニンテンドースイッチ",
+        "ja_typings": [
+          "nintendo-suitchi"
+        ]
+      },
+      {
+        "en": "Wii U",
+        "ja": "ウィーユー",
+        "ja_typings": [
+          "wi-yu-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03008",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nintendo handheld introduced stereoscopic 3D without glasses?",
+      "ja": "裸眼3D表示を搭載した任天堂の携帯機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nintendo DS",
+        "ja": "ニンテンドーDS",
+        "ja_typings": [
+          "nintendo-ds",
+          "nintendo-dei-esu"
+        ]
+      },
+      {
+        "en": "Nintendo 3DS",
+        "ja": "ニンテンドー3DS",
+        "ja_typings": [
+          "nintendo-3ds",
+          "nintendo-suri-dei-esu"
+        ]
+      },
+      {
+        "en": "Nintendo Switch",
+        "ja": "ニンテンドースイッチ",
+        "ja_typings": [
+          "nintendo-suitchi"
+        ]
+      },
+      {
+        "en": "PlayStation Portal",
+        "ja": "プレイステーション・ポータル",
+        "ja_typings": [
+          "pureisute-shon/po-taru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03009",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nintendo dual-screen handheld launched in 2004?",
+      "ja": "2004年発売の任天堂二画面携帯機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Overwatch",
+        "ja": "オーバーウォッチ",
+        "ja_typings": [
+          "o-ba-wotchi"
+        ]
+      },
+      {
+        "en": "Valorant",
+        "ja": "ヴァロラント",
+        "ja_typings": [
+          "varoranto"
+        ]
+      },
+      {
+        "en": "Apex Legends",
+        "ja": "エーペックスレジェンズ",
+        "ja_typings": [
+          "e-pekkusurejenzu"
+        ]
+      },
+      {
+        "en": "Team Fortress",
+        "ja": "チームフォートレス",
+        "ja_typings": [
+          "chi-mufo-toresu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03010",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Blizzard hero shooter features Tracer and Reinhardt?",
+      "ja": "トレーサーやラインハルトが登場するブリザードのFPSは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Paper Mario",
+        "ja": "ペーパーマリオ",
+        "ja_typings": [
+          "pe-pa-mario"
+        ]
+      },
+      {
+        "en": "Dr. Mario",
+        "ja": "ドクターマリオ",
+        "ja_typings": [
+          "dokuta-mario"
+        ]
+      },
+      {
+        "en": "Mario Party",
+        "ja": "マリオパーティ",
+        "ja_typings": [
+          "mariopa-ti"
+        ]
+      },
+      {
+        "en": "Mario Kart",
+        "ja": "マリオカート",
+        "ja_typings": [
+          "marioka-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03011",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mario spin-off RPG uses 2D paper visuals?",
+      "ja": "紙のような2D表現を使うマリオRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pikmin",
+        "ja": "ピクミン",
+        "ja_typings": [
+          "pikumin"
+        ]
+      },
+      {
+        "en": "Pikmin Bloom",
+        "ja": "ピクミンブルーム",
+        "ja_typings": [
+          "pikuminburu-mu"
+        ]
+      },
+      {
+        "en": "Splatoon",
+        "ja": "スプラトゥーン",
+        "ja_typings": [
+          "supuratu-n"
+        ]
+      },
+      {
+        "en": "Star Fox",
+        "ja": "スターフォックス",
+        "ja_typings": [
+          "suta-fokkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03012",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Miyamoto strategy series has players directing tiny plant creatures?",
+      "ja": "宮本茂作の植物人間を率いる戦略アクションは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pikmin Bloom",
+        "ja": "ピクミンブルーム",
+        "ja_typings": [
+          "pikuminburu-mu"
+        ]
+      },
+      {
+        "en": "Pikmin",
+        "ja": "ピクミン",
+        "ja_typings": [
+          "pikumin"
+        ]
+      },
+      {
+        "en": "Ingress",
+        "ja": "イングレス",
+        "ja_typings": [
+          "inguresu"
+        ]
+      },
+      {
+        "en": "Harry Potter: Wizards Unite",
+        "ja": "ハリーポッター 魔法同盟",
+        "ja_typings": [
+          "mahou doumei",
+          "mahoudoumei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03013",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Niantic walking-AR app uses Pikmin to track steps?",
+      "ja": "ピクミンが歩数を彩るナイアンティックの散歩アプリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PlayStation",
+        "ja": "プレイステーション",
+        "ja_typings": [
+          "pureisute-shon"
+        ]
+      },
+      {
+        "en": "Nintendo Switch",
+        "ja": "ニンテンドースイッチ",
+        "ja_typings": [
+          "nintendo-suitchi"
+        ]
+      },
+      {
+        "en": "Wii U",
+        "ja": "ウィーユー",
+        "ja_typings": [
+          "wi-yu-"
+        ]
+      },
+      {
+        "en": "Steam Deck",
+        "ja": "スチームデック",
+        "ja_typings": [
+          "suchi-mudekku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03014",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Sony game console brand started in 1994?",
+      "ja": "1994年発売のソニー据置ゲーム機ブランドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PlayStation Portal",
+        "ja": "プレイステーション・ポータル",
+        "ja_typings": [
+          "pureisute-shon/po-taru"
+        ]
+      },
+      {
+        "en": "Steam Deck",
+        "ja": "スチームデック",
+        "ja_typings": [
+          "suchi-mudekku"
+        ]
+      },
+      {
+        "en": "ROG Ally",
+        "ja": "ロジー・アライ",
+        "ja_typings": [
+          "roji-/arai"
+        ]
+      },
+      {
+        "en": "Nintendo Switch",
+        "ja": "ニンテンドースイッチ",
+        "ja_typings": [
+          "nintendo-suitchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03015",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Sony streaming handheld plays PS5 games over Wi-Fi?",
+      "ja": "PS5の映像をWi-Fi越しに遊ぶソニーの携帯端末は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Portal",
+        "ja": "ポータル",
+        "ja_typings": [
+          "po-taru"
+        ]
+      },
+      {
+        "en": "Breakout",
+        "ja": "ブレイクアウト",
+        "ja_typings": [
+          "bureikuauto"
+        ]
+      },
+      {
+        "en": "Quake",
+        "ja": "クエイク",
+        "ja_typings": [
+          "kueiku"
+        ]
+      },
+      {
+        "en": "Doom",
+        "ja": "ドゥーム",
+        "ja_typings": [
+          "du-mu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03016",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Valve puzzle game features a portal-creating gun?",
+      "ja": "ポータルを撃つValveのパズルゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Princess Connect",
+        "ja": "プリンセスコネクト",
+        "ja_typings": [
+          "purinsesukonekuto"
+        ]
+      },
+      {
+        "en": "Granblue Fantasy",
+        "ja": "グランブルーファンタジー",
+        "ja_typings": [
+          "guranburu-fantaji-"
+        ]
+      },
+      {
+        "en": "Azur Lane",
+        "ja": "アズールレーン",
+        "ja_typings": [
+          "azu-rure-n"
+        ]
+      },
+      {
+        "en": "Shadowverse",
+        "ja": "シャドウバース",
+        "ja_typings": [
+          "shadoba-su",
+          "shadouba-su"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03017",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Cygames anime-style mobile RPG features a guild of girls?",
+      "ja": "サイゲームスの美少女ギルド系モバイルRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pro Spirits",
+        "ja": "プロスピ",
+        "ja_typings": [
+          "purosupi"
+        ]
+      },
+      {
+        "en": "Pro Yakyu Spirits",
+        "ja": "プロ野球スピリッツ",
+        "ja_typings": [
+          "pro yakyu spirits",
+          "puroyakyuusupirittsu"
+        ]
+      },
+      {
+        "en": "Moero Pro Yakyu",
+        "ja": "燃えろ!!プロ野球",
+        "ja_typings": [
+          "moero pro yakyu",
+          "moeropuroyakyuu"
+        ]
+      },
+      {
+        "en": "Winning Eleven",
+        "ja": "ウイニングイレブン",
+        "ja_typings": [
+          "uininguirebun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03018",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Konami baseball series is abbreviated as Pro Spi?",
+      "ja": "プロスピと略されるコナミ野球ゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pro Yakyu Spirits",
+        "ja": "プロ野球スピリッツ",
+        "ja_typings": [
+          "pro yakyu spirits",
+          "puroyakyuusupirittsu"
+        ]
+      },
+      {
+        "en": "Pro Spirits",
+        "ja": "プロスピ",
+        "ja_typings": [
+          "purosupi"
+        ]
+      },
+      {
+        "en": "Moero Pro Yakyu",
+        "ja": "燃えろ!!プロ野球",
+        "ja_typings": [
+          "moero pro yakyu",
+          "moeropuroyakyuu"
+        ]
+      },
+      {
+        "en": "Football Manager",
+        "ja": "フットボールマネージャー",
+        "ja_typings": [
+          "futtobo-rumane-ja-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03019",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Konami simulation series is the official Pro Yakyu game?",
+      "ja": "プロ野球の正式ライセンスを持つコナミの本格野球シミュは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Puyo Puyo",
+        "ja": "ぷよぷよ",
+        "ja_typings": [
+          "puyopuyo"
+        ]
+      },
+      {
+        "en": "Columns",
+        "ja": "コラムス",
+        "ja_typings": [
+          "koramusu"
+        ]
+      },
+      {
+        "en": "Dr. Mario",
+        "ja": "ドクターマリオ",
+        "ja_typings": [
+          "dokuta-mario"
+        ]
+      },
+      {
+        "en": "Tetris",
+        "ja": "テトリス",
+        "ja_typings": [
+          "tetorisu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03020",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Compile/Sega puzzle game features chain-clearing colored blobs?",
+      "ja": "連鎖で消すコンパイル/セガのカラフルパズルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Quake",
+        "ja": "クエイク",
+        "ja_typings": [
+          "kueiku"
+        ]
+      },
+      {
+        "en": "Doom",
+        "ja": "ドゥーム",
+        "ja_typings": [
+          "du-mu"
+        ]
+      },
+      {
+        "en": "Half-Life",
+        "ja": "ハーフライフ",
+        "ja_typings": [
+          "ha-furaifu"
+        ]
+      },
+      {
+        "en": "Wolfenstein",
+        "ja": "ウルフェンシュタイン",
+        "ja_typings": [
+          "urufenshutain"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03021",
+    "image_path": null,
+    "question_text": {
+      "en": "Which id Software FPS succeeded Doom with full 3D graphics?",
+      "ja": "ドゥームに続くid Softwareの3D FPSは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ROG Ally",
+        "ja": "ロジー・アライ",
+        "ja_typings": [
+          "roji-/arai"
+        ]
+      },
+      {
+        "en": "Steam Deck",
+        "ja": "スチームデック",
+        "ja_typings": [
+          "suchi-mudekku"
+        ]
+      },
+      {
+        "en": "PlayStation Portal",
+        "ja": "プレイステーション・ポータル",
+        "ja_typings": [
+          "pureisute-shon/po-taru"
+        ]
+      },
+      {
+        "en": "Nintendo Switch",
+        "ja": "ニンテンドースイッチ",
+        "ja_typings": [
+          "nintendo-suitchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03022",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ASUS Windows handheld competes with Steam Deck?",
+      "ja": "Steam Deckの競合となるASUSのWindows携帯機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "RPG",
+        "ja": "ロールプレイングゲーム",
+        "ja_typings": [
+          "ro-rupureinguge-mu"
+        ]
+      },
+      {
+        "en": "MOBA",
+        "ja": "モバ",
+        "ja_typings": [
+          "moba"
+        ]
+      },
+      {
+        "en": "RTS",
+        "ja": "リアルタイムストラテジー",
+        "ja_typings": [
+          "riarutaimusutorateji-"
+        ]
+      },
+      {
+        "en": "Hack and Slash",
+        "ja": "ハックアンドスラッシュ",
+        "ja_typings": [
+          "hakkuandosurasshu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03023",
+    "image_path": null,
+    "question_text": {
+      "en": "Which genre includes Final Fantasy and Dragon Quest?",
+      "ja": "FFやドラクエが代表するジャンル名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "RTS",
+        "ja": "リアルタイムストラテジー",
+        "ja_typings": [
+          "riarutaimusutorateji-"
+        ]
+      },
+      {
+        "en": "Turn-based Strategy",
+        "ja": "ターン制ストラテジー",
+        "ja_typings": [
+          "ta-nseisutorateji-"
+        ]
+      },
+      {
+        "en": "MOBA",
+        "ja": "モバ",
+        "ja_typings": [
+          "moba"
+        ]
+      },
+      {
+        "en": "RPG",
+        "ja": "ロールプレイングゲーム",
+        "ja_typings": [
+          "ro-rupureinguge-mu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03024",
+    "image_path": null,
+    "question_text": {
+      "en": "Which genre includes StarCraft and Age of Empires?",
+      "ja": "StarCraftやAge of Empiresのジャンル名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rainbow Six",
+        "ja": "レインボーシックス",
+        "ja_typings": [
+          "reinbo-shikkusu"
+        ]
+      },
+      {
+        "en": "Rainbow Six Siege",
+        "ja": "レインボーシックス シージ",
+        "ja_typings": [
+          "reinbo-shikkusu shi-ji"
+        ]
+      },
+      {
+        "en": "CS:GO",
+        "ja": "シーエスゴー",
+        "ja_typings": [
+          "shi-esugo-"
+        ]
+      },
+      {
+        "en": "Valorant",
+        "ja": "ヴァロラント",
+        "ja_typings": [
+          "varoranto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03025",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Ubisoft tactical shooter is named after Tom Clancy's novel?",
+      "ja": "トム・クランシー原作のユービーアイ戦術シューターは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rainbow Six Siege",
+        "ja": "レインボーシックス シージ",
+        "ja_typings": [
+          "reinbo-shikkusu shi-ji"
+        ]
+      },
+      {
+        "en": "Rainbow Six",
+        "ja": "レインボーシックス",
+        "ja_typings": [
+          "reinbo-shikkusu"
+        ]
+      },
+      {
+        "en": "Apex Legends",
+        "ja": "エーペックスレジェンズ",
+        "ja_typings": [
+          "e-pekkusurejenzu"
+        ]
+      },
+      {
+        "en": "Valorant",
+        "ja": "ヴァロラント",
+        "ja_typings": [
+          "varoranto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03026",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2015 Ubisoft 5v5 attack-defend shooter became an esports staple?",
+      "ja": "2015年発売の5対5攻防シューター(R6)は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ratchet & Clank",
+        "ja": "ラチェット&クランク",
+        "ja_typings": [
+          "rachettokuranku"
+        ]
+      },
+      {
+        "en": "Jak and Daxter",
+        "ja": "ジャック×ダクスター",
+        "ja_typings": [
+          "jakkudakusuta-"
+        ]
+      },
+      {
+        "en": "Uncharted",
+        "ja": "アンチャーテッド",
+        "ja_typings": [
+          "ancha-teddo"
+        ]
+      },
+      {
+        "en": "Sly Cooper",
+        "ja": "怪盗スライ",
+        "ja_typings": [
+          "kaitou suraikuupaa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03027",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Insomniac PS series pairs a lombax with a robot?",
+      "ja": "ロンバックスとロボットが冒険するインソムニアックの作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rocket League",
+        "ja": "ロケットリーグ",
+        "ja_typings": [
+          "rokettori-gu"
+        ]
+      },
+      {
+        "en": "Mario Kart",
+        "ja": "マリオカート",
+        "ja_typings": [
+          "marioka-to"
+        ]
+      },
+      {
+        "en": "Smite",
+        "ja": "スマイト",
+        "ja_typings": [
+          "sumaito"
+        ]
+      },
+      {
+        "en": "Dota 2",
+        "ja": "ドータ2",
+        "ja_typings": [
+          "do-ta2",
+          "do-tatsu-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03028",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Psyonix game combines soccer with rocket-powered cars?",
+      "ja": "ロケット推進の車でサッカーをするPsyonixのゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rune Factory",
+        "ja": "ルーンファクトリー",
+        "ja_typings": [
+          "ru-nfakutori-"
+        ]
+      },
+      {
+        "en": "Story of Seasons",
+        "ja": "牧場物語",
+        "ja_typings": [
+          "bokujou monogatari",
+          "bokujoumonogatari"
+        ]
+      },
+      {
+        "en": "Hay Day",
+        "ja": "ヘイデイ",
+        "ja_typings": [
+          "heidei"
+        ]
+      },
+      {
+        "en": "Pikmin Bloom",
+        "ja": "ピクミンブルーム",
+        "ja_typings": [
+          "pikuminburu-mu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03029",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Marvelous farming RPG was once called Harvest Moon overseas?",
+      "ja": "海外でハーベストムーン名義だった牧場経営RPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sakura Wars",
+        "ja": "サクラ大戦",
+        "ja_typings": [
+          "sakura taisen",
+          "sakurataisen"
+        ]
+      },
+      {
+        "en": "Sengoku Basara",
+        "ja": "戦国BASARA",
+        "ja_typings": [
+          "sengoku basara"
+        ]
+      },
+      {
+        "en": "Granblue Fantasy",
+        "ja": "グランブルーファンタジー",
+        "ja_typings": [
+          "guranburu-fantaji-"
+        ]
+      },
+      {
+        "en": "Princess Connect",
+        "ja": "プリンセスコネクト",
+        "ja_typings": [
+          "purinsesukonekuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03030",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Sega series features the Imperial Floral Assault Troupe?",
+      "ja": "帝国華撃団が活躍するセガの作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sam Fisher",
+        "ja": "サム・フィッシャー",
+        "ja_typings": [
+          "samu/fissha-"
+        ]
+      },
+      {
+        "en": "Agent 47",
+        "ja": "エージェント47",
+        "ja_typings": [
+          "e-jento47"
+        ]
+      },
+      {
+        "en": "Jason Bourne",
+        "ja": "ジェイソン・ボーン",
+        "ja_typings": [
+          "jeison/bo-n"
+        ]
+      },
+      {
+        "en": "Ichiban Kasuga",
+        "ja": "春日一番",
+        "ja_typings": [
+          "kasuga ichiban",
+          "kasugaichiban"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03031",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the bald Splinter Cell stealth agent?",
+      "ja": "スプリンターセルの主人公の禿頭スパイは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Satoru Iwata",
+        "ja": "岩田聡",
+        "ja_typings": [
+          "iwata satoru",
+          "iwatasatoru"
+        ]
+      },
+      {
+        "en": "Gunpei Yokoi",
+        "ja": "横井軍平",
+        "ja_typings": [
+          "yokoi gunpei",
+          "yokoigunpei"
+        ]
+      },
+      {
+        "en": "Masahiro Sakurai",
+        "ja": "桜井政博",
+        "ja_typings": [
+          "sakurai masahiro",
+          "sakuraimasahiro"
+        ]
+      },
+      {
+        "en": "Satoshi Tajiri",
+        "ja": "田尻智",
+        "ja_typings": [
+          "tajiri satoshi",
+          "tajirisatoshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03032",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Nintendo president and HAL Laboratory programmer?",
+      "ja": "任天堂社長を務めた元HAL研プログラマは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Satoshi Tajiri",
+        "ja": "田尻智",
+        "ja_typings": [
+          "tajiri satoshi",
+          "tajirisatoshi"
+        ]
+      },
+      {
+        "en": "Satoru Iwata",
+        "ja": "岩田聡",
+        "ja_typings": [
+          "iwata satoru",
+          "iwatasatoru"
+        ]
+      },
+      {
+        "en": "Gunpei Yokoi",
+        "ja": "横井軍平",
+        "ja_typings": [
+          "yokoi gunpei",
+          "yokoigunpei"
+        ]
+      },
+      {
+        "en": "Koichi Nakamura",
+        "ja": "中村光一",
+        "ja_typings": [
+          "nakamura koichi",
+          "nakamurakouichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03033",
+    "image_path": null,
+    "question_text": {
+      "en": "Who founded Game Freak and created Pokemon?",
+      "ja": "ゲームフリークを創業しポケモンを生んだ人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sekiro",
+        "ja": "隻狼",
+        "ja_typings": [
+          "sekiro",
+          "sekirou"
+        ]
+      },
+      {
+        "en": "Ghost of Tsushima",
+        "ja": "ゴースト・オブ・ツシマ",
+        "ja_typings": [
+          "go-suto/obu/tsushima"
+        ]
+      },
+      {
+        "en": "Monster Hunter",
+        "ja": "モンスターハンター",
+        "ja_typings": [
+          "monsuta-hanta-"
+        ]
+      },
+      {
+        "en": "Witcher",
+        "ja": "ウィッチャー",
+        "ja_typings": [
+          "witcha-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03034",
+    "image_path": null,
+    "question_text": {
+      "en": "Which FromSoftware Sengoku-era stealth-action game won Game of the Year 2019?",
+      "ja": "2019年GOTYのフロムソフトウェア戦国忍者ゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sengoku Basara",
+        "ja": "戦国BASARA",
+        "ja_typings": [
+          "sengoku basara"
+        ]
+      },
+      {
+        "en": "Sakura Wars",
+        "ja": "サクラ大戦",
+        "ja_typings": [
+          "sakura taisen",
+          "sakurataisen"
+        ]
+      },
+      {
+        "en": "Monster Hunter",
+        "ja": "モンスターハンター",
+        "ja_typings": [
+          "monsuta-hanta-"
+        ]
+      },
+      {
+        "en": "Mega Man",
+        "ja": "ロックマン",
+        "ja_typings": [
+          "rokkuman"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03035",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Capcom series features over-the-top Sengoku warriors?",
+      "ja": "派手な戦国武将アクションのカプコン作は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shadowrun",
+        "ja": "シャドウラン",
+        "ja_typings": [
+          "shadoran",
+          "shadouran"
+        ]
+      },
+      {
+        "en": "Shadowverse",
+        "ja": "シャドウバース",
+        "ja_typings": [
+          "shadoba-su",
+          "shadouba-su"
+        ]
+      },
+      {
+        "en": "Deus Ex",
+        "ja": "デウスエクス",
+        "ja_typings": [
+          "deusuekusu"
+        ]
+      },
+      {
+        "en": "Cyberpunk 2077",
+        "ja": "サイバーパンク2077",
+        "ja_typings": [
+          "saiba-panku2077"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03036",
+    "image_path": null,
+    "question_text": {
+      "en": "Which tabletop-origin RPG mixes cyberpunk with fantasy races?",
+      "ja": "サイバーパンクとファンタジー種族が混ざるテーブルトークRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shadowverse",
+        "ja": "シャドウバース",
+        "ja_typings": [
+          "shadoba-su",
+          "shadouba-su"
+        ]
+      },
+      {
+        "en": "Shadowrun",
+        "ja": "シャドウラン",
+        "ja_typings": [
+          "shadoran",
+          "shadouran"
+        ]
+      },
+      {
+        "en": "Granblue Fantasy",
+        "ja": "グランブルーファンタジー",
+        "ja_typings": [
+          "guranburu-fantaji-"
+        ]
+      },
+      {
+        "en": "Princess Connect",
+        "ja": "プリンセスコネクト",
+        "ja_typings": [
+          "purinsesukonekuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03037",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Cygames digital card battler launched in 2016?",
+      "ja": "サイゲームスの2016年デジタルカードゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shinji Mikami",
+        "ja": "三上真司",
+        "ja_typings": [
+          "mikami shinji",
+          "mikamishinji"
+        ]
+      },
+      {
+        "en": "Hideki Kamiya",
+        "ja": "神谷英樹",
+        "ja_typings": [
+          "kamiya hideki",
+          "kamiyahideki"
+        ]
+      },
+      {
+        "en": "Goichi Suda",
+        "ja": "須田剛一",
+        "ja_typings": [
+          "suda goichi",
+          "sudagouichi"
+        ]
+      },
+      {
+        "en": "Keiji Inafune",
+        "ja": "稲船敬二",
+        "ja_typings": [
+          "inafune keiji",
+          "inafunekeiji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03038",
+    "image_path": null,
+    "question_text": {
+      "en": "Who directed Resident Evil 1 and founded Tango Gameworks?",
+      "ja": "バイオハザード1の監督でタンゴ創業者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Smite",
+        "ja": "スマイト",
+        "ja_typings": [
+          "sumaito"
+        ]
+      },
+      {
+        "en": "Dota 2",
+        "ja": "ドータ2",
+        "ja_typings": [
+          "do-ta2",
+          "do-tatsu-"
+        ]
+      },
+      {
+        "en": "Heroes of the Storm",
+        "ja": "ヒーローズ・オブ・ザ・ストーム",
+        "ja_typings": [
+          "hi-ro-zu/obu/za/suto-mu"
+        ]
+      },
+      {
+        "en": "Rocket League",
+        "ja": "ロケットリーグ",
+        "ja_typings": [
+          "rokettori-gu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03039",
+    "image_path": null,
+    "question_text": {
+      "en": "Which MOBA features gods and mythological figures in third-person view?",
+      "ja": "神話のキャラがTPS視点で戦うMOBAは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Space Invaders",
+        "ja": "スペースインベーダー",
+        "ja_typings": [
+          "supe-suinbe-da-"
+        ]
+      },
+      {
+        "en": "Galaxian",
+        "ja": "ギャラクシアン",
+        "ja_typings": [
+          "gyarakushian"
+        ]
+      },
+      {
+        "en": "Moon Cresta",
+        "ja": "ムーンクレスタ",
+        "ja_typings": [
+          "mu-nkuresuta"
+        ]
+      },
+      {
+        "en": "Xevious",
+        "ja": "ゼビウス",
+        "ja_typings": [
+          "zebiusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03040",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1978 Taito arcade game popularized the shooter genre?",
+      "ja": "1978年タイトーの和製シューティングの金字塔は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Splatoon",
+        "ja": "スプラトゥーン",
+        "ja_typings": [
+          "supuratu-n"
+        ]
+      },
+      {
+        "en": "ARMS",
+        "ja": "アームズ",
+        "ja_typings": [
+          "a-muzu"
+        ]
+      },
+      {
+        "en": "Star Fox",
+        "ja": "スターフォックス",
+        "ja_typings": [
+          "suta-fokkusu"
+        ]
+      },
+      {
+        "en": "Pikmin",
+        "ja": "ピクミン",
+        "ja_typings": [
+          "pikumin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03041",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nintendo shooter has squids inking turf?",
+      "ja": "イカが街にインクを塗る任天堂のシューターは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Star Fox",
+        "ja": "スターフォックス",
+        "ja_typings": [
+          "suta-fokkusu"
+        ]
+      },
+      {
+        "en": "Splatoon",
+        "ja": "スプラトゥーン",
+        "ja_typings": [
+          "supuratu-n"
+        ]
+      },
+      {
+        "en": "Pikmin",
+        "ja": "ピクミン",
+        "ja_typings": [
+          "pikumin"
+        ]
+      },
+      {
+        "en": "ARMS",
+        "ja": "アームズ",
+        "ja_typings": [
+          "a-muzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03042",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nintendo on-rails shooter stars a fox pilot?",
+      "ja": "キツネのパイロットが宇宙を飛ぶ任天堂作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Steam Deck",
+        "ja": "スチームデック",
+        "ja_typings": [
+          "suchi-mudekku"
+        ]
+      },
+      {
+        "en": "ROG Ally",
+        "ja": "ロジー・アライ",
+        "ja_typings": [
+          "roji-/arai"
+        ]
+      },
+      {
+        "en": "PlayStation Portal",
+        "ja": "プレイステーション・ポータル",
+        "ja_typings": [
+          "pureisute-shon/po-taru"
+        ]
+      },
+      {
+        "en": "Nintendo Switch",
+        "ja": "ニンテンドースイッチ",
+        "ja_typings": [
+          "nintendo-suitchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03043",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Valve handheld runs SteamOS and launched in 2022?",
+      "ja": "SteamOSを搭載する2022年Valveの携帯機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Story of Seasons",
+        "ja": "牧場物語",
+        "ja_typings": [
+          "bokujou monogatari",
+          "bokujoumonogatari"
+        ]
+      },
+      {
+        "en": "Rune Factory",
+        "ja": "ルーンファクトリー",
+        "ja_typings": [
+          "ru-nfakutori-"
+        ]
+      },
+      {
+        "en": "Hay Day",
+        "ja": "ヘイデイ",
+        "ja_typings": [
+          "heidei"
+        ]
+      },
+      {
+        "en": "Pikmin Bloom",
+        "ja": "ピクミンブルーム",
+        "ja_typings": [
+          "pikuminburu-mu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03044",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Marvelous farm simulation is the rebrand of Bokujou Monogatari?",
+      "ja": "牧場物語の海外向け新ブランド名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Take-Two Interactive",
+        "ja": "テイクツー",
+        "ja_typings": [
+          "teikutsu-"
+        ]
+      },
+      {
+        "en": "Activision",
+        "ja": "アクティビジョン",
+        "ja_typings": [
+          "akutibijon"
+        ]
+      },
+      {
+        "en": "Epic Games",
+        "ja": "エピックゲームズ",
+        "ja_typings": [
+          "epikkuge-muzu"
+        ]
+      },
+      {
+        "en": "Ubisoft",
+        "ja": "ユービーアイソフト",
+        "ja_typings": [
+          "yu-bi-aisofuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03045",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company owns Rockstar Games and 2K?",
+      "ja": "ロックスターと2Kを傘下に持つ会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Team Fortress",
+        "ja": "チームフォートレス",
+        "ja_typings": [
+          "chi-mufo-toresu"
+        ]
+      },
+      {
+        "en": "CS:GO",
+        "ja": "シーエスゴー",
+        "ja_typings": [
+          "shi-esugo-"
+        ]
+      },
+      {
+        "en": "Overwatch",
+        "ja": "オーバーウォッチ",
+        "ja_typings": [
+          "o-ba-wotchi"
+        ]
+      },
+      {
+        "en": "Valorant",
+        "ja": "ヴァロラント",
+        "ja_typings": [
+          "varoranto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03046",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Valve class-based shooter is famous for the Sandvich?",
+      "ja": "サンドビッチで知られるValveのクラスFPSは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tetsuya Nomura",
+        "ja": "野村哲也",
+        "ja_typings": [
+          "nomura tetsuya",
+          "nomuratetsuya"
+        ]
+      },
+      {
+        "en": "Motomu Toriyama",
+        "ja": "鳥山求",
+        "ja_typings": [
+          "toriyama motomu",
+          "toriyamamotomu"
+        ]
+      },
+      {
+        "en": "Hironobu Sakaguchi",
+        "ja": "坂口博信",
+        "ja_typings": [
+          "sakaguchi hironobu",
+          "sakaguchihironobu"
+        ]
+      },
+      {
+        "en": "Yuji Horii",
+        "ja": "堀井雄二",
+        "ja_typings": [
+          "horii yuji",
+          "horiiyuuji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03047",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the Final Fantasy character designer behind Kingdom Hearts?",
+      "ja": "キングダムハーツのキャラデザを担当したFF美術家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Elder Scrolls",
+        "ja": "エルダースクロールズ",
+        "ja_typings": [
+          "eruda-sukuro-ruzu"
+        ]
+      },
+      {
+        "en": "Fallout",
+        "ja": "フォールアウト",
+        "ja_typings": [
+          "fo-ruauto"
+        ]
+      },
+      {
+        "en": "Witcher",
+        "ja": "ウィッチャー",
+        "ja_typings": [
+          "witcha-"
+        ]
+      },
+      {
+        "en": "Borderlands",
+        "ja": "ボーダーランズ",
+        "ja_typings": [
+          "bo-da-ranzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03048",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Bethesda fantasy RPG series includes Skyrim and Oblivion?",
+      "ja": "スカイリムやオブリビオンを擁するベセスダのRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Game of Life",
+        "ja": "人生ゲーム",
+        "ja_typings": [
+          "jinsei game",
+          "jinseigeemu"
+        ]
+      },
+      {
+        "en": "Itadaki Street",
+        "ja": "いただきストリート",
+        "ja_typings": [
+          "itadakisutori-to"
+        ]
+      },
+      {
+        "en": "Mario Party",
+        "ja": "マリオパーティ",
+        "ja_typings": [
+          "mariopa-ti"
+        ]
+      },
+      {
+        "en": "Monopoly",
+        "ja": "モノポリー",
+        "ja_typings": [
+          "monopori-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03049",
+    "image_path": null,
+    "question_text": {
+      "en": "Which classic Hasbro board game simulates birth-to-retirement?",
+      "ja": "誕生から引退までを辿るハズブロのボードゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Legend of Zelda: Skyward Sword",
+        "ja": "ゼルダの伝説 スカイウォードソード",
+        "ja_typings": [
+          "zerudanodensetsusukaiwa-dosa-do"
+        ]
+      },
+      {
+        "en": "The Legend of Zelda: Tears of the Kingdom",
+        "ja": "ゼルダの伝説 ティアーズ オブ ザ キングダム",
+        "ja_typings": [
+          "zerudanodensetsutia-zuobuzakingudamu"
+        ]
+      },
+      {
+        "en": "The Legend of Zelda: Twilight Princess",
+        "ja": "ゼルダの伝説 トワイライトプリンセス",
+        "ja_typings": [
+          "zerudanodensetsutowairaitopurinsesu"
+        ]
+      },
+      {
+        "en": "The Legend of Zelda: Breath of the Wild",
+        "ja": "ゼルダの伝説 ブレス オブ ザ ワイルド",
+        "ja_typings": [
+          "zerudanodensetsuburesuobuzawairudo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03050",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Zelda title introduced motion-controlled sword combat on Wii?",
+      "ja": "Wiiで剣のモーション操作を導入したゼルダは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Legend of Zelda: Tears of the Kingdom",
+        "ja": "ゼルダの伝説 ティアーズ オブ ザ キングダム",
+        "ja_typings": [
+          "zerudanodensetsutia-zuobuzakingudamu"
+        ]
+      },
+      {
+        "en": "The Legend of Zelda: Skyward Sword",
+        "ja": "ゼルダの伝説 スカイウォードソード",
+        "ja_typings": [
+          "zerudanodensetsusukaiwa-dosa-do"
+        ]
+      },
+      {
+        "en": "The Legend of Zelda: Twilight Princess",
+        "ja": "ゼルダの伝説 トワイライトプリンセス",
+        "ja_typings": [
+          "zerudanodensetsutowairaitopurinsesu"
+        ]
+      },
+      {
+        "en": "The Legend of Zelda: Breath of the Wild",
+        "ja": "ゼルダの伝説 ブレス オブ ザ ワイルド",
+        "ja_typings": [
+          "zerudanodensetsuburesuobuzawairudo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03051",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2023 Switch Zelda sequel features a sky-falling Hyrule?",
+      "ja": "2023年発売のスイッチのゼルダ続編は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Legend of Zelda: Twilight Princess",
+        "ja": "ゼルダの伝説 トワイライトプリンセス",
+        "ja_typings": [
+          "zerudanodensetsutowairaitopurinsesu"
+        ]
+      },
+      {
+        "en": "The Legend of Zelda: Skyward Sword",
+        "ja": "ゼルダの伝説 スカイウォードソード",
+        "ja_typings": [
+          "zerudanodensetsusukaiwa-dosa-do"
+        ]
+      },
+      {
+        "en": "The Legend of Zelda: Tears of the Kingdom",
+        "ja": "ゼルダの伝説 ティアーズ オブ ザ キングダム",
+        "ja_typings": [
+          "zerudanodensetsutia-zuobuzakingudamu"
+        ]
+      },
+      {
+        "en": "The Legend of Zelda: Breath of the Wild",
+        "ja": "ゼルダの伝説 ブレス オブ ザ ワイルド",
+        "ja_typings": [
+          "zerudanodensetsuburesuobuzawairudo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03052",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2006 Wii/GC Zelda features Link transforming into a wolf?",
+      "ja": "リンクが狼になる2006年のゼルダ作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tomb Raider",
+        "ja": "トゥームレイダー",
+        "ja_typings": [
+          "tu-mureida-"
+        ]
+      },
+      {
+        "en": "Uncharted",
+        "ja": "アンチャーテッド",
+        "ja_typings": [
+          "ancha-teddo"
+        ]
+      },
+      {
+        "en": "Sekiro",
+        "ja": "隻狼",
+        "ja_typings": [
+          "sekiro",
+          "sekirou"
+        ]
+      },
+      {
+        "en": "Ghost of Tsushima",
+        "ja": "ゴースト・オブ・ツシマ",
+        "ja_typings": [
+          "go-suto/obu/tsushima"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03053",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Square Enix series stars Lara Croft as a treasure hunter?",
+      "ja": "ララ・クロフトが活躍するスクエニの冒険シリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tomonobu Itagaki",
+        "ja": "板垣伴信",
+        "ja_typings": [
+          "itagaki tomonobu",
+          "itagakitomonobu"
+        ]
+      },
+      {
+        "en": "Shinji Mikami",
+        "ja": "三上真司",
+        "ja_typings": [
+          "mikami shinji",
+          "mikamishinji"
+        ]
+      },
+      {
+        "en": "Hideki Kamiya",
+        "ja": "神谷英樹",
+        "ja_typings": [
+          "kamiya hideki",
+          "kamiyahideki"
+        ]
+      },
+      {
+        "en": "Keiji Inafune",
+        "ja": "稲船敬二",
+        "ja_typings": [
+          "inafune keiji",
+          "inafunekeiji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03054",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the founder of Team Ninja and director of Ninja Gaiden?",
+      "ja": "Team Ninja創設者でニンジャガイデン監督は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tower of Fantasy",
+        "ja": "幻塔",
+        "ja_typings": [
+          "gentou"
+        ]
+      },
+      {
+        "en": "Honkai Star Rail",
+        "ja": "崩壊スターレイル",
+        "ja_typings": [
+          "houkai sutareiru",
+          "houkaisutareiru"
+        ]
+      },
+      {
+        "en": "Lost Ark",
+        "ja": "ロストアーク",
+        "ja_typings": [
+          "rosutoa-ku"
+        ]
+      },
+      {
+        "en": "Black Desert",
+        "ja": "黒い砂漠",
+        "ja_typings": [
+          "kuroi sabaku",
+          "kuroisabaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03055",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hotta Studio open-world MMORPG resembles Genshin Impact?",
+      "ja": "原神に類似した中国産オープンワールドMMORPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Turn-based Strategy",
+        "ja": "ターン制ストラテジー",
+        "ja_typings": [
+          "ta-nseisutorateji-"
+        ]
+      },
+      {
+        "en": "RTS",
+        "ja": "リアルタイムストラテジー",
+        "ja_typings": [
+          "riarutaimusutorateji-"
+        ]
+      },
+      {
+        "en": "MOBA",
+        "ja": "モバ",
+        "ja_typings": [
+          "moba"
+        ]
+      },
+      {
+        "en": "Hack and Slash",
+        "ja": "ハックアンドスラッシュ",
+        "ja_typings": [
+          "hakkuandosurasshu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03056",
+    "image_path": null,
+    "question_text": {
+      "en": "Which strategy genre is abbreviated TBS?",
+      "ja": "TBSと略される戦略ゲームのジャンルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ubisoft",
+        "ja": "ユービーアイソフト",
+        "ja_typings": [
+          "yu-bi-aisofuto"
+        ]
+      },
+      {
+        "en": "Activision",
+        "ja": "アクティビジョン",
+        "ja_typings": [
+          "akutibijon"
+        ]
+      },
+      {
+        "en": "Bethesda",
+        "ja": "ベセスダ",
+        "ja_typings": [
+          "besesuda"
+        ]
+      },
+      {
+        "en": "Take-Two Interactive",
+        "ja": "テイクツー",
+        "ja_typings": [
+          "teikutsu-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03057",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French publisher makes Assassin's Creed?",
+      "ja": "アサシンクリードのフランスの発売会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Uncharted",
+        "ja": "アンチャーテッド",
+        "ja_typings": [
+          "ancha-teddo"
+        ]
+      },
+      {
+        "en": "Jak and Daxter",
+        "ja": "ジャック×ダクスター",
+        "ja_typings": [
+          "jakkudakusuta-"
+        ]
+      },
+      {
+        "en": "Tomb Raider",
+        "ja": "トゥームレイダー",
+        "ja_typings": [
+          "tu-mureida-"
+        ]
+      },
+      {
+        "en": "Days Gone",
+        "ja": "デイズ ゴーン",
+        "ja_typings": [
+          "deizu go-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03058",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Naughty Dog series stars treasure hunter Nathan Drake?",
+      "ja": "ネイサン・ドレイクが活躍するノーティードッグ作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Valorant",
+        "ja": "ヴァロラント",
+        "ja_typings": [
+          "varoranto"
+        ]
+      },
+      {
+        "en": "CS:GO",
+        "ja": "シーエスゴー",
+        "ja_typings": [
+          "shi-esugo-"
+        ]
+      },
+      {
+        "en": "Apex Legends",
+        "ja": "エーペックスレジェンズ",
+        "ja_typings": [
+          "e-pekkusurejenzu"
+        ]
+      },
+      {
+        "en": "Overwatch",
+        "ja": "オーバーウォッチ",
+        "ja_typings": [
+          "o-ba-wotchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03059",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Riot Games tactical 5v5 shooter launched in 2020?",
+      "ja": "2020年公開のライオット製5対5戦術FPSは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Visual Novel",
+        "ja": "ビジュアルノベル",
+        "ja_typings": [
+          "bijuarunoberu"
+        ]
+      },
+      {
+        "en": "Hack and Slash",
+        "ja": "ハックアンドスラッシュ",
+        "ja_typings": [
+          "hakkuandosurasshu"
+        ]
+      },
+      {
+        "en": "RTS",
+        "ja": "リアルタイムストラテジー",
+        "ja_typings": [
+          "riarutaimusutorateji-"
+        ]
+      },
+      {
+        "en": "MOBA",
+        "ja": "モバ",
+        "ja_typings": [
+          "moba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03060",
+    "image_path": null,
+    "question_text": {
+      "en": "Which narrative game genre features text and character art (NVL)?",
+      "ja": "立ち絵とテキストで物語を進めるADVのジャンル名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wii U",
+        "ja": "ウィーユー",
+        "ja_typings": [
+          "wi-yu-"
+        ]
+      },
+      {
+        "en": "Nintendo Switch",
+        "ja": "ニンテンドースイッチ",
+        "ja_typings": [
+          "nintendo-suitchi"
+        ]
+      },
+      {
+        "en": "Nintendo 3DS",
+        "ja": "ニンテンドー3DS",
+        "ja_typings": [
+          "nintendo-3ds",
+          "nintendo-suri-dei-esu"
+        ]
+      },
+      {
+        "en": "Steam Deck",
+        "ja": "スチームデック",
+        "ja_typings": [
+          "suchi-mudekku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03061",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nintendo home console launched in 2012 had a tablet controller?",
+      "ja": "タブレット型コントローラの2012年任天堂据置機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Winning Eleven",
+        "ja": "ウイニングイレブン",
+        "ja_typings": [
+          "uininguirebun"
+        ]
+      },
+      {
+        "en": "Football Manager",
+        "ja": "フットボールマネージャー",
+        "ja_typings": [
+          "futtobo-rumane-ja-"
+        ]
+      },
+      {
+        "en": "Pro Spirits",
+        "ja": "プロスピ",
+        "ja_typings": [
+          "purosupi"
+        ]
+      },
+      {
+        "en": "Pro Yakyu Spirits",
+        "ja": "プロ野球スピリッツ",
+        "ja_typings": [
+          "pro yakyu spirits",
+          "puroyakyuusupirittsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03062",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Konami soccer series was rebranded to eFootball?",
+      "ja": "eFootballに改名されたコナミのサッカーシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Witcher",
+        "ja": "ウィッチャー",
+        "ja_typings": [
+          "witcha-"
+        ]
+      },
+      {
+        "en": "Fallout",
+        "ja": "フォールアウト",
+        "ja_typings": [
+          "fo-ruauto"
+        ]
+      },
+      {
+        "en": "The Elder Scrolls",
+        "ja": "エルダースクロールズ",
+        "ja_typings": [
+          "eruda-sukuro-ruzu"
+        ]
+      },
+      {
+        "en": "Cyberpunk 2077",
+        "ja": "サイバーパンク2077",
+        "ja_typings": [
+          "saiba-panku2077"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03063",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CD Projekt RED series follows Geralt of Rivia?",
+      "ja": "ゲラルトが主人公のCD Projekt RPGシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "World of Warcraft",
+        "ja": "ワールド オブ ウォークラフト",
+        "ja_typings": [
+          "wa-rudo obu wo-kurafuto"
+        ]
+      },
+      {
+        "en": "EverQuest",
+        "ja": "エバークエスト",
+        "ja_typings": [
+          "eba-kuesuto"
+        ]
+      },
+      {
+        "en": "Guild Wars 2",
+        "ja": "ギルドウォーズ2",
+        "ja_typings": [
+          "girudouo-zu2",
+          "girudouo-zutsu-",
+          "girudowo-zu2"
+        ]
+      },
+      {
+        "en": "Lost Ark",
+        "ja": "ロストアーク",
+        "ja_typings": [
+          "rosutoa-ku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03064",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Blizzard MMORPG launched in 2004 and dominated the genre?",
+      "ja": "2004年公開のブリザード製MMORPGの代名詞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Xevious",
+        "ja": "ゼビウス",
+        "ja_typings": [
+          "zebiusu"
+        ]
+      },
+      {
+        "en": "Galaga",
+        "ja": "ギャラガ",
+        "ja_typings": [
+          "gyaraga"
+        ]
+      },
+      {
+        "en": "Galaxian",
+        "ja": "ギャラクシアン",
+        "ja_typings": [
+          "gyarakushian"
+        ]
+      },
+      {
+        "en": "Dig Dug",
+        "ja": "ディグダグ",
+        "ja_typings": [
+          "digudagu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03065",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Namco 1982 vertical-scrolling shooter features Solvalou?",
+      "ja": "ソルバルウが主人公の1982年ナムコ縦シューは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yuji Horii",
+        "ja": "堀井雄二",
+        "ja_typings": [
+          "horii yuji",
+          "horiiyuuji"
+        ]
+      },
+      {
+        "en": "Hironobu Sakaguchi",
+        "ja": "坂口博信",
+        "ja_typings": [
+          "sakaguchi hironobu",
+          "sakaguchihironobu"
+        ]
+      },
+      {
+        "en": "Koichi Nakamura",
+        "ja": "中村光一",
+        "ja_typings": [
+          "nakamura koichi",
+          "nakamurakouichi"
+        ]
+      },
+      {
+        "en": "Satoshi Tajiri",
+        "ja": "田尻智",
+        "ja_typings": [
+          "tajiri satoshi",
+          "tajirisatoshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03066",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the creator of the Dragon Quest series?",
+      "ja": "ドラゴンクエストシリーズの生みの親は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yuji Naka",
+        "ja": "中裕司",
+        "ja_typings": [
+          "naka yuji",
+          "nakayuuji"
+        ]
+      },
+      {
+        "en": "Yuji Horii",
+        "ja": "堀井雄二",
+        "ja_typings": [
+          "horii yuji",
+          "horiiyuuji"
+        ]
+      },
+      {
+        "en": "Koichi Nakamura",
+        "ja": "中村光一",
+        "ja_typings": [
+          "nakamura koichi",
+          "nakamurakouichi"
+        ]
+      },
+      {
+        "en": "Gunpei Yokoi",
+        "ja": "横井軍平",
+        "ja_typings": [
+          "yokoi gunpei",
+          "yokoigunpei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03067",
+    "image_path": null,
+    "question_text": {
+      "en": "Who programmed Sonic the Hedgehog at Sega?",
+      "ja": "セガのソニックを生んだプログラマは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1789",
+        "ja": "1789年",
+        "ja_typings": [
+          "1789nen"
+        ]
+      },
+      {
+        "en": "1812",
+        "ja": "1812年",
+        "ja_typings": [
+          "1812nen"
+        ]
+      },
+      {
+        "en": "1865",
+        "ja": "1865年",
+        "ja_typings": [
+          "1865nen"
+        ]
+      },
+      {
+        "en": "1776",
+        "ja": "1776年",
+        "ja_typings": [
+          "1776nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03068",
+    "image_path": null,
+    "question_text": {
+      "en": "In which year did the French Revolution begin?",
+      "ja": "フランス革命が勃発した年は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1812",
+        "ja": "1812年",
+        "ja_typings": [
+          "1812nen"
+        ]
+      },
+      {
+        "en": "1789",
+        "ja": "1789年",
+        "ja_typings": [
+          "1789nen"
+        ]
+      },
+      {
+        "en": "1865",
+        "ja": "1865年",
+        "ja_typings": [
+          "1865nen"
+        ]
+      },
+      {
+        "en": "1776",
+        "ja": "1776年",
+        "ja_typings": [
+          "1776nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03069",
+    "image_path": null,
+    "question_text": {
+      "en": "In which year did the War of 1812 between the US and Britain begin?",
+      "ja": "米英戦争が始まった年は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1865",
+        "ja": "1865年",
+        "ja_typings": [
+          "1865nen"
+        ]
+      },
+      {
+        "en": "1812",
+        "ja": "1812年",
+        "ja_typings": [
+          "1812nen"
+        ]
+      },
+      {
+        "en": "1789",
+        "ja": "1789年",
+        "ja_typings": [
+          "1789nen"
+        ]
+      },
+      {
+        "en": "1776",
+        "ja": "1776年",
+        "ja_typings": [
+          "1776nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03070",
+    "image_path": null,
+    "question_text": {
+      "en": "In which year did the American Civil War end?",
+      "ja": "アメリカ南北戦争が終結した年は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Abbasid Caliphate",
+        "ja": "アッバース朝",
+        "ja_typings": [
+          "abbaasu chou",
+          "abbaasuchou"
+        ]
+      },
+      {
+        "en": "Mughal Empire",
+        "ja": "ムガル帝国",
+        "ja_typings": [
+          "mugaru teikoku",
+          "mugaruteikoku"
+        ]
+      },
+      {
+        "en": "Safavid Empire",
+        "ja": "サファヴィー朝",
+        "ja_typings": [
+          "safavii chou",
+          "safaviichou"
+        ]
+      },
+      {
+        "en": "Ottoman Empire",
+        "ja": "オスマン帝国",
+        "ja_typings": [
+          "osuman teikoku",
+          "osumanteikoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03071",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Islamic caliphate ruled from Baghdad starting in 750?",
+      "ja": "750年からバグダッドで統治したイスラム王朝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Adam Laxman",
+        "ja": "ラクスマン",
+        "ja_typings": [
+          "rakusuman"
+        ]
+      },
+      {
+        "en": "Yevfimiy Putyatin",
+        "ja": "プチャーチン",
+        "ja_typings": [
+          "puchaachin",
+          "pucha-chin"
+        ]
+      },
+      {
+        "en": "Townsend Harris",
+        "ja": "ハリス",
+        "ja_typings": [
+          "harisu"
+        ]
+      },
+      {
+        "en": "Napoleon III",
+        "ja": "ナポレオン3世",
+        "ja_typings": [
+          "naporeon 3 sei",
+          "naporeonsansei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03072",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Russian envoy arrived in Nemuro in 1792 demanding trade with Japan?",
+      "ja": "1792年に根室に来航し通商を要求したロシア使節は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Adolf Hitler",
+        "ja": "アドルフ・ヒトラー",
+        "ja_typings": [
+          "adorufu/hitora-"
+        ]
+      },
+      {
+        "en": "Joseph Stalin",
+        "ja": "スターリン",
+        "ja_typings": [
+          "sutaarin",
+          "suta-rin"
+        ]
+      },
+      {
+        "en": "Francisco Franco",
+        "ja": "フランコ",
+        "ja_typings": [
+          "furanko"
+        ]
+      },
+      {
+        "en": "Salazar",
+        "ja": "サラザール",
+        "ja_typings": [
+          "sarazaaru",
+          "saraza-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03073",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led Nazi Germany during World War II?",
+      "ja": "第二次大戦時のナチス・ドイツの指導者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Alexander Hamilton",
+        "ja": "ハミルトン",
+        "ja_typings": [
+          "hamiruton"
+        ]
+      },
+      {
+        "en": "Benjamin Franklin",
+        "ja": "フランクリン",
+        "ja_typings": [
+          "furankurin"
+        ]
+      },
+      {
+        "en": "Thomas Jefferson",
+        "ja": "ジェファーソン",
+        "ja_typings": [
+          "jefaason",
+          "jefa-son"
+        ]
+      },
+      {
+        "en": "John Adams",
+        "ja": "ジョン・アダムズ",
+        "ja_typings": [
+          "jon/adamuzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03074",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first US Secretary of the Treasury?",
+      "ja": "アメリカ初代財務長官は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Alexander Kerensky",
+        "ja": "ケレンスキー",
+        "ja_typings": [
+          "kerensukii",
+          "kerensuki-"
+        ]
+      },
+      {
+        "en": "Leon Trotsky",
+        "ja": "トロツキー",
+        "ja_typings": [
+          "torotsukii",
+          "torotsuki-"
+        ]
+      },
+      {
+        "en": "Joseph Stalin",
+        "ja": "スターリン",
+        "ja_typings": [
+          "sutaarin",
+          "suta-rin"
+        ]
+      },
+      {
+        "en": "Adolf Hitler",
+        "ja": "アドルフ・ヒトラー",
+        "ja_typings": [
+          "adorufu/hitora-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03075",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led Russia's Provisional Government in 1917 before the Bolsheviks?",
+      "ja": "1917年ロシア臨時政府を率いた人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Attack on Pearl Harbor",
+        "ja": "真珠湾攻撃",
+        "ja_typings": [
+          "shinjuwan kougeki",
+          "shinjuwankougeki"
+        ]
+      },
+      {
+        "en": "Battle of Stalingrad",
+        "ja": "スターリングラード攻防戦",
+        "ja_typings": [
+          "sutaaringuraado koubousen",
+          "sutaaringuraadokoubousen"
+        ]
+      },
+      {
+        "en": "Munich Agreement",
+        "ja": "ミュンヘン会談",
+        "ja_typings": [
+          "myunhen kaidan",
+          "myunhenkaidan"
+        ]
+      },
+      {
+        "en": "Boxer Rebellion",
+        "ja": "義和団事件",
+        "ja_typings": [
+          "giwadan jiken",
+          "giwadanjiken"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03076",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1941 Japanese strike brought the US into WWII?",
+      "ja": "1941年に米国を参戦させた日本の奇襲は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Battle of Stalingrad",
+        "ja": "スターリングラード攻防戦",
+        "ja_typings": [
+          "sutaaringuraado koubousen",
+          "sutaaringuraadokoubousen"
+        ]
+      },
+      {
+        "en": "Attack on Pearl Harbor",
+        "ja": "真珠湾攻撃",
+        "ja_typings": [
+          "shinjuwan kougeki",
+          "shinjuwankougeki"
+        ]
+      },
+      {
+        "en": "Hundred Years' War",
+        "ja": "百年戦争",
+        "ja_typings": [
+          "hyakunen sensou",
+          "hyakunensensou"
+        ]
+      },
+      {
+        "en": "Thirty Years' War",
+        "ja": "三十年戦争",
+        "ja_typings": [
+          "sanjuunen sensou",
+          "sanjuunensensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03077",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1942-43 battle marked the turning point on the Eastern Front?",
+      "ja": "1942-43年東部戦線の転換点となった戦いは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Behistun Inscription",
+        "ja": "ベヒストゥン碑文",
+        "ja_typings": [
+          "behisutun hibun",
+          "behisutunhibun"
+        ]
+      },
+      {
+        "en": "Code of Hammurabi stele",
+        "ja": "ハンムラビ法典碑",
+        "ja_typings": [
+          "hanmurabi houten hi",
+          "hanmurabihoutenhi"
+        ]
+      },
+      {
+        "en": "Palermo Stone",
+        "ja": "パレルモ石",
+        "ja_typings": [
+          "parerumo seki",
+          "parerumoseki"
+        ]
+      },
+      {
+        "en": "Great Wall of China",
+        "ja": "万里の長城",
+        "ja_typings": [
+          "banri no choujou",
+          "banrinochoujou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03078",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Iranian trilingual inscription helped decipher cuneiform?",
+      "ja": "楔形文字解読の鍵となったイランの三言語碑文は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Benjamin Franklin",
+        "ja": "フランクリン",
+        "ja_typings": [
+          "furankurin"
+        ]
+      },
+      {
+        "en": "Alexander Hamilton",
+        "ja": "ハミルトン",
+        "ja_typings": [
+          "hamiruton"
+        ]
+      },
+      {
+        "en": "Thomas Jefferson",
+        "ja": "ジェファーソン",
+        "ja_typings": [
+          "jefaason",
+          "jefa-son"
+        ]
+      },
+      {
+        "en": "George Washington",
+        "ja": "ジョージ・ワシントン",
+        "ja_typings": [
+          "jo-ji/washinton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03079",
+    "image_path": null,
+    "question_text": {
+      "en": "Who flew a kite during a thunderstorm and signed the Declaration of Independence?",
+      "ja": "雷雨に凧を上げ独立宣言にも署名した人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bockscar",
+        "ja": "ボックスカー",
+        "ja_typings": [
+          "bokkusukaa",
+          "bokkusuka-"
+        ]
+      },
+      {
+        "en": "Memphis Belle",
+        "ja": "メンフィス・ベル",
+        "ja_typings": [
+          "menfisu/beru"
+        ]
+      },
+      {
+        "en": "Little Boy",
+        "ja": "リトルボーイ",
+        "ja_typings": [
+          "ritorubo-i"
+        ]
+      },
+      {
+        "en": "Enola Gay",
+        "ja": "エノラ・ゲイ",
+        "ja_typings": [
+          "enora/gei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03080",
+    "image_path": null,
+    "question_text": {
+      "en": "Which B-29 dropped the atomic bomb on Nagasaki?",
+      "ja": "長崎に原爆を投下したB-29の機名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Boxer Rebellion",
+        "ja": "義和団事件",
+        "ja_typings": [
+          "giwadan jiken",
+          "giwadanjiken"
+        ]
+      },
+      {
+        "en": "Taiping Rebellion",
+        "ja": "太平天国の乱",
+        "ja_typings": [
+          "taihei tengoku no ran",
+          "taiheitengokunoran"
+        ]
+      },
+      {
+        "en": "Second Opium War",
+        "ja": "アロー戦争",
+        "ja_typings": [
+          "aroo sensou",
+          "aroosensou"
+        ]
+      },
+      {
+        "en": "Wars of Religion",
+        "ja": "宗教戦争",
+        "ja_typings": [
+          "shuukyou sensou",
+          "shuukyousensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03081",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1900 anti-foreign uprising in China was suppressed by an eight-nation alliance?",
+      "ja": "1900年に8カ国連合軍が鎮圧した中国の排外運動は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Buzz Aldrin",
+        "ja": "オルドリン",
+        "ja_typings": [
+          "orudorin"
+        ]
+      },
+      {
+        "en": "John Glenn",
+        "ja": "ジョン・グレン",
+        "ja_typings": [
+          "jon/guren"
+        ]
+      },
+      {
+        "en": "Yuri Gagarin",
+        "ja": "ガガーリン",
+        "ja_typings": [
+          "gagaarin",
+          "gaga-rin"
+        ]
+      },
+      {
+        "en": "Thomas Edison",
+        "ja": "エジソン",
+        "ja_typings": [
+          "ejison"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03082",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the second American to walk on the Moon, after Armstrong?",
+      "ja": "アームストロングに次いで月面に立ったアメリカ人は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cannon",
+        "ja": "大砲",
+        "ja_typings": [
+          "taihou"
+        ]
+      },
+      {
+        "en": "Crossbow",
+        "ja": "クロスボウ",
+        "ja_typings": [
+          "kurosubo",
+          "kurosubou"
+        ]
+      },
+      {
+        "en": "Catapult",
+        "ja": "カタパルト",
+        "ja_typings": [
+          "kataparuto"
+        ]
+      },
+      {
+        "en": "Cavalry",
+        "ja": "騎兵",
+        "ja_typings": [
+          "kihei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03083",
+    "image_path": null,
+    "question_text": {
+      "en": "Which gunpowder weapon revolutionized warfare in the late Middle Ages?",
+      "ja": "中世末期に戦争を変えた火薬兵器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cao Cao",
+        "ja": "曹操",
+        "ja_typings": [
+          "sousou"
+        ]
+      },
+      {
+        "en": "Sun Quan",
+        "ja": "孫権",
+        "ja_typings": [
+          "sonken"
+        ]
+      },
+      {
+        "en": "Zhuge Liang",
+        "ja": "諸葛亮",
+        "ja_typings": [
+          "shokatsuryou"
+        ]
+      },
+      {
+        "en": "Liu Bei",
+        "ja": "劉備",
+        "ja_typings": [
+          "ryuubi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03084",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Wei king during China's Three Kingdoms period is known as a brilliant strategist?",
+      "ja": "三国志で魏を築いた知将は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Catapult",
+        "ja": "カタパルト",
+        "ja_typings": [
+          "kataparuto"
+        ]
+      },
+      {
+        "en": "Cannon",
+        "ja": "大砲",
+        "ja_typings": [
+          "taihou"
+        ]
+      },
+      {
+        "en": "Crossbow",
+        "ja": "クロスボウ",
+        "ja_typings": [
+          "kurosubo",
+          "kurosubou"
+        ]
+      },
+      {
+        "en": "Trebuchet",
+        "ja": "トレビュシェット",
+        "ja_typings": [
+          "torebyushetto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03085",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient siege weapon hurled stones using torsion or counterweight?",
+      "ja": "投石で城を攻めた古代の兵器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Catherine de' Medici",
+        "ja": "カトリーヌ・ド・メディシス",
+        "ja_typings": [
+          "katori-nu/do/medishisu"
+        ]
+      },
+      {
+        "en": "Marie Antoinette",
+        "ja": "マリー・アントワネット",
+        "ja_typings": [
+          "mari-/antowanetto"
+        ]
+      },
+      {
+        "en": "Eleanor of Aquitaine",
+        "ja": "エレオノール",
+        "ja_typings": [
+          "ereonooru",
+          "ereono-ru"
+        ]
+      },
+      {
+        "en": "Golda Meir",
+        "ja": "ゴルダ・メイア",
+        "ja_typings": [
+          "goruda/meia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03086",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Italian-born queen of France during the Wars of Religion?",
+      "ja": "宗教戦争期のフランス王妃でイタリア出身の女性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Clovis",
+        "ja": "クロヴィス",
+        "ja_typings": [
+          "kurovisu"
+        ]
+      },
+      {
+        "en": "Otto I",
+        "ja": "オットー1世",
+        "ja_typings": [
+          "ottoo 1 sei",
+          "ottooissei"
+        ]
+      },
+      {
+        "en": "Pepin the Short",
+        "ja": "ピピン",
+        "ja_typings": [
+          "pipin"
+        ]
+      },
+      {
+        "en": "Henry VIII",
+        "ja": "ヘンリー8世",
+        "ja_typings": [
+          "henrii 8 sei",
+          "henriihassei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03087",
+    "image_path": null,
+    "question_text": {
+      "en": "Who united the Franks and converted to Christianity around 496?",
+      "ja": "フランク王国を統一しキリスト教に改宗した王は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Code of Hammurabi stele",
+        "ja": "ハンムラビ法典碑",
+        "ja_typings": [
+          "hanmurabi houten hi",
+          "hanmurabihoutenhi"
+        ]
+      },
+      {
+        "en": "Behistun Inscription",
+        "ja": "ベヒストゥン碑文",
+        "ja_typings": [
+          "behisutun hibun",
+          "behisutunhibun"
+        ]
+      },
+      {
+        "en": "Palermo Stone",
+        "ja": "パレルモ石",
+        "ja_typings": [
+          "parerumo seki",
+          "parerumoseki"
+        ]
+      },
+      {
+        "en": "Rosetta Stone",
+        "ja": "ロゼッタストーン",
+        "ja_typings": [
+          "rozettasuto-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03088",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Babylonian stele inscribed an eye-for-an-eye law code?",
+      "ja": "目には目をで知られるバビロニアの法典碑は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Corsica",
+        "ja": "コルシカ島",
+        "ja_typings": [
+          "korushika tou",
+          "korushikatou"
+        ]
+      },
+      {
+        "en": "Sardinia",
+        "ja": "サルデーニャ島",
+        "ja_typings": [
+          "sarudeenya tou",
+          "sarudeenyatou"
+        ]
+      },
+      {
+        "en": "Sicily",
+        "ja": "シチリア島",
+        "ja_typings": [
+          "shichiria tou",
+          "shichiriatou"
+        ]
+      },
+      {
+        "en": "Izumo",
+        "ja": "出雲",
+        "ja_typings": [
+          "izumo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03089",
+    "image_path": null,
+    "question_text": {
+      "en": "On which Mediterranean island was Napoleon Bonaparte born?",
+      "ja": "ナポレオン・ボナパルトの生まれた地中海の島は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Crossbow",
+        "ja": "クロスボウ",
+        "ja_typings": [
+          "kurosubo",
+          "kurosubou"
+        ]
+      },
+      {
+        "en": "Cannon",
+        "ja": "大砲",
+        "ja_typings": [
+          "taihou"
+        ]
+      },
+      {
+        "en": "Catapult",
+        "ja": "カタパルト",
+        "ja_typings": [
+          "kataparuto"
+        ]
+      },
+      {
+        "en": "Bow",
+        "ja": "弓",
+        "ja_typings": [
+          "yumi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03090",
+    "image_path": null,
+    "question_text": {
+      "en": "Which medieval ranged weapon was banned by the Church for use against Christians?",
+      "ja": "中世に教会が同胞使用を禁じた飛び道具は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Czechoslovakia",
+        "ja": "チェコスロバキア",
+        "ja_typings": [
+          "chekosurobakia"
+        ]
+      },
+      {
+        "en": "Yugoslavia",
+        "ja": "ユーゴスラビア",
+        "ja_typings": [
+          "yu-gosurabia"
+        ]
+      },
+      {
+        "en": "East Germany",
+        "ja": "東ドイツ",
+        "ja_typings": [
+          "higashi doitsu",
+          "higashidoitsu"
+        ]
+      },
+      {
+        "en": "Germany",
+        "ja": "ドイツ",
+        "ja_typings": [
+          "doitsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03091",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Central European country split into Czech Republic and Slovakia in 1993?",
+      "ja": "1993年にチェコとスロバキアに分かれた中欧の国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Deng Xiaoping",
+        "ja": "鄧小平",
+        "ja_typings": [
+          "toushouhei"
+        ]
+      },
+      {
+        "en": "Sun Yat-sen",
+        "ja": "孫文",
+        "ja_typings": [
+          "sonbun"
+        ]
+      },
+      {
+        "en": "Zhou Enlai",
+        "ja": "周恩来",
+        "ja_typings": [
+          "shuuonrai"
+        ]
+      },
+      {
+        "en": "Cao Cao",
+        "ja": "曹操",
+        "ja_typings": [
+          "sousou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03092",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led China's reform and opening-up policy from 1978?",
+      "ja": "1978年から中国の改革開放を主導した人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "East Germany",
+        "ja": "東ドイツ",
+        "ja_typings": [
+          "higashi doitsu",
+          "higashidoitsu"
+        ]
+      },
+      {
+        "en": "Czechoslovakia",
+        "ja": "チェコスロバキア",
+        "ja_typings": [
+          "chekosurobakia"
+        ]
+      },
+      {
+        "en": "Yugoslavia",
+        "ja": "ユーゴスラビア",
+        "ja_typings": [
+          "yu-gosurabia"
+        ]
+      },
+      {
+        "en": "Germany",
+        "ja": "ドイツ",
+        "ja_typings": [
+          "doitsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03093",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country existed as the German Democratic Republic until 1990?",
+      "ja": "1990年まで存在したドイツ民主共和国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Eleanor of Aquitaine",
+        "ja": "エレオノール",
+        "ja_typings": [
+          "ereonooru",
+          "ereono-ru"
+        ]
+      },
+      {
+        "en": "Catherine de' Medici",
+        "ja": "カトリーヌ・ド・メディシス",
+        "ja_typings": [
+          "katori-nu/do/medishisu"
+        ]
+      },
+      {
+        "en": "Marie Antoinette",
+        "ja": "マリー・アントワネット",
+        "ja_typings": [
+          "mari-/antowanetto"
+        ]
+      },
+      {
+        "en": "Golda Meir",
+        "ja": "ゴルダ・メイア",
+        "ja_typings": [
+          "goruda/meia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03094",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the 12th-century queen consort of both France and England?",
+      "ja": "12世紀にフランスとイングランド両国の王妃となった女性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Erasmus",
+        "ja": "エラスムス",
+        "ja_typings": [
+          "erasumusu"
+        ]
+      },
+      {
+        "en": "Huldrych Zwingli",
+        "ja": "ツヴィングリ",
+        "ja_typings": [
+          "tsuvinguri"
+        ]
+      },
+      {
+        "en": "John Calvin",
+        "ja": "カルヴァン",
+        "ja_typings": [
+          "karuvan"
+        ]
+      },
+      {
+        "en": "Plato",
+        "ja": "プラトン",
+        "ja_typings": [
+          "puraton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03095",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Dutch humanist wrote 'In Praise of Folly'?",
+      "ja": "『痴愚神礼讃』を書いたオランダの人文主義者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "France",
+        "ja": "フランス",
+        "ja_typings": [
+          "furansu"
+        ]
+      },
+      {
+        "en": "Germany",
+        "ja": "ドイツ",
+        "ja_typings": [
+          "doitsu"
+        ]
+      },
+      {
+        "en": "United States",
+        "ja": "アメリカ合衆国",
+        "ja_typings": [
+          "amerika gasshuukoku",
+          "amerikagasshuukoku"
+        ]
+      },
+      {
+        "en": "Yugoslavia",
+        "ja": "ユーゴスラビア",
+        "ja_typings": [
+          "yu-gosurabia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03096",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country experienced the Revolution of 1789?",
+      "ja": "1789年に大革命が起きた国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Francisco Franco",
+        "ja": "フランコ",
+        "ja_typings": [
+          "furanko"
+        ]
+      },
+      {
+        "en": "Salazar",
+        "ja": "サラザール",
+        "ja_typings": [
+          "sarazaaru",
+          "saraza-ru"
+        ]
+      },
+      {
+        "en": "Adolf Hitler",
+        "ja": "アドルフ・ヒトラー",
+        "ja_typings": [
+          "adorufu/hitora-"
+        ]
+      },
+      {
+        "en": "Joseph Stalin",
+        "ja": "スターリン",
+        "ja_typings": [
+          "sutaarin",
+          "suta-rin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03097",
+    "image_path": null,
+    "question_text": {
+      "en": "Who ruled Spain as dictator from 1939 to 1975?",
+      "ja": "1939年から1975年までスペインを独裁したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Galileo Galilei",
+        "ja": "ガリレオ・ガリレイ",
+        "ja_typings": [
+          "garireo/garirei"
+        ]
+      },
+      {
+        "en": "Nicolaus Copernicus",
+        "ja": "コペルニクス",
+        "ja_typings": [
+          "koperunikusu"
+        ]
+      },
+      {
+        "en": "Isaac Newton",
+        "ja": "ニュートン",
+        "ja_typings": [
+          "nyuuton",
+          "nyu-ton"
+        ]
+      },
+      {
+        "en": "Michael Faraday",
+        "ja": "ファラデー",
+        "ja_typings": [
+          "faradee",
+          "farade-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03098",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian astronomer was tried by the Inquisition for heliocentrism?",
+      "ja": "地動説で異端審問にかけられたイタリアの天文学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "George Washington",
+        "ja": "ジョージ・ワシントン",
+        "ja_typings": [
+          "jo-ji/washinton"
+        ]
+      },
+      {
+        "en": "Thomas Jefferson",
+        "ja": "ジェファーソン",
+        "ja_typings": [
+          "jefaason",
+          "jefa-son"
+        ]
+      },
+      {
+        "en": "John Adams",
+        "ja": "ジョン・アダムズ",
+        "ja_typings": [
+          "jon/adamuzu"
+        ]
+      },
+      {
+        "en": "Benjamin Franklin",
+        "ja": "フランクリン",
+        "ja_typings": [
+          "furankurin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03099",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first president of the United States?",
+      "ja": "アメリカ合衆国の初代大統領は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Germany",
+        "ja": "ドイツ",
+        "ja_typings": [
+          "doitsu"
+        ]
+      },
+      {
+        "en": "Yugoslavia",
+        "ja": "ユーゴスラビア",
+        "ja_typings": [
+          "yu-gosurabia"
+        ]
+      },
+      {
+        "en": "Czechoslovakia",
+        "ja": "チェコスロバキア",
+        "ja_typings": [
+          "chekosurobakia"
+        ]
+      },
+      {
+        "en": "France",
+        "ja": "フランス",
+        "ja_typings": [
+          "furansu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03100",
+    "image_path": null,
+    "question_text": {
+      "en": "Which European country was reunited in 1990?",
+      "ja": "1990年に再統一されたヨーロッパの国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Golda Meir",
+        "ja": "ゴルダ・メイア",
+        "ja_typings": [
+          "goruda/meia"
+        ]
+      },
+      {
+        "en": "Menachem Begin",
+        "ja": "メナヘム・ベギン",
+        "ja_typings": [
+          "menahemu/begin"
+        ]
+      },
+      {
+        "en": "Yitzhak Rabin",
+        "ja": "イツハク・ラビン",
+        "ja_typings": [
+          "itsuhaku/rabin"
+        ]
+      },
+      {
+        "en": "Catherine de' Medici",
+        "ja": "カトリーヌ・ド・メディシス",
+        "ja_typings": [
+          "katori-nu/do/medishisu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03101",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first female Prime Minister of Israel?",
+      "ja": "イスラエル初の女性首相は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Great Wall of China",
+        "ja": "万里の長城",
+        "ja_typings": [
+          "banri no choujou",
+          "banrinochoujou"
+        ]
+      },
+      {
+        "en": "Maginot Line",
+        "ja": "マジノ線",
+        "ja_typings": [
+          "majino sen",
+          "majinosen"
+        ]
+      },
+      {
+        "en": "Iron Curtain",
+        "ja": "鉄のカーテン",
+        "ja_typings": [
+          "tetsu no kaaten",
+          "tetsunokaaten"
+        ]
+      },
+      {
+        "en": "Behistun Inscription",
+        "ja": "ベヒストゥン碑文",
+        "ja_typings": [
+          "behisutun hibun",
+          "behisutunhibun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03102",
+    "image_path": null,
+    "question_text": {
+      "en": "Which massive fortification stretches across northern China?",
+      "ja": "中国北部に延々と続く大要塞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Harriet Tubman",
+        "ja": "ハリエット・タブマン",
+        "ja_typings": [
+          "harietto/tabuman"
+        ]
+      },
+      {
+        "en": "Malcolm X",
+        "ja": "マルコムX",
+        "ja_typings": [
+          "marukomux",
+          "marukomuekusu"
+        ]
+      },
+      {
+        "en": "Martin Luther King Jr.",
+        "ja": "キング牧師",
+        "ja_typings": [
+          "kingu bokushi",
+          "kingubokushi"
+        ]
+      },
+      {
+        "en": "Ulysses S. Grant",
+        "ja": "グラント",
+        "ja_typings": [
+          "guranto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03103",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led the Underground Railroad freeing slaves before the Civil War?",
+      "ja": "南北戦争以前に地下鉄道で奴隷を救った活動家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Harris Treaty",
+        "ja": "日米修好通商条約",
+        "ja_typings": [
+          "nichibei shuukou tsuushou jouyaku",
+          "nichibeishuukoutsuushoujouyaku"
+        ]
+      },
+      {
+        "en": "Treaty of San Francisco",
+        "ja": "サンフランシスコ平和条約",
+        "ja_typings": [
+          "san furanshisuko heiwa jouyaku",
+          "sanfuranshisukoheiwajouyaku"
+        ]
+      },
+      {
+        "en": "Potsdam Declaration",
+        "ja": "ポツダム宣言",
+        "ja_typings": [
+          "potsudamu sengen",
+          "potsudamusengen"
+        ]
+      },
+      {
+        "en": "Treaty of Utrecht",
+        "ja": "ユトレヒト条約",
+        "ja_typings": [
+          "yutorehito jouyaku",
+          "yutorehitojouyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03104",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1858 treaty opened more Japanese ports to American trade?",
+      "ja": "1858年に米国との通商を認めた条約は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Henry VIII",
+        "ja": "ヘンリー8世",
+        "ja_typings": [
+          "henrii 8 sei",
+          "henriihassei"
+        ]
+      },
+      {
+        "en": "Clovis",
+        "ja": "クロヴィス",
+        "ja_typings": [
+          "kurovisu"
+        ]
+      },
+      {
+        "en": "Otto I",
+        "ja": "オットー1世",
+        "ja_typings": [
+          "ottoo 1 sei",
+          "ottooissei"
+        ]
+      },
+      {
+        "en": "Pepin the Short",
+        "ja": "ピピン",
+        "ja_typings": [
+          "pipin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03105",
+    "image_path": null,
+    "question_text": {
+      "en": "Which English king had six wives and broke with Rome?",
+      "ja": "6人の妃を持ちローマ教会と決別した英国王は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hesiod",
+        "ja": "ヘシオドス",
+        "ja_typings": [
+          "heshiodosu"
+        ]
+      },
+      {
+        "en": "Homer",
+        "ja": "ホメロス",
+        "ja_typings": [
+          "homerosu"
+        ]
+      },
+      {
+        "en": "Plato",
+        "ja": "プラトン",
+        "ja_typings": [
+          "puraton"
+        ]
+      },
+      {
+        "en": "Socrates",
+        "ja": "ソクラテス",
+        "ja_typings": [
+          "sokuratesu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03106",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Greek poet wrote 'Works and Days'?",
+      "ja": "『労働と日々』を書いたギリシャの詩人は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Homer",
+        "ja": "ホメロス",
+        "ja_typings": [
+          "homerosu"
+        ]
+      },
+      {
+        "en": "Hesiod",
+        "ja": "ヘシオドス",
+        "ja_typings": [
+          "heshiodosu"
+        ]
+      },
+      {
+        "en": "Thucydides",
+        "ja": "トゥキディデス",
+        "ja_typings": [
+          "tukidideesu",
+          "tukididesu"
+        ]
+      },
+      {
+        "en": "Pythagoras",
+        "ja": "ピタゴラス",
+        "ja_typings": [
+          "pitagorasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03107",
+    "image_path": null,
+    "question_text": {
+      "en": "Which legendary Greek poet wrote the Iliad and Odyssey?",
+      "ja": "『イリアス』『オデュッセイア』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Huldrych Zwingli",
+        "ja": "ツヴィングリ",
+        "ja_typings": [
+          "tsuvinguri"
+        ]
+      },
+      {
+        "en": "John Calvin",
+        "ja": "カルヴァン",
+        "ja_typings": [
+          "karuvan"
+        ]
+      },
+      {
+        "en": "Erasmus",
+        "ja": "エラスムス",
+        "ja_typings": [
+          "erasumusu"
+        ]
+      },
+      {
+        "en": "Plato",
+        "ja": "プラトン",
+        "ja_typings": [
+          "puraton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03108",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Swiss reformer led the Reformation in Zurich?",
+      "ja": "チューリヒで宗教改革を進めたスイスの改革者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hundred Years' War",
+        "ja": "百年戦争",
+        "ja_typings": [
+          "hyakunen sensou",
+          "hyakunensensou"
+        ]
+      },
+      {
+        "en": "Thirty Years' War",
+        "ja": "三十年戦争",
+        "ja_typings": [
+          "sanjuunen sensou",
+          "sanjuunensensou"
+        ]
+      },
+      {
+        "en": "Wars of Religion",
+        "ja": "宗教戦争",
+        "ja_typings": [
+          "shuukyou sensou",
+          "shuukyousensou"
+        ]
+      },
+      {
+        "en": "Second Opium War",
+        "ja": "アロー戦争",
+        "ja_typings": [
+          "aroo sensou",
+          "aroosensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03109",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 14th-15th century war was fought between England and France?",
+      "ja": "14-15世紀のイングランドとフランスの長期戦争は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Iron Curtain",
+        "ja": "鉄のカーテン",
+        "ja_typings": [
+          "tetsu no kaaten",
+          "tetsunokaaten"
+        ]
+      },
+      {
+        "en": "Maginot Line",
+        "ja": "マジノ線",
+        "ja_typings": [
+          "majino sen",
+          "majinosen"
+        ]
+      },
+      {
+        "en": "Great Wall of China",
+        "ja": "万里の長城",
+        "ja_typings": [
+          "banri no choujou",
+          "banrinochoujou"
+        ]
+      },
+      {
+        "en": "Munich Agreement",
+        "ja": "ミュンヘン会談",
+        "ja_typings": [
+          "myunhen kaidan",
+          "myunhenkaidan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03110",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Cold War metaphor did Churchill coin for Europe's divide?",
+      "ja": "チャーチルが欧州の分断に用いた冷戦のメタファーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Isaac Newton",
+        "ja": "ニュートン",
+        "ja_typings": [
+          "nyuuton",
+          "nyu-ton"
+        ]
+      },
+      {
+        "en": "Galileo Galilei",
+        "ja": "ガリレオ・ガリレイ",
+        "ja_typings": [
+          "garireo/garirei"
+        ]
+      },
+      {
+        "en": "Nicolaus Copernicus",
+        "ja": "コペルニクス",
+        "ja_typings": [
+          "koperunikusu"
+        ]
+      },
+      {
+        "en": "Michael Faraday",
+        "ja": "ファラデー",
+        "ja_typings": [
+          "faradee",
+          "farade-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03111",
+    "image_path": null,
+    "question_text": {
+      "en": "Who formulated the law of universal gravitation?",
+      "ja": "万有引力の法則を定式化した人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ishida Mitsunari",
+        "ja": "石田三成",
+        "ja_typings": [
+          "ishida mitsunari",
+          "ishidamitsunari"
+        ]
+      },
+      {
+        "en": "Tokugawa Ieyasu",
+        "ja": "徳川家康",
+        "ja_typings": [
+          "tokugawa ieyasu",
+          "tokugawaieyasu"
+        ]
+      },
+      {
+        "en": "Toyotomi Hideyoshi",
+        "ja": "豊臣秀吉",
+        "ja_typings": [
+          "toyotomi hideyoshi",
+          "toyotomihideyoshi"
+        ]
+      },
+      {
+        "en": "Mori Terumoto",
+        "ja": "毛利輝元",
+        "ja_typings": [
+          "mori terumoto",
+          "moriterumoto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03112",
+    "image_path": null,
+    "question_text": {
+      "en": "Who commanded the Western Army at the Battle of Sekigahara?",
+      "ja": "関ヶ原で西軍を率いた武将は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Itagaki Taisuke",
+        "ja": "板垣退助",
+        "ja_typings": [
+          "itagaki taisuke",
+          "itagakitaisuke"
+        ]
+      },
+      {
+        "en": "Okuma Shigenobu",
+        "ja": "大隈重信",
+        "ja_typings": [
+          "ookuma shigenobu",
+          "ookumashigenobu"
+        ]
+      },
+      {
+        "en": "Yamagata Aritomo",
+        "ja": "山県有朋",
+        "ja_typings": [
+          "yamagata aritomo",
+          "yamagataaritomo"
+        ]
+      },
+      {
+        "en": "Sun Yat-sen",
+        "ja": "孫文",
+        "ja_typings": [
+          "sonbun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03113",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led the Meiji Restoration government and founded the Liberal Party?",
+      "ja": "明治政府の元勲で自由党を結成したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Izumo",
+        "ja": "出雲",
+        "ja_typings": [
+          "izumo"
+        ]
+      },
+      {
+        "en": "Yamato Court",
+        "ja": "大和朝廷",
+        "ja_typings": [
+          "yamato choutei",
+          "yamatochoutei"
+        ]
+      },
+      {
+        "en": "Mughal Empire",
+        "ja": "ムガル帝国",
+        "ja_typings": [
+          "mugaru teikoku",
+          "mugaruteikoku"
+        ]
+      },
+      {
+        "en": "Corsica",
+        "ja": "コルシカ島",
+        "ja_typings": [
+          "korushika tou",
+          "korushikatou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03114",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient province of Japan houses the famous grand shrine?",
+      "ja": "出雲大社のある日本の旧国名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "John Adams",
+        "ja": "ジョン・アダムズ",
+        "ja_typings": [
+          "jon/adamuzu"
+        ]
+      },
+      {
+        "en": "Thomas Jefferson",
+        "ja": "ジェファーソン",
+        "ja_typings": [
+          "jefaason",
+          "jefa-son"
+        ]
+      },
+      {
+        "en": "George Washington",
+        "ja": "ジョージ・ワシントン",
+        "ja_typings": [
+          "jo-ji/washinton"
+        ]
+      },
+      {
+        "en": "Ulysses S. Grant",
+        "ja": "グラント",
+        "ja_typings": [
+          "guranto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03115",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the second president of the United States?",
+      "ja": "アメリカ合衆国の第2代大統領は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "John Calvin",
+        "ja": "カルヴァン",
+        "ja_typings": [
+          "karuvan"
+        ]
+      },
+      {
+        "en": "Huldrych Zwingli",
+        "ja": "ツヴィングリ",
+        "ja_typings": [
+          "tsuvinguri"
+        ]
+      },
+      {
+        "en": "Erasmus",
+        "ja": "エラスムス",
+        "ja_typings": [
+          "erasumusu"
+        ]
+      },
+      {
+        "en": "Martin Luther King Jr.",
+        "ja": "キング牧師",
+        "ja_typings": [
+          "kingu bokushi",
+          "kingubokushi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03116",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French theologian led the Reformation in Geneva?",
+      "ja": "ジュネーブで宗教改革を率いたフランス出身の神学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "John Glenn",
+        "ja": "ジョン・グレン",
+        "ja_typings": [
+          "jon/guren"
+        ]
+      },
+      {
+        "en": "Buzz Aldrin",
+        "ja": "オルドリン",
+        "ja_typings": [
+          "orudorin"
+        ]
+      },
+      {
+        "en": "Yuri Gagarin",
+        "ja": "ガガーリン",
+        "ja_typings": [
+          "gagaarin",
+          "gaga-rin"
+        ]
+      },
+      {
+        "en": "Neil Armstrong",
+        "ja": "アームストロング",
+        "ja_typings": [
+          "aamusutorongu",
+          "a-musutorongu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03117",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first American to orbit Earth?",
+      "ja": "アメリカ人で初めて地球周回飛行をしたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Leon Trotsky",
+        "ja": "トロツキー",
+        "ja_typings": [
+          "torotsukii",
+          "torotsuki-"
+        ]
+      },
+      {
+        "en": "Alexander Kerensky",
+        "ja": "ケレンスキー",
+        "ja_typings": [
+          "kerensukii",
+          "kerensuki-"
+        ]
+      },
+      {
+        "en": "Joseph Stalin",
+        "ja": "スターリン",
+        "ja_typings": [
+          "sutaarin",
+          "suta-rin"
+        ]
+      },
+      {
+        "en": "Deng Xiaoping",
+        "ja": "鄧小平",
+        "ja_typings": [
+          "toushouhei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03118",
+    "image_path": null,
+    "question_text": {
+      "en": "Who founded the Red Army and was exiled by Stalin?",
+      "ja": "赤軍を組織しスターリンに追放された革命家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Little Boy",
+        "ja": "リトルボーイ",
+        "ja_typings": [
+          "ritorubo-i"
+        ]
+      },
+      {
+        "en": "Bockscar",
+        "ja": "ボックスカー",
+        "ja_typings": [
+          "bokkusukaa",
+          "bokkusuka-"
+        ]
+      },
+      {
+        "en": "Memphis Belle",
+        "ja": "メンフィス・ベル",
+        "ja_typings": [
+          "menfisu/beru"
+        ]
+      },
+      {
+        "en": "Fat Man",
+        "ja": "ファットマン",
+        "ja_typings": [
+          "fattoman"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03119",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the codename of the atomic bomb dropped on Hiroshima?",
+      "ja": "広島に投下された原爆のコードネームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Maginot Line",
+        "ja": "マジノ線",
+        "ja_typings": [
+          "majino sen",
+          "majinosen"
+        ]
+      },
+      {
+        "en": "Iron Curtain",
+        "ja": "鉄のカーテン",
+        "ja_typings": [
+          "tetsu no kaaten",
+          "tetsunokaaten"
+        ]
+      },
+      {
+        "en": "Great Wall of China",
+        "ja": "万里の長城",
+        "ja_typings": [
+          "banri no choujou",
+          "banrinochoujou"
+        ]
+      },
+      {
+        "en": "Hundred Years' War",
+        "ja": "百年戦争",
+        "ja_typings": [
+          "hyakunen sensou",
+          "hyakunensensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03120",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French defensive fortification was built before WWII?",
+      "ja": "第二次大戦前にフランスが築いた防衛線は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Malcolm X",
+        "ja": "マルコムX",
+        "ja_typings": [
+          "marukomux",
+          "marukomuekusu"
+        ]
+      },
+      {
+        "en": "Martin Luther King Jr.",
+        "ja": "キング牧師",
+        "ja_typings": [
+          "kingu bokushi",
+          "kingubokushi"
+        ]
+      },
+      {
+        "en": "Harriet Tubman",
+        "ja": "ハリエット・タブマン",
+        "ja_typings": [
+          "harietto/tabuman"
+        ]
+      },
+      {
+        "en": "Ulysses S. Grant",
+        "ja": "グラント",
+        "ja_typings": [
+          "guranto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03121",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Nation of Islam minister assassinated in 1965?",
+      "ja": "1965年に暗殺されたネーション・オブ・イスラムの活動家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Marie Antoinette",
+        "ja": "マリー・アントワネット",
+        "ja_typings": [
+          "mari-/antowanetto"
+        ]
+      },
+      {
+        "en": "Catherine de' Medici",
+        "ja": "カトリーヌ・ド・メディシス",
+        "ja_typings": [
+          "katori-nu/do/medishisu"
+        ]
+      },
+      {
+        "en": "Eleanor of Aquitaine",
+        "ja": "エレオノール",
+        "ja_typings": [
+          "ereonooru",
+          "ereono-ru"
+        ]
+      },
+      {
+        "en": "Golda Meir",
+        "ja": "ゴルダ・メイア",
+        "ja_typings": [
+          "goruda/meia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03122",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the queen guillotined during the French Revolution?",
+      "ja": "フランス革命で処刑された王妃は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Marquis de Lafayette",
+        "ja": "ラファイエット",
+        "ja_typings": [
+          "rafaietto"
+        ]
+      },
+      {
+        "en": "Talleyrand",
+        "ja": "タレーラン",
+        "ja_typings": [
+          "tareeran",
+          "tare-ran"
+        ]
+      },
+      {
+        "en": "Maximilien Robespierre",
+        "ja": "ロベスピエール",
+        "ja_typings": [
+          "robesupieeru",
+          "robesupie-ru"
+        ]
+      },
+      {
+        "en": "Napoleon III",
+        "ja": "ナポレオン3世",
+        "ja_typings": [
+          "naporeon 3 sei",
+          "naporeonsansei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03123",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French nobleman aided the American Revolution as a general?",
+      "ja": "アメリカ独立戦争で将軍として参戦したフランス貴族は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Martin Luther King Jr.",
+        "ja": "キング牧師",
+        "ja_typings": [
+          "kingu bokushi",
+          "kingubokushi"
+        ]
+      },
+      {
+        "en": "Malcolm X",
+        "ja": "マルコムX",
+        "ja_typings": [
+          "marukomux",
+          "marukomuekusu"
+        ]
+      },
+      {
+        "en": "Harriet Tubman",
+        "ja": "ハリエット・タブマン",
+        "ja_typings": [
+          "harietto/tabuman"
+        ]
+      },
+      {
+        "en": "Buzz Aldrin",
+        "ja": "オルドリン",
+        "ja_typings": [
+          "orudorin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03124",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led the US civil rights movement and gave the 'I Have a Dream' speech?",
+      "ja": "「私には夢がある」演説を行った米公民権運動家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Maximilien Robespierre",
+        "ja": "ロベスピエール",
+        "ja_typings": [
+          "robesupieeru",
+          "robesupie-ru"
+        ]
+      },
+      {
+        "en": "Marquis de Lafayette",
+        "ja": "ラファイエット",
+        "ja_typings": [
+          "rafaietto"
+        ]
+      },
+      {
+        "en": "Talleyrand",
+        "ja": "タレーラン",
+        "ja_typings": [
+          "tareeran",
+          "tare-ran"
+        ]
+      },
+      {
+        "en": "Napoleon III",
+        "ja": "ナポレオン3世",
+        "ja_typings": [
+          "naporeon 3 sei",
+          "naporeonsansei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03125",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led the radical phase of the French Revolution's Reign of Terror?",
+      "ja": "フランス革命の恐怖政治を主導した人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Memphis Belle",
+        "ja": "メンフィス・ベル",
+        "ja_typings": [
+          "menfisu/beru"
+        ]
+      },
+      {
+        "en": "Bockscar",
+        "ja": "ボックスカー",
+        "ja_typings": [
+          "bokkusukaa",
+          "bokkusuka-"
+        ]
+      },
+      {
+        "en": "Little Boy",
+        "ja": "リトルボーイ",
+        "ja_typings": [
+          "ritorubo-i"
+        ]
+      },
+      {
+        "en": "Enola Gay",
+        "ja": "エノラ・ゲイ",
+        "ja_typings": [
+          "enora/gei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03126",
+    "image_path": null,
+    "question_text": {
+      "en": "Which B-17 bomber became famous for completing 25 WWII missions?",
+      "ja": "第二次大戦で25回出撃を生き延びた有名なB-17は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Menachem Begin",
+        "ja": "メナヘム・ベギン",
+        "ja_typings": [
+          "menahemu/begin"
+        ]
+      },
+      {
+        "en": "Yitzhak Rabin",
+        "ja": "イツハク・ラビン",
+        "ja_typings": [
+          "itsuhaku/rabin"
+        ]
+      },
+      {
+        "en": "Golda Meir",
+        "ja": "ゴルダ・メイア",
+        "ja_typings": [
+          "goruda/meia"
+        ]
+      },
+      {
+        "en": "Muhammad Ali Jinnah",
+        "ja": "ジンナー",
+        "ja_typings": [
+          "jinnaa",
+          "jinnna-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03127",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Likud Prime Minister of Israel who signed Camp David?",
+      "ja": "キャンプ・デービッド合意を結んだイスラエルのリクード首相は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Michael Faraday",
+        "ja": "ファラデー",
+        "ja_typings": [
+          "faradee",
+          "farade-"
+        ]
+      },
+      {
+        "en": "Thomas Edison",
+        "ja": "エジソン",
+        "ja_typings": [
+          "ejison"
+        ]
+      },
+      {
+        "en": "Isaac Newton",
+        "ja": "ニュートン",
+        "ja_typings": [
+          "nyuuton",
+          "nyu-ton"
+        ]
+      },
+      {
+        "en": "Galileo Galilei",
+        "ja": "ガリレオ・ガリレイ",
+        "ja_typings": [
+          "garireo/garirei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03128",
+    "image_path": null,
+    "question_text": {
+      "en": "Who discovered electromagnetic induction in 1831?",
+      "ja": "1831年に電磁誘導を発見した人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mori Terumoto",
+        "ja": "毛利輝元",
+        "ja_typings": [
+          "mori terumoto",
+          "moriterumoto"
+        ]
+      },
+      {
+        "en": "Ishida Mitsunari",
+        "ja": "石田三成",
+        "ja_typings": [
+          "ishida mitsunari",
+          "ishidamitsunari"
+        ]
+      },
+      {
+        "en": "Tokugawa Ieyasu",
+        "ja": "徳川家康",
+        "ja_typings": [
+          "tokugawa ieyasu",
+          "tokugawaieyasu"
+        ]
+      },
+      {
+        "en": "Uesugi Kagekatsu",
+        "ja": "上杉景勝",
+        "ja_typings": [
+          "uesugi kagekatsu",
+          "uesugikagekatsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03129",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Mori clan leader and titular head of the Western Army at Sekigahara?",
+      "ja": "関ヶ原で西軍総大将を務めた毛利家当主は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mughal Empire",
+        "ja": "ムガル帝国",
+        "ja_typings": [
+          "mugaru teikoku",
+          "mugaruteikoku"
+        ]
+      },
+      {
+        "en": "Safavid Empire",
+        "ja": "サファヴィー朝",
+        "ja_typings": [
+          "safavii chou",
+          "safaviichou"
+        ]
+      },
+      {
+        "en": "Abbasid Caliphate",
+        "ja": "アッバース朝",
+        "ja_typings": [
+          "abbaasu chou",
+          "abbaasuchou"
+        ]
+      },
+      {
+        "en": "Ottoman Empire",
+        "ja": "オスマン帝国",
+        "ja_typings": [
+          "osuman teikoku",
+          "osumanteikoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03130",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Islamic empire ruled India from 1526 to the 19th century?",
+      "ja": "1526年から19世紀までインドを支配したイスラム王朝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Muhammad Ali Jinnah",
+        "ja": "ジンナー",
+        "ja_typings": [
+          "jinnaa",
+          "jinnna-"
+        ]
+      },
+      {
+        "en": "Rabindranath Tagore",
+        "ja": "タゴール",
+        "ja_typings": [
+          "tagooru",
+          "tago-ru"
+        ]
+      },
+      {
+        "en": "Menachem Begin",
+        "ja": "メナヘム・ベギン",
+        "ja_typings": [
+          "menahemu/begin"
+        ]
+      },
+      {
+        "en": "Sun Yat-sen",
+        "ja": "孫文",
+        "ja_typings": [
+          "sonbun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03131",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the founder of Pakistan?",
+      "ja": "パキスタン建国の父と呼ばれる人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Munich Agreement",
+        "ja": "ミュンヘン会談",
+        "ja_typings": [
+          "myunhen kaidan",
+          "myunhenkaidan"
+        ]
+      },
+      {
+        "en": "Peace of Westphalia",
+        "ja": "ウェストファリア条約",
+        "ja_typings": [
+          "uesutofaria jouyaku",
+          "uesutofariajouyaku"
+        ]
+      },
+      {
+        "en": "Potsdam Declaration",
+        "ja": "ポツダム宣言",
+        "ja_typings": [
+          "potsudamu sengen",
+          "potsudamusengen"
+        ]
+      },
+      {
+        "en": "Treaty of Utrecht",
+        "ja": "ユトレヒト条約",
+        "ja_typings": [
+          "yutorehito jouyaku",
+          "yutorehitojouyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03132",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1938 pact ceded the Sudetenland to Nazi Germany?",
+      "ja": "1938年にズデーテン地方をナチスに割譲した協定は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Na",
+        "ja": "ナトリウム",
+        "ja_typings": [
+          "natoriumu"
+        ]
+      },
+      {
+        "en": "Iron Curtain",
+        "ja": "鉄のカーテン",
+        "ja_typings": [
+          "tetsu no kaaten",
+          "tetsunokaaten"
+        ]
+      },
+      {
+        "en": "Nile River",
+        "ja": "ナイル川",
+        "ja_typings": [
+          "nairu gawa",
+          "nairugawa"
+        ]
+      },
+      {
+        "en": "Cannon",
+        "ja": "大砲",
+        "ja_typings": [
+          "taihou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03133",
+    "image_path": null,
+    "question_text": {
+      "en": "Which chemical element has the symbol Na?",
+      "ja": "元素記号Naで表される元素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Napoleon III",
+        "ja": "ナポレオン3世",
+        "ja_typings": [
+          "naporeon 3 sei",
+          "naporeonsansei"
+        ]
+      },
+      {
+        "en": "Maximilien Robespierre",
+        "ja": "ロベスピエール",
+        "ja_typings": [
+          "robesupieeru",
+          "robesupie-ru"
+        ]
+      },
+      {
+        "en": "Talleyrand",
+        "ja": "タレーラン",
+        "ja_typings": [
+          "tareeran",
+          "tare-ran"
+        ]
+      },
+      {
+        "en": "Marquis de Lafayette",
+        "ja": "ラファイエット",
+        "ja_typings": [
+          "rafaietto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03134",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Emperor of France during the Second Empire?",
+      "ja": "フランス第二帝政の皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nicolaus Copernicus",
+        "ja": "コペルニクス",
+        "ja_typings": [
+          "koperunikusu"
+        ]
+      },
+      {
+        "en": "Galileo Galilei",
+        "ja": "ガリレオ・ガリレイ",
+        "ja_typings": [
+          "garireo/garirei"
+        ]
+      },
+      {
+        "en": "Isaac Newton",
+        "ja": "ニュートン",
+        "ja_typings": [
+          "nyuuton",
+          "nyu-ton"
+        ]
+      },
+      {
+        "en": "Pythagoras",
+        "ja": "ピタゴラス",
+        "ja_typings": [
+          "pitagorasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03135",
+    "image_path": null,
+    "question_text": {
+      "en": "Who proposed the heliocentric model of the solar system in the 16th century?",
+      "ja": "16世紀に太陽中心説を唱えた人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nile River",
+        "ja": "ナイル川",
+        "ja_typings": [
+          "nairu gawa",
+          "nairugawa"
+        ]
+      },
+      {
+        "en": "Rhine River",
+        "ja": "ライン川",
+        "ja_typings": [
+          "rain gawa",
+          "raingawa"
+        ]
+      },
+      {
+        "en": "Tiber River",
+        "ja": "テヴェレ川",
+        "ja_typings": [
+          "tevere gawa",
+          "teveregawa"
+        ]
+      },
+      {
+        "en": "Great Wall of China",
+        "ja": "万里の長城",
+        "ja_typings": [
+          "banri no choujou",
+          "banrinochoujou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03136",
+    "image_path": null,
+    "question_text": {
+      "en": "Which African river was central to ancient Egyptian civilization?",
+      "ja": "古代エジプト文明を育んだアフリカの大河は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nixon and Brezhnev",
+        "ja": "ニクソンとブレジネフ",
+        "ja_typings": [
+          "nikusontoburejinefu"
+        ]
+      },
+      {
+        "en": "Reagan and Gorbachev",
+        "ja": "レーガンとゴルバチョフ",
+        "ja_typings": [
+          "re-gantogorubachofu"
+        ]
+      },
+      {
+        "en": "Truman and Stalin",
+        "ja": "トルーマンとスターリン",
+        "ja_typings": [
+          "toru-mantosuta-rin"
+        ]
+      },
+      {
+        "en": "Munich Agreement",
+        "ja": "ミュンヘン会談",
+        "ja_typings": [
+          "myunhen kaidan",
+          "myunhenkaidan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03137",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1972 detente summit was held in Moscow between US and USSR?",
+      "ja": "1972年にモスクワで行われた米ソ緊張緩和の首脳会談は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Okuma Shigenobu",
+        "ja": "大隈重信",
+        "ja_typings": [
+          "ookuma shigenobu",
+          "ookumashigenobu"
+        ]
+      },
+      {
+        "en": "Itagaki Taisuke",
+        "ja": "板垣退助",
+        "ja_typings": [
+          "itagaki taisuke",
+          "itagakitaisuke"
+        ]
+      },
+      {
+        "en": "Yamagata Aritomo",
+        "ja": "山県有朋",
+        "ja_typings": [
+          "yamagata aritomo",
+          "yamagataaritomo"
+        ]
+      },
+      {
+        "en": "Tokugawa Ieyasu",
+        "ja": "徳川家康",
+        "ja_typings": [
+          "tokugawa ieyasu",
+          "tokugawaieyasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03138",
+    "image_path": null,
+    "question_text": {
+      "en": "Who founded Waseda University and served as Prime Minister of Japan?",
+      "ja": "早稲田大学を創設し首相も務めた人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Otto I",
+        "ja": "オットー1世",
+        "ja_typings": [
+          "ottoo 1 sei",
+          "ottooissei"
+        ]
+      },
+      {
+        "en": "Clovis",
+        "ja": "クロヴィス",
+        "ja_typings": [
+          "kurovisu"
+        ]
+      },
+      {
+        "en": "Pepin the Short",
+        "ja": "ピピン",
+        "ja_typings": [
+          "pipin"
+        ]
+      },
+      {
+        "en": "Henry VIII",
+        "ja": "ヘンリー8世",
+        "ja_typings": [
+          "henrii 8 sei",
+          "henriihassei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03139",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was crowned the first Holy Roman Emperor in 962?",
+      "ja": "962年に神聖ローマ皇帝に戴冠した君主は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Palermo Stone",
+        "ja": "パレルモ石",
+        "ja_typings": [
+          "parerumo seki",
+          "parerumoseki"
+        ]
+      },
+      {
+        "en": "Code of Hammurabi stele",
+        "ja": "ハンムラビ法典碑",
+        "ja_typings": [
+          "hanmurabi houten hi",
+          "hanmurabihoutenhi"
+        ]
+      },
+      {
+        "en": "Behistun Inscription",
+        "ja": "ベヒストゥン碑文",
+        "ja_typings": [
+          "behisutun hibun",
+          "behisutunhibun"
+        ]
+      },
+      {
+        "en": "Rosetta Stone",
+        "ja": "ロゼッタストーン",
+        "ja_typings": [
+          "rozettasuto-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03140",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Egyptian stone records the early dynasties' kings?",
+      "ja": "古代エジプト初期王朝史を刻む石碑は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Peace of Westphalia",
+        "ja": "ウェストファリア条約",
+        "ja_typings": [
+          "uesutofaria jouyaku",
+          "uesutofariajouyaku"
+        ]
+      },
+      {
+        "en": "Treaty of Utrecht",
+        "ja": "ユトレヒト条約",
+        "ja_typings": [
+          "yutorehito jouyaku",
+          "yutorehitojouyaku"
+        ]
+      },
+      {
+        "en": "Treaty of San Francisco",
+        "ja": "サンフランシスコ平和条約",
+        "ja_typings": [
+          "san furanshisuko heiwa jouyaku",
+          "sanfuranshisukoheiwajouyaku"
+        ]
+      },
+      {
+        "en": "Munich Agreement",
+        "ja": "ミュンヘン会談",
+        "ja_typings": [
+          "myunhen kaidan",
+          "myunhenkaidan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03141",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1648 treaty ended the Thirty Years' War?",
+      "ja": "1648年に三十年戦争を終結させた条約は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pepin the Short",
+        "ja": "ピピン",
+        "ja_typings": [
+          "pipin"
+        ]
+      },
+      {
+        "en": "Clovis",
+        "ja": "クロヴィス",
+        "ja_typings": [
+          "kurovisu"
+        ]
+      },
+      {
+        "en": "Otto I",
+        "ja": "オットー1世",
+        "ja_typings": [
+          "ottoo 1 sei",
+          "ottooissei"
+        ]
+      },
+      {
+        "en": "Henry VIII",
+        "ja": "ヘンリー8世",
+        "ja_typings": [
+          "henrii 8 sei",
+          "henriihassei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03142",
+    "image_path": null,
+    "question_text": {
+      "en": "Who founded the Carolingian dynasty by deposing the last Merovingian king?",
+      "ja": "メロヴィング朝最後の王を廃しカロリング朝を開いたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Plato",
+        "ja": "プラトン",
+        "ja_typings": [
+          "puraton"
+        ]
+      },
+      {
+        "en": "Socrates",
+        "ja": "ソクラテス",
+        "ja_typings": [
+          "sokuratesu"
+        ]
+      },
+      {
+        "en": "Pythagoras",
+        "ja": "ピタゴラス",
+        "ja_typings": [
+          "pitagorasu"
+        ]
+      },
+      {
+        "en": "Thucydides",
+        "ja": "トゥキディデス",
+        "ja_typings": [
+          "tukidideesu",
+          "tukididesu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03143",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Greek philosopher founded the Academy and wrote 'The Republic'?",
+      "ja": "アカデメイアを開き『国家』を著したギリシャの哲学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Potsdam Declaration",
+        "ja": "ポツダム宣言",
+        "ja_typings": [
+          "potsudamu sengen",
+          "potsudamusengen"
+        ]
+      },
+      {
+        "en": "Treaty of San Francisco",
+        "ja": "サンフランシスコ平和条約",
+        "ja_typings": [
+          "san furanshisuko heiwa jouyaku",
+          "sanfuranshisukoheiwajouyaku"
+        ]
+      },
+      {
+        "en": "Harris Treaty",
+        "ja": "日米修好通商条約",
+        "ja_typings": [
+          "nichibei shuukou tsuushou jouyaku",
+          "nichibeishuukoutsuushoujouyaku"
+        ]
+      },
+      {
+        "en": "Munich Agreement",
+        "ja": "ミュンヘン会談",
+        "ja_typings": [
+          "myunhen kaidan",
+          "myunhenkaidan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03144",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1945 declaration demanded Japan's unconditional surrender?",
+      "ja": "1945年に日本に無条件降伏を求めた宣言は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pythagoras",
+        "ja": "ピタゴラス",
+        "ja_typings": [
+          "pitagorasu"
+        ]
+      },
+      {
+        "en": "Plato",
+        "ja": "プラトン",
+        "ja_typings": [
+          "puraton"
+        ]
+      },
+      {
+        "en": "Socrates",
+        "ja": "ソクラテス",
+        "ja_typings": [
+          "sokuratesu"
+        ]
+      },
+      {
+        "en": "Hesiod",
+        "ja": "ヘシオドス",
+        "ja_typings": [
+          "heshiodosu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03145",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Greek mathematician is famous for a theorem about right triangles?",
+      "ja": "直角三角形の定理で知られるギリシャの数学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rabindranath Tagore",
+        "ja": "タゴール",
+        "ja_typings": [
+          "tagooru",
+          "tago-ru"
+        ]
+      },
+      {
+        "en": "Muhammad Ali Jinnah",
+        "ja": "ジンナー",
+        "ja_typings": [
+          "jinnaa",
+          "jinnna-"
+        ]
+      },
+      {
+        "en": "Homer",
+        "ja": "ホメロス",
+        "ja_typings": [
+          "homerosu"
+        ]
+      },
+      {
+        "en": "Plato",
+        "ja": "プラトン",
+        "ja_typings": [
+          "puraton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03146",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Bengali poet who won the 1913 Nobel Prize in Literature?",
+      "ja": "1913年にノーベル文学賞を受けたベンガルの詩人は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Reagan and Gorbachev",
+        "ja": "レーガンとゴルバチョフ",
+        "ja_typings": [
+          "re-gantogorubachofu"
+        ]
+      },
+      {
+        "en": "Nixon and Brezhnev",
+        "ja": "ニクソンとブレジネフ",
+        "ja_typings": [
+          "nikusontoburejinefu"
+        ]
+      },
+      {
+        "en": "Truman and Stalin",
+        "ja": "トルーマンとスターリン",
+        "ja_typings": [
+          "toru-mantosuta-rin"
+        ]
+      },
+      {
+        "en": "Munich Agreement",
+        "ja": "ミュンヘン会談",
+        "ja_typings": [
+          "myunhen kaidan",
+          "myunhenkaidan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03147",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1985-88 summit thawed the Cold War between US and USSR?",
+      "ja": "1985-88年に冷戦終結に向かった米ソ首脳会談は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rhine River",
+        "ja": "ライン川",
+        "ja_typings": [
+          "rain gawa",
+          "raingawa"
+        ]
+      },
+      {
+        "en": "Nile River",
+        "ja": "ナイル川",
+        "ja_typings": [
+          "nairu gawa",
+          "nairugawa"
+        ]
+      },
+      {
+        "en": "Tiber River",
+        "ja": "テヴェレ川",
+        "ja_typings": [
+          "tevere gawa",
+          "teveregawa"
+        ]
+      },
+      {
+        "en": "Maginot Line",
+        "ja": "マジノ線",
+        "ja_typings": [
+          "majino sen",
+          "majinosen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03148",
+    "image_path": null,
+    "question_text": {
+      "en": "Which European river flows through Germany and the Netherlands to the North Sea?",
+      "ja": "ドイツからオランダを経て北海に注ぐ欧州の大河は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Safavid Empire",
+        "ja": "サファヴィー朝",
+        "ja_typings": [
+          "safavii chou",
+          "safaviichou"
+        ]
+      },
+      {
+        "en": "Mughal Empire",
+        "ja": "ムガル帝国",
+        "ja_typings": [
+          "mugaru teikoku",
+          "mugaruteikoku"
+        ]
+      },
+      {
+        "en": "Abbasid Caliphate",
+        "ja": "アッバース朝",
+        "ja_typings": [
+          "abbaasu chou",
+          "abbaasuchou"
+        ]
+      },
+      {
+        "en": "Yamato Court",
+        "ja": "大和朝廷",
+        "ja_typings": [
+          "yamato choutei",
+          "yamatochoutei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03149",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Persian Shia empire rose in 1501 in Iran?",
+      "ja": "1501年にイランで興ったシーア派ペルシア王朝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Salazar",
+        "ja": "サラザール",
+        "ja_typings": [
+          "sarazaaru",
+          "saraza-ru"
+        ]
+      },
+      {
+        "en": "Francisco Franco",
+        "ja": "フランコ",
+        "ja_typings": [
+          "furanko"
+        ]
+      },
+      {
+        "en": "Adolf Hitler",
+        "ja": "アドルフ・ヒトラー",
+        "ja_typings": [
+          "adorufu/hitora-"
+        ]
+      },
+      {
+        "en": "Joseph Stalin",
+        "ja": "スターリン",
+        "ja_typings": [
+          "sutaarin",
+          "suta-rin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03150",
+    "image_path": null,
+    "question_text": {
+      "en": "Who ruled Portugal as authoritarian leader during Estado Novo?",
+      "ja": "エスタド・ノヴォ体制下でポルトガルを統治したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sardinia",
+        "ja": "サルデーニャ島",
+        "ja_typings": [
+          "sarudeenya tou",
+          "sarudeenyatou"
+        ]
+      },
+      {
+        "en": "Corsica",
+        "ja": "コルシカ島",
+        "ja_typings": [
+          "korushika tou",
+          "korushikatou"
+        ]
+      },
+      {
+        "en": "Sicily",
+        "ja": "シチリア島",
+        "ja_typings": [
+          "shichiria tou",
+          "shichiriatou"
+        ]
+      },
+      {
+        "en": "Izumo",
+        "ja": "出雲",
+        "ja_typings": [
+          "izumo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03151",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian island was a kingdom that united Italy in the 19th century?",
+      "ja": "19世紀イタリア統一の核となった島の王国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Second Opium War",
+        "ja": "アロー戦争",
+        "ja_typings": [
+          "aroo sensou",
+          "aroosensou"
+        ]
+      },
+      {
+        "en": "Boxer Rebellion",
+        "ja": "義和団事件",
+        "ja_typings": [
+          "giwadan jiken",
+          "giwadanjiken"
+        ]
+      },
+      {
+        "en": "Taiping Rebellion",
+        "ja": "太平天国の乱",
+        "ja_typings": [
+          "taihei tengoku no ran",
+          "taiheitengokunoran"
+        ]
+      },
+      {
+        "en": "Hundred Years' War",
+        "ja": "百年戦争",
+        "ja_typings": [
+          "hyakunen sensou",
+          "hyakunensensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03152",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1856-60 war pitted Britain and France against Qing China?",
+      "ja": "1856-60年に英仏が清と戦った戦争は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Socrates",
+        "ja": "ソクラテス",
+        "ja_typings": [
+          "sokuratesu"
+        ]
+      },
+      {
+        "en": "Plato",
+        "ja": "プラトン",
+        "ja_typings": [
+          "puraton"
+        ]
+      },
+      {
+        "en": "Pythagoras",
+        "ja": "ピタゴラス",
+        "ja_typings": [
+          "pitagorasu"
+        ]
+      },
+      {
+        "en": "Hesiod",
+        "ja": "ヘシオドス",
+        "ja_typings": [
+          "heshiodosu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03153",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Greek philosopher was tried and executed in Athens?",
+      "ja": "アテネで死刑に処されたギリシャの哲学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sun Quan",
+        "ja": "孫権",
+        "ja_typings": [
+          "sonken"
+        ]
+      },
+      {
+        "en": "Cao Cao",
+        "ja": "曹操",
+        "ja_typings": [
+          "sousou"
+        ]
+      },
+      {
+        "en": "Zhuge Liang",
+        "ja": "諸葛亮",
+        "ja_typings": [
+          "shokatsuryou"
+        ]
+      },
+      {
+        "en": "Liu Bei",
+        "ja": "劉備",
+        "ja_typings": [
+          "ryuubi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03154",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the king of Wu during the Three Kingdoms period?",
+      "ja": "三国志で呉を建てた君主は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sun Yat-sen",
+        "ja": "孫文",
+        "ja_typings": [
+          "sonbun"
+        ]
+      },
+      {
+        "en": "Deng Xiaoping",
+        "ja": "鄧小平",
+        "ja_typings": [
+          "toushouhei"
+        ]
+      },
+      {
+        "en": "Zhou Enlai",
+        "ja": "周恩来",
+        "ja_typings": [
+          "shuuonrai"
+        ]
+      },
+      {
+        "en": "Cao Cao",
+        "ja": "曹操",
+        "ja_typings": [
+          "sousou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03155",
+    "image_path": null,
+    "question_text": {
+      "en": "Who founded the Republic of China in 1912?",
+      "ja": "1912年に中華民国を建てた人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Taiping Rebellion",
+        "ja": "太平天国の乱",
+        "ja_typings": [
+          "taihei tengoku no ran",
+          "taiheitengokunoran"
+        ]
+      },
+      {
+        "en": "Boxer Rebellion",
+        "ja": "義和団事件",
+        "ja_typings": [
+          "giwadan jiken",
+          "giwadanjiken"
+        ]
+      },
+      {
+        "en": "Second Opium War",
+        "ja": "アロー戦争",
+        "ja_typings": [
+          "aroo sensou",
+          "aroosensou"
+        ]
+      },
+      {
+        "en": "Wars of Religion",
+        "ja": "宗教戦争",
+        "ja_typings": [
+          "shuukyou sensou",
+          "shuukyousensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03156",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mid-19th century Christian-inspired uprising shook the Qing dynasty?",
+      "ja": "19世紀半ばに清朝を揺るがしたキリスト教系大反乱は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Takeda Shingen",
+        "ja": "武田信玄",
+        "ja_typings": [
+          "takeda shingen",
+          "takedashingen"
+        ]
+      },
+      {
+        "en": "Uesugi Kagekatsu",
+        "ja": "上杉景勝",
+        "ja_typings": [
+          "uesugi kagekatsu",
+          "uesugikagekatsu"
+        ]
+      },
+      {
+        "en": "Ishida Mitsunari",
+        "ja": "石田三成",
+        "ja_typings": [
+          "ishida mitsunari",
+          "ishidamitsunari"
+        ]
+      },
+      {
+        "en": "Tokugawa Ieyasu",
+        "ja": "徳川家康",
+        "ja_typings": [
+          "tokugawa ieyasu",
+          "tokugawaieyasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03157",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Kai daimyo nicknamed 'Tiger of Kai' in Sengoku Japan?",
+      "ja": "甲斐の虎と呼ばれた戦国大名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Talleyrand",
+        "ja": "タレーラン",
+        "ja_typings": [
+          "tareeran",
+          "tare-ran"
+        ]
+      },
+      {
+        "en": "Marquis de Lafayette",
+        "ja": "ラファイエット",
+        "ja_typings": [
+          "rafaietto"
+        ]
+      },
+      {
+        "en": "Maximilien Robespierre",
+        "ja": "ロベスピエール",
+        "ja_typings": [
+          "robesupieeru",
+          "robesupie-ru"
+        ]
+      },
+      {
+        "en": "Napoleon III",
+        "ja": "ナポレオン3世",
+        "ja_typings": [
+          "naporeon 3 sei",
+          "naporeonsansei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03158",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French diplomat served Napoleon and represented France at Vienna?",
+      "ja": "ナポレオンに仕えウィーン会議でフランス代表となった外交官は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thirty Years' War",
+        "ja": "三十年戦争",
+        "ja_typings": [
+          "sanjuunen sensou",
+          "sanjuunensensou"
+        ]
+      },
+      {
+        "en": "Hundred Years' War",
+        "ja": "百年戦争",
+        "ja_typings": [
+          "hyakunen sensou",
+          "hyakunensensou"
+        ]
+      },
+      {
+        "en": "Wars of Religion",
+        "ja": "宗教戦争",
+        "ja_typings": [
+          "shuukyou sensou",
+          "shuukyousensou"
+        ]
+      },
+      {
+        "en": "Boxer Rebellion",
+        "ja": "義和団事件",
+        "ja_typings": [
+          "giwadan jiken",
+          "giwadanjiken"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03159",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1618-1648 war devastated Central Europe over religion and politics?",
+      "ja": "1618-1648年に中欧を荒廃させた宗教戦争は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thomas Edison",
+        "ja": "エジソン",
+        "ja_typings": [
+          "ejison"
+        ]
+      },
+      {
+        "en": "Michael Faraday",
+        "ja": "ファラデー",
+        "ja_typings": [
+          "faradee",
+          "farade-"
+        ]
+      },
+      {
+        "en": "Isaac Newton",
+        "ja": "ニュートン",
+        "ja_typings": [
+          "nyuuton",
+          "nyu-ton"
+        ]
+      },
+      {
+        "en": "Galileo Galilei",
+        "ja": "ガリレオ・ガリレイ",
+        "ja_typings": [
+          "garireo/garirei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03160",
+    "image_path": null,
+    "question_text": {
+      "en": "Who invented the practical incandescent light bulb?",
+      "ja": "実用的な白熱電球を発明した人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thomas Jefferson",
+        "ja": "ジェファーソン",
+        "ja_typings": [
+          "jefaason",
+          "jefa-son"
+        ]
+      },
+      {
+        "en": "John Adams",
+        "ja": "ジョン・アダムズ",
+        "ja_typings": [
+          "jon/adamuzu"
+        ]
+      },
+      {
+        "en": "George Washington",
+        "ja": "ジョージ・ワシントン",
+        "ja_typings": [
+          "jo-ji/washinton"
+        ]
+      },
+      {
+        "en": "Benjamin Franklin",
+        "ja": "フランクリン",
+        "ja_typings": [
+          "furankurin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03161",
+    "image_path": null,
+    "question_text": {
+      "en": "Who authored the US Declaration of Independence and became 3rd president?",
+      "ja": "米独立宣言を起草し第3代大統領となったのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thucydides",
+        "ja": "トゥキディデス",
+        "ja_typings": [
+          "tukidideesu",
+          "tukididesu"
+        ]
+      },
+      {
+        "en": "Homer",
+        "ja": "ホメロス",
+        "ja_typings": [
+          "homerosu"
+        ]
+      },
+      {
+        "en": "Hesiod",
+        "ja": "ヘシオドス",
+        "ja_typings": [
+          "heshiodosu"
+        ]
+      },
+      {
+        "en": "Plato",
+        "ja": "プラトン",
+        "ja_typings": [
+          "puraton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03162",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Greek historian wrote 'History of the Peloponnesian War'?",
+      "ja": "『ペロポネソス戦争史』を書いたギリシャの歴史家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tiber River",
+        "ja": "テヴェレ川",
+        "ja_typings": [
+          "tevere gawa",
+          "teveregawa"
+        ]
+      },
+      {
+        "en": "Rhine River",
+        "ja": "ライン川",
+        "ja_typings": [
+          "rain gawa",
+          "raingawa"
+        ]
+      },
+      {
+        "en": "Nile River",
+        "ja": "ナイル川",
+        "ja_typings": [
+          "nairu gawa",
+          "nairugawa"
+        ]
+      },
+      {
+        "en": "Great Wall of China",
+        "ja": "万里の長城",
+        "ja_typings": [
+          "banri no choujou",
+          "banrinochoujou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03163",
+    "image_path": null,
+    "question_text": {
+      "en": "Which river flows through Rome?",
+      "ja": "ローマを流れる川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Timur",
+        "ja": "ティムール",
+        "ja_typings": [
+          "timuuru",
+          "timu-ru"
+        ]
+      },
+      {
+        "en": "Clovis",
+        "ja": "クロヴィス",
+        "ja_typings": [
+          "kurovisu"
+        ]
+      },
+      {
+        "en": "Otto I",
+        "ja": "オットー1世",
+        "ja_typings": [
+          "ottoo 1 sei",
+          "ottooissei"
+        ]
+      },
+      {
+        "en": "Pepin the Short",
+        "ja": "ピピン",
+        "ja_typings": [
+          "pipin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03164",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Turco-Mongol conqueror who founded an empire in 14th-century Central Asia?",
+      "ja": "14世紀中央アジアに大帝国を築いたトルコ・モンゴル系の征服者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tokugawa Ieyasu",
+        "ja": "徳川家康",
+        "ja_typings": [
+          "tokugawa ieyasu",
+          "tokugawaieyasu"
+        ]
+      },
+      {
+        "en": "Toyotomi Hideyoshi",
+        "ja": "豊臣秀吉",
+        "ja_typings": [
+          "toyotomi hideyoshi",
+          "toyotomihideyoshi"
+        ]
+      },
+      {
+        "en": "Ishida Mitsunari",
+        "ja": "石田三成",
+        "ja_typings": [
+          "ishida mitsunari",
+          "ishidamitsunari"
+        ]
+      },
+      {
+        "en": "Takeda Shingen",
+        "ja": "武田信玄",
+        "ja_typings": [
+          "takeda shingen",
+          "takedashingen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03165",
+    "image_path": null,
+    "question_text": {
+      "en": "Who founded the Tokugawa shogunate after Sekigahara?",
+      "ja": "関ヶ原の戦い後に江戸幕府を開いた人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Townsend Harris",
+        "ja": "ハリス",
+        "ja_typings": [
+          "harisu"
+        ]
+      },
+      {
+        "en": "Adam Laxman",
+        "ja": "ラクスマン",
+        "ja_typings": [
+          "rakusuman"
+        ]
+      },
+      {
+        "en": "Yevfimiy Putyatin",
+        "ja": "プチャーチン",
+        "ja_typings": [
+          "puchaachin",
+          "pucha-chin"
+        ]
+      },
+      {
+        "en": "Thomas Jefferson",
+        "ja": "ジェファーソン",
+        "ja_typings": [
+          "jefaason",
+          "jefa-son"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03166",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first US consul to Japan in 1856?",
+      "ja": "1856年に初代米国総領事として来日した人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Toyotomi Hideyoshi",
+        "ja": "豊臣秀吉",
+        "ja_typings": [
+          "toyotomi hideyoshi",
+          "toyotomihideyoshi"
+        ]
+      },
+      {
+        "en": "Tokugawa Ieyasu",
+        "ja": "徳川家康",
+        "ja_typings": [
+          "tokugawa ieyasu",
+          "tokugawaieyasu"
+        ]
+      },
+      {
+        "en": "Ishida Mitsunari",
+        "ja": "石田三成",
+        "ja_typings": [
+          "ishida mitsunari",
+          "ishidamitsunari"
+        ]
+      },
+      {
+        "en": "Takeda Shingen",
+        "ja": "武田信玄",
+        "ja_typings": [
+          "takeda shingen",
+          "takedashingen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03167",
+    "image_path": null,
+    "question_text": {
+      "en": "Who unified Japan as Taiko in the late 16th century?",
+      "ja": "16世紀末に太閤として日本を統一した人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Treaty of San Francisco",
+        "ja": "サンフランシスコ平和条約",
+        "ja_typings": [
+          "san furanshisuko heiwa jouyaku",
+          "sanfuranshisukoheiwajouyaku"
+        ]
+      },
+      {
+        "en": "Harris Treaty",
+        "ja": "日米修好通商条約",
+        "ja_typings": [
+          "nichibei shuukou tsuushou jouyaku",
+          "nichibeishuukoutsuushoujouyaku"
+        ]
+      },
+      {
+        "en": "Potsdam Declaration",
+        "ja": "ポツダム宣言",
+        "ja_typings": [
+          "potsudamu sengen",
+          "potsudamusengen"
+        ]
+      },
+      {
+        "en": "Treaty of Utrecht",
+        "ja": "ユトレヒト条約",
+        "ja_typings": [
+          "yutorehito jouyaku",
+          "yutorehitojouyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03168",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1951 treaty ended the Allied occupation of Japan?",
+      "ja": "1951年に連合国の占領を終わらせた日本の条約は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Treaty of Utrecht",
+        "ja": "ユトレヒト条約",
+        "ja_typings": [
+          "yutorehito jouyaku",
+          "yutorehitojouyaku"
+        ]
+      },
+      {
+        "en": "Peace of Westphalia",
+        "ja": "ウェストファリア条約",
+        "ja_typings": [
+          "uesutofaria jouyaku",
+          "uesutofariajouyaku"
+        ]
+      },
+      {
+        "en": "Treaty of San Francisco",
+        "ja": "サンフランシスコ平和条約",
+        "ja_typings": [
+          "san furanshisuko heiwa jouyaku",
+          "sanfuranshisukoheiwajouyaku"
+        ]
+      },
+      {
+        "en": "Harris Treaty",
+        "ja": "日米修好通商条約",
+        "ja_typings": [
+          "nichibei shuukou tsuushou jouyaku",
+          "nichibeishuukoutsuushoujouyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03169",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1713 treaty ended the War of the Spanish Succession?",
+      "ja": "1713年にスペイン継承戦争を終結させた条約は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Truman and Stalin",
+        "ja": "トルーマンとスターリン",
+        "ja_typings": [
+          "toru-mantosuta-rin"
+        ]
+      },
+      {
+        "en": "Nixon and Brezhnev",
+        "ja": "ニクソンとブレジネフ",
+        "ja_typings": [
+          "nikusontoburejinefu"
+        ]
+      },
+      {
+        "en": "Reagan and Gorbachev",
+        "ja": "レーガンとゴルバチョフ",
+        "ja_typings": [
+          "re-gantogorubachofu"
+        ]
+      },
+      {
+        "en": "Munich Agreement",
+        "ja": "ミュンヘン会談",
+        "ja_typings": [
+          "myunhen kaidan",
+          "myunhenkaidan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03170",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1945 Potsdam meeting featured these Allied leaders?",
+      "ja": "1945年ポツダム会談で対面した米ソの指導者ペアは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "US Declaration of Independence",
+        "ja": "アメリカ独立宣言",
+        "ja_typings": [
+          "amerika dokuritsu sengen",
+          "amerikadokuritsusengen"
+        ]
+      },
+      {
+        "en": "Universal Declaration of Human Rights",
+        "ja": "世界人権宣言",
+        "ja_typings": [
+          "sekai jinken sengen",
+          "sekaijinkensengen"
+        ]
+      },
+      {
+        "en": "Potsdam Declaration",
+        "ja": "ポツダム宣言",
+        "ja_typings": [
+          "potsudamu sengen",
+          "potsudamusengen"
+        ]
+      },
+      {
+        "en": "Treaty of Utrecht",
+        "ja": "ユトレヒト条約",
+        "ja_typings": [
+          "yutorehito jouyaku",
+          "yutorehitojouyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03171",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1776 document declared American independence from Britain?",
+      "ja": "1776年に英国からの独立を宣した文書は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Uesugi Kagekatsu",
+        "ja": "上杉景勝",
+        "ja_typings": [
+          "uesugi kagekatsu",
+          "uesugikagekatsu"
+        ]
+      },
+      {
+        "en": "Mori Terumoto",
+        "ja": "毛利輝元",
+        "ja_typings": [
+          "mori terumoto",
+          "moriterumoto"
+        ]
+      },
+      {
+        "en": "Ishida Mitsunari",
+        "ja": "石田三成",
+        "ja_typings": [
+          "ishida mitsunari",
+          "ishidamitsunari"
+        ]
+      },
+      {
+        "en": "Takeda Shingen",
+        "ja": "武田信玄",
+        "ja_typings": [
+          "takeda shingen",
+          "takedashingen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03172",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Uesugi clan head who fought Tokugawa in 1600?",
+      "ja": "1600年に徳川と対立した上杉家当主は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ulysses S. Grant",
+        "ja": "グラント",
+        "ja_typings": [
+          "guranto"
+        ]
+      },
+      {
+        "en": "George Washington",
+        "ja": "ジョージ・ワシントン",
+        "ja_typings": [
+          "jo-ji/washinton"
+        ]
+      },
+      {
+        "en": "John Adams",
+        "ja": "ジョン・アダムズ",
+        "ja_typings": [
+          "jon/adamuzu"
+        ]
+      },
+      {
+        "en": "Thomas Jefferson",
+        "ja": "ジェファーソン",
+        "ja_typings": [
+          "jefaason",
+          "jefa-son"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03173",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Union general and 18th US President?",
+      "ja": "南北戦争の北軍将軍で第18代米大統領は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "United States",
+        "ja": "アメリカ合衆国",
+        "ja_typings": [
+          "amerika gasshuukoku",
+          "amerikagasshuukoku"
+        ]
+      },
+      {
+        "en": "France",
+        "ja": "フランス",
+        "ja_typings": [
+          "furansu"
+        ]
+      },
+      {
+        "en": "Germany",
+        "ja": "ドイツ",
+        "ja_typings": [
+          "doitsu"
+        ]
+      },
+      {
+        "en": "Yugoslavia",
+        "ja": "ユーゴスラビア",
+        "ja_typings": [
+          "yu-gosurabia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03174",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country gained independence on July 4, 1776?",
+      "ja": "1776年7月4日に独立を宣した国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Universal Declaration of Human Rights",
+        "ja": "世界人権宣言",
+        "ja_typings": [
+          "sekai jinken sengen",
+          "sekaijinkensengen"
+        ]
+      },
+      {
+        "en": "US Declaration of Independence",
+        "ja": "アメリカ独立宣言",
+        "ja_typings": [
+          "amerika dokuritsu sengen",
+          "amerikadokuritsusengen"
+        ]
+      },
+      {
+        "en": "Potsdam Declaration",
+        "ja": "ポツダム宣言",
+        "ja_typings": [
+          "potsudamu sengen",
+          "potsudamusengen"
+        ]
+      },
+      {
+        "en": "Peace of Westphalia",
+        "ja": "ウェストファリア条約",
+        "ja_typings": [
+          "uesutofaria jouyaku",
+          "uesutofariajouyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03175",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1948 UN document outlines fundamental human rights?",
+      "ja": "1948年に国連が採択した人権の基本文書は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wars of Religion",
+        "ja": "宗教戦争",
+        "ja_typings": [
+          "shuukyou sensou",
+          "shuukyousensou"
+        ]
+      },
+      {
+        "en": "Thirty Years' War",
+        "ja": "三十年戦争",
+        "ja_typings": [
+          "sanjuunen sensou",
+          "sanjuunensensou"
+        ]
+      },
+      {
+        "en": "Hundred Years' War",
+        "ja": "百年戦争",
+        "ja_typings": [
+          "hyakunen sensou",
+          "hyakunensensou"
+        ]
+      },
+      {
+        "en": "Second Opium War",
+        "ja": "アロー戦争",
+        "ja_typings": [
+          "aroo sensou",
+          "aroosensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03176",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 16th-17th century conflicts pitted Catholics against Protestants in France?",
+      "ja": "16-17世紀フランスでカトリックとプロテスタントが争った内戦は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yamagata Aritomo",
+        "ja": "山県有朋",
+        "ja_typings": [
+          "yamagata aritomo",
+          "yamagataaritomo"
+        ]
+      },
+      {
+        "en": "Itagaki Taisuke",
+        "ja": "板垣退助",
+        "ja_typings": [
+          "itagaki taisuke",
+          "itagakitaisuke"
+        ]
+      },
+      {
+        "en": "Okuma Shigenobu",
+        "ja": "大隈重信",
+        "ja_typings": [
+          "ookuma shigenobu",
+          "ookumashigenobu"
+        ]
+      },
+      {
+        "en": "Tokugawa Ieyasu",
+        "ja": "徳川家康",
+        "ja_typings": [
+          "tokugawa ieyasu",
+          "tokugawaieyasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03177",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Meiji-era army marshal and twice Prime Minister of Japan?",
+      "ja": "明治の元帥陸軍大将で二度首相となった人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yamato Court",
+        "ja": "大和朝廷",
+        "ja_typings": [
+          "yamato choutei",
+          "yamatochoutei"
+        ]
+      },
+      {
+        "en": "Izumo",
+        "ja": "出雲",
+        "ja_typings": [
+          "izumo"
+        ]
+      },
+      {
+        "en": "Abbasid Caliphate",
+        "ja": "アッバース朝",
+        "ja_typings": [
+          "abbaasu chou",
+          "abbaasuchou"
+        ]
+      },
+      {
+        "en": "Mughal Empire",
+        "ja": "ムガル帝国",
+        "ja_typings": [
+          "mugaru teikoku",
+          "mugaruteikoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03178",
+    "image_path": null,
+    "question_text": {
+      "en": "Which early Japanese polity centered around the Nara basin in the 4th-7th century?",
+      "ja": "4-7世紀に奈良盆地を中心に栄えた日本の政権は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yevfimiy Putyatin",
+        "ja": "プチャーチン",
+        "ja_typings": [
+          "puchaachin",
+          "pucha-chin"
+        ]
+      },
+      {
+        "en": "Adam Laxman",
+        "ja": "ラクスマン",
+        "ja_typings": [
+          "rakusuman"
+        ]
+      },
+      {
+        "en": "Townsend Harris",
+        "ja": "ハリス",
+        "ja_typings": [
+          "harisu"
+        ]
+      },
+      {
+        "en": "Napoleon III",
+        "ja": "ナポレオン3世",
+        "ja_typings": [
+          "naporeon 3 sei",
+          "naporeonsansei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03179",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Russian admiral arrived in Nagasaki in 1853 seeking trade?",
+      "ja": "1853年に長崎に来航した露提督は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yitzhak Rabin",
+        "ja": "イツハク・ラビン",
+        "ja_typings": [
+          "itsuhaku/rabin"
+        ]
+      },
+      {
+        "en": "Menachem Begin",
+        "ja": "メナヘム・ベギン",
+        "ja_typings": [
+          "menahemu/begin"
+        ]
+      },
+      {
+        "en": "Golda Meir",
+        "ja": "ゴルダ・メイア",
+        "ja_typings": [
+          "goruda/meia"
+        ]
+      },
+      {
+        "en": "Muhammad Ali Jinnah",
+        "ja": "ジンナー",
+        "ja_typings": [
+          "jinnaa",
+          "jinnna-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03180",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Israeli PM assassinated in 1995 after signing Oslo Accords?",
+      "ja": "オスロ合意後の1995年に暗殺されたイスラエル首相は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yugoslavia",
+        "ja": "ユーゴスラビア",
+        "ja_typings": [
+          "yu-gosurabia"
+        ]
+      },
+      {
+        "en": "Czechoslovakia",
+        "ja": "チェコスロバキア",
+        "ja_typings": [
+          "chekosurobakia"
+        ]
+      },
+      {
+        "en": "East Germany",
+        "ja": "東ドイツ",
+        "ja_typings": [
+          "higashi doitsu",
+          "higashidoitsu"
+        ]
+      },
+      {
+        "en": "Germany",
+        "ja": "ドイツ",
+        "ja_typings": [
+          "doitsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03181",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Balkan federation broke apart in the 1990s into multiple states?",
+      "ja": "1990年代に複数国家に分裂したバルカンの連邦は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yuri Gagarin",
+        "ja": "ガガーリン",
+        "ja_typings": [
+          "gagaarin",
+          "gaga-rin"
+        ]
+      },
+      {
+        "en": "Buzz Aldrin",
+        "ja": "オルドリン",
+        "ja_typings": [
+          "orudorin"
+        ]
+      },
+      {
+        "en": "John Glenn",
+        "ja": "ジョン・グレン",
+        "ja_typings": [
+          "jon/guren"
+        ]
+      },
+      {
+        "en": "Neil Armstrong",
+        "ja": "アームストロング",
+        "ja_typings": [
+          "aamusutorongu",
+          "a-musutorongu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03182",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first human to journey into outer space in 1961?",
+      "ja": "1961年に人類初の宇宙飛行を達成したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Zhou Enlai",
+        "ja": "周恩来",
+        "ja_typings": [
+          "shuuonrai"
+        ]
+      },
+      {
+        "en": "Deng Xiaoping",
+        "ja": "鄧小平",
+        "ja_typings": [
+          "toushouhei"
+        ]
+      },
+      {
+        "en": "Sun Yat-sen",
+        "ja": "孫文",
+        "ja_typings": [
+          "sonbun"
+        ]
+      },
+      {
+        "en": "Cao Cao",
+        "ja": "曹操",
+        "ja_typings": [
+          "sousou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03183",
+    "image_path": null,
+    "question_text": {
+      "en": "Who served as the first Premier of the People's Republic of China?",
+      "ja": "中華人民共和国の初代国務院総理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Zhuge Liang",
+        "ja": "諸葛亮",
+        "ja_typings": [
+          "shokatsuryou"
+        ]
+      },
+      {
+        "en": "Cao Cao",
+        "ja": "曹操",
+        "ja_typings": [
+          "sousou"
+        ]
+      },
+      {
+        "en": "Sun Quan",
+        "ja": "孫権",
+        "ja_typings": [
+          "sonken"
+        ]
+      },
+      {
+        "en": "Liu Bei",
+        "ja": "劉備",
+        "ja_typings": [
+          "ryuubi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03184",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the chief strategist of Shu in China's Three Kingdoms period?",
+      "ja": "三国志で蜀の軍師として活躍した人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Abel Prize",
+        "ja": "アーベル賞",
+        "ja_typings": [
+          "a-beruxsiyou",
+          "abeluxsyou"
+        ]
+      },
+      {
+        "en": "Fields Medal",
+        "ja": "フィールズ賞",
+        "ja_typings": [
+          "fi-ruzuxsiyou",
+          "fixi-luzusyou"
+        ]
+      },
+      {
+        "en": "Wolf Prize",
+        "ja": "ウルフ賞",
+        "ja_typings": [
+          "uruhuxsiyou",
+          "uluhusyou"
+        ]
+      },
+      {
+        "en": "Turing Award",
+        "ja": "チューリング賞",
+        "ja_typings": [
+          "tixyu-ringuxsiyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03185",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is a major international mathematics award named after a Norwegian mathematician?",
+      "ja": "ノルウェーの数学者にちなんで名づけられた、数学の国際的な賞はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Algebraic geometry",
+        "ja": "代数幾何学",
+        "ja_typings": [
+          "daisuukikagaku"
+        ]
+      },
+      {
+        "en": "Number theory",
+        "ja": "数論",
+        "ja_typings": [
+          "suuron"
+        ]
+      },
+      {
+        "en": "Analysis",
+        "ja": "解析学",
+        "ja_typings": [
+          "kaisekigaku"
+        ]
+      },
+      {
+        "en": "Topology",
+        "ja": "トポロジー",
+        "ja_typings": [
+          "toporoji-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03186",
+    "image_path": null,
+    "question_text": {
+      "en": "Which branch of mathematics studies geometric objects defined by polynomial equations?",
+      "ja": "多項式で定義される図形を扱う数学の分野はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Analysis",
+        "ja": "解析学",
+        "ja_typings": [
+          "kaisekigaku"
+        ]
+      },
+      {
+        "en": "Algebra",
+        "ja": "代数学",
+        "ja_typings": [
+          "daisuugaku"
+        ]
+      },
+      {
+        "en": "Geometry",
+        "ja": "幾何学",
+        "ja_typings": [
+          "kikagaku"
+        ]
+      },
+      {
+        "en": "Combinatorics",
+        "ja": "組合せ論",
+        "ja_typings": [
+          "kumiawaseron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03187",
+    "image_path": null,
+    "question_text": {
+      "en": "Which branch of mathematics deals with limits, derivatives and integrals?",
+      "ja": "極限・微分・積分を扱う数学の分野はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Archimedes",
+        "ja": "アルキメデス",
+        "ja_typings": [
+          "arukimedesu"
+        ]
+      },
+      {
+        "en": "Euclid",
+        "ja": "ユークリッド",
+        "ja_typings": [
+          "yu-kuriltudo"
+        ]
+      },
+      {
+        "en": "Pythagoras",
+        "ja": "ピタゴラス",
+        "ja_typings": [
+          "pitagorasu"
+        ]
+      },
+      {
+        "en": "Thales",
+        "ja": "タレス",
+        "ja_typings": [
+          "taresu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03188",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Greek mathematician is known for the law of buoyancy?",
+      "ja": "浮力の原理で知られる古代ギリシャの数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aristotle",
+        "ja": "アリストテレス",
+        "ja_typings": [
+          "arisutoteresu"
+        ]
+      },
+      {
+        "en": "Plato",
+        "ja": "プラトン",
+        "ja_typings": [
+          "puraton"
+        ]
+      },
+      {
+        "en": "Socrates",
+        "ja": "ソクラテス",
+        "ja_typings": [
+          "sokuratesu"
+        ]
+      },
+      {
+        "en": "Democritus",
+        "ja": "デモクリトス",
+        "ja_typings": [
+          "demokuritosu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03189",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Greek philosopher wrote on logic and natural science?",
+      "ja": "論理学や自然学の著作を残した古代ギリシャの哲学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Babbage",
+        "ja": "バベッジ",
+        "ja_typings": [
+          "bayatuji",
+          "babejji"
+        ]
+      },
+      {
+        "en": "Turing",
+        "ja": "チューリング",
+        "ja_typings": [
+          "tixyu-ringu"
+        ]
+      },
+      {
+        "en": "Von Neumann",
+        "ja": "フォン・ノイマン",
+        "ja_typings": [
+          "fon/noiman"
+        ]
+      },
+      {
+        "en": "Shannon",
+        "ja": "シャノン",
+        "ja_typings": [
+          "shanon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03190",
+    "image_path": null,
+    "question_text": {
+      "en": "Who designed the Analytical Engine, a forerunner of the computer?",
+      "ja": "解析機関を設計した、コンピュータの先駆者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bayes' theorem",
+        "ja": "ベイズの定理",
+        "ja_typings": [
+          "beizunoteiri"
+        ]
+      },
+      {
+        "en": "Law of large numbers",
+        "ja": "大数の法則",
+        "ja_typings": [
+          "taisuunohousoku"
+        ]
+      },
+      {
+        "en": "Central limit theorem",
+        "ja": "中心極限定理",
+        "ja_typings": [
+          "tixyuusinkyokugenteiri"
+        ]
+      },
+      {
+        "en": "Chebyshev's inequality",
+        "ja": "チェビシェフの不等式",
+        "ja_typings": [
+          "tiebisiehunohutousiki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03191",
+    "image_path": null,
+    "question_text": {
+      "en": "Which theorem in probability updates a probability given new evidence?",
+      "ja": "新しい情報をもとに確率を更新する確率論の定理はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Beta function",
+        "ja": "ベータ関数",
+        "ja_typings": [
+          "be-takansuu"
+        ]
+      },
+      {
+        "en": "Gamma function",
+        "ja": "ガンマ関数",
+        "ja_typings": [
+          "ganmakansuu"
+        ]
+      },
+      {
+        "en": "Delta function",
+        "ja": "デルタ関数",
+        "ja_typings": [
+          "derutakansuu"
+        ]
+      },
+      {
+        "en": "Zeta function",
+        "ja": "ゼータ関数",
+        "ja_typings": [
+          "ze-takansuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03192",
+    "image_path": null,
+    "question_text": {
+      "en": "Which special function in mathematics is denoted B(x,y)?",
+      "ja": "B(x,y)で表される数学の特殊関数はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bose",
+        "ja": "ボース",
+        "ja_typings": [
+          "bo-su"
+        ]
+      },
+      {
+        "en": "Fermi",
+        "ja": "フェルミ",
+        "ja_typings": [
+          "herumi",
+          "felumi",
+          "ferumi"
+        ]
+      },
+      {
+        "en": "Dirac",
+        "ja": "ディラック",
+        "ja_typings": [
+          "dexiratuku",
+          "dilatuku",
+          "dirakku"
+        ]
+      },
+      {
+        "en": "Pauli",
+        "ja": "パウリ",
+        "ja_typings": [
+          "pauri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03193",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Indian physicist gave his name to particles called bosons?",
+      "ja": "ボース粒子（ボソン）に名を残したインドの物理学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cantor",
+        "ja": "カントール",
+        "ja_typings": [
+          "kanto-ru"
+        ]
+      },
+      {
+        "en": "Frege",
+        "ja": "フレーゲ",
+        "ja_typings": [
+          "hure-ge"
+        ]
+      },
+      {
+        "en": "Russell",
+        "ja": "ラッセル",
+        "ja_typings": [
+          "ratuseru",
+          "rasseru"
+        ]
+      },
+      {
+        "en": "Hilbert",
+        "ja": "ヒルベルト",
+        "ja_typings": [
+          "hiruberuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03194",
+    "image_path": null,
+    "question_text": {
+      "en": "Who founded modern set theory and the theory of transfinite numbers?",
+      "ja": "近代集合論と超限数の理論を築いた数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Carl Friedrich Gauss",
+        "ja": "カール・フリードリヒ・ガウス",
+        "ja_typings": [
+          "ka-ru/furi-dorihi/gausu"
+        ]
+      },
+      {
+        "en": "Leonhard Euler",
+        "ja": "レオンハルト・オイラー",
+        "ja_typings": [
+          "reonharuto/oira-"
+        ]
+      },
+      {
+        "en": "Bernhard Riemann",
+        "ja": "ベルンハルト・リーマン",
+        "ja_typings": [
+          "berunharuto/ri-man"
+        ]
+      },
+      {
+        "en": "David Hilbert",
+        "ja": "ダフィット・ヒルベルト",
+        "ja_typings": [
+          "dahuxituto/hiruberuto",
+          "dafuxitto/hiluberuto",
+          "dafitto/hiruberuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03195",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the German mathematician called the prince of mathematicians?",
+      "ja": "「数学者の王」と呼ばれたドイツの大数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chandrasekhar",
+        "ja": "チャンドラセカール",
+        "ja_typings": [
+          "tiyandorasekaa-ru",
+          "tyandolasekaa-lu",
+          "chandoraseka-ru"
+        ]
+      },
+      {
+        "en": "Hawking",
+        "ja": "ホーキング",
+        "ja_typings": [
+          "ho-kingu"
+        ]
+      },
+      {
+        "en": "Penrose",
+        "ja": "ペンローズ",
+        "ja_typings": [
+          "penro-zu"
+        ]
+      },
+      {
+        "en": "Eddington",
+        "ja": "エディントン",
+        "ja_typings": [
+          "edexinton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03196",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Indian-American astrophysicist's name labels a stellar mass limit?",
+      "ja": "恒星の質量限界に名を残したインド系の天体物理学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chebyshev's inequality",
+        "ja": "チェビシェフの不等式",
+        "ja_typings": [
+          "tiebisiehunohutousiki"
+        ]
+      },
+      {
+        "en": "Markov's inequality",
+        "ja": "マルコフの不等式",
+        "ja_typings": [
+          "marukohunohutousiki"
+        ]
+      },
+      {
+        "en": "Jensen's inequality",
+        "ja": "イェンセンの不等式",
+        "ja_typings": [
+          "ixensennohutousiki",
+          "yensennnohutousiki"
+        ]
+      },
+      {
+        "en": "Cauchy-Schwarz inequality",
+        "ja": "コーシー・シュワルツの不等式",
+        "ja_typings": [
+          "ko-sii-/siyuwarutunohutousiki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03197",
+    "image_path": null,
+    "question_text": {
+      "en": "Which inequality bounds the probability that a random variable deviates from its mean?",
+      "ja": "確率変数が平均から外れる確率を抑える不等式はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Concave polygon",
+        "ja": "凹多角形",
+        "ja_typings": [
+          "outakakukei"
+        ]
+      },
+      {
+        "en": "Convex polygon",
+        "ja": "凸多角形",
+        "ja_typings": [
+          "totutakakukei"
+        ]
+      },
+      {
+        "en": "Regular polygon",
+        "ja": "正多角形",
+        "ja_typings": [
+          "seitakakukei"
+        ]
+      },
+      {
+        "en": "Similar polygon",
+        "ja": "相似多角形",
+        "ja_typings": [
+          "soujitakakukei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03198",
+    "image_path": null,
+    "question_text": {
+      "en": "Which type of polygon has at least one interior angle greater than 180°?",
+      "ja": "内角に180°より大きい角がある多角形はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Convex polygon",
+        "ja": "凸多角形",
+        "ja_typings": [
+          "totutakakukei"
+        ]
+      },
+      {
+        "en": "Concave polygon",
+        "ja": "凹多角形",
+        "ja_typings": [
+          "outakakukei"
+        ]
+      },
+      {
+        "en": "Star polygon",
+        "ja": "星型多角形",
+        "ja_typings": [
+          "hosigatatakakukei"
+        ]
+      },
+      {
+        "en": "Regular polygon",
+        "ja": "正多角形",
+        "ja_typings": [
+          "seitakakukei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03199",
+    "image_path": null,
+    "question_text": {
+      "en": "Which type of polygon has all interior angles less than 180°?",
+      "ja": "全ての内角が180°未満である多角形はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "D'Alembertian",
+        "ja": "ダランベルシアン",
+        "ja_typings": [
+          "daranberushian"
+        ]
+      },
+      {
+        "en": "Laplacian",
+        "ja": "ラプラシアン",
+        "ja_typings": [
+          "rapurashian"
+        ]
+      },
+      {
+        "en": "Nabla",
+        "ja": "ナブラ",
+        "ja_typings": [
+          "nabura",
+          "nabula"
+        ]
+      },
+      {
+        "en": "Hessian",
+        "ja": "ヘッシアン",
+        "ja_typings": [
+          "hetusian",
+          "hesshian"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03200",
+    "image_path": null,
+    "question_text": {
+      "en": "Which operator, used in relativity, is the wave operator in 4-dimensional spacetime?",
+      "ja": "相対論で4次元時空の波動を表す微分作用素はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Delta",
+        "ja": "デルタ",
+        "ja_typings": [
+          "deruta",
+          "deluta"
+        ]
+      },
+      {
+        "en": "Sigma",
+        "ja": "シグマ",
+        "ja_typings": [
+          "shiguma"
+        ]
+      },
+      {
+        "en": "Omega",
+        "ja": "オメガ",
+        "ja_typings": [
+          "omega"
+        ]
+      },
+      {
+        "en": "Lambda",
+        "ja": "ラムダ",
+        "ja_typings": [
+          "ramuda",
+          "lamuda"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03201",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Greek letter is often used to denote a small change in mathematics?",
+      "ja": "数学で微小な変化を表すのによく使うギリシャ文字はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Delta function",
+        "ja": "デルタ関数",
+        "ja_typings": [
+          "derutakansuu"
+        ]
+      },
+      {
+        "en": "Gamma function",
+        "ja": "ガンマ関数",
+        "ja_typings": [
+          "ganmakansuu"
+        ]
+      },
+      {
+        "en": "Beta function",
+        "ja": "ベータ関数",
+        "ja_typings": [
+          "be-takansuu"
+        ]
+      },
+      {
+        "en": "Step function",
+        "ja": "階段関数",
+        "ja_typings": [
+          "kaidankansuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03202",
+    "image_path": null,
+    "question_text": {
+      "en": "Which generalized function, introduced by Dirac, equals zero except at one point?",
+      "ja": "ディラックが導入した、1点以外でゼロとなる超関数はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Descartes",
+        "ja": "デカルト",
+        "ja_typings": [
+          "dekaruto",
+          "dekaluto"
+        ]
+      },
+      {
+        "en": "Pascal",
+        "ja": "パスカル",
+        "ja_typings": [
+          "pasukaru",
+          "pasukalu"
+        ]
+      },
+      {
+        "en": "Fermat",
+        "ja": "フェルマー",
+        "ja_typings": [
+          "herumaa",
+          "felumaa",
+          "feruma-"
+        ]
+      },
+      {
+        "en": "Leibniz",
+        "ja": "ライプニッツ",
+        "ja_typings": [
+          "raipunitutu",
+          "laipunittu",
+          "raipunittsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03203",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 17th-century French philosopher introduced analytic geometry?",
+      "ja": "解析幾何学を創始した17世紀フランスの哲学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Euclid",
+        "ja": "ユークリッド",
+        "ja_typings": [
+          "yu-kuriltudo"
+        ]
+      },
+      {
+        "en": "Archimedes",
+        "ja": "アルキメデス",
+        "ja_typings": [
+          "arukimedesu"
+        ]
+      },
+      {
+        "en": "Pythagoras",
+        "ja": "ピタゴラス",
+        "ja_typings": [
+          "pitagorasu"
+        ]
+      },
+      {
+        "en": "Apollonius",
+        "ja": "アポロニウス",
+        "ja_typings": [
+          "aporoniusu",
+          "apoloniusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03204",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote the Elements, the foundational text of geometry?",
+      "ja": "幾何学の基礎となる『原論』を著したのは誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Euler",
+        "ja": "オイラー",
+        "ja_typings": [
+          "oira-"
+        ]
+      },
+      {
+        "en": "Bernoulli",
+        "ja": "ベルヌーイ",
+        "ja_typings": [
+          "berunu-i",
+          "belunu-i"
+        ]
+      },
+      {
+        "en": "Gauss",
+        "ja": "ガウス",
+        "ja_typings": [
+          "gausu"
+        ]
+      },
+      {
+        "en": "Lagrange",
+        "ja": "ラグランジュ",
+        "ja_typings": [
+          "raguranjixu",
+          "lagulanju",
+          "raguranju"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03205",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Swiss mathematician introduced the constant e and much modern notation?",
+      "ja": "定数 e を導入し、近代数学記法を整備したスイスの数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Factorization",
+        "ja": "因数分解",
+        "ja_typings": [
+          "insuubunkai"
+        ]
+      },
+      {
+        "en": "Expansion",
+        "ja": "展開",
+        "ja_typings": [
+          "tenkai"
+        ]
+      },
+      {
+        "en": "Integration",
+        "ja": "積分",
+        "ja_typings": [
+          "sekibun"
+        ]
+      },
+      {
+        "en": "Differentiation",
+        "ja": "微分",
+        "ja_typings": [
+          "bibun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03206",
+    "image_path": null,
+    "question_text": {
+      "en": "Which operation breaks a number into a product of primes?",
+      "ja": "ある数を素数の積に分ける操作はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fermat",
+        "ja": "フェルマー",
+        "ja_typings": [
+          "herumaa",
+          "felumaa",
+          "feruma-"
+        ]
+      },
+      {
+        "en": "Euler",
+        "ja": "オイラー",
+        "ja_typings": [
+          "oira-"
+        ]
+      },
+      {
+        "en": "Gauss",
+        "ja": "ガウス",
+        "ja_typings": [
+          "gausu"
+        ]
+      },
+      {
+        "en": "Galois",
+        "ja": "ガロア",
+        "ja_typings": [
+          "garoa",
+          "galoa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03207",
+    "image_path": null,
+    "question_text": {
+      "en": "Whose Last Theorem about x^n+y^n=z^n was proved by Andrew Wiles?",
+      "ja": "ワイルズが証明した「最終定理」を残した数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Frege",
+        "ja": "フレーゲ",
+        "ja_typings": [
+          "hure-ge"
+        ]
+      },
+      {
+        "en": "Russell",
+        "ja": "ラッセル",
+        "ja_typings": [
+          "ratuseru",
+          "rasseru"
+        ]
+      },
+      {
+        "en": "Wittgenstein",
+        "ja": "ウィトゲンシュタイン",
+        "ja_typings": [
+          "uxitogensiyutain",
+          "wxitogenshutain",
+          "witogenshutain"
+        ]
+      },
+      {
+        "en": "Gödel",
+        "ja": "ゲーデル",
+        "ja_typings": [
+          "ge-deru",
+          "ge-delu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03208",
+    "image_path": null,
+    "question_text": {
+      "en": "Which German logician founded modern logic with his Begriffsschrift?",
+      "ja": "『概念記法』で近代論理学を築いたドイツの論理学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Function",
+        "ja": "関数",
+        "ja_typings": [
+          "kansuu"
+        ]
+      },
+      {
+        "en": "Relation",
+        "ja": "関係",
+        "ja_typings": [
+          "kankei"
+        ]
+      },
+      {
+        "en": "Mapping",
+        "ja": "写像",
+        "ja_typings": [
+          "siyazou",
+          "syazou"
+        ]
+      },
+      {
+        "en": "Operation",
+        "ja": "演算",
+        "ja_typings": [
+          "enzan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03209",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mathematical concept assigns each input exactly one output?",
+      "ja": "各入力にちょうど1つの出力を対応させる概念はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Galois",
+        "ja": "ガロア",
+        "ja_typings": [
+          "garoa",
+          "galoa"
+        ]
+      },
+      {
+        "en": "Abel",
+        "ja": "アーベル",
+        "ja_typings": [
+          "a-beru",
+          "a-belu"
+        ]
+      },
+      {
+        "en": "Cauchy",
+        "ja": "コーシー",
+        "ja_typings": [
+          "ko-sii-",
+          "ko-shi-"
+        ]
+      },
+      {
+        "en": "Jacobi",
+        "ja": "ヤコビ",
+        "ja_typings": [
+          "yakobi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03210",
+    "image_path": null,
+    "question_text": {
+      "en": "Which young French mathematician founded group theory before dying in a duel?",
+      "ja": "決闘で若くして亡くなり、群論を築いたフランスの数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gamma function",
+        "ja": "ガンマ関数",
+        "ja_typings": [
+          "ganmakansuu"
+        ]
+      },
+      {
+        "en": "Beta function",
+        "ja": "ベータ関数",
+        "ja_typings": [
+          "be-takansuu"
+        ]
+      },
+      {
+        "en": "Zeta function",
+        "ja": "ゼータ関数",
+        "ja_typings": [
+          "ze-takansuu"
+        ]
+      },
+      {
+        "en": "Delta function",
+        "ja": "デルタ関数",
+        "ja_typings": [
+          "derutakansuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03211",
+    "image_path": null,
+    "question_text": {
+      "en": "Which function, denoted Γ(x), generalizes the factorial to real numbers?",
+      "ja": "階乗を実数に拡張した Γ(x) で表される関数はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gauss",
+        "ja": "ガウス",
+        "ja_typings": [
+          "gausu"
+        ]
+      },
+      {
+        "en": "Poisson",
+        "ja": "ポアソン",
+        "ja_typings": [
+          "poason"
+        ]
+      },
+      {
+        "en": "Laplace",
+        "ja": "ラプラス",
+        "ja_typings": [
+          "rapurasu",
+          "lapulasu"
+        ]
+      },
+      {
+        "en": "Bernoulli",
+        "ja": "ベルヌーイ",
+        "ja_typings": [
+          "berunu-i",
+          "belunu-i"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03212",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mathematician's name labels the normal distribution's bell curve?",
+      "ja": "正規分布の釣鐘型曲線に名を残した数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Georg Cantor",
+        "ja": "ゲオルク・カントール",
+        "ja_typings": [
+          "georuku/kanto-ru",
+          "geoluku/kanto-lu"
+        ]
+      },
+      {
+        "en": "Richard Dedekind",
+        "ja": "リヒャルト・デデキント",
+        "ja_typings": [
+          "rihiyaruto/dedekinto",
+          "lihyaluto/dedekinto",
+          "rihyaruto/dedekinto"
+        ]
+      },
+      {
+        "en": "David Hilbert",
+        "ja": "ダフィット・ヒルベルト",
+        "ja_typings": [
+          "dahuxituto/hiruberuto",
+          "dafitto/hiruberuto"
+        ]
+      },
+      {
+        "en": "Henri Poincaré",
+        "ja": "アンリ・ポアンカレ",
+        "ja_typings": [
+          "anri/poankare",
+          "anli/poankale"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03213",
+    "image_path": null,
+    "question_text": {
+      "en": "Who founded set theory and proved different sizes of infinity?",
+      "ja": "集合論を創り、無限に大小があることを示した数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Golden ratio",
+        "ja": "黄金比",
+        "ja_typings": [
+          "ougonhi"
+        ]
+      },
+      {
+        "en": "Silver ratio",
+        "ja": "白銀比",
+        "ja_typings": [
+          "hakuginhi"
+        ]
+      },
+      {
+        "en": "Bronze ratio",
+        "ja": "青銅比",
+        "ja_typings": [
+          "seidouhi"
+        ]
+      },
+      {
+        "en": "Platinum ratio",
+        "ja": "白金比",
+        "ja_typings": [
+          "hakkinhi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03214",
+    "image_path": null,
+    "question_text": {
+      "en": "Which famous ratio is approximately 1.618?",
+      "ja": "約1.618の値を持つ有名な比はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Golden ratio φ",
+        "ja": "黄金比φ",
+        "ja_typings": [
+          "ougonhihuxi-",
+          "ougonhifi"
+        ]
+      },
+      {
+        "en": "Pi π",
+        "ja": "円周率π",
+        "ja_typings": [
+          "ensiyuuritupai"
+        ]
+      },
+      {
+        "en": "Euler's e",
+        "ja": "ネイピア数 e",
+        "ja_typings": [
+          "neipiasuui-"
+        ]
+      },
+      {
+        "en": "Imaginary i",
+        "ja": "虚数単位 i",
+        "ja_typings": [
+          "kiyosuutanniai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03215",
+    "image_path": null,
+    "question_text": {
+      "en": "Which symbol denotes the golden ratio?",
+      "ja": "黄金比を表す記号はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Grigori Perelman",
+        "ja": "グリゴリー・ペレルマン",
+        "ja_typings": [
+          "gurigori-/pereruman"
+        ]
+      },
+      {
+        "en": "Terence Tao",
+        "ja": "テレンス・タオ",
+        "ja_typings": [
+          "terensu/tao"
+        ]
+      },
+      {
+        "en": "John Nash",
+        "ja": "ジョン・ナッシュ",
+        "ja_typings": [
+          "jiyon/natusiyu",
+          "jon/nasshu"
+        ]
+      },
+      {
+        "en": "Andrew Wiles",
+        "ja": "アンドリュー・ワイルズ",
+        "ja_typings": [
+          "andoriyuu/wairuzu",
+          "andolyuu/wailuzu",
+          "andoryu-/wairuzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03216",
+    "image_path": null,
+    "question_text": {
+      "en": "Who proved the Poincaré conjecture and declined the Fields Medal?",
+      "ja": "ポアンカレ予想を証明しフィールズ賞を辞退した数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gödel",
+        "ja": "ゲーデル",
+        "ja_typings": [
+          "ge-deru",
+          "ge-delu"
+        ]
+      },
+      {
+        "en": "Tarski",
+        "ja": "タルスキ",
+        "ja_typings": [
+          "tarusuki",
+          "talusuki"
+        ]
+      },
+      {
+        "en": "Hilbert",
+        "ja": "ヒルベルト",
+        "ja_typings": [
+          "hiruberuto"
+        ]
+      },
+      {
+        "en": "Russell",
+        "ja": "ラッセル",
+        "ja_typings": [
+          "ratuseru",
+          "rasseru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03217",
+    "image_path": null,
+    "question_text": {
+      "en": "Who proved the incompleteness theorems of formal arithmetic?",
+      "ja": "形式的算術の不完全性定理を証明した数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hardy",
+        "ja": "ハーディ",
+        "ja_typings": [
+          "ha-dexi"
+        ]
+      },
+      {
+        "en": "Littlewood",
+        "ja": "リトルウッド",
+        "ja_typings": [
+          "riturouxtudo",
+          "litoluuxtudo",
+          "ritoruuddo"
+        ]
+      },
+      {
+        "en": "Russell",
+        "ja": "ラッセル",
+        "ja_typings": [
+          "ratuseru",
+          "rasseru"
+        ]
+      },
+      {
+        "en": "Turing",
+        "ja": "チューリング",
+        "ja_typings": [
+          "tixyu-ringu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03218",
+    "image_path": null,
+    "question_text": {
+      "en": "Which English mathematician collaborated extensively with Ramanujan?",
+      "ja": "ラマヌジャンと長く共同研究したイギリスの数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hyperbola",
+        "ja": "双曲線",
+        "ja_typings": [
+          "soukyokusen"
+        ]
+      },
+      {
+        "en": "Parabola",
+        "ja": "放物線",
+        "ja_typings": [
+          "houbutusen"
+        ]
+      },
+      {
+        "en": "Ellipse",
+        "ja": "楕円",
+        "ja_typings": [
+          "daen"
+        ]
+      },
+      {
+        "en": "Circle",
+        "ja": "円",
+        "ja_typings": [
+          "en"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03219",
+    "image_path": null,
+    "question_text": {
+      "en": "Which conic section is the graph of y = 1/x?",
+      "ja": "y = 1/x のグラフが描く円錐曲線はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Integration",
+        "ja": "積分",
+        "ja_typings": [
+          "sekibun"
+        ]
+      },
+      {
+        "en": "Differentiation",
+        "ja": "微分",
+        "ja_typings": [
+          "bibun"
+        ]
+      },
+      {
+        "en": "Factorization",
+        "ja": "因数分解",
+        "ja_typings": [
+          "insuubunkai"
+        ]
+      },
+      {
+        "en": "Substitution",
+        "ja": "代入",
+        "ja_typings": [
+          "dainiyuu",
+          "dainyuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03220",
+    "image_path": null,
+    "question_text": {
+      "en": "Which calculus operation finds the area under a curve?",
+      "ja": "曲線の下の面積を求める微積分の操作はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "John Nash",
+        "ja": "ジョン・ナッシュ",
+        "ja_typings": [
+          "jiyon/natusiyu",
+          "jon/nasshu"
+        ]
+      },
+      {
+        "en": "John von Neumann",
+        "ja": "ジョン・フォン・ノイマン",
+        "ja_typings": [
+          "jiyon/fuxon/noiman",
+          "jon/foxn/noiman",
+          "jon/fon/noiman"
+        ]
+      },
+      {
+        "en": "Lloyd Shapley",
+        "ja": "ロイド・シャプレー",
+        "ja_typings": [
+          "roido/siyapure-",
+          "loido/shaple-",
+          "roido/shapure-"
+        ]
+      },
+      {
+        "en": "Reinhard Selten",
+        "ja": "ラインハルト・ゼルテン",
+        "ja_typings": [
+          "rainharuto/zeruten",
+          "lainhaluto/zeluten"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03221",
+    "image_path": null,
+    "question_text": {
+      "en": "Which American mathematician won a Nobel Prize for game theory?",
+      "ja": "ゲーム理論でノーベル経済学賞を受けたアメリカの数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kolmogorov",
+        "ja": "コルモゴロフ",
+        "ja_typings": [
+          "korumogorohu"
+        ]
+      },
+      {
+        "en": "Chebyshev",
+        "ja": "チェビシェフ",
+        "ja_typings": [
+          "tiebisiehu",
+          "chebishefu"
+        ]
+      },
+      {
+        "en": "Lobachevsky",
+        "ja": "ロバチェフスキー",
+        "ja_typings": [
+          "robatiehusuki-",
+          "lobatiehusuki-",
+          "robachefusuki-"
+        ]
+      },
+      {
+        "en": "Markov",
+        "ja": "マルコフ",
+        "ja_typings": [
+          "marukohu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03222",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Russian mathematician axiomatized probability theory in 1933?",
+      "ja": "1933年に確率論を公理化したロシアの数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lambda",
+        "ja": "ラムダ",
+        "ja_typings": [
+          "ramuda",
+          "lamuda"
+        ]
+      },
+      {
+        "en": "Mu",
+        "ja": "ミュー",
+        "ja_typings": [
+          "miyu-",
+          "myu-"
+        ]
+      },
+      {
+        "en": "Nu",
+        "ja": "ニュー",
+        "ja_typings": [
+          "niyu-",
+          "nyu-"
+        ]
+      },
+      {
+        "en": "Kappa",
+        "ja": "カッパ",
+        "ja_typings": [
+          "katupa",
+          "kappa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03223",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Greek letter is the 11th and often denotes wavelength or eigenvalue?",
+      "ja": "波長や固有値を表すのによく使うギリシャ文字（第11字）はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Laplacian",
+        "ja": "ラプラシアン",
+        "ja_typings": [
+          "rapurashian"
+        ]
+      },
+      {
+        "en": "D'Alembertian",
+        "ja": "ダランベルシアン",
+        "ja_typings": [
+          "daranberushian"
+        ]
+      },
+      {
+        "en": "Nabla",
+        "ja": "ナブラ",
+        "ja_typings": [
+          "nabura",
+          "nabula"
+        ]
+      },
+      {
+        "en": "Hessian",
+        "ja": "ヘッシアン",
+        "ja_typings": [
+          "hetusian",
+          "hesshian"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03224",
+    "image_path": null,
+    "question_text": {
+      "en": "Which differential operator is the divergence of the gradient?",
+      "ja": "勾配の発散として定義される微分作用素はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Law of large numbers",
+        "ja": "大数の法則",
+        "ja_typings": [
+          "taisuunohousoku"
+        ]
+      },
+      {
+        "en": "Central limit theorem",
+        "ja": "中心極限定理",
+        "ja_typings": [
+          "tixyuusinkyokugenteiri"
+        ]
+      },
+      {
+        "en": "Bayes' theorem",
+        "ja": "ベイズの定理",
+        "ja_typings": [
+          "beizunoteiri"
+        ]
+      },
+      {
+        "en": "Chebyshev's inequality",
+        "ja": "チェビシェフの不等式",
+        "ja_typings": [
+          "tiebisiehunohutousiki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03225",
+    "image_path": null,
+    "question_text": {
+      "en": "Which theorem says sample averages converge to the expected value?",
+      "ja": "標本平均が期待値に収束することを述べる定理はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Leibniz",
+        "ja": "ライプニッツ",
+        "ja_typings": [
+          "raipunitutu",
+          "laipunittu",
+          "raipunittsu"
+        ]
+      },
+      {
+        "en": "Newton",
+        "ja": "ニュートン",
+        "ja_typings": [
+          "niyu-ton",
+          "nyu-ton"
+        ]
+      },
+      {
+        "en": "Euler",
+        "ja": "オイラー",
+        "ja_typings": [
+          "oira-"
+        ]
+      },
+      {
+        "en": "Bernoulli",
+        "ja": "ベルヌーイ",
+        "ja_typings": [
+          "berunu-i",
+          "belunu-i"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03226",
+    "image_path": null,
+    "question_text": {
+      "en": "Which German philosopher-mathematician independently invented calculus?",
+      "ja": "微積分を独立に発見したドイツの哲学者・数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Limit",
+        "ja": "極限",
+        "ja_typings": [
+          "kyokugen"
+        ]
+      },
+      {
+        "en": "Derivative",
+        "ja": "微分",
+        "ja_typings": [
+          "bibun"
+        ]
+      },
+      {
+        "en": "Integral",
+        "ja": "積分",
+        "ja_typings": [
+          "sekibun"
+        ]
+      },
+      {
+        "en": "Series",
+        "ja": "級数",
+        "ja_typings": [
+          "kiyuusuu",
+          "kyusuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03227",
+    "image_path": null,
+    "question_text": {
+      "en": "Which calculus concept is the value a function approaches near a point?",
+      "ja": "ある点に近づけたときの値を表す微積分の概念はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lobachevsky",
+        "ja": "ロバチェフスキー",
+        "ja_typings": [
+          "robatiehusuki-",
+          "lobatiehusuki-",
+          "robachefusuki-"
+        ]
+      },
+      {
+        "en": "Riemann",
+        "ja": "リーマン",
+        "ja_typings": [
+          "ri-man"
+        ]
+      },
+      {
+        "en": "Bolyai",
+        "ja": "ボヤイ",
+        "ja_typings": [
+          "boyai"
+        ]
+      },
+      {
+        "en": "Gauss",
+        "ja": "ガウス",
+        "ja_typings": [
+          "gausu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03228",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Russian mathematician developed non-Euclidean hyperbolic geometry?",
+      "ja": "双曲幾何学を生んだロシアの数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Logarithmic curve",
+        "ja": "対数曲線",
+        "ja_typings": [
+          "taisuukyokusen"
+        ]
+      },
+      {
+        "en": "Exponential curve",
+        "ja": "指数曲線",
+        "ja_typings": [
+          "sisuukyokusen"
+        ]
+      },
+      {
+        "en": "Sigmoid curve",
+        "ja": "シグモイド曲線",
+        "ja_typings": [
+          "sigumoidokyokusen"
+        ]
+      },
+      {
+        "en": "Hyperbola",
+        "ja": "双曲線",
+        "ja_typings": [
+          "soukyokusen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03229",
+    "image_path": null,
+    "question_text": {
+      "en": "Which curve is the graph of y = log x?",
+      "ja": "y = log x のグラフが描く曲線はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mapping",
+        "ja": "写像",
+        "ja_typings": [
+          "siyazou",
+          "syazou"
+        ]
+      },
+      {
+        "en": "Function",
+        "ja": "関数",
+        "ja_typings": [
+          "kansuu"
+        ]
+      },
+      {
+        "en": "Relation",
+        "ja": "関係",
+        "ja_typings": [
+          "kankei"
+        ]
+      },
+      {
+        "en": "Operation",
+        "ja": "演算",
+        "ja_typings": [
+          "enzan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03230",
+    "image_path": null,
+    "question_text": {
+      "en": "Which concept assigns each element of one set to an element of another?",
+      "ja": "ある集合の各要素を別の集合の要素に対応させる概念はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nabla",
+        "ja": "ナブラ",
+        "ja_typings": [
+          "nabura",
+          "nabula"
+        ]
+      },
+      {
+        "en": "Delta",
+        "ja": "デルタ",
+        "ja_typings": [
+          "deruta",
+          "deluta"
+        ]
+      },
+      {
+        "en": "Laplacian",
+        "ja": "ラプラシアン",
+        "ja_typings": [
+          "rapurashian"
+        ]
+      },
+      {
+        "en": "Sigma",
+        "ja": "シグマ",
+        "ja_typings": [
+          "shiguma"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03231",
+    "image_path": null,
+    "question_text": {
+      "en": "Which symbol ∇ is used for the gradient operator?",
+      "ja": "勾配を表す記号 ∇ の名前はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Number theory",
+        "ja": "数論",
+        "ja_typings": [
+          "suuron"
+        ]
+      },
+      {
+        "en": "Algebraic geometry",
+        "ja": "代数幾何学",
+        "ja_typings": [
+          "daisuukikagaku"
+        ]
+      },
+      {
+        "en": "Analysis",
+        "ja": "解析学",
+        "ja_typings": [
+          "kaisekigaku"
+        ]
+      },
+      {
+        "en": "Topology",
+        "ja": "トポロジー",
+        "ja_typings": [
+          "toporoji-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03232",
+    "image_path": null,
+    "question_text": {
+      "en": "Which branch of mathematics studies properties of integers?",
+      "ja": "整数の性質を研究する数学の分野はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Omega",
+        "ja": "オメガ",
+        "ja_typings": [
+          "omega"
+        ]
+      },
+      {
+        "en": "Alpha",
+        "ja": "アルファ",
+        "ja_typings": [
+          "aruhua",
+          "alufa",
+          "arufa"
+        ]
+      },
+      {
+        "en": "Sigma",
+        "ja": "シグマ",
+        "ja_typings": [
+          "shiguma"
+        ]
+      },
+      {
+        "en": "Psi",
+        "ja": "プサイ",
+        "ja_typings": [
+          "pusai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03233",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the last letter of the Greek alphabet?",
+      "ja": "ギリシャ文字の最後の文字はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Operation",
+        "ja": "演算",
+        "ja_typings": [
+          "enzan"
+        ]
+      },
+      {
+        "en": "Function",
+        "ja": "関数",
+        "ja_typings": [
+          "kansuu"
+        ]
+      },
+      {
+        "en": "Relation",
+        "ja": "関係",
+        "ja_typings": [
+          "kankei"
+        ]
+      },
+      {
+        "en": "Mapping",
+        "ja": "写像",
+        "ja_typings": [
+          "siyazou",
+          "syazou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03234",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mathematical concept combines elements like +, ×, ∘?",
+      "ja": "+ や × のように要素を組み合わせる数学的概念はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pi π",
+        "ja": "円周率π",
+        "ja_typings": [
+          "ensiyuuritupai"
+        ]
+      },
+      {
+        "en": "Euler's e",
+        "ja": "ネイピア数 e",
+        "ja_typings": [
+          "neipiasuui-"
+        ]
+      },
+      {
+        "en": "Golden ratio φ",
+        "ja": "黄金比φ",
+        "ja_typings": [
+          "ougonhihuxi-"
+        ]
+      },
+      {
+        "en": "Imaginary i",
+        "ja": "虚数単位 i",
+        "ja_typings": [
+          "kiyosuutanniai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03235",
+    "image_path": null,
+    "question_text": {
+      "en": "Which famous constant gives the ratio of a circle's circumference to its diameter?",
+      "ja": "円周と直径の比を表す有名な定数はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Poincaré",
+        "ja": "ポアンカレ",
+        "ja_typings": [
+          "poankare",
+          "poankale"
+        ]
+      },
+      {
+        "en": "Galois",
+        "ja": "ガロア",
+        "ja_typings": [
+          "garoa",
+          "galoa"
+        ]
+      },
+      {
+        "en": "Fourier",
+        "ja": "フーリエ",
+        "ja_typings": [
+          "hu-rie"
+        ]
+      },
+      {
+        "en": "Cauchy",
+        "ja": "コーシー",
+        "ja_typings": [
+          "ko-sii-",
+          "ko-shi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03236",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French polymath stated a famous topology conjecture about 3-spheres?",
+      "ja": "3次元球面に関する有名な位相幾何の予想を残したフランスの数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pythagorean theorem",
+        "ja": "ピタゴラスの定理",
+        "ja_typings": [
+          "pitagorasunoteiri"
+        ]
+      },
+      {
+        "en": "Thales' theorem",
+        "ja": "タレスの定理",
+        "ja_typings": [
+          "taresunoteiri"
+        ]
+      },
+      {
+        "en": "Euclidean theorem",
+        "ja": "ユークリッドの定理",
+        "ja_typings": [
+          "yu-kuriltudonoteiri"
+        ]
+      },
+      {
+        "en": "Heron's formula",
+        "ja": "ヘロンの公式",
+        "ja_typings": [
+          "heronnokousiki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03237",
+    "image_path": null,
+    "question_text": {
+      "en": "Which theorem states a² + b² = c² for right triangles?",
+      "ja": "直角三角形で a² + b² = c² が成り立つ定理はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ramanujan",
+        "ja": "ラマヌジャン",
+        "ja_typings": [
+          "ramanujiyan",
+          "lamanujan",
+          "ramanujan"
+        ]
+      },
+      {
+        "en": "Bose",
+        "ja": "ボース",
+        "ja_typings": [
+          "bo-su"
+        ]
+      },
+      {
+        "en": "Chandrasekhar",
+        "ja": "チャンドラセカール",
+        "ja_typings": [
+          "tiyandorasekaa-ru",
+          "tyandolasekaa-lu",
+          "chandoraseka-ru"
+        ]
+      },
+      {
+        "en": "Aryabhata",
+        "ja": "アーリヤバタ",
+        "ja_typings": [
+          "a-riyabata",
+          "a-liyabata"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03238",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Indian mathematician was famous for self-taught genius and infinite series?",
+      "ja": "独学の天才で無限級数の研究で知られるインドの数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Relation",
+        "ja": "関係",
+        "ja_typings": [
+          "kankei"
+        ]
+      },
+      {
+        "en": "Function",
+        "ja": "関数",
+        "ja_typings": [
+          "kansuu"
+        ]
+      },
+      {
+        "en": "Mapping",
+        "ja": "写像",
+        "ja_typings": [
+          "siyazou",
+          "syazou"
+        ]
+      },
+      {
+        "en": "Operation",
+        "ja": "演算",
+        "ja_typings": [
+          "enzan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03239",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mathematical concept connects elements without requiring a unique image?",
+      "ja": "1対多も許す、要素同士の対応を表す数学概念はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Russell",
+        "ja": "ラッセル",
+        "ja_typings": [
+          "ratuseru",
+          "rasseru"
+        ]
+      },
+      {
+        "en": "Frege",
+        "ja": "フレーゲ",
+        "ja_typings": [
+          "hure-ge"
+        ]
+      },
+      {
+        "en": "Wittgenstein",
+        "ja": "ウィトゲンシュタイン",
+        "ja_typings": [
+          "uxitogensiyutain",
+          "witogenshutain"
+        ]
+      },
+      {
+        "en": "Moore",
+        "ja": "ムーア",
+        "ja_typings": [
+          "muu-a",
+          "mu-a"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03240",
+    "image_path": null,
+    "question_text": {
+      "en": "Which British philosopher co-wrote Principia Mathematica with Whitehead?",
+      "ja": "ホワイトヘッドと『プリンキピア・マテマティカ』を著した英国の哲学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shannon",
+        "ja": "シャノン",
+        "ja_typings": [
+          "shanon"
+        ]
+      },
+      {
+        "en": "Turing",
+        "ja": "チューリング",
+        "ja_typings": [
+          "tixyu-ringu"
+        ]
+      },
+      {
+        "en": "Von Neumann",
+        "ja": "フォン・ノイマン",
+        "ja_typings": [
+          "fon/noiman"
+        ]
+      },
+      {
+        "en": "Wiener",
+        "ja": "ウィーナー",
+        "ja_typings": [
+          "uxi-na-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03241",
+    "image_path": null,
+    "question_text": {
+      "en": "Which American mathematician founded information theory?",
+      "ja": "情報理論を創始したアメリカの数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sigma",
+        "ja": "シグマ",
+        "ja_typings": [
+          "shiguma"
+        ]
+      },
+      {
+        "en": "Pi",
+        "ja": "パイ",
+        "ja_typings": [
+          "pai"
+        ]
+      },
+      {
+        "en": "Delta",
+        "ja": "デルタ",
+        "ja_typings": [
+          "deruta",
+          "deluta"
+        ]
+      },
+      {
+        "en": "Lambda",
+        "ja": "ラムダ",
+        "ja_typings": [
+          "ramuda",
+          "lamuda"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03242",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Greek letter Σ denotes summation in mathematics?",
+      "ja": "総和を表すギリシャ文字Σはどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sigmoid curve",
+        "ja": "シグモイド曲線",
+        "ja_typings": [
+          "sigumoidokyokusen"
+        ]
+      },
+      {
+        "en": "Logarithmic curve",
+        "ja": "対数曲線",
+        "ja_typings": [
+          "taisuukyokusen"
+        ]
+      },
+      {
+        "en": "Exponential curve",
+        "ja": "指数曲線",
+        "ja_typings": [
+          "sisuukyokusen"
+        ]
+      },
+      {
+        "en": "Hyperbola",
+        "ja": "双曲線",
+        "ja_typings": [
+          "soukyokusen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03243",
+    "image_path": null,
+    "question_text": {
+      "en": "Which S-shaped curve is widely used in neural network activations?",
+      "ja": "ニューラルネットの活性化関数で使われるS字曲線はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Similar polygon",
+        "ja": "相似多角形",
+        "ja_typings": [
+          "soujitakakukei"
+        ]
+      },
+      {
+        "en": "Congruent polygon",
+        "ja": "合同多角形",
+        "ja_typings": [
+          "goudoutakakukei"
+        ]
+      },
+      {
+        "en": "Regular polygon",
+        "ja": "正多角形",
+        "ja_typings": [
+          "seitakakukei"
+        ]
+      },
+      {
+        "en": "Convex polygon",
+        "ja": "凸多角形",
+        "ja_typings": [
+          "totutakakukei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03244",
+    "image_path": null,
+    "question_text": {
+      "en": "Which type of polygon has the same shape but different size as another?",
+      "ja": "形が同じで大きさが異なる多角形を何という?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tarski",
+        "ja": "タルスキ",
+        "ja_typings": [
+          "tarusuki",
+          "talusuki"
+        ]
+      },
+      {
+        "en": "Gödel",
+        "ja": "ゲーデル",
+        "ja_typings": [
+          "ge-deru",
+          "ge-delu"
+        ]
+      },
+      {
+        "en": "Church",
+        "ja": "チャーチ",
+        "ja_typings": [
+          "cha-chi"
+        ]
+      },
+      {
+        "en": "Kleene",
+        "ja": "クリーネ",
+        "ja_typings": [
+          "kuri-ne",
+          "kuli-ne"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03245",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Polish-American logician is known for the definition of truth in formal languages?",
+      "ja": "形式言語における真理の定義で知られるポーランド系米国の論理学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Terence Tao",
+        "ja": "テレンス・タオ",
+        "ja_typings": [
+          "terensu/tao"
+        ]
+      },
+      {
+        "en": "Grigori Perelman",
+        "ja": "グリゴリー・ペレルマン",
+        "ja_typings": [
+          "gurigori-/pereruman"
+        ]
+      },
+      {
+        "en": "Andrei Okounkov",
+        "ja": "アンドレイ・オクンコフ",
+        "ja_typings": [
+          "andorei/okunkofu"
+        ]
+      },
+      {
+        "en": "Wendelin Werner",
+        "ja": "ヴェンデリン・ヴェルナー",
+        "ja_typings": [
+          "venderin/veruna-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03246",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Australian-American mathematician received the Fields Medal in 2006?",
+      "ja": "2006年にフィールズ賞を受賞した豪州系米国の数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Turing Award",
+        "ja": "チューリング賞",
+        "ja_typings": [
+          "tixyu-ringuxsiyou"
+        ]
+      },
+      {
+        "en": "Fields Medal",
+        "ja": "フィールズ賞",
+        "ja_typings": [
+          "fi-ruzuxsiyou"
+        ]
+      },
+      {
+        "en": "Abel Prize",
+        "ja": "アーベル賞",
+        "ja_typings": [
+          "a-beruxsiyou"
+        ]
+      },
+      {
+        "en": "Wolf Prize",
+        "ja": "ウルフ賞",
+        "ja_typings": [
+          "uruhuxsiyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03247",
+    "image_path": null,
+    "question_text": {
+      "en": "Which prize is the highest honor in computer science, given by the ACM?",
+      "ja": "ACM が授与する計算機科学最高の賞はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vector",
+        "ja": "ベクトル",
+        "ja_typings": [
+          "bekutoru",
+          "bekutolu"
+        ]
+      },
+      {
+        "en": "Scalar",
+        "ja": "スカラー",
+        "ja_typings": [
+          "sukaraa-",
+          "sukalaa-",
+          "sukara-"
+        ]
+      },
+      {
+        "en": "Tensor",
+        "ja": "テンソル",
+        "ja_typings": [
+          "tensoru",
+          "tensolu"
+        ]
+      },
+      {
+        "en": "Matrix",
+        "ja": "行列",
+        "ja_typings": [
+          "gyouretu",
+          "gyouletu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03248",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mathematical object has both magnitude and direction?",
+      "ja": "大きさと向きを持つ数学的対象はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Von Neumann",
+        "ja": "フォン・ノイマン",
+        "ja_typings": [
+          "fon/noiman"
+        ]
+      },
+      {
+        "en": "Turing",
+        "ja": "チューリング",
+        "ja_typings": [
+          "tixyu-ringu"
+        ]
+      },
+      {
+        "en": "Babbage",
+        "ja": "バベッジ",
+        "ja_typings": [
+          "bayatuji",
+          "babejji"
+        ]
+      },
+      {
+        "en": "Shannon",
+        "ja": "シャノン",
+        "ja_typings": [
+          "shanon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03249",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the Hungarian-American polymath who pioneered modern computer architecture?",
+      "ja": "現代コンピュータ・アーキテクチャを築いたハンガリー系米国の万能学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wolf Prize",
+        "ja": "ウルフ賞",
+        "ja_typings": [
+          "uruhuxsiyou",
+          "uluhusyou"
+        ]
+      },
+      {
+        "en": "Abel Prize",
+        "ja": "アーベル賞",
+        "ja_typings": [
+          "a-beruxsiyou"
+        ]
+      },
+      {
+        "en": "Fields Medal",
+        "ja": "フィールズ賞",
+        "ja_typings": [
+          "fi-ruzuxsiyou"
+        ]
+      },
+      {
+        "en": "Turing Award",
+        "ja": "チューリング賞",
+        "ja_typings": [
+          "tixyu-ringuxsiyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03250",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Israeli prize is given for outstanding achievements in mathematics and the arts?",
+      "ja": "数学や芸術での業績に贈られるイスラエルの賞はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1",
+        "ja": "1輪",
+        "ja_typings": [
+          "1rin",
+          "itirin"
+        ]
+      },
+      {
+        "en": "2",
+        "ja": "2輪",
+        "ja_typings": [
+          "2rin",
+          "nirin"
+        ]
+      },
+      {
+        "en": "3",
+        "ja": "3輪",
+        "ja_typings": [
+          "3rin",
+          "sanrin"
+        ]
+      },
+      {
+        "en": "4",
+        "ja": "4輪",
+        "ja_typings": [
+          "4rin",
+          "yonrin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03251",
+    "image_path": null,
+    "question_text": {
+      "en": "How many wheels does a unicycle have?",
+      "ja": "一輪車のタイヤは何輪?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "12",
+        "ja": "12か月",
+        "ja_typings": [
+          "12kagetsu"
+        ]
+      },
+      {
+        "en": "10",
+        "ja": "10か月",
+        "ja_typings": [
+          "10kagetsu"
+        ]
+      },
+      {
+        "en": "13",
+        "ja": "13か月",
+        "ja_typings": [
+          "13kagetsu"
+        ]
+      },
+      {
+        "en": "24",
+        "ja": "24か月",
+        "ja_typings": [
+          "24kagetsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03252",
+    "image_path": null,
+    "question_text": {
+      "en": "How many months are in a year?",
+      "ja": "1年は何か月?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "2",
+        "ja": "2輪",
+        "ja_typings": [
+          "2rin",
+          "nirin"
+        ]
+      },
+      {
+        "en": "1",
+        "ja": "1輪",
+        "ja_typings": [
+          "1rin",
+          "itirin"
+        ]
+      },
+      {
+        "en": "3",
+        "ja": "3輪",
+        "ja_typings": [
+          "3rin",
+          "sanrin"
+        ]
+      },
+      {
+        "en": "4",
+        "ja": "4輪",
+        "ja_typings": [
+          "4rin",
+          "yonrin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03253",
+    "image_path": null,
+    "question_text": {
+      "en": "How many wheels does a bicycle have?",
+      "ja": "自転車のタイヤは何輪?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "20",
+        "ja": "20本",
+        "ja_typings": [
+          "nijuxtupon"
+        ]
+      },
+      {
+        "en": "10",
+        "ja": "10本",
+        "ja_typings": [
+          "juxtupon"
+        ]
+      },
+      {
+        "en": "12",
+        "ja": "12本",
+        "ja_typings": [
+          "12hon",
+          "12bon",
+          "juunihon"
+        ]
+      },
+      {
+        "en": "16",
+        "ja": "16本",
+        "ja_typings": [
+          "16hon",
+          "16bon",
+          "juurokuhon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03254",
+    "image_path": null,
+    "question_text": {
+      "en": "How many fingers does a typical human have in total?",
+      "ja": "人の指は両手で何本?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "26 km",
+        "ja": "約26km",
+        "ja_typings": [
+          "yaku26kiro",
+          "yaku26km"
+        ]
+      },
+      {
+        "en": "10 km",
+        "ja": "約10km",
+        "ja_typings": [
+          "yaku10kiro",
+          "yaku10km"
+        ]
+      },
+      {
+        "en": "42 km",
+        "ja": "約42km",
+        "ja_typings": [
+          "yaku42kiro",
+          "yaku42km"
+        ]
+      },
+      {
+        "en": "100 km",
+        "ja": "約100km",
+        "ja_typings": [
+          "yaku100kiro",
+          "yaku100km"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03255",
+    "image_path": null,
+    "question_text": {
+      "en": "About how long is a full marathon?",
+      "ja": "フルマラソンの距離はおよそ何km?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "30",
+        "ja": "30日",
+        "ja_typings": [
+          "30nichi"
+        ]
+      },
+      {
+        "en": "31",
+        "ja": "31日",
+        "ja_typings": [
+          "31nichi"
+        ]
+      },
+      {
+        "en": "28",
+        "ja": "28日",
+        "ja_typings": [
+          "28nichi"
+        ]
+      },
+      {
+        "en": "29",
+        "ja": "29日",
+        "ja_typings": [
+          "29nichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03256",
+    "image_path": null,
+    "question_text": {
+      "en": "How many days does April have?",
+      "ja": "4月は何日まで?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "30 km",
+        "ja": "約30km",
+        "ja_typings": [
+          "yaku30kiro",
+          "yaku30km"
+        ]
+      },
+      {
+        "en": "21 km",
+        "ja": "約21km",
+        "ja_typings": [
+          "yaku21kiro",
+          "yaku21km"
+        ]
+      },
+      {
+        "en": "15 km",
+        "ja": "約15km",
+        "ja_typings": [
+          "yaku15kiro",
+          "yaku15km"
+        ]
+      },
+      {
+        "en": "42 km",
+        "ja": "約42km",
+        "ja_typings": [
+          "yaku42kiro",
+          "yaku42km"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03257",
+    "image_path": null,
+    "question_text": {
+      "en": "About how long is a half marathon?",
+      "ja": "ハーフマラソンの距離はおよそ何km?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "30 minutes",
+        "ja": "30分",
+        "ja_typings": [
+          "30hun",
+          "30pun",
+          "30bun",
+          "sanjuxtupun"
+        ]
+      },
+      {
+        "en": "10 minutes",
+        "ja": "10分",
+        "ja_typings": [
+          "10hun",
+          "10pun",
+          "10bun",
+          "juxtupun"
+        ]
+      },
+      {
+        "en": "8 minutes",
+        "ja": "8分",
+        "ja_typings": [
+          "8hun",
+          "8pun",
+          "8bun",
+          "hatupun"
+        ]
+      },
+      {
+        "en": "12 minutes",
+        "ja": "12分",
+        "ja_typings": [
+          "12hun",
+          "12pun",
+          "12bun",
+          "juunihun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03258",
+    "image_path": null,
+    "question_text": {
+      "en": "How long is one period in a high school basketball game?",
+      "ja": "高校バスケのクォーター1ピリオドは何分?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "4",
+        "ja": "4つ",
+        "ja_typings": [
+          "4tsu"
+        ]
+      },
+      {
+        "en": "2",
+        "ja": "2つ",
+        "ja_typings": [
+          "futatsu"
+        ]
+      },
+      {
+        "en": "3",
+        "ja": "3つ",
+        "ja_typings": [
+          "3tsu"
+        ]
+      },
+      {
+        "en": "5",
+        "ja": "5つ",
+        "ja_typings": [
+          "5tsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03259",
+    "image_path": null,
+    "question_text": {
+      "en": "How many seasons are there in a year?",
+      "ja": "1年の季節はいくつ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "40 minutes",
+        "ja": "40分",
+        "ja_typings": [
+          "40hun",
+          "40pun",
+          "40bun",
+          "yonjuxtupun"
+        ]
+      },
+      {
+        "en": "30 minutes",
+        "ja": "30分",
+        "ja_typings": [
+          "30hun",
+          "30pun",
+          "30bun"
+        ]
+      },
+      {
+        "en": "20 minutes",
+        "ja": "20分",
+        "ja_typings": [
+          "20hun",
+          "20pun",
+          "20bun"
+        ]
+      },
+      {
+        "en": "45 minutes",
+        "ja": "45分",
+        "ja_typings": [
+          "45hun",
+          "45pun",
+          "45bun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03260",
+    "image_path": null,
+    "question_text": {
+      "en": "How long is one half in a college basketball game (NCAA men)?",
+      "ja": "NCAA男子バスケのハーフは何分?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "50 km",
+        "ja": "時速50km",
+        "ja_typings": [
+          "jisoku50kiro",
+          "jisoku50km"
+        ]
+      },
+      {
+        "en": "30 km",
+        "ja": "時速30km",
+        "ja_typings": [
+          "jisoku30kiro",
+          "jisoku30km"
+        ]
+      },
+      {
+        "en": "80 km",
+        "ja": "時速80km",
+        "ja_typings": [
+          "jisoku80kiro",
+          "jisoku80km"
+        ]
+      },
+      {
+        "en": "100 km",
+        "ja": "時速100km",
+        "ja_typings": [
+          "jisoku100kiro",
+          "jisoku100km"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03261",
+    "image_path": null,
+    "question_text": {
+      "en": "About how fast does a 100m sprinter run in km/h?",
+      "ja": "100m走の世界トップ選手のおよその速度は時速何km?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "60 minutes",
+        "ja": "60分",
+        "ja_typings": [
+          "60hun",
+          "60pun",
+          "60bun",
+          "rokujuxtupun"
+        ]
+      },
+      {
+        "en": "45 minutes",
+        "ja": "45分",
+        "ja_typings": [
+          "45hun",
+          "45pun",
+          "45bun"
+        ]
+      },
+      {
+        "en": "30 minutes",
+        "ja": "30分",
+        "ja_typings": [
+          "30hun",
+          "30pun",
+          "30bun"
+        ]
+      },
+      {
+        "en": "90 minutes",
+        "ja": "90分",
+        "ja_typings": [
+          "90hun",
+          "90pun",
+          "90bun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03262",
+    "image_path": null,
+    "question_text": {
+      "en": "How long is one half of a soccer match?",
+      "ja": "サッカーの前半・後半は何分?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Alexander Graham Bell",
+        "ja": "アレクサンダー・グラハム・ベル",
+        "ja_typings": [
+          "arekusanda-/gurahamu/beru",
+          "alekusanda-/gulahamu/belu"
+        ]
+      },
+      {
+        "en": "Thomas Edison",
+        "ja": "トーマス・エジソン",
+        "ja_typings": [
+          "to-masu/ejison"
+        ]
+      },
+      {
+        "en": "Samuel Morse",
+        "ja": "サミュエル・モールス",
+        "ja_typings": [
+          "samiyueru/mo-rusu",
+          "samyueru/mo-lusu",
+          "samyueru/mo-rusu"
+        ]
+      },
+      {
+        "en": "Nikola Tesla",
+        "ja": "ニコラ・テスラ",
+        "ja_typings": [
+          "nikora/tesura",
+          "nikola/tesula"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03263",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is credited with inventing the telephone in 1876?",
+      "ja": "1876年に電話を発明したとされる人物は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Anton Chekhov",
+        "ja": "アントン・チェーホフ",
+        "ja_typings": [
+          "anton/tie-hohu",
+          "anton/che-hofu"
+        ]
+      },
+      {
+        "en": "Leo Tolstoy",
+        "ja": "レフ・トルストイ",
+        "ja_typings": [
+          "refu/torusutoi"
+        ]
+      },
+      {
+        "en": "Maxim Gorky",
+        "ja": "マクシム・ゴーリキー",
+        "ja_typings": [
+          "makushimu/go-riki-"
+        ]
+      },
+      {
+        "en": "Fyodor Dostoevsky",
+        "ja": "ドストエフスキー",
+        "ja_typings": [
+          "dosutoehusuki-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03264",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the Russian playwright that wrote The Cherry Orchard?",
+      "ja": "『桜の園』を書いたロシアの劇作家は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Belle",
+        "ja": "ベル",
+        "ja_typings": [
+          "beru",
+          "belu"
+        ]
+      },
+      {
+        "en": "Ariel",
+        "ja": "アリエル",
+        "ja_typings": [
+          "arieru",
+          "alielu"
+        ]
+      },
+      {
+        "en": "Cinderella",
+        "ja": "シンデレラ",
+        "ja_typings": [
+          "sindererera",
+          "shindelelela",
+          "shinderera"
+        ]
+      },
+      {
+        "en": "Jasmine",
+        "ja": "ジャスミン",
+        "ja_typings": [
+          "jiyasumin",
+          "jasumin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03265",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the heroine of Disney's Beauty and the Beast?",
+      "ja": "ディズニー『美女と野獣』のヒロインは誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bill Gates",
+        "ja": "ビル・ゲイツ",
+        "ja_typings": [
+          "biru/geitsu"
+        ]
+      },
+      {
+        "en": "Steve Jobs",
+        "ja": "スティーブ・ジョブズ",
+        "ja_typings": [
+          "sutexi-bu/jiyobuzu",
+          "suti-bu/jobuzu"
+        ]
+      },
+      {
+        "en": "Steve Wozniak",
+        "ja": "スティーブ・ウォズニアック",
+        "ja_typings": [
+          "sutexi-bu/uxozuniatuku",
+          "suti-bu/wozuniakku"
+        ]
+      },
+      {
+        "en": "Larry Page",
+        "ja": "ラリー・ペイジ",
+        "ja_typings": [
+          "rari-/peiji",
+          "lali-/peiji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03266",
+    "image_path": null,
+    "question_text": {
+      "en": "Who co-founded Microsoft with Paul Allen?",
+      "ja": "ポール・アレンとマイクロソフトを共同創業したのは誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Brazil",
+        "ja": "ブラジル",
+        "ja_typings": [
+          "burajiru",
+          "bulajiru"
+        ]
+      },
+      {
+        "en": "Argentina",
+        "ja": "アルゼンチン",
+        "ja_typings": [
+          "aruzenchin"
+        ]
+      },
+      {
+        "en": "Mexico",
+        "ja": "メキシコ",
+        "ja_typings": [
+          "mekishiko"
+        ]
+      },
+      {
+        "en": "Colombia",
+        "ja": "コロンビア",
+        "ja_typings": [
+          "koronbia",
+          "kolonbia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03267",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country's flag features a yellow lozenge on a green field?",
+      "ja": "緑地に黄色のひし形がある国旗はどこの国?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "C. S. Lewis",
+        "ja": "C.S.ルイス",
+        "ja_typings": [
+          "c.s.ruisu",
+          "shi-esuruisu"
+        ]
+      },
+      {
+        "en": "J. R. R. Tolkien",
+        "ja": "J.R.R.トールキン",
+        "ja_typings": [
+          "j.r.r.to-rukin",
+          "jeia-rua-ruto-rukin"
+        ]
+      },
+      {
+        "en": "Roald Dahl",
+        "ja": "ロアルド・ダール",
+        "ja_typings": [
+          "roarudo/daa-ru",
+          "loaludo/daa-lu",
+          "roarudo/da-ru"
+        ]
+      },
+      {
+        "en": "Lewis Carroll",
+        "ja": "ルイス・キャロル",
+        "ja_typings": [
+          "ruisu/kiyaroru",
+          "luisu/kyalolu",
+          "ruisu/kyaroru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03268",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote The Chronicles of Narnia?",
+      "ja": "『ナルニア国物語』を書いた作家は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Charles Dickens",
+        "ja": "チャールズ・ディケンズ",
+        "ja_typings": [
+          "tiya-ruzu/dexikenzu",
+          "cha-luzu/dikenzu",
+          "cha-ruzu/dikenzu"
+        ]
+      },
+      {
+        "en": "Mark Twain",
+        "ja": "マーク・トウェイン",
+        "ja_typings": [
+          "maa-ku/touxein"
+        ]
+      },
+      {
+        "en": "Oscar Wilde",
+        "ja": "オスカー・ワイルド",
+        "ja_typings": [
+          "osukaa-/wairudo",
+          "osukaa-/wailudo",
+          "osuka-/wairudo"
+        ]
+      },
+      {
+        "en": "Jane Austen",
+        "ja": "ジェーン・オースティン",
+        "ja_typings": [
+          "jixe-n/oo-sutexin",
+          "je-n/o-sutin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03269",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote A Christmas Carol and Oliver Twist?",
+      "ja": "『クリスマス・キャロル』『オリバー・ツイスト』を書いた英国の作家は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "China",
+        "ja": "中国",
+        "ja_typings": [
+          "tixyuugoku"
+        ]
+      },
+      {
+        "en": "United States",
+        "ja": "アメリカ合衆国",
+        "ja_typings": [
+          "amerikagatusiyuukoku"
+        ]
+      },
+      {
+        "en": "Russia",
+        "ja": "ロシア",
+        "ja_typings": [
+          "roshia"
+        ]
+      },
+      {
+        "en": "Indonesia",
+        "ja": "インドネシア",
+        "ja_typings": [
+          "indoneshia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03270",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has the world's largest population alongside India?",
+      "ja": "インドと並んで世界最大級の人口を持つ国はどこ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Daisy",
+        "ja": "デイジー",
+        "ja_typings": [
+          "deiji-"
+        ]
+      },
+      {
+        "en": "Bessie",
+        "ja": "ベッシー",
+        "ja_typings": [
+          "betusi-",
+          "besshi-"
+        ]
+      },
+      {
+        "en": "Buttercup",
+        "ja": "バターカップ",
+        "ja_typings": [
+          "bataa-katupu",
+          "bataa-kappu",
+          "bata-kappu"
+        ]
+      },
+      {
+        "en": "Clover",
+        "ja": "クローバー",
+        "ja_typings": [
+          "kuroo-baa-",
+          "kuloo-baa-",
+          "kuro-ba-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03271",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is a common pet name often associated with cows in English?",
+      "ja": "英語圏で乳牛によく付けられる名前はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dutch",
+        "ja": "オランダ語",
+        "ja_typings": [
+          "orandago",
+          "olandago"
+        ]
+      },
+      {
+        "en": "German",
+        "ja": "ドイツ語",
+        "ja_typings": [
+          "doitsugo"
+        ]
+      },
+      {
+        "en": "French",
+        "ja": "フランス語",
+        "ja_typings": [
+          "huransugo",
+          "fulansugo"
+        ]
+      },
+      {
+        "en": "English",
+        "ja": "英語",
+        "ja_typings": [
+          "eigo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03272",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the official language of the Netherlands?",
+      "ja": "オランダの公用語はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Egypt",
+        "ja": "エジプト",
+        "ja_typings": [
+          "ejiputo"
+        ]
+      },
+      {
+        "en": "Sudan",
+        "ja": "スーダン",
+        "ja_typings": [
+          "suu-dan",
+          "su-dan"
+        ]
+      },
+      {
+        "en": "Libya",
+        "ja": "リビア",
+        "ja_typings": [
+          "ribia",
+          "libia"
+        ]
+      },
+      {
+        "en": "Iraq",
+        "ja": "イラク",
+        "ja_typings": [
+          "iraku",
+          "ilaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03273",
+    "image_path": null,
+    "question_text": {
+      "en": "In which country are the Pyramids of Giza located?",
+      "ja": "ギザのピラミッドがある国はどこ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fabaceae",
+        "ja": "マメ科",
+        "ja_typings": [
+          "mameka"
+        ]
+      },
+      {
+        "en": "Rosaceae",
+        "ja": "バラ科",
+        "ja_typings": [
+          "baraka",
+          "balaka"
+        ]
+      },
+      {
+        "en": "Solanaceae",
+        "ja": "ナス科",
+        "ja_typings": [
+          "nasuka"
+        ]
+      },
+      {
+        "en": "Brassicaceae",
+        "ja": "アブラナ科",
+        "ja_typings": [
+          "aburanaka",
+          "abulanaka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03274",
+    "image_path": null,
+    "question_text": {
+      "en": "Which plant family includes peas and beans?",
+      "ja": "エンドウやマメを含む植物の科はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Florence",
+        "ja": "フィレンツェ",
+        "ja_typings": [
+          "huxirentue",
+          "filentse",
+          "firentse"
+        ]
+      },
+      {
+        "en": "Milan",
+        "ja": "ミラノ",
+        "ja_typings": [
+          "mirano",
+          "milano"
+        ]
+      },
+      {
+        "en": "Rome",
+        "ja": "ローマ",
+        "ja_typings": [
+          "roo-ma",
+          "loo-ma",
+          "ro-ma"
+        ]
+      },
+      {
+        "en": "Venice",
+        "ja": "ヴェネツィア",
+        "ja_typings": [
+          "venetsuxia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03275",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian city is famous as the cradle of the Renaissance?",
+      "ja": "ルネサンス発祥の地として知られるイタリアの都市はどこ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Frances Hodgson Burnett",
+        "ja": "バーネット",
+        "ja_typings": [
+          "baa-netuto",
+          "ba-netto"
+        ]
+      },
+      {
+        "en": "Louisa May Alcott",
+        "ja": "オルコット",
+        "ja_typings": [
+          "orukotuto",
+          "olukotto",
+          "orukotto"
+        ]
+      },
+      {
+        "en": "Beatrix Potter",
+        "ja": "ポター",
+        "ja_typings": [
+          "potaa-",
+          "pota-"
+        ]
+      },
+      {
+        "en": "Lucy Maud Montgomery",
+        "ja": "モンゴメリ",
+        "ja_typings": [
+          "mongomeri",
+          "mongomeli"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03276",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote The Secret Garden and A Little Princess?",
+      "ja": "『秘密の花園』『小公女』を書いた英米の作家は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fyodor Dostoevsky",
+        "ja": "ドストエフスキー",
+        "ja_typings": [
+          "dosutoehusuki-"
+        ]
+      },
+      {
+        "en": "Leo Tolstoy",
+        "ja": "レフ・トルストイ",
+        "ja_typings": [
+          "refu/torusutoi"
+        ]
+      },
+      {
+        "en": "Anton Chekhov",
+        "ja": "アントン・チェーホフ",
+        "ja_typings": [
+          "anton/tie-hohu",
+          "anton/che-hofu"
+        ]
+      },
+      {
+        "en": "Nikolai Gogol",
+        "ja": "ニコライ・ゴーゴリ",
+        "ja_typings": [
+          "nikorai/go-gori"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03277",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote Crime and Punishment and The Brothers Karamazov?",
+      "ja": "『罪と罰』『カラマーゾフの兄弟』を書いた作家は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Germany",
+        "ja": "ドイツ",
+        "ja_typings": [
+          "doitsu"
+        ]
+      },
+      {
+        "en": "Austria",
+        "ja": "オーストリア",
+        "ja_typings": [
+          "oo-sutoria",
+          "oo-sutolia",
+          "o-sutoria"
+        ]
+      },
+      {
+        "en": "Switzerland",
+        "ja": "スイス",
+        "ja_typings": [
+          "suisu"
+        ]
+      },
+      {
+        "en": "Netherlands",
+        "ja": "オランダ",
+        "ja_typings": [
+          "oranda",
+          "olanda"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03278",
+    "image_path": null,
+    "question_text": {
+      "en": "In which country is the city Munich located?",
+      "ja": "ミュンヘンがある国はどこ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hideyo Noguchi",
+        "ja": "野口英世",
+        "ja_typings": [
+          "noguthihideyo",
+          "noguchihideyo"
+        ]
+      },
+      {
+        "en": "Kiyoshi Shiga",
+        "ja": "志賀潔",
+        "ja_typings": [
+          "shigakiyoshi"
+        ]
+      },
+      {
+        "en": "Shibasaburo Kitasato",
+        "ja": "北里柴三郎",
+        "ja_typings": [
+          "kitasatoshibasaburou"
+        ]
+      },
+      {
+        "en": "Jokichi Takamine",
+        "ja": "高峰譲吉",
+        "ja_typings": [
+          "takaminejiyuukiti",
+          "takaminejoukichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03279",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese bacteriologist appears on the 1000-yen note?",
+      "ja": "1000円札の肖像となった日本の細菌学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "J. R. R. Tolkien",
+        "ja": "J.R.R.トールキン",
+        "ja_typings": [
+          "j.r.r.to-rukin"
+        ]
+      },
+      {
+        "en": "C. S. Lewis",
+        "ja": "C.S.ルイス",
+        "ja_typings": [
+          "c.s.ruisu"
+        ]
+      },
+      {
+        "en": "George R. R. Martin",
+        "ja": "ジョージ・R.R.マーティン",
+        "ja_typings": [
+          "jiyo-ji/r.r.maa-texin",
+          "jo-ji/r.r.ma-tin"
+        ]
+      },
+      {
+        "en": "Terry Pratchett",
+        "ja": "テリー・プラチェット",
+        "ja_typings": [
+          "teri-/puratietuto",
+          "teli-/pulachetto",
+          "teri-/purachetto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03280",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote The Lord of the Rings?",
+      "ja": "『指輪物語』を書いた英国の作家は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jokichi Takamine",
+        "ja": "高峰譲吉",
+        "ja_typings": [
+          "takaminejiyuukiti",
+          "takaminejoukichi"
+        ]
+      },
+      {
+        "en": "Hideyo Noguchi",
+        "ja": "野口英世",
+        "ja_typings": [
+          "noguthihideyo",
+          "noguchihideyo"
+        ]
+      },
+      {
+        "en": "Kiyoshi Shiga",
+        "ja": "志賀潔",
+        "ja_typings": [
+          "shigakiyoshi"
+        ]
+      },
+      {
+        "en": "Umetaro Suzuki",
+        "ja": "鈴木梅太郎",
+        "ja_typings": [
+          "suzukiumetarou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03281",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese chemist first isolated adrenaline?",
+      "ja": "アドレナリンを世界で初めて結晶化した日本の化学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kiyoshi Shiga",
+        "ja": "志賀潔",
+        "ja_typings": [
+          "shigakiyoshi"
+        ]
+      },
+      {
+        "en": "Hideyo Noguchi",
+        "ja": "野口英世",
+        "ja_typings": [
+          "noguthihideyo",
+          "noguchihideyo"
+        ]
+      },
+      {
+        "en": "Shibasaburo Kitasato",
+        "ja": "北里柴三郎",
+        "ja_typings": [
+          "kitasatosibasaburou"
+        ]
+      },
+      {
+        "en": "Sahachiro Hata",
+        "ja": "秦佐八郎",
+        "ja_typings": [
+          "hatasahachirou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03282",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese bacteriologist discovered the dysentery bacillus?",
+      "ja": "赤痢菌を発見した日本の細菌学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Los Angeles",
+        "ja": "ロサンゼルス",
+        "ja_typings": [
+          "rosanzerusu",
+          "losanzelusu"
+        ]
+      },
+      {
+        "en": "New York",
+        "ja": "ニューヨーク",
+        "ja_typings": [
+          "niyuu-yoo-ku",
+          "nyuu-yoo-ku",
+          "nyu-yo-ku"
+        ]
+      },
+      {
+        "en": "Chicago",
+        "ja": "シカゴ",
+        "ja_typings": [
+          "shikago"
+        ]
+      },
+      {
+        "en": "San Francisco",
+        "ja": "サンフランシスコ",
+        "ja_typings": [
+          "sanfuranshisuko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03283",
+    "image_path": null,
+    "question_text": {
+      "en": "Which American city is the heart of the U.S. film industry (Hollywood)?",
+      "ja": "ハリウッドがある、米国映画産業の中心都市はどこ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Magnoliaceae",
+        "ja": "モクレン科",
+        "ja_typings": [
+          "mokurenka",
+          "mokulenka"
+        ]
+      },
+      {
+        "en": "Rosaceae",
+        "ja": "バラ科",
+        "ja_typings": [
+          "baraka",
+          "balaka"
+        ]
+      },
+      {
+        "en": "Theaceae",
+        "ja": "ツバキ科",
+        "ja_typings": [
+          "tsubakika"
+        ]
+      },
+      {
+        "en": "Fabaceae",
+        "ja": "マメ科",
+        "ja_typings": [
+          "mameka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03284",
+    "image_path": null,
+    "question_text": {
+      "en": "Which plant family includes magnolias?",
+      "ja": "モクレンやコブシを含む植物の科はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Melanie",
+        "ja": "メラニー",
+        "ja_typings": [
+          "merani-",
+          "melani-"
+        ]
+      },
+      {
+        "en": "Scarlett",
+        "ja": "スカーレット",
+        "ja_typings": [
+          "sukaa-retuto",
+          "sukaa-letto",
+          "suka-retto"
+        ]
+      },
+      {
+        "en": "Suellen",
+        "ja": "スーエレン",
+        "ja_typings": [
+          "suu-eren",
+          "suu-elen",
+          "su-eren"
+        ]
+      },
+      {
+        "en": "Prissy",
+        "ja": "プリシー",
+        "ja_typings": [
+          "purishi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03285",
+    "image_path": null,
+    "question_text": {
+      "en": "Which character is the antagonist's sister in Gone with the Wind?",
+      "ja": "『風と共に去りぬ』に登場するアシュレーの妻の名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Milan",
+        "ja": "ミラノ",
+        "ja_typings": [
+          "mirano",
+          "milano"
+        ]
+      },
+      {
+        "en": "Rome",
+        "ja": "ローマ",
+        "ja_typings": [
+          "roo-ma",
+          "loo-ma",
+          "ro-ma"
+        ]
+      },
+      {
+        "en": "Florence",
+        "ja": "フィレンツェ",
+        "ja_typings": [
+          "huxirentue",
+          "firentse"
+        ]
+      },
+      {
+        "en": "Naples",
+        "ja": "ナポリ",
+        "ja_typings": [
+          "napori",
+          "napoli"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03286",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian city is famous for fashion and the La Scala opera house?",
+      "ja": "ファッションとスカラ座で有名なイタリアの都市はどこ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "New York",
+        "ja": "ニューヨーク",
+        "ja_typings": [
+          "niyuu-yoo-ku",
+          "nyuu-yoo-ku",
+          "nyu-yo-ku"
+        ]
+      },
+      {
+        "en": "Los Angeles",
+        "ja": "ロサンゼルス",
+        "ja_typings": [
+          "rosanzerusu"
+        ]
+      },
+      {
+        "en": "Boston",
+        "ja": "ボストン",
+        "ja_typings": [
+          "bosuton"
+        ]
+      },
+      {
+        "en": "Washington",
+        "ja": "ワシントン",
+        "ja_typings": [
+          "washinton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03287",
+    "image_path": null,
+    "question_text": {
+      "en": "Which American city is home to the Statue of Liberty?",
+      "ja": "自由の女神像があるアメリカの都市はどこ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nikolai Gogol",
+        "ja": "ニコライ・ゴーゴリ",
+        "ja_typings": [
+          "nikorai/go-gori",
+          "nikolai/go-goli"
+        ]
+      },
+      {
+        "en": "Anton Chekhov",
+        "ja": "アントン・チェーホフ",
+        "ja_typings": [
+          "anton/tie-hohu",
+          "anton/che-hofu"
+        ]
+      },
+      {
+        "en": "Fyodor Dostoevsky",
+        "ja": "ドストエフスキー",
+        "ja_typings": [
+          "dosutoehusuki-"
+        ]
+      },
+      {
+        "en": "Ivan Turgenev",
+        "ja": "ツルゲーネフ",
+        "ja_typings": [
+          "tsuruge-nefu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03288",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote the Russian short story The Overcoat?",
+      "ja": "『外套』を書いたロシアの作家は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Oscar Wilde",
+        "ja": "オスカー・ワイルド",
+        "ja_typings": [
+          "osukaa-/wairudo",
+          "osukaa-/wailudo",
+          "osuka-/wairudo"
+        ]
+      },
+      {
+        "en": "Charles Dickens",
+        "ja": "チャールズ・ディケンズ",
+        "ja_typings": [
+          "tiya-ruzu/dexikenzu",
+          "cha-ruzu/dikenzu"
+        ]
+      },
+      {
+        "en": "Bram Stoker",
+        "ja": "ブラム・ストーカー",
+        "ja_typings": [
+          "buramu/sutoo-kaa-",
+          "bulamu/sutoo-kaa-",
+          "buramu/suto-ka-"
+        ]
+      },
+      {
+        "en": "Robert L. Stevenson",
+        "ja": "スティーブンソン",
+        "ja_typings": [
+          "sutexi-bunson",
+          "suti-bunson"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03289",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote The Picture of Dorian Gray?",
+      "ja": "『ドリアン・グレイの肖像』を書いた作家は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Red cabbage",
+        "ja": "紫キャベツ",
+        "ja_typings": [
+          "murasakikiyabetu",
+          "murasakikyabetsu"
+        ]
+      },
+      {
+        "en": "Red radish",
+        "ja": "ラディッシュ",
+        "ja_typings": [
+          "radexitusiyu",
+          "radixisshu",
+          "radisshu"
+        ]
+      },
+      {
+        "en": "Red onion",
+        "ja": "赤玉ねぎ",
+        "ja_typings": [
+          "akatamanegi"
+        ]
+      },
+      {
+        "en": "Beetroot",
+        "ja": "ビーツ",
+        "ja_typings": [
+          "bii-tsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03290",
+    "image_path": null,
+    "question_text": {
+      "en": "Which vegetable is purple-leaved and used in coleslaw and salads?",
+      "ja": "紫色の葉でサラダやコールスローに使う野菜はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Red radish",
+        "ja": "ラディッシュ",
+        "ja_typings": [
+          "radexitusiyu",
+          "radixisshu",
+          "radisshu"
+        ]
+      },
+      {
+        "en": "Red cabbage",
+        "ja": "紫キャベツ",
+        "ja_typings": [
+          "murasakikiyabetu"
+        ]
+      },
+      {
+        "en": "Carrot",
+        "ja": "ニンジン",
+        "ja_typings": [
+          "ninjin"
+        ]
+      },
+      {
+        "en": "Beetroot",
+        "ja": "ビーツ",
+        "ja_typings": [
+          "bii-tsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03291",
+    "image_path": null,
+    "question_text": {
+      "en": "Which small red root vegetable is often called the salad radish?",
+      "ja": "サラダによく使う小さな赤い根菜はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Roald Dahl",
+        "ja": "ロアルド・ダール",
+        "ja_typings": [
+          "roarudo/daa-ru",
+          "loaludo/daa-lu",
+          "roarudo/da-ru"
+        ]
+      },
+      {
+        "en": "J. K. Rowling",
+        "ja": "J.K.ローリング",
+        "ja_typings": [
+          "j.k.roo-ringu",
+          "j.k.ro-ringu"
+        ]
+      },
+      {
+        "en": "C. S. Lewis",
+        "ja": "C.S.ルイス",
+        "ja_typings": [
+          "c.s.ruisu"
+        ]
+      },
+      {
+        "en": "Lewis Carroll",
+        "ja": "ルイス・キャロル",
+        "ja_typings": [
+          "ruisu/kiyaroru",
+          "ruisu/kyaroru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03292",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote Charlie and the Chocolate Factory?",
+      "ja": "『チョコレート工場の秘密』を書いた作家は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rome",
+        "ja": "ローマ",
+        "ja_typings": [
+          "roo-ma",
+          "loo-ma",
+          "ro-ma"
+        ]
+      },
+      {
+        "en": "Milan",
+        "ja": "ミラノ",
+        "ja_typings": [
+          "mirano",
+          "milano"
+        ]
+      },
+      {
+        "en": "Florence",
+        "ja": "フィレンツェ",
+        "ja_typings": [
+          "huxirentue",
+          "firentse"
+        ]
+      },
+      {
+        "en": "Venice",
+        "ja": "ヴェネツィア",
+        "ja_typings": [
+          "vuxenetuxia",
+          "venetsia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03293",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the capital of Italy?",
+      "ja": "イタリアの首都はどこ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Samuel Morse",
+        "ja": "サミュエル・モールス",
+        "ja_typings": [
+          "samiyueru/mo-rusu",
+          "samyueru/mo-lusu",
+          "samyueru/mo-rusu"
+        ]
+      },
+      {
+        "en": "Alexander Graham Bell",
+        "ja": "アレクサンダー・グラハム・ベル",
+        "ja_typings": [
+          "arekusanda-/gurahamu/beru"
+        ]
+      },
+      {
+        "en": "Thomas Edison",
+        "ja": "トーマス・エジソン",
+        "ja_typings": [
+          "to-masu/ejison"
+        ]
+      },
+      {
+        "en": "Nikola Tesla",
+        "ja": "ニコラ・テスラ",
+        "ja_typings": [
+          "nikora/tesura"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03294",
+    "image_path": null,
+    "question_text": {
+      "en": "Who invented the famous telegraph code of dots and dashes?",
+      "ja": "点と線の電信符号を発明した米国の発明家は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "San Francisco",
+        "ja": "サンフランシスコ",
+        "ja_typings": [
+          "sanfuranshisuko"
+        ]
+      },
+      {
+        "en": "Los Angeles",
+        "ja": "ロサンゼルス",
+        "ja_typings": [
+          "rosanzerusu"
+        ]
+      },
+      {
+        "en": "San Diego",
+        "ja": "サンディエゴ",
+        "ja_typings": [
+          "sandexiego"
+        ]
+      },
+      {
+        "en": "Sacramento",
+        "ja": "サクラメント",
+        "ja_typings": [
+          "sakuramento",
+          "sakulamento"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03295",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Californian city is famous for the Golden Gate Bridge?",
+      "ja": "ゴールデンゲートブリッジで有名なカリフォルニアの都市はどこ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Steve Wozniak",
+        "ja": "スティーブ・ウォズニアック",
+        "ja_typings": [
+          "sutexi-bu/uxozuniatuku",
+          "suti-bu/wozuniakku"
+        ]
+      },
+      {
+        "en": "Bill Gates",
+        "ja": "ビル・ゲイツ",
+        "ja_typings": [
+          "biru/geitsu"
+        ]
+      },
+      {
+        "en": "Tim Cook",
+        "ja": "ティム・クック",
+        "ja_typings": [
+          "teximu/kutuku",
+          "timu/kukku"
+        ]
+      },
+      {
+        "en": "Ronald Wayne",
+        "ja": "ロナルド・ウェイン",
+        "ja_typings": [
+          "ronarudo/wein"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03296",
+    "image_path": null,
+    "question_text": {
+      "en": "Who co-founded Apple Computer with Steve Jobs in 1976?",
+      "ja": "1976年にスティーブ・ジョブズとアップルを共同創業したのは誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Swedish",
+        "ja": "スウェーデン語",
+        "ja_typings": [
+          "suuxe-dengo"
+        ]
+      },
+      {
+        "en": "Norwegian",
+        "ja": "ノルウェー語",
+        "ja_typings": [
+          "noruuxe-go",
+          "noluwe-go"
+        ]
+      },
+      {
+        "en": "Danish",
+        "ja": "デンマーク語",
+        "ja_typings": [
+          "denmaa-kugo"
+        ]
+      },
+      {
+        "en": "Finnish",
+        "ja": "フィンランド語",
+        "ja_typings": [
+          "huxinrandogo",
+          "finlandogo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03297",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the official language of Sweden?",
+      "ja": "スウェーデンの公用語はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thailand",
+        "ja": "タイ",
+        "ja_typings": [
+          "tai"
+        ]
+      },
+      {
+        "en": "Vietnam",
+        "ja": "ベトナム",
+        "ja_typings": [
+          "betonamu"
+        ]
+      },
+      {
+        "en": "Cambodia",
+        "ja": "カンボジア",
+        "ja_typings": [
+          "kanbojia"
+        ]
+      },
+      {
+        "en": "Laos",
+        "ja": "ラオス",
+        "ja_typings": [
+          "raosu",
+          "laosu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03298",
+    "image_path": null,
+    "question_text": {
+      "en": "In which country is Bangkok the capital?",
+      "ja": "首都がバンコクの国はどこ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Theaceae",
+        "ja": "ツバキ科",
+        "ja_typings": [
+          "tsubakika"
+        ]
+      },
+      {
+        "en": "Rosaceae",
+        "ja": "バラ科",
+        "ja_typings": [
+          "baraka"
+        ]
+      },
+      {
+        "en": "Magnoliaceae",
+        "ja": "モクレン科",
+        "ja_typings": [
+          "mokurenka"
+        ]
+      },
+      {
+        "en": "Fabaceae",
+        "ja": "マメ科",
+        "ja_typings": [
+          "mameka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03299",
+    "image_path": null,
+    "question_text": {
+      "en": "Which plant family includes tea and camellia?",
+      "ja": "ツバキやチャを含む植物の科はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tim Cook",
+        "ja": "ティム・クック",
+        "ja_typings": [
+          "teximu/kutuku",
+          "timu/kukku"
+        ]
+      },
+      {
+        "en": "Jonathan Ive",
+        "ja": "ジョナサン・アイブ",
+        "ja_typings": [
+          "jiyonasan/aibu",
+          "jonasan/aibu"
+        ]
+      },
+      {
+        "en": "Eddy Cue",
+        "ja": "エディ・キュー",
+        "ja_typings": [
+          "edexi-/kiyuu-",
+          "edii-/kyuu-",
+          "edi/kyu-"
+        ]
+      },
+      {
+        "en": "Craig Federighi",
+        "ja": "クレイグ・フェデリギ",
+        "ja_typings": [
+          "kureigu/huederigi",
+          "kuleigu/federigi",
+          "kureigu/federigi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03300",
+    "image_path": null,
+    "question_text": {
+      "en": "Who succeeded Steve Jobs as CEO of Apple?",
+      "ja": "スティーブ・ジョブズの後を継ぎアップルCEOになったのは誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Turkey",
+        "ja": "トルコ",
+        "ja_typings": [
+          "toruko",
+          "toluko"
+        ]
+      },
+      {
+        "en": "Greece",
+        "ja": "ギリシャ",
+        "ja_typings": [
+          "girisiya",
+          "gilisya",
+          "girisha"
+        ]
+      },
+      {
+        "en": "Bulgaria",
+        "ja": "ブルガリア",
+        "ja_typings": [
+          "burugaria",
+          "bulugalia"
+        ]
+      },
+      {
+        "en": "Syria",
+        "ja": "シリア",
+        "ja_typings": [
+          "shiria"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03301",
+    "image_path": null,
+    "question_text": {
+      "en": "In which country is the city Istanbul located?",
+      "ja": "イスタンブールがある国はどこ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "United States",
+        "ja": "アメリカ合衆国",
+        "ja_typings": [
+          "amerikagatusiyuukoku"
+        ]
+      },
+      {
+        "en": "Canada",
+        "ja": "カナダ",
+        "ja_typings": [
+          "kanada"
+        ]
+      },
+      {
+        "en": "Mexico",
+        "ja": "メキシコ",
+        "ja_typings": [
+          "mekishiko"
+        ]
+      },
+      {
+        "en": "United Kingdom",
+        "ja": "イギリス",
+        "ja_typings": [
+          "igirisu",
+          "igilisu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03302",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has its capital at Washington, D.C.?",
+      "ja": "首都がワシントンD.C.の国はどこ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yemen",
+        "ja": "イエメン",
+        "ja_typings": [
+          "iemen"
+        ]
+      },
+      {
+        "en": "Oman",
+        "ja": "オマーン",
+        "ja_typings": [
+          "omaa-n",
+          "oma-n"
+        ]
+      },
+      {
+        "en": "Qatar",
+        "ja": "カタール",
+        "ja_typings": [
+          "kataa-ru",
+          "kataa-lu",
+          "kata-ru"
+        ]
+      },
+      {
+        "en": "Bahrain",
+        "ja": "バーレーン",
+        "ja_typings": [
+          "baa-re-n",
+          "baa-le-n",
+          "ba-re-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03303",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country's capital is Sana'a in the Arabian Peninsula?",
+      "ja": "首都がサヌアであるアラビア半島の国はどこ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "amphibians",
+        "ja": "両生類",
+        "ja_typings": [
+          "riyouseirui",
+          "ryouseirui"
+        ]
+      },
+      {
+        "en": "reptiles",
+        "ja": "爬虫類",
+        "ja_typings": [
+          "hatiyuurui",
+          "hachuurui"
+        ]
+      },
+      {
+        "en": "mammals",
+        "ja": "哺乳類",
+        "ja_typings": [
+          "honiyuurui",
+          "honyuurui"
+        ]
+      },
+      {
+        "en": "fish",
+        "ja": "魚類",
+        "ja_typings": [
+          "gyorui"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03304",
+    "image_path": null,
+    "question_text": {
+      "en": "Frogs and salamanders belong to which class of animals?",
+      "ja": "カエルやサンショウウオが属する動物の綱はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "every 2 years",
+        "ja": "2年ごと",
+        "ja_typings": [
+          "2nengoto"
+        ]
+      },
+      {
+        "en": "every 4 years",
+        "ja": "4年ごと",
+        "ja_typings": [
+          "4nengoto"
+        ]
+      },
+      {
+        "en": "every 3 years",
+        "ja": "3年ごと",
+        "ja_typings": [
+          "3nengoto"
+        ]
+      },
+      {
+        "en": "every 5 years",
+        "ja": "5年ごと",
+        "ja_typings": [
+          "5nengoto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03305",
+    "image_path": null,
+    "question_text": {
+      "en": "How often are the Summer Olympics normally held?",
+      "ja": "夏季オリンピックは通常何年ごとに開催される?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "every 5 years",
+        "ja": "5年ごと",
+        "ja_typings": [
+          "5nengoto"
+        ]
+      },
+      {
+        "en": "every 2 years",
+        "ja": "2年ごと",
+        "ja_typings": [
+          "2nengoto"
+        ]
+      },
+      {
+        "en": "every 3 years",
+        "ja": "3年ごと",
+        "ja_typings": [
+          "3nengoto"
+        ]
+      },
+      {
+        "en": "every 4 years",
+        "ja": "4年ごと",
+        "ja_typings": [
+          "4nengoto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03306",
+    "image_path": null,
+    "question_text": {
+      "en": "How often is the World Athletics Championships held in odd years (recently)?",
+      "ja": "近年、世界陸上は何年ごとに開催される?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "flash of lightning",
+        "ja": "稲妻の光",
+        "ja_typings": [
+          "inazumanohikari"
+        ]
+      },
+      {
+        "en": "flash of a camera",
+        "ja": "カメラのフラッシュ",
+        "ja_typings": [
+          "kameranohuratusiyu",
+          "kameranofurasshu"
+        ]
+      },
+      {
+        "en": "city neon lights",
+        "ja": "ネオンの輝き",
+        "ja_typings": [
+          "neonnokagayaki"
+        ]
+      },
+      {
+        "en": "torch flame",
+        "ja": "松明の炎",
+        "ja_typings": [
+          "taimatunohonoo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03307",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the kanji 電 (as in 電光) literally depict?",
+      "ja": "「電光石火」の「電光」が指すのはどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "footprint of a runner",
+        "ja": "俊足の走者",
+        "ja_typings": [
+          "siyunsokunosousiya",
+          "shunsokunosousha"
+        ]
+      },
+      {
+        "en": "god of war",
+        "ja": "戦の神",
+        "ja_typings": [
+          "ikusanokami"
+        ]
+      },
+      {
+        "en": "temple guardian",
+        "ja": "寺院の守護神",
+        "ja_typings": [
+          "jiinnosiyugosin"
+        ]
+      },
+      {
+        "en": "running deer",
+        "ja": "走る鹿",
+        "ja_typings": [
+          "hasiruxsika"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03308",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the kanji 韋 in 韋駄天 originally evoke as an image?",
+      "ja": "「韋駄天走り」のもとになるイメージはどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "four doubles",
+        "ja": "4二塁打",
+        "ja_typings": [
+          "4niruida"
+        ]
+      },
+      {
+        "en": "cycle hit",
+        "ja": "サイクルヒット",
+        "ja_typings": [
+          "saikuruhitututo",
+          "saikuluhitto",
+          "saikuruhitto"
+        ]
+      },
+      {
+        "en": "four home runs",
+        "ja": "4本塁打",
+        "ja_typings": [
+          "4honruida"
+        ]
+      },
+      {
+        "en": "perfect day",
+        "ja": "パーフェクトデー",
+        "ja_typings": [
+          "paa-huxekutode-",
+          "pa-fekutode-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03309",
+    "image_path": null,
+    "question_text": {
+      "en": "In baseball, hitting four doubles in a single game is colloquially what?",
+      "ja": "野球で1試合に二塁打を4本打つことを何と呼ぶ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "four home runs",
+        "ja": "4本塁打",
+        "ja_typings": [
+          "4honruida"
+        ]
+      },
+      {
+        "en": "four doubles",
+        "ja": "4二塁打",
+        "ja_typings": [
+          "4niruida"
+        ]
+      },
+      {
+        "en": "grand slam",
+        "ja": "満塁本塁打",
+        "ja_typings": [
+          "manruihonruida"
+        ]
+      },
+      {
+        "en": "cycle hit",
+        "ja": "サイクルヒット",
+        "ja_typings": [
+          "saikuruhitututo",
+          "saikuruhitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03310",
+    "image_path": null,
+    "question_text": {
+      "en": "In baseball, what do you call hitting four home runs in one game?",
+      "ja": "野球で1試合に本塁打を4本打つことを何と呼ぶ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "frog",
+        "ja": "カエル",
+        "ja_typings": [
+          "kaeru",
+          "kaelu"
+        ]
+      },
+      {
+        "en": "salamander",
+        "ja": "サンショウウオ",
+        "ja_typings": [
+          "sansiyouuo",
+          "sanshouuo",
+          "sanshouo"
+        ]
+      },
+      {
+        "en": "newt",
+        "ja": "イモリ",
+        "ja_typings": [
+          "imori",
+          "imoli"
+        ]
+      },
+      {
+        "en": "caecilian",
+        "ja": "アシナシイモリ",
+        "ja_typings": [
+          "ashinashiimori"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03311",
+    "image_path": null,
+    "question_text": {
+      "en": "Which amphibian is known for metamorphosing from a tadpole?",
+      "ja": "オタマジャクシから変態することで知られる両生類はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "fruit",
+        "ja": "果実",
+        "ja_typings": [
+          "kajitsu"
+        ]
+      },
+      {
+        "en": "flower",
+        "ja": "花",
+        "ja_typings": [
+          "hana"
+        ]
+      },
+      {
+        "en": "leaf",
+        "ja": "葉",
+        "ja_typings": [
+          "ha"
+        ]
+      },
+      {
+        "en": "stem",
+        "ja": "茎",
+        "ja_typings": [
+          "kuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03312",
+    "image_path": null,
+    "question_text": {
+      "en": "What part of a plant typically develops from a fertilized flower and contains seeds?",
+      "ja": "受粉した花が成熟してできる、種子を含む部分はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "magnetic sense",
+        "ja": "磁気感覚",
+        "ja_typings": [
+          "jikikankaku"
+        ]
+      },
+      {
+        "en": "sense of smell",
+        "ja": "嗅覚",
+        "ja_typings": [
+          "kiyuukaku",
+          "kyuukaku"
+        ]
+      },
+      {
+        "en": "night vision",
+        "ja": "夜視力",
+        "ja_typings": [
+          "yasiriyoku",
+          "yashiryoku"
+        ]
+      },
+      {
+        "en": "echolocation",
+        "ja": "反響定位",
+        "ja_typings": [
+          "hankiyouteii",
+          "hankyouteii"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03313",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sense allows some animals to navigate using Earth's field?",
+      "ja": "地磁気を使ってナビゲーションする動物が持つ感覚はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "meat",
+        "ja": "肉",
+        "ja_typings": [
+          "niku"
+        ]
+      },
+      {
+        "en": "fruit",
+        "ja": "果実",
+        "ja_typings": [
+          "kajitsu"
+        ]
+      },
+      {
+        "en": "grain",
+        "ja": "穀物",
+        "ja_typings": [
+          "kokumotsu"
+        ]
+      },
+      {
+        "en": "vegetable",
+        "ja": "野菜",
+        "ja_typings": [
+          "yasai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03314",
+    "image_path": null,
+    "question_text": {
+      "en": "Which food group is the primary source of animal protein in many diets?",
+      "ja": "多くの食生活で動物性たんぱく質の主な供給源はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "night vision",
+        "ja": "夜視力",
+        "ja_typings": [
+          "yasiriyoku",
+          "yashiryoku"
+        ]
+      },
+      {
+        "en": "magnetic sense",
+        "ja": "磁気感覚",
+        "ja_typings": [
+          "jikikankaku"
+        ]
+      },
+      {
+        "en": "echolocation",
+        "ja": "反響定位",
+        "ja_typings": [
+          "hankiyouteii"
+        ]
+      },
+      {
+        "en": "color vision",
+        "ja": "色覚",
+        "ja_typings": [
+          "shikikaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03315",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ability lets owls and cats hunt in very low light?",
+      "ja": "フクロウやネコが暗所で狩りができる視覚能力はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "pigeon",
+        "ja": "ハト",
+        "ja_typings": [
+          "hato"
+        ]
+      },
+      {
+        "en": "crow",
+        "ja": "カラス",
+        "ja_typings": [
+          "karasu",
+          "kalasu"
+        ]
+      },
+      {
+        "en": "sparrow",
+        "ja": "スズメ",
+        "ja_typings": [
+          "suzume"
+        ]
+      },
+      {
+        "en": "eagle",
+        "ja": "ワシ",
+        "ja_typings": [
+          "washi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03316",
+    "image_path": null,
+    "question_text": {
+      "en": "Which bird is famous for its homing ability and is often white in symbolism?",
+      "ja": "帰巣本能で知られ、平和の象徴とされる鳥はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "rabbit",
+        "ja": "ウサギ",
+        "ja_typings": [
+          "usagi"
+        ]
+      },
+      {
+        "en": "hare",
+        "ja": "ノウサギ",
+        "ja_typings": [
+          "nousagi",
+          "nosagi"
+        ]
+      },
+      {
+        "en": "squirrel",
+        "ja": "リス",
+        "ja_typings": [
+          "risu",
+          "lisu"
+        ]
+      },
+      {
+        "en": "guinea pig",
+        "ja": "モルモット",
+        "ja_typings": [
+          "morumotutoto",
+          "molumotto",
+          "morumotto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03317",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mammal is famous for long ears and rapid reproduction?",
+      "ja": "長い耳と繁殖力で知られる哺乳類はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "reptiles",
+        "ja": "爬虫類",
+        "ja_typings": [
+          "hatiyuurui",
+          "hachuurui"
+        ]
+      },
+      {
+        "en": "amphibians",
+        "ja": "両生類",
+        "ja_typings": [
+          "riyouseirui"
+        ]
+      },
+      {
+        "en": "mammals",
+        "ja": "哺乳類",
+        "ja_typings": [
+          "honiyuurui"
+        ]
+      },
+      {
+        "en": "birds",
+        "ja": "鳥類",
+        "ja_typings": [
+          "tiyourui",
+          "chourui"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03318",
+    "image_path": null,
+    "question_text": {
+      "en": "Snakes, turtles and lizards belong to which class of animals?",
+      "ja": "ヘビ・カメ・トカゲが属する動物の綱はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sense of smell",
+        "ja": "嗅覚",
+        "ja_typings": [
+          "kiyuukaku",
+          "kyuukaku"
+        ]
+      },
+      {
+        "en": "magnetic sense",
+        "ja": "磁気感覚",
+        "ja_typings": [
+          "jikikankaku"
+        ]
+      },
+      {
+        "en": "night vision",
+        "ja": "夜視力",
+        "ja_typings": [
+          "yasiriyoku"
+        ]
+      },
+      {
+        "en": "hearing",
+        "ja": "聴覚",
+        "ja_typings": [
+          "tiyoukaku",
+          "choukaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03319",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sense do dogs use exceptionally well to track prey or people?",
+      "ja": "犬が獲物や人を追跡するときに特に優れている感覚はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "three strikeouts",
+        "ja": "3三振",
+        "ja_typings": [
+          "3sanshin"
+        ]
+      },
+      {
+        "en": "perfect inning",
+        "ja": "完全イニング",
+        "ja_typings": [
+          "kanzeniningu"
+        ]
+      },
+      {
+        "en": "immaculate inning",
+        "ja": "イマキュレートイニング",
+        "ja_typings": [
+          "imakiyure-toiningu",
+          "imakyure-toiningu"
+        ]
+      },
+      {
+        "en": "no-hitter",
+        "ja": "ノーヒッター",
+        "ja_typings": [
+          "noo-hitutaa-",
+          "noo-hittaa-",
+          "no-hitta-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03320",
+    "image_path": null,
+    "question_text": {
+      "en": "In baseball, getting three strikeouts in one inning is called what?",
+      "ja": "野球で1イニングに3つ三振を取ることを何と呼ぶ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "trail of an arrow",
+        "ja": "矢の軌跡",
+        "ja_typings": [
+          "yanokiseki"
+        ]
+      },
+      {
+        "en": "shadow of a bird",
+        "ja": "鳥の影",
+        "ja_typings": [
+          "torinokage"
+        ]
+      },
+      {
+        "en": "smoke of a fire",
+        "ja": "火の煙",
+        "ja_typings": [
+          "hinokemuri"
+        ]
+      },
+      {
+        "en": "ripple of water",
+        "ja": "水の波紋",
+        "ja_typings": [
+          "mizunohamon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03321",
+    "image_path": null,
+    "question_text": {
+      "en": "What does an arrow leave behind in flight, often used as an idiom?",
+      "ja": "矢が飛んだ後に残るとされる、慣用句にもなるものはどれ?"
     }
   }
 ]

--- a/data/questions_en.json
+++ b/data/questions_en.json
@@ -101447,8 +101447,8 @@
     "id": "q02503",
     "image_path": null,
     "question_text": {
-      "en": "エジプトの地中海沿岸に位置し、古代に大図書館があった都市は?",
-      "ja": "Which Egyptian city on the Mediterranean coast was home to a famous ancient library?"
+      "en": "Which Egyptian city on the Mediterranean coast was home to a famous ancient library?",
+      "ja": "エジプトの地中海沿岸に位置し、古代に大図書館があった都市は?"
     }
   },
   {
@@ -101491,8 +101491,8 @@
     "id": "q02504",
     "image_path": null,
     "question_text": {
-      "en": "南米大陸を流れる世界最大級の流域面積を持つ川は?",
-      "ja": "Which river in South America has one of the largest drainage basins in the world?"
+      "en": "Which river in South America has one of the largest drainage basins in the world?",
+      "ja": "南米大陸を流れる世界最大級の流域面積を持つ川は?"
     }
   },
   {
@@ -101531,8 +101531,8 @@
     "id": "q02505",
     "image_path": null,
     "question_text": {
-      "en": "地球で最も北に位置する海洋は?",
-      "ja": "Which is the northernmost ocean on Earth?"
+      "en": "Which is the northernmost ocean on Earth?",
+      "ja": "地球で最も北に位置する海洋は?"
     }
   },
   {
@@ -101571,8 +101571,8 @@
     "id": "q02506",
     "image_path": null,
     "question_text": {
-      "en": "北海道のほぼ中央にあり、上川盆地に位置する都市は?",
-      "ja": "Which Hokkaido city is located in the Kamikawa Basin near the center of the island?"
+      "en": "Which Hokkaido city is located in the Kamikawa Basin near the center of the island?",
+      "ja": "北海道のほぼ中央にあり、上川盆地に位置する都市は?"
     }
   },
   {
@@ -101611,8 +101611,8 @@
     "id": "q02507",
     "image_path": null,
     "question_text": {
-      "en": "世界で最も広い大陸は?",
-      "ja": "Which is the largest continent in the world?"
+      "en": "Which is the largest continent in the world?",
+      "ja": "世界で最も広い大陸は?"
     }
   },
   {
@@ -101651,8 +101651,8 @@
     "id": "q02508",
     "image_path": null,
     "question_text": {
-      "en": "パラグアイの首都は?",
-      "ja": "What is the capital of Paraguay?"
+      "en": "What is the capital of Paraguay?",
+      "ja": "パラグアイの首都は?"
     }
   },
   {
@@ -101691,8 +101691,8 @@
     "id": "q02509",
     "image_path": null,
     "question_text": {
-      "en": "ヨーロッパとアメリカ大陸の間に広がる海洋は?",
-      "ja": "Which ocean lies between Europe and the Americas?"
+      "en": "Which ocean lies between Europe and the Americas?",
+      "ja": "ヨーロッパとアメリカ大陸の間に広がる海洋は?"
     }
   },
   {
@@ -101731,8 +101731,8 @@
     "id": "q02510",
     "image_path": null,
     "question_text": {
-      "en": "北アフリカを横断する大山脈は?",
-      "ja": "Which mountain range stretches across North Africa?"
+      "en": "Which mountain range stretches across North Africa?",
+      "ja": "北アフリカを横断する大山脈は?"
     }
   },
   {
@@ -101771,8 +101771,8 @@
     "id": "q02511",
     "image_path": null,
     "question_text": {
-      "en": "インドのIT産業の中心地として知られる都市は?",
-      "ja": "Which Indian city is known as the center of the IT industry?"
+      "en": "Which Indian city is known as the center of the IT industry?",
+      "ja": "インドのIT産業の中心地として知られる都市は?"
     }
   },
   {
@@ -101811,8 +101811,8 @@
     "id": "q02512",
     "image_path": null,
     "question_text": {
-      "en": "サグラダ・ファミリアがあるスペイン東部の都市は?",
-      "ja": "Which city in eastern Spain is home to the Sagrada Familia?"
+      "en": "Which city in northeastern Spain is home to the Sagrada Familia?",
+      "ja": "サグラダ・ファミリアがあるスペイン北東部の都市は?"
     }
   },
   {
@@ -101851,8 +101851,8 @@
     "id": "q02513",
     "image_path": null,
     "question_text": {
-      "en": "ドイツの首都は?",
-      "ja": "What is the capital of Germany?"
+      "en": "What is the capital of Germany?",
+      "ja": "ドイツの首都は?"
     }
   },
   {
@@ -101891,8 +101891,8 @@
     "id": "q02514",
     "image_path": null,
     "question_text": {
-      "en": "ヒマラヤ山脈にある「幸福度」で知られる国は?",
-      "ja": "Which Himalayan country is known for its focus on Gross National Happiness?"
+      "en": "Which Himalayan country is known for its focus on Gross National Happiness?",
+      "ja": "ヒマラヤ山脈にある「幸福度」で知られる国は?"
     }
   },
   {
@@ -101935,8 +101935,8 @@
     "id": "q02515",
     "image_path": null,
     "question_text": {
-      "en": "東南アジアにある世界で3番目に大きい島は?",
-      "ja": "Which is the third largest island in the world, located in Southeast Asia?"
+      "en": "Which is the third largest island in the world, located in Southeast Asia?",
+      "ja": "東南アジアにある世界で3番目に大きい島は?"
     }
   },
   {
@@ -101975,8 +101975,8 @@
     "id": "q02516",
     "image_path": null,
     "question_text": {
-      "en": "イグアスの滝が国境にある国の組み合わせは?",
-      "ja": "Iguazu Falls lies on the border between which two countries?"
+      "en": "Iguazu Falls lies on the border between which two countries?",
+      "ja": "イグアスの滝が国境にある国の組み合わせは?"
     }
   },
   {
@@ -102015,8 +102015,8 @@
     "id": "q02517",
     "image_path": null,
     "question_text": {
-      "en": "アルゼンチンの首都は?",
-      "ja": "What is the capital of Argentina?"
+      "en": "What is the capital of Argentina?",
+      "ja": "アルゼンチンの首都は?"
     }
   },
   {
@@ -102055,8 +102055,8 @@
     "id": "q02518",
     "image_path": null,
     "question_text": {
-      "en": "トルコ北西部の旧オスマン帝国首都として知られる都市は?",
-      "ja": "Which northwestern Turkish city was a former capital of the Ottoman Empire?"
+      "en": "Which northwestern Turkish city was a former capital of the Ottoman Empire?",
+      "ja": "トルコ北西部の旧オスマン帝国首都として知られる都市は?"
     }
   },
   {
@@ -102095,8 +102095,8 @@
     "id": "q02519",
     "image_path": null,
     "question_text": {
-      "en": "韓国第2の都市で南東部の主要港湾都市は?",
-      "ja": "Which is South Korea's second largest city and a major southeastern port?"
+      "en": "Which is South Korea's second largest city and a major southeastern port?",
+      "ja": "韓国第2の都市で南東部の主要港湾都市は?"
     }
   },
   {
@@ -102135,8 +102135,8 @@
     "id": "q02520",
     "image_path": null,
     "question_text": {
-      "en": "メキシコ・ユカタン半島のリゾート都市は?",
-      "ja": "Which resort city is on Mexico's Yucatan Peninsula?"
+      "en": "Which resort city is on Mexico's Yucatan Peninsula?",
+      "ja": "メキシコ・ユカタン半島のリゾート都市は?"
     }
   },
   {
@@ -102175,8 +102175,8 @@
     "id": "q02521",
     "image_path": null,
     "question_text": {
-      "en": "アゼルバイジャンのバクーがあるのは?",
-      "ja": "Baku, the capital of Azerbaijan, is located on which shore?"
+      "en": "Baku, the capital of Azerbaijan, is located on which shore?",
+      "ja": "アゼルバイジャンのバクーがあるのは?"
     }
   },
   {
@@ -102215,8 +102215,8 @@
     "id": "q02522",
     "image_path": null,
     "question_text": {
-      "en": "黒海とカスピ海の間に広がる山脈は?",
-      "ja": "Which mountain range lies between the Black Sea and the Caspian Sea?"
+      "en": "Which mountain range lies between the Black Sea and the Caspian Sea?",
+      "ja": "黒海とカスピ海の間に広がる山脈は?"
     }
   },
   {
@@ -102255,8 +102255,8 @@
     "id": "q02523",
     "image_path": null,
     "question_text": {
-      "en": "アメリカ五大湖のミシガン湖畔に位置する都市は?",
-      "ja": "Which U.S. city is located on the shore of Lake Michigan?"
+      "en": "Which U.S. city is located on the shore of Lake Michigan?",
+      "ja": "アメリカ五大湖のミシガン湖畔に位置する都市は?"
     }
   },
   {
@@ -102295,8 +102295,8 @@
     "id": "q02524",
     "image_path": null,
     "question_text": {
-      "en": "ペロポネソス半島の付け根にある古代ギリシャの都市は?",
-      "ja": "Which ancient Greek city stood at the isthmus of the Peloponnese?"
+      "en": "Which ancient Greek city stood at the isthmus of the Peloponnese?",
+      "ja": "ペロポネソス半島の付け根にある古代ギリシャの都市は?"
     }
   },
   {
@@ -102335,8 +102335,8 @@
     "id": "q02525",
     "image_path": null,
     "question_text": {
-      "en": "ベトナム中部の主要港湾都市は?",
-      "ja": "Which city is a major port in central Vietnam?"
+      "en": "Which city is a major port in central Vietnam?",
+      "ja": "ベトナム中部の主要港湾都市は?"
     }
   },
   {
@@ -102375,8 +102375,8 @@
     "id": "q02526",
     "image_path": null,
     "question_text": {
-      "en": "アイルランドの首都は?",
-      "ja": "What is the capital of Ireland?"
+      "en": "What is the capital of Ireland?",
+      "ja": "アイルランドの首都は?"
     }
   },
   {
@@ -102415,8 +102415,8 @@
     "id": "q02527",
     "image_path": null,
     "question_text": {
-      "en": "スコットランドの首都は?",
-      "ja": "What is the capital of Scotland?"
+      "en": "What is the capital of Scotland?",
+      "ja": "スコットランドの首都は?"
     }
   },
   {
@@ -102455,8 +102455,8 @@
     "id": "q02528",
     "image_path": null,
     "question_text": {
-      "en": "イタリアのトスカーナ州の州都でルネサンス発祥の地は?",
-      "ja": "Which Tuscan city is known as the birthplace of the Renaissance?"
+      "en": "Which Tuscan city is known as the birthplace of the Renaissance?",
+      "ja": "イタリアのトスカーナ州の州都でルネサンス発祥の地は?"
     }
   },
   {
@@ -102495,8 +102495,8 @@
     "id": "q02529",
     "image_path": null,
     "question_text": {
-      "en": "ドイツの金融の中心地として知られる都市は?",
-      "ja": "Which German city is the country's financial center?"
+      "en": "Which German city is the country's financial center?",
+      "ja": "ドイツの金融の中心地として知られる都市は?"
     }
   },
   {
@@ -102535,8 +102535,8 @@
     "id": "q02530",
     "image_path": null,
     "question_text": {
-      "en": "沖縄本島中部の都市で米軍基地が多いことで知られるのは?",
-      "ja": "Which Okinawan city is known for hosting many U.S. military bases?"
+      "en": "Which Okinawan city is known for hosting many U.S. military bases?",
+      "ja": "沖縄本島中部の都市で米軍基地が多いことで知られるのは?"
     }
   },
   {
@@ -102575,8 +102575,8 @@
     "id": "q02531",
     "image_path": null,
     "question_text": {
-      "en": "ピラミッドとスフィンクスがあるエジプトの都市は?",
-      "ja": "Which Egyptian city is home to the pyramids and the Sphinx?"
+      "en": "Which Egyptian city is home to the pyramids and the Sphinx?",
+      "ja": "ピラミッドとスフィンクスがあるエジプトの都市は?"
     }
   },
   {
@@ -102617,8 +102617,8 @@
     "id": "q02532",
     "image_path": null,
     "question_text": {
-      "en": "世界最大の島でデンマーク自治領なのは?",
-      "ja": "Which is the world's largest island, an autonomous territory of Denmark?"
+      "en": "Which is the world's largest island, an autonomous territory of Denmark?",
+      "ja": "世界最大の島でデンマーク自治領なのは?"
     }
   },
   {
@@ -102657,8 +102657,8 @@
     "id": "q02533",
     "image_path": null,
     "question_text": {
-      "en": "メキシコ第2の都市でテキーラの産地として有名な都市は?",
-      "ja": "Which Mexican city is famous as the home of tequila?"
+      "en": "Which Mexican city is famous as the home of tequila?",
+      "ja": "メキシコ第2の都市でテキーラの産地として有名な都市は?"
     }
   },
   {
@@ -102697,8 +102697,8 @@
     "id": "q02534",
     "image_path": null,
     "question_text": {
-      "en": "北海道南部にある夜景が有名な港町は?",
-      "ja": "Which Hokkaido port town is famous for its night view?"
+      "en": "Which Hokkaido port town is famous for its night view?",
+      "ja": "北海道南部にある夜景が有名な港町は?"
     }
   },
   {
@@ -102737,8 +102737,8 @@
     "id": "q02535",
     "image_path": null,
     "question_text": {
-      "en": "ドイツ北部の主要港湾都市は?",
-      "ja": "Which city is a major northern German port?"
+      "en": "Which city is a major northern German port?",
+      "ja": "ドイツ北部の主要港湾都市は?"
     }
   },
   {
@@ -102777,8 +102777,8 @@
     "id": "q02536",
     "image_path": null,
     "question_text": {
-      "en": "ベトナムの首都は?",
-      "ja": "What is the capital of Vietnam?"
+      "en": "What is the capital of Vietnam?",
+      "ja": "ベトナムの首都は?"
     }
   },
   {
@@ -102817,8 +102817,8 @@
     "id": "q02537",
     "image_path": null,
     "question_text": {
-      "en": "ベトナム南部最大の都市は?",
-      "ja": "Which is the largest city in southern Vietnam?"
+      "en": "Which is the largest city in southern Vietnam?",
+      "ja": "ベトナム南部最大の都市は?"
     }
   },
   {
@@ -102857,8 +102857,8 @@
     "id": "q02538",
     "image_path": null,
     "question_text": {
-      "en": "中国南部にある特別行政区で金融センターとして知られる都市は?",
-      "ja": "Which Special Administrative Region of southern China is a major financial hub?"
+      "en": "Which Special Administrative Region of southern China is a major financial hub?",
+      "ja": "中国南部にある特別行政区で金融センターとして知られる都市は?"
     }
   },
   {
@@ -102897,8 +102897,8 @@
     "id": "q02539",
     "image_path": null,
     "question_text": {
-      "en": "ベトナム中部の旧王朝の都は?",
-      "ja": "Which central Vietnamese city was the imperial capital under the Nguyen dynasty?"
+      "en": "Which central Vietnamese city was the imperial capital under the Nguyen dynasty?",
+      "ja": "ベトナム中部の旧王朝の都は?"
     }
   },
   {
@@ -102937,8 +102937,8 @@
     "id": "q02540",
     "image_path": null,
     "question_text": {
-      "en": "韓国の国際空港があるソウル近郊の港湾都市は?",
-      "ja": "Which port city near Seoul hosts South Korea's main international airport?"
+      "en": "Which port city near Seoul hosts South Korea's main international airport?",
+      "ja": "韓国の国際空港があるソウル近郊の港湾都市は?"
     }
   },
   {
@@ -102977,8 +102977,8 @@
     "id": "q02541",
     "image_path": null,
     "question_text": {
-      "en": "南アジアで人口最多の国は?",
-      "ja": "Which is the most populous country in South Asia?"
+      "en": "Which is the most populous country in South Asia?",
+      "ja": "南アジアで人口最多の国は?"
     }
   },
   {
@@ -103017,8 +103017,8 @@
     "id": "q02542",
     "image_path": null,
     "question_text": {
-      "en": "アフリカとオーストラリアの間に広がる海洋は?",
-      "ja": "Which ocean lies between Africa and Australia?"
+      "en": "Which ocean lies between Africa and Australia?",
+      "ja": "アフリカとオーストラリアの間に広がる海洋は?"
     }
   },
   {
@@ -103058,8 +103058,8 @@
     "id": "q02543",
     "image_path": null,
     "question_text": {
-      "en": "八重山諸島の中心の島は?",
-      "ja": "Which is the main island of the Yaeyama Islands?"
+      "en": "Which is the main island of the Yaeyama Islands?",
+      "ja": "八重山諸島の中心の島は?"
     }
   },
   {
@@ -103102,8 +103102,8 @@
     "id": "q02544",
     "image_path": null,
     "question_text": {
-      "en": "北海道で最長の川は?",
-      "ja": "Which is the longest river in Hokkaido?"
+      "en": "Which is the longest river in Hokkaido?",
+      "ja": "北海道で最長の川は?"
     }
   },
   {
@@ -103142,8 +103142,8 @@
     "id": "q02545",
     "image_path": null,
     "question_text": {
-      "en": "トルコ第3の都市でエーゲ海沿岸の港湾都市は?",
-      "ja": "Which is Turkey's third largest city, a port on the Aegean coast?"
+      "en": "Which is Turkey's third largest city, a port on the Aegean coast?",
+      "ja": "トルコ第3の都市でエーゲ海沿岸の港湾都市は?"
     }
   },
   {
@@ -103182,8 +103182,8 @@
     "id": "q02546",
     "image_path": null,
     "question_text": {
-      "en": "サウジアラビアの紅海沿岸の主要都市は?",
-      "ja": "Which is Saudi Arabia's main city on the Red Sea coast?"
+      "en": "Which is Saudi Arabia's main city on the Red Sea coast?",
+      "ja": "サウジアラビアの紅海沿岸の主要都市は?"
     }
   },
   {
@@ -103222,8 +103222,8 @@
     "id": "q02547",
     "image_path": null,
     "question_text": {
-      "en": "南部アフリカに広がる砂漠は?",
-      "ja": "Which desert covers much of southern Africa?"
+      "en": "Which desert covers much of southern Africa?",
+      "ja": "南部アフリカに広がる砂漠は?"
     }
   },
   {
@@ -103263,8 +103263,8 @@
     "id": "q02548",
     "image_path": null,
     "question_text": {
-      "en": "本州と九州を結ぶ関門海峡にかかる橋は?",
-      "ja": "Which bridge spans the Kanmon Strait between Honshu and Kyushu?"
+      "en": "Which bridge spans the Kanmon Strait between Honshu and Kyushu?",
+      "ja": "本州と九州を結ぶ関門海峡にかかる橋は?"
     }
   },
   {
@@ -103303,8 +103303,8 @@
     "id": "q02549",
     "image_path": null,
     "question_text": {
-      "en": "インド東部の大都市で旧称カルカッタの都市は?",
-      "ja": "Which large eastern Indian city was formerly called Calcutta?"
+      "en": "Which large eastern Indian city was formerly called Calcutta?",
+      "ja": "インド東部の大都市で旧称カルカッタの都市は?"
     }
   },
   {
@@ -103343,8 +103343,8 @@
     "id": "q02550",
     "image_path": null,
     "question_text": {
-      "en": "北海道道東にある霧で有名な港町は?",
-      "ja": "Which port town in eastern Hokkaido is famous for its fog?"
+      "en": "Which port town in eastern Hokkaido is famous for its fog?",
+      "ja": "北海道道東にある霧で有名な港町は?"
     }
   },
   {
@@ -103383,8 +103383,8 @@
     "id": "q02551",
     "image_path": null,
     "question_text": {
-      "en": "ジブチにある世界で最も標高の低い湖は?",
-      "ja": "Which lake in Djibouti is the lowest point on land?"
+      "en": "Which lake in Djibouti is the lowest point on land?",
+      "ja": "ジブチにある世界で最も標高の低い湖は?"
     }
   },
   {
@@ -103423,8 +103423,8 @@
     "id": "q02552",
     "image_path": null,
     "question_text": {
-      "en": "福島県にある日本で4番目に大きい湖は?",
-      "ja": "Which Fukushima lake is the fourth largest in Japan?"
+      "en": "Which Fukushima lake is the fourth largest in Japan?",
+      "ja": "福島県にある日本で4番目に大きい湖は?"
     }
   },
   {
@@ -103463,8 +103463,8 @@
     "id": "q02553",
     "image_path": null,
     "question_text": {
-      "en": "茨城県にある日本で2番目に大きい湖は?",
-      "ja": "Which Ibaraki lake is the second largest in Japan?"
+      "en": "Which Ibaraki lake is the second largest in Japan?",
+      "ja": "茨城県にある日本で2番目に大きい湖は?"
     }
   },
   {
@@ -103503,8 +103503,8 @@
     "id": "q02554",
     "image_path": null,
     "question_text": {
-      "en": "北海道東部のオホーツク海に面した日本最大の汽水湖は?",
-      "ja": "Which is Japan's largest brackish lake, on Hokkaido's Sea of Okhotsk coast?"
+      "en": "Which is Japan's largest brackish lake, on Hokkaido's Sea of Okhotsk coast?",
+      "ja": "北海道東部のオホーツク海に面した日本最大の汽水湖は?"
     }
   },
   {
@@ -103543,8 +103543,8 @@
     "id": "q02555",
     "image_path": null,
     "question_text": {
-      "en": "アメリカ・カリフォルニア州南部の大都市は?",
-      "ja": "Which is the largest city in Southern California?"
+      "en": "Which is the largest city in Southern California?",
+      "ja": "アメリカ・カリフォルニア州南部の大都市は?"
     }
   },
   {
@@ -103583,8 +103583,8 @@
     "id": "q02556",
     "image_path": null,
     "question_text": {
-      "en": "エジプト南部にあるカルナック神殿で有名な都市は?",
-      "ja": "Which southern Egyptian city is famous for the Karnak Temple?"
+      "en": "Which southern Egyptian city is famous for the Karnak Temple?",
+      "ja": "エジプト南部にあるカルナック神殿で有名な都市は?"
     }
   },
   {
@@ -103625,8 +103625,8 @@
     "id": "q02557",
     "image_path": null,
     "question_text": {
-      "en": "アフリカ南東沖にある世界で4番目に大きい島は?",
-      "ja": "Which is the fourth largest island in the world, off southeastern Africa?"
+      "en": "Which is the fourth largest island in the world, off southeastern Africa?",
+      "ja": "アフリカ南東沖にある世界で4番目に大きい島は?"
     }
   },
   {
@@ -103665,8 +103665,8 @@
     "id": "q02558",
     "image_path": null,
     "question_text": {
-      "en": "スペインの首都は?",
-      "ja": "What is the capital of Spain?"
+      "en": "What is the capital of Spain?",
+      "ja": "スペインの首都は?"
     }
   },
   {
@@ -103705,8 +103705,8 @@
     "id": "q02559",
     "image_path": null,
     "question_text": {
-      "en": "イギリス北西部の工業都市でサッカーが盛んな都市は?",
-      "ja": "Which northwestern English industrial city is famous for football?"
+      "en": "Which northwestern English industrial city is famous for football?",
+      "ja": "イギリス北西部の工業都市でサッカーが盛んな都市は?"
     }
   },
   {
@@ -103745,8 +103745,8 @@
     "id": "q02560",
     "image_path": null,
     "question_text": {
-      "en": "イスラム教最大の聖地はサウジアラビアの?",
-      "ja": "Which Saudi Arabian city is Islam's holiest site?"
+      "en": "Which Saudi Arabian city is Islam's holiest site?",
+      "ja": "イスラム教最大の聖地はサウジアラビアの?"
     }
   },
   {
@@ -103785,8 +103785,8 @@
     "id": "q02561",
     "image_path": null,
     "question_text": {
-      "en": "イスラム教第2の聖地で預言者ムハンマドの墓がある都市は?",
-      "ja": "Which city is Islam's second holiest, home to the Prophet Muhammad's tomb?"
+      "en": "Which city is Islam's second holiest, home to the Prophet Muhammad's tomb?",
+      "ja": "イスラム教第2の聖地で預言者ムハンマドの墓がある都市は?"
     }
   },
   {
@@ -103825,8 +103825,8 @@
     "id": "q02562",
     "image_path": null,
     "question_text": {
-      "en": "イスラエルのテルアビブやレバノンのベイルートが面しているのは?",
-      "ja": "Tel Aviv and Beirut both face which coastal region?"
+      "en": "Tel Aviv and Beirut both face which coastal region?",
+      "ja": "イスラエルのテルアビブやレバノンのベイルートが面しているのは?"
     }
   },
   {
@@ -103865,8 +103865,8 @@
     "id": "q02563",
     "image_path": null,
     "question_text": {
-      "en": "イタリア北部の経済の中心地でファッションの都は?",
-      "ja": "Which northern Italian city is its economic and fashion capital?"
+      "en": "Which northern Italian city is its economic and fashion capital?",
+      "ja": "イタリア北部の経済の中心地でファッションの都は?"
     }
   },
   {
@@ -103909,8 +103909,8 @@
     "id": "q02564",
     "image_path": null,
     "question_text": {
-      "en": "アメリカ中部を南北に貫く大河は?",
-      "ja": "Which great river runs north-south through the central United States?"
+      "en": "Which great river runs north-south through the central United States?",
+      "ja": "アメリカ中部を南北に貫く大河は?"
     }
   },
   {
@@ -103949,8 +103949,8 @@
     "id": "q02565",
     "image_path": null,
     "question_text": {
-      "en": "メキシコ北部の工業都市は?",
-      "ja": "Which northern Mexican city is a major industrial center?"
+      "en": "Which northern Mexican city is a major industrial center?",
+      "ja": "メキシコ北部の工業都市は?"
     }
   },
   {
@@ -103989,8 +103989,8 @@
     "id": "q02566",
     "image_path": null,
     "question_text": {
-      "en": "ウルグアイの首都は?",
-      "ja": "What is the capital of Uruguay?"
+      "en": "What is the capital of Uruguay?",
+      "ja": "ウルグアイの首都は?"
     }
   },
   {
@@ -104029,8 +104029,8 @@
     "id": "q02567",
     "image_path": null,
     "question_text": {
-      "en": "カナダ・ケベック州の最大都市は?",
-      "ja": "Which is the largest city in Quebec, Canada?"
+      "en": "Which is the largest city in Quebec, Canada?",
+      "ja": "カナダ・ケベック州の最大都市は?"
     }
   },
   {
@@ -104069,8 +104069,8 @@
     "id": "q02568",
     "image_path": null,
     "question_text": {
-      "en": "北アルプスにある標高3190mの山は?",
-      "ja": "Which Northern Japan Alps peak rises to 3190 meters?"
+      "en": "Which Northern Japan Alps peak rises to 3190 meters?",
+      "ja": "北アルプスにある標高3190mの山は?"
     }
   },
   {
@@ -104109,8 +104109,8 @@
     "id": "q02569",
     "image_path": null,
     "question_text": {
-      "en": "タンザニアにあるアフリカ最高峰は?",
-      "ja": "Which is Africa's highest mountain, located in Tanzania?"
+      "en": "Which is Africa's highest mountain, located in Tanzania?",
+      "ja": "タンザニアにあるアフリカ最高峰は?"
     }
   },
   {
@@ -104149,8 +104149,8 @@
     "id": "q02570",
     "image_path": null,
     "question_text": {
-      "en": "南アルプスにある標高3193mで日本第2位の高峰は?",
-      "ja": "Which Southern Japan Alps peak is Japan's second highest at 3193 meters?"
+      "en": "Which Southern Japan Alps peak is Japan's second highest at 3193 meters?",
+      "ja": "南アルプスにある標高3193mで日本第2位の高峰は?"
     }
   },
   {
@@ -104189,8 +104189,8 @@
     "id": "q02571",
     "image_path": null,
     "question_text": {
-      "en": "アラスカにある北米最高峰の旧称は?",
-      "ja": "Which is the former name of North America's highest peak in Alaska?"
+      "en": "Which is the former name of North America's highest peak in Alaska?",
+      "ja": "アラスカにある北米最高峰の旧称は?"
     }
   },
   {
@@ -104229,8 +104229,8 @@
     "id": "q02572",
     "image_path": null,
     "question_text": {
-      "en": "ウガンダとコンゴ民主共和国の国境にある山は?",
-      "ja": "Which mountain range lies on the border between Uganda and DR Congo?"
+      "en": "Which mountain range lies on the border between Uganda and DR Congo?",
+      "ja": "ウガンダとコンゴ民主共和国の国境にある山は?"
     }
   },
   {
@@ -104269,8 +104269,8 @@
     "id": "q02573",
     "image_path": null,
     "question_text": {
-      "en": "北アルプスの槍状の山頂で知られる山は?",
-      "ja": "Which Northern Japan Alps peak is famous for its spear-like summit?"
+      "en": "Which Northern Japan Alps peak is famous for its spear-like summit?",
+      "ja": "北アルプスの槍状の山頂で知られる山は?"
     }
   },
   {
@@ -104309,8 +104309,8 @@
     "id": "q02574",
     "image_path": null,
     "question_text": {
-      "en": "インド最大の都市で旧称ボンベイは?",
-      "ja": "Which is India's largest city, formerly known as Bombay?"
+      "en": "Which is India's largest city, formerly known as Bombay?",
+      "ja": "インド最大の都市で旧称ボンベイは?"
     }
   },
   {
@@ -104349,8 +104349,8 @@
     "id": "q02575",
     "image_path": null,
     "question_text": {
-      "en": "ドイツ・バイエルン州の州都は?",
-      "ja": "What is the capital of Bavaria, Germany?"
+      "en": "What is the capital of Bavaria, Germany?",
+      "ja": "ドイツ・バイエルン州の州都は?"
     }
   },
   {
@@ -104389,8 +104389,8 @@
     "id": "q02576",
     "image_path": null,
     "question_text": {
-      "en": "沖縄本島北部の中心都市は?",
-      "ja": "Which is the central city of northern Okinawa Island?"
+      "en": "Which is the central city of northern Okinawa Island?",
+      "ja": "沖縄本島北部の中心都市は?"
     }
   },
   {
@@ -104429,8 +104429,8 @@
     "id": "q02577",
     "image_path": null,
     "question_text": {
-      "en": "中国の旧首都で長江下流域にある都市は?",
-      "ja": "Which former Chinese capital lies on the lower Yangtze River?"
+      "en": "Which former Chinese capital lies on the lower Yangtze River?",
+      "ja": "中国の旧首都で長江下流域にある都市は?"
     }
   },
   {
@@ -104469,8 +104469,8 @@
     "id": "q02578",
     "image_path": null,
     "question_text": {
-      "en": "エベレストがある南アジアの内陸国は?",
-      "ja": "Which landlocked South Asian country is home to Mount Everest?"
+      "en": "Which landlocked South Asian country is home to Mount Everest?",
+      "ja": "エベレストがある南アジアの内陸国は?"
     }
   },
   {
@@ -104509,8 +104509,8 @@
     "id": "q02579",
     "image_path": null,
     "question_text": {
-      "en": "アムステルダムを首都とするヨーロッパの国は?",
-      "ja": "Which European country has Amsterdam as its capital?"
+      "en": "Which European country has Amsterdam as its capital?",
+      "ja": "アムステルダムを首都とするヨーロッパの国は?"
     }
   },
   {
@@ -104552,8 +104552,8 @@
     "id": "q02580",
     "image_path": null,
     "question_text": {
-      "en": "世界第2位の大きさを持つ島でインドネシアとパプアニューギニアに分かれているのは?",
-      "ja": "Which is the world's second largest island, split between Indonesia and Papua New Guinea?"
+      "en": "Which is the world's second largest island, split between Indonesia and Papua New Guinea?",
+      "ja": "世界第2位の大きさを持つ島でインドネシアとパプアニューギニアに分かれているのは?"
     }
   },
   {
@@ -104592,8 +104592,8 @@
     "id": "q02581",
     "image_path": null,
     "question_text": {
-      "en": "アメリカ東海岸の世界都市は?",
-      "ja": "Which is the U.S. east coast's global city?"
+      "en": "Which is the U.S. east coast's global city?",
+      "ja": "アメリカ東海岸の世界都市は?"
     }
   },
   {
@@ -104632,8 +104632,8 @@
     "id": "q02582",
     "image_path": null,
     "question_text": {
-      "en": "シベリア最大の都市は?",
-      "ja": "Which is the largest city in Siberia?"
+      "en": "Which is the largest city in Siberia?",
+      "ja": "シベリア最大の都市は?"
     }
   },
   {
@@ -104672,8 +104672,8 @@
     "id": "q02583",
     "image_path": null,
     "question_text": {
-      "en": "カンボジアの首都は?",
-      "ja": "What is the capital of Cambodia?"
+      "en": "What is the capital of Cambodia?",
+      "ja": "カンボジアの首都は?"
     }
   },
   {
@@ -104713,8 +104713,8 @@
     "id": "q02584",
     "image_path": null,
     "question_text": {
-      "en": "北朝鮮の首都は?",
-      "ja": "What is the capital of North Korea?"
+      "en": "What is the capital of North Korea?",
+      "ja": "北朝鮮の首都は?"
     }
   },
   {
@@ -104754,8 +104754,8 @@
     "id": "q02585",
     "image_path": null,
     "question_text": {
-      "en": "東京湾のお台場と芝浦を結ぶ橋は?",
-      "ja": "Which bridge connects Odaiba and Shibaura over Tokyo Bay?"
+      "en": "Which bridge connects Odaiba and Shibaura over Tokyo Bay?",
+      "ja": "東京湾のお台場と芝浦を結ぶ橋は?"
     }
   },
   {
@@ -104794,8 +104794,8 @@
     "id": "q02586",
     "image_path": null,
     "question_text": {
-      "en": "ブラジルでコルコバードのキリスト像で有名な都市は?",
-      "ja": "Which Brazilian city is famous for the Christ the Redeemer statue?"
+      "en": "Which Brazilian city is famous for the Christ the Redeemer statue?",
+      "ja": "ブラジルでコルコバードのキリスト像で有名な都市は?"
     }
   },
   {
@@ -104834,8 +104834,8 @@
     "id": "q02587",
     "image_path": null,
     "question_text": {
-      "en": "オランダの主要港湾都市でユーロポートを擁するのは?",
-      "ja": "Which Dutch port city houses Europoort, one of Europe's largest ports?"
+      "en": "Which Dutch port city houses Europoort, one of Europe's largest ports?",
+      "ja": "オランダの主要港湾都市でユーロポートを擁するのは?"
     }
   },
   {
@@ -104874,8 +104874,8 @@
     "id": "q02588",
     "image_path": null,
     "question_text": {
-      "en": "ロシアの旧首都でバルト海沿岸の都市は?",
-      "ja": "Which is Russia's former capital on the Baltic coast?"
+      "en": "Which is Russia's former capital on the Baltic coast?",
+      "ja": "ロシアの旧首都でバルト海沿岸の都市は?"
     }
   },
   {
@@ -104914,8 +104914,8 @@
     "id": "q02589",
     "image_path": null,
     "question_text": {
-      "en": "チリの首都は?",
-      "ja": "What is the capital of Chile?"
+      "en": "What is the capital of Chile?",
+      "ja": "チリの首都は?"
     }
   },
   {
@@ -104954,8 +104954,8 @@
     "id": "q02590",
     "image_path": null,
     "question_text": {
-      "en": "ブラジル最大の都市は?",
-      "ja": "Which is the largest city in Brazil?"
+      "en": "Which is the largest city in Brazil?",
+      "ja": "ブラジル最大の都市は?"
     }
   },
   {
@@ -104994,8 +104994,8 @@
     "id": "q02591",
     "image_path": null,
     "question_text": {
-      "en": "スペイン南部アンダルシア州の州都は?",
-      "ja": "What is the capital of Andalusia in southern Spain?"
+      "en": "What is the capital of Andalusia in southern Spain?",
+      "ja": "スペイン南部アンダルシア州の州都は?"
     }
   },
   {
@@ -105034,8 +105034,8 @@
     "id": "q02592",
     "image_path": null,
     "question_text": {
-      "en": "中国最大の都市で長江河口の港湾都市は?",
-      "ja": "Which is China's largest city, located at the mouth of the Yangtze?"
+      "en": "Which is China's largest city, located at the mouth of the Yangtze?",
+      "ja": "中国最大の都市で長江河口の港湾都市は?"
     }
   },
   {
@@ -105074,8 +105074,8 @@
     "id": "q02593",
     "image_path": null,
     "question_text": {
-      "en": "ロシア東部に広がる広大な地域は?",
-      "ja": "Which vast region covers eastern Russia?"
+      "en": "Which vast region covers eastern Russia?",
+      "ja": "ロシア東部に広がる広大な地域は?"
     }
   },
   {
@@ -105114,8 +105114,8 @@
     "id": "q02594",
     "image_path": null,
     "question_text": {
-      "en": "ケープタウンを擁するアフリカ大陸南端の国は?",
-      "ja": "Which country at Africa's southern tip is home to Cape Town?"
+      "en": "Which country at Africa's southern tip is home to Cape Town?",
+      "ja": "ケープタウンを擁するアフリカ大陸南端の国は?"
     }
   },
   {
@@ -105154,8 +105154,8 @@
     "id": "q02595",
     "image_path": null,
     "question_text": {
-      "en": "ブラジルやアルゼンチンを含む大陸は?",
-      "ja": "Which continent includes Brazil and Argentina?"
+      "en": "Which continent includes Brazil and Argentina?",
+      "ja": "ブラジルやアルゼンチンを含む大陸は?"
     }
   },
   {
@@ -105194,8 +105194,8 @@
     "id": "q02596",
     "image_path": null,
     "question_text": {
-      "en": "古代ギリシャの軍事都市国家は?",
-      "ja": "Which ancient Greek city-state was famous for its military?"
+      "en": "Which ancient Greek city-state was famous for its military?",
+      "ja": "古代ギリシャの軍事都市国家は?"
     }
   },
   {
@@ -105238,8 +105238,8 @@
     "id": "q02597",
     "image_path": null,
     "question_text": {
-      "en": "長野県・静岡県を流れて遠州灘に注ぐ川は?",
-      "ja": "Which river flows from Nagano through Shizuoka into Enshu-nada Sea?"
+      "en": "Which river flows from Nagano through Shizuoka into Enshu-nada Sea?",
+      "ja": "長野県・静岡県を流れて遠州灘に注ぐ川は?"
     }
   },
   {
@@ -105278,8 +105278,8 @@
     "id": "q02598",
     "image_path": null,
     "question_text": {
-      "en": "国際司法裁判所が置かれるオランダの都市は?",
-      "ja": "Which Dutch city is home to the International Court of Justice?"
+      "en": "Which Dutch city is home to the International Court of Justice?",
+      "ja": "国際司法裁判所が置かれるオランダの都市は?"
     }
   },
   {
@@ -105318,8 +105318,8 @@
     "id": "q02599",
     "image_path": null,
     "question_text": {
-      "en": "ギリシャ第2の都市は?",
-      "ja": "Which is Greece's second largest city?"
+      "en": "Which is Greece's second largest city?",
+      "ja": "ギリシャ第2の都市は?"
     }
   },
   {
@@ -105359,8 +105359,8 @@
     "id": "q02600",
     "image_path": null,
     "question_text": {
-      "en": "東京と神奈川を結ぶ東京湾を横断する道路は?",
-      "ja": "Which highway crosses Tokyo Bay between Tokyo area and Kanagawa?"
+      "en": "Which highway crosses Tokyo Bay between Tokyo area and Kanagawa?",
+      "ja": "東京と神奈川を結ぶ東京湾を横断する道路は?"
     }
   },
   {
@@ -105403,8 +105403,8 @@
     "id": "q02601",
     "image_path": null,
     "question_text": {
-      "en": "関東平野を流れる日本最大の流域面積を持つ川は?",
-      "ja": "Which Kanto Plain river has Japan's largest drainage basin?"
+      "en": "Which Kanto Plain river has Japan's largest drainage basin?",
+      "ja": "関東平野を流れる日本最大の流域面積を持つ川は?"
     }
   },
   {
@@ -105443,8 +105443,8 @@
     "id": "q02602",
     "image_path": null,
     "question_text": {
-      "en": "カナダ最大の都市は?",
-      "ja": "Which is the largest city in Canada?"
+      "en": "Which is the largest city in Canada?",
+      "ja": "カナダ最大の都市は?"
     }
   },
   {
@@ -105483,8 +105483,8 @@
     "id": "q02603",
     "image_path": null,
     "question_text": {
-      "en": "中国新疆ウイグル自治区にある中国で最も低い場所は?",
-      "ja": "Which depression in China's Xinjiang region is the country's lowest point?"
+      "en": "Which depression in China's Xinjiang region is the country's lowest point?",
+      "ja": "中国新疆ウイグル自治区にある中国で最も低い場所は?"
     }
   },
   {
@@ -105523,8 +105523,8 @@
     "id": "q02604",
     "image_path": null,
     "question_text": {
-      "en": "リオ・グランデ川が国境を流れている国の組み合わせは?",
-      "ja": "The Rio Grande forms the border between which two countries?"
+      "en": "The Rio Grande forms the border between which two countries?",
+      "ja": "リオ・グランデ川が国境を流れている国の組み合わせは?"
     }
   },
   {
@@ -105563,8 +105563,8 @@
     "id": "q02605",
     "image_path": null,
     "question_text": {
-      "en": "オランダ中央部の大学都市は?",
-      "ja": "Which Dutch central city is a major university town?"
+      "en": "Which Dutch central city is a major university town?",
+      "ja": "オランダ中央部の大学都市は?"
     }
   },
   {
@@ -105603,8 +105603,8 @@
     "id": "q02606",
     "image_path": null,
     "question_text": {
-      "en": "スペイン東部地中海沿岸の都市でパエリア発祥地は?",
-      "ja": "Which eastern Spanish city on the Mediterranean is the birthplace of paella?"
+      "en": "Which eastern Spanish city on the Mediterranean is the birthplace of paella?",
+      "ja": "スペイン東部地中海沿岸の都市でパエリア発祥地は?"
     }
   },
   {
@@ -105643,8 +105643,8 @@
     "id": "q02607",
     "image_path": null,
     "question_text": {
-      "en": "カナダ西海岸の港湾都市は?",
-      "ja": "Which is Canada's main west coast port city?"
+      "en": "Which is Canada's main west coast port city?",
+      "ja": "カナダ西海岸の港湾都市は?"
     }
   },
   {
@@ -105683,8 +105683,8 @@
     "id": "q02608",
     "image_path": null,
     "question_text": {
-      "en": "イタリア北東部の運河の街は?",
-      "ja": "Which northeastern Italian city is famous for its canals?"
+      "en": "Which northeastern Italian city is famous for its canals?",
+      "ja": "イタリア北東部の運河の街は?"
     }
   },
   {
@@ -105723,8 +105723,8 @@
     "id": "q02609",
     "image_path": null,
     "question_text": {
-      "en": "ラオスの首都は?",
-      "ja": "What is the capital of Laos?"
+      "en": "What is the capital of Laos?",
+      "ja": "ラオスの首都は?"
     }
   },
   {
@@ -105763,8 +105763,8 @@
     "id": "q02610",
     "image_path": null,
     "question_text": {
-      "en": "ロシア極東の最大都市は?",
-      "ja": "Which is the largest city in the Russian Far East?"
+      "en": "Which is the largest city in the Russian Far East?",
+      "ja": "ロシア極東の最大都市は?"
     }
   },
   {
@@ -105806,8 +105806,8 @@
     "id": "q02611",
     "image_path": null,
     "question_text": {
-      "en": "中国を流れるアジア最長の川は?",
-      "ja": "Which is Asia's longest river, flowing through China?"
+      "en": "Which is Asia's longest river, flowing through China?",
+      "ja": "中国を流れるアジア最長の川は?"
     }
   },
   {
@@ -105846,8 +105846,8 @@
     "id": "q02612",
     "image_path": null,
     "question_text": {
-      "en": "ビクトリアの滝が国境にある国の組み合わせは?",
-      "ja": "Victoria Falls lies on the border between which two countries?"
+      "en": "Victoria Falls lies on the border between which two countries?",
+      "ja": "ビクトリアの滝が国境にある国の組み合わせは?"
     }
   },
   {
@@ -105886,17 +105886,17 @@
     "id": "q02613",
     "image_path": null,
     "question_text": {
-      "en": "IPv4でルータが特別な用途で予約しているTTLのデフォルト最大値の1つは?",
-      "ja": "Which is one of the typical default maximum TTL values used in IPv4?"
+      "en": "Which is one of the typical default maximum TTL values used in IPv4?",
+      "ja": "IPv4でルータが特別な用途で予約しているTTLのデフォルト最大値の1つは?"
     }
   },
   {
     "choices": [
       {
-        "en": "128",
-        "ja": "128",
+        "en": "255",
+        "ja": "255",
         "ja_typings": [
-          "128"
+          "255"
         ]
       },
       {
@@ -105926,8 +105926,8 @@
     "id": "q02614",
     "image_path": null,
     "question_text": {
-      "en": "8ビット符号なし整数で表せる最大値は?",
-      "ja": "What is the maximum value of an 8-bit unsigned integer?"
+      "en": "What is the maximum value of an 8-bit unsigned integer?",
+      "ja": "8ビット符号なし整数で表せる最大値は?"
     }
   },
   {
@@ -105966,8 +105966,8 @@
     "id": "q02615",
     "image_path": null,
     "question_text": {
-      "en": "C言語のshort型で多くの環境におけるビット数は?",
-      "ja": "How many bits does C's short type typically have?"
+      "en": "How many bits does C's short type typically have?",
+      "ja": "C言語のshort型で多くの環境におけるビット数は?"
     }
   },
   {
@@ -106006,8 +106006,8 @@
     "id": "q02616",
     "image_path": null,
     "question_text": {
-      "en": "8ビット整数で表現できる値の総数は?",
-      "ja": "How many distinct values can be represented with 8 bits?"
+      "en": "How many distinct values can be represented with 8 bits?",
+      "ja": "8ビット整数で表現できる値の総数は?"
     }
   },
   {
@@ -106046,8 +106046,8 @@
     "id": "q02617",
     "image_path": null,
     "question_text": {
-      "en": "x86_64アーキテクチャでの汎用レジスタの幅は何ビット?",
-      "ja": "How many bits wide is a general purpose register in x86_64?"
+      "en": "How many bits wide is a general purpose register in x86_64?",
+      "ja": "x86_64アーキテクチャでの汎用レジスタの幅は何ビット?"
     }
   },
   {
@@ -106086,8 +106086,8 @@
     "id": "q02618",
     "image_path": null,
     "question_text": {
-      "en": "IPv4の1オクテットは何ビット?",
-      "ja": "How many bits is one octet in IPv4?"
+      "en": "How many bits is one octet in IPv4?",
+      "ja": "IPv4の1オクテットは何ビット?"
     }
   },
   {
@@ -106126,8 +106126,8 @@
     "id": "q02619",
     "image_path": null,
     "question_text": {
-      "en": "IPアドレスからMACアドレスを解決するプロトコルは?",
-      "ja": "Which protocol resolves IP addresses to MAC addresses?"
+      "en": "Which protocol resolves IP addresses to MAC addresses?",
+      "ja": "IPアドレスからMACアドレスを解決するプロトコルは?"
     }
   },
   {
@@ -106166,8 +106166,8 @@
     "id": "q02620",
     "image_path": null,
     "question_text": {
-      "en": "サーバ構成管理ツールでYAMLで定義しエージェントレスで動作するのは?",
-      "ja": "Which agentless configuration management tool uses YAML playbooks?"
+      "en": "Which agentless configuration management tool uses YAML playbooks?",
+      "ja": "サーバ構成管理ツールでYAMLで定義しエージェントレスで動作するのは?"
     }
   },
   {
@@ -106206,8 +106206,8 @@
     "id": "q02621",
     "image_path": null,
     "question_text": {
-      "en": "Javaのビルドツールで古くから使われているXMLベースのものは?",
-      "ja": "Which old XML-based build tool is used for Java projects?"
+      "en": "Which old XML-based build tool is used for Java projects?",
+      "ja": "Javaのビルドツールで古くから使われているXMLベースのものは?"
     }
   },
   {
@@ -106246,8 +106246,8 @@
     "id": "q02622",
     "image_path": null,
     "question_text": {
-      "en": "Mozillaが開発したJavaScriptランタイム向けの新ブラウザは?",
-      "ja": "Which browser was made by The Browser Company with a focus on tabs and workflows?"
+      "en": "Which browser was made by The Browser Company with a focus on tabs and workflows?",
+      "ja": "Mozillaが開発したJavaScriptランタイム向けの新ブラウザは?"
     }
   },
   {
@@ -106286,8 +106286,8 @@
     "id": "q02623",
     "image_path": null,
     "question_text": {
-      "en": "アセンブリ言語を機械語に変換するプログラムは?",
-      "ja": "Which program translates assembly language into machine code?"
+      "en": "Which program translates assembly language into machine code?",
+      "ja": "アセンブリ言語を機械語に変換するプログラムは?"
     }
   },
   {
@@ -106326,8 +106326,8 @@
     "id": "q02624",
     "image_path": null,
     "question_text": {
-      "en": "CPUの命令を直接表現する低水準言語は?",
-      "ja": "Which low-level language directly represents CPU instructions?"
+      "en": "Which low-level language directly represents CPU instructions?",
+      "ja": "CPUの命令を直接表現する低水準言語は?"
     }
   },
   {
@@ -106366,8 +106366,8 @@
     "id": "q02625",
     "image_path": null,
     "question_text": {
-      "en": "プログラミングで変数に値を入れる操作は?",
-      "ja": "What is the operation of setting a value into a variable called?"
+      "en": "What is the operation of setting a value into a variable called?",
+      "ja": "プログラミングで変数に値を入れる操作は?"
     }
   },
   {
@@ -106406,8 +106406,8 @@
     "id": "q02626",
     "image_path": null,
     "question_text": {
-      "en": "プロファイラで関数の平均実行回数を示す指標は?",
-      "ja": "Which profiling metric shows the average number of times a function ran?"
+      "en": "Which profiling metric shows the average number of times a function ran?",
+      "ja": "プロファイラで関数の平均実行回数を示す指標は?"
     }
   },
   {
@@ -106446,8 +106446,8 @@
     "id": "q02627",
     "image_path": null,
     "question_text": {
-      "en": "グラフ探索で全方向に広く探索する手法は?",
-      "ja": "Which graph traversal explores all neighbors level by level?"
+      "en": "Which graph traversal explores all neighbors level by level?",
+      "ja": "グラフ探索で全方向に広く探索する手法は?"
     }
   },
   {
@@ -106486,8 +106486,8 @@
     "id": "q02628",
     "image_path": null,
     "question_text": {
-      "en": "ビットレートの単位で1秒間のビット数を表すのは?",
-      "ja": "Which unit represents bits transferred per second?"
+      "en": "Which unit represents bits transferred per second?",
+      "ja": "ビットレートの単位で1秒間のビット数を表すのは?"
     }
   },
   {
@@ -106528,8 +106528,8 @@
     "id": "q02629",
     "image_path": null,
     "question_text": {
-      "en": "HTTPステータスコード400が示すのは?",
-      "ja": "What does HTTP status code 400 indicate?"
+      "en": "What does HTTP status code 400 indicate?",
+      "ja": "HTTPステータスコード400が示すのは?"
     }
   },
   {
@@ -106568,8 +106568,8 @@
     "id": "q02630",
     "image_path": null,
     "question_text": {
-      "en": "Linuxで標準的に使われるシェルは?",
-      "ja": "Which is the standard shell on most Linux distributions?"
+      "en": "Which is the standard shell on most Linux distributions?",
+      "ja": "Linuxで標準的に使われるシェルは?"
     }
   },
   {
@@ -106612,8 +106612,8 @@
     "id": "q02631",
     "image_path": null,
     "question_text": {
-      "en": "viエディタを開発した人物は?",
-      "ja": "Who is the author of the vi editor?"
+      "en": "Who is the author of the vi editor?",
+      "ja": "viエディタを開発した人物は?"
     }
   },
   {
@@ -106652,8 +106652,8 @@
     "id": "q02632",
     "image_path": null,
     "question_text": {
-      "en": "ビット単位で「どちらかが1なら1」を取る演算は?",
-      "ja": "Which bitwise operation returns 1 if either bit is 1?"
+      "en": "Which bitwise operation returns 1 if either bit is 1?",
+      "ja": "ビット単位で「どちらかが1なら1」を取る演算は?"
     }
   },
   {
@@ -106696,8 +106696,8 @@
     "id": "q02633",
     "image_path": null,
     "question_text": {
-      "en": "C++を設計した人物は?",
-      "ja": "Who designed the C++ programming language?"
+      "en": "Who designed the C++ programming language?",
+      "ja": "C++を設計した人物は?"
     }
   },
   {
@@ -106736,8 +106736,8 @@
     "id": "q02634",
     "image_path": null,
     "question_text": {
-      "en": "Rustのヒープに値を1つ置くスマートポインタ型は?",
-      "ja": "Which Rust smart pointer places a single value on the heap?"
+      "en": "Which Rust smart pointer places a single value on the heap?",
+      "ja": "Rustのヒープに値を1つ置くスマートポインタ型は?"
     }
   },
   {
@@ -106780,8 +106780,8 @@
     "id": "q02635",
     "image_path": null,
     "question_text": {
-      "en": "JavaScriptを設計した人物は?",
-      "ja": "Who designed JavaScript?"
+      "en": "Who designed JavaScript?",
+      "ja": "JavaScriptを設計した人物は?"
     }
   },
   {
@@ -106824,8 +106824,8 @@
     "id": "q02636",
     "image_path": null,
     "question_text": {
-      "en": "AWKの開発者の1人で『プログラミング言語C』の共著者は?",
-      "ja": "Who co-authored 'The C Programming Language' and co-created AWK?"
+      "en": "Who co-authored 'The C Programming Language' and co-created AWK?",
+      "ja": "AWKの開発者の1人で『プログラミング言語C』の共著者は?"
     }
   },
   {
@@ -106864,8 +106864,8 @@
     "id": "q02637",
     "image_path": null,
     "question_text": {
-      "en": "UNIX上で生まれた構造化プログラミング言語は?",
-      "ja": "Which structured language was developed on UNIX in the 1970s?"
+      "en": "Which structured language was developed on UNIX in the 1970s?",
+      "ja": "UNIX上で生まれた構造化プログラミング言語は?"
     }
   },
   {
@@ -106904,8 +106904,8 @@
     "id": "q02638",
     "image_path": null,
     "question_text": {
-      "en": ".NETの共通言語ランタイムの略称は?",
-      "ja": "What is the abbreviation for .NET's common language runtime?"
+      "en": "What is the abbreviation for .NET's common language runtime?",
+      "ja": ".NETの共通言語ランタイムの略称は?"
     }
   },
   {
@@ -106944,8 +106944,8 @@
     "id": "q02639",
     "image_path": null,
     "question_text": {
-      "en": "事務処理用に1959年に作られた言語は?",
-      "ja": "Which programming language was designed in 1959 for business processing?"
+      "en": "Which programming language was designed in 1959 for business processing?",
+      "ja": "事務処理用に1959年に作られた言語は?"
     }
   },
   {
@@ -106984,8 +106984,8 @@
     "id": "q02640",
     "image_path": null,
     "question_text": {
-      "en": "HTMLの見た目を装飾する言語は?",
-      "ja": "Which language styles HTML documents?"
+      "en": "Which language styles HTML documents?",
+      "ja": "HTMLの見た目を装飾する言語は?"
     }
   },
   {
@@ -107024,8 +107024,8 @@
     "id": "q02641",
     "image_path": null,
     "question_text": {
-      "en": "Rustのパッケージマネージャ兼ビルドツールは?",
-      "ja": "What is Rust's package manager and build tool called?"
+      "en": "What is Rust's package manager and build tool called?",
+      "ja": "Rustのパッケージマネージャ兼ビルドツールは?"
     }
   },
   {
@@ -107064,8 +107064,8 @@
     "id": "q02642",
     "image_path": null,
     "question_text": {
-      "en": "分散NoSQLデータベースの1つで列指向ストアなのは?",
-      "ja": "Which distributed NoSQL database uses a column-family store?"
+      "en": "Which distributed NoSQL database uses a column-family store?",
+      "ja": "分散NoSQLデータベースの1つで列指向ストアなのは?"
     }
   },
   {
@@ -107104,8 +107104,8 @@
     "id": "q02643",
     "image_path": null,
     "question_text": {
-      "en": "HTTPの4xx系ステータスコードが意味するのは?",
-      "ja": "What category does HTTP 4xx status code belong to?"
+      "en": "What category does HTTP 4xx status code belong to?",
+      "ja": "HTTPの4xx系ステータスコードが意味するのは?"
     }
   },
   {
@@ -107144,8 +107144,8 @@
     "id": "q02644",
     "image_path": null,
     "question_text": {
-      "en": "ソースコードを機械語などに翻訳するソフトウェアは?",
-      "ja": "Which software translates source code into machine code?"
+      "en": "Which software translates source code into machine code?",
+      "ja": "ソースコードを機械語などに翻訳するソフトウェアは?"
     }
   },
   {
@@ -107184,8 +107184,8 @@
     "id": "q02645",
     "image_path": null,
     "question_text": {
-      "en": "グラフ探索でできるだけ深く進むのは?",
-      "ja": "Which graph traversal explores as deep as possible first?"
+      "en": "Which graph traversal explores as deep as possible first?",
+      "ja": "グラフ探索でできるだけ深く進むのは?"
     }
   },
   {
@@ -107224,8 +107224,8 @@
     "id": "q02646",
     "image_path": null,
     "question_text": {
-      "en": "1秒間に与えるダメージ量の指標は?",
-      "ja": "Which gaming metric measures damage dealt per second?"
+      "en": "Which gaming metric measures damage dealt per second?",
+      "ja": "1秒間に与えるダメージ量の指標は?"
     }
   },
   {
@@ -107264,8 +107264,8 @@
     "id": "q02647",
     "image_path": null,
     "question_text": {
-      "en": "プログラムをステップ実行・変数監視できるツールは?",
-      "ja": "Which tool lets you step through code and inspect variables?"
+      "en": "Which tool lets you step through code and inspect variables?",
+      "ja": "プログラムをステップ実行・変数監視できるツールは?"
     }
   },
   {
@@ -107308,8 +107308,8 @@
     "id": "q02648",
     "image_path": null,
     "question_text": {
-      "en": "0から9までの記号を使う数値表現は?",
-      "ja": "Which numeral system uses digits 0 through 9?"
+      "en": "Which numeral system uses digits 0 through 9?",
+      "ja": "0から9までの記号を使う数値表現は?"
     }
   },
   {
@@ -107352,8 +107352,8 @@
     "id": "q02649",
     "image_path": null,
     "question_text": {
-      "en": "C言語を開発した人物は?",
-      "ja": "Who developed the C programming language?"
+      "en": "Who developed the C programming language?",
+      "ja": "C言語を開発した人物は?"
     }
   },
   {
@@ -107393,8 +107393,8 @@
     "id": "q02650",
     "image_path": null,
     "question_text": {
-      "en": "複数のコンテナをまとめて定義・起動するツールは?",
-      "ja": "Which tool runs multi-container Docker applications via YAML?"
+      "en": "Which tool runs multi-container Docker applications via YAML?",
+      "ja": "複数のコンテナをまとめて定義・起動するツールは?"
     }
   },
   {
@@ -107433,8 +107433,8 @@
     "id": "q02651",
     "image_path": null,
     "question_text": {
-      "en": "実行時に型が決まる言語の性質を表す語は?",
-      "ja": "Which term describes a language whose types are determined at runtime?"
+      "en": "Which term describes a language whose types are determined at runtime?",
+      "ja": "実行時に型が決まる言語の性質を表す語は?"
     }
   },
   {
@@ -107473,8 +107473,8 @@
     "id": "q02652",
     "image_path": null,
     "question_text": {
-      "en": "オブジェクト指向で内部状態を隠す概念は?",
-      "ja": "Which OOP concept hides internal state and exposes a public interface?"
+      "en": "Which OOP concept hides internal state and exposes a public interface?",
+      "ja": "オブジェクト指向で内部状態を隠す概念は?"
     }
   },
   {
@@ -107513,8 +107513,8 @@
     "id": "q02653",
     "image_path": null,
     "question_text": {
-      "en": "SQLでデータを取得するために使われるカーソル操作の文は?",
-      "ja": "Which SQL statement retrieves rows from a cursor?"
+      "en": "Which SQL statement retrieves rows from a cursor?",
+      "ja": "SQLでデータを取得するために使われるカーソル操作の文は?"
     }
   },
   {
@@ -107553,8 +107553,8 @@
     "id": "q02654",
     "image_path": null,
     "question_text": {
-      "en": "BSD系UNIXで使われた高速ファイルシステムは?",
-      "ja": "Which fast file system was developed for BSD UNIX?"
+      "en": "Which fast file system was developed for BSD UNIX?",
+      "ja": "BSD系UNIXで使われた高速ファイルシステムは?"
     }
   },
   {
@@ -107593,8 +107593,8 @@
     "id": "q02655",
     "image_path": null,
     "question_text": {
-      "en": "ファイルを転送する古典的なプロトコルは?",
-      "ja": "Which classic protocol is used to transfer files?"
+      "en": "Which classic protocol is used to transfer files?",
+      "ja": "ファイルを転送する古典的なプロトコルは?"
     }
   },
   {
@@ -107634,8 +107634,8 @@
     "id": "q02656",
     "image_path": null,
     "question_text": {
-      "en": "GoFのデザインパターンで生成系の1つは?",
-      "ja": "Which is one of the GoF creational design patterns?"
+      "en": "Which is one of the GoF creational design patterns?",
+      "ja": "GoFのデザインパターンで生成系の1つは?"
     }
   },
   {
@@ -107674,8 +107674,8 @@
     "id": "q02657",
     "image_path": null,
     "question_text": {
-      "en": "軽量スレッドのことを指す概念は?",
-      "ja": "Which term refers to lightweight threads scheduled by a runtime?"
+      "en": "Which term refers to lightweight threads scheduled by a runtime?",
+      "ja": "軽量スレッドのことを指す概念は?"
     }
   },
   {
@@ -107716,8 +107716,8 @@
     "id": "q02658",
     "image_path": null,
     "question_text": {
-      "en": "HTTPステータスコード403が示すのは?",
-      "ja": "What does HTTP status code 403 indicate?"
+      "en": "What does HTTP status code 403 indicate?",
+      "ja": "HTTPステータスコード403が示すのは?"
     }
   },
   {
@@ -107756,8 +107756,8 @@
     "id": "q02659",
     "image_path": null,
     "question_text": {
-      "en": "科学計算用に1957年に作られた言語は?",
-      "ja": "Which language was created in 1957 for scientific computation?"
+      "en": "Which language was created in 1957 for scientific computation?",
+      "ja": "科学計算用に1957年に作られた言語は?"
     }
   },
   {
@@ -107796,8 +107796,8 @@
     "id": "q02660",
     "image_path": null,
     "question_text": {
-      "en": "SQLで列ごとに集計するための句は?",
-      "ja": "Which SQL clause aggregates rows by column values?"
+      "en": "Which SQL clause aggregates rows by column values?",
+      "ja": "SQLで列ごとに集計するための句は?"
     }
   },
   {
@@ -107836,8 +107836,8 @@
     "id": "q02661",
     "image_path": null,
     "question_text": {
-      "en": "Googleが開発した静的型付きの並行処理向け言語は?",
-      "ja": "Which Google-designed statically typed language emphasizes concurrency?"
+      "en": "Which Google-designed statically typed language emphasizes concurrency?",
+      "ja": "Googleが開発した静的型付きの並行処理向け言語は?"
     }
   },
   {
@@ -107876,8 +107876,8 @@
     "id": "q02662",
     "image_path": null,
     "question_text": {
-      "en": "ノードとエッジで関係を表すデータ構造は?",
-      "ja": "Which data structure represents relations with nodes and edges?"
+      "en": "Which data structure represents relations with nodes and edges?",
+      "ja": "ノードとエッジで関係を表すデータ構造は?"
     }
   },
   {
@@ -107920,8 +107920,8 @@
     "id": "q02663",
     "image_path": null,
     "question_text": {
-      "en": "Pythonを設計した人物は?",
-      "ja": "Who designed the Python programming language?"
+      "en": "Who designed the Python programming language?",
+      "ja": "Pythonを設計した人物は?"
     }
   },
   {
@@ -107960,8 +107960,8 @@
     "id": "q02664",
     "image_path": null,
     "question_text": {
-      "en": "HTTPでヘッダだけ取得するメソッドは?",
-      "ja": "Which HTTP method fetches only headers without a body?"
+      "en": "Which HTTP method fetches only headers without a body?",
+      "ja": "HTTPでヘッダだけ取得するメソッドは?"
     }
   },
   {
@@ -108000,8 +108000,8 @@
     "id": "q02665",
     "image_path": null,
     "question_text": {
-      "en": "Webページの構造を記述するマークアップ言語は?",
-      "ja": "Which markup language describes the structure of a web page?"
+      "en": "Which markup language describes the structure of a web page?",
+      "ja": "Webページの構造を記述するマークアップ言語は?"
     }
   },
   {
@@ -108044,8 +108044,8 @@
     "id": "q02666",
     "image_path": null,
     "question_text": {
-      "en": "0からF までの記号を使う数値表現は?",
-      "ja": "Which numeral system uses digits 0-9 and A-F?"
+      "en": "Which numeral system uses digits 0-9 and A-F?",
+      "ja": "0からF までの記号を使う数値表現は?"
     }
   },
   {
@@ -108084,8 +108084,8 @@
     "id": "q02667",
     "image_path": null,
     "question_text": {
-      "en": "pingで使われるIP制御メッセージプロトコルは?",
-      "ja": "Which IP control message protocol does ping use?"
+      "en": "Which IP control message protocol does ping use?",
+      "ja": "pingで使われるIP制御メッセージプロトコルは?"
     }
   },
   {
@@ -108124,8 +108124,8 @@
     "id": "q02668",
     "image_path": null,
     "question_text": {
-      "en": "一度作ったら変更できない性質を表す語は?",
-      "ja": "Which term describes objects that cannot be modified after creation?"
+      "en": "Which term describes objects that cannot be modified after creation?",
+      "ja": "一度作ったら変更できない性質を表す語は?"
     }
   },
   {
@@ -108167,8 +108167,8 @@
     "id": "q02669",
     "image_path": null,
     "question_text": {
-      "en": "HTTPステータスコード500が示すのは?",
-      "ja": "What does HTTP status code 500 indicate?"
+      "en": "What does HTTP status code 500 indicate?",
+      "ja": "HTTPステータスコード500が示すのは?"
     }
   },
   {
@@ -108207,8 +108207,8 @@
     "id": "q02670",
     "image_path": null,
     "question_text": {
-      "en": "ソースコードを逐次解釈実行するソフトウェアは?",
-      "ja": "Which software executes source code line by line?"
+      "en": "Which software executes source code line by line?",
+      "ja": "ソースコードを逐次解釈実行するソフトウェアは?"
     }
   },
   {
@@ -108247,8 +108247,8 @@
     "id": "q02671",
     "image_path": null,
     "question_text": {
-      "en": "Pythonで `#` 記号の役割は?",
-      "ja": "What does the `#` symbol indicate in Python?"
+      "en": "What does the `#` symbol indicate in Python?",
+      "ja": "Pythonで `#` 記号の役割は?"
     }
   },
   {
@@ -108287,8 +108287,8 @@
     "id": "q02672",
     "image_path": null,
     "question_text": {
-      "en": "関数定義で `->` 記号が示すのは?",
-      "ja": "What does the `->` arrow indicate in a function signature?"
+      "en": "What does the `->` arrow indicate in a function signature?",
+      "ja": "関数定義で `->` 記号が示すのは?"
     }
   },
   {
@@ -108327,8 +108327,8 @@
     "id": "q02673",
     "image_path": null,
     "question_text": {
-      "en": "TypeScriptで `: number` のように書く記号 `:` の役割は?",
-      "ja": "What does the `:` colon indicate in TypeScript annotations like `: number`?"
+      "en": "What does the `:` colon indicate in TypeScript annotations like `: number`?",
+      "ja": "TypeScriptで `: number` のように書く記号 `:` の役割は?"
     }
   },
   {
@@ -108367,8 +108367,8 @@
     "id": "q02674",
     "image_path": null,
     "question_text": {
-      "en": "JSONのフルネームの誤った候補として混同されがちなのは?",
-      "ja": "Which is a common (incorrect) fake expansion of JSON?"
+      "en": "Which is a common (incorrect) fake expansion of JSON?",
+      "ja": "JSONのフルネームの誤った候補として混同されがちなのは?"
     }
   },
   {
@@ -108407,8 +108407,8 @@
     "id": "q02675",
     "image_path": null,
     "question_text": {
-      "en": "ブラウザで動く動的言語は?",
-      "ja": "Which dynamic language runs in web browsers?"
+      "en": "Which dynamic language runs in web browsers?",
+      "ja": "ブラウザで動く動的言語は?"
     }
   },
   {
@@ -108447,8 +108447,8 @@
     "id": "q02676",
     "image_path": null,
     "question_text": {
-      "en": "JSONの正式名称として誤って語られがちなのは?",
-      "ja": "Which is another common false expansion of JSON?"
+      "en": "Which is another common false expansion of JSON?",
+      "ja": "JSONの正式名称として誤って語られがちなのは?"
     }
   },
   {
@@ -108487,8 +108487,8 @@
     "id": "q02677",
     "image_path": null,
     "question_text": {
-      "en": "JSONの誤った命名候補としてしばしば挙げられるのは?",
-      "ja": "Which is another false expansion sometimes given for JSON?"
+      "en": "Which is another false expansion sometimes given for JSON?",
+      "ja": "JSONの誤った命名候補としてしばしば挙げられるのは?"
     }
   },
   {
@@ -108531,8 +108531,8 @@
     "id": "q02678",
     "image_path": null,
     "question_text": {
-      "en": "Gitの現在のメンテナを務める日本人開発者は?",
-      "ja": "Which Japanese developer maintains Git?"
+      "en": "Which Japanese developer maintains Git?",
+      "ja": "Gitの現在のメンテナを務める日本人開発者は?"
     }
   },
   {
@@ -108571,8 +108571,8 @@
     "id": "q02679",
     "image_path": null,
     "question_text": {
-      "en": "Clang/Swiftなどが利用するコンパイラ基盤は?",
-      "ja": "Which compiler infrastructure is used by Clang and Swift?"
+      "en": "Which compiler infrastructure is used by Clang and Swift?",
+      "ja": "Clang/Swiftなどが利用するコンパイラ基盤は?"
     }
   },
   {
@@ -108615,8 +108615,8 @@
     "id": "q02680",
     "image_path": null,
     "question_text": {
-      "en": "Perlを設計した人物は?",
-      "ja": "Who designed the Perl programming language?"
+      "en": "Who designed the Perl programming language?",
+      "ja": "Perlを設計した人物は?"
     }
   },
   {
@@ -108655,8 +108655,8 @@
     "id": "q02681",
     "image_path": null,
     "question_text": {
-      "en": "オブジェクトファイルをまとめて実行ファイルを作るのは?",
-      "ja": "Which tool combines object files into an executable?"
+      "en": "Which tool combines object files into an executable?",
+      "ja": "オブジェクトファイルをまとめて実行ファイルを作るのは?"
     }
   },
   {
@@ -108699,8 +108699,8 @@
     "id": "q02682",
     "image_path": null,
     "question_text": {
-      "en": "Linuxカーネルを最初に開発した人物は?",
-      "ja": "Who originally developed the Linux kernel?"
+      "en": "Who originally developed the Linux kernel?",
+      "ja": "Linuxカーネルを最初に開発した人物は?"
     }
   },
   {
@@ -108739,38 +108739,38 @@
     "id": "q02683",
     "image_path": null,
     "question_text": {
-      "en": "ビット単位で「両方1のときだけ1」を取る演算の論理版は?",
-      "ja": "Which logical operation returns true only when both operands are true?"
+      "en": "Which logical operation returns true only when both operands are true?",
+      "ja": "ビット単位で「両方1のときだけ1」を取る演算の論理版は?"
     }
   },
   {
     "choices": [
       {
-        "en": "Lower bound of complexity",
-        "ja": "計算量の下限",
+        "en": "O(n log n)",
+        "ja": "O(n log n)",
         "ja_typings": [
-          "keisanryounokagen"
+          "O(nlogn)"
         ]
       },
       {
-        "en": "Upper bound of complexity",
-        "ja": "計算量の上限",
+        "en": "O(n)",
+        "ja": "O(n)",
         "ja_typings": [
-          "keisanryounokougen"
+          "O(n)"
         ]
       },
       {
-        "en": "Average run count",
-        "ja": "平均実行回数",
+        "en": "O(n^2)",
+        "ja": "O(n^2)",
         "ja_typings": [
-          "heikinjikkoukaisuu"
+          "O(n^2)"
         ]
       },
       {
-        "en": "Memory usage",
-        "ja": "メモリ使用量",
+        "en": "O(log n)",
+        "ja": "O(log n)",
         "ja_typings": [
-          "memorishiyouryou"
+          "O(logn)"
         ]
       }
     ],
@@ -108779,8 +108779,8 @@
     "id": "q02684",
     "image_path": null,
     "question_text": {
-      "en": "比較ソートで証明されている計算量の下限は?",
-      "ja": "What is the proven lower bound of complexity for comparison sorting?"
+      "en": "What is the proven lower bound of complexity for comparison-based sorting?",
+      "ja": "比較ソートで証明されている計算量の下限は?"
     }
   },
   {
@@ -108819,8 +108819,8 @@
     "id": "q02685",
     "image_path": null,
     "question_text": {
-      "en": "SQLでINSERT/UPDATEを一度に行う命令は?",
-      "ja": "Which SQL statement combines INSERT and UPDATE in one operation?"
+      "en": "Which SQL statement combines INSERT and UPDATE in one operation?",
+      "ja": "SQLでINSERT/UPDATEを一度に行う命令は?"
     }
   },
   {
@@ -108859,8 +108859,8 @@
     "id": "q02686",
     "image_path": null,
     "question_text": {
-      "en": "CPUが直接実行できるバイナリ表現の命令は?",
-      "ja": "Which form of instructions is directly executed by the CPU?"
+      "en": "Which form of instructions is directly executed by the CPU?",
+      "ja": "CPUが直接実行できるバイナリ表現の命令は?"
     }
   },
   {
@@ -108899,8 +108899,8 @@
     "id": "q02687",
     "image_path": null,
     "question_text": {
-      "en": "JavaのXMLベースのビルドツールでpom.xmlを使うのは?",
-      "ja": "Which Java build tool uses pom.xml configuration?"
+      "en": "Which Java build tool uses pom.xml configuration?",
+      "ja": "JavaのXMLベースのビルドツールでpom.xmlを使うのは?"
     }
   },
   {
@@ -108940,8 +108940,8 @@
     "id": "q02688",
     "image_path": null,
     "question_text": {
-      "en": "解放されないメモリが蓄積する不具合は?",
-      "ja": "Which bug refers to memory that is never released?"
+      "en": "Which bug refers to memory that is never released?",
+      "ja": "解放されないメモリが蓄積する不具合は?"
     }
   },
   {
@@ -108980,8 +108980,8 @@
     "id": "q02689",
     "image_path": null,
     "question_text": {
-      "en": "プロファイラで「メモリの使用量」を示す指標は?",
-      "ja": "Which profiling metric shows how much memory the program uses?"
+      "en": "Which profiling metric shows how much memory the program uses?",
+      "ja": "プロファイラで「メモリの使用量」を示す指標は?"
     }
   },
   {
@@ -109020,8 +109020,8 @@
     "id": "q02690",
     "image_path": null,
     "question_text": {
-      "en": "分割統治法による安定ソートでO(n log n)を保証するのは?",
-      "ja": "Which divide-and-conquer stable sort guarantees O(n log n)?"
+      "en": "Which divide-and-conquer stable sort guarantees O(n log n)?",
+      "ja": "分割統治法による安定ソートでO(n log n)を保証するのは?"
     }
   },
   {
@@ -109060,8 +109060,8 @@
     "id": "q02691",
     "image_path": null,
     "question_text": {
-      "en": "ドキュメント指向NoSQLの代表例は?",
-      "ja": "Which is a leading document-oriented NoSQL database?"
+      "en": "Which is a leading document-oriented NoSQL database?",
+      "ja": "ドキュメント指向NoSQLの代表例は?"
     }
   },
   {
@@ -109100,8 +109100,8 @@
     "id": "q02692",
     "image_path": null,
     "question_text": {
-      "en": "複数スレッドが同時にアクセスしないよう制御する仕組みは?",
-      "ja": "Which primitive ensures only one thread accesses a resource at a time?"
+      "en": "Which primitive ensures only one thread accesses a resource at a time?",
+      "ja": "複数スレッドが同時にアクセスしないよう制御する仕組みは?"
     }
   },
   {
@@ -109140,8 +109140,8 @@
     "id": "q02693",
     "image_path": null,
     "question_text": {
-      "en": "オープンソースの代表的なリレーショナルDBで「m」で始まるのは?",
-      "ja": "Which popular open-source relational database starts with 'M'?"
+      "en": "Which popular open-source relational database starts with 'M'?",
+      "ja": "オープンソースの代表的なリレーショナルDBで「m」で始まるのは?"
     }
   },
   {
@@ -109180,8 +109180,8 @@
     "id": "q02694",
     "image_path": null,
     "question_text": {
-      "en": "グラフ型データベースの代表は?",
-      "ja": "Which is a leading graph database?"
+      "en": "Which is a leading graph database?",
+      "ja": "グラフ型データベースの代表は?"
     }
   },
   {
@@ -109222,8 +109222,8 @@
     "id": "q02695",
     "image_path": null,
     "question_text": {
-      "en": "HTTPステータスコード404が示すのは?",
-      "ja": "What does HTTP status code 404 indicate?"
+      "en": "What does HTTP status code 404 indicate?",
+      "ja": "HTTPステータスコード404が示すのは?"
     }
   },
   {
@@ -109262,8 +109262,8 @@
     "id": "q02696",
     "image_path": null,
     "question_text": {
-      "en": "ハッシュテーブルの平均的な検索計算量は?",
-      "ja": "What is the average-case lookup complexity of a hash table?"
+      "en": "What is the average-case lookup complexity of a hash table?",
+      "ja": "ハッシュテーブルの平均的な検索計算量は?"
     }
   },
   {
@@ -109302,8 +109302,8 @@
     "id": "q02697",
     "image_path": null,
     "question_text": {
-      "en": "二分探索の計算量は?",
-      "ja": "What is the time complexity of binary search?"
+      "en": "What is the time complexity of binary search?",
+      "ja": "二分探索の計算量は?"
     }
   },
   {
@@ -109342,8 +109342,8 @@
     "id": "q02698",
     "image_path": null,
     "question_text": {
-      "en": "比較ソートの最良計算量は?",
-      "ja": "What is the best achievable complexity for comparison sorting?"
+      "en": "What is the best achievable complexity for comparison sorting?",
+      "ja": "比較ソートの最良計算量は?"
     }
   },
   {
@@ -109382,8 +109382,8 @@
     "id": "q02699",
     "image_path": null,
     "question_text": {
-      "en": "配列を1度走査する線形探索の計算量は?",
-      "ja": "What is the time complexity of a single-pass linear search?"
+      "en": "What is the time complexity of a single-pass linear search?",
+      "ja": "配列を1度走査する線形探索の計算量は?"
     }
   },
   {
@@ -109424,8 +109424,8 @@
     "id": "q02700",
     "image_path": null,
     "question_text": {
-      "en": "HTTPステータスコード200が示すのは?",
-      "ja": "What does HTTP status code 200 indicate?"
+      "en": "What does HTTP status code 200 indicate?",
+      "ja": "HTTPステータスコード200が示すのは?"
     }
   },
   {
@@ -109465,8 +109465,8 @@
     "id": "q02701",
     "image_path": null,
     "question_text": {
-      "en": "GoFパターンで状態変化を購読者に通知するのは?",
-      "ja": "Which GoF pattern notifies subscribers of state changes?"
+      "en": "Which GoF pattern notifies subscribers of state changes?",
+      "ja": "GoFパターンで状態変化を購読者に通知するのは?"
     }
   },
   {
@@ -109509,8 +109509,8 @@
     "id": "q02702",
     "image_path": null,
     "question_text": {
-      "en": "0から7までの数字で表す進数は?",
-      "ja": "Which numeral system uses digits 0-7?"
+      "en": "Which numeral system uses digits 0-7?",
+      "ja": "0から7までの数字で表す進数は?"
     }
   },
   {
@@ -109549,8 +109549,8 @@
     "id": "q02703",
     "image_path": null,
     "question_text": {
-      "en": "HTTPでリソースの一部更新を表すメソッドは?",
-      "ja": "Which HTTP method represents a partial update of a resource?"
+      "en": "Which HTTP method represents a partial update of a resource?",
+      "ja": "HTTPでリソースの一部更新を表すメソッドは?"
     }
   },
   {
@@ -109589,8 +109589,8 @@
     "id": "q02704",
     "image_path": null,
     "question_text": {
-      "en": "サーバサイドで動的Webページを生成する人気言語は?",
-      "ja": "Which server-side language is widely used for generating dynamic web pages?"
+      "en": "Which server-side language is widely used for generating dynamic web pages?",
+      "ja": "サーバサイドで動的Webページを生成する人気言語は?"
     }
   },
   {
@@ -109629,8 +109629,8 @@
     "id": "q02705",
     "image_path": null,
     "question_text": {
-      "en": "HTTPでデータをサーバに送信する代表的なメソッドは?",
-      "ja": "Which HTTP method commonly submits data to the server?"
+      "en": "Which HTTP method commonly submits data to the server?",
+      "ja": "HTTPでデータをサーバに送信する代表的なメソッドは?"
     }
   },
   {
@@ -109669,8 +109669,8 @@
     "id": "q02706",
     "image_path": null,
     "question_text": {
-      "en": "HTTPでリソース全体を置き換えるメソッドは?",
-      "ja": "Which HTTP method replaces a resource entirely?"
+      "en": "Which HTTP method replaces a resource entirely?",
+      "ja": "HTTPでリソース全体を置き換えるメソッドは?"
     }
   },
   {
@@ -109709,8 +109709,8 @@
     "id": "q02707",
     "image_path": null,
     "question_text": {
-      "en": "Niklaus Wirthが設計した教育用言語は?",
-      "ja": "Which educational language was designed by Niklaus Wirth?"
+      "en": "Which educational language was designed by Niklaus Wirth?",
+      "ja": "Niklaus Wirthが設計した教育用言語は?"
     }
   },
   {
@@ -109749,8 +109749,8 @@
     "id": "q02708",
     "image_path": null,
     "question_text": {
-      "en": "オブジェクト指向で同じインタフェースで多様な振る舞いをする概念は?",
-      "ja": "Which OOP concept lets one interface serve many implementations?"
+      "en": "Which OOP concept lets one interface serve many implementations?",
+      "ja": "オブジェクト指向で同じインタフェースで多様な振る舞いをする概念は?"
     }
   },
   {
@@ -109789,8 +109789,8 @@
     "id": "q02709",
     "image_path": null,
     "question_text": {
-      "en": "高機能で拡張性に優れたオープンソースRDBは?",
-      "ja": "Which is a feature-rich, extensible open-source RDBMS?"
+      "en": "Which is a feature-rich, extensible open-source RDBMS?",
+      "ja": "高機能で拡張性に優れたオープンソースRDBは?"
     }
   },
   {
@@ -109829,8 +109829,8 @@
     "id": "q02710",
     "image_path": null,
     "question_text": {
-      "en": "OSが管理する実行単位でメモリ空間を独立して持つのは?",
-      "ja": "Which OS-managed execution unit has its own memory space?"
+      "en": "Which OS-managed execution unit has its own memory space?",
+      "ja": "OSが管理する実行単位でメモリ空間を独立して持つのは?"
     }
   },
   {
@@ -109869,8 +109869,8 @@
     "id": "q02711",
     "image_path": null,
     "question_text": {
-      "en": "プログラムの性能を測定し分析するツールは?",
-      "ja": "Which tool measures and analyzes a program's performance?"
+      "en": "Which tool measures and analyzes a program's performance?",
+      "ja": "プログラムの性能を測定し分析するツールは?"
     }
   },
   {
@@ -109909,8 +109909,8 @@
     "id": "q02712",
     "image_path": null,
     "question_text": {
-      "en": "FIFO方式で出し入れするデータ構造は?",
-      "ja": "Which data structure follows FIFO (first-in, first-out)?"
+      "en": "Which data structure follows FIFO (first-in, first-out)?",
+      "ja": "FIFO方式で出し入れするデータ構造は?"
     }
   },
   {
@@ -109949,8 +109949,8 @@
     "id": "q02713",
     "image_path": null,
     "question_text": {
-      "en": "Rustのシングルスレッド向け参照カウントスマートポインタは?",
-      "ja": "Which Rust smart pointer is a single-threaded reference counter?"
+      "en": "Which Rust smart pointer is a single-threaded reference counter?",
+      "ja": "Rustのシングルスレッド向け参照カウントスマートポインタは?"
     }
   },
   {
@@ -109989,8 +109989,8 @@
     "id": "q02714",
     "image_path": null,
     "question_text": {
-      "en": "HTTPで別URLに転送することを表す3xx系の意味は?",
-      "ja": "What is the meaning of the HTTP 3xx status family?"
+      "en": "What is the meaning of the HTTP 3xx status family?",
+      "ja": "HTTPで別URLに転送することを表す3xx系の意味は?"
     }
   },
   {
@@ -110033,8 +110033,8 @@
     "id": "q02715",
     "image_path": null,
     "question_text": {
-      "en": "GNUプロジェクトを創設した人物は?",
-      "ja": "Who founded the GNU Project?"
+      "en": "Who founded the GNU Project?",
+      "ja": "GNUプロジェクトを創設した人物は?"
     }
   },
   {
@@ -110073,8 +110073,8 @@
     "id": "q02716",
     "image_path": null,
     "question_text": {
-      "en": "メール送信に使われるプロトコルは?",
-      "ja": "Which protocol is used to send emails?"
+      "en": "Which protocol is used to send emails?",
+      "ja": "メール送信に使われるプロトコルは?"
     }
   },
   {
@@ -110113,8 +110113,8 @@
     "id": "q02717",
     "image_path": null,
     "question_text": {
-      "en": "リレーショナルDBを操作する標準言語は?",
-      "ja": "Which standard language manipulates relational databases?"
+      "en": "Which standard language manipulates relational databases?",
+      "ja": "リレーショナルDBを操作する標準言語は?"
     }
   },
   {
@@ -110153,8 +110153,8 @@
     "id": "q02718",
     "image_path": null,
     "question_text": {
-      "en": "ファイル1つで動く軽量な組み込みRDBは?",
-      "ja": "Which lightweight embedded RDBMS stores data in a single file?"
+      "en": "Which lightweight embedded RDBMS stores data in a single file?",
+      "ja": "ファイル1つで動く軽量な組み込みRDBは?"
     }
   },
   {
@@ -110195,8 +110195,8 @@
     "id": "q02719",
     "image_path": null,
     "question_text": {
-      "en": "不正なメモリアクセスで発生する典型的なエラーは?",
-      "ja": "Which error is typically caused by invalid memory access?"
+      "en": "Which error is typically caused by invalid memory access?",
+      "ja": "不正なメモリアクセスで発生する典型的なエラーは?"
     }
   },
   {
@@ -110235,8 +110235,8 @@
     "id": "q02720",
     "image_path": null,
     "question_text": {
-      "en": "Unixでプロセスに送る通知の仕組みは?",
-      "ja": "Which Unix mechanism sends notifications to processes?"
+      "en": "Which Unix mechanism sends notifications to processes?",
+      "ja": "Unixでプロセスに送る通知の仕組みは?"
     }
   },
   {
@@ -110276,8 +110276,8 @@
     "id": "q02721",
     "image_path": null,
     "question_text": {
-      "en": "GoFパターンでインスタンスを1つに制限するのは?",
-      "ja": "Which GoF pattern restricts a class to a single instance?"
+      "en": "Which GoF pattern restricts a class to a single instance?",
+      "ja": "GoFパターンでインスタンスを1つに制限するのは?"
     }
   },
   {
@@ -110317,8 +110317,8 @@
     "id": "q02722",
     "image_path": null,
     "question_text": {
-      "en": "ミニファイされたコードと元のコードを対応付けるファイルは?",
-      "ja": "Which file maps minified code back to the original source?"
+      "en": "Which file maps minified code back to the original source?",
+      "ja": "ミニファイされたコードと元のコードを対応付けるファイルは?"
     }
   },
   {
@@ -110357,8 +110357,8 @@
     "id": "q02723",
     "image_path": null,
     "question_text": {
-      "en": "LIFO方式で出し入れするデータ構造は?",
-      "ja": "Which data structure follows LIFO (last-in, first-out)?"
+      "en": "Which data structure follows LIFO (last-in, first-out)?",
+      "ja": "LIFO方式で出し入れするデータ構造は?"
     }
   },
   {
@@ -110398,8 +110398,8 @@
     "id": "q02724",
     "image_path": null,
     "question_text": {
-      "en": "スタック領域が溢れたときに起きるエラーは?",
-      "ja": "Which error occurs when the call stack exceeds its limit?"
+      "en": "Which error occurs when the call stack exceeds its limit?",
+      "ja": "スタック領域が溢れたときに起きるエラーは?"
     }
   },
   {
@@ -110438,8 +110438,8 @@
     "id": "q02725",
     "image_path": null,
     "question_text": {
-      "en": "コンパイル時に型が決まる言語の性質を表す語は?",
-      "ja": "Which term describes a language whose types are checked at compile time?"
+      "en": "Which term describes a language whose types are checked at compile time?",
+      "ja": "コンパイル時に型が決まる言語の性質を表す語は?"
     }
   },
   {
@@ -110478,8 +110478,8 @@
     "id": "q02726",
     "image_path": null,
     "question_text": {
-      "en": "HTTPの2xx系ステータスコードのカテゴリ名は?",
-      "ja": "What is the meaning of the HTTP 2xx status family?"
+      "en": "What is the meaning of the HTTP 2xx status family?",
+      "ja": "HTTPの2xx系ステータスコードのカテゴリ名は?"
     }
   },
   {
@@ -110518,8 +110518,8 @@
     "id": "q02727",
     "image_path": null,
     "question_text": {
-      "en": "古くからある暗号化されないリモートログインプロトコルは?",
-      "ja": "Which old remote-login protocol transmits data unencrypted?"
+      "en": "Which old remote-login protocol transmits data unencrypted?",
+      "ja": "古くからある暗号化されないリモートログインプロトコルは?"
     }
   },
   {
@@ -110559,8 +110559,8 @@
     "id": "q02728",
     "image_path": null,
     "question_text": {
-      "en": "HashiCorpが開発するインフラ宣言型ツールは?",
-      "ja": "Which HashiCorp tool provisions infrastructure declaratively?"
+      "en": "Which HashiCorp tool provisions infrastructure declaratively?",
+      "ja": "HashiCorpが開発するインフラ宣言型ツールは?"
     }
   },
   {
@@ -110599,8 +110599,8 @@
     "id": "q02729",
     "image_path": null,
     "question_text": {
-      "en": "プロセス内で並行実行されメモリ空間を共有する単位は?",
-      "ja": "Which execution unit runs in a process and shares its memory?"
+      "en": "Which execution unit runs in a process and shares its memory?",
+      "ja": "プロセス内で並行実行されメモリ空間を共有する単位は?"
     }
   },
   {
@@ -110643,8 +110643,8 @@
     "id": "q02730",
     "image_path": null,
     "question_text": {
-      "en": "World Wide Webを発明した人物は?",
-      "ja": "Who invented the World Wide Web?"
+      "en": "Who invented the World Wide Web?",
+      "ja": "World Wide Webを発明した人物は?"
     }
   },
   {
@@ -110683,8 +110683,8 @@
     "id": "q02731",
     "image_path": null,
     "question_text": {
-      "en": "節点と枝で階層構造を表すデータ構造は?",
-      "ja": "Which data structure represents hierarchical relations with nodes and branches?"
+      "en": "Which data structure represents hierarchical relations with nodes and branches?",
+      "ja": "節点と枝で階層構造を表すデータ構造は?"
     }
   },
   {
@@ -110723,8 +110723,8 @@
     "id": "q02732",
     "image_path": null,
     "question_text": {
-      "en": "コネクションレスで信頼性を保証しないトランスポート層プロトコルは?",
-      "ja": "Which transport protocol is connectionless and unreliable?"
+      "en": "Which transport protocol is connectionless and unreliable?",
+      "ja": "コネクションレスで信頼性を保証しないトランスポート層プロトコルは?"
     }
   },
   {
@@ -110765,8 +110765,8 @@
     "id": "q02733",
     "image_path": null,
     "question_text": {
-      "en": "HTTPステータスコード401が示すのは?",
-      "ja": "What does HTTP status code 401 indicate?"
+      "en": "What does HTTP status code 401 indicate?",
+      "ja": "HTTPステータスコード401が示すのは?"
     }
   },
   {
@@ -110805,8 +110805,8 @@
     "id": "q02734",
     "image_path": null,
     "question_text": {
-      "en": "GoogleのChromeなどで動くJavaScriptエンジンは?",
-      "ja": "Which JavaScript engine powers Google Chrome?"
+      "en": "Which JavaScript engine powers Google Chrome?",
+      "ja": "GoogleのChromeなどで動くJavaScriptエンジンは?"
     }
   },
   {
@@ -110845,8 +110845,8 @@
     "id": "q02735",
     "image_path": null,
     "question_text": {
-      "en": "Linuxユーザに愛される高機能テキストエディタは?",
-      "ja": "Which highly extensible terminal text editor is beloved by Linux users?"
+      "en": "Which highly extensible terminal text editor is beloved by Linux users?",
+      "ja": "Linuxユーザに愛される高機能テキストエディタは?"
     }
   },
   {
@@ -110885,8 +110885,8 @@
     "id": "q02736",
     "image_path": null,
     "question_text": {
-      "en": "OGC仕様の地理空間ベクタフィーチャ取得サービスは?",
-      "ja": "Which OGC service provides geospatial vector features over the web?"
+      "en": "Which OGC service provides geospatial vector features over the web?",
+      "ja": "OGC仕様の地理空間ベクタフィーチャ取得サービスは?"
     }
   },
   {
@@ -110929,8 +110929,8 @@
     "id": "q02737",
     "image_path": null,
     "question_text": {
-      "en": "Rubyを設計した人物は?",
-      "ja": "Who designed the Ruby programming language?"
+      "en": "Who designed the Ruby programming language?",
+      "ja": "Rubyを設計した人物は?"
     }
   },
   {
@@ -110973,8 +110973,8 @@
     "id": "q02738",
     "image_path": null,
     "question_text": {
-      "en": "多くの言語でコメント開始を表す記号は?",
-      "ja": "Which character commonly starts a line comment in many languages?"
+      "en": "Which character commonly starts a line comment in many languages?",
+      "ja": "多くの言語でコメント開始を表す記号は?"
     }
   },
   {
@@ -111017,8 +111017,8 @@
     "id": "q02739",
     "image_path": null,
     "question_text": {
-      "en": "シェルで変数を参照するときに使う記号は?",
-      "ja": "Which character is used to reference shell variables?"
+      "en": "Which character is used to reference shell variables?",
+      "ja": "シェルで変数を参照するときに使う記号は?"
     }
   },
   {
@@ -111061,8 +111061,8 @@
     "id": "q02740",
     "image_path": null,
     "question_text": {
-      "en": "C系言語で剰余演算を表す記号は?",
-      "ja": "Which operator represents modulo in C-like languages?"
+      "en": "Which operator represents modulo in C-like languages?",
+      "ja": "C系言語で剰余演算を表す記号は?"
     }
   },
   {
@@ -111105,8 +111105,8 @@
     "id": "q02741",
     "image_path": null,
     "question_text": {
-      "en": "シェルでコマンドをバックグラウンド実行する記号は?",
-      "ja": "Which shell character runs a command in the background?"
+      "en": "Which shell character runs a command in the background?",
+      "ja": "シェルでコマンドをバックグラウンド実行する記号は?"
     }
   },
   {
@@ -111149,8 +111149,8 @@
     "id": "q02742",
     "image_path": null,
     "question_text": {
-      "en": "C系言語でポインタの参照外しや乗算を表す記号は?",
-      "ja": "Which operator dereferences pointers or denotes multiplication in C?"
+      "en": "Which operator dereferences pointers or denotes multiplication in C?",
+      "ja": "C系言語でポインタの参照外しや乗算を表す記号は?"
     }
   },
   {
@@ -111193,8 +111193,8 @@
     "id": "q02743",
     "image_path": null,
     "question_text": {
-      "en": "Pythonでデコレータを表す記号は?",
-      "ja": "Which character marks a decorator in Python?"
+      "en": "Which character marks a decorator in Python?",
+      "ja": "Pythonでデコレータを表す記号は?"
     }
   },
   {
@@ -111237,8 +111237,8 @@
     "id": "q02744",
     "image_path": null,
     "question_text": {
-      "en": "非同期関数の完了を待つPython/JSのキーワードは?",
-      "ja": "Which keyword in Python and JS waits for an async result?"
+      "en": "Which keyword in Python and JS waits for an async result?",
+      "ja": "非同期関数の完了を待つPython/JSのキーワードは?"
     }
   },
   {
@@ -111281,8 +111281,8 @@
     "id": "q02745",
     "image_path": null,
     "question_text": {
-      "en": "Pythonで関数を定義するキーワードは?",
-      "ja": "Which Python keyword defines a function?"
+      "en": "Which Python keyword defines a function?",
+      "ja": "Pythonで関数を定義するキーワードは?"
     }
   },
   {
@@ -111325,8 +111325,8 @@
     "id": "q02746",
     "image_path": null,
     "question_text": {
-      "en": "Goで関数終了時に処理を予約するキーワードは?",
-      "ja": "Which Go keyword schedules a call to run when the function returns?"
+      "en": "Which Go keyword schedules a call to run when the function returns?",
+      "ja": "Goで関数終了時に処理を予約するキーワードは?"
     }
   },
   {
@@ -111369,8 +111369,8 @@
     "id": "q02747",
     "image_path": null,
     "question_text": {
-      "en": "Rustで関数を定義するキーワードは?",
-      "ja": "Which Rust keyword defines a function?"
+      "en": "Which Rust keyword defines a function?",
+      "ja": "Rustで関数を定義するキーワードは?"
     }
   },
   {
@@ -111413,8 +111413,8 @@
     "id": "q02748",
     "image_path": null,
     "question_text": {
-      "en": "関数から値を返すための多くの言語で共通のキーワードは?",
-      "ja": "Which keyword returns a value from a function in most languages?"
+      "en": "Which keyword returns a value from a function in most languages?",
+      "ja": "関数から値を返すための多くの言語で共通のキーワードは?"
     }
   },
   {
@@ -111457,8 +111457,8 @@
     "id": "q02749",
     "image_path": null,
     "question_text": {
-      "en": "ジェネレータで値を1つずつ生成するキーワードは?",
-      "ja": "Which keyword produces values one at a time from a generator?"
+      "en": "Which keyword produces values one at a time from a generator?",
+      "ja": "ジェネレータで値を1つずつ生成するキーワードは?"
     }
   },
   {
@@ -111497,8 +111497,8 @@
     "id": "q02750",
     "image_path": null,
     "question_text": {
-      "en": "Pythonのパッケージインストーラは?",
-      "ja": "Which is the standard package installer for Python?"
+      "en": "Which is the standard package installer for Python?",
+      "ja": "Pythonのパッケージインストーラは?"
     }
   },
   {
@@ -127027,10 +127027,9 @@
     "choices": [
       {
         "en": "Munich Agreement",
-        "ja": "ミュンヘン会談",
+        "ja": "ミュンヘン協定",
         "ja_typings": [
-          "myunhen kaidan",
-          "myunhenkaidan"
+          "myunhenkyoutei"
         ]
       },
       {
@@ -132197,11 +132196,10 @@
   {
     "choices": [
       {
-        "en": "26 km",
-        "ja": "約26km",
+        "en": "42 km",
+        "ja": "約42km",
         "ja_typings": [
-          "yaku26kiro",
-          "yaku26km"
+          "yaku42km"
         ]
       },
       {
@@ -132213,11 +132211,10 @@
         ]
       },
       {
-        "en": "42 km",
-        "ja": "約42km",
+        "en": "26 km",
+        "ja": "約26km",
         "ja_typings": [
-          "yaku42kiro",
-          "yaku42km"
+          "yaku26km"
         ]
       },
       {
@@ -132325,13 +132322,10 @@
   {
     "choices": [
       {
-        "en": "30 minutes",
-        "ja": "30分",
+        "en": "8 minutes",
+        "ja": "8分",
         "ja_typings": [
-          "30hun",
-          "30pun",
-          "30bun",
-          "sanjuxtupun"
+          "8fun"
         ]
       },
       {
@@ -132345,13 +132339,11 @@
         ]
       },
       {
-        "en": "8 minutes",
-        "ja": "8分",
+        "en": "30 minutes",
+        "ja": "30分",
         "ja_typings": [
-          "8hun",
-          "8pun",
-          "8bun",
-          "hatupun"
+          "30fun",
+          "30pun"
         ]
       },
       {
@@ -132510,22 +132502,18 @@
   {
     "choices": [
       {
-        "en": "60 minutes",
-        "ja": "60分",
-        "ja_typings": [
-          "60hun",
-          "60pun",
-          "60bun",
-          "rokujuxtupun"
-        ]
-      },
-      {
         "en": "45 minutes",
         "ja": "45分",
         "ja_typings": [
-          "45hun",
-          "45pun",
-          "45bun"
+          "45fun"
+        ]
+      },
+      {
+        "en": "60 minutes",
+        "ja": "60分",
+        "ja_typings": [
+          "60fun",
+          "60pun"
         ]
       },
       {

--- a/data/questions_ja.json
+++ b/data/questions_ja.json
@@ -30989,7 +30989,7 @@
         "en": "Linear A",
         "ja": "線文字A",
         "ja_typings": [
-          "senmojiA"
+          "senmojia"
         ]
       },
       {
@@ -45905,7 +45905,7 @@
         "ja": "咲-Saki-",
         "ja_typings": [
           "saki",
-          "saki-Saki-"
+          "saki-saki-"
         ]
       },
       {
@@ -50304,7 +50304,7 @@
         "en": "C++20",
         "ja": "シープラプラニジュウ",
         "ja_typings": [
-          "C++20",
+          "c++20",
           "shi-purapuranijuu"
         ]
       },
@@ -50312,7 +50312,7 @@
         "en": "C++17",
         "ja": "シープラプラジュウナナ",
         "ja_typings": [
-          "C++17",
+          "c++17",
           "shi-purapurajuunana"
         ]
       },
@@ -50320,7 +50320,7 @@
         "en": "C++14",
         "ja": "シープラプラジュウヨン",
         "ja_typings": [
-          "C++14",
+          "c++14",
           "shi-purapurajuuyon"
         ]
       },
@@ -50328,7 +50328,7 @@
         "en": "C++11",
         "ja": "シープラプラジュウイチ",
         "ja_typings": [
-          "C++11",
+          "c++11",
           "shi-purapurajuuichi"
         ]
       }
@@ -50588,7 +50588,7 @@
         "en": "O(n^2)",
         "ja": "オーエヌジジョウ",
         "ja_typings": [
-          "O(n^2)",
+          "o(n^2)",
           "o-enujijo",
           "o-enujijou"
         ]
@@ -50597,7 +50597,7 @@
         "en": "O(n log n)",
         "ja": "オーエヌログエヌ",
         "ja_typings": [
-          "O(n log n)",
+          "o(n log n)",
           "o-enuroguenu"
         ]
       },
@@ -50605,7 +50605,7 @@
         "en": "O(1)",
         "ja": "オーイチ",
         "ja_typings": [
-          "O(1)",
+          "o(1)",
           "o-ichi"
         ]
       },
@@ -50613,7 +50613,7 @@
         "en": "O(log n)",
         "ja": "オーログエヌ",
         "ja_typings": [
-          "O(log n)",
+          "o(log n)",
           "o-roguenu"
         ]
       }
@@ -53975,7 +53975,7 @@
         "en": "RFC 3986 strict",
         "ja": "アールエフシーサンキュウハチロクストリクト",
         "ja_typings": [
-          "RFC 3986 strict",
+          "rfc 3986 strict",
           "a-ruefushi-sankyuuhachirokusutorikuto"
         ]
       },
@@ -54433,7 +54433,7 @@
         "en": "Layzner",
         "ja": "蒼き流星SPTレイズナー",
         "ja_typings": [
-          "aokiryuuseiSPTreizunaa"
+          "aokiryuuseisptreizunaa"
         ]
       }
     ],
@@ -54452,7 +54452,7 @@
         "en": "Patlabor: The Movie",
         "ja": "機動警察パトレイバー the Movie",
         "ja_typings": [
-          "kidoukeisatsupatoreibaatheMovie"
+          "kidoukeisatsupatoreibaathemovie"
         ]
       },
       {
@@ -54553,7 +54553,7 @@
         "en": "Lensman",
         "ja": "SF新世紀レンズマン",
         "ja_typings": [
-          "SFshinseikirenzuman"
+          "sfshinseikirenzuman"
         ]
       }
     ],
@@ -54701,7 +54701,7 @@
         "en": "Lupin III Part 2",
         "ja": "ルパン三世 PART2",
         "ja_typings": [
-          "rupansansei PART2"
+          "rupansansei part2"
         ]
       },
       {
@@ -55142,7 +55142,7 @@
         "en": "Wolf Children",
         "ja": "おおかみこどもの雨と雪",
         "ja_typings": [
-          "ookamikodomonoameToyuki"
+          "ookamikodomonoametoyuki"
         ]
       },
       {
@@ -55455,7 +55455,7 @@
         "en": "Kyoto Animation",
         "ja": "京都アニメーション",
         "ja_typings": [
-          "kyouToanimeeshon"
+          "kyoutoanimeeshon"
         ]
       },
       {
@@ -55502,7 +55502,7 @@
         "en": "Kyoto Animation",
         "ja": "京都アニメーション",
         "ja_typings": [
-          "kyouToanimeeshon"
+          "kyoutoanimeeshon"
         ]
       },
       {
@@ -63524,7 +63524,7 @@
         "en": "P vs NP",
         "ja": "P対NP問題",
         "ja_typings": [
-          "P tai NP mondai"
+          "p tai np mondai"
         ]
       },
       {
@@ -63725,7 +63725,7 @@
         "en": "A4",
         "ja": "A4群",
         "ja_typings": [
-          "A4gun"
+          "a4gun"
         ]
       },
       {
@@ -65926,7 +65926,7 @@
         "en": "a derpy Pepe emote",
         "ja": "間抜けなPepeエモート",
         "ja_typings": [
-          "manukenaPepeemo-to"
+          "manukenapepeemo-to"
         ]
       },
       {
@@ -78724,8 +78724,8 @@
         "en": "AVL tree",
         "ja": "AVL 木",
         "ja_typings": [
-          "AVLki",
-          "AVLgi"
+          "avlki",
+          "avlgi"
         ]
       }
     ],
@@ -96924,8 +96924,8 @@
         "en": "Ohara",
         "ja": "小原流",
         "ja_typings": [
-          "oharaRyuu",
-          "oharaRyu"
+          "ohararyuu",
+          "ohararyu"
         ]
       },
       {
@@ -98622,7 +98622,7 @@
         "en": "SLA",
         "ja": "SLA",
         "ja_typings": [
-          "esueruE-",
+          "esuerue-",
           "sla"
         ]
       }
@@ -98666,7 +98666,7 @@
         "en": "SLA",
         "ja": "SLA",
         "ja_typings": [
-          "esueruE-",
+          "esuerue-",
           "sla"
         ]
       }
@@ -98710,7 +98710,7 @@
         "en": "SLA",
         "ja": "SLA",
         "ja_typings": [
-          "esueruE-",
+          "esuerue-",
           "sla"
         ]
       }
@@ -101409,6 +101409,33663 @@
     "question_text": {
       "en": "Which component produces sequences for cryptography and simulations?",
       "ja": "暗号やシミュレーションに使う列を生成する装置は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Alexandria",
+        "ja": "アレクサンドリア",
+        "ja_typings": [
+          "arekusandoria"
+        ]
+      },
+      {
+        "en": "Cairo",
+        "ja": "カイロ",
+        "ja_typings": [
+          "kairo"
+        ]
+      },
+      {
+        "en": "Luxor",
+        "ja": "ルクソール",
+        "ja_typings": [
+          "rukuso-ru"
+        ]
+      },
+      {
+        "en": "Aswan",
+        "ja": "アスワン",
+        "ja_typings": [
+          "asuwan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02503",
+    "image_path": null,
+    "question_text": {
+      "en": "エジプトの地中海沿岸に位置し、古代に大図書館があった都市は?",
+      "ja": "Which Egyptian city on the Mediterranean coast was home to a famous ancient library?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Amazon River",
+        "ja": "アマゾン川",
+        "ja_typings": [
+          "amazongawa",
+          "amazonkawa"
+        ]
+      },
+      {
+        "en": "Nile River",
+        "ja": "ナイル川",
+        "ja_typings": [
+          "nairugawa",
+          "nairukawa"
+        ]
+      },
+      {
+        "en": "Mississippi River",
+        "ja": "ミシシッピ川",
+        "ja_typings": [
+          "mishishippigawa",
+          "mishishippikawa"
+        ]
+      },
+      {
+        "en": "Yangtze River",
+        "ja": "長江",
+        "ja_typings": [
+          "chouko",
+          "choukou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02504",
+    "image_path": null,
+    "question_text": {
+      "en": "南米大陸を流れる世界最大級の流域面積を持つ川は?",
+      "ja": "Which river in South America has one of the largest drainage basins in the world?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Arctic Ocean",
+        "ja": "北極海",
+        "ja_typings": [
+          "hokkyokukai"
+        ]
+      },
+      {
+        "en": "Atlantic Ocean",
+        "ja": "大西洋",
+        "ja_typings": [
+          "taiseiyou"
+        ]
+      },
+      {
+        "en": "Indian Ocean",
+        "ja": "インド洋",
+        "ja_typings": [
+          "indoyou"
+        ]
+      },
+      {
+        "en": "Pacific Ocean",
+        "ja": "太平洋",
+        "ja_typings": [
+          "taiheiyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02505",
+    "image_path": null,
+    "question_text": {
+      "en": "地球で最も北に位置する海洋は?",
+      "ja": "Which is the northernmost ocean on Earth?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Asahikawa",
+        "ja": "旭川",
+        "ja_typings": [
+          "asahikawa"
+        ]
+      },
+      {
+        "en": "Sapporo",
+        "ja": "札幌",
+        "ja_typings": [
+          "sapporo"
+        ]
+      },
+      {
+        "en": "Hakodate",
+        "ja": "函館",
+        "ja_typings": [
+          "hakodate"
+        ]
+      },
+      {
+        "en": "Kushiro",
+        "ja": "釧路",
+        "ja_typings": [
+          "kushiro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02506",
+    "image_path": null,
+    "question_text": {
+      "en": "北海道のほぼ中央にあり、上川盆地に位置する都市は?",
+      "ja": "Which Hokkaido city is located in the Kamikawa Basin near the center of the island?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Asia",
+        "ja": "アジア",
+        "ja_typings": [
+          "ajia"
+        ]
+      },
+      {
+        "en": "Africa",
+        "ja": "アフリカ",
+        "ja_typings": [
+          "afurika"
+        ]
+      },
+      {
+        "en": "Europe",
+        "ja": "ヨーロッパ",
+        "ja_typings": [
+          "yo-roppa"
+        ]
+      },
+      {
+        "en": "Oceania",
+        "ja": "オセアニア",
+        "ja_typings": [
+          "oseania"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02507",
+    "image_path": null,
+    "question_text": {
+      "en": "世界で最も広い大陸は?",
+      "ja": "Which is the largest continent in the world?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Asuncion",
+        "ja": "アスンシオン",
+        "ja_typings": [
+          "asunshion"
+        ]
+      },
+      {
+        "en": "Montevideo",
+        "ja": "モンテビデオ",
+        "ja_typings": [
+          "montebideo"
+        ]
+      },
+      {
+        "en": "La Paz",
+        "ja": "ラパス",
+        "ja_typings": [
+          "rapasu"
+        ]
+      },
+      {
+        "en": "Lima",
+        "ja": "リマ",
+        "ja_typings": [
+          "rima"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02508",
+    "image_path": null,
+    "question_text": {
+      "en": "パラグアイの首都は?",
+      "ja": "What is the capital of Paraguay?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Atlantic Ocean",
+        "ja": "大西洋",
+        "ja_typings": [
+          "taiseiyou"
+        ]
+      },
+      {
+        "en": "Pacific Ocean",
+        "ja": "太平洋",
+        "ja_typings": [
+          "taiheiyou"
+        ]
+      },
+      {
+        "en": "Indian Ocean",
+        "ja": "インド洋",
+        "ja_typings": [
+          "indoyou"
+        ]
+      },
+      {
+        "en": "Arctic Ocean",
+        "ja": "北極海",
+        "ja_typings": [
+          "hokkyokukai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02509",
+    "image_path": null,
+    "question_text": {
+      "en": "ヨーロッパとアメリカ大陸の間に広がる海洋は?",
+      "ja": "Which ocean lies between Europe and the Americas?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Atlas Mountains",
+        "ja": "アトラス山脈",
+        "ja_typings": [
+          "atorasusanmyaku"
+        ]
+      },
+      {
+        "en": "Alps",
+        "ja": "アルプス山脈",
+        "ja_typings": [
+          "arupususanmyaku"
+        ]
+      },
+      {
+        "en": "Andes",
+        "ja": "アンデス山脈",
+        "ja_typings": [
+          "andesusanmyaku"
+        ]
+      },
+      {
+        "en": "Caucasus Mountains",
+        "ja": "コーカサス山脈",
+        "ja_typings": [
+          "ko-kasasusanmyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02510",
+    "image_path": null,
+    "question_text": {
+      "en": "北アフリカを横断する大山脈は?",
+      "ja": "Which mountain range stretches across North Africa?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bangalore",
+        "ja": "バンガロール",
+        "ja_typings": [
+          "bangaro-ru"
+        ]
+      },
+      {
+        "en": "Mumbai",
+        "ja": "ムンバイ",
+        "ja_typings": [
+          "munbai"
+        ]
+      },
+      {
+        "en": "Kolkata",
+        "ja": "コルカタ",
+        "ja_typings": [
+          "korukata"
+        ]
+      },
+      {
+        "en": "Delhi",
+        "ja": "デリー",
+        "ja_typings": [
+          "deri-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02511",
+    "image_path": null,
+    "question_text": {
+      "en": "インドのIT産業の中心地として知られる都市は?",
+      "ja": "Which Indian city is known as the center of the IT industry?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Barcelona",
+        "ja": "バルセロナ",
+        "ja_typings": [
+          "baruserona"
+        ]
+      },
+      {
+        "en": "Madrid",
+        "ja": "マドリード",
+        "ja_typings": [
+          "madori-do"
+        ]
+      },
+      {
+        "en": "Seville",
+        "ja": "セビリア",
+        "ja_typings": [
+          "sebiria"
+        ]
+      },
+      {
+        "en": "Valencia",
+        "ja": "バレンシア",
+        "ja_typings": [
+          "barenshia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02512",
+    "image_path": null,
+    "question_text": {
+      "en": "サグラダ・ファミリアがあるスペイン東部の都市は?",
+      "ja": "Which city in eastern Spain is home to the Sagrada Familia?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Berlin",
+        "ja": "ベルリン",
+        "ja_typings": [
+          "berurin"
+        ]
+      },
+      {
+        "en": "Munich",
+        "ja": "ミュンヘン",
+        "ja_typings": [
+          "myunhen"
+        ]
+      },
+      {
+        "en": "Hamburg",
+        "ja": "ハンブルク",
+        "ja_typings": [
+          "hanburuku"
+        ]
+      },
+      {
+        "en": "Frankfurt",
+        "ja": "フランクフルト",
+        "ja_typings": [
+          "furankufuruto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02513",
+    "image_path": null,
+    "question_text": {
+      "en": "ドイツの首都は?",
+      "ja": "What is the capital of Germany?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bhutan",
+        "ja": "ブータン",
+        "ja_typings": [
+          "bu-tan"
+        ]
+      },
+      {
+        "en": "Nepal",
+        "ja": "ネパール",
+        "ja_typings": [
+          "nepa-ru"
+        ]
+      },
+      {
+        "en": "India",
+        "ja": "インド",
+        "ja_typings": [
+          "indo"
+        ]
+      },
+      {
+        "en": "Bangladesh",
+        "ja": "バングラデシュ",
+        "ja_typings": [
+          "banguradeshu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02514",
+    "image_path": null,
+    "question_text": {
+      "en": "ヒマラヤ山脈にある「幸福度」で知られる国は?",
+      "ja": "Which Himalayan country is known for its focus on Gross National Happiness?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Borneo",
+        "ja": "ボルネオ島",
+        "ja_typings": [
+          "boruneotou",
+          "boruneoshima"
+        ]
+      },
+      {
+        "en": "Sumatra",
+        "ja": "スマトラ島",
+        "ja_typings": [
+          "sumatoratou",
+          "sumatorashima"
+        ]
+      },
+      {
+        "en": "Java",
+        "ja": "ジャワ島",
+        "ja_typings": [
+          "jawatou",
+          "jawashima"
+        ]
+      },
+      {
+        "en": "New Guinea",
+        "ja": "ニューギニア島",
+        "ja_typings": [
+          "nyu-gineatou",
+          "nyu-gineashima"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02515",
+    "image_path": null,
+    "question_text": {
+      "en": "東南アジアにある世界で3番目に大きい島は?",
+      "ja": "Which is the third largest island in the world, located in Southeast Asia?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Brazil and Argentina",
+        "ja": "ブラジルとアルゼンチン",
+        "ja_typings": [
+          "burajirutoaruzenchin"
+        ]
+      },
+      {
+        "en": "Chile and Peru",
+        "ja": "チリとペルー",
+        "ja_typings": [
+          "chiritoperu-"
+        ]
+      },
+      {
+        "en": "Colombia and Venezuela",
+        "ja": "コロンビアとベネズエラ",
+        "ja_typings": [
+          "koronbiatobenezuera"
+        ]
+      },
+      {
+        "en": "Bolivia and Paraguay",
+        "ja": "ボリビアとパラグアイ",
+        "ja_typings": [
+          "boribiatoparaguai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02516",
+    "image_path": null,
+    "question_text": {
+      "en": "イグアスの滝が国境にある国の組み合わせは?",
+      "ja": "Iguazu Falls lies on the border between which two countries?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Buenos Aires",
+        "ja": "ブエノスアイレス",
+        "ja_typings": [
+          "buenosuairesu"
+        ]
+      },
+      {
+        "en": "Santiago",
+        "ja": "サンティアゴ",
+        "ja_typings": [
+          "santiago"
+        ]
+      },
+      {
+        "en": "Montevideo",
+        "ja": "モンテビデオ",
+        "ja_typings": [
+          "montebideo"
+        ]
+      },
+      {
+        "en": "Asuncion",
+        "ja": "アスンシオン",
+        "ja_typings": [
+          "asunshion"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02517",
+    "image_path": null,
+    "question_text": {
+      "en": "アルゼンチンの首都は?",
+      "ja": "What is the capital of Argentina?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bursa",
+        "ja": "ブルサ",
+        "ja_typings": [
+          "burusa"
+        ]
+      },
+      {
+        "en": "Izmir",
+        "ja": "イズミル",
+        "ja_typings": [
+          "izumiru"
+        ]
+      },
+      {
+        "en": "Ankara",
+        "ja": "アンカラ",
+        "ja_typings": [
+          "ankara"
+        ]
+      },
+      {
+        "en": "Konya",
+        "ja": "コンヤ",
+        "ja_typings": [
+          "konnya"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02518",
+    "image_path": null,
+    "question_text": {
+      "en": "トルコ北西部の旧オスマン帝国首都として知られる都市は?",
+      "ja": "Which northwestern Turkish city was a former capital of the Ottoman Empire?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Busan",
+        "ja": "プサン",
+        "ja_typings": [
+          "pusan"
+        ]
+      },
+      {
+        "en": "Incheon",
+        "ja": "インチョン",
+        "ja_typings": [
+          "inchon"
+        ]
+      },
+      {
+        "en": "Daegu",
+        "ja": "テグ",
+        "ja_typings": [
+          "tegu"
+        ]
+      },
+      {
+        "en": "Gwangju",
+        "ja": "クァンジュ",
+        "ja_typings": [
+          "kuanju"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02519",
+    "image_path": null,
+    "question_text": {
+      "en": "韓国第2の都市で南東部の主要港湾都市は?",
+      "ja": "Which is South Korea's second largest city and a major southeastern port?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cancun",
+        "ja": "カンクン",
+        "ja_typings": [
+          "kankun"
+        ]
+      },
+      {
+        "en": "Acapulco",
+        "ja": "アカプルコ",
+        "ja_typings": [
+          "akapuruko"
+        ]
+      },
+      {
+        "en": "Tijuana",
+        "ja": "ティフアナ",
+        "ja_typings": [
+          "tifuana"
+        ]
+      },
+      {
+        "en": "Veracruz",
+        "ja": "ベラクルス",
+        "ja_typings": [
+          "berakurusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02520",
+    "image_path": null,
+    "question_text": {
+      "en": "メキシコ・ユカタン半島のリゾート都市は?",
+      "ja": "Which resort city is on Mexico's Yucatan Peninsula?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Caspian Sea shore",
+        "ja": "カスピ海沿岸",
+        "ja_typings": [
+          "kasupikaiengan"
+        ]
+      },
+      {
+        "en": "Black Sea shore",
+        "ja": "黒海沿岸",
+        "ja_typings": [
+          "kokkaiengan"
+        ]
+      },
+      {
+        "en": "Mediterranean coast",
+        "ja": "地中海沿岸",
+        "ja_typings": [
+          "chichuukaiengan"
+        ]
+      },
+      {
+        "en": "Red Sea shore",
+        "ja": "紅海沿岸",
+        "ja_typings": [
+          "koukaiengan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02521",
+    "image_path": null,
+    "question_text": {
+      "en": "アゼルバイジャンのバクーがあるのは?",
+      "ja": "Baku, the capital of Azerbaijan, is located on which shore?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Caucasus Mountains",
+        "ja": "コーカサス山脈",
+        "ja_typings": [
+          "ko-kasasusanmyaku"
+        ]
+      },
+      {
+        "en": "Ural Mountains",
+        "ja": "ウラル山脈",
+        "ja_typings": [
+          "ururusanmyaku"
+        ]
+      },
+      {
+        "en": "Atlas Mountains",
+        "ja": "アトラス山脈",
+        "ja_typings": [
+          "atorasusanmyaku"
+        ]
+      },
+      {
+        "en": "Pyrenees",
+        "ja": "ピレネー山脈",
+        "ja_typings": [
+          "pirene-sanmyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02522",
+    "image_path": null,
+    "question_text": {
+      "en": "黒海とカスピ海の間に広がる山脈は?",
+      "ja": "Which mountain range lies between the Black Sea and the Caspian Sea?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chicago",
+        "ja": "シカゴ",
+        "ja_typings": [
+          "shikago"
+        ]
+      },
+      {
+        "en": "Detroit",
+        "ja": "デトロイト",
+        "ja_typings": [
+          "detoroito"
+        ]
+      },
+      {
+        "en": "Cleveland",
+        "ja": "クリーブランド",
+        "ja_typings": [
+          "kuri-burando"
+        ]
+      },
+      {
+        "en": "Milwaukee",
+        "ja": "ミルウォーキー",
+        "ja_typings": [
+          "miruwo-ki-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02523",
+    "image_path": null,
+    "question_text": {
+      "en": "アメリカ五大湖のミシガン湖畔に位置する都市は?",
+      "ja": "Which U.S. city is located on the shore of Lake Michigan?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Corinth",
+        "ja": "コリント",
+        "ja_typings": [
+          "korinto"
+        ]
+      },
+      {
+        "en": "Sparta",
+        "ja": "スパルタ",
+        "ja_typings": [
+          "suparuta"
+        ]
+      },
+      {
+        "en": "Thebes",
+        "ja": "テーベ",
+        "ja_typings": [
+          "te-be"
+        ]
+      },
+      {
+        "en": "Athens",
+        "ja": "アテネ",
+        "ja_typings": [
+          "atene"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02524",
+    "image_path": null,
+    "question_text": {
+      "en": "ペロポネソス半島の付け根にある古代ギリシャの都市は?",
+      "ja": "Which ancient Greek city stood at the isthmus of the Peloponnese?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Da Nang",
+        "ja": "ダナン",
+        "ja_typings": [
+          "danan"
+        ]
+      },
+      {
+        "en": "Hue",
+        "ja": "フエ",
+        "ja_typings": [
+          "fue"
+        ]
+      },
+      {
+        "en": "Hanoi",
+        "ja": "ハノイ",
+        "ja_typings": [
+          "hanoi"
+        ]
+      },
+      {
+        "en": "Ho Chi Minh City",
+        "ja": "ホーチミン",
+        "ja_typings": [
+          "ho-chimin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02525",
+    "image_path": null,
+    "question_text": {
+      "en": "ベトナム中部の主要港湾都市は?",
+      "ja": "Which city is a major port in central Vietnam?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dublin",
+        "ja": "ダブリン",
+        "ja_typings": [
+          "daburin"
+        ]
+      },
+      {
+        "en": "Belfast",
+        "ja": "ベルファスト",
+        "ja_typings": [
+          "berufasuto"
+        ]
+      },
+      {
+        "en": "Cork",
+        "ja": "コーク",
+        "ja_typings": [
+          "ko-ku"
+        ]
+      },
+      {
+        "en": "Galway",
+        "ja": "ゴールウェイ",
+        "ja_typings": [
+          "go-ruwei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02526",
+    "image_path": null,
+    "question_text": {
+      "en": "アイルランドの首都は?",
+      "ja": "What is the capital of Ireland?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Edinburgh",
+        "ja": "エディンバラ",
+        "ja_typings": [
+          "edinbara"
+        ]
+      },
+      {
+        "en": "Glasgow",
+        "ja": "グラスゴー",
+        "ja_typings": [
+          "gurasugo-"
+        ]
+      },
+      {
+        "en": "Aberdeen",
+        "ja": "アバディーン",
+        "ja_typings": [
+          "abadi-n"
+        ]
+      },
+      {
+        "en": "Dundee",
+        "ja": "ダンディー",
+        "ja_typings": [
+          "dandi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02527",
+    "image_path": null,
+    "question_text": {
+      "en": "スコットランドの首都は?",
+      "ja": "What is the capital of Scotland?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Florence",
+        "ja": "フィレンツェ",
+        "ja_typings": [
+          "firentse"
+        ]
+      },
+      {
+        "en": "Rome",
+        "ja": "ローマ",
+        "ja_typings": [
+          "ro-ma"
+        ]
+      },
+      {
+        "en": "Milan",
+        "ja": "ミラノ",
+        "ja_typings": [
+          "mirano"
+        ]
+      },
+      {
+        "en": "Venice",
+        "ja": "ベネチア",
+        "ja_typings": [
+          "benechia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02528",
+    "image_path": null,
+    "question_text": {
+      "en": "イタリアのトスカーナ州の州都でルネサンス発祥の地は?",
+      "ja": "Which Tuscan city is known as the birthplace of the Renaissance?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Frankfurt",
+        "ja": "フランクフルト",
+        "ja_typings": [
+          "furankufuruto"
+        ]
+      },
+      {
+        "en": "Berlin",
+        "ja": "ベルリン",
+        "ja_typings": [
+          "berurin"
+        ]
+      },
+      {
+        "en": "Hamburg",
+        "ja": "ハンブルク",
+        "ja_typings": [
+          "hanburuku"
+        ]
+      },
+      {
+        "en": "Munich",
+        "ja": "ミュンヘン",
+        "ja_typings": [
+          "myunhen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02529",
+    "image_path": null,
+    "question_text": {
+      "en": "ドイツの金融の中心地として知られる都市は?",
+      "ja": "Which German city is the country's financial center?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ginowan",
+        "ja": "宜野湾",
+        "ja_typings": [
+          "ginowan"
+        ]
+      },
+      {
+        "en": "Naha",
+        "ja": "那覇",
+        "ja_typings": [
+          "naha"
+        ]
+      },
+      {
+        "en": "Nago",
+        "ja": "名護",
+        "ja_typings": [
+          "nago"
+        ]
+      },
+      {
+        "en": "Uruma",
+        "ja": "うるま",
+        "ja_typings": [
+          "uruma"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02530",
+    "image_path": null,
+    "question_text": {
+      "en": "沖縄本島中部の都市で米軍基地が多いことで知られるのは?",
+      "ja": "Which Okinawan city is known for hosting many U.S. military bases?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Giza",
+        "ja": "ギザ",
+        "ja_typings": [
+          "giza"
+        ]
+      },
+      {
+        "en": "Luxor",
+        "ja": "ルクソール",
+        "ja_typings": [
+          "rukuso-ru"
+        ]
+      },
+      {
+        "en": "Alexandria",
+        "ja": "アレクサンドリア",
+        "ja_typings": [
+          "arekusandoria"
+        ]
+      },
+      {
+        "en": "Cairo",
+        "ja": "カイロ",
+        "ja_typings": [
+          "kairo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02531",
+    "image_path": null,
+    "question_text": {
+      "en": "ピラミッドとスフィンクスがあるエジプトの都市は?",
+      "ja": "Which Egyptian city is home to the pyramids and the Sphinx?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Greenland",
+        "ja": "グリーンランド",
+        "ja_typings": [
+          "guri-nrando"
+        ]
+      },
+      {
+        "en": "New Guinea",
+        "ja": "ニューギニア島",
+        "ja_typings": [
+          "nyu-gineatou",
+          "nyu-gineashima"
+        ]
+      },
+      {
+        "en": "Borneo",
+        "ja": "ボルネオ島",
+        "ja_typings": [
+          "boruneotou",
+          "boruneoshima"
+        ]
+      },
+      {
+        "en": "Madagascar",
+        "ja": "マダガスカル",
+        "ja_typings": [
+          "madagasukaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02532",
+    "image_path": null,
+    "question_text": {
+      "en": "世界最大の島でデンマーク自治領なのは?",
+      "ja": "Which is the world's largest island, an autonomous territory of Denmark?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Guadalajara",
+        "ja": "グアダラハラ",
+        "ja_typings": [
+          "guadarahara"
+        ]
+      },
+      {
+        "en": "Monterrey",
+        "ja": "モンテレイ",
+        "ja_typings": [
+          "monterei"
+        ]
+      },
+      {
+        "en": "Puebla",
+        "ja": "プエブラ",
+        "ja_typings": [
+          "puebura"
+        ]
+      },
+      {
+        "en": "Tijuana",
+        "ja": "ティフアナ",
+        "ja_typings": [
+          "tifuana"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02533",
+    "image_path": null,
+    "question_text": {
+      "en": "メキシコ第2の都市でテキーラの産地として有名な都市は?",
+      "ja": "Which Mexican city is famous as the home of tequila?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hakodate",
+        "ja": "函館",
+        "ja_typings": [
+          "hakodate"
+        ]
+      },
+      {
+        "en": "Otaru",
+        "ja": "小樽",
+        "ja_typings": [
+          "otaru"
+        ]
+      },
+      {
+        "en": "Muroran",
+        "ja": "室蘭",
+        "ja_typings": [
+          "muroran"
+        ]
+      },
+      {
+        "en": "Kushiro",
+        "ja": "釧路",
+        "ja_typings": [
+          "kushiro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02534",
+    "image_path": null,
+    "question_text": {
+      "en": "北海道南部にある夜景が有名な港町は?",
+      "ja": "Which Hokkaido port town is famous for its night view?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hamburg",
+        "ja": "ハンブルク",
+        "ja_typings": [
+          "hanburuku"
+        ]
+      },
+      {
+        "en": "Bremen",
+        "ja": "ブレーメン",
+        "ja_typings": [
+          "bure-men"
+        ]
+      },
+      {
+        "en": "Kiel",
+        "ja": "キール",
+        "ja_typings": [
+          "ki-ru"
+        ]
+      },
+      {
+        "en": "Rostock",
+        "ja": "ロストック",
+        "ja_typings": [
+          "rosutokku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02535",
+    "image_path": null,
+    "question_text": {
+      "en": "ドイツ北部の主要港湾都市は?",
+      "ja": "Which city is a major northern German port?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hanoi",
+        "ja": "ハノイ",
+        "ja_typings": [
+          "hanoi"
+        ]
+      },
+      {
+        "en": "Ho Chi Minh City",
+        "ja": "ホーチミン",
+        "ja_typings": [
+          "ho-chimin"
+        ]
+      },
+      {
+        "en": "Da Nang",
+        "ja": "ダナン",
+        "ja_typings": [
+          "danan"
+        ]
+      },
+      {
+        "en": "Hue",
+        "ja": "フエ",
+        "ja_typings": [
+          "fue"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02536",
+    "image_path": null,
+    "question_text": {
+      "en": "ベトナムの首都は?",
+      "ja": "What is the capital of Vietnam?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ho Chi Minh City",
+        "ja": "ホーチミン",
+        "ja_typings": [
+          "ho-chimin"
+        ]
+      },
+      {
+        "en": "Hanoi",
+        "ja": "ハノイ",
+        "ja_typings": [
+          "hanoi"
+        ]
+      },
+      {
+        "en": "Hue",
+        "ja": "フエ",
+        "ja_typings": [
+          "fue"
+        ]
+      },
+      {
+        "en": "Da Nang",
+        "ja": "ダナン",
+        "ja_typings": [
+          "danan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02537",
+    "image_path": null,
+    "question_text": {
+      "en": "ベトナム南部最大の都市は?",
+      "ja": "Which is the largest city in southern Vietnam?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hong Kong",
+        "ja": "香港",
+        "ja_typings": [
+          "honkon"
+        ]
+      },
+      {
+        "en": "Macao",
+        "ja": "マカオ",
+        "ja_typings": [
+          "makao"
+        ]
+      },
+      {
+        "en": "Shenzhen",
+        "ja": "深圳",
+        "ja_typings": [
+          "shinsen"
+        ]
+      },
+      {
+        "en": "Guangzhou",
+        "ja": "広州",
+        "ja_typings": [
+          "koushuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02538",
+    "image_path": null,
+    "question_text": {
+      "en": "中国南部にある特別行政区で金融センターとして知られる都市は?",
+      "ja": "Which Special Administrative Region of southern China is a major financial hub?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hue",
+        "ja": "フエ",
+        "ja_typings": [
+          "fue"
+        ]
+      },
+      {
+        "en": "Hanoi",
+        "ja": "ハノイ",
+        "ja_typings": [
+          "hanoi"
+        ]
+      },
+      {
+        "en": "Da Nang",
+        "ja": "ダナン",
+        "ja_typings": [
+          "danan"
+        ]
+      },
+      {
+        "en": "Ho Chi Minh City",
+        "ja": "ホーチミン",
+        "ja_typings": [
+          "ho-chimin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02539",
+    "image_path": null,
+    "question_text": {
+      "en": "ベトナム中部の旧王朝の都は?",
+      "ja": "Which central Vietnamese city was the imperial capital under the Nguyen dynasty?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Incheon",
+        "ja": "インチョン",
+        "ja_typings": [
+          "inchon"
+        ]
+      },
+      {
+        "en": "Busan",
+        "ja": "プサン",
+        "ja_typings": [
+          "pusan"
+        ]
+      },
+      {
+        "en": "Daegu",
+        "ja": "テグ",
+        "ja_typings": [
+          "tegu"
+        ]
+      },
+      {
+        "en": "Ulsan",
+        "ja": "ウルサン",
+        "ja_typings": [
+          "urusan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02540",
+    "image_path": null,
+    "question_text": {
+      "en": "韓国の国際空港があるソウル近郊の港湾都市は?",
+      "ja": "Which port city near Seoul hosts South Korea's main international airport?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "India",
+        "ja": "インド",
+        "ja_typings": [
+          "indo"
+        ]
+      },
+      {
+        "en": "Pakistan",
+        "ja": "パキスタン",
+        "ja_typings": [
+          "pakisutan"
+        ]
+      },
+      {
+        "en": "Bangladesh",
+        "ja": "バングラデシュ",
+        "ja_typings": [
+          "banguradeshu"
+        ]
+      },
+      {
+        "en": "Sri Lanka",
+        "ja": "スリランカ",
+        "ja_typings": [
+          "suriranka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02541",
+    "image_path": null,
+    "question_text": {
+      "en": "南アジアで人口最多の国は?",
+      "ja": "Which is the most populous country in South Asia?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Indian Ocean",
+        "ja": "インド洋",
+        "ja_typings": [
+          "indoyou"
+        ]
+      },
+      {
+        "en": "Pacific Ocean",
+        "ja": "太平洋",
+        "ja_typings": [
+          "taiheiyou"
+        ]
+      },
+      {
+        "en": "Atlantic Ocean",
+        "ja": "大西洋",
+        "ja_typings": [
+          "taiseiyou"
+        ]
+      },
+      {
+        "en": "Arctic Ocean",
+        "ja": "北極海",
+        "ja_typings": [
+          "hokkyokukai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02542",
+    "image_path": null,
+    "question_text": {
+      "en": "アフリカとオーストラリアの間に広がる海洋は?",
+      "ja": "Which ocean lies between Africa and Australia?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ishigaki",
+        "ja": "石垣島",
+        "ja_typings": [
+          "ishigakijima",
+          "ishigakitou"
+        ]
+      },
+      {
+        "en": "Iriomote",
+        "ja": "西表島",
+        "ja_typings": [
+          "iriomotejima"
+        ]
+      },
+      {
+        "en": "Yonaguni",
+        "ja": "与那国島",
+        "ja_typings": [
+          "yonagunijima"
+        ]
+      },
+      {
+        "en": "Miyako",
+        "ja": "宮古島",
+        "ja_typings": [
+          "miyakojima"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02543",
+    "image_path": null,
+    "question_text": {
+      "en": "八重山諸島の中心の島は?",
+      "ja": "Which is the main island of the Yaeyama Islands?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ishikari River",
+        "ja": "石狩川",
+        "ja_typings": [
+          "ishikarigawa",
+          "ishikarikawa"
+        ]
+      },
+      {
+        "en": "Tone River",
+        "ja": "利根川",
+        "ja_typings": [
+          "tonegawa",
+          "tonekawa"
+        ]
+      },
+      {
+        "en": "Tenryu River",
+        "ja": "天竜川",
+        "ja_typings": [
+          "tenryuugawa",
+          "tenryuukawa"
+        ]
+      },
+      {
+        "en": "Yodo River",
+        "ja": "淀川",
+        "ja_typings": [
+          "yodogawa",
+          "yodokawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02544",
+    "image_path": null,
+    "question_text": {
+      "en": "北海道で最長の川は?",
+      "ja": "Which is the longest river in Hokkaido?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Izmir",
+        "ja": "イズミル",
+        "ja_typings": [
+          "izumiru"
+        ]
+      },
+      {
+        "en": "Bursa",
+        "ja": "ブルサ",
+        "ja_typings": [
+          "burusa"
+        ]
+      },
+      {
+        "en": "Antalya",
+        "ja": "アンタルヤ",
+        "ja_typings": [
+          "antaruya"
+        ]
+      },
+      {
+        "en": "Adana",
+        "ja": "アダナ",
+        "ja_typings": [
+          "adana"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02545",
+    "image_path": null,
+    "question_text": {
+      "en": "トルコ第3の都市でエーゲ海沿岸の港湾都市は?",
+      "ja": "Which is Turkey's third largest city, a port on the Aegean coast?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jeddah",
+        "ja": "ジッダ",
+        "ja_typings": [
+          "jidda"
+        ]
+      },
+      {
+        "en": "Mecca",
+        "ja": "メッカ",
+        "ja_typings": [
+          "mekka"
+        ]
+      },
+      {
+        "en": "Medina",
+        "ja": "メディナ",
+        "ja_typings": [
+          "medina"
+        ]
+      },
+      {
+        "en": "Riyadh",
+        "ja": "リヤド",
+        "ja_typings": [
+          "riyado"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02546",
+    "image_path": null,
+    "question_text": {
+      "en": "サウジアラビアの紅海沿岸の主要都市は?",
+      "ja": "Which is Saudi Arabia's main city on the Red Sea coast?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kalahari Desert",
+        "ja": "カラハリ砂漠",
+        "ja_typings": [
+          "karaharisabaku"
+        ]
+      },
+      {
+        "en": "Sahara Desert",
+        "ja": "サハラ砂漠",
+        "ja_typings": [
+          "saharasabaku"
+        ]
+      },
+      {
+        "en": "Namib Desert",
+        "ja": "ナミブ砂漠",
+        "ja_typings": [
+          "namibusabaku"
+        ]
+      },
+      {
+        "en": "Gobi Desert",
+        "ja": "ゴビ砂漠",
+        "ja_typings": [
+          "gobisabaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02547",
+    "image_path": null,
+    "question_text": {
+      "en": "南部アフリカに広がる砂漠は?",
+      "ja": "Which desert covers much of southern Africa?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kanmon Bridge",
+        "ja": "関門橋",
+        "ja_typings": [
+          "kanmonkyou",
+          "kanmonbashi"
+        ]
+      },
+      {
+        "en": "Akashi Kaikyo Bridge",
+        "ja": "明石海峡大橋",
+        "ja_typings": [
+          "akashikaikyouoohashi"
+        ]
+      },
+      {
+        "en": "Seto Ohashi",
+        "ja": "瀬戸大橋",
+        "ja_typings": [
+          "setoohashi"
+        ]
+      },
+      {
+        "en": "Rainbow Bridge",
+        "ja": "レインボーブリッジ",
+        "ja_typings": [
+          "reinbo-burijji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02548",
+    "image_path": null,
+    "question_text": {
+      "en": "本州と九州を結ぶ関門海峡にかかる橋は?",
+      "ja": "Which bridge spans the Kanmon Strait between Honshu and Kyushu?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kolkata",
+        "ja": "コルカタ",
+        "ja_typings": [
+          "korukata"
+        ]
+      },
+      {
+        "en": "Mumbai",
+        "ja": "ムンバイ",
+        "ja_typings": [
+          "munbai"
+        ]
+      },
+      {
+        "en": "Chennai",
+        "ja": "チェンナイ",
+        "ja_typings": [
+          "chennnai"
+        ]
+      },
+      {
+        "en": "Bangalore",
+        "ja": "バンガロール",
+        "ja_typings": [
+          "bangaro-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02549",
+    "image_path": null,
+    "question_text": {
+      "en": "インド東部の大都市で旧称カルカッタの都市は?",
+      "ja": "Which large eastern Indian city was formerly called Calcutta?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kushiro",
+        "ja": "釧路",
+        "ja_typings": [
+          "kushiro"
+        ]
+      },
+      {
+        "en": "Nemuro",
+        "ja": "根室",
+        "ja_typings": [
+          "nemuro"
+        ]
+      },
+      {
+        "en": "Abashiri",
+        "ja": "網走",
+        "ja_typings": [
+          "abashiri"
+        ]
+      },
+      {
+        "en": "Obihiro",
+        "ja": "帯広",
+        "ja_typings": [
+          "obihiro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02550",
+    "image_path": null,
+    "question_text": {
+      "en": "北海道道東にある霧で有名な港町は?",
+      "ja": "Which port town in eastern Hokkaido is famous for its fog?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lake Assal",
+        "ja": "アッサル湖",
+        "ja_typings": [
+          "assaruko"
+        ]
+      },
+      {
+        "en": "Dead Sea",
+        "ja": "死海",
+        "ja_typings": [
+          "shikai"
+        ]
+      },
+      {
+        "en": "Caspian Sea",
+        "ja": "カスピ海",
+        "ja_typings": [
+          "kasupikai"
+        ]
+      },
+      {
+        "en": "Lake Eyre",
+        "ja": "エア湖",
+        "ja_typings": [
+          "eako"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02551",
+    "image_path": null,
+    "question_text": {
+      "en": "ジブチにある世界で最も標高の低い湖は?",
+      "ja": "Which lake in Djibouti is the lowest point on land?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lake Inawashiro",
+        "ja": "猪苗代湖",
+        "ja_typings": [
+          "inawashiroko"
+        ]
+      },
+      {
+        "en": "Lake Biwa",
+        "ja": "琵琶湖",
+        "ja_typings": [
+          "biwako"
+        ]
+      },
+      {
+        "en": "Lake Kasumigaura",
+        "ja": "霞ヶ浦",
+        "ja_typings": [
+          "kasumigaura"
+        ]
+      },
+      {
+        "en": "Lake Towada",
+        "ja": "十和田湖",
+        "ja_typings": [
+          "towadako"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02552",
+    "image_path": null,
+    "question_text": {
+      "en": "福島県にある日本で4番目に大きい湖は?",
+      "ja": "Which Fukushima lake is the fourth largest in Japan?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lake Kasumigaura",
+        "ja": "霞ヶ浦",
+        "ja_typings": [
+          "kasumigaura"
+        ]
+      },
+      {
+        "en": "Lake Biwa",
+        "ja": "琵琶湖",
+        "ja_typings": [
+          "biwako"
+        ]
+      },
+      {
+        "en": "Lake Inawashiro",
+        "ja": "猪苗代湖",
+        "ja_typings": [
+          "inawashiroko"
+        ]
+      },
+      {
+        "en": "Lake Suwa",
+        "ja": "諏訪湖",
+        "ja_typings": [
+          "suwako"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02553",
+    "image_path": null,
+    "question_text": {
+      "en": "茨城県にある日本で2番目に大きい湖は?",
+      "ja": "Which Ibaraki lake is the second largest in Japan?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lake Saroma",
+        "ja": "サロマ湖",
+        "ja_typings": [
+          "saromako"
+        ]
+      },
+      {
+        "en": "Lake Akan",
+        "ja": "阿寒湖",
+        "ja_typings": [
+          "akanko"
+        ]
+      },
+      {
+        "en": "Lake Mashu",
+        "ja": "摩周湖",
+        "ja_typings": [
+          "mashuuko"
+        ]
+      },
+      {
+        "en": "Lake Kussharo",
+        "ja": "屈斜路湖",
+        "ja_typings": [
+          "kussharoko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02554",
+    "image_path": null,
+    "question_text": {
+      "en": "北海道東部のオホーツク海に面した日本最大の汽水湖は?",
+      "ja": "Which is Japan's largest brackish lake, on Hokkaido's Sea of Okhotsk coast?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Los Angeles",
+        "ja": "ロサンゼルス",
+        "ja_typings": [
+          "rosanzerusu"
+        ]
+      },
+      {
+        "en": "San Diego",
+        "ja": "サンディエゴ",
+        "ja_typings": [
+          "sandiego"
+        ]
+      },
+      {
+        "en": "San Francisco",
+        "ja": "サンフランシスコ",
+        "ja_typings": [
+          "sanfuranshisuko"
+        ]
+      },
+      {
+        "en": "Sacramento",
+        "ja": "サクラメント",
+        "ja_typings": [
+          "sakuramento"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02555",
+    "image_path": null,
+    "question_text": {
+      "en": "アメリカ・カリフォルニア州南部の大都市は?",
+      "ja": "Which is the largest city in Southern California?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Luxor",
+        "ja": "ルクソール",
+        "ja_typings": [
+          "rukuso-ru"
+        ]
+      },
+      {
+        "en": "Alexandria",
+        "ja": "アレクサンドリア",
+        "ja_typings": [
+          "arekusandoria"
+        ]
+      },
+      {
+        "en": "Giza",
+        "ja": "ギザ",
+        "ja_typings": [
+          "giza"
+        ]
+      },
+      {
+        "en": "Aswan",
+        "ja": "アスワン",
+        "ja_typings": [
+          "asuwan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02556",
+    "image_path": null,
+    "question_text": {
+      "en": "エジプト南部にあるカルナック神殿で有名な都市は?",
+      "ja": "Which southern Egyptian city is famous for the Karnak Temple?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Madagascar",
+        "ja": "マダガスカル",
+        "ja_typings": [
+          "madagasukaru"
+        ]
+      },
+      {
+        "en": "Greenland",
+        "ja": "グリーンランド",
+        "ja_typings": [
+          "guri-nrando"
+        ]
+      },
+      {
+        "en": "Borneo",
+        "ja": "ボルネオ島",
+        "ja_typings": [
+          "boruneotou",
+          "boruneoshima"
+        ]
+      },
+      {
+        "en": "New Guinea",
+        "ja": "ニューギニア島",
+        "ja_typings": [
+          "nyu-gineatou",
+          "nyu-gineashima"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02557",
+    "image_path": null,
+    "question_text": {
+      "en": "アフリカ南東沖にある世界で4番目に大きい島は?",
+      "ja": "Which is the fourth largest island in the world, off southeastern Africa?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Madrid",
+        "ja": "マドリード",
+        "ja_typings": [
+          "madori-do"
+        ]
+      },
+      {
+        "en": "Barcelona",
+        "ja": "バルセロナ",
+        "ja_typings": [
+          "baruserona"
+        ]
+      },
+      {
+        "en": "Seville",
+        "ja": "セビリア",
+        "ja_typings": [
+          "sebiria"
+        ]
+      },
+      {
+        "en": "Valencia",
+        "ja": "バレンシア",
+        "ja_typings": [
+          "barenshia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02558",
+    "image_path": null,
+    "question_text": {
+      "en": "スペインの首都は?",
+      "ja": "What is the capital of Spain?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Manchester",
+        "ja": "マンチェスター",
+        "ja_typings": [
+          "manchesuta-"
+        ]
+      },
+      {
+        "en": "Liverpool",
+        "ja": "リバプール",
+        "ja_typings": [
+          "ribapu-ru"
+        ]
+      },
+      {
+        "en": "Leeds",
+        "ja": "リーズ",
+        "ja_typings": [
+          "ri-zu"
+        ]
+      },
+      {
+        "en": "Birmingham",
+        "ja": "バーミンガム",
+        "ja_typings": [
+          "ba-mingamu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02559",
+    "image_path": null,
+    "question_text": {
+      "en": "イギリス北西部の工業都市でサッカーが盛んな都市は?",
+      "ja": "Which northwestern English industrial city is famous for football?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mecca",
+        "ja": "メッカ",
+        "ja_typings": [
+          "mekka"
+        ]
+      },
+      {
+        "en": "Medina",
+        "ja": "メディナ",
+        "ja_typings": [
+          "medina"
+        ]
+      },
+      {
+        "en": "Jeddah",
+        "ja": "ジッダ",
+        "ja_typings": [
+          "jidda"
+        ]
+      },
+      {
+        "en": "Riyadh",
+        "ja": "リヤド",
+        "ja_typings": [
+          "riyado"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02560",
+    "image_path": null,
+    "question_text": {
+      "en": "イスラム教最大の聖地はサウジアラビアの?",
+      "ja": "Which Saudi Arabian city is Islam's holiest site?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Medina",
+        "ja": "メディナ",
+        "ja_typings": [
+          "medina"
+        ]
+      },
+      {
+        "en": "Mecca",
+        "ja": "メッカ",
+        "ja_typings": [
+          "mekka"
+        ]
+      },
+      {
+        "en": "Jeddah",
+        "ja": "ジッダ",
+        "ja_typings": [
+          "jidda"
+        ]
+      },
+      {
+        "en": "Riyadh",
+        "ja": "リヤド",
+        "ja_typings": [
+          "riyado"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02561",
+    "image_path": null,
+    "question_text": {
+      "en": "イスラム教第2の聖地で預言者ムハンマドの墓がある都市は?",
+      "ja": "Which city is Islam's second holiest, home to the Prophet Muhammad's tomb?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mediterranean coast",
+        "ja": "地中海沿岸",
+        "ja_typings": [
+          "chichuukaiengan"
+        ]
+      },
+      {
+        "en": "Red Sea shore",
+        "ja": "紅海沿岸",
+        "ja_typings": [
+          "koukaiengan"
+        ]
+      },
+      {
+        "en": "Caspian Sea shore",
+        "ja": "カスピ海沿岸",
+        "ja_typings": [
+          "kasupikaiengan"
+        ]
+      },
+      {
+        "en": "Black Sea shore",
+        "ja": "黒海沿岸",
+        "ja_typings": [
+          "kokkaiengan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02562",
+    "image_path": null,
+    "question_text": {
+      "en": "イスラエルのテルアビブやレバノンのベイルートが面しているのは?",
+      "ja": "Tel Aviv and Beirut both face which coastal region?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Milan",
+        "ja": "ミラノ",
+        "ja_typings": [
+          "mirano"
+        ]
+      },
+      {
+        "en": "Rome",
+        "ja": "ローマ",
+        "ja_typings": [
+          "ro-ma"
+        ]
+      },
+      {
+        "en": "Florence",
+        "ja": "フィレンツェ",
+        "ja_typings": [
+          "firentse"
+        ]
+      },
+      {
+        "en": "Turin",
+        "ja": "トリノ",
+        "ja_typings": [
+          "torino"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02563",
+    "image_path": null,
+    "question_text": {
+      "en": "イタリア北部の経済の中心地でファッションの都は?",
+      "ja": "Which northern Italian city is its economic and fashion capital?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mississippi River",
+        "ja": "ミシシッピ川",
+        "ja_typings": [
+          "mishishippigawa",
+          "mishishippikawa"
+        ]
+      },
+      {
+        "en": "Missouri River",
+        "ja": "ミズーリ川",
+        "ja_typings": [
+          "mizu-rigawa",
+          "mizu-rikawa"
+        ]
+      },
+      {
+        "en": "Colorado River",
+        "ja": "コロラド川",
+        "ja_typings": [
+          "kororadogawa",
+          "kororadokawa"
+        ]
+      },
+      {
+        "en": "Rio Grande",
+        "ja": "リオグランデ川",
+        "ja_typings": [
+          "riogurandegawa",
+          "riogurandekawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02564",
+    "image_path": null,
+    "question_text": {
+      "en": "アメリカ中部を南北に貫く大河は?",
+      "ja": "Which great river runs north-south through the central United States?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Monterrey",
+        "ja": "モンテレイ",
+        "ja_typings": [
+          "monterei"
+        ]
+      },
+      {
+        "en": "Guadalajara",
+        "ja": "グアダラハラ",
+        "ja_typings": [
+          "guadarahara"
+        ]
+      },
+      {
+        "en": "Tijuana",
+        "ja": "ティフアナ",
+        "ja_typings": [
+          "tifuana"
+        ]
+      },
+      {
+        "en": "Puebla",
+        "ja": "プエブラ",
+        "ja_typings": [
+          "puebura"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02565",
+    "image_path": null,
+    "question_text": {
+      "en": "メキシコ北部の工業都市は?",
+      "ja": "Which northern Mexican city is a major industrial center?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Montevideo",
+        "ja": "モンテビデオ",
+        "ja_typings": [
+          "montebideo"
+        ]
+      },
+      {
+        "en": "Buenos Aires",
+        "ja": "ブエノスアイレス",
+        "ja_typings": [
+          "buenosuairesu"
+        ]
+      },
+      {
+        "en": "Asuncion",
+        "ja": "アスンシオン",
+        "ja_typings": [
+          "asunshion"
+        ]
+      },
+      {
+        "en": "Santiago",
+        "ja": "サンティアゴ",
+        "ja_typings": [
+          "santiago"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02566",
+    "image_path": null,
+    "question_text": {
+      "en": "ウルグアイの首都は?",
+      "ja": "What is the capital of Uruguay?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Montreal",
+        "ja": "モントリオール",
+        "ja_typings": [
+          "montorio-ru"
+        ]
+      },
+      {
+        "en": "Toronto",
+        "ja": "トロント",
+        "ja_typings": [
+          "toronto"
+        ]
+      },
+      {
+        "en": "Vancouver",
+        "ja": "バンクーバー",
+        "ja_typings": [
+          "banku-ba-"
+        ]
+      },
+      {
+        "en": "Ottawa",
+        "ja": "オタワ",
+        "ja_typings": [
+          "otawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02567",
+    "image_path": null,
+    "question_text": {
+      "en": "カナダ・ケベック州の最大都市は?",
+      "ja": "Which is the largest city in Quebec, Canada?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mount Hotaka",
+        "ja": "穂高岳",
+        "ja_typings": [
+          "hotakadake"
+        ]
+      },
+      {
+        "en": "Mount Yari",
+        "ja": "槍ヶ岳",
+        "ja_typings": [
+          "yarigatake"
+        ]
+      },
+      {
+        "en": "Mount Tate",
+        "ja": "立山",
+        "ja_typings": [
+          "tateyama"
+        ]
+      },
+      {
+        "en": "Mount Norikura",
+        "ja": "乗鞍岳",
+        "ja_typings": [
+          "norikuradake"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02568",
+    "image_path": null,
+    "question_text": {
+      "en": "北アルプスにある標高3190mの山は?",
+      "ja": "Which Northern Japan Alps peak rises to 3190 meters?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mount Kilimanjaro",
+        "ja": "キリマンジャロ",
+        "ja_typings": [
+          "kirimanjaro"
+        ]
+      },
+      {
+        "en": "Mount Kenya",
+        "ja": "ケニア山",
+        "ja_typings": [
+          "keniasan"
+        ]
+      },
+      {
+        "en": "Mount Rwenzori",
+        "ja": "ルウェンゾリ山",
+        "ja_typings": [
+          "ruwenzorisan"
+        ]
+      },
+      {
+        "en": "Mount Meru",
+        "ja": "メルー山",
+        "ja_typings": [
+          "meru-san"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02569",
+    "image_path": null,
+    "question_text": {
+      "en": "タンザニアにあるアフリカ最高峰は?",
+      "ja": "Which is Africa's highest mountain, located in Tanzania?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mount Kita",
+        "ja": "北岳",
+        "ja_typings": [
+          "kitadake"
+        ]
+      },
+      {
+        "en": "Mount Fuji",
+        "ja": "富士山",
+        "ja_typings": [
+          "fujisan"
+        ]
+      },
+      {
+        "en": "Mount Hotaka",
+        "ja": "穂高岳",
+        "ja_typings": [
+          "hotakadake"
+        ]
+      },
+      {
+        "en": "Mount Yari",
+        "ja": "槍ヶ岳",
+        "ja_typings": [
+          "yarigatake"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02570",
+    "image_path": null,
+    "question_text": {
+      "en": "南アルプスにある標高3193mで日本第2位の高峰は?",
+      "ja": "Which Southern Japan Alps peak is Japan's second highest at 3193 meters?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mount McKinley",
+        "ja": "マッキンリー",
+        "ja_typings": [
+          "makkinri-"
+        ]
+      },
+      {
+        "en": "Mount Logan",
+        "ja": "ローガン山",
+        "ja_typings": [
+          "ro-gansan"
+        ]
+      },
+      {
+        "en": "Mount Saint Elias",
+        "ja": "セントエライアス山",
+        "ja_typings": [
+          "sentoeraiasusan"
+        ]
+      },
+      {
+        "en": "Mount Foraker",
+        "ja": "フォレイカー山",
+        "ja_typings": [
+          "foreika-san"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02571",
+    "image_path": null,
+    "question_text": {
+      "en": "アラスカにある北米最高峰の旧称は?",
+      "ja": "Which is the former name of North America's highest peak in Alaska?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mount Rwenzori",
+        "ja": "ルウェンゾリ山",
+        "ja_typings": [
+          "ruwenzorisan"
+        ]
+      },
+      {
+        "en": "Mount Kilimanjaro",
+        "ja": "キリマンジャロ",
+        "ja_typings": [
+          "kirimanjaro"
+        ]
+      },
+      {
+        "en": "Mount Kenya",
+        "ja": "ケニア山",
+        "ja_typings": [
+          "keniasan"
+        ]
+      },
+      {
+        "en": "Mount Elgon",
+        "ja": "エルゴン山",
+        "ja_typings": [
+          "erugonsan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02572",
+    "image_path": null,
+    "question_text": {
+      "en": "ウガンダとコンゴ民主共和国の国境にある山は?",
+      "ja": "Which mountain range lies on the border between Uganda and DR Congo?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mount Yari",
+        "ja": "槍ヶ岳",
+        "ja_typings": [
+          "yarigatake"
+        ]
+      },
+      {
+        "en": "Mount Hotaka",
+        "ja": "穂高岳",
+        "ja_typings": [
+          "hotakadake"
+        ]
+      },
+      {
+        "en": "Mount Tate",
+        "ja": "立山",
+        "ja_typings": [
+          "tateyama"
+        ]
+      },
+      {
+        "en": "Mount Kita",
+        "ja": "北岳",
+        "ja_typings": [
+          "kitadake"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02573",
+    "image_path": null,
+    "question_text": {
+      "en": "北アルプスの槍状の山頂で知られる山は?",
+      "ja": "Which Northern Japan Alps peak is famous for its spear-like summit?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mumbai",
+        "ja": "ムンバイ",
+        "ja_typings": [
+          "munbai"
+        ]
+      },
+      {
+        "en": "Delhi",
+        "ja": "デリー",
+        "ja_typings": [
+          "deri-"
+        ]
+      },
+      {
+        "en": "Kolkata",
+        "ja": "コルカタ",
+        "ja_typings": [
+          "korukata"
+        ]
+      },
+      {
+        "en": "Chennai",
+        "ja": "チェンナイ",
+        "ja_typings": [
+          "chennnai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02574",
+    "image_path": null,
+    "question_text": {
+      "en": "インド最大の都市で旧称ボンベイは?",
+      "ja": "Which is India's largest city, formerly known as Bombay?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Munich",
+        "ja": "ミュンヘン",
+        "ja_typings": [
+          "myunhen"
+        ]
+      },
+      {
+        "en": "Berlin",
+        "ja": "ベルリン",
+        "ja_typings": [
+          "berurin"
+        ]
+      },
+      {
+        "en": "Hamburg",
+        "ja": "ハンブルク",
+        "ja_typings": [
+          "hanburuku"
+        ]
+      },
+      {
+        "en": "Frankfurt",
+        "ja": "フランクフルト",
+        "ja_typings": [
+          "furankufuruto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02575",
+    "image_path": null,
+    "question_text": {
+      "en": "ドイツ・バイエルン州の州都は?",
+      "ja": "What is the capital of Bavaria, Germany?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nago",
+        "ja": "名護",
+        "ja_typings": [
+          "nago"
+        ]
+      },
+      {
+        "en": "Naha",
+        "ja": "那覇",
+        "ja_typings": [
+          "naha"
+        ]
+      },
+      {
+        "en": "Ginowan",
+        "ja": "宜野湾",
+        "ja_typings": [
+          "ginowan"
+        ]
+      },
+      {
+        "en": "Uruma",
+        "ja": "うるま",
+        "ja_typings": [
+          "uruma"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02576",
+    "image_path": null,
+    "question_text": {
+      "en": "沖縄本島北部の中心都市は?",
+      "ja": "Which is the central city of northern Okinawa Island?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nanjing",
+        "ja": "南京",
+        "ja_typings": [
+          "nankin"
+        ]
+      },
+      {
+        "en": "Beijing",
+        "ja": "北京",
+        "ja_typings": [
+          "pekin"
+        ]
+      },
+      {
+        "en": "Shanghai",
+        "ja": "上海",
+        "ja_typings": [
+          "shanhai"
+        ]
+      },
+      {
+        "en": "Hangzhou",
+        "ja": "杭州",
+        "ja_typings": [
+          "koushuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02577",
+    "image_path": null,
+    "question_text": {
+      "en": "中国の旧首都で長江下流域にある都市は?",
+      "ja": "Which former Chinese capital lies on the lower Yangtze River?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nepal",
+        "ja": "ネパール",
+        "ja_typings": [
+          "nepa-ru"
+        ]
+      },
+      {
+        "en": "Bhutan",
+        "ja": "ブータン",
+        "ja_typings": [
+          "bu-tan"
+        ]
+      },
+      {
+        "en": "Tibet",
+        "ja": "チベット",
+        "ja_typings": [
+          "chibetto"
+        ]
+      },
+      {
+        "en": "Sikkim",
+        "ja": "シッキム",
+        "ja_typings": [
+          "shikkimu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02578",
+    "image_path": null,
+    "question_text": {
+      "en": "エベレストがある南アジアの内陸国は?",
+      "ja": "Which landlocked South Asian country is home to Mount Everest?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Netherlands",
+        "ja": "オランダ",
+        "ja_typings": [
+          "oranda"
+        ]
+      },
+      {
+        "en": "Belgium",
+        "ja": "ベルギー",
+        "ja_typings": [
+          "berugi-"
+        ]
+      },
+      {
+        "en": "Denmark",
+        "ja": "デンマーク",
+        "ja_typings": [
+          "denma-ku"
+        ]
+      },
+      {
+        "en": "Luxembourg",
+        "ja": "ルクセンブルク",
+        "ja_typings": [
+          "rukusenburuku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02579",
+    "image_path": null,
+    "question_text": {
+      "en": "アムステルダムを首都とするヨーロッパの国は?",
+      "ja": "Which European country has Amsterdam as its capital?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "New Guinea",
+        "ja": "ニューギニア島",
+        "ja_typings": [
+          "nyu-gineatou",
+          "nyu-gineashima"
+        ]
+      },
+      {
+        "en": "Borneo",
+        "ja": "ボルネオ島",
+        "ja_typings": [
+          "boruneotou",
+          "boruneoshima"
+        ]
+      },
+      {
+        "en": "Madagascar",
+        "ja": "マダガスカル",
+        "ja_typings": [
+          "madagasukaru"
+        ]
+      },
+      {
+        "en": "Sumatra",
+        "ja": "スマトラ島",
+        "ja_typings": [
+          "sumatoratou",
+          "sumatorashima"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02580",
+    "image_path": null,
+    "question_text": {
+      "en": "世界第2位の大きさを持つ島でインドネシアとパプアニューギニアに分かれているのは?",
+      "ja": "Which is the world's second largest island, split between Indonesia and Papua New Guinea?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "New York",
+        "ja": "ニューヨーク",
+        "ja_typings": [
+          "nyu-yo-ku"
+        ]
+      },
+      {
+        "en": "Boston",
+        "ja": "ボストン",
+        "ja_typings": [
+          "bosuton"
+        ]
+      },
+      {
+        "en": "Philadelphia",
+        "ja": "フィラデルフィア",
+        "ja_typings": [
+          "firaderufia"
+        ]
+      },
+      {
+        "en": "Washington",
+        "ja": "ワシントン",
+        "ja_typings": [
+          "washinton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02581",
+    "image_path": null,
+    "question_text": {
+      "en": "アメリカ東海岸の世界都市は?",
+      "ja": "Which is the U.S. east coast's global city?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Novosibirsk",
+        "ja": "ノボシビルスク",
+        "ja_typings": [
+          "noboshibirusuku"
+        ]
+      },
+      {
+        "en": "Vladivostok",
+        "ja": "ウラジオストク",
+        "ja_typings": [
+          "urajiosutoku"
+        ]
+      },
+      {
+        "en": "Irkutsk",
+        "ja": "イルクーツク",
+        "ja_typings": [
+          "iruku-tsuku"
+        ]
+      },
+      {
+        "en": "Krasnoyarsk",
+        "ja": "クラスノヤルスク",
+        "ja_typings": [
+          "kurasunoyarusuku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02582",
+    "image_path": null,
+    "question_text": {
+      "en": "シベリア最大の都市は?",
+      "ja": "Which is the largest city in Siberia?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Phnom Penh",
+        "ja": "プノンペン",
+        "ja_typings": [
+          "punonpen"
+        ]
+      },
+      {
+        "en": "Siem Reap",
+        "ja": "シェムリアップ",
+        "ja_typings": [
+          "shemuriappu"
+        ]
+      },
+      {
+        "en": "Vientiane",
+        "ja": "ビエンチャン",
+        "ja_typings": [
+          "bienchan"
+        ]
+      },
+      {
+        "en": "Hanoi",
+        "ja": "ハノイ",
+        "ja_typings": [
+          "hanoi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02583",
+    "image_path": null,
+    "question_text": {
+      "en": "カンボジアの首都は?",
+      "ja": "What is the capital of Cambodia?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pyongyang",
+        "ja": "ピョンヤン",
+        "ja_typings": [
+          "pyonnyan"
+        ]
+      },
+      {
+        "en": "Seoul",
+        "ja": "ソウル",
+        "ja_typings": [
+          "soru",
+          "souru"
+        ]
+      },
+      {
+        "en": "Kaesong",
+        "ja": "ケソン",
+        "ja_typings": [
+          "keson"
+        ]
+      },
+      {
+        "en": "Wonsan",
+        "ja": "ウォンサン",
+        "ja_typings": [
+          "wonsan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02584",
+    "image_path": null,
+    "question_text": {
+      "en": "北朝鮮の首都は?",
+      "ja": "What is the capital of North Korea?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rainbow Bridge",
+        "ja": "レインボーブリッジ",
+        "ja_typings": [
+          "reinbo-burijji"
+        ]
+      },
+      {
+        "en": "Tokyo Bay Aqua-Line",
+        "ja": "東京湾アクアライン",
+        "ja_typings": [
+          "toukyouwanakurarain"
+        ]
+      },
+      {
+        "en": "Kanmon Bridge",
+        "ja": "関門橋",
+        "ja_typings": [
+          "kanmonkyou",
+          "kanmonbashi"
+        ]
+      },
+      {
+        "en": "Seto Ohashi",
+        "ja": "瀬戸大橋",
+        "ja_typings": [
+          "setoohashi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02585",
+    "image_path": null,
+    "question_text": {
+      "en": "東京湾のお台場と芝浦を結ぶ橋は?",
+      "ja": "Which bridge connects Odaiba and Shibaura over Tokyo Bay?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rio de Janeiro",
+        "ja": "リオデジャネイロ",
+        "ja_typings": [
+          "riodejaneiro"
+        ]
+      },
+      {
+        "en": "Sao Paulo",
+        "ja": "サンパウロ",
+        "ja_typings": [
+          "sanpauro"
+        ]
+      },
+      {
+        "en": "Brasilia",
+        "ja": "ブラジリア",
+        "ja_typings": [
+          "burajiria"
+        ]
+      },
+      {
+        "en": "Salvador",
+        "ja": "サルバドール",
+        "ja_typings": [
+          "sarubado-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02586",
+    "image_path": null,
+    "question_text": {
+      "en": "ブラジルでコルコバードのキリスト像で有名な都市は?",
+      "ja": "Which Brazilian city is famous for the Christ the Redeemer statue?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rotterdam",
+        "ja": "ロッテルダム",
+        "ja_typings": [
+          "rotterudamu"
+        ]
+      },
+      {
+        "en": "Amsterdam",
+        "ja": "アムステルダム",
+        "ja_typings": [
+          "amusuterudamu"
+        ]
+      },
+      {
+        "en": "The Hague",
+        "ja": "ハーグ",
+        "ja_typings": [
+          "ha-gu"
+        ]
+      },
+      {
+        "en": "Utrecht",
+        "ja": "ユトレヒト",
+        "ja_typings": [
+          "yutorehito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02587",
+    "image_path": null,
+    "question_text": {
+      "en": "オランダの主要港湾都市でユーロポートを擁するのは?",
+      "ja": "Which Dutch port city houses Europoort, one of Europe's largest ports?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Saint Petersburg",
+        "ja": "サンクトペテルブルク",
+        "ja_typings": [
+          "sankutopeteruburuku"
+        ]
+      },
+      {
+        "en": "Moscow",
+        "ja": "モスクワ",
+        "ja_typings": [
+          "mosukuwa"
+        ]
+      },
+      {
+        "en": "Kazan",
+        "ja": "カザン",
+        "ja_typings": [
+          "kazan"
+        ]
+      },
+      {
+        "en": "Yekaterinburg",
+        "ja": "エカテリンブルク",
+        "ja_typings": [
+          "ekaterinburuku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02588",
+    "image_path": null,
+    "question_text": {
+      "en": "ロシアの旧首都でバルト海沿岸の都市は?",
+      "ja": "Which is Russia's former capital on the Baltic coast?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Santiago",
+        "ja": "サンティアゴ",
+        "ja_typings": [
+          "santiago"
+        ]
+      },
+      {
+        "en": "Buenos Aires",
+        "ja": "ブエノスアイレス",
+        "ja_typings": [
+          "buenosuairesu"
+        ]
+      },
+      {
+        "en": "Lima",
+        "ja": "リマ",
+        "ja_typings": [
+          "rima"
+        ]
+      },
+      {
+        "en": "La Paz",
+        "ja": "ラパス",
+        "ja_typings": [
+          "rapasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02589",
+    "image_path": null,
+    "question_text": {
+      "en": "チリの首都は?",
+      "ja": "What is the capital of Chile?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sao Paulo",
+        "ja": "サンパウロ",
+        "ja_typings": [
+          "sanpauro"
+        ]
+      },
+      {
+        "en": "Rio de Janeiro",
+        "ja": "リオデジャネイロ",
+        "ja_typings": [
+          "riodejaneiro"
+        ]
+      },
+      {
+        "en": "Brasilia",
+        "ja": "ブラジリア",
+        "ja_typings": [
+          "burajiria"
+        ]
+      },
+      {
+        "en": "Salvador",
+        "ja": "サルバドール",
+        "ja_typings": [
+          "sarubado-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02590",
+    "image_path": null,
+    "question_text": {
+      "en": "ブラジル最大の都市は?",
+      "ja": "Which is the largest city in Brazil?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Seville",
+        "ja": "セビリア",
+        "ja_typings": [
+          "sebiria"
+        ]
+      },
+      {
+        "en": "Cordoba",
+        "ja": "コルドバ",
+        "ja_typings": [
+          "korudoba"
+        ]
+      },
+      {
+        "en": "Granada",
+        "ja": "グラナダ",
+        "ja_typings": [
+          "guranada"
+        ]
+      },
+      {
+        "en": "Malaga",
+        "ja": "マラガ",
+        "ja_typings": [
+          "maraga"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02591",
+    "image_path": null,
+    "question_text": {
+      "en": "スペイン南部アンダルシア州の州都は?",
+      "ja": "What is the capital of Andalusia in southern Spain?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shanghai",
+        "ja": "上海",
+        "ja_typings": [
+          "shanhai"
+        ]
+      },
+      {
+        "en": "Beijing",
+        "ja": "北京",
+        "ja_typings": [
+          "pekin"
+        ]
+      },
+      {
+        "en": "Guangzhou",
+        "ja": "広州",
+        "ja_typings": [
+          "koushuu"
+        ]
+      },
+      {
+        "en": "Shenzhen",
+        "ja": "深圳",
+        "ja_typings": [
+          "shinsen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02592",
+    "image_path": null,
+    "question_text": {
+      "en": "中国最大の都市で長江河口の港湾都市は?",
+      "ja": "Which is China's largest city, located at the mouth of the Yangtze?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Siberia",
+        "ja": "シベリア",
+        "ja_typings": [
+          "shiberia"
+        ]
+      },
+      {
+        "en": "Mongolia",
+        "ja": "モンゴル",
+        "ja_typings": [
+          "mongoru"
+        ]
+      },
+      {
+        "en": "Manchuria",
+        "ja": "満州",
+        "ja_typings": [
+          "manshuu"
+        ]
+      },
+      {
+        "en": "Caucasus",
+        "ja": "コーカサス",
+        "ja_typings": [
+          "ko-kasasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02593",
+    "image_path": null,
+    "question_text": {
+      "en": "ロシア東部に広がる広大な地域は?",
+      "ja": "Which vast region covers eastern Russia?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "South Africa",
+        "ja": "南アフリカ",
+        "ja_typings": [
+          "minamiafurika"
+        ]
+      },
+      {
+        "en": "Namibia",
+        "ja": "ナミビア",
+        "ja_typings": [
+          "namibia"
+        ]
+      },
+      {
+        "en": "Botswana",
+        "ja": "ボツワナ",
+        "ja_typings": [
+          "botsuwana"
+        ]
+      },
+      {
+        "en": "Zimbabwe",
+        "ja": "ジンバブエ",
+        "ja_typings": [
+          "jinbabue"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02594",
+    "image_path": null,
+    "question_text": {
+      "en": "ケープタウンを擁するアフリカ大陸南端の国は?",
+      "ja": "Which country at Africa's southern tip is home to Cape Town?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "South America",
+        "ja": "南アメリカ",
+        "ja_typings": [
+          "minamiamerika"
+        ]
+      },
+      {
+        "en": "North America",
+        "ja": "北アメリカ",
+        "ja_typings": [
+          "kitaamerika"
+        ]
+      },
+      {
+        "en": "Africa",
+        "ja": "アフリカ",
+        "ja_typings": [
+          "afurika"
+        ]
+      },
+      {
+        "en": "Asia",
+        "ja": "アジア",
+        "ja_typings": [
+          "ajia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02595",
+    "image_path": null,
+    "question_text": {
+      "en": "ブラジルやアルゼンチンを含む大陸は?",
+      "ja": "Which continent includes Brazil and Argentina?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sparta",
+        "ja": "スパルタ",
+        "ja_typings": [
+          "suparuta"
+        ]
+      },
+      {
+        "en": "Athens",
+        "ja": "アテネ",
+        "ja_typings": [
+          "atene"
+        ]
+      },
+      {
+        "en": "Corinth",
+        "ja": "コリント",
+        "ja_typings": [
+          "korinto"
+        ]
+      },
+      {
+        "en": "Thebes",
+        "ja": "テーベ",
+        "ja_typings": [
+          "te-be"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02596",
+    "image_path": null,
+    "question_text": {
+      "en": "古代ギリシャの軍事都市国家は?",
+      "ja": "Which ancient Greek city-state was famous for its military?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tenryu River",
+        "ja": "天竜川",
+        "ja_typings": [
+          "tenryuugawa",
+          "tenryuukawa"
+        ]
+      },
+      {
+        "en": "Tone River",
+        "ja": "利根川",
+        "ja_typings": [
+          "tonegawa",
+          "tonekawa"
+        ]
+      },
+      {
+        "en": "Ishikari River",
+        "ja": "石狩川",
+        "ja_typings": [
+          "ishikarigawa",
+          "ishikarikawa"
+        ]
+      },
+      {
+        "en": "Shinano River",
+        "ja": "信濃川",
+        "ja_typings": [
+          "shinanogawa",
+          "shinanokawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02597",
+    "image_path": null,
+    "question_text": {
+      "en": "長野県・静岡県を流れて遠州灘に注ぐ川は?",
+      "ja": "Which river flows from Nagano through Shizuoka into Enshu-nada Sea?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Hague",
+        "ja": "ハーグ",
+        "ja_typings": [
+          "ha-gu"
+        ]
+      },
+      {
+        "en": "Amsterdam",
+        "ja": "アムステルダム",
+        "ja_typings": [
+          "amusuterudamu"
+        ]
+      },
+      {
+        "en": "Rotterdam",
+        "ja": "ロッテルダム",
+        "ja_typings": [
+          "rotterudamu"
+        ]
+      },
+      {
+        "en": "Utrecht",
+        "ja": "ユトレヒト",
+        "ja_typings": [
+          "yutorehito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02598",
+    "image_path": null,
+    "question_text": {
+      "en": "国際司法裁判所が置かれるオランダの都市は?",
+      "ja": "Which Dutch city is home to the International Court of Justice?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thessaloniki",
+        "ja": "テッサロニキ",
+        "ja_typings": [
+          "tessaroniki"
+        ]
+      },
+      {
+        "en": "Athens",
+        "ja": "アテネ",
+        "ja_typings": [
+          "atene"
+        ]
+      },
+      {
+        "en": "Patras",
+        "ja": "パトラ",
+        "ja_typings": [
+          "patora"
+        ]
+      },
+      {
+        "en": "Heraklion",
+        "ja": "イラクリオン",
+        "ja_typings": [
+          "irakurion"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02599",
+    "image_path": null,
+    "question_text": {
+      "en": "ギリシャ第2の都市は?",
+      "ja": "Which is Greece's second largest city?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tokyo Bay Aqua-Line",
+        "ja": "東京湾アクアライン",
+        "ja_typings": [
+          "toukyouwanakurarain"
+        ]
+      },
+      {
+        "en": "Rainbow Bridge",
+        "ja": "レインボーブリッジ",
+        "ja_typings": [
+          "reinbo-burijji"
+        ]
+      },
+      {
+        "en": "Kanmon Bridge",
+        "ja": "関門橋",
+        "ja_typings": [
+          "kanmonkyou",
+          "kanmonbashi"
+        ]
+      },
+      {
+        "en": "Seto Ohashi",
+        "ja": "瀬戸大橋",
+        "ja_typings": [
+          "setoohashi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02600",
+    "image_path": null,
+    "question_text": {
+      "en": "東京と神奈川を結ぶ東京湾を横断する道路は?",
+      "ja": "Which highway crosses Tokyo Bay between Tokyo area and Kanagawa?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tone River",
+        "ja": "利根川",
+        "ja_typings": [
+          "tonegawa",
+          "tonekawa"
+        ]
+      },
+      {
+        "en": "Shinano River",
+        "ja": "信濃川",
+        "ja_typings": [
+          "shinanogawa",
+          "shinanokawa"
+        ]
+      },
+      {
+        "en": "Ishikari River",
+        "ja": "石狩川",
+        "ja_typings": [
+          "ishikarigawa",
+          "ishikarikawa"
+        ]
+      },
+      {
+        "en": "Kitakami River",
+        "ja": "北上川",
+        "ja_typings": [
+          "kitakamigawa",
+          "kitakamikawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02601",
+    "image_path": null,
+    "question_text": {
+      "en": "関東平野を流れる日本最大の流域面積を持つ川は?",
+      "ja": "Which Kanto Plain river has Japan's largest drainage basin?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Toronto",
+        "ja": "トロント",
+        "ja_typings": [
+          "toronto"
+        ]
+      },
+      {
+        "en": "Montreal",
+        "ja": "モントリオール",
+        "ja_typings": [
+          "montorio-ru"
+        ]
+      },
+      {
+        "en": "Vancouver",
+        "ja": "バンクーバー",
+        "ja_typings": [
+          "banku-ba-"
+        ]
+      },
+      {
+        "en": "Ottawa",
+        "ja": "オタワ",
+        "ja_typings": [
+          "otawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02602",
+    "image_path": null,
+    "question_text": {
+      "en": "カナダ最大の都市は?",
+      "ja": "Which is the largest city in Canada?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Turpan Depression",
+        "ja": "トルファン盆地",
+        "ja_typings": [
+          "torufanbonchi"
+        ]
+      },
+      {
+        "en": "Tarim Basin",
+        "ja": "タリム盆地",
+        "ja_typings": [
+          "tarimubonchi"
+        ]
+      },
+      {
+        "en": "Junggar Basin",
+        "ja": "ジュンガル盆地",
+        "ja_typings": [
+          "junngarubonchi"
+        ]
+      },
+      {
+        "en": "Qaidam Basin",
+        "ja": "ツァイダム盆地",
+        "ja_typings": [
+          "tsuaidamubonchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02603",
+    "image_path": null,
+    "question_text": {
+      "en": "中国新疆ウイグル自治区にある中国で最も低い場所は?",
+      "ja": "Which depression in China's Xinjiang region is the country's lowest point?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "USA and Mexico",
+        "ja": "アメリカとメキシコ",
+        "ja_typings": [
+          "amerikatomekishiko"
+        ]
+      },
+      {
+        "en": "Brazil and Argentina",
+        "ja": "ブラジルとアルゼンチン",
+        "ja_typings": [
+          "burajirutoaruzenchin"
+        ]
+      },
+      {
+        "en": "Canada and USA",
+        "ja": "カナダとアメリカ",
+        "ja_typings": [
+          "kanadatoamerika"
+        ]
+      },
+      {
+        "en": "Chile and Peru",
+        "ja": "チリとペルー",
+        "ja_typings": [
+          "chiritoperu-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02604",
+    "image_path": null,
+    "question_text": {
+      "en": "リオ・グランデ川が国境を流れている国の組み合わせは?",
+      "ja": "The Rio Grande forms the border between which two countries?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Utrecht",
+        "ja": "ユトレヒト",
+        "ja_typings": [
+          "yutorehito"
+        ]
+      },
+      {
+        "en": "Amsterdam",
+        "ja": "アムステルダム",
+        "ja_typings": [
+          "amusuterudamu"
+        ]
+      },
+      {
+        "en": "Rotterdam",
+        "ja": "ロッテルダム",
+        "ja_typings": [
+          "rotterudamu"
+        ]
+      },
+      {
+        "en": "The Hague",
+        "ja": "ハーグ",
+        "ja_typings": [
+          "ha-gu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02605",
+    "image_path": null,
+    "question_text": {
+      "en": "オランダ中央部の大学都市は?",
+      "ja": "Which Dutch central city is a major university town?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Valencia",
+        "ja": "バレンシア",
+        "ja_typings": [
+          "barenshia"
+        ]
+      },
+      {
+        "en": "Barcelona",
+        "ja": "バルセロナ",
+        "ja_typings": [
+          "baruserona"
+        ]
+      },
+      {
+        "en": "Madrid",
+        "ja": "マドリード",
+        "ja_typings": [
+          "madori-do"
+        ]
+      },
+      {
+        "en": "Seville",
+        "ja": "セビリア",
+        "ja_typings": [
+          "sebiria"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02606",
+    "image_path": null,
+    "question_text": {
+      "en": "スペイン東部地中海沿岸の都市でパエリア発祥地は?",
+      "ja": "Which eastern Spanish city on the Mediterranean is the birthplace of paella?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vancouver",
+        "ja": "バンクーバー",
+        "ja_typings": [
+          "banku-ba-"
+        ]
+      },
+      {
+        "en": "Toronto",
+        "ja": "トロント",
+        "ja_typings": [
+          "toronto"
+        ]
+      },
+      {
+        "en": "Montreal",
+        "ja": "モントリオール",
+        "ja_typings": [
+          "montorio-ru"
+        ]
+      },
+      {
+        "en": "Calgary",
+        "ja": "カルガリー",
+        "ja_typings": [
+          "karugari-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02607",
+    "image_path": null,
+    "question_text": {
+      "en": "カナダ西海岸の港湾都市は?",
+      "ja": "Which is Canada's main west coast port city?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Venice",
+        "ja": "ベネチア",
+        "ja_typings": [
+          "benechia"
+        ]
+      },
+      {
+        "en": "Florence",
+        "ja": "フィレンツェ",
+        "ja_typings": [
+          "firentse"
+        ]
+      },
+      {
+        "en": "Milan",
+        "ja": "ミラノ",
+        "ja_typings": [
+          "mirano"
+        ]
+      },
+      {
+        "en": "Verona",
+        "ja": "ベローナ",
+        "ja_typings": [
+          "bero-na"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02608",
+    "image_path": null,
+    "question_text": {
+      "en": "イタリア北東部の運河の街は?",
+      "ja": "Which northeastern Italian city is famous for its canals?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vientiane",
+        "ja": "ビエンチャン",
+        "ja_typings": [
+          "bienchan"
+        ]
+      },
+      {
+        "en": "Phnom Penh",
+        "ja": "プノンペン",
+        "ja_typings": [
+          "punonpen"
+        ]
+      },
+      {
+        "en": "Hanoi",
+        "ja": "ハノイ",
+        "ja_typings": [
+          "hanoi"
+        ]
+      },
+      {
+        "en": "Yangon",
+        "ja": "ヤンゴン",
+        "ja_typings": [
+          "yangon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02609",
+    "image_path": null,
+    "question_text": {
+      "en": "ラオスの首都は?",
+      "ja": "What is the capital of Laos?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vladivostok",
+        "ja": "ウラジオストク",
+        "ja_typings": [
+          "urajiosutoku"
+        ]
+      },
+      {
+        "en": "Khabarovsk",
+        "ja": "ハバロフスク",
+        "ja_typings": [
+          "habarofusuku"
+        ]
+      },
+      {
+        "en": "Novosibirsk",
+        "ja": "ノボシビルスク",
+        "ja_typings": [
+          "noboshibirusuku"
+        ]
+      },
+      {
+        "en": "Irkutsk",
+        "ja": "イルクーツク",
+        "ja_typings": [
+          "iruku-tsuku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02610",
+    "image_path": null,
+    "question_text": {
+      "en": "ロシア極東の最大都市は?",
+      "ja": "Which is the largest city in the Russian Far East?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yangtze River",
+        "ja": "長江",
+        "ja_typings": [
+          "chouko",
+          "choukou"
+        ]
+      },
+      {
+        "en": "Yellow River",
+        "ja": "黄河",
+        "ja_typings": [
+          "kouga"
+        ]
+      },
+      {
+        "en": "Mekong River",
+        "ja": "メコン川",
+        "ja_typings": [
+          "mekongawa",
+          "mekonkawa"
+        ]
+      },
+      {
+        "en": "Amur River",
+        "ja": "アムール川",
+        "ja_typings": [
+          "amu-rugawa",
+          "amu-rukawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02611",
+    "image_path": null,
+    "question_text": {
+      "en": "中国を流れるアジア最長の川は?",
+      "ja": "Which is Asia's longest river, flowing through China?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Zambia and Zimbabwe",
+        "ja": "ザンビアとジンバブエ",
+        "ja_typings": [
+          "zanbiatojinbabue"
+        ]
+      },
+      {
+        "en": "Brazil and Argentina",
+        "ja": "ブラジルとアルゼンチン",
+        "ja_typings": [
+          "burajirutoaruzenchin"
+        ]
+      },
+      {
+        "en": "USA and Mexico",
+        "ja": "アメリカとメキシコ",
+        "ja_typings": [
+          "amerikatomekishiko"
+        ]
+      },
+      {
+        "en": "Tanzania and Kenya",
+        "ja": "タンザニアとケニア",
+        "ja_typings": [
+          "tanzaniatokenia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "geography",
+    "id": "q02612",
+    "image_path": null,
+    "question_text": {
+      "en": "ビクトリアの滝が国境にある国の組み合わせは?",
+      "ja": "Victoria Falls lies on the border between which two countries?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "127",
+        "ja": "127",
+        "ja_typings": [
+          "127"
+        ]
+      },
+      {
+        "en": "64",
+        "ja": "64",
+        "ja_typings": [
+          "64"
+        ]
+      },
+      {
+        "en": "32",
+        "ja": "32",
+        "ja_typings": [
+          "32"
+        ]
+      },
+      {
+        "en": "255",
+        "ja": "255",
+        "ja_typings": [
+          "255"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02613",
+    "image_path": null,
+    "question_text": {
+      "en": "IPv4でルータが特別な用途で予約しているTTLのデフォルト最大値の1つは?",
+      "ja": "Which is one of the typical default maximum TTL values used in IPv4?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "128",
+        "ja": "128",
+        "ja_typings": [
+          "128"
+        ]
+      },
+      {
+        "en": "256",
+        "ja": "256",
+        "ja_typings": [
+          "256"
+        ]
+      },
+      {
+        "en": "64",
+        "ja": "64",
+        "ja_typings": [
+          "64"
+        ]
+      },
+      {
+        "en": "127",
+        "ja": "127",
+        "ja_typings": [
+          "127"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02614",
+    "image_path": null,
+    "question_text": {
+      "en": "8ビット符号なし整数で表せる最大値は?",
+      "ja": "What is the maximum value of an 8-bit unsigned integer?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "16",
+        "ja": "16ビット",
+        "ja_typings": [
+          "16bitto"
+        ]
+      },
+      {
+        "en": "32",
+        "ja": "32ビット",
+        "ja_typings": [
+          "32bitto"
+        ]
+      },
+      {
+        "en": "8",
+        "ja": "8ビット",
+        "ja_typings": [
+          "8bitto"
+        ]
+      },
+      {
+        "en": "64",
+        "ja": "64ビット",
+        "ja_typings": [
+          "64bitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02615",
+    "image_path": null,
+    "question_text": {
+      "en": "C言語のshort型で多くの環境におけるビット数は?",
+      "ja": "How many bits does C's short type typically have?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "256",
+        "ja": "256通り",
+        "ja_typings": [
+          "256toori"
+        ]
+      },
+      {
+        "en": "128",
+        "ja": "128通り",
+        "ja_typings": [
+          "128toori"
+        ]
+      },
+      {
+        "en": "512",
+        "ja": "512通り",
+        "ja_typings": [
+          "512toori"
+        ]
+      },
+      {
+        "en": "64",
+        "ja": "64通り",
+        "ja_typings": [
+          "64toori"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02616",
+    "image_path": null,
+    "question_text": {
+      "en": "8ビット整数で表現できる値の総数は?",
+      "ja": "How many distinct values can be represented with 8 bits?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "64",
+        "ja": "64ビット",
+        "ja_typings": [
+          "64bitto"
+        ]
+      },
+      {
+        "en": "32",
+        "ja": "32ビット",
+        "ja_typings": [
+          "32bitto"
+        ]
+      },
+      {
+        "en": "16",
+        "ja": "16ビット",
+        "ja_typings": [
+          "16bitto"
+        ]
+      },
+      {
+        "en": "128",
+        "ja": "128ビット",
+        "ja_typings": [
+          "128bitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02617",
+    "image_path": null,
+    "question_text": {
+      "en": "x86_64アーキテクチャでの汎用レジスタの幅は何ビット?",
+      "ja": "How many bits wide is a general purpose register in x86_64?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "8",
+        "ja": "8ビット",
+        "ja_typings": [
+          "8bitto"
+        ]
+      },
+      {
+        "en": "4",
+        "ja": "4ビット",
+        "ja_typings": [
+          "4bitto"
+        ]
+      },
+      {
+        "en": "16",
+        "ja": "16ビット",
+        "ja_typings": [
+          "16bitto"
+        ]
+      },
+      {
+        "en": "32",
+        "ja": "32ビット",
+        "ja_typings": [
+          "32bitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02618",
+    "image_path": null,
+    "question_text": {
+      "en": "IPv4の1オクテットは何ビット?",
+      "ja": "How many bits is one octet in IPv4?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ARP",
+        "ja": "ARP",
+        "ja_typings": [
+          "arp"
+        ]
+      },
+      {
+        "en": "DNS",
+        "ja": "DNS",
+        "ja_typings": [
+          "dns"
+        ]
+      },
+      {
+        "en": "DHCP",
+        "ja": "DHCP",
+        "ja_typings": [
+          "dhcp"
+        ]
+      },
+      {
+        "en": "ICMP",
+        "ja": "ICMP",
+        "ja_typings": [
+          "icmp"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02619",
+    "image_path": null,
+    "question_text": {
+      "en": "IPアドレスからMACアドレスを解決するプロトコルは?",
+      "ja": "Which protocol resolves IP addresses to MAC addresses?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ansible",
+        "ja": "Ansible",
+        "ja_typings": [
+          "ansible"
+        ]
+      },
+      {
+        "en": "Terraform",
+        "ja": "Terraform",
+        "ja_typings": [
+          "terraform"
+        ]
+      },
+      {
+        "en": "Chef",
+        "ja": "Chef",
+        "ja_typings": [
+          "chef"
+        ]
+      },
+      {
+        "en": "Puppet",
+        "ja": "Puppet",
+        "ja_typings": [
+          "puppet"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02620",
+    "image_path": null,
+    "question_text": {
+      "en": "サーバ構成管理ツールでYAMLで定義しエージェントレスで動作するのは?",
+      "ja": "Which agentless configuration management tool uses YAML playbooks?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ant",
+        "ja": "Ant",
+        "ja_typings": [
+          "ant"
+        ]
+      },
+      {
+        "en": "Maven",
+        "ja": "Maven",
+        "ja_typings": [
+          "maven"
+        ]
+      },
+      {
+        "en": "Gradle",
+        "ja": "Gradle",
+        "ja_typings": [
+          "gradle"
+        ]
+      },
+      {
+        "en": "Cargo",
+        "ja": "Cargo",
+        "ja_typings": [
+          "cargo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02621",
+    "image_path": null,
+    "question_text": {
+      "en": "Javaのビルドツールで古くから使われているXMLベースのものは?",
+      "ja": "Which old XML-based build tool is used for Java projects?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Arc",
+        "ja": "Arc",
+        "ja_typings": [
+          "arc"
+        ]
+      },
+      {
+        "en": "Brave",
+        "ja": "Brave",
+        "ja_typings": [
+          "brave"
+        ]
+      },
+      {
+        "en": "Vivaldi",
+        "ja": "Vivaldi",
+        "ja_typings": [
+          "vivaldi"
+        ]
+      },
+      {
+        "en": "Opera",
+        "ja": "Opera",
+        "ja_typings": [
+          "opera"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02622",
+    "image_path": null,
+    "question_text": {
+      "en": "Mozillaが開発したJavaScriptランタイム向けの新ブラウザは?",
+      "ja": "Which browser was made by The Browser Company with a focus on tabs and workflows?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Assembler",
+        "ja": "アセンブラ",
+        "ja_typings": [
+          "asenbura"
+        ]
+      },
+      {
+        "en": "Compiler",
+        "ja": "コンパイラ",
+        "ja_typings": [
+          "konpaira"
+        ]
+      },
+      {
+        "en": "Interpreter",
+        "ja": "インタプリタ",
+        "ja_typings": [
+          "intapurita"
+        ]
+      },
+      {
+        "en": "Linker",
+        "ja": "リンカ",
+        "ja_typings": [
+          "rinka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02623",
+    "image_path": null,
+    "question_text": {
+      "en": "アセンブリ言語を機械語に変換するプログラムは?",
+      "ja": "Which program translates assembly language into machine code?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Assembly",
+        "ja": "アセンブリ言語",
+        "ja_typings": [
+          "asenburigengo"
+        ]
+      },
+      {
+        "en": "Machine Code",
+        "ja": "機械語",
+        "ja_typings": [
+          "kikaigo"
+        ]
+      },
+      {
+        "en": "C",
+        "ja": "C言語",
+        "ja_typings": [
+          "cgengo"
+        ]
+      },
+      {
+        "en": "Fortran",
+        "ja": "Fortran",
+        "ja_typings": [
+          "fortran"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02624",
+    "image_path": null,
+    "question_text": {
+      "en": "CPUの命令を直接表現する低水準言語は?",
+      "ja": "Which low-level language directly represents CPU instructions?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Assignment",
+        "ja": "代入",
+        "ja_typings": [
+          "dainyuu"
+        ]
+      },
+      {
+        "en": "Declaration",
+        "ja": "宣言",
+        "ja_typings": [
+          "sengen"
+        ]
+      },
+      {
+        "en": "Initialization",
+        "ja": "初期化",
+        "ja_typings": [
+          "shokika"
+        ]
+      },
+      {
+        "en": "Reference",
+        "ja": "参照",
+        "ja_typings": [
+          "sanshou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02625",
+    "image_path": null,
+    "question_text": {
+      "en": "プログラミングで変数に値を入れる操作は?",
+      "ja": "What is the operation of setting a value into a variable called?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Average run count",
+        "ja": "平均実行回数",
+        "ja_typings": [
+          "heikinjikkoukaisuu"
+        ]
+      },
+      {
+        "en": "Memory usage",
+        "ja": "メモリ使用量",
+        "ja_typings": [
+          "memorishiyouryou"
+        ]
+      },
+      {
+        "en": "Source Map",
+        "ja": "ソースマップ",
+        "ja_typings": [
+          "so-sumappu"
+        ]
+      },
+      {
+        "en": "Stack Overflow",
+        "ja": "スタックオーバーフロー",
+        "ja_typings": [
+          "sutakkuo-ba-furo-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02626",
+    "image_path": null,
+    "question_text": {
+      "en": "プロファイラで関数の平均実行回数を示す指標は?",
+      "ja": "Which profiling metric shows the average number of times a function ran?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "BFS",
+        "ja": "幅優先探索",
+        "ja_typings": [
+          "habayuusentansaku"
+        ]
+      },
+      {
+        "en": "DFS",
+        "ja": "深さ優先探索",
+        "ja_typings": [
+          "fukasayuusentansaku"
+        ]
+      },
+      {
+        "en": "Mergesort",
+        "ja": "マージソート",
+        "ja_typings": [
+          "ma-jiso-to"
+        ]
+      },
+      {
+        "en": "Quicksort",
+        "ja": "クイックソート",
+        "ja_typings": [
+          "kuikkuso-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02627",
+    "image_path": null,
+    "question_text": {
+      "en": "グラフ探索で全方向に広く探索する手法は?",
+      "ja": "Which graph traversal explores all neighbors level by level?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "BPS",
+        "ja": "BPS",
+        "ja_typings": [
+          "bps"
+        ]
+      },
+      {
+        "en": "FPS",
+        "ja": "FPS",
+        "ja_typings": [
+          "fps"
+        ]
+      },
+      {
+        "en": "DPS",
+        "ja": "DPS",
+        "ja_typings": [
+          "dps"
+        ]
+      },
+      {
+        "en": "FFS",
+        "ja": "FFS",
+        "ja_typings": [
+          "ffs"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02628",
+    "image_path": null,
+    "question_text": {
+      "en": "ビットレートの単位で1秒間のビット数を表すのは?",
+      "ja": "Which unit represents bits transferred per second?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bad Request",
+        "ja": "Bad Request",
+        "ja_typings": [
+          "bad request",
+          "badrequest"
+        ]
+      },
+      {
+        "en": "Not Found",
+        "ja": "Not Found",
+        "ja_typings": [
+          "not found",
+          "notfound"
+        ]
+      },
+      {
+        "en": "Forbidden",
+        "ja": "Forbidden",
+        "ja_typings": [
+          "forbidden"
+        ]
+      },
+      {
+        "en": "Unauthorized",
+        "ja": "Unauthorized",
+        "ja_typings": [
+          "unauthorized"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02629",
+    "image_path": null,
+    "question_text": {
+      "en": "HTTPステータスコード400が示すのは?",
+      "ja": "What does HTTP status code 400 indicate?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bash",
+        "ja": "Bash",
+        "ja_typings": [
+          "bash"
+        ]
+      },
+      {
+        "en": "Zsh",
+        "ja": "Zsh",
+        "ja_typings": [
+          "zsh"
+        ]
+      },
+      {
+        "en": "Fish",
+        "ja": "Fish",
+        "ja_typings": [
+          "fish"
+        ]
+      },
+      {
+        "en": "Tcsh",
+        "ja": "Tcsh",
+        "ja_typings": [
+          "tcsh"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02630",
+    "image_path": null,
+    "question_text": {
+      "en": "Linuxで標準的に使われるシェルは?",
+      "ja": "Which is the standard shell on most Linux distributions?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bill Joy",
+        "ja": "Bill Joy",
+        "ja_typings": [
+          "bill joy",
+          "billjoy"
+        ]
+      },
+      {
+        "en": "Bjarne Stroustrup",
+        "ja": "Bjarne Stroustrup",
+        "ja_typings": [
+          "bjarne stroustrup",
+          "bjarnestroustrup"
+        ]
+      },
+      {
+        "en": "Linus Torvalds",
+        "ja": "Linus Torvalds",
+        "ja_typings": [
+          "linus torvalds",
+          "linustorvalds"
+        ]
+      },
+      {
+        "en": "Richard Stallman",
+        "ja": "Richard Stallman",
+        "ja_typings": [
+          "richard stallman",
+          "richardstallman"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02631",
+    "image_path": null,
+    "question_text": {
+      "en": "viエディタを開発した人物は?",
+      "ja": "Who is the author of the vi editor?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bitwise OR",
+        "ja": "ビット論理和",
+        "ja_typings": [
+          "bittoronriwa"
+        ]
+      },
+      {
+        "en": "Logical AND",
+        "ja": "論理積",
+        "ja_typings": [
+          "ronriseki"
+        ]
+      },
+      {
+        "en": "Bitwise XOR",
+        "ja": "ビット排他的論理和",
+        "ja_typings": [
+          "bittohaitatekironriwa"
+        ]
+      },
+      {
+        "en": "Bitwise AND",
+        "ja": "ビット論理積",
+        "ja_typings": [
+          "bittoronriseki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02632",
+    "image_path": null,
+    "question_text": {
+      "en": "ビット単位で「どちらかが1なら1」を取る演算は?",
+      "ja": "Which bitwise operation returns 1 if either bit is 1?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bjarne Stroustrup",
+        "ja": "Bjarne Stroustrup",
+        "ja_typings": [
+          "bjarne stroustrup",
+          "bjarnestroustrup"
+        ]
+      },
+      {
+        "en": "Dennis Ritchie",
+        "ja": "Dennis Ritchie",
+        "ja_typings": [
+          "dennis ritchie",
+          "dennisritchie"
+        ]
+      },
+      {
+        "en": "Bill Joy",
+        "ja": "Bill Joy",
+        "ja_typings": [
+          "bill joy",
+          "billjoy"
+        ]
+      },
+      {
+        "en": "Brian Kernighan",
+        "ja": "Brian Kernighan",
+        "ja_typings": [
+          "brian kernighan",
+          "briankernighan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02633",
+    "image_path": null,
+    "question_text": {
+      "en": "C++を設計した人物は?",
+      "ja": "Who designed the C++ programming language?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Box",
+        "ja": "Box",
+        "ja_typings": [
+          "box"
+        ]
+      },
+      {
+        "en": "Rc",
+        "ja": "Rc",
+        "ja_typings": [
+          "rc"
+        ]
+      },
+      {
+        "en": "Arc",
+        "ja": "Arc",
+        "ja_typings": [
+          "arc"
+        ]
+      },
+      {
+        "en": "RefCell",
+        "ja": "RefCell",
+        "ja_typings": [
+          "refcell"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02634",
+    "image_path": null,
+    "question_text": {
+      "en": "Rustのヒープに値を1つ置くスマートポインタ型は?",
+      "ja": "Which Rust smart pointer places a single value on the heap?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Brendan Eich",
+        "ja": "Brendan Eich",
+        "ja_typings": [
+          "brendan eich",
+          "brendaneich"
+        ]
+      },
+      {
+        "en": "Guido van Rossum",
+        "ja": "Guido van Rossum",
+        "ja_typings": [
+          "guido van rossum",
+          "guidovanrossum"
+        ]
+      },
+      {
+        "en": "Larry Wall",
+        "ja": "Larry Wall",
+        "ja_typings": [
+          "larry wall",
+          "larrywall"
+        ]
+      },
+      {
+        "en": "Yukihiro Matsumoto",
+        "ja": "Yukihiro Matsumoto",
+        "ja_typings": [
+          "yukihiro matsumoto",
+          "yukihiromatsumoto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02635",
+    "image_path": null,
+    "question_text": {
+      "en": "JavaScriptを設計した人物は?",
+      "ja": "Who designed JavaScript?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Brian Kernighan",
+        "ja": "Brian Kernighan",
+        "ja_typings": [
+          "brian kernighan",
+          "briankernighan"
+        ]
+      },
+      {
+        "en": "Dennis Ritchie",
+        "ja": "Dennis Ritchie",
+        "ja_typings": [
+          "dennis ritchie",
+          "dennisritchie"
+        ]
+      },
+      {
+        "en": "Bjarne Stroustrup",
+        "ja": "Bjarne Stroustrup",
+        "ja_typings": [
+          "bjarne stroustrup",
+          "bjarnestroustrup"
+        ]
+      },
+      {
+        "en": "Bill Joy",
+        "ja": "Bill Joy",
+        "ja_typings": [
+          "bill joy",
+          "billjoy"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02636",
+    "image_path": null,
+    "question_text": {
+      "en": "AWKの開発者の1人で『プログラミング言語C』の共著者は?",
+      "ja": "Who co-authored 'The C Programming Language' and co-created AWK?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "C",
+        "ja": "C言語",
+        "ja_typings": [
+          "cgengo"
+        ]
+      },
+      {
+        "en": "Pascal",
+        "ja": "Pascal",
+        "ja_typings": [
+          "pascal"
+        ]
+      },
+      {
+        "en": "Fortran",
+        "ja": "Fortran",
+        "ja_typings": [
+          "fortran"
+        ]
+      },
+      {
+        "en": "COBOL",
+        "ja": "COBOL",
+        "ja_typings": [
+          "cobol"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02637",
+    "image_path": null,
+    "question_text": {
+      "en": "UNIX上で生まれた構造化プログラミング言語は?",
+      "ja": "Which structured language was developed on UNIX in the 1970s?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CLR",
+        "ja": "CLR",
+        "ja_typings": [
+          "clr"
+        ]
+      },
+      {
+        "en": "JVM",
+        "ja": "JVM",
+        "ja_typings": [
+          "jvm"
+        ]
+      },
+      {
+        "en": "LLVM",
+        "ja": "LLVM",
+        "ja_typings": [
+          "llvm"
+        ]
+      },
+      {
+        "en": "V8",
+        "ja": "V8",
+        "ja_typings": [
+          "v8"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02638",
+    "image_path": null,
+    "question_text": {
+      "en": ".NETの共通言語ランタイムの略称は?",
+      "ja": "What is the abbreviation for .NET's common language runtime?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "COBOL",
+        "ja": "COBOL",
+        "ja_typings": [
+          "cobol"
+        ]
+      },
+      {
+        "en": "Fortran",
+        "ja": "Fortran",
+        "ja_typings": [
+          "fortran"
+        ]
+      },
+      {
+        "en": "Pascal",
+        "ja": "Pascal",
+        "ja_typings": [
+          "pascal"
+        ]
+      },
+      {
+        "en": "Assembly",
+        "ja": "アセンブリ言語",
+        "ja_typings": [
+          "asenburigengo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02639",
+    "image_path": null,
+    "question_text": {
+      "en": "事務処理用に1959年に作られた言語は?",
+      "ja": "Which programming language was designed in 1959 for business processing?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CSS",
+        "ja": "CSS",
+        "ja_typings": [
+          "css"
+        ]
+      },
+      {
+        "en": "HTML",
+        "ja": "HTML",
+        "ja_typings": [
+          "html"
+        ]
+      },
+      {
+        "en": "JavaScript",
+        "ja": "JavaScript",
+        "ja_typings": [
+          "javascript"
+        ]
+      },
+      {
+        "en": "XML",
+        "ja": "XML",
+        "ja_typings": [
+          "xml"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02640",
+    "image_path": null,
+    "question_text": {
+      "en": "HTMLの見た目を装飾する言語は?",
+      "ja": "Which language styles HTML documents?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cargo",
+        "ja": "Cargo",
+        "ja_typings": [
+          "cargo"
+        ]
+      },
+      {
+        "en": "Maven",
+        "ja": "Maven",
+        "ja_typings": [
+          "maven"
+        ]
+      },
+      {
+        "en": "Ant",
+        "ja": "Ant",
+        "ja_typings": [
+          "ant"
+        ]
+      },
+      {
+        "en": "pip",
+        "ja": "pip",
+        "ja_typings": [
+          "pip"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02641",
+    "image_path": null,
+    "question_text": {
+      "en": "Rustのパッケージマネージャ兼ビルドツールは?",
+      "ja": "What is Rust's package manager and build tool called?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cassandra",
+        "ja": "Cassandra",
+        "ja_typings": [
+          "cassandra"
+        ]
+      },
+      {
+        "en": "MongoDB",
+        "ja": "MongoDB",
+        "ja_typings": [
+          "mongodb"
+        ]
+      },
+      {
+        "en": "Neo4j",
+        "ja": "Neo4j",
+        "ja_typings": [
+          "neo4j"
+        ]
+      },
+      {
+        "en": "SQLite",
+        "ja": "SQLite",
+        "ja_typings": [
+          "sqlite"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02642",
+    "image_path": null,
+    "question_text": {
+      "en": "分散NoSQLデータベースの1つで列指向ストアなのは?",
+      "ja": "Which distributed NoSQL database uses a column-family store?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Client Error",
+        "ja": "クライアントエラー",
+        "ja_typings": [
+          "kuraiantoera-"
+        ]
+      },
+      {
+        "en": "Server Error",
+        "ja": "サーバーエラー",
+        "ja_typings": [
+          "sa-ba-era-"
+        ]
+      },
+      {
+        "en": "Redirect",
+        "ja": "リダイレクト",
+        "ja_typings": [
+          "ridairekuto"
+        ]
+      },
+      {
+        "en": "Success",
+        "ja": "成功",
+        "ja_typings": [
+          "seikou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02643",
+    "image_path": null,
+    "question_text": {
+      "en": "HTTPの4xx系ステータスコードが意味するのは?",
+      "ja": "What category does HTTP 4xx status code belong to?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Compiler",
+        "ja": "コンパイラ",
+        "ja_typings": [
+          "konpaira"
+        ]
+      },
+      {
+        "en": "Interpreter",
+        "ja": "インタプリタ",
+        "ja_typings": [
+          "intapurita"
+        ]
+      },
+      {
+        "en": "Assembler",
+        "ja": "アセンブラ",
+        "ja_typings": [
+          "asenbura"
+        ]
+      },
+      {
+        "en": "Linker",
+        "ja": "リンカ",
+        "ja_typings": [
+          "rinka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02644",
+    "image_path": null,
+    "question_text": {
+      "en": "ソースコードを機械語などに翻訳するソフトウェアは?",
+      "ja": "Which software translates source code into machine code?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DFS",
+        "ja": "深さ優先探索",
+        "ja_typings": [
+          "fukasayuusentansaku"
+        ]
+      },
+      {
+        "en": "BFS",
+        "ja": "幅優先探索",
+        "ja_typings": [
+          "habayuusentansaku"
+        ]
+      },
+      {
+        "en": "Quicksort",
+        "ja": "クイックソート",
+        "ja_typings": [
+          "kuikkuso-to"
+        ]
+      },
+      {
+        "en": "Mergesort",
+        "ja": "マージソート",
+        "ja_typings": [
+          "ma-jiso-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02645",
+    "image_path": null,
+    "question_text": {
+      "en": "グラフ探索でできるだけ深く進むのは?",
+      "ja": "Which graph traversal explores as deep as possible first?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DPS",
+        "ja": "DPS",
+        "ja_typings": [
+          "dps"
+        ]
+      },
+      {
+        "en": "BPS",
+        "ja": "BPS",
+        "ja_typings": [
+          "bps"
+        ]
+      },
+      {
+        "en": "FPS",
+        "ja": "FPS",
+        "ja_typings": [
+          "fps"
+        ]
+      },
+      {
+        "en": "FFS",
+        "ja": "FFS",
+        "ja_typings": [
+          "ffs"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02646",
+    "image_path": null,
+    "question_text": {
+      "en": "1秒間に与えるダメージ量の指標は?",
+      "ja": "Which gaming metric measures damage dealt per second?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Debugger",
+        "ja": "デバッガ",
+        "ja_typings": [
+          "debagga"
+        ]
+      },
+      {
+        "en": "Profiler",
+        "ja": "プロファイラ",
+        "ja_typings": [
+          "purofaira"
+        ]
+      },
+      {
+        "en": "Compiler",
+        "ja": "コンパイラ",
+        "ja_typings": [
+          "konpaira"
+        ]
+      },
+      {
+        "en": "Linker",
+        "ja": "リンカ",
+        "ja_typings": [
+          "rinka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02647",
+    "image_path": null,
+    "question_text": {
+      "en": "プログラムをステップ実行・変数監視できるツールは?",
+      "ja": "Which tool lets you step through code and inspect variables?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Decimal",
+        "ja": "10進数",
+        "ja_typings": [
+          "10shinsuu",
+          "juushinsuu"
+        ]
+      },
+      {
+        "en": "Hexadecimal",
+        "ja": "16進数",
+        "ja_typings": [
+          "16shinsuu",
+          "juurokushinsuu"
+        ]
+      },
+      {
+        "en": "Octal",
+        "ja": "8進数",
+        "ja_typings": [
+          "8shinsuu",
+          "hasshinsuu"
+        ]
+      },
+      {
+        "en": "Binary",
+        "ja": "2進数",
+        "ja_typings": [
+          "2shinsuu",
+          "nishinsuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02648",
+    "image_path": null,
+    "question_text": {
+      "en": "0から9までの記号を使う数値表現は?",
+      "ja": "Which numeral system uses digits 0 through 9?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dennis Ritchie",
+        "ja": "Dennis Ritchie",
+        "ja_typings": [
+          "dennis ritchie",
+          "dennisritchie"
+        ]
+      },
+      {
+        "en": "Brian Kernighan",
+        "ja": "Brian Kernighan",
+        "ja_typings": [
+          "brian kernighan",
+          "briankernighan"
+        ]
+      },
+      {
+        "en": "Bjarne Stroustrup",
+        "ja": "Bjarne Stroustrup",
+        "ja_typings": [
+          "bjarne stroustrup",
+          "bjarnestroustrup"
+        ]
+      },
+      {
+        "en": "Bill Joy",
+        "ja": "Bill Joy",
+        "ja_typings": [
+          "bill joy",
+          "billjoy"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02649",
+    "image_path": null,
+    "question_text": {
+      "en": "C言語を開発した人物は?",
+      "ja": "Who developed the C programming language?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Docker Compose",
+        "ja": "Docker Compose",
+        "ja_typings": [
+          "docker compose",
+          "dockercompose"
+        ]
+      },
+      {
+        "en": "Terraform",
+        "ja": "Terraform",
+        "ja_typings": [
+          "terraform"
+        ]
+      },
+      {
+        "en": "Ansible",
+        "ja": "Ansible",
+        "ja_typings": [
+          "ansible"
+        ]
+      },
+      {
+        "en": "Kubernetes",
+        "ja": "Kubernetes",
+        "ja_typings": [
+          "kubernetes"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02650",
+    "image_path": null,
+    "question_text": {
+      "en": "複数のコンテナをまとめて定義・起動するツールは?",
+      "ja": "Which tool runs multi-container Docker applications via YAML?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dynamic",
+        "ja": "動的",
+        "ja_typings": [
+          "douteki"
+        ]
+      },
+      {
+        "en": "Static",
+        "ja": "静的",
+        "ja_typings": [
+          "seiteki"
+        ]
+      },
+      {
+        "en": "Immutable",
+        "ja": "イミュータブル",
+        "ja_typings": [
+          "imyu-taburu"
+        ]
+      },
+      {
+        "en": "Compiled",
+        "ja": "コンパイル型",
+        "ja_typings": [
+          "konpairugata"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02651",
+    "image_path": null,
+    "question_text": {
+      "en": "実行時に型が決まる言語の性質を表す語は?",
+      "ja": "Which term describes a language whose types are determined at runtime?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Encapsulation",
+        "ja": "カプセル化",
+        "ja_typings": [
+          "kapuseruka"
+        ]
+      },
+      {
+        "en": "Polymorphism",
+        "ja": "ポリモーフィズム",
+        "ja_typings": [
+          "porimo-fizumu"
+        ]
+      },
+      {
+        "en": "Inheritance",
+        "ja": "継承",
+        "ja_typings": [
+          "keishou"
+        ]
+      },
+      {
+        "en": "Abstraction",
+        "ja": "抽象化",
+        "ja_typings": [
+          "chuushouka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02652",
+    "image_path": null,
+    "question_text": {
+      "en": "オブジェクト指向で内部状態を隠す概念は?",
+      "ja": "Which OOP concept hides internal state and exposes a public interface?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FETCH",
+        "ja": "FETCH",
+        "ja_typings": [
+          "fetch"
+        ]
+      },
+      {
+        "en": "MERGE",
+        "ja": "MERGE",
+        "ja_typings": [
+          "merge"
+        ]
+      },
+      {
+        "en": "GROUP",
+        "ja": "GROUP",
+        "ja_typings": [
+          "group"
+        ]
+      },
+      {
+        "en": "HEAD",
+        "ja": "HEAD",
+        "ja_typings": [
+          "head"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02653",
+    "image_path": null,
+    "question_text": {
+      "en": "SQLでデータを取得するために使われるカーソル操作の文は?",
+      "ja": "Which SQL statement retrieves rows from a cursor?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FFS",
+        "ja": "FFS",
+        "ja_typings": [
+          "ffs"
+        ]
+      },
+      {
+        "en": "WFS",
+        "ja": "WFS",
+        "ja_typings": [
+          "wfs"
+        ]
+      },
+      {
+        "en": "FTP",
+        "ja": "FTP",
+        "ja_typings": [
+          "ftp"
+        ]
+      },
+      {
+        "en": "BPS",
+        "ja": "BPS",
+        "ja_typings": [
+          "bps"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02654",
+    "image_path": null,
+    "question_text": {
+      "en": "BSD系UNIXで使われた高速ファイルシステムは?",
+      "ja": "Which fast file system was developed for BSD UNIX?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FTP",
+        "ja": "FTP",
+        "ja_typings": [
+          "ftp"
+        ]
+      },
+      {
+        "en": "SMTP",
+        "ja": "SMTP",
+        "ja_typings": [
+          "smtp"
+        ]
+      },
+      {
+        "en": "Telnet",
+        "ja": "Telnet",
+        "ja_typings": [
+          "telnet"
+        ]
+      },
+      {
+        "en": "ICMP",
+        "ja": "ICMP",
+        "ja_typings": [
+          "icmp"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02655",
+    "image_path": null,
+    "question_text": {
+      "en": "ファイルを転送する古典的なプロトコルは?",
+      "ja": "Which classic protocol is used to transfer files?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Factory",
+        "ja": "ファクトリー",
+        "ja_typings": [
+          "fakutori-"
+        ]
+      },
+      {
+        "en": "Singleton",
+        "ja": "シングルトン",
+        "ja_typings": [
+          "shingoruton",
+          "shinguruton"
+        ]
+      },
+      {
+        "en": "Observer",
+        "ja": "オブザーバー",
+        "ja_typings": [
+          "obuza-ba-"
+        ]
+      },
+      {
+        "en": "Mergesort",
+        "ja": "マージソート",
+        "ja_typings": [
+          "ma-jiso-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02656",
+    "image_path": null,
+    "question_text": {
+      "en": "GoFのデザインパターンで生成系の1つは?",
+      "ja": "Which is one of the GoF creational design patterns?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fiber",
+        "ja": "ファイバー",
+        "ja_typings": [
+          "faiba-"
+        ]
+      },
+      {
+        "en": "Thread",
+        "ja": "スレッド",
+        "ja_typings": [
+          "sureddo"
+        ]
+      },
+      {
+        "en": "Process",
+        "ja": "プロセス",
+        "ja_typings": [
+          "purosesu"
+        ]
+      },
+      {
+        "en": "Mutex",
+        "ja": "ミューテックス",
+        "ja_typings": [
+          "myu-tekkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02657",
+    "image_path": null,
+    "question_text": {
+      "en": "軽量スレッドのことを指す概念は?",
+      "ja": "Which term refers to lightweight threads scheduled by a runtime?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Forbidden",
+        "ja": "Forbidden",
+        "ja_typings": [
+          "forbidden"
+        ]
+      },
+      {
+        "en": "Unauthorized",
+        "ja": "Unauthorized",
+        "ja_typings": [
+          "unauthorized"
+        ]
+      },
+      {
+        "en": "Not Found",
+        "ja": "Not Found",
+        "ja_typings": [
+          "not found",
+          "notfound"
+        ]
+      },
+      {
+        "en": "Bad Request",
+        "ja": "Bad Request",
+        "ja_typings": [
+          "bad request",
+          "badrequest"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02658",
+    "image_path": null,
+    "question_text": {
+      "en": "HTTPステータスコード403が示すのは?",
+      "ja": "What does HTTP status code 403 indicate?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fortran",
+        "ja": "Fortran",
+        "ja_typings": [
+          "fortran"
+        ]
+      },
+      {
+        "en": "COBOL",
+        "ja": "COBOL",
+        "ja_typings": [
+          "cobol"
+        ]
+      },
+      {
+        "en": "Pascal",
+        "ja": "Pascal",
+        "ja_typings": [
+          "pascal"
+        ]
+      },
+      {
+        "en": "Lisp",
+        "ja": "Lisp",
+        "ja_typings": [
+          "lisp"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02659",
+    "image_path": null,
+    "question_text": {
+      "en": "科学計算用に1957年に作られた言語は?",
+      "ja": "Which language was created in 1957 for scientific computation?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "GROUP",
+        "ja": "GROUP",
+        "ja_typings": [
+          "group"
+        ]
+      },
+      {
+        "en": "MERGE",
+        "ja": "MERGE",
+        "ja_typings": [
+          "merge"
+        ]
+      },
+      {
+        "en": "FETCH",
+        "ja": "FETCH",
+        "ja_typings": [
+          "fetch"
+        ]
+      },
+      {
+        "en": "HEAD",
+        "ja": "HEAD",
+        "ja_typings": [
+          "head"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02660",
+    "image_path": null,
+    "question_text": {
+      "en": "SQLで列ごとに集計するための句は?",
+      "ja": "Which SQL clause aggregates rows by column values?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Go",
+        "ja": "Go",
+        "ja_typings": [
+          "go"
+        ]
+      },
+      {
+        "en": "Rust",
+        "ja": "Rust",
+        "ja_typings": [
+          "rust"
+        ]
+      },
+      {
+        "en": "Java",
+        "ja": "Java",
+        "ja_typings": [
+          "java"
+        ]
+      },
+      {
+        "en": "Python",
+        "ja": "Python",
+        "ja_typings": [
+          "python"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02661",
+    "image_path": null,
+    "question_text": {
+      "en": "Googleが開発した静的型付きの並行処理向け言語は?",
+      "ja": "Which Google-designed statically typed language emphasizes concurrency?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Graph",
+        "ja": "グラフ",
+        "ja_typings": [
+          "gurafu"
+        ]
+      },
+      {
+        "en": "Tree",
+        "ja": "木",
+        "ja_typings": [
+          "ki"
+        ]
+      },
+      {
+        "en": "Stack",
+        "ja": "スタック",
+        "ja_typings": [
+          "sutakku"
+        ]
+      },
+      {
+        "en": "Queue",
+        "ja": "キュー",
+        "ja_typings": [
+          "kyu-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02662",
+    "image_path": null,
+    "question_text": {
+      "en": "ノードとエッジで関係を表すデータ構造は?",
+      "ja": "Which data structure represents relations with nodes and edges?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Guido van Rossum",
+        "ja": "Guido van Rossum",
+        "ja_typings": [
+          "guido van rossum",
+          "guidovanrossum"
+        ]
+      },
+      {
+        "en": "Brendan Eich",
+        "ja": "Brendan Eich",
+        "ja_typings": [
+          "brendan eich",
+          "brendaneich"
+        ]
+      },
+      {
+        "en": "Larry Wall",
+        "ja": "Larry Wall",
+        "ja_typings": [
+          "larry wall",
+          "larrywall"
+        ]
+      },
+      {
+        "en": "Yukihiro Matsumoto",
+        "ja": "Yukihiro Matsumoto",
+        "ja_typings": [
+          "yukihiro matsumoto",
+          "yukihiromatsumoto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02663",
+    "image_path": null,
+    "question_text": {
+      "en": "Pythonを設計した人物は?",
+      "ja": "Who designed the Python programming language?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HEAD",
+        "ja": "HEAD",
+        "ja_typings": [
+          "head"
+        ]
+      },
+      {
+        "en": "GET",
+        "ja": "GET",
+        "ja_typings": [
+          "get"
+        ]
+      },
+      {
+        "en": "POST",
+        "ja": "POST",
+        "ja_typings": [
+          "post"
+        ]
+      },
+      {
+        "en": "PUT",
+        "ja": "PUT",
+        "ja_typings": [
+          "put"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02664",
+    "image_path": null,
+    "question_text": {
+      "en": "HTTPでヘッダだけ取得するメソッドは?",
+      "ja": "Which HTTP method fetches only headers without a body?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HTML",
+        "ja": "HTML",
+        "ja_typings": [
+          "html"
+        ]
+      },
+      {
+        "en": "CSS",
+        "ja": "CSS",
+        "ja_typings": [
+          "css"
+        ]
+      },
+      {
+        "en": "XML",
+        "ja": "XML",
+        "ja_typings": [
+          "xml"
+        ]
+      },
+      {
+        "en": "JSON",
+        "ja": "JSON",
+        "ja_typings": [
+          "json"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02665",
+    "image_path": null,
+    "question_text": {
+      "en": "Webページの構造を記述するマークアップ言語は?",
+      "ja": "Which markup language describes the structure of a web page?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hexadecimal",
+        "ja": "16進数",
+        "ja_typings": [
+          "16shinsuu",
+          "juurokushinsuu"
+        ]
+      },
+      {
+        "en": "Decimal",
+        "ja": "10進数",
+        "ja_typings": [
+          "10shinsuu",
+          "juushinsuu"
+        ]
+      },
+      {
+        "en": "Octal",
+        "ja": "8進数",
+        "ja_typings": [
+          "8shinsuu",
+          "hasshinsuu"
+        ]
+      },
+      {
+        "en": "Binary",
+        "ja": "2進数",
+        "ja_typings": [
+          "2shinsuu",
+          "nishinsuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02666",
+    "image_path": null,
+    "question_text": {
+      "en": "0からF までの記号を使う数値表現は?",
+      "ja": "Which numeral system uses digits 0-9 and A-F?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ICMP",
+        "ja": "ICMP",
+        "ja_typings": [
+          "icmp"
+        ]
+      },
+      {
+        "en": "ARP",
+        "ja": "ARP",
+        "ja_typings": [
+          "arp"
+        ]
+      },
+      {
+        "en": "UDP",
+        "ja": "UDP",
+        "ja_typings": [
+          "udp"
+        ]
+      },
+      {
+        "en": "SMTP",
+        "ja": "SMTP",
+        "ja_typings": [
+          "smtp"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02667",
+    "image_path": null,
+    "question_text": {
+      "en": "pingで使われるIP制御メッセージプロトコルは?",
+      "ja": "Which IP control message protocol does ping use?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Immutable",
+        "ja": "イミュータブル",
+        "ja_typings": [
+          "imyu-taburu"
+        ]
+      },
+      {
+        "en": "Dynamic",
+        "ja": "動的",
+        "ja_typings": [
+          "douteki"
+        ]
+      },
+      {
+        "en": "Static",
+        "ja": "静的",
+        "ja_typings": [
+          "seiteki"
+        ]
+      },
+      {
+        "en": "Mutable",
+        "ja": "ミュータブル",
+        "ja_typings": [
+          "myu-taburu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02668",
+    "image_path": null,
+    "question_text": {
+      "en": "一度作ったら変更できない性質を表す語は?",
+      "ja": "Which term describes objects that cannot be modified after creation?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Internal Server Error",
+        "ja": "Internal Server Error",
+        "ja_typings": [
+          "internal server error",
+          "internalservererror"
+        ]
+      },
+      {
+        "en": "Bad Request",
+        "ja": "Bad Request",
+        "ja_typings": [
+          "bad request",
+          "badrequest"
+        ]
+      },
+      {
+        "en": "Not Found",
+        "ja": "Not Found",
+        "ja_typings": [
+          "not found",
+          "notfound"
+        ]
+      },
+      {
+        "en": "Forbidden",
+        "ja": "Forbidden",
+        "ja_typings": [
+          "forbidden"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02669",
+    "image_path": null,
+    "question_text": {
+      "en": "HTTPステータスコード500が示すのは?",
+      "ja": "What does HTTP status code 500 indicate?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Interpreter",
+        "ja": "インタプリタ",
+        "ja_typings": [
+          "intapurita"
+        ]
+      },
+      {
+        "en": "Compiler",
+        "ja": "コンパイラ",
+        "ja_typings": [
+          "konpaira"
+        ]
+      },
+      {
+        "en": "Assembler",
+        "ja": "アセンブラ",
+        "ja_typings": [
+          "asenbura"
+        ]
+      },
+      {
+        "en": "Linker",
+        "ja": "リンカ",
+        "ja_typings": [
+          "rinka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02670",
+    "image_path": null,
+    "question_text": {
+      "en": "ソースコードを逐次解釈実行するソフトウェアは?",
+      "ja": "Which software executes source code line by line?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "It indicates comments",
+        "ja": "コメントを表す",
+        "ja_typings": [
+          "komentowohyousu"
+        ]
+      },
+      {
+        "en": "It indicates return values",
+        "ja": "戻り値を表す",
+        "ja_typings": [
+          "modoriatewohyousu"
+        ]
+      },
+      {
+        "en": "It indicates types",
+        "ja": "型を表す",
+        "ja_typings": [
+          "katawohyousu"
+        ]
+      },
+      {
+        "en": "It indicates assignments",
+        "ja": "代入を表す",
+        "ja_typings": [
+          "dainyuuwohyousu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02671",
+    "image_path": null,
+    "question_text": {
+      "en": "Pythonで `#` 記号の役割は?",
+      "ja": "What does the `#` symbol indicate in Python?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "It indicates return values",
+        "ja": "戻り値を表す",
+        "ja_typings": [
+          "modoriatewohyousu"
+        ]
+      },
+      {
+        "en": "It indicates comments",
+        "ja": "コメントを表す",
+        "ja_typings": [
+          "komentowohyousu"
+        ]
+      },
+      {
+        "en": "It indicates types",
+        "ja": "型を表す",
+        "ja_typings": [
+          "katawohyousu"
+        ]
+      },
+      {
+        "en": "It indicates assignments",
+        "ja": "代入を表す",
+        "ja_typings": [
+          "dainyuuwohyousu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02672",
+    "image_path": null,
+    "question_text": {
+      "en": "関数定義で `->` 記号が示すのは?",
+      "ja": "What does the `->` arrow indicate in a function signature?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "It indicates types",
+        "ja": "型を表す",
+        "ja_typings": [
+          "katawohyousu"
+        ]
+      },
+      {
+        "en": "It indicates comments",
+        "ja": "コメントを表す",
+        "ja_typings": [
+          "komentowohyousu"
+        ]
+      },
+      {
+        "en": "It indicates return values",
+        "ja": "戻り値を表す",
+        "ja_typings": [
+          "modoriatewohyousu"
+        ]
+      },
+      {
+        "en": "It indicates assignments",
+        "ja": "代入を表す",
+        "ja_typings": [
+          "dainyuuwohyousu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02673",
+    "image_path": null,
+    "question_text": {
+      "en": "TypeScriptで `: number` のように書く記号 `:` の役割は?",
+      "ja": "What does the `:` colon indicate in TypeScript annotations like `: number`?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Java Source Object Network",
+        "ja": "Java Source Object Network",
+        "ja_typings": [
+          "java source object network"
+        ]
+      },
+      {
+        "en": "JavaScript Object Notation",
+        "ja": "JavaScript Object Notation",
+        "ja_typings": [
+          "javascript object notation"
+        ]
+      },
+      {
+        "en": "Joint Standard Object Notation",
+        "ja": "Joint Standard Object Notation",
+        "ja_typings": [
+          "joint standard object notation"
+        ]
+      },
+      {
+        "en": "JavaScript Open Network",
+        "ja": "JavaScript Open Network",
+        "ja_typings": [
+          "javascript open network"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02674",
+    "image_path": null,
+    "question_text": {
+      "en": "JSONのフルネームの誤った候補として混同されがちなのは?",
+      "ja": "Which is a common (incorrect) fake expansion of JSON?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JavaScript",
+        "ja": "JavaScript",
+        "ja_typings": [
+          "javascript"
+        ]
+      },
+      {
+        "en": "TypeScript",
+        "ja": "TypeScript",
+        "ja_typings": [
+          "typescript"
+        ]
+      },
+      {
+        "en": "Python",
+        "ja": "Python",
+        "ja_typings": [
+          "python"
+        ]
+      },
+      {
+        "en": "Ruby",
+        "ja": "Ruby",
+        "ja_typings": [
+          "ruby"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02675",
+    "image_path": null,
+    "question_text": {
+      "en": "ブラウザで動く動的言語は?",
+      "ja": "Which dynamic language runs in web browsers?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JavaScript Open Network",
+        "ja": "JavaScript Open Network",
+        "ja_typings": [
+          "javascript open network"
+        ]
+      },
+      {
+        "en": "JavaScript Object Notation",
+        "ja": "JavaScript Object Notation",
+        "ja_typings": [
+          "javascript object notation"
+        ]
+      },
+      {
+        "en": "Java Source Object Network",
+        "ja": "Java Source Object Network",
+        "ja_typings": [
+          "java source object network"
+        ]
+      },
+      {
+        "en": "Joint Standard Object Notation",
+        "ja": "Joint Standard Object Notation",
+        "ja_typings": [
+          "joint standard object notation"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02676",
+    "image_path": null,
+    "question_text": {
+      "en": "JSONの正式名称として誤って語られがちなのは?",
+      "ja": "Which is another common false expansion of JSON?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Joint Standard Object Notation",
+        "ja": "Joint Standard Object Notation",
+        "ja_typings": [
+          "joint standard object notation"
+        ]
+      },
+      {
+        "en": "JavaScript Object Notation",
+        "ja": "JavaScript Object Notation",
+        "ja_typings": [
+          "javascript object notation"
+        ]
+      },
+      {
+        "en": "Java Source Object Network",
+        "ja": "Java Source Object Network",
+        "ja_typings": [
+          "java source object network"
+        ]
+      },
+      {
+        "en": "JavaScript Open Network",
+        "ja": "JavaScript Open Network",
+        "ja_typings": [
+          "javascript open network"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02677",
+    "image_path": null,
+    "question_text": {
+      "en": "JSONの誤った命名候補としてしばしば挙げられるのは?",
+      "ja": "Which is another false expansion sometimes given for JSON?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Junio Hamano",
+        "ja": "Junio Hamano",
+        "ja_typings": [
+          "junio hamano",
+          "juniohamano"
+        ]
+      },
+      {
+        "en": "Yukihiro Matsumoto",
+        "ja": "Yukihiro Matsumoto",
+        "ja_typings": [
+          "yukihiro matsumoto",
+          "yukihiromatsumoto"
+        ]
+      },
+      {
+        "en": "Linus Torvalds",
+        "ja": "Linus Torvalds",
+        "ja_typings": [
+          "linus torvalds",
+          "linustorvalds"
+        ]
+      },
+      {
+        "en": "Brian Kernighan",
+        "ja": "Brian Kernighan",
+        "ja_typings": [
+          "brian kernighan",
+          "briankernighan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02678",
+    "image_path": null,
+    "question_text": {
+      "en": "Gitの現在のメンテナを務める日本人開発者は?",
+      "ja": "Which Japanese developer maintains Git?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "LLVM",
+        "ja": "LLVM",
+        "ja_typings": [
+          "llvm"
+        ]
+      },
+      {
+        "en": "CLR",
+        "ja": "CLR",
+        "ja_typings": [
+          "clr"
+        ]
+      },
+      {
+        "en": "JVM",
+        "ja": "JVM",
+        "ja_typings": [
+          "jvm"
+        ]
+      },
+      {
+        "en": "V8",
+        "ja": "V8",
+        "ja_typings": [
+          "v8"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02679",
+    "image_path": null,
+    "question_text": {
+      "en": "Clang/Swiftなどが利用するコンパイラ基盤は?",
+      "ja": "Which compiler infrastructure is used by Clang and Swift?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Larry Wall",
+        "ja": "Larry Wall",
+        "ja_typings": [
+          "larry wall",
+          "larrywall"
+        ]
+      },
+      {
+        "en": "Guido van Rossum",
+        "ja": "Guido van Rossum",
+        "ja_typings": [
+          "guido van rossum",
+          "guidovanrossum"
+        ]
+      },
+      {
+        "en": "Brendan Eich",
+        "ja": "Brendan Eich",
+        "ja_typings": [
+          "brendan eich",
+          "brendaneich"
+        ]
+      },
+      {
+        "en": "Yukihiro Matsumoto",
+        "ja": "Yukihiro Matsumoto",
+        "ja_typings": [
+          "yukihiro matsumoto",
+          "yukihiromatsumoto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02680",
+    "image_path": null,
+    "question_text": {
+      "en": "Perlを設計した人物は?",
+      "ja": "Who designed the Perl programming language?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Linker",
+        "ja": "リンカ",
+        "ja_typings": [
+          "rinka"
+        ]
+      },
+      {
+        "en": "Compiler",
+        "ja": "コンパイラ",
+        "ja_typings": [
+          "konpaira"
+        ]
+      },
+      {
+        "en": "Assembler",
+        "ja": "アセンブラ",
+        "ja_typings": [
+          "asenbura"
+        ]
+      },
+      {
+        "en": "Loader",
+        "ja": "ローダー",
+        "ja_typings": [
+          "ro-da-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02681",
+    "image_path": null,
+    "question_text": {
+      "en": "オブジェクトファイルをまとめて実行ファイルを作るのは?",
+      "ja": "Which tool combines object files into an executable?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Linus Torvalds",
+        "ja": "Linus Torvalds",
+        "ja_typings": [
+          "linus torvalds",
+          "linustorvalds"
+        ]
+      },
+      {
+        "en": "Richard Stallman",
+        "ja": "Richard Stallman",
+        "ja_typings": [
+          "richard stallman",
+          "richardstallman"
+        ]
+      },
+      {
+        "en": "Dennis Ritchie",
+        "ja": "Dennis Ritchie",
+        "ja_typings": [
+          "dennis ritchie",
+          "dennisritchie"
+        ]
+      },
+      {
+        "en": "Brian Kernighan",
+        "ja": "Brian Kernighan",
+        "ja_typings": [
+          "brian kernighan",
+          "briankernighan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02682",
+    "image_path": null,
+    "question_text": {
+      "en": "Linuxカーネルを最初に開発した人物は?",
+      "ja": "Who originally developed the Linux kernel?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Logical AND",
+        "ja": "論理積",
+        "ja_typings": [
+          "ronriseki"
+        ]
+      },
+      {
+        "en": "Bitwise OR",
+        "ja": "ビット論理和",
+        "ja_typings": [
+          "bittoronriwa"
+        ]
+      },
+      {
+        "en": "Logical OR",
+        "ja": "論理和",
+        "ja_typings": [
+          "ronriwa"
+        ]
+      },
+      {
+        "en": "Bitwise XOR",
+        "ja": "ビット排他的論理和",
+        "ja_typings": [
+          "bittohaitatekironriwa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02683",
+    "image_path": null,
+    "question_text": {
+      "en": "ビット単位で「両方1のときだけ1」を取る演算の論理版は?",
+      "ja": "Which logical operation returns true only when both operands are true?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lower bound of complexity",
+        "ja": "計算量の下限",
+        "ja_typings": [
+          "keisanryounokagen"
+        ]
+      },
+      {
+        "en": "Upper bound of complexity",
+        "ja": "計算量の上限",
+        "ja_typings": [
+          "keisanryounokougen"
+        ]
+      },
+      {
+        "en": "Average run count",
+        "ja": "平均実行回数",
+        "ja_typings": [
+          "heikinjikkoukaisuu"
+        ]
+      },
+      {
+        "en": "Memory usage",
+        "ja": "メモリ使用量",
+        "ja_typings": [
+          "memorishiyouryou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02684",
+    "image_path": null,
+    "question_text": {
+      "en": "比較ソートで証明されている計算量の下限は?",
+      "ja": "What is the proven lower bound of complexity for comparison sorting?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MERGE",
+        "ja": "MERGE",
+        "ja_typings": [
+          "merge"
+        ]
+      },
+      {
+        "en": "FETCH",
+        "ja": "FETCH",
+        "ja_typings": [
+          "fetch"
+        ]
+      },
+      {
+        "en": "GROUP",
+        "ja": "GROUP",
+        "ja_typings": [
+          "group"
+        ]
+      },
+      {
+        "en": "HEAD",
+        "ja": "HEAD",
+        "ja_typings": [
+          "head"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02685",
+    "image_path": null,
+    "question_text": {
+      "en": "SQLでINSERT/UPDATEを一度に行う命令は?",
+      "ja": "Which SQL statement combines INSERT and UPDATE in one operation?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Machine Code",
+        "ja": "機械語",
+        "ja_typings": [
+          "kikaigo"
+        ]
+      },
+      {
+        "en": "Assembly",
+        "ja": "アセンブリ言語",
+        "ja_typings": [
+          "asenburigengo"
+        ]
+      },
+      {
+        "en": "Source Map",
+        "ja": "ソースマップ",
+        "ja_typings": [
+          "so-sumappu"
+        ]
+      },
+      {
+        "en": "Bytecode",
+        "ja": "バイトコード",
+        "ja_typings": [
+          "baitoko-do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02686",
+    "image_path": null,
+    "question_text": {
+      "en": "CPUが直接実行できるバイナリ表現の命令は?",
+      "ja": "Which form of instructions is directly executed by the CPU?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Maven",
+        "ja": "Maven",
+        "ja_typings": [
+          "maven"
+        ]
+      },
+      {
+        "en": "Ant",
+        "ja": "Ant",
+        "ja_typings": [
+          "ant"
+        ]
+      },
+      {
+        "en": "Gradle",
+        "ja": "Gradle",
+        "ja_typings": [
+          "gradle"
+        ]
+      },
+      {
+        "en": "Cargo",
+        "ja": "Cargo",
+        "ja_typings": [
+          "cargo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02687",
+    "image_path": null,
+    "question_text": {
+      "en": "JavaのXMLベースのビルドツールでpom.xmlを使うのは?",
+      "ja": "Which Java build tool uses pom.xml configuration?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Memory Leak",
+        "ja": "メモリリーク",
+        "ja_typings": [
+          "memori-ri-ku",
+          "memoriri-ku"
+        ]
+      },
+      {
+        "en": "Segmentation Fault",
+        "ja": "セグメンテーション違反",
+        "ja_typings": [
+          "segumente-shonihan"
+        ]
+      },
+      {
+        "en": "Stack Overflow",
+        "ja": "スタックオーバーフロー",
+        "ja_typings": [
+          "sutakkuo-ba-furo-"
+        ]
+      },
+      {
+        "en": "Mutex",
+        "ja": "ミューテックス",
+        "ja_typings": [
+          "myu-tekkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02688",
+    "image_path": null,
+    "question_text": {
+      "en": "解放されないメモリが蓄積する不具合は?",
+      "ja": "Which bug refers to memory that is never released?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Memory usage",
+        "ja": "メモリ使用量",
+        "ja_typings": [
+          "memorishiyouryou"
+        ]
+      },
+      {
+        "en": "Average run count",
+        "ja": "平均実行回数",
+        "ja_typings": [
+          "heikinjikkoukaisuu"
+        ]
+      },
+      {
+        "en": "Stack Overflow",
+        "ja": "スタックオーバーフロー",
+        "ja_typings": [
+          "sutakkuo-ba-furo-"
+        ]
+      },
+      {
+        "en": "Source Map",
+        "ja": "ソースマップ",
+        "ja_typings": [
+          "so-sumappu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02689",
+    "image_path": null,
+    "question_text": {
+      "en": "プロファイラで「メモリの使用量」を示す指標は?",
+      "ja": "Which profiling metric shows how much memory the program uses?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mergesort",
+        "ja": "マージソート",
+        "ja_typings": [
+          "ma-jiso-to"
+        ]
+      },
+      {
+        "en": "Quicksort",
+        "ja": "クイックソート",
+        "ja_typings": [
+          "kuikkuso-to"
+        ]
+      },
+      {
+        "en": "Bubble Sort",
+        "ja": "バブルソート",
+        "ja_typings": [
+          "baburuso-to"
+        ]
+      },
+      {
+        "en": "Insertion Sort",
+        "ja": "挿入ソート",
+        "ja_typings": [
+          "sounyuuso-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02690",
+    "image_path": null,
+    "question_text": {
+      "en": "分割統治法による安定ソートでO(n log n)を保証するのは?",
+      "ja": "Which divide-and-conquer stable sort guarantees O(n log n)?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MongoDB",
+        "ja": "MongoDB",
+        "ja_typings": [
+          "mongodb"
+        ]
+      },
+      {
+        "en": "Cassandra",
+        "ja": "Cassandra",
+        "ja_typings": [
+          "cassandra"
+        ]
+      },
+      {
+        "en": "Neo4j",
+        "ja": "Neo4j",
+        "ja_typings": [
+          "neo4j"
+        ]
+      },
+      {
+        "en": "PostgreSQL",
+        "ja": "PostgreSQL",
+        "ja_typings": [
+          "postgresql"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02691",
+    "image_path": null,
+    "question_text": {
+      "en": "ドキュメント指向NoSQLの代表例は?",
+      "ja": "Which is a leading document-oriented NoSQL database?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mutex",
+        "ja": "ミューテックス",
+        "ja_typings": [
+          "myu-tekkusu"
+        ]
+      },
+      {
+        "en": "Thread",
+        "ja": "スレッド",
+        "ja_typings": [
+          "sureddo"
+        ]
+      },
+      {
+        "en": "Fiber",
+        "ja": "ファイバー",
+        "ja_typings": [
+          "faiba-"
+        ]
+      },
+      {
+        "en": "Signal",
+        "ja": "シグナル",
+        "ja_typings": [
+          "shigunaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02692",
+    "image_path": null,
+    "question_text": {
+      "en": "複数スレッドが同時にアクセスしないよう制御する仕組みは?",
+      "ja": "Which primitive ensures only one thread accesses a resource at a time?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MySQL",
+        "ja": "MySQL",
+        "ja_typings": [
+          "mysql"
+        ]
+      },
+      {
+        "en": "PostgreSQL",
+        "ja": "PostgreSQL",
+        "ja_typings": [
+          "postgresql"
+        ]
+      },
+      {
+        "en": "SQLite",
+        "ja": "SQLite",
+        "ja_typings": [
+          "sqlite"
+        ]
+      },
+      {
+        "en": "MongoDB",
+        "ja": "MongoDB",
+        "ja_typings": [
+          "mongodb"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02693",
+    "image_path": null,
+    "question_text": {
+      "en": "オープンソースの代表的なリレーショナルDBで「m」で始まるのは?",
+      "ja": "Which popular open-source relational database starts with 'M'?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Neo4j",
+        "ja": "Neo4j",
+        "ja_typings": [
+          "neo4j"
+        ]
+      },
+      {
+        "en": "MongoDB",
+        "ja": "MongoDB",
+        "ja_typings": [
+          "mongodb"
+        ]
+      },
+      {
+        "en": "Cassandra",
+        "ja": "Cassandra",
+        "ja_typings": [
+          "cassandra"
+        ]
+      },
+      {
+        "en": "MySQL",
+        "ja": "MySQL",
+        "ja_typings": [
+          "mysql"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02694",
+    "image_path": null,
+    "question_text": {
+      "en": "グラフ型データベースの代表は?",
+      "ja": "Which is a leading graph database?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Not Found",
+        "ja": "Not Found",
+        "ja_typings": [
+          "not found",
+          "notfound"
+        ]
+      },
+      {
+        "en": "Forbidden",
+        "ja": "Forbidden",
+        "ja_typings": [
+          "forbidden"
+        ]
+      },
+      {
+        "en": "Bad Request",
+        "ja": "Bad Request",
+        "ja_typings": [
+          "bad request",
+          "badrequest"
+        ]
+      },
+      {
+        "en": "Unauthorized",
+        "ja": "Unauthorized",
+        "ja_typings": [
+          "unauthorized"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02695",
+    "image_path": null,
+    "question_text": {
+      "en": "HTTPステータスコード404が示すのは?",
+      "ja": "What does HTTP status code 404 indicate?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "O(1)",
+        "ja": "O(1)",
+        "ja_typings": [
+          "o(1)"
+        ]
+      },
+      {
+        "en": "O(log n)",
+        "ja": "O(log n)",
+        "ja_typings": [
+          "o(log n)"
+        ]
+      },
+      {
+        "en": "O(n)",
+        "ja": "O(n)",
+        "ja_typings": [
+          "o(n)"
+        ]
+      },
+      {
+        "en": "O(n log n)",
+        "ja": "O(n log n)",
+        "ja_typings": [
+          "o(n log n)"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02696",
+    "image_path": null,
+    "question_text": {
+      "en": "ハッシュテーブルの平均的な検索計算量は?",
+      "ja": "What is the average-case lookup complexity of a hash table?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "O(log n)",
+        "ja": "O(log n)",
+        "ja_typings": [
+          "o(log n)"
+        ]
+      },
+      {
+        "en": "O(1)",
+        "ja": "O(1)",
+        "ja_typings": [
+          "o(1)"
+        ]
+      },
+      {
+        "en": "O(n)",
+        "ja": "O(n)",
+        "ja_typings": [
+          "o(n)"
+        ]
+      },
+      {
+        "en": "O(n log n)",
+        "ja": "O(n log n)",
+        "ja_typings": [
+          "o(n log n)"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02697",
+    "image_path": null,
+    "question_text": {
+      "en": "二分探索の計算量は?",
+      "ja": "What is the time complexity of binary search?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "O(n log n)",
+        "ja": "O(n log n)",
+        "ja_typings": [
+          "o(n log n)"
+        ]
+      },
+      {
+        "en": "O(log n)",
+        "ja": "O(log n)",
+        "ja_typings": [
+          "o(log n)"
+        ]
+      },
+      {
+        "en": "O(n)",
+        "ja": "O(n)",
+        "ja_typings": [
+          "o(n)"
+        ]
+      },
+      {
+        "en": "O(1)",
+        "ja": "O(1)",
+        "ja_typings": [
+          "o(1)"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02698",
+    "image_path": null,
+    "question_text": {
+      "en": "比較ソートの最良計算量は?",
+      "ja": "What is the best achievable complexity for comparison sorting?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "O(n)",
+        "ja": "O(n)",
+        "ja_typings": [
+          "o(n)"
+        ]
+      },
+      {
+        "en": "O(1)",
+        "ja": "O(1)",
+        "ja_typings": [
+          "o(1)"
+        ]
+      },
+      {
+        "en": "O(log n)",
+        "ja": "O(log n)",
+        "ja_typings": [
+          "o(log n)"
+        ]
+      },
+      {
+        "en": "O(n log n)",
+        "ja": "O(n log n)",
+        "ja_typings": [
+          "o(n log n)"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02699",
+    "image_path": null,
+    "question_text": {
+      "en": "配列を1度走査する線形探索の計算量は?",
+      "ja": "What is the time complexity of a single-pass linear search?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "OK",
+        "ja": "OK",
+        "ja_typings": [
+          "ok"
+        ]
+      },
+      {
+        "en": "Bad Request",
+        "ja": "Bad Request",
+        "ja_typings": [
+          "bad request",
+          "badrequest"
+        ]
+      },
+      {
+        "en": "Not Found",
+        "ja": "Not Found",
+        "ja_typings": [
+          "not found",
+          "notfound"
+        ]
+      },
+      {
+        "en": "Forbidden",
+        "ja": "Forbidden",
+        "ja_typings": [
+          "forbidden"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02700",
+    "image_path": null,
+    "question_text": {
+      "en": "HTTPステータスコード200が示すのは?",
+      "ja": "What does HTTP status code 200 indicate?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Observer",
+        "ja": "オブザーバー",
+        "ja_typings": [
+          "obuza-ba-"
+        ]
+      },
+      {
+        "en": "Singleton",
+        "ja": "シングルトン",
+        "ja_typings": [
+          "shingoruton",
+          "shinguruton"
+        ]
+      },
+      {
+        "en": "Factory",
+        "ja": "ファクトリー",
+        "ja_typings": [
+          "fakutori-"
+        ]
+      },
+      {
+        "en": "Decorator",
+        "ja": "デコレーター",
+        "ja_typings": [
+          "dekore-ta-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02701",
+    "image_path": null,
+    "question_text": {
+      "en": "GoFパターンで状態変化を購読者に通知するのは?",
+      "ja": "Which GoF pattern notifies subscribers of state changes?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Octal",
+        "ja": "8進数",
+        "ja_typings": [
+          "8shinsuu",
+          "hasshinsuu"
+        ]
+      },
+      {
+        "en": "Hexadecimal",
+        "ja": "16進数",
+        "ja_typings": [
+          "16shinsuu",
+          "juurokushinsuu"
+        ]
+      },
+      {
+        "en": "Binary",
+        "ja": "2進数",
+        "ja_typings": [
+          "2shinsuu",
+          "nishinsuu"
+        ]
+      },
+      {
+        "en": "Decimal",
+        "ja": "10進数",
+        "ja_typings": [
+          "10shinsuu",
+          "juushinsuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02702",
+    "image_path": null,
+    "question_text": {
+      "en": "0から7までの数字で表す進数は?",
+      "ja": "Which numeral system uses digits 0-7?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PATCH",
+        "ja": "PATCH",
+        "ja_typings": [
+          "patch"
+        ]
+      },
+      {
+        "en": "PUT",
+        "ja": "PUT",
+        "ja_typings": [
+          "put"
+        ]
+      },
+      {
+        "en": "POST",
+        "ja": "POST",
+        "ja_typings": [
+          "post"
+        ]
+      },
+      {
+        "en": "HEAD",
+        "ja": "HEAD",
+        "ja_typings": [
+          "head"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02703",
+    "image_path": null,
+    "question_text": {
+      "en": "HTTPでリソースの一部更新を表すメソッドは?",
+      "ja": "Which HTTP method represents a partial update of a resource?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PHP",
+        "ja": "PHP",
+        "ja_typings": [
+          "php"
+        ]
+      },
+      {
+        "en": "Perl",
+        "ja": "Perl",
+        "ja_typings": [
+          "perl"
+        ]
+      },
+      {
+        "en": "Ruby",
+        "ja": "Ruby",
+        "ja_typings": [
+          "ruby"
+        ]
+      },
+      {
+        "en": "Python",
+        "ja": "Python",
+        "ja_typings": [
+          "python"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02704",
+    "image_path": null,
+    "question_text": {
+      "en": "サーバサイドで動的Webページを生成する人気言語は?",
+      "ja": "Which server-side language is widely used for generating dynamic web pages?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "POST",
+        "ja": "POST",
+        "ja_typings": [
+          "post"
+        ]
+      },
+      {
+        "en": "GET",
+        "ja": "GET",
+        "ja_typings": [
+          "get"
+        ]
+      },
+      {
+        "en": "PUT",
+        "ja": "PUT",
+        "ja_typings": [
+          "put"
+        ]
+      },
+      {
+        "en": "HEAD",
+        "ja": "HEAD",
+        "ja_typings": [
+          "head"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02705",
+    "image_path": null,
+    "question_text": {
+      "en": "HTTPでデータをサーバに送信する代表的なメソッドは?",
+      "ja": "Which HTTP method commonly submits data to the server?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PUT",
+        "ja": "PUT",
+        "ja_typings": [
+          "put"
+        ]
+      },
+      {
+        "en": "PATCH",
+        "ja": "PATCH",
+        "ja_typings": [
+          "patch"
+        ]
+      },
+      {
+        "en": "POST",
+        "ja": "POST",
+        "ja_typings": [
+          "post"
+        ]
+      },
+      {
+        "en": "HEAD",
+        "ja": "HEAD",
+        "ja_typings": [
+          "head"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02706",
+    "image_path": null,
+    "question_text": {
+      "en": "HTTPでリソース全体を置き換えるメソッドは?",
+      "ja": "Which HTTP method replaces a resource entirely?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pascal",
+        "ja": "Pascal",
+        "ja_typings": [
+          "pascal"
+        ]
+      },
+      {
+        "en": "Fortran",
+        "ja": "Fortran",
+        "ja_typings": [
+          "fortran"
+        ]
+      },
+      {
+        "en": "COBOL",
+        "ja": "COBOL",
+        "ja_typings": [
+          "cobol"
+        ]
+      },
+      {
+        "en": "Ada",
+        "ja": "Ada",
+        "ja_typings": [
+          "ada"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02707",
+    "image_path": null,
+    "question_text": {
+      "en": "Niklaus Wirthが設計した教育用言語は?",
+      "ja": "Which educational language was designed by Niklaus Wirth?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Polymorphism",
+        "ja": "ポリモーフィズム",
+        "ja_typings": [
+          "porimo-fizumu"
+        ]
+      },
+      {
+        "en": "Encapsulation",
+        "ja": "カプセル化",
+        "ja_typings": [
+          "kapuseruka"
+        ]
+      },
+      {
+        "en": "Inheritance",
+        "ja": "継承",
+        "ja_typings": [
+          "keishou"
+        ]
+      },
+      {
+        "en": "Abstraction",
+        "ja": "抽象化",
+        "ja_typings": [
+          "chuushouka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02708",
+    "image_path": null,
+    "question_text": {
+      "en": "オブジェクト指向で同じインタフェースで多様な振る舞いをする概念は?",
+      "ja": "Which OOP concept lets one interface serve many implementations?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PostgreSQL",
+        "ja": "PostgreSQL",
+        "ja_typings": [
+          "postgresql"
+        ]
+      },
+      {
+        "en": "MySQL",
+        "ja": "MySQL",
+        "ja_typings": [
+          "mysql"
+        ]
+      },
+      {
+        "en": "SQLite",
+        "ja": "SQLite",
+        "ja_typings": [
+          "sqlite"
+        ]
+      },
+      {
+        "en": "MongoDB",
+        "ja": "MongoDB",
+        "ja_typings": [
+          "mongodb"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02709",
+    "image_path": null,
+    "question_text": {
+      "en": "高機能で拡張性に優れたオープンソースRDBは?",
+      "ja": "Which is a feature-rich, extensible open-source RDBMS?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Process",
+        "ja": "プロセス",
+        "ja_typings": [
+          "purosesu"
+        ]
+      },
+      {
+        "en": "Thread",
+        "ja": "スレッド",
+        "ja_typings": [
+          "sureddo"
+        ]
+      },
+      {
+        "en": "Fiber",
+        "ja": "ファイバー",
+        "ja_typings": [
+          "faiba-"
+        ]
+      },
+      {
+        "en": "Mutex",
+        "ja": "ミューテックス",
+        "ja_typings": [
+          "myu-tekkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02710",
+    "image_path": null,
+    "question_text": {
+      "en": "OSが管理する実行単位でメモリ空間を独立して持つのは?",
+      "ja": "Which OS-managed execution unit has its own memory space?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Profiler",
+        "ja": "プロファイラ",
+        "ja_typings": [
+          "purofaira"
+        ]
+      },
+      {
+        "en": "Debugger",
+        "ja": "デバッガ",
+        "ja_typings": [
+          "debagga"
+        ]
+      },
+      {
+        "en": "Compiler",
+        "ja": "コンパイラ",
+        "ja_typings": [
+          "konpaira"
+        ]
+      },
+      {
+        "en": "Linker",
+        "ja": "リンカ",
+        "ja_typings": [
+          "rinka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02711",
+    "image_path": null,
+    "question_text": {
+      "en": "プログラムの性能を測定し分析するツールは?",
+      "ja": "Which tool measures and analyzes a program's performance?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Queue",
+        "ja": "キュー",
+        "ja_typings": [
+          "kyu-"
+        ]
+      },
+      {
+        "en": "Stack",
+        "ja": "スタック",
+        "ja_typings": [
+          "sutakku"
+        ]
+      },
+      {
+        "en": "Tree",
+        "ja": "木",
+        "ja_typings": [
+          "ki"
+        ]
+      },
+      {
+        "en": "Graph",
+        "ja": "グラフ",
+        "ja_typings": [
+          "gurafu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02712",
+    "image_path": null,
+    "question_text": {
+      "en": "FIFO方式で出し入れするデータ構造は?",
+      "ja": "Which data structure follows FIFO (first-in, first-out)?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rc",
+        "ja": "Rc",
+        "ja_typings": [
+          "rc"
+        ]
+      },
+      {
+        "en": "Arc",
+        "ja": "Arc",
+        "ja_typings": [
+          "arc"
+        ]
+      },
+      {
+        "en": "Box",
+        "ja": "Box",
+        "ja_typings": [
+          "box"
+        ]
+      },
+      {
+        "en": "RefCell",
+        "ja": "RefCell",
+        "ja_typings": [
+          "refcell"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02713",
+    "image_path": null,
+    "question_text": {
+      "en": "Rustのシングルスレッド向け参照カウントスマートポインタは?",
+      "ja": "Which Rust smart pointer is a single-threaded reference counter?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Redirect",
+        "ja": "リダイレクト",
+        "ja_typings": [
+          "ridairekuto"
+        ]
+      },
+      {
+        "en": "Client Error",
+        "ja": "クライアントエラー",
+        "ja_typings": [
+          "kuraiantoera-"
+        ]
+      },
+      {
+        "en": "Server Error",
+        "ja": "サーバーエラー",
+        "ja_typings": [
+          "sa-ba-era-"
+        ]
+      },
+      {
+        "en": "Success",
+        "ja": "成功",
+        "ja_typings": [
+          "seikou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02714",
+    "image_path": null,
+    "question_text": {
+      "en": "HTTPで別URLに転送することを表す3xx系の意味は?",
+      "ja": "What is the meaning of the HTTP 3xx status family?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Richard Stallman",
+        "ja": "Richard Stallman",
+        "ja_typings": [
+          "richard stallman",
+          "richardstallman"
+        ]
+      },
+      {
+        "en": "Linus Torvalds",
+        "ja": "Linus Torvalds",
+        "ja_typings": [
+          "linus torvalds",
+          "linustorvalds"
+        ]
+      },
+      {
+        "en": "Bill Joy",
+        "ja": "Bill Joy",
+        "ja_typings": [
+          "bill joy",
+          "billjoy"
+        ]
+      },
+      {
+        "en": "Dennis Ritchie",
+        "ja": "Dennis Ritchie",
+        "ja_typings": [
+          "dennis ritchie",
+          "dennisritchie"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02715",
+    "image_path": null,
+    "question_text": {
+      "en": "GNUプロジェクトを創設した人物は?",
+      "ja": "Who founded the GNU Project?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SMTP",
+        "ja": "SMTP",
+        "ja_typings": [
+          "smtp"
+        ]
+      },
+      {
+        "en": "FTP",
+        "ja": "FTP",
+        "ja_typings": [
+          "ftp"
+        ]
+      },
+      {
+        "en": "ICMP",
+        "ja": "ICMP",
+        "ja_typings": [
+          "icmp"
+        ]
+      },
+      {
+        "en": "Telnet",
+        "ja": "Telnet",
+        "ja_typings": [
+          "telnet"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02716",
+    "image_path": null,
+    "question_text": {
+      "en": "メール送信に使われるプロトコルは?",
+      "ja": "Which protocol is used to send emails?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SQL",
+        "ja": "SQL",
+        "ja_typings": [
+          "sql"
+        ]
+      },
+      {
+        "en": "CSS",
+        "ja": "CSS",
+        "ja_typings": [
+          "css"
+        ]
+      },
+      {
+        "en": "HTML",
+        "ja": "HTML",
+        "ja_typings": [
+          "html"
+        ]
+      },
+      {
+        "en": "XML",
+        "ja": "XML",
+        "ja_typings": [
+          "xml"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02717",
+    "image_path": null,
+    "question_text": {
+      "en": "リレーショナルDBを操作する標準言語は?",
+      "ja": "Which standard language manipulates relational databases?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SQLite",
+        "ja": "SQLite",
+        "ja_typings": [
+          "sqlite"
+        ]
+      },
+      {
+        "en": "MySQL",
+        "ja": "MySQL",
+        "ja_typings": [
+          "mysql"
+        ]
+      },
+      {
+        "en": "PostgreSQL",
+        "ja": "PostgreSQL",
+        "ja_typings": [
+          "postgresql"
+        ]
+      },
+      {
+        "en": "MongoDB",
+        "ja": "MongoDB",
+        "ja_typings": [
+          "mongodb"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02718",
+    "image_path": null,
+    "question_text": {
+      "en": "ファイル1つで動く軽量な組み込みRDBは?",
+      "ja": "Which lightweight embedded RDBMS stores data in a single file?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Segmentation Fault",
+        "ja": "セグメンテーション違反",
+        "ja_typings": [
+          "segumente-shonihan"
+        ]
+      },
+      {
+        "en": "Memory Leak",
+        "ja": "メモリリーク",
+        "ja_typings": [
+          "memori-ri-ku",
+          "memoriri-ku"
+        ]
+      },
+      {
+        "en": "Stack Overflow",
+        "ja": "スタックオーバーフロー",
+        "ja_typings": [
+          "sutakkuo-ba-furo-"
+        ]
+      },
+      {
+        "en": "Bad Request",
+        "ja": "Bad Request",
+        "ja_typings": [
+          "bad request",
+          "badrequest"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02719",
+    "image_path": null,
+    "question_text": {
+      "en": "不正なメモリアクセスで発生する典型的なエラーは?",
+      "ja": "Which error is typically caused by invalid memory access?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Signal",
+        "ja": "シグナル",
+        "ja_typings": [
+          "shigunaru"
+        ]
+      },
+      {
+        "en": "Mutex",
+        "ja": "ミューテックス",
+        "ja_typings": [
+          "myu-tekkusu"
+        ]
+      },
+      {
+        "en": "Thread",
+        "ja": "スレッド",
+        "ja_typings": [
+          "sureddo"
+        ]
+      },
+      {
+        "en": "Fiber",
+        "ja": "ファイバー",
+        "ja_typings": [
+          "faiba-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02720",
+    "image_path": null,
+    "question_text": {
+      "en": "Unixでプロセスに送る通知の仕組みは?",
+      "ja": "Which Unix mechanism sends notifications to processes?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Singleton",
+        "ja": "シングルトン",
+        "ja_typings": [
+          "shingoruton",
+          "shinguruton"
+        ]
+      },
+      {
+        "en": "Factory",
+        "ja": "ファクトリー",
+        "ja_typings": [
+          "fakutori-"
+        ]
+      },
+      {
+        "en": "Observer",
+        "ja": "オブザーバー",
+        "ja_typings": [
+          "obuza-ba-"
+        ]
+      },
+      {
+        "en": "Decorator",
+        "ja": "デコレーター",
+        "ja_typings": [
+          "dekore-ta-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02721",
+    "image_path": null,
+    "question_text": {
+      "en": "GoFパターンでインスタンスを1つに制限するのは?",
+      "ja": "Which GoF pattern restricts a class to a single instance?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Source Map",
+        "ja": "ソースマップ",
+        "ja_typings": [
+          "so-sumappu"
+        ]
+      },
+      {
+        "en": "Memory Leak",
+        "ja": "メモリリーク",
+        "ja_typings": [
+          "memori-ri-ku",
+          "memoriri-ku"
+        ]
+      },
+      {
+        "en": "Stack Overflow",
+        "ja": "スタックオーバーフロー",
+        "ja_typings": [
+          "sutakkuo-ba-furo-"
+        ]
+      },
+      {
+        "en": "Average run count",
+        "ja": "平均実行回数",
+        "ja_typings": [
+          "heikinjikkoukaisuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02722",
+    "image_path": null,
+    "question_text": {
+      "en": "ミニファイされたコードと元のコードを対応付けるファイルは?",
+      "ja": "Which file maps minified code back to the original source?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Stack",
+        "ja": "スタック",
+        "ja_typings": [
+          "sutakku"
+        ]
+      },
+      {
+        "en": "Queue",
+        "ja": "キュー",
+        "ja_typings": [
+          "kyu-"
+        ]
+      },
+      {
+        "en": "Tree",
+        "ja": "木",
+        "ja_typings": [
+          "ki"
+        ]
+      },
+      {
+        "en": "Graph",
+        "ja": "グラフ",
+        "ja_typings": [
+          "gurafu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02723",
+    "image_path": null,
+    "question_text": {
+      "en": "LIFO方式で出し入れするデータ構造は?",
+      "ja": "Which data structure follows LIFO (last-in, first-out)?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Stack Overflow",
+        "ja": "スタックオーバーフロー",
+        "ja_typings": [
+          "sutakkuo-ba-furo-"
+        ]
+      },
+      {
+        "en": "Memory Leak",
+        "ja": "メモリリーク",
+        "ja_typings": [
+          "memori-ri-ku",
+          "memoriri-ku"
+        ]
+      },
+      {
+        "en": "Segmentation Fault",
+        "ja": "セグメンテーション違反",
+        "ja_typings": [
+          "segumente-shonihan"
+        ]
+      },
+      {
+        "en": "Source Map",
+        "ja": "ソースマップ",
+        "ja_typings": [
+          "so-sumappu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02724",
+    "image_path": null,
+    "question_text": {
+      "en": "スタック領域が溢れたときに起きるエラーは?",
+      "ja": "Which error occurs when the call stack exceeds its limit?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Static",
+        "ja": "静的",
+        "ja_typings": [
+          "seiteki"
+        ]
+      },
+      {
+        "en": "Dynamic",
+        "ja": "動的",
+        "ja_typings": [
+          "douteki"
+        ]
+      },
+      {
+        "en": "Immutable",
+        "ja": "イミュータブル",
+        "ja_typings": [
+          "imyu-taburu"
+        ]
+      },
+      {
+        "en": "Interpreted",
+        "ja": "インタプリタ型",
+        "ja_typings": [
+          "intapuritagata"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02725",
+    "image_path": null,
+    "question_text": {
+      "en": "コンパイル時に型が決まる言語の性質を表す語は?",
+      "ja": "Which term describes a language whose types are checked at compile time?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Success",
+        "ja": "成功",
+        "ja_typings": [
+          "seikou"
+        ]
+      },
+      {
+        "en": "Redirect",
+        "ja": "リダイレクト",
+        "ja_typings": [
+          "ridairekuto"
+        ]
+      },
+      {
+        "en": "Client Error",
+        "ja": "クライアントエラー",
+        "ja_typings": [
+          "kuraiantoera-"
+        ]
+      },
+      {
+        "en": "Server Error",
+        "ja": "サーバーエラー",
+        "ja_typings": [
+          "sa-ba-era-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02726",
+    "image_path": null,
+    "question_text": {
+      "en": "HTTPの2xx系ステータスコードのカテゴリ名は?",
+      "ja": "What is the meaning of the HTTP 2xx status family?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Telnet",
+        "ja": "Telnet",
+        "ja_typings": [
+          "telnet"
+        ]
+      },
+      {
+        "en": "FTP",
+        "ja": "FTP",
+        "ja_typings": [
+          "ftp"
+        ]
+      },
+      {
+        "en": "SMTP",
+        "ja": "SMTP",
+        "ja_typings": [
+          "smtp"
+        ]
+      },
+      {
+        "en": "ARP",
+        "ja": "ARP",
+        "ja_typings": [
+          "arp"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02727",
+    "image_path": null,
+    "question_text": {
+      "en": "古くからある暗号化されないリモートログインプロトコルは?",
+      "ja": "Which old remote-login protocol transmits data unencrypted?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Terraform",
+        "ja": "Terraform",
+        "ja_typings": [
+          "terraform"
+        ]
+      },
+      {
+        "en": "Ansible",
+        "ja": "Ansible",
+        "ja_typings": [
+          "ansible"
+        ]
+      },
+      {
+        "en": "Docker Compose",
+        "ja": "Docker Compose",
+        "ja_typings": [
+          "docker compose",
+          "dockercompose"
+        ]
+      },
+      {
+        "en": "Maven",
+        "ja": "Maven",
+        "ja_typings": [
+          "maven"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02728",
+    "image_path": null,
+    "question_text": {
+      "en": "HashiCorpが開発するインフラ宣言型ツールは?",
+      "ja": "Which HashiCorp tool provisions infrastructure declaratively?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thread",
+        "ja": "スレッド",
+        "ja_typings": [
+          "sureddo"
+        ]
+      },
+      {
+        "en": "Process",
+        "ja": "プロセス",
+        "ja_typings": [
+          "purosesu"
+        ]
+      },
+      {
+        "en": "Fiber",
+        "ja": "ファイバー",
+        "ja_typings": [
+          "faiba-"
+        ]
+      },
+      {
+        "en": "Mutex",
+        "ja": "ミューテックス",
+        "ja_typings": [
+          "myu-tekkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02729",
+    "image_path": null,
+    "question_text": {
+      "en": "プロセス内で並行実行されメモリ空間を共有する単位は?",
+      "ja": "Which execution unit runs in a process and shares its memory?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tim Berners-Lee",
+        "ja": "Tim Berners-Lee",
+        "ja_typings": [
+          "tim berners-lee",
+          "timberners-lee"
+        ]
+      },
+      {
+        "en": "Linus Torvalds",
+        "ja": "Linus Torvalds",
+        "ja_typings": [
+          "linus torvalds",
+          "linustorvalds"
+        ]
+      },
+      {
+        "en": "Brendan Eich",
+        "ja": "Brendan Eich",
+        "ja_typings": [
+          "brendan eich",
+          "brendaneich"
+        ]
+      },
+      {
+        "en": "Dennis Ritchie",
+        "ja": "Dennis Ritchie",
+        "ja_typings": [
+          "dennis ritchie",
+          "dennisritchie"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02730",
+    "image_path": null,
+    "question_text": {
+      "en": "World Wide Webを発明した人物は?",
+      "ja": "Who invented the World Wide Web?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tree",
+        "ja": "木",
+        "ja_typings": [
+          "ki"
+        ]
+      },
+      {
+        "en": "Graph",
+        "ja": "グラフ",
+        "ja_typings": [
+          "gurafu"
+        ]
+      },
+      {
+        "en": "Stack",
+        "ja": "スタック",
+        "ja_typings": [
+          "sutakku"
+        ]
+      },
+      {
+        "en": "Queue",
+        "ja": "キュー",
+        "ja_typings": [
+          "kyu-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02731",
+    "image_path": null,
+    "question_text": {
+      "en": "節点と枝で階層構造を表すデータ構造は?",
+      "ja": "Which data structure represents hierarchical relations with nodes and branches?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "UDP",
+        "ja": "UDP",
+        "ja_typings": [
+          "udp"
+        ]
+      },
+      {
+        "en": "TCP",
+        "ja": "TCP",
+        "ja_typings": [
+          "tcp"
+        ]
+      },
+      {
+        "en": "ICMP",
+        "ja": "ICMP",
+        "ja_typings": [
+          "icmp"
+        ]
+      },
+      {
+        "en": "ARP",
+        "ja": "ARP",
+        "ja_typings": [
+          "arp"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02732",
+    "image_path": null,
+    "question_text": {
+      "en": "コネクションレスで信頼性を保証しないトランスポート層プロトコルは?",
+      "ja": "Which transport protocol is connectionless and unreliable?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Unauthorized",
+        "ja": "Unauthorized",
+        "ja_typings": [
+          "unauthorized"
+        ]
+      },
+      {
+        "en": "Forbidden",
+        "ja": "Forbidden",
+        "ja_typings": [
+          "forbidden"
+        ]
+      },
+      {
+        "en": "Bad Request",
+        "ja": "Bad Request",
+        "ja_typings": [
+          "bad request",
+          "badrequest"
+        ]
+      },
+      {
+        "en": "Not Found",
+        "ja": "Not Found",
+        "ja_typings": [
+          "not found",
+          "notfound"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02733",
+    "image_path": null,
+    "question_text": {
+      "en": "HTTPステータスコード401が示すのは?",
+      "ja": "What does HTTP status code 401 indicate?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "V8",
+        "ja": "V8",
+        "ja_typings": [
+          "v8"
+        ]
+      },
+      {
+        "en": "LLVM",
+        "ja": "LLVM",
+        "ja_typings": [
+          "llvm"
+        ]
+      },
+      {
+        "en": "CLR",
+        "ja": "CLR",
+        "ja_typings": [
+          "clr"
+        ]
+      },
+      {
+        "en": "JVM",
+        "ja": "JVM",
+        "ja_typings": [
+          "jvm"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02734",
+    "image_path": null,
+    "question_text": {
+      "en": "GoogleのChromeなどで動くJavaScriptエンジンは?",
+      "ja": "Which JavaScript engine powers Google Chrome?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vim",
+        "ja": "Vim",
+        "ja_typings": [
+          "vim"
+        ]
+      },
+      {
+        "en": "Emacs",
+        "ja": "Emacs",
+        "ja_typings": [
+          "emacs"
+        ]
+      },
+      {
+        "en": "Nano",
+        "ja": "Nano",
+        "ja_typings": [
+          "nano"
+        ]
+      },
+      {
+        "en": "Bash",
+        "ja": "Bash",
+        "ja_typings": [
+          "bash"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02735",
+    "image_path": null,
+    "question_text": {
+      "en": "Linuxユーザに愛される高機能テキストエディタは?",
+      "ja": "Which highly extensible terminal text editor is beloved by Linux users?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "WFS",
+        "ja": "WFS",
+        "ja_typings": [
+          "wfs"
+        ]
+      },
+      {
+        "en": "FFS",
+        "ja": "FFS",
+        "ja_typings": [
+          "ffs"
+        ]
+      },
+      {
+        "en": "FTP",
+        "ja": "FTP",
+        "ja_typings": [
+          "ftp"
+        ]
+      },
+      {
+        "en": "BPS",
+        "ja": "BPS",
+        "ja_typings": [
+          "bps"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02736",
+    "image_path": null,
+    "question_text": {
+      "en": "OGC仕様の地理空間ベクタフィーチャ取得サービスは?",
+      "ja": "Which OGC service provides geospatial vector features over the web?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yukihiro Matsumoto",
+        "ja": "Yukihiro Matsumoto",
+        "ja_typings": [
+          "yukihiro matsumoto",
+          "yukihiromatsumoto"
+        ]
+      },
+      {
+        "en": "Guido van Rossum",
+        "ja": "Guido van Rossum",
+        "ja_typings": [
+          "guido van rossum",
+          "guidovanrossum"
+        ]
+      },
+      {
+        "en": "Brendan Eich",
+        "ja": "Brendan Eich",
+        "ja_typings": [
+          "brendan eich",
+          "brendaneich"
+        ]
+      },
+      {
+        "en": "Larry Wall",
+        "ja": "Larry Wall",
+        "ja_typings": [
+          "larry wall",
+          "larrywall"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02737",
+    "image_path": null,
+    "question_text": {
+      "en": "Rubyを設計した人物は?",
+      "ja": "Who designed the Ruby programming language?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`#`",
+        "ja": "`#`",
+        "ja_typings": [
+          "#",
+          "`#`"
+        ]
+      },
+      {
+        "en": "`$`",
+        "ja": "`$`",
+        "ja_typings": [
+          "$",
+          "`$`"
+        ]
+      },
+      {
+        "en": "`%`",
+        "ja": "`%`",
+        "ja_typings": [
+          "%",
+          "`%`"
+        ]
+      },
+      {
+        "en": "`@`",
+        "ja": "`@`",
+        "ja_typings": [
+          "@",
+          "`@`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02738",
+    "image_path": null,
+    "question_text": {
+      "en": "多くの言語でコメント開始を表す記号は?",
+      "ja": "Which character commonly starts a line comment in many languages?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`$`",
+        "ja": "`$`",
+        "ja_typings": [
+          "$",
+          "`$`"
+        ]
+      },
+      {
+        "en": "`#`",
+        "ja": "`#`",
+        "ja_typings": [
+          "#",
+          "`#`"
+        ]
+      },
+      {
+        "en": "`%`",
+        "ja": "`%`",
+        "ja_typings": [
+          "%",
+          "`%`"
+        ]
+      },
+      {
+        "en": "`&`",
+        "ja": "`&`",
+        "ja_typings": [
+          "&",
+          "`&`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02739",
+    "image_path": null,
+    "question_text": {
+      "en": "シェルで変数を参照するときに使う記号は?",
+      "ja": "Which character is used to reference shell variables?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`%`",
+        "ja": "`%`",
+        "ja_typings": [
+          "%",
+          "`%`"
+        ]
+      },
+      {
+        "en": "`*`",
+        "ja": "`*`",
+        "ja_typings": [
+          "*",
+          "`*`"
+        ]
+      },
+      {
+        "en": "`#`",
+        "ja": "`#`",
+        "ja_typings": [
+          "#",
+          "`#`"
+        ]
+      },
+      {
+        "en": "`$`",
+        "ja": "`$`",
+        "ja_typings": [
+          "$",
+          "`$`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02740",
+    "image_path": null,
+    "question_text": {
+      "en": "C系言語で剰余演算を表す記号は?",
+      "ja": "Which operator represents modulo in C-like languages?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`&`",
+        "ja": "`&`",
+        "ja_typings": [
+          "&",
+          "`&`"
+        ]
+      },
+      {
+        "en": "`*`",
+        "ja": "`*`",
+        "ja_typings": [
+          "*",
+          "`*`"
+        ]
+      },
+      {
+        "en": "`@`",
+        "ja": "`@`",
+        "ja_typings": [
+          "@",
+          "`@`"
+        ]
+      },
+      {
+        "en": "`#`",
+        "ja": "`#`",
+        "ja_typings": [
+          "#",
+          "`#`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02741",
+    "image_path": null,
+    "question_text": {
+      "en": "シェルでコマンドをバックグラウンド実行する記号は?",
+      "ja": "Which shell character runs a command in the background?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`*`",
+        "ja": "`*`",
+        "ja_typings": [
+          "*",
+          "`*`"
+        ]
+      },
+      {
+        "en": "`&`",
+        "ja": "`&`",
+        "ja_typings": [
+          "&",
+          "`&`"
+        ]
+      },
+      {
+        "en": "`%`",
+        "ja": "`%`",
+        "ja_typings": [
+          "%",
+          "`%`"
+        ]
+      },
+      {
+        "en": "`#`",
+        "ja": "`#`",
+        "ja_typings": [
+          "#",
+          "`#`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02742",
+    "image_path": null,
+    "question_text": {
+      "en": "C系言語でポインタの参照外しや乗算を表す記号は?",
+      "ja": "Which operator dereferences pointers or denotes multiplication in C?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`@`",
+        "ja": "`@`",
+        "ja_typings": [
+          "@",
+          "`@`"
+        ]
+      },
+      {
+        "en": "`#`",
+        "ja": "`#`",
+        "ja_typings": [
+          "#",
+          "`#`"
+        ]
+      },
+      {
+        "en": "`$`",
+        "ja": "`$`",
+        "ja_typings": [
+          "$",
+          "`$`"
+        ]
+      },
+      {
+        "en": "`&`",
+        "ja": "`&`",
+        "ja_typings": [
+          "&",
+          "`&`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02743",
+    "image_path": null,
+    "question_text": {
+      "en": "Pythonでデコレータを表す記号は?",
+      "ja": "Which character marks a decorator in Python?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`await`",
+        "ja": "`await`",
+        "ja_typings": [
+          "await",
+          "`await`"
+        ]
+      },
+      {
+        "en": "`yield`",
+        "ja": "`yield`",
+        "ja_typings": [
+          "yield",
+          "`yield`"
+        ]
+      },
+      {
+        "en": "`return`",
+        "ja": "`return`",
+        "ja_typings": [
+          "return",
+          "`return`"
+        ]
+      },
+      {
+        "en": "`defer`",
+        "ja": "`defer`",
+        "ja_typings": [
+          "defer",
+          "`defer`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02744",
+    "image_path": null,
+    "question_text": {
+      "en": "非同期関数の完了を待つPython/JSのキーワードは?",
+      "ja": "Which keyword in Python and JS waits for an async result?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`def`",
+        "ja": "`def`",
+        "ja_typings": [
+          "def",
+          "`def`"
+        ]
+      },
+      {
+        "en": "`fn`",
+        "ja": "`fn`",
+        "ja_typings": [
+          "fn",
+          "`fn`"
+        ]
+      },
+      {
+        "en": "`return`",
+        "ja": "`return`",
+        "ja_typings": [
+          "return",
+          "`return`"
+        ]
+      },
+      {
+        "en": "`yield`",
+        "ja": "`yield`",
+        "ja_typings": [
+          "yield",
+          "`yield`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02745",
+    "image_path": null,
+    "question_text": {
+      "en": "Pythonで関数を定義するキーワードは?",
+      "ja": "Which Python keyword defines a function?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`defer`",
+        "ja": "`defer`",
+        "ja_typings": [
+          "defer",
+          "`defer`"
+        ]
+      },
+      {
+        "en": "`await`",
+        "ja": "`await`",
+        "ja_typings": [
+          "await",
+          "`await`"
+        ]
+      },
+      {
+        "en": "`yield`",
+        "ja": "`yield`",
+        "ja_typings": [
+          "yield",
+          "`yield`"
+        ]
+      },
+      {
+        "en": "`return`",
+        "ja": "`return`",
+        "ja_typings": [
+          "return",
+          "`return`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02746",
+    "image_path": null,
+    "question_text": {
+      "en": "Goで関数終了時に処理を予約するキーワードは?",
+      "ja": "Which Go keyword schedules a call to run when the function returns?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`fn`",
+        "ja": "`fn`",
+        "ja_typings": [
+          "fn",
+          "`fn`"
+        ]
+      },
+      {
+        "en": "`def`",
+        "ja": "`def`",
+        "ja_typings": [
+          "def",
+          "`def`"
+        ]
+      },
+      {
+        "en": "`return`",
+        "ja": "`return`",
+        "ja_typings": [
+          "return",
+          "`return`"
+        ]
+      },
+      {
+        "en": "`yield`",
+        "ja": "`yield`",
+        "ja_typings": [
+          "yield",
+          "`yield`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02747",
+    "image_path": null,
+    "question_text": {
+      "en": "Rustで関数を定義するキーワードは?",
+      "ja": "Which Rust keyword defines a function?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`return`",
+        "ja": "`return`",
+        "ja_typings": [
+          "return",
+          "`return`"
+        ]
+      },
+      {
+        "en": "`yield`",
+        "ja": "`yield`",
+        "ja_typings": [
+          "yield",
+          "`yield`"
+        ]
+      },
+      {
+        "en": "`await`",
+        "ja": "`await`",
+        "ja_typings": [
+          "await",
+          "`await`"
+        ]
+      },
+      {
+        "en": "`defer`",
+        "ja": "`defer`",
+        "ja_typings": [
+          "defer",
+          "`defer`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02748",
+    "image_path": null,
+    "question_text": {
+      "en": "関数から値を返すための多くの言語で共通のキーワードは?",
+      "ja": "Which keyword returns a value from a function in most languages?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`yield`",
+        "ja": "`yield`",
+        "ja_typings": [
+          "yield",
+          "`yield`"
+        ]
+      },
+      {
+        "en": "`return`",
+        "ja": "`return`",
+        "ja_typings": [
+          "return",
+          "`return`"
+        ]
+      },
+      {
+        "en": "`await`",
+        "ja": "`await`",
+        "ja_typings": [
+          "await",
+          "`await`"
+        ]
+      },
+      {
+        "en": "`defer`",
+        "ja": "`defer`",
+        "ja_typings": [
+          "defer",
+          "`defer`"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02749",
+    "image_path": null,
+    "question_text": {
+      "en": "ジェネレータで値を1つずつ生成するキーワードは?",
+      "ja": "Which keyword produces values one at a time from a generator?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "pip",
+        "ja": "pip",
+        "ja_typings": [
+          "pip"
+        ]
+      },
+      {
+        "en": "Cargo",
+        "ja": "Cargo",
+        "ja_typings": [
+          "cargo"
+        ]
+      },
+      {
+        "en": "Maven",
+        "ja": "Maven",
+        "ja_typings": [
+          "maven"
+        ]
+      },
+      {
+        "en": "Ant",
+        "ja": "Ant",
+        "ja_typings": [
+          "ant"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "programming",
+    "id": "q02750",
+    "image_path": null,
+    "question_text": {
+      "en": "Pythonのパッケージインストーラは?",
+      "ja": "Which is the standard package installer for Python?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "API Key",
+        "ja": "APIキー",
+        "ja_typings": [
+          "apiki-"
+        ]
+      },
+      {
+        "en": "Session ID",
+        "ja": "セッションID",
+        "ja_typings": [
+          "sesshonid"
+        ]
+      },
+      {
+        "en": "CSRF Token",
+        "ja": "CSRFトークン",
+        "ja_typings": [
+          "csrfto-kun"
+        ]
+      },
+      {
+        "en": "Refresh Token",
+        "ja": "リフレッシュトークン",
+        "ja_typings": [
+          "rifuresshuto-kun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02751",
+    "image_path": null,
+    "question_text": {
+      "en": "Which credential string identifies a client to a web API?",
+      "ja": "Web API でクライアントを識別する資格情報文字列は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Angular",
+        "ja": "アンギュラー",
+        "ja_typings": [
+          "angyura-"
+        ]
+      },
+      {
+        "en": "React",
+        "ja": "リアクト",
+        "ja_typings": [
+          "riakuto"
+        ]
+      },
+      {
+        "en": "Vue",
+        "ja": "ビュー",
+        "ja_typings": [
+          "byu-"
+        ]
+      },
+      {
+        "en": "Svelte",
+        "ja": "スベルト",
+        "ja_typings": [
+          "suberuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02752",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Google-backed SPA framework uses TypeScript and decorators?",
+      "ja": "Google が開発した TypeScript ベースの SPA フレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Authentication required",
+        "ja": "認証が必要",
+        "ja_typings": [
+          "ninshougahitsuyou"
+        ]
+      },
+      {
+        "en": "Forbidden access",
+        "ja": "アクセス禁止",
+        "ja_typings": [
+          "akusesukinshi"
+        ]
+      },
+      {
+        "en": "Resource not found",
+        "ja": "リソースが見つからない",
+        "ja_typings": [
+          "risoosugamitsukaranai"
+        ]
+      },
+      {
+        "en": "Internal server error",
+        "ja": "内部サーバエラー",
+        "ja_typings": [
+          "naibusaabaeraa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02753",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status family message says credentials are required?",
+      "ja": "認証情報が必要であることを示す HTTP メッセージは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Backbone",
+        "ja": "バックボーン",
+        "ja_typings": [
+          "bakkubo-n"
+        ]
+      },
+      {
+        "en": "Ember",
+        "ja": "エンバー",
+        "ja_typings": [
+          "enba-"
+        ]
+      },
+      {
+        "en": "Knockout",
+        "ja": "ノックアウト",
+        "ja_typings": [
+          "nokkuauto"
+        ]
+      },
+      {
+        "en": "Meteor",
+        "ja": "メテオ",
+        "ja_typings": [
+          "meteo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02754",
+    "image_path": null,
+    "question_text": {
+      "en": "Which early MVC JavaScript framework popularized models and collections?",
+      "ja": "モデルとコレクションで知られた初期の MVC 系 JS フレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Basic authentication",
+        "ja": "ベーシック認証",
+        "ja_typings": [
+          "beeshikkuninshou"
+        ]
+      },
+      {
+        "en": "Digest authentication",
+        "ja": "ダイジェスト認証",
+        "ja_typings": [
+          "daijesutoninshou"
+        ]
+      },
+      {
+        "en": "Bearer authentication",
+        "ja": "ベアラー認証",
+        "ja_typings": [
+          "bearaaninshou"
+        ]
+      },
+      {
+        "en": "Kerberos authentication",
+        "ja": "ケルベロス認証",
+        "ja_typings": [
+          "keruberosuninshou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02755",
+    "image_path": null,
+    "question_text": {
+      "en": "Which scheme sends username:password Base64-encoded in HTTP headers?",
+      "ja": "ユーザー名とパスワードを Base64 で送る HTTP 認証方式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bootstrap",
+        "ja": "ブートストラップ",
+        "ja_typings": [
+          "bu-tosutorappu"
+        ]
+      },
+      {
+        "en": "Tailwind CSS",
+        "ja": "テイルウィンドCSS",
+        "ja_typings": [
+          "teiruwindocss"
+        ]
+      },
+      {
+        "en": "Bulma",
+        "ja": "ブルマ",
+        "ja_typings": [
+          "buruma"
+        ]
+      },
+      {
+        "en": "Foundation",
+        "ja": "ファウンデーション",
+        "ja_typings": [
+          "faunde-shon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02756",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS framework popularized grid systems and component classes from Twitter?",
+      "ja": "Twitter 発のグリッドとコンポーネントクラスを広めた CSS フレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Built on UDP",
+        "ja": "UDP上に構築",
+        "ja_typings": [
+          "udpjounikoutiku"
+        ]
+      },
+      {
+        "en": "Built on TCP",
+        "ja": "TCP上に構築",
+        "ja_typings": [
+          "tcpjounikoutiku"
+        ]
+      },
+      {
+        "en": "Text-based protocol",
+        "ja": "テキストベースプロトコル",
+        "ja_typings": [
+          "tekisutobe-supurotokoru"
+        ]
+      },
+      {
+        "en": "Mandatory encryption only",
+        "ja": "暗号化必須",
+        "ja_typings": [
+          "angoukahissu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02757",
+    "image_path": null,
+    "question_text": {
+      "en": "Which phrase describes the QUIC protocol's transport choice?",
+      "ja": "QUIC プロトコルのトランスポート選択を表す表現は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bundlers",
+        "ja": "バンドラー",
+        "ja_typings": [
+          "bandora-"
+        ]
+      },
+      {
+        "en": "Linters",
+        "ja": "リンター",
+        "ja_typings": [
+          "rinta-"
+        ]
+      },
+      {
+        "en": "Transpilers",
+        "ja": "トランスパイラ",
+        "ja_typings": [
+          "toransupaira"
+        ]
+      },
+      {
+        "en": "Polyfills",
+        "ja": "ポリフィル",
+        "ja_typings": [
+          "porifiru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02758",
+    "image_path": null,
+    "question_text": {
+      "en": "What collective name covers tools like webpack, Rollup, and Vite?",
+      "ja": "webpack や Rollup、Vite などをまとめて指す呼称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CSP",
+        "ja": "シーエスピー",
+        "ja_typings": [
+          "shi-esupi-"
+        ]
+      },
+      {
+        "en": "CORS",
+        "ja": "コルス",
+        "ja_typings": [
+          "korusu"
+        ]
+      },
+      {
+        "en": "HSTS",
+        "ja": "エイチエスティーエス",
+        "ja_typings": [
+          "eichiesuti-esu"
+        ]
+      },
+      {
+        "en": "SRI",
+        "ja": "エスアールアイ",
+        "ja_typings": [
+          "esua-ruai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02759",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP header lets a server declare allowed script sources?",
+      "ja": "許可するスクリプト配信元をサーバーが宣言するための HTTP ヘッダの略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CSR",
+        "ja": "シーエスアール",
+        "ja_typings": [
+          "shi-esua-ru"
+        ]
+      },
+      {
+        "en": "SSR",
+        "ja": "エスエスアール",
+        "ja_typings": [
+          "esuesua-ru"
+        ]
+      },
+      {
+        "en": "SSG",
+        "ja": "エスエスジー",
+        "ja_typings": [
+          "esuesuji-"
+        ]
+      },
+      {
+        "en": "ISR",
+        "ja": "アイエスアール",
+        "ja_typings": [
+          "aiesua-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02760",
+    "image_path": null,
+    "question_text": {
+      "en": "Which rendering strategy generates HTML on the server per request?",
+      "ja": "リクエストごとにサーバーで HTML を生成する描画方式の略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CSRF",
+        "ja": "シーエスアールエフ",
+        "ja_typings": [
+          "shi-esua-ruefu"
+        ]
+      },
+      {
+        "en": "XSS",
+        "ja": "クロスサイトスクリプティング",
+        "ja_typings": [
+          "kurosusaitosukuriputingu"
+        ]
+      },
+      {
+        "en": "SSRF",
+        "ja": "エスエスアールエフ",
+        "ja_typings": [
+          "esuesua-ruefu"
+        ]
+      },
+      {
+        "en": "Clickjacking",
+        "ja": "クリックジャッキング",
+        "ja_typings": [
+          "kurikkujakkingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02761",
+    "image_path": null,
+    "question_text": {
+      "en": "Which attack tricks a logged-in user into submitting unwanted requests?",
+      "ja": "ログイン中のユーザーに意図しないリクエストを送らせる攻撃の略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CSS frameworks",
+        "ja": "CSSフレームワーク",
+        "ja_typings": [
+          "cssfure-muwa-ku"
+        ]
+      },
+      {
+        "en": "JS frameworks",
+        "ja": "JSフレームワーク",
+        "ja_typings": [
+          "jsfure-muwa-ku"
+        ]
+      },
+      {
+        "en": "Template engines",
+        "ja": "テンプレートエンジン",
+        "ja_typings": [
+          "tenpure-toenjin"
+        ]
+      },
+      {
+        "en": "Static site generators",
+        "ja": "静的サイトジェネレータ",
+        "ja_typings": [
+          "seitekisaitojenereeta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02762",
+    "image_path": null,
+    "question_text": {
+      "en": "What collective name describes libraries like Bootstrap and Tailwind?",
+      "ja": "Bootstrap や Tailwind のようなライブラリ群の総称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cache Storage",
+        "ja": "キャッシュストレージ",
+        "ja_typings": [
+          "kyasshusutore-ji"
+        ]
+      },
+      {
+        "en": "IndexedDB",
+        "ja": "インデックスドDB",
+        "ja_typings": [
+          "indekkusudodb"
+        ]
+      },
+      {
+        "en": "Local Storage",
+        "ja": "ローカルストレージ",
+        "ja_typings": [
+          "ro-karusutore-ji"
+        ]
+      },
+      {
+        "en": "Session Storage",
+        "ja": "セッションストレージ",
+        "ja_typings": [
+          "sesshonsutore-ji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02763",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Service Worker API caches HTTP request/response pairs?",
+      "ja": "Service Worker でリクエストとレスポンスのペアをキャッシュする API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Callback",
+        "ja": "コールバック",
+        "ja_typings": [
+          "ko-rubakku"
+        ]
+      },
+      {
+        "en": "Promise",
+        "ja": "プロミス",
+        "ja_typings": [
+          "puromisu"
+        ]
+      },
+      {
+        "en": "Generator",
+        "ja": "ジェネレータ",
+        "ja_typings": [
+          "jenere-ta"
+        ]
+      },
+      {
+        "en": "Iterator",
+        "ja": "イテレータ",
+        "ja_typings": [
+          "itere-ta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02764",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript pattern passes a function to be executed later?",
+      "ja": "後で実行される関数を引数として渡す JS のパターンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cookie",
+        "ja": "クッキー",
+        "ja_typings": [
+          "kukki-"
+        ]
+      },
+      {
+        "en": "Session",
+        "ja": "セッション",
+        "ja_typings": [
+          "sesshon"
+        ]
+      },
+      {
+        "en": "Token",
+        "ja": "トークン",
+        "ja_typings": [
+          "to-kun"
+        ]
+      },
+      {
+        "en": "Header",
+        "ja": "ヘッダ",
+        "ja_typings": [
+          "hedda"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02765",
+    "image_path": null,
+    "question_text": {
+      "en": "Which small piece of data does a server store in the user's browser?",
+      "ja": "サーバーがユーザーのブラウザに保存する小さなデータは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DDoS",
+        "ja": "ディードス",
+        "ja_typings": [
+          "di-dosu"
+        ]
+      },
+      {
+        "en": "XSS",
+        "ja": "クロスサイトスクリプティング",
+        "ja_typings": [
+          "kurosusaitosukuriputingu"
+        ]
+      },
+      {
+        "en": "CSRF",
+        "ja": "シーエスアールエフ",
+        "ja_typings": [
+          "shi-esua-ruefu"
+        ]
+      },
+      {
+        "en": "SQLi",
+        "ja": "エスキューエルアイ",
+        "ja_typings": [
+          "esukyu-eruai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02766",
+    "image_path": null,
+    "question_text": {
+      "en": "Which attack floods a service with traffic from many sources?",
+      "ja": "多数のソースから大量のトラフィックでサービスを麻痺させる攻撃の略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DNS Lookup",
+        "ja": "DNSルックアップ",
+        "ja_typings": [
+          "dnsrukkuappu"
+        ]
+      },
+      {
+        "en": "TCP Handshake",
+        "ja": "TCPハンドシェイク",
+        "ja_typings": [
+          "tcphandosheiku"
+        ]
+      },
+      {
+        "en": "TLS Handshake",
+        "ja": "TLSハンドシェイク",
+        "ja_typings": [
+          "tlshandosheiku"
+        ]
+      },
+      {
+        "en": "HTTP Request",
+        "ja": "HTTPリクエスト",
+        "ja_typings": [
+          "httprikuesuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02767",
+    "image_path": null,
+    "question_text": {
+      "en": "Which step resolves a domain name into an IP address?",
+      "ja": "ドメイン名を IP アドレスに解決する手順は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Data Object Model",
+        "ja": "データオブジェクトモデル",
+        "ja_typings": [
+          "de-taobujekutomoderu"
+        ]
+      },
+      {
+        "en": "Document Object Model",
+        "ja": "ドキュメントオブジェクトモデル",
+        "ja_typings": [
+          "dokyumentobujekutomoderu",
+          "dokyumentoobujekutomoderu"
+        ]
+      },
+      {
+        "en": "Display Object Model",
+        "ja": "ディスプレイオブジェクトモデル",
+        "ja_typings": [
+          "disupureiobujekutomoderu"
+        ]
+      },
+      {
+        "en": "Dynamic Object Module",
+        "ja": "ダイナミックオブジェクトモジュール",
+        "ja_typings": [
+          "dainamikkuobujekutomoju-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02768",
+    "image_path": null,
+    "question_text": {
+      "en": "Which option is a decoy expansion sometimes confused with DOM?",
+      "ja": "DOM と紛らわしいダミーの展開語はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Digest authentication",
+        "ja": "ダイジェスト認証",
+        "ja_typings": [
+          "daijesutoninshou"
+        ]
+      },
+      {
+        "en": "Basic authentication",
+        "ja": "ベーシック認証",
+        "ja_typings": [
+          "beeshikkuninshou"
+        ]
+      },
+      {
+        "en": "Bearer authentication",
+        "ja": "ベアラー認証",
+        "ja_typings": [
+          "bearaaninshou"
+        ]
+      },
+      {
+        "en": "Form authentication",
+        "ja": "フォーム認証",
+        "ja_typings": [
+          "foomuninshou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02769",
+    "image_path": null,
+    "question_text": {
+      "en": "Which authentication scheme hashes credentials with a server nonce?",
+      "ja": "サーバーのノンスで資格情報をハッシュ化する認証方式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Display Object Model",
+        "ja": "ディスプレイオブジェクトモデル",
+        "ja_typings": [
+          "disupureiobujekutomoderu"
+        ]
+      },
+      {
+        "en": "Document Object Model",
+        "ja": "ドキュメントオブジェクトモデル",
+        "ja_typings": [
+          "dokyumentobujekutomoderu",
+          "dokyumentoobujekutomoderu"
+        ]
+      },
+      {
+        "en": "Data Object Model",
+        "ja": "データオブジェクトモデル",
+        "ja_typings": [
+          "de-taobujekutomoderu"
+        ]
+      },
+      {
+        "en": "Dynamic Object Module",
+        "ja": "ダイナミックオブジェクトモジュール",
+        "ja_typings": [
+          "dainamikkuobujekutomoju-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02770",
+    "image_path": null,
+    "question_text": {
+      "en": "Which DOM expansion is also a decoy display-oriented term?",
+      "ja": "DOM に似せたディスプレイ系の誤答候補はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dynamic Object Module",
+        "ja": "ダイナミックオブジェクトモジュール",
+        "ja_typings": [
+          "dainamikkuobujekutomoju-ru"
+        ]
+      },
+      {
+        "en": "Data Object Model",
+        "ja": "データオブジェクトモデル",
+        "ja_typings": [
+          "de-taobujekutomoderu"
+        ]
+      },
+      {
+        "en": "Display Object Model",
+        "ja": "ディスプレイオブジェクトモデル",
+        "ja_typings": [
+          "disupureiobujekutomoderu"
+        ]
+      },
+      {
+        "en": "Document Object Model",
+        "ja": "ドキュメントオブジェクトモデル",
+        "ja_typings": [
+          "dokyumentobujekutomoderu",
+          "dokyumentoobujekutomoderu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02771",
+    "image_path": null,
+    "question_text": {
+      "en": "Which DOM-like decoy uses the word 'Module' instead of 'Model'?",
+      "ja": "Model ではなく Module を使った DOM 風の誤答候補は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Elements",
+        "ja": "エレメンツ",
+        "ja_typings": [
+          "erementsu"
+        ]
+      },
+      {
+        "en": "Sources",
+        "ja": "ソース",
+        "ja_typings": [
+          "so-su"
+        ]
+      },
+      {
+        "en": "Network",
+        "ja": "ネットワーク",
+        "ja_typings": [
+          "nettowa-ku"
+        ]
+      },
+      {
+        "en": "Console",
+        "ja": "コンソール",
+        "ja_typings": [
+          "konso-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02772",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Chrome DevTools tab shows the live DOM tree of a page?",
+      "ja": "Chrome DevTools でページの DOM ツリーを表示するタブは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ember",
+        "ja": "エンバー",
+        "ja_typings": [
+          "enba-"
+        ]
+      },
+      {
+        "en": "Backbone",
+        "ja": "バックボーン",
+        "ja_typings": [
+          "bakkubo-n"
+        ]
+      },
+      {
+        "en": "Knockout",
+        "ja": "ノックアウト",
+        "ja_typings": [
+          "nokkuauto"
+        ]
+      },
+      {
+        "en": "Meteor",
+        "ja": "メテオ",
+        "ja_typings": [
+          "meteo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02773",
+    "image_path": null,
+    "question_text": {
+      "en": "Which early MVC framework was built on top of Handlebars?",
+      "ja": "Handlebars を採用した初期の MVC 系 JS フレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Forbidden access",
+        "ja": "アクセス禁止",
+        "ja_typings": [
+          "akusesukinshi"
+        ]
+      },
+      {
+        "en": "Authentication required",
+        "ja": "認証が必要",
+        "ja_typings": [
+          "ninshougahitsuyou"
+        ]
+      },
+      {
+        "en": "Resource not found",
+        "ja": "リソースが見つからない",
+        "ja_typings": [
+          "risoosugamitsukaranai"
+        ]
+      },
+      {
+        "en": "Internal server error",
+        "ja": "内部サーバエラー",
+        "ja_typings": [
+          "naibusaabaeraa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02774",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status message says the server refuses to authorize the request?",
+      "ja": "サーバーが認可を拒否することを示す HTTP メッセージは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fragment",
+        "ja": "フラグメント",
+        "ja_typings": [
+          "furagumento"
+        ]
+      },
+      {
+        "en": "Query",
+        "ja": "クエリ",
+        "ja_typings": [
+          "kueri"
+        ]
+      },
+      {
+        "en": "Path",
+        "ja": "パス",
+        "ja_typings": [
+          "pasu"
+        ]
+      },
+      {
+        "en": "Host",
+        "ja": "ホスト",
+        "ja_typings": [
+          "hosuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02775",
+    "image_path": null,
+    "question_text": {
+      "en": "Which URL part follows a `#` and is not sent to the server?",
+      "ja": "URL の `#` 以降にあたり、サーバーに送られない部分は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "GET",
+        "ja": "ゲット",
+        "ja_typings": [
+          "getto"
+        ]
+      },
+      {
+        "en": "POST",
+        "ja": "ポスト",
+        "ja_typings": [
+          "posuto"
+        ]
+      },
+      {
+        "en": "PUT",
+        "ja": "プット",
+        "ja_typings": [
+          "putto"
+        ]
+      },
+      {
+        "en": "DELETE",
+        "ja": "デリート",
+        "ja_typings": [
+          "deri-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02776",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP method retrieves a resource without modifying it?",
+      "ja": "リソースを変更せず取得する HTTP メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HTML",
+        "ja": "エイチティーエムエル",
+        "ja_typings": [
+          "eichiti-emueru"
+        ]
+      },
+      {
+        "en": "CSS",
+        "ja": "シーエスエス",
+        "ja_typings": [
+          "shi-esuesu"
+        ]
+      },
+      {
+        "en": "XML",
+        "ja": "エックスエムエル",
+        "ja_typings": [
+          "ekkusuemueru"
+        ]
+      },
+      {
+        "en": "SVG",
+        "ja": "エスブイジー",
+        "ja_typings": [
+          "esubuiji-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02777",
+    "image_path": null,
+    "question_text": {
+      "en": "Which markup language describes the structure of a web page?",
+      "ja": "Web ページの構造を記述するマークアップ言語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HTTP/1.1",
+        "ja": "HTTP1.1",
+        "ja_typings": [
+          "http1.1"
+        ]
+      },
+      {
+        "en": "HTTP/1.0",
+        "ja": "HTTP1.0",
+        "ja_typings": [
+          "http1.0"
+        ]
+      },
+      {
+        "en": "HTTP/2",
+        "ja": "HTTP2",
+        "ja_typings": [
+          "http2"
+        ]
+      },
+      {
+        "en": "HTTP/3",
+        "ja": "HTTP3",
+        "ja_typings": [
+          "http3"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02778",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP version introduced persistent connections by default?",
+      "ja": "持続的接続を既定で導入した HTTP のバージョンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "IndexedDB",
+        "ja": "インデックスドDB",
+        "ja_typings": [
+          "indekkusudodb"
+        ]
+      },
+      {
+        "en": "Local Storage",
+        "ja": "ローカルストレージ",
+        "ja_typings": [
+          "ro-karusutore-ji"
+        ]
+      },
+      {
+        "en": "Cache Storage",
+        "ja": "キャッシュストレージ",
+        "ja_typings": [
+          "kyasshusutore-ji"
+        ]
+      },
+      {
+        "en": "Cookie",
+        "ja": "クッキー",
+        "ja_typings": [
+          "kukki-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02779",
+    "image_path": null,
+    "question_text": {
+      "en": "Which browser API stores large structured data with key-based access?",
+      "ja": "キーで大きな構造化データを保存するブラウザ API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Internal server error",
+        "ja": "内部サーバエラー",
+        "ja_typings": [
+          "naibusaabaeraa"
+        ]
+      },
+      {
+        "en": "Forbidden access",
+        "ja": "アクセス禁止",
+        "ja_typings": [
+          "akusesukinshi"
+        ]
+      },
+      {
+        "en": "Authentication required",
+        "ja": "認証が必要",
+        "ja_typings": [
+          "ninshougahitsuyou"
+        ]
+      },
+      {
+        "en": "Resource not found",
+        "ja": "リソースが見つからない",
+        "ja_typings": [
+          "risoosugamitsukaranai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02780",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status message indicates an unexpected server-side failure?",
+      "ja": "サーバー側で予期しない失敗が起きたことを示す HTTP メッセージは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JSON",
+        "ja": "ジェイソン",
+        "ja_typings": [
+          "jeison"
+        ]
+      },
+      {
+        "en": "XML",
+        "ja": "エックスエムエル",
+        "ja_typings": [
+          "ekkusuemueru"
+        ]
+      },
+      {
+        "en": "YAML",
+        "ja": "ヤムル",
+        "ja_typings": [
+          "yamuru"
+        ]
+      },
+      {
+        "en": "CSV",
+        "ja": "シーエスブイ",
+        "ja_typings": [
+          "shi-esubui"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02781",
+    "image_path": null,
+    "question_text": {
+      "en": "Which lightweight text format is widely used for web APIs?",
+      "ja": "Web API で広く使われる軽量テキスト形式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "JavaScript runtimes",
+        "ja": "JavaScriptランタイム",
+        "ja_typings": [
+          "javascriptrantaimu"
+        ]
+      },
+      {
+        "en": "Web browsers",
+        "ja": "Webブラウザ",
+        "ja_typings": [
+          "webburauza"
+        ]
+      },
+      {
+        "en": "Package managers",
+        "ja": "パッケージマネージャ",
+        "ja_typings": [
+          "pakke-jimane-ja"
+        ]
+      },
+      {
+        "en": "Bundlers",
+        "ja": "バンドラー",
+        "ja_typings": [
+          "bandora-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02782",
+    "image_path": null,
+    "question_text": {
+      "en": "What collective term covers Node.js, Deno, and Bun?",
+      "ja": "Node.js や Deno、Bun の総称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kerberos",
+        "ja": "ケルベロス",
+        "ja_typings": [
+          "keruberosu"
+        ]
+      },
+      {
+        "en": "LDAP",
+        "ja": "エルダップ",
+        "ja_typings": [
+          "erudappu"
+        ]
+      },
+      {
+        "en": "OAuth",
+        "ja": "オーオース",
+        "ja_typings": [
+          "o-o-su"
+        ]
+      },
+      {
+        "en": "SAML",
+        "ja": "サムル",
+        "ja_typings": [
+          "samuru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02783",
+    "image_path": null,
+    "question_text": {
+      "en": "Which network authentication protocol uses tickets and a KDC?",
+      "ja": "チケットと KDC を使うネットワーク認証プロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "LCP",
+        "ja": "エルシーピー",
+        "ja_typings": [
+          "erushi-pi-"
+        ]
+      },
+      {
+        "en": "FID",
+        "ja": "エフアイディー",
+        "ja_typings": [
+          "efuaidi-"
+        ]
+      },
+      {
+        "en": "CLS",
+        "ja": "シーエルエス",
+        "ja_typings": [
+          "shi-eruesu"
+        ]
+      },
+      {
+        "en": "TTFB",
+        "ja": "ティーティーエフビー",
+        "ja_typings": [
+          "ti-ti-efubi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02784",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Core Web Vitals metric measures the largest visible content paint time?",
+      "ja": "最大の可視コンテンツ描画時間を測る Core Web Vitals 指標の略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "LDAP",
+        "ja": "エルダップ",
+        "ja_typings": [
+          "erudappu"
+        ]
+      },
+      {
+        "en": "Kerberos",
+        "ja": "ケルベロス",
+        "ja_typings": [
+          "keruberosu"
+        ]
+      },
+      {
+        "en": "OAuth",
+        "ja": "オーオース",
+        "ja_typings": [
+          "o-o-su"
+        ]
+      },
+      {
+        "en": "SAML",
+        "ja": "サムル",
+        "ja_typings": [
+          "samuru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02785",
+    "image_path": null,
+    "question_text": {
+      "en": "Which directory access protocol underpins many enterprise auth systems?",
+      "ja": "多くの企業認証の基盤になるディレクトリアクセスプロトコルの略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Long Polling",
+        "ja": "ロングポーリング",
+        "ja_typings": [
+          "rongupo-ringu"
+        ]
+      },
+      {
+        "en": "Short Polling",
+        "ja": "ショートポーリング",
+        "ja_typings": [
+          "sho-topo-ringu"
+        ]
+      },
+      {
+        "en": "Server-Sent Events",
+        "ja": "サーバー送信イベント",
+        "ja_typings": [
+          "saabaasoushinibento"
+        ]
+      },
+      {
+        "en": "WebSocket",
+        "ja": "ウェブソケット",
+        "ja_typings": [
+          "webusoketto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02786",
+    "image_path": null,
+    "question_text": {
+      "en": "Which technique keeps an HTTP request open until the server has data?",
+      "ja": "サーバーにデータが届くまで HTTP リクエストを開いたままにする手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MIME",
+        "ja": "マイム",
+        "ja_typings": [
+          "maimu"
+        ]
+      },
+      {
+        "en": "URI",
+        "ja": "ユーアールアイ",
+        "ja_typings": [
+          "yu-a-ruai"
+        ]
+      },
+      {
+        "en": "URL",
+        "ja": "ユーアールエル",
+        "ja_typings": [
+          "yu-a-rueru"
+        ]
+      },
+      {
+        "en": "URN",
+        "ja": "ユーアールエヌ",
+        "ja_typings": [
+          "yu-a-ruenu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02787",
+    "image_path": null,
+    "question_text": {
+      "en": "Which standard labels content types like text/html and image/png?",
+      "ja": "text/html や image/png のようにコンテンツ種別を表す標準は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mandatory encryption only",
+        "ja": "暗号化必須",
+        "ja_typings": [
+          "angoukahissu"
+        ]
+      },
+      {
+        "en": "Optional encryption",
+        "ja": "暗号化任意",
+        "ja_typings": [
+          "angoukanin'i"
+        ]
+      },
+      {
+        "en": "Built on UDP",
+        "ja": "UDP上に構築",
+        "ja_typings": [
+          "udpjounikoutiku"
+        ]
+      },
+      {
+        "en": "Text-based protocol",
+        "ja": "テキストベースプロトコル",
+        "ja_typings": [
+          "tekisutobe-supurotokoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02788",
+    "image_path": null,
+    "question_text": {
+      "en": "Which phrase describes HTTPS being required with no plaintext fallback?",
+      "ja": "平文へのフォールバックなしに HTTPS を必須とする方針を表す表現は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mutation",
+        "ja": "ミューテーション",
+        "ja_typings": [
+          "myu-te-shon"
+        ]
+      },
+      {
+        "en": "Query",
+        "ja": "クエリ",
+        "ja_typings": [
+          "kueri"
+        ]
+      },
+      {
+        "en": "Subscription",
+        "ja": "サブスクリプション",
+        "ja_typings": [
+          "sabusukuripushon"
+        ]
+      },
+      {
+        "en": "Fragment",
+        "ja": "フラグメント",
+        "ja_typings": [
+          "furagumento"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02789",
+    "image_path": null,
+    "question_text": {
+      "en": "In GraphQL, which root operation type changes server-side data?",
+      "ja": "GraphQL でサーバーのデータを変更するルート操作タイプは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Network",
+        "ja": "ネットワーク",
+        "ja_typings": [
+          "nettowa-ku"
+        ]
+      },
+      {
+        "en": "Sources",
+        "ja": "ソース",
+        "ja_typings": [
+          "so-su"
+        ]
+      },
+      {
+        "en": "Elements",
+        "ja": "エレメンツ",
+        "ja_typings": [
+          "erementsu"
+        ]
+      },
+      {
+        "en": "Performance",
+        "ja": "パフォーマンス",
+        "ja_typings": [
+          "pafo-mansu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02790",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Chrome DevTools tab shows HTTP requests made by the page?",
+      "ja": "ページが行った HTTP リクエストを表示する DevTools のタブは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Next",
+        "ja": "ネクスト",
+        "ja_typings": [
+          "nekusuto"
+        ]
+      },
+      {
+        "en": "Nuxt",
+        "ja": "ナクスト",
+        "ja_typings": [
+          "nakusuto"
+        ]
+      },
+      {
+        "en": "Remix",
+        "ja": "リミックス",
+        "ja_typings": [
+          "rimikkusu"
+        ]
+      },
+      {
+        "en": "Astro",
+        "ja": "アストロ",
+        "ja_typings": [
+          "asutoro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02791",
+    "image_path": null,
+    "question_text": {
+      "en": "Which one-syllable word names the React-based meta-framework by Vercel?",
+      "ja": "Vercel が作る React ベースのメタフレームワークの省略形は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Next.js",
+        "ja": "ネクストJS",
+        "ja_typings": [
+          "nekusutojs"
+        ]
+      },
+      {
+        "en": "Nuxt.js",
+        "ja": "ナクストJS",
+        "ja_typings": [
+          "nakusutojs"
+        ]
+      },
+      {
+        "en": "Node.js",
+        "ja": "ノードJS",
+        "ja_typings": [
+          "no-dojs"
+        ]
+      },
+      {
+        "en": "Nest.js",
+        "ja": "ネストJS",
+        "ja_typings": [
+          "nesutojs"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02792",
+    "image_path": null,
+    "question_text": {
+      "en": "Which framework's full name pairs Next with the `.js` suffix?",
+      "ja": "Next にファイル拡張子 `.js` を付けた正式名のフレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PATCH",
+        "ja": "パッチ",
+        "ja_typings": [
+          "patchi"
+        ]
+      },
+      {
+        "en": "PUT",
+        "ja": "プット",
+        "ja_typings": [
+          "putto"
+        ]
+      },
+      {
+        "en": "POST",
+        "ja": "ポスト",
+        "ja_typings": [
+          "posuto"
+        ]
+      },
+      {
+        "en": "DELETE",
+        "ja": "デリート",
+        "ja_typings": [
+          "deri-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02793",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP method applies a partial update to a resource?",
+      "ja": "リソースに部分的な更新を適用する HTTP メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PUT",
+        "ja": "プット",
+        "ja_typings": [
+          "putto"
+        ]
+      },
+      {
+        "en": "PATCH",
+        "ja": "パッチ",
+        "ja_typings": [
+          "patchi"
+        ]
+      },
+      {
+        "en": "POST",
+        "ja": "ポスト",
+        "ja_typings": [
+          "posuto"
+        ]
+      },
+      {
+        "en": "GET",
+        "ja": "ゲット",
+        "ja_typings": [
+          "getto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02794",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP method replaces a resource at a given URL?",
+      "ja": "指定 URL のリソースを丸ごと置き換える HTTP メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PWA",
+        "ja": "ピーダブリューエー",
+        "ja_typings": [
+          "pi-daburyu-e-"
+        ]
+      },
+      {
+        "en": "SPA",
+        "ja": "エスピーエー",
+        "ja_typings": [
+          "esupi-e-"
+        ]
+      },
+      {
+        "en": "SSG",
+        "ja": "エスエスジー",
+        "ja_typings": [
+          "esuesuji-"
+        ]
+      },
+      {
+        "en": "CSR",
+        "ja": "シーエスアール",
+        "ja_typings": [
+          "shi-esua-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02795",
+    "image_path": null,
+    "question_text": {
+      "en": "Which acronym describes installable, offline-capable web apps?",
+      "ja": "インストール可能でオフライン対応の Web アプリの略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Query",
+        "ja": "クエリ",
+        "ja_typings": [
+          "kueri"
+        ]
+      },
+      {
+        "en": "Mutation",
+        "ja": "ミューテーション",
+        "ja_typings": [
+          "myu-te-shon"
+        ]
+      },
+      {
+        "en": "Subscription",
+        "ja": "サブスクリプション",
+        "ja_typings": [
+          "sabusukuripushon"
+        ]
+      },
+      {
+        "en": "Fragment",
+        "ja": "フラグメント",
+        "ja_typings": [
+          "furagumento"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02796",
+    "image_path": null,
+    "question_text": {
+      "en": "In GraphQL, which root operation type reads data without changing it?",
+      "ja": "GraphQL でデータを変更せず読み取るルート操作タイプは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "REST",
+        "ja": "レスト",
+        "ja_typings": [
+          "resuto"
+        ]
+      },
+      {
+        "en": "SOAP",
+        "ja": "ソープ",
+        "ja_typings": [
+          "so-pu"
+        ]
+      },
+      {
+        "en": "gRPC",
+        "ja": "ジーアールピーシー",
+        "ja_typings": [
+          "ji-a-rupi-shi-"
+        ]
+      },
+      {
+        "en": "GraphQL",
+        "ja": "グラフQL",
+        "ja_typings": [
+          "gurafuql"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02797",
+    "image_path": null,
+    "question_text": {
+      "en": "Which architectural style uses URIs, verbs, and stateless servers?",
+      "ja": "URI と HTTP 動詞、ステートレスサーバを用いる API アーキテクチャは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "React",
+        "ja": "リアクト",
+        "ja_typings": [
+          "riakuto"
+        ]
+      },
+      {
+        "en": "Vue",
+        "ja": "ビュー",
+        "ja_typings": [
+          "byu-"
+        ]
+      },
+      {
+        "en": "Angular",
+        "ja": "アンギュラー",
+        "ja_typings": [
+          "angyura-"
+        ]
+      },
+      {
+        "en": "Svelte",
+        "ja": "スベルト",
+        "ja_typings": [
+          "suberuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02798",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Meta-developed UI library popularized the virtual DOM?",
+      "ja": "仮想 DOM を広めた Meta 製の UI ライブラリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Request succeeded",
+        "ja": "リクエスト成功",
+        "ja_typings": [
+          "rikuesutoseikou"
+        ]
+      },
+      {
+        "en": "Resource not found",
+        "ja": "リソースが見つからない",
+        "ja_typings": [
+          "risoosugamitsukaranai"
+        ]
+      },
+      {
+        "en": "Forbidden access",
+        "ja": "アクセス禁止",
+        "ja_typings": [
+          "akusesukinshi"
+        ]
+      },
+      {
+        "en": "Internal server error",
+        "ja": "内部サーバエラー",
+        "ja_typings": [
+          "naibusaabaeraa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02799",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status message says the request was processed successfully?",
+      "ja": "リクエストが正常に処理されたことを示す HTTP メッセージは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Resource not found",
+        "ja": "リソースが見つからない",
+        "ja_typings": [
+          "risoosugamitsukaranai"
+        ]
+      },
+      {
+        "en": "Forbidden access",
+        "ja": "アクセス禁止",
+        "ja_typings": [
+          "akusesukinshi"
+        ]
+      },
+      {
+        "en": "Authentication required",
+        "ja": "認証が必要",
+        "ja_typings": [
+          "ninshougahitsuyou"
+        ]
+      },
+      {
+        "en": "Internal server error",
+        "ja": "内部サーバエラー",
+        "ja_typings": [
+          "naibusaabaeraa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02800",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTTP status message indicates the URL has no matching resource?",
+      "ja": "URL に該当するリソースが無いことを示す HTTP メッセージは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SCTP",
+        "ja": "エスシーティーピー",
+        "ja_typings": [
+          "esushi-ti-pi-"
+        ]
+      },
+      {
+        "en": "TCP",
+        "ja": "ティーシーピー",
+        "ja_typings": [
+          "ti-shi-pi-"
+        ]
+      },
+      {
+        "en": "UDP",
+        "ja": "ユーディーピー",
+        "ja_typings": [
+          "yu-di-pi-"
+        ]
+      },
+      {
+        "en": "QUIC",
+        "ja": "クイック",
+        "ja_typings": [
+          "kuikku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02801",
+    "image_path": null,
+    "question_text": {
+      "en": "Which IETF transport protocol provides message-oriented streams?",
+      "ja": "メッセージ指向のストリームを提供する IETF のトランスポートプロトコルの略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SOAP",
+        "ja": "ソープ",
+        "ja_typings": [
+          "so-pu"
+        ]
+      },
+      {
+        "en": "REST",
+        "ja": "レスト",
+        "ja_typings": [
+          "resuto"
+        ]
+      },
+      {
+        "en": "gRPC",
+        "ja": "ジーアールピーシー",
+        "ja_typings": [
+          "ji-a-rupi-shi-"
+        ]
+      },
+      {
+        "en": "GraphQL",
+        "ja": "グラフQL",
+        "ja_typings": [
+          "gurafuql"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02802",
+    "image_path": null,
+    "question_text": {
+      "en": "Which XML-based RPC protocol pre-dates REST in enterprise services?",
+      "ja": "企業向けで REST 以前に広まった XML ベースの RPC プロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SOP",
+        "ja": "エスオーピー",
+        "ja_typings": [
+          "esuo-pi-"
+        ]
+      },
+      {
+        "en": "CORS",
+        "ja": "コルス",
+        "ja_typings": [
+          "korusu"
+        ]
+      },
+      {
+        "en": "CSP",
+        "ja": "シーエスピー",
+        "ja_typings": [
+          "shi-esupi-"
+        ]
+      },
+      {
+        "en": "CSRF",
+        "ja": "シーエスアールエフ",
+        "ja_typings": [
+          "shi-esua-ruefu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02803",
+    "image_path": null,
+    "question_text": {
+      "en": "Which browser policy restricts cross-origin scripting access by default?",
+      "ja": "クロスオリジンのスクリプトアクセスを既定で制限するブラウザの方針の略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SPA",
+        "ja": "エスピーエー",
+        "ja_typings": [
+          "esupi-e-"
+        ]
+      },
+      {
+        "en": "PWA",
+        "ja": "ピーダブリューエー",
+        "ja_typings": [
+          "pi-daburyu-e-"
+        ]
+      },
+      {
+        "en": "MPA",
+        "ja": "エムピーエー",
+        "ja_typings": [
+          "emupi-e-"
+        ]
+      },
+      {
+        "en": "SSR",
+        "ja": "エスエスアール",
+        "ja_typings": [
+          "esuesua-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02804",
+    "image_path": null,
+    "question_text": {
+      "en": "Which acronym describes a client-side app that updates one HTML shell?",
+      "ja": "1 枚の HTML を更新し続けるクライアント側アプリの略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SSG",
+        "ja": "エスエスジー",
+        "ja_typings": [
+          "esuesuji-"
+        ]
+      },
+      {
+        "en": "SSR",
+        "ja": "エスエスアール",
+        "ja_typings": [
+          "esuesua-ru"
+        ]
+      },
+      {
+        "en": "CSR",
+        "ja": "シーエスアール",
+        "ja_typings": [
+          "shi-esua-ru"
+        ]
+      },
+      {
+        "en": "ISR",
+        "ja": "アイエスアール",
+        "ja_typings": [
+          "aiesua-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02805",
+    "image_path": null,
+    "question_text": {
+      "en": "Which rendering strategy builds all pages at build time?",
+      "ja": "ビルド時にすべてのページを生成する描画方式の略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Schema",
+        "ja": "スキーマ",
+        "ja_typings": [
+          "suki-ma"
+        ]
+      },
+      {
+        "en": "Query",
+        "ja": "クエリ",
+        "ja_typings": [
+          "kueri"
+        ]
+      },
+      {
+        "en": "Mutation",
+        "ja": "ミューテーション",
+        "ja_typings": [
+          "myu-te-shon"
+        ]
+      },
+      {
+        "en": "Fragment",
+        "ja": "フラグメント",
+        "ja_typings": [
+          "furagumento"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02806",
+    "image_path": null,
+    "question_text": {
+      "en": "In GraphQL, which document defines the available types and fields?",
+      "ja": "GraphQL で利用可能な型とフィールドを定義する文書は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Session ID",
+        "ja": "セッションID",
+        "ja_typings": [
+          "sesshonid"
+        ]
+      },
+      {
+        "en": "API Key",
+        "ja": "APIキー",
+        "ja_typings": [
+          "apiki-"
+        ]
+      },
+      {
+        "en": "CSRF Token",
+        "ja": "CSRFトークン",
+        "ja_typings": [
+          "csrfto-kun"
+        ]
+      },
+      {
+        "en": "Nonce",
+        "ja": "ノンス",
+        "ja_typings": [
+          "nonsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02807",
+    "image_path": null,
+    "question_text": {
+      "en": "Which identifier ties subsequent HTTP requests to one user session?",
+      "ja": "後続の HTTP リクエストを 1 つのユーザーセッションに紐づける識別子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Session hijacking",
+        "ja": "セッションハイジャック",
+        "ja_typings": [
+          "sesshonhaijakku"
+        ]
+      },
+      {
+        "en": "Session fixation",
+        "ja": "セッション固定化",
+        "ja_typings": [
+          "sesyonkoteika",
+          "sesshonkoteika"
+        ]
+      },
+      {
+        "en": "CSRF",
+        "ja": "シーエスアールエフ",
+        "ja_typings": [
+          "shi-esua-ruefu"
+        ]
+      },
+      {
+        "en": "XSS",
+        "ja": "クロスサイトスクリプティング",
+        "ja_typings": [
+          "kurosusaitosukuriputingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02808",
+    "image_path": null,
+    "question_text": {
+      "en": "Which attack steals or reuses a valid user session token?",
+      "ja": "正規のセッショントークンを盗んだり再利用する攻撃は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shared Worker",
+        "ja": "シェアードワーカー",
+        "ja_typings": [
+          "shea-dowa-ka-"
+        ]
+      },
+      {
+        "en": "Service Worker",
+        "ja": "サービスワーカー",
+        "ja_typings": [
+          "sa-bisuwa-ka-"
+        ]
+      },
+      {
+        "en": "Web Worker",
+        "ja": "ウェブワーカー",
+        "ja_typings": [
+          "webuwa-ka-"
+        ]
+      },
+      {
+        "en": "Dedicated Worker",
+        "ja": "デディケーテッドワーカー",
+        "ja_typings": [
+          "dedike-teddowa-ka-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02809",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Web Worker variant can be reached from multiple browsing contexts?",
+      "ja": "複数のブラウジングコンテキストから利用できる Web Worker は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sources",
+        "ja": "ソース",
+        "ja_typings": [
+          "so-su"
+        ]
+      },
+      {
+        "en": "Elements",
+        "ja": "エレメンツ",
+        "ja_typings": [
+          "erementsu"
+        ]
+      },
+      {
+        "en": "Network",
+        "ja": "ネットワーク",
+        "ja_typings": [
+          "nettowa-ku"
+        ]
+      },
+      {
+        "en": "Performance",
+        "ja": "パフォーマンス",
+        "ja_typings": [
+          "pafo-mansu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02810",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Chrome DevTools tab shows the original JavaScript sources?",
+      "ja": "オリジナルの JavaScript ソースを表示する DevTools のタブは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Svelte",
+        "ja": "スベルト",
+        "ja_typings": [
+          "suberuto"
+        ]
+      },
+      {
+        "en": "React",
+        "ja": "リアクト",
+        "ja_typings": [
+          "riakuto"
+        ]
+      },
+      {
+        "en": "Vue",
+        "ja": "ビュー",
+        "ja_typings": [
+          "byu-"
+        ]
+      },
+      {
+        "en": "Angular",
+        "ja": "アンギュラー",
+        "ja_typings": [
+          "angyura-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02811",
+    "image_path": null,
+    "question_text": {
+      "en": "Which framework compiles components to plain JS at build time?",
+      "ja": "コンポーネントをビルド時に素の JS にコンパイルするフレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "TCP",
+        "ja": "ティーシーピー",
+        "ja_typings": [
+          "ti-shi-pi-"
+        ]
+      },
+      {
+        "en": "UDP",
+        "ja": "ユーディーピー",
+        "ja_typings": [
+          "yu-di-pi-"
+        ]
+      },
+      {
+        "en": "SCTP",
+        "ja": "エスシーティーピー",
+        "ja_typings": [
+          "esushi-ti-pi-"
+        ]
+      },
+      {
+        "en": "QUIC",
+        "ja": "クイック",
+        "ja_typings": [
+          "kuikku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02812",
+    "image_path": null,
+    "question_text": {
+      "en": "Which transport protocol provides reliable, ordered byte streams?",
+      "ja": "信頼性のある順序付きバイトストリームを提供するトランスポートは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "TLS",
+        "ja": "ティーエルエス",
+        "ja_typings": [
+          "ti-eruesu"
+        ]
+      },
+      {
+        "en": "SSL",
+        "ja": "エスエスエル",
+        "ja_typings": [
+          "esuesueru"
+        ]
+      },
+      {
+        "en": "SSH",
+        "ja": "エスエスエイチ",
+        "ja_typings": [
+          "esuesueichi"
+        ]
+      },
+      {
+        "en": "IPsec",
+        "ja": "アイピーセック",
+        "ja_typings": [
+          "aipi-sekku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02813",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol encrypts HTTP between browser and server?",
+      "ja": "ブラウザとサーバ間の HTTP を暗号化するプロトコルの略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "TTFB",
+        "ja": "ティーティーエフビー",
+        "ja_typings": [
+          "ti-ti-efubi-"
+        ]
+      },
+      {
+        "en": "LCP",
+        "ja": "エルシーピー",
+        "ja_typings": [
+          "erushi-pi-"
+        ]
+      },
+      {
+        "en": "FID",
+        "ja": "エフアイディー",
+        "ja_typings": [
+          "efuaidi-"
+        ]
+      },
+      {
+        "en": "CLS",
+        "ja": "シーエルエス",
+        "ja_typings": [
+          "shi-eruesu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02814",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Web Vitals metric measures the time to the first response byte?",
+      "ja": "最初のレスポンスバイトまでの時間を測る Web Vitals 指標の略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tailwind CSS",
+        "ja": "テイルウィンドCSS",
+        "ja_typings": [
+          "teiruwindocss"
+        ]
+      },
+      {
+        "en": "Bootstrap",
+        "ja": "ブートストラップ",
+        "ja_typings": [
+          "bu-tosutorappu"
+        ]
+      },
+      {
+        "en": "Bulma",
+        "ja": "ブルマ",
+        "ja_typings": [
+          "buruma"
+        ]
+      },
+      {
+        "en": "Foundation",
+        "ja": "ファウンデーション",
+        "ja_typings": [
+          "faunde-shon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02815",
+    "image_path": null,
+    "question_text": {
+      "en": "Which utility-first CSS framework uses class names like `flex` and `gap-4`?",
+      "ja": "`flex` や `gap-4` のようなユーティリティクラス中心の CSS フレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Text-based protocol",
+        "ja": "テキストベースプロトコル",
+        "ja_typings": [
+          "tekisutobe-supurotokoru"
+        ]
+      },
+      {
+        "en": "Binary protocol",
+        "ja": "バイナリプロトコル",
+        "ja_typings": [
+          "bainaripurotokoru"
+        ]
+      },
+      {
+        "en": "Built on UDP",
+        "ja": "UDP上に構築",
+        "ja_typings": [
+          "udpjounikoutiku"
+        ]
+      },
+      {
+        "en": "Mandatory encryption only",
+        "ja": "暗号化必須",
+        "ja_typings": [
+          "angoukahissu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02816",
+    "image_path": null,
+    "question_text": {
+      "en": "Which phrase describes HTTP/1.1 as human-readable on the wire?",
+      "ja": "HTTP/1.1 が人間可読な形式で送られることを表す表現は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thread",
+        "ja": "スレッド",
+        "ja_typings": [
+          "sureddo"
+        ]
+      },
+      {
+        "en": "Process",
+        "ja": "プロセス",
+        "ja_typings": [
+          "purosesu"
+        ]
+      },
+      {
+        "en": "Fiber",
+        "ja": "ファイバー",
+        "ja_typings": [
+          "faiba-"
+        ]
+      },
+      {
+        "en": "Coroutine",
+        "ja": "コルーチン",
+        "ja_typings": [
+          "koru-chin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02817",
+    "image_path": null,
+    "question_text": {
+      "en": "Which unit of execution is scheduled by the OS within a process?",
+      "ja": "プロセス内で OS がスケジュールする実行単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vue",
+        "ja": "ビュー",
+        "ja_typings": [
+          "byu-"
+        ]
+      },
+      {
+        "en": "React",
+        "ja": "リアクト",
+        "ja_typings": [
+          "riakuto"
+        ]
+      },
+      {
+        "en": "Angular",
+        "ja": "アンギュラー",
+        "ja_typings": [
+          "angyura-"
+        ]
+      },
+      {
+        "en": "Svelte",
+        "ja": "スベルト",
+        "ja_typings": [
+          "suberuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02818",
+    "image_path": null,
+    "question_text": {
+      "en": "Which progressive JS framework was created by Evan You?",
+      "ja": "Evan You が作った漸進的に採用できる JS フレームワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Web Worker",
+        "ja": "ウェブワーカー",
+        "ja_typings": [
+          "webuwa-ka-"
+        ]
+      },
+      {
+        "en": "Service Worker",
+        "ja": "サービスワーカー",
+        "ja_typings": [
+          "sa-bisuwa-ka-"
+        ]
+      },
+      {
+        "en": "Shared Worker",
+        "ja": "シェアードワーカー",
+        "ja_typings": [
+          "shea-dowa-ka-"
+        ]
+      },
+      {
+        "en": "Worklet",
+        "ja": "ワークレット",
+        "ja_typings": [
+          "wa-kuretto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02819",
+    "image_path": null,
+    "question_text": {
+      "en": "Which worker type lets web pages run scripts off the main thread?",
+      "ja": "メインスレッド外でスクリプトを実行できるワーカーの基本形は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "WebSocket",
+        "ja": "ウェブソケット",
+        "ja_typings": [
+          "webusoketto"
+        ]
+      },
+      {
+        "en": "HTTP",
+        "ja": "エイチティーティーピー",
+        "ja_typings": [
+          "eichiti-ti-pi-"
+        ]
+      },
+      {
+        "en": "gRPC",
+        "ja": "ジーアールピーシー",
+        "ja_typings": [
+          "ji-a-rupi-shi-"
+        ]
+      },
+      {
+        "en": "Long Polling",
+        "ja": "ロングポーリング",
+        "ja_typings": [
+          "rongupo-ringu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02820",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol gives full-duplex communication over a single TCP connection?",
+      "ja": "1 本の TCP 接続で全二重通信を提供するプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "XSS",
+        "ja": "クロスサイトスクリプティング",
+        "ja_typings": [
+          "kurosusaitosukuriputingu"
+        ]
+      },
+      {
+        "en": "CSRF",
+        "ja": "シーエスアールエフ",
+        "ja_typings": [
+          "shi-esua-ruefu"
+        ]
+      },
+      {
+        "en": "SSRF",
+        "ja": "エスエスアールエフ",
+        "ja_typings": [
+          "esuesua-ruefu"
+        ]
+      },
+      {
+        "en": "Clickjacking",
+        "ja": "クリックジャッキング",
+        "ja_typings": [
+          "kurikkujakkingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02821",
+    "image_path": null,
+    "question_text": {
+      "en": "Which attack injects malicious scripts that run in other users' browsers?",
+      "ja": "他ユーザーのブラウザで悪意あるスクリプトを実行させる攻撃の略は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`!=`",
+        "ja": "イコールでない",
+        "ja_typings": [
+          "ikoorudenai",
+          "iko-rudenai"
+        ]
+      },
+      {
+        "en": "`==`",
+        "ja": "イコール2つ",
+        "ja_typings": [
+          "ikooru2tsu"
+        ]
+      },
+      {
+        "en": "`===`",
+        "ja": "イコール3つ",
+        "ja_typings": [
+          "ikooru3tsu"
+        ]
+      },
+      {
+        "en": "`=`",
+        "ja": "イコール1つ",
+        "ja_typings": [
+          "ikooru1tsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02822",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript operator tests for strict inequality?",
+      "ja": "厳密な不等価を判定する JavaScript 演算子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`#`",
+        "ja": "シャープ",
+        "ja_typings": [
+          "sha-pu"
+        ]
+      },
+      {
+        "en": "`?`",
+        "ja": "クエスチョン",
+        "ja_typings": [
+          "kuesuchon"
+        ]
+      },
+      {
+        "en": "`&`",
+        "ja": "アンパサンド",
+        "ja_typings": [
+          "anpasando"
+        ]
+      },
+      {
+        "en": "`@`",
+        "ja": "アットマーク",
+        "ja_typings": [
+          "attoma-ku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02823",
+    "image_path": null,
+    "question_text": {
+      "en": "Which symbol starts a URL fragment identifier?",
+      "ja": "URL のフラグメント識別子の先頭に来る記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`&`",
+        "ja": "アンパサンド",
+        "ja_typings": [
+          "anpasando"
+        ]
+      },
+      {
+        "en": "`?`",
+        "ja": "クエスチョン",
+        "ja_typings": [
+          "kuesuchon"
+        ]
+      },
+      {
+        "en": "`#`",
+        "ja": "シャープ",
+        "ja_typings": [
+          "sha-pu"
+        ]
+      },
+      {
+        "en": "`=`",
+        "ja": "イコール",
+        "ja_typings": [
+          "iko-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02824",
+    "image_path": null,
+    "question_text": {
+      "en": "Which symbol separates query parameters in a URL?",
+      "ja": "URL のクエリパラメータを区切る記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`*`",
+        "ja": "アスタリスク",
+        "ja_typings": [
+          "asutarisuku"
+        ]
+      },
+      {
+        "en": "`.`",
+        "ja": "ドット",
+        "ja_typings": [
+          "dotto"
+        ]
+      },
+      {
+        "en": "`#`",
+        "ja": "シャープ",
+        "ja_typings": [
+          "sha-pu"
+        ]
+      },
+      {
+        "en": "`:`",
+        "ja": "コロン",
+        "ja_typings": [
+          "koron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02825",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS selector matches any element?",
+      "ja": "任意の要素にマッチする CSS セレクタ記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`.`",
+        "ja": "ドット",
+        "ja_typings": [
+          "dotto"
+        ]
+      },
+      {
+        "en": "`#`",
+        "ja": "シャープ",
+        "ja_typings": [
+          "sha-pu"
+        ]
+      },
+      {
+        "en": "`*`",
+        "ja": "アスタリスク",
+        "ja_typings": [
+          "asutarisuku"
+        ]
+      },
+      {
+        "en": "`:`",
+        "ja": "コロン",
+        "ja_typings": [
+          "koron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02826",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS selector prefix matches by class name?",
+      "ja": "クラス名で一致させる CSS セレクタの先頭記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`:`",
+        "ja": "コロン",
+        "ja_typings": [
+          "koron"
+        ]
+      },
+      {
+        "en": "`.`",
+        "ja": "ドット",
+        "ja_typings": [
+          "dotto"
+        ]
+      },
+      {
+        "en": "`#`",
+        "ja": "シャープ",
+        "ja_typings": [
+          "sha-pu"
+        ]
+      },
+      {
+        "en": "`*`",
+        "ja": "アスタリスク",
+        "ja_typings": [
+          "asutarisuku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02827",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS character prefixes a pseudo-class like `:hover`?",
+      "ja": "`:hover` のような擬似クラスの先頭に置かれる CSS の文字は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`<picture>` tag",
+        "ja": "ピクチャタグ",
+        "ja_typings": [
+          "pikuchatagu"
+        ]
+      },
+      {
+        "en": "`<img>` tag",
+        "ja": "イメージタグ",
+        "ja_typings": [
+          "ime-jitagu"
+        ]
+      },
+      {
+        "en": "`<figure>` tag",
+        "ja": "フィギュアタグ",
+        "ja_typings": [
+          "figyuatagu"
+        ]
+      },
+      {
+        "en": "`<svg>` tag",
+        "ja": "エスブイジータグ",
+        "ja_typings": [
+          "esubuiji-tagu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02828",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HTML element serves responsive images via multiple `<source>` children?",
+      "ja": "複数の `<source>` でレスポンシブ画像を提供する HTML 要素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`==`",
+        "ja": "イコール2つ",
+        "ja_typings": [
+          "ikooru2tsu"
+        ]
+      },
+      {
+        "en": "`===`",
+        "ja": "イコール3つ",
+        "ja_typings": [
+          "ikooru3tsu"
+        ]
+      },
+      {
+        "en": "`!=`",
+        "ja": "イコールでない",
+        "ja_typings": [
+          "ikoorudenai",
+          "iko-rudenai"
+        ]
+      },
+      {
+        "en": "`=`",
+        "ja": "イコール1つ",
+        "ja_typings": [
+          "ikooru1tsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02829",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript operator tests for loose equality with type coercion?",
+      "ja": "型変換ありで等価を判定する JavaScript 演算子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`=`",
+        "ja": "イコール1つ",
+        "ja_typings": [
+          "ikooru1tsu"
+        ]
+      },
+      {
+        "en": "`==`",
+        "ja": "イコール2つ",
+        "ja_typings": [
+          "ikooru2tsu"
+        ]
+      },
+      {
+        "en": "`===`",
+        "ja": "イコール3つ",
+        "ja_typings": [
+          "ikooru3tsu"
+        ]
+      },
+      {
+        "en": "`!=`",
+        "ja": "イコールでない",
+        "ja_typings": [
+          "ikoorudenai",
+          "iko-rudenai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02830",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript operator assigns a value to a variable?",
+      "ja": "JavaScript で変数に値を代入する演算子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`@`",
+        "ja": "アットマーク",
+        "ja_typings": [
+          "attoma-ku"
+        ]
+      },
+      {
+        "en": "`#`",
+        "ja": "シャープ",
+        "ja_typings": [
+          "sha-pu"
+        ]
+      },
+      {
+        "en": "`&`",
+        "ja": "アンパサンド",
+        "ja_typings": [
+          "anpasando"
+        ]
+      },
+      {
+        "en": "`.`",
+        "ja": "ドット",
+        "ja_typings": [
+          "dotto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02831",
+    "image_path": null,
+    "question_text": {
+      "en": "Which symbol separates a user name from a host in an email address?",
+      "ja": "メールアドレスでユーザー名とホストを区切る記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`border`",
+        "ja": "ボーダー",
+        "ja_typings": [
+          "bo-da-"
+        ]
+      },
+      {
+        "en": "`outline`",
+        "ja": "アウトライン",
+        "ja_typings": [
+          "autorain"
+        ]
+      },
+      {
+        "en": "`margin`",
+        "ja": "マージン",
+        "ja_typings": [
+          "ma-jin"
+        ]
+      },
+      {
+        "en": "`padding`",
+        "ja": "パディング",
+        "ja_typings": [
+          "padingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02832",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS shorthand property sets all four borders at once?",
+      "ja": "4 辺のボーダーを一括で指定する CSS のショートハンドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`final`",
+        "ja": "ファイナル",
+        "ja_typings": [
+          "fainaru"
+        ]
+      },
+      {
+        "en": "`const`",
+        "ja": "コンスト",
+        "ja_typings": [
+          "konsuto"
+        ]
+      },
+      {
+        "en": "`var`",
+        "ja": "バー",
+        "ja_typings": [
+          "ba-"
+        ]
+      },
+      {
+        "en": "`let`",
+        "ja": "レット",
+        "ja_typings": [
+          "retto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02833",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Java/Dart keyword prevents reassignment of a variable?",
+      "ja": "Java や Dart で再代入を禁じる変数宣言キーワードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`forEach`",
+        "ja": "フォーイーチ",
+        "ja_typings": [
+          "fo-i-chi"
+        ]
+      },
+      {
+        "en": "`map`",
+        "ja": "マップ",
+        "ja_typings": [
+          "mappu"
+        ]
+      },
+      {
+        "en": "`reduce`",
+        "ja": "リデュース",
+        "ja_typings": [
+          "rideyu-su"
+        ]
+      },
+      {
+        "en": "`some`",
+        "ja": "サム",
+        "ja_typings": [
+          "samu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02834",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript array method executes a callback for each element without returning a new array?",
+      "ja": "新しい配列を返さず各要素にコールバックを実行する JS の配列メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`gap`",
+        "ja": "ギャップ",
+        "ja_typings": [
+          "gyappu"
+        ]
+      },
+      {
+        "en": "`margin`",
+        "ja": "マージン",
+        "ja_typings": [
+          "ma-jin"
+        ]
+      },
+      {
+        "en": "`padding`",
+        "ja": "パディング",
+        "ja_typings": [
+          "padingu"
+        ]
+      },
+      {
+        "en": "`spacing`",
+        "ja": "スペーシング",
+        "ja_typings": [
+          "supe-shingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02835",
+    "image_path": null,
+    "question_text": {
+      "en": "Which modern CSS property sets spacing between flex or grid items?",
+      "ja": "Flex/Grid 項目間の間隔を指定する現代的な CSS プロパティは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`inset`",
+        "ja": "インセット",
+        "ja_typings": [
+          "insetto"
+        ]
+      },
+      {
+        "en": "`offset`",
+        "ja": "オフセット",
+        "ja_typings": [
+          "ofusetto"
+        ]
+      },
+      {
+        "en": "`margin`",
+        "ja": "マージン",
+        "ja_typings": [
+          "ma-jin"
+        ]
+      },
+      {
+        "en": "`padding`",
+        "ja": "パディング",
+        "ja_typings": [
+          "padingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02836",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS shorthand sets top/right/bottom/left for positioned elements?",
+      "ja": "配置済み要素の上下左右オフセットを一括指定する CSS プロパティは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`let`",
+        "ja": "レット",
+        "ja_typings": [
+          "retto"
+        ]
+      },
+      {
+        "en": "`const`",
+        "ja": "コンスト",
+        "ja_typings": [
+          "konsuto"
+        ]
+      },
+      {
+        "en": "`var`",
+        "ja": "バー",
+        "ja_typings": [
+          "ba-"
+        ]
+      },
+      {
+        "en": "`final`",
+        "ja": "ファイナル",
+        "ja_typings": [
+          "fainaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02837",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript keyword declares a block-scoped mutable variable?",
+      "ja": "ブロックスコープで可変な変数を宣言する JS キーワードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`map`",
+        "ja": "マップ",
+        "ja_typings": [
+          "mappu"
+        ]
+      },
+      {
+        "en": "`forEach`",
+        "ja": "フォーイーチ",
+        "ja_typings": [
+          "fo-i-chi"
+        ]
+      },
+      {
+        "en": "`filter`",
+        "ja": "フィルター",
+        "ja_typings": [
+          "firuta-"
+        ]
+      },
+      {
+        "en": "`reduce`",
+        "ja": "リデュース",
+        "ja_typings": [
+          "rideyu-su"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02838",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript array method returns a new array with each element transformed?",
+      "ja": "各要素を変換した新しい配列を返す JS の配列メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`margin`",
+        "ja": "マージン",
+        "ja_typings": [
+          "ma-jin"
+        ]
+      },
+      {
+        "en": "`padding`",
+        "ja": "パディング",
+        "ja_typings": [
+          "padingu"
+        ]
+      },
+      {
+        "en": "`border`",
+        "ja": "ボーダー",
+        "ja_typings": [
+          "bo-da-"
+        ]
+      },
+      {
+        "en": "`gap`",
+        "ja": "ギャップ",
+        "ja_typings": [
+          "gyappu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02839",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS shorthand sets the outer space around an element?",
+      "ja": "要素の外側の余白を一括指定する CSS のショートハンドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`padding`",
+        "ja": "パディング",
+        "ja_typings": [
+          "padingu"
+        ]
+      },
+      {
+        "en": "`margin`",
+        "ja": "マージン",
+        "ja_typings": [
+          "ma-jin"
+        ]
+      },
+      {
+        "en": "`border`",
+        "ja": "ボーダー",
+        "ja_typings": [
+          "bo-da-"
+        ]
+      },
+      {
+        "en": "`gap`",
+        "ja": "ギャップ",
+        "ja_typings": [
+          "gyappu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02840",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CSS shorthand sets the inner space inside an element's border?",
+      "ja": "要素の内側の余白を一括指定する CSS のショートハンドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`reduce`",
+        "ja": "リデュース",
+        "ja_typings": [
+          "rideyu-su"
+        ]
+      },
+      {
+        "en": "`map`",
+        "ja": "マップ",
+        "ja_typings": [
+          "mappu"
+        ]
+      },
+      {
+        "en": "`forEach`",
+        "ja": "フォーイーチ",
+        "ja_typings": [
+          "fo-i-chi"
+        ]
+      },
+      {
+        "en": "`filter`",
+        "ja": "フィルター",
+        "ja_typings": [
+          "firuta-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02841",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript array method reduces values to a single accumulated result?",
+      "ja": "配列の値を 1 つの累積値にまとめる JS の配列メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`some`",
+        "ja": "サム",
+        "ja_typings": [
+          "samu"
+        ]
+      },
+      {
+        "en": "`every`",
+        "ja": "エブリ",
+        "ja_typings": [
+          "eburi"
+        ]
+      },
+      {
+        "en": "`map`",
+        "ja": "マップ",
+        "ja_typings": [
+          "mappu"
+        ]
+      },
+      {
+        "en": "`reduce`",
+        "ja": "リデュース",
+        "ja_typings": [
+          "rideyu-su"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02842",
+    "image_path": null,
+    "question_text": {
+      "en": "Which JavaScript array method checks whether at least one element passes a test?",
+      "ja": "少なくとも 1 要素が条件を満たすかを判定する JS の配列メソッドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`spacing`",
+        "ja": "スペーシング",
+        "ja_typings": [
+          "supe-shingu"
+        ]
+      },
+      {
+        "en": "`gap`",
+        "ja": "ギャップ",
+        "ja_typings": [
+          "gyappu"
+        ]
+      },
+      {
+        "en": "`margin`",
+        "ja": "マージン",
+        "ja_typings": [
+          "ma-jin"
+        ]
+      },
+      {
+        "en": "`padding`",
+        "ja": "パディング",
+        "ja_typings": [
+          "padingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02843",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Tailwind-style class word is used for inter-item gap utilities?",
+      "ja": "Tailwind 系で要素間の間隔ユーティリティに使われる語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "`var`",
+        "ja": "バー",
+        "ja_typings": [
+          "ba-"
+        ]
+      },
+      {
+        "en": "`let`",
+        "ja": "レット",
+        "ja_typings": [
+          "retto"
+        ]
+      },
+      {
+        "en": "`const`",
+        "ja": "コンスト",
+        "ja_typings": [
+          "konsuto"
+        ]
+      },
+      {
+        "en": "`final`",
+        "ja": "ファイナル",
+        "ja_typings": [
+          "fainaru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02844",
+    "image_path": null,
+    "question_text": {
+      "en": "Which legacy JavaScript keyword declares a function-scoped variable?",
+      "ja": "関数スコープで変数を宣言する従来からの JS キーワードは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "bun",
+        "ja": "バン",
+        "ja_typings": [
+          "ban"
+        ]
+      },
+      {
+        "en": "yarn",
+        "ja": "ヤーン",
+        "ja_typings": [
+          "ya-n"
+        ]
+      },
+      {
+        "en": "pnpm",
+        "ja": "ピーエヌピーエム",
+        "ja_typings": [
+          "pi-enupi-emu"
+        ]
+      },
+      {
+        "en": "npm",
+        "ja": "エヌピーエム",
+        "ja_typings": [
+          "enupi-emu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02845",
+    "image_path": null,
+    "question_text": {
+      "en": "Which all-in-one JavaScript runtime by Jarred Sumner ships its own bundler?",
+      "ja": "Jarred Sumner が作るバンドラ同梱の JS ランタイムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "gRPC",
+        "ja": "ジーアールピーシー",
+        "ja_typings": [
+          "ji-a-rupi-shi-"
+        ]
+      },
+      {
+        "en": "REST",
+        "ja": "レスト",
+        "ja_typings": [
+          "resuto"
+        ]
+      },
+      {
+        "en": "SOAP",
+        "ja": "ソープ",
+        "ja_typings": [
+          "so-pu"
+        ]
+      },
+      {
+        "en": "GraphQL",
+        "ja": "グラフQL",
+        "ja_typings": [
+          "gurafuql"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02846",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Google-made high-performance RPC framework uses HTTP/2 and protobuf?",
+      "ja": "HTTP/2 と Protocol Buffers を使う Google 製の高性能 RPC は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "pnpm",
+        "ja": "ピーエヌピーエム",
+        "ja_typings": [
+          "pi-enupi-emu"
+        ]
+      },
+      {
+        "en": "npm",
+        "ja": "エヌピーエム",
+        "ja_typings": [
+          "enupi-emu"
+        ]
+      },
+      {
+        "en": "yarn",
+        "ja": "ヤーン",
+        "ja_typings": [
+          "ya-n"
+        ]
+      },
+      {
+        "en": "bun",
+        "ja": "バン",
+        "ja_typings": [
+          "ban"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02847",
+    "image_path": null,
+    "question_text": {
+      "en": "Which package manager stores dependencies in a content-addressable store with hard links?",
+      "ja": "コンテンツアドレス指定のストアとハードリンクで依存を管理する Node のパッケージマネージャは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sessionStorage",
+        "ja": "セッションストレージ",
+        "ja_typings": [
+          "sesshonsutore-ji"
+        ]
+      },
+      {
+        "en": "localStorage",
+        "ja": "ローカルストレージ",
+        "ja_typings": [
+          "ro-karusutore-ji"
+        ]
+      },
+      {
+        "en": "Cache Storage",
+        "ja": "キャッシュストレージ",
+        "ja_typings": [
+          "kyasshusutore-ji"
+        ]
+      },
+      {
+        "en": "IndexedDB",
+        "ja": "インデックスドDB",
+        "ja_typings": [
+          "indekkusudodb"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02848",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Web Storage API persists key/value pairs only until the tab closes?",
+      "ja": "タブを閉じるまでキー/値を保持する Web Storage API は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "yarn",
+        "ja": "ヤーン",
+        "ja_typings": [
+          "ya-n"
+        ]
+      },
+      {
+        "en": "npm",
+        "ja": "エヌピーエム",
+        "ja_typings": [
+          "enupi-emu"
+        ]
+      },
+      {
+        "en": "pnpm",
+        "ja": "ピーエヌピーエム",
+        "ja_typings": [
+          "pi-enupi-emu"
+        ]
+      },
+      {
+        "en": "bun",
+        "ja": "バン",
+        "ja_typings": [
+          "ban"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "web_development",
+    "id": "q02849",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Node package manager was originally created by Facebook?",
+      "ja": "Facebook が最初に作った Node のパッケージマネージャは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aki Hayakawa",
+        "ja": "早川アキ",
+        "ja_typings": [
+          "hayakawaaki"
+        ]
+      },
+      {
+        "en": "Denji",
+        "ja": "デンジ",
+        "ja_typings": [
+          "denji"
+        ]
+      },
+      {
+        "en": "Kobeni",
+        "ja": "コベニ",
+        "ja_typings": [
+          "kobeni"
+        ]
+      },
+      {
+        "en": "Himeno",
+        "ja": "ヒメノ",
+        "ja_typings": [
+          "himeno"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02850",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Public Safety Devil Hunter partners with Denji in Chainsaw Man?",
+      "ja": "チェンソーマンでデンジと組む公安のデビルハンターは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Akira Kamiya",
+        "ja": "神谷明",
+        "ja_typings": [
+          "kamiyaakira"
+        ]
+      },
+      {
+        "en": "Toru Furuya",
+        "ja": "古谷徹",
+        "ja_typings": [
+          "furuyatooru"
+        ]
+      },
+      {
+        "en": "Banjo Ginga",
+        "ja": "銀河万丈",
+        "ja_typings": [
+          "gingabanjou"
+        ]
+      },
+      {
+        "en": "Kenji Utsumi",
+        "ja": "内海賢二",
+        "ja_typings": [
+          "utsumikenji",
+          "uchiumikenji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02851",
+    "image_path": null,
+    "question_text": {
+      "en": "Which veteran voice actor is known for Ryo Saeba in City Hunter?",
+      "ja": "シティーハンターの冴羽獠を演じたベテラン声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "All Might",
+        "ja": "オールマイト",
+        "ja_typings": [
+          "o-rumaito"
+        ]
+      },
+      {
+        "en": "Endeavor",
+        "ja": "エンデヴァー",
+        "ja_typings": [
+          "endeva-"
+        ]
+      },
+      {
+        "en": "Hawks",
+        "ja": "ホークス",
+        "ja_typings": [
+          "ho-kusu"
+        ]
+      },
+      {
+        "en": "Best Jeanist",
+        "ja": "ベストジーニスト",
+        "ja_typings": [
+          "besutoji-nisuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02852",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Symbol of Peace is the No.1 hero in My Hero Academia?",
+      "ja": "ヒロアカで「平和の象徴」と呼ばれる No.1 ヒーローは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Alphonse Elric",
+        "ja": "アルフォンス・エルリック",
+        "ja_typings": [
+          "arufonsu/erurikku"
+        ]
+      },
+      {
+        "en": "Edward Elric",
+        "ja": "エドワード・エルリック",
+        "ja_typings": [
+          "edowa-do/erurikku"
+        ]
+      },
+      {
+        "en": "Roy Mustang",
+        "ja": "ロイ・マスタング",
+        "ja_typings": [
+          "roi/masutangu"
+        ]
+      },
+      {
+        "en": "Winry Rockbell",
+        "ja": "ウィンリィ・ロックベル",
+        "ja_typings": [
+          "winrii/rokkuberu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02853",
+    "image_path": null,
+    "question_text": {
+      "en": "Which younger Elric brother has his soul bound to a suit of armor?",
+      "ja": "魂を鎧に定着させた弟のエルリック兄弟は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Anya Forger",
+        "ja": "アーニャ・フォージャー",
+        "ja_typings": [
+          "a-nya/fo-ja-"
+        ]
+      },
+      {
+        "en": "Yor Forger",
+        "ja": "ヨル・フォージャー",
+        "ja_typings": [
+          "yoru/fo-ja-"
+        ]
+      },
+      {
+        "en": "Loid Forger",
+        "ja": "ロイド・フォージャー",
+        "ja_typings": [
+          "roido/fo-ja-"
+        ]
+      },
+      {
+        "en": "Becky Blackbell",
+        "ja": "ベッキー・ブラックベル",
+        "ja_typings": [
+          "bekki-/burakkuberu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02854",
+    "image_path": null,
+    "question_text": {
+      "en": "Which pink-haired telepath is the daughter in the Forger family?",
+      "ja": "フォージャー家のピンク髪の超能力少女は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Armin Arlert",
+        "ja": "アルミン・アルレルト",
+        "ja_typings": [
+          "arumin/arureruto"
+        ]
+      },
+      {
+        "en": "Eren Yeager",
+        "ja": "エレン・イェーガー",
+        "ja_typings": [
+          "eren/ye-ga-"
+        ]
+      },
+      {
+        "en": "Jean Kirstein",
+        "ja": "ジャン・キルシュタイン",
+        "ja_typings": [
+          "jan/kirushutain"
+        ]
+      },
+      {
+        "en": "Connie Springer",
+        "ja": "コニー・スプリンガー",
+        "ja_typings": [
+          "koni-/supuringa-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02855",
+    "image_path": null,
+    "question_text": {
+      "en": "Which short blond strategist of the Survey Corps is Eren's friend?",
+      "ja": "調査兵団でエレンの友人にあたる金髪の戦略家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Asuka Langley Soryu",
+        "ja": "惣流・アスカ・ラングレー",
+        "ja_typings": [
+          "souryuuasukaranguree",
+          "souryuuasukarangure"
+        ]
+      },
+      {
+        "en": "Rei Ayanami",
+        "ja": "綾波レイ",
+        "ja_typings": [
+          "ayanamirei"
+        ]
+      },
+      {
+        "en": "Mari Makinami",
+        "ja": "真希波・マリ",
+        "ja_typings": [
+          "makinamimari"
+        ]
+      },
+      {
+        "en": "Kaworu Nagisa",
+        "ja": "渚カヲル",
+        "ja_typings": [
+          "nagisakaworu",
+          "nagisakaoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02856",
+    "image_path": null,
+    "question_text": {
+      "en": "Which redheaded Eva pilot is designated the Second Child?",
+      "ja": "セカンドチルドレンに指定された赤毛のエヴァパイロットは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Banjo Ginga",
+        "ja": "銀河万丈",
+        "ja_typings": [
+          "gingabanjou"
+        ]
+      },
+      {
+        "en": "Akira Kamiya",
+        "ja": "神谷明",
+        "ja_typings": [
+          "kamiyaakira"
+        ]
+      },
+      {
+        "en": "Kenji Utsumi",
+        "ja": "内海賢二",
+        "ja_typings": [
+          "utsumikenji",
+          "uchiumikenji"
+        ]
+      },
+      {
+        "en": "Toru Furuya",
+        "ja": "古谷徹",
+        "ja_typings": [
+          "furuyatooru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02857",
+    "image_path": null,
+    "question_text": {
+      "en": "Which deep-voiced veteran voice actor is associated with characters like Dorf and General Revil?",
+      "ja": "ドルフやレビル将軍などで知られる重低音のベテラン声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Char Aznable",
+        "ja": "シャア・アズナブル",
+        "ja_typings": [
+          "shaa/azunaburu"
+        ]
+      },
+      {
+        "en": "Amuro Ray",
+        "ja": "アムロ・レイ",
+        "ja_typings": [
+          "amuro/rei"
+        ]
+      },
+      {
+        "en": "Kamille Bidan",
+        "ja": "カミーユ・ビダン",
+        "ja_typings": [
+          "kami-yu/bidan"
+        ]
+      },
+      {
+        "en": "Judau Ashta",
+        "ja": "ジュドー・アーシタ",
+        "ja_typings": [
+          "judo-/a-shita"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02858",
+    "image_path": null,
+    "question_text": {
+      "en": "Which masked blond Zeon ace is also known as 'the Red Comet'?",
+      "ja": "「赤い彗星」と呼ばれる仮面のジオンのエースは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chimera Shadow Garden",
+        "ja": "嵌合暗翳庭",
+        "ja_typings": [
+          "kangouan'eitei"
+        ]
+      },
+      {
+        "en": "Malevolent Shrine",
+        "ja": "伏魔御厨子",
+        "ja_typings": [
+          "fukumamizushi"
+        ]
+      },
+      {
+        "en": "Unlimited Void",
+        "ja": "無量空処",
+        "ja_typings": [
+          "muryoukuusho"
+        ]
+      },
+      {
+        "en": "Time Prison",
+        "ja": "時胞月宮殿",
+        "ja_typings": [
+          "jihougetsukyuuden"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02859",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Domain Expansion belongs to Megumi Fushiguro in Jujutsu Kaisen?",
+      "ja": "呪術廻戦で伏黒恵が使う領域展開の名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Coffin of the Iron Mountain",
+        "ja": "鉄山の柩",
+        "ja_typings": [
+          "tetsuzannohitsugi"
+        ]
+      },
+      {
+        "en": "Malevolent Shrine",
+        "ja": "伏魔御厨子",
+        "ja_typings": [
+          "fukumamizushi"
+        ]
+      },
+      {
+        "en": "Unlimited Void",
+        "ja": "無量空処",
+        "ja_typings": [
+          "muryoukuusho"
+        ]
+      },
+      {
+        "en": "Chimera Shadow Garden",
+        "ja": "嵌合暗翳庭",
+        "ja_typings": [
+          "kangouan'eitei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02860",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hashira's Domain Expansion name belongs to Muzan-adjacent foe Akaza? (decoy set: which name from JJK's signature domains is *not* in JJK?)",
+      "ja": "呪術廻戦の代表的領域展開のうち、上弦ぽいけど実在しない名前はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fujiko F. Fujio",
+        "ja": "藤子・F・不二雄",
+        "ja_typings": [
+          "hujikofhujio"
+        ]
+      },
+      {
+        "en": "Osamu Tezuka",
+        "ja": "手塚治虫",
+        "ja_typings": [
+          "tezukaosamu"
+        ]
+      },
+      {
+        "en": "Shotaro Ishinomori",
+        "ja": "石ノ森章太郎",
+        "ja_typings": [
+          "ishinomorishoutarou"
+        ]
+      },
+      {
+        "en": "Hideaki Anno",
+        "ja": "庵野秀明",
+        "ja_typings": [
+          "annohideaki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02861",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga artist created Doraemon as one half of his duo pen name?",
+      "ja": "コンビ筆名の片割れとしてドラえもんを描いた漫画家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gainax",
+        "ja": "ガイナックス",
+        "ja_typings": [
+          "gainakkusu"
+        ]
+      },
+      {
+        "en": "Studio Khara",
+        "ja": "スタジオカラー",
+        "ja_typings": [
+          "sutajiokara-"
+        ]
+      },
+      {
+        "en": "Studio Ghibli",
+        "ja": "スタジオジブリ",
+        "ja_typings": [
+          "sutajiojiburi"
+        ]
+      },
+      {
+        "en": "Toei Animation",
+        "ja": "東映アニメーション",
+        "ja_typings": [
+          "toueianimeeshon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02862",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio produced Neon Genesis Evangelion in the 1990s?",
+      "ja": "1990 年代に新世紀エヴァンゲリオンを制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gege Akutami",
+        "ja": "芥見下々",
+        "ja_typings": [
+          "akutamigege"
+        ]
+      },
+      {
+        "en": "Kohei Horikoshi",
+        "ja": "堀越耕平",
+        "ja_typings": [
+          "horikoshikouhei"
+        ]
+      },
+      {
+        "en": "Tatsuki Fujimoto",
+        "ja": "藤本タツキ",
+        "ja_typings": [
+          "fujimototatsuki"
+        ]
+      },
+      {
+        "en": "Hajime Isayama",
+        "ja": "諫山創",
+        "ja_typings": [
+          "isayamahajime"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02863",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga author created Jujutsu Kaisen?",
+      "ja": "呪術廻戦の原作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Giorno Giovanna",
+        "ja": "ジョルノ・ジョバァーナ",
+        "ja_typings": [
+          "joruno/jobaa-na"
+        ]
+      },
+      {
+        "en": "Jonathan Joestar",
+        "ja": "ジョナサン・ジョースター",
+        "ja_typings": [
+          "jonasan/jo-suta-"
+        ]
+      },
+      {
+        "en": "Josuke Higashikata",
+        "ja": "東方仗助",
+        "ja_typings": [
+          "higasikatajousuke"
+        ]
+      },
+      {
+        "en": "Jotaro Kujo",
+        "ja": "空条承太郎",
+        "ja_typings": [
+          "kujoujoutarou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02864",
+    "image_path": null,
+    "question_text": {
+      "en": "Which blond protagonist of JoJo Part 5 wants to become a Gang-Star?",
+      "ja": "ジョジョ第5部でギャングのトップを目指す金髪の主人公は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hajime Isayama",
+        "ja": "諫山創",
+        "ja_typings": [
+          "isayamahajime"
+        ]
+      },
+      {
+        "en": "Gege Akutami",
+        "ja": "芥見下々",
+        "ja_typings": [
+          "akutamigege"
+        ]
+      },
+      {
+        "en": "Kohei Horikoshi",
+        "ja": "堀越耕平",
+        "ja_typings": [
+          "horikoshikouhei"
+        ]
+      },
+      {
+        "en": "Tatsuki Fujimoto",
+        "ja": "藤本タツキ",
+        "ja_typings": [
+          "fujimototatsuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02865",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga author created Attack on Titan?",
+      "ja": "進撃の巨人の原作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hideaki Anno",
+        "ja": "庵野秀明",
+        "ja_typings": [
+          "annohideaki"
+        ]
+      },
+      {
+        "en": "Mamoru Oshii",
+        "ja": "押井守",
+        "ja_typings": [
+          "oshiimamoru"
+        ]
+      },
+      {
+        "en": "Isao Takahata",
+        "ja": "高畑勲",
+        "ja_typings": [
+          "takahataisao"
+        ]
+      },
+      {
+        "en": "Mamoru Hosoda",
+        "ja": "細田守",
+        "ja_typings": [
+          "hosodamamoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02866",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Gainax co-founder directed the original Neon Genesis Evangelion?",
+      "ja": "新世紀エヴァンゲリオンを監督した Gainax の共同創業者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Inosuke Hashibira",
+        "ja": "嘴平伊之助",
+        "ja_typings": [
+          "hashibirainosuke"
+        ]
+      },
+      {
+        "en": "Zenitsu Agatsuma",
+        "ja": "我妻善逸",
+        "ja_typings": [
+          "agatsumazenitsu"
+        ]
+      },
+      {
+        "en": "Tanjiro Kamado",
+        "ja": "竈門炭治郎",
+        "ja_typings": [
+          "kamadotanjirou"
+        ]
+      },
+      {
+        "en": "Giyu Tomioka",
+        "ja": "冨岡義勇",
+        "ja_typings": [
+          "tomiokagiyuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02867",
+    "image_path": null,
+    "question_text": {
+      "en": "Which wild boar-headed Demon Slayer fights with twin nichirin blades?",
+      "ja": "猪の頭をかぶり、二刀流で戦う鬼殺隊士は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Isao Takahata",
+        "ja": "高畑勲",
+        "ja_typings": [
+          "takahataisao"
+        ]
+      },
+      {
+        "en": "Hayao Miyazaki",
+        "ja": "宮崎駿",
+        "ja_typings": [
+          "miyazakihayao"
+        ]
+      },
+      {
+        "en": "Mamoru Hosoda",
+        "ja": "細田守",
+        "ja_typings": [
+          "hosodamamoru"
+        ]
+      },
+      {
+        "en": "Hideaki Anno",
+        "ja": "庵野秀明",
+        "ja_typings": [
+          "annohideaki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02868",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Ghibli co-founder directed Grave of the Fireflies?",
+      "ja": "火垂るの墓を監督したジブリの共同創業者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jonathan Joestar",
+        "ja": "ジョナサン・ジョースター",
+        "ja_typings": [
+          "jonasan/jo-suta-"
+        ]
+      },
+      {
+        "en": "Joseph Joestar",
+        "ja": "ジョセフ・ジョースター",
+        "ja_typings": [
+          "josefu/jo-suta-"
+        ]
+      },
+      {
+        "en": "Jotaro Kujo",
+        "ja": "空条承太郎",
+        "ja_typings": [
+          "kujoujoutarou"
+        ]
+      },
+      {
+        "en": "Giorno Giovanna",
+        "ja": "ジョルノ・ジョバァーナ",
+        "ja_typings": [
+          "joruno/jobaa-na"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02869",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 19th-century English gentleman is the first JoJo of Part 1?",
+      "ja": "第1部の主人公にあたる 19 世紀イギリス紳士のジョジョは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Josuke Higashikata",
+        "ja": "東方仗助",
+        "ja_typings": [
+          "higasikatajousuke"
+        ]
+      },
+      {
+        "en": "Giorno Giovanna",
+        "ja": "ジョルノ・ジョバァーナ",
+        "ja_typings": [
+          "joruno/jobaa-na"
+        ]
+      },
+      {
+        "en": "Jonathan Joestar",
+        "ja": "ジョナサン・ジョースター",
+        "ja_typings": [
+          "jonasan/jo-suta-"
+        ]
+      },
+      {
+        "en": "Jotaro Kujo",
+        "ja": "空条承太郎",
+        "ja_typings": [
+          "kujoujoutarou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02870",
+    "image_path": null,
+    "question_text": {
+      "en": "Which pompadour-haired Part 4 hero protects Morioh from Stand users?",
+      "ja": "杜王町を守るリーゼント髪のジョジョ第4部の主人公は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Judau Ashta",
+        "ja": "ジュドー・アーシタ",
+        "ja_typings": [
+          "judo-/a-shita"
+        ]
+      },
+      {
+        "en": "Kamille Bidan",
+        "ja": "カミーユ・ビダン",
+        "ja_typings": [
+          "kami-yu/bidan"
+        ]
+      },
+      {
+        "en": "Amuro Ray",
+        "ja": "アムロ・レイ",
+        "ja_typings": [
+          "amuro/rei"
+        ]
+      },
+      {
+        "en": "Char Aznable",
+        "ja": "シャア・アズナブル",
+        "ja_typings": [
+          "shaa/azunaburu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02871",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protagonist of Zeta Gundam's sequel ZZ pilots the Double Zeta Gundam?",
+      "ja": "機動戦士ガンダムZZでΖΖガンダムに乗る主人公は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kaito Ishikawa",
+        "ja": "石川界人",
+        "ja_typings": [
+          "ishikawakaito"
+        ]
+      },
+      {
+        "en": "Koki Uchiyama",
+        "ja": "内山昂輝",
+        "ja_typings": [
+          "uchiyamakouki"
+        ]
+      },
+      {
+        "en": "Toru Furuya",
+        "ja": "古谷徹",
+        "ja_typings": [
+          "furuyatooru"
+        ]
+      },
+      {
+        "en": "Akira Kamiya",
+        "ja": "神谷明",
+        "ja_typings": [
+          "kamiyaakira"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02872",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actor for Tobio Kageyama in Haikyu!! also voices many shōnen leads?",
+      "ja": "ハイキュー!! の影山飛雄役を演じた声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kakashi Hatake",
+        "ja": "はたけカカシ",
+        "ja_typings": [
+          "hatakekakashi"
+        ]
+      },
+      {
+        "en": "Sasuke Uchiha",
+        "ja": "うちはサスケ",
+        "ja_typings": [
+          "uchihasasuke"
+        ]
+      },
+      {
+        "en": "Yashamaru",
+        "ja": "夜叉丸",
+        "ja_typings": [
+          "yashamaru"
+        ]
+      },
+      {
+        "en": "Tsunade",
+        "ja": "綱手",
+        "ja_typings": [
+          "tsunade"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02873",
+    "image_path": null,
+    "question_text": {
+      "en": "Which silver-haired ninja with a Sharingan eye leads Team 7 in Naruto?",
+      "ja": "ナルトで第七班を率いる写輪眼を持つ銀髪の忍は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kamille Bidan",
+        "ja": "カミーユ・ビダン",
+        "ja_typings": [
+          "kami-yu/bidan"
+        ]
+      },
+      {
+        "en": "Judau Ashta",
+        "ja": "ジュドー・アーシタ",
+        "ja_typings": [
+          "judo-/a-shita"
+        ]
+      },
+      {
+        "en": "Amuro Ray",
+        "ja": "アムロ・レイ",
+        "ja_typings": [
+          "amuro/rei"
+        ]
+      },
+      {
+        "en": "Char Aznable",
+        "ja": "シャア・アズナブル",
+        "ja_typings": [
+          "shaa/azunaburu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02874",
+    "image_path": null,
+    "question_text": {
+      "en": "Which moody Newtype pilots the Zeta Gundam in its title series?",
+      "ja": "機動戦士Ζガンダムで Ζガンダムに乗るニュータイプは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kanao Tsuyuri",
+        "ja": "栗花落カナヲ",
+        "ja_typings": [
+          "turiyurikanawo",
+          "tsuyurikanawo"
+        ]
+      },
+      {
+        "en": "Shinobu Kocho",
+        "ja": "胡蝶しのぶ",
+        "ja_typings": [
+          "kochoushinobu"
+        ]
+      },
+      {
+        "en": "Mitsuri Kanroji",
+        "ja": "甘露寺蜜璃",
+        "ja_typings": [
+          "kanrojimitsuri"
+        ]
+      },
+      {
+        "en": "Nezuko Kamado",
+        "ja": "竈門禰豆子",
+        "ja_typings": [
+          "kamadonezuko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02875",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Tsuguko of the Insect Hashira wields a sword with two crescent blades?",
+      "ja": "蟲柱の継子で二日月型の刀を使う鬼殺隊士は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Katsuki Bakugo",
+        "ja": "爆豪勝己",
+        "ja_typings": [
+          "bakugoukatsuki"
+        ]
+      },
+      {
+        "en": "Shoto Todoroki",
+        "ja": "轟焦凍",
+        "ja_typings": [
+          "todorokishouto"
+        ]
+      },
+      {
+        "en": "All Might",
+        "ja": "オールマイト",
+        "ja_typings": [
+          "o-rumaito"
+        ]
+      },
+      {
+        "en": "Tenya Iida",
+        "ja": "飯田天哉",
+        "ja_typings": [
+          "iidatenya"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02876",
+    "image_path": null,
+    "question_text": {
+      "en": "Which explosive-quirk classmate of Deku calls himself the future No.1 hero?",
+      "ja": "デクの同級生で爆破個性を持ち、未来の No.1 を自称するのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kaworu Nagisa",
+        "ja": "渚カヲル",
+        "ja_typings": [
+          "nagisakaworu",
+          "nagisakaoru"
+        ]
+      },
+      {
+        "en": "Rei Ayanami",
+        "ja": "綾波レイ",
+        "ja_typings": [
+          "ayanamirei"
+        ]
+      },
+      {
+        "en": "Asuka Langley Soryu",
+        "ja": "惣流・アスカ・ラングレー",
+        "ja_typings": [
+          "souryuuasukaranguree",
+          "souryuuasukarangure"
+        ]
+      },
+      {
+        "en": "Shinji Ikari",
+        "ja": "碇シンジ",
+        "ja_typings": [
+          "ikarishinji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02877",
+    "image_path": null,
+    "question_text": {
+      "en": "Which gray-haired Evangelion pilot is designated the Fifth Child?",
+      "ja": "フィフスチルドレンに指定された灰色の髪のエヴァパイロットは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kenji Utsumi",
+        "ja": "内海賢二",
+        "ja_typings": [
+          "utsumikenji",
+          "uchiumikenji"
+        ]
+      },
+      {
+        "en": "Banjo Ginga",
+        "ja": "銀河万丈",
+        "ja_typings": [
+          "gingabanjou"
+        ]
+      },
+      {
+        "en": "Akira Kamiya",
+        "ja": "神谷明",
+        "ja_typings": [
+          "kamiyaakira"
+        ]
+      },
+      {
+        "en": "Toru Furuya",
+        "ja": "古谷徹",
+        "ja_typings": [
+          "furuyatooru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02878",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actor was famous for booming villains like Raoh in Fist of the North Star?",
+      "ja": "北斗の拳のラオウ等の威厳ある悪役で知られた声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kohei Horikoshi",
+        "ja": "堀越耕平",
+        "ja_typings": [
+          "horikoshikouhei"
+        ]
+      },
+      {
+        "en": "Gege Akutami",
+        "ja": "芥見下々",
+        "ja_typings": [
+          "akutamigege"
+        ]
+      },
+      {
+        "en": "Hajime Isayama",
+        "ja": "諫山創",
+        "ja_typings": [
+          "isayamahajime"
+        ]
+      },
+      {
+        "en": "Tatsuki Fujimoto",
+        "ja": "藤本タツキ",
+        "ja_typings": [
+          "fujimototatsuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02879",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga author created My Hero Academia?",
+      "ja": "僕のヒーローアカデミアの原作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Koki Uchiyama",
+        "ja": "内山昂輝",
+        "ja_typings": [
+          "uchiyamakouki"
+        ]
+      },
+      {
+        "en": "Kaito Ishikawa",
+        "ja": "石川界人",
+        "ja_typings": [
+          "ishikawakaito"
+        ]
+      },
+      {
+        "en": "Megumi Ogata",
+        "ja": "緒方恵美",
+        "ja_typings": [
+          "ogatamegumi"
+        ]
+      },
+      {
+        "en": "Toru Furuya",
+        "ja": "古谷徹",
+        "ja_typings": [
+          "furuyatooru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02880",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actor for L (Death Note) is also known for Echizen in Prince of Tennis?",
+      "ja": "デスノートのＬや越前リョーマを演じた声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Krillin",
+        "ja": "クリリン",
+        "ja_typings": [
+          "kuririn"
+        ]
+      },
+      {
+        "en": "Piccolo",
+        "ja": "ピッコロ",
+        "ja_typings": [
+          "pikkoro"
+        ]
+      },
+      {
+        "en": "Vegeta",
+        "ja": "ベジータ",
+        "ja_typings": [
+          "beji-ta"
+        ]
+      },
+      {
+        "en": "Yamcha",
+        "ja": "ヤムチャ",
+        "ja_typings": [
+          "yamucha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02881",
+    "image_path": null,
+    "question_text": {
+      "en": "Which short, bald Z-Fighter is one of Goku's oldest friends?",
+      "ja": "悟空の最古参の親友にあたる坊主頭の Z 戦士は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lawliet",
+        "ja": "ローライト",
+        "ja_typings": [
+          "ro-raito"
+        ]
+      },
+      {
+        "en": "Ryuk",
+        "ja": "リューク",
+        "ja_typings": [
+          "ryu-ku"
+        ]
+      },
+      {
+        "en": "Misa Amane",
+        "ja": "弥海砂",
+        "ja_typings": [
+          "amanemisa"
+        ]
+      },
+      {
+        "en": "Yagami",
+        "ja": "夜神",
+        "ja_typings": [
+          "yagami"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02882",
+    "image_path": null,
+    "question_text": {
+      "en": "Which white-haired detective in Death Note uses the alias 'L'?",
+      "ja": "デスノートで L を名乗る白髪交じりの探偵の本名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Levi Ackerman",
+        "ja": "リヴァイ・アッカーマン",
+        "ja_typings": [
+          "rivai/akka-man"
+        ]
+      },
+      {
+        "en": "Mikasa Ackerman",
+        "ja": "ミカサ・アッカーマン",
+        "ja_typings": [
+          "mikasa/akka-man"
+        ]
+      },
+      {
+        "en": "Erwin Smith",
+        "ja": "エルヴィン・スミス",
+        "ja_typings": [
+          "eruvin/sumisu"
+        ]
+      },
+      {
+        "en": "Armin Arlert",
+        "ja": "アルミン・アルレルト",
+        "ja_typings": [
+          "arumin/arureruto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02883",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Survey Corps captain is humanity's strongest soldier?",
+      "ja": "人類最強の兵士と呼ばれる調査兵団の兵長は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Makima",
+        "ja": "マキマ",
+        "ja_typings": [
+          "makima"
+        ]
+      },
+      {
+        "en": "Power",
+        "ja": "パワー",
+        "ja_typings": [
+          "pawa-"
+        ]
+      },
+      {
+        "en": "Reze",
+        "ja": "レゼ",
+        "ja_typings": [
+          "reze"
+        ]
+      },
+      {
+        "en": "Kobeni",
+        "ja": "コベニ",
+        "ja_typings": [
+          "kobeni"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02884",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Chainsaw Man character is a control devil who recruits Denji?",
+      "ja": "チェンソーマンでデンジを勧誘する支配の悪魔の姿の女性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Malevolent Shrine",
+        "ja": "伏魔御厨子",
+        "ja_typings": [
+          "fukumamizushi"
+        ]
+      },
+      {
+        "en": "Chimera Shadow Garden",
+        "ja": "嵌合暗翳庭",
+        "ja_typings": [
+          "kangouan'eitei"
+        ]
+      },
+      {
+        "en": "Unlimited Void",
+        "ja": "無量空処",
+        "ja_typings": [
+          "muryoukuusho"
+        ]
+      },
+      {
+        "en": "Time Prison",
+        "ja": "時胞月宮殿",
+        "ja_typings": [
+          "jihougetsukyuuden"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02885",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Domain Expansion belongs to Ryomen Sukuna in Jujutsu Kaisen?",
+      "ja": "呪術廻戦で両面宿儺が使う領域展開の名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mamoru Hosoda",
+        "ja": "細田守",
+        "ja_typings": [
+          "hosodamamoru"
+        ]
+      },
+      {
+        "en": "Hayao Miyazaki",
+        "ja": "宮崎駿",
+        "ja_typings": [
+          "miyazakihayao"
+        ]
+      },
+      {
+        "en": "Isao Takahata",
+        "ja": "高畑勲",
+        "ja_typings": [
+          "takahataisao"
+        ]
+      },
+      {
+        "en": "Mamoru Oshii",
+        "ja": "押井守",
+        "ja_typings": [
+          "oshiimamoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02886",
+    "image_path": null,
+    "question_text": {
+      "en": "Which director helmed Summer Wars and Mirai (Mirai no Mirai)?",
+      "ja": "サマーウォーズや未来のミライを監督したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mamoru Oshii",
+        "ja": "押井守",
+        "ja_typings": [
+          "oshiimamoru"
+        ]
+      },
+      {
+        "en": "Mamoru Hosoda",
+        "ja": "細田守",
+        "ja_typings": [
+          "hosodamamoru"
+        ]
+      },
+      {
+        "en": "Hideaki Anno",
+        "ja": "庵野秀明",
+        "ja_typings": [
+          "annohideaki"
+        ]
+      },
+      {
+        "en": "Satoshi Kon",
+        "ja": "今敏",
+        "ja_typings": [
+          "konsatoshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02887",
+    "image_path": null,
+    "question_text": {
+      "en": "Which director helmed Ghost in the Shell (1995)?",
+      "ja": "1995 年の劇場版『攻殻機動隊』を監督したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mayumi Tanaka",
+        "ja": "田中真弓",
+        "ja_typings": [
+          "tanakamayumi"
+        ]
+      },
+      {
+        "en": "Megumi Hayashibara",
+        "ja": "林原めぐみ",
+        "ja_typings": [
+          "hayashibaramegumi"
+        ]
+      },
+      {
+        "en": "Minami Takayama",
+        "ja": "高山みなみ",
+        "ja_typings": [
+          "takayamaminami"
+        ]
+      },
+      {
+        "en": "Nobuyo Oyama",
+        "ja": "大山のぶ代",
+        "ja_typings": [
+          "ooyamanobuyo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02888",
+    "image_path": null,
+    "question_text": {
+      "en": "Which longtime Japanese voice actress played Krillin and Luffy?",
+      "ja": "クリリンやルフィを演じた長年の女性声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Megumi Fushiguro",
+        "ja": "伏黒恵",
+        "ja_typings": [
+          "fukuromegumi"
+        ]
+      },
+      {
+        "en": "Yuji Itadori",
+        "ja": "虎杖悠仁",
+        "ja_typings": [
+          "itadoriyuuji"
+        ]
+      },
+      {
+        "en": "Nobara Kugisaki",
+        "ja": "釘崎野薔薇",
+        "ja_typings": [
+          "kugisakinobara"
+        ]
+      },
+      {
+        "en": "Satoru Gojo",
+        "ja": "五条悟",
+        "ja_typings": [
+          "gojousatoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02889",
+    "image_path": null,
+    "question_text": {
+      "en": "Which shadow-summoning sorcerer is the Ten Shadows user in JJK?",
+      "ja": "呪術廻戦で十種影法術を使う影使いの呪術師は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Megumi Hayashibara",
+        "ja": "林原めぐみ",
+        "ja_typings": [
+          "hayashibaramegumi"
+        ]
+      },
+      {
+        "en": "Megumi Ogata",
+        "ja": "緒方恵美",
+        "ja_typings": [
+          "ogatamegumi"
+        ]
+      },
+      {
+        "en": "Megumi Toyoguchi",
+        "ja": "豊口めぐみ",
+        "ja_typings": [
+          "toyoguchimegumi"
+        ]
+      },
+      {
+        "en": "Mayumi Tanaka",
+        "ja": "田中真弓",
+        "ja_typings": [
+          "tanakamayumi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02890",
+    "image_path": null,
+    "question_text": {
+      "en": "Which prolific voice actress played Rei Ayanami and Faye Valentine?",
+      "ja": "綾波レイやフェイ・バレンタインを演じた女性声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Megumi Ogata",
+        "ja": "緒方恵美",
+        "ja_typings": [
+          "ogatamegumi"
+        ]
+      },
+      {
+        "en": "Megumi Hayashibara",
+        "ja": "林原めぐみ",
+        "ja_typings": [
+          "hayashibaramegumi"
+        ]
+      },
+      {
+        "en": "Megumi Toyoguchi",
+        "ja": "豊口めぐみ",
+        "ja_typings": [
+          "toyoguchimegumi"
+        ]
+      },
+      {
+        "en": "Minami Takayama",
+        "ja": "高山みなみ",
+        "ja_typings": [
+          "takayamaminami"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02891",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actress is associated with Shinji Ikari and Sailor Uranus?",
+      "ja": "碇シンジや天王はるかを演じた女性声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Megumi Toyoguchi",
+        "ja": "豊口めぐみ",
+        "ja_typings": [
+          "toyoguchimegumi"
+        ]
+      },
+      {
+        "en": "Megumi Hayashibara",
+        "ja": "林原めぐみ",
+        "ja_typings": [
+          "hayashibaramegumi"
+        ]
+      },
+      {
+        "en": "Megumi Ogata",
+        "ja": "緒方恵美",
+        "ja_typings": [
+          "ogatamegumi"
+        ]
+      },
+      {
+        "en": "Mayumi Tanaka",
+        "ja": "田中真弓",
+        "ja_typings": [
+          "tanakamayumi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02892",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actress played Revy in Black Lagoon and Winry in FMA?",
+      "ja": "ブラックラグーンのレヴィや FMA のウィンリィを演じた女性声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mikasa Ackerman",
+        "ja": "ミカサ・アッカーマン",
+        "ja_typings": [
+          "mikasa/akka-man"
+        ]
+      },
+      {
+        "en": "Levi Ackerman",
+        "ja": "リヴァイ・アッカーマン",
+        "ja_typings": [
+          "rivai/akka-man"
+        ]
+      },
+      {
+        "en": "Annie Leonhart",
+        "ja": "アニ・レオンハート",
+        "ja_typings": [
+          "ani/reonha-to"
+        ]
+      },
+      {
+        "en": "Historia Reiss",
+        "ja": "ヒストリア・レイス",
+        "ja_typings": [
+          "hisutoria/reisu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02893",
+    "image_path": null,
+    "question_text": {
+      "en": "Which black-haired Ackerman is Eren's adoptive sister and a top soldier?",
+      "ja": "エレンの義妹で最強クラスの兵士、アッカーマン家の黒髪少女は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Minami Takayama",
+        "ja": "高山みなみ",
+        "ja_typings": [
+          "takayamaminami"
+        ]
+      },
+      {
+        "en": "Megumi Hayashibara",
+        "ja": "林原めぐみ",
+        "ja_typings": [
+          "hayashibaramegumi"
+        ]
+      },
+      {
+        "en": "Mayumi Tanaka",
+        "ja": "田中真弓",
+        "ja_typings": [
+          "tanakamayumi"
+        ]
+      },
+      {
+        "en": "Nobuyo Oyama",
+        "ja": "大山のぶ代",
+        "ja_typings": [
+          "ooyamanobuyo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02894",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actress plays Conan Edogawa in Detective Conan?",
+      "ja": "名探偵コナンで江戸川コナンを演じる女性声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Misa Amane",
+        "ja": "弥海砂",
+        "ja_typings": [
+          "amanemisa"
+        ]
+      },
+      {
+        "en": "Sayu Yagami",
+        "ja": "夜神粧裕",
+        "ja_typings": [
+          "yagamisayu"
+        ]
+      },
+      {
+        "en": "Naomi Misora",
+        "ja": "南空ナオミ",
+        "ja_typings": [
+          "misoranaomi"
+        ]
+      },
+      {
+        "en": "Kiyomi Takada",
+        "ja": "高田清美",
+        "ja_typings": [
+          "takadakiyomi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02895",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Death Note heroine becomes the second Kira out of love for Light?",
+      "ja": "デスノートでライトへの愛から第二のキラになるヒロインは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mitsuri Kanroji",
+        "ja": "甘露寺蜜璃",
+        "ja_typings": [
+          "kanrojimitsuri"
+        ]
+      },
+      {
+        "en": "Shinobu Kocho",
+        "ja": "胡蝶しのぶ",
+        "ja_typings": [
+          "kochoushinobu"
+        ]
+      },
+      {
+        "en": "Kanao Tsuyuri",
+        "ja": "栗花落カナヲ",
+        "ja_typings": [
+          "turiyurikanawo",
+          "tsuyurikanawo"
+        ]
+      },
+      {
+        "en": "Nezuko Kamado",
+        "ja": "竈門禰豆子",
+        "ja_typings": [
+          "kamadonezuko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02896",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Demon Slayer Love Hashira fights with a uniquely flexible katana?",
+      "ja": "鬼殺隊の恋柱で柔軟な刀を扱うのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nami",
+        "ja": "ナミ",
+        "ja_typings": [
+          "nami"
+        ]
+      },
+      {
+        "en": "Robin",
+        "ja": "ロビン",
+        "ja_typings": [
+          "robin"
+        ]
+      },
+      {
+        "en": "Vivi",
+        "ja": "ビビ",
+        "ja_typings": [
+          "bibi"
+        ]
+      },
+      {
+        "en": "Hancock",
+        "ja": "ハンコック",
+        "ja_typings": [
+          "hankokku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02897",
+    "image_path": null,
+    "question_text": {
+      "en": "Which orange-haired navigator of the Straw Hat Pirates loves money?",
+      "ja": "麦わら海賊団の航海士で金が大好きなオレンジ髪の女性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nezuko Kamado",
+        "ja": "竈門禰豆子",
+        "ja_typings": [
+          "kamadonezuko"
+        ]
+      },
+      {
+        "en": "Mitsuri Kanroji",
+        "ja": "甘露寺蜜璃",
+        "ja_typings": [
+          "kanrojimitsuri"
+        ]
+      },
+      {
+        "en": "Shinobu Kocho",
+        "ja": "胡蝶しのぶ",
+        "ja_typings": [
+          "kochoushinobu"
+        ]
+      },
+      {
+        "en": "Kanao Tsuyuri",
+        "ja": "栗花落カナヲ",
+        "ja_typings": [
+          "turiyurikanawo",
+          "tsuyurikanawo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02898",
+    "image_path": null,
+    "question_text": {
+      "en": "Which pink-clad demon-girl in a box is Tanjiro's younger sister?",
+      "ja": "炭治郎の妹で、箱に入った桃色の鬼の少女は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nobara Kugisaki",
+        "ja": "釘崎野薔薇",
+        "ja_typings": [
+          "kugisakinobara"
+        ]
+      },
+      {
+        "en": "Megumi Fushiguro",
+        "ja": "伏黒恵",
+        "ja_typings": [
+          "fukuromegumi"
+        ]
+      },
+      {
+        "en": "Yuji Itadori",
+        "ja": "虎杖悠仁",
+        "ja_typings": [
+          "itadoriyuuji"
+        ]
+      },
+      {
+        "en": "Maki Zenin",
+        "ja": "禪院真希",
+        "ja_typings": [
+          "zen'inmaki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02899",
+    "image_path": null,
+    "question_text": {
+      "en": "Which hammer-wielding female student of Tokyo Jujutsu High wears short hair?",
+      "ja": "東京呪術高専所属で金槌を扱うショートヘアの女子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nobuyo Oyama",
+        "ja": "大山のぶ代",
+        "ja_typings": [
+          "ooyamanobuyo"
+        ]
+      },
+      {
+        "en": "Minami Takayama",
+        "ja": "高山みなみ",
+        "ja_typings": [
+          "takayamaminami"
+        ]
+      },
+      {
+        "en": "Mayumi Tanaka",
+        "ja": "田中真弓",
+        "ja_typings": [
+          "tanakamayumi"
+        ]
+      },
+      {
+        "en": "Megumi Hayashibara",
+        "ja": "林原めぐみ",
+        "ja_typings": [
+          "hayashibaramegumi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02900",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice actress is the original Doraemon (1979–2005)?",
+      "ja": "1979 年版のオリジナル・ドラえもんを演じた声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Orihime Inoue",
+        "ja": "井上織姫",
+        "ja_typings": [
+          "inoueorihime"
+        ]
+      },
+      {
+        "en": "Rukia Kuchiki",
+        "ja": "朽木ルキア",
+        "ja_typings": [
+          "kuchikirukia"
+        ]
+      },
+      {
+        "en": "Yoruichi Shihouin",
+        "ja": "四楓院夜一",
+        "ja_typings": [
+          "shihouinyoruichi"
+        ]
+      },
+      {
+        "en": "Rangiku Matsumoto",
+        "ja": "松本乱菊",
+        "ja_typings": [
+          "matsumotorangiku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02901",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Bleach heroine is Ichigo's longtime crush with healing powers?",
+      "ja": "BLEACH で一護の幼馴染にあたる治癒能力者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Osamu Tezuka",
+        "ja": "手塚治虫",
+        "ja_typings": [
+          "tezukaosamu"
+        ]
+      },
+      {
+        "en": "Shotaro Ishinomori",
+        "ja": "石ノ森章太郎",
+        "ja_typings": [
+          "ishinomorishoutarou"
+        ]
+      },
+      {
+        "en": "Fujiko F. Fujio",
+        "ja": "藤子・F・不二雄",
+        "ja_typings": [
+          "hujikofhujio"
+        ]
+      },
+      {
+        "en": "Hideaki Anno",
+        "ja": "庵野秀明",
+        "ja_typings": [
+          "annohideaki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02902",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga artist is called 'the God of Manga' for works like Astro Boy?",
+      "ja": "鉄腕アトムなどで「漫画の神様」と呼ばれる漫画家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Piccolo",
+        "ja": "ピッコロ",
+        "ja_typings": [
+          "pikkoro"
+        ]
+      },
+      {
+        "en": "Vegeta",
+        "ja": "ベジータ",
+        "ja_typings": [
+          "beji-ta"
+        ]
+      },
+      {
+        "en": "Krillin",
+        "ja": "クリリン",
+        "ja_typings": [
+          "kuririn"
+        ]
+      },
+      {
+        "en": "Frieza",
+        "ja": "フリーザ",
+        "ja_typings": [
+          "furi-za"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02903",
+    "image_path": null,
+    "question_text": {
+      "en": "Which green-skinned Namekian is Goku's former rival turned ally?",
+      "ja": "悟空の元ライバルで仲間になった緑の肌のナメック星人は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Power",
+        "ja": "パワー",
+        "ja_typings": [
+          "pawa-"
+        ]
+      },
+      {
+        "en": "Makima",
+        "ja": "マキマ",
+        "ja_typings": [
+          "makima"
+        ]
+      },
+      {
+        "en": "Denji",
+        "ja": "デンジ",
+        "ja_typings": [
+          "denji"
+        ]
+      },
+      {
+        "en": "Reze",
+        "ja": "レゼ",
+        "ja_typings": [
+          "reze"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02904",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Chainsaw Man devil is Aki Hayakawa's blood-loving partner?",
+      "ja": "チェンソーマンで早川アキの相棒となる血を好む悪魔は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rei Ayanami",
+        "ja": "綾波レイ",
+        "ja_typings": [
+          "ayanamirei"
+        ]
+      },
+      {
+        "en": "Asuka Langley Soryu",
+        "ja": "惣流・アスカ・ラングレー",
+        "ja_typings": [
+          "souryuuasukaranguree",
+          "souryuuasukarangure"
+        ]
+      },
+      {
+        "en": "Kaworu Nagisa",
+        "ja": "渚カヲル",
+        "ja_typings": [
+          "nagisakaworu",
+          "nagisakaoru"
+        ]
+      },
+      {
+        "en": "Mari Makinami",
+        "ja": "真希波・マリ",
+        "ja_typings": [
+          "makinamimari"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02905",
+    "image_path": null,
+    "question_text": {
+      "en": "Which blue-haired Eva pilot is designated the First Child?",
+      "ja": "ファーストチルドレンに指定された青髪のエヴァパイロットは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Romantic comedy",
+        "ja": "ラブコメ",
+        "ja_typings": [
+          "rabukome"
+        ]
+      },
+      {
+        "en": "Slice of life",
+        "ja": "日常系",
+        "ja_typings": [
+          "nitijoukei"
+        ]
+      },
+      {
+        "en": "Sports",
+        "ja": "スポーツ",
+        "ja_typings": [
+          "supo-tsu"
+        ]
+      },
+      {
+        "en": "Mecha",
+        "ja": "メカ",
+        "ja_typings": [
+          "meka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02906",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime genre is the term for love-comedy series?",
+      "ja": "恋愛コメディ系のアニメジャンルを指す英語表現は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Roronoa Zoro",
+        "ja": "ロロノア・ゾロ",
+        "ja_typings": [
+          "roronoa/zoro"
+        ]
+      },
+      {
+        "en": "Sanji",
+        "ja": "サンジ",
+        "ja_typings": [
+          "sanji"
+        ]
+      },
+      {
+        "en": "Nami",
+        "ja": "ナミ",
+        "ja_typings": [
+          "nami"
+        ]
+      },
+      {
+        "en": "Luffy",
+        "ja": "ルフィ",
+        "ja_typings": [
+          "rufi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02907",
+    "image_path": null,
+    "question_text": {
+      "en": "Which green-haired swordsman of the Straw Hats uses three swords at once?",
+      "ja": "麦わら海賊団で三刀流を使う緑髪の剣士は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Roy Mustang",
+        "ja": "ロイ・マスタング",
+        "ja_typings": [
+          "roi/masutangu"
+        ]
+      },
+      {
+        "en": "Alphonse Elric",
+        "ja": "アルフォンス・エルリック",
+        "ja_typings": [
+          "arufonsu/erurikku"
+        ]
+      },
+      {
+        "en": "Edward Elric",
+        "ja": "エドワード・エルリック",
+        "ja_typings": [
+          "edowa-do/erurikku"
+        ]
+      },
+      {
+        "en": "Winry Rockbell",
+        "ja": "ウィンリィ・ロックベル",
+        "ja_typings": [
+          "winrii/rokkuberu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02908",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Flame Alchemist colonel in FMA can snap fire from his fingers?",
+      "ja": "鋼の錬金術師で指を鳴らして炎を操る大佐は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rukia Kuchiki",
+        "ja": "朽木ルキア",
+        "ja_typings": [
+          "kuchikirukia"
+        ]
+      },
+      {
+        "en": "Orihime Inoue",
+        "ja": "井上織姫",
+        "ja_typings": [
+          "inoueorihime"
+        ]
+      },
+      {
+        "en": "Yoruichi Shihouin",
+        "ja": "四楓院夜一",
+        "ja_typings": [
+          "shihouinyoruichi"
+        ]
+      },
+      {
+        "en": "Rangiku Matsumoto",
+        "ja": "松本乱菊",
+        "ja_typings": [
+          "matsumotorangiku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02909",
+    "image_path": null,
+    "question_text": {
+      "en": "Which black-haired shinigami lieutenant lent her powers to Ichigo in Bleach?",
+      "ja": "BLEACH で一護に死神の力を貸した黒髪の死神は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ryuk",
+        "ja": "リューク",
+        "ja_typings": [
+          "ryu-ku"
+        ]
+      },
+      {
+        "en": "Lawliet",
+        "ja": "ローライト",
+        "ja_typings": [
+          "ro-raito"
+        ]
+      },
+      {
+        "en": "Misa Amane",
+        "ja": "弥海砂",
+        "ja_typings": [
+          "amanemisa"
+        ]
+      },
+      {
+        "en": "Rem",
+        "ja": "レム",
+        "ja_typings": [
+          "remu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02910",
+    "image_path": null,
+    "question_text": {
+      "en": "Which apple-loving shinigami drops the Death Note in the human world?",
+      "ja": "リンゴ好きで人間界にデスノートを落とした死神は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sanji",
+        "ja": "サンジ",
+        "ja_typings": [
+          "sanji"
+        ]
+      },
+      {
+        "en": "Roronoa Zoro",
+        "ja": "ロロノア・ゾロ",
+        "ja_typings": [
+          "roronoa/zoro"
+        ]
+      },
+      {
+        "en": "Luffy",
+        "ja": "ルフィ",
+        "ja_typings": [
+          "rufi"
+        ]
+      },
+      {
+        "en": "Usopp",
+        "ja": "ウソップ",
+        "ja_typings": [
+          "usoppu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02911",
+    "image_path": null,
+    "question_text": {
+      "en": "Which chivalrous, kicking-only chef of the Straw Hats has a curly eyebrow?",
+      "ja": "麦わら海賊団で蹴り技専門のコック、ぐるぐる眉毛のキャラは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sasuke Uchiha",
+        "ja": "うちはサスケ",
+        "ja_typings": [
+          "uchihasasuke"
+        ]
+      },
+      {
+        "en": "Kakashi Hatake",
+        "ja": "はたけカカシ",
+        "ja_typings": [
+          "hatakekakashi"
+        ]
+      },
+      {
+        "en": "Naruto Uzumaki",
+        "ja": "うずまきナルト",
+        "ja_typings": [
+          "uzumakinaruto"
+        ]
+      },
+      {
+        "en": "Tsunade",
+        "ja": "綱手",
+        "ja_typings": [
+          "tsunade"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02912",
+    "image_path": null,
+    "question_text": {
+      "en": "Which raven-haired prodigy rival to Naruto wields the Sharingan?",
+      "ja": "ナルトのライバルで写輪眼を持つ黒髪の天才忍者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Satoru Gojo",
+        "ja": "五条悟",
+        "ja_typings": [
+          "gojousatoru"
+        ]
+      },
+      {
+        "en": "Megumi Fushiguro",
+        "ja": "伏黒恵",
+        "ja_typings": [
+          "fukuromegumi"
+        ]
+      },
+      {
+        "en": "Yuji Itadori",
+        "ja": "虎杖悠仁",
+        "ja_typings": [
+          "itadoriyuuji"
+        ]
+      },
+      {
+        "en": "Suguru Geto",
+        "ja": "夏油傑",
+        "ja_typings": [
+          "getousuguru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02913",
+    "image_path": null,
+    "question_text": {
+      "en": "Which white-haired strongest jujutsu sorcerer wears a blindfold?",
+      "ja": "目隠しを巻いた最強の呪術師は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Satoshi Kon",
+        "ja": "今敏",
+        "ja_typings": [
+          "konsatoshi"
+        ]
+      },
+      {
+        "en": "Mamoru Oshii",
+        "ja": "押井守",
+        "ja_typings": [
+          "oshiimamoru"
+        ]
+      },
+      {
+        "en": "Mamoru Hosoda",
+        "ja": "細田守",
+        "ja_typings": [
+          "hosodamamoru"
+        ]
+      },
+      {
+        "en": "Hideaki Anno",
+        "ja": "庵野秀明",
+        "ja_typings": [
+          "annohideaki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02914",
+    "image_path": null,
+    "question_text": {
+      "en": "Which director helmed Perfect Blue and Paprika before his early death?",
+      "ja": "パーフェクトブルーやパプリカを監督した、夭折のアニメ監督は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shaft",
+        "ja": "シャフト",
+        "ja_typings": [
+          "shafuto"
+        ]
+      },
+      {
+        "en": "Gainax",
+        "ja": "ガイナックス",
+        "ja_typings": [
+          "gainakkusu"
+        ]
+      },
+      {
+        "en": "ufotable",
+        "ja": "ユーフォーテーブル",
+        "ja_typings": [
+          "yu-fo-te-buru"
+        ]
+      },
+      {
+        "en": "WIT STUDIO",
+        "ja": "WITスタジオ",
+        "ja_typings": [
+          "witsutajio"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02915",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio is known for Bakemonogatari and the Monogatari series?",
+      "ja": "化物語など〈物語〉シリーズで知られる制作スタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shinobu Kocho",
+        "ja": "胡蝶しのぶ",
+        "ja_typings": [
+          "kochoushinobu"
+        ]
+      },
+      {
+        "en": "Mitsuri Kanroji",
+        "ja": "甘露寺蜜璃",
+        "ja_typings": [
+          "kanrojimitsuri"
+        ]
+      },
+      {
+        "en": "Kanao Tsuyuri",
+        "ja": "栗花落カナヲ",
+        "ja_typings": [
+          "turiyurikanawo",
+          "tsuyurikanawo"
+        ]
+      },
+      {
+        "en": "Nezuko Kamado",
+        "ja": "竈門禰豆子",
+        "ja_typings": [
+          "kamadonezuko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02916",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Insect Hashira fights with poison-laced thrust attacks?",
+      "ja": "毒を仕込んだ突き技で戦う蟲柱は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shotaro Ishinomori",
+        "ja": "石ノ森章太郎",
+        "ja_typings": [
+          "ishinomorishoutarou"
+        ]
+      },
+      {
+        "en": "Osamu Tezuka",
+        "ja": "手塚治虫",
+        "ja_typings": [
+          "tezukaosamu"
+        ]
+      },
+      {
+        "en": "Fujiko F. Fujio",
+        "ja": "藤子・F・不二雄",
+        "ja_typings": [
+          "hujikofhujio"
+        ]
+      },
+      {
+        "en": "Hideaki Anno",
+        "ja": "庵野秀明",
+        "ja_typings": [
+          "annohideaki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02917",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga artist created Kamen Rider and Cyborg 009?",
+      "ja": "仮面ライダーやサイボーグ009を創造した漫画家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shoto Todoroki",
+        "ja": "轟焦凍",
+        "ja_typings": [
+          "todorokishouto"
+        ]
+      },
+      {
+        "en": "Katsuki Bakugo",
+        "ja": "爆豪勝己",
+        "ja_typings": [
+          "bakugoukatsuki"
+        ]
+      },
+      {
+        "en": "All Might",
+        "ja": "オールマイト",
+        "ja_typings": [
+          "o-rumaito"
+        ]
+      },
+      {
+        "en": "Tenya Iida",
+        "ja": "飯田天哉",
+        "ja_typings": [
+          "iidatenya"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02918",
+    "image_path": null,
+    "question_text": {
+      "en": "Which half-and-half-haired classmate of Deku has both fire and ice quirks?",
+      "ja": "デクの同級生で炎と氷の両方の個性を持つハーフカラー髪のヒーローは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Slice of life",
+        "ja": "日常系",
+        "ja_typings": [
+          "nitijoukei"
+        ]
+      },
+      {
+        "en": "Romantic comedy",
+        "ja": "ラブコメ",
+        "ja_typings": [
+          "rabukome"
+        ]
+      },
+      {
+        "en": "Sports",
+        "ja": "スポーツ",
+        "ja_typings": [
+          "supo-tsu"
+        ]
+      },
+      {
+        "en": "Mecha",
+        "ja": "メカ",
+        "ja_typings": [
+          "meka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02919",
+    "image_path": null,
+    "question_text": {
+      "en": "Which anime genre label describes laid-back everyday-life shows?",
+      "ja": "日々の生活をのんびり描くアニメのジャンル英語表記は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sports",
+        "ja": "スポーツ",
+        "ja_typings": [
+          "supo-tsu"
+        ]
+      },
+      {
+        "en": "Slice of life",
+        "ja": "日常系",
+        "ja_typings": [
+          "nitijoukei"
+        ]
+      },
+      {
+        "en": "Romantic comedy",
+        "ja": "ラブコメ",
+        "ja_typings": [
+          "rabukome"
+        ]
+      },
+      {
+        "en": "Mecha",
+        "ja": "メカ",
+        "ja_typings": [
+          "meka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02920",
+    "image_path": null,
+    "question_text": {
+      "en": "Which broad anime genre covers Haikyu!!, Slam Dunk, and Captain Tsubasa?",
+      "ja": "ハイキュー!! や SLAM DUNK、キャプテン翼を含む広いジャンルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Studio Ghibli",
+        "ja": "スタジオジブリ",
+        "ja_typings": [
+          "sutajiojiburi"
+        ]
+      },
+      {
+        "en": "Studio Khara",
+        "ja": "スタジオカラー",
+        "ja_typings": [
+          "sutajiokara-"
+        ]
+      },
+      {
+        "en": "Gainax",
+        "ja": "ガイナックス",
+        "ja_typings": [
+          "gainakkusu"
+        ]
+      },
+      {
+        "en": "Toei Animation",
+        "ja": "東映アニメーション",
+        "ja_typings": [
+          "toueianimeeshon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02921",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Tokyo-based studio produced Spirited Away and Princess Mononoke?",
+      "ja": "千と千尋の神隠しやもののけ姫を制作した東京のスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Studio Khara",
+        "ja": "スタジオカラー",
+        "ja_typings": [
+          "sutajiokara-"
+        ]
+      },
+      {
+        "en": "Gainax",
+        "ja": "ガイナックス",
+        "ja_typings": [
+          "gainakkusu"
+        ]
+      },
+      {
+        "en": "Studio Ghibli",
+        "ja": "スタジオジブリ",
+        "ja_typings": [
+          "sutajiojiburi"
+        ]
+      },
+      {
+        "en": "WIT STUDIO",
+        "ja": "WITスタジオ",
+        "ja_typings": [
+          "witsutajio"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02922",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio is led by Hideaki Anno and produced the Rebuild of Evangelion films?",
+      "ja": "庵野秀明が率い、新劇場版エヴァンゲリオンを制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sunrise",
+        "ja": "サンライズ",
+        "ja_typings": [
+          "sanraizu"
+        ]
+      },
+      {
+        "en": "Gainax",
+        "ja": "ガイナックス",
+        "ja_typings": [
+          "gainakkusu"
+        ]
+      },
+      {
+        "en": "Toei Animation",
+        "ja": "東映アニメーション",
+        "ja_typings": [
+          "toueianimeeshon"
+        ]
+      },
+      {
+        "en": "Studio Ghibli",
+        "ja": "スタジオジブリ",
+        "ja_typings": [
+          "sutajiojiburi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02923",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio is the historical home of Gundam, Cowboy Bebop, and Code Geass?",
+      "ja": "ガンダム、カウボーイビバップ、コードギアスの伝統的な制作スタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tatsuki Fujimoto",
+        "ja": "藤本タツキ",
+        "ja_typings": [
+          "fujimototatsuki"
+        ]
+      },
+      {
+        "en": "Gege Akutami",
+        "ja": "芥見下々",
+        "ja_typings": [
+          "akutamigege"
+        ]
+      },
+      {
+        "en": "Kohei Horikoshi",
+        "ja": "堀越耕平",
+        "ja_typings": [
+          "horikoshikouhei"
+        ]
+      },
+      {
+        "en": "Hajime Isayama",
+        "ja": "諫山創",
+        "ja_typings": [
+          "isayamahajime"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02924",
+    "image_path": null,
+    "question_text": {
+      "en": "Which manga author created Chainsaw Man and Fire Punch?",
+      "ja": "チェンソーマンとファイアパンチの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tetsuro Kuroo",
+        "ja": "黒尾鉄朗",
+        "ja_typings": [
+          "kurootetsurou"
+        ]
+      },
+      {
+        "en": "Tobio Kageyama",
+        "ja": "影山飛雄",
+        "ja_typings": [
+          "kageyamatobio"
+        ]
+      },
+      {
+        "en": "Toru Oikawa",
+        "ja": "及川徹",
+        "ja_typings": [
+          "oikawatooru"
+        ]
+      },
+      {
+        "en": "Shoyo Hinata",
+        "ja": "日向翔陽",
+        "ja_typings": [
+          "hinatashouyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02925",
+    "image_path": null,
+    "question_text": {
+      "en": "Which black-haired Nekoma captain in Haikyu!! tangles with Karasuno?",
+      "ja": "ハイキュー!! で烏野と戦う音駒高校の黒髪キャプテンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Time Prison",
+        "ja": "時胞月宮殿",
+        "ja_typings": [
+          "jihougetsukyuuden"
+        ]
+      },
+      {
+        "en": "Malevolent Shrine",
+        "ja": "伏魔御厨子",
+        "ja_typings": [
+          "fukumamizushi"
+        ]
+      },
+      {
+        "en": "Unlimited Void",
+        "ja": "無量空処",
+        "ja_typings": [
+          "muryoukuusho"
+        ]
+      },
+      {
+        "en": "Chimera Shadow Garden",
+        "ja": "嵌合暗翳庭",
+        "ja_typings": [
+          "kangouan'eitei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02926",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Jujutsu Kaisen domain belongs to Kenjaku and traps targets in time?",
+      "ja": "呪術廻戦で羂索が用いる時間制圧の領域展開は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tobio Kageyama",
+        "ja": "影山飛雄",
+        "ja_typings": [
+          "kageyamatobio"
+        ]
+      },
+      {
+        "en": "Tetsuro Kuroo",
+        "ja": "黒尾鉄朗",
+        "ja_typings": [
+          "kurootetsurou"
+        ]
+      },
+      {
+        "en": "Toru Oikawa",
+        "ja": "及川徹",
+        "ja_typings": [
+          "oikawatooru"
+        ]
+      },
+      {
+        "en": "Shoyo Hinata",
+        "ja": "日向翔陽",
+        "ja_typings": [
+          "hinatashouyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02927",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Karasuno setter has prodigious aim and a fierce temper in Haikyu!!?",
+      "ja": "ハイキュー!! の烏野のセッターで気性の荒い天才は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Toei Animation",
+        "ja": "東映アニメーション",
+        "ja_typings": [
+          "toueianimeeshon"
+        ]
+      },
+      {
+        "en": "Sunrise",
+        "ja": "サンライズ",
+        "ja_typings": [
+          "sanraizu"
+        ]
+      },
+      {
+        "en": "Gainax",
+        "ja": "ガイナックス",
+        "ja_typings": [
+          "gainakkusu"
+        ]
+      },
+      {
+        "en": "Studio Ghibli",
+        "ja": "スタジオジブリ",
+        "ja_typings": [
+          "sutajiojiburi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02928",
+    "image_path": null,
+    "question_text": {
+      "en": "Which classic anime studio is famous for Dragon Ball, Sailor Moon, and One Piece?",
+      "ja": "ドラゴンボール、セーラームーン、ワンピースを制作した老舗スタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Toru Furuya",
+        "ja": "古谷徹",
+        "ja_typings": [
+          "furuyatooru"
+        ]
+      },
+      {
+        "en": "Banjo Ginga",
+        "ja": "銀河万丈",
+        "ja_typings": [
+          "gingabanjou"
+        ]
+      },
+      {
+        "en": "Kenji Utsumi",
+        "ja": "内海賢二",
+        "ja_typings": [
+          "utsumikenji",
+          "uchiumikenji"
+        ]
+      },
+      {
+        "en": "Akira Kamiya",
+        "ja": "神谷明",
+        "ja_typings": [
+          "kamiyaakira"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02929",
+    "image_path": null,
+    "question_text": {
+      "en": "Which iconic voice actor played Amuro Ray and Tuxedo Mask?",
+      "ja": "アムロ・レイやタキシード仮面を演じた往年の男性声優は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Toru Oikawa",
+        "ja": "及川徹",
+        "ja_typings": [
+          "oikawatooru"
+        ]
+      },
+      {
+        "en": "Tobio Kageyama",
+        "ja": "影山飛雄",
+        "ja_typings": [
+          "kageyamatobio"
+        ]
+      },
+      {
+        "en": "Tetsuro Kuroo",
+        "ja": "黒尾鉄朗",
+        "ja_typings": [
+          "kurootetsurou"
+        ]
+      },
+      {
+        "en": "Shoyo Hinata",
+        "ja": "日向翔陽",
+        "ja_typings": [
+          "hinatashouyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02930",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Aoba Johsai setter rivals Kageyama as 'the Grand King' in Haikyu!!?",
+      "ja": "ハイキュー!! で影山のライバル、青葉城西の「大王様」と呼ばれるセッターは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tsunade",
+        "ja": "綱手",
+        "ja_typings": [
+          "tsunade"
+        ]
+      },
+      {
+        "en": "Jiraiya",
+        "ja": "自来也",
+        "ja_typings": [
+          "jiraiya"
+        ]
+      },
+      {
+        "en": "Orochimaru",
+        "ja": "大蛇丸",
+        "ja_typings": [
+          "orochimaru"
+        ]
+      },
+      {
+        "en": "Kakashi Hatake",
+        "ja": "はたけカカシ",
+        "ja_typings": [
+          "hatakekakashi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02931",
+    "image_path": null,
+    "question_text": {
+      "en": "Which busty blonde Sannin becomes the Fifth Hokage in Naruto?",
+      "ja": "ナルトで五代目火影に就任する金髪・巨乳の伝説の三忍は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Unlimited Void",
+        "ja": "無量空処",
+        "ja_typings": [
+          "muryoukuusho"
+        ]
+      },
+      {
+        "en": "Malevolent Shrine",
+        "ja": "伏魔御厨子",
+        "ja_typings": [
+          "fukumamizushi"
+        ]
+      },
+      {
+        "en": "Chimera Shadow Garden",
+        "ja": "嵌合暗翳庭",
+        "ja_typings": [
+          "kangouan'eitei"
+        ]
+      },
+      {
+        "en": "Time Prison",
+        "ja": "時胞月宮殿",
+        "ja_typings": [
+          "jihougetsukyuuden"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02932",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Gojo domain forces total sensory input on everyone inside it?",
+      "ja": "五条悟の領域展開で内部の全員に膨大な情報を流し込むのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Uryu Ishida",
+        "ja": "石田雨竜",
+        "ja_typings": [
+          "ishidauryuu"
+        ]
+      },
+      {
+        "en": "Orihime Inoue",
+        "ja": "井上織姫",
+        "ja_typings": [
+          "inoueorihime"
+        ]
+      },
+      {
+        "en": "Rukia Kuchiki",
+        "ja": "朽木ルキア",
+        "ja_typings": [
+          "kuchikirukia"
+        ]
+      },
+      {
+        "en": "Yasutora Sado",
+        "ja": "茶渡泰虎",
+        "ja_typings": [
+          "sadoyasutora"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02933",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Bleach Quincy archer is one of Ichigo's school friends?",
+      "ja": "BLEACH で一護のクラスメイトの滅却師の弓使いは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vegeta",
+        "ja": "ベジータ",
+        "ja_typings": [
+          "beji-ta"
+        ]
+      },
+      {
+        "en": "Piccolo",
+        "ja": "ピッコロ",
+        "ja_typings": [
+          "pikkoro"
+        ]
+      },
+      {
+        "en": "Krillin",
+        "ja": "クリリン",
+        "ja_typings": [
+          "kuririn"
+        ]
+      },
+      {
+        "en": "Frieza",
+        "ja": "フリーザ",
+        "ja_typings": [
+          "furi-za"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02934",
+    "image_path": null,
+    "question_text": {
+      "en": "Which proud Saiyan prince is Goku's longtime rival and ally?",
+      "ja": "悟空のライバルにして仲間となる誇り高きサイヤ人の王子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "WIT STUDIO",
+        "ja": "WITスタジオ",
+        "ja_typings": [
+          "witsutajio"
+        ]
+      },
+      {
+        "en": "ufotable",
+        "ja": "ユーフォーテーブル",
+        "ja_typings": [
+          "yu-fo-te-buru"
+        ]
+      },
+      {
+        "en": "Toei Animation",
+        "ja": "東映アニメーション",
+        "ja_typings": [
+          "toueianimeeshon"
+        ]
+      },
+      {
+        "en": "Sunrise",
+        "ja": "サンライズ",
+        "ja_typings": [
+          "sanraizu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02935",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio produced Attack on Titan seasons 1–3?",
+      "ja": "進撃の巨人 シーズン1～3を制作したスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Winry Rockbell",
+        "ja": "ウィンリィ・ロックベル",
+        "ja_typings": [
+          "winrii/rokkuberu"
+        ]
+      },
+      {
+        "en": "Alphonse Elric",
+        "ja": "アルフォンス・エルリック",
+        "ja_typings": [
+          "arufonsu/erurikku"
+        ]
+      },
+      {
+        "en": "Edward Elric",
+        "ja": "エドワード・エルリック",
+        "ja_typings": [
+          "edowa-do/erurikku"
+        ]
+      },
+      {
+        "en": "Roy Mustang",
+        "ja": "ロイ・マスタング",
+        "ja_typings": [
+          "roi/masutangu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02936",
+    "image_path": null,
+    "question_text": {
+      "en": "Which blonde automail mechanic in FMA grew up with the Elric brothers?",
+      "ja": "鋼の錬金術師でエルリック兄弟と幼馴染の機械鎧技師は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yashamaru",
+        "ja": "夜叉丸",
+        "ja_typings": [
+          "yashamaru"
+        ]
+      },
+      {
+        "en": "Kakashi Hatake",
+        "ja": "はたけカカシ",
+        "ja_typings": [
+          "hatakekakashi"
+        ]
+      },
+      {
+        "en": "Sasuke Uchiha",
+        "ja": "うちはサスケ",
+        "ja_typings": [
+          "uchihasasuke"
+        ]
+      },
+      {
+        "en": "Tsunade",
+        "ja": "綱手",
+        "ja_typings": [
+          "tsunade"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02937",
+    "image_path": null,
+    "question_text": {
+      "en": "Which masked maternal-uncle bodyguard of young Gaara dies in early Naruto?",
+      "ja": "ナルト初期で幼少の我愛羅の世話役だった仮面の母方の叔父は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yor Forger",
+        "ja": "ヨル・フォージャー",
+        "ja_typings": [
+          "yoru/fo-ja-"
+        ]
+      },
+      {
+        "en": "Anya Forger",
+        "ja": "アーニャ・フォージャー",
+        "ja_typings": [
+          "a-nya/fo-ja-"
+        ]
+      },
+      {
+        "en": "Loid Forger",
+        "ja": "ロイド・フォージャー",
+        "ja_typings": [
+          "roido/fo-ja-"
+        ]
+      },
+      {
+        "en": "Yuri Briar",
+        "ja": "ユーリ・ブライア",
+        "ja_typings": [
+          "yu-ri/buraia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02938",
+    "image_path": null,
+    "question_text": {
+      "en": "Which dark-haired Spy x Family mother is secretly the assassin 'Thorn Princess'?",
+      "ja": "スパイファミリーの母親で正体が殺し屋「いばら姫」の女性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yoshiyuki Tomino",
+        "ja": "富野由悠季",
+        "ja_typings": [
+          "tominoyoshiyuki"
+        ]
+      },
+      {
+        "en": "Hideaki Anno",
+        "ja": "庵野秀明",
+        "ja_typings": [
+          "annohideaki"
+        ]
+      },
+      {
+        "en": "Mamoru Oshii",
+        "ja": "押井守",
+        "ja_typings": [
+          "oshiimamoru"
+        ]
+      },
+      {
+        "en": "Mamoru Hosoda",
+        "ja": "細田守",
+        "ja_typings": [
+          "hosodamamoru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02939",
+    "image_path": null,
+    "question_text": {
+      "en": "Which veteran director created Mobile Suit Gundam and is called the 'father of Gundam'?",
+      "ja": "機動戦士ガンダムを生み「ガンダムの父」と呼ばれる監督は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yuri Briar",
+        "ja": "ユーリ・ブライア",
+        "ja_typings": [
+          "yu-ri/buraia"
+        ]
+      },
+      {
+        "en": "Yor Forger",
+        "ja": "ヨル・フォージャー",
+        "ja_typings": [
+          "yoru/fo-ja-"
+        ]
+      },
+      {
+        "en": "Loid Forger",
+        "ja": "ロイド・フォージャー",
+        "ja_typings": [
+          "roido/fo-ja-"
+        ]
+      },
+      {
+        "en": "Anya Forger",
+        "ja": "アーニャ・フォージャー",
+        "ja_typings": [
+          "a-nya/fo-ja-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02940",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sister-obsessed State Security officer is Yor's younger brother?",
+      "ja": "スパイファミリーでヨルを溺愛する弟・国家保安局員は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Zenitsu Agatsuma",
+        "ja": "我妻善逸",
+        "ja_typings": [
+          "agatsumazenitsu"
+        ]
+      },
+      {
+        "en": "Inosuke Hashibira",
+        "ja": "嘴平伊之助",
+        "ja_typings": [
+          "hashibirainosuke"
+        ]
+      },
+      {
+        "en": "Tanjiro Kamado",
+        "ja": "竈門炭治郎",
+        "ja_typings": [
+          "kamadotanjirou"
+        ]
+      },
+      {
+        "en": "Giyu Tomioka",
+        "ja": "冨岡義勇",
+        "ja_typings": [
+          "tomiokagiyuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02941",
+    "image_path": null,
+    "question_text": {
+      "en": "Which cowardly thunder-breathing Demon Slayer is in love with Nezuko?",
+      "ja": "禰豆子に惚れている雷の呼吸の臆病な鬼殺隊士は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ufotable",
+        "ja": "ユーフォーテーブル",
+        "ja_typings": [
+          "yu-fo-te-buru"
+        ]
+      },
+      {
+        "en": "WIT STUDIO",
+        "ja": "WITスタジオ",
+        "ja_typings": [
+          "witsutajio"
+        ]
+      },
+      {
+        "en": "Shaft",
+        "ja": "シャフト",
+        "ja_typings": [
+          "shafuto"
+        ]
+      },
+      {
+        "en": "Sunrise",
+        "ja": "サンライズ",
+        "ja_typings": [
+          "sanraizu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "anime",
+    "id": "q02942",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio is known for high-quality battle animation in Demon Slayer and Fate/Zero?",
+      "ja": "鬼滅の刃や Fate/Zero の戦闘作画で知られるスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ARMS",
+        "ja": "アームズ",
+        "ja_typings": [
+          "a-muzu"
+        ]
+      },
+      {
+        "en": "Splatoon",
+        "ja": "スプラトゥーン",
+        "ja_typings": [
+          "supuratu-n"
+        ]
+      },
+      {
+        "en": "Pikmin",
+        "ja": "ピクミン",
+        "ja_typings": [
+          "pikumin"
+        ]
+      },
+      {
+        "en": "Star Fox",
+        "ja": "スターフォックス",
+        "ja_typings": [
+          "suta-fokkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02943",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nintendo Switch fighting game uses extendable arms?",
+      "ja": "ニンテンドースイッチで腕が伸びる格闘ゲームはどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Activision",
+        "ja": "アクティビジョン",
+        "ja_typings": [
+          "akutibijon"
+        ]
+      },
+      {
+        "en": "Bungie",
+        "ja": "バンジー",
+        "ja_typings": [
+          "banji-"
+        ]
+      },
+      {
+        "en": "Bethesda",
+        "ja": "ベセスダ",
+        "ja_typings": [
+          "besesuda"
+        ]
+      },
+      {
+        "en": "Ubisoft",
+        "ja": "ユービーアイソフト",
+        "ja_typings": [
+          "yu-bi-aisofuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02944",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company publishes Call of Duty?",
+      "ja": "コール オブ デューティを発売している会社はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Agent 47",
+        "ja": "エージェント47",
+        "ja_typings": [
+          "e-jento47"
+        ]
+      },
+      {
+        "en": "Sam Fisher",
+        "ja": "サム・フィッシャー",
+        "ja_typings": [
+          "samu/fissha-"
+        ]
+      },
+      {
+        "en": "Jason Bourne",
+        "ja": "ジェイソン・ボーン",
+        "ja_typings": [
+          "jeison/bo-n"
+        ]
+      },
+      {
+        "en": "Goro Majima",
+        "ja": "真島吾朗",
+        "ja_typings": [
+          "majima goro",
+          "majimagorou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02945",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the bald assassin protagonist of the Hitman series?",
+      "ja": "ヒットマンシリーズの主人公である禿頭の暗殺者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Akira Nishikiyama",
+        "ja": "錦山彰",
+        "ja_typings": [
+          "nishikiyama akira",
+          "nishikiyamaakira"
+        ]
+      },
+      {
+        "en": "Goro Majima",
+        "ja": "真島吾朗",
+        "ja_typings": [
+          "majima goro",
+          "majimagorou"
+        ]
+      },
+      {
+        "en": "Ichiban Kasuga",
+        "ja": "春日一番",
+        "ja_typings": [
+          "kasuga ichiban",
+          "kasugaichiban"
+        ]
+      },
+      {
+        "en": "Goichi Suda",
+        "ja": "須田剛一",
+        "ja_typings": [
+          "suda goichi",
+          "sudagouichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02946",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the Tojo Clan captain who Kiryu fought in Yakuza?",
+      "ja": "龍が如くで桐生が戦う東城会の若頭は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Apex Legends",
+        "ja": "エーペックスレジェンズ",
+        "ja_typings": [
+          "e-pekkusurejenzu"
+        ]
+      },
+      {
+        "en": "Valorant",
+        "ja": "ヴァロラント",
+        "ja_typings": [
+          "varoranto"
+        ]
+      },
+      {
+        "en": "Overwatch",
+        "ja": "オーバーウォッチ",
+        "ja_typings": [
+          "o-ba-wotchi"
+        ]
+      },
+      {
+        "en": "Fortnite",
+        "ja": "フォートナイト",
+        "ja_typings": [
+          "fo-tonaito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02947",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Respawn battle royale features Legends with unique abilities?",
+      "ja": "リスポーンのバトルロイヤルでレジェンドが登場する作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Azur Lane",
+        "ja": "アズールレーン",
+        "ja_typings": [
+          "azu-rure-n"
+        ]
+      },
+      {
+        "en": "Granblue Fantasy",
+        "ja": "グランブルーファンタジー",
+        "ja_typings": [
+          "guranburu-fantaji-"
+        ]
+      },
+      {
+        "en": "Princess Connect",
+        "ja": "プリンセスコネクト",
+        "ja_typings": [
+          "purinsesukonekuto"
+        ]
+      },
+      {
+        "en": "Shadowverse",
+        "ja": "シャドウバース",
+        "ja_typings": [
+          "shadoba-su",
+          "shadouba-su"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02948",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mobile game features anthropomorphized warship girls?",
+      "ja": "艦船を擬人化したモバイルゲームはどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Battlefield",
+        "ja": "バトルフィールド",
+        "ja_typings": [
+          "batorufi-rudo"
+        ]
+      },
+      {
+        "en": "Medal of Honor",
+        "ja": "メダル・オブ・オナー",
+        "ja_typings": [
+          "medaru/obu/ona-"
+        ]
+      },
+      {
+        "en": "Rainbow Six",
+        "ja": "レインボーシックス",
+        "ja_typings": [
+          "reinbo-shikkusu"
+        ]
+      },
+      {
+        "en": "Team Fortress",
+        "ja": "チームフォートレス",
+        "ja_typings": [
+          "chi-mufo-toresu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02949",
+    "image_path": null,
+    "question_text": {
+      "en": "Which EA first-person shooter series competes with Call of Duty?",
+      "ja": "EAが出すCoDのライバルとなるFPSシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bethesda",
+        "ja": "ベセスダ",
+        "ja_typings": [
+          "besesuda"
+        ]
+      },
+      {
+        "en": "Bungie",
+        "ja": "バンジー",
+        "ja_typings": [
+          "banji-"
+        ]
+      },
+      {
+        "en": "Activision",
+        "ja": "アクティビジョン",
+        "ja_typings": [
+          "akutibijon"
+        ]
+      },
+      {
+        "en": "Epic Games",
+        "ja": "エピックゲームズ",
+        "ja_typings": [
+          "epikkuge-muzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02950",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio makes The Elder Scrolls and Fallout?",
+      "ja": "エルダースクロールズやフォールアウトを作る会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Black Desert",
+        "ja": "黒い砂漠",
+        "ja_typings": [
+          "kuroi sabaku",
+          "kuroisabaku"
+        ]
+      },
+      {
+        "en": "Lost Ark",
+        "ja": "ロストアーク",
+        "ja_typings": [
+          "rosutoa-ku"
+        ]
+      },
+      {
+        "en": "Guild Wars 2",
+        "ja": "ギルドウォーズ2",
+        "ja_typings": [
+          "girudouo-zu2",
+          "girudouo-zutsu-",
+          "girudowo-zu2"
+        ]
+      },
+      {
+        "en": "EverQuest",
+        "ja": "エバークエスト",
+        "ja_typings": [
+          "eba-kuesuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02951",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Korean MMORPG known for graphics was made by Pearl Abyss?",
+      "ja": "パールアビスが開発した韓国産MMORPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bomberman",
+        "ja": "ボンバーマン",
+        "ja_typings": [
+          "bonba-man"
+        ]
+      },
+      {
+        "en": "Dig Dug",
+        "ja": "ディグダグ",
+        "ja_typings": [
+          "digudagu"
+        ]
+      },
+      {
+        "en": "Galaga",
+        "ja": "ギャラガ",
+        "ja_typings": [
+          "gyaraga"
+        ]
+      },
+      {
+        "en": "Xevious",
+        "ja": "ゼビウス",
+        "ja_typings": [
+          "zebiusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02952",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hudson classic features a character planting bombs in a maze?",
+      "ja": "ハドソンの爆弾を置く迷路ゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Boom Beach",
+        "ja": "ブームビーチ",
+        "ja_typings": [
+          "bu-mubi-chi"
+        ]
+      },
+      {
+        "en": "Hay Day",
+        "ja": "ヘイデイ",
+        "ja_typings": [
+          "heidei"
+        ]
+      },
+      {
+        "en": "Brawl Stars",
+        "ja": "ブロスタ",
+        "ja_typings": [
+          "burosuta"
+        ]
+      },
+      {
+        "en": "Ingress",
+        "ja": "イングレス",
+        "ja_typings": [
+          "inguresu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02953",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Supercell game has players raiding tropical beaches?",
+      "ja": "スーパーセル社の南の島を攻略するゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Borderlands",
+        "ja": "ボーダーランズ",
+        "ja_typings": [
+          "bo-da-ranzu"
+        ]
+      },
+      {
+        "en": "Doom",
+        "ja": "ドゥーム",
+        "ja_typings": [
+          "du-mu"
+        ]
+      },
+      {
+        "en": "Quake",
+        "ja": "クエイク",
+        "ja_typings": [
+          "kueiku"
+        ]
+      },
+      {
+        "en": "Deus Ex",
+        "ja": "デウスエクス",
+        "ja_typings": [
+          "deusuekusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02954",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2K loot-shooter series features cel-shaded graphics on Pandora?",
+      "ja": "2Kのトゥーン調FPSでパンドラ星を舞台にする作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Brawl Stars",
+        "ja": "ブロスタ",
+        "ja_typings": [
+          "burosuta"
+        ]
+      },
+      {
+        "en": "Boom Beach",
+        "ja": "ブームビーチ",
+        "ja_typings": [
+          "bu-mubi-chi"
+        ]
+      },
+      {
+        "en": "Hay Day",
+        "ja": "ヘイデイ",
+        "ja_typings": [
+          "heidei"
+        ]
+      },
+      {
+        "en": "Pikmin Bloom",
+        "ja": "ピクミンブルーム",
+        "ja_typings": [
+          "pikuminburu-mu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02955",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Supercell mobile game features 3v3 team brawls?",
+      "ja": "スーパーセルの3対3のチーム対戦モバイルゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Breakout",
+        "ja": "ブレイクアウト",
+        "ja_typings": [
+          "bureikuauto"
+        ]
+      },
+      {
+        "en": "Columns",
+        "ja": "コラムス",
+        "ja_typings": [
+          "koramusu"
+        ]
+      },
+      {
+        "en": "Galaxian",
+        "ja": "ギャラクシアン",
+        "ja_typings": [
+          "gyarakushian"
+        ]
+      },
+      {
+        "en": "Moon Cresta",
+        "ja": "ムーンクレスタ",
+        "ja_typings": [
+          "mu-nkuresuta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02956",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Atari classic involves bouncing a ball to break bricks?",
+      "ja": "ボールでブロックを崩すアタリのゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bungie",
+        "ja": "バンジー",
+        "ja_typings": [
+          "banji-"
+        ]
+      },
+      {
+        "en": "Bethesda",
+        "ja": "ベセスダ",
+        "ja_typings": [
+          "besesuda"
+        ]
+      },
+      {
+        "en": "Activision",
+        "ja": "アクティビジョン",
+        "ja_typings": [
+          "akutibijon"
+        ]
+      },
+      {
+        "en": "Take-Two Interactive",
+        "ja": "テイクツー",
+        "ja_typings": [
+          "teikutsu-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02957",
+    "image_path": null,
+    "question_text": {
+      "en": "Which studio created Destiny and Halo?",
+      "ja": "ヘイローやデスティニーを作ったスタジオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CS:GO",
+        "ja": "シーエスゴー",
+        "ja_typings": [
+          "shi-esugo-"
+        ]
+      },
+      {
+        "en": "Valorant",
+        "ja": "ヴァロラント",
+        "ja_typings": [
+          "varoranto"
+        ]
+      },
+      {
+        "en": "Quake",
+        "ja": "クエイク",
+        "ja_typings": [
+          "kueiku"
+        ]
+      },
+      {
+        "en": "Apex Legends",
+        "ja": "エーペックスレジェンズ",
+        "ja_typings": [
+          "e-pekkusurejenzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02958",
+    "image_path": null,
+    "question_text": {
+      "en": "Which competitive FPS is short for Counter-Strike: Global Offensive?",
+      "ja": "カウンターストライクの略称で語られる対戦FPSは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Call of Duty",
+        "ja": "コール オブ デューティ",
+        "ja_typings": [
+          "ko-ru obu deyu-ti"
+        ]
+      },
+      {
+        "en": "Battlefield",
+        "ja": "バトルフィールド",
+        "ja_typings": [
+          "batorufi-rudo"
+        ]
+      },
+      {
+        "en": "Medal of Honor",
+        "ja": "メダル・オブ・オナー",
+        "ja_typings": [
+          "medaru/obu/ona-"
+        ]
+      },
+      {
+        "en": "Doom",
+        "ja": "ドゥーム",
+        "ja_typings": [
+          "du-mu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02959",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Activision FPS series has Modern Warfare entries?",
+      "ja": "モダンウォーフェアを含むアクティビジョンのFPSは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Columns",
+        "ja": "コラムス",
+        "ja_typings": [
+          "koramusu"
+        ]
+      },
+      {
+        "en": "Puyo Puyo",
+        "ja": "ぷよぷよ",
+        "ja_typings": [
+          "puyopuyo"
+        ]
+      },
+      {
+        "en": "Dr. Mario",
+        "ja": "ドクターマリオ",
+        "ja_typings": [
+          "dokuta-mario"
+        ]
+      },
+      {
+        "en": "Tetris",
+        "ja": "テトリス",
+        "ja_typings": [
+          "tetorisu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02960",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Sega puzzle game involves matching colored stones in columns?",
+      "ja": "セガの落ちもの宝石パズルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cyberpunk 2077",
+        "ja": "サイバーパンク2077",
+        "ja_typings": [
+          "saiba-panku2077"
+        ]
+      },
+      {
+        "en": "Witcher",
+        "ja": "ウィッチャー",
+        "ja_typings": [
+          "witcha-"
+        ]
+      },
+      {
+        "en": "Fallout",
+        "ja": "フォールアウト",
+        "ja_typings": [
+          "fo-ruauto"
+        ]
+      },
+      {
+        "en": "Deus Ex",
+        "ja": "デウスエクス",
+        "ja_typings": [
+          "deusuekusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02961",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CD Projekt RED dystopian RPG was released in 2020?",
+      "ja": "CDプロジェクト製の2020年発売SF RPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Days Gone",
+        "ja": "デイズ ゴーン",
+        "ja_typings": [
+          "deizu go-n"
+        ]
+      },
+      {
+        "en": "Death Stranding",
+        "ja": "デス・ストランディング",
+        "ja_typings": [
+          "desu/sutorandingu"
+        ]
+      },
+      {
+        "en": "Detroit: Become Human",
+        "ja": "デトロイト ビカム ヒューマン",
+        "ja_typings": [
+          "detoroito bikamu hyu-man"
+        ]
+      },
+      {
+        "en": "Ghost of Tsushima",
+        "ja": "ゴースト・オブ・ツシマ",
+        "ja_typings": [
+          "go-suto/obu/tsushima"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02962",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Sony post-apocalyptic biker game features Deacon St. John?",
+      "ja": "ディーコンが主人公のソニーのバイクゾンビゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Death Stranding",
+        "ja": "デス・ストランディング",
+        "ja_typings": [
+          "desu/sutorandingu"
+        ]
+      },
+      {
+        "en": "Days Gone",
+        "ja": "デイズ ゴーン",
+        "ja_typings": [
+          "deizu go-n"
+        ]
+      },
+      {
+        "en": "Sekiro",
+        "ja": "隻狼",
+        "ja_typings": [
+          "sekiro",
+          "sekirou"
+        ]
+      },
+      {
+        "en": "Cyberpunk 2077",
+        "ja": "サイバーパンク2077",
+        "ja_typings": [
+          "saiba-panku2077"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02963",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Kojima Productions delivery game features Sam Bridges?",
+      "ja": "サム・ブリッジズが配達するコジマプロの作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Detroit: Become Human",
+        "ja": "デトロイト ビカム ヒューマン",
+        "ja_typings": [
+          "detoroito bikamu hyu-man"
+        ]
+      },
+      {
+        "en": "Death Stranding",
+        "ja": "デス・ストランディング",
+        "ja_typings": [
+          "desu/sutorandingu"
+        ]
+      },
+      {
+        "en": "Days Gone",
+        "ja": "デイズ ゴーン",
+        "ja_typings": [
+          "deizu go-n"
+        ]
+      },
+      {
+        "en": "Doom",
+        "ja": "ドゥーム",
+        "ja_typings": [
+          "du-mu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02964",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Quantic Dream game depicts a society of sentient androids?",
+      "ja": "クアンティック・ドリームのアンドロイドが主役の作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Deus Ex",
+        "ja": "デウスエクス",
+        "ja_typings": [
+          "deusuekusu"
+        ]
+      },
+      {
+        "en": "Cyberpunk 2077",
+        "ja": "サイバーパンク2077",
+        "ja_typings": [
+          "saiba-panku2077"
+        ]
+      },
+      {
+        "en": "Shadowrun",
+        "ja": "シャドウラン",
+        "ja_typings": [
+          "shadoran",
+          "shadouran"
+        ]
+      },
+      {
+        "en": "Fallout",
+        "ja": "フォールアウト",
+        "ja_typings": [
+          "fo-ruauto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02965",
+    "image_path": null,
+    "question_text": {
+      "en": "Which cyberpunk RPG series features augmented agent Adam Jensen?",
+      "ja": "アダム・ジェンセンが主人公のサイバーパンクRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dig Dug",
+        "ja": "ディグダグ",
+        "ja_typings": [
+          "digudagu"
+        ]
+      },
+      {
+        "en": "Galaga",
+        "ja": "ギャラガ",
+        "ja_typings": [
+          "gyaraga"
+        ]
+      },
+      {
+        "en": "Xevious",
+        "ja": "ゼビウス",
+        "ja_typings": [
+          "zebiusu"
+        ]
+      },
+      {
+        "en": "Galaxian",
+        "ja": "ギャラクシアン",
+        "ja_typings": [
+          "gyarakushian"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02966",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Namco classic involves a character pumping up underground monsters?",
+      "ja": "地中の敵を膨らませて倒すナムコのゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Doom",
+        "ja": "ドゥーム",
+        "ja_typings": [
+          "du-mu"
+        ]
+      },
+      {
+        "en": "Quake",
+        "ja": "クエイク",
+        "ja_typings": [
+          "kueiku"
+        ]
+      },
+      {
+        "en": "Wolfenstein",
+        "ja": "ウルフェンシュタイン",
+        "ja_typings": [
+          "urufenshutain"
+        ]
+      },
+      {
+        "en": "Half-Life",
+        "ja": "ハーフライフ",
+        "ja_typings": [
+          "ha-furaifu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02967",
+    "image_path": null,
+    "question_text": {
+      "en": "Which id Software FPS features a Space Marine fighting demons?",
+      "ja": "id Softwareの悪魔を倒す宇宙海兵FPSは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dota 2",
+        "ja": "ドータ2",
+        "ja_typings": [
+          "do-ta2",
+          "do-tatsu-"
+        ]
+      },
+      {
+        "en": "Smite",
+        "ja": "スマイト",
+        "ja_typings": [
+          "sumaito"
+        ]
+      },
+      {
+        "en": "Heroes of the Storm",
+        "ja": "ヒーローズ・オブ・ザ・ストーム",
+        "ja_typings": [
+          "hi-ro-zu/obu/za/suto-mu"
+        ]
+      },
+      {
+        "en": "Rocket League",
+        "ja": "ロケットリーグ",
+        "ja_typings": [
+          "rokettori-gu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02968",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Valve MOBA features heroes battling for ancients?",
+      "ja": "Valveのエンシェントを破壊するMOBAは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dr. Mario",
+        "ja": "ドクターマリオ",
+        "ja_typings": [
+          "dokuta-mario"
+        ]
+      },
+      {
+        "en": "Paper Mario",
+        "ja": "ペーパーマリオ",
+        "ja_typings": [
+          "pe-pa-mario"
+        ]
+      },
+      {
+        "en": "Mario Party",
+        "ja": "マリオパーティ",
+        "ja_typings": [
+          "mariopa-ti"
+        ]
+      },
+      {
+        "en": "Mario Kart",
+        "ja": "マリオカート",
+        "ja_typings": [
+          "marioka-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02969",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Game Boy puzzle game has Mario throwing pills at viruses?",
+      "ja": "マリオがウイルスを薬で倒すゲームボーイのパズルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dragon Quest X",
+        "ja": "ドラゴンクエストX",
+        "ja_typings": [
+          "doragonkuesutox",
+          "doragonkuesutoten"
+        ]
+      },
+      {
+        "en": "Dragon Quest IX",
+        "ja": "ドラゴンクエストIX",
+        "ja_typings": [
+          "doragonkuesutoix",
+          "doragonkuesutonain"
+        ]
+      },
+      {
+        "en": "Dragon Quest XI",
+        "ja": "ドラゴンクエストXI",
+        "ja_typings": [
+          "doragonkuesutoxi",
+          "doragonkuesutoirebun"
+        ]
+      },
+      {
+        "en": "Dragon Quest VIII",
+        "ja": "ドラゴンクエストVIII",
+        "ja_typings": [
+          "doragonkuesutoviii",
+          "doragonkuesutoeito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02970",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Dragon Quest entry is the MMORPG numbered ten?",
+      "ja": "ドラクエシリーズで唯一のMMORPGの番号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Epic Games",
+        "ja": "エピックゲームズ",
+        "ja_typings": [
+          "epikkuge-muzu"
+        ]
+      },
+      {
+        "en": "Ubisoft",
+        "ja": "ユービーアイソフト",
+        "ja_typings": [
+          "yu-bi-aisofuto"
+        ]
+      },
+      {
+        "en": "Activision",
+        "ja": "アクティビジョン",
+        "ja_typings": [
+          "akutibijon"
+        ]
+      },
+      {
+        "en": "Take-Two Interactive",
+        "ja": "テイクツー",
+        "ja_typings": [
+          "teikutsu-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02971",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company makes Unreal Engine and Fortnite?",
+      "ja": "アンリアルエンジンとフォートナイトの会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "EverQuest",
+        "ja": "エバークエスト",
+        "ja_typings": [
+          "eba-kuesuto"
+        ]
+      },
+      {
+        "en": "Lost Ark",
+        "ja": "ロストアーク",
+        "ja_typings": [
+          "rosutoa-ku"
+        ]
+      },
+      {
+        "en": "Guild Wars 2",
+        "ja": "ギルドウォーズ2",
+        "ja_typings": [
+          "girudouo-zu2",
+          "girudouo-zutsu-",
+          "girudowo-zu2"
+        ]
+      },
+      {
+        "en": "Black Desert",
+        "ja": "黒い砂漠",
+        "ja_typings": [
+          "kuroi sabaku",
+          "kuroisabaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02972",
+    "image_path": null,
+    "question_text": {
+      "en": "Which classic Sony Online MMORPG predated World of Warcraft?",
+      "ja": "WoW登場以前のソニー製代表的MMORPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fallout",
+        "ja": "フォールアウト",
+        "ja_typings": [
+          "fo-ruauto"
+        ]
+      },
+      {
+        "en": "The Elder Scrolls",
+        "ja": "エルダースクロールズ",
+        "ja_typings": [
+          "eruda-sukuro-ruzu"
+        ]
+      },
+      {
+        "en": "Borderlands",
+        "ja": "ボーダーランズ",
+        "ja_typings": [
+          "bo-da-ranzu"
+        ]
+      },
+      {
+        "en": "Witcher",
+        "ja": "ウィッチャー",
+        "ja_typings": [
+          "witcha-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02973",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Bethesda post-apocalyptic RPG features Vault Boy?",
+      "ja": "ベセスダのVault Boyが象徴のポストアポカリプスRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Football Manager",
+        "ja": "フットボールマネージャー",
+        "ja_typings": [
+          "futtobo-rumane-ja-"
+        ]
+      },
+      {
+        "en": "Winning Eleven",
+        "ja": "ウイニングイレブン",
+        "ja_typings": [
+          "uininguirebun"
+        ]
+      },
+      {
+        "en": "Pro Spirits",
+        "ja": "プロスピ",
+        "ja_typings": [
+          "purosupi"
+        ]
+      },
+      {
+        "en": "Pro Yakyu Spirits",
+        "ja": "プロ野球スピリッツ",
+        "ja_typings": [
+          "pro yakyu spirits",
+          "puroyakyuusupirittsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02974",
+    "image_path": null,
+    "question_text": {
+      "en": "Which SEGA Sports Interactive series simulates soccer team management?",
+      "ja": "セガが出すサッカークラブ経営シミュは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Galaga",
+        "ja": "ギャラガ",
+        "ja_typings": [
+          "gyaraga"
+        ]
+      },
+      {
+        "en": "Galaxian",
+        "ja": "ギャラクシアン",
+        "ja_typings": [
+          "gyarakushian"
+        ]
+      },
+      {
+        "en": "Xevious",
+        "ja": "ゼビウス",
+        "ja_typings": [
+          "zebiusu"
+        ]
+      },
+      {
+        "en": "Moon Cresta",
+        "ja": "ムーンクレスタ",
+        "ja_typings": [
+          "mu-nkuresuta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02975",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Namco shooter has insects forming attack formations?",
+      "ja": "編隊で攻撃してくるナムコのシューティングは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Galaxian",
+        "ja": "ギャラクシアン",
+        "ja_typings": [
+          "gyarakushian"
+        ]
+      },
+      {
+        "en": "Galaga",
+        "ja": "ギャラガ",
+        "ja_typings": [
+          "gyaraga"
+        ]
+      },
+      {
+        "en": "Xevious",
+        "ja": "ゼビウス",
+        "ja_typings": [
+          "zebiusu"
+        ]
+      },
+      {
+        "en": "Space Invaders",
+        "ja": "スペースインベーダー",
+        "ja_typings": [
+          "supe-suinbe-da-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02976",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Namco shooter from 1979 preceded Galaga?",
+      "ja": "ギャラガの前作にあたる1979年のナムコ作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ghost of Tsushima",
+        "ja": "ゴースト・オブ・ツシマ",
+        "ja_typings": [
+          "go-suto/obu/tsushima"
+        ]
+      },
+      {
+        "en": "Sekiro",
+        "ja": "隻狼",
+        "ja_typings": [
+          "sekiro",
+          "sekirou"
+        ]
+      },
+      {
+        "en": "Days Gone",
+        "ja": "デイズ ゴーン",
+        "ja_typings": [
+          "deizu go-n"
+        ]
+      },
+      {
+        "en": "Death Stranding",
+        "ja": "デス・ストランディング",
+        "ja_typings": [
+          "desu/sutorandingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02977",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Sucker Punch samurai game is set on a Mongol-invaded island?",
+      "ja": "サッカーパンチ社の蒙古襲来を舞台にしたサムライ作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Goichi Suda",
+        "ja": "須田剛一",
+        "ja_typings": [
+          "suda goichi",
+          "sudagouichi"
+        ]
+      },
+      {
+        "en": "Hideki Kamiya",
+        "ja": "神谷英樹",
+        "ja_typings": [
+          "kamiya hideki",
+          "kamiyahideki"
+        ]
+      },
+      {
+        "en": "Shinji Mikami",
+        "ja": "三上真司",
+        "ja_typings": [
+          "mikami shinji",
+          "mikamishinji"
+        ]
+      },
+      {
+        "en": "Tomonobu Itagaki",
+        "ja": "板垣伴信",
+        "ja_typings": [
+          "itagaki tomonobu",
+          "itagakitomonobu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02978",
+    "image_path": null,
+    "question_text": {
+      "en": "Who founded Grasshopper Manufacture and directed No More Heroes?",
+      "ja": "ノーモア★ヒーローズを生んだグラスホッパー創業者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Goro Majima",
+        "ja": "真島吾朗",
+        "ja_typings": [
+          "majima goro",
+          "majimagorou"
+        ]
+      },
+      {
+        "en": "Akira Nishikiyama",
+        "ja": "錦山彰",
+        "ja_typings": [
+          "nishikiyama akira",
+          "nishikiyamaakira"
+        ]
+      },
+      {
+        "en": "Ichiban Kasuga",
+        "ja": "春日一番",
+        "ja_typings": [
+          "kasuga ichiban",
+          "kasugaichiban"
+        ]
+      },
+      {
+        "en": "Kazuma Kiryu",
+        "ja": "桐生一馬",
+        "ja_typings": [
+          "kiryu kazuma",
+          "kiryuukazuma"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02979",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the eyepatch-wearing Mad Dog of Shimano in Yakuza?",
+      "ja": "龍が如くで眼帯姿の嶋野の狂犬は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Granblue Fantasy",
+        "ja": "グランブルーファンタジー",
+        "ja_typings": [
+          "guranburu-fantaji-"
+        ]
+      },
+      {
+        "en": "Princess Connect",
+        "ja": "プリンセスコネクト",
+        "ja_typings": [
+          "purinsesukonekuto"
+        ]
+      },
+      {
+        "en": "Shadowverse",
+        "ja": "シャドウバース",
+        "ja_typings": [
+          "shadoba-su",
+          "shadouba-su"
+        ]
+      },
+      {
+        "en": "Azur Lane",
+        "ja": "アズールレーン",
+        "ja_typings": [
+          "azu-rure-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02980",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Cygames fantasy mobile RPG features sky-faring adventurers?",
+      "ja": "サイゲームスの空の旅を描くファンタジーRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Guild Wars 2",
+        "ja": "ギルドウォーズ2",
+        "ja_typings": [
+          "girudouo-zu2",
+          "girudouo-zutsu-",
+          "girudowo-zu2"
+        ]
+      },
+      {
+        "en": "EverQuest",
+        "ja": "エバークエスト",
+        "ja_typings": [
+          "eba-kuesuto"
+        ]
+      },
+      {
+        "en": "Lost Ark",
+        "ja": "ロストアーク",
+        "ja_typings": [
+          "rosutoa-ku"
+        ]
+      },
+      {
+        "en": "World of Warcraft",
+        "ja": "ワールド オブ ウォークラフト",
+        "ja_typings": [
+          "wa-rudo obu wo-kurafuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02981",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ArenaNet MMORPG sequel released in 2012 has no monthly fee?",
+      "ja": "アリーナネットの月額無料MMORPG続編は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gunpei Yokoi",
+        "ja": "横井軍平",
+        "ja_typings": [
+          "yokoi gunpei",
+          "yokoigunpei"
+        ]
+      },
+      {
+        "en": "Satoru Iwata",
+        "ja": "岩田聡",
+        "ja_typings": [
+          "iwata satoru",
+          "iwatasatoru"
+        ]
+      },
+      {
+        "en": "Satoshi Tajiri",
+        "ja": "田尻智",
+        "ja_typings": [
+          "tajiri satoshi",
+          "tajirisatoshi"
+        ]
+      },
+      {
+        "en": "Yuji Naka",
+        "ja": "中裕司",
+        "ja_typings": [
+          "naka yuji",
+          "nakayuuji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02982",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created the Game & Watch and Game Boy at Nintendo?",
+      "ja": "ゲーム&ウオッチとゲームボーイの生みの親は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hack and Slash",
+        "ja": "ハックアンドスラッシュ",
+        "ja_typings": [
+          "hakkuandosurasshu"
+        ]
+      },
+      {
+        "en": "Turn-based Strategy",
+        "ja": "ターン制ストラテジー",
+        "ja_typings": [
+          "ta-nseisutorateji-"
+        ]
+      },
+      {
+        "en": "MOBA",
+        "ja": "モバ",
+        "ja_typings": [
+          "moba"
+        ]
+      },
+      {
+        "en": "RTS",
+        "ja": "リアルタイムストラテジー",
+        "ja_typings": [
+          "riarutaimusutorateji-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02983",
+    "image_path": null,
+    "question_text": {
+      "en": "Which action game genre is abbreviated H&S?",
+      "ja": "ハクスラとも呼ばれるアクションゲームのジャンルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Harry Potter: Wizards Unite",
+        "ja": "ハリーポッター 魔法同盟",
+        "ja_typings": [
+          "mahou doumei",
+          "mahoudoumei"
+        ]
+      },
+      {
+        "en": "Pikmin Bloom",
+        "ja": "ピクミンブルーム",
+        "ja_typings": [
+          "pikuminburu-mu"
+        ]
+      },
+      {
+        "en": "Ingress",
+        "ja": "イングレス",
+        "ja_typings": [
+          "inguresu"
+        ]
+      },
+      {
+        "en": "Pokemon GO",
+        "ja": "ポケモンGO",
+        "ja_typings": [
+          "pokemongo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02984",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Niantic AR game uses the Harry Potter universe?",
+      "ja": "ナイアンティックのハリーポッターAR位置情報ゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hay Day",
+        "ja": "ヘイデイ",
+        "ja_typings": [
+          "heidei"
+        ]
+      },
+      {
+        "en": "Boom Beach",
+        "ja": "ブームビーチ",
+        "ja_typings": [
+          "bu-mubi-chi"
+        ]
+      },
+      {
+        "en": "Brawl Stars",
+        "ja": "ブロスタ",
+        "ja_typings": [
+          "burosuta"
+        ]
+      },
+      {
+        "en": "Story of Seasons",
+        "ja": "牧場物語",
+        "ja_typings": [
+          "bokujou monogatari",
+          "bokujoumonogatari"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02985",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Supercell game has players running a small farm?",
+      "ja": "スーパーセル製の農場経営モバイルゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Heroes of the Storm",
+        "ja": "ヒーローズ・オブ・ザ・ストーム",
+        "ja_typings": [
+          "hi-ro-zu/obu/za/suto-mu"
+        ]
+      },
+      {
+        "en": "Dota 2",
+        "ja": "ドータ2",
+        "ja_typings": [
+          "do-ta2",
+          "do-tatsu-"
+        ]
+      },
+      {
+        "en": "Smite",
+        "ja": "スマイト",
+        "ja_typings": [
+          "sumaito"
+        ]
+      },
+      {
+        "en": "Overwatch",
+        "ja": "オーバーウォッチ",
+        "ja_typings": [
+          "o-ba-wotchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02986",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Blizzard MOBA features characters from across its franchises?",
+      "ja": "ブリザード全作品のキャラが集うMOBAは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hideki Kamiya",
+        "ja": "神谷英樹",
+        "ja_typings": [
+          "kamiya hideki",
+          "kamiyahideki"
+        ]
+      },
+      {
+        "en": "Shinji Mikami",
+        "ja": "三上真司",
+        "ja_typings": [
+          "mikami shinji",
+          "mikamishinji"
+        ]
+      },
+      {
+        "en": "Goichi Suda",
+        "ja": "須田剛一",
+        "ja_typings": [
+          "suda goichi",
+          "sudagouichi"
+        ]
+      },
+      {
+        "en": "Hideo Kojima",
+        "ja": "小島秀夫",
+        "ja_typings": [
+          "kojima hideo",
+          "kojimahideo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02987",
+    "image_path": null,
+    "question_text": {
+      "en": "Who directed Bayonetta and founded PlatinumGames?",
+      "ja": "ベヨネッタの監督でプラチナゲームズ創業者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hideo Kojima",
+        "ja": "小島秀夫",
+        "ja_typings": [
+          "kojima hideo",
+          "kojimahideo"
+        ]
+      },
+      {
+        "en": "Hideki Kamiya",
+        "ja": "神谷英樹",
+        "ja_typings": [
+          "kamiya hideki",
+          "kamiyahideki"
+        ]
+      },
+      {
+        "en": "Shinji Mikami",
+        "ja": "三上真司",
+        "ja_typings": [
+          "mikami shinji",
+          "mikamishinji"
+        ]
+      },
+      {
+        "en": "Tetsuya Nomura",
+        "ja": "野村哲也",
+        "ja_typings": [
+          "nomura tetsuya",
+          "nomuratetsuya"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02988",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Metal Gear Solid and Death Stranding?",
+      "ja": "メタルギアやデス・ストランディングの作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hironobu Sakaguchi",
+        "ja": "坂口博信",
+        "ja_typings": [
+          "sakaguchi hironobu",
+          "sakaguchihironobu"
+        ]
+      },
+      {
+        "en": "Yuji Horii",
+        "ja": "堀井雄二",
+        "ja_typings": [
+          "horii yuji",
+          "horiiyuuji"
+        ]
+      },
+      {
+        "en": "Tetsuya Nomura",
+        "ja": "野村哲也",
+        "ja_typings": [
+          "nomura tetsuya",
+          "nomuratetsuya"
+        ]
+      },
+      {
+        "en": "Motomu Toriyama",
+        "ja": "鳥山求",
+        "ja_typings": [
+          "toriyama motomu",
+          "toriyamamotomu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02989",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created the Final Fantasy series at Square?",
+      "ja": "ファイナルファンタジーシリーズの生みの親は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Honkai Star Rail",
+        "ja": "崩壊スターレイル",
+        "ja_typings": [
+          "houkai sutareiru",
+          "houkaisutareiru"
+        ]
+      },
+      {
+        "en": "Tower of Fantasy",
+        "ja": "幻塔",
+        "ja_typings": [
+          "gentou"
+        ]
+      },
+      {
+        "en": "Granblue Fantasy",
+        "ja": "グランブルーファンタジー",
+        "ja_typings": [
+          "guranburu-fantaji-"
+        ]
+      },
+      {
+        "en": "Azur Lane",
+        "ja": "アズールレーン",
+        "ja_typings": [
+          "azu-rure-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02990",
+    "image_path": null,
+    "question_text": {
+      "en": "Which HoYoverse space-themed turn-based RPG launched in 2023?",
+      "ja": "ホヨバースの2023年宇宙ターン制RPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ichiban Kasuga",
+        "ja": "春日一番",
+        "ja_typings": [
+          "kasuga ichiban",
+          "kasugaichiban"
+        ]
+      },
+      {
+        "en": "Goro Majima",
+        "ja": "真島吾朗",
+        "ja_typings": [
+          "majima goro",
+          "majimagorou"
+        ]
+      },
+      {
+        "en": "Akira Nishikiyama",
+        "ja": "錦山彰",
+        "ja_typings": [
+          "nishikiyama akira",
+          "nishikiyamaakira"
+        ]
+      },
+      {
+        "en": "Kazuma Kiryu",
+        "ja": "桐生一馬",
+        "ja_typings": [
+          "kiryu kazuma",
+          "kiryuukazuma"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02991",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the protagonist of Yakuza: Like a Dragon?",
+      "ja": "龍が如く7の主人公は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ingress",
+        "ja": "イングレス",
+        "ja_typings": [
+          "inguresu"
+        ]
+      },
+      {
+        "en": "Pikmin Bloom",
+        "ja": "ピクミンブルーム",
+        "ja_typings": [
+          "pikuminburu-mu"
+        ]
+      },
+      {
+        "en": "Harry Potter: Wizards Unite",
+        "ja": "ハリーポッター 魔法同盟",
+        "ja_typings": [
+          "mahou doumei",
+          "mahoudoumei"
+        ]
+      },
+      {
+        "en": "Hay Day",
+        "ja": "ヘイデイ",
+        "ja_typings": [
+          "heidei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02992",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Niantic AR game predated Pokemon GO?",
+      "ja": "ナイアンティックがポケモンGOより前に出した位置情報ARゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Itadaki Street",
+        "ja": "いただきストリート",
+        "ja_typings": [
+          "itadakisutori-to"
+        ]
+      },
+      {
+        "en": "Mario Party",
+        "ja": "マリオパーティ",
+        "ja_typings": [
+          "mariopa-ti"
+        ]
+      },
+      {
+        "en": "The Game of Life",
+        "ja": "人生ゲーム",
+        "ja_typings": [
+          "jinsei game",
+          "jinseigeemu"
+        ]
+      },
+      {
+        "en": "Mario Kart",
+        "ja": "マリオカート",
+        "ja_typings": [
+          "marioka-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02993",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Square board-game series features Dragon Quest characters?",
+      "ja": "ドラクエキャラが登場するスクウェアの双六ゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jak and Daxter",
+        "ja": "ジャック×ダクスター",
+        "ja_typings": [
+          "jakkudakusuta-"
+        ]
+      },
+      {
+        "en": "Ratchet & Clank",
+        "ja": "ラチェット&クランク",
+        "ja_typings": [
+          "rachettokuranku"
+        ]
+      },
+      {
+        "en": "Uncharted",
+        "ja": "アンチャーテッド",
+        "ja_typings": [
+          "ancha-teddo"
+        ]
+      },
+      {
+        "en": "Sly Cooper",
+        "ja": "怪盗スライ",
+        "ja_typings": [
+          "kaitou suraikuupaa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02994",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Naughty Dog PS2 platformer pairs a boy with a furry sidekick?",
+      "ja": "ノーティードッグのPS2ジャンプアクションは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Keiji Inafune",
+        "ja": "稲船敬二",
+        "ja_typings": [
+          "inafune keiji",
+          "inafunekeiji"
+        ]
+      },
+      {
+        "en": "Shinji Mikami",
+        "ja": "三上真司",
+        "ja_typings": [
+          "mikami shinji",
+          "mikamishinji"
+        ]
+      },
+      {
+        "en": "Yoshiki Okamoto",
+        "ja": "岡本吉起",
+        "ja_typings": [
+          "okamoto yoshiki",
+          "okamotoyoshiki"
+        ]
+      },
+      {
+        "en": "Hideki Kamiya",
+        "ja": "神谷英樹",
+        "ja_typings": [
+          "kamiya hideki",
+          "kamiyahideki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02995",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created Mega Man at Capcom?",
+      "ja": "カプコンでロックマンを生んだ人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Koichi Nakamura",
+        "ja": "中村光一",
+        "ja_typings": [
+          "nakamura koichi",
+          "nakamurakouichi"
+        ]
+      },
+      {
+        "en": "Yuji Horii",
+        "ja": "堀井雄二",
+        "ja_typings": [
+          "horii yuji",
+          "horiiyuuji"
+        ]
+      },
+      {
+        "en": "Yuji Naka",
+        "ja": "中裕司",
+        "ja_typings": [
+          "naka yuji",
+          "nakayuuji"
+        ]
+      },
+      {
+        "en": "Satoshi Tajiri",
+        "ja": "田尻智",
+        "ja_typings": [
+          "tajiri satoshi",
+          "tajirisatoshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02996",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created the original Dragon Quest game system at Chunsoft?",
+      "ja": "ドラクエ初代のプログラマでチュンソフト創業者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lost Ark",
+        "ja": "ロストアーク",
+        "ja_typings": [
+          "rosutoa-ku"
+        ]
+      },
+      {
+        "en": "Black Desert",
+        "ja": "黒い砂漠",
+        "ja_typings": [
+          "kuroi sabaku",
+          "kuroisabaku"
+        ]
+      },
+      {
+        "en": "EverQuest",
+        "ja": "エバークエスト",
+        "ja_typings": [
+          "eba-kuesuto"
+        ]
+      },
+      {
+        "en": "Guild Wars 2",
+        "ja": "ギルドウォーズ2",
+        "ja_typings": [
+          "girudouo-zu2",
+          "girudouo-zutsu-",
+          "girudowo-zu2"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02997",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Smilegate MMORPG with isometric view launched globally in 2022?",
+      "ja": "スマイルゲートの2022年世界配信トップダウンMMORPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MOBA",
+        "ja": "モバ",
+        "ja_typings": [
+          "moba"
+        ]
+      },
+      {
+        "en": "RTS",
+        "ja": "リアルタイムストラテジー",
+        "ja_typings": [
+          "riarutaimusutorateji-"
+        ]
+      },
+      {
+        "en": "RPG",
+        "ja": "ロールプレイングゲーム",
+        "ja_typings": [
+          "ro-rupureinguge-mu"
+        ]
+      },
+      {
+        "en": "Hack and Slash",
+        "ja": "ハックアンドスラッシュ",
+        "ja_typings": [
+          "hakkuandosurasshu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02998",
+    "image_path": null,
+    "question_text": {
+      "en": "Which genre includes League of Legends and Dota 2?",
+      "ja": "LoLやDota 2のジャンル名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mario Kart",
+        "ja": "マリオカート",
+        "ja_typings": [
+          "marioka-to"
+        ]
+      },
+      {
+        "en": "Mario Party",
+        "ja": "マリオパーティ",
+        "ja_typings": [
+          "mariopa-ti"
+        ]
+      },
+      {
+        "en": "Rocket League",
+        "ja": "ロケットリーグ",
+        "ja_typings": [
+          "rokettori-gu"
+        ]
+      },
+      {
+        "en": "Star Fox",
+        "ja": "スターフォックス",
+        "ja_typings": [
+          "suta-fokkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q02999",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nintendo racing series features banana peels and shells?",
+      "ja": "甲羅やバナナを投げる任天堂レースゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mario Party",
+        "ja": "マリオパーティ",
+        "ja_typings": [
+          "mariopa-ti"
+        ]
+      },
+      {
+        "en": "Mario Kart",
+        "ja": "マリオカート",
+        "ja_typings": [
+          "marioka-to"
+        ]
+      },
+      {
+        "en": "Itadaki Street",
+        "ja": "いただきストリート",
+        "ja_typings": [
+          "itadakisutori-to"
+        ]
+      },
+      {
+        "en": "The Game of Life",
+        "ja": "人生ゲーム",
+        "ja_typings": [
+          "jinsei game",
+          "jinseigeemu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03000",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nintendo party game series features minigame board play?",
+      "ja": "ミニゲーム集の任天堂パーティーゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Masahiro Sakurai",
+        "ja": "桜井政博",
+        "ja_typings": [
+          "sakurai masahiro",
+          "sakuraimasahiro"
+        ]
+      },
+      {
+        "en": "Satoru Iwata",
+        "ja": "岩田聡",
+        "ja_typings": [
+          "iwata satoru",
+          "iwatasatoru"
+        ]
+      },
+      {
+        "en": "Gunpei Yokoi",
+        "ja": "横井軍平",
+        "ja_typings": [
+          "yokoi gunpei",
+          "yokoigunpei"
+        ]
+      },
+      {
+        "en": "Hideki Kamiya",
+        "ja": "神谷英樹",
+        "ja_typings": [
+          "kamiya hideki",
+          "kamiyahideki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03001",
+    "image_path": null,
+    "question_text": {
+      "en": "Who directed Super Smash Bros. and Kirby?",
+      "ja": "スマブラやカービィの生みの親は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Medal of Honor",
+        "ja": "メダル・オブ・オナー",
+        "ja_typings": [
+          "medaru/obu/ona-"
+        ]
+      },
+      {
+        "en": "Battlefield",
+        "ja": "バトルフィールド",
+        "ja_typings": [
+          "batorufi-rudo"
+        ]
+      },
+      {
+        "en": "Doom",
+        "ja": "ドゥーム",
+        "ja_typings": [
+          "du-mu"
+        ]
+      },
+      {
+        "en": "Team Fortress",
+        "ja": "チームフォートレス",
+        "ja_typings": [
+          "chi-mufo-toresu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03002",
+    "image_path": null,
+    "question_text": {
+      "en": "Which EA WWII FPS series competed with early Call of Duty?",
+      "ja": "EAの第二次大戦FPSで初期CoDの競合は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mega Man",
+        "ja": "ロックマン",
+        "ja_typings": [
+          "rokkuman"
+        ]
+      },
+      {
+        "en": "Sengoku Basara",
+        "ja": "戦国BASARA",
+        "ja_typings": [
+          "sengoku basara"
+        ]
+      },
+      {
+        "en": "Monster Hunter",
+        "ja": "モンスターハンター",
+        "ja_typings": [
+          "monsuta-hanta-"
+        ]
+      },
+      {
+        "en": "Tomb Raider",
+        "ja": "トゥームレイダー",
+        "ja_typings": [
+          "tu-mureida-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03003",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Capcom blue-armored robot hero series began in 1987?",
+      "ja": "1987年に始まった青い鎧のカプコンロボットは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Moero Pro Yakyu",
+        "ja": "燃えろ!!プロ野球",
+        "ja_typings": [
+          "moero pro yakyu",
+          "moeropuroyakyuu"
+        ]
+      },
+      {
+        "en": "Pro Spirits",
+        "ja": "プロスピ",
+        "ja_typings": [
+          "purosupi"
+        ]
+      },
+      {
+        "en": "Pro Yakyu Spirits",
+        "ja": "プロ野球スピリッツ",
+        "ja_typings": [
+          "pro yakyu spirits",
+          "puroyakyuusupirittsu"
+        ]
+      },
+      {
+        "en": "Winning Eleven",
+        "ja": "ウイニングイレブン",
+        "ja_typings": [
+          "uininguirebun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03004",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Konami baseball series features pixel-style players?",
+      "ja": "燃えろプロ野球の二頭身プロ野球ゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Monster Hunter",
+        "ja": "モンスターハンター",
+        "ja_typings": [
+          "monsuta-hanta-"
+        ]
+      },
+      {
+        "en": "Mega Man",
+        "ja": "ロックマン",
+        "ja_typings": [
+          "rokkuman"
+        ]
+      },
+      {
+        "en": "Sengoku Basara",
+        "ja": "戦国BASARA",
+        "ja_typings": [
+          "sengoku basara"
+        ]
+      },
+      {
+        "en": "Sekiro",
+        "ja": "隻狼",
+        "ja_typings": [
+          "sekiro",
+          "sekirou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03005",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Capcom action series has hunters slaying giant beasts?",
+      "ja": "巨大モンスターを狩るカプコン代表作は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Moon Cresta",
+        "ja": "ムーンクレスタ",
+        "ja_typings": [
+          "mu-nkuresuta"
+        ]
+      },
+      {
+        "en": "Galaxian",
+        "ja": "ギャラクシアン",
+        "ja_typings": [
+          "gyarakushian"
+        ]
+      },
+      {
+        "en": "Xevious",
+        "ja": "ゼビウス",
+        "ja_typings": [
+          "zebiusu"
+        ]
+      },
+      {
+        "en": "Space Invaders",
+        "ja": "スペースインベーダー",
+        "ja_typings": [
+          "supe-suinbe-da-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03006",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1980 Nichibutsu shooter sequel to Cosmos features docking?",
+      "ja": "三段ロケットがドッキングする日物のシューティングは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Motomu Toriyama",
+        "ja": "鳥山求",
+        "ja_typings": [
+          "toriyama motomu",
+          "toriyamamotomu"
+        ]
+      },
+      {
+        "en": "Tetsuya Nomura",
+        "ja": "野村哲也",
+        "ja_typings": [
+          "nomura tetsuya",
+          "nomuratetsuya"
+        ]
+      },
+      {
+        "en": "Hironobu Sakaguchi",
+        "ja": "坂口博信",
+        "ja_typings": [
+          "sakaguchi hironobu",
+          "sakaguchihironobu"
+        ]
+      },
+      {
+        "en": "Yuji Horii",
+        "ja": "堀井雄二",
+        "ja_typings": [
+          "horii yuji",
+          "horiiyuuji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03007",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the Final Fantasy XIII director at Square Enix?",
+      "ja": "FF13シリーズの監督を務めたスクエニ社員は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nintendo 3DS",
+        "ja": "ニンテンドー3DS",
+        "ja_typings": [
+          "nintendo-3ds",
+          "nintendo-suri-dei-esu"
+        ]
+      },
+      {
+        "en": "Nintendo DS",
+        "ja": "ニンテンドーDS",
+        "ja_typings": [
+          "nintendo-ds",
+          "nintendo-dei-esu"
+        ]
+      },
+      {
+        "en": "Nintendo Switch",
+        "ja": "ニンテンドースイッチ",
+        "ja_typings": [
+          "nintendo-suitchi"
+        ]
+      },
+      {
+        "en": "Wii U",
+        "ja": "ウィーユー",
+        "ja_typings": [
+          "wi-yu-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03008",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nintendo handheld introduced stereoscopic 3D without glasses?",
+      "ja": "裸眼3D表示を搭載した任天堂の携帯機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nintendo DS",
+        "ja": "ニンテンドーDS",
+        "ja_typings": [
+          "nintendo-ds",
+          "nintendo-dei-esu"
+        ]
+      },
+      {
+        "en": "Nintendo 3DS",
+        "ja": "ニンテンドー3DS",
+        "ja_typings": [
+          "nintendo-3ds",
+          "nintendo-suri-dei-esu"
+        ]
+      },
+      {
+        "en": "Nintendo Switch",
+        "ja": "ニンテンドースイッチ",
+        "ja_typings": [
+          "nintendo-suitchi"
+        ]
+      },
+      {
+        "en": "PlayStation Portal",
+        "ja": "プレイステーション・ポータル",
+        "ja_typings": [
+          "pureisute-shon/po-taru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03009",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nintendo dual-screen handheld launched in 2004?",
+      "ja": "2004年発売の任天堂二画面携帯機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Overwatch",
+        "ja": "オーバーウォッチ",
+        "ja_typings": [
+          "o-ba-wotchi"
+        ]
+      },
+      {
+        "en": "Valorant",
+        "ja": "ヴァロラント",
+        "ja_typings": [
+          "varoranto"
+        ]
+      },
+      {
+        "en": "Apex Legends",
+        "ja": "エーペックスレジェンズ",
+        "ja_typings": [
+          "e-pekkusurejenzu"
+        ]
+      },
+      {
+        "en": "Team Fortress",
+        "ja": "チームフォートレス",
+        "ja_typings": [
+          "chi-mufo-toresu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03010",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Blizzard hero shooter features Tracer and Reinhardt?",
+      "ja": "トレーサーやラインハルトが登場するブリザードのFPSは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Paper Mario",
+        "ja": "ペーパーマリオ",
+        "ja_typings": [
+          "pe-pa-mario"
+        ]
+      },
+      {
+        "en": "Dr. Mario",
+        "ja": "ドクターマリオ",
+        "ja_typings": [
+          "dokuta-mario"
+        ]
+      },
+      {
+        "en": "Mario Party",
+        "ja": "マリオパーティ",
+        "ja_typings": [
+          "mariopa-ti"
+        ]
+      },
+      {
+        "en": "Mario Kart",
+        "ja": "マリオカート",
+        "ja_typings": [
+          "marioka-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03011",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mario spin-off RPG uses 2D paper visuals?",
+      "ja": "紙のような2D表現を使うマリオRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pikmin",
+        "ja": "ピクミン",
+        "ja_typings": [
+          "pikumin"
+        ]
+      },
+      {
+        "en": "Pikmin Bloom",
+        "ja": "ピクミンブルーム",
+        "ja_typings": [
+          "pikuminburu-mu"
+        ]
+      },
+      {
+        "en": "Splatoon",
+        "ja": "スプラトゥーン",
+        "ja_typings": [
+          "supuratu-n"
+        ]
+      },
+      {
+        "en": "Star Fox",
+        "ja": "スターフォックス",
+        "ja_typings": [
+          "suta-fokkusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03012",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Miyamoto strategy series has players directing tiny plant creatures?",
+      "ja": "宮本茂作の植物人間を率いる戦略アクションは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pikmin Bloom",
+        "ja": "ピクミンブルーム",
+        "ja_typings": [
+          "pikuminburu-mu"
+        ]
+      },
+      {
+        "en": "Pikmin",
+        "ja": "ピクミン",
+        "ja_typings": [
+          "pikumin"
+        ]
+      },
+      {
+        "en": "Ingress",
+        "ja": "イングレス",
+        "ja_typings": [
+          "inguresu"
+        ]
+      },
+      {
+        "en": "Harry Potter: Wizards Unite",
+        "ja": "ハリーポッター 魔法同盟",
+        "ja_typings": [
+          "mahou doumei",
+          "mahoudoumei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03013",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Niantic walking-AR app uses Pikmin to track steps?",
+      "ja": "ピクミンが歩数を彩るナイアンティックの散歩アプリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PlayStation",
+        "ja": "プレイステーション",
+        "ja_typings": [
+          "pureisute-shon"
+        ]
+      },
+      {
+        "en": "Nintendo Switch",
+        "ja": "ニンテンドースイッチ",
+        "ja_typings": [
+          "nintendo-suitchi"
+        ]
+      },
+      {
+        "en": "Wii U",
+        "ja": "ウィーユー",
+        "ja_typings": [
+          "wi-yu-"
+        ]
+      },
+      {
+        "en": "Steam Deck",
+        "ja": "スチームデック",
+        "ja_typings": [
+          "suchi-mudekku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03014",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Sony game console brand started in 1994?",
+      "ja": "1994年発売のソニー据置ゲーム機ブランドは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PlayStation Portal",
+        "ja": "プレイステーション・ポータル",
+        "ja_typings": [
+          "pureisute-shon/po-taru"
+        ]
+      },
+      {
+        "en": "Steam Deck",
+        "ja": "スチームデック",
+        "ja_typings": [
+          "suchi-mudekku"
+        ]
+      },
+      {
+        "en": "ROG Ally",
+        "ja": "ロジー・アライ",
+        "ja_typings": [
+          "roji-/arai"
+        ]
+      },
+      {
+        "en": "Nintendo Switch",
+        "ja": "ニンテンドースイッチ",
+        "ja_typings": [
+          "nintendo-suitchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03015",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Sony streaming handheld plays PS5 games over Wi-Fi?",
+      "ja": "PS5の映像をWi-Fi越しに遊ぶソニーの携帯端末は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Portal",
+        "ja": "ポータル",
+        "ja_typings": [
+          "po-taru"
+        ]
+      },
+      {
+        "en": "Breakout",
+        "ja": "ブレイクアウト",
+        "ja_typings": [
+          "bureikuauto"
+        ]
+      },
+      {
+        "en": "Quake",
+        "ja": "クエイク",
+        "ja_typings": [
+          "kueiku"
+        ]
+      },
+      {
+        "en": "Doom",
+        "ja": "ドゥーム",
+        "ja_typings": [
+          "du-mu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03016",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Valve puzzle game features a portal-creating gun?",
+      "ja": "ポータルを撃つValveのパズルゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Princess Connect",
+        "ja": "プリンセスコネクト",
+        "ja_typings": [
+          "purinsesukonekuto"
+        ]
+      },
+      {
+        "en": "Granblue Fantasy",
+        "ja": "グランブルーファンタジー",
+        "ja_typings": [
+          "guranburu-fantaji-"
+        ]
+      },
+      {
+        "en": "Azur Lane",
+        "ja": "アズールレーン",
+        "ja_typings": [
+          "azu-rure-n"
+        ]
+      },
+      {
+        "en": "Shadowverse",
+        "ja": "シャドウバース",
+        "ja_typings": [
+          "shadoba-su",
+          "shadouba-su"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03017",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Cygames anime-style mobile RPG features a guild of girls?",
+      "ja": "サイゲームスの美少女ギルド系モバイルRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pro Spirits",
+        "ja": "プロスピ",
+        "ja_typings": [
+          "purosupi"
+        ]
+      },
+      {
+        "en": "Pro Yakyu Spirits",
+        "ja": "プロ野球スピリッツ",
+        "ja_typings": [
+          "pro yakyu spirits",
+          "puroyakyuusupirittsu"
+        ]
+      },
+      {
+        "en": "Moero Pro Yakyu",
+        "ja": "燃えろ!!プロ野球",
+        "ja_typings": [
+          "moero pro yakyu",
+          "moeropuroyakyuu"
+        ]
+      },
+      {
+        "en": "Winning Eleven",
+        "ja": "ウイニングイレブン",
+        "ja_typings": [
+          "uininguirebun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03018",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Konami baseball series is abbreviated as Pro Spi?",
+      "ja": "プロスピと略されるコナミ野球ゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pro Yakyu Spirits",
+        "ja": "プロ野球スピリッツ",
+        "ja_typings": [
+          "pro yakyu spirits",
+          "puroyakyuusupirittsu"
+        ]
+      },
+      {
+        "en": "Pro Spirits",
+        "ja": "プロスピ",
+        "ja_typings": [
+          "purosupi"
+        ]
+      },
+      {
+        "en": "Moero Pro Yakyu",
+        "ja": "燃えろ!!プロ野球",
+        "ja_typings": [
+          "moero pro yakyu",
+          "moeropuroyakyuu"
+        ]
+      },
+      {
+        "en": "Football Manager",
+        "ja": "フットボールマネージャー",
+        "ja_typings": [
+          "futtobo-rumane-ja-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03019",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Konami simulation series is the official Pro Yakyu game?",
+      "ja": "プロ野球の正式ライセンスを持つコナミの本格野球シミュは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Puyo Puyo",
+        "ja": "ぷよぷよ",
+        "ja_typings": [
+          "puyopuyo"
+        ]
+      },
+      {
+        "en": "Columns",
+        "ja": "コラムス",
+        "ja_typings": [
+          "koramusu"
+        ]
+      },
+      {
+        "en": "Dr. Mario",
+        "ja": "ドクターマリオ",
+        "ja_typings": [
+          "dokuta-mario"
+        ]
+      },
+      {
+        "en": "Tetris",
+        "ja": "テトリス",
+        "ja_typings": [
+          "tetorisu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03020",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Compile/Sega puzzle game features chain-clearing colored blobs?",
+      "ja": "連鎖で消すコンパイル/セガのカラフルパズルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Quake",
+        "ja": "クエイク",
+        "ja_typings": [
+          "kueiku"
+        ]
+      },
+      {
+        "en": "Doom",
+        "ja": "ドゥーム",
+        "ja_typings": [
+          "du-mu"
+        ]
+      },
+      {
+        "en": "Half-Life",
+        "ja": "ハーフライフ",
+        "ja_typings": [
+          "ha-furaifu"
+        ]
+      },
+      {
+        "en": "Wolfenstein",
+        "ja": "ウルフェンシュタイン",
+        "ja_typings": [
+          "urufenshutain"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03021",
+    "image_path": null,
+    "question_text": {
+      "en": "Which id Software FPS succeeded Doom with full 3D graphics?",
+      "ja": "ドゥームに続くid Softwareの3D FPSは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ROG Ally",
+        "ja": "ロジー・アライ",
+        "ja_typings": [
+          "roji-/arai"
+        ]
+      },
+      {
+        "en": "Steam Deck",
+        "ja": "スチームデック",
+        "ja_typings": [
+          "suchi-mudekku"
+        ]
+      },
+      {
+        "en": "PlayStation Portal",
+        "ja": "プレイステーション・ポータル",
+        "ja_typings": [
+          "pureisute-shon/po-taru"
+        ]
+      },
+      {
+        "en": "Nintendo Switch",
+        "ja": "ニンテンドースイッチ",
+        "ja_typings": [
+          "nintendo-suitchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03022",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ASUS Windows handheld competes with Steam Deck?",
+      "ja": "Steam Deckの競合となるASUSのWindows携帯機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "RPG",
+        "ja": "ロールプレイングゲーム",
+        "ja_typings": [
+          "ro-rupureinguge-mu"
+        ]
+      },
+      {
+        "en": "MOBA",
+        "ja": "モバ",
+        "ja_typings": [
+          "moba"
+        ]
+      },
+      {
+        "en": "RTS",
+        "ja": "リアルタイムストラテジー",
+        "ja_typings": [
+          "riarutaimusutorateji-"
+        ]
+      },
+      {
+        "en": "Hack and Slash",
+        "ja": "ハックアンドスラッシュ",
+        "ja_typings": [
+          "hakkuandosurasshu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03023",
+    "image_path": null,
+    "question_text": {
+      "en": "Which genre includes Final Fantasy and Dragon Quest?",
+      "ja": "FFやドラクエが代表するジャンル名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "RTS",
+        "ja": "リアルタイムストラテジー",
+        "ja_typings": [
+          "riarutaimusutorateji-"
+        ]
+      },
+      {
+        "en": "Turn-based Strategy",
+        "ja": "ターン制ストラテジー",
+        "ja_typings": [
+          "ta-nseisutorateji-"
+        ]
+      },
+      {
+        "en": "MOBA",
+        "ja": "モバ",
+        "ja_typings": [
+          "moba"
+        ]
+      },
+      {
+        "en": "RPG",
+        "ja": "ロールプレイングゲーム",
+        "ja_typings": [
+          "ro-rupureinguge-mu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03024",
+    "image_path": null,
+    "question_text": {
+      "en": "Which genre includes StarCraft and Age of Empires?",
+      "ja": "StarCraftやAge of Empiresのジャンル名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rainbow Six",
+        "ja": "レインボーシックス",
+        "ja_typings": [
+          "reinbo-shikkusu"
+        ]
+      },
+      {
+        "en": "Rainbow Six Siege",
+        "ja": "レインボーシックス シージ",
+        "ja_typings": [
+          "reinbo-shikkusu shi-ji"
+        ]
+      },
+      {
+        "en": "CS:GO",
+        "ja": "シーエスゴー",
+        "ja_typings": [
+          "shi-esugo-"
+        ]
+      },
+      {
+        "en": "Valorant",
+        "ja": "ヴァロラント",
+        "ja_typings": [
+          "varoranto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03025",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Ubisoft tactical shooter is named after Tom Clancy's novel?",
+      "ja": "トム・クランシー原作のユービーアイ戦術シューターは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rainbow Six Siege",
+        "ja": "レインボーシックス シージ",
+        "ja_typings": [
+          "reinbo-shikkusu shi-ji"
+        ]
+      },
+      {
+        "en": "Rainbow Six",
+        "ja": "レインボーシックス",
+        "ja_typings": [
+          "reinbo-shikkusu"
+        ]
+      },
+      {
+        "en": "Apex Legends",
+        "ja": "エーペックスレジェンズ",
+        "ja_typings": [
+          "e-pekkusurejenzu"
+        ]
+      },
+      {
+        "en": "Valorant",
+        "ja": "ヴァロラント",
+        "ja_typings": [
+          "varoranto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03026",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2015 Ubisoft 5v5 attack-defend shooter became an esports staple?",
+      "ja": "2015年発売の5対5攻防シューター(R6)は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ratchet & Clank",
+        "ja": "ラチェット&クランク",
+        "ja_typings": [
+          "rachettokuranku"
+        ]
+      },
+      {
+        "en": "Jak and Daxter",
+        "ja": "ジャック×ダクスター",
+        "ja_typings": [
+          "jakkudakusuta-"
+        ]
+      },
+      {
+        "en": "Uncharted",
+        "ja": "アンチャーテッド",
+        "ja_typings": [
+          "ancha-teddo"
+        ]
+      },
+      {
+        "en": "Sly Cooper",
+        "ja": "怪盗スライ",
+        "ja_typings": [
+          "kaitou suraikuupaa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03027",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Insomniac PS series pairs a lombax with a robot?",
+      "ja": "ロンバックスとロボットが冒険するインソムニアックの作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rocket League",
+        "ja": "ロケットリーグ",
+        "ja_typings": [
+          "rokettori-gu"
+        ]
+      },
+      {
+        "en": "Mario Kart",
+        "ja": "マリオカート",
+        "ja_typings": [
+          "marioka-to"
+        ]
+      },
+      {
+        "en": "Smite",
+        "ja": "スマイト",
+        "ja_typings": [
+          "sumaito"
+        ]
+      },
+      {
+        "en": "Dota 2",
+        "ja": "ドータ2",
+        "ja_typings": [
+          "do-ta2",
+          "do-tatsu-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03028",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Psyonix game combines soccer with rocket-powered cars?",
+      "ja": "ロケット推進の車でサッカーをするPsyonixのゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rune Factory",
+        "ja": "ルーンファクトリー",
+        "ja_typings": [
+          "ru-nfakutori-"
+        ]
+      },
+      {
+        "en": "Story of Seasons",
+        "ja": "牧場物語",
+        "ja_typings": [
+          "bokujou monogatari",
+          "bokujoumonogatari"
+        ]
+      },
+      {
+        "en": "Hay Day",
+        "ja": "ヘイデイ",
+        "ja_typings": [
+          "heidei"
+        ]
+      },
+      {
+        "en": "Pikmin Bloom",
+        "ja": "ピクミンブルーム",
+        "ja_typings": [
+          "pikuminburu-mu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03029",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Marvelous farming RPG was once called Harvest Moon overseas?",
+      "ja": "海外でハーベストムーン名義だった牧場経営RPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sakura Wars",
+        "ja": "サクラ大戦",
+        "ja_typings": [
+          "sakura taisen",
+          "sakurataisen"
+        ]
+      },
+      {
+        "en": "Sengoku Basara",
+        "ja": "戦国BASARA",
+        "ja_typings": [
+          "sengoku basara"
+        ]
+      },
+      {
+        "en": "Granblue Fantasy",
+        "ja": "グランブルーファンタジー",
+        "ja_typings": [
+          "guranburu-fantaji-"
+        ]
+      },
+      {
+        "en": "Princess Connect",
+        "ja": "プリンセスコネクト",
+        "ja_typings": [
+          "purinsesukonekuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03030",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Sega series features the Imperial Floral Assault Troupe?",
+      "ja": "帝国華撃団が活躍するセガの作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sam Fisher",
+        "ja": "サム・フィッシャー",
+        "ja_typings": [
+          "samu/fissha-"
+        ]
+      },
+      {
+        "en": "Agent 47",
+        "ja": "エージェント47",
+        "ja_typings": [
+          "e-jento47"
+        ]
+      },
+      {
+        "en": "Jason Bourne",
+        "ja": "ジェイソン・ボーン",
+        "ja_typings": [
+          "jeison/bo-n"
+        ]
+      },
+      {
+        "en": "Ichiban Kasuga",
+        "ja": "春日一番",
+        "ja_typings": [
+          "kasuga ichiban",
+          "kasugaichiban"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03031",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the bald Splinter Cell stealth agent?",
+      "ja": "スプリンターセルの主人公の禿頭スパイは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Satoru Iwata",
+        "ja": "岩田聡",
+        "ja_typings": [
+          "iwata satoru",
+          "iwatasatoru"
+        ]
+      },
+      {
+        "en": "Gunpei Yokoi",
+        "ja": "横井軍平",
+        "ja_typings": [
+          "yokoi gunpei",
+          "yokoigunpei"
+        ]
+      },
+      {
+        "en": "Masahiro Sakurai",
+        "ja": "桜井政博",
+        "ja_typings": [
+          "sakurai masahiro",
+          "sakuraimasahiro"
+        ]
+      },
+      {
+        "en": "Satoshi Tajiri",
+        "ja": "田尻智",
+        "ja_typings": [
+          "tajiri satoshi",
+          "tajirisatoshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03032",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Nintendo president and HAL Laboratory programmer?",
+      "ja": "任天堂社長を務めた元HAL研プログラマは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Satoshi Tajiri",
+        "ja": "田尻智",
+        "ja_typings": [
+          "tajiri satoshi",
+          "tajirisatoshi"
+        ]
+      },
+      {
+        "en": "Satoru Iwata",
+        "ja": "岩田聡",
+        "ja_typings": [
+          "iwata satoru",
+          "iwatasatoru"
+        ]
+      },
+      {
+        "en": "Gunpei Yokoi",
+        "ja": "横井軍平",
+        "ja_typings": [
+          "yokoi gunpei",
+          "yokoigunpei"
+        ]
+      },
+      {
+        "en": "Koichi Nakamura",
+        "ja": "中村光一",
+        "ja_typings": [
+          "nakamura koichi",
+          "nakamurakouichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03033",
+    "image_path": null,
+    "question_text": {
+      "en": "Who founded Game Freak and created Pokemon?",
+      "ja": "ゲームフリークを創業しポケモンを生んだ人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sekiro",
+        "ja": "隻狼",
+        "ja_typings": [
+          "sekiro",
+          "sekirou"
+        ]
+      },
+      {
+        "en": "Ghost of Tsushima",
+        "ja": "ゴースト・オブ・ツシマ",
+        "ja_typings": [
+          "go-suto/obu/tsushima"
+        ]
+      },
+      {
+        "en": "Monster Hunter",
+        "ja": "モンスターハンター",
+        "ja_typings": [
+          "monsuta-hanta-"
+        ]
+      },
+      {
+        "en": "Witcher",
+        "ja": "ウィッチャー",
+        "ja_typings": [
+          "witcha-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03034",
+    "image_path": null,
+    "question_text": {
+      "en": "Which FromSoftware Sengoku-era stealth-action game won Game of the Year 2019?",
+      "ja": "2019年GOTYのフロムソフトウェア戦国忍者ゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sengoku Basara",
+        "ja": "戦国BASARA",
+        "ja_typings": [
+          "sengoku basara"
+        ]
+      },
+      {
+        "en": "Sakura Wars",
+        "ja": "サクラ大戦",
+        "ja_typings": [
+          "sakura taisen",
+          "sakurataisen"
+        ]
+      },
+      {
+        "en": "Monster Hunter",
+        "ja": "モンスターハンター",
+        "ja_typings": [
+          "monsuta-hanta-"
+        ]
+      },
+      {
+        "en": "Mega Man",
+        "ja": "ロックマン",
+        "ja_typings": [
+          "rokkuman"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03035",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Capcom series features over-the-top Sengoku warriors?",
+      "ja": "派手な戦国武将アクションのカプコン作は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shadowrun",
+        "ja": "シャドウラン",
+        "ja_typings": [
+          "shadoran",
+          "shadouran"
+        ]
+      },
+      {
+        "en": "Shadowverse",
+        "ja": "シャドウバース",
+        "ja_typings": [
+          "shadoba-su",
+          "shadouba-su"
+        ]
+      },
+      {
+        "en": "Deus Ex",
+        "ja": "デウスエクス",
+        "ja_typings": [
+          "deusuekusu"
+        ]
+      },
+      {
+        "en": "Cyberpunk 2077",
+        "ja": "サイバーパンク2077",
+        "ja_typings": [
+          "saiba-panku2077"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03036",
+    "image_path": null,
+    "question_text": {
+      "en": "Which tabletop-origin RPG mixes cyberpunk with fantasy races?",
+      "ja": "サイバーパンクとファンタジー種族が混ざるテーブルトークRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shadowverse",
+        "ja": "シャドウバース",
+        "ja_typings": [
+          "shadoba-su",
+          "shadouba-su"
+        ]
+      },
+      {
+        "en": "Shadowrun",
+        "ja": "シャドウラン",
+        "ja_typings": [
+          "shadoran",
+          "shadouran"
+        ]
+      },
+      {
+        "en": "Granblue Fantasy",
+        "ja": "グランブルーファンタジー",
+        "ja_typings": [
+          "guranburu-fantaji-"
+        ]
+      },
+      {
+        "en": "Princess Connect",
+        "ja": "プリンセスコネクト",
+        "ja_typings": [
+          "purinsesukonekuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03037",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Cygames digital card battler launched in 2016?",
+      "ja": "サイゲームスの2016年デジタルカードゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shinji Mikami",
+        "ja": "三上真司",
+        "ja_typings": [
+          "mikami shinji",
+          "mikamishinji"
+        ]
+      },
+      {
+        "en": "Hideki Kamiya",
+        "ja": "神谷英樹",
+        "ja_typings": [
+          "kamiya hideki",
+          "kamiyahideki"
+        ]
+      },
+      {
+        "en": "Goichi Suda",
+        "ja": "須田剛一",
+        "ja_typings": [
+          "suda goichi",
+          "sudagouichi"
+        ]
+      },
+      {
+        "en": "Keiji Inafune",
+        "ja": "稲船敬二",
+        "ja_typings": [
+          "inafune keiji",
+          "inafunekeiji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03038",
+    "image_path": null,
+    "question_text": {
+      "en": "Who directed Resident Evil 1 and founded Tango Gameworks?",
+      "ja": "バイオハザード1の監督でタンゴ創業者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Smite",
+        "ja": "スマイト",
+        "ja_typings": [
+          "sumaito"
+        ]
+      },
+      {
+        "en": "Dota 2",
+        "ja": "ドータ2",
+        "ja_typings": [
+          "do-ta2",
+          "do-tatsu-"
+        ]
+      },
+      {
+        "en": "Heroes of the Storm",
+        "ja": "ヒーローズ・オブ・ザ・ストーム",
+        "ja_typings": [
+          "hi-ro-zu/obu/za/suto-mu"
+        ]
+      },
+      {
+        "en": "Rocket League",
+        "ja": "ロケットリーグ",
+        "ja_typings": [
+          "rokettori-gu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03039",
+    "image_path": null,
+    "question_text": {
+      "en": "Which MOBA features gods and mythological figures in third-person view?",
+      "ja": "神話のキャラがTPS視点で戦うMOBAは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Space Invaders",
+        "ja": "スペースインベーダー",
+        "ja_typings": [
+          "supe-suinbe-da-"
+        ]
+      },
+      {
+        "en": "Galaxian",
+        "ja": "ギャラクシアン",
+        "ja_typings": [
+          "gyarakushian"
+        ]
+      },
+      {
+        "en": "Moon Cresta",
+        "ja": "ムーンクレスタ",
+        "ja_typings": [
+          "mu-nkuresuta"
+        ]
+      },
+      {
+        "en": "Xevious",
+        "ja": "ゼビウス",
+        "ja_typings": [
+          "zebiusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03040",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1978 Taito arcade game popularized the shooter genre?",
+      "ja": "1978年タイトーの和製シューティングの金字塔は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Splatoon",
+        "ja": "スプラトゥーン",
+        "ja_typings": [
+          "supuratu-n"
+        ]
+      },
+      {
+        "en": "ARMS",
+        "ja": "アームズ",
+        "ja_typings": [
+          "a-muzu"
+        ]
+      },
+      {
+        "en": "Star Fox",
+        "ja": "スターフォックス",
+        "ja_typings": [
+          "suta-fokkusu"
+        ]
+      },
+      {
+        "en": "Pikmin",
+        "ja": "ピクミン",
+        "ja_typings": [
+          "pikumin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03041",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nintendo shooter has squids inking turf?",
+      "ja": "イカが街にインクを塗る任天堂のシューターは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Star Fox",
+        "ja": "スターフォックス",
+        "ja_typings": [
+          "suta-fokkusu"
+        ]
+      },
+      {
+        "en": "Splatoon",
+        "ja": "スプラトゥーン",
+        "ja_typings": [
+          "supuratu-n"
+        ]
+      },
+      {
+        "en": "Pikmin",
+        "ja": "ピクミン",
+        "ja_typings": [
+          "pikumin"
+        ]
+      },
+      {
+        "en": "ARMS",
+        "ja": "アームズ",
+        "ja_typings": [
+          "a-muzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03042",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nintendo on-rails shooter stars a fox pilot?",
+      "ja": "キツネのパイロットが宇宙を飛ぶ任天堂作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Steam Deck",
+        "ja": "スチームデック",
+        "ja_typings": [
+          "suchi-mudekku"
+        ]
+      },
+      {
+        "en": "ROG Ally",
+        "ja": "ロジー・アライ",
+        "ja_typings": [
+          "roji-/arai"
+        ]
+      },
+      {
+        "en": "PlayStation Portal",
+        "ja": "プレイステーション・ポータル",
+        "ja_typings": [
+          "pureisute-shon/po-taru"
+        ]
+      },
+      {
+        "en": "Nintendo Switch",
+        "ja": "ニンテンドースイッチ",
+        "ja_typings": [
+          "nintendo-suitchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03043",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Valve handheld runs SteamOS and launched in 2022?",
+      "ja": "SteamOSを搭載する2022年Valveの携帯機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Story of Seasons",
+        "ja": "牧場物語",
+        "ja_typings": [
+          "bokujou monogatari",
+          "bokujoumonogatari"
+        ]
+      },
+      {
+        "en": "Rune Factory",
+        "ja": "ルーンファクトリー",
+        "ja_typings": [
+          "ru-nfakutori-"
+        ]
+      },
+      {
+        "en": "Hay Day",
+        "ja": "ヘイデイ",
+        "ja_typings": [
+          "heidei"
+        ]
+      },
+      {
+        "en": "Pikmin Bloom",
+        "ja": "ピクミンブルーム",
+        "ja_typings": [
+          "pikuminburu-mu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03044",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Marvelous farm simulation is the rebrand of Bokujou Monogatari?",
+      "ja": "牧場物語の海外向け新ブランド名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Take-Two Interactive",
+        "ja": "テイクツー",
+        "ja_typings": [
+          "teikutsu-"
+        ]
+      },
+      {
+        "en": "Activision",
+        "ja": "アクティビジョン",
+        "ja_typings": [
+          "akutibijon"
+        ]
+      },
+      {
+        "en": "Epic Games",
+        "ja": "エピックゲームズ",
+        "ja_typings": [
+          "epikkuge-muzu"
+        ]
+      },
+      {
+        "en": "Ubisoft",
+        "ja": "ユービーアイソフト",
+        "ja_typings": [
+          "yu-bi-aisofuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03045",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company owns Rockstar Games and 2K?",
+      "ja": "ロックスターと2Kを傘下に持つ会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Team Fortress",
+        "ja": "チームフォートレス",
+        "ja_typings": [
+          "chi-mufo-toresu"
+        ]
+      },
+      {
+        "en": "CS:GO",
+        "ja": "シーエスゴー",
+        "ja_typings": [
+          "shi-esugo-"
+        ]
+      },
+      {
+        "en": "Overwatch",
+        "ja": "オーバーウォッチ",
+        "ja_typings": [
+          "o-ba-wotchi"
+        ]
+      },
+      {
+        "en": "Valorant",
+        "ja": "ヴァロラント",
+        "ja_typings": [
+          "varoranto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03046",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Valve class-based shooter is famous for the Sandvich?",
+      "ja": "サンドビッチで知られるValveのクラスFPSは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tetsuya Nomura",
+        "ja": "野村哲也",
+        "ja_typings": [
+          "nomura tetsuya",
+          "nomuratetsuya"
+        ]
+      },
+      {
+        "en": "Motomu Toriyama",
+        "ja": "鳥山求",
+        "ja_typings": [
+          "toriyama motomu",
+          "toriyamamotomu"
+        ]
+      },
+      {
+        "en": "Hironobu Sakaguchi",
+        "ja": "坂口博信",
+        "ja_typings": [
+          "sakaguchi hironobu",
+          "sakaguchihironobu"
+        ]
+      },
+      {
+        "en": "Yuji Horii",
+        "ja": "堀井雄二",
+        "ja_typings": [
+          "horii yuji",
+          "horiiyuuji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03047",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the Final Fantasy character designer behind Kingdom Hearts?",
+      "ja": "キングダムハーツのキャラデザを担当したFF美術家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Elder Scrolls",
+        "ja": "エルダースクロールズ",
+        "ja_typings": [
+          "eruda-sukuro-ruzu"
+        ]
+      },
+      {
+        "en": "Fallout",
+        "ja": "フォールアウト",
+        "ja_typings": [
+          "fo-ruauto"
+        ]
+      },
+      {
+        "en": "Witcher",
+        "ja": "ウィッチャー",
+        "ja_typings": [
+          "witcha-"
+        ]
+      },
+      {
+        "en": "Borderlands",
+        "ja": "ボーダーランズ",
+        "ja_typings": [
+          "bo-da-ranzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03048",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Bethesda fantasy RPG series includes Skyrim and Oblivion?",
+      "ja": "スカイリムやオブリビオンを擁するベセスダのRPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Game of Life",
+        "ja": "人生ゲーム",
+        "ja_typings": [
+          "jinsei game",
+          "jinseigeemu"
+        ]
+      },
+      {
+        "en": "Itadaki Street",
+        "ja": "いただきストリート",
+        "ja_typings": [
+          "itadakisutori-to"
+        ]
+      },
+      {
+        "en": "Mario Party",
+        "ja": "マリオパーティ",
+        "ja_typings": [
+          "mariopa-ti"
+        ]
+      },
+      {
+        "en": "Monopoly",
+        "ja": "モノポリー",
+        "ja_typings": [
+          "monopori-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03049",
+    "image_path": null,
+    "question_text": {
+      "en": "Which classic Hasbro board game simulates birth-to-retirement?",
+      "ja": "誕生から引退までを辿るハズブロのボードゲームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Legend of Zelda: Skyward Sword",
+        "ja": "ゼルダの伝説 スカイウォードソード",
+        "ja_typings": [
+          "zerudanodensetsusukaiwa-dosa-do"
+        ]
+      },
+      {
+        "en": "The Legend of Zelda: Tears of the Kingdom",
+        "ja": "ゼルダの伝説 ティアーズ オブ ザ キングダム",
+        "ja_typings": [
+          "zerudanodensetsutia-zuobuzakingudamu"
+        ]
+      },
+      {
+        "en": "The Legend of Zelda: Twilight Princess",
+        "ja": "ゼルダの伝説 トワイライトプリンセス",
+        "ja_typings": [
+          "zerudanodensetsutowairaitopurinsesu"
+        ]
+      },
+      {
+        "en": "The Legend of Zelda: Breath of the Wild",
+        "ja": "ゼルダの伝説 ブレス オブ ザ ワイルド",
+        "ja_typings": [
+          "zerudanodensetsuburesuobuzawairudo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03050",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Zelda title introduced motion-controlled sword combat on Wii?",
+      "ja": "Wiiで剣のモーション操作を導入したゼルダは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Legend of Zelda: Tears of the Kingdom",
+        "ja": "ゼルダの伝説 ティアーズ オブ ザ キングダム",
+        "ja_typings": [
+          "zerudanodensetsutia-zuobuzakingudamu"
+        ]
+      },
+      {
+        "en": "The Legend of Zelda: Skyward Sword",
+        "ja": "ゼルダの伝説 スカイウォードソード",
+        "ja_typings": [
+          "zerudanodensetsusukaiwa-dosa-do"
+        ]
+      },
+      {
+        "en": "The Legend of Zelda: Twilight Princess",
+        "ja": "ゼルダの伝説 トワイライトプリンセス",
+        "ja_typings": [
+          "zerudanodensetsutowairaitopurinsesu"
+        ]
+      },
+      {
+        "en": "The Legend of Zelda: Breath of the Wild",
+        "ja": "ゼルダの伝説 ブレス オブ ザ ワイルド",
+        "ja_typings": [
+          "zerudanodensetsuburesuobuzawairudo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03051",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2023 Switch Zelda sequel features a sky-falling Hyrule?",
+      "ja": "2023年発売のスイッチのゼルダ続編は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Legend of Zelda: Twilight Princess",
+        "ja": "ゼルダの伝説 トワイライトプリンセス",
+        "ja_typings": [
+          "zerudanodensetsutowairaitopurinsesu"
+        ]
+      },
+      {
+        "en": "The Legend of Zelda: Skyward Sword",
+        "ja": "ゼルダの伝説 スカイウォードソード",
+        "ja_typings": [
+          "zerudanodensetsusukaiwa-dosa-do"
+        ]
+      },
+      {
+        "en": "The Legend of Zelda: Tears of the Kingdom",
+        "ja": "ゼルダの伝説 ティアーズ オブ ザ キングダム",
+        "ja_typings": [
+          "zerudanodensetsutia-zuobuzakingudamu"
+        ]
+      },
+      {
+        "en": "The Legend of Zelda: Breath of the Wild",
+        "ja": "ゼルダの伝説 ブレス オブ ザ ワイルド",
+        "ja_typings": [
+          "zerudanodensetsuburesuobuzawairudo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03052",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 2006 Wii/GC Zelda features Link transforming into a wolf?",
+      "ja": "リンクが狼になる2006年のゼルダ作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tomb Raider",
+        "ja": "トゥームレイダー",
+        "ja_typings": [
+          "tu-mureida-"
+        ]
+      },
+      {
+        "en": "Uncharted",
+        "ja": "アンチャーテッド",
+        "ja_typings": [
+          "ancha-teddo"
+        ]
+      },
+      {
+        "en": "Sekiro",
+        "ja": "隻狼",
+        "ja_typings": [
+          "sekiro",
+          "sekirou"
+        ]
+      },
+      {
+        "en": "Ghost of Tsushima",
+        "ja": "ゴースト・オブ・ツシマ",
+        "ja_typings": [
+          "go-suto/obu/tsushima"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03053",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Square Enix series stars Lara Croft as a treasure hunter?",
+      "ja": "ララ・クロフトが活躍するスクエニの冒険シリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tomonobu Itagaki",
+        "ja": "板垣伴信",
+        "ja_typings": [
+          "itagaki tomonobu",
+          "itagakitomonobu"
+        ]
+      },
+      {
+        "en": "Shinji Mikami",
+        "ja": "三上真司",
+        "ja_typings": [
+          "mikami shinji",
+          "mikamishinji"
+        ]
+      },
+      {
+        "en": "Hideki Kamiya",
+        "ja": "神谷英樹",
+        "ja_typings": [
+          "kamiya hideki",
+          "kamiyahideki"
+        ]
+      },
+      {
+        "en": "Keiji Inafune",
+        "ja": "稲船敬二",
+        "ja_typings": [
+          "inafune keiji",
+          "inafunekeiji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03054",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the founder of Team Ninja and director of Ninja Gaiden?",
+      "ja": "Team Ninja創設者でニンジャガイデン監督は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tower of Fantasy",
+        "ja": "幻塔",
+        "ja_typings": [
+          "gentou"
+        ]
+      },
+      {
+        "en": "Honkai Star Rail",
+        "ja": "崩壊スターレイル",
+        "ja_typings": [
+          "houkai sutareiru",
+          "houkaisutareiru"
+        ]
+      },
+      {
+        "en": "Lost Ark",
+        "ja": "ロストアーク",
+        "ja_typings": [
+          "rosutoa-ku"
+        ]
+      },
+      {
+        "en": "Black Desert",
+        "ja": "黒い砂漠",
+        "ja_typings": [
+          "kuroi sabaku",
+          "kuroisabaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03055",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hotta Studio open-world MMORPG resembles Genshin Impact?",
+      "ja": "原神に類似した中国産オープンワールドMMORPGは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Turn-based Strategy",
+        "ja": "ターン制ストラテジー",
+        "ja_typings": [
+          "ta-nseisutorateji-"
+        ]
+      },
+      {
+        "en": "RTS",
+        "ja": "リアルタイムストラテジー",
+        "ja_typings": [
+          "riarutaimusutorateji-"
+        ]
+      },
+      {
+        "en": "MOBA",
+        "ja": "モバ",
+        "ja_typings": [
+          "moba"
+        ]
+      },
+      {
+        "en": "Hack and Slash",
+        "ja": "ハックアンドスラッシュ",
+        "ja_typings": [
+          "hakkuandosurasshu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03056",
+    "image_path": null,
+    "question_text": {
+      "en": "Which strategy genre is abbreviated TBS?",
+      "ja": "TBSと略される戦略ゲームのジャンルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ubisoft",
+        "ja": "ユービーアイソフト",
+        "ja_typings": [
+          "yu-bi-aisofuto"
+        ]
+      },
+      {
+        "en": "Activision",
+        "ja": "アクティビジョン",
+        "ja_typings": [
+          "akutibijon"
+        ]
+      },
+      {
+        "en": "Bethesda",
+        "ja": "ベセスダ",
+        "ja_typings": [
+          "besesuda"
+        ]
+      },
+      {
+        "en": "Take-Two Interactive",
+        "ja": "テイクツー",
+        "ja_typings": [
+          "teikutsu-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03057",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French publisher makes Assassin's Creed?",
+      "ja": "アサシンクリードのフランスの発売会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Uncharted",
+        "ja": "アンチャーテッド",
+        "ja_typings": [
+          "ancha-teddo"
+        ]
+      },
+      {
+        "en": "Jak and Daxter",
+        "ja": "ジャック×ダクスター",
+        "ja_typings": [
+          "jakkudakusuta-"
+        ]
+      },
+      {
+        "en": "Tomb Raider",
+        "ja": "トゥームレイダー",
+        "ja_typings": [
+          "tu-mureida-"
+        ]
+      },
+      {
+        "en": "Days Gone",
+        "ja": "デイズ ゴーン",
+        "ja_typings": [
+          "deizu go-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03058",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Naughty Dog series stars treasure hunter Nathan Drake?",
+      "ja": "ネイサン・ドレイクが活躍するノーティードッグ作品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Valorant",
+        "ja": "ヴァロラント",
+        "ja_typings": [
+          "varoranto"
+        ]
+      },
+      {
+        "en": "CS:GO",
+        "ja": "シーエスゴー",
+        "ja_typings": [
+          "shi-esugo-"
+        ]
+      },
+      {
+        "en": "Apex Legends",
+        "ja": "エーペックスレジェンズ",
+        "ja_typings": [
+          "e-pekkusurejenzu"
+        ]
+      },
+      {
+        "en": "Overwatch",
+        "ja": "オーバーウォッチ",
+        "ja_typings": [
+          "o-ba-wotchi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03059",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Riot Games tactical 5v5 shooter launched in 2020?",
+      "ja": "2020年公開のライオット製5対5戦術FPSは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Visual Novel",
+        "ja": "ビジュアルノベル",
+        "ja_typings": [
+          "bijuarunoberu"
+        ]
+      },
+      {
+        "en": "Hack and Slash",
+        "ja": "ハックアンドスラッシュ",
+        "ja_typings": [
+          "hakkuandosurasshu"
+        ]
+      },
+      {
+        "en": "RTS",
+        "ja": "リアルタイムストラテジー",
+        "ja_typings": [
+          "riarutaimusutorateji-"
+        ]
+      },
+      {
+        "en": "MOBA",
+        "ja": "モバ",
+        "ja_typings": [
+          "moba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03060",
+    "image_path": null,
+    "question_text": {
+      "en": "Which narrative game genre features text and character art (NVL)?",
+      "ja": "立ち絵とテキストで物語を進めるADVのジャンル名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wii U",
+        "ja": "ウィーユー",
+        "ja_typings": [
+          "wi-yu-"
+        ]
+      },
+      {
+        "en": "Nintendo Switch",
+        "ja": "ニンテンドースイッチ",
+        "ja_typings": [
+          "nintendo-suitchi"
+        ]
+      },
+      {
+        "en": "Nintendo 3DS",
+        "ja": "ニンテンドー3DS",
+        "ja_typings": [
+          "nintendo-3ds",
+          "nintendo-suri-dei-esu"
+        ]
+      },
+      {
+        "en": "Steam Deck",
+        "ja": "スチームデック",
+        "ja_typings": [
+          "suchi-mudekku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03061",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nintendo home console launched in 2012 had a tablet controller?",
+      "ja": "タブレット型コントローラの2012年任天堂据置機は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Winning Eleven",
+        "ja": "ウイニングイレブン",
+        "ja_typings": [
+          "uininguirebun"
+        ]
+      },
+      {
+        "en": "Football Manager",
+        "ja": "フットボールマネージャー",
+        "ja_typings": [
+          "futtobo-rumane-ja-"
+        ]
+      },
+      {
+        "en": "Pro Spirits",
+        "ja": "プロスピ",
+        "ja_typings": [
+          "purosupi"
+        ]
+      },
+      {
+        "en": "Pro Yakyu Spirits",
+        "ja": "プロ野球スピリッツ",
+        "ja_typings": [
+          "pro yakyu spirits",
+          "puroyakyuusupirittsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03062",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Konami soccer series was rebranded to eFootball?",
+      "ja": "eFootballに改名されたコナミのサッカーシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Witcher",
+        "ja": "ウィッチャー",
+        "ja_typings": [
+          "witcha-"
+        ]
+      },
+      {
+        "en": "Fallout",
+        "ja": "フォールアウト",
+        "ja_typings": [
+          "fo-ruauto"
+        ]
+      },
+      {
+        "en": "The Elder Scrolls",
+        "ja": "エルダースクロールズ",
+        "ja_typings": [
+          "eruda-sukuro-ruzu"
+        ]
+      },
+      {
+        "en": "Cyberpunk 2077",
+        "ja": "サイバーパンク2077",
+        "ja_typings": [
+          "saiba-panku2077"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03063",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CD Projekt RED series follows Geralt of Rivia?",
+      "ja": "ゲラルトが主人公のCD Projekt RPGシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "World of Warcraft",
+        "ja": "ワールド オブ ウォークラフト",
+        "ja_typings": [
+          "wa-rudo obu wo-kurafuto"
+        ]
+      },
+      {
+        "en": "EverQuest",
+        "ja": "エバークエスト",
+        "ja_typings": [
+          "eba-kuesuto"
+        ]
+      },
+      {
+        "en": "Guild Wars 2",
+        "ja": "ギルドウォーズ2",
+        "ja_typings": [
+          "girudouo-zu2",
+          "girudouo-zutsu-",
+          "girudowo-zu2"
+        ]
+      },
+      {
+        "en": "Lost Ark",
+        "ja": "ロストアーク",
+        "ja_typings": [
+          "rosutoa-ku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03064",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Blizzard MMORPG launched in 2004 and dominated the genre?",
+      "ja": "2004年公開のブリザード製MMORPGの代名詞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Xevious",
+        "ja": "ゼビウス",
+        "ja_typings": [
+          "zebiusu"
+        ]
+      },
+      {
+        "en": "Galaga",
+        "ja": "ギャラガ",
+        "ja_typings": [
+          "gyaraga"
+        ]
+      },
+      {
+        "en": "Galaxian",
+        "ja": "ギャラクシアン",
+        "ja_typings": [
+          "gyarakushian"
+        ]
+      },
+      {
+        "en": "Dig Dug",
+        "ja": "ディグダグ",
+        "ja_typings": [
+          "digudagu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03065",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Namco 1982 vertical-scrolling shooter features Solvalou?",
+      "ja": "ソルバルウが主人公の1982年ナムコ縦シューは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yuji Horii",
+        "ja": "堀井雄二",
+        "ja_typings": [
+          "horii yuji",
+          "horiiyuuji"
+        ]
+      },
+      {
+        "en": "Hironobu Sakaguchi",
+        "ja": "坂口博信",
+        "ja_typings": [
+          "sakaguchi hironobu",
+          "sakaguchihironobu"
+        ]
+      },
+      {
+        "en": "Koichi Nakamura",
+        "ja": "中村光一",
+        "ja_typings": [
+          "nakamura koichi",
+          "nakamurakouichi"
+        ]
+      },
+      {
+        "en": "Satoshi Tajiri",
+        "ja": "田尻智",
+        "ja_typings": [
+          "tajiri satoshi",
+          "tajirisatoshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03066",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the creator of the Dragon Quest series?",
+      "ja": "ドラゴンクエストシリーズの生みの親は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yuji Naka",
+        "ja": "中裕司",
+        "ja_typings": [
+          "naka yuji",
+          "nakayuuji"
+        ]
+      },
+      {
+        "en": "Yuji Horii",
+        "ja": "堀井雄二",
+        "ja_typings": [
+          "horii yuji",
+          "horiiyuuji"
+        ]
+      },
+      {
+        "en": "Koichi Nakamura",
+        "ja": "中村光一",
+        "ja_typings": [
+          "nakamura koichi",
+          "nakamurakouichi"
+        ]
+      },
+      {
+        "en": "Gunpei Yokoi",
+        "ja": "横井軍平",
+        "ja_typings": [
+          "yokoi gunpei",
+          "yokoigunpei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "game",
+    "id": "q03067",
+    "image_path": null,
+    "question_text": {
+      "en": "Who programmed Sonic the Hedgehog at Sega?",
+      "ja": "セガのソニックを生んだプログラマは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1789",
+        "ja": "1789年",
+        "ja_typings": [
+          "1789nen"
+        ]
+      },
+      {
+        "en": "1812",
+        "ja": "1812年",
+        "ja_typings": [
+          "1812nen"
+        ]
+      },
+      {
+        "en": "1865",
+        "ja": "1865年",
+        "ja_typings": [
+          "1865nen"
+        ]
+      },
+      {
+        "en": "1776",
+        "ja": "1776年",
+        "ja_typings": [
+          "1776nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03068",
+    "image_path": null,
+    "question_text": {
+      "en": "In which year did the French Revolution begin?",
+      "ja": "フランス革命が勃発した年は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1812",
+        "ja": "1812年",
+        "ja_typings": [
+          "1812nen"
+        ]
+      },
+      {
+        "en": "1789",
+        "ja": "1789年",
+        "ja_typings": [
+          "1789nen"
+        ]
+      },
+      {
+        "en": "1865",
+        "ja": "1865年",
+        "ja_typings": [
+          "1865nen"
+        ]
+      },
+      {
+        "en": "1776",
+        "ja": "1776年",
+        "ja_typings": [
+          "1776nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03069",
+    "image_path": null,
+    "question_text": {
+      "en": "In which year did the War of 1812 between the US and Britain begin?",
+      "ja": "米英戦争が始まった年は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1865",
+        "ja": "1865年",
+        "ja_typings": [
+          "1865nen"
+        ]
+      },
+      {
+        "en": "1812",
+        "ja": "1812年",
+        "ja_typings": [
+          "1812nen"
+        ]
+      },
+      {
+        "en": "1789",
+        "ja": "1789年",
+        "ja_typings": [
+          "1789nen"
+        ]
+      },
+      {
+        "en": "1776",
+        "ja": "1776年",
+        "ja_typings": [
+          "1776nen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03070",
+    "image_path": null,
+    "question_text": {
+      "en": "In which year did the American Civil War end?",
+      "ja": "アメリカ南北戦争が終結した年は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Abbasid Caliphate",
+        "ja": "アッバース朝",
+        "ja_typings": [
+          "abbaasu chou",
+          "abbaasuchou"
+        ]
+      },
+      {
+        "en": "Mughal Empire",
+        "ja": "ムガル帝国",
+        "ja_typings": [
+          "mugaru teikoku",
+          "mugaruteikoku"
+        ]
+      },
+      {
+        "en": "Safavid Empire",
+        "ja": "サファヴィー朝",
+        "ja_typings": [
+          "safavii chou",
+          "safaviichou"
+        ]
+      },
+      {
+        "en": "Ottoman Empire",
+        "ja": "オスマン帝国",
+        "ja_typings": [
+          "osuman teikoku",
+          "osumanteikoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03071",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Islamic caliphate ruled from Baghdad starting in 750?",
+      "ja": "750年からバグダッドで統治したイスラム王朝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Adam Laxman",
+        "ja": "ラクスマン",
+        "ja_typings": [
+          "rakusuman"
+        ]
+      },
+      {
+        "en": "Yevfimiy Putyatin",
+        "ja": "プチャーチン",
+        "ja_typings": [
+          "puchaachin",
+          "pucha-chin"
+        ]
+      },
+      {
+        "en": "Townsend Harris",
+        "ja": "ハリス",
+        "ja_typings": [
+          "harisu"
+        ]
+      },
+      {
+        "en": "Napoleon III",
+        "ja": "ナポレオン3世",
+        "ja_typings": [
+          "naporeon 3 sei",
+          "naporeonsansei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03072",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Russian envoy arrived in Nemuro in 1792 demanding trade with Japan?",
+      "ja": "1792年に根室に来航し通商を要求したロシア使節は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Adolf Hitler",
+        "ja": "アドルフ・ヒトラー",
+        "ja_typings": [
+          "adorufu/hitora-"
+        ]
+      },
+      {
+        "en": "Joseph Stalin",
+        "ja": "スターリン",
+        "ja_typings": [
+          "sutaarin",
+          "suta-rin"
+        ]
+      },
+      {
+        "en": "Francisco Franco",
+        "ja": "フランコ",
+        "ja_typings": [
+          "furanko"
+        ]
+      },
+      {
+        "en": "Salazar",
+        "ja": "サラザール",
+        "ja_typings": [
+          "sarazaaru",
+          "saraza-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03073",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led Nazi Germany during World War II?",
+      "ja": "第二次大戦時のナチス・ドイツの指導者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Alexander Hamilton",
+        "ja": "ハミルトン",
+        "ja_typings": [
+          "hamiruton"
+        ]
+      },
+      {
+        "en": "Benjamin Franklin",
+        "ja": "フランクリン",
+        "ja_typings": [
+          "furankurin"
+        ]
+      },
+      {
+        "en": "Thomas Jefferson",
+        "ja": "ジェファーソン",
+        "ja_typings": [
+          "jefaason",
+          "jefa-son"
+        ]
+      },
+      {
+        "en": "John Adams",
+        "ja": "ジョン・アダムズ",
+        "ja_typings": [
+          "jon/adamuzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03074",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first US Secretary of the Treasury?",
+      "ja": "アメリカ初代財務長官は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Alexander Kerensky",
+        "ja": "ケレンスキー",
+        "ja_typings": [
+          "kerensukii",
+          "kerensuki-"
+        ]
+      },
+      {
+        "en": "Leon Trotsky",
+        "ja": "トロツキー",
+        "ja_typings": [
+          "torotsukii",
+          "torotsuki-"
+        ]
+      },
+      {
+        "en": "Joseph Stalin",
+        "ja": "スターリン",
+        "ja_typings": [
+          "sutaarin",
+          "suta-rin"
+        ]
+      },
+      {
+        "en": "Adolf Hitler",
+        "ja": "アドルフ・ヒトラー",
+        "ja_typings": [
+          "adorufu/hitora-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03075",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led Russia's Provisional Government in 1917 before the Bolsheviks?",
+      "ja": "1917年ロシア臨時政府を率いた人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Attack on Pearl Harbor",
+        "ja": "真珠湾攻撃",
+        "ja_typings": [
+          "shinjuwan kougeki",
+          "shinjuwankougeki"
+        ]
+      },
+      {
+        "en": "Battle of Stalingrad",
+        "ja": "スターリングラード攻防戦",
+        "ja_typings": [
+          "sutaaringuraado koubousen",
+          "sutaaringuraadokoubousen"
+        ]
+      },
+      {
+        "en": "Munich Agreement",
+        "ja": "ミュンヘン会談",
+        "ja_typings": [
+          "myunhen kaidan",
+          "myunhenkaidan"
+        ]
+      },
+      {
+        "en": "Boxer Rebellion",
+        "ja": "義和団事件",
+        "ja_typings": [
+          "giwadan jiken",
+          "giwadanjiken"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03076",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1941 Japanese strike brought the US into WWII?",
+      "ja": "1941年に米国を参戦させた日本の奇襲は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Battle of Stalingrad",
+        "ja": "スターリングラード攻防戦",
+        "ja_typings": [
+          "sutaaringuraado koubousen",
+          "sutaaringuraadokoubousen"
+        ]
+      },
+      {
+        "en": "Attack on Pearl Harbor",
+        "ja": "真珠湾攻撃",
+        "ja_typings": [
+          "shinjuwan kougeki",
+          "shinjuwankougeki"
+        ]
+      },
+      {
+        "en": "Hundred Years' War",
+        "ja": "百年戦争",
+        "ja_typings": [
+          "hyakunen sensou",
+          "hyakunensensou"
+        ]
+      },
+      {
+        "en": "Thirty Years' War",
+        "ja": "三十年戦争",
+        "ja_typings": [
+          "sanjuunen sensou",
+          "sanjuunensensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03077",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1942-43 battle marked the turning point on the Eastern Front?",
+      "ja": "1942-43年東部戦線の転換点となった戦いは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Behistun Inscription",
+        "ja": "ベヒストゥン碑文",
+        "ja_typings": [
+          "behisutun hibun",
+          "behisutunhibun"
+        ]
+      },
+      {
+        "en": "Code of Hammurabi stele",
+        "ja": "ハンムラビ法典碑",
+        "ja_typings": [
+          "hanmurabi houten hi",
+          "hanmurabihoutenhi"
+        ]
+      },
+      {
+        "en": "Palermo Stone",
+        "ja": "パレルモ石",
+        "ja_typings": [
+          "parerumo seki",
+          "parerumoseki"
+        ]
+      },
+      {
+        "en": "Great Wall of China",
+        "ja": "万里の長城",
+        "ja_typings": [
+          "banri no choujou",
+          "banrinochoujou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03078",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Iranian trilingual inscription helped decipher cuneiform?",
+      "ja": "楔形文字解読の鍵となったイランの三言語碑文は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Benjamin Franklin",
+        "ja": "フランクリン",
+        "ja_typings": [
+          "furankurin"
+        ]
+      },
+      {
+        "en": "Alexander Hamilton",
+        "ja": "ハミルトン",
+        "ja_typings": [
+          "hamiruton"
+        ]
+      },
+      {
+        "en": "Thomas Jefferson",
+        "ja": "ジェファーソン",
+        "ja_typings": [
+          "jefaason",
+          "jefa-son"
+        ]
+      },
+      {
+        "en": "George Washington",
+        "ja": "ジョージ・ワシントン",
+        "ja_typings": [
+          "jo-ji/washinton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03079",
+    "image_path": null,
+    "question_text": {
+      "en": "Who flew a kite during a thunderstorm and signed the Declaration of Independence?",
+      "ja": "雷雨に凧を上げ独立宣言にも署名した人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bockscar",
+        "ja": "ボックスカー",
+        "ja_typings": [
+          "bokkusukaa",
+          "bokkusuka-"
+        ]
+      },
+      {
+        "en": "Memphis Belle",
+        "ja": "メンフィス・ベル",
+        "ja_typings": [
+          "menfisu/beru"
+        ]
+      },
+      {
+        "en": "Little Boy",
+        "ja": "リトルボーイ",
+        "ja_typings": [
+          "ritorubo-i"
+        ]
+      },
+      {
+        "en": "Enola Gay",
+        "ja": "エノラ・ゲイ",
+        "ja_typings": [
+          "enora/gei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03080",
+    "image_path": null,
+    "question_text": {
+      "en": "Which B-29 dropped the atomic bomb on Nagasaki?",
+      "ja": "長崎に原爆を投下したB-29の機名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Boxer Rebellion",
+        "ja": "義和団事件",
+        "ja_typings": [
+          "giwadan jiken",
+          "giwadanjiken"
+        ]
+      },
+      {
+        "en": "Taiping Rebellion",
+        "ja": "太平天国の乱",
+        "ja_typings": [
+          "taihei tengoku no ran",
+          "taiheitengokunoran"
+        ]
+      },
+      {
+        "en": "Second Opium War",
+        "ja": "アロー戦争",
+        "ja_typings": [
+          "aroo sensou",
+          "aroosensou"
+        ]
+      },
+      {
+        "en": "Wars of Religion",
+        "ja": "宗教戦争",
+        "ja_typings": [
+          "shuukyou sensou",
+          "shuukyousensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03081",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1900 anti-foreign uprising in China was suppressed by an eight-nation alliance?",
+      "ja": "1900年に8カ国連合軍が鎮圧した中国の排外運動は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Buzz Aldrin",
+        "ja": "オルドリン",
+        "ja_typings": [
+          "orudorin"
+        ]
+      },
+      {
+        "en": "John Glenn",
+        "ja": "ジョン・グレン",
+        "ja_typings": [
+          "jon/guren"
+        ]
+      },
+      {
+        "en": "Yuri Gagarin",
+        "ja": "ガガーリン",
+        "ja_typings": [
+          "gagaarin",
+          "gaga-rin"
+        ]
+      },
+      {
+        "en": "Thomas Edison",
+        "ja": "エジソン",
+        "ja_typings": [
+          "ejison"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03082",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the second American to walk on the Moon, after Armstrong?",
+      "ja": "アームストロングに次いで月面に立ったアメリカ人は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cannon",
+        "ja": "大砲",
+        "ja_typings": [
+          "taihou"
+        ]
+      },
+      {
+        "en": "Crossbow",
+        "ja": "クロスボウ",
+        "ja_typings": [
+          "kurosubo",
+          "kurosubou"
+        ]
+      },
+      {
+        "en": "Catapult",
+        "ja": "カタパルト",
+        "ja_typings": [
+          "kataparuto"
+        ]
+      },
+      {
+        "en": "Cavalry",
+        "ja": "騎兵",
+        "ja_typings": [
+          "kihei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03083",
+    "image_path": null,
+    "question_text": {
+      "en": "Which gunpowder weapon revolutionized warfare in the late Middle Ages?",
+      "ja": "中世末期に戦争を変えた火薬兵器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cao Cao",
+        "ja": "曹操",
+        "ja_typings": [
+          "sousou"
+        ]
+      },
+      {
+        "en": "Sun Quan",
+        "ja": "孫権",
+        "ja_typings": [
+          "sonken"
+        ]
+      },
+      {
+        "en": "Zhuge Liang",
+        "ja": "諸葛亮",
+        "ja_typings": [
+          "shokatsuryou"
+        ]
+      },
+      {
+        "en": "Liu Bei",
+        "ja": "劉備",
+        "ja_typings": [
+          "ryuubi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03084",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Wei king during China's Three Kingdoms period is known as a brilliant strategist?",
+      "ja": "三国志で魏を築いた知将は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Catapult",
+        "ja": "カタパルト",
+        "ja_typings": [
+          "kataparuto"
+        ]
+      },
+      {
+        "en": "Cannon",
+        "ja": "大砲",
+        "ja_typings": [
+          "taihou"
+        ]
+      },
+      {
+        "en": "Crossbow",
+        "ja": "クロスボウ",
+        "ja_typings": [
+          "kurosubo",
+          "kurosubou"
+        ]
+      },
+      {
+        "en": "Trebuchet",
+        "ja": "トレビュシェット",
+        "ja_typings": [
+          "torebyushetto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03085",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient siege weapon hurled stones using torsion or counterweight?",
+      "ja": "投石で城を攻めた古代の兵器は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Catherine de' Medici",
+        "ja": "カトリーヌ・ド・メディシス",
+        "ja_typings": [
+          "katori-nu/do/medishisu"
+        ]
+      },
+      {
+        "en": "Marie Antoinette",
+        "ja": "マリー・アントワネット",
+        "ja_typings": [
+          "mari-/antowanetto"
+        ]
+      },
+      {
+        "en": "Eleanor of Aquitaine",
+        "ja": "エレオノール",
+        "ja_typings": [
+          "ereonooru",
+          "ereono-ru"
+        ]
+      },
+      {
+        "en": "Golda Meir",
+        "ja": "ゴルダ・メイア",
+        "ja_typings": [
+          "goruda/meia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03086",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Italian-born queen of France during the Wars of Religion?",
+      "ja": "宗教戦争期のフランス王妃でイタリア出身の女性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Clovis",
+        "ja": "クロヴィス",
+        "ja_typings": [
+          "kurovisu"
+        ]
+      },
+      {
+        "en": "Otto I",
+        "ja": "オットー1世",
+        "ja_typings": [
+          "ottoo 1 sei",
+          "ottooissei"
+        ]
+      },
+      {
+        "en": "Pepin the Short",
+        "ja": "ピピン",
+        "ja_typings": [
+          "pipin"
+        ]
+      },
+      {
+        "en": "Henry VIII",
+        "ja": "ヘンリー8世",
+        "ja_typings": [
+          "henrii 8 sei",
+          "henriihassei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03087",
+    "image_path": null,
+    "question_text": {
+      "en": "Who united the Franks and converted to Christianity around 496?",
+      "ja": "フランク王国を統一しキリスト教に改宗した王は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Code of Hammurabi stele",
+        "ja": "ハンムラビ法典碑",
+        "ja_typings": [
+          "hanmurabi houten hi",
+          "hanmurabihoutenhi"
+        ]
+      },
+      {
+        "en": "Behistun Inscription",
+        "ja": "ベヒストゥン碑文",
+        "ja_typings": [
+          "behisutun hibun",
+          "behisutunhibun"
+        ]
+      },
+      {
+        "en": "Palermo Stone",
+        "ja": "パレルモ石",
+        "ja_typings": [
+          "parerumo seki",
+          "parerumoseki"
+        ]
+      },
+      {
+        "en": "Rosetta Stone",
+        "ja": "ロゼッタストーン",
+        "ja_typings": [
+          "rozettasuto-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03088",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Babylonian stele inscribed an eye-for-an-eye law code?",
+      "ja": "目には目をで知られるバビロニアの法典碑は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Corsica",
+        "ja": "コルシカ島",
+        "ja_typings": [
+          "korushika tou",
+          "korushikatou"
+        ]
+      },
+      {
+        "en": "Sardinia",
+        "ja": "サルデーニャ島",
+        "ja_typings": [
+          "sarudeenya tou",
+          "sarudeenyatou"
+        ]
+      },
+      {
+        "en": "Sicily",
+        "ja": "シチリア島",
+        "ja_typings": [
+          "shichiria tou",
+          "shichiriatou"
+        ]
+      },
+      {
+        "en": "Izumo",
+        "ja": "出雲",
+        "ja_typings": [
+          "izumo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03089",
+    "image_path": null,
+    "question_text": {
+      "en": "On which Mediterranean island was Napoleon Bonaparte born?",
+      "ja": "ナポレオン・ボナパルトの生まれた地中海の島は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Crossbow",
+        "ja": "クロスボウ",
+        "ja_typings": [
+          "kurosubo",
+          "kurosubou"
+        ]
+      },
+      {
+        "en": "Cannon",
+        "ja": "大砲",
+        "ja_typings": [
+          "taihou"
+        ]
+      },
+      {
+        "en": "Catapult",
+        "ja": "カタパルト",
+        "ja_typings": [
+          "kataparuto"
+        ]
+      },
+      {
+        "en": "Bow",
+        "ja": "弓",
+        "ja_typings": [
+          "yumi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03090",
+    "image_path": null,
+    "question_text": {
+      "en": "Which medieval ranged weapon was banned by the Church for use against Christians?",
+      "ja": "中世に教会が同胞使用を禁じた飛び道具は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Czechoslovakia",
+        "ja": "チェコスロバキア",
+        "ja_typings": [
+          "chekosurobakia"
+        ]
+      },
+      {
+        "en": "Yugoslavia",
+        "ja": "ユーゴスラビア",
+        "ja_typings": [
+          "yu-gosurabia"
+        ]
+      },
+      {
+        "en": "East Germany",
+        "ja": "東ドイツ",
+        "ja_typings": [
+          "higashi doitsu",
+          "higashidoitsu"
+        ]
+      },
+      {
+        "en": "Germany",
+        "ja": "ドイツ",
+        "ja_typings": [
+          "doitsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03091",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Central European country split into Czech Republic and Slovakia in 1993?",
+      "ja": "1993年にチェコとスロバキアに分かれた中欧の国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Deng Xiaoping",
+        "ja": "鄧小平",
+        "ja_typings": [
+          "toushouhei"
+        ]
+      },
+      {
+        "en": "Sun Yat-sen",
+        "ja": "孫文",
+        "ja_typings": [
+          "sonbun"
+        ]
+      },
+      {
+        "en": "Zhou Enlai",
+        "ja": "周恩来",
+        "ja_typings": [
+          "shuuonrai"
+        ]
+      },
+      {
+        "en": "Cao Cao",
+        "ja": "曹操",
+        "ja_typings": [
+          "sousou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03092",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led China's reform and opening-up policy from 1978?",
+      "ja": "1978年から中国の改革開放を主導した人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "East Germany",
+        "ja": "東ドイツ",
+        "ja_typings": [
+          "higashi doitsu",
+          "higashidoitsu"
+        ]
+      },
+      {
+        "en": "Czechoslovakia",
+        "ja": "チェコスロバキア",
+        "ja_typings": [
+          "chekosurobakia"
+        ]
+      },
+      {
+        "en": "Yugoslavia",
+        "ja": "ユーゴスラビア",
+        "ja_typings": [
+          "yu-gosurabia"
+        ]
+      },
+      {
+        "en": "Germany",
+        "ja": "ドイツ",
+        "ja_typings": [
+          "doitsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03093",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country existed as the German Democratic Republic until 1990?",
+      "ja": "1990年まで存在したドイツ民主共和国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Eleanor of Aquitaine",
+        "ja": "エレオノール",
+        "ja_typings": [
+          "ereonooru",
+          "ereono-ru"
+        ]
+      },
+      {
+        "en": "Catherine de' Medici",
+        "ja": "カトリーヌ・ド・メディシス",
+        "ja_typings": [
+          "katori-nu/do/medishisu"
+        ]
+      },
+      {
+        "en": "Marie Antoinette",
+        "ja": "マリー・アントワネット",
+        "ja_typings": [
+          "mari-/antowanetto"
+        ]
+      },
+      {
+        "en": "Golda Meir",
+        "ja": "ゴルダ・メイア",
+        "ja_typings": [
+          "goruda/meia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03094",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the 12th-century queen consort of both France and England?",
+      "ja": "12世紀にフランスとイングランド両国の王妃となった女性は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Erasmus",
+        "ja": "エラスムス",
+        "ja_typings": [
+          "erasumusu"
+        ]
+      },
+      {
+        "en": "Huldrych Zwingli",
+        "ja": "ツヴィングリ",
+        "ja_typings": [
+          "tsuvinguri"
+        ]
+      },
+      {
+        "en": "John Calvin",
+        "ja": "カルヴァン",
+        "ja_typings": [
+          "karuvan"
+        ]
+      },
+      {
+        "en": "Plato",
+        "ja": "プラトン",
+        "ja_typings": [
+          "puraton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03095",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Dutch humanist wrote 'In Praise of Folly'?",
+      "ja": "『痴愚神礼讃』を書いたオランダの人文主義者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "France",
+        "ja": "フランス",
+        "ja_typings": [
+          "furansu"
+        ]
+      },
+      {
+        "en": "Germany",
+        "ja": "ドイツ",
+        "ja_typings": [
+          "doitsu"
+        ]
+      },
+      {
+        "en": "United States",
+        "ja": "アメリカ合衆国",
+        "ja_typings": [
+          "amerika gasshuukoku",
+          "amerikagasshuukoku"
+        ]
+      },
+      {
+        "en": "Yugoslavia",
+        "ja": "ユーゴスラビア",
+        "ja_typings": [
+          "yu-gosurabia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03096",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country experienced the Revolution of 1789?",
+      "ja": "1789年に大革命が起きた国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Francisco Franco",
+        "ja": "フランコ",
+        "ja_typings": [
+          "furanko"
+        ]
+      },
+      {
+        "en": "Salazar",
+        "ja": "サラザール",
+        "ja_typings": [
+          "sarazaaru",
+          "saraza-ru"
+        ]
+      },
+      {
+        "en": "Adolf Hitler",
+        "ja": "アドルフ・ヒトラー",
+        "ja_typings": [
+          "adorufu/hitora-"
+        ]
+      },
+      {
+        "en": "Joseph Stalin",
+        "ja": "スターリン",
+        "ja_typings": [
+          "sutaarin",
+          "suta-rin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03097",
+    "image_path": null,
+    "question_text": {
+      "en": "Who ruled Spain as dictator from 1939 to 1975?",
+      "ja": "1939年から1975年までスペインを独裁したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Galileo Galilei",
+        "ja": "ガリレオ・ガリレイ",
+        "ja_typings": [
+          "garireo/garirei"
+        ]
+      },
+      {
+        "en": "Nicolaus Copernicus",
+        "ja": "コペルニクス",
+        "ja_typings": [
+          "koperunikusu"
+        ]
+      },
+      {
+        "en": "Isaac Newton",
+        "ja": "ニュートン",
+        "ja_typings": [
+          "nyuuton",
+          "nyu-ton"
+        ]
+      },
+      {
+        "en": "Michael Faraday",
+        "ja": "ファラデー",
+        "ja_typings": [
+          "faradee",
+          "farade-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03098",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian astronomer was tried by the Inquisition for heliocentrism?",
+      "ja": "地動説で異端審問にかけられたイタリアの天文学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "George Washington",
+        "ja": "ジョージ・ワシントン",
+        "ja_typings": [
+          "jo-ji/washinton"
+        ]
+      },
+      {
+        "en": "Thomas Jefferson",
+        "ja": "ジェファーソン",
+        "ja_typings": [
+          "jefaason",
+          "jefa-son"
+        ]
+      },
+      {
+        "en": "John Adams",
+        "ja": "ジョン・アダムズ",
+        "ja_typings": [
+          "jon/adamuzu"
+        ]
+      },
+      {
+        "en": "Benjamin Franklin",
+        "ja": "フランクリン",
+        "ja_typings": [
+          "furankurin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03099",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first president of the United States?",
+      "ja": "アメリカ合衆国の初代大統領は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Germany",
+        "ja": "ドイツ",
+        "ja_typings": [
+          "doitsu"
+        ]
+      },
+      {
+        "en": "Yugoslavia",
+        "ja": "ユーゴスラビア",
+        "ja_typings": [
+          "yu-gosurabia"
+        ]
+      },
+      {
+        "en": "Czechoslovakia",
+        "ja": "チェコスロバキア",
+        "ja_typings": [
+          "chekosurobakia"
+        ]
+      },
+      {
+        "en": "France",
+        "ja": "フランス",
+        "ja_typings": [
+          "furansu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03100",
+    "image_path": null,
+    "question_text": {
+      "en": "Which European country was reunited in 1990?",
+      "ja": "1990年に再統一されたヨーロッパの国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Golda Meir",
+        "ja": "ゴルダ・メイア",
+        "ja_typings": [
+          "goruda/meia"
+        ]
+      },
+      {
+        "en": "Menachem Begin",
+        "ja": "メナヘム・ベギン",
+        "ja_typings": [
+          "menahemu/begin"
+        ]
+      },
+      {
+        "en": "Yitzhak Rabin",
+        "ja": "イツハク・ラビン",
+        "ja_typings": [
+          "itsuhaku/rabin"
+        ]
+      },
+      {
+        "en": "Catherine de' Medici",
+        "ja": "カトリーヌ・ド・メディシス",
+        "ja_typings": [
+          "katori-nu/do/medishisu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03101",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first female Prime Minister of Israel?",
+      "ja": "イスラエル初の女性首相は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Great Wall of China",
+        "ja": "万里の長城",
+        "ja_typings": [
+          "banri no choujou",
+          "banrinochoujou"
+        ]
+      },
+      {
+        "en": "Maginot Line",
+        "ja": "マジノ線",
+        "ja_typings": [
+          "majino sen",
+          "majinosen"
+        ]
+      },
+      {
+        "en": "Iron Curtain",
+        "ja": "鉄のカーテン",
+        "ja_typings": [
+          "tetsu no kaaten",
+          "tetsunokaaten"
+        ]
+      },
+      {
+        "en": "Behistun Inscription",
+        "ja": "ベヒストゥン碑文",
+        "ja_typings": [
+          "behisutun hibun",
+          "behisutunhibun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03102",
+    "image_path": null,
+    "question_text": {
+      "en": "Which massive fortification stretches across northern China?",
+      "ja": "中国北部に延々と続く大要塞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Harriet Tubman",
+        "ja": "ハリエット・タブマン",
+        "ja_typings": [
+          "harietto/tabuman"
+        ]
+      },
+      {
+        "en": "Malcolm X",
+        "ja": "マルコムX",
+        "ja_typings": [
+          "marukomux",
+          "marukomuekusu"
+        ]
+      },
+      {
+        "en": "Martin Luther King Jr.",
+        "ja": "キング牧師",
+        "ja_typings": [
+          "kingu bokushi",
+          "kingubokushi"
+        ]
+      },
+      {
+        "en": "Ulysses S. Grant",
+        "ja": "グラント",
+        "ja_typings": [
+          "guranto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03103",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led the Underground Railroad freeing slaves before the Civil War?",
+      "ja": "南北戦争以前に地下鉄道で奴隷を救った活動家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Harris Treaty",
+        "ja": "日米修好通商条約",
+        "ja_typings": [
+          "nichibei shuukou tsuushou jouyaku",
+          "nichibeishuukoutsuushoujouyaku"
+        ]
+      },
+      {
+        "en": "Treaty of San Francisco",
+        "ja": "サンフランシスコ平和条約",
+        "ja_typings": [
+          "san furanshisuko heiwa jouyaku",
+          "sanfuranshisukoheiwajouyaku"
+        ]
+      },
+      {
+        "en": "Potsdam Declaration",
+        "ja": "ポツダム宣言",
+        "ja_typings": [
+          "potsudamu sengen",
+          "potsudamusengen"
+        ]
+      },
+      {
+        "en": "Treaty of Utrecht",
+        "ja": "ユトレヒト条約",
+        "ja_typings": [
+          "yutorehito jouyaku",
+          "yutorehitojouyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03104",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1858 treaty opened more Japanese ports to American trade?",
+      "ja": "1858年に米国との通商を認めた条約は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Henry VIII",
+        "ja": "ヘンリー8世",
+        "ja_typings": [
+          "henrii 8 sei",
+          "henriihassei"
+        ]
+      },
+      {
+        "en": "Clovis",
+        "ja": "クロヴィス",
+        "ja_typings": [
+          "kurovisu"
+        ]
+      },
+      {
+        "en": "Otto I",
+        "ja": "オットー1世",
+        "ja_typings": [
+          "ottoo 1 sei",
+          "ottooissei"
+        ]
+      },
+      {
+        "en": "Pepin the Short",
+        "ja": "ピピン",
+        "ja_typings": [
+          "pipin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03105",
+    "image_path": null,
+    "question_text": {
+      "en": "Which English king had six wives and broke with Rome?",
+      "ja": "6人の妃を持ちローマ教会と決別した英国王は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hesiod",
+        "ja": "ヘシオドス",
+        "ja_typings": [
+          "heshiodosu"
+        ]
+      },
+      {
+        "en": "Homer",
+        "ja": "ホメロス",
+        "ja_typings": [
+          "homerosu"
+        ]
+      },
+      {
+        "en": "Plato",
+        "ja": "プラトン",
+        "ja_typings": [
+          "puraton"
+        ]
+      },
+      {
+        "en": "Socrates",
+        "ja": "ソクラテス",
+        "ja_typings": [
+          "sokuratesu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03106",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Greek poet wrote 'Works and Days'?",
+      "ja": "『労働と日々』を書いたギリシャの詩人は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Homer",
+        "ja": "ホメロス",
+        "ja_typings": [
+          "homerosu"
+        ]
+      },
+      {
+        "en": "Hesiod",
+        "ja": "ヘシオドス",
+        "ja_typings": [
+          "heshiodosu"
+        ]
+      },
+      {
+        "en": "Thucydides",
+        "ja": "トゥキディデス",
+        "ja_typings": [
+          "tukidideesu",
+          "tukididesu"
+        ]
+      },
+      {
+        "en": "Pythagoras",
+        "ja": "ピタゴラス",
+        "ja_typings": [
+          "pitagorasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03107",
+    "image_path": null,
+    "question_text": {
+      "en": "Which legendary Greek poet wrote the Iliad and Odyssey?",
+      "ja": "『イリアス』『オデュッセイア』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Huldrych Zwingli",
+        "ja": "ツヴィングリ",
+        "ja_typings": [
+          "tsuvinguri"
+        ]
+      },
+      {
+        "en": "John Calvin",
+        "ja": "カルヴァン",
+        "ja_typings": [
+          "karuvan"
+        ]
+      },
+      {
+        "en": "Erasmus",
+        "ja": "エラスムス",
+        "ja_typings": [
+          "erasumusu"
+        ]
+      },
+      {
+        "en": "Plato",
+        "ja": "プラトン",
+        "ja_typings": [
+          "puraton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03108",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Swiss reformer led the Reformation in Zurich?",
+      "ja": "チューリヒで宗教改革を進めたスイスの改革者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hundred Years' War",
+        "ja": "百年戦争",
+        "ja_typings": [
+          "hyakunen sensou",
+          "hyakunensensou"
+        ]
+      },
+      {
+        "en": "Thirty Years' War",
+        "ja": "三十年戦争",
+        "ja_typings": [
+          "sanjuunen sensou",
+          "sanjuunensensou"
+        ]
+      },
+      {
+        "en": "Wars of Religion",
+        "ja": "宗教戦争",
+        "ja_typings": [
+          "shuukyou sensou",
+          "shuukyousensou"
+        ]
+      },
+      {
+        "en": "Second Opium War",
+        "ja": "アロー戦争",
+        "ja_typings": [
+          "aroo sensou",
+          "aroosensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03109",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 14th-15th century war was fought between England and France?",
+      "ja": "14-15世紀のイングランドとフランスの長期戦争は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Iron Curtain",
+        "ja": "鉄のカーテン",
+        "ja_typings": [
+          "tetsu no kaaten",
+          "tetsunokaaten"
+        ]
+      },
+      {
+        "en": "Maginot Line",
+        "ja": "マジノ線",
+        "ja_typings": [
+          "majino sen",
+          "majinosen"
+        ]
+      },
+      {
+        "en": "Great Wall of China",
+        "ja": "万里の長城",
+        "ja_typings": [
+          "banri no choujou",
+          "banrinochoujou"
+        ]
+      },
+      {
+        "en": "Munich Agreement",
+        "ja": "ミュンヘン会談",
+        "ja_typings": [
+          "myunhen kaidan",
+          "myunhenkaidan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03110",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Cold War metaphor did Churchill coin for Europe's divide?",
+      "ja": "チャーチルが欧州の分断に用いた冷戦のメタファーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Isaac Newton",
+        "ja": "ニュートン",
+        "ja_typings": [
+          "nyuuton",
+          "nyu-ton"
+        ]
+      },
+      {
+        "en": "Galileo Galilei",
+        "ja": "ガリレオ・ガリレイ",
+        "ja_typings": [
+          "garireo/garirei"
+        ]
+      },
+      {
+        "en": "Nicolaus Copernicus",
+        "ja": "コペルニクス",
+        "ja_typings": [
+          "koperunikusu"
+        ]
+      },
+      {
+        "en": "Michael Faraday",
+        "ja": "ファラデー",
+        "ja_typings": [
+          "faradee",
+          "farade-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03111",
+    "image_path": null,
+    "question_text": {
+      "en": "Who formulated the law of universal gravitation?",
+      "ja": "万有引力の法則を定式化した人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ishida Mitsunari",
+        "ja": "石田三成",
+        "ja_typings": [
+          "ishida mitsunari",
+          "ishidamitsunari"
+        ]
+      },
+      {
+        "en": "Tokugawa Ieyasu",
+        "ja": "徳川家康",
+        "ja_typings": [
+          "tokugawa ieyasu",
+          "tokugawaieyasu"
+        ]
+      },
+      {
+        "en": "Toyotomi Hideyoshi",
+        "ja": "豊臣秀吉",
+        "ja_typings": [
+          "toyotomi hideyoshi",
+          "toyotomihideyoshi"
+        ]
+      },
+      {
+        "en": "Mori Terumoto",
+        "ja": "毛利輝元",
+        "ja_typings": [
+          "mori terumoto",
+          "moriterumoto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03112",
+    "image_path": null,
+    "question_text": {
+      "en": "Who commanded the Western Army at the Battle of Sekigahara?",
+      "ja": "関ヶ原で西軍を率いた武将は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Itagaki Taisuke",
+        "ja": "板垣退助",
+        "ja_typings": [
+          "itagaki taisuke",
+          "itagakitaisuke"
+        ]
+      },
+      {
+        "en": "Okuma Shigenobu",
+        "ja": "大隈重信",
+        "ja_typings": [
+          "ookuma shigenobu",
+          "ookumashigenobu"
+        ]
+      },
+      {
+        "en": "Yamagata Aritomo",
+        "ja": "山県有朋",
+        "ja_typings": [
+          "yamagata aritomo",
+          "yamagataaritomo"
+        ]
+      },
+      {
+        "en": "Sun Yat-sen",
+        "ja": "孫文",
+        "ja_typings": [
+          "sonbun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03113",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led the Meiji Restoration government and founded the Liberal Party?",
+      "ja": "明治政府の元勲で自由党を結成したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Izumo",
+        "ja": "出雲",
+        "ja_typings": [
+          "izumo"
+        ]
+      },
+      {
+        "en": "Yamato Court",
+        "ja": "大和朝廷",
+        "ja_typings": [
+          "yamato choutei",
+          "yamatochoutei"
+        ]
+      },
+      {
+        "en": "Mughal Empire",
+        "ja": "ムガル帝国",
+        "ja_typings": [
+          "mugaru teikoku",
+          "mugaruteikoku"
+        ]
+      },
+      {
+        "en": "Corsica",
+        "ja": "コルシカ島",
+        "ja_typings": [
+          "korushika tou",
+          "korushikatou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03114",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient province of Japan houses the famous grand shrine?",
+      "ja": "出雲大社のある日本の旧国名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "John Adams",
+        "ja": "ジョン・アダムズ",
+        "ja_typings": [
+          "jon/adamuzu"
+        ]
+      },
+      {
+        "en": "Thomas Jefferson",
+        "ja": "ジェファーソン",
+        "ja_typings": [
+          "jefaason",
+          "jefa-son"
+        ]
+      },
+      {
+        "en": "George Washington",
+        "ja": "ジョージ・ワシントン",
+        "ja_typings": [
+          "jo-ji/washinton"
+        ]
+      },
+      {
+        "en": "Ulysses S. Grant",
+        "ja": "グラント",
+        "ja_typings": [
+          "guranto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03115",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the second president of the United States?",
+      "ja": "アメリカ合衆国の第2代大統領は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "John Calvin",
+        "ja": "カルヴァン",
+        "ja_typings": [
+          "karuvan"
+        ]
+      },
+      {
+        "en": "Huldrych Zwingli",
+        "ja": "ツヴィングリ",
+        "ja_typings": [
+          "tsuvinguri"
+        ]
+      },
+      {
+        "en": "Erasmus",
+        "ja": "エラスムス",
+        "ja_typings": [
+          "erasumusu"
+        ]
+      },
+      {
+        "en": "Martin Luther King Jr.",
+        "ja": "キング牧師",
+        "ja_typings": [
+          "kingu bokushi",
+          "kingubokushi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03116",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French theologian led the Reformation in Geneva?",
+      "ja": "ジュネーブで宗教改革を率いたフランス出身の神学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "John Glenn",
+        "ja": "ジョン・グレン",
+        "ja_typings": [
+          "jon/guren"
+        ]
+      },
+      {
+        "en": "Buzz Aldrin",
+        "ja": "オルドリン",
+        "ja_typings": [
+          "orudorin"
+        ]
+      },
+      {
+        "en": "Yuri Gagarin",
+        "ja": "ガガーリン",
+        "ja_typings": [
+          "gagaarin",
+          "gaga-rin"
+        ]
+      },
+      {
+        "en": "Neil Armstrong",
+        "ja": "アームストロング",
+        "ja_typings": [
+          "aamusutorongu",
+          "a-musutorongu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03117",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first American to orbit Earth?",
+      "ja": "アメリカ人で初めて地球周回飛行をしたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Leon Trotsky",
+        "ja": "トロツキー",
+        "ja_typings": [
+          "torotsukii",
+          "torotsuki-"
+        ]
+      },
+      {
+        "en": "Alexander Kerensky",
+        "ja": "ケレンスキー",
+        "ja_typings": [
+          "kerensukii",
+          "kerensuki-"
+        ]
+      },
+      {
+        "en": "Joseph Stalin",
+        "ja": "スターリン",
+        "ja_typings": [
+          "sutaarin",
+          "suta-rin"
+        ]
+      },
+      {
+        "en": "Deng Xiaoping",
+        "ja": "鄧小平",
+        "ja_typings": [
+          "toushouhei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03118",
+    "image_path": null,
+    "question_text": {
+      "en": "Who founded the Red Army and was exiled by Stalin?",
+      "ja": "赤軍を組織しスターリンに追放された革命家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Little Boy",
+        "ja": "リトルボーイ",
+        "ja_typings": [
+          "ritorubo-i"
+        ]
+      },
+      {
+        "en": "Bockscar",
+        "ja": "ボックスカー",
+        "ja_typings": [
+          "bokkusukaa",
+          "bokkusuka-"
+        ]
+      },
+      {
+        "en": "Memphis Belle",
+        "ja": "メンフィス・ベル",
+        "ja_typings": [
+          "menfisu/beru"
+        ]
+      },
+      {
+        "en": "Fat Man",
+        "ja": "ファットマン",
+        "ja_typings": [
+          "fattoman"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03119",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the codename of the atomic bomb dropped on Hiroshima?",
+      "ja": "広島に投下された原爆のコードネームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Maginot Line",
+        "ja": "マジノ線",
+        "ja_typings": [
+          "majino sen",
+          "majinosen"
+        ]
+      },
+      {
+        "en": "Iron Curtain",
+        "ja": "鉄のカーテン",
+        "ja_typings": [
+          "tetsu no kaaten",
+          "tetsunokaaten"
+        ]
+      },
+      {
+        "en": "Great Wall of China",
+        "ja": "万里の長城",
+        "ja_typings": [
+          "banri no choujou",
+          "banrinochoujou"
+        ]
+      },
+      {
+        "en": "Hundred Years' War",
+        "ja": "百年戦争",
+        "ja_typings": [
+          "hyakunen sensou",
+          "hyakunensensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03120",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French defensive fortification was built before WWII?",
+      "ja": "第二次大戦前にフランスが築いた防衛線は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Malcolm X",
+        "ja": "マルコムX",
+        "ja_typings": [
+          "marukomux",
+          "marukomuekusu"
+        ]
+      },
+      {
+        "en": "Martin Luther King Jr.",
+        "ja": "キング牧師",
+        "ja_typings": [
+          "kingu bokushi",
+          "kingubokushi"
+        ]
+      },
+      {
+        "en": "Harriet Tubman",
+        "ja": "ハリエット・タブマン",
+        "ja_typings": [
+          "harietto/tabuman"
+        ]
+      },
+      {
+        "en": "Ulysses S. Grant",
+        "ja": "グラント",
+        "ja_typings": [
+          "guranto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03121",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Nation of Islam minister assassinated in 1965?",
+      "ja": "1965年に暗殺されたネーション・オブ・イスラムの活動家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Marie Antoinette",
+        "ja": "マリー・アントワネット",
+        "ja_typings": [
+          "mari-/antowanetto"
+        ]
+      },
+      {
+        "en": "Catherine de' Medici",
+        "ja": "カトリーヌ・ド・メディシス",
+        "ja_typings": [
+          "katori-nu/do/medishisu"
+        ]
+      },
+      {
+        "en": "Eleanor of Aquitaine",
+        "ja": "エレオノール",
+        "ja_typings": [
+          "ereonooru",
+          "ereono-ru"
+        ]
+      },
+      {
+        "en": "Golda Meir",
+        "ja": "ゴルダ・メイア",
+        "ja_typings": [
+          "goruda/meia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03122",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the queen guillotined during the French Revolution?",
+      "ja": "フランス革命で処刑された王妃は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Marquis de Lafayette",
+        "ja": "ラファイエット",
+        "ja_typings": [
+          "rafaietto"
+        ]
+      },
+      {
+        "en": "Talleyrand",
+        "ja": "タレーラン",
+        "ja_typings": [
+          "tareeran",
+          "tare-ran"
+        ]
+      },
+      {
+        "en": "Maximilien Robespierre",
+        "ja": "ロベスピエール",
+        "ja_typings": [
+          "robesupieeru",
+          "robesupie-ru"
+        ]
+      },
+      {
+        "en": "Napoleon III",
+        "ja": "ナポレオン3世",
+        "ja_typings": [
+          "naporeon 3 sei",
+          "naporeonsansei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03123",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French nobleman aided the American Revolution as a general?",
+      "ja": "アメリカ独立戦争で将軍として参戦したフランス貴族は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Martin Luther King Jr.",
+        "ja": "キング牧師",
+        "ja_typings": [
+          "kingu bokushi",
+          "kingubokushi"
+        ]
+      },
+      {
+        "en": "Malcolm X",
+        "ja": "マルコムX",
+        "ja_typings": [
+          "marukomux",
+          "marukomuekusu"
+        ]
+      },
+      {
+        "en": "Harriet Tubman",
+        "ja": "ハリエット・タブマン",
+        "ja_typings": [
+          "harietto/tabuman"
+        ]
+      },
+      {
+        "en": "Buzz Aldrin",
+        "ja": "オルドリン",
+        "ja_typings": [
+          "orudorin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03124",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led the US civil rights movement and gave the 'I Have a Dream' speech?",
+      "ja": "「私には夢がある」演説を行った米公民権運動家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Maximilien Robespierre",
+        "ja": "ロベスピエール",
+        "ja_typings": [
+          "robesupieeru",
+          "robesupie-ru"
+        ]
+      },
+      {
+        "en": "Marquis de Lafayette",
+        "ja": "ラファイエット",
+        "ja_typings": [
+          "rafaietto"
+        ]
+      },
+      {
+        "en": "Talleyrand",
+        "ja": "タレーラン",
+        "ja_typings": [
+          "tareeran",
+          "tare-ran"
+        ]
+      },
+      {
+        "en": "Napoleon III",
+        "ja": "ナポレオン3世",
+        "ja_typings": [
+          "naporeon 3 sei",
+          "naporeonsansei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03125",
+    "image_path": null,
+    "question_text": {
+      "en": "Who led the radical phase of the French Revolution's Reign of Terror?",
+      "ja": "フランス革命の恐怖政治を主導した人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Memphis Belle",
+        "ja": "メンフィス・ベル",
+        "ja_typings": [
+          "menfisu/beru"
+        ]
+      },
+      {
+        "en": "Bockscar",
+        "ja": "ボックスカー",
+        "ja_typings": [
+          "bokkusukaa",
+          "bokkusuka-"
+        ]
+      },
+      {
+        "en": "Little Boy",
+        "ja": "リトルボーイ",
+        "ja_typings": [
+          "ritorubo-i"
+        ]
+      },
+      {
+        "en": "Enola Gay",
+        "ja": "エノラ・ゲイ",
+        "ja_typings": [
+          "enora/gei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03126",
+    "image_path": null,
+    "question_text": {
+      "en": "Which B-17 bomber became famous for completing 25 WWII missions?",
+      "ja": "第二次大戦で25回出撃を生き延びた有名なB-17は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Menachem Begin",
+        "ja": "メナヘム・ベギン",
+        "ja_typings": [
+          "menahemu/begin"
+        ]
+      },
+      {
+        "en": "Yitzhak Rabin",
+        "ja": "イツハク・ラビン",
+        "ja_typings": [
+          "itsuhaku/rabin"
+        ]
+      },
+      {
+        "en": "Golda Meir",
+        "ja": "ゴルダ・メイア",
+        "ja_typings": [
+          "goruda/meia"
+        ]
+      },
+      {
+        "en": "Muhammad Ali Jinnah",
+        "ja": "ジンナー",
+        "ja_typings": [
+          "jinnaa",
+          "jinnna-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03127",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Likud Prime Minister of Israel who signed Camp David?",
+      "ja": "キャンプ・デービッド合意を結んだイスラエルのリクード首相は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Michael Faraday",
+        "ja": "ファラデー",
+        "ja_typings": [
+          "faradee",
+          "farade-"
+        ]
+      },
+      {
+        "en": "Thomas Edison",
+        "ja": "エジソン",
+        "ja_typings": [
+          "ejison"
+        ]
+      },
+      {
+        "en": "Isaac Newton",
+        "ja": "ニュートン",
+        "ja_typings": [
+          "nyuuton",
+          "nyu-ton"
+        ]
+      },
+      {
+        "en": "Galileo Galilei",
+        "ja": "ガリレオ・ガリレイ",
+        "ja_typings": [
+          "garireo/garirei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03128",
+    "image_path": null,
+    "question_text": {
+      "en": "Who discovered electromagnetic induction in 1831?",
+      "ja": "1831年に電磁誘導を発見した人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mori Terumoto",
+        "ja": "毛利輝元",
+        "ja_typings": [
+          "mori terumoto",
+          "moriterumoto"
+        ]
+      },
+      {
+        "en": "Ishida Mitsunari",
+        "ja": "石田三成",
+        "ja_typings": [
+          "ishida mitsunari",
+          "ishidamitsunari"
+        ]
+      },
+      {
+        "en": "Tokugawa Ieyasu",
+        "ja": "徳川家康",
+        "ja_typings": [
+          "tokugawa ieyasu",
+          "tokugawaieyasu"
+        ]
+      },
+      {
+        "en": "Uesugi Kagekatsu",
+        "ja": "上杉景勝",
+        "ja_typings": [
+          "uesugi kagekatsu",
+          "uesugikagekatsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03129",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Mori clan leader and titular head of the Western Army at Sekigahara?",
+      "ja": "関ヶ原で西軍総大将を務めた毛利家当主は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mughal Empire",
+        "ja": "ムガル帝国",
+        "ja_typings": [
+          "mugaru teikoku",
+          "mugaruteikoku"
+        ]
+      },
+      {
+        "en": "Safavid Empire",
+        "ja": "サファヴィー朝",
+        "ja_typings": [
+          "safavii chou",
+          "safaviichou"
+        ]
+      },
+      {
+        "en": "Abbasid Caliphate",
+        "ja": "アッバース朝",
+        "ja_typings": [
+          "abbaasu chou",
+          "abbaasuchou"
+        ]
+      },
+      {
+        "en": "Ottoman Empire",
+        "ja": "オスマン帝国",
+        "ja_typings": [
+          "osuman teikoku",
+          "osumanteikoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03130",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Islamic empire ruled India from 1526 to the 19th century?",
+      "ja": "1526年から19世紀までインドを支配したイスラム王朝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Muhammad Ali Jinnah",
+        "ja": "ジンナー",
+        "ja_typings": [
+          "jinnaa",
+          "jinnna-"
+        ]
+      },
+      {
+        "en": "Rabindranath Tagore",
+        "ja": "タゴール",
+        "ja_typings": [
+          "tagooru",
+          "tago-ru"
+        ]
+      },
+      {
+        "en": "Menachem Begin",
+        "ja": "メナヘム・ベギン",
+        "ja_typings": [
+          "menahemu/begin"
+        ]
+      },
+      {
+        "en": "Sun Yat-sen",
+        "ja": "孫文",
+        "ja_typings": [
+          "sonbun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03131",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the founder of Pakistan?",
+      "ja": "パキスタン建国の父と呼ばれる人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Munich Agreement",
+        "ja": "ミュンヘン会談",
+        "ja_typings": [
+          "myunhen kaidan",
+          "myunhenkaidan"
+        ]
+      },
+      {
+        "en": "Peace of Westphalia",
+        "ja": "ウェストファリア条約",
+        "ja_typings": [
+          "uesutofaria jouyaku",
+          "uesutofariajouyaku"
+        ]
+      },
+      {
+        "en": "Potsdam Declaration",
+        "ja": "ポツダム宣言",
+        "ja_typings": [
+          "potsudamu sengen",
+          "potsudamusengen"
+        ]
+      },
+      {
+        "en": "Treaty of Utrecht",
+        "ja": "ユトレヒト条約",
+        "ja_typings": [
+          "yutorehito jouyaku",
+          "yutorehitojouyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03132",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1938 pact ceded the Sudetenland to Nazi Germany?",
+      "ja": "1938年にズデーテン地方をナチスに割譲した協定は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Na",
+        "ja": "ナトリウム",
+        "ja_typings": [
+          "natoriumu"
+        ]
+      },
+      {
+        "en": "Iron Curtain",
+        "ja": "鉄のカーテン",
+        "ja_typings": [
+          "tetsu no kaaten",
+          "tetsunokaaten"
+        ]
+      },
+      {
+        "en": "Nile River",
+        "ja": "ナイル川",
+        "ja_typings": [
+          "nairu gawa",
+          "nairugawa"
+        ]
+      },
+      {
+        "en": "Cannon",
+        "ja": "大砲",
+        "ja_typings": [
+          "taihou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03133",
+    "image_path": null,
+    "question_text": {
+      "en": "Which chemical element has the symbol Na?",
+      "ja": "元素記号Naで表される元素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Napoleon III",
+        "ja": "ナポレオン3世",
+        "ja_typings": [
+          "naporeon 3 sei",
+          "naporeonsansei"
+        ]
+      },
+      {
+        "en": "Maximilien Robespierre",
+        "ja": "ロベスピエール",
+        "ja_typings": [
+          "robesupieeru",
+          "robesupie-ru"
+        ]
+      },
+      {
+        "en": "Talleyrand",
+        "ja": "タレーラン",
+        "ja_typings": [
+          "tareeran",
+          "tare-ran"
+        ]
+      },
+      {
+        "en": "Marquis de Lafayette",
+        "ja": "ラファイエット",
+        "ja_typings": [
+          "rafaietto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03134",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was Emperor of France during the Second Empire?",
+      "ja": "フランス第二帝政の皇帝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nicolaus Copernicus",
+        "ja": "コペルニクス",
+        "ja_typings": [
+          "koperunikusu"
+        ]
+      },
+      {
+        "en": "Galileo Galilei",
+        "ja": "ガリレオ・ガリレイ",
+        "ja_typings": [
+          "garireo/garirei"
+        ]
+      },
+      {
+        "en": "Isaac Newton",
+        "ja": "ニュートン",
+        "ja_typings": [
+          "nyuuton",
+          "nyu-ton"
+        ]
+      },
+      {
+        "en": "Pythagoras",
+        "ja": "ピタゴラス",
+        "ja_typings": [
+          "pitagorasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03135",
+    "image_path": null,
+    "question_text": {
+      "en": "Who proposed the heliocentric model of the solar system in the 16th century?",
+      "ja": "16世紀に太陽中心説を唱えた人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nile River",
+        "ja": "ナイル川",
+        "ja_typings": [
+          "nairu gawa",
+          "nairugawa"
+        ]
+      },
+      {
+        "en": "Rhine River",
+        "ja": "ライン川",
+        "ja_typings": [
+          "rain gawa",
+          "raingawa"
+        ]
+      },
+      {
+        "en": "Tiber River",
+        "ja": "テヴェレ川",
+        "ja_typings": [
+          "tevere gawa",
+          "teveregawa"
+        ]
+      },
+      {
+        "en": "Great Wall of China",
+        "ja": "万里の長城",
+        "ja_typings": [
+          "banri no choujou",
+          "banrinochoujou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03136",
+    "image_path": null,
+    "question_text": {
+      "en": "Which African river was central to ancient Egyptian civilization?",
+      "ja": "古代エジプト文明を育んだアフリカの大河は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nixon and Brezhnev",
+        "ja": "ニクソンとブレジネフ",
+        "ja_typings": [
+          "nikusontoburejinefu"
+        ]
+      },
+      {
+        "en": "Reagan and Gorbachev",
+        "ja": "レーガンとゴルバチョフ",
+        "ja_typings": [
+          "re-gantogorubachofu"
+        ]
+      },
+      {
+        "en": "Truman and Stalin",
+        "ja": "トルーマンとスターリン",
+        "ja_typings": [
+          "toru-mantosuta-rin"
+        ]
+      },
+      {
+        "en": "Munich Agreement",
+        "ja": "ミュンヘン会談",
+        "ja_typings": [
+          "myunhen kaidan",
+          "myunhenkaidan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03137",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1972 detente summit was held in Moscow between US and USSR?",
+      "ja": "1972年にモスクワで行われた米ソ緊張緩和の首脳会談は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Okuma Shigenobu",
+        "ja": "大隈重信",
+        "ja_typings": [
+          "ookuma shigenobu",
+          "ookumashigenobu"
+        ]
+      },
+      {
+        "en": "Itagaki Taisuke",
+        "ja": "板垣退助",
+        "ja_typings": [
+          "itagaki taisuke",
+          "itagakitaisuke"
+        ]
+      },
+      {
+        "en": "Yamagata Aritomo",
+        "ja": "山県有朋",
+        "ja_typings": [
+          "yamagata aritomo",
+          "yamagataaritomo"
+        ]
+      },
+      {
+        "en": "Tokugawa Ieyasu",
+        "ja": "徳川家康",
+        "ja_typings": [
+          "tokugawa ieyasu",
+          "tokugawaieyasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03138",
+    "image_path": null,
+    "question_text": {
+      "en": "Who founded Waseda University and served as Prime Minister of Japan?",
+      "ja": "早稲田大学を創設し首相も務めた人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Otto I",
+        "ja": "オットー1世",
+        "ja_typings": [
+          "ottoo 1 sei",
+          "ottooissei"
+        ]
+      },
+      {
+        "en": "Clovis",
+        "ja": "クロヴィス",
+        "ja_typings": [
+          "kurovisu"
+        ]
+      },
+      {
+        "en": "Pepin the Short",
+        "ja": "ピピン",
+        "ja_typings": [
+          "pipin"
+        ]
+      },
+      {
+        "en": "Henry VIII",
+        "ja": "ヘンリー8世",
+        "ja_typings": [
+          "henrii 8 sei",
+          "henriihassei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03139",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was crowned the first Holy Roman Emperor in 962?",
+      "ja": "962年に神聖ローマ皇帝に戴冠した君主は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Palermo Stone",
+        "ja": "パレルモ石",
+        "ja_typings": [
+          "parerumo seki",
+          "parerumoseki"
+        ]
+      },
+      {
+        "en": "Code of Hammurabi stele",
+        "ja": "ハンムラビ法典碑",
+        "ja_typings": [
+          "hanmurabi houten hi",
+          "hanmurabihoutenhi"
+        ]
+      },
+      {
+        "en": "Behistun Inscription",
+        "ja": "ベヒストゥン碑文",
+        "ja_typings": [
+          "behisutun hibun",
+          "behisutunhibun"
+        ]
+      },
+      {
+        "en": "Rosetta Stone",
+        "ja": "ロゼッタストーン",
+        "ja_typings": [
+          "rozettasuto-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03140",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Egyptian stone records the early dynasties' kings?",
+      "ja": "古代エジプト初期王朝史を刻む石碑は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Peace of Westphalia",
+        "ja": "ウェストファリア条約",
+        "ja_typings": [
+          "uesutofaria jouyaku",
+          "uesutofariajouyaku"
+        ]
+      },
+      {
+        "en": "Treaty of Utrecht",
+        "ja": "ユトレヒト条約",
+        "ja_typings": [
+          "yutorehito jouyaku",
+          "yutorehitojouyaku"
+        ]
+      },
+      {
+        "en": "Treaty of San Francisco",
+        "ja": "サンフランシスコ平和条約",
+        "ja_typings": [
+          "san furanshisuko heiwa jouyaku",
+          "sanfuranshisukoheiwajouyaku"
+        ]
+      },
+      {
+        "en": "Munich Agreement",
+        "ja": "ミュンヘン会談",
+        "ja_typings": [
+          "myunhen kaidan",
+          "myunhenkaidan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03141",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1648 treaty ended the Thirty Years' War?",
+      "ja": "1648年に三十年戦争を終結させた条約は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pepin the Short",
+        "ja": "ピピン",
+        "ja_typings": [
+          "pipin"
+        ]
+      },
+      {
+        "en": "Clovis",
+        "ja": "クロヴィス",
+        "ja_typings": [
+          "kurovisu"
+        ]
+      },
+      {
+        "en": "Otto I",
+        "ja": "オットー1世",
+        "ja_typings": [
+          "ottoo 1 sei",
+          "ottooissei"
+        ]
+      },
+      {
+        "en": "Henry VIII",
+        "ja": "ヘンリー8世",
+        "ja_typings": [
+          "henrii 8 sei",
+          "henriihassei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03142",
+    "image_path": null,
+    "question_text": {
+      "en": "Who founded the Carolingian dynasty by deposing the last Merovingian king?",
+      "ja": "メロヴィング朝最後の王を廃しカロリング朝を開いたのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Plato",
+        "ja": "プラトン",
+        "ja_typings": [
+          "puraton"
+        ]
+      },
+      {
+        "en": "Socrates",
+        "ja": "ソクラテス",
+        "ja_typings": [
+          "sokuratesu"
+        ]
+      },
+      {
+        "en": "Pythagoras",
+        "ja": "ピタゴラス",
+        "ja_typings": [
+          "pitagorasu"
+        ]
+      },
+      {
+        "en": "Thucydides",
+        "ja": "トゥキディデス",
+        "ja_typings": [
+          "tukidideesu",
+          "tukididesu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03143",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Greek philosopher founded the Academy and wrote 'The Republic'?",
+      "ja": "アカデメイアを開き『国家』を著したギリシャの哲学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Potsdam Declaration",
+        "ja": "ポツダム宣言",
+        "ja_typings": [
+          "potsudamu sengen",
+          "potsudamusengen"
+        ]
+      },
+      {
+        "en": "Treaty of San Francisco",
+        "ja": "サンフランシスコ平和条約",
+        "ja_typings": [
+          "san furanshisuko heiwa jouyaku",
+          "sanfuranshisukoheiwajouyaku"
+        ]
+      },
+      {
+        "en": "Harris Treaty",
+        "ja": "日米修好通商条約",
+        "ja_typings": [
+          "nichibei shuukou tsuushou jouyaku",
+          "nichibeishuukoutsuushoujouyaku"
+        ]
+      },
+      {
+        "en": "Munich Agreement",
+        "ja": "ミュンヘン会談",
+        "ja_typings": [
+          "myunhen kaidan",
+          "myunhenkaidan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03144",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1945 declaration demanded Japan's unconditional surrender?",
+      "ja": "1945年に日本に無条件降伏を求めた宣言は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pythagoras",
+        "ja": "ピタゴラス",
+        "ja_typings": [
+          "pitagorasu"
+        ]
+      },
+      {
+        "en": "Plato",
+        "ja": "プラトン",
+        "ja_typings": [
+          "puraton"
+        ]
+      },
+      {
+        "en": "Socrates",
+        "ja": "ソクラテス",
+        "ja_typings": [
+          "sokuratesu"
+        ]
+      },
+      {
+        "en": "Hesiod",
+        "ja": "ヘシオドス",
+        "ja_typings": [
+          "heshiodosu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03145",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Greek mathematician is famous for a theorem about right triangles?",
+      "ja": "直角三角形の定理で知られるギリシャの数学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rabindranath Tagore",
+        "ja": "タゴール",
+        "ja_typings": [
+          "tagooru",
+          "tago-ru"
+        ]
+      },
+      {
+        "en": "Muhammad Ali Jinnah",
+        "ja": "ジンナー",
+        "ja_typings": [
+          "jinnaa",
+          "jinnna-"
+        ]
+      },
+      {
+        "en": "Homer",
+        "ja": "ホメロス",
+        "ja_typings": [
+          "homerosu"
+        ]
+      },
+      {
+        "en": "Plato",
+        "ja": "プラトン",
+        "ja_typings": [
+          "puraton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03146",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Bengali poet who won the 1913 Nobel Prize in Literature?",
+      "ja": "1913年にノーベル文学賞を受けたベンガルの詩人は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Reagan and Gorbachev",
+        "ja": "レーガンとゴルバチョフ",
+        "ja_typings": [
+          "re-gantogorubachofu"
+        ]
+      },
+      {
+        "en": "Nixon and Brezhnev",
+        "ja": "ニクソンとブレジネフ",
+        "ja_typings": [
+          "nikusontoburejinefu"
+        ]
+      },
+      {
+        "en": "Truman and Stalin",
+        "ja": "トルーマンとスターリン",
+        "ja_typings": [
+          "toru-mantosuta-rin"
+        ]
+      },
+      {
+        "en": "Munich Agreement",
+        "ja": "ミュンヘン会談",
+        "ja_typings": [
+          "myunhen kaidan",
+          "myunhenkaidan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03147",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1985-88 summit thawed the Cold War between US and USSR?",
+      "ja": "1985-88年に冷戦終結に向かった米ソ首脳会談は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rhine River",
+        "ja": "ライン川",
+        "ja_typings": [
+          "rain gawa",
+          "raingawa"
+        ]
+      },
+      {
+        "en": "Nile River",
+        "ja": "ナイル川",
+        "ja_typings": [
+          "nairu gawa",
+          "nairugawa"
+        ]
+      },
+      {
+        "en": "Tiber River",
+        "ja": "テヴェレ川",
+        "ja_typings": [
+          "tevere gawa",
+          "teveregawa"
+        ]
+      },
+      {
+        "en": "Maginot Line",
+        "ja": "マジノ線",
+        "ja_typings": [
+          "majino sen",
+          "majinosen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03148",
+    "image_path": null,
+    "question_text": {
+      "en": "Which European river flows through Germany and the Netherlands to the North Sea?",
+      "ja": "ドイツからオランダを経て北海に注ぐ欧州の大河は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Safavid Empire",
+        "ja": "サファヴィー朝",
+        "ja_typings": [
+          "safavii chou",
+          "safaviichou"
+        ]
+      },
+      {
+        "en": "Mughal Empire",
+        "ja": "ムガル帝国",
+        "ja_typings": [
+          "mugaru teikoku",
+          "mugaruteikoku"
+        ]
+      },
+      {
+        "en": "Abbasid Caliphate",
+        "ja": "アッバース朝",
+        "ja_typings": [
+          "abbaasu chou",
+          "abbaasuchou"
+        ]
+      },
+      {
+        "en": "Yamato Court",
+        "ja": "大和朝廷",
+        "ja_typings": [
+          "yamato choutei",
+          "yamatochoutei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03149",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Persian Shia empire rose in 1501 in Iran?",
+      "ja": "1501年にイランで興ったシーア派ペルシア王朝は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Salazar",
+        "ja": "サラザール",
+        "ja_typings": [
+          "sarazaaru",
+          "saraza-ru"
+        ]
+      },
+      {
+        "en": "Francisco Franco",
+        "ja": "フランコ",
+        "ja_typings": [
+          "furanko"
+        ]
+      },
+      {
+        "en": "Adolf Hitler",
+        "ja": "アドルフ・ヒトラー",
+        "ja_typings": [
+          "adorufu/hitora-"
+        ]
+      },
+      {
+        "en": "Joseph Stalin",
+        "ja": "スターリン",
+        "ja_typings": [
+          "sutaarin",
+          "suta-rin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03150",
+    "image_path": null,
+    "question_text": {
+      "en": "Who ruled Portugal as authoritarian leader during Estado Novo?",
+      "ja": "エスタド・ノヴォ体制下でポルトガルを統治したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sardinia",
+        "ja": "サルデーニャ島",
+        "ja_typings": [
+          "sarudeenya tou",
+          "sarudeenyatou"
+        ]
+      },
+      {
+        "en": "Corsica",
+        "ja": "コルシカ島",
+        "ja_typings": [
+          "korushika tou",
+          "korushikatou"
+        ]
+      },
+      {
+        "en": "Sicily",
+        "ja": "シチリア島",
+        "ja_typings": [
+          "shichiria tou",
+          "shichiriatou"
+        ]
+      },
+      {
+        "en": "Izumo",
+        "ja": "出雲",
+        "ja_typings": [
+          "izumo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03151",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian island was a kingdom that united Italy in the 19th century?",
+      "ja": "19世紀イタリア統一の核となった島の王国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Second Opium War",
+        "ja": "アロー戦争",
+        "ja_typings": [
+          "aroo sensou",
+          "aroosensou"
+        ]
+      },
+      {
+        "en": "Boxer Rebellion",
+        "ja": "義和団事件",
+        "ja_typings": [
+          "giwadan jiken",
+          "giwadanjiken"
+        ]
+      },
+      {
+        "en": "Taiping Rebellion",
+        "ja": "太平天国の乱",
+        "ja_typings": [
+          "taihei tengoku no ran",
+          "taiheitengokunoran"
+        ]
+      },
+      {
+        "en": "Hundred Years' War",
+        "ja": "百年戦争",
+        "ja_typings": [
+          "hyakunen sensou",
+          "hyakunensensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03152",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1856-60 war pitted Britain and France against Qing China?",
+      "ja": "1856-60年に英仏が清と戦った戦争は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Socrates",
+        "ja": "ソクラテス",
+        "ja_typings": [
+          "sokuratesu"
+        ]
+      },
+      {
+        "en": "Plato",
+        "ja": "プラトン",
+        "ja_typings": [
+          "puraton"
+        ]
+      },
+      {
+        "en": "Pythagoras",
+        "ja": "ピタゴラス",
+        "ja_typings": [
+          "pitagorasu"
+        ]
+      },
+      {
+        "en": "Hesiod",
+        "ja": "ヘシオドス",
+        "ja_typings": [
+          "heshiodosu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03153",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Greek philosopher was tried and executed in Athens?",
+      "ja": "アテネで死刑に処されたギリシャの哲学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sun Quan",
+        "ja": "孫権",
+        "ja_typings": [
+          "sonken"
+        ]
+      },
+      {
+        "en": "Cao Cao",
+        "ja": "曹操",
+        "ja_typings": [
+          "sousou"
+        ]
+      },
+      {
+        "en": "Zhuge Liang",
+        "ja": "諸葛亮",
+        "ja_typings": [
+          "shokatsuryou"
+        ]
+      },
+      {
+        "en": "Liu Bei",
+        "ja": "劉備",
+        "ja_typings": [
+          "ryuubi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03154",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the king of Wu during the Three Kingdoms period?",
+      "ja": "三国志で呉を建てた君主は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sun Yat-sen",
+        "ja": "孫文",
+        "ja_typings": [
+          "sonbun"
+        ]
+      },
+      {
+        "en": "Deng Xiaoping",
+        "ja": "鄧小平",
+        "ja_typings": [
+          "toushouhei"
+        ]
+      },
+      {
+        "en": "Zhou Enlai",
+        "ja": "周恩来",
+        "ja_typings": [
+          "shuuonrai"
+        ]
+      },
+      {
+        "en": "Cao Cao",
+        "ja": "曹操",
+        "ja_typings": [
+          "sousou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03155",
+    "image_path": null,
+    "question_text": {
+      "en": "Who founded the Republic of China in 1912?",
+      "ja": "1912年に中華民国を建てた人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Taiping Rebellion",
+        "ja": "太平天国の乱",
+        "ja_typings": [
+          "taihei tengoku no ran",
+          "taiheitengokunoran"
+        ]
+      },
+      {
+        "en": "Boxer Rebellion",
+        "ja": "義和団事件",
+        "ja_typings": [
+          "giwadan jiken",
+          "giwadanjiken"
+        ]
+      },
+      {
+        "en": "Second Opium War",
+        "ja": "アロー戦争",
+        "ja_typings": [
+          "aroo sensou",
+          "aroosensou"
+        ]
+      },
+      {
+        "en": "Wars of Religion",
+        "ja": "宗教戦争",
+        "ja_typings": [
+          "shuukyou sensou",
+          "shuukyousensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03156",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mid-19th century Christian-inspired uprising shook the Qing dynasty?",
+      "ja": "19世紀半ばに清朝を揺るがしたキリスト教系大反乱は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Takeda Shingen",
+        "ja": "武田信玄",
+        "ja_typings": [
+          "takeda shingen",
+          "takedashingen"
+        ]
+      },
+      {
+        "en": "Uesugi Kagekatsu",
+        "ja": "上杉景勝",
+        "ja_typings": [
+          "uesugi kagekatsu",
+          "uesugikagekatsu"
+        ]
+      },
+      {
+        "en": "Ishida Mitsunari",
+        "ja": "石田三成",
+        "ja_typings": [
+          "ishida mitsunari",
+          "ishidamitsunari"
+        ]
+      },
+      {
+        "en": "Tokugawa Ieyasu",
+        "ja": "徳川家康",
+        "ja_typings": [
+          "tokugawa ieyasu",
+          "tokugawaieyasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03157",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Kai daimyo nicknamed 'Tiger of Kai' in Sengoku Japan?",
+      "ja": "甲斐の虎と呼ばれた戦国大名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Talleyrand",
+        "ja": "タレーラン",
+        "ja_typings": [
+          "tareeran",
+          "tare-ran"
+        ]
+      },
+      {
+        "en": "Marquis de Lafayette",
+        "ja": "ラファイエット",
+        "ja_typings": [
+          "rafaietto"
+        ]
+      },
+      {
+        "en": "Maximilien Robespierre",
+        "ja": "ロベスピエール",
+        "ja_typings": [
+          "robesupieeru",
+          "robesupie-ru"
+        ]
+      },
+      {
+        "en": "Napoleon III",
+        "ja": "ナポレオン3世",
+        "ja_typings": [
+          "naporeon 3 sei",
+          "naporeonsansei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03158",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French diplomat served Napoleon and represented France at Vienna?",
+      "ja": "ナポレオンに仕えウィーン会議でフランス代表となった外交官は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thirty Years' War",
+        "ja": "三十年戦争",
+        "ja_typings": [
+          "sanjuunen sensou",
+          "sanjuunensensou"
+        ]
+      },
+      {
+        "en": "Hundred Years' War",
+        "ja": "百年戦争",
+        "ja_typings": [
+          "hyakunen sensou",
+          "hyakunensensou"
+        ]
+      },
+      {
+        "en": "Wars of Religion",
+        "ja": "宗教戦争",
+        "ja_typings": [
+          "shuukyou sensou",
+          "shuukyousensou"
+        ]
+      },
+      {
+        "en": "Boxer Rebellion",
+        "ja": "義和団事件",
+        "ja_typings": [
+          "giwadan jiken",
+          "giwadanjiken"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03159",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1618-1648 war devastated Central Europe over religion and politics?",
+      "ja": "1618-1648年に中欧を荒廃させた宗教戦争は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thomas Edison",
+        "ja": "エジソン",
+        "ja_typings": [
+          "ejison"
+        ]
+      },
+      {
+        "en": "Michael Faraday",
+        "ja": "ファラデー",
+        "ja_typings": [
+          "faradee",
+          "farade-"
+        ]
+      },
+      {
+        "en": "Isaac Newton",
+        "ja": "ニュートン",
+        "ja_typings": [
+          "nyuuton",
+          "nyu-ton"
+        ]
+      },
+      {
+        "en": "Galileo Galilei",
+        "ja": "ガリレオ・ガリレイ",
+        "ja_typings": [
+          "garireo/garirei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03160",
+    "image_path": null,
+    "question_text": {
+      "en": "Who invented the practical incandescent light bulb?",
+      "ja": "実用的な白熱電球を発明した人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thomas Jefferson",
+        "ja": "ジェファーソン",
+        "ja_typings": [
+          "jefaason",
+          "jefa-son"
+        ]
+      },
+      {
+        "en": "John Adams",
+        "ja": "ジョン・アダムズ",
+        "ja_typings": [
+          "jon/adamuzu"
+        ]
+      },
+      {
+        "en": "George Washington",
+        "ja": "ジョージ・ワシントン",
+        "ja_typings": [
+          "jo-ji/washinton"
+        ]
+      },
+      {
+        "en": "Benjamin Franklin",
+        "ja": "フランクリン",
+        "ja_typings": [
+          "furankurin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03161",
+    "image_path": null,
+    "question_text": {
+      "en": "Who authored the US Declaration of Independence and became 3rd president?",
+      "ja": "米独立宣言を起草し第3代大統領となったのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thucydides",
+        "ja": "トゥキディデス",
+        "ja_typings": [
+          "tukidideesu",
+          "tukididesu"
+        ]
+      },
+      {
+        "en": "Homer",
+        "ja": "ホメロス",
+        "ja_typings": [
+          "homerosu"
+        ]
+      },
+      {
+        "en": "Hesiod",
+        "ja": "ヘシオドス",
+        "ja_typings": [
+          "heshiodosu"
+        ]
+      },
+      {
+        "en": "Plato",
+        "ja": "プラトン",
+        "ja_typings": [
+          "puraton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03162",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Greek historian wrote 'History of the Peloponnesian War'?",
+      "ja": "『ペロポネソス戦争史』を書いたギリシャの歴史家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tiber River",
+        "ja": "テヴェレ川",
+        "ja_typings": [
+          "tevere gawa",
+          "teveregawa"
+        ]
+      },
+      {
+        "en": "Rhine River",
+        "ja": "ライン川",
+        "ja_typings": [
+          "rain gawa",
+          "raingawa"
+        ]
+      },
+      {
+        "en": "Nile River",
+        "ja": "ナイル川",
+        "ja_typings": [
+          "nairu gawa",
+          "nairugawa"
+        ]
+      },
+      {
+        "en": "Great Wall of China",
+        "ja": "万里の長城",
+        "ja_typings": [
+          "banri no choujou",
+          "banrinochoujou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03163",
+    "image_path": null,
+    "question_text": {
+      "en": "Which river flows through Rome?",
+      "ja": "ローマを流れる川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Timur",
+        "ja": "ティムール",
+        "ja_typings": [
+          "timuuru",
+          "timu-ru"
+        ]
+      },
+      {
+        "en": "Clovis",
+        "ja": "クロヴィス",
+        "ja_typings": [
+          "kurovisu"
+        ]
+      },
+      {
+        "en": "Otto I",
+        "ja": "オットー1世",
+        "ja_typings": [
+          "ottoo 1 sei",
+          "ottooissei"
+        ]
+      },
+      {
+        "en": "Pepin the Short",
+        "ja": "ピピン",
+        "ja_typings": [
+          "pipin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03164",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Turco-Mongol conqueror who founded an empire in 14th-century Central Asia?",
+      "ja": "14世紀中央アジアに大帝国を築いたトルコ・モンゴル系の征服者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tokugawa Ieyasu",
+        "ja": "徳川家康",
+        "ja_typings": [
+          "tokugawa ieyasu",
+          "tokugawaieyasu"
+        ]
+      },
+      {
+        "en": "Toyotomi Hideyoshi",
+        "ja": "豊臣秀吉",
+        "ja_typings": [
+          "toyotomi hideyoshi",
+          "toyotomihideyoshi"
+        ]
+      },
+      {
+        "en": "Ishida Mitsunari",
+        "ja": "石田三成",
+        "ja_typings": [
+          "ishida mitsunari",
+          "ishidamitsunari"
+        ]
+      },
+      {
+        "en": "Takeda Shingen",
+        "ja": "武田信玄",
+        "ja_typings": [
+          "takeda shingen",
+          "takedashingen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03165",
+    "image_path": null,
+    "question_text": {
+      "en": "Who founded the Tokugawa shogunate after Sekigahara?",
+      "ja": "関ヶ原の戦い後に江戸幕府を開いた人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Townsend Harris",
+        "ja": "ハリス",
+        "ja_typings": [
+          "harisu"
+        ]
+      },
+      {
+        "en": "Adam Laxman",
+        "ja": "ラクスマン",
+        "ja_typings": [
+          "rakusuman"
+        ]
+      },
+      {
+        "en": "Yevfimiy Putyatin",
+        "ja": "プチャーチン",
+        "ja_typings": [
+          "puchaachin",
+          "pucha-chin"
+        ]
+      },
+      {
+        "en": "Thomas Jefferson",
+        "ja": "ジェファーソン",
+        "ja_typings": [
+          "jefaason",
+          "jefa-son"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03166",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first US consul to Japan in 1856?",
+      "ja": "1856年に初代米国総領事として来日した人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Toyotomi Hideyoshi",
+        "ja": "豊臣秀吉",
+        "ja_typings": [
+          "toyotomi hideyoshi",
+          "toyotomihideyoshi"
+        ]
+      },
+      {
+        "en": "Tokugawa Ieyasu",
+        "ja": "徳川家康",
+        "ja_typings": [
+          "tokugawa ieyasu",
+          "tokugawaieyasu"
+        ]
+      },
+      {
+        "en": "Ishida Mitsunari",
+        "ja": "石田三成",
+        "ja_typings": [
+          "ishida mitsunari",
+          "ishidamitsunari"
+        ]
+      },
+      {
+        "en": "Takeda Shingen",
+        "ja": "武田信玄",
+        "ja_typings": [
+          "takeda shingen",
+          "takedashingen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03167",
+    "image_path": null,
+    "question_text": {
+      "en": "Who unified Japan as Taiko in the late 16th century?",
+      "ja": "16世紀末に太閤として日本を統一した人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Treaty of San Francisco",
+        "ja": "サンフランシスコ平和条約",
+        "ja_typings": [
+          "san furanshisuko heiwa jouyaku",
+          "sanfuranshisukoheiwajouyaku"
+        ]
+      },
+      {
+        "en": "Harris Treaty",
+        "ja": "日米修好通商条約",
+        "ja_typings": [
+          "nichibei shuukou tsuushou jouyaku",
+          "nichibeishuukoutsuushoujouyaku"
+        ]
+      },
+      {
+        "en": "Potsdam Declaration",
+        "ja": "ポツダム宣言",
+        "ja_typings": [
+          "potsudamu sengen",
+          "potsudamusengen"
+        ]
+      },
+      {
+        "en": "Treaty of Utrecht",
+        "ja": "ユトレヒト条約",
+        "ja_typings": [
+          "yutorehito jouyaku",
+          "yutorehitojouyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03168",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1951 treaty ended the Allied occupation of Japan?",
+      "ja": "1951年に連合国の占領を終わらせた日本の条約は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Treaty of Utrecht",
+        "ja": "ユトレヒト条約",
+        "ja_typings": [
+          "yutorehito jouyaku",
+          "yutorehitojouyaku"
+        ]
+      },
+      {
+        "en": "Peace of Westphalia",
+        "ja": "ウェストファリア条約",
+        "ja_typings": [
+          "uesutofaria jouyaku",
+          "uesutofariajouyaku"
+        ]
+      },
+      {
+        "en": "Treaty of San Francisco",
+        "ja": "サンフランシスコ平和条約",
+        "ja_typings": [
+          "san furanshisuko heiwa jouyaku",
+          "sanfuranshisukoheiwajouyaku"
+        ]
+      },
+      {
+        "en": "Harris Treaty",
+        "ja": "日米修好通商条約",
+        "ja_typings": [
+          "nichibei shuukou tsuushou jouyaku",
+          "nichibeishuukoutsuushoujouyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03169",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1713 treaty ended the War of the Spanish Succession?",
+      "ja": "1713年にスペイン継承戦争を終結させた条約は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Truman and Stalin",
+        "ja": "トルーマンとスターリン",
+        "ja_typings": [
+          "toru-mantosuta-rin"
+        ]
+      },
+      {
+        "en": "Nixon and Brezhnev",
+        "ja": "ニクソンとブレジネフ",
+        "ja_typings": [
+          "nikusontoburejinefu"
+        ]
+      },
+      {
+        "en": "Reagan and Gorbachev",
+        "ja": "レーガンとゴルバチョフ",
+        "ja_typings": [
+          "re-gantogorubachofu"
+        ]
+      },
+      {
+        "en": "Munich Agreement",
+        "ja": "ミュンヘン会談",
+        "ja_typings": [
+          "myunhen kaidan",
+          "myunhenkaidan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03170",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1945 Potsdam meeting featured these Allied leaders?",
+      "ja": "1945年ポツダム会談で対面した米ソの指導者ペアは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "US Declaration of Independence",
+        "ja": "アメリカ独立宣言",
+        "ja_typings": [
+          "amerika dokuritsu sengen",
+          "amerikadokuritsusengen"
+        ]
+      },
+      {
+        "en": "Universal Declaration of Human Rights",
+        "ja": "世界人権宣言",
+        "ja_typings": [
+          "sekai jinken sengen",
+          "sekaijinkensengen"
+        ]
+      },
+      {
+        "en": "Potsdam Declaration",
+        "ja": "ポツダム宣言",
+        "ja_typings": [
+          "potsudamu sengen",
+          "potsudamusengen"
+        ]
+      },
+      {
+        "en": "Treaty of Utrecht",
+        "ja": "ユトレヒト条約",
+        "ja_typings": [
+          "yutorehito jouyaku",
+          "yutorehitojouyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03171",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1776 document declared American independence from Britain?",
+      "ja": "1776年に英国からの独立を宣した文書は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Uesugi Kagekatsu",
+        "ja": "上杉景勝",
+        "ja_typings": [
+          "uesugi kagekatsu",
+          "uesugikagekatsu"
+        ]
+      },
+      {
+        "en": "Mori Terumoto",
+        "ja": "毛利輝元",
+        "ja_typings": [
+          "mori terumoto",
+          "moriterumoto"
+        ]
+      },
+      {
+        "en": "Ishida Mitsunari",
+        "ja": "石田三成",
+        "ja_typings": [
+          "ishida mitsunari",
+          "ishidamitsunari"
+        ]
+      },
+      {
+        "en": "Takeda Shingen",
+        "ja": "武田信玄",
+        "ja_typings": [
+          "takeda shingen",
+          "takedashingen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03172",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Uesugi clan head who fought Tokugawa in 1600?",
+      "ja": "1600年に徳川と対立した上杉家当主は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ulysses S. Grant",
+        "ja": "グラント",
+        "ja_typings": [
+          "guranto"
+        ]
+      },
+      {
+        "en": "George Washington",
+        "ja": "ジョージ・ワシントン",
+        "ja_typings": [
+          "jo-ji/washinton"
+        ]
+      },
+      {
+        "en": "John Adams",
+        "ja": "ジョン・アダムズ",
+        "ja_typings": [
+          "jon/adamuzu"
+        ]
+      },
+      {
+        "en": "Thomas Jefferson",
+        "ja": "ジェファーソン",
+        "ja_typings": [
+          "jefaason",
+          "jefa-son"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03173",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Union general and 18th US President?",
+      "ja": "南北戦争の北軍将軍で第18代米大統領は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "United States",
+        "ja": "アメリカ合衆国",
+        "ja_typings": [
+          "amerika gasshuukoku",
+          "amerikagasshuukoku"
+        ]
+      },
+      {
+        "en": "France",
+        "ja": "フランス",
+        "ja_typings": [
+          "furansu"
+        ]
+      },
+      {
+        "en": "Germany",
+        "ja": "ドイツ",
+        "ja_typings": [
+          "doitsu"
+        ]
+      },
+      {
+        "en": "Yugoslavia",
+        "ja": "ユーゴスラビア",
+        "ja_typings": [
+          "yu-gosurabia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03174",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country gained independence on July 4, 1776?",
+      "ja": "1776年7月4日に独立を宣した国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Universal Declaration of Human Rights",
+        "ja": "世界人権宣言",
+        "ja_typings": [
+          "sekai jinken sengen",
+          "sekaijinkensengen"
+        ]
+      },
+      {
+        "en": "US Declaration of Independence",
+        "ja": "アメリカ独立宣言",
+        "ja_typings": [
+          "amerika dokuritsu sengen",
+          "amerikadokuritsusengen"
+        ]
+      },
+      {
+        "en": "Potsdam Declaration",
+        "ja": "ポツダム宣言",
+        "ja_typings": [
+          "potsudamu sengen",
+          "potsudamusengen"
+        ]
+      },
+      {
+        "en": "Peace of Westphalia",
+        "ja": "ウェストファリア条約",
+        "ja_typings": [
+          "uesutofaria jouyaku",
+          "uesutofariajouyaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03175",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1948 UN document outlines fundamental human rights?",
+      "ja": "1948年に国連が採択した人権の基本文書は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wars of Religion",
+        "ja": "宗教戦争",
+        "ja_typings": [
+          "shuukyou sensou",
+          "shuukyousensou"
+        ]
+      },
+      {
+        "en": "Thirty Years' War",
+        "ja": "三十年戦争",
+        "ja_typings": [
+          "sanjuunen sensou",
+          "sanjuunensensou"
+        ]
+      },
+      {
+        "en": "Hundred Years' War",
+        "ja": "百年戦争",
+        "ja_typings": [
+          "hyakunen sensou",
+          "hyakunensensou"
+        ]
+      },
+      {
+        "en": "Second Opium War",
+        "ja": "アロー戦争",
+        "ja_typings": [
+          "aroo sensou",
+          "aroosensou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03176",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 16th-17th century conflicts pitted Catholics against Protestants in France?",
+      "ja": "16-17世紀フランスでカトリックとプロテスタントが争った内戦は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yamagata Aritomo",
+        "ja": "山県有朋",
+        "ja_typings": [
+          "yamagata aritomo",
+          "yamagataaritomo"
+        ]
+      },
+      {
+        "en": "Itagaki Taisuke",
+        "ja": "板垣退助",
+        "ja_typings": [
+          "itagaki taisuke",
+          "itagakitaisuke"
+        ]
+      },
+      {
+        "en": "Okuma Shigenobu",
+        "ja": "大隈重信",
+        "ja_typings": [
+          "ookuma shigenobu",
+          "ookumashigenobu"
+        ]
+      },
+      {
+        "en": "Tokugawa Ieyasu",
+        "ja": "徳川家康",
+        "ja_typings": [
+          "tokugawa ieyasu",
+          "tokugawaieyasu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03177",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Meiji-era army marshal and twice Prime Minister of Japan?",
+      "ja": "明治の元帥陸軍大将で二度首相となった人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yamato Court",
+        "ja": "大和朝廷",
+        "ja_typings": [
+          "yamato choutei",
+          "yamatochoutei"
+        ]
+      },
+      {
+        "en": "Izumo",
+        "ja": "出雲",
+        "ja_typings": [
+          "izumo"
+        ]
+      },
+      {
+        "en": "Abbasid Caliphate",
+        "ja": "アッバース朝",
+        "ja_typings": [
+          "abbaasu chou",
+          "abbaasuchou"
+        ]
+      },
+      {
+        "en": "Mughal Empire",
+        "ja": "ムガル帝国",
+        "ja_typings": [
+          "mugaru teikoku",
+          "mugaruteikoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03178",
+    "image_path": null,
+    "question_text": {
+      "en": "Which early Japanese polity centered around the Nara basin in the 4th-7th century?",
+      "ja": "4-7世紀に奈良盆地を中心に栄えた日本の政権は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yevfimiy Putyatin",
+        "ja": "プチャーチン",
+        "ja_typings": [
+          "puchaachin",
+          "pucha-chin"
+        ]
+      },
+      {
+        "en": "Adam Laxman",
+        "ja": "ラクスマン",
+        "ja_typings": [
+          "rakusuman"
+        ]
+      },
+      {
+        "en": "Townsend Harris",
+        "ja": "ハリス",
+        "ja_typings": [
+          "harisu"
+        ]
+      },
+      {
+        "en": "Napoleon III",
+        "ja": "ナポレオン3世",
+        "ja_typings": [
+          "naporeon 3 sei",
+          "naporeonsansei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03179",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Russian admiral arrived in Nagasaki in 1853 seeking trade?",
+      "ja": "1853年に長崎に来航した露提督は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yitzhak Rabin",
+        "ja": "イツハク・ラビン",
+        "ja_typings": [
+          "itsuhaku/rabin"
+        ]
+      },
+      {
+        "en": "Menachem Begin",
+        "ja": "メナヘム・ベギン",
+        "ja_typings": [
+          "menahemu/begin"
+        ]
+      },
+      {
+        "en": "Golda Meir",
+        "ja": "ゴルダ・メイア",
+        "ja_typings": [
+          "goruda/meia"
+        ]
+      },
+      {
+        "en": "Muhammad Ali Jinnah",
+        "ja": "ジンナー",
+        "ja_typings": [
+          "jinnaa",
+          "jinnna-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03180",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the Israeli PM assassinated in 1995 after signing Oslo Accords?",
+      "ja": "オスロ合意後の1995年に暗殺されたイスラエル首相は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yugoslavia",
+        "ja": "ユーゴスラビア",
+        "ja_typings": [
+          "yu-gosurabia"
+        ]
+      },
+      {
+        "en": "Czechoslovakia",
+        "ja": "チェコスロバキア",
+        "ja_typings": [
+          "chekosurobakia"
+        ]
+      },
+      {
+        "en": "East Germany",
+        "ja": "東ドイツ",
+        "ja_typings": [
+          "higashi doitsu",
+          "higashidoitsu"
+        ]
+      },
+      {
+        "en": "Germany",
+        "ja": "ドイツ",
+        "ja_typings": [
+          "doitsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03181",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Balkan federation broke apart in the 1990s into multiple states?",
+      "ja": "1990年代に複数国家に分裂したバルカンの連邦は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yuri Gagarin",
+        "ja": "ガガーリン",
+        "ja_typings": [
+          "gagaarin",
+          "gaga-rin"
+        ]
+      },
+      {
+        "en": "Buzz Aldrin",
+        "ja": "オルドリン",
+        "ja_typings": [
+          "orudorin"
+        ]
+      },
+      {
+        "en": "John Glenn",
+        "ja": "ジョン・グレン",
+        "ja_typings": [
+          "jon/guren"
+        ]
+      },
+      {
+        "en": "Neil Armstrong",
+        "ja": "アームストロング",
+        "ja_typings": [
+          "aamusutorongu",
+          "a-musutorongu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03182",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the first human to journey into outer space in 1961?",
+      "ja": "1961年に人類初の宇宙飛行を達成したのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Zhou Enlai",
+        "ja": "周恩来",
+        "ja_typings": [
+          "shuuonrai"
+        ]
+      },
+      {
+        "en": "Deng Xiaoping",
+        "ja": "鄧小平",
+        "ja_typings": [
+          "toushouhei"
+        ]
+      },
+      {
+        "en": "Sun Yat-sen",
+        "ja": "孫文",
+        "ja_typings": [
+          "sonbun"
+        ]
+      },
+      {
+        "en": "Cao Cao",
+        "ja": "曹操",
+        "ja_typings": [
+          "sousou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03183",
+    "image_path": null,
+    "question_text": {
+      "en": "Who served as the first Premier of the People's Republic of China?",
+      "ja": "中華人民共和国の初代国務院総理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Zhuge Liang",
+        "ja": "諸葛亮",
+        "ja_typings": [
+          "shokatsuryou"
+        ]
+      },
+      {
+        "en": "Cao Cao",
+        "ja": "曹操",
+        "ja_typings": [
+          "sousou"
+        ]
+      },
+      {
+        "en": "Sun Quan",
+        "ja": "孫権",
+        "ja_typings": [
+          "sonken"
+        ]
+      },
+      {
+        "en": "Liu Bei",
+        "ja": "劉備",
+        "ja_typings": [
+          "ryuubi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "history",
+    "id": "q03184",
+    "image_path": null,
+    "question_text": {
+      "en": "Who was the chief strategist of Shu in China's Three Kingdoms period?",
+      "ja": "三国志で蜀の軍師として活躍した人物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Abel Prize",
+        "ja": "アーベル賞",
+        "ja_typings": [
+          "a-beruxsiyou",
+          "abeluxsyou"
+        ]
+      },
+      {
+        "en": "Fields Medal",
+        "ja": "フィールズ賞",
+        "ja_typings": [
+          "fi-ruzuxsiyou",
+          "fixi-luzusyou"
+        ]
+      },
+      {
+        "en": "Wolf Prize",
+        "ja": "ウルフ賞",
+        "ja_typings": [
+          "uruhuxsiyou",
+          "uluhusyou"
+        ]
+      },
+      {
+        "en": "Turing Award",
+        "ja": "チューリング賞",
+        "ja_typings": [
+          "tixyu-ringuxsiyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03185",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is a major international mathematics award named after a Norwegian mathematician?",
+      "ja": "ノルウェーの数学者にちなんで名づけられた、数学の国際的な賞はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Algebraic geometry",
+        "ja": "代数幾何学",
+        "ja_typings": [
+          "daisuukikagaku"
+        ]
+      },
+      {
+        "en": "Number theory",
+        "ja": "数論",
+        "ja_typings": [
+          "suuron"
+        ]
+      },
+      {
+        "en": "Analysis",
+        "ja": "解析学",
+        "ja_typings": [
+          "kaisekigaku"
+        ]
+      },
+      {
+        "en": "Topology",
+        "ja": "トポロジー",
+        "ja_typings": [
+          "toporoji-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03186",
+    "image_path": null,
+    "question_text": {
+      "en": "Which branch of mathematics studies geometric objects defined by polynomial equations?",
+      "ja": "多項式で定義される図形を扱う数学の分野はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Analysis",
+        "ja": "解析学",
+        "ja_typings": [
+          "kaisekigaku"
+        ]
+      },
+      {
+        "en": "Algebra",
+        "ja": "代数学",
+        "ja_typings": [
+          "daisuugaku"
+        ]
+      },
+      {
+        "en": "Geometry",
+        "ja": "幾何学",
+        "ja_typings": [
+          "kikagaku"
+        ]
+      },
+      {
+        "en": "Combinatorics",
+        "ja": "組合せ論",
+        "ja_typings": [
+          "kumiawaseron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03187",
+    "image_path": null,
+    "question_text": {
+      "en": "Which branch of mathematics deals with limits, derivatives and integrals?",
+      "ja": "極限・微分・積分を扱う数学の分野はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Archimedes",
+        "ja": "アルキメデス",
+        "ja_typings": [
+          "arukimedesu"
+        ]
+      },
+      {
+        "en": "Euclid",
+        "ja": "ユークリッド",
+        "ja_typings": [
+          "yu-kuriltudo"
+        ]
+      },
+      {
+        "en": "Pythagoras",
+        "ja": "ピタゴラス",
+        "ja_typings": [
+          "pitagorasu"
+        ]
+      },
+      {
+        "en": "Thales",
+        "ja": "タレス",
+        "ja_typings": [
+          "taresu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03188",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Greek mathematician is known for the law of buoyancy?",
+      "ja": "浮力の原理で知られる古代ギリシャの数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aristotle",
+        "ja": "アリストテレス",
+        "ja_typings": [
+          "arisutoteresu"
+        ]
+      },
+      {
+        "en": "Plato",
+        "ja": "プラトン",
+        "ja_typings": [
+          "puraton"
+        ]
+      },
+      {
+        "en": "Socrates",
+        "ja": "ソクラテス",
+        "ja_typings": [
+          "sokuratesu"
+        ]
+      },
+      {
+        "en": "Democritus",
+        "ja": "デモクリトス",
+        "ja_typings": [
+          "demokuritosu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03189",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Greek philosopher wrote on logic and natural science?",
+      "ja": "論理学や自然学の著作を残した古代ギリシャの哲学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Babbage",
+        "ja": "バベッジ",
+        "ja_typings": [
+          "bayatuji",
+          "babejji"
+        ]
+      },
+      {
+        "en": "Turing",
+        "ja": "チューリング",
+        "ja_typings": [
+          "tixyu-ringu"
+        ]
+      },
+      {
+        "en": "Von Neumann",
+        "ja": "フォン・ノイマン",
+        "ja_typings": [
+          "fon/noiman"
+        ]
+      },
+      {
+        "en": "Shannon",
+        "ja": "シャノン",
+        "ja_typings": [
+          "shanon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03190",
+    "image_path": null,
+    "question_text": {
+      "en": "Who designed the Analytical Engine, a forerunner of the computer?",
+      "ja": "解析機関を設計した、コンピュータの先駆者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bayes' theorem",
+        "ja": "ベイズの定理",
+        "ja_typings": [
+          "beizunoteiri"
+        ]
+      },
+      {
+        "en": "Law of large numbers",
+        "ja": "大数の法則",
+        "ja_typings": [
+          "taisuunohousoku"
+        ]
+      },
+      {
+        "en": "Central limit theorem",
+        "ja": "中心極限定理",
+        "ja_typings": [
+          "tixyuusinkyokugenteiri"
+        ]
+      },
+      {
+        "en": "Chebyshev's inequality",
+        "ja": "チェビシェフの不等式",
+        "ja_typings": [
+          "tiebisiehunohutousiki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03191",
+    "image_path": null,
+    "question_text": {
+      "en": "Which theorem in probability updates a probability given new evidence?",
+      "ja": "新しい情報をもとに確率を更新する確率論の定理はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Beta function",
+        "ja": "ベータ関数",
+        "ja_typings": [
+          "be-takansuu"
+        ]
+      },
+      {
+        "en": "Gamma function",
+        "ja": "ガンマ関数",
+        "ja_typings": [
+          "ganmakansuu"
+        ]
+      },
+      {
+        "en": "Delta function",
+        "ja": "デルタ関数",
+        "ja_typings": [
+          "derutakansuu"
+        ]
+      },
+      {
+        "en": "Zeta function",
+        "ja": "ゼータ関数",
+        "ja_typings": [
+          "ze-takansuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03192",
+    "image_path": null,
+    "question_text": {
+      "en": "Which special function in mathematics is denoted B(x,y)?",
+      "ja": "B(x,y)で表される数学の特殊関数はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bose",
+        "ja": "ボース",
+        "ja_typings": [
+          "bo-su"
+        ]
+      },
+      {
+        "en": "Fermi",
+        "ja": "フェルミ",
+        "ja_typings": [
+          "herumi",
+          "felumi",
+          "ferumi"
+        ]
+      },
+      {
+        "en": "Dirac",
+        "ja": "ディラック",
+        "ja_typings": [
+          "dexiratuku",
+          "dilatuku",
+          "dirakku"
+        ]
+      },
+      {
+        "en": "Pauli",
+        "ja": "パウリ",
+        "ja_typings": [
+          "pauri"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03193",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Indian physicist gave his name to particles called bosons?",
+      "ja": "ボース粒子（ボソン）に名を残したインドの物理学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cantor",
+        "ja": "カントール",
+        "ja_typings": [
+          "kanto-ru"
+        ]
+      },
+      {
+        "en": "Frege",
+        "ja": "フレーゲ",
+        "ja_typings": [
+          "hure-ge"
+        ]
+      },
+      {
+        "en": "Russell",
+        "ja": "ラッセル",
+        "ja_typings": [
+          "ratuseru",
+          "rasseru"
+        ]
+      },
+      {
+        "en": "Hilbert",
+        "ja": "ヒルベルト",
+        "ja_typings": [
+          "hiruberuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03194",
+    "image_path": null,
+    "question_text": {
+      "en": "Who founded modern set theory and the theory of transfinite numbers?",
+      "ja": "近代集合論と超限数の理論を築いた数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Carl Friedrich Gauss",
+        "ja": "カール・フリードリヒ・ガウス",
+        "ja_typings": [
+          "ka-ru/furi-dorihi/gausu"
+        ]
+      },
+      {
+        "en": "Leonhard Euler",
+        "ja": "レオンハルト・オイラー",
+        "ja_typings": [
+          "reonharuto/oira-"
+        ]
+      },
+      {
+        "en": "Bernhard Riemann",
+        "ja": "ベルンハルト・リーマン",
+        "ja_typings": [
+          "berunharuto/ri-man"
+        ]
+      },
+      {
+        "en": "David Hilbert",
+        "ja": "ダフィット・ヒルベルト",
+        "ja_typings": [
+          "dahuxituto/hiruberuto",
+          "dafuxitto/hiluberuto",
+          "dafitto/hiruberuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03195",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the German mathematician called the prince of mathematicians?",
+      "ja": "「数学者の王」と呼ばれたドイツの大数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chandrasekhar",
+        "ja": "チャンドラセカール",
+        "ja_typings": [
+          "tiyandorasekaa-ru",
+          "tyandolasekaa-lu",
+          "chandoraseka-ru"
+        ]
+      },
+      {
+        "en": "Hawking",
+        "ja": "ホーキング",
+        "ja_typings": [
+          "ho-kingu"
+        ]
+      },
+      {
+        "en": "Penrose",
+        "ja": "ペンローズ",
+        "ja_typings": [
+          "penro-zu"
+        ]
+      },
+      {
+        "en": "Eddington",
+        "ja": "エディントン",
+        "ja_typings": [
+          "edexinton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03196",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Indian-American astrophysicist's name labels a stellar mass limit?",
+      "ja": "恒星の質量限界に名を残したインド系の天体物理学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chebyshev's inequality",
+        "ja": "チェビシェフの不等式",
+        "ja_typings": [
+          "tiebisiehunohutousiki"
+        ]
+      },
+      {
+        "en": "Markov's inequality",
+        "ja": "マルコフの不等式",
+        "ja_typings": [
+          "marukohunohutousiki"
+        ]
+      },
+      {
+        "en": "Jensen's inequality",
+        "ja": "イェンセンの不等式",
+        "ja_typings": [
+          "ixensennohutousiki",
+          "yensennnohutousiki"
+        ]
+      },
+      {
+        "en": "Cauchy-Schwarz inequality",
+        "ja": "コーシー・シュワルツの不等式",
+        "ja_typings": [
+          "ko-sii-/siyuwarutunohutousiki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03197",
+    "image_path": null,
+    "question_text": {
+      "en": "Which inequality bounds the probability that a random variable deviates from its mean?",
+      "ja": "確率変数が平均から外れる確率を抑える不等式はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Concave polygon",
+        "ja": "凹多角形",
+        "ja_typings": [
+          "outakakukei"
+        ]
+      },
+      {
+        "en": "Convex polygon",
+        "ja": "凸多角形",
+        "ja_typings": [
+          "totutakakukei"
+        ]
+      },
+      {
+        "en": "Regular polygon",
+        "ja": "正多角形",
+        "ja_typings": [
+          "seitakakukei"
+        ]
+      },
+      {
+        "en": "Similar polygon",
+        "ja": "相似多角形",
+        "ja_typings": [
+          "soujitakakukei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03198",
+    "image_path": null,
+    "question_text": {
+      "en": "Which type of polygon has at least one interior angle greater than 180°?",
+      "ja": "内角に180°より大きい角がある多角形はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Convex polygon",
+        "ja": "凸多角形",
+        "ja_typings": [
+          "totutakakukei"
+        ]
+      },
+      {
+        "en": "Concave polygon",
+        "ja": "凹多角形",
+        "ja_typings": [
+          "outakakukei"
+        ]
+      },
+      {
+        "en": "Star polygon",
+        "ja": "星型多角形",
+        "ja_typings": [
+          "hosigatatakakukei"
+        ]
+      },
+      {
+        "en": "Regular polygon",
+        "ja": "正多角形",
+        "ja_typings": [
+          "seitakakukei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03199",
+    "image_path": null,
+    "question_text": {
+      "en": "Which type of polygon has all interior angles less than 180°?",
+      "ja": "全ての内角が180°未満である多角形はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "D'Alembertian",
+        "ja": "ダランベルシアン",
+        "ja_typings": [
+          "daranberushian"
+        ]
+      },
+      {
+        "en": "Laplacian",
+        "ja": "ラプラシアン",
+        "ja_typings": [
+          "rapurashian"
+        ]
+      },
+      {
+        "en": "Nabla",
+        "ja": "ナブラ",
+        "ja_typings": [
+          "nabura",
+          "nabula"
+        ]
+      },
+      {
+        "en": "Hessian",
+        "ja": "ヘッシアン",
+        "ja_typings": [
+          "hetusian",
+          "hesshian"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03200",
+    "image_path": null,
+    "question_text": {
+      "en": "Which operator, used in relativity, is the wave operator in 4-dimensional spacetime?",
+      "ja": "相対論で4次元時空の波動を表す微分作用素はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Delta",
+        "ja": "デルタ",
+        "ja_typings": [
+          "deruta",
+          "deluta"
+        ]
+      },
+      {
+        "en": "Sigma",
+        "ja": "シグマ",
+        "ja_typings": [
+          "shiguma"
+        ]
+      },
+      {
+        "en": "Omega",
+        "ja": "オメガ",
+        "ja_typings": [
+          "omega"
+        ]
+      },
+      {
+        "en": "Lambda",
+        "ja": "ラムダ",
+        "ja_typings": [
+          "ramuda",
+          "lamuda"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03201",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Greek letter is often used to denote a small change in mathematics?",
+      "ja": "数学で微小な変化を表すのによく使うギリシャ文字はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Delta function",
+        "ja": "デルタ関数",
+        "ja_typings": [
+          "derutakansuu"
+        ]
+      },
+      {
+        "en": "Gamma function",
+        "ja": "ガンマ関数",
+        "ja_typings": [
+          "ganmakansuu"
+        ]
+      },
+      {
+        "en": "Beta function",
+        "ja": "ベータ関数",
+        "ja_typings": [
+          "be-takansuu"
+        ]
+      },
+      {
+        "en": "Step function",
+        "ja": "階段関数",
+        "ja_typings": [
+          "kaidankansuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03202",
+    "image_path": null,
+    "question_text": {
+      "en": "Which generalized function, introduced by Dirac, equals zero except at one point?",
+      "ja": "ディラックが導入した、1点以外でゼロとなる超関数はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Descartes",
+        "ja": "デカルト",
+        "ja_typings": [
+          "dekaruto",
+          "dekaluto"
+        ]
+      },
+      {
+        "en": "Pascal",
+        "ja": "パスカル",
+        "ja_typings": [
+          "pasukaru",
+          "pasukalu"
+        ]
+      },
+      {
+        "en": "Fermat",
+        "ja": "フェルマー",
+        "ja_typings": [
+          "herumaa",
+          "felumaa",
+          "feruma-"
+        ]
+      },
+      {
+        "en": "Leibniz",
+        "ja": "ライプニッツ",
+        "ja_typings": [
+          "raipunitutu",
+          "laipunittu",
+          "raipunittsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03203",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 17th-century French philosopher introduced analytic geometry?",
+      "ja": "解析幾何学を創始した17世紀フランスの哲学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Euclid",
+        "ja": "ユークリッド",
+        "ja_typings": [
+          "yu-kuriltudo"
+        ]
+      },
+      {
+        "en": "Archimedes",
+        "ja": "アルキメデス",
+        "ja_typings": [
+          "arukimedesu"
+        ]
+      },
+      {
+        "en": "Pythagoras",
+        "ja": "ピタゴラス",
+        "ja_typings": [
+          "pitagorasu"
+        ]
+      },
+      {
+        "en": "Apollonius",
+        "ja": "アポロニウス",
+        "ja_typings": [
+          "aporoniusu",
+          "apoloniusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03204",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote the Elements, the foundational text of geometry?",
+      "ja": "幾何学の基礎となる『原論』を著したのは誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Euler",
+        "ja": "オイラー",
+        "ja_typings": [
+          "oira-"
+        ]
+      },
+      {
+        "en": "Bernoulli",
+        "ja": "ベルヌーイ",
+        "ja_typings": [
+          "berunu-i",
+          "belunu-i"
+        ]
+      },
+      {
+        "en": "Gauss",
+        "ja": "ガウス",
+        "ja_typings": [
+          "gausu"
+        ]
+      },
+      {
+        "en": "Lagrange",
+        "ja": "ラグランジュ",
+        "ja_typings": [
+          "raguranjixu",
+          "lagulanju",
+          "raguranju"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03205",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Swiss mathematician introduced the constant e and much modern notation?",
+      "ja": "定数 e を導入し、近代数学記法を整備したスイスの数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Factorization",
+        "ja": "因数分解",
+        "ja_typings": [
+          "insuubunkai"
+        ]
+      },
+      {
+        "en": "Expansion",
+        "ja": "展開",
+        "ja_typings": [
+          "tenkai"
+        ]
+      },
+      {
+        "en": "Integration",
+        "ja": "積分",
+        "ja_typings": [
+          "sekibun"
+        ]
+      },
+      {
+        "en": "Differentiation",
+        "ja": "微分",
+        "ja_typings": [
+          "bibun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03206",
+    "image_path": null,
+    "question_text": {
+      "en": "Which operation breaks a number into a product of primes?",
+      "ja": "ある数を素数の積に分ける操作はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fermat",
+        "ja": "フェルマー",
+        "ja_typings": [
+          "herumaa",
+          "felumaa",
+          "feruma-"
+        ]
+      },
+      {
+        "en": "Euler",
+        "ja": "オイラー",
+        "ja_typings": [
+          "oira-"
+        ]
+      },
+      {
+        "en": "Gauss",
+        "ja": "ガウス",
+        "ja_typings": [
+          "gausu"
+        ]
+      },
+      {
+        "en": "Galois",
+        "ja": "ガロア",
+        "ja_typings": [
+          "garoa",
+          "galoa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03207",
+    "image_path": null,
+    "question_text": {
+      "en": "Whose Last Theorem about x^n+y^n=z^n was proved by Andrew Wiles?",
+      "ja": "ワイルズが証明した「最終定理」を残した数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Frege",
+        "ja": "フレーゲ",
+        "ja_typings": [
+          "hure-ge"
+        ]
+      },
+      {
+        "en": "Russell",
+        "ja": "ラッセル",
+        "ja_typings": [
+          "ratuseru",
+          "rasseru"
+        ]
+      },
+      {
+        "en": "Wittgenstein",
+        "ja": "ウィトゲンシュタイン",
+        "ja_typings": [
+          "uxitogensiyutain",
+          "wxitogenshutain",
+          "witogenshutain"
+        ]
+      },
+      {
+        "en": "Gödel",
+        "ja": "ゲーデル",
+        "ja_typings": [
+          "ge-deru",
+          "ge-delu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03208",
+    "image_path": null,
+    "question_text": {
+      "en": "Which German logician founded modern logic with his Begriffsschrift?",
+      "ja": "『概念記法』で近代論理学を築いたドイツの論理学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Function",
+        "ja": "関数",
+        "ja_typings": [
+          "kansuu"
+        ]
+      },
+      {
+        "en": "Relation",
+        "ja": "関係",
+        "ja_typings": [
+          "kankei"
+        ]
+      },
+      {
+        "en": "Mapping",
+        "ja": "写像",
+        "ja_typings": [
+          "siyazou",
+          "syazou"
+        ]
+      },
+      {
+        "en": "Operation",
+        "ja": "演算",
+        "ja_typings": [
+          "enzan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03209",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mathematical concept assigns each input exactly one output?",
+      "ja": "各入力にちょうど1つの出力を対応させる概念はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Galois",
+        "ja": "ガロア",
+        "ja_typings": [
+          "garoa",
+          "galoa"
+        ]
+      },
+      {
+        "en": "Abel",
+        "ja": "アーベル",
+        "ja_typings": [
+          "a-beru",
+          "a-belu"
+        ]
+      },
+      {
+        "en": "Cauchy",
+        "ja": "コーシー",
+        "ja_typings": [
+          "ko-sii-",
+          "ko-shi-"
+        ]
+      },
+      {
+        "en": "Jacobi",
+        "ja": "ヤコビ",
+        "ja_typings": [
+          "yakobi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03210",
+    "image_path": null,
+    "question_text": {
+      "en": "Which young French mathematician founded group theory before dying in a duel?",
+      "ja": "決闘で若くして亡くなり、群論を築いたフランスの数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gamma function",
+        "ja": "ガンマ関数",
+        "ja_typings": [
+          "ganmakansuu"
+        ]
+      },
+      {
+        "en": "Beta function",
+        "ja": "ベータ関数",
+        "ja_typings": [
+          "be-takansuu"
+        ]
+      },
+      {
+        "en": "Zeta function",
+        "ja": "ゼータ関数",
+        "ja_typings": [
+          "ze-takansuu"
+        ]
+      },
+      {
+        "en": "Delta function",
+        "ja": "デルタ関数",
+        "ja_typings": [
+          "derutakansuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03211",
+    "image_path": null,
+    "question_text": {
+      "en": "Which function, denoted Γ(x), generalizes the factorial to real numbers?",
+      "ja": "階乗を実数に拡張した Γ(x) で表される関数はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gauss",
+        "ja": "ガウス",
+        "ja_typings": [
+          "gausu"
+        ]
+      },
+      {
+        "en": "Poisson",
+        "ja": "ポアソン",
+        "ja_typings": [
+          "poason"
+        ]
+      },
+      {
+        "en": "Laplace",
+        "ja": "ラプラス",
+        "ja_typings": [
+          "rapurasu",
+          "lapulasu"
+        ]
+      },
+      {
+        "en": "Bernoulli",
+        "ja": "ベルヌーイ",
+        "ja_typings": [
+          "berunu-i",
+          "belunu-i"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03212",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mathematician's name labels the normal distribution's bell curve?",
+      "ja": "正規分布の釣鐘型曲線に名を残した数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Georg Cantor",
+        "ja": "ゲオルク・カントール",
+        "ja_typings": [
+          "georuku/kanto-ru",
+          "geoluku/kanto-lu"
+        ]
+      },
+      {
+        "en": "Richard Dedekind",
+        "ja": "リヒャルト・デデキント",
+        "ja_typings": [
+          "rihiyaruto/dedekinto",
+          "lihyaluto/dedekinto",
+          "rihyaruto/dedekinto"
+        ]
+      },
+      {
+        "en": "David Hilbert",
+        "ja": "ダフィット・ヒルベルト",
+        "ja_typings": [
+          "dahuxituto/hiruberuto",
+          "dafitto/hiruberuto"
+        ]
+      },
+      {
+        "en": "Henri Poincaré",
+        "ja": "アンリ・ポアンカレ",
+        "ja_typings": [
+          "anri/poankare",
+          "anli/poankale"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03213",
+    "image_path": null,
+    "question_text": {
+      "en": "Who founded set theory and proved different sizes of infinity?",
+      "ja": "集合論を創り、無限に大小があることを示した数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Golden ratio",
+        "ja": "黄金比",
+        "ja_typings": [
+          "ougonhi"
+        ]
+      },
+      {
+        "en": "Silver ratio",
+        "ja": "白銀比",
+        "ja_typings": [
+          "hakuginhi"
+        ]
+      },
+      {
+        "en": "Bronze ratio",
+        "ja": "青銅比",
+        "ja_typings": [
+          "seidouhi"
+        ]
+      },
+      {
+        "en": "Platinum ratio",
+        "ja": "白金比",
+        "ja_typings": [
+          "hakkinhi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03214",
+    "image_path": null,
+    "question_text": {
+      "en": "Which famous ratio is approximately 1.618?",
+      "ja": "約1.618の値を持つ有名な比はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Golden ratio φ",
+        "ja": "黄金比φ",
+        "ja_typings": [
+          "ougonhihuxi-",
+          "ougonhifi"
+        ]
+      },
+      {
+        "en": "Pi π",
+        "ja": "円周率π",
+        "ja_typings": [
+          "ensiyuuritupai"
+        ]
+      },
+      {
+        "en": "Euler's e",
+        "ja": "ネイピア数 e",
+        "ja_typings": [
+          "neipiasuui-"
+        ]
+      },
+      {
+        "en": "Imaginary i",
+        "ja": "虚数単位 i",
+        "ja_typings": [
+          "kiyosuutanniai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03215",
+    "image_path": null,
+    "question_text": {
+      "en": "Which symbol denotes the golden ratio?",
+      "ja": "黄金比を表す記号はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Grigori Perelman",
+        "ja": "グリゴリー・ペレルマン",
+        "ja_typings": [
+          "gurigori-/pereruman"
+        ]
+      },
+      {
+        "en": "Terence Tao",
+        "ja": "テレンス・タオ",
+        "ja_typings": [
+          "terensu/tao"
+        ]
+      },
+      {
+        "en": "John Nash",
+        "ja": "ジョン・ナッシュ",
+        "ja_typings": [
+          "jiyon/natusiyu",
+          "jon/nasshu"
+        ]
+      },
+      {
+        "en": "Andrew Wiles",
+        "ja": "アンドリュー・ワイルズ",
+        "ja_typings": [
+          "andoriyuu/wairuzu",
+          "andolyuu/wailuzu",
+          "andoryu-/wairuzu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03216",
+    "image_path": null,
+    "question_text": {
+      "en": "Who proved the Poincaré conjecture and declined the Fields Medal?",
+      "ja": "ポアンカレ予想を証明しフィールズ賞を辞退した数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gödel",
+        "ja": "ゲーデル",
+        "ja_typings": [
+          "ge-deru",
+          "ge-delu"
+        ]
+      },
+      {
+        "en": "Tarski",
+        "ja": "タルスキ",
+        "ja_typings": [
+          "tarusuki",
+          "talusuki"
+        ]
+      },
+      {
+        "en": "Hilbert",
+        "ja": "ヒルベルト",
+        "ja_typings": [
+          "hiruberuto"
+        ]
+      },
+      {
+        "en": "Russell",
+        "ja": "ラッセル",
+        "ja_typings": [
+          "ratuseru",
+          "rasseru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03217",
+    "image_path": null,
+    "question_text": {
+      "en": "Who proved the incompleteness theorems of formal arithmetic?",
+      "ja": "形式的算術の不完全性定理を証明した数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hardy",
+        "ja": "ハーディ",
+        "ja_typings": [
+          "ha-dexi"
+        ]
+      },
+      {
+        "en": "Littlewood",
+        "ja": "リトルウッド",
+        "ja_typings": [
+          "riturouxtudo",
+          "litoluuxtudo",
+          "ritoruuddo"
+        ]
+      },
+      {
+        "en": "Russell",
+        "ja": "ラッセル",
+        "ja_typings": [
+          "ratuseru",
+          "rasseru"
+        ]
+      },
+      {
+        "en": "Turing",
+        "ja": "チューリング",
+        "ja_typings": [
+          "tixyu-ringu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03218",
+    "image_path": null,
+    "question_text": {
+      "en": "Which English mathematician collaborated extensively with Ramanujan?",
+      "ja": "ラマヌジャンと長く共同研究したイギリスの数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hyperbola",
+        "ja": "双曲線",
+        "ja_typings": [
+          "soukyokusen"
+        ]
+      },
+      {
+        "en": "Parabola",
+        "ja": "放物線",
+        "ja_typings": [
+          "houbutusen"
+        ]
+      },
+      {
+        "en": "Ellipse",
+        "ja": "楕円",
+        "ja_typings": [
+          "daen"
+        ]
+      },
+      {
+        "en": "Circle",
+        "ja": "円",
+        "ja_typings": [
+          "en"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03219",
+    "image_path": null,
+    "question_text": {
+      "en": "Which conic section is the graph of y = 1/x?",
+      "ja": "y = 1/x のグラフが描く円錐曲線はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Integration",
+        "ja": "積分",
+        "ja_typings": [
+          "sekibun"
+        ]
+      },
+      {
+        "en": "Differentiation",
+        "ja": "微分",
+        "ja_typings": [
+          "bibun"
+        ]
+      },
+      {
+        "en": "Factorization",
+        "ja": "因数分解",
+        "ja_typings": [
+          "insuubunkai"
+        ]
+      },
+      {
+        "en": "Substitution",
+        "ja": "代入",
+        "ja_typings": [
+          "dainiyuu",
+          "dainyuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03220",
+    "image_path": null,
+    "question_text": {
+      "en": "Which calculus operation finds the area under a curve?",
+      "ja": "曲線の下の面積を求める微積分の操作はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "John Nash",
+        "ja": "ジョン・ナッシュ",
+        "ja_typings": [
+          "jiyon/natusiyu",
+          "jon/nasshu"
+        ]
+      },
+      {
+        "en": "John von Neumann",
+        "ja": "ジョン・フォン・ノイマン",
+        "ja_typings": [
+          "jiyon/fuxon/noiman",
+          "jon/foxn/noiman",
+          "jon/fon/noiman"
+        ]
+      },
+      {
+        "en": "Lloyd Shapley",
+        "ja": "ロイド・シャプレー",
+        "ja_typings": [
+          "roido/siyapure-",
+          "loido/shaple-",
+          "roido/shapure-"
+        ]
+      },
+      {
+        "en": "Reinhard Selten",
+        "ja": "ラインハルト・ゼルテン",
+        "ja_typings": [
+          "rainharuto/zeruten",
+          "lainhaluto/zeluten"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03221",
+    "image_path": null,
+    "question_text": {
+      "en": "Which American mathematician won a Nobel Prize for game theory?",
+      "ja": "ゲーム理論でノーベル経済学賞を受けたアメリカの数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kolmogorov",
+        "ja": "コルモゴロフ",
+        "ja_typings": [
+          "korumogorohu"
+        ]
+      },
+      {
+        "en": "Chebyshev",
+        "ja": "チェビシェフ",
+        "ja_typings": [
+          "tiebisiehu",
+          "chebishefu"
+        ]
+      },
+      {
+        "en": "Lobachevsky",
+        "ja": "ロバチェフスキー",
+        "ja_typings": [
+          "robatiehusuki-",
+          "lobatiehusuki-",
+          "robachefusuki-"
+        ]
+      },
+      {
+        "en": "Markov",
+        "ja": "マルコフ",
+        "ja_typings": [
+          "marukohu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03222",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Russian mathematician axiomatized probability theory in 1933?",
+      "ja": "1933年に確率論を公理化したロシアの数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lambda",
+        "ja": "ラムダ",
+        "ja_typings": [
+          "ramuda",
+          "lamuda"
+        ]
+      },
+      {
+        "en": "Mu",
+        "ja": "ミュー",
+        "ja_typings": [
+          "miyu-",
+          "myu-"
+        ]
+      },
+      {
+        "en": "Nu",
+        "ja": "ニュー",
+        "ja_typings": [
+          "niyu-",
+          "nyu-"
+        ]
+      },
+      {
+        "en": "Kappa",
+        "ja": "カッパ",
+        "ja_typings": [
+          "katupa",
+          "kappa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03223",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Greek letter is the 11th and often denotes wavelength or eigenvalue?",
+      "ja": "波長や固有値を表すのによく使うギリシャ文字（第11字）はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Laplacian",
+        "ja": "ラプラシアン",
+        "ja_typings": [
+          "rapurashian"
+        ]
+      },
+      {
+        "en": "D'Alembertian",
+        "ja": "ダランベルシアン",
+        "ja_typings": [
+          "daranberushian"
+        ]
+      },
+      {
+        "en": "Nabla",
+        "ja": "ナブラ",
+        "ja_typings": [
+          "nabura",
+          "nabula"
+        ]
+      },
+      {
+        "en": "Hessian",
+        "ja": "ヘッシアン",
+        "ja_typings": [
+          "hetusian",
+          "hesshian"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03224",
+    "image_path": null,
+    "question_text": {
+      "en": "Which differential operator is the divergence of the gradient?",
+      "ja": "勾配の発散として定義される微分作用素はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Law of large numbers",
+        "ja": "大数の法則",
+        "ja_typings": [
+          "taisuunohousoku"
+        ]
+      },
+      {
+        "en": "Central limit theorem",
+        "ja": "中心極限定理",
+        "ja_typings": [
+          "tixyuusinkyokugenteiri"
+        ]
+      },
+      {
+        "en": "Bayes' theorem",
+        "ja": "ベイズの定理",
+        "ja_typings": [
+          "beizunoteiri"
+        ]
+      },
+      {
+        "en": "Chebyshev's inequality",
+        "ja": "チェビシェフの不等式",
+        "ja_typings": [
+          "tiebisiehunohutousiki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03225",
+    "image_path": null,
+    "question_text": {
+      "en": "Which theorem says sample averages converge to the expected value?",
+      "ja": "標本平均が期待値に収束することを述べる定理はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Leibniz",
+        "ja": "ライプニッツ",
+        "ja_typings": [
+          "raipunitutu",
+          "laipunittu",
+          "raipunittsu"
+        ]
+      },
+      {
+        "en": "Newton",
+        "ja": "ニュートン",
+        "ja_typings": [
+          "niyu-ton",
+          "nyu-ton"
+        ]
+      },
+      {
+        "en": "Euler",
+        "ja": "オイラー",
+        "ja_typings": [
+          "oira-"
+        ]
+      },
+      {
+        "en": "Bernoulli",
+        "ja": "ベルヌーイ",
+        "ja_typings": [
+          "berunu-i",
+          "belunu-i"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03226",
+    "image_path": null,
+    "question_text": {
+      "en": "Which German philosopher-mathematician independently invented calculus?",
+      "ja": "微積分を独立に発見したドイツの哲学者・数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Limit",
+        "ja": "極限",
+        "ja_typings": [
+          "kyokugen"
+        ]
+      },
+      {
+        "en": "Derivative",
+        "ja": "微分",
+        "ja_typings": [
+          "bibun"
+        ]
+      },
+      {
+        "en": "Integral",
+        "ja": "積分",
+        "ja_typings": [
+          "sekibun"
+        ]
+      },
+      {
+        "en": "Series",
+        "ja": "級数",
+        "ja_typings": [
+          "kiyuusuu",
+          "kyusuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03227",
+    "image_path": null,
+    "question_text": {
+      "en": "Which calculus concept is the value a function approaches near a point?",
+      "ja": "ある点に近づけたときの値を表す微積分の概念はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Lobachevsky",
+        "ja": "ロバチェフスキー",
+        "ja_typings": [
+          "robatiehusuki-",
+          "lobatiehusuki-",
+          "robachefusuki-"
+        ]
+      },
+      {
+        "en": "Riemann",
+        "ja": "リーマン",
+        "ja_typings": [
+          "ri-man"
+        ]
+      },
+      {
+        "en": "Bolyai",
+        "ja": "ボヤイ",
+        "ja_typings": [
+          "boyai"
+        ]
+      },
+      {
+        "en": "Gauss",
+        "ja": "ガウス",
+        "ja_typings": [
+          "gausu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03228",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Russian mathematician developed non-Euclidean hyperbolic geometry?",
+      "ja": "双曲幾何学を生んだロシアの数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Logarithmic curve",
+        "ja": "対数曲線",
+        "ja_typings": [
+          "taisuukyokusen"
+        ]
+      },
+      {
+        "en": "Exponential curve",
+        "ja": "指数曲線",
+        "ja_typings": [
+          "sisuukyokusen"
+        ]
+      },
+      {
+        "en": "Sigmoid curve",
+        "ja": "シグモイド曲線",
+        "ja_typings": [
+          "sigumoidokyokusen"
+        ]
+      },
+      {
+        "en": "Hyperbola",
+        "ja": "双曲線",
+        "ja_typings": [
+          "soukyokusen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03229",
+    "image_path": null,
+    "question_text": {
+      "en": "Which curve is the graph of y = log x?",
+      "ja": "y = log x のグラフが描く曲線はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mapping",
+        "ja": "写像",
+        "ja_typings": [
+          "siyazou",
+          "syazou"
+        ]
+      },
+      {
+        "en": "Function",
+        "ja": "関数",
+        "ja_typings": [
+          "kansuu"
+        ]
+      },
+      {
+        "en": "Relation",
+        "ja": "関係",
+        "ja_typings": [
+          "kankei"
+        ]
+      },
+      {
+        "en": "Operation",
+        "ja": "演算",
+        "ja_typings": [
+          "enzan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03230",
+    "image_path": null,
+    "question_text": {
+      "en": "Which concept assigns each element of one set to an element of another?",
+      "ja": "ある集合の各要素を別の集合の要素に対応させる概念はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nabla",
+        "ja": "ナブラ",
+        "ja_typings": [
+          "nabura",
+          "nabula"
+        ]
+      },
+      {
+        "en": "Delta",
+        "ja": "デルタ",
+        "ja_typings": [
+          "deruta",
+          "deluta"
+        ]
+      },
+      {
+        "en": "Laplacian",
+        "ja": "ラプラシアン",
+        "ja_typings": [
+          "rapurashian"
+        ]
+      },
+      {
+        "en": "Sigma",
+        "ja": "シグマ",
+        "ja_typings": [
+          "shiguma"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03231",
+    "image_path": null,
+    "question_text": {
+      "en": "Which symbol ∇ is used for the gradient operator?",
+      "ja": "勾配を表す記号 ∇ の名前はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Number theory",
+        "ja": "数論",
+        "ja_typings": [
+          "suuron"
+        ]
+      },
+      {
+        "en": "Algebraic geometry",
+        "ja": "代数幾何学",
+        "ja_typings": [
+          "daisuukikagaku"
+        ]
+      },
+      {
+        "en": "Analysis",
+        "ja": "解析学",
+        "ja_typings": [
+          "kaisekigaku"
+        ]
+      },
+      {
+        "en": "Topology",
+        "ja": "トポロジー",
+        "ja_typings": [
+          "toporoji-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03232",
+    "image_path": null,
+    "question_text": {
+      "en": "Which branch of mathematics studies properties of integers?",
+      "ja": "整数の性質を研究する数学の分野はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Omega",
+        "ja": "オメガ",
+        "ja_typings": [
+          "omega"
+        ]
+      },
+      {
+        "en": "Alpha",
+        "ja": "アルファ",
+        "ja_typings": [
+          "aruhua",
+          "alufa",
+          "arufa"
+        ]
+      },
+      {
+        "en": "Sigma",
+        "ja": "シグマ",
+        "ja_typings": [
+          "shiguma"
+        ]
+      },
+      {
+        "en": "Psi",
+        "ja": "プサイ",
+        "ja_typings": [
+          "pusai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03233",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the last letter of the Greek alphabet?",
+      "ja": "ギリシャ文字の最後の文字はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Operation",
+        "ja": "演算",
+        "ja_typings": [
+          "enzan"
+        ]
+      },
+      {
+        "en": "Function",
+        "ja": "関数",
+        "ja_typings": [
+          "kansuu"
+        ]
+      },
+      {
+        "en": "Relation",
+        "ja": "関係",
+        "ja_typings": [
+          "kankei"
+        ]
+      },
+      {
+        "en": "Mapping",
+        "ja": "写像",
+        "ja_typings": [
+          "siyazou",
+          "syazou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03234",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mathematical concept combines elements like +, ×, ∘?",
+      "ja": "+ や × のように要素を組み合わせる数学的概念はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pi π",
+        "ja": "円周率π",
+        "ja_typings": [
+          "ensiyuuritupai"
+        ]
+      },
+      {
+        "en": "Euler's e",
+        "ja": "ネイピア数 e",
+        "ja_typings": [
+          "neipiasuui-"
+        ]
+      },
+      {
+        "en": "Golden ratio φ",
+        "ja": "黄金比φ",
+        "ja_typings": [
+          "ougonhihuxi-"
+        ]
+      },
+      {
+        "en": "Imaginary i",
+        "ja": "虚数単位 i",
+        "ja_typings": [
+          "kiyosuutanniai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03235",
+    "image_path": null,
+    "question_text": {
+      "en": "Which famous constant gives the ratio of a circle's circumference to its diameter?",
+      "ja": "円周と直径の比を表す有名な定数はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Poincaré",
+        "ja": "ポアンカレ",
+        "ja_typings": [
+          "poankare",
+          "poankale"
+        ]
+      },
+      {
+        "en": "Galois",
+        "ja": "ガロア",
+        "ja_typings": [
+          "garoa",
+          "galoa"
+        ]
+      },
+      {
+        "en": "Fourier",
+        "ja": "フーリエ",
+        "ja_typings": [
+          "hu-rie"
+        ]
+      },
+      {
+        "en": "Cauchy",
+        "ja": "コーシー",
+        "ja_typings": [
+          "ko-sii-",
+          "ko-shi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03236",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French polymath stated a famous topology conjecture about 3-spheres?",
+      "ja": "3次元球面に関する有名な位相幾何の予想を残したフランスの数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pythagorean theorem",
+        "ja": "ピタゴラスの定理",
+        "ja_typings": [
+          "pitagorasunoteiri"
+        ]
+      },
+      {
+        "en": "Thales' theorem",
+        "ja": "タレスの定理",
+        "ja_typings": [
+          "taresunoteiri"
+        ]
+      },
+      {
+        "en": "Euclidean theorem",
+        "ja": "ユークリッドの定理",
+        "ja_typings": [
+          "yu-kuriltudonoteiri"
+        ]
+      },
+      {
+        "en": "Heron's formula",
+        "ja": "ヘロンの公式",
+        "ja_typings": [
+          "heronnokousiki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03237",
+    "image_path": null,
+    "question_text": {
+      "en": "Which theorem states a² + b² = c² for right triangles?",
+      "ja": "直角三角形で a² + b² = c² が成り立つ定理はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ramanujan",
+        "ja": "ラマヌジャン",
+        "ja_typings": [
+          "ramanujiyan",
+          "lamanujan",
+          "ramanujan"
+        ]
+      },
+      {
+        "en": "Bose",
+        "ja": "ボース",
+        "ja_typings": [
+          "bo-su"
+        ]
+      },
+      {
+        "en": "Chandrasekhar",
+        "ja": "チャンドラセカール",
+        "ja_typings": [
+          "tiyandorasekaa-ru",
+          "tyandolasekaa-lu",
+          "chandoraseka-ru"
+        ]
+      },
+      {
+        "en": "Aryabhata",
+        "ja": "アーリヤバタ",
+        "ja_typings": [
+          "a-riyabata",
+          "a-liyabata"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03238",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Indian mathematician was famous for self-taught genius and infinite series?",
+      "ja": "独学の天才で無限級数の研究で知られるインドの数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Relation",
+        "ja": "関係",
+        "ja_typings": [
+          "kankei"
+        ]
+      },
+      {
+        "en": "Function",
+        "ja": "関数",
+        "ja_typings": [
+          "kansuu"
+        ]
+      },
+      {
+        "en": "Mapping",
+        "ja": "写像",
+        "ja_typings": [
+          "siyazou",
+          "syazou"
+        ]
+      },
+      {
+        "en": "Operation",
+        "ja": "演算",
+        "ja_typings": [
+          "enzan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03239",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mathematical concept connects elements without requiring a unique image?",
+      "ja": "1対多も許す、要素同士の対応を表す数学概念はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Russell",
+        "ja": "ラッセル",
+        "ja_typings": [
+          "ratuseru",
+          "rasseru"
+        ]
+      },
+      {
+        "en": "Frege",
+        "ja": "フレーゲ",
+        "ja_typings": [
+          "hure-ge"
+        ]
+      },
+      {
+        "en": "Wittgenstein",
+        "ja": "ウィトゲンシュタイン",
+        "ja_typings": [
+          "uxitogensiyutain",
+          "witogenshutain"
+        ]
+      },
+      {
+        "en": "Moore",
+        "ja": "ムーア",
+        "ja_typings": [
+          "muu-a",
+          "mu-a"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03240",
+    "image_path": null,
+    "question_text": {
+      "en": "Which British philosopher co-wrote Principia Mathematica with Whitehead?",
+      "ja": "ホワイトヘッドと『プリンキピア・マテマティカ』を著した英国の哲学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shannon",
+        "ja": "シャノン",
+        "ja_typings": [
+          "shanon"
+        ]
+      },
+      {
+        "en": "Turing",
+        "ja": "チューリング",
+        "ja_typings": [
+          "tixyu-ringu"
+        ]
+      },
+      {
+        "en": "Von Neumann",
+        "ja": "フォン・ノイマン",
+        "ja_typings": [
+          "fon/noiman"
+        ]
+      },
+      {
+        "en": "Wiener",
+        "ja": "ウィーナー",
+        "ja_typings": [
+          "uxi-na-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03241",
+    "image_path": null,
+    "question_text": {
+      "en": "Which American mathematician founded information theory?",
+      "ja": "情報理論を創始したアメリカの数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sigma",
+        "ja": "シグマ",
+        "ja_typings": [
+          "shiguma"
+        ]
+      },
+      {
+        "en": "Pi",
+        "ja": "パイ",
+        "ja_typings": [
+          "pai"
+        ]
+      },
+      {
+        "en": "Delta",
+        "ja": "デルタ",
+        "ja_typings": [
+          "deruta",
+          "deluta"
+        ]
+      },
+      {
+        "en": "Lambda",
+        "ja": "ラムダ",
+        "ja_typings": [
+          "ramuda",
+          "lamuda"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03242",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Greek letter Σ denotes summation in mathematics?",
+      "ja": "総和を表すギリシャ文字Σはどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sigmoid curve",
+        "ja": "シグモイド曲線",
+        "ja_typings": [
+          "sigumoidokyokusen"
+        ]
+      },
+      {
+        "en": "Logarithmic curve",
+        "ja": "対数曲線",
+        "ja_typings": [
+          "taisuukyokusen"
+        ]
+      },
+      {
+        "en": "Exponential curve",
+        "ja": "指数曲線",
+        "ja_typings": [
+          "sisuukyokusen"
+        ]
+      },
+      {
+        "en": "Hyperbola",
+        "ja": "双曲線",
+        "ja_typings": [
+          "soukyokusen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03243",
+    "image_path": null,
+    "question_text": {
+      "en": "Which S-shaped curve is widely used in neural network activations?",
+      "ja": "ニューラルネットの活性化関数で使われるS字曲線はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Similar polygon",
+        "ja": "相似多角形",
+        "ja_typings": [
+          "soujitakakukei"
+        ]
+      },
+      {
+        "en": "Congruent polygon",
+        "ja": "合同多角形",
+        "ja_typings": [
+          "goudoutakakukei"
+        ]
+      },
+      {
+        "en": "Regular polygon",
+        "ja": "正多角形",
+        "ja_typings": [
+          "seitakakukei"
+        ]
+      },
+      {
+        "en": "Convex polygon",
+        "ja": "凸多角形",
+        "ja_typings": [
+          "totutakakukei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03244",
+    "image_path": null,
+    "question_text": {
+      "en": "Which type of polygon has the same shape but different size as another?",
+      "ja": "形が同じで大きさが異なる多角形を何という?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tarski",
+        "ja": "タルスキ",
+        "ja_typings": [
+          "tarusuki",
+          "talusuki"
+        ]
+      },
+      {
+        "en": "Gödel",
+        "ja": "ゲーデル",
+        "ja_typings": [
+          "ge-deru",
+          "ge-delu"
+        ]
+      },
+      {
+        "en": "Church",
+        "ja": "チャーチ",
+        "ja_typings": [
+          "cha-chi"
+        ]
+      },
+      {
+        "en": "Kleene",
+        "ja": "クリーネ",
+        "ja_typings": [
+          "kuri-ne",
+          "kuli-ne"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03245",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Polish-American logician is known for the definition of truth in formal languages?",
+      "ja": "形式言語における真理の定義で知られるポーランド系米国の論理学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Terence Tao",
+        "ja": "テレンス・タオ",
+        "ja_typings": [
+          "terensu/tao"
+        ]
+      },
+      {
+        "en": "Grigori Perelman",
+        "ja": "グリゴリー・ペレルマン",
+        "ja_typings": [
+          "gurigori-/pereruman"
+        ]
+      },
+      {
+        "en": "Andrei Okounkov",
+        "ja": "アンドレイ・オクンコフ",
+        "ja_typings": [
+          "andorei/okunkofu"
+        ]
+      },
+      {
+        "en": "Wendelin Werner",
+        "ja": "ヴェンデリン・ヴェルナー",
+        "ja_typings": [
+          "venderin/veruna-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03246",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Australian-American mathematician received the Fields Medal in 2006?",
+      "ja": "2006年にフィールズ賞を受賞した豪州系米国の数学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Turing Award",
+        "ja": "チューリング賞",
+        "ja_typings": [
+          "tixyu-ringuxsiyou"
+        ]
+      },
+      {
+        "en": "Fields Medal",
+        "ja": "フィールズ賞",
+        "ja_typings": [
+          "fi-ruzuxsiyou"
+        ]
+      },
+      {
+        "en": "Abel Prize",
+        "ja": "アーベル賞",
+        "ja_typings": [
+          "a-beruxsiyou"
+        ]
+      },
+      {
+        "en": "Wolf Prize",
+        "ja": "ウルフ賞",
+        "ja_typings": [
+          "uruhuxsiyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03247",
+    "image_path": null,
+    "question_text": {
+      "en": "Which prize is the highest honor in computer science, given by the ACM?",
+      "ja": "ACM が授与する計算機科学最高の賞はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vector",
+        "ja": "ベクトル",
+        "ja_typings": [
+          "bekutoru",
+          "bekutolu"
+        ]
+      },
+      {
+        "en": "Scalar",
+        "ja": "スカラー",
+        "ja_typings": [
+          "sukaraa-",
+          "sukalaa-",
+          "sukara-"
+        ]
+      },
+      {
+        "en": "Tensor",
+        "ja": "テンソル",
+        "ja_typings": [
+          "tensoru",
+          "tensolu"
+        ]
+      },
+      {
+        "en": "Matrix",
+        "ja": "行列",
+        "ja_typings": [
+          "gyouretu",
+          "gyouletu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03248",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mathematical object has both magnitude and direction?",
+      "ja": "大きさと向きを持つ数学的対象はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Von Neumann",
+        "ja": "フォン・ノイマン",
+        "ja_typings": [
+          "fon/noiman"
+        ]
+      },
+      {
+        "en": "Turing",
+        "ja": "チューリング",
+        "ja_typings": [
+          "tixyu-ringu"
+        ]
+      },
+      {
+        "en": "Babbage",
+        "ja": "バベッジ",
+        "ja_typings": [
+          "bayatuji",
+          "babejji"
+        ]
+      },
+      {
+        "en": "Shannon",
+        "ja": "シャノン",
+        "ja_typings": [
+          "shanon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03249",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the Hungarian-American polymath who pioneered modern computer architecture?",
+      "ja": "現代コンピュータ・アーキテクチャを築いたハンガリー系米国の万能学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Wolf Prize",
+        "ja": "ウルフ賞",
+        "ja_typings": [
+          "uruhuxsiyou",
+          "uluhusyou"
+        ]
+      },
+      {
+        "en": "Abel Prize",
+        "ja": "アーベル賞",
+        "ja_typings": [
+          "a-beruxsiyou"
+        ]
+      },
+      {
+        "en": "Fields Medal",
+        "ja": "フィールズ賞",
+        "ja_typings": [
+          "fi-ruzuxsiyou"
+        ]
+      },
+      {
+        "en": "Turing Award",
+        "ja": "チューリング賞",
+        "ja_typings": [
+          "tixyu-ringuxsiyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "math",
+    "id": "q03250",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Israeli prize is given for outstanding achievements in mathematics and the arts?",
+      "ja": "数学や芸術での業績に贈られるイスラエルの賞はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "1",
+        "ja": "1輪",
+        "ja_typings": [
+          "1rin",
+          "itirin"
+        ]
+      },
+      {
+        "en": "2",
+        "ja": "2輪",
+        "ja_typings": [
+          "2rin",
+          "nirin"
+        ]
+      },
+      {
+        "en": "3",
+        "ja": "3輪",
+        "ja_typings": [
+          "3rin",
+          "sanrin"
+        ]
+      },
+      {
+        "en": "4",
+        "ja": "4輪",
+        "ja_typings": [
+          "4rin",
+          "yonrin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03251",
+    "image_path": null,
+    "question_text": {
+      "en": "How many wheels does a unicycle have?",
+      "ja": "一輪車のタイヤは何輪?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "12",
+        "ja": "12か月",
+        "ja_typings": [
+          "12kagetsu"
+        ]
+      },
+      {
+        "en": "10",
+        "ja": "10か月",
+        "ja_typings": [
+          "10kagetsu"
+        ]
+      },
+      {
+        "en": "13",
+        "ja": "13か月",
+        "ja_typings": [
+          "13kagetsu"
+        ]
+      },
+      {
+        "en": "24",
+        "ja": "24か月",
+        "ja_typings": [
+          "24kagetsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03252",
+    "image_path": null,
+    "question_text": {
+      "en": "How many months are in a year?",
+      "ja": "1年は何か月?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "2",
+        "ja": "2輪",
+        "ja_typings": [
+          "2rin",
+          "nirin"
+        ]
+      },
+      {
+        "en": "1",
+        "ja": "1輪",
+        "ja_typings": [
+          "1rin",
+          "itirin"
+        ]
+      },
+      {
+        "en": "3",
+        "ja": "3輪",
+        "ja_typings": [
+          "3rin",
+          "sanrin"
+        ]
+      },
+      {
+        "en": "4",
+        "ja": "4輪",
+        "ja_typings": [
+          "4rin",
+          "yonrin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03253",
+    "image_path": null,
+    "question_text": {
+      "en": "How many wheels does a bicycle have?",
+      "ja": "自転車のタイヤは何輪?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "20",
+        "ja": "20本",
+        "ja_typings": [
+          "nijuxtupon"
+        ]
+      },
+      {
+        "en": "10",
+        "ja": "10本",
+        "ja_typings": [
+          "juxtupon"
+        ]
+      },
+      {
+        "en": "12",
+        "ja": "12本",
+        "ja_typings": [
+          "12hon",
+          "12bon",
+          "juunihon"
+        ]
+      },
+      {
+        "en": "16",
+        "ja": "16本",
+        "ja_typings": [
+          "16hon",
+          "16bon",
+          "juurokuhon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03254",
+    "image_path": null,
+    "question_text": {
+      "en": "How many fingers does a typical human have in total?",
+      "ja": "人の指は両手で何本?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "26 km",
+        "ja": "約26km",
+        "ja_typings": [
+          "yaku26kiro",
+          "yaku26km"
+        ]
+      },
+      {
+        "en": "10 km",
+        "ja": "約10km",
+        "ja_typings": [
+          "yaku10kiro",
+          "yaku10km"
+        ]
+      },
+      {
+        "en": "42 km",
+        "ja": "約42km",
+        "ja_typings": [
+          "yaku42kiro",
+          "yaku42km"
+        ]
+      },
+      {
+        "en": "100 km",
+        "ja": "約100km",
+        "ja_typings": [
+          "yaku100kiro",
+          "yaku100km"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03255",
+    "image_path": null,
+    "question_text": {
+      "en": "About how long is a full marathon?",
+      "ja": "フルマラソンの距離はおよそ何km?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "30",
+        "ja": "30日",
+        "ja_typings": [
+          "30nichi"
+        ]
+      },
+      {
+        "en": "31",
+        "ja": "31日",
+        "ja_typings": [
+          "31nichi"
+        ]
+      },
+      {
+        "en": "28",
+        "ja": "28日",
+        "ja_typings": [
+          "28nichi"
+        ]
+      },
+      {
+        "en": "29",
+        "ja": "29日",
+        "ja_typings": [
+          "29nichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03256",
+    "image_path": null,
+    "question_text": {
+      "en": "How many days does April have?",
+      "ja": "4月は何日まで?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "30 km",
+        "ja": "約30km",
+        "ja_typings": [
+          "yaku30kiro",
+          "yaku30km"
+        ]
+      },
+      {
+        "en": "21 km",
+        "ja": "約21km",
+        "ja_typings": [
+          "yaku21kiro",
+          "yaku21km"
+        ]
+      },
+      {
+        "en": "15 km",
+        "ja": "約15km",
+        "ja_typings": [
+          "yaku15kiro",
+          "yaku15km"
+        ]
+      },
+      {
+        "en": "42 km",
+        "ja": "約42km",
+        "ja_typings": [
+          "yaku42kiro",
+          "yaku42km"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03257",
+    "image_path": null,
+    "question_text": {
+      "en": "About how long is a half marathon?",
+      "ja": "ハーフマラソンの距離はおよそ何km?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "30 minutes",
+        "ja": "30分",
+        "ja_typings": [
+          "30hun",
+          "30pun",
+          "30bun",
+          "sanjuxtupun"
+        ]
+      },
+      {
+        "en": "10 minutes",
+        "ja": "10分",
+        "ja_typings": [
+          "10hun",
+          "10pun",
+          "10bun",
+          "juxtupun"
+        ]
+      },
+      {
+        "en": "8 minutes",
+        "ja": "8分",
+        "ja_typings": [
+          "8hun",
+          "8pun",
+          "8bun",
+          "hatupun"
+        ]
+      },
+      {
+        "en": "12 minutes",
+        "ja": "12分",
+        "ja_typings": [
+          "12hun",
+          "12pun",
+          "12bun",
+          "juunihun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03258",
+    "image_path": null,
+    "question_text": {
+      "en": "How long is one period in a high school basketball game?",
+      "ja": "高校バスケのクォーター1ピリオドは何分?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "4",
+        "ja": "4つ",
+        "ja_typings": [
+          "4tsu"
+        ]
+      },
+      {
+        "en": "2",
+        "ja": "2つ",
+        "ja_typings": [
+          "futatsu"
+        ]
+      },
+      {
+        "en": "3",
+        "ja": "3つ",
+        "ja_typings": [
+          "3tsu"
+        ]
+      },
+      {
+        "en": "5",
+        "ja": "5つ",
+        "ja_typings": [
+          "5tsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03259",
+    "image_path": null,
+    "question_text": {
+      "en": "How many seasons are there in a year?",
+      "ja": "1年の季節はいくつ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "40 minutes",
+        "ja": "40分",
+        "ja_typings": [
+          "40hun",
+          "40pun",
+          "40bun",
+          "yonjuxtupun"
+        ]
+      },
+      {
+        "en": "30 minutes",
+        "ja": "30分",
+        "ja_typings": [
+          "30hun",
+          "30pun",
+          "30bun"
+        ]
+      },
+      {
+        "en": "20 minutes",
+        "ja": "20分",
+        "ja_typings": [
+          "20hun",
+          "20pun",
+          "20bun"
+        ]
+      },
+      {
+        "en": "45 minutes",
+        "ja": "45分",
+        "ja_typings": [
+          "45hun",
+          "45pun",
+          "45bun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03260",
+    "image_path": null,
+    "question_text": {
+      "en": "How long is one half in a college basketball game (NCAA men)?",
+      "ja": "NCAA男子バスケのハーフは何分?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "50 km",
+        "ja": "時速50km",
+        "ja_typings": [
+          "jisoku50kiro",
+          "jisoku50km"
+        ]
+      },
+      {
+        "en": "30 km",
+        "ja": "時速30km",
+        "ja_typings": [
+          "jisoku30kiro",
+          "jisoku30km"
+        ]
+      },
+      {
+        "en": "80 km",
+        "ja": "時速80km",
+        "ja_typings": [
+          "jisoku80kiro",
+          "jisoku80km"
+        ]
+      },
+      {
+        "en": "100 km",
+        "ja": "時速100km",
+        "ja_typings": [
+          "jisoku100kiro",
+          "jisoku100km"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03261",
+    "image_path": null,
+    "question_text": {
+      "en": "About how fast does a 100m sprinter run in km/h?",
+      "ja": "100m走の世界トップ選手のおよその速度は時速何km?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "60 minutes",
+        "ja": "60分",
+        "ja_typings": [
+          "60hun",
+          "60pun",
+          "60bun",
+          "rokujuxtupun"
+        ]
+      },
+      {
+        "en": "45 minutes",
+        "ja": "45分",
+        "ja_typings": [
+          "45hun",
+          "45pun",
+          "45bun"
+        ]
+      },
+      {
+        "en": "30 minutes",
+        "ja": "30分",
+        "ja_typings": [
+          "30hun",
+          "30pun",
+          "30bun"
+        ]
+      },
+      {
+        "en": "90 minutes",
+        "ja": "90分",
+        "ja_typings": [
+          "90hun",
+          "90pun",
+          "90bun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03262",
+    "image_path": null,
+    "question_text": {
+      "en": "How long is one half of a soccer match?",
+      "ja": "サッカーの前半・後半は何分?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Alexander Graham Bell",
+        "ja": "アレクサンダー・グラハム・ベル",
+        "ja_typings": [
+          "arekusanda-/gurahamu/beru",
+          "alekusanda-/gulahamu/belu"
+        ]
+      },
+      {
+        "en": "Thomas Edison",
+        "ja": "トーマス・エジソン",
+        "ja_typings": [
+          "to-masu/ejison"
+        ]
+      },
+      {
+        "en": "Samuel Morse",
+        "ja": "サミュエル・モールス",
+        "ja_typings": [
+          "samiyueru/mo-rusu",
+          "samyueru/mo-lusu",
+          "samyueru/mo-rusu"
+        ]
+      },
+      {
+        "en": "Nikola Tesla",
+        "ja": "ニコラ・テスラ",
+        "ja_typings": [
+          "nikora/tesura",
+          "nikola/tesula"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03263",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is credited with inventing the telephone in 1876?",
+      "ja": "1876年に電話を発明したとされる人物は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Anton Chekhov",
+        "ja": "アントン・チェーホフ",
+        "ja_typings": [
+          "anton/tie-hohu",
+          "anton/che-hofu"
+        ]
+      },
+      {
+        "en": "Leo Tolstoy",
+        "ja": "レフ・トルストイ",
+        "ja_typings": [
+          "refu/torusutoi"
+        ]
+      },
+      {
+        "en": "Maxim Gorky",
+        "ja": "マクシム・ゴーリキー",
+        "ja_typings": [
+          "makushimu/go-riki-"
+        ]
+      },
+      {
+        "en": "Fyodor Dostoevsky",
+        "ja": "ドストエフスキー",
+        "ja_typings": [
+          "dosutoehusuki-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03264",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the Russian playwright that wrote The Cherry Orchard?",
+      "ja": "『桜の園』を書いたロシアの劇作家は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Belle",
+        "ja": "ベル",
+        "ja_typings": [
+          "beru",
+          "belu"
+        ]
+      },
+      {
+        "en": "Ariel",
+        "ja": "アリエル",
+        "ja_typings": [
+          "arieru",
+          "alielu"
+        ]
+      },
+      {
+        "en": "Cinderella",
+        "ja": "シンデレラ",
+        "ja_typings": [
+          "sindererera",
+          "shindelelela",
+          "shinderera"
+        ]
+      },
+      {
+        "en": "Jasmine",
+        "ja": "ジャスミン",
+        "ja_typings": [
+          "jiyasumin",
+          "jasumin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03265",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the heroine of Disney's Beauty and the Beast?",
+      "ja": "ディズニー『美女と野獣』のヒロインは誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bill Gates",
+        "ja": "ビル・ゲイツ",
+        "ja_typings": [
+          "biru/geitsu"
+        ]
+      },
+      {
+        "en": "Steve Jobs",
+        "ja": "スティーブ・ジョブズ",
+        "ja_typings": [
+          "sutexi-bu/jiyobuzu",
+          "suti-bu/jobuzu"
+        ]
+      },
+      {
+        "en": "Steve Wozniak",
+        "ja": "スティーブ・ウォズニアック",
+        "ja_typings": [
+          "sutexi-bu/uxozuniatuku",
+          "suti-bu/wozuniakku"
+        ]
+      },
+      {
+        "en": "Larry Page",
+        "ja": "ラリー・ペイジ",
+        "ja_typings": [
+          "rari-/peiji",
+          "lali-/peiji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03266",
+    "image_path": null,
+    "question_text": {
+      "en": "Who co-founded Microsoft with Paul Allen?",
+      "ja": "ポール・アレンとマイクロソフトを共同創業したのは誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Brazil",
+        "ja": "ブラジル",
+        "ja_typings": [
+          "burajiru",
+          "bulajiru"
+        ]
+      },
+      {
+        "en": "Argentina",
+        "ja": "アルゼンチン",
+        "ja_typings": [
+          "aruzenchin"
+        ]
+      },
+      {
+        "en": "Mexico",
+        "ja": "メキシコ",
+        "ja_typings": [
+          "mekishiko"
+        ]
+      },
+      {
+        "en": "Colombia",
+        "ja": "コロンビア",
+        "ja_typings": [
+          "koronbia",
+          "kolonbia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03267",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country's flag features a yellow lozenge on a green field?",
+      "ja": "緑地に黄色のひし形がある国旗はどこの国?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "C. S. Lewis",
+        "ja": "C.S.ルイス",
+        "ja_typings": [
+          "c.s.ruisu",
+          "shi-esuruisu"
+        ]
+      },
+      {
+        "en": "J. R. R. Tolkien",
+        "ja": "J.R.R.トールキン",
+        "ja_typings": [
+          "j.r.r.to-rukin",
+          "jeia-rua-ruto-rukin"
+        ]
+      },
+      {
+        "en": "Roald Dahl",
+        "ja": "ロアルド・ダール",
+        "ja_typings": [
+          "roarudo/daa-ru",
+          "loaludo/daa-lu",
+          "roarudo/da-ru"
+        ]
+      },
+      {
+        "en": "Lewis Carroll",
+        "ja": "ルイス・キャロル",
+        "ja_typings": [
+          "ruisu/kiyaroru",
+          "luisu/kyalolu",
+          "ruisu/kyaroru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03268",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote The Chronicles of Narnia?",
+      "ja": "『ナルニア国物語』を書いた作家は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Charles Dickens",
+        "ja": "チャールズ・ディケンズ",
+        "ja_typings": [
+          "tiya-ruzu/dexikenzu",
+          "cha-luzu/dikenzu",
+          "cha-ruzu/dikenzu"
+        ]
+      },
+      {
+        "en": "Mark Twain",
+        "ja": "マーク・トウェイン",
+        "ja_typings": [
+          "maa-ku/touxein"
+        ]
+      },
+      {
+        "en": "Oscar Wilde",
+        "ja": "オスカー・ワイルド",
+        "ja_typings": [
+          "osukaa-/wairudo",
+          "osukaa-/wailudo",
+          "osuka-/wairudo"
+        ]
+      },
+      {
+        "en": "Jane Austen",
+        "ja": "ジェーン・オースティン",
+        "ja_typings": [
+          "jixe-n/oo-sutexin",
+          "je-n/o-sutin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03269",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote A Christmas Carol and Oliver Twist?",
+      "ja": "『クリスマス・キャロル』『オリバー・ツイスト』を書いた英国の作家は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "China",
+        "ja": "中国",
+        "ja_typings": [
+          "tixyuugoku"
+        ]
+      },
+      {
+        "en": "United States",
+        "ja": "アメリカ合衆国",
+        "ja_typings": [
+          "amerikagatusiyuukoku"
+        ]
+      },
+      {
+        "en": "Russia",
+        "ja": "ロシア",
+        "ja_typings": [
+          "roshia"
+        ]
+      },
+      {
+        "en": "Indonesia",
+        "ja": "インドネシア",
+        "ja_typings": [
+          "indoneshia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03270",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has the world's largest population alongside India?",
+      "ja": "インドと並んで世界最大級の人口を持つ国はどこ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Daisy",
+        "ja": "デイジー",
+        "ja_typings": [
+          "deiji-"
+        ]
+      },
+      {
+        "en": "Bessie",
+        "ja": "ベッシー",
+        "ja_typings": [
+          "betusi-",
+          "besshi-"
+        ]
+      },
+      {
+        "en": "Buttercup",
+        "ja": "バターカップ",
+        "ja_typings": [
+          "bataa-katupu",
+          "bataa-kappu",
+          "bata-kappu"
+        ]
+      },
+      {
+        "en": "Clover",
+        "ja": "クローバー",
+        "ja_typings": [
+          "kuroo-baa-",
+          "kuloo-baa-",
+          "kuro-ba-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03271",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is a common pet name often associated with cows in English?",
+      "ja": "英語圏で乳牛によく付けられる名前はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Dutch",
+        "ja": "オランダ語",
+        "ja_typings": [
+          "orandago",
+          "olandago"
+        ]
+      },
+      {
+        "en": "German",
+        "ja": "ドイツ語",
+        "ja_typings": [
+          "doitsugo"
+        ]
+      },
+      {
+        "en": "French",
+        "ja": "フランス語",
+        "ja_typings": [
+          "huransugo",
+          "fulansugo"
+        ]
+      },
+      {
+        "en": "English",
+        "ja": "英語",
+        "ja_typings": [
+          "eigo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03272",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the official language of the Netherlands?",
+      "ja": "オランダの公用語はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Egypt",
+        "ja": "エジプト",
+        "ja_typings": [
+          "ejiputo"
+        ]
+      },
+      {
+        "en": "Sudan",
+        "ja": "スーダン",
+        "ja_typings": [
+          "suu-dan",
+          "su-dan"
+        ]
+      },
+      {
+        "en": "Libya",
+        "ja": "リビア",
+        "ja_typings": [
+          "ribia",
+          "libia"
+        ]
+      },
+      {
+        "en": "Iraq",
+        "ja": "イラク",
+        "ja_typings": [
+          "iraku",
+          "ilaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03273",
+    "image_path": null,
+    "question_text": {
+      "en": "In which country are the Pyramids of Giza located?",
+      "ja": "ギザのピラミッドがある国はどこ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fabaceae",
+        "ja": "マメ科",
+        "ja_typings": [
+          "mameka"
+        ]
+      },
+      {
+        "en": "Rosaceae",
+        "ja": "バラ科",
+        "ja_typings": [
+          "baraka",
+          "balaka"
+        ]
+      },
+      {
+        "en": "Solanaceae",
+        "ja": "ナス科",
+        "ja_typings": [
+          "nasuka"
+        ]
+      },
+      {
+        "en": "Brassicaceae",
+        "ja": "アブラナ科",
+        "ja_typings": [
+          "aburanaka",
+          "abulanaka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03274",
+    "image_path": null,
+    "question_text": {
+      "en": "Which plant family includes peas and beans?",
+      "ja": "エンドウやマメを含む植物の科はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Florence",
+        "ja": "フィレンツェ",
+        "ja_typings": [
+          "huxirentue",
+          "filentse",
+          "firentse"
+        ]
+      },
+      {
+        "en": "Milan",
+        "ja": "ミラノ",
+        "ja_typings": [
+          "mirano",
+          "milano"
+        ]
+      },
+      {
+        "en": "Rome",
+        "ja": "ローマ",
+        "ja_typings": [
+          "roo-ma",
+          "loo-ma",
+          "ro-ma"
+        ]
+      },
+      {
+        "en": "Venice",
+        "ja": "ヴェネツィア",
+        "ja_typings": [
+          "venetsuxia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03275",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian city is famous as the cradle of the Renaissance?",
+      "ja": "ルネサンス発祥の地として知られるイタリアの都市はどこ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Frances Hodgson Burnett",
+        "ja": "バーネット",
+        "ja_typings": [
+          "baa-netuto",
+          "ba-netto"
+        ]
+      },
+      {
+        "en": "Louisa May Alcott",
+        "ja": "オルコット",
+        "ja_typings": [
+          "orukotuto",
+          "olukotto",
+          "orukotto"
+        ]
+      },
+      {
+        "en": "Beatrix Potter",
+        "ja": "ポター",
+        "ja_typings": [
+          "potaa-",
+          "pota-"
+        ]
+      },
+      {
+        "en": "Lucy Maud Montgomery",
+        "ja": "モンゴメリ",
+        "ja_typings": [
+          "mongomeri",
+          "mongomeli"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03276",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote The Secret Garden and A Little Princess?",
+      "ja": "『秘密の花園』『小公女』を書いた英米の作家は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fyodor Dostoevsky",
+        "ja": "ドストエフスキー",
+        "ja_typings": [
+          "dosutoehusuki-"
+        ]
+      },
+      {
+        "en": "Leo Tolstoy",
+        "ja": "レフ・トルストイ",
+        "ja_typings": [
+          "refu/torusutoi"
+        ]
+      },
+      {
+        "en": "Anton Chekhov",
+        "ja": "アントン・チェーホフ",
+        "ja_typings": [
+          "anton/tie-hohu",
+          "anton/che-hofu"
+        ]
+      },
+      {
+        "en": "Nikolai Gogol",
+        "ja": "ニコライ・ゴーゴリ",
+        "ja_typings": [
+          "nikorai/go-gori"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03277",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote Crime and Punishment and The Brothers Karamazov?",
+      "ja": "『罪と罰』『カラマーゾフの兄弟』を書いた作家は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Germany",
+        "ja": "ドイツ",
+        "ja_typings": [
+          "doitsu"
+        ]
+      },
+      {
+        "en": "Austria",
+        "ja": "オーストリア",
+        "ja_typings": [
+          "oo-sutoria",
+          "oo-sutolia",
+          "o-sutoria"
+        ]
+      },
+      {
+        "en": "Switzerland",
+        "ja": "スイス",
+        "ja_typings": [
+          "suisu"
+        ]
+      },
+      {
+        "en": "Netherlands",
+        "ja": "オランダ",
+        "ja_typings": [
+          "oranda",
+          "olanda"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03278",
+    "image_path": null,
+    "question_text": {
+      "en": "In which country is the city Munich located?",
+      "ja": "ミュンヘンがある国はどこ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hideyo Noguchi",
+        "ja": "野口英世",
+        "ja_typings": [
+          "noguthihideyo",
+          "noguchihideyo"
+        ]
+      },
+      {
+        "en": "Kiyoshi Shiga",
+        "ja": "志賀潔",
+        "ja_typings": [
+          "shigakiyoshi"
+        ]
+      },
+      {
+        "en": "Shibasaburo Kitasato",
+        "ja": "北里柴三郎",
+        "ja_typings": [
+          "kitasatoshibasaburou"
+        ]
+      },
+      {
+        "en": "Jokichi Takamine",
+        "ja": "高峰譲吉",
+        "ja_typings": [
+          "takaminejiyuukiti",
+          "takaminejoukichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03279",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese bacteriologist appears on the 1000-yen note?",
+      "ja": "1000円札の肖像となった日本の細菌学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "J. R. R. Tolkien",
+        "ja": "J.R.R.トールキン",
+        "ja_typings": [
+          "j.r.r.to-rukin"
+        ]
+      },
+      {
+        "en": "C. S. Lewis",
+        "ja": "C.S.ルイス",
+        "ja_typings": [
+          "c.s.ruisu"
+        ]
+      },
+      {
+        "en": "George R. R. Martin",
+        "ja": "ジョージ・R.R.マーティン",
+        "ja_typings": [
+          "jiyo-ji/r.r.maa-texin",
+          "jo-ji/r.r.ma-tin"
+        ]
+      },
+      {
+        "en": "Terry Pratchett",
+        "ja": "テリー・プラチェット",
+        "ja_typings": [
+          "teri-/puratietuto",
+          "teli-/pulachetto",
+          "teri-/purachetto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03280",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote The Lord of the Rings?",
+      "ja": "『指輪物語』を書いた英国の作家は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jokichi Takamine",
+        "ja": "高峰譲吉",
+        "ja_typings": [
+          "takaminejiyuukiti",
+          "takaminejoukichi"
+        ]
+      },
+      {
+        "en": "Hideyo Noguchi",
+        "ja": "野口英世",
+        "ja_typings": [
+          "noguthihideyo",
+          "noguchihideyo"
+        ]
+      },
+      {
+        "en": "Kiyoshi Shiga",
+        "ja": "志賀潔",
+        "ja_typings": [
+          "shigakiyoshi"
+        ]
+      },
+      {
+        "en": "Umetaro Suzuki",
+        "ja": "鈴木梅太郎",
+        "ja_typings": [
+          "suzukiumetarou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03281",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese chemist first isolated adrenaline?",
+      "ja": "アドレナリンを世界で初めて結晶化した日本の化学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kiyoshi Shiga",
+        "ja": "志賀潔",
+        "ja_typings": [
+          "shigakiyoshi"
+        ]
+      },
+      {
+        "en": "Hideyo Noguchi",
+        "ja": "野口英世",
+        "ja_typings": [
+          "noguthihideyo",
+          "noguchihideyo"
+        ]
+      },
+      {
+        "en": "Shibasaburo Kitasato",
+        "ja": "北里柴三郎",
+        "ja_typings": [
+          "kitasatosibasaburou"
+        ]
+      },
+      {
+        "en": "Sahachiro Hata",
+        "ja": "秦佐八郎",
+        "ja_typings": [
+          "hatasahachirou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03282",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese bacteriologist discovered the dysentery bacillus?",
+      "ja": "赤痢菌を発見した日本の細菌学者は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Los Angeles",
+        "ja": "ロサンゼルス",
+        "ja_typings": [
+          "rosanzerusu",
+          "losanzelusu"
+        ]
+      },
+      {
+        "en": "New York",
+        "ja": "ニューヨーク",
+        "ja_typings": [
+          "niyuu-yoo-ku",
+          "nyuu-yoo-ku",
+          "nyu-yo-ku"
+        ]
+      },
+      {
+        "en": "Chicago",
+        "ja": "シカゴ",
+        "ja_typings": [
+          "shikago"
+        ]
+      },
+      {
+        "en": "San Francisco",
+        "ja": "サンフランシスコ",
+        "ja_typings": [
+          "sanfuranshisuko"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03283",
+    "image_path": null,
+    "question_text": {
+      "en": "Which American city is the heart of the U.S. film industry (Hollywood)?",
+      "ja": "ハリウッドがある、米国映画産業の中心都市はどこ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Magnoliaceae",
+        "ja": "モクレン科",
+        "ja_typings": [
+          "mokurenka",
+          "mokulenka"
+        ]
+      },
+      {
+        "en": "Rosaceae",
+        "ja": "バラ科",
+        "ja_typings": [
+          "baraka",
+          "balaka"
+        ]
+      },
+      {
+        "en": "Theaceae",
+        "ja": "ツバキ科",
+        "ja_typings": [
+          "tsubakika"
+        ]
+      },
+      {
+        "en": "Fabaceae",
+        "ja": "マメ科",
+        "ja_typings": [
+          "mameka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03284",
+    "image_path": null,
+    "question_text": {
+      "en": "Which plant family includes magnolias?",
+      "ja": "モクレンやコブシを含む植物の科はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Melanie",
+        "ja": "メラニー",
+        "ja_typings": [
+          "merani-",
+          "melani-"
+        ]
+      },
+      {
+        "en": "Scarlett",
+        "ja": "スカーレット",
+        "ja_typings": [
+          "sukaa-retuto",
+          "sukaa-letto",
+          "suka-retto"
+        ]
+      },
+      {
+        "en": "Suellen",
+        "ja": "スーエレン",
+        "ja_typings": [
+          "suu-eren",
+          "suu-elen",
+          "su-eren"
+        ]
+      },
+      {
+        "en": "Prissy",
+        "ja": "プリシー",
+        "ja_typings": [
+          "purishi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03285",
+    "image_path": null,
+    "question_text": {
+      "en": "Which character is the antagonist's sister in Gone with the Wind?",
+      "ja": "『風と共に去りぬ』に登場するアシュレーの妻の名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Milan",
+        "ja": "ミラノ",
+        "ja_typings": [
+          "mirano",
+          "milano"
+        ]
+      },
+      {
+        "en": "Rome",
+        "ja": "ローマ",
+        "ja_typings": [
+          "roo-ma",
+          "loo-ma",
+          "ro-ma"
+        ]
+      },
+      {
+        "en": "Florence",
+        "ja": "フィレンツェ",
+        "ja_typings": [
+          "huxirentue",
+          "firentse"
+        ]
+      },
+      {
+        "en": "Naples",
+        "ja": "ナポリ",
+        "ja_typings": [
+          "napori",
+          "napoli"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03286",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian city is famous for fashion and the La Scala opera house?",
+      "ja": "ファッションとスカラ座で有名なイタリアの都市はどこ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "New York",
+        "ja": "ニューヨーク",
+        "ja_typings": [
+          "niyuu-yoo-ku",
+          "nyuu-yoo-ku",
+          "nyu-yo-ku"
+        ]
+      },
+      {
+        "en": "Los Angeles",
+        "ja": "ロサンゼルス",
+        "ja_typings": [
+          "rosanzerusu"
+        ]
+      },
+      {
+        "en": "Boston",
+        "ja": "ボストン",
+        "ja_typings": [
+          "bosuton"
+        ]
+      },
+      {
+        "en": "Washington",
+        "ja": "ワシントン",
+        "ja_typings": [
+          "washinton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03287",
+    "image_path": null,
+    "question_text": {
+      "en": "Which American city is home to the Statue of Liberty?",
+      "ja": "自由の女神像があるアメリカの都市はどこ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nikolai Gogol",
+        "ja": "ニコライ・ゴーゴリ",
+        "ja_typings": [
+          "nikorai/go-gori",
+          "nikolai/go-goli"
+        ]
+      },
+      {
+        "en": "Anton Chekhov",
+        "ja": "アントン・チェーホフ",
+        "ja_typings": [
+          "anton/tie-hohu",
+          "anton/che-hofu"
+        ]
+      },
+      {
+        "en": "Fyodor Dostoevsky",
+        "ja": "ドストエフスキー",
+        "ja_typings": [
+          "dosutoehusuki-"
+        ]
+      },
+      {
+        "en": "Ivan Turgenev",
+        "ja": "ツルゲーネフ",
+        "ja_typings": [
+          "tsuruge-nefu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03288",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote the Russian short story The Overcoat?",
+      "ja": "『外套』を書いたロシアの作家は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Oscar Wilde",
+        "ja": "オスカー・ワイルド",
+        "ja_typings": [
+          "osukaa-/wairudo",
+          "osukaa-/wailudo",
+          "osuka-/wairudo"
+        ]
+      },
+      {
+        "en": "Charles Dickens",
+        "ja": "チャールズ・ディケンズ",
+        "ja_typings": [
+          "tiya-ruzu/dexikenzu",
+          "cha-ruzu/dikenzu"
+        ]
+      },
+      {
+        "en": "Bram Stoker",
+        "ja": "ブラム・ストーカー",
+        "ja_typings": [
+          "buramu/sutoo-kaa-",
+          "bulamu/sutoo-kaa-",
+          "buramu/suto-ka-"
+        ]
+      },
+      {
+        "en": "Robert L. Stevenson",
+        "ja": "スティーブンソン",
+        "ja_typings": [
+          "sutexi-bunson",
+          "suti-bunson"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03289",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote The Picture of Dorian Gray?",
+      "ja": "『ドリアン・グレイの肖像』を書いた作家は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Red cabbage",
+        "ja": "紫キャベツ",
+        "ja_typings": [
+          "murasakikiyabetu",
+          "murasakikyabetsu"
+        ]
+      },
+      {
+        "en": "Red radish",
+        "ja": "ラディッシュ",
+        "ja_typings": [
+          "radexitusiyu",
+          "radixisshu",
+          "radisshu"
+        ]
+      },
+      {
+        "en": "Red onion",
+        "ja": "赤玉ねぎ",
+        "ja_typings": [
+          "akatamanegi"
+        ]
+      },
+      {
+        "en": "Beetroot",
+        "ja": "ビーツ",
+        "ja_typings": [
+          "bii-tsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03290",
+    "image_path": null,
+    "question_text": {
+      "en": "Which vegetable is purple-leaved and used in coleslaw and salads?",
+      "ja": "紫色の葉でサラダやコールスローに使う野菜はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Red radish",
+        "ja": "ラディッシュ",
+        "ja_typings": [
+          "radexitusiyu",
+          "radixisshu",
+          "radisshu"
+        ]
+      },
+      {
+        "en": "Red cabbage",
+        "ja": "紫キャベツ",
+        "ja_typings": [
+          "murasakikiyabetu"
+        ]
+      },
+      {
+        "en": "Carrot",
+        "ja": "ニンジン",
+        "ja_typings": [
+          "ninjin"
+        ]
+      },
+      {
+        "en": "Beetroot",
+        "ja": "ビーツ",
+        "ja_typings": [
+          "bii-tsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03291",
+    "image_path": null,
+    "question_text": {
+      "en": "Which small red root vegetable is often called the salad radish?",
+      "ja": "サラダによく使う小さな赤い根菜はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Roald Dahl",
+        "ja": "ロアルド・ダール",
+        "ja_typings": [
+          "roarudo/daa-ru",
+          "loaludo/daa-lu",
+          "roarudo/da-ru"
+        ]
+      },
+      {
+        "en": "J. K. Rowling",
+        "ja": "J.K.ローリング",
+        "ja_typings": [
+          "j.k.roo-ringu",
+          "j.k.ro-ringu"
+        ]
+      },
+      {
+        "en": "C. S. Lewis",
+        "ja": "C.S.ルイス",
+        "ja_typings": [
+          "c.s.ruisu"
+        ]
+      },
+      {
+        "en": "Lewis Carroll",
+        "ja": "ルイス・キャロル",
+        "ja_typings": [
+          "ruisu/kiyaroru",
+          "ruisu/kyaroru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03292",
+    "image_path": null,
+    "question_text": {
+      "en": "Who wrote Charlie and the Chocolate Factory?",
+      "ja": "『チョコレート工場の秘密』を書いた作家は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rome",
+        "ja": "ローマ",
+        "ja_typings": [
+          "roo-ma",
+          "loo-ma",
+          "ro-ma"
+        ]
+      },
+      {
+        "en": "Milan",
+        "ja": "ミラノ",
+        "ja_typings": [
+          "mirano",
+          "milano"
+        ]
+      },
+      {
+        "en": "Florence",
+        "ja": "フィレンツェ",
+        "ja_typings": [
+          "huxirentue",
+          "firentse"
+        ]
+      },
+      {
+        "en": "Venice",
+        "ja": "ヴェネツィア",
+        "ja_typings": [
+          "vuxenetuxia",
+          "venetsia"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03293",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the capital of Italy?",
+      "ja": "イタリアの首都はどこ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Samuel Morse",
+        "ja": "サミュエル・モールス",
+        "ja_typings": [
+          "samiyueru/mo-rusu",
+          "samyueru/mo-lusu",
+          "samyueru/mo-rusu"
+        ]
+      },
+      {
+        "en": "Alexander Graham Bell",
+        "ja": "アレクサンダー・グラハム・ベル",
+        "ja_typings": [
+          "arekusanda-/gurahamu/beru"
+        ]
+      },
+      {
+        "en": "Thomas Edison",
+        "ja": "トーマス・エジソン",
+        "ja_typings": [
+          "to-masu/ejison"
+        ]
+      },
+      {
+        "en": "Nikola Tesla",
+        "ja": "ニコラ・テスラ",
+        "ja_typings": [
+          "nikora/tesura"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03294",
+    "image_path": null,
+    "question_text": {
+      "en": "Who invented the famous telegraph code of dots and dashes?",
+      "ja": "点と線の電信符号を発明した米国の発明家は誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "San Francisco",
+        "ja": "サンフランシスコ",
+        "ja_typings": [
+          "sanfuranshisuko"
+        ]
+      },
+      {
+        "en": "Los Angeles",
+        "ja": "ロサンゼルス",
+        "ja_typings": [
+          "rosanzerusu"
+        ]
+      },
+      {
+        "en": "San Diego",
+        "ja": "サンディエゴ",
+        "ja_typings": [
+          "sandexiego"
+        ]
+      },
+      {
+        "en": "Sacramento",
+        "ja": "サクラメント",
+        "ja_typings": [
+          "sakuramento",
+          "sakulamento"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03295",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Californian city is famous for the Golden Gate Bridge?",
+      "ja": "ゴールデンゲートブリッジで有名なカリフォルニアの都市はどこ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Steve Wozniak",
+        "ja": "スティーブ・ウォズニアック",
+        "ja_typings": [
+          "sutexi-bu/uxozuniatuku",
+          "suti-bu/wozuniakku"
+        ]
+      },
+      {
+        "en": "Bill Gates",
+        "ja": "ビル・ゲイツ",
+        "ja_typings": [
+          "biru/geitsu"
+        ]
+      },
+      {
+        "en": "Tim Cook",
+        "ja": "ティム・クック",
+        "ja_typings": [
+          "teximu/kutuku",
+          "timu/kukku"
+        ]
+      },
+      {
+        "en": "Ronald Wayne",
+        "ja": "ロナルド・ウェイン",
+        "ja_typings": [
+          "ronarudo/wein"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03296",
+    "image_path": null,
+    "question_text": {
+      "en": "Who co-founded Apple Computer with Steve Jobs in 1976?",
+      "ja": "1976年にスティーブ・ジョブズとアップルを共同創業したのは誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Swedish",
+        "ja": "スウェーデン語",
+        "ja_typings": [
+          "suuxe-dengo"
+        ]
+      },
+      {
+        "en": "Norwegian",
+        "ja": "ノルウェー語",
+        "ja_typings": [
+          "noruuxe-go",
+          "noluwe-go"
+        ]
+      },
+      {
+        "en": "Danish",
+        "ja": "デンマーク語",
+        "ja_typings": [
+          "denmaa-kugo"
+        ]
+      },
+      {
+        "en": "Finnish",
+        "ja": "フィンランド語",
+        "ja_typings": [
+          "huxinrandogo",
+          "finlandogo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03297",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the official language of Sweden?",
+      "ja": "スウェーデンの公用語はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thailand",
+        "ja": "タイ",
+        "ja_typings": [
+          "tai"
+        ]
+      },
+      {
+        "en": "Vietnam",
+        "ja": "ベトナム",
+        "ja_typings": [
+          "betonamu"
+        ]
+      },
+      {
+        "en": "Cambodia",
+        "ja": "カンボジア",
+        "ja_typings": [
+          "kanbojia"
+        ]
+      },
+      {
+        "en": "Laos",
+        "ja": "ラオス",
+        "ja_typings": [
+          "raosu",
+          "laosu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03298",
+    "image_path": null,
+    "question_text": {
+      "en": "In which country is Bangkok the capital?",
+      "ja": "首都がバンコクの国はどこ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Theaceae",
+        "ja": "ツバキ科",
+        "ja_typings": [
+          "tsubakika"
+        ]
+      },
+      {
+        "en": "Rosaceae",
+        "ja": "バラ科",
+        "ja_typings": [
+          "baraka"
+        ]
+      },
+      {
+        "en": "Magnoliaceae",
+        "ja": "モクレン科",
+        "ja_typings": [
+          "mokurenka"
+        ]
+      },
+      {
+        "en": "Fabaceae",
+        "ja": "マメ科",
+        "ja_typings": [
+          "mameka"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03299",
+    "image_path": null,
+    "question_text": {
+      "en": "Which plant family includes tea and camellia?",
+      "ja": "ツバキやチャを含む植物の科はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tim Cook",
+        "ja": "ティム・クック",
+        "ja_typings": [
+          "teximu/kutuku",
+          "timu/kukku"
+        ]
+      },
+      {
+        "en": "Jonathan Ive",
+        "ja": "ジョナサン・アイブ",
+        "ja_typings": [
+          "jiyonasan/aibu",
+          "jonasan/aibu"
+        ]
+      },
+      {
+        "en": "Eddy Cue",
+        "ja": "エディ・キュー",
+        "ja_typings": [
+          "edexi-/kiyuu-",
+          "edii-/kyuu-",
+          "edi/kyu-"
+        ]
+      },
+      {
+        "en": "Craig Federighi",
+        "ja": "クレイグ・フェデリギ",
+        "ja_typings": [
+          "kureigu/huederigi",
+          "kuleigu/federigi",
+          "kureigu/federigi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03300",
+    "image_path": null,
+    "question_text": {
+      "en": "Who succeeded Steve Jobs as CEO of Apple?",
+      "ja": "スティーブ・ジョブズの後を継ぎアップルCEOになったのは誰?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Turkey",
+        "ja": "トルコ",
+        "ja_typings": [
+          "toruko",
+          "toluko"
+        ]
+      },
+      {
+        "en": "Greece",
+        "ja": "ギリシャ",
+        "ja_typings": [
+          "girisiya",
+          "gilisya",
+          "girisha"
+        ]
+      },
+      {
+        "en": "Bulgaria",
+        "ja": "ブルガリア",
+        "ja_typings": [
+          "burugaria",
+          "bulugalia"
+        ]
+      },
+      {
+        "en": "Syria",
+        "ja": "シリア",
+        "ja_typings": [
+          "shiria"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03301",
+    "image_path": null,
+    "question_text": {
+      "en": "In which country is the city Istanbul located?",
+      "ja": "イスタンブールがある国はどこ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "United States",
+        "ja": "アメリカ合衆国",
+        "ja_typings": [
+          "amerikagatusiyuukoku"
+        ]
+      },
+      {
+        "en": "Canada",
+        "ja": "カナダ",
+        "ja_typings": [
+          "kanada"
+        ]
+      },
+      {
+        "en": "Mexico",
+        "ja": "メキシコ",
+        "ja_typings": [
+          "mekishiko"
+        ]
+      },
+      {
+        "en": "United Kingdom",
+        "ja": "イギリス",
+        "ja_typings": [
+          "igirisu",
+          "igilisu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03302",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country has its capital at Washington, D.C.?",
+      "ja": "首都がワシントンD.C.の国はどこ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yemen",
+        "ja": "イエメン",
+        "ja_typings": [
+          "iemen"
+        ]
+      },
+      {
+        "en": "Oman",
+        "ja": "オマーン",
+        "ja_typings": [
+          "omaa-n",
+          "oma-n"
+        ]
+      },
+      {
+        "en": "Qatar",
+        "ja": "カタール",
+        "ja_typings": [
+          "kataa-ru",
+          "kataa-lu",
+          "kata-ru"
+        ]
+      },
+      {
+        "en": "Bahrain",
+        "ja": "バーレーン",
+        "ja_typings": [
+          "baa-re-n",
+          "baa-le-n",
+          "ba-re-n"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03303",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country's capital is Sana'a in the Arabian Peninsula?",
+      "ja": "首都がサヌアであるアラビア半島の国はどこ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "amphibians",
+        "ja": "両生類",
+        "ja_typings": [
+          "riyouseirui",
+          "ryouseirui"
+        ]
+      },
+      {
+        "en": "reptiles",
+        "ja": "爬虫類",
+        "ja_typings": [
+          "hatiyuurui",
+          "hachuurui"
+        ]
+      },
+      {
+        "en": "mammals",
+        "ja": "哺乳類",
+        "ja_typings": [
+          "honiyuurui",
+          "honyuurui"
+        ]
+      },
+      {
+        "en": "fish",
+        "ja": "魚類",
+        "ja_typings": [
+          "gyorui"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03304",
+    "image_path": null,
+    "question_text": {
+      "en": "Frogs and salamanders belong to which class of animals?",
+      "ja": "カエルやサンショウウオが属する動物の綱はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "every 2 years",
+        "ja": "2年ごと",
+        "ja_typings": [
+          "2nengoto"
+        ]
+      },
+      {
+        "en": "every 4 years",
+        "ja": "4年ごと",
+        "ja_typings": [
+          "4nengoto"
+        ]
+      },
+      {
+        "en": "every 3 years",
+        "ja": "3年ごと",
+        "ja_typings": [
+          "3nengoto"
+        ]
+      },
+      {
+        "en": "every 5 years",
+        "ja": "5年ごと",
+        "ja_typings": [
+          "5nengoto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03305",
+    "image_path": null,
+    "question_text": {
+      "en": "How often are the Summer Olympics normally held?",
+      "ja": "夏季オリンピックは通常何年ごとに開催される?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "every 5 years",
+        "ja": "5年ごと",
+        "ja_typings": [
+          "5nengoto"
+        ]
+      },
+      {
+        "en": "every 2 years",
+        "ja": "2年ごと",
+        "ja_typings": [
+          "2nengoto"
+        ]
+      },
+      {
+        "en": "every 3 years",
+        "ja": "3年ごと",
+        "ja_typings": [
+          "3nengoto"
+        ]
+      },
+      {
+        "en": "every 4 years",
+        "ja": "4年ごと",
+        "ja_typings": [
+          "4nengoto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03306",
+    "image_path": null,
+    "question_text": {
+      "en": "How often is the World Athletics Championships held in odd years (recently)?",
+      "ja": "近年、世界陸上は何年ごとに開催される?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "flash of lightning",
+        "ja": "稲妻の光",
+        "ja_typings": [
+          "inazumanohikari"
+        ]
+      },
+      {
+        "en": "flash of a camera",
+        "ja": "カメラのフラッシュ",
+        "ja_typings": [
+          "kameranohuratusiyu",
+          "kameranofurasshu"
+        ]
+      },
+      {
+        "en": "city neon lights",
+        "ja": "ネオンの輝き",
+        "ja_typings": [
+          "neonnokagayaki"
+        ]
+      },
+      {
+        "en": "torch flame",
+        "ja": "松明の炎",
+        "ja_typings": [
+          "taimatunohonoo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03307",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the kanji 電 (as in 電光) literally depict?",
+      "ja": "「電光石火」の「電光」が指すのはどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "footprint of a runner",
+        "ja": "俊足の走者",
+        "ja_typings": [
+          "siyunsokunosousiya",
+          "shunsokunosousha"
+        ]
+      },
+      {
+        "en": "god of war",
+        "ja": "戦の神",
+        "ja_typings": [
+          "ikusanokami"
+        ]
+      },
+      {
+        "en": "temple guardian",
+        "ja": "寺院の守護神",
+        "ja_typings": [
+          "jiinnosiyugosin"
+        ]
+      },
+      {
+        "en": "running deer",
+        "ja": "走る鹿",
+        "ja_typings": [
+          "hasiruxsika"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03308",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the kanji 韋 in 韋駄天 originally evoke as an image?",
+      "ja": "「韋駄天走り」のもとになるイメージはどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "four doubles",
+        "ja": "4二塁打",
+        "ja_typings": [
+          "4niruida"
+        ]
+      },
+      {
+        "en": "cycle hit",
+        "ja": "サイクルヒット",
+        "ja_typings": [
+          "saikuruhitututo",
+          "saikuluhitto",
+          "saikuruhitto"
+        ]
+      },
+      {
+        "en": "four home runs",
+        "ja": "4本塁打",
+        "ja_typings": [
+          "4honruida"
+        ]
+      },
+      {
+        "en": "perfect day",
+        "ja": "パーフェクトデー",
+        "ja_typings": [
+          "paa-huxekutode-",
+          "pa-fekutode-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03309",
+    "image_path": null,
+    "question_text": {
+      "en": "In baseball, hitting four doubles in a single game is colloquially what?",
+      "ja": "野球で1試合に二塁打を4本打つことを何と呼ぶ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "four home runs",
+        "ja": "4本塁打",
+        "ja_typings": [
+          "4honruida"
+        ]
+      },
+      {
+        "en": "four doubles",
+        "ja": "4二塁打",
+        "ja_typings": [
+          "4niruida"
+        ]
+      },
+      {
+        "en": "grand slam",
+        "ja": "満塁本塁打",
+        "ja_typings": [
+          "manruihonruida"
+        ]
+      },
+      {
+        "en": "cycle hit",
+        "ja": "サイクルヒット",
+        "ja_typings": [
+          "saikuruhitututo",
+          "saikuruhitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03310",
+    "image_path": null,
+    "question_text": {
+      "en": "In baseball, what do you call hitting four home runs in one game?",
+      "ja": "野球で1試合に本塁打を4本打つことを何と呼ぶ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "frog",
+        "ja": "カエル",
+        "ja_typings": [
+          "kaeru",
+          "kaelu"
+        ]
+      },
+      {
+        "en": "salamander",
+        "ja": "サンショウウオ",
+        "ja_typings": [
+          "sansiyouuo",
+          "sanshouuo",
+          "sanshouo"
+        ]
+      },
+      {
+        "en": "newt",
+        "ja": "イモリ",
+        "ja_typings": [
+          "imori",
+          "imoli"
+        ]
+      },
+      {
+        "en": "caecilian",
+        "ja": "アシナシイモリ",
+        "ja_typings": [
+          "ashinashiimori"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03311",
+    "image_path": null,
+    "question_text": {
+      "en": "Which amphibian is known for metamorphosing from a tadpole?",
+      "ja": "オタマジャクシから変態することで知られる両生類はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "fruit",
+        "ja": "果実",
+        "ja_typings": [
+          "kajitsu"
+        ]
+      },
+      {
+        "en": "flower",
+        "ja": "花",
+        "ja_typings": [
+          "hana"
+        ]
+      },
+      {
+        "en": "leaf",
+        "ja": "葉",
+        "ja_typings": [
+          "ha"
+        ]
+      },
+      {
+        "en": "stem",
+        "ja": "茎",
+        "ja_typings": [
+          "kuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03312",
+    "image_path": null,
+    "question_text": {
+      "en": "What part of a plant typically develops from a fertilized flower and contains seeds?",
+      "ja": "受粉した花が成熟してできる、種子を含む部分はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "magnetic sense",
+        "ja": "磁気感覚",
+        "ja_typings": [
+          "jikikankaku"
+        ]
+      },
+      {
+        "en": "sense of smell",
+        "ja": "嗅覚",
+        "ja_typings": [
+          "kiyuukaku",
+          "kyuukaku"
+        ]
+      },
+      {
+        "en": "night vision",
+        "ja": "夜視力",
+        "ja_typings": [
+          "yasiriyoku",
+          "yashiryoku"
+        ]
+      },
+      {
+        "en": "echolocation",
+        "ja": "反響定位",
+        "ja_typings": [
+          "hankiyouteii",
+          "hankyouteii"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03313",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sense allows some animals to navigate using Earth's field?",
+      "ja": "地磁気を使ってナビゲーションする動物が持つ感覚はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "meat",
+        "ja": "肉",
+        "ja_typings": [
+          "niku"
+        ]
+      },
+      {
+        "en": "fruit",
+        "ja": "果実",
+        "ja_typings": [
+          "kajitsu"
+        ]
+      },
+      {
+        "en": "grain",
+        "ja": "穀物",
+        "ja_typings": [
+          "kokumotsu"
+        ]
+      },
+      {
+        "en": "vegetable",
+        "ja": "野菜",
+        "ja_typings": [
+          "yasai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03314",
+    "image_path": null,
+    "question_text": {
+      "en": "Which food group is the primary source of animal protein in many diets?",
+      "ja": "多くの食生活で動物性たんぱく質の主な供給源はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "night vision",
+        "ja": "夜視力",
+        "ja_typings": [
+          "yasiriyoku",
+          "yashiryoku"
+        ]
+      },
+      {
+        "en": "magnetic sense",
+        "ja": "磁気感覚",
+        "ja_typings": [
+          "jikikankaku"
+        ]
+      },
+      {
+        "en": "echolocation",
+        "ja": "反響定位",
+        "ja_typings": [
+          "hankiyouteii"
+        ]
+      },
+      {
+        "en": "color vision",
+        "ja": "色覚",
+        "ja_typings": [
+          "shikikaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03315",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ability lets owls and cats hunt in very low light?",
+      "ja": "フクロウやネコが暗所で狩りができる視覚能力はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "pigeon",
+        "ja": "ハト",
+        "ja_typings": [
+          "hato"
+        ]
+      },
+      {
+        "en": "crow",
+        "ja": "カラス",
+        "ja_typings": [
+          "karasu",
+          "kalasu"
+        ]
+      },
+      {
+        "en": "sparrow",
+        "ja": "スズメ",
+        "ja_typings": [
+          "suzume"
+        ]
+      },
+      {
+        "en": "eagle",
+        "ja": "ワシ",
+        "ja_typings": [
+          "washi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03316",
+    "image_path": null,
+    "question_text": {
+      "en": "Which bird is famous for its homing ability and is often white in symbolism?",
+      "ja": "帰巣本能で知られ、平和の象徴とされる鳥はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "rabbit",
+        "ja": "ウサギ",
+        "ja_typings": [
+          "usagi"
+        ]
+      },
+      {
+        "en": "hare",
+        "ja": "ノウサギ",
+        "ja_typings": [
+          "nousagi",
+          "nosagi"
+        ]
+      },
+      {
+        "en": "squirrel",
+        "ja": "リス",
+        "ja_typings": [
+          "risu",
+          "lisu"
+        ]
+      },
+      {
+        "en": "guinea pig",
+        "ja": "モルモット",
+        "ja_typings": [
+          "morumotutoto",
+          "molumotto",
+          "morumotto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03317",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mammal is famous for long ears and rapid reproduction?",
+      "ja": "長い耳と繁殖力で知られる哺乳類はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "reptiles",
+        "ja": "爬虫類",
+        "ja_typings": [
+          "hatiyuurui",
+          "hachuurui"
+        ]
+      },
+      {
+        "en": "amphibians",
+        "ja": "両生類",
+        "ja_typings": [
+          "riyouseirui"
+        ]
+      },
+      {
+        "en": "mammals",
+        "ja": "哺乳類",
+        "ja_typings": [
+          "honiyuurui"
+        ]
+      },
+      {
+        "en": "birds",
+        "ja": "鳥類",
+        "ja_typings": [
+          "tiyourui",
+          "chourui"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03318",
+    "image_path": null,
+    "question_text": {
+      "en": "Snakes, turtles and lizards belong to which class of animals?",
+      "ja": "ヘビ・カメ・トカゲが属する動物の綱はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "sense of smell",
+        "ja": "嗅覚",
+        "ja_typings": [
+          "kiyuukaku",
+          "kyuukaku"
+        ]
+      },
+      {
+        "en": "magnetic sense",
+        "ja": "磁気感覚",
+        "ja_typings": [
+          "jikikankaku"
+        ]
+      },
+      {
+        "en": "night vision",
+        "ja": "夜視力",
+        "ja_typings": [
+          "yasiriyoku"
+        ]
+      },
+      {
+        "en": "hearing",
+        "ja": "聴覚",
+        "ja_typings": [
+          "tiyoukaku",
+          "choukaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03319",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sense do dogs use exceptionally well to track prey or people?",
+      "ja": "犬が獲物や人を追跡するときに特に優れている感覚はどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "three strikeouts",
+        "ja": "3三振",
+        "ja_typings": [
+          "3sanshin"
+        ]
+      },
+      {
+        "en": "perfect inning",
+        "ja": "完全イニング",
+        "ja_typings": [
+          "kanzeniningu"
+        ]
+      },
+      {
+        "en": "immaculate inning",
+        "ja": "イマキュレートイニング",
+        "ja_typings": [
+          "imakiyure-toiningu",
+          "imakyure-toiningu"
+        ]
+      },
+      {
+        "en": "no-hitter",
+        "ja": "ノーヒッター",
+        "ja_typings": [
+          "noo-hitutaa-",
+          "noo-hittaa-",
+          "no-hitta-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03320",
+    "image_path": null,
+    "question_text": {
+      "en": "In baseball, getting three strikeouts in one inning is called what?",
+      "ja": "野球で1イニングに3つ三振を取ることを何と呼ぶ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "trail of an arrow",
+        "ja": "矢の軌跡",
+        "ja_typings": [
+          "yanokiseki"
+        ]
+      },
+      {
+        "en": "shadow of a bird",
+        "ja": "鳥の影",
+        "ja_typings": [
+          "torinokage"
+        ]
+      },
+      {
+        "en": "smoke of a fire",
+        "ja": "火の煙",
+        "ja_typings": [
+          "hinokemuri"
+        ]
+      },
+      {
+        "en": "ripple of water",
+        "ja": "水の波紋",
+        "ja_typings": [
+          "mizunohamon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "general_knowledge",
+    "id": "q03321",
+    "image_path": null,
+    "question_text": {
+      "en": "What does an arrow leave behind in flight, often used as an idiom?",
+      "ja": "矢が飛んだ後に残るとされる、慣用句にもなるものはどれ?"
     }
   }
 ]

--- a/data/questions_ja.json
+++ b/data/questions_ja.json
@@ -101447,8 +101447,8 @@
     "id": "q02503",
     "image_path": null,
     "question_text": {
-      "en": "エジプトの地中海沿岸に位置し、古代に大図書館があった都市は?",
-      "ja": "Which Egyptian city on the Mediterranean coast was home to a famous ancient library?"
+      "en": "Which Egyptian city on the Mediterranean coast was home to a famous ancient library?",
+      "ja": "エジプトの地中海沿岸に位置し、古代に大図書館があった都市は?"
     }
   },
   {
@@ -101491,8 +101491,8 @@
     "id": "q02504",
     "image_path": null,
     "question_text": {
-      "en": "南米大陸を流れる世界最大級の流域面積を持つ川は?",
-      "ja": "Which river in South America has one of the largest drainage basins in the world?"
+      "en": "Which river in South America has one of the largest drainage basins in the world?",
+      "ja": "南米大陸を流れる世界最大級の流域面積を持つ川は?"
     }
   },
   {
@@ -101531,8 +101531,8 @@
     "id": "q02505",
     "image_path": null,
     "question_text": {
-      "en": "地球で最も北に位置する海洋は?",
-      "ja": "Which is the northernmost ocean on Earth?"
+      "en": "Which is the northernmost ocean on Earth?",
+      "ja": "地球で最も北に位置する海洋は?"
     }
   },
   {
@@ -101571,8 +101571,8 @@
     "id": "q02506",
     "image_path": null,
     "question_text": {
-      "en": "北海道のほぼ中央にあり、上川盆地に位置する都市は?",
-      "ja": "Which Hokkaido city is located in the Kamikawa Basin near the center of the island?"
+      "en": "Which Hokkaido city is located in the Kamikawa Basin near the center of the island?",
+      "ja": "北海道のほぼ中央にあり、上川盆地に位置する都市は?"
     }
   },
   {
@@ -101611,8 +101611,8 @@
     "id": "q02507",
     "image_path": null,
     "question_text": {
-      "en": "世界で最も広い大陸は?",
-      "ja": "Which is the largest continent in the world?"
+      "en": "Which is the largest continent in the world?",
+      "ja": "世界で最も広い大陸は?"
     }
   },
   {
@@ -101651,8 +101651,8 @@
     "id": "q02508",
     "image_path": null,
     "question_text": {
-      "en": "パラグアイの首都は?",
-      "ja": "What is the capital of Paraguay?"
+      "en": "What is the capital of Paraguay?",
+      "ja": "パラグアイの首都は?"
     }
   },
   {
@@ -101691,8 +101691,8 @@
     "id": "q02509",
     "image_path": null,
     "question_text": {
-      "en": "ヨーロッパとアメリカ大陸の間に広がる海洋は?",
-      "ja": "Which ocean lies between Europe and the Americas?"
+      "en": "Which ocean lies between Europe and the Americas?",
+      "ja": "ヨーロッパとアメリカ大陸の間に広がる海洋は?"
     }
   },
   {
@@ -101731,8 +101731,8 @@
     "id": "q02510",
     "image_path": null,
     "question_text": {
-      "en": "北アフリカを横断する大山脈は?",
-      "ja": "Which mountain range stretches across North Africa?"
+      "en": "Which mountain range stretches across North Africa?",
+      "ja": "北アフリカを横断する大山脈は?"
     }
   },
   {
@@ -101771,8 +101771,8 @@
     "id": "q02511",
     "image_path": null,
     "question_text": {
-      "en": "インドのIT産業の中心地として知られる都市は?",
-      "ja": "Which Indian city is known as the center of the IT industry?"
+      "en": "Which Indian city is known as the center of the IT industry?",
+      "ja": "インドのIT産業の中心地として知られる都市は?"
     }
   },
   {
@@ -101811,8 +101811,8 @@
     "id": "q02512",
     "image_path": null,
     "question_text": {
-      "en": "サグラダ・ファミリアがあるスペイン東部の都市は?",
-      "ja": "Which city in eastern Spain is home to the Sagrada Familia?"
+      "en": "Which city in northeastern Spain is home to the Sagrada Familia?",
+      "ja": "サグラダ・ファミリアがあるスペイン北東部の都市は?"
     }
   },
   {
@@ -101851,8 +101851,8 @@
     "id": "q02513",
     "image_path": null,
     "question_text": {
-      "en": "ドイツの首都は?",
-      "ja": "What is the capital of Germany?"
+      "en": "What is the capital of Germany?",
+      "ja": "ドイツの首都は?"
     }
   },
   {
@@ -101891,8 +101891,8 @@
     "id": "q02514",
     "image_path": null,
     "question_text": {
-      "en": "ヒマラヤ山脈にある「幸福度」で知られる国は?",
-      "ja": "Which Himalayan country is known for its focus on Gross National Happiness?"
+      "en": "Which Himalayan country is known for its focus on Gross National Happiness?",
+      "ja": "ヒマラヤ山脈にある「幸福度」で知られる国は?"
     }
   },
   {
@@ -101935,8 +101935,8 @@
     "id": "q02515",
     "image_path": null,
     "question_text": {
-      "en": "東南アジアにある世界で3番目に大きい島は?",
-      "ja": "Which is the third largest island in the world, located in Southeast Asia?"
+      "en": "Which is the third largest island in the world, located in Southeast Asia?",
+      "ja": "東南アジアにある世界で3番目に大きい島は?"
     }
   },
   {
@@ -101975,8 +101975,8 @@
     "id": "q02516",
     "image_path": null,
     "question_text": {
-      "en": "イグアスの滝が国境にある国の組み合わせは?",
-      "ja": "Iguazu Falls lies on the border between which two countries?"
+      "en": "Iguazu Falls lies on the border between which two countries?",
+      "ja": "イグアスの滝が国境にある国の組み合わせは?"
     }
   },
   {
@@ -102015,8 +102015,8 @@
     "id": "q02517",
     "image_path": null,
     "question_text": {
-      "en": "アルゼンチンの首都は?",
-      "ja": "What is the capital of Argentina?"
+      "en": "What is the capital of Argentina?",
+      "ja": "アルゼンチンの首都は?"
     }
   },
   {
@@ -102055,8 +102055,8 @@
     "id": "q02518",
     "image_path": null,
     "question_text": {
-      "en": "トルコ北西部の旧オスマン帝国首都として知られる都市は?",
-      "ja": "Which northwestern Turkish city was a former capital of the Ottoman Empire?"
+      "en": "Which northwestern Turkish city was a former capital of the Ottoman Empire?",
+      "ja": "トルコ北西部の旧オスマン帝国首都として知られる都市は?"
     }
   },
   {
@@ -102095,8 +102095,8 @@
     "id": "q02519",
     "image_path": null,
     "question_text": {
-      "en": "韓国第2の都市で南東部の主要港湾都市は?",
-      "ja": "Which is South Korea's second largest city and a major southeastern port?"
+      "en": "Which is South Korea's second largest city and a major southeastern port?",
+      "ja": "韓国第2の都市で南東部の主要港湾都市は?"
     }
   },
   {
@@ -102135,8 +102135,8 @@
     "id": "q02520",
     "image_path": null,
     "question_text": {
-      "en": "メキシコ・ユカタン半島のリゾート都市は?",
-      "ja": "Which resort city is on Mexico's Yucatan Peninsula?"
+      "en": "Which resort city is on Mexico's Yucatan Peninsula?",
+      "ja": "メキシコ・ユカタン半島のリゾート都市は?"
     }
   },
   {
@@ -102175,8 +102175,8 @@
     "id": "q02521",
     "image_path": null,
     "question_text": {
-      "en": "アゼルバイジャンのバクーがあるのは?",
-      "ja": "Baku, the capital of Azerbaijan, is located on which shore?"
+      "en": "Baku, the capital of Azerbaijan, is located on which shore?",
+      "ja": "アゼルバイジャンのバクーがあるのは?"
     }
   },
   {
@@ -102215,8 +102215,8 @@
     "id": "q02522",
     "image_path": null,
     "question_text": {
-      "en": "黒海とカスピ海の間に広がる山脈は?",
-      "ja": "Which mountain range lies between the Black Sea and the Caspian Sea?"
+      "en": "Which mountain range lies between the Black Sea and the Caspian Sea?",
+      "ja": "黒海とカスピ海の間に広がる山脈は?"
     }
   },
   {
@@ -102255,8 +102255,8 @@
     "id": "q02523",
     "image_path": null,
     "question_text": {
-      "en": "アメリカ五大湖のミシガン湖畔に位置する都市は?",
-      "ja": "Which U.S. city is located on the shore of Lake Michigan?"
+      "en": "Which U.S. city is located on the shore of Lake Michigan?",
+      "ja": "アメリカ五大湖のミシガン湖畔に位置する都市は?"
     }
   },
   {
@@ -102295,8 +102295,8 @@
     "id": "q02524",
     "image_path": null,
     "question_text": {
-      "en": "ペロポネソス半島の付け根にある古代ギリシャの都市は?",
-      "ja": "Which ancient Greek city stood at the isthmus of the Peloponnese?"
+      "en": "Which ancient Greek city stood at the isthmus of the Peloponnese?",
+      "ja": "ペロポネソス半島の付け根にある古代ギリシャの都市は?"
     }
   },
   {
@@ -102335,8 +102335,8 @@
     "id": "q02525",
     "image_path": null,
     "question_text": {
-      "en": "ベトナム中部の主要港湾都市は?",
-      "ja": "Which city is a major port in central Vietnam?"
+      "en": "Which city is a major port in central Vietnam?",
+      "ja": "ベトナム中部の主要港湾都市は?"
     }
   },
   {
@@ -102375,8 +102375,8 @@
     "id": "q02526",
     "image_path": null,
     "question_text": {
-      "en": "アイルランドの首都は?",
-      "ja": "What is the capital of Ireland?"
+      "en": "What is the capital of Ireland?",
+      "ja": "アイルランドの首都は?"
     }
   },
   {
@@ -102415,8 +102415,8 @@
     "id": "q02527",
     "image_path": null,
     "question_text": {
-      "en": "スコットランドの首都は?",
-      "ja": "What is the capital of Scotland?"
+      "en": "What is the capital of Scotland?",
+      "ja": "スコットランドの首都は?"
     }
   },
   {
@@ -102455,8 +102455,8 @@
     "id": "q02528",
     "image_path": null,
     "question_text": {
-      "en": "イタリアのトスカーナ州の州都でルネサンス発祥の地は?",
-      "ja": "Which Tuscan city is known as the birthplace of the Renaissance?"
+      "en": "Which Tuscan city is known as the birthplace of the Renaissance?",
+      "ja": "イタリアのトスカーナ州の州都でルネサンス発祥の地は?"
     }
   },
   {
@@ -102495,8 +102495,8 @@
     "id": "q02529",
     "image_path": null,
     "question_text": {
-      "en": "ドイツの金融の中心地として知られる都市は?",
-      "ja": "Which German city is the country's financial center?"
+      "en": "Which German city is the country's financial center?",
+      "ja": "ドイツの金融の中心地として知られる都市は?"
     }
   },
   {
@@ -102535,8 +102535,8 @@
     "id": "q02530",
     "image_path": null,
     "question_text": {
-      "en": "沖縄本島中部の都市で米軍基地が多いことで知られるのは?",
-      "ja": "Which Okinawan city is known for hosting many U.S. military bases?"
+      "en": "Which Okinawan city is known for hosting many U.S. military bases?",
+      "ja": "沖縄本島中部の都市で米軍基地が多いことで知られるのは?"
     }
   },
   {
@@ -102575,8 +102575,8 @@
     "id": "q02531",
     "image_path": null,
     "question_text": {
-      "en": "ピラミッドとスフィンクスがあるエジプトの都市は?",
-      "ja": "Which Egyptian city is home to the pyramids and the Sphinx?"
+      "en": "Which Egyptian city is home to the pyramids and the Sphinx?",
+      "ja": "ピラミッドとスフィンクスがあるエジプトの都市は?"
     }
   },
   {
@@ -102617,8 +102617,8 @@
     "id": "q02532",
     "image_path": null,
     "question_text": {
-      "en": "世界最大の島でデンマーク自治領なのは?",
-      "ja": "Which is the world's largest island, an autonomous territory of Denmark?"
+      "en": "Which is the world's largest island, an autonomous territory of Denmark?",
+      "ja": "世界最大の島でデンマーク自治領なのは?"
     }
   },
   {
@@ -102657,8 +102657,8 @@
     "id": "q02533",
     "image_path": null,
     "question_text": {
-      "en": "メキシコ第2の都市でテキーラの産地として有名な都市は?",
-      "ja": "Which Mexican city is famous as the home of tequila?"
+      "en": "Which Mexican city is famous as the home of tequila?",
+      "ja": "メキシコ第2の都市でテキーラの産地として有名な都市は?"
     }
   },
   {
@@ -102697,8 +102697,8 @@
     "id": "q02534",
     "image_path": null,
     "question_text": {
-      "en": "北海道南部にある夜景が有名な港町は?",
-      "ja": "Which Hokkaido port town is famous for its night view?"
+      "en": "Which Hokkaido port town is famous for its night view?",
+      "ja": "北海道南部にある夜景が有名な港町は?"
     }
   },
   {
@@ -102737,8 +102737,8 @@
     "id": "q02535",
     "image_path": null,
     "question_text": {
-      "en": "ドイツ北部の主要港湾都市は?",
-      "ja": "Which city is a major northern German port?"
+      "en": "Which city is a major northern German port?",
+      "ja": "ドイツ北部の主要港湾都市は?"
     }
   },
   {
@@ -102777,8 +102777,8 @@
     "id": "q02536",
     "image_path": null,
     "question_text": {
-      "en": "ベトナムの首都は?",
-      "ja": "What is the capital of Vietnam?"
+      "en": "What is the capital of Vietnam?",
+      "ja": "ベトナムの首都は?"
     }
   },
   {
@@ -102817,8 +102817,8 @@
     "id": "q02537",
     "image_path": null,
     "question_text": {
-      "en": "ベトナム南部最大の都市は?",
-      "ja": "Which is the largest city in southern Vietnam?"
+      "en": "Which is the largest city in southern Vietnam?",
+      "ja": "ベトナム南部最大の都市は?"
     }
   },
   {
@@ -102857,8 +102857,8 @@
     "id": "q02538",
     "image_path": null,
     "question_text": {
-      "en": "中国南部にある特別行政区で金融センターとして知られる都市は?",
-      "ja": "Which Special Administrative Region of southern China is a major financial hub?"
+      "en": "Which Special Administrative Region of southern China is a major financial hub?",
+      "ja": "中国南部にある特別行政区で金融センターとして知られる都市は?"
     }
   },
   {
@@ -102897,8 +102897,8 @@
     "id": "q02539",
     "image_path": null,
     "question_text": {
-      "en": "ベトナム中部の旧王朝の都は?",
-      "ja": "Which central Vietnamese city was the imperial capital under the Nguyen dynasty?"
+      "en": "Which central Vietnamese city was the imperial capital under the Nguyen dynasty?",
+      "ja": "ベトナム中部の旧王朝の都は?"
     }
   },
   {
@@ -102937,8 +102937,8 @@
     "id": "q02540",
     "image_path": null,
     "question_text": {
-      "en": "韓国の国際空港があるソウル近郊の港湾都市は?",
-      "ja": "Which port city near Seoul hosts South Korea's main international airport?"
+      "en": "Which port city near Seoul hosts South Korea's main international airport?",
+      "ja": "韓国の国際空港があるソウル近郊の港湾都市は?"
     }
   },
   {
@@ -102977,8 +102977,8 @@
     "id": "q02541",
     "image_path": null,
     "question_text": {
-      "en": "南アジアで人口最多の国は?",
-      "ja": "Which is the most populous country in South Asia?"
+      "en": "Which is the most populous country in South Asia?",
+      "ja": "南アジアで人口最多の国は?"
     }
   },
   {
@@ -103017,8 +103017,8 @@
     "id": "q02542",
     "image_path": null,
     "question_text": {
-      "en": "アフリカとオーストラリアの間に広がる海洋は?",
-      "ja": "Which ocean lies between Africa and Australia?"
+      "en": "Which ocean lies between Africa and Australia?",
+      "ja": "アフリカとオーストラリアの間に広がる海洋は?"
     }
   },
   {
@@ -103058,8 +103058,8 @@
     "id": "q02543",
     "image_path": null,
     "question_text": {
-      "en": "八重山諸島の中心の島は?",
-      "ja": "Which is the main island of the Yaeyama Islands?"
+      "en": "Which is the main island of the Yaeyama Islands?",
+      "ja": "八重山諸島の中心の島は?"
     }
   },
   {
@@ -103102,8 +103102,8 @@
     "id": "q02544",
     "image_path": null,
     "question_text": {
-      "en": "北海道で最長の川は?",
-      "ja": "Which is the longest river in Hokkaido?"
+      "en": "Which is the longest river in Hokkaido?",
+      "ja": "北海道で最長の川は?"
     }
   },
   {
@@ -103142,8 +103142,8 @@
     "id": "q02545",
     "image_path": null,
     "question_text": {
-      "en": "トルコ第3の都市でエーゲ海沿岸の港湾都市は?",
-      "ja": "Which is Turkey's third largest city, a port on the Aegean coast?"
+      "en": "Which is Turkey's third largest city, a port on the Aegean coast?",
+      "ja": "トルコ第3の都市でエーゲ海沿岸の港湾都市は?"
     }
   },
   {
@@ -103182,8 +103182,8 @@
     "id": "q02546",
     "image_path": null,
     "question_text": {
-      "en": "サウジアラビアの紅海沿岸の主要都市は?",
-      "ja": "Which is Saudi Arabia's main city on the Red Sea coast?"
+      "en": "Which is Saudi Arabia's main city on the Red Sea coast?",
+      "ja": "サウジアラビアの紅海沿岸の主要都市は?"
     }
   },
   {
@@ -103222,8 +103222,8 @@
     "id": "q02547",
     "image_path": null,
     "question_text": {
-      "en": "南部アフリカに広がる砂漠は?",
-      "ja": "Which desert covers much of southern Africa?"
+      "en": "Which desert covers much of southern Africa?",
+      "ja": "南部アフリカに広がる砂漠は?"
     }
   },
   {
@@ -103263,8 +103263,8 @@
     "id": "q02548",
     "image_path": null,
     "question_text": {
-      "en": "本州と九州を結ぶ関門海峡にかかる橋は?",
-      "ja": "Which bridge spans the Kanmon Strait between Honshu and Kyushu?"
+      "en": "Which bridge spans the Kanmon Strait between Honshu and Kyushu?",
+      "ja": "本州と九州を結ぶ関門海峡にかかる橋は?"
     }
   },
   {
@@ -103303,8 +103303,8 @@
     "id": "q02549",
     "image_path": null,
     "question_text": {
-      "en": "インド東部の大都市で旧称カルカッタの都市は?",
-      "ja": "Which large eastern Indian city was formerly called Calcutta?"
+      "en": "Which large eastern Indian city was formerly called Calcutta?",
+      "ja": "インド東部の大都市で旧称カルカッタの都市は?"
     }
   },
   {
@@ -103343,8 +103343,8 @@
     "id": "q02550",
     "image_path": null,
     "question_text": {
-      "en": "北海道道東にある霧で有名な港町は?",
-      "ja": "Which port town in eastern Hokkaido is famous for its fog?"
+      "en": "Which port town in eastern Hokkaido is famous for its fog?",
+      "ja": "北海道道東にある霧で有名な港町は?"
     }
   },
   {
@@ -103383,8 +103383,8 @@
     "id": "q02551",
     "image_path": null,
     "question_text": {
-      "en": "ジブチにある世界で最も標高の低い湖は?",
-      "ja": "Which lake in Djibouti is the lowest point on land?"
+      "en": "Which lake in Djibouti is the lowest point on land?",
+      "ja": "ジブチにある世界で最も標高の低い湖は?"
     }
   },
   {
@@ -103423,8 +103423,8 @@
     "id": "q02552",
     "image_path": null,
     "question_text": {
-      "en": "福島県にある日本で4番目に大きい湖は?",
-      "ja": "Which Fukushima lake is the fourth largest in Japan?"
+      "en": "Which Fukushima lake is the fourth largest in Japan?",
+      "ja": "福島県にある日本で4番目に大きい湖は?"
     }
   },
   {
@@ -103463,8 +103463,8 @@
     "id": "q02553",
     "image_path": null,
     "question_text": {
-      "en": "茨城県にある日本で2番目に大きい湖は?",
-      "ja": "Which Ibaraki lake is the second largest in Japan?"
+      "en": "Which Ibaraki lake is the second largest in Japan?",
+      "ja": "茨城県にある日本で2番目に大きい湖は?"
     }
   },
   {
@@ -103503,8 +103503,8 @@
     "id": "q02554",
     "image_path": null,
     "question_text": {
-      "en": "北海道東部のオホーツク海に面した日本最大の汽水湖は?",
-      "ja": "Which is Japan's largest brackish lake, on Hokkaido's Sea of Okhotsk coast?"
+      "en": "Which is Japan's largest brackish lake, on Hokkaido's Sea of Okhotsk coast?",
+      "ja": "北海道東部のオホーツク海に面した日本最大の汽水湖は?"
     }
   },
   {
@@ -103543,8 +103543,8 @@
     "id": "q02555",
     "image_path": null,
     "question_text": {
-      "en": "アメリカ・カリフォルニア州南部の大都市は?",
-      "ja": "Which is the largest city in Southern California?"
+      "en": "Which is the largest city in Southern California?",
+      "ja": "アメリカ・カリフォルニア州南部の大都市は?"
     }
   },
   {
@@ -103583,8 +103583,8 @@
     "id": "q02556",
     "image_path": null,
     "question_text": {
-      "en": "エジプト南部にあるカルナック神殿で有名な都市は?",
-      "ja": "Which southern Egyptian city is famous for the Karnak Temple?"
+      "en": "Which southern Egyptian city is famous for the Karnak Temple?",
+      "ja": "エジプト南部にあるカルナック神殿で有名な都市は?"
     }
   },
   {
@@ -103625,8 +103625,8 @@
     "id": "q02557",
     "image_path": null,
     "question_text": {
-      "en": "アフリカ南東沖にある世界で4番目に大きい島は?",
-      "ja": "Which is the fourth largest island in the world, off southeastern Africa?"
+      "en": "Which is the fourth largest island in the world, off southeastern Africa?",
+      "ja": "アフリカ南東沖にある世界で4番目に大きい島は?"
     }
   },
   {
@@ -103665,8 +103665,8 @@
     "id": "q02558",
     "image_path": null,
     "question_text": {
-      "en": "スペインの首都は?",
-      "ja": "What is the capital of Spain?"
+      "en": "What is the capital of Spain?",
+      "ja": "スペインの首都は?"
     }
   },
   {
@@ -103705,8 +103705,8 @@
     "id": "q02559",
     "image_path": null,
     "question_text": {
-      "en": "イギリス北西部の工業都市でサッカーが盛んな都市は?",
-      "ja": "Which northwestern English industrial city is famous for football?"
+      "en": "Which northwestern English industrial city is famous for football?",
+      "ja": "イギリス北西部の工業都市でサッカーが盛んな都市は?"
     }
   },
   {
@@ -103745,8 +103745,8 @@
     "id": "q02560",
     "image_path": null,
     "question_text": {
-      "en": "イスラム教最大の聖地はサウジアラビアの?",
-      "ja": "Which Saudi Arabian city is Islam's holiest site?"
+      "en": "Which Saudi Arabian city is Islam's holiest site?",
+      "ja": "イスラム教最大の聖地はサウジアラビアの?"
     }
   },
   {
@@ -103785,8 +103785,8 @@
     "id": "q02561",
     "image_path": null,
     "question_text": {
-      "en": "イスラム教第2の聖地で預言者ムハンマドの墓がある都市は?",
-      "ja": "Which city is Islam's second holiest, home to the Prophet Muhammad's tomb?"
+      "en": "Which city is Islam's second holiest, home to the Prophet Muhammad's tomb?",
+      "ja": "イスラム教第2の聖地で預言者ムハンマドの墓がある都市は?"
     }
   },
   {
@@ -103825,8 +103825,8 @@
     "id": "q02562",
     "image_path": null,
     "question_text": {
-      "en": "イスラエルのテルアビブやレバノンのベイルートが面しているのは?",
-      "ja": "Tel Aviv and Beirut both face which coastal region?"
+      "en": "Tel Aviv and Beirut both face which coastal region?",
+      "ja": "イスラエルのテルアビブやレバノンのベイルートが面しているのは?"
     }
   },
   {
@@ -103865,8 +103865,8 @@
     "id": "q02563",
     "image_path": null,
     "question_text": {
-      "en": "イタリア北部の経済の中心地でファッションの都は?",
-      "ja": "Which northern Italian city is its economic and fashion capital?"
+      "en": "Which northern Italian city is its economic and fashion capital?",
+      "ja": "イタリア北部の経済の中心地でファッションの都は?"
     }
   },
   {
@@ -103909,8 +103909,8 @@
     "id": "q02564",
     "image_path": null,
     "question_text": {
-      "en": "アメリカ中部を南北に貫く大河は?",
-      "ja": "Which great river runs north-south through the central United States?"
+      "en": "Which great river runs north-south through the central United States?",
+      "ja": "アメリカ中部を南北に貫く大河は?"
     }
   },
   {
@@ -103949,8 +103949,8 @@
     "id": "q02565",
     "image_path": null,
     "question_text": {
-      "en": "メキシコ北部の工業都市は?",
-      "ja": "Which northern Mexican city is a major industrial center?"
+      "en": "Which northern Mexican city is a major industrial center?",
+      "ja": "メキシコ北部の工業都市は?"
     }
   },
   {
@@ -103989,8 +103989,8 @@
     "id": "q02566",
     "image_path": null,
     "question_text": {
-      "en": "ウルグアイの首都は?",
-      "ja": "What is the capital of Uruguay?"
+      "en": "What is the capital of Uruguay?",
+      "ja": "ウルグアイの首都は?"
     }
   },
   {
@@ -104029,8 +104029,8 @@
     "id": "q02567",
     "image_path": null,
     "question_text": {
-      "en": "カナダ・ケベック州の最大都市は?",
-      "ja": "Which is the largest city in Quebec, Canada?"
+      "en": "Which is the largest city in Quebec, Canada?",
+      "ja": "カナダ・ケベック州の最大都市は?"
     }
   },
   {
@@ -104069,8 +104069,8 @@
     "id": "q02568",
     "image_path": null,
     "question_text": {
-      "en": "北アルプスにある標高3190mの山は?",
-      "ja": "Which Northern Japan Alps peak rises to 3190 meters?"
+      "en": "Which Northern Japan Alps peak rises to 3190 meters?",
+      "ja": "北アルプスにある標高3190mの山は?"
     }
   },
   {
@@ -104109,8 +104109,8 @@
     "id": "q02569",
     "image_path": null,
     "question_text": {
-      "en": "タンザニアにあるアフリカ最高峰は?",
-      "ja": "Which is Africa's highest mountain, located in Tanzania?"
+      "en": "Which is Africa's highest mountain, located in Tanzania?",
+      "ja": "タンザニアにあるアフリカ最高峰は?"
     }
   },
   {
@@ -104149,8 +104149,8 @@
     "id": "q02570",
     "image_path": null,
     "question_text": {
-      "en": "南アルプスにある標高3193mで日本第2位の高峰は?",
-      "ja": "Which Southern Japan Alps peak is Japan's second highest at 3193 meters?"
+      "en": "Which Southern Japan Alps peak is Japan's second highest at 3193 meters?",
+      "ja": "南アルプスにある標高3193mで日本第2位の高峰は?"
     }
   },
   {
@@ -104189,8 +104189,8 @@
     "id": "q02571",
     "image_path": null,
     "question_text": {
-      "en": "アラスカにある北米最高峰の旧称は?",
-      "ja": "Which is the former name of North America's highest peak in Alaska?"
+      "en": "Which is the former name of North America's highest peak in Alaska?",
+      "ja": "アラスカにある北米最高峰の旧称は?"
     }
   },
   {
@@ -104229,8 +104229,8 @@
     "id": "q02572",
     "image_path": null,
     "question_text": {
-      "en": "ウガンダとコンゴ民主共和国の国境にある山は?",
-      "ja": "Which mountain range lies on the border between Uganda and DR Congo?"
+      "en": "Which mountain range lies on the border between Uganda and DR Congo?",
+      "ja": "ウガンダとコンゴ民主共和国の国境にある山は?"
     }
   },
   {
@@ -104269,8 +104269,8 @@
     "id": "q02573",
     "image_path": null,
     "question_text": {
-      "en": "北アルプスの槍状の山頂で知られる山は?",
-      "ja": "Which Northern Japan Alps peak is famous for its spear-like summit?"
+      "en": "Which Northern Japan Alps peak is famous for its spear-like summit?",
+      "ja": "北アルプスの槍状の山頂で知られる山は?"
     }
   },
   {
@@ -104309,8 +104309,8 @@
     "id": "q02574",
     "image_path": null,
     "question_text": {
-      "en": "インド最大の都市で旧称ボンベイは?",
-      "ja": "Which is India's largest city, formerly known as Bombay?"
+      "en": "Which is India's largest city, formerly known as Bombay?",
+      "ja": "インド最大の都市で旧称ボンベイは?"
     }
   },
   {
@@ -104349,8 +104349,8 @@
     "id": "q02575",
     "image_path": null,
     "question_text": {
-      "en": "ドイツ・バイエルン州の州都は?",
-      "ja": "What is the capital of Bavaria, Germany?"
+      "en": "What is the capital of Bavaria, Germany?",
+      "ja": "ドイツ・バイエルン州の州都は?"
     }
   },
   {
@@ -104389,8 +104389,8 @@
     "id": "q02576",
     "image_path": null,
     "question_text": {
-      "en": "沖縄本島北部の中心都市は?",
-      "ja": "Which is the central city of northern Okinawa Island?"
+      "en": "Which is the central city of northern Okinawa Island?",
+      "ja": "沖縄本島北部の中心都市は?"
     }
   },
   {
@@ -104429,8 +104429,8 @@
     "id": "q02577",
     "image_path": null,
     "question_text": {
-      "en": "中国の旧首都で長江下流域にある都市は?",
-      "ja": "Which former Chinese capital lies on the lower Yangtze River?"
+      "en": "Which former Chinese capital lies on the lower Yangtze River?",
+      "ja": "中国の旧首都で長江下流域にある都市は?"
     }
   },
   {
@@ -104469,8 +104469,8 @@
     "id": "q02578",
     "image_path": null,
     "question_text": {
-      "en": "エベレストがある南アジアの内陸国は?",
-      "ja": "Which landlocked South Asian country is home to Mount Everest?"
+      "en": "Which landlocked South Asian country is home to Mount Everest?",
+      "ja": "エベレストがある南アジアの内陸国は?"
     }
   },
   {
@@ -104509,8 +104509,8 @@
     "id": "q02579",
     "image_path": null,
     "question_text": {
-      "en": "アムステルダムを首都とするヨーロッパの国は?",
-      "ja": "Which European country has Amsterdam as its capital?"
+      "en": "Which European country has Amsterdam as its capital?",
+      "ja": "アムステルダムを首都とするヨーロッパの国は?"
     }
   },
   {
@@ -104552,8 +104552,8 @@
     "id": "q02580",
     "image_path": null,
     "question_text": {
-      "en": "世界第2位の大きさを持つ島でインドネシアとパプアニューギニアに分かれているのは?",
-      "ja": "Which is the world's second largest island, split between Indonesia and Papua New Guinea?"
+      "en": "Which is the world's second largest island, split between Indonesia and Papua New Guinea?",
+      "ja": "世界第2位の大きさを持つ島でインドネシアとパプアニューギニアに分かれているのは?"
     }
   },
   {
@@ -104592,8 +104592,8 @@
     "id": "q02581",
     "image_path": null,
     "question_text": {
-      "en": "アメリカ東海岸の世界都市は?",
-      "ja": "Which is the U.S. east coast's global city?"
+      "en": "Which is the U.S. east coast's global city?",
+      "ja": "アメリカ東海岸の世界都市は?"
     }
   },
   {
@@ -104632,8 +104632,8 @@
     "id": "q02582",
     "image_path": null,
     "question_text": {
-      "en": "シベリア最大の都市は?",
-      "ja": "Which is the largest city in Siberia?"
+      "en": "Which is the largest city in Siberia?",
+      "ja": "シベリア最大の都市は?"
     }
   },
   {
@@ -104672,8 +104672,8 @@
     "id": "q02583",
     "image_path": null,
     "question_text": {
-      "en": "カンボジアの首都は?",
-      "ja": "What is the capital of Cambodia?"
+      "en": "What is the capital of Cambodia?",
+      "ja": "カンボジアの首都は?"
     }
   },
   {
@@ -104713,8 +104713,8 @@
     "id": "q02584",
     "image_path": null,
     "question_text": {
-      "en": "北朝鮮の首都は?",
-      "ja": "What is the capital of North Korea?"
+      "en": "What is the capital of North Korea?",
+      "ja": "北朝鮮の首都は?"
     }
   },
   {
@@ -104754,8 +104754,8 @@
     "id": "q02585",
     "image_path": null,
     "question_text": {
-      "en": "東京湾のお台場と芝浦を結ぶ橋は?",
-      "ja": "Which bridge connects Odaiba and Shibaura over Tokyo Bay?"
+      "en": "Which bridge connects Odaiba and Shibaura over Tokyo Bay?",
+      "ja": "東京湾のお台場と芝浦を結ぶ橋は?"
     }
   },
   {
@@ -104794,8 +104794,8 @@
     "id": "q02586",
     "image_path": null,
     "question_text": {
-      "en": "ブラジルでコルコバードのキリスト像で有名な都市は?",
-      "ja": "Which Brazilian city is famous for the Christ the Redeemer statue?"
+      "en": "Which Brazilian city is famous for the Christ the Redeemer statue?",
+      "ja": "ブラジルでコルコバードのキリスト像で有名な都市は?"
     }
   },
   {
@@ -104834,8 +104834,8 @@
     "id": "q02587",
     "image_path": null,
     "question_text": {
-      "en": "オランダの主要港湾都市でユーロポートを擁するのは?",
-      "ja": "Which Dutch port city houses Europoort, one of Europe's largest ports?"
+      "en": "Which Dutch port city houses Europoort, one of Europe's largest ports?",
+      "ja": "オランダの主要港湾都市でユーロポートを擁するのは?"
     }
   },
   {
@@ -104874,8 +104874,8 @@
     "id": "q02588",
     "image_path": null,
     "question_text": {
-      "en": "ロシアの旧首都でバルト海沿岸の都市は?",
-      "ja": "Which is Russia's former capital on the Baltic coast?"
+      "en": "Which is Russia's former capital on the Baltic coast?",
+      "ja": "ロシアの旧首都でバルト海沿岸の都市は?"
     }
   },
   {
@@ -104914,8 +104914,8 @@
     "id": "q02589",
     "image_path": null,
     "question_text": {
-      "en": "チリの首都は?",
-      "ja": "What is the capital of Chile?"
+      "en": "What is the capital of Chile?",
+      "ja": "チリの首都は?"
     }
   },
   {
@@ -104954,8 +104954,8 @@
     "id": "q02590",
     "image_path": null,
     "question_text": {
-      "en": "ブラジル最大の都市は?",
-      "ja": "Which is the largest city in Brazil?"
+      "en": "Which is the largest city in Brazil?",
+      "ja": "ブラジル最大の都市は?"
     }
   },
   {
@@ -104994,8 +104994,8 @@
     "id": "q02591",
     "image_path": null,
     "question_text": {
-      "en": "スペイン南部アンダルシア州の州都は?",
-      "ja": "What is the capital of Andalusia in southern Spain?"
+      "en": "What is the capital of Andalusia in southern Spain?",
+      "ja": "スペイン南部アンダルシア州の州都は?"
     }
   },
   {
@@ -105034,8 +105034,8 @@
     "id": "q02592",
     "image_path": null,
     "question_text": {
-      "en": "中国最大の都市で長江河口の港湾都市は?",
-      "ja": "Which is China's largest city, located at the mouth of the Yangtze?"
+      "en": "Which is China's largest city, located at the mouth of the Yangtze?",
+      "ja": "中国最大の都市で長江河口の港湾都市は?"
     }
   },
   {
@@ -105074,8 +105074,8 @@
     "id": "q02593",
     "image_path": null,
     "question_text": {
-      "en": "ロシア東部に広がる広大な地域は?",
-      "ja": "Which vast region covers eastern Russia?"
+      "en": "Which vast region covers eastern Russia?",
+      "ja": "ロシア東部に広がる広大な地域は?"
     }
   },
   {
@@ -105114,8 +105114,8 @@
     "id": "q02594",
     "image_path": null,
     "question_text": {
-      "en": "ケープタウンを擁するアフリカ大陸南端の国は?",
-      "ja": "Which country at Africa's southern tip is home to Cape Town?"
+      "en": "Which country at Africa's southern tip is home to Cape Town?",
+      "ja": "ケープタウンを擁するアフリカ大陸南端の国は?"
     }
   },
   {
@@ -105154,8 +105154,8 @@
     "id": "q02595",
     "image_path": null,
     "question_text": {
-      "en": "ブラジルやアルゼンチンを含む大陸は?",
-      "ja": "Which continent includes Brazil and Argentina?"
+      "en": "Which continent includes Brazil and Argentina?",
+      "ja": "ブラジルやアルゼンチンを含む大陸は?"
     }
   },
   {
@@ -105194,8 +105194,8 @@
     "id": "q02596",
     "image_path": null,
     "question_text": {
-      "en": "古代ギリシャの軍事都市国家は?",
-      "ja": "Which ancient Greek city-state was famous for its military?"
+      "en": "Which ancient Greek city-state was famous for its military?",
+      "ja": "古代ギリシャの軍事都市国家は?"
     }
   },
   {
@@ -105238,8 +105238,8 @@
     "id": "q02597",
     "image_path": null,
     "question_text": {
-      "en": "長野県・静岡県を流れて遠州灘に注ぐ川は?",
-      "ja": "Which river flows from Nagano through Shizuoka into Enshu-nada Sea?"
+      "en": "Which river flows from Nagano through Shizuoka into Enshu-nada Sea?",
+      "ja": "長野県・静岡県を流れて遠州灘に注ぐ川は?"
     }
   },
   {
@@ -105278,8 +105278,8 @@
     "id": "q02598",
     "image_path": null,
     "question_text": {
-      "en": "国際司法裁判所が置かれるオランダの都市は?",
-      "ja": "Which Dutch city is home to the International Court of Justice?"
+      "en": "Which Dutch city is home to the International Court of Justice?",
+      "ja": "国際司法裁判所が置かれるオランダの都市は?"
     }
   },
   {
@@ -105318,8 +105318,8 @@
     "id": "q02599",
     "image_path": null,
     "question_text": {
-      "en": "ギリシャ第2の都市は?",
-      "ja": "Which is Greece's second largest city?"
+      "en": "Which is Greece's second largest city?",
+      "ja": "ギリシャ第2の都市は?"
     }
   },
   {
@@ -105359,8 +105359,8 @@
     "id": "q02600",
     "image_path": null,
     "question_text": {
-      "en": "東京と神奈川を結ぶ東京湾を横断する道路は?",
-      "ja": "Which highway crosses Tokyo Bay between Tokyo area and Kanagawa?"
+      "en": "Which highway crosses Tokyo Bay between Tokyo area and Kanagawa?",
+      "ja": "東京と神奈川を結ぶ東京湾を横断する道路は?"
     }
   },
   {
@@ -105403,8 +105403,8 @@
     "id": "q02601",
     "image_path": null,
     "question_text": {
-      "en": "関東平野を流れる日本最大の流域面積を持つ川は?",
-      "ja": "Which Kanto Plain river has Japan's largest drainage basin?"
+      "en": "Which Kanto Plain river has Japan's largest drainage basin?",
+      "ja": "関東平野を流れる日本最大の流域面積を持つ川は?"
     }
   },
   {
@@ -105443,8 +105443,8 @@
     "id": "q02602",
     "image_path": null,
     "question_text": {
-      "en": "カナダ最大の都市は?",
-      "ja": "Which is the largest city in Canada?"
+      "en": "Which is the largest city in Canada?",
+      "ja": "カナダ最大の都市は?"
     }
   },
   {
@@ -105483,8 +105483,8 @@
     "id": "q02603",
     "image_path": null,
     "question_text": {
-      "en": "中国新疆ウイグル自治区にある中国で最も低い場所は?",
-      "ja": "Which depression in China's Xinjiang region is the country's lowest point?"
+      "en": "Which depression in China's Xinjiang region is the country's lowest point?",
+      "ja": "中国新疆ウイグル自治区にある中国で最も低い場所は?"
     }
   },
   {
@@ -105523,8 +105523,8 @@
     "id": "q02604",
     "image_path": null,
     "question_text": {
-      "en": "リオ・グランデ川が国境を流れている国の組み合わせは?",
-      "ja": "The Rio Grande forms the border between which two countries?"
+      "en": "The Rio Grande forms the border between which two countries?",
+      "ja": "リオ・グランデ川が国境を流れている国の組み合わせは?"
     }
   },
   {
@@ -105563,8 +105563,8 @@
     "id": "q02605",
     "image_path": null,
     "question_text": {
-      "en": "オランダ中央部の大学都市は?",
-      "ja": "Which Dutch central city is a major university town?"
+      "en": "Which Dutch central city is a major university town?",
+      "ja": "オランダ中央部の大学都市は?"
     }
   },
   {
@@ -105603,8 +105603,8 @@
     "id": "q02606",
     "image_path": null,
     "question_text": {
-      "en": "スペイン東部地中海沿岸の都市でパエリア発祥地は?",
-      "ja": "Which eastern Spanish city on the Mediterranean is the birthplace of paella?"
+      "en": "Which eastern Spanish city on the Mediterranean is the birthplace of paella?",
+      "ja": "スペイン東部地中海沿岸の都市でパエリア発祥地は?"
     }
   },
   {
@@ -105643,8 +105643,8 @@
     "id": "q02607",
     "image_path": null,
     "question_text": {
-      "en": "カナダ西海岸の港湾都市は?",
-      "ja": "Which is Canada's main west coast port city?"
+      "en": "Which is Canada's main west coast port city?",
+      "ja": "カナダ西海岸の港湾都市は?"
     }
   },
   {
@@ -105683,8 +105683,8 @@
     "id": "q02608",
     "image_path": null,
     "question_text": {
-      "en": "イタリア北東部の運河の街は?",
-      "ja": "Which northeastern Italian city is famous for its canals?"
+      "en": "Which northeastern Italian city is famous for its canals?",
+      "ja": "イタリア北東部の運河の街は?"
     }
   },
   {
@@ -105723,8 +105723,8 @@
     "id": "q02609",
     "image_path": null,
     "question_text": {
-      "en": "ラオスの首都は?",
-      "ja": "What is the capital of Laos?"
+      "en": "What is the capital of Laos?",
+      "ja": "ラオスの首都は?"
     }
   },
   {
@@ -105763,8 +105763,8 @@
     "id": "q02610",
     "image_path": null,
     "question_text": {
-      "en": "ロシア極東の最大都市は?",
-      "ja": "Which is the largest city in the Russian Far East?"
+      "en": "Which is the largest city in the Russian Far East?",
+      "ja": "ロシア極東の最大都市は?"
     }
   },
   {
@@ -105806,8 +105806,8 @@
     "id": "q02611",
     "image_path": null,
     "question_text": {
-      "en": "中国を流れるアジア最長の川は?",
-      "ja": "Which is Asia's longest river, flowing through China?"
+      "en": "Which is Asia's longest river, flowing through China?",
+      "ja": "中国を流れるアジア最長の川は?"
     }
   },
   {
@@ -105846,8 +105846,8 @@
     "id": "q02612",
     "image_path": null,
     "question_text": {
-      "en": "ビクトリアの滝が国境にある国の組み合わせは?",
-      "ja": "Victoria Falls lies on the border between which two countries?"
+      "en": "Victoria Falls lies on the border between which two countries?",
+      "ja": "ビクトリアの滝が国境にある国の組み合わせは?"
     }
   },
   {
@@ -105886,17 +105886,17 @@
     "id": "q02613",
     "image_path": null,
     "question_text": {
-      "en": "IPv4でルータが特別な用途で予約しているTTLのデフォルト最大値の1つは?",
-      "ja": "Which is one of the typical default maximum TTL values used in IPv4?"
+      "en": "Which is one of the typical default maximum TTL values used in IPv4?",
+      "ja": "IPv4でルータが特別な用途で予約しているTTLのデフォルト最大値の1つは?"
     }
   },
   {
     "choices": [
       {
-        "en": "128",
-        "ja": "128",
+        "en": "255",
+        "ja": "255",
         "ja_typings": [
-          "128"
+          "255"
         ]
       },
       {
@@ -105926,8 +105926,8 @@
     "id": "q02614",
     "image_path": null,
     "question_text": {
-      "en": "8ビット符号なし整数で表せる最大値は?",
-      "ja": "What is the maximum value of an 8-bit unsigned integer?"
+      "en": "What is the maximum value of an 8-bit unsigned integer?",
+      "ja": "8ビット符号なし整数で表せる最大値は?"
     }
   },
   {
@@ -105966,8 +105966,8 @@
     "id": "q02615",
     "image_path": null,
     "question_text": {
-      "en": "C言語のshort型で多くの環境におけるビット数は?",
-      "ja": "How many bits does C's short type typically have?"
+      "en": "How many bits does C's short type typically have?",
+      "ja": "C言語のshort型で多くの環境におけるビット数は?"
     }
   },
   {
@@ -106006,8 +106006,8 @@
     "id": "q02616",
     "image_path": null,
     "question_text": {
-      "en": "8ビット整数で表現できる値の総数は?",
-      "ja": "How many distinct values can be represented with 8 bits?"
+      "en": "How many distinct values can be represented with 8 bits?",
+      "ja": "8ビット整数で表現できる値の総数は?"
     }
   },
   {
@@ -106046,8 +106046,8 @@
     "id": "q02617",
     "image_path": null,
     "question_text": {
-      "en": "x86_64アーキテクチャでの汎用レジスタの幅は何ビット?",
-      "ja": "How many bits wide is a general purpose register in x86_64?"
+      "en": "How many bits wide is a general purpose register in x86_64?",
+      "ja": "x86_64アーキテクチャでの汎用レジスタの幅は何ビット?"
     }
   },
   {
@@ -106086,8 +106086,8 @@
     "id": "q02618",
     "image_path": null,
     "question_text": {
-      "en": "IPv4の1オクテットは何ビット?",
-      "ja": "How many bits is one octet in IPv4?"
+      "en": "How many bits is one octet in IPv4?",
+      "ja": "IPv4の1オクテットは何ビット?"
     }
   },
   {
@@ -106126,8 +106126,8 @@
     "id": "q02619",
     "image_path": null,
     "question_text": {
-      "en": "IPアドレスからMACアドレスを解決するプロトコルは?",
-      "ja": "Which protocol resolves IP addresses to MAC addresses?"
+      "en": "Which protocol resolves IP addresses to MAC addresses?",
+      "ja": "IPアドレスからMACアドレスを解決するプロトコルは?"
     }
   },
   {
@@ -106166,8 +106166,8 @@
     "id": "q02620",
     "image_path": null,
     "question_text": {
-      "en": "サーバ構成管理ツールでYAMLで定義しエージェントレスで動作するのは?",
-      "ja": "Which agentless configuration management tool uses YAML playbooks?"
+      "en": "Which agentless configuration management tool uses YAML playbooks?",
+      "ja": "サーバ構成管理ツールでYAMLで定義しエージェントレスで動作するのは?"
     }
   },
   {
@@ -106206,8 +106206,8 @@
     "id": "q02621",
     "image_path": null,
     "question_text": {
-      "en": "Javaのビルドツールで古くから使われているXMLベースのものは?",
-      "ja": "Which old XML-based build tool is used for Java projects?"
+      "en": "Which old XML-based build tool is used for Java projects?",
+      "ja": "Javaのビルドツールで古くから使われているXMLベースのものは?"
     }
   },
   {
@@ -106246,8 +106246,8 @@
     "id": "q02622",
     "image_path": null,
     "question_text": {
-      "en": "Mozillaが開発したJavaScriptランタイム向けの新ブラウザは?",
-      "ja": "Which browser was made by The Browser Company with a focus on tabs and workflows?"
+      "en": "Which browser was made by The Browser Company with a focus on tabs and workflows?",
+      "ja": "Mozillaが開発したJavaScriptランタイム向けの新ブラウザは?"
     }
   },
   {
@@ -106286,8 +106286,8 @@
     "id": "q02623",
     "image_path": null,
     "question_text": {
-      "en": "アセンブリ言語を機械語に変換するプログラムは?",
-      "ja": "Which program translates assembly language into machine code?"
+      "en": "Which program translates assembly language into machine code?",
+      "ja": "アセンブリ言語を機械語に変換するプログラムは?"
     }
   },
   {
@@ -106326,8 +106326,8 @@
     "id": "q02624",
     "image_path": null,
     "question_text": {
-      "en": "CPUの命令を直接表現する低水準言語は?",
-      "ja": "Which low-level language directly represents CPU instructions?"
+      "en": "Which low-level language directly represents CPU instructions?",
+      "ja": "CPUの命令を直接表現する低水準言語は?"
     }
   },
   {
@@ -106366,8 +106366,8 @@
     "id": "q02625",
     "image_path": null,
     "question_text": {
-      "en": "プログラミングで変数に値を入れる操作は?",
-      "ja": "What is the operation of setting a value into a variable called?"
+      "en": "What is the operation of setting a value into a variable called?",
+      "ja": "プログラミングで変数に値を入れる操作は?"
     }
   },
   {
@@ -106406,8 +106406,8 @@
     "id": "q02626",
     "image_path": null,
     "question_text": {
-      "en": "プロファイラで関数の平均実行回数を示す指標は?",
-      "ja": "Which profiling metric shows the average number of times a function ran?"
+      "en": "Which profiling metric shows the average number of times a function ran?",
+      "ja": "プロファイラで関数の平均実行回数を示す指標は?"
     }
   },
   {
@@ -106446,8 +106446,8 @@
     "id": "q02627",
     "image_path": null,
     "question_text": {
-      "en": "グラフ探索で全方向に広く探索する手法は?",
-      "ja": "Which graph traversal explores all neighbors level by level?"
+      "en": "Which graph traversal explores all neighbors level by level?",
+      "ja": "グラフ探索で全方向に広く探索する手法は?"
     }
   },
   {
@@ -106486,8 +106486,8 @@
     "id": "q02628",
     "image_path": null,
     "question_text": {
-      "en": "ビットレートの単位で1秒間のビット数を表すのは?",
-      "ja": "Which unit represents bits transferred per second?"
+      "en": "Which unit represents bits transferred per second?",
+      "ja": "ビットレートの単位で1秒間のビット数を表すのは?"
     }
   },
   {
@@ -106528,8 +106528,8 @@
     "id": "q02629",
     "image_path": null,
     "question_text": {
-      "en": "HTTPステータスコード400が示すのは?",
-      "ja": "What does HTTP status code 400 indicate?"
+      "en": "What does HTTP status code 400 indicate?",
+      "ja": "HTTPステータスコード400が示すのは?"
     }
   },
   {
@@ -106568,8 +106568,8 @@
     "id": "q02630",
     "image_path": null,
     "question_text": {
-      "en": "Linuxで標準的に使われるシェルは?",
-      "ja": "Which is the standard shell on most Linux distributions?"
+      "en": "Which is the standard shell on most Linux distributions?",
+      "ja": "Linuxで標準的に使われるシェルは?"
     }
   },
   {
@@ -106612,8 +106612,8 @@
     "id": "q02631",
     "image_path": null,
     "question_text": {
-      "en": "viエディタを開発した人物は?",
-      "ja": "Who is the author of the vi editor?"
+      "en": "Who is the author of the vi editor?",
+      "ja": "viエディタを開発した人物は?"
     }
   },
   {
@@ -106652,8 +106652,8 @@
     "id": "q02632",
     "image_path": null,
     "question_text": {
-      "en": "ビット単位で「どちらかが1なら1」を取る演算は?",
-      "ja": "Which bitwise operation returns 1 if either bit is 1?"
+      "en": "Which bitwise operation returns 1 if either bit is 1?",
+      "ja": "ビット単位で「どちらかが1なら1」を取る演算は?"
     }
   },
   {
@@ -106696,8 +106696,8 @@
     "id": "q02633",
     "image_path": null,
     "question_text": {
-      "en": "C++を設計した人物は?",
-      "ja": "Who designed the C++ programming language?"
+      "en": "Who designed the C++ programming language?",
+      "ja": "C++を設計した人物は?"
     }
   },
   {
@@ -106736,8 +106736,8 @@
     "id": "q02634",
     "image_path": null,
     "question_text": {
-      "en": "Rustのヒープに値を1つ置くスマートポインタ型は?",
-      "ja": "Which Rust smart pointer places a single value on the heap?"
+      "en": "Which Rust smart pointer places a single value on the heap?",
+      "ja": "Rustのヒープに値を1つ置くスマートポインタ型は?"
     }
   },
   {
@@ -106780,8 +106780,8 @@
     "id": "q02635",
     "image_path": null,
     "question_text": {
-      "en": "JavaScriptを設計した人物は?",
-      "ja": "Who designed JavaScript?"
+      "en": "Who designed JavaScript?",
+      "ja": "JavaScriptを設計した人物は?"
     }
   },
   {
@@ -106824,8 +106824,8 @@
     "id": "q02636",
     "image_path": null,
     "question_text": {
-      "en": "AWKの開発者の1人で『プログラミング言語C』の共著者は?",
-      "ja": "Who co-authored 'The C Programming Language' and co-created AWK?"
+      "en": "Who co-authored 'The C Programming Language' and co-created AWK?",
+      "ja": "AWKの開発者の1人で『プログラミング言語C』の共著者は?"
     }
   },
   {
@@ -106864,8 +106864,8 @@
     "id": "q02637",
     "image_path": null,
     "question_text": {
-      "en": "UNIX上で生まれた構造化プログラミング言語は?",
-      "ja": "Which structured language was developed on UNIX in the 1970s?"
+      "en": "Which structured language was developed on UNIX in the 1970s?",
+      "ja": "UNIX上で生まれた構造化プログラミング言語は?"
     }
   },
   {
@@ -106904,8 +106904,8 @@
     "id": "q02638",
     "image_path": null,
     "question_text": {
-      "en": ".NETの共通言語ランタイムの略称は?",
-      "ja": "What is the abbreviation for .NET's common language runtime?"
+      "en": "What is the abbreviation for .NET's common language runtime?",
+      "ja": ".NETの共通言語ランタイムの略称は?"
     }
   },
   {
@@ -106944,8 +106944,8 @@
     "id": "q02639",
     "image_path": null,
     "question_text": {
-      "en": "事務処理用に1959年に作られた言語は?",
-      "ja": "Which programming language was designed in 1959 for business processing?"
+      "en": "Which programming language was designed in 1959 for business processing?",
+      "ja": "事務処理用に1959年に作られた言語は?"
     }
   },
   {
@@ -106984,8 +106984,8 @@
     "id": "q02640",
     "image_path": null,
     "question_text": {
-      "en": "HTMLの見た目を装飾する言語は?",
-      "ja": "Which language styles HTML documents?"
+      "en": "Which language styles HTML documents?",
+      "ja": "HTMLの見た目を装飾する言語は?"
     }
   },
   {
@@ -107024,8 +107024,8 @@
     "id": "q02641",
     "image_path": null,
     "question_text": {
-      "en": "Rustのパッケージマネージャ兼ビルドツールは?",
-      "ja": "What is Rust's package manager and build tool called?"
+      "en": "What is Rust's package manager and build tool called?",
+      "ja": "Rustのパッケージマネージャ兼ビルドツールは?"
     }
   },
   {
@@ -107064,8 +107064,8 @@
     "id": "q02642",
     "image_path": null,
     "question_text": {
-      "en": "分散NoSQLデータベースの1つで列指向ストアなのは?",
-      "ja": "Which distributed NoSQL database uses a column-family store?"
+      "en": "Which distributed NoSQL database uses a column-family store?",
+      "ja": "分散NoSQLデータベースの1つで列指向ストアなのは?"
     }
   },
   {
@@ -107104,8 +107104,8 @@
     "id": "q02643",
     "image_path": null,
     "question_text": {
-      "en": "HTTPの4xx系ステータスコードが意味するのは?",
-      "ja": "What category does HTTP 4xx status code belong to?"
+      "en": "What category does HTTP 4xx status code belong to?",
+      "ja": "HTTPの4xx系ステータスコードが意味するのは?"
     }
   },
   {
@@ -107144,8 +107144,8 @@
     "id": "q02644",
     "image_path": null,
     "question_text": {
-      "en": "ソースコードを機械語などに翻訳するソフトウェアは?",
-      "ja": "Which software translates source code into machine code?"
+      "en": "Which software translates source code into machine code?",
+      "ja": "ソースコードを機械語などに翻訳するソフトウェアは?"
     }
   },
   {
@@ -107184,8 +107184,8 @@
     "id": "q02645",
     "image_path": null,
     "question_text": {
-      "en": "グラフ探索でできるだけ深く進むのは?",
-      "ja": "Which graph traversal explores as deep as possible first?"
+      "en": "Which graph traversal explores as deep as possible first?",
+      "ja": "グラフ探索でできるだけ深く進むのは?"
     }
   },
   {
@@ -107224,8 +107224,8 @@
     "id": "q02646",
     "image_path": null,
     "question_text": {
-      "en": "1秒間に与えるダメージ量の指標は?",
-      "ja": "Which gaming metric measures damage dealt per second?"
+      "en": "Which gaming metric measures damage dealt per second?",
+      "ja": "1秒間に与えるダメージ量の指標は?"
     }
   },
   {
@@ -107264,8 +107264,8 @@
     "id": "q02647",
     "image_path": null,
     "question_text": {
-      "en": "プログラムをステップ実行・変数監視できるツールは?",
-      "ja": "Which tool lets you step through code and inspect variables?"
+      "en": "Which tool lets you step through code and inspect variables?",
+      "ja": "プログラムをステップ実行・変数監視できるツールは?"
     }
   },
   {
@@ -107308,8 +107308,8 @@
     "id": "q02648",
     "image_path": null,
     "question_text": {
-      "en": "0から9までの記号を使う数値表現は?",
-      "ja": "Which numeral system uses digits 0 through 9?"
+      "en": "Which numeral system uses digits 0 through 9?",
+      "ja": "0から9までの記号を使う数値表現は?"
     }
   },
   {
@@ -107352,8 +107352,8 @@
     "id": "q02649",
     "image_path": null,
     "question_text": {
-      "en": "C言語を開発した人物は?",
-      "ja": "Who developed the C programming language?"
+      "en": "Who developed the C programming language?",
+      "ja": "C言語を開発した人物は?"
     }
   },
   {
@@ -107393,8 +107393,8 @@
     "id": "q02650",
     "image_path": null,
     "question_text": {
-      "en": "複数のコンテナをまとめて定義・起動するツールは?",
-      "ja": "Which tool runs multi-container Docker applications via YAML?"
+      "en": "Which tool runs multi-container Docker applications via YAML?",
+      "ja": "複数のコンテナをまとめて定義・起動するツールは?"
     }
   },
   {
@@ -107433,8 +107433,8 @@
     "id": "q02651",
     "image_path": null,
     "question_text": {
-      "en": "実行時に型が決まる言語の性質を表す語は?",
-      "ja": "Which term describes a language whose types are determined at runtime?"
+      "en": "Which term describes a language whose types are determined at runtime?",
+      "ja": "実行時に型が決まる言語の性質を表す語は?"
     }
   },
   {
@@ -107473,8 +107473,8 @@
     "id": "q02652",
     "image_path": null,
     "question_text": {
-      "en": "オブジェクト指向で内部状態を隠す概念は?",
-      "ja": "Which OOP concept hides internal state and exposes a public interface?"
+      "en": "Which OOP concept hides internal state and exposes a public interface?",
+      "ja": "オブジェクト指向で内部状態を隠す概念は?"
     }
   },
   {
@@ -107513,8 +107513,8 @@
     "id": "q02653",
     "image_path": null,
     "question_text": {
-      "en": "SQLでデータを取得するために使われるカーソル操作の文は?",
-      "ja": "Which SQL statement retrieves rows from a cursor?"
+      "en": "Which SQL statement retrieves rows from a cursor?",
+      "ja": "SQLでデータを取得するために使われるカーソル操作の文は?"
     }
   },
   {
@@ -107553,8 +107553,8 @@
     "id": "q02654",
     "image_path": null,
     "question_text": {
-      "en": "BSD系UNIXで使われた高速ファイルシステムは?",
-      "ja": "Which fast file system was developed for BSD UNIX?"
+      "en": "Which fast file system was developed for BSD UNIX?",
+      "ja": "BSD系UNIXで使われた高速ファイルシステムは?"
     }
   },
   {
@@ -107593,8 +107593,8 @@
     "id": "q02655",
     "image_path": null,
     "question_text": {
-      "en": "ファイルを転送する古典的なプロトコルは?",
-      "ja": "Which classic protocol is used to transfer files?"
+      "en": "Which classic protocol is used to transfer files?",
+      "ja": "ファイルを転送する古典的なプロトコルは?"
     }
   },
   {
@@ -107634,8 +107634,8 @@
     "id": "q02656",
     "image_path": null,
     "question_text": {
-      "en": "GoFのデザインパターンで生成系の1つは?",
-      "ja": "Which is one of the GoF creational design patterns?"
+      "en": "Which is one of the GoF creational design patterns?",
+      "ja": "GoFのデザインパターンで生成系の1つは?"
     }
   },
   {
@@ -107674,8 +107674,8 @@
     "id": "q02657",
     "image_path": null,
     "question_text": {
-      "en": "軽量スレッドのことを指す概念は?",
-      "ja": "Which term refers to lightweight threads scheduled by a runtime?"
+      "en": "Which term refers to lightweight threads scheduled by a runtime?",
+      "ja": "軽量スレッドのことを指す概念は?"
     }
   },
   {
@@ -107716,8 +107716,8 @@
     "id": "q02658",
     "image_path": null,
     "question_text": {
-      "en": "HTTPステータスコード403が示すのは?",
-      "ja": "What does HTTP status code 403 indicate?"
+      "en": "What does HTTP status code 403 indicate?",
+      "ja": "HTTPステータスコード403が示すのは?"
     }
   },
   {
@@ -107756,8 +107756,8 @@
     "id": "q02659",
     "image_path": null,
     "question_text": {
-      "en": "科学計算用に1957年に作られた言語は?",
-      "ja": "Which language was created in 1957 for scientific computation?"
+      "en": "Which language was created in 1957 for scientific computation?",
+      "ja": "科学計算用に1957年に作られた言語は?"
     }
   },
   {
@@ -107796,8 +107796,8 @@
     "id": "q02660",
     "image_path": null,
     "question_text": {
-      "en": "SQLで列ごとに集計するための句は?",
-      "ja": "Which SQL clause aggregates rows by column values?"
+      "en": "Which SQL clause aggregates rows by column values?",
+      "ja": "SQLで列ごとに集計するための句は?"
     }
   },
   {
@@ -107836,8 +107836,8 @@
     "id": "q02661",
     "image_path": null,
     "question_text": {
-      "en": "Googleが開発した静的型付きの並行処理向け言語は?",
-      "ja": "Which Google-designed statically typed language emphasizes concurrency?"
+      "en": "Which Google-designed statically typed language emphasizes concurrency?",
+      "ja": "Googleが開発した静的型付きの並行処理向け言語は?"
     }
   },
   {
@@ -107876,8 +107876,8 @@
     "id": "q02662",
     "image_path": null,
     "question_text": {
-      "en": "ノードとエッジで関係を表すデータ構造は?",
-      "ja": "Which data structure represents relations with nodes and edges?"
+      "en": "Which data structure represents relations with nodes and edges?",
+      "ja": "ノードとエッジで関係を表すデータ構造は?"
     }
   },
   {
@@ -107920,8 +107920,8 @@
     "id": "q02663",
     "image_path": null,
     "question_text": {
-      "en": "Pythonを設計した人物は?",
-      "ja": "Who designed the Python programming language?"
+      "en": "Who designed the Python programming language?",
+      "ja": "Pythonを設計した人物は?"
     }
   },
   {
@@ -107960,8 +107960,8 @@
     "id": "q02664",
     "image_path": null,
     "question_text": {
-      "en": "HTTPでヘッダだけ取得するメソッドは?",
-      "ja": "Which HTTP method fetches only headers without a body?"
+      "en": "Which HTTP method fetches only headers without a body?",
+      "ja": "HTTPでヘッダだけ取得するメソッドは?"
     }
   },
   {
@@ -108000,8 +108000,8 @@
     "id": "q02665",
     "image_path": null,
     "question_text": {
-      "en": "Webページの構造を記述するマークアップ言語は?",
-      "ja": "Which markup language describes the structure of a web page?"
+      "en": "Which markup language describes the structure of a web page?",
+      "ja": "Webページの構造を記述するマークアップ言語は?"
     }
   },
   {
@@ -108044,8 +108044,8 @@
     "id": "q02666",
     "image_path": null,
     "question_text": {
-      "en": "0からF までの記号を使う数値表現は?",
-      "ja": "Which numeral system uses digits 0-9 and A-F?"
+      "en": "Which numeral system uses digits 0-9 and A-F?",
+      "ja": "0からF までの記号を使う数値表現は?"
     }
   },
   {
@@ -108084,8 +108084,8 @@
     "id": "q02667",
     "image_path": null,
     "question_text": {
-      "en": "pingで使われるIP制御メッセージプロトコルは?",
-      "ja": "Which IP control message protocol does ping use?"
+      "en": "Which IP control message protocol does ping use?",
+      "ja": "pingで使われるIP制御メッセージプロトコルは?"
     }
   },
   {
@@ -108124,8 +108124,8 @@
     "id": "q02668",
     "image_path": null,
     "question_text": {
-      "en": "一度作ったら変更できない性質を表す語は?",
-      "ja": "Which term describes objects that cannot be modified after creation?"
+      "en": "Which term describes objects that cannot be modified after creation?",
+      "ja": "一度作ったら変更できない性質を表す語は?"
     }
   },
   {
@@ -108167,8 +108167,8 @@
     "id": "q02669",
     "image_path": null,
     "question_text": {
-      "en": "HTTPステータスコード500が示すのは?",
-      "ja": "What does HTTP status code 500 indicate?"
+      "en": "What does HTTP status code 500 indicate?",
+      "ja": "HTTPステータスコード500が示すのは?"
     }
   },
   {
@@ -108207,8 +108207,8 @@
     "id": "q02670",
     "image_path": null,
     "question_text": {
-      "en": "ソースコードを逐次解釈実行するソフトウェアは?",
-      "ja": "Which software executes source code line by line?"
+      "en": "Which software executes source code line by line?",
+      "ja": "ソースコードを逐次解釈実行するソフトウェアは?"
     }
   },
   {
@@ -108247,8 +108247,8 @@
     "id": "q02671",
     "image_path": null,
     "question_text": {
-      "en": "Pythonで `#` 記号の役割は?",
-      "ja": "What does the `#` symbol indicate in Python?"
+      "en": "What does the `#` symbol indicate in Python?",
+      "ja": "Pythonで `#` 記号の役割は?"
     }
   },
   {
@@ -108287,8 +108287,8 @@
     "id": "q02672",
     "image_path": null,
     "question_text": {
-      "en": "関数定義で `->` 記号が示すのは?",
-      "ja": "What does the `->` arrow indicate in a function signature?"
+      "en": "What does the `->` arrow indicate in a function signature?",
+      "ja": "関数定義で `->` 記号が示すのは?"
     }
   },
   {
@@ -108327,8 +108327,8 @@
     "id": "q02673",
     "image_path": null,
     "question_text": {
-      "en": "TypeScriptで `: number` のように書く記号 `:` の役割は?",
-      "ja": "What does the `:` colon indicate in TypeScript annotations like `: number`?"
+      "en": "What does the `:` colon indicate in TypeScript annotations like `: number`?",
+      "ja": "TypeScriptで `: number` のように書く記号 `:` の役割は?"
     }
   },
   {
@@ -108367,8 +108367,8 @@
     "id": "q02674",
     "image_path": null,
     "question_text": {
-      "en": "JSONのフルネームの誤った候補として混同されがちなのは?",
-      "ja": "Which is a common (incorrect) fake expansion of JSON?"
+      "en": "Which is a common (incorrect) fake expansion of JSON?",
+      "ja": "JSONのフルネームの誤った候補として混同されがちなのは?"
     }
   },
   {
@@ -108407,8 +108407,8 @@
     "id": "q02675",
     "image_path": null,
     "question_text": {
-      "en": "ブラウザで動く動的言語は?",
-      "ja": "Which dynamic language runs in web browsers?"
+      "en": "Which dynamic language runs in web browsers?",
+      "ja": "ブラウザで動く動的言語は?"
     }
   },
   {
@@ -108447,8 +108447,8 @@
     "id": "q02676",
     "image_path": null,
     "question_text": {
-      "en": "JSONの正式名称として誤って語られがちなのは?",
-      "ja": "Which is another common false expansion of JSON?"
+      "en": "Which is another common false expansion of JSON?",
+      "ja": "JSONの正式名称として誤って語られがちなのは?"
     }
   },
   {
@@ -108487,8 +108487,8 @@
     "id": "q02677",
     "image_path": null,
     "question_text": {
-      "en": "JSONの誤った命名候補としてしばしば挙げられるのは?",
-      "ja": "Which is another false expansion sometimes given for JSON?"
+      "en": "Which is another false expansion sometimes given for JSON?",
+      "ja": "JSONの誤った命名候補としてしばしば挙げられるのは?"
     }
   },
   {
@@ -108531,8 +108531,8 @@
     "id": "q02678",
     "image_path": null,
     "question_text": {
-      "en": "Gitの現在のメンテナを務める日本人開発者は?",
-      "ja": "Which Japanese developer maintains Git?"
+      "en": "Which Japanese developer maintains Git?",
+      "ja": "Gitの現在のメンテナを務める日本人開発者は?"
     }
   },
   {
@@ -108571,8 +108571,8 @@
     "id": "q02679",
     "image_path": null,
     "question_text": {
-      "en": "Clang/Swiftなどが利用するコンパイラ基盤は?",
-      "ja": "Which compiler infrastructure is used by Clang and Swift?"
+      "en": "Which compiler infrastructure is used by Clang and Swift?",
+      "ja": "Clang/Swiftなどが利用するコンパイラ基盤は?"
     }
   },
   {
@@ -108615,8 +108615,8 @@
     "id": "q02680",
     "image_path": null,
     "question_text": {
-      "en": "Perlを設計した人物は?",
-      "ja": "Who designed the Perl programming language?"
+      "en": "Who designed the Perl programming language?",
+      "ja": "Perlを設計した人物は?"
     }
   },
   {
@@ -108655,8 +108655,8 @@
     "id": "q02681",
     "image_path": null,
     "question_text": {
-      "en": "オブジェクトファイルをまとめて実行ファイルを作るのは?",
-      "ja": "Which tool combines object files into an executable?"
+      "en": "Which tool combines object files into an executable?",
+      "ja": "オブジェクトファイルをまとめて実行ファイルを作るのは?"
     }
   },
   {
@@ -108699,8 +108699,8 @@
     "id": "q02682",
     "image_path": null,
     "question_text": {
-      "en": "Linuxカーネルを最初に開発した人物は?",
-      "ja": "Who originally developed the Linux kernel?"
+      "en": "Who originally developed the Linux kernel?",
+      "ja": "Linuxカーネルを最初に開発した人物は?"
     }
   },
   {
@@ -108739,38 +108739,38 @@
     "id": "q02683",
     "image_path": null,
     "question_text": {
-      "en": "ビット単位で「両方1のときだけ1」を取る演算の論理版は?",
-      "ja": "Which logical operation returns true only when both operands are true?"
+      "en": "Which logical operation returns true only when both operands are true?",
+      "ja": "ビット単位で「両方1のときだけ1」を取る演算の論理版は?"
     }
   },
   {
     "choices": [
       {
-        "en": "Lower bound of complexity",
-        "ja": "計算量の下限",
+        "en": "O(n log n)",
+        "ja": "O(n log n)",
         "ja_typings": [
-          "keisanryounokagen"
+          "O(nlogn)"
         ]
       },
       {
-        "en": "Upper bound of complexity",
-        "ja": "計算量の上限",
+        "en": "O(n)",
+        "ja": "O(n)",
         "ja_typings": [
-          "keisanryounokougen"
+          "O(n)"
         ]
       },
       {
-        "en": "Average run count",
-        "ja": "平均実行回数",
+        "en": "O(n^2)",
+        "ja": "O(n^2)",
         "ja_typings": [
-          "heikinjikkoukaisuu"
+          "O(n^2)"
         ]
       },
       {
-        "en": "Memory usage",
-        "ja": "メモリ使用量",
+        "en": "O(log n)",
+        "ja": "O(log n)",
         "ja_typings": [
-          "memorishiyouryou"
+          "O(logn)"
         ]
       }
     ],
@@ -108779,8 +108779,8 @@
     "id": "q02684",
     "image_path": null,
     "question_text": {
-      "en": "比較ソートで証明されている計算量の下限は?",
-      "ja": "What is the proven lower bound of complexity for comparison sorting?"
+      "en": "What is the proven lower bound of complexity for comparison-based sorting?",
+      "ja": "比較ソートで証明されている計算量の下限は?"
     }
   },
   {
@@ -108819,8 +108819,8 @@
     "id": "q02685",
     "image_path": null,
     "question_text": {
-      "en": "SQLでINSERT/UPDATEを一度に行う命令は?",
-      "ja": "Which SQL statement combines INSERT and UPDATE in one operation?"
+      "en": "Which SQL statement combines INSERT and UPDATE in one operation?",
+      "ja": "SQLでINSERT/UPDATEを一度に行う命令は?"
     }
   },
   {
@@ -108859,8 +108859,8 @@
     "id": "q02686",
     "image_path": null,
     "question_text": {
-      "en": "CPUが直接実行できるバイナリ表現の命令は?",
-      "ja": "Which form of instructions is directly executed by the CPU?"
+      "en": "Which form of instructions is directly executed by the CPU?",
+      "ja": "CPUが直接実行できるバイナリ表現の命令は?"
     }
   },
   {
@@ -108899,8 +108899,8 @@
     "id": "q02687",
     "image_path": null,
     "question_text": {
-      "en": "JavaのXMLベースのビルドツールでpom.xmlを使うのは?",
-      "ja": "Which Java build tool uses pom.xml configuration?"
+      "en": "Which Java build tool uses pom.xml configuration?",
+      "ja": "JavaのXMLベースのビルドツールでpom.xmlを使うのは?"
     }
   },
   {
@@ -108940,8 +108940,8 @@
     "id": "q02688",
     "image_path": null,
     "question_text": {
-      "en": "解放されないメモリが蓄積する不具合は?",
-      "ja": "Which bug refers to memory that is never released?"
+      "en": "Which bug refers to memory that is never released?",
+      "ja": "解放されないメモリが蓄積する不具合は?"
     }
   },
   {
@@ -108980,8 +108980,8 @@
     "id": "q02689",
     "image_path": null,
     "question_text": {
-      "en": "プロファイラで「メモリの使用量」を示す指標は?",
-      "ja": "Which profiling metric shows how much memory the program uses?"
+      "en": "Which profiling metric shows how much memory the program uses?",
+      "ja": "プロファイラで「メモリの使用量」を示す指標は?"
     }
   },
   {
@@ -109020,8 +109020,8 @@
     "id": "q02690",
     "image_path": null,
     "question_text": {
-      "en": "分割統治法による安定ソートでO(n log n)を保証するのは?",
-      "ja": "Which divide-and-conquer stable sort guarantees O(n log n)?"
+      "en": "Which divide-and-conquer stable sort guarantees O(n log n)?",
+      "ja": "分割統治法による安定ソートでO(n log n)を保証するのは?"
     }
   },
   {
@@ -109060,8 +109060,8 @@
     "id": "q02691",
     "image_path": null,
     "question_text": {
-      "en": "ドキュメント指向NoSQLの代表例は?",
-      "ja": "Which is a leading document-oriented NoSQL database?"
+      "en": "Which is a leading document-oriented NoSQL database?",
+      "ja": "ドキュメント指向NoSQLの代表例は?"
     }
   },
   {
@@ -109100,8 +109100,8 @@
     "id": "q02692",
     "image_path": null,
     "question_text": {
-      "en": "複数スレッドが同時にアクセスしないよう制御する仕組みは?",
-      "ja": "Which primitive ensures only one thread accesses a resource at a time?"
+      "en": "Which primitive ensures only one thread accesses a resource at a time?",
+      "ja": "複数スレッドが同時にアクセスしないよう制御する仕組みは?"
     }
   },
   {
@@ -109140,8 +109140,8 @@
     "id": "q02693",
     "image_path": null,
     "question_text": {
-      "en": "オープンソースの代表的なリレーショナルDBで「m」で始まるのは?",
-      "ja": "Which popular open-source relational database starts with 'M'?"
+      "en": "Which popular open-source relational database starts with 'M'?",
+      "ja": "オープンソースの代表的なリレーショナルDBで「m」で始まるのは?"
     }
   },
   {
@@ -109180,8 +109180,8 @@
     "id": "q02694",
     "image_path": null,
     "question_text": {
-      "en": "グラフ型データベースの代表は?",
-      "ja": "Which is a leading graph database?"
+      "en": "Which is a leading graph database?",
+      "ja": "グラフ型データベースの代表は?"
     }
   },
   {
@@ -109222,8 +109222,8 @@
     "id": "q02695",
     "image_path": null,
     "question_text": {
-      "en": "HTTPステータスコード404が示すのは?",
-      "ja": "What does HTTP status code 404 indicate?"
+      "en": "What does HTTP status code 404 indicate?",
+      "ja": "HTTPステータスコード404が示すのは?"
     }
   },
   {
@@ -109262,8 +109262,8 @@
     "id": "q02696",
     "image_path": null,
     "question_text": {
-      "en": "ハッシュテーブルの平均的な検索計算量は?",
-      "ja": "What is the average-case lookup complexity of a hash table?"
+      "en": "What is the average-case lookup complexity of a hash table?",
+      "ja": "ハッシュテーブルの平均的な検索計算量は?"
     }
   },
   {
@@ -109302,8 +109302,8 @@
     "id": "q02697",
     "image_path": null,
     "question_text": {
-      "en": "二分探索の計算量は?",
-      "ja": "What is the time complexity of binary search?"
+      "en": "What is the time complexity of binary search?",
+      "ja": "二分探索の計算量は?"
     }
   },
   {
@@ -109342,8 +109342,8 @@
     "id": "q02698",
     "image_path": null,
     "question_text": {
-      "en": "比較ソートの最良計算量は?",
-      "ja": "What is the best achievable complexity for comparison sorting?"
+      "en": "What is the best achievable complexity for comparison sorting?",
+      "ja": "比較ソートの最良計算量は?"
     }
   },
   {
@@ -109382,8 +109382,8 @@
     "id": "q02699",
     "image_path": null,
     "question_text": {
-      "en": "配列を1度走査する線形探索の計算量は?",
-      "ja": "What is the time complexity of a single-pass linear search?"
+      "en": "What is the time complexity of a single-pass linear search?",
+      "ja": "配列を1度走査する線形探索の計算量は?"
     }
   },
   {
@@ -109424,8 +109424,8 @@
     "id": "q02700",
     "image_path": null,
     "question_text": {
-      "en": "HTTPステータスコード200が示すのは?",
-      "ja": "What does HTTP status code 200 indicate?"
+      "en": "What does HTTP status code 200 indicate?",
+      "ja": "HTTPステータスコード200が示すのは?"
     }
   },
   {
@@ -109465,8 +109465,8 @@
     "id": "q02701",
     "image_path": null,
     "question_text": {
-      "en": "GoFパターンで状態変化を購読者に通知するのは?",
-      "ja": "Which GoF pattern notifies subscribers of state changes?"
+      "en": "Which GoF pattern notifies subscribers of state changes?",
+      "ja": "GoFパターンで状態変化を購読者に通知するのは?"
     }
   },
   {
@@ -109509,8 +109509,8 @@
     "id": "q02702",
     "image_path": null,
     "question_text": {
-      "en": "0から7までの数字で表す進数は?",
-      "ja": "Which numeral system uses digits 0-7?"
+      "en": "Which numeral system uses digits 0-7?",
+      "ja": "0から7までの数字で表す進数は?"
     }
   },
   {
@@ -109549,8 +109549,8 @@
     "id": "q02703",
     "image_path": null,
     "question_text": {
-      "en": "HTTPでリソースの一部更新を表すメソッドは?",
-      "ja": "Which HTTP method represents a partial update of a resource?"
+      "en": "Which HTTP method represents a partial update of a resource?",
+      "ja": "HTTPでリソースの一部更新を表すメソッドは?"
     }
   },
   {
@@ -109589,8 +109589,8 @@
     "id": "q02704",
     "image_path": null,
     "question_text": {
-      "en": "サーバサイドで動的Webページを生成する人気言語は?",
-      "ja": "Which server-side language is widely used for generating dynamic web pages?"
+      "en": "Which server-side language is widely used for generating dynamic web pages?",
+      "ja": "サーバサイドで動的Webページを生成する人気言語は?"
     }
   },
   {
@@ -109629,8 +109629,8 @@
     "id": "q02705",
     "image_path": null,
     "question_text": {
-      "en": "HTTPでデータをサーバに送信する代表的なメソッドは?",
-      "ja": "Which HTTP method commonly submits data to the server?"
+      "en": "Which HTTP method commonly submits data to the server?",
+      "ja": "HTTPでデータをサーバに送信する代表的なメソッドは?"
     }
   },
   {
@@ -109669,8 +109669,8 @@
     "id": "q02706",
     "image_path": null,
     "question_text": {
-      "en": "HTTPでリソース全体を置き換えるメソッドは?",
-      "ja": "Which HTTP method replaces a resource entirely?"
+      "en": "Which HTTP method replaces a resource entirely?",
+      "ja": "HTTPでリソース全体を置き換えるメソッドは?"
     }
   },
   {
@@ -109709,8 +109709,8 @@
     "id": "q02707",
     "image_path": null,
     "question_text": {
-      "en": "Niklaus Wirthが設計した教育用言語は?",
-      "ja": "Which educational language was designed by Niklaus Wirth?"
+      "en": "Which educational language was designed by Niklaus Wirth?",
+      "ja": "Niklaus Wirthが設計した教育用言語は?"
     }
   },
   {
@@ -109749,8 +109749,8 @@
     "id": "q02708",
     "image_path": null,
     "question_text": {
-      "en": "オブジェクト指向で同じインタフェースで多様な振る舞いをする概念は?",
-      "ja": "Which OOP concept lets one interface serve many implementations?"
+      "en": "Which OOP concept lets one interface serve many implementations?",
+      "ja": "オブジェクト指向で同じインタフェースで多様な振る舞いをする概念は?"
     }
   },
   {
@@ -109789,8 +109789,8 @@
     "id": "q02709",
     "image_path": null,
     "question_text": {
-      "en": "高機能で拡張性に優れたオープンソースRDBは?",
-      "ja": "Which is a feature-rich, extensible open-source RDBMS?"
+      "en": "Which is a feature-rich, extensible open-source RDBMS?",
+      "ja": "高機能で拡張性に優れたオープンソースRDBは?"
     }
   },
   {
@@ -109829,8 +109829,8 @@
     "id": "q02710",
     "image_path": null,
     "question_text": {
-      "en": "OSが管理する実行単位でメモリ空間を独立して持つのは?",
-      "ja": "Which OS-managed execution unit has its own memory space?"
+      "en": "Which OS-managed execution unit has its own memory space?",
+      "ja": "OSが管理する実行単位でメモリ空間を独立して持つのは?"
     }
   },
   {
@@ -109869,8 +109869,8 @@
     "id": "q02711",
     "image_path": null,
     "question_text": {
-      "en": "プログラムの性能を測定し分析するツールは?",
-      "ja": "Which tool measures and analyzes a program's performance?"
+      "en": "Which tool measures and analyzes a program's performance?",
+      "ja": "プログラムの性能を測定し分析するツールは?"
     }
   },
   {
@@ -109909,8 +109909,8 @@
     "id": "q02712",
     "image_path": null,
     "question_text": {
-      "en": "FIFO方式で出し入れするデータ構造は?",
-      "ja": "Which data structure follows FIFO (first-in, first-out)?"
+      "en": "Which data structure follows FIFO (first-in, first-out)?",
+      "ja": "FIFO方式で出し入れするデータ構造は?"
     }
   },
   {
@@ -109949,8 +109949,8 @@
     "id": "q02713",
     "image_path": null,
     "question_text": {
-      "en": "Rustのシングルスレッド向け参照カウントスマートポインタは?",
-      "ja": "Which Rust smart pointer is a single-threaded reference counter?"
+      "en": "Which Rust smart pointer is a single-threaded reference counter?",
+      "ja": "Rustのシングルスレッド向け参照カウントスマートポインタは?"
     }
   },
   {
@@ -109989,8 +109989,8 @@
     "id": "q02714",
     "image_path": null,
     "question_text": {
-      "en": "HTTPで別URLに転送することを表す3xx系の意味は?",
-      "ja": "What is the meaning of the HTTP 3xx status family?"
+      "en": "What is the meaning of the HTTP 3xx status family?",
+      "ja": "HTTPで別URLに転送することを表す3xx系の意味は?"
     }
   },
   {
@@ -110033,8 +110033,8 @@
     "id": "q02715",
     "image_path": null,
     "question_text": {
-      "en": "GNUプロジェクトを創設した人物は?",
-      "ja": "Who founded the GNU Project?"
+      "en": "Who founded the GNU Project?",
+      "ja": "GNUプロジェクトを創設した人物は?"
     }
   },
   {
@@ -110073,8 +110073,8 @@
     "id": "q02716",
     "image_path": null,
     "question_text": {
-      "en": "メール送信に使われるプロトコルは?",
-      "ja": "Which protocol is used to send emails?"
+      "en": "Which protocol is used to send emails?",
+      "ja": "メール送信に使われるプロトコルは?"
     }
   },
   {
@@ -110113,8 +110113,8 @@
     "id": "q02717",
     "image_path": null,
     "question_text": {
-      "en": "リレーショナルDBを操作する標準言語は?",
-      "ja": "Which standard language manipulates relational databases?"
+      "en": "Which standard language manipulates relational databases?",
+      "ja": "リレーショナルDBを操作する標準言語は?"
     }
   },
   {
@@ -110153,8 +110153,8 @@
     "id": "q02718",
     "image_path": null,
     "question_text": {
-      "en": "ファイル1つで動く軽量な組み込みRDBは?",
-      "ja": "Which lightweight embedded RDBMS stores data in a single file?"
+      "en": "Which lightweight embedded RDBMS stores data in a single file?",
+      "ja": "ファイル1つで動く軽量な組み込みRDBは?"
     }
   },
   {
@@ -110195,8 +110195,8 @@
     "id": "q02719",
     "image_path": null,
     "question_text": {
-      "en": "不正なメモリアクセスで発生する典型的なエラーは?",
-      "ja": "Which error is typically caused by invalid memory access?"
+      "en": "Which error is typically caused by invalid memory access?",
+      "ja": "不正なメモリアクセスで発生する典型的なエラーは?"
     }
   },
   {
@@ -110235,8 +110235,8 @@
     "id": "q02720",
     "image_path": null,
     "question_text": {
-      "en": "Unixでプロセスに送る通知の仕組みは?",
-      "ja": "Which Unix mechanism sends notifications to processes?"
+      "en": "Which Unix mechanism sends notifications to processes?",
+      "ja": "Unixでプロセスに送る通知の仕組みは?"
     }
   },
   {
@@ -110276,8 +110276,8 @@
     "id": "q02721",
     "image_path": null,
     "question_text": {
-      "en": "GoFパターンでインスタンスを1つに制限するのは?",
-      "ja": "Which GoF pattern restricts a class to a single instance?"
+      "en": "Which GoF pattern restricts a class to a single instance?",
+      "ja": "GoFパターンでインスタンスを1つに制限するのは?"
     }
   },
   {
@@ -110317,8 +110317,8 @@
     "id": "q02722",
     "image_path": null,
     "question_text": {
-      "en": "ミニファイされたコードと元のコードを対応付けるファイルは?",
-      "ja": "Which file maps minified code back to the original source?"
+      "en": "Which file maps minified code back to the original source?",
+      "ja": "ミニファイされたコードと元のコードを対応付けるファイルは?"
     }
   },
   {
@@ -110357,8 +110357,8 @@
     "id": "q02723",
     "image_path": null,
     "question_text": {
-      "en": "LIFO方式で出し入れするデータ構造は?",
-      "ja": "Which data structure follows LIFO (last-in, first-out)?"
+      "en": "Which data structure follows LIFO (last-in, first-out)?",
+      "ja": "LIFO方式で出し入れするデータ構造は?"
     }
   },
   {
@@ -110398,8 +110398,8 @@
     "id": "q02724",
     "image_path": null,
     "question_text": {
-      "en": "スタック領域が溢れたときに起きるエラーは?",
-      "ja": "Which error occurs when the call stack exceeds its limit?"
+      "en": "Which error occurs when the call stack exceeds its limit?",
+      "ja": "スタック領域が溢れたときに起きるエラーは?"
     }
   },
   {
@@ -110438,8 +110438,8 @@
     "id": "q02725",
     "image_path": null,
     "question_text": {
-      "en": "コンパイル時に型が決まる言語の性質を表す語は?",
-      "ja": "Which term describes a language whose types are checked at compile time?"
+      "en": "Which term describes a language whose types are checked at compile time?",
+      "ja": "コンパイル時に型が決まる言語の性質を表す語は?"
     }
   },
   {
@@ -110478,8 +110478,8 @@
     "id": "q02726",
     "image_path": null,
     "question_text": {
-      "en": "HTTPの2xx系ステータスコードのカテゴリ名は?",
-      "ja": "What is the meaning of the HTTP 2xx status family?"
+      "en": "What is the meaning of the HTTP 2xx status family?",
+      "ja": "HTTPの2xx系ステータスコードのカテゴリ名は?"
     }
   },
   {
@@ -110518,8 +110518,8 @@
     "id": "q02727",
     "image_path": null,
     "question_text": {
-      "en": "古くからある暗号化されないリモートログインプロトコルは?",
-      "ja": "Which old remote-login protocol transmits data unencrypted?"
+      "en": "Which old remote-login protocol transmits data unencrypted?",
+      "ja": "古くからある暗号化されないリモートログインプロトコルは?"
     }
   },
   {
@@ -110559,8 +110559,8 @@
     "id": "q02728",
     "image_path": null,
     "question_text": {
-      "en": "HashiCorpが開発するインフラ宣言型ツールは?",
-      "ja": "Which HashiCorp tool provisions infrastructure declaratively?"
+      "en": "Which HashiCorp tool provisions infrastructure declaratively?",
+      "ja": "HashiCorpが開発するインフラ宣言型ツールは?"
     }
   },
   {
@@ -110599,8 +110599,8 @@
     "id": "q02729",
     "image_path": null,
     "question_text": {
-      "en": "プロセス内で並行実行されメモリ空間を共有する単位は?",
-      "ja": "Which execution unit runs in a process and shares its memory?"
+      "en": "Which execution unit runs in a process and shares its memory?",
+      "ja": "プロセス内で並行実行されメモリ空間を共有する単位は?"
     }
   },
   {
@@ -110643,8 +110643,8 @@
     "id": "q02730",
     "image_path": null,
     "question_text": {
-      "en": "World Wide Webを発明した人物は?",
-      "ja": "Who invented the World Wide Web?"
+      "en": "Who invented the World Wide Web?",
+      "ja": "World Wide Webを発明した人物は?"
     }
   },
   {
@@ -110683,8 +110683,8 @@
     "id": "q02731",
     "image_path": null,
     "question_text": {
-      "en": "節点と枝で階層構造を表すデータ構造は?",
-      "ja": "Which data structure represents hierarchical relations with nodes and branches?"
+      "en": "Which data structure represents hierarchical relations with nodes and branches?",
+      "ja": "節点と枝で階層構造を表すデータ構造は?"
     }
   },
   {
@@ -110723,8 +110723,8 @@
     "id": "q02732",
     "image_path": null,
     "question_text": {
-      "en": "コネクションレスで信頼性を保証しないトランスポート層プロトコルは?",
-      "ja": "Which transport protocol is connectionless and unreliable?"
+      "en": "Which transport protocol is connectionless and unreliable?",
+      "ja": "コネクションレスで信頼性を保証しないトランスポート層プロトコルは?"
     }
   },
   {
@@ -110765,8 +110765,8 @@
     "id": "q02733",
     "image_path": null,
     "question_text": {
-      "en": "HTTPステータスコード401が示すのは?",
-      "ja": "What does HTTP status code 401 indicate?"
+      "en": "What does HTTP status code 401 indicate?",
+      "ja": "HTTPステータスコード401が示すのは?"
     }
   },
   {
@@ -110805,8 +110805,8 @@
     "id": "q02734",
     "image_path": null,
     "question_text": {
-      "en": "GoogleのChromeなどで動くJavaScriptエンジンは?",
-      "ja": "Which JavaScript engine powers Google Chrome?"
+      "en": "Which JavaScript engine powers Google Chrome?",
+      "ja": "GoogleのChromeなどで動くJavaScriptエンジンは?"
     }
   },
   {
@@ -110845,8 +110845,8 @@
     "id": "q02735",
     "image_path": null,
     "question_text": {
-      "en": "Linuxユーザに愛される高機能テキストエディタは?",
-      "ja": "Which highly extensible terminal text editor is beloved by Linux users?"
+      "en": "Which highly extensible terminal text editor is beloved by Linux users?",
+      "ja": "Linuxユーザに愛される高機能テキストエディタは?"
     }
   },
   {
@@ -110885,8 +110885,8 @@
     "id": "q02736",
     "image_path": null,
     "question_text": {
-      "en": "OGC仕様の地理空間ベクタフィーチャ取得サービスは?",
-      "ja": "Which OGC service provides geospatial vector features over the web?"
+      "en": "Which OGC service provides geospatial vector features over the web?",
+      "ja": "OGC仕様の地理空間ベクタフィーチャ取得サービスは?"
     }
   },
   {
@@ -110929,8 +110929,8 @@
     "id": "q02737",
     "image_path": null,
     "question_text": {
-      "en": "Rubyを設計した人物は?",
-      "ja": "Who designed the Ruby programming language?"
+      "en": "Who designed the Ruby programming language?",
+      "ja": "Rubyを設計した人物は?"
     }
   },
   {
@@ -110973,8 +110973,8 @@
     "id": "q02738",
     "image_path": null,
     "question_text": {
-      "en": "多くの言語でコメント開始を表す記号は?",
-      "ja": "Which character commonly starts a line comment in many languages?"
+      "en": "Which character commonly starts a line comment in many languages?",
+      "ja": "多くの言語でコメント開始を表す記号は?"
     }
   },
   {
@@ -111017,8 +111017,8 @@
     "id": "q02739",
     "image_path": null,
     "question_text": {
-      "en": "シェルで変数を参照するときに使う記号は?",
-      "ja": "Which character is used to reference shell variables?"
+      "en": "Which character is used to reference shell variables?",
+      "ja": "シェルで変数を参照するときに使う記号は?"
     }
   },
   {
@@ -111061,8 +111061,8 @@
     "id": "q02740",
     "image_path": null,
     "question_text": {
-      "en": "C系言語で剰余演算を表す記号は?",
-      "ja": "Which operator represents modulo in C-like languages?"
+      "en": "Which operator represents modulo in C-like languages?",
+      "ja": "C系言語で剰余演算を表す記号は?"
     }
   },
   {
@@ -111105,8 +111105,8 @@
     "id": "q02741",
     "image_path": null,
     "question_text": {
-      "en": "シェルでコマンドをバックグラウンド実行する記号は?",
-      "ja": "Which shell character runs a command in the background?"
+      "en": "Which shell character runs a command in the background?",
+      "ja": "シェルでコマンドをバックグラウンド実行する記号は?"
     }
   },
   {
@@ -111149,8 +111149,8 @@
     "id": "q02742",
     "image_path": null,
     "question_text": {
-      "en": "C系言語でポインタの参照外しや乗算を表す記号は?",
-      "ja": "Which operator dereferences pointers or denotes multiplication in C?"
+      "en": "Which operator dereferences pointers or denotes multiplication in C?",
+      "ja": "C系言語でポインタの参照外しや乗算を表す記号は?"
     }
   },
   {
@@ -111193,8 +111193,8 @@
     "id": "q02743",
     "image_path": null,
     "question_text": {
-      "en": "Pythonでデコレータを表す記号は?",
-      "ja": "Which character marks a decorator in Python?"
+      "en": "Which character marks a decorator in Python?",
+      "ja": "Pythonでデコレータを表す記号は?"
     }
   },
   {
@@ -111237,8 +111237,8 @@
     "id": "q02744",
     "image_path": null,
     "question_text": {
-      "en": "非同期関数の完了を待つPython/JSのキーワードは?",
-      "ja": "Which keyword in Python and JS waits for an async result?"
+      "en": "Which keyword in Python and JS waits for an async result?",
+      "ja": "非同期関数の完了を待つPython/JSのキーワードは?"
     }
   },
   {
@@ -111281,8 +111281,8 @@
     "id": "q02745",
     "image_path": null,
     "question_text": {
-      "en": "Pythonで関数を定義するキーワードは?",
-      "ja": "Which Python keyword defines a function?"
+      "en": "Which Python keyword defines a function?",
+      "ja": "Pythonで関数を定義するキーワードは?"
     }
   },
   {
@@ -111325,8 +111325,8 @@
     "id": "q02746",
     "image_path": null,
     "question_text": {
-      "en": "Goで関数終了時に処理を予約するキーワードは?",
-      "ja": "Which Go keyword schedules a call to run when the function returns?"
+      "en": "Which Go keyword schedules a call to run when the function returns?",
+      "ja": "Goで関数終了時に処理を予約するキーワードは?"
     }
   },
   {
@@ -111369,8 +111369,8 @@
     "id": "q02747",
     "image_path": null,
     "question_text": {
-      "en": "Rustで関数を定義するキーワードは?",
-      "ja": "Which Rust keyword defines a function?"
+      "en": "Which Rust keyword defines a function?",
+      "ja": "Rustで関数を定義するキーワードは?"
     }
   },
   {
@@ -111413,8 +111413,8 @@
     "id": "q02748",
     "image_path": null,
     "question_text": {
-      "en": "関数から値を返すための多くの言語で共通のキーワードは?",
-      "ja": "Which keyword returns a value from a function in most languages?"
+      "en": "Which keyword returns a value from a function in most languages?",
+      "ja": "関数から値を返すための多くの言語で共通のキーワードは?"
     }
   },
   {
@@ -111457,8 +111457,8 @@
     "id": "q02749",
     "image_path": null,
     "question_text": {
-      "en": "ジェネレータで値を1つずつ生成するキーワードは?",
-      "ja": "Which keyword produces values one at a time from a generator?"
+      "en": "Which keyword produces values one at a time from a generator?",
+      "ja": "ジェネレータで値を1つずつ生成するキーワードは?"
     }
   },
   {
@@ -111497,8 +111497,8 @@
     "id": "q02750",
     "image_path": null,
     "question_text": {
-      "en": "Pythonのパッケージインストーラは?",
-      "ja": "Which is the standard package installer for Python?"
+      "en": "Which is the standard package installer for Python?",
+      "ja": "Pythonのパッケージインストーラは?"
     }
   },
   {
@@ -127027,10 +127027,9 @@
     "choices": [
       {
         "en": "Munich Agreement",
-        "ja": "ミュンヘン会談",
+        "ja": "ミュンヘン協定",
         "ja_typings": [
-          "myunhen kaidan",
-          "myunhenkaidan"
+          "myunhenkyoutei"
         ]
       },
       {
@@ -132197,11 +132196,10 @@
   {
     "choices": [
       {
-        "en": "26 km",
-        "ja": "約26km",
+        "en": "42 km",
+        "ja": "約42km",
         "ja_typings": [
-          "yaku26kiro",
-          "yaku26km"
+          "yaku42km"
         ]
       },
       {
@@ -132213,11 +132211,10 @@
         ]
       },
       {
-        "en": "42 km",
-        "ja": "約42km",
+        "en": "26 km",
+        "ja": "約26km",
         "ja_typings": [
-          "yaku42kiro",
-          "yaku42km"
+          "yaku26km"
         ]
       },
       {
@@ -132325,13 +132322,10 @@
   {
     "choices": [
       {
-        "en": "30 minutes",
-        "ja": "30分",
+        "en": "8 minutes",
+        "ja": "8分",
         "ja_typings": [
-          "30hun",
-          "30pun",
-          "30bun",
-          "sanjuxtupun"
+          "8fun"
         ]
       },
       {
@@ -132345,13 +132339,11 @@
         ]
       },
       {
-        "en": "8 minutes",
-        "ja": "8分",
+        "en": "30 minutes",
+        "ja": "30分",
         "ja_typings": [
-          "8hun",
-          "8pun",
-          "8bun",
-          "hatupun"
+          "30fun",
+          "30pun"
         ]
       },
       {
@@ -132510,22 +132502,18 @@
   {
     "choices": [
       {
-        "en": "60 minutes",
-        "ja": "60分",
-        "ja_typings": [
-          "60hun",
-          "60pun",
-          "60bun",
-          "rokujuxtupun"
-        ]
-      },
-      {
         "en": "45 minutes",
         "ja": "45分",
         "ja_typings": [
-          "45hun",
-          "45pun",
-          "45bun"
+          "45fun"
+        ]
+      },
+      {
+        "en": "60 minutes",
+        "ja": "60分",
+        "ja_typings": [
+          "60fun",
+          "60pun"
         ]
       },
       {


### PR DESCRIPTION
## Summary
PR #118 (Round 3) でカバレッジ 38%、ただし 8 ジャンルが 40% 未満だった。本 PR でそれらに特化して追加。

## カバレッジ推移
| 段階 | 全体 |
|---|---|
| Round 1 完了 | 8% |
| Round 3 完了 | 38% |
| **Round 4 完了** | **81%** |

## ジャンル別 (Round 4 ターゲット)
| genre | round3後 | round4後 |
|---|---|---|
| geography | 25% | **100%** |
| programming | 27% | 99% |
| web_development | 33% | **100%** |
| anime | 26% | **100%** |
| game | 25% | 99% |
| history | 21% | 99% |
| math | 40% | 99% |
| general_knowledge | 35% | 97% |

## 未達 (Round 4 対象外、次ラウンド候補)
- technology 43%
- vtuber_net_culture 43%
- science 51%
- culture 54%
- it_terminology 59%
- language 61%
- manga 63%

## Test plan
- [x] lint-questions: 0 conflicts, 0 errors
- [x] cargo test --release: 236 passed
- [x] backfill-ja-typing 通過