### PR TITLE
feat: Round 5 — 全7残ジャンル完遂、+339問 (3321→3660)、カバレッジ98.5%達成

### DIFF
--- a/data/questions_en.json
+++ b/data/questions_en.json
@@ -108749,28 +108749,30 @@
         "en": "O(n log n)",
         "ja": "O(n log n)",
         "ja_typings": [
-          "O(nlogn)"
+          "o(nlogn)",
+          "o(n log n)"
         ]
       },
       {
         "en": "O(n)",
         "ja": "O(n)",
         "ja_typings": [
-          "O(n)"
+          "o(n)"
         ]
       },
       {
         "en": "O(n^2)",
         "ja": "O(n^2)",
         "ja_typings": [
-          "O(n^2)"
+          "o(n^2)"
         ]
       },
       {
         "en": "O(log n)",
         "ja": "O(log n)",
         "ja_typings": [
-          "O(logn)"
+          "o(logn)",
+          "o(log n)"
         ]
       }
     ],
@@ -114359,21 +114361,24 @@
         "en": "`==`",
         "ja": "イコール2つ",
         "ja_typings": [
-          "ikooru2tsu"
+          "ikooru2tsu",
+          "iko-ru2tsu"
         ]
       },
       {
         "en": "`===`",
         "ja": "イコール3つ",
         "ja_typings": [
-          "ikooru3tsu"
+          "ikooru3tsu",
+          "iko-ru3tsu"
         ]
       },
       {
         "en": "`=`",
         "ja": "イコール1つ",
         "ja_typings": [
-          "ikooru1tsu"
+          "ikooru1tsu",
+          "iko-ru1tsu"
         ]
       }
     ],
@@ -114632,14 +114637,16 @@
         "en": "`==`",
         "ja": "イコール2つ",
         "ja_typings": [
-          "ikooru2tsu"
+          "ikooru2tsu",
+          "iko-ru2tsu"
         ]
       },
       {
         "en": "`===`",
         "ja": "イコール3つ",
         "ja_typings": [
-          "ikooru3tsu"
+          "ikooru3tsu",
+          "iko-ru3tsu"
         ]
       },
       {
@@ -114654,7 +114661,8 @@
         "en": "`=`",
         "ja": "イコール1つ",
         "ja_typings": [
-          "ikooru1tsu"
+          "ikooru1tsu",
+          "iko-ru1tsu"
         ]
       }
     ],
@@ -114673,21 +114681,24 @@
         "en": "`=`",
         "ja": "イコール1つ",
         "ja_typings": [
-          "ikooru1tsu"
+          "ikooru1tsu",
+          "iko-ru1tsu"
         ]
       },
       {
         "en": "`==`",
         "ja": "イコール2つ",
         "ja_typings": [
-          "ikooru2tsu"
+          "ikooru2tsu",
+          "iko-ru2tsu"
         ]
       },
       {
         "en": "`===`",
         "ja": "イコール3つ",
         "ja_typings": [
-          "ikooru3tsu"
+          "ikooru3tsu",
+          "iko-ru3tsu"
         ]
       },
       {
@@ -132379,7 +132390,8 @@
         "en": "2",
         "ja": "2つ",
         "ja_typings": [
-          "futatsu"
+          "futatsu",
+          "2tsu"
         ]
       },
       {
@@ -132820,7 +132832,8 @@
         "en": "Mark Twain",
         "ja": "マーク・トウェイン",
         "ja_typings": [
-          "maa-ku/touxein"
+          "maa-ku/touxein",
+          "ma-ku/towein"
         ]
       },
       {
@@ -133094,7 +133107,8 @@
         "en": "Venice",
         "ja": "ヴェネツィア",
         "ja_typings": [
-          "venetsuxia"
+          "venetsuxia",
+          "venetsia"
         ]
       }
     ],
@@ -133739,7 +133753,8 @@
         "en": "Beetroot",
         "ja": "ビーツ",
         "ja_typings": [
-          "bii-tsu"
+          "bii-tsu",
+          "bi-tsu"
         ]
       }
     ],
@@ -133781,7 +133796,8 @@
         "en": "Beetroot",
         "ja": "ビーツ",
         "ja_typings": [
-          "bii-tsu"
+          "bii-tsu",
+          "bi-tsu"
         ]
       }
     ],
@@ -135054,6 +135070,13620 @@
     "question_text": {
       "en": "What does an arrow leave behind in flight, often used as an idiom?",
       "ja": "矢が飛んだ後に残るとされる、慣用句にもなるものはどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "128 bits",
+        "ja": "128ビット",
+        "ja_typings": [
+          "128bitto"
+        ]
+      },
+      {
+        "en": "64 bits",
+        "ja": "64ビット",
+        "ja_typings": [
+          "64bitto"
+        ]
+      },
+      {
+        "en": "32 bits",
+        "ja": "32ビット",
+        "ja_typings": [
+          "32bitto"
+        ]
+      },
+      {
+        "en": "256 bits",
+        "ja": "256ビット",
+        "ja_typings": [
+          "256bitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03322",
+    "image_path": null,
+    "question_text": {
+      "en": "Which bit width can represent IPv6 addresses?",
+      "ja": "IPv6アドレスを表現できるビット幅は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "2 bits",
+        "ja": "2ビット",
+        "ja_typings": [
+          "2bitto"
+        ]
+      },
+      {
+        "en": "4 bits",
+        "ja": "4ビット",
+        "ja_typings": [
+          "4bitto"
+        ]
+      },
+      {
+        "en": "8 bits",
+        "ja": "8ビット",
+        "ja_typings": [
+          "8bitto"
+        ]
+      },
+      {
+        "en": "16 bits",
+        "ja": "16ビット",
+        "ja_typings": [
+          "16bitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03323",
+    "image_path": null,
+    "question_text": {
+      "en": "Which bit width can represent only two values, 0 and 1?",
+      "ja": "0と1の2値しか表現できないビット幅は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "4 bits",
+        "ja": "4ビット",
+        "ja_typings": [
+          "4bitto"
+        ]
+      },
+      {
+        "en": "8 bits",
+        "ja": "8ビット",
+        "ja_typings": [
+          "8bitto"
+        ]
+      },
+      {
+        "en": "2 bits",
+        "ja": "2ビット",
+        "ja_typings": [
+          "2bitto"
+        ]
+      },
+      {
+        "en": "16 bits",
+        "ja": "16ビット",
+        "ja_typings": [
+          "16bitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03324",
+    "image_path": null,
+    "question_text": {
+      "en": "Which bit width is called a nibble?",
+      "ja": "ニブルと呼ばれるビット幅は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "8 bits",
+        "ja": "8ビット",
+        "ja_typings": [
+          "8bitto"
+        ]
+      },
+      {
+        "en": "4 bits",
+        "ja": "4ビット",
+        "ja_typings": [
+          "4bitto"
+        ]
+      },
+      {
+        "en": "16 bits",
+        "ja": "16ビット",
+        "ja_typings": [
+          "16bitto"
+        ]
+      },
+      {
+        "en": "2 bits",
+        "ja": "2ビット",
+        "ja_typings": [
+          "2bitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03325",
+    "image_path": null,
+    "question_text": {
+      "en": "Which bit width equals one byte?",
+      "ja": "1バイトに相当するビット幅は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ALTAIR",
+        "ja": "アルテア",
+        "ja_typings": [
+          "arutea"
+        ]
+      },
+      {
+        "en": "ENIAC",
+        "ja": "エニアック",
+        "ja_typings": [
+          "eniakku"
+        ]
+      },
+      {
+        "en": "PDP-8",
+        "ja": "ピーディーピー8",
+        "ja_typings": [
+          "pi-di-pi-8"
+        ]
+      },
+      {
+        "en": "IBM 5100",
+        "ja": "アイビーエム5100",
+        "ja_typings": [
+          "aibi-emu5100"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03326",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the famous early microcomputer kit released in 1975?",
+      "ja": "1975年に発売された有名な初期マイコンキットは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ARM",
+        "ja": "アーム",
+        "ja_typings": [
+          "a-mu"
+        ]
+      },
+      {
+        "en": "x86",
+        "ja": "エックス86",
+        "ja_typings": [
+          "ekkusu86"
+        ]
+      },
+      {
+        "en": "MIPS",
+        "ja": "ミップス",
+        "ja_typings": [
+          "mippusu"
+        ]
+      },
+      {
+        "en": "SPARC",
+        "ja": "スパーク",
+        "ja_typings": [
+          "supa-ku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03327",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CPU architecture is widely used in smartphones?",
+      "ja": "スマートフォンで広く使われているCPUアーキテクチャは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Apple",
+        "ja": "アップル",
+        "ja_typings": [
+          "appuru"
+        ]
+      },
+      {
+        "en": "Samsung",
+        "ja": "サムスン",
+        "ja_typings": [
+          "samusun"
+        ]
+      },
+      {
+        "en": "Google",
+        "ja": "グーグル",
+        "ja_typings": [
+          "gu-guru"
+        ]
+      },
+      {
+        "en": "Sony",
+        "ja": "ソニー",
+        "ja_typings": [
+          "soni-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03328",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company makes the iPhone?",
+      "ja": "iPhoneを製造している企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "BIOS",
+        "ja": "バイオス",
+        "ja_typings": [
+          "baiosu"
+        ]
+      },
+      {
+        "en": "UEFI",
+        "ja": "ユーイーエフアイ",
+        "ja_typings": [
+          "yu-i-efuai"
+        ]
+      },
+      {
+        "en": "GRUB",
+        "ja": "グラブ",
+        "ja_typings": [
+          "gurabu"
+        ]
+      },
+      {
+        "en": "POST",
+        "ja": "ポスト",
+        "ja_typings": [
+          "posuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03329",
+    "image_path": null,
+    "question_text": {
+      "en": "Which firmware initializes hardware at PC boot?",
+      "ja": "PC起動時にハードウェアを初期化するファームウェアは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bluetooth",
+        "ja": "ブルートゥース",
+        "ja_typings": [
+          "buru-tu-su"
+        ]
+      },
+      {
+        "en": "Wi-Fi",
+        "ja": "ワイファイ",
+        "ja_typings": [
+          "waifai"
+        ]
+      },
+      {
+        "en": "Zigbee",
+        "ja": "ジグビー",
+        "ja_typings": [
+          "jigubi-"
+        ]
+      },
+      {
+        "en": "NFC",
+        "ja": "エヌエフシー",
+        "ja_typings": [
+          "enuefushi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03330",
+    "image_path": null,
+    "question_text": {
+      "en": "Which short-range wireless standard is used for headsets?",
+      "ja": "ヘッドセットなどで使われる近距離無線規格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Buffer",
+        "ja": "バッファ",
+        "ja_typings": [
+          "baffa"
+        ]
+      },
+      {
+        "en": "Cache",
+        "ja": "キャッシュ",
+        "ja_typings": [
+          "kyasshu"
+        ]
+      },
+      {
+        "en": "Queue",
+        "ja": "キュー",
+        "ja_typings": [
+          "kyu-"
+        ]
+      },
+      {
+        "en": "Stack",
+        "ja": "スタック",
+        "ja_typings": [
+          "sutakku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03331",
+    "image_path": null,
+    "question_text": {
+      "en": "Which temporary storage smooths the speed gap between devices?",
+      "ja": "機器間の速度差を吸収する一時記憶領域は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CPU",
+        "ja": "シーピーユー",
+        "ja_typings": [
+          "shi-pi-yu-"
+        ]
+      },
+      {
+        "en": "GPU",
+        "ja": "ジーピーユー",
+        "ja_typings": [
+          "ji-pi-yu-"
+        ]
+      },
+      {
+        "en": "RAM",
+        "ja": "ラム",
+        "ja_typings": [
+          "ramu"
+        ]
+      },
+      {
+        "en": "SSD",
+        "ja": "エスエスディー",
+        "ja_typings": [
+          "esuesudi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03332",
+    "image_path": null,
+    "question_text": {
+      "en": "Which component is the brain of a computer?",
+      "ja": "コンピュータの頭脳に相当する部品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CRC32",
+        "ja": "シーアールシー32",
+        "ja_typings": [
+          "shi-a-rushi-32"
+        ]
+      },
+      {
+        "en": "MD5",
+        "ja": "エムディー5",
+        "ja_typings": [
+          "emudi-5"
+        ]
+      },
+      {
+        "en": "SHA1",
+        "ja": "シャー1",
+        "ja_typings": [
+          "sha-1"
+        ]
+      },
+      {
+        "en": "Adler32",
+        "ja": "アドラー32",
+        "ja_typings": [
+          "adora-32"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03333",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 32-bit cyclic redundancy check is widely used for error detection?",
+      "ja": "エラー検出に広く使われる32ビットの巡回冗長検査は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cache memory",
+        "ja": "キャッシュメモリ",
+        "ja_typings": [
+          "kyasshumemori"
+        ]
+      },
+      {
+        "en": "Virtual memory",
+        "ja": "仮想メモリ",
+        "ja_typings": [
+          "kasoumemori"
+        ]
+      },
+      {
+        "en": "Swap memory",
+        "ja": "スワップメモリ",
+        "ja_typings": [
+          "suwappumemori"
+        ]
+      },
+      {
+        "en": "Flash memory",
+        "ja": "フラッシュメモリ",
+        "ja_typings": [
+          "furasshumemori"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03334",
+    "image_path": null,
+    "question_text": {
+      "en": "Which high-speed memory sits between the CPU and main memory?",
+      "ja": "CPUと主記憶の間にある高速メモリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cisco",
+        "ja": "シスコ",
+        "ja_typings": [
+          "shisuko"
+        ]
+      },
+      {
+        "en": "Juniper",
+        "ja": "ジュニパー",
+        "ja_typings": [
+          "junipa-"
+        ]
+      },
+      {
+        "en": "Arista",
+        "ja": "アリスタ",
+        "ja_typings": [
+          "arisuta"
+        ]
+      },
+      {
+        "en": "Huawei",
+        "ja": "ファーウェイ",
+        "ja_typings": [
+          "fa-wei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03335",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company is a major networking equipment vendor?",
+      "ja": "大手ネットワーク機器ベンダーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DDR",
+        "ja": "ディーディーアール",
+        "ja_typings": [
+          "di-di-a-ru"
+        ]
+      },
+      {
+        "en": "SDR",
+        "ja": "エスディーアール",
+        "ja_typings": [
+          "esudi-a-ru"
+        ]
+      },
+      {
+        "en": "RDRAM",
+        "ja": "アールディーラム",
+        "ja_typings": [
+          "a-rudi-ramu"
+        ]
+      },
+      {
+        "en": "EDO",
+        "ja": "イーディーオー",
+        "ja_typings": [
+          "i-di-o-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03336",
+    "image_path": null,
+    "question_text": {
+      "en": "Which memory standard is commonly used in modern PCs?",
+      "ja": "現代のPCで広く使われるメモリ規格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DHCP",
+        "ja": "ディーエイチシーピー",
+        "ja_typings": [
+          "di-eichishi-pi-"
+        ]
+      },
+      {
+        "en": "DNS",
+        "ja": "ディーエヌエス",
+        "ja_typings": [
+          "di-enuesu"
+        ]
+      },
+      {
+        "en": "ARP",
+        "ja": "エーアールピー",
+        "ja_typings": [
+          "e-a-rupi-"
+        ]
+      },
+      {
+        "en": "NAT",
+        "ja": "エヌエーティー",
+        "ja_typings": [
+          "enue-ti-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03337",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol automatically assigns IP addresses to hosts?",
+      "ja": "ホストにIPアドレスを自動配布するプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DNS",
+        "ja": "ディーエヌエス",
+        "ja_typings": [
+          "di-enuesu"
+        ]
+      },
+      {
+        "en": "DHCP",
+        "ja": "ディーエイチシーピー",
+        "ja_typings": [
+          "di-eichishi-pi-"
+        ]
+      },
+      {
+        "en": "NAT",
+        "ja": "エヌエーティー",
+        "ja_typings": [
+          "enue-ti-"
+        ]
+      },
+      {
+        "en": "ARP",
+        "ja": "エーアールピー",
+        "ja_typings": [
+          "e-a-rupi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03338",
+    "image_path": null,
+    "question_text": {
+      "en": "Which system resolves domain names to IP addresses?",
+      "ja": "ドメイン名をIPアドレスに解決する仕組みは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "EEPROM",
+        "ja": "イーイーピーロム",
+        "ja_typings": [
+          "i-i-pi-romu"
+        ]
+      },
+      {
+        "en": "DRAM",
+        "ja": "ディーラム",
+        "ja_typings": [
+          "di-ramu"
+        ]
+      },
+      {
+        "en": "SRAM",
+        "ja": "エスラム",
+        "ja_typings": [
+          "esuramu"
+        ]
+      },
+      {
+        "en": "ROM",
+        "ja": "ロム",
+        "ja_typings": [
+          "romu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03339",
+    "image_path": null,
+    "question_text": {
+      "en": "Which non-volatile memory can be electrically erased and rewritten?",
+      "ja": "電気的に消去・書き換え可能な不揮発性メモリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FAT32",
+        "ja": "ファット32",
+        "ja_typings": [
+          "fatto32"
+        ]
+      },
+      {
+        "en": "NTFS",
+        "ja": "エヌティーエフエス",
+        "ja_typings": [
+          "enuti-efuesu"
+        ]
+      },
+      {
+        "en": "ext4",
+        "ja": "イーエックスティー4",
+        "ja_typings": [
+          "i-ekkusuti-4"
+        ]
+      },
+      {
+        "en": "HFS",
+        "ja": "エイチエフエス",
+        "ja_typings": [
+          "eichiefuesu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03340",
+    "image_path": null,
+    "question_text": {
+      "en": "Which file system was widely used in older Windows versions?",
+      "ja": "古いWindowsで広く使われたファイルシステムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Flash",
+        "ja": "フラッシュ",
+        "ja_typings": [
+          "furasshu"
+        ]
+      },
+      {
+        "en": "DRAM",
+        "ja": "ディーラム",
+        "ja_typings": [
+          "di-ramu"
+        ]
+      },
+      {
+        "en": "SRAM",
+        "ja": "エスラム",
+        "ja_typings": [
+          "esuramu"
+        ]
+      },
+      {
+        "en": "EEPROM",
+        "ja": "イーイーピーロム",
+        "ja_typings": [
+          "i-i-pi-romu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03341",
+    "image_path": null,
+    "question_text": {
+      "en": "Which type of non-volatile memory is used in USB drives?",
+      "ja": "USBメモリに使われる不揮発性メモリの種類は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FreeBSD",
+        "ja": "フリービーエスディー",
+        "ja_typings": [
+          "furi-bi-esudi-"
+        ]
+      },
+      {
+        "en": "Linux",
+        "ja": "リナックス",
+        "ja_typings": [
+          "rinakkusu"
+        ]
+      },
+      {
+        "en": "Minix",
+        "ja": "ミニックス",
+        "ja_typings": [
+          "minikkusu"
+        ]
+      },
+      {
+        "en": "Solaris",
+        "ja": "ソラリス",
+        "ja_typings": [
+          "sorarisu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03342",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Unix-like OS evolved from the Berkeley Software Distribution?",
+      "ja": "BSDから派生したUnix系OSは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "GPU",
+        "ja": "ジーピーユー",
+        "ja_typings": [
+          "ji-pi-yu-"
+        ]
+      },
+      {
+        "en": "CPU",
+        "ja": "シーピーユー",
+        "ja_typings": [
+          "shi-pi-yu-"
+        ]
+      },
+      {
+        "en": "DSP",
+        "ja": "ディーエスピー",
+        "ja_typings": [
+          "di-esupi-"
+        ]
+      },
+      {
+        "en": "FPGA",
+        "ja": "エフピージーエー",
+        "ja_typings": [
+          "efupi-ji-e-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03343",
+    "image_path": null,
+    "question_text": {
+      "en": "Which processor specializes in parallel graphics computation?",
+      "ja": "並列グラフィクス演算に特化したプロセッサは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Google",
+        "ja": "グーグル",
+        "ja_typings": [
+          "gu-guru"
+        ]
+      },
+      {
+        "en": "Apple",
+        "ja": "アップル",
+        "ja_typings": [
+          "appuru"
+        ]
+      },
+      {
+        "en": "Microsoft",
+        "ja": "マイクロソフト",
+        "ja_typings": [
+          "maikurosofuto"
+        ]
+      },
+      {
+        "en": "Samsung",
+        "ja": "サムスン",
+        "ja_typings": [
+          "samusun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03344",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed the Android operating system?",
+      "ja": "Android OSを開発した企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HDD",
+        "ja": "エイチディーディー",
+        "ja_typings": [
+          "eichidi-di-"
+        ]
+      },
+      {
+        "en": "SSD",
+        "ja": "エスエスディー",
+        "ja_typings": [
+          "esuesudi-"
+        ]
+      },
+      {
+        "en": "USB",
+        "ja": "ユーエスビー",
+        "ja_typings": [
+          "yu-esubi-"
+        ]
+      },
+      {
+        "en": "NAS",
+        "ja": "エヌエーエス",
+        "ja_typings": [
+          "enue-esu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03345",
+    "image_path": null,
+    "question_text": {
+      "en": "Which magnetic storage device uses spinning platters?",
+      "ja": "回転するプラッタを使う磁気記憶装置は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HDMI",
+        "ja": "エイチディーエムアイ",
+        "ja_typings": [
+          "eichidi-emuai"
+        ]
+      },
+      {
+        "en": "VGA",
+        "ja": "ブイジーエー",
+        "ja_typings": [
+          "buiji-e-"
+        ]
+      },
+      {
+        "en": "DVI",
+        "ja": "ディーブイアイ",
+        "ja_typings": [
+          "di-buiai"
+        ]
+      },
+      {
+        "en": "DisplayPort",
+        "ja": "ディスプレイポート",
+        "ja_typings": [
+          "disupureipo-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03346",
+    "image_path": null,
+    "question_text": {
+      "en": "Which digital audio-video interface is common on TVs?",
+      "ja": "テレビで広く使われるデジタル映像音声端子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HFS",
+        "ja": "エイチエフエス",
+        "ja_typings": [
+          "eichiefuesu"
+        ]
+      },
+      {
+        "en": "NTFS",
+        "ja": "エヌティーエフエス",
+        "ja_typings": [
+          "enuti-efuesu"
+        ]
+      },
+      {
+        "en": "FAT32",
+        "ja": "ファット32",
+        "ja_typings": [
+          "fatto32"
+        ]
+      },
+      {
+        "en": "ext4",
+        "ja": "イーエックスティー4",
+        "ja_typings": [
+          "i-ekkusuti-4"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03347",
+    "image_path": null,
+    "question_text": {
+      "en": "Which file system was developed by Apple?",
+      "ja": "Appleが開発したファイルシステムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HTTP",
+        "ja": "エイチティーティーピー",
+        "ja_typings": [
+          "eichiti-ti-pi-"
+        ]
+      },
+      {
+        "en": "FTP",
+        "ja": "エフティーピー",
+        "ja_typings": [
+          "efuti-pi-"
+        ]
+      },
+      {
+        "en": "SMTP",
+        "ja": "エスエムティーピー",
+        "ja_typings": [
+          "esuemuti-pi-"
+        ]
+      },
+      {
+        "en": "SSH",
+        "ja": "エスエスエイチ",
+        "ja_typings": [
+          "esuesueichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03348",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol is the foundation of the World Wide Web?",
+      "ja": "World Wide Webの基礎となるプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hash function",
+        "ja": "ハッシュ関数",
+        "ja_typings": [
+          "hasshukansuu"
+        ]
+      },
+      {
+        "en": "Sort function",
+        "ja": "ソート関数",
+        "ja_typings": [
+          "so-tokansuu"
+        ]
+      },
+      {
+        "en": "Search function",
+        "ja": "検索関数",
+        "ja_typings": [
+          "kennsakukansuu"
+        ]
+      },
+      {
+        "en": "Filter function",
+        "ja": "フィルタ関数",
+        "ja_typings": [
+          "firutakansuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03349",
+    "image_path": null,
+    "question_text": {
+      "en": "Which function maps arbitrary data to a fixed-size value?",
+      "ja": "任意のデータを固定長の値に変換する関数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "IBM",
+        "ja": "アイビーエム",
+        "ja_typings": [
+          "aibi-emu"
+        ]
+      },
+      {
+        "en": "DEC",
+        "ja": "ディーイーシー",
+        "ja_typings": [
+          "di-i-shi-"
+        ]
+      },
+      {
+        "en": "HP",
+        "ja": "エイチピー",
+        "ja_typings": [
+          "eichipi-"
+        ]
+      },
+      {
+        "en": "Cray",
+        "ja": "クレイ",
+        "ja_typings": [
+          "kurei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03350",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company built the System/360 mainframe family?",
+      "ja": "System/360メインフレームを生み出した企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "IDE",
+        "ja": "アイディーイー",
+        "ja_typings": [
+          "aidi-i-"
+        ]
+      },
+      {
+        "en": "SCSI",
+        "ja": "スカジー",
+        "ja_typings": [
+          "sukaji-"
+        ]
+      },
+      {
+        "en": "SATA",
+        "ja": "サタ",
+        "ja_typings": [
+          "sata"
+        ]
+      },
+      {
+        "en": "NVMe",
+        "ja": "エヌブイエムイー",
+        "ja_typings": [
+          "enubuiemui-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03351",
+    "image_path": null,
+    "question_text": {
+      "en": "Which parallel interface was once common for connecting hard drives?",
+      "ja": "かつてHDD接続に広く使われたパラレル規格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kernel",
+        "ja": "カーネル",
+        "ja_typings": [
+          "ka-neru"
+        ]
+      },
+      {
+        "en": "Shell",
+        "ja": "シェル",
+        "ja_typings": [
+          "sheru"
+        ]
+      },
+      {
+        "en": "Driver",
+        "ja": "ドライバ",
+        "ja_typings": [
+          "doraiba"
+        ]
+      },
+      {
+        "en": "Library",
+        "ja": "ライブラリ",
+        "ja_typings": [
+          "raiburari"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03352",
+    "image_path": null,
+    "question_text": {
+      "en": "Which core part of an operating system manages resources?",
+      "ja": "OSの中核としてリソースを管理する部分は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "LTE",
+        "ja": "エルティーイー",
+        "ja_typings": [
+          "eruti-i-"
+        ]
+      },
+      {
+        "en": "HSPA",
+        "ja": "エイチエスピーエー",
+        "ja_typings": [
+          "eichiesupi-e-"
+        ]
+      },
+      {
+        "en": "GSM",
+        "ja": "ジーエスエム",
+        "ja_typings": [
+          "ji-esuemu"
+        ]
+      },
+      {
+        "en": "CDMA",
+        "ja": "シーディーエムエー",
+        "ja_typings": [
+          "shi-di-emue-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03353",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 4G mobile communication standard succeeded 3G?",
+      "ja": "3Gの次世代となった4G移動通信規格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "LVM",
+        "ja": "エルブイエム",
+        "ja_typings": [
+          "erubuiemu"
+        ]
+      },
+      {
+        "en": "RAID",
+        "ja": "レイド",
+        "ja_typings": [
+          "reido"
+        ]
+      },
+      {
+        "en": "ZFS",
+        "ja": "ゼットエフエス",
+        "ja_typings": [
+          "zettoefuesu"
+        ]
+      },
+      {
+        "en": "Btrfs",
+        "ja": "ビーティーアールエフエス",
+        "ja_typings": [
+          "bi-ti-a-ruefuesu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03354",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Linux disk management abstraction allows flexible volumes?",
+      "ja": "柔軟なボリューム管理を行うLinuxの仕組みは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Load balancer",
+        "ja": "ロードバランサ",
+        "ja_typings": [
+          "ro-dobaransa"
+        ]
+      },
+      {
+        "en": "Router",
+        "ja": "ルータ",
+        "ja_typings": [
+          "ru-ta"
+        ]
+      },
+      {
+        "en": "Switch",
+        "ja": "スイッチ",
+        "ja_typings": [
+          "suitchi"
+        ]
+      },
+      {
+        "en": "Firewall",
+        "ja": "ファイアウォール",
+        "ja_typings": [
+          "faiawo-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03355",
+    "image_path": null,
+    "question_text": {
+      "en": "Which device distributes traffic across multiple servers?",
+      "ja": "複数サーバへ通信を分散する装置は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MARK I",
+        "ja": "マーク1",
+        "ja_typings": [
+          "ma-ku1"
+        ]
+      },
+      {
+        "en": "ENIAC",
+        "ja": "エニアック",
+        "ja_typings": [
+          "eniakku"
+        ]
+      },
+      {
+        "en": "UNIVAC",
+        "ja": "ユニバック",
+        "ja_typings": [
+          "yunibakku"
+        ]
+      },
+      {
+        "en": "EDVAC",
+        "ja": "エドバック",
+        "ja_typings": [
+          "edobakku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03356",
+    "image_path": null,
+    "question_text": {
+      "en": "Which early Harvard relay-based computer was completed in 1944?",
+      "ja": "1944年に完成したハーバードのリレー式初期コンピュータは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Main memory",
+        "ja": "主記憶",
+        "ja_typings": [
+          "shukioku"
+        ]
+      },
+      {
+        "en": "Cache memory",
+        "ja": "キャッシュメモリ",
+        "ja_typings": [
+          "kyasshumemori"
+        ]
+      },
+      {
+        "en": "Virtual memory",
+        "ja": "仮想メモリ",
+        "ja_typings": [
+          "kasoumemori"
+        ]
+      },
+      {
+        "en": "Flash memory",
+        "ja": "フラッシュメモリ",
+        "ja_typings": [
+          "furasshumemori"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03357",
+    "image_path": null,
+    "question_text": {
+      "en": "Which memory directly accessed by the CPU during execution?",
+      "ja": "CPUが実行中に直接アクセスする記憶領域は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Meta",
+        "ja": "メタ",
+        "ja_typings": [
+          "meta"
+        ]
+      },
+      {
+        "en": "Google",
+        "ja": "グーグル",
+        "ja_typings": [
+          "gu-guru"
+        ]
+      },
+      {
+        "en": "Apple",
+        "ja": "アップル",
+        "ja_typings": [
+          "appuru"
+        ]
+      },
+      {
+        "en": "Amazon",
+        "ja": "アマゾン",
+        "ja_typings": [
+          "amazon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03358",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company owns Facebook and Instagram?",
+      "ja": "FacebookとInstagramを保有する企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Microsoft",
+        "ja": "マイクロソフト",
+        "ja_typings": [
+          "maikurosofuto"
+        ]
+      },
+      {
+        "en": "Apple",
+        "ja": "アップル",
+        "ja_typings": [
+          "appuru"
+        ]
+      },
+      {
+        "en": "IBM",
+        "ja": "アイビーエム",
+        "ja_typings": [
+          "aibi-emu"
+        ]
+      },
+      {
+        "en": "Google",
+        "ja": "グーグル",
+        "ja_typings": [
+          "gu-guru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03359",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed the Windows operating system?",
+      "ja": "Windows OSを開発した企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NAS",
+        "ja": "エヌエーエス",
+        "ja_typings": [
+          "enue-esu"
+        ]
+      },
+      {
+        "en": "SAN",
+        "ja": "エスエーエヌ",
+        "ja_typings": [
+          "esue-enu"
+        ]
+      },
+      {
+        "en": "HDD",
+        "ja": "エイチディーディー",
+        "ja_typings": [
+          "eichidi-di-"
+        ]
+      },
+      {
+        "en": "SSD",
+        "ja": "エスエスディー",
+        "ja_typings": [
+          "esuesudi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03360",
+    "image_path": null,
+    "question_text": {
+      "en": "Which storage device is dedicated to file sharing over a network?",
+      "ja": "ネットワーク経由でファイル共有する専用ストレージは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NAT",
+        "ja": "エヌエーティー",
+        "ja_typings": [
+          "enue-ti-"
+        ]
+      },
+      {
+        "en": "DNS",
+        "ja": "ディーエヌエス",
+        "ja_typings": [
+          "di-enuesu"
+        ]
+      },
+      {
+        "en": "DHCP",
+        "ja": "ディーエイチシーピー",
+        "ja_typings": [
+          "di-eichishi-pi-"
+        ]
+      },
+      {
+        "en": "ARP",
+        "ja": "エーアールピー",
+        "ja_typings": [
+          "e-a-rupi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03361",
+    "image_path": null,
+    "question_text": {
+      "en": "Which technology translates private and public IP addresses?",
+      "ja": "プライベートとグローバルIPを変換する技術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NFC",
+        "ja": "エヌエフシー",
+        "ja_typings": [
+          "enuefushi-"
+        ]
+      },
+      {
+        "en": "Bluetooth",
+        "ja": "ブルートゥース",
+        "ja_typings": [
+          "buru-tu-su"
+        ]
+      },
+      {
+        "en": "Zigbee",
+        "ja": "ジグビー",
+        "ja_typings": [
+          "jigubi-"
+        ]
+      },
+      {
+        "en": "Wi-Fi",
+        "ja": "ワイファイ",
+        "ja_typings": [
+          "waifai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03362",
+    "image_path": null,
+    "question_text": {
+      "en": "Which very short range wireless tech is used for contactless payment?",
+      "ja": "非接触決済で使われるごく短距離無線技術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NTFS",
+        "ja": "エヌティーエフエス",
+        "ja_typings": [
+          "enuti-efuesu"
+        ]
+      },
+      {
+        "en": "FAT32",
+        "ja": "ファット32",
+        "ja_typings": [
+          "fatto32"
+        ]
+      },
+      {
+        "en": "HFS",
+        "ja": "エイチエフエス",
+        "ja_typings": [
+          "eichiefuesu"
+        ]
+      },
+      {
+        "en": "ext4",
+        "ja": "イーエックスティー4",
+        "ja_typings": [
+          "i-ekkusuti-4"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03363",
+    "image_path": null,
+    "question_text": {
+      "en": "Which file system is the default for modern Windows?",
+      "ja": "現代のWindowsで標準のファイルシステムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Oracle",
+        "ja": "オラクル",
+        "ja_typings": [
+          "orakuru"
+        ]
+      },
+      {
+        "en": "Microsoft",
+        "ja": "マイクロソフト",
+        "ja_typings": [
+          "maikurosofuto"
+        ]
+      },
+      {
+        "en": "IBM",
+        "ja": "アイビーエム",
+        "ja_typings": [
+          "aibi-emu"
+        ]
+      },
+      {
+        "en": "SAP",
+        "ja": "エスエーピー",
+        "ja_typings": [
+          "esue-pi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03364",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company is famous for enterprise database products?",
+      "ja": "企業向けデータベースで知られる企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PCIe",
+        "ja": "ピーシーアイイー",
+        "ja_typings": [
+          "pi-shi-aii-"
+        ]
+      },
+      {
+        "en": "PCI",
+        "ja": "ピーシーアイ",
+        "ja_typings": [
+          "pi-shi-ai"
+        ]
+      },
+      {
+        "en": "ISA",
+        "ja": "アイエスエー",
+        "ja_typings": [
+          "aiesue-"
+        ]
+      },
+      {
+        "en": "AGP",
+        "ja": "エージーピー",
+        "ja_typings": [
+          "e-ji-pi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03365",
+    "image_path": null,
+    "question_text": {
+      "en": "Which high-speed serial expansion bus is used inside modern PCs?",
+      "ja": "現代PC内部の高速シリアル拡張バスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PS/2",
+        "ja": "ピーエス2",
+        "ja_typings": [
+          "pi-esu2"
+        ]
+      },
+      {
+        "en": "USB",
+        "ja": "ユーエスビー",
+        "ja_typings": [
+          "yu-esubi-"
+        ]
+      },
+      {
+        "en": "RS-232C",
+        "ja": "アールエス232シー",
+        "ja_typings": [
+          "a-ruesu232shi-"
+        ]
+      },
+      {
+        "en": "DIN",
+        "ja": "ディン",
+        "ja_typings": [
+          "din"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03366",
+    "image_path": null,
+    "question_text": {
+      "en": "Which old round connector was used for keyboards and mice?",
+      "ja": "キーボードやマウスに使われた古い丸型コネクタは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Process",
+        "ja": "プロセス",
+        "ja_typings": [
+          "purosesu"
+        ]
+      },
+      {
+        "en": "Thread",
+        "ja": "スレッド",
+        "ja_typings": [
+          "sureddo"
+        ]
+      },
+      {
+        "en": "Kernel",
+        "ja": "カーネル",
+        "ja_typings": [
+          "ka-neru"
+        ]
+      },
+      {
+        "en": "Daemon",
+        "ja": "デーモン",
+        "ja_typings": [
+          "de-mon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03367",
+    "image_path": null,
+    "question_text": {
+      "en": "Which OS abstraction represents a running program?",
+      "ja": "実行中のプログラムを表すOSの抽象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Proxy",
+        "ja": "プロキシ",
+        "ja_typings": [
+          "purokishi"
+        ]
+      },
+      {
+        "en": "Gateway",
+        "ja": "ゲートウェイ",
+        "ja_typings": [
+          "ge-towei"
+        ]
+      },
+      {
+        "en": "Router",
+        "ja": "ルータ",
+        "ja_typings": [
+          "ru-ta"
+        ]
+      },
+      {
+        "en": "Firewall",
+        "ja": "ファイアウォール",
+        "ja_typings": [
+          "faiawo-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03368",
+    "image_path": null,
+    "question_text": {
+      "en": "Which server relays client requests to other servers?",
+      "ja": "クライアントの要求を他サーバへ中継するサーバは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Qualcomm",
+        "ja": "クアルコム",
+        "ja_typings": [
+          "kuarukomu"
+        ]
+      },
+      {
+        "en": "MediaTek",
+        "ja": "メディアテック",
+        "ja_typings": [
+          "mediatekku"
+        ]
+      },
+      {
+        "en": "Broadcom",
+        "ja": "ブロードコム",
+        "ja_typings": [
+          "buro-dokomu"
+        ]
+      },
+      {
+        "en": "Marvell",
+        "ja": "マーベル",
+        "ja_typings": [
+          "ma-beru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03369",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company is known for the Snapdragon mobile SoC?",
+      "ja": "Snapdragonモバイル向けSoCで知られる企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "RAM",
+        "ja": "ラム",
+        "ja_typings": [
+          "ramu"
+        ]
+      },
+      {
+        "en": "ROM",
+        "ja": "ロム",
+        "ja_typings": [
+          "romu"
+        ]
+      },
+      {
+        "en": "HDD",
+        "ja": "エイチディーディー",
+        "ja_typings": [
+          "eichidi-di-"
+        ]
+      },
+      {
+        "en": "SSD",
+        "ja": "エスエスディー",
+        "ja_typings": [
+          "esuesudi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03370",
+    "image_path": null,
+    "question_text": {
+      "en": "Which volatile memory holds data while a computer is running?",
+      "ja": "稼働中のPCでデータを保持する揮発性メモリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "RJ-45",
+        "ja": "アールジェイ45",
+        "ja_typings": [
+          "a-rujei45"
+        ]
+      },
+      {
+        "en": "RJ-11",
+        "ja": "アールジェイ11",
+        "ja_typings": [
+          "a-rujei11"
+        ]
+      },
+      {
+        "en": "BNC",
+        "ja": "ビーエヌシー",
+        "ja_typings": [
+          "bi-enushi-"
+        ]
+      },
+      {
+        "en": "SC",
+        "ja": "エスシー",
+        "ja_typings": [
+          "esushi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03371",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 8-pin modular connector is standard for Ethernet?",
+      "ja": "イーサネットで標準的な8ピンモジュラ端子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ROT13",
+        "ja": "ロット13",
+        "ja_typings": [
+          "rotto13"
+        ]
+      },
+      {
+        "en": "ROT47",
+        "ja": "ロット47",
+        "ja_typings": [
+          "rotto47"
+        ]
+      },
+      {
+        "en": "Caesar",
+        "ja": "シーザー",
+        "ja_typings": [
+          "shi-za-"
+        ]
+      },
+      {
+        "en": "Vigenere",
+        "ja": "ビジュネル",
+        "ja_typings": [
+          "bijuneru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03372",
+    "image_path": null,
+    "question_text": {
+      "en": "Which simple cipher shifts letters by 13 positions?",
+      "ja": "アルファベットを13文字ずらす単純な暗号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "RS-232C",
+        "ja": "アールエス232シー",
+        "ja_typings": [
+          "a-ruesu232shi-"
+        ]
+      },
+      {
+        "en": "USB",
+        "ja": "ユーエスビー",
+        "ja_typings": [
+          "yu-esubi-"
+        ]
+      },
+      {
+        "en": "PS/2",
+        "ja": "ピーエス2",
+        "ja_typings": [
+          "pi-esu2"
+        ]
+      },
+      {
+        "en": "IrDA",
+        "ja": "アイアールディーエー",
+        "ja_typings": [
+          "aia-rudi-e-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03373",
+    "image_path": null,
+    "question_text": {
+      "en": "Which serial interface standard was once common on PCs?",
+      "ja": "かつてPCで一般的だったシリアル通信規格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "RSA",
+        "ja": "アールエスエー",
+        "ja_typings": [
+          "a-ruesue-"
+        ]
+      },
+      {
+        "en": "DSA",
+        "ja": "ディーエスエー",
+        "ja_typings": [
+          "di-esue-"
+        ]
+      },
+      {
+        "en": "ECC",
+        "ja": "イーシーシー",
+        "ja_typings": [
+          "i-shi-shi-"
+        ]
+      },
+      {
+        "en": "AES",
+        "ja": "エーイーエス",
+        "ja_typings": [
+          "e-i-esu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03374",
+    "image_path": null,
+    "question_text": {
+      "en": "Which public-key cryptosystem is named after its three inventors?",
+      "ja": "発明者3人の頭文字を取った公開鍵暗号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Register",
+        "ja": "レジスタ",
+        "ja_typings": [
+          "rejisuta"
+        ]
+      },
+      {
+        "en": "Cache",
+        "ja": "キャッシュ",
+        "ja_typings": [
+          "kyasshu"
+        ]
+      },
+      {
+        "en": "RAM",
+        "ja": "ラム",
+        "ja_typings": [
+          "ramu"
+        ]
+      },
+      {
+        "en": "Stack",
+        "ja": "スタック",
+        "ja_typings": [
+          "sutakku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03375",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CPU component holds small, fast data for immediate use?",
+      "ja": "CPU内部で即時利用される小さく高速な記憶領域は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Reverse shell",
+        "ja": "リバースシェル",
+        "ja_typings": [
+          "riba-susheru"
+        ]
+      },
+      {
+        "en": "Bind shell",
+        "ja": "バインドシェル",
+        "ja_typings": [
+          "baindosheru"
+        ]
+      },
+      {
+        "en": "Web shell",
+        "ja": "ウェブシェル",
+        "ja_typings": [
+          "webusheru"
+        ]
+      },
+      {
+        "en": "Root shell",
+        "ja": "ルートシェル",
+        "ja_typings": [
+          "ru-tosheru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03376",
+    "image_path": null,
+    "question_text": {
+      "en": "Which attack makes a victim host connect back to the attacker?",
+      "ja": "被害ホストから攻撃者へ接続させる攻撃手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SAN",
+        "ja": "エスエーエヌ",
+        "ja_typings": [
+          "esue-enu"
+        ]
+      },
+      {
+        "en": "NAS",
+        "ja": "エヌエーエス",
+        "ja_typings": [
+          "enue-esu"
+        ]
+      },
+      {
+        "en": "LAN",
+        "ja": "ラン",
+        "ja_typings": [
+          "ran"
+        ]
+      },
+      {
+        "en": "WAN",
+        "ja": "ワン",
+        "ja_typings": [
+          "wan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03377",
+    "image_path": null,
+    "question_text": {
+      "en": "Which network is dedicated to high-speed block storage access?",
+      "ja": "高速ブロックストレージ専用のネットワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SRAM",
+        "ja": "エスラム",
+        "ja_typings": [
+          "esuramu"
+        ]
+      },
+      {
+        "en": "DRAM",
+        "ja": "ディーラム",
+        "ja_typings": [
+          "di-ramu"
+        ]
+      },
+      {
+        "en": "SDRAM",
+        "ja": "エスディーラム",
+        "ja_typings": [
+          "esudi-ramu"
+        ]
+      },
+      {
+        "en": "VRAM",
+        "ja": "ブイラム",
+        "ja_typings": [
+          "buiramu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03378",
+    "image_path": null,
+    "question_text": {
+      "en": "Which type of RAM uses flip-flops and needs no refresh?",
+      "ja": "フリップフロップで構成しリフレッシュ不要なRAMは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SSD",
+        "ja": "エスエスディー",
+        "ja_typings": [
+          "esuesudi-"
+        ]
+      },
+      {
+        "en": "HDD",
+        "ja": "エイチディーディー",
+        "ja_typings": [
+          "eichidi-di-"
+        ]
+      },
+      {
+        "en": "NAS",
+        "ja": "エヌエーエス",
+        "ja_typings": [
+          "enue-esu"
+        ]
+      },
+      {
+        "en": "DVD",
+        "ja": "ディーブイディー",
+        "ja_typings": [
+          "di-buidi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03379",
+    "image_path": null,
+    "question_text": {
+      "en": "Which storage uses flash memory and has no moving parts?",
+      "ja": "フラッシュメモリを使い可動部品が無いストレージは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SSH",
+        "ja": "エスエスエイチ",
+        "ja_typings": [
+          "esuesueichi"
+        ]
+      },
+      {
+        "en": "Telnet",
+        "ja": "テルネット",
+        "ja_typings": [
+          "terunetto"
+        ]
+      },
+      {
+        "en": "FTP",
+        "ja": "エフティーピー",
+        "ja_typings": [
+          "efuti-pi-"
+        ]
+      },
+      {
+        "en": "HTTP",
+        "ja": "エイチティーティーピー",
+        "ja_typings": [
+          "eichiti-ti-pi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03380",
+    "image_path": null,
+    "question_text": {
+      "en": "Which encrypted protocol is used for secure remote shell?",
+      "ja": "暗号化された遠隔シェルで使うプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Samsung",
+        "ja": "サムスン",
+        "ja_typings": [
+          "samusun"
+        ]
+      },
+      {
+        "en": "LG",
+        "ja": "エルジー",
+        "ja_typings": [
+          "eruji-"
+        ]
+      },
+      {
+        "en": "Apple",
+        "ja": "アップル",
+        "ja_typings": [
+          "appuru"
+        ]
+      },
+      {
+        "en": "Sony",
+        "ja": "ソニー",
+        "ja_typings": [
+          "soni-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03381",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Korean conglomerate is a major smartphone maker?",
+      "ja": "大手スマートフォンメーカーの韓国系コングロマリットは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Swap",
+        "ja": "スワップ",
+        "ja_typings": [
+          "suwappu"
+        ]
+      },
+      {
+        "en": "Cache",
+        "ja": "キャッシュ",
+        "ja_typings": [
+          "kyasshu"
+        ]
+      },
+      {
+        "en": "Buffer",
+        "ja": "バッファ",
+        "ja_typings": [
+          "baffa"
+        ]
+      },
+      {
+        "en": "Paging",
+        "ja": "ページング",
+        "ja_typings": [
+          "pe-jingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03382",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mechanism moves memory pages between RAM and disk?",
+      "ja": "RAMとディスク間でメモリページを退避する仕組みは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "TCP",
+        "ja": "ティーシーピー",
+        "ja_typings": [
+          "ti-shi-pi-"
+        ]
+      },
+      {
+        "en": "UDP",
+        "ja": "ユーディーピー",
+        "ja_typings": [
+          "yu-di-pi-"
+        ]
+      },
+      {
+        "en": "IP",
+        "ja": "アイピー",
+        "ja_typings": [
+          "aipi-"
+        ]
+      },
+      {
+        "en": "ICMP",
+        "ja": "アイシーエムピー",
+        "ja_typings": [
+          "aishi-emupi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03383",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol provides reliable, ordered data delivery on the Internet?",
+      "ja": "信頼性のある順序付き配送を提供するインターネットプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Telnet",
+        "ja": "テルネット",
+        "ja_typings": [
+          "terunetto"
+        ]
+      },
+      {
+        "en": "SSH",
+        "ja": "エスエスエイチ",
+        "ja_typings": [
+          "esuesueichi"
+        ]
+      },
+      {
+        "en": "FTP",
+        "ja": "エフティーピー",
+        "ja_typings": [
+          "efuti-pi-"
+        ]
+      },
+      {
+        "en": "HTTP",
+        "ja": "エイチティーティーピー",
+        "ja_typings": [
+          "eichiti-ti-pi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03384",
+    "image_path": null,
+    "question_text": {
+      "en": "Which old plaintext protocol is used for remote terminal access?",
+      "ja": "古い平文の遠隔端末アクセスプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "UDP",
+        "ja": "ユーディーピー",
+        "ja_typings": [
+          "yu-di-pi-"
+        ]
+      },
+      {
+        "en": "TCP",
+        "ja": "ティーシーピー",
+        "ja_typings": [
+          "ti-shi-pi-"
+        ]
+      },
+      {
+        "en": "IP",
+        "ja": "アイピー",
+        "ja_typings": [
+          "aipi-"
+        ]
+      },
+      {
+        "en": "ARP",
+        "ja": "エーアールピー",
+        "ja_typings": [
+          "e-a-rupi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03385",
+    "image_path": null,
+    "question_text": {
+      "en": "Which connectionless protocol prioritizes speed over reliability?",
+      "ja": "信頼性より速度を優先するコネクションレスプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "UNIVAC",
+        "ja": "ユニバック",
+        "ja_typings": [
+          "yunibakku"
+        ]
+      },
+      {
+        "en": "MARK I",
+        "ja": "マーク1",
+        "ja_typings": [
+          "ma-ku1"
+        ]
+      },
+      {
+        "en": "EDVAC",
+        "ja": "エドバック",
+        "ja_typings": [
+          "edobakku"
+        ]
+      },
+      {
+        "en": "ALTAIR",
+        "ja": "アルテア",
+        "ja_typings": [
+          "arutea"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03386",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1951 commercial computer succeeded the ENIAC line?",
+      "ja": "ENIAC系を継いだ1951年の商用コンピュータは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "USB",
+        "ja": "ユーエスビー",
+        "ja_typings": [
+          "yu-esubi-"
+        ]
+      },
+      {
+        "en": "PS/2",
+        "ja": "ピーエス2",
+        "ja_typings": [
+          "pi-esu2"
+        ]
+      },
+      {
+        "en": "RS-232C",
+        "ja": "アールエス232シー",
+        "ja_typings": [
+          "a-ruesu232shi-"
+        ]
+      },
+      {
+        "en": "FireWire",
+        "ja": "ファイアワイヤ",
+        "ja_typings": [
+          "faiawaiya"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03387",
+    "image_path": null,
+    "question_text": {
+      "en": "Which serial bus is most common for connecting peripherals?",
+      "ja": "周辺機器接続で最も一般的なシリアルバスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Virtual memory",
+        "ja": "仮想メモリ",
+        "ja_typings": [
+          "kasoumemori"
+        ]
+      },
+      {
+        "en": "Main memory",
+        "ja": "主記憶",
+        "ja_typings": [
+          "shukioku"
+        ]
+      },
+      {
+        "en": "Cache memory",
+        "ja": "キャッシュメモリ",
+        "ja_typings": [
+          "kyasshumemori"
+        ]
+      },
+      {
+        "en": "Flash memory",
+        "ja": "フラッシュメモリ",
+        "ja_typings": [
+          "furasshumemori"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03388",
+    "image_path": null,
+    "question_text": {
+      "en": "Which OS technique uses disk to extend addressable memory?",
+      "ja": "ディスクを使って利用可能なメモリを拡張するOSの仕組みは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Windows",
+        "ja": "ウィンドウズ",
+        "ja_typings": [
+          "windozu",
+          "windouzu"
+        ]
+      },
+      {
+        "en": "macOS",
+        "ja": "マックオーエス",
+        "ja_typings": [
+          "makkuo-esu"
+        ]
+      },
+      {
+        "en": "Linux",
+        "ja": "リナックス",
+        "ja_typings": [
+          "rinakkusu"
+        ]
+      },
+      {
+        "en": "Chrome OS",
+        "ja": "クロームオーエス",
+        "ja_typings": [
+          "kuro-muo-esu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03389",
+    "image_path": null,
+    "question_text": {
+      "en": "Which OS is developed by Microsoft for personal computers?",
+      "ja": "Microsoftが開発するPC向けOSは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Zigbee",
+        "ja": "ジグビー",
+        "ja_typings": [
+          "jigubi-"
+        ]
+      },
+      {
+        "en": "Bluetooth",
+        "ja": "ブルートゥース",
+        "ja_typings": [
+          "buru-tu-su"
+        ]
+      },
+      {
+        "en": "Wi-Fi",
+        "ja": "ワイファイ",
+        "ja_typings": [
+          "waifai"
+        ]
+      },
+      {
+        "en": "LTE",
+        "ja": "エルティーイー",
+        "ja_typings": [
+          "eruti-i-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03390",
+    "image_path": null,
+    "question_text": {
+      "en": "Which low-power mesh wireless standard is used in IoT?",
+      "ja": "IoTで使われる低消費電力のメッシュ無線規格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ext4",
+        "ja": "イーエックスティー4",
+        "ja_typings": [
+          "i-ekkusuti-4"
+        ]
+      },
+      {
+        "en": "NTFS",
+        "ja": "エヌティーエフエス",
+        "ja_typings": [
+          "enuti-efuesu"
+        ]
+      },
+      {
+        "en": "FAT32",
+        "ja": "ファット32",
+        "ja_typings": [
+          "fatto32"
+        ]
+      },
+      {
+        "en": "HFS",
+        "ja": "エイチエフエス",
+        "ja_typings": [
+          "eichiefuesu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03391",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is a modern default journaling file system on Linux?",
+      "ja": "現代のLinuxで標準的なジャーナリングファイルシステムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "macOS",
+        "ja": "マックオーエス",
+        "ja_typings": [
+          "makkuo-esu"
+        ]
+      },
+      {
+        "en": "Windows",
+        "ja": "ウィンドウズ",
+        "ja_typings": [
+          "windozu",
+          "windouzu"
+        ]
+      },
+      {
+        "en": "Linux",
+        "ja": "リナックス",
+        "ja_typings": [
+          "rinakkusu"
+        ]
+      },
+      {
+        "en": "FreeBSD",
+        "ja": "フリービーエスディー",
+        "ja_typings": [
+          "furi-bi-esudi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03392",
+    "image_path": null,
+    "question_text": {
+      "en": "Which OS is developed by Apple for Macintosh computers?",
+      "ja": "AppleがMacintosh向けに開発するOSは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "-100 degrees",
+        "ja": "マイナス100度",
+        "ja_typings": [
+          "mainasu100do"
+        ]
+      },
+      {
+        "en": "-20 degrees",
+        "ja": "マイナス20度",
+        "ja_typings": [
+          "mainasu20do"
+        ]
+      },
+      {
+        "en": "0 degrees",
+        "ja": "0度",
+        "ja_typings": [
+          "0do"
+        ]
+      },
+      {
+        "en": "-500 degrees",
+        "ja": "マイナス500度",
+        "ja_typings": [
+          "mainasu500do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03393",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is roughly the average winter temperature at the South Pole?",
+      "ja": "南極の冬の平均気温に近いのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "-500 degrees",
+        "ja": "マイナス500度",
+        "ja_typings": [
+          "mainasu500do"
+        ]
+      },
+      {
+        "en": "-100 degrees",
+        "ja": "マイナス100度",
+        "ja_typings": [
+          "mainasu100do"
+        ]
+      },
+      {
+        "en": "-50 degrees",
+        "ja": "マイナス50度",
+        "ja_typings": [
+          "mainasu50do"
+        ]
+      },
+      {
+        "en": "-200 degrees",
+        "ja": "マイナス200度",
+        "ja_typings": [
+          "mainasu200do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03394",
+    "image_path": null,
+    "question_text": {
+      "en": "Which temperature is physically impossible since absolute zero is -273 degrees?",
+      "ja": "絶対零度がマイナス273度であるため物理的にあり得ない温度は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "0 degrees",
+        "ja": "0度",
+        "ja_typings": [
+          "0do"
+        ]
+      },
+      {
+        "en": "4 degrees",
+        "ja": "4度",
+        "ja_typings": [
+          "4do"
+        ]
+      },
+      {
+        "en": "-10 degrees",
+        "ja": "マイナス10度",
+        "ja_typings": [
+          "mainasu10do"
+        ]
+      },
+      {
+        "en": "100 degrees",
+        "ja": "100度",
+        "ja_typings": [
+          "100do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03395",
+    "image_path": null,
+    "question_text": {
+      "en": "At which Celsius temperature does pure water freeze at 1 atm?",
+      "ja": "1気圧で純水が凍る摂氏温度は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "25 degrees",
+        "ja": "25度",
+        "ja_typings": [
+          "25do"
+        ]
+      },
+      {
+        "en": "0 degrees",
+        "ja": "0度",
+        "ja_typings": [
+          "0do"
+        ]
+      },
+      {
+        "en": "40 degrees",
+        "ja": "40度",
+        "ja_typings": [
+          "40do"
+        ]
+      },
+      {
+        "en": "-10 degrees",
+        "ja": "マイナス10度",
+        "ja_typings": [
+          "mainasu10do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03396",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Celsius temperature is typical for a comfortable room?",
+      "ja": "快適な室温として典型的な摂氏温度は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "30 degrees",
+        "ja": "30度",
+        "ja_typings": [
+          "30do"
+        ]
+      },
+      {
+        "en": "0 degrees",
+        "ja": "0度",
+        "ja_typings": [
+          "0do"
+        ]
+      },
+      {
+        "en": "15 degrees",
+        "ja": "15度",
+        "ja_typings": [
+          "15do"
+        ]
+      },
+      {
+        "en": "-5 degrees",
+        "ja": "マイナス5度",
+        "ja_typings": [
+          "mainasu5do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03397",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Celsius temperature is considered a hot summer day in Japan?",
+      "ja": "日本で真夏日の目安となる摂氏温度は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "40 degrees",
+        "ja": "40度",
+        "ja_typings": [
+          "40do"
+        ]
+      },
+      {
+        "en": "25 degrees",
+        "ja": "25度",
+        "ja_typings": [
+          "25do"
+        ]
+      },
+      {
+        "en": "10 degrees",
+        "ja": "10度",
+        "ja_typings": [
+          "10do"
+        ]
+      },
+      {
+        "en": "0 degrees",
+        "ja": "0度",
+        "ja_typings": [
+          "0do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03398",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Celsius temperature is classified as an extremely hot day in Japan?",
+      "ja": "日本で猛暑日と分類される摂氏温度の目安は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "A type",
+        "ja": "A型",
+        "ja_typings": [
+          "agata"
+        ]
+      },
+      {
+        "en": "B type",
+        "ja": "B型",
+        "ja_typings": [
+          "bgata"
+        ]
+      },
+      {
+        "en": "O type",
+        "ja": "O型",
+        "ja_typings": [
+          "ogata"
+        ]
+      },
+      {
+        "en": "AB type",
+        "ja": "AB型",
+        "ja_typings": [
+          "abgata"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03399",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ABO blood type has antigen A on red blood cells?",
+      "ja": "赤血球にA抗原を持つABO式血液型は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aluminum",
+        "ja": "アルミニウム",
+        "ja_typings": [
+          "aruminiumu"
+        ]
+      },
+      {
+        "en": "Iron",
+        "ja": "鉄",
+        "ja_typings": [
+          "tetsu"
+        ]
+      },
+      {
+        "en": "Copper",
+        "ja": "銅",
+        "ja_typings": [
+          "dou"
+        ]
+      },
+      {
+        "en": "Magnesium",
+        "ja": "マグネシウム",
+        "ja_typings": [
+          "maguneshiumu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03400",
+    "image_path": null,
+    "question_text": {
+      "en": "Which lightweight metal has atomic number 13?",
+      "ja": "原子番号13番の軽い金属は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Archimedes",
+        "ja": "アルキメデス",
+        "ja_typings": [
+          "arukimedesu"
+        ]
+      },
+      {
+        "en": "Pythagoras",
+        "ja": "ピタゴラス",
+        "ja_typings": [
+          "pitagorasu"
+        ]
+      },
+      {
+        "en": "Euclid",
+        "ja": "ユークリッド",
+        "ja_typings": [
+          "yu-kuriddo"
+        ]
+      },
+      {
+        "en": "Aristotle",
+        "ja": "アリストテレス",
+        "ja_typings": [
+          "arisutoteresu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03401",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Greek scholar discovered the principle of buoyancy?",
+      "ja": "浮力の原理を発見した古代ギリシアの学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Au",
+        "ja": "エーユー",
+        "ja_typings": [
+          "e-yu-"
+        ]
+      },
+      {
+        "en": "Ag",
+        "ja": "エージー",
+        "ja_typings": [
+          "e-ji-"
+        ]
+      },
+      {
+        "en": "Cu",
+        "ja": "シーユー",
+        "ja_typings": [
+          "shi-yu-"
+        ]
+      },
+      {
+        "en": "Fe",
+        "ja": "エフイー",
+        "ja_typings": [
+          "efui-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03402",
+    "image_path": null,
+    "question_text": {
+      "en": "Which element symbol represents gold?",
+      "ja": "金を表す元素記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aurora",
+        "ja": "オーロラ",
+        "ja_typings": [
+          "o-rora"
+        ]
+      },
+      {
+        "en": "Mirage",
+        "ja": "蜃気楼",
+        "ja_typings": [
+          "shinkirou"
+        ]
+      },
+      {
+        "en": "Rainbow",
+        "ja": "虹",
+        "ja_typings": [
+          "niji"
+        ]
+      },
+      {
+        "en": "Halo",
+        "ja": "ハロ",
+        "ja_typings": [
+          "haro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03403",
+    "image_path": null,
+    "question_text": {
+      "en": "Which polar atmospheric phenomenon shows colorful curtains of light?",
+      "ja": "極地で色とりどりの光のカーテンが見える大気現象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "B type",
+        "ja": "B型",
+        "ja_typings": [
+          "bgata"
+        ]
+      },
+      {
+        "en": "A type",
+        "ja": "A型",
+        "ja_typings": [
+          "agata"
+        ]
+      },
+      {
+        "en": "O type",
+        "ja": "O型",
+        "ja_typings": [
+          "ogata"
+        ]
+      },
+      {
+        "en": "AB type",
+        "ja": "AB型",
+        "ja_typings": [
+          "abgata"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03404",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ABO blood type has antigen B on red blood cells?",
+      "ja": "赤血球にB抗原を持つABO式血液型は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "BMI",
+        "ja": "ビーエムアイ",
+        "ja_typings": [
+          "bi-emuai"
+        ]
+      },
+      {
+        "en": "IQ",
+        "ja": "アイキュー",
+        "ja_typings": [
+          "aikyu-"
+        ]
+      },
+      {
+        "en": "EQ",
+        "ja": "イーキュー",
+        "ja_typings": [
+          "i-kyu-"
+        ]
+      },
+      {
+        "en": "BMR",
+        "ja": "ビーエムアール",
+        "ja_typings": [
+          "bi-emua-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03405",
+    "image_path": null,
+    "question_text": {
+      "en": "Which index combines weight and height to estimate body fat?",
+      "ja": "体重と身長から肥満度を推定する指数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Becquerel",
+        "ja": "ベクレル",
+        "ja_typings": [
+          "bekureru"
+        ]
+      },
+      {
+        "en": "Curie",
+        "ja": "キュリー",
+        "ja_typings": [
+          "kyuri-"
+        ]
+      },
+      {
+        "en": "Roentgen",
+        "ja": "レントゲン",
+        "ja_typings": [
+          "rentogen"
+        ]
+      },
+      {
+        "en": "Rutherford",
+        "ja": "ラザフォード",
+        "ja_typings": [
+          "razafo-do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03406",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French physicist discovered natural radioactivity in 1896?",
+      "ja": "1896年に天然放射能を発見したフランスの物理学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Carbon",
+        "ja": "炭素",
+        "ja_typings": [
+          "tannso"
+        ]
+      },
+      {
+        "en": "Oxygen",
+        "ja": "酸素",
+        "ja_typings": [
+          "sannso"
+        ]
+      },
+      {
+        "en": "Hydrogen",
+        "ja": "水素",
+        "ja_typings": [
+          "suiso"
+        ]
+      },
+      {
+        "en": "Nitrogen",
+        "ja": "窒素",
+        "ja_typings": [
+          "chissoso",
+          "chisso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03407",
+    "image_path": null,
+    "question_text": {
+      "en": "Which element with symbol C is the basis of organic chemistry?",
+      "ja": "有機化学の基盤となる元素記号Cの元素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Coal",
+        "ja": "石炭",
+        "ja_typings": [
+          "sekitan"
+        ]
+      },
+      {
+        "en": "Oil",
+        "ja": "石油",
+        "ja_typings": [
+          "sekiyu"
+        ]
+      },
+      {
+        "en": "Natural gas",
+        "ja": "天然ガス",
+        "ja_typings": [
+          "tennenngasu"
+        ]
+      },
+      {
+        "en": "Peat",
+        "ja": "泥炭",
+        "ja_typings": [
+          "deitan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03408",
+    "image_path": null,
+    "question_text": {
+      "en": "Which fossil fuel is a black sedimentary rock burned for energy?",
+      "ja": "黒い堆積岩でエネルギー源として燃やされる化石燃料は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Combustion",
+        "ja": "燃焼",
+        "ja_typings": [
+          "nennshou"
+        ]
+      },
+      {
+        "en": "Oxidation",
+        "ja": "酸化",
+        "ja_typings": [
+          "sannka"
+        ]
+      },
+      {
+        "en": "Reduction",
+        "ja": "還元",
+        "ja_typings": [
+          "kanngen"
+        ]
+      },
+      {
+        "en": "Electrolysis",
+        "ja": "電気分解",
+        "ja_typings": [
+          "dennkibunnkai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03409",
+    "image_path": null,
+    "question_text": {
+      "en": "Which chemical reaction with oxygen produces heat and light?",
+      "ja": "酸素と反応して熱と光を出す化学反応は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Coulomb",
+        "ja": "クーロン",
+        "ja_typings": [
+          "ku-ron"
+        ]
+      },
+      {
+        "en": "Volta",
+        "ja": "ボルタ",
+        "ja_typings": [
+          "boruta"
+        ]
+      },
+      {
+        "en": "Ampere",
+        "ja": "アンペール",
+        "ja_typings": [
+          "anpe-ru"
+        ]
+      },
+      {
+        "en": "Ohm",
+        "ja": "オーム",
+        "ja_typings": [
+          "o-mu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03410",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French physicist gave his name to the SI unit of electric charge?",
+      "ja": "電荷のSI単位に名を残すフランスの物理学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Decibel",
+        "ja": "デシベル",
+        "ja_typings": [
+          "deshiberu"
+        ]
+      },
+      {
+        "en": "Hertz",
+        "ja": "ヘルツ",
+        "ja_typings": [
+          "herutsu"
+        ]
+      },
+      {
+        "en": "Pascal",
+        "ja": "パスカル",
+        "ja_typings": [
+          "pasukaru"
+        ]
+      },
+      {
+        "en": "Watt",
+        "ja": "ワット",
+        "ja_typings": [
+          "watto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03411",
+    "image_path": null,
+    "question_text": {
+      "en": "Which logarithmic unit expresses sound pressure level?",
+      "ja": "音圧レベルを対数で表す単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Einstein",
+        "ja": "アインシュタイン",
+        "ja_typings": [
+          "ainshutain"
+        ]
+      },
+      {
+        "en": "Bohr",
+        "ja": "ボーア",
+        "ja_typings": [
+          "bo-a"
+        ]
+      },
+      {
+        "en": "Planck",
+        "ja": "プランク",
+        "ja_typings": [
+          "puranku"
+        ]
+      },
+      {
+        "en": "Heisenberg",
+        "ja": "ハイゼンベルク",
+        "ja_typings": [
+          "haizenberuku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03412",
+    "image_path": null,
+    "question_text": {
+      "en": "Which physicist published the theory of relativity in 1905 and 1915?",
+      "ja": "1905年と1915年に相対性理論を発表した物理学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Electromagnetic force",
+        "ja": "電磁気力",
+        "ja_typings": [
+          "dennjikiryoku"
+        ]
+      },
+      {
+        "en": "Gravity",
+        "ja": "重力",
+        "ja_typings": [
+          "juuryoku"
+        ]
+      },
+      {
+        "en": "Strong force",
+        "ja": "強い力",
+        "ja_typings": [
+          "tsuyoichikara"
+        ]
+      },
+      {
+        "en": "Weak force",
+        "ja": "弱い力",
+        "ja_typings": [
+          "yowaichikara"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03413",
+    "image_path": null,
+    "question_text": {
+      "en": "Which fundamental force acts between electrically charged particles?",
+      "ja": "電荷を持つ粒子の間に働く基本相互作用は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fe",
+        "ja": "エフイー",
+        "ja_typings": [
+          "efui-"
+        ]
+      },
+      {
+        "en": "Au",
+        "ja": "エーユー",
+        "ja_typings": [
+          "e-yu-"
+        ]
+      },
+      {
+        "en": "Ag",
+        "ja": "エージー",
+        "ja_typings": [
+          "e-ji-"
+        ]
+      },
+      {
+        "en": "Cu",
+        "ja": "シーユー",
+        "ja_typings": [
+          "shi-yu-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03414",
+    "image_path": null,
+    "question_text": {
+      "en": "Which element symbol represents iron?",
+      "ja": "鉄を表す元素記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fleming",
+        "ja": "フレミング",
+        "ja_typings": [
+          "furemingu"
+        ]
+      },
+      {
+        "en": "Faraday",
+        "ja": "ファラデー",
+        "ja_typings": [
+          "farade-"
+        ]
+      },
+      {
+        "en": "Maxwell",
+        "ja": "マクスウェル",
+        "ja_typings": [
+          "makusuweru"
+        ]
+      },
+      {
+        "en": "Ampere",
+        "ja": "アンペール",
+        "ja_typings": [
+          "anpe-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03415",
+    "image_path": null,
+    "question_text": {
+      "en": "Which British scientist formulated rules for the direction of induced current?",
+      "ja": "誘導電流の向きに関する法則を定めた英国の科学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Friction",
+        "ja": "摩擦",
+        "ja_typings": [
+          "masatsu"
+        ]
+      },
+      {
+        "en": "Gravity",
+        "ja": "重力",
+        "ja_typings": [
+          "juuryoku"
+        ]
+      },
+      {
+        "en": "Tension",
+        "ja": "張力",
+        "ja_typings": [
+          "chouryoku"
+        ]
+      },
+      {
+        "en": "Buoyancy",
+        "ja": "浮力",
+        "ja_typings": [
+          "furyoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03416",
+    "image_path": null,
+    "question_text": {
+      "en": "Which force resists motion between surfaces in contact?",
+      "ja": "接触する面の運動を妨げる力は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Galileo",
+        "ja": "ガリレオ",
+        "ja_typings": [
+          "garireo"
+        ]
+      },
+      {
+        "en": "Copernicus",
+        "ja": "コペルニクス",
+        "ja_typings": [
+          "koperunikusu"
+        ]
+      },
+      {
+        "en": "Kepler",
+        "ja": "ケプラー",
+        "ja_typings": [
+          "kepura-"
+        ]
+      },
+      {
+        "en": "Newton",
+        "ja": "ニュートン",
+        "ja_typings": [
+          "nyu-ton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03417",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian astronomer first observed Jupiter's four largest moons?",
+      "ja": "木星の四大衛星を最初に観測したイタリアの天文学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gravity",
+        "ja": "重力",
+        "ja_typings": [
+          "juuryoku"
+        ]
+      },
+      {
+        "en": "Friction",
+        "ja": "摩擦",
+        "ja_typings": [
+          "masatsu"
+        ]
+      },
+      {
+        "en": "Magnetism",
+        "ja": "磁力",
+        "ja_typings": [
+          "jiryoku"
+        ]
+      },
+      {
+        "en": "Tension",
+        "ja": "張力",
+        "ja_typings": [
+          "chouryoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03418",
+    "image_path": null,
+    "question_text": {
+      "en": "Which attractive force pulls objects toward the Earth?",
+      "ja": "地球が物体を引き寄せる力は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hideyo Noguchi",
+        "ja": "野口英世",
+        "ja_typings": [
+          "noguchihideyo"
+        ]
+      },
+      {
+        "en": "Shibasaburo Kitasato",
+        "ja": "北里柴三郎",
+        "ja_typings": [
+          "kitazatoshibasaburou",
+          "kitasatoshibasaburou"
+        ]
+      },
+      {
+        "en": "Hachiro Hata",
+        "ja": "秦佐八郎",
+        "ja_typings": [
+          "hatasahachirou"
+        ]
+      },
+      {
+        "en": "Umetaro Suzuki",
+        "ja": "鈴木梅太郎",
+        "ja_typings": [
+          "suzukiumetarou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03419",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese bacteriologist studied yellow fever and is on the 1000 yen note?",
+      "ja": "黄熱病を研究し千円札の肖像にもなった日本の細菌学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hooke",
+        "ja": "フック",
+        "ja_typings": [
+          "fukku"
+        ]
+      },
+      {
+        "en": "Newton",
+        "ja": "ニュートン",
+        "ja_typings": [
+          "nyu-ton"
+        ]
+      },
+      {
+        "en": "Boyle",
+        "ja": "ボイル",
+        "ja_typings": [
+          "boiru"
+        ]
+      },
+      {
+        "en": "Cavendish",
+        "ja": "キャベンディッシュ",
+        "ja_typings": [
+          "kyabendisshu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03420",
+    "image_path": null,
+    "question_text": {
+      "en": "Which English scientist formulated the law of elasticity for springs?",
+      "ja": "ばねの弾性に関する法則を定めた英国の科学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hubble",
+        "ja": "ハッブル",
+        "ja_typings": [
+          "habburu"
+        ]
+      },
+      {
+        "en": "Sagan",
+        "ja": "セーガン",
+        "ja_typings": [
+          "se-gan"
+        ]
+      },
+      {
+        "en": "Galileo",
+        "ja": "ガリレオ",
+        "ja_typings": [
+          "garireo"
+        ]
+      },
+      {
+        "en": "Kepler",
+        "ja": "ケプラー",
+        "ja_typings": [
+          "kepura-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03421",
+    "image_path": null,
+    "question_text": {
+      "en": "Which American astronomer found that distant galaxies are receding?",
+      "ja": "遠方銀河が後退していることを発見した米国の天文学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hydrogen",
+        "ja": "水素",
+        "ja_typings": [
+          "suiso"
+        ]
+      },
+      {
+        "en": "Helium",
+        "ja": "ヘリウム",
+        "ja_typings": [
+          "heriumu"
+        ]
+      },
+      {
+        "en": "Oxygen",
+        "ja": "酸素",
+        "ja_typings": [
+          "sannso"
+        ]
+      },
+      {
+        "en": "Nitrogen",
+        "ja": "窒素",
+        "ja_typings": [
+          "chissoso",
+          "chisso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03422",
+    "image_path": null,
+    "question_text": {
+      "en": "Which element has atomic number 1 and symbol H?",
+      "ja": "原子番号1番で記号Hの元素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "IQ",
+        "ja": "アイキュー",
+        "ja_typings": [
+          "aikyu-"
+        ]
+      },
+      {
+        "en": "BMI",
+        "ja": "ビーエムアイ",
+        "ja_typings": [
+          "bi-emuai"
+        ]
+      },
+      {
+        "en": "EQ",
+        "ja": "イーキュー",
+        "ja_typings": [
+          "i-kyu-"
+        ]
+      },
+      {
+        "en": "GPA",
+        "ja": "ジーピーエー",
+        "ja_typings": [
+          "ji-pi-e-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03423",
+    "image_path": null,
+    "question_text": {
+      "en": "Which score is a numerical estimate of intelligence?",
+      "ja": "知能を数値化した指標は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Interference",
+        "ja": "干渉",
+        "ja_typings": [
+          "kannshou"
+        ]
+      },
+      {
+        "en": "Diffraction",
+        "ja": "回折",
+        "ja_typings": [
+          "kaisetsu"
+        ]
+      },
+      {
+        "en": "Reflection",
+        "ja": "反射",
+        "ja_typings": [
+          "hannsha"
+        ]
+      },
+      {
+        "en": "Refraction",
+        "ja": "屈折",
+        "ja_typings": [
+          "kussetsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03424",
+    "image_path": null,
+    "question_text": {
+      "en": "Which wave phenomenon results from superposition producing reinforcement and cancellation?",
+      "ja": "波の重ね合わせで強め合いや打ち消しが起きる現象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jenner",
+        "ja": "ジェンナー",
+        "ja_typings": [
+          "jennna-"
+        ]
+      },
+      {
+        "en": "Pasteur",
+        "ja": "パスツール",
+        "ja_typings": [
+          "pasutsu-ru"
+        ]
+      },
+      {
+        "en": "Koch",
+        "ja": "コッホ",
+        "ja_typings": [
+          "kohho"
+        ]
+      },
+      {
+        "en": "Lister",
+        "ja": "リスター",
+        "ja_typings": [
+          "risuta-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03425",
+    "image_path": null,
+    "question_text": {
+      "en": "Which English doctor developed the first smallpox vaccine?",
+      "ja": "天然痘の世界初のワクチンを開発した英国の医師は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jurassic",
+        "ja": "ジュラ紀",
+        "ja_typings": [
+          "juraki"
+        ]
+      },
+      {
+        "en": "Triassic",
+        "ja": "三畳紀",
+        "ja_typings": [
+          "sannjouki"
+        ]
+      },
+      {
+        "en": "Cretaceous",
+        "ja": "白亜紀",
+        "ja_typings": [
+          "hakuaki"
+        ]
+      },
+      {
+        "en": "Cambrian",
+        "ja": "カンブリア紀",
+        "ja_typings": [
+          "kannburiaki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03426",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mesozoic geological period is famous for large dinosaurs?",
+      "ja": "大型恐竜で有名な中生代の地質時代は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Leeuwenhoek",
+        "ja": "レーウェンフック",
+        "ja_typings": [
+          "re-wenfukku"
+        ]
+      },
+      {
+        "en": "Hooke",
+        "ja": "フック",
+        "ja_typings": [
+          "fukku"
+        ]
+      },
+      {
+        "en": "Pasteur",
+        "ja": "パスツール",
+        "ja_typings": [
+          "pasutsu-ru"
+        ]
+      },
+      {
+        "en": "Koch",
+        "ja": "コッホ",
+        "ja_typings": [
+          "kohho"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03427",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Dutch pioneer first observed microorganisms with a microscope?",
+      "ja": "顕微鏡で初めて微生物を観察したオランダの先駆者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Magnetic storm",
+        "ja": "磁気嵐",
+        "ja_typings": [
+          "jikiarashi"
+        ]
+      },
+      {
+        "en": "Aurora",
+        "ja": "オーロラ",
+        "ja_typings": [
+          "o-rora"
+        ]
+      },
+      {
+        "en": "Solar flare",
+        "ja": "太陽フレア",
+        "ja_typings": [
+          "taiyoufurea"
+        ]
+      },
+      {
+        "en": "Mirage",
+        "ja": "蜃気楼",
+        "ja_typings": [
+          "shinkirou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03428",
+    "image_path": null,
+    "question_text": {
+      "en": "Which disturbance of Earth's magnetic field is caused by solar wind?",
+      "ja": "太陽風によって生じる地球磁場の擾乱は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mirage",
+        "ja": "蜃気楼",
+        "ja_typings": [
+          "shinkirou"
+        ]
+      },
+      {
+        "en": "Rainbow",
+        "ja": "虹",
+        "ja_typings": [
+          "niji"
+        ]
+      },
+      {
+        "en": "Aurora",
+        "ja": "オーロラ",
+        "ja_typings": [
+          "o-rora"
+        ]
+      },
+      {
+        "en": "Halo",
+        "ja": "ハロ",
+        "ja_typings": [
+          "haro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03429",
+    "image_path": null,
+    "question_text": {
+      "en": "Which optical phenomenon makes distant objects appear distorted over hot ground?",
+      "ja": "熱い地面の上で遠くの物体が歪んで見える光学現象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NaOH",
+        "ja": "エヌエーオーエイチ",
+        "ja_typings": [
+          "enue-o-eichi"
+        ]
+      },
+      {
+        "en": "HCl",
+        "ja": "エイチシーエル",
+        "ja_typings": [
+          "eichishi-eru"
+        ]
+      },
+      {
+        "en": "H2SO4",
+        "ja": "エイチ2エスオー4",
+        "ja_typings": [
+          "eichi2esuo-4"
+        ]
+      },
+      {
+        "en": "NH3",
+        "ja": "エヌエイチ3",
+        "ja_typings": [
+          "enueichi3"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03430",
+    "image_path": null,
+    "question_text": {
+      "en": "Which chemical formula represents sodium hydroxide?",
+      "ja": "水酸化ナトリウムを表す化学式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Natural gas",
+        "ja": "天然ガス",
+        "ja_typings": [
+          "tennenngasu"
+        ]
+      },
+      {
+        "en": "Coal",
+        "ja": "石炭",
+        "ja_typings": [
+          "sekitan"
+        ]
+      },
+      {
+        "en": "Oil",
+        "ja": "石油",
+        "ja_typings": [
+          "sekiyu"
+        ]
+      },
+      {
+        "en": "Peat",
+        "ja": "泥炭",
+        "ja_typings": [
+          "deitan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03431",
+    "image_path": null,
+    "question_text": {
+      "en": "Which fossil fuel is primarily composed of methane?",
+      "ja": "主にメタンからなる化石燃料は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Neutron",
+        "ja": "中性子",
+        "ja_typings": [
+          "chuuseishi"
+        ]
+      },
+      {
+        "en": "Proton",
+        "ja": "陽子",
+        "ja_typings": [
+          "youshi"
+        ]
+      },
+      {
+        "en": "Electron",
+        "ja": "電子",
+        "ja_typings": [
+          "denshi"
+        ]
+      },
+      {
+        "en": "Photon",
+        "ja": "光子",
+        "ja_typings": [
+          "koushi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03432",
+    "image_path": null,
+    "question_text": {
+      "en": "Which electrically neutral subatomic particle is found in atomic nuclei?",
+      "ja": "原子核に含まれる電気的に中性の粒子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nuclear reaction",
+        "ja": "核反応",
+        "ja_typings": [
+          "kakuhannnou",
+          "kakuhannou"
+        ]
+      },
+      {
+        "en": "Chemical reaction",
+        "ja": "化学反応",
+        "ja_typings": [
+          "kagakuhannnou",
+          "kagakuhannou"
+        ]
+      },
+      {
+        "en": "Combustion",
+        "ja": "燃焼",
+        "ja_typings": [
+          "nennshou"
+        ]
+      },
+      {
+        "en": "Electrolysis",
+        "ja": "電気分解",
+        "ja_typings": [
+          "dennkibunnkai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03433",
+    "image_path": null,
+    "question_text": {
+      "en": "Which type of reaction occurs in the Sun's core?",
+      "ja": "太陽の中心で起きている反応の種類は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "O type",
+        "ja": "O型",
+        "ja_typings": [
+          "ogata"
+        ]
+      },
+      {
+        "en": "A type",
+        "ja": "A型",
+        "ja_typings": [
+          "agata"
+        ]
+      },
+      {
+        "en": "B type",
+        "ja": "B型",
+        "ja_typings": [
+          "bgata"
+        ]
+      },
+      {
+        "en": "AB type",
+        "ja": "AB型",
+        "ja_typings": [
+          "abgata"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03434",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ABO blood type has neither A nor B antigen?",
+      "ja": "A抗原もB抗原も持たないABO式血液型は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ohm",
+        "ja": "オーム",
+        "ja_typings": [
+          "o-mu"
+        ]
+      },
+      {
+        "en": "Volta",
+        "ja": "ボルタ",
+        "ja_typings": [
+          "boruta"
+        ]
+      },
+      {
+        "en": "Ampere",
+        "ja": "アンペール",
+        "ja_typings": [
+          "anpe-ru"
+        ]
+      },
+      {
+        "en": "Coulomb",
+        "ja": "クーロン",
+        "ja_typings": [
+          "ku-ron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03435",
+    "image_path": null,
+    "question_text": {
+      "en": "Which German physicist gave his name to the unit of electrical resistance?",
+      "ja": "電気抵抗の単位に名を残すドイツの物理学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Oil",
+        "ja": "石油",
+        "ja_typings": [
+          "sekiyu"
+        ]
+      },
+      {
+        "en": "Coal",
+        "ja": "石炭",
+        "ja_typings": [
+          "sekitan"
+        ]
+      },
+      {
+        "en": "Natural gas",
+        "ja": "天然ガス",
+        "ja_typings": [
+          "tennenngasu"
+        ]
+      },
+      {
+        "en": "Peat",
+        "ja": "泥炭",
+        "ja_typings": [
+          "deitan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03436",
+    "image_path": null,
+    "question_text": {
+      "en": "Which fossil fuel is refined into gasoline and diesel?",
+      "ja": "ガソリンや軽油に精製される化石燃料は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Oxygen",
+        "ja": "酸素",
+        "ja_typings": [
+          "sannso"
+        ]
+      },
+      {
+        "en": "Hydrogen",
+        "ja": "水素",
+        "ja_typings": [
+          "suiso"
+        ]
+      },
+      {
+        "en": "Carbon",
+        "ja": "炭素",
+        "ja_typings": [
+          "tannso"
+        ]
+      },
+      {
+        "en": "Nitrogen",
+        "ja": "窒素",
+        "ja_typings": [
+          "chissoso",
+          "chisso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03437",
+    "image_path": null,
+    "question_text": {
+      "en": "Which element with symbol O is essential for respiration?",
+      "ja": "呼吸に不可欠な記号Oの元素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Paleogene",
+        "ja": "古第三紀",
+        "ja_typings": [
+          "kodaisannki"
+        ]
+      },
+      {
+        "en": "Neogene",
+        "ja": "新第三紀",
+        "ja_typings": [
+          "shinndaisannki"
+        ]
+      },
+      {
+        "en": "Quaternary",
+        "ja": "第四紀",
+        "ja_typings": [
+          "daiyonki"
+        ]
+      },
+      {
+        "en": "Cretaceous",
+        "ja": "白亜紀",
+        "ja_typings": [
+          "hakuaki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03438",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Cenozoic geological period followed the Cretaceous?",
+      "ja": "白亜紀のあとに続く新生代の地質時代は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pasteur",
+        "ja": "パスツール",
+        "ja_typings": [
+          "pasutsu-ru"
+        ]
+      },
+      {
+        "en": "Jenner",
+        "ja": "ジェンナー",
+        "ja_typings": [
+          "jennna-"
+        ]
+      },
+      {
+        "en": "Koch",
+        "ja": "コッホ",
+        "ja_typings": [
+          "kohho"
+        ]
+      },
+      {
+        "en": "Lister",
+        "ja": "リスター",
+        "ja_typings": [
+          "risuta-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03439",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French scientist developed pasteurization and a rabies vaccine?",
+      "ja": "低温殺菌法と狂犬病ワクチンを開発したフランスの科学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Photon",
+        "ja": "光子",
+        "ja_typings": [
+          "koushi"
+        ]
+      },
+      {
+        "en": "Electron",
+        "ja": "電子",
+        "ja_typings": [
+          "denshi"
+        ]
+      },
+      {
+        "en": "Neutron",
+        "ja": "中性子",
+        "ja_typings": [
+          "chuuseishi"
+        ]
+      },
+      {
+        "en": "Proton",
+        "ja": "陽子",
+        "ja_typings": [
+          "youshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03440",
+    "image_path": null,
+    "question_text": {
+      "en": "Which elementary particle is the quantum of light?",
+      "ja": "光の量子に相当する素粒子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Proton",
+        "ja": "陽子",
+        "ja_typings": [
+          "youshi"
+        ]
+      },
+      {
+        "en": "Neutron",
+        "ja": "中性子",
+        "ja_typings": [
+          "chuuseishi"
+        ]
+      },
+      {
+        "en": "Electron",
+        "ja": "電子",
+        "ja_typings": [
+          "denshi"
+        ]
+      },
+      {
+        "en": "Photon",
+        "ja": "光子",
+        "ja_typings": [
+          "koushi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03441",
+    "image_path": null,
+    "question_text": {
+      "en": "Which positively charged particle is found in atomic nuclei?",
+      "ja": "原子核に含まれる正電荷の粒子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ptolemy",
+        "ja": "プトレマイオス",
+        "ja_typings": [
+          "putoremaiosu"
+        ]
+      },
+      {
+        "en": "Copernicus",
+        "ja": "コペルニクス",
+        "ja_typings": [
+          "koperunikusu"
+        ]
+      },
+      {
+        "en": "Galileo",
+        "ja": "ガリレオ",
+        "ja_typings": [
+          "garireo"
+        ]
+      },
+      {
+        "en": "Kepler",
+        "ja": "ケプラー",
+        "ja_typings": [
+          "kepura-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03442",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Greek astronomer is known for a geocentric model?",
+      "ja": "天動説で知られる古代ギリシアの天文学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Purple",
+        "ja": "紫",
+        "ja_typings": [
+          "murasaki"
+        ]
+      },
+      {
+        "en": "Yellow",
+        "ja": "黄",
+        "ja_typings": [
+          "ki"
+        ]
+      },
+      {
+        "en": "Green",
+        "ja": "緑",
+        "ja_typings": [
+          "midori"
+        ]
+      },
+      {
+        "en": "Orange",
+        "ja": "橙",
+        "ja_typings": [
+          "daidai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03443",
+    "image_path": null,
+    "question_text": {
+      "en": "Which color is produced by mixing red and blue light?",
+      "ja": "赤い光と青い光を混ぜると見える色は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rainbow",
+        "ja": "虹",
+        "ja_typings": [
+          "niji"
+        ]
+      },
+      {
+        "en": "Aurora",
+        "ja": "オーロラ",
+        "ja_typings": [
+          "o-rora"
+        ]
+      },
+      {
+        "en": "Mirage",
+        "ja": "蜃気楼",
+        "ja_typings": [
+          "shinkirou"
+        ]
+      },
+      {
+        "en": "Halo",
+        "ja": "ハロ",
+        "ja_typings": [
+          "haro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03444",
+    "image_path": null,
+    "question_text": {
+      "en": "Which optical phenomenon appears as a colored arc after rain?",
+      "ja": "雨上がりに見える色の弧の光学現象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Roentgen",
+        "ja": "レントゲン",
+        "ja_typings": [
+          "rentogen"
+        ]
+      },
+      {
+        "en": "Becquerel",
+        "ja": "ベクレル",
+        "ja_typings": [
+          "bekureru"
+        ]
+      },
+      {
+        "en": "Curie",
+        "ja": "キュリー",
+        "ja_typings": [
+          "kyuri-"
+        ]
+      },
+      {
+        "en": "Rutherford",
+        "ja": "ラザフォード",
+        "ja_typings": [
+          "razafo-do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03445",
+    "image_path": null,
+    "question_text": {
+      "en": "Which German physicist discovered X-rays in 1895?",
+      "ja": "1895年にX線を発見したドイツの物理学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Schleiden",
+        "ja": "シュライデン",
+        "ja_typings": [
+          "shuraiden"
+        ]
+      },
+      {
+        "en": "Schwann",
+        "ja": "シュワン",
+        "ja_typings": [
+          "shuwan"
+        ]
+      },
+      {
+        "en": "Virchow",
+        "ja": "ウィルヒョウ",
+        "ja_typings": [
+          "wiruhyo",
+          "wiruhyou"
+        ]
+      },
+      {
+        "en": "Hooke",
+        "ja": "フック",
+        "ja_typings": [
+          "fukku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03446",
+    "image_path": null,
+    "question_text": {
+      "en": "Which German botanist co-founded the cell theory for plants?",
+      "ja": "植物の細胞説を共同で提唱したドイツの植物学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Seismic intensity",
+        "ja": "震度",
+        "ja_typings": [
+          "shinndo"
+        ]
+      },
+      {
+        "en": "Magnitude",
+        "ja": "マグニチュード",
+        "ja_typings": [
+          "magunichu-do"
+        ]
+      },
+      {
+        "en": "Richter scale",
+        "ja": "リヒタースケール",
+        "ja_typings": [
+          "rihita-suke-ru"
+        ]
+      },
+      {
+        "en": "Mercalli",
+        "ja": "メルカリ",
+        "ja_typings": [
+          "merukari"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03447",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese scale measures the strength of shaking at a location?",
+      "ja": "ある地点での揺れの強さを表す日本の尺度は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Silicon",
+        "ja": "ケイ素",
+        "ja_typings": [
+          "keiso"
+        ]
+      },
+      {
+        "en": "Carbon",
+        "ja": "炭素",
+        "ja_typings": [
+          "tannso"
+        ]
+      },
+      {
+        "en": "Germanium",
+        "ja": "ゲルマニウム",
+        "ja_typings": [
+          "gerumaniumu"
+        ]
+      },
+      {
+        "en": "Gallium",
+        "ja": "ガリウム",
+        "ja_typings": [
+          "gariumu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03448",
+    "image_path": null,
+    "question_text": {
+      "en": "Which element with symbol Si is the main material of semiconductors?",
+      "ja": "半導体の主材料となる記号Siの元素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sirius",
+        "ja": "シリウス",
+        "ja_typings": [
+          "shiriusu"
+        ]
+      },
+      {
+        "en": "Vega",
+        "ja": "ベガ",
+        "ja_typings": [
+          "bega"
+        ]
+      },
+      {
+        "en": "Polaris",
+        "ja": "北極星",
+        "ja_typings": [
+          "hokkyokusei"
+        ]
+      },
+      {
+        "en": "Betelgeuse",
+        "ja": "ベテルギウス",
+        "ja_typings": [
+          "beterugiusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03449",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the brightest star in Earth's night sky?",
+      "ja": "地球の夜空で最も明るく見える恒星は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sulfur",
+        "ja": "硫黄",
+        "ja_typings": [
+          "iou"
+        ]
+      },
+      {
+        "en": "Carbon",
+        "ja": "炭素",
+        "ja_typings": [
+          "tannso"
+        ]
+      },
+      {
+        "en": "Silicon",
+        "ja": "ケイ素",
+        "ja_typings": [
+          "keiso"
+        ]
+      },
+      {
+        "en": "Phosphorus",
+        "ja": "リン",
+        "ja_typings": [
+          "rinn"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03450",
+    "image_path": null,
+    "question_text": {
+      "en": "Which yellow element with symbol S is found near volcanoes?",
+      "ja": "火山周辺で見られる記号Sの黄色い元素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Triassic",
+        "ja": "三畳紀",
+        "ja_typings": [
+          "sannjouki"
+        ]
+      },
+      {
+        "en": "Jurassic",
+        "ja": "ジュラ紀",
+        "ja_typings": [
+          "juraki"
+        ]
+      },
+      {
+        "en": "Cretaceous",
+        "ja": "白亜紀",
+        "ja_typings": [
+          "hakuaki"
+        ]
+      },
+      {
+        "en": "Permian",
+        "ja": "ペルム紀",
+        "ja_typings": [
+          "perumuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03451",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mesozoic period came right before the Jurassic?",
+      "ja": "ジュラ紀の直前に位置する中生代の地質時代は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "White",
+        "ja": "白",
+        "ja_typings": [
+          "shiro"
+        ]
+      },
+      {
+        "en": "Black",
+        "ja": "黒",
+        "ja_typings": [
+          "kuro"
+        ]
+      },
+      {
+        "en": "Gray",
+        "ja": "灰色",
+        "ja_typings": [
+          "haiiro"
+        ]
+      },
+      {
+        "en": "Silver",
+        "ja": "銀",
+        "ja_typings": [
+          "gin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03452",
+    "image_path": null,
+    "question_text": {
+      "en": "Which color is the result of mixing all visible wavelengths of light equally?",
+      "ja": "可視光のすべての波長を均等に混ぜたときに見える色は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yellow",
+        "ja": "黄",
+        "ja_typings": [
+          "ki"
+        ]
+      },
+      {
+        "en": "Red",
+        "ja": "赤",
+        "ja_typings": [
+          "aka"
+        ]
+      },
+      {
+        "en": "Green",
+        "ja": "緑",
+        "ja_typings": [
+          "midori"
+        ]
+      },
+      {
+        "en": "Purple",
+        "ja": "紫",
+        "ja_typings": [
+          "murasaki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03453",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the color of a ripe lemon?",
+      "ja": "熟したレモンの色は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ppm",
+        "ja": "ピーピーエム",
+        "ja_typings": [
+          "pi-pi-emu"
+        ]
+      },
+      {
+        "en": "ppb",
+        "ja": "ピーピービー",
+        "ja_typings": [
+          "pi-pi-bi-"
+        ]
+      },
+      {
+        "en": "ppt",
+        "ja": "ピーピーティー",
+        "ja_typings": [
+          "pi-pi-ti-"
+        ]
+      },
+      {
+        "en": "phr",
+        "ja": "ピーエイチアール",
+        "ja_typings": [
+          "pi-eichia-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03454",
+    "image_path": null,
+    "question_text": {
+      "en": "Which unit expresses concentration as parts per million?",
+      "ja": "100万分のいくつかで濃度を表す単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "AZKi",
+        "ja": "AZKi",
+        "ja_typings": [
+          "azuki",
+          "azki"
+        ]
+      },
+      {
+        "en": "Minato Aqua",
+        "ja": "湊あくあ",
+        "ja_typings": [
+          "minatoakua"
+        ]
+      },
+      {
+        "en": "Nakiri Ayame",
+        "ja": "百鬼あやめ",
+        "ja_typings": [
+          "nakiriayame"
+        ]
+      },
+      {
+        "en": "Shirakami Fubuki",
+        "ja": "白上フブキ",
+        "ja_typings": [
+          "shirakamifubuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03455",
+    "image_path": null,
+    "question_text": {
+      "en": "Which hololive VTuber is known for music activities and is sometimes called the goddess of music?",
+      "ja": "ホロライブで音楽活動を中心にする「ソング・フォー・ユー」を歌うVTuberは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aba",
+        "ja": "アバ",
+        "ja_typings": [
+          "aba"
+        ]
+      },
+      {
+        "en": "Gara",
+        "ja": "ガラ",
+        "ja_typings": [
+          "gara"
+        ]
+      },
+      {
+        "en": "Gomi",
+        "ja": "ゴミ",
+        "ja_typings": [
+          "gomi"
+        ]
+      },
+      {
+        "en": "Zako",
+        "ja": "ザコ",
+        "ja_typings": [
+          "zako"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03456",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the net-slang term for an avatar or anonymous online persona?",
+      "ja": "ネットスラングで匿名のあだ名や仮の名前を指す言葉は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Angry",
+        "ja": "アングリー",
+        "ja_typings": [
+          "anguri-"
+        ]
+      },
+      {
+        "en": "Sorry",
+        "ja": "ソーリー",
+        "ja_typings": [
+          "so-ri-"
+        ]
+      },
+      {
+        "en": "Thanks",
+        "ja": "サンクス",
+        "ja_typings": [
+          "sankusu"
+        ]
+      },
+      {
+        "en": "Bye",
+        "ja": "バイ",
+        "ja_typings": [
+          "bai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03457",
+    "image_path": null,
+    "question_text": {
+      "en": "Which English word is often used in net slang to express frustration?",
+      "ja": "ネットで怒りを表す英単語スラングは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Arashi",
+        "ja": "嵐",
+        "ja_typings": [
+          "arashi"
+        ]
+      },
+      {
+        "en": "Tamashii",
+        "ja": "魂",
+        "ja_typings": [
+          "tamashii"
+        ]
+      },
+      {
+        "en": "Kuromaku",
+        "ja": "黒幕",
+        "ja_typings": [
+          "kuromaku"
+        ]
+      },
+      {
+        "en": "Persona",
+        "ja": "ペルソナ",
+        "ja_typings": [
+          "perusona"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03458",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese word means 'storm' and is also a famous idol group name?",
+      "ja": "「嵐」を意味し有名アイドルグループ名でもある言葉は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "BTW",
+        "ja": "ところで",
+        "ja_typings": [
+          "btw",
+          "tokorode"
+        ]
+      },
+      {
+        "en": "FYI",
+        "ja": "参考までに",
+        "ja_typings": [
+          "fyi"
+        ]
+      },
+      {
+        "en": "TBH",
+        "ja": "正直に言うと",
+        "ja_typings": [
+          "tbh"
+        ]
+      },
+      {
+        "en": "BRB",
+        "ja": "すぐ戻る",
+        "ja_typings": [
+          "brb"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03459",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the net abbreviation 'BTW' stand for?",
+      "ja": "ネット略語「BTW」の意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bimyou",
+        "ja": "微妙",
+        "ja_typings": [
+          "bimyou",
+          "bimyo-"
+        ]
+      },
+      {
+        "en": "Gomi",
+        "ja": "ゴミ",
+        "ja_typings": [
+          "gomi"
+        ]
+      },
+      {
+        "en": "Zako",
+        "ja": "ザコ",
+        "ja_typings": [
+          "zako"
+        ]
+      },
+      {
+        "en": "Gara",
+        "ja": "ガラ",
+        "ja_typings": [
+          "gara"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03460",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese word means 'subtle' or 'so-so'?",
+      "ja": "「微妙」を意味する日本語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bits",
+        "ja": "ビッツ",
+        "ja_typings": [
+          "bittsu"
+        ]
+      },
+      {
+        "en": "Supacha",
+        "ja": "スパチャ",
+        "ja_typings": [
+          "supacha"
+        ]
+      },
+      {
+        "en": "Renkome",
+        "ja": "連コメ",
+        "ja_typings": [
+          "renkome"
+        ]
+      },
+      {
+        "en": "Laicha",
+        "ja": "ライチャ",
+        "ja_typings": [
+          "raicha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03461",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the name of the virtual currency used to cheer on Twitch?",
+      "ja": "Twitchで配信者を応援するために使う仮想通貨は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bushiroad",
+        "ja": "ブシロード",
+        "ja_typings": [
+          "bushiro-do"
+        ]
+      },
+      {
+        "en": "Kadokawa",
+        "ja": "KADOKAWA",
+        "ja_typings": [
+          "kadokawa"
+        ]
+      },
+      {
+        "en": "Dwango",
+        "ja": "ドワンゴ",
+        "ja_typings": [
+          "dowango"
+        ]
+      },
+      {
+        "en": "DeNA",
+        "ja": "DeNA",
+        "ja_typings": [
+          "dena",
+          "deiienue-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03462",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese company produces Bang Dream and Revue Starlight, and runs many TCGs?",
+      "ja": "バンドリやヴァイスシュヴァルツを運営する日本企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bye",
+        "ja": "バイ",
+        "ja_typings": [
+          "bai"
+        ]
+      },
+      {
+        "en": "Sorry",
+        "ja": "ソーリー",
+        "ja_typings": [
+          "so-ri-"
+        ]
+      },
+      {
+        "en": "Thanks",
+        "ja": "サンクス",
+        "ja_typings": [
+          "sankusu"
+        ]
+      },
+      {
+        "en": "Spam",
+        "ja": "スパム",
+        "ja_typings": [
+          "supamu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03463",
+    "image_path": null,
+    "question_text": {
+      "en": "Which English word is commonly used as a parting greeting?",
+      "ja": "英語で別れの挨拶として使われる短い単語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Collab haishin",
+        "ja": "コラボ配信",
+        "ja_typings": [
+          "korabohaishin"
+        ]
+      },
+      {
+        "en": "Mirror haishin",
+        "ja": "ミラー配信",
+        "ja_typings": [
+          "mira-haishin"
+        ]
+      },
+      {
+        "en": "Reaction douga",
+        "ja": "リアクション動画",
+        "ja_typings": [
+          "riakushondouga",
+          "riakushondo-ga"
+        ]
+      },
+      {
+        "en": "Nico Utagassen",
+        "ja": "ニコニコ歌合戦",
+        "ja_typings": [
+          "nikonikoutagassen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03464",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a streaming format where multiple VTubers appear together called?",
+      "ja": "複数のVTuberが一緒に出演する配信形式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cover Corp",
+        "ja": "カバー",
+        "ja_typings": [
+          "kaba-"
+        ]
+      },
+      {
+        "en": "ANYCOLOR",
+        "ja": "ANYCOLOR",
+        "ja_typings": [
+          "anycolor"
+        ]
+      },
+      {
+        "en": "Sony",
+        "ja": "ソニー",
+        "ja_typings": [
+          "soni-"
+        ]
+      },
+      {
+        "en": "DeNA",
+        "ja": "DeNA",
+        "ja_typings": [
+          "dena"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03465",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company runs the Hololive Production VTuber agency?",
+      "ja": "ホロライブプロダクションを運営する会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Crew",
+        "ja": "クルー",
+        "ja_typings": [
+          "kuru-"
+        ]
+      },
+      {
+        "en": "Staff",
+        "ja": "スタッフ",
+        "ja_typings": [
+          "sutaffu"
+        ]
+      },
+      {
+        "en": "Listener",
+        "ja": "リスナー",
+        "ja_typings": [
+          "risuna-"
+        ]
+      },
+      {
+        "en": "Member",
+        "ja": "メンバー",
+        "ja_typings": [
+          "menba-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03466",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a group of regular fans of a specific streamer or VTuber called in English?",
+      "ja": "特定の配信者の常連ファン集団を英語で何と呼ぶ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DeNA",
+        "ja": "DeNA",
+        "ja_typings": [
+          "dena",
+          "deiienue-"
+        ]
+      },
+      {
+        "en": "Dwango",
+        "ja": "ドワンゴ",
+        "ja_typings": [
+          "dowango"
+        ]
+      },
+      {
+        "en": "Sony",
+        "ja": "ソニー",
+        "ja_typings": [
+          "soni-"
+        ]
+      },
+      {
+        "en": "ANYCOLOR",
+        "ja": "ANYCOLOR",
+        "ja_typings": [
+          "anycolor"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03467",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company is known for the mobile games Pokemon Masters and Mobage platform?",
+      "ja": "モバゲーやポケモンマスターズで知られる日本企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Enja",
+        "ja": "英じゃ",
+        "ja_typings": [
+          "enja"
+        ]
+      },
+      {
+        "en": "Aba",
+        "ja": "アバ",
+        "ja_typings": [
+          "aba"
+        ]
+      },
+      {
+        "en": "Gara",
+        "ja": "ガラ",
+        "ja_typings": [
+          "gara"
+        ]
+      },
+      {
+        "en": "Bimyou",
+        "ja": "微妙",
+        "ja_typings": [
+          "bimyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03468",
+    "image_path": null,
+    "question_text": {
+      "en": "What net slang refers to the English language or being in English?",
+      "ja": "英語であることを指すネットスラングは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FYI",
+        "ja": "参考までに",
+        "ja_typings": [
+          "fyi"
+        ]
+      },
+      {
+        "en": "BTW",
+        "ja": "ところで",
+        "ja_typings": [
+          "btw",
+          "tokorode"
+        ]
+      },
+      {
+        "en": "TBH",
+        "ja": "正直に言うと",
+        "ja_typings": [
+          "tbh"
+        ]
+      },
+      {
+        "en": "BRB",
+        "ja": "すぐ戻る",
+        "ja_typings": [
+          "brb"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03469",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the net abbreviation 'FYI' stand for?",
+      "ja": "ネット略語「FYI」の意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gara",
+        "ja": "ガラ",
+        "ja_typings": [
+          "gara"
+        ]
+      },
+      {
+        "en": "Aba",
+        "ja": "アバ",
+        "ja_typings": [
+          "aba"
+        ]
+      },
+      {
+        "en": "Gomi",
+        "ja": "ゴミ",
+        "ja_typings": [
+          "gomi"
+        ]
+      },
+      {
+        "en": "Zako",
+        "ja": "ザコ",
+        "ja_typings": [
+          "zako"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03470",
+    "image_path": null,
+    "question_text": {
+      "en": "Which net slang word refers to character traits in Japanese?",
+      "ja": "ネットスラングで「キャラ性」「性格」を指す日本語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gold member",
+        "ja": "ゴールドメンバー",
+        "ja_typings": [
+          "go-rudomenba-"
+        ]
+      },
+      {
+        "en": "Plus member",
+        "ja": "プラスメンバー",
+        "ja_typings": [
+          "purasumenba-"
+        ]
+      },
+      {
+        "en": "Member",
+        "ja": "メンバー",
+        "ja_typings": [
+          "menba-"
+        ]
+      },
+      {
+        "en": "Crew",
+        "ja": "クルー",
+        "ja_typings": [
+          "kuru-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03471",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the top-tier paid YouTube channel membership called?",
+      "ja": "YouTubeチャンネルメンバーシップの最上位プランは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gomi",
+        "ja": "ゴミ",
+        "ja_typings": [
+          "gomi"
+        ]
+      },
+      {
+        "en": "Zako",
+        "ja": "ザコ",
+        "ja_typings": [
+          "zako"
+        ]
+      },
+      {
+        "en": "Bimyou",
+        "ja": "微妙",
+        "ja_typings": [
+          "bimyou"
+        ]
+      },
+      {
+        "en": "Aba",
+        "ja": "アバ",
+        "ja_typings": [
+          "aba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03472",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese word means 'trash' and is used as net slang?",
+      "ja": "ネットスラングで「ゴミ」を意味する言葉は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Good morning",
+        "ja": "グッドモーニング",
+        "ja_typings": [
+          "guddomo-ningu"
+        ]
+      },
+      {
+        "en": "Bye",
+        "ja": "バイ",
+        "ja_typings": [
+          "bai"
+        ]
+      },
+      {
+        "en": "Sorry",
+        "ja": "ソーリー",
+        "ja_typings": [
+          "so-ri-"
+        ]
+      },
+      {
+        "en": "Thanks",
+        "ja": "サンクス",
+        "ja_typings": [
+          "sankusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03473",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a typical morning greeting in English?",
+      "ja": "英語で朝の挨拶として使われる定型句は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hololive",
+        "ja": "ホロライブ",
+        "ja_typings": [
+          "hororaibu"
+        ]
+      },
+      {
+        "en": "Nijisanji",
+        "ja": "にじさんじ",
+        "ja_typings": [
+          "nijisanji"
+        ]
+      },
+      {
+        "en": "VSPO!",
+        "ja": "ぶいすぽっ!",
+        "ja_typings": [
+          "buisupo"
+        ]
+      },
+      {
+        "en": "Noripro",
+        "ja": "ノリプロ",
+        "ja_typings": [
+          "noripuro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03474",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the largest Japanese VTuber agency featuring Pekora and Fubuki?",
+      "ja": "兎田ぺこらや白上フブキが所属するVTuber事務所は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Indonesia",
+        "ja": "インドネシア",
+        "ja_typings": [
+          "indoneshia"
+        ]
+      },
+      {
+        "en": "Korea",
+        "ja": "コリア",
+        "ja_typings": [
+          "koria"
+        ]
+      },
+      {
+        "en": "Japan",
+        "ja": "ジャパン",
+        "ja_typings": [
+          "japan"
+        ]
+      },
+      {
+        "en": "Persona",
+        "ja": "ペルソナ",
+        "ja_typings": [
+          "perusona"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03475",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Southeast Asian country has its own Hololive branch?",
+      "ja": "ホロライブの支部があった東南アジアの国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Inuyama Tamaki",
+        "ja": "犬山たまき",
+        "ja_typings": [
+          "inuyamatamaki"
+        ]
+      },
+      {
+        "en": "Tenkai Tsukasa",
+        "ja": "天開司",
+        "ja_typings": [
+          "tenkaitsukasa"
+        ]
+      },
+      {
+        "en": "Yamato Iori",
+        "ja": "ヤマトイオリ",
+        "ja_typings": [
+          "yamatoiori"
+        ]
+      },
+      {
+        "en": "Robocosan",
+        "ja": "ロボ子さん",
+        "ja_typings": [
+          "robokosan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03476",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nijisanji VTuber is the leader of the 'Iwagumi' generation and has cat ears?",
+      "ja": "にじさんじの「岩組」のリーダーで猫耳のVTuberは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Japan",
+        "ja": "日本",
+        "ja_typings": [
+          "nippon",
+          "nihon",
+          "japan"
+        ]
+      },
+      {
+        "en": "Korea",
+        "ja": "韓国",
+        "ja_typings": [
+          "kankoku",
+          "koria"
+        ]
+      },
+      {
+        "en": "Indonesia",
+        "ja": "インドネシア",
+        "ja_typings": [
+          "indoneshia"
+        ]
+      },
+      {
+        "en": "China",
+        "ja": "中国",
+        "ja_typings": [
+          "chuugoku",
+          "chu-goku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03477",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country is the headquarters of Hololive based in?",
+      "ja": "ホロライブの本社がある国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kadokawa",
+        "ja": "KADOKAWA",
+        "ja_typings": [
+          "kadokawa"
+        ]
+      },
+      {
+        "en": "Dwango",
+        "ja": "ドワンゴ",
+        "ja_typings": [
+          "dowango"
+        ]
+      },
+      {
+        "en": "Sony",
+        "ja": "ソニー",
+        "ja_typings": [
+          "soni-"
+        ]
+      },
+      {
+        "en": "Bushiroad",
+        "ja": "ブシロード",
+        "ja_typings": [
+          "bushiro-do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03478",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese publisher owns Dwango and is famous for light novels?",
+      "ja": "ドワンゴを子会社に持ち、ライトノベルでも有名な日本の出版社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Korea",
+        "ja": "韓国",
+        "ja_typings": [
+          "kankoku",
+          "koria"
+        ]
+      },
+      {
+        "en": "Indonesia",
+        "ja": "インドネシア",
+        "ja_typings": [
+          "indoneshia"
+        ]
+      },
+      {
+        "en": "Japan",
+        "ja": "日本",
+        "ja_typings": [
+          "nihon"
+        ]
+      },
+      {
+        "en": "Persona",
+        "ja": "ペルソナ",
+        "ja_typings": [
+          "perusona"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03479",
+    "image_path": null,
+    "question_text": {
+      "en": "Which East Asian country borders Japan and has its own VTuber scene?",
+      "ja": "日本の隣にあり独自のVTuber文化を持つ東アジアの国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kuromaku",
+        "ja": "黒幕",
+        "ja_typings": [
+          "kuromaku"
+        ]
+      },
+      {
+        "en": "Tamashii",
+        "ja": "魂",
+        "ja_typings": [
+          "tamashii"
+        ]
+      },
+      {
+        "en": "Persona",
+        "ja": "ペルソナ",
+        "ja_typings": [
+          "perusona"
+        ]
+      },
+      {
+        "en": "Arashi",
+        "ja": "嵐",
+        "ja_typings": [
+          "arashi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03480",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese word means 'mastermind' behind the scenes?",
+      "ja": "陰で操る黒幕を意味する日本語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kuzuha and Kenmochi",
+        "ja": "葛葉と剣持",
+        "ja_typings": [
+          "kuzuhatokenmochi"
+        ]
+      },
+      {
+        "en": "Kuromaku",
+        "ja": "黒幕",
+        "ja_typings": [
+          "kuromaku"
+        ]
+      },
+      {
+        "en": "Tenkai Tsukasa",
+        "ja": "天開司",
+        "ja_typings": [
+          "tenkaitsukasa"
+        ]
+      },
+      {
+        "en": "Inuyama Tamaki",
+        "ja": "犬山たまき",
+        "ja_typings": [
+          "inuyamatamaki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03481",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nijisanji male duo became hugely popular as the 'ChroNoiR' unit?",
+      "ja": "にじさんじでChroNoiRとして活動する男性デュオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Supacha",
+        "ja": "スパチャ",
+        "ja_typings": [
+          "supacha"
+        ]
+      },
+      {
+        "en": "Laicha",
+        "ja": "ライチャ",
+        "ja_typings": [
+          "raicha"
+        ]
+      },
+      {
+        "en": "Renkome",
+        "ja": "連コメ",
+        "ja_typings": [
+          "renkome"
+        ]
+      },
+      {
+        "en": "Bits",
+        "ja": "ビッツ",
+        "ja_typings": [
+          "bittsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03482",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the slang term for a stream of paid YouTube Super Chat messages?",
+      "ja": "YouTubeのスーパーチャットの俗称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Listener",
+        "ja": "リスナー",
+        "ja_typings": [
+          "risuna-"
+        ]
+      },
+      {
+        "en": "Member",
+        "ja": "メンバー",
+        "ja_typings": [
+          "menba-"
+        ]
+      },
+      {
+        "en": "Staff",
+        "ja": "スタッフ",
+        "ja_typings": [
+          "sutaffu"
+        ]
+      },
+      {
+        "en": "Crew",
+        "ja": "クルー",
+        "ja_typings": [
+          "kuru-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03483",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call a viewer who watches and comments on streams?",
+      "ja": "配信を見ながらコメントする視聴者を指す言葉は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Member",
+        "ja": "メンバー",
+        "ja_typings": [
+          "menba-"
+        ]
+      },
+      {
+        "en": "Listener",
+        "ja": "リスナー",
+        "ja_typings": [
+          "risuna-"
+        ]
+      },
+      {
+        "en": "Crew",
+        "ja": "クルー",
+        "ja_typings": [
+          "kuru-"
+        ]
+      },
+      {
+        "en": "Staff",
+        "ja": "スタッフ",
+        "ja_typings": [
+          "sutaffu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03484",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a paid YouTube channel supporter called?",
+      "ja": "有料のチャンネル登録者をなんと呼ぶ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Messe",
+        "ja": "メッセ",
+        "ja_typings": [
+          "messe"
+        ]
+      },
+      {
+        "en": "Spam",
+        "ja": "スパム",
+        "ja_typings": [
+          "supamu"
+        ]
+      },
+      {
+        "en": "Persona",
+        "ja": "ペルソナ",
+        "ja_typings": [
+          "perusona"
+        ]
+      },
+      {
+        "en": "Tamashii",
+        "ja": "魂",
+        "ja_typings": [
+          "tamashii"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03485",
+    "image_path": null,
+    "question_text": {
+      "en": "Which English word borrowed into Japanese means 'message'?",
+      "ja": "「メッセージ」を意味するドイツ語由来の言葉で、見本市の意味もある語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Minato Aqua",
+        "ja": "湊あくあ",
+        "ja_typings": [
+          "minatoakua"
+        ]
+      },
+      {
+        "en": "Murasaki Shion",
+        "ja": "紫咲シオン",
+        "ja_typings": [
+          "murasakishion"
+        ]
+      },
+      {
+        "en": "Nakiri Ayame",
+        "ja": "百鬼あやめ",
+        "ja_typings": [
+          "nakiriayame"
+        ]
+      },
+      {
+        "en": "Shirakami Fubuki",
+        "ja": "白上フブキ",
+        "ja_typings": [
+          "shirakamifubuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03486",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive VTuber has blue twintails and is famous for the 'Aqua Crew'?",
+      "ja": "ホロライブで青いツインテールが特徴のVTuberは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mirror haishin",
+        "ja": "ミラー配信",
+        "ja_typings": [
+          "mira-haishin"
+        ]
+      },
+      {
+        "en": "Collab haishin",
+        "ja": "コラボ配信",
+        "ja_typings": [
+          "korabohaishin"
+        ]
+      },
+      {
+        "en": "Reaction douga",
+        "ja": "リアクション動画",
+        "ja_typings": [
+          "riakushondo-ga"
+        ]
+      },
+      {
+        "en": "Nico Utagassen",
+        "ja": "ニコニコ歌合戦",
+        "ja_typings": [
+          "nikonikoutagassen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03487",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call replaying another streamer's broadcast on your own channel?",
+      "ja": "他人の配信を自分の画面で同時に映す配信形式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Murasaki Shion",
+        "ja": "紫咲シオン",
+        "ja_typings": [
+          "murasakishion"
+        ]
+      },
+      {
+        "en": "Minato Aqua",
+        "ja": "湊あくあ",
+        "ja_typings": [
+          "minatoakua"
+        ]
+      },
+      {
+        "en": "Nakiri Ayame",
+        "ja": "百鬼あやめ",
+        "ja_typings": [
+          "nakiriayame"
+        ]
+      },
+      {
+        "en": "Shirakami Fubuki",
+        "ja": "白上フブキ",
+        "ja_typings": [
+          "shirakamifubuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03488",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive VTuber has purple hair and is the younger sister of Yozora Mel?",
+      "ja": "ホロライブの紫髪のVTuberで、夜空メルの妹分とされるのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nakiri Ayame",
+        "ja": "百鬼あやめ",
+        "ja_typings": [
+          "nakiriayame"
+        ]
+      },
+      {
+        "en": "Murasaki Shion",
+        "ja": "紫咲シオン",
+        "ja_typings": [
+          "murasakishion"
+        ]
+      },
+      {
+        "en": "Minato Aqua",
+        "ja": "湊あくあ",
+        "ja_typings": [
+          "minatoakua"
+        ]
+      },
+      {
+        "en": "Shirakami Fubuki",
+        "ja": "白上フブキ",
+        "ja_typings": [
+          "shirakamifubuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03489",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive VTuber has red oni horns and is part of 'Yo-rappers'?",
+      "ja": "赤い鬼の角が特徴のホロライブVTuberは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nico Utagassen",
+        "ja": "ニコニコ歌合戦",
+        "ja_typings": [
+          "nikonikoutagassen"
+        ]
+      },
+      {
+        "en": "Niconico Festival",
+        "ja": "ニコニコ祭",
+        "ja_typings": [
+          "nikonikomatsuri"
+        ]
+      },
+      {
+        "en": "Nicochu",
+        "ja": "ニコ厨",
+        "ja_typings": [
+          "nikochu",
+          "nikochuu"
+        ]
+      },
+      {
+        "en": "Collab haishin",
+        "ja": "コラボ配信",
+        "ja_typings": [
+          "korabohaishin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03490",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the name of NHK's traditional New Year's Eve singing contest, parodied on Niconico?",
+      "ja": "NHK紅白歌合戦をパロディしたニコニコ動画の年末イベントは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nicochu",
+        "ja": "ニコ厨",
+        "ja_typings": [
+          "nikochu",
+          "nikochuu"
+        ]
+      },
+      {
+        "en": "Listener",
+        "ja": "リスナー",
+        "ja_typings": [
+          "risuna-"
+        ]
+      },
+      {
+        "en": "Member",
+        "ja": "メンバー",
+        "ja_typings": [
+          "menba-"
+        ]
+      },
+      {
+        "en": "Crew",
+        "ja": "クルー",
+        "ja_typings": [
+          "kuru-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03491",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the slang term for a die-hard Niconico Douga fan?",
+      "ja": "ニコニコ動画に熱中する人を指すスラングは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Niconico Festival",
+        "ja": "ニコニコ超会議",
+        "ja_typings": [
+          "nikonikochoukaigi"
+        ]
+      },
+      {
+        "en": "Nico Utagassen",
+        "ja": "ニコニコ歌合戦",
+        "ja_typings": [
+          "nikonikoutagassen"
+        ]
+      },
+      {
+        "en": "Toukaigi",
+        "ja": "闘会議",
+        "ja_typings": [
+          "toukaigi"
+        ]
+      },
+      {
+        "en": "Messe",
+        "ja": "メッセ",
+        "ja_typings": [
+          "messe"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03492",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the annual Niconico user festival held in Makuhari called?",
+      "ja": "幕張メッセで行われるニコニコ動画のリアルイベントは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Persona",
+        "ja": "ペルソナ",
+        "ja_typings": [
+          "perusona"
+        ]
+      },
+      {
+        "en": "Tamashii",
+        "ja": "魂",
+        "ja_typings": [
+          "tamashii"
+        ]
+      },
+      {
+        "en": "Arashi",
+        "ja": "嵐",
+        "ja_typings": [
+          "arashi"
+        ]
+      },
+      {
+        "en": "Kuromaku",
+        "ja": "黒幕",
+        "ja_typings": [
+          "kuromaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03493",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Atlus RPG series features Shadows and the Velvet Room?",
+      "ja": "アトラスのRPGで「ベルベットルーム」が登場するシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Plus member",
+        "ja": "プラスメンバー",
+        "ja_typings": [
+          "purasumenba-"
+        ]
+      },
+      {
+        "en": "Gold member",
+        "ja": "ゴールドメンバー",
+        "ja_typings": [
+          "go-rudomenba-"
+        ]
+      },
+      {
+        "en": "Member",
+        "ja": "メンバー",
+        "ja_typings": [
+          "menba-"
+        ]
+      },
+      {
+        "en": "Listener",
+        "ja": "リスナー",
+        "ja_typings": [
+          "risuna-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03494",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a mid-tier YouTube channel membership plan often called?",
+      "ja": "YouTubeメンバーシップで中位のプラン名としてよく使われるのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Reaction douga",
+        "ja": "リアクション動画",
+        "ja_typings": [
+          "riakushondo-ga",
+          "riakushondouga"
+        ]
+      },
+      {
+        "en": "Collab haishin",
+        "ja": "コラボ配信",
+        "ja_typings": [
+          "korabohaishin"
+        ]
+      },
+      {
+        "en": "Mirror haishin",
+        "ja": "ミラー配信",
+        "ja_typings": [
+          "mira-haishin"
+        ]
+      },
+      {
+        "en": "Nico Utagassen",
+        "ja": "ニコニコ歌合戦",
+        "ja_typings": [
+          "nikonikoutagassen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03495",
+    "image_path": null,
+    "question_text": {
+      "en": "What kind of video shows a streamer's responses to other content?",
+      "ja": "他の動画や配信に対する反応を撮った動画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Renkome",
+        "ja": "連コメ",
+        "ja_typings": [
+          "renkome"
+        ]
+      },
+      {
+        "en": "Supacha",
+        "ja": "スパチャ",
+        "ja_typings": [
+          "supacha"
+        ]
+      },
+      {
+        "en": "Spam",
+        "ja": "スパム",
+        "ja_typings": [
+          "supamu"
+        ]
+      },
+      {
+        "en": "Laicha",
+        "ja": "ライチャ",
+        "ja_typings": [
+          "raicha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03496",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the slang term for spamming the same comment repeatedly?",
+      "ja": "同じコメントを何度も連投することを指すスラングは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Robocosan",
+        "ja": "ロボ子さん",
+        "ja_typings": [
+          "robokosan"
+        ]
+      },
+      {
+        "en": "Yamato Iori",
+        "ja": "ヤマトイオリ",
+        "ja_typings": [
+          "yamatoiori"
+        ]
+      },
+      {
+        "en": "Inuyama Tamaki",
+        "ja": "犬山たまき",
+        "ja_typings": [
+          "inuyamatamaki"
+        ]
+      },
+      {
+        "en": "Tenkai Tsukasa",
+        "ja": "天開司",
+        "ja_typings": [
+          "tenkaitsukasa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03497",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive VTuber is a robot girl voiced as a tinkerer who builds Robohouse?",
+      "ja": "ホロライブのロボット娘で工作好きなVTuberは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shirakami Fubuki",
+        "ja": "白上フブキ",
+        "ja_typings": [
+          "shirakamifubuki"
+        ]
+      },
+      {
+        "en": "Minato Aqua",
+        "ja": "湊あくあ",
+        "ja_typings": [
+          "minatoakua"
+        ]
+      },
+      {
+        "en": "Nakiri Ayame",
+        "ja": "百鬼あやめ",
+        "ja_typings": [
+          "nakiriayame"
+        ]
+      },
+      {
+        "en": "Murasaki Shion",
+        "ja": "紫咲シオン",
+        "ja_typings": [
+          "murasakishion"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03498",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive VTuber is a white fox-girl and 'gamers' group member?",
+      "ja": "ホロライブGAMERSの白い狐のVTuberは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sony",
+        "ja": "ソニー",
+        "ja_typings": [
+          "soni-"
+        ]
+      },
+      {
+        "en": "Kadokawa",
+        "ja": "KADOKAWA",
+        "ja_typings": [
+          "kadokawa"
+        ]
+      },
+      {
+        "en": "DeNA",
+        "ja": "DeNA",
+        "ja_typings": [
+          "dena"
+        ]
+      },
+      {
+        "en": "Bushiroad",
+        "ja": "ブシロード",
+        "ja_typings": [
+          "bushiro-do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03499",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese global electronics and entertainment giant owns PlayStation?",
+      "ja": "PlayStationを展開する日本の大手電機・エンタメ企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sorry",
+        "ja": "ソーリー",
+        "ja_typings": [
+          "so-ri-"
+        ]
+      },
+      {
+        "en": "Thanks",
+        "ja": "サンクス",
+        "ja_typings": [
+          "sankusu"
+        ]
+      },
+      {
+        "en": "Bye",
+        "ja": "バイ",
+        "ja_typings": [
+          "bai"
+        ]
+      },
+      {
+        "en": "Spam",
+        "ja": "スパム",
+        "ja_typings": [
+          "supamu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03500",
+    "image_path": null,
+    "question_text": {
+      "en": "Which English word is used to apologize politely?",
+      "ja": "英語で丁寧に謝罪する一語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Spam",
+        "ja": "スパム",
+        "ja_typings": [
+          "supamu"
+        ]
+      },
+      {
+        "en": "Renkome",
+        "ja": "連コメ",
+        "ja_typings": [
+          "renkome"
+        ]
+      },
+      {
+        "en": "Supacha",
+        "ja": "スパチャ",
+        "ja_typings": [
+          "supacha"
+        ]
+      },
+      {
+        "en": "Bits",
+        "ja": "ビッツ",
+        "ja_typings": [
+          "bittsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03501",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call unsolicited junk messages on the internet?",
+      "ja": "ネット上の迷惑な大量メッセージのことを何という?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Staff",
+        "ja": "スタッフ",
+        "ja_typings": [
+          "sutaffu"
+        ]
+      },
+      {
+        "en": "Crew",
+        "ja": "クルー",
+        "ja_typings": [
+          "kuru-"
+        ]
+      },
+      {
+        "en": "Listener",
+        "ja": "リスナー",
+        "ja_typings": [
+          "risuna-"
+        ]
+      },
+      {
+        "en": "Member",
+        "ja": "メンバー",
+        "ja_typings": [
+          "menba-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03502",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call the production team behind the scenes of a stream?",
+      "ja": "配信を支える裏方のスタッフを英語で何と呼ぶ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Supacha",
+        "ja": "スパチャ",
+        "ja_typings": [
+          "supacha"
+        ]
+      },
+      {
+        "en": "Laicha",
+        "ja": "ライチャ",
+        "ja_typings": [
+          "raicha"
+        ]
+      },
+      {
+        "en": "Bits",
+        "ja": "ビッツ",
+        "ja_typings": [
+          "bittsu"
+        ]
+      },
+      {
+        "en": "Renkome",
+        "ja": "renkome",
+        "ja_typings": [
+          "renkome"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03503",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the slang term for a paid Twitch chat similar to Supacha?",
+      "ja": "Twitchの有料コメント機能を指す俗称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "TBH",
+        "ja": "正直に言うと",
+        "ja_typings": [
+          "tbh"
+        ]
+      },
+      {
+        "en": "BTW",
+        "ja": "ところで",
+        "ja_typings": [
+          "btw",
+          "tokorode"
+        ]
+      },
+      {
+        "en": "FYI",
+        "ja": "参考までに",
+        "ja_typings": [
+          "fyi"
+        ]
+      },
+      {
+        "en": "BRB",
+        "ja": "すぐ戻る",
+        "ja_typings": [
+          "brb"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03504",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the net abbreviation 'TBH' stand for?",
+      "ja": "ネット略語「TBH」の意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tamashii",
+        "ja": "魂",
+        "ja_typings": [
+          "tamashii"
+        ]
+      },
+      {
+        "en": "Persona",
+        "ja": "ペルソナ",
+        "ja_typings": [
+          "perusona"
+        ]
+      },
+      {
+        "en": "Kuromaku",
+        "ja": "黒幕",
+        "ja_typings": [
+          "kuromaku"
+        ]
+      },
+      {
+        "en": "Gara",
+        "ja": "ガラ",
+        "ja_typings": [
+          "gara"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03505",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese word refers to the 'soul' inside a VTuber avatar?",
+      "ja": "VTuberのアバターの中の人(魂)を指す日本語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tenkai Tsukasa",
+        "ja": "天開司",
+        "ja_typings": [
+          "tenkaitsukasa"
+        ]
+      },
+      {
+        "en": "Inuyama Tamaki",
+        "ja": "犬山たまき",
+        "ja_typings": [
+          "inuyamatamaki"
+        ]
+      },
+      {
+        "en": "Robocosan",
+        "ja": "ロボ子さん",
+        "ja_typings": [
+          "robokosan"
+        ]
+      },
+      {
+        "en": "Yamato Iori",
+        "ja": "ヤマトイオリ",
+        "ja_typings": [
+          "yamatoiori"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03506",
+    "image_path": null,
+    "question_text": {
+      "en": "Which male VTuber is known as the leader of 'Tasokare Hotel' and 774 inc?",
+      "ja": "774inc.に所属し「黄昏ホテル」で知られる男性VTuberは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thanks",
+        "ja": "サンクス",
+        "ja_typings": [
+          "sankusu"
+        ]
+      },
+      {
+        "en": "Sorry",
+        "ja": "ソーリー",
+        "ja_typings": [
+          "so-ri-"
+        ]
+      },
+      {
+        "en": "Bye",
+        "ja": "バイ",
+        "ja_typings": [
+          "bai"
+        ]
+      },
+      {
+        "en": "Spam",
+        "ja": "スパム",
+        "ja_typings": [
+          "supamu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03507",
+    "image_path": null,
+    "question_text": {
+      "en": "Which English word is used to express gratitude?",
+      "ja": "英語で感謝を伝える短い単語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The streamer",
+        "ja": "ストリーマー",
+        "ja_typings": [
+          "sutori-ma-"
+        ]
+      },
+      {
+        "en": "Listener",
+        "ja": "リスナー",
+        "ja_typings": [
+          "risuna-"
+        ]
+      },
+      {
+        "en": "Staff",
+        "ja": "スタッフ",
+        "ja_typings": [
+          "sutaffu"
+        ]
+      },
+      {
+        "en": "Crew",
+        "ja": "クルー",
+        "ja_typings": [
+          "kuru-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03508",
+    "image_path": null,
+    "question_text": {
+      "en": "What term refers to the main personality being broadcast in a stream?",
+      "ja": "配信のメインとなる配信者を英語で何と呼ぶ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "TikTok",
+        "ja": "ティックトック",
+        "ja_typings": [
+          "tikkutokku"
+        ]
+      },
+      {
+        "en": "Twitch",
+        "ja": "ツイッチ",
+        "ja_typings": [
+          "tsuicchi",
+          "tsuitchi"
+        ]
+      },
+      {
+        "en": "YouTube",
+        "ja": "ユーチューブ",
+        "ja_typings": [
+          "yu-chu-bu"
+        ]
+      },
+      {
+        "en": "Nicochu",
+        "ja": "ニコ厨",
+        "ja_typings": [
+          "nikochu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03509",
+    "image_path": null,
+    "question_text": {
+      "en": "Which short-form video app is owned by ByteDance and popular for dance trends?",
+      "ja": "ByteDanceが運営するショート動画アプリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Toukaigi",
+        "ja": "闘会議",
+        "ja_typings": [
+          "toukaigi"
+        ]
+      },
+      {
+        "en": "Niconico Festival",
+        "ja": "ニコニコ超会議",
+        "ja_typings": [
+          "nikonikochoukaigi"
+        ]
+      },
+      {
+        "en": "Nico Utagassen",
+        "ja": "ニコニコ歌合戦",
+        "ja_typings": [
+          "nikonikoutagassen"
+        ]
+      },
+      {
+        "en": "Messe",
+        "ja": "メッセ",
+        "ja_typings": [
+          "messe"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03510",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the annual Niconico gaming festival called?",
+      "ja": "ニコニコが主催するゲームのリアルイベントは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Twitch",
+        "ja": "ツイッチ",
+        "ja_typings": [
+          "tsuicchi",
+          "tsuitchi"
+        ]
+      },
+      {
+        "en": "TikTok",
+        "ja": "ティックトック",
+        "ja_typings": [
+          "tikkutokku"
+        ]
+      },
+      {
+        "en": "YouTube",
+        "ja": "ユーチューブ",
+        "ja_typings": [
+          "yu-chu-bu"
+        ]
+      },
+      {
+        "en": "Nicochu",
+        "ja": "ニコ厨",
+        "ja_typings": [
+          "nikochu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03511",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Amazon-owned live streaming platform is centered on gaming?",
+      "ja": "Amazon傘下のゲーム配信に強いストリーミングサービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Usada Pekora",
+        "ja": "兎田ぺこら",
+        "ja_typings": [
+          "usadapekora"
+        ]
+      },
+      {
+        "en": "Minato Aqua",
+        "ja": "湊あくあ",
+        "ja_typings": [
+          "minatoakua"
+        ]
+      },
+      {
+        "en": "Shirakami Fubuki",
+        "ja": "白上フブキ",
+        "ja_typings": [
+          "shirakamifubuki"
+        ]
+      },
+      {
+        "en": "Murasaki Shion",
+        "ja": "紫咲シオン",
+        "ja_typings": [
+          "murasakishion"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03512",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive VTuber is a bunny girl famous for 'peko peko peko'?",
+      "ja": "「ぺこぺこぺこ」で有名なホロライブのバニーVTuberは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Voice changer",
+        "ja": "ボイスチェンジャー",
+        "ja_typings": [
+          "boisuchenja-"
+        ]
+      },
+      {
+        "en": "Mirror haishin",
+        "ja": "ミラー配信",
+        "ja_typings": [
+          "mira-haishin"
+        ]
+      },
+      {
+        "en": "Reaction douga",
+        "ja": "リアクション動画",
+        "ja_typings": [
+          "riakushondo-ga"
+        ]
+      },
+      {
+        "en": "Spam",
+        "ja": "スパム",
+        "ja_typings": [
+          "supamu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03513",
+    "image_path": null,
+    "question_text": {
+      "en": "What kind of software changes the pitch or tone of a streamer's voice?",
+      "ja": "配信者の声を加工するソフトウェアの一般名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yamato Iori",
+        "ja": "ヤマトイオリ",
+        "ja_typings": [
+          "yamatoiori"
+        ]
+      },
+      {
+        "en": "Inuyama Tamaki",
+        "ja": "犬山たまき",
+        "ja_typings": [
+          "inuyamatamaki"
+        ]
+      },
+      {
+        "en": "Robocosan",
+        "ja": "ロボ子さん",
+        "ja_typings": [
+          "robokosan"
+        ]
+      },
+      {
+        "en": "Tenkai Tsukasa",
+        "ja": "天開司",
+        "ja_typings": [
+          "tenkaitsukasa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03514",
+    "image_path": null,
+    "question_text": {
+      "en": "Which early .LIVE VTuber is known as a quiet aesthetic singer with long hair?",
+      "ja": "アイドル部の長髪で物静かな歌姫VTuberは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "YouTube",
+        "ja": "ユーチューブ",
+        "ja_typings": [
+          "yu-chu-bu"
+        ]
+      },
+      {
+        "en": "Twitch",
+        "ja": "ツイッチ",
+        "ja_typings": [
+          "tsuicchi",
+          "tsuitchi"
+        ]
+      },
+      {
+        "en": "TikTok",
+        "ja": "ティックトック",
+        "ja_typings": [
+          "tikkutokku"
+        ]
+      },
+      {
+        "en": "Nicochu",
+        "ja": "ニコ厨",
+        "ja_typings": [
+          "nikochu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03515",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Google-owned video platform is the largest in the world?",
+      "ja": "Googleが運営する世界最大の動画共有サイトは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Zako",
+        "ja": "ザコ",
+        "ja_typings": [
+          "zako"
+        ]
+      },
+      {
+        "en": "Gomi",
+        "ja": "ゴミ",
+        "ja_typings": [
+          "gomi"
+        ]
+      },
+      {
+        "en": "Bimyou",
+        "ja": "微妙",
+        "ja_typings": [
+          "bimyou"
+        ]
+      },
+      {
+        "en": "Gara",
+        "ja": "ガラ",
+        "ja_typings": [
+          "gara"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03516",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese word means 'weakling' and is often shouted by streamers?",
+      "ja": "「雑魚」を意味し配信者がよく叫ぶスラングは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ao Dai",
+        "ja": "アオザイ",
+        "ja_typings": [
+          "aozai"
+        ]
+      },
+      {
+        "en": "Hanbok",
+        "ja": "ハンボク",
+        "ja_typings": [
+          "hanboku"
+        ]
+      },
+      {
+        "en": "Toga",
+        "ja": "トーガ",
+        "ja_typings": [
+          "to-ga"
+        ]
+      },
+      {
+        "en": "Poncho",
+        "ja": "ポンチョ",
+        "ja_typings": [
+          "poncho"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03517",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the traditional long Vietnamese silk tunic dress called?",
+      "ja": "ベトナムの伝統的な長い絹のチュニック衣装は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Arrabbiata",
+        "ja": "アラビアータ",
+        "ja_typings": [
+          "arabia-ta"
+        ]
+      },
+      {
+        "en": "Bolognese",
+        "ja": "ボロネーゼ",
+        "ja_typings": [
+          "borone-ze"
+        ]
+      },
+      {
+        "en": "Pescatore",
+        "ja": "ペスカトーレ",
+        "ja_typings": [
+          "pesukato-re"
+        ]
+      },
+      {
+        "en": "Calzone",
+        "ja": "カルツォーネ",
+        "ja_typings": [
+          "karutso-ne"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03518",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian pasta sauce is made with garlic, chili and tomato, and means 'angry'?",
+      "ja": "ニンニクと唐辛子のトマトソースで「怒り」を意味するイタリア料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aztec civilization",
+        "ja": "アステカ文明",
+        "ja_typings": [
+          "asutekabunmei"
+        ]
+      },
+      {
+        "en": "Maya civilization",
+        "ja": "マヤ文明",
+        "ja_typings": [
+          "mayabunmei"
+        ]
+      },
+      {
+        "en": "Olmec civilization",
+        "ja": "オルメカ文明",
+        "ja_typings": [
+          "orumekabunmei"
+        ]
+      },
+      {
+        "en": "Indus River",
+        "ja": "インダス川",
+        "ja_typings": [
+          "indasugawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03519",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Mesoamerican civilization built Tenochtitlan?",
+      "ja": "テノチティトランを築いた古代メソアメリカ文明は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bible",
+        "ja": "聖書",
+        "ja_typings": [
+          "seisho"
+        ]
+      },
+      {
+        "en": "Torah",
+        "ja": "トーラー",
+        "ja_typings": [
+          "to-ra-"
+        ]
+      },
+      {
+        "en": "Vedas",
+        "ja": "ヴェーダ",
+        "ja_typings": [
+          "ve-da"
+        ]
+      },
+      {
+        "en": "Pesach",
+        "ja": "ペサハ",
+        "ja_typings": [
+          "pesaha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03520",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the central sacred book of Christianity called?",
+      "ja": "キリスト教の聖典は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bolognese",
+        "ja": "ボロネーゼ",
+        "ja_typings": [
+          "borone-ze"
+        ]
+      },
+      {
+        "en": "Arrabbiata",
+        "ja": "アラビアータ",
+        "ja_typings": [
+          "arabia-ta"
+        ]
+      },
+      {
+        "en": "Pescatore",
+        "ja": "ペスカトーレ",
+        "ja_typings": [
+          "pesukato-re"
+        ]
+      },
+      {
+        "en": "Piadina",
+        "ja": "ピアディーナ",
+        "ja_typings": [
+          "piadi-na"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03521",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian pasta sauce comes from a city in Emilia-Romagna and uses ground meat?",
+      "ja": "エミリア=ロマーニャ州の都市発祥のひき肉トマトソースは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bossa Nova",
+        "ja": "ボサノバ",
+        "ja_typings": [
+          "bosanoba"
+        ]
+      },
+      {
+        "en": "Flamenco",
+        "ja": "フラメンコ",
+        "ja_typings": [
+          "furamenko"
+        ]
+      },
+      {
+        "en": "Krav Maga",
+        "ja": "クラヴマガ",
+        "ja_typings": [
+          "kuravumaga"
+        ]
+      },
+      {
+        "en": "Taekwondo",
+        "ja": "テコンドー",
+        "ja_typings": [
+          "tekondo-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03522",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Brazilian music genre is closely associated with 'The Girl from Ipanema'?",
+      "ja": "「イパネマの娘」で有名なブラジル発祥の音楽ジャンルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Brahmaputra River",
+        "ja": "ブラフマプトラ川",
+        "ja_typings": [
+          "burafumaputoragawa"
+        ]
+      },
+      {
+        "en": "Indus River",
+        "ja": "インダス川",
+        "ja_typings": [
+          "indasugawa"
+        ]
+      },
+      {
+        "en": "Yamuna River",
+        "ja": "ヤムナー川",
+        "ja_typings": [
+          "yamuna-gawa"
+        ]
+      },
+      {
+        "en": "Eiffel Tower",
+        "ja": "エッフェル塔",
+        "ja_typings": [
+          "efferutou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03523",
+    "image_path": null,
+    "question_text": {
+      "en": "Which major river flows through Tibet, India and Bangladesh?",
+      "ja": "チベット、インド、バングラデシュを流れる大河は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Brasilia",
+        "ja": "ブラジリア",
+        "ja_typings": [
+          "burajiria"
+        ]
+      },
+      {
+        "en": "Pantheon",
+        "ja": "パンテオン",
+        "ja_typings": [
+          "panteon"
+        ]
+      },
+      {
+        "en": "Eiffel Tower",
+        "ja": "エッフェル塔",
+        "ja_typings": [
+          "efferutou"
+        ]
+      },
+      {
+        "en": "Louvre Museum",
+        "ja": "ルーブル美術館",
+        "ja_typings": [
+          "ru-burubijutsukan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03524",
+    "image_path": null,
+    "question_text": {
+      "en": "Which planned city, designed by Oscar Niemeyer, is the capital of Brazil?",
+      "ja": "オスカー・ニーマイヤー設計のブラジルの計画都市の首都は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Burrito",
+        "ja": "ブリトー",
+        "ja_typings": [
+          "burito-"
+        ]
+      },
+      {
+        "en": "Taco",
+        "ja": "タコス",
+        "ja_typings": [
+          "takosu"
+        ]
+      },
+      {
+        "en": "Enchilada",
+        "ja": "エンチラーダ",
+        "ja_typings": [
+          "enchira-da"
+        ]
+      },
+      {
+        "en": "Calzone",
+        "ja": "カルツォーネ",
+        "ja_typings": [
+          "karutso-ne"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03525",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mexican wrap consists of fillings inside a wheat flour tortilla?",
+      "ja": "小麦粉トルティーヤで具を包んだメキシコ料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Calzone",
+        "ja": "カルツォーネ",
+        "ja_typings": [
+          "karutso-ne"
+        ]
+      },
+      {
+        "en": "Focaccia",
+        "ja": "フォカッチャ",
+        "ja_typings": [
+          "fokaccha",
+          "fokatcha"
+        ]
+      },
+      {
+        "en": "Piadina",
+        "ja": "ピアディーナ",
+        "ja_typings": [
+          "piadi-na"
+        ]
+      },
+      {
+        "en": "Bolognese",
+        "ja": "ボロネーゼ",
+        "ja_typings": [
+          "borone-ze"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03526",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian dish is a folded pizza, baked or fried?",
+      "ja": "二つ折りにして焼くイタリアのピザは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Eiffel Tower",
+        "ja": "エッフェル塔",
+        "ja_typings": [
+          "efferutou"
+        ]
+      },
+      {
+        "en": "Louvre Museum",
+        "ja": "ルーブル美術館",
+        "ja_typings": [
+          "ru-burubijutsukan"
+        ]
+      },
+      {
+        "en": "Pantheon",
+        "ja": "パンテオン",
+        "ja_typings": [
+          "panteon"
+        ]
+      },
+      {
+        "en": "Brasilia",
+        "ja": "ブラジリア",
+        "ja_typings": [
+          "burajiria"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03527",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Parisian iron landmark was built for the 1889 World's Fair?",
+      "ja": "1889年パリ万博のために建てられた鉄の塔は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Enchilada",
+        "ja": "エンチラーダ",
+        "ja_typings": [
+          "enchira-da"
+        ]
+      },
+      {
+        "en": "Burrito",
+        "ja": "ブリトー",
+        "ja_typings": [
+          "burito-"
+        ]
+      },
+      {
+        "en": "Taco",
+        "ja": "タコス",
+        "ja_typings": [
+          "takosu"
+        ]
+      },
+      {
+        "en": "Tabbouleh",
+        "ja": "タブレ",
+        "ja_typings": [
+          "tabure"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03528",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mexican dish involves corn tortillas filled, rolled and covered in chili sauce?",
+      "ja": "トウモロコシのトルティーヤを巻きチリソースをかけたメキシコ料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Flamenco",
+        "ja": "フラメンコ",
+        "ja_typings": [
+          "furamenko"
+        ]
+      },
+      {
+        "en": "Bossa Nova",
+        "ja": "ボサノバ",
+        "ja_typings": [
+          "bosanoba"
+        ]
+      },
+      {
+        "en": "Krav Maga",
+        "ja": "クラヴマガ",
+        "ja_typings": [
+          "kuravumaga"
+        ]
+      },
+      {
+        "en": "Taekwondo",
+        "ja": "テコンドー",
+        "ja_typings": [
+          "tekondo-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03529",
+    "image_path": null,
+    "question_text": {
+      "en": "Which passionate Spanish dance is associated with Andalusia?",
+      "ja": "アンダルシア地方発祥の情熱的なスペインの舞踊は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Focaccia",
+        "ja": "フォカッチャ",
+        "ja_typings": [
+          "fokaccha",
+          "fokatcha"
+        ]
+      },
+      {
+        "en": "Piadina",
+        "ja": "ピアディーナ",
+        "ja_typings": [
+          "piadi-na"
+        ]
+      },
+      {
+        "en": "Calzone",
+        "ja": "カルツォーネ",
+        "ja_typings": [
+          "karutso-ne"
+        ]
+      },
+      {
+        "en": "Pesach",
+        "ja": "ペサハ",
+        "ja_typings": [
+          "pesaha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03530",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian flatbread is topped with olive oil and herbs?",
+      "ja": "オリーブオイルとハーブを使ったイタリアの平焼きパンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Frank Lloyd Wright",
+        "ja": "フランク・ロイド・ライト",
+        "ja_typings": [
+          "furankuroidoraito",
+          "furanku/roido/raito"
+        ]
+      },
+      {
+        "en": "Le Corbusier",
+        "ja": "ル・コルビュジエ",
+        "ja_typings": [
+          "rukorubyujie",
+          "ru/korubyujie"
+        ]
+      },
+      {
+        "en": "Zaha Hadid",
+        "ja": "ザハ・ハディド",
+        "ja_typings": [
+          "zahahadeido",
+          "zaha/hadido"
+        ]
+      },
+      {
+        "en": "Eiffel Tower",
+        "ja": "エッフェル塔",
+        "ja_typings": [
+          "efferutou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03531",
+    "image_path": null,
+    "question_text": {
+      "en": "Which American architect designed Fallingwater and the Guggenheim Museum?",
+      "ja": "落水荘やグッゲンハイム美術館を設計したアメリカの建築家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Geta",
+        "ja": "下駄",
+        "ja_typings": [
+          "geta"
+        ]
+      },
+      {
+        "en": "Sabot",
+        "ja": "サボ",
+        "ja_typings": [
+          "sabo"
+        ]
+      },
+      {
+        "en": "Moccasin",
+        "ja": "モカシン",
+        "ja_typings": [
+          "mokashin"
+        ]
+      },
+      {
+        "en": "Toga",
+        "ja": "トーガ",
+        "ja_typings": [
+          "to-ga"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03532",
+    "image_path": null,
+    "question_text": {
+      "en": "Which traditional Japanese wooden footwear has a raised platform on two 'teeth'?",
+      "ja": "二本歯の台がある日本の伝統的な木の履物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hanbok",
+        "ja": "ハンボク",
+        "ja_typings": [
+          "hanboku"
+        ]
+      },
+      {
+        "en": "Ao Dai",
+        "ja": "アオザイ",
+        "ja_typings": [
+          "aozai"
+        ]
+      },
+      {
+        "en": "Toga",
+        "ja": "トーガ",
+        "ja_typings": [
+          "to-ga"
+        ]
+      },
+      {
+        "en": "Keffiyeh",
+        "ja": "ケフィエ",
+        "ja_typings": [
+          "kefie"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03533",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the traditional Korean dress, worn during festivals and ceremonies?",
+      "ja": "祝祭で着用される韓国の伝統衣装は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hummus",
+        "ja": "フムス",
+        "ja_typings": [
+          "fumusu"
+        ]
+      },
+      {
+        "en": "Tabbouleh",
+        "ja": "タブレ",
+        "ja_typings": [
+          "tabure"
+        ]
+      },
+      {
+        "en": "Kebab",
+        "ja": "ケバブ",
+        "ja_typings": [
+          "kebabu"
+        ]
+      },
+      {
+        "en": "Pesach",
+        "ja": "ペサハ",
+        "ja_typings": [
+          "pesaha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03534",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Middle Eastern dip is made from chickpeas, tahini and lemon?",
+      "ja": "ひよこ豆とタヒニで作る中東の料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Indus River",
+        "ja": "インダス川",
+        "ja_typings": [
+          "indasugawa"
+        ]
+      },
+      {
+        "en": "Brahmaputra River",
+        "ja": "ブラフマプトラ川",
+        "ja_typings": [
+          "burafumaputoragawa"
+        ]
+      },
+      {
+        "en": "Yamuna River",
+        "ja": "ヤムナー川",
+        "ja_typings": [
+          "yamuna-gawa"
+        ]
+      },
+      {
+        "en": "Bible",
+        "ja": "聖書",
+        "ja_typings": [
+          "seisho"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03535",
+    "image_path": null,
+    "question_text": {
+      "en": "Which major South Asian river gave its name to an ancient civilization in Pakistan?",
+      "ja": "パキスタンを流れ古代文明の名にもなった大河は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kebab",
+        "ja": "ケバブ",
+        "ja_typings": [
+          "kebabu"
+        ]
+      },
+      {
+        "en": "Hummus",
+        "ja": "フムス",
+        "ja_typings": [
+          "fumusu"
+        ]
+      },
+      {
+        "en": "Tabbouleh",
+        "ja": "タブレ",
+        "ja_typings": [
+          "tabure"
+        ]
+      },
+      {
+        "en": "Burrito",
+        "ja": "ブリトー",
+        "ja_typings": [
+          "burito-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03536",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Middle Eastern grilled meat dish is often served on skewers or in wraps?",
+      "ja": "串焼きや包み焼きにする中東発祥の肉料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Keffiyeh",
+        "ja": "ケフィエ",
+        "ja_typings": [
+          "kefie"
+        ]
+      },
+      {
+        "en": "Turban",
+        "ja": "ターバン",
+        "ja_typings": [
+          "ta-ban"
+        ]
+      },
+      {
+        "en": "Veil",
+        "ja": "ベール",
+        "ja_typings": [
+          "be-ru"
+        ]
+      },
+      {
+        "en": "Hanbok",
+        "ja": "ハンボク",
+        "ja_typings": [
+          "hanboku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03537",
+    "image_path": null,
+    "question_text": {
+      "en": "Which patterned headscarf is associated with traditional Arab dress?",
+      "ja": "アラブ圏で頭に巻く格子模様の伝統的なスカーフは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Komusubi",
+        "ja": "小結",
+        "ja_typings": [
+          "komusubi"
+        ]
+      },
+      {
+        "en": "Sekiwake",
+        "ja": "関脇",
+        "ja_typings": [
+          "sekiwake"
+        ]
+      },
+      {
+        "en": "Ozeki",
+        "ja": "大関",
+        "ja_typings": [
+          "oozeki",
+          "ouzeki"
+        ]
+      },
+      {
+        "en": "Geta",
+        "ja": "下駄",
+        "ja_typings": [
+          "geta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03538",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sumo rank is the fourth-highest, ranked just below Sekiwake?",
+      "ja": "大相撲の番付で関脇のすぐ下の地位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Krav Maga",
+        "ja": "クラヴマガ",
+        "ja_typings": [
+          "kuravumaga"
+        ]
+      },
+      {
+        "en": "Taekwondo",
+        "ja": "テコンドー",
+        "ja_typings": [
+          "tekondo-"
+        ]
+      },
+      {
+        "en": "Flamenco",
+        "ja": "フラメンコ",
+        "ja_typings": [
+          "furamenko"
+        ]
+      },
+      {
+        "en": "Bossa Nova",
+        "ja": "ボサノバ",
+        "ja_typings": [
+          "bosanoba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03539",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Israeli self-defense martial art was developed for military use?",
+      "ja": "イスラエル軍で生まれた自己防衛のための格闘術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Le Corbusier",
+        "ja": "ル・コルビュジエ",
+        "ja_typings": [
+          "rukorubyujie",
+          "ru/korubyujie"
+        ]
+      },
+      {
+        "en": "Frank Lloyd Wright",
+        "ja": "フランク・ロイド・ライト",
+        "ja_typings": [
+          "furankuroidoraito",
+          "furanku/roido/raito"
+        ]
+      },
+      {
+        "en": "Zaha Hadid",
+        "ja": "ザハ・ハディド",
+        "ja_typings": [
+          "zahahadeido",
+          "zaha/hadido"
+        ]
+      },
+      {
+        "en": "Pantheon",
+        "ja": "パンテオン",
+        "ja_typings": [
+          "panteon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03540",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Swiss-French architect designed the Villa Savoye and Unite d'Habitation?",
+      "ja": "サヴォア邸とユニテ・ダビタシオンを設計した建築家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Louvre Museum",
+        "ja": "ルーブル美術館",
+        "ja_typings": [
+          "ru-burubijutsukan"
+        ]
+      },
+      {
+        "en": "Eiffel Tower",
+        "ja": "エッフェル塔",
+        "ja_typings": [
+          "efferutou"
+        ]
+      },
+      {
+        "en": "Pantheon",
+        "ja": "パンテオン",
+        "ja_typings": [
+          "panteon"
+        ]
+      },
+      {
+        "en": "Brasilia",
+        "ja": "ブラジリア",
+        "ja_typings": [
+          "burajiria"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03541",
+    "image_path": null,
+    "question_text": {
+      "en": "Which famous Paris museum houses the Mona Lisa?",
+      "ja": "モナ・リザを所蔵するパリの美術館は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Maya civilization",
+        "ja": "マヤ文明",
+        "ja_typings": [
+          "mayabunmei"
+        ]
+      },
+      {
+        "en": "Aztec civilization",
+        "ja": "アステカ文明",
+        "ja_typings": [
+          "asutekabunmei"
+        ]
+      },
+      {
+        "en": "Olmec civilization",
+        "ja": "オルメカ文明",
+        "ja_typings": [
+          "orumekabunmei"
+        ]
+      },
+      {
+        "en": "Indus River",
+        "ja": "インダス川",
+        "ja_typings": [
+          "indasugawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03542",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Mesoamerican civilization is known for Chichen Itza and the Long Count calendar?",
+      "ja": "チチェン・イッツァや長期暦で知られる古代メソアメリカ文明は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Moccasin",
+        "ja": "モカシン",
+        "ja_typings": [
+          "mokashin"
+        ]
+      },
+      {
+        "en": "Sabot",
+        "ja": "サボ",
+        "ja_typings": [
+          "sabo"
+        ]
+      },
+      {
+        "en": "Geta",
+        "ja": "下駄",
+        "ja_typings": [
+          "geta"
+        ]
+      },
+      {
+        "en": "Poncho",
+        "ja": "ポンチョ",
+        "ja_typings": [
+          "poncho"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03543",
+    "image_path": null,
+    "question_text": {
+      "en": "Which soft leather shoe is associated with Native American tradition?",
+      "ja": "ネイティブアメリカンの伝統的な柔らかい革靴は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Olmec civilization",
+        "ja": "オルメカ文明",
+        "ja_typings": [
+          "orumekabunmei"
+        ]
+      },
+      {
+        "en": "Maya civilization",
+        "ja": "マヤ文明",
+        "ja_typings": [
+          "mayabunmei"
+        ]
+      },
+      {
+        "en": "Aztec civilization",
+        "ja": "アステカ文明",
+        "ja_typings": [
+          "asutekabunmei"
+        ]
+      },
+      {
+        "en": "Vedas",
+        "ja": "ヴェーダ",
+        "ja_typings": [
+          "ve-da"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03544",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is considered the earliest known major civilization of Mesoamerica, predating the Maya?",
+      "ja": "マヤ文明より古い、メソアメリカ最古とされる文明は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ozeki",
+        "ja": "大関",
+        "ja_typings": [
+          "oozeki",
+          "ouzeki"
+        ]
+      },
+      {
+        "en": "Sekiwake",
+        "ja": "関脇",
+        "ja_typings": [
+          "sekiwake"
+        ]
+      },
+      {
+        "en": "Komusubi",
+        "ja": "小結",
+        "ja_typings": [
+          "komusubi"
+        ]
+      },
+      {
+        "en": "Geta",
+        "ja": "下駄",
+        "ja_typings": [
+          "geta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03545",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sumo rank is the second-highest, just below Yokozuna?",
+      "ja": "大相撲の番付で横綱のすぐ下の地位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pantheon",
+        "ja": "パンテオン",
+        "ja_typings": [
+          "panteon"
+        ]
+      },
+      {
+        "en": "Louvre Museum",
+        "ja": "ルーブル美術館",
+        "ja_typings": [
+          "ru-burubijutsukan"
+        ]
+      },
+      {
+        "en": "Eiffel Tower",
+        "ja": "エッフェル塔",
+        "ja_typings": [
+          "efferutou"
+        ]
+      },
+      {
+        "en": "Brasilia",
+        "ja": "ブラジリア",
+        "ja_typings": [
+          "burajiria"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03546",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Roman temple in Rome has a famous dome and oculus?",
+      "ja": "ローマにあるドームと天窓で有名な古代神殿は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pesach",
+        "ja": "ペサハ",
+        "ja_typings": [
+          "pesaha"
+        ]
+      },
+      {
+        "en": "Torah",
+        "ja": "トーラー",
+        "ja_typings": [
+          "to-ra-"
+        ]
+      },
+      {
+        "en": "Bible",
+        "ja": "聖書",
+        "ja_typings": [
+          "seisho"
+        ]
+      },
+      {
+        "en": "Vedas",
+        "ja": "ヴェーダ",
+        "ja_typings": [
+          "ve-da"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03547",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Jewish holiday commemorates the Exodus from Egypt?",
+      "ja": "ユダヤ教でエジプト脱出を記念する祭りは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pescatore",
+        "ja": "ペスカトーレ",
+        "ja_typings": [
+          "pesukato-re"
+        ]
+      },
+      {
+        "en": "Arrabbiata",
+        "ja": "アラビアータ",
+        "ja_typings": [
+          "arabia-ta"
+        ]
+      },
+      {
+        "en": "Bolognese",
+        "ja": "ボロネーゼ",
+        "ja_typings": [
+          "borone-ze"
+        ]
+      },
+      {
+        "en": "Calzone",
+        "ja": "カルツォーネ",
+        "ja_typings": [
+          "karutso-ne"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03548",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian seafood pasta sauce features shellfish and tomato?",
+      "ja": "魚介とトマトで作るイタリアのパスタソースは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Piadina",
+        "ja": "ピアディーナ",
+        "ja_typings": [
+          "piadi-na"
+        ]
+      },
+      {
+        "en": "Focaccia",
+        "ja": "フォカッチャ",
+        "ja_typings": [
+          "fokaccha",
+          "fokatcha"
+        ]
+      },
+      {
+        "en": "Calzone",
+        "ja": "カルツォーネ",
+        "ja_typings": [
+          "karutso-ne"
+        ]
+      },
+      {
+        "en": "Tabbouleh",
+        "ja": "タブレ",
+        "ja_typings": [
+          "tabure"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03549",
+    "image_path": null,
+    "question_text": {
+      "en": "Which flatbread from Emilia-Romagna is similar to a tortilla?",
+      "ja": "エミリア=ロマーニャ州のトルティーヤに似た平焼きパンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Poncho",
+        "ja": "ポンチョ",
+        "ja_typings": [
+          "poncho"
+        ]
+      },
+      {
+        "en": "Toga",
+        "ja": "トーガ",
+        "ja_typings": [
+          "to-ga"
+        ]
+      },
+      {
+        "en": "Hanbok",
+        "ja": "ハンボク",
+        "ja_typings": [
+          "hanboku"
+        ]
+      },
+      {
+        "en": "Ao Dai",
+        "ja": "アオザイ",
+        "ja_typings": [
+          "aozai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03550",
+    "image_path": null,
+    "question_text": {
+      "en": "Which South American garment is a single piece of cloth with a hole for the head?",
+      "ja": "頭を通す穴があいた一枚布の南米の衣服は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sabot",
+        "ja": "サボ",
+        "ja_typings": [
+          "sabo"
+        ]
+      },
+      {
+        "en": "Geta",
+        "ja": "下駄",
+        "ja_typings": [
+          "geta"
+        ]
+      },
+      {
+        "en": "Moccasin",
+        "ja": "モカシン",
+        "ja_typings": [
+          "mokashin"
+        ]
+      },
+      {
+        "en": "Veil",
+        "ja": "ベール",
+        "ja_typings": [
+          "be-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03551",
+    "image_path": null,
+    "question_text": {
+      "en": "Which traditional wooden shoe is associated with France and the Netherlands?",
+      "ja": "フランスやオランダの木製の伝統的な靴は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sekiwake",
+        "ja": "関脇",
+        "ja_typings": [
+          "sekiwake"
+        ]
+      },
+      {
+        "en": "Komusubi",
+        "ja": "小結",
+        "ja_typings": [
+          "komusubi"
+        ]
+      },
+      {
+        "en": "Ozeki",
+        "ja": "大関",
+        "ja_typings": [
+          "oozeki"
+        ]
+      },
+      {
+        "en": "Geta",
+        "ja": "下駄",
+        "ja_typings": [
+          "geta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03552",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sumo rank is the third-highest, just below Ozeki?",
+      "ja": "大相撲の番付で大関のすぐ下の地位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tabbouleh",
+        "ja": "タブレ",
+        "ja_typings": [
+          "tabure"
+        ]
+      },
+      {
+        "en": "Hummus",
+        "ja": "フムス",
+        "ja_typings": [
+          "fumusu"
+        ]
+      },
+      {
+        "en": "Kebab",
+        "ja": "ケバブ",
+        "ja_typings": [
+          "kebabu"
+        ]
+      },
+      {
+        "en": "Keffiyeh",
+        "ja": "ケフィエ",
+        "ja_typings": [
+          "kefie"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03553",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Levantine salad is made of bulgur, parsley, tomato and mint?",
+      "ja": "ブルグル、パセリ、トマト、ミントで作る中東のサラダは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Taco",
+        "ja": "タコス",
+        "ja_typings": [
+          "takosu"
+        ]
+      },
+      {
+        "en": "Burrito",
+        "ja": "ブリトー",
+        "ja_typings": [
+          "burito-"
+        ]
+      },
+      {
+        "en": "Enchilada",
+        "ja": "エンチラーダ",
+        "ja_typings": [
+          "enchira-da"
+        ]
+      },
+      {
+        "en": "Calzone",
+        "ja": "カルツォーネ",
+        "ja_typings": [
+          "karutso-ne"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03554",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mexican dish uses a folded corn tortilla with various fillings?",
+      "ja": "コーントルティーヤに具を挟んだメキシコ料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Taekwondo",
+        "ja": "テコンドー",
+        "ja_typings": [
+          "tekondo-"
+        ]
+      },
+      {
+        "en": "Krav Maga",
+        "ja": "クラヴマガ",
+        "ja_typings": [
+          "kuravumaga"
+        ]
+      },
+      {
+        "en": "Flamenco",
+        "ja": "フラメンコ",
+        "ja_typings": [
+          "furamenko"
+        ]
+      },
+      {
+        "en": "Bossa Nova",
+        "ja": "ボサノバ",
+        "ja_typings": [
+          "bosanoba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03555",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Korean martial art is known for its powerful kicks and is an Olympic sport?",
+      "ja": "強力な蹴りで知られ五輪競技にもなった韓国発祥の格闘技は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tartan",
+        "ja": "タータン",
+        "ja_typings": [
+          "ta-tan"
+        ]
+      },
+      {
+        "en": "Keffiyeh",
+        "ja": "ケフィエ",
+        "ja_typings": [
+          "kefie"
+        ]
+      },
+      {
+        "en": "Hanbok",
+        "ja": "ハンボク",
+        "ja_typings": [
+          "hanboku"
+        ]
+      },
+      {
+        "en": "Ao Dai",
+        "ja": "アオザイ",
+        "ja_typings": [
+          "aozai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03556",
+    "image_path": null,
+    "question_text": {
+      "en": "Which checkered woven pattern is associated with Scottish kilts?",
+      "ja": "スコットランドのキルトに使われる格子模様は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Toga",
+        "ja": "トーガ",
+        "ja_typings": [
+          "to-ga"
+        ]
+      },
+      {
+        "en": "Poncho",
+        "ja": "ポンチョ",
+        "ja_typings": [
+          "poncho"
+        ]
+      },
+      {
+        "en": "Ao Dai",
+        "ja": "アオザイ",
+        "ja_typings": [
+          "aozai"
+        ]
+      },
+      {
+        "en": "Hanbok",
+        "ja": "ハンボク",
+        "ja_typings": [
+          "hanboku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03557",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Roman garment was a draped piece of cloth worn by citizens?",
+      "ja": "古代ローマの市民が身につけた、布をまとう衣服は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Torah",
+        "ja": "トーラー",
+        "ja_typings": [
+          "to-ra-"
+        ]
+      },
+      {
+        "en": "Bible",
+        "ja": "聖書",
+        "ja_typings": [
+          "seisho"
+        ]
+      },
+      {
+        "en": "Vedas",
+        "ja": "ヴェーダ",
+        "ja_typings": [
+          "ve-da"
+        ]
+      },
+      {
+        "en": "Pesach",
+        "ja": "ペサハ",
+        "ja_typings": [
+          "pesaha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03558",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sacred Jewish scripture corresponds to the first five books of the Hebrew Bible?",
+      "ja": "ヘブライ語聖書の最初の五書に当たるユダヤ教の聖典は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Turban",
+        "ja": "ターバン",
+        "ja_typings": [
+          "ta-ban"
+        ]
+      },
+      {
+        "en": "Keffiyeh",
+        "ja": "ケフィエ",
+        "ja_typings": [
+          "kefie"
+        ]
+      },
+      {
+        "en": "Veil",
+        "ja": "ベール",
+        "ja_typings": [
+          "be-ru"
+        ]
+      },
+      {
+        "en": "Hanbok",
+        "ja": "ハンボク",
+        "ja_typings": [
+          "hanboku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03559",
+    "image_path": null,
+    "question_text": {
+      "en": "Which wrapped headgear is traditionally worn by Sikh men and others across South Asia?",
+      "ja": "南アジアでシーク教徒の男性などが頭に巻く布は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vedas",
+        "ja": "ヴェーダ",
+        "ja_typings": [
+          "ve-da"
+        ]
+      },
+      {
+        "en": "Torah",
+        "ja": "トーラー",
+        "ja_typings": [
+          "to-ra-"
+        ]
+      },
+      {
+        "en": "Bible",
+        "ja": "聖書",
+        "ja_typings": [
+          "seisho"
+        ]
+      },
+      {
+        "en": "Pesach",
+        "ja": "ペサハ",
+        "ja_typings": [
+          "pesaha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03560",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Indian sacred texts form the foundation of Hindu scripture?",
+      "ja": "ヒンドゥー教の聖典の基礎となる古代インドの聖典は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Veil",
+        "ja": "ベール",
+        "ja_typings": [
+          "be-ru"
+        ]
+      },
+      {
+        "en": "Turban",
+        "ja": "ターバン",
+        "ja_typings": [
+          "ta-ban"
+        ]
+      },
+      {
+        "en": "Keffiyeh",
+        "ja": "ケフィエ",
+        "ja_typings": [
+          "kefie"
+        ]
+      },
+      {
+        "en": "Tartan",
+        "ja": "タータン",
+        "ja_typings": [
+          "ta-tan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03561",
+    "image_path": null,
+    "question_text": {
+      "en": "Which thin fabric covering is worn over the face, often in religious or wedding contexts?",
+      "ja": "宗教儀礼や結婚式で顔を覆う薄い布は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yamuna River",
+        "ja": "ヤムナー川",
+        "ja_typings": [
+          "yamuna-gawa"
+        ]
+      },
+      {
+        "en": "Brahmaputra River",
+        "ja": "ブラフマプトラ川",
+        "ja_typings": [
+          "burafumaputoragawa"
+        ]
+      },
+      {
+        "en": "Indus River",
+        "ja": "インダス川",
+        "ja_typings": [
+          "indasugawa"
+        ]
+      },
+      {
+        "en": "Eiffel Tower",
+        "ja": "エッフェル塔",
+        "ja_typings": [
+          "efferutou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03562",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sacred river of India flows through Delhi and joins the Ganges at Prayagraj?",
+      "ja": "デリーを流れプラヤーグラージでガンジス川と合流するインドの聖なる川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Zaha Hadid",
+        "ja": "ザハ・ハディド",
+        "ja_typings": [
+          "zahahadeido",
+          "zaha/hadido"
+        ]
+      },
+      {
+        "en": "Frank Lloyd Wright",
+        "ja": "フランク・ロイド・ライト",
+        "ja_typings": [
+          "furankuroidoraito",
+          "furanku/roido/raito"
+        ]
+      },
+      {
+        "en": "Le Corbusier",
+        "ja": "ル・コルビュジエ",
+        "ja_typings": [
+          "rukorubyujie",
+          "ru/korubyujie"
+        ]
+      },
+      {
+        "en": "Pantheon",
+        "ja": "パンテオン",
+        "ja_typings": [
+          "panteon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03563",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Iraqi-British architect designed the Heydar Aliyev Center and the London Aquatics Centre?",
+      "ja": "ヘイダル・アリエフ・センターを設計したイラク出身の建築家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "AGPL",
+        "ja": "AGPL",
+        "ja_typings": [
+          "agpl"
+        ]
+      },
+      {
+        "en": "MIT",
+        "ja": "MIT",
+        "ja_typings": [
+          "mit"
+        ]
+      },
+      {
+        "en": "BSD",
+        "ja": "BSD",
+        "ja_typings": [
+          "bsd"
+        ]
+      },
+      {
+        "en": "Apache",
+        "ja": "Apache",
+        "ja_typings": [
+          "apache"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03564",
+    "image_path": null,
+    "question_text": {
+      "en": "Which copyleft license requires source disclosure even for network-served software?",
+      "ja": "ネットワーク経由で提供されるソフトウェアにもソース開示を求めるコピーレフトライセンスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "API Gateway",
+        "ja": "API Gateway",
+        "ja_typings": [
+          "api gateway"
+        ]
+      },
+      {
+        "en": "CloudFront",
+        "ja": "CloudFront",
+        "ja_typings": [
+          "cloudfront"
+        ]
+      },
+      {
+        "en": "Route 53",
+        "ja": "Route 53",
+        "ja_typings": [
+          "route 53"
+        ]
+      },
+      {
+        "en": "AppSync",
+        "ja": "AppSync",
+        "ja_typings": [
+          "appsync"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03565",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS service acts as a managed front door for APIs with routing, auth, and throttling?",
+      "ja": "API のルーティングや認証、スロットリングを担う AWS のマネージドサービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Alpha",
+        "ja": "Alpha",
+        "ja_typings": [
+          "alpha"
+        ]
+      },
+      {
+        "en": "Beta",
+        "ja": "Beta",
+        "ja_typings": [
+          "beta"
+        ]
+      },
+      {
+        "en": "RC",
+        "ja": "RC",
+        "ja_typings": [
+          "rc"
+        ]
+      },
+      {
+        "en": "GA",
+        "ja": "GA",
+        "ja_typings": [
+          "ga"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03566",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the term for an early pre-release version used for internal or limited testing?",
+      "ja": "限定的な内部テスト向けに公開される初期段階の試験版を何と呼ぶ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aurora Serverless",
+        "ja": "Aurora Serverless",
+        "ja_typings": [
+          "aurora serverless"
+        ]
+      },
+      {
+        "en": "DynamoDB",
+        "ja": "DynamoDB",
+        "ja_typings": [
+          "dynamodb"
+        ]
+      },
+      {
+        "en": "Redshift",
+        "ja": "Redshift",
+        "ja_typings": [
+          "redshift"
+        ]
+      },
+      {
+        "en": "ElastiCache",
+        "ja": "ElastiCache",
+        "ja_typings": [
+          "elasticache"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03567",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS service auto-scales relational database capacity on demand?",
+      "ja": "需要に応じてリレーショナルDBの容量を自動スケールする AWS サービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Beta",
+        "ja": "Beta",
+        "ja_typings": [
+          "beta"
+        ]
+      },
+      {
+        "en": "Alpha",
+        "ja": "Alpha",
+        "ja_typings": [
+          "alpha"
+        ]
+      },
+      {
+        "en": "Nightly",
+        "ja": "Nightly",
+        "ja_typings": [
+          "nightly"
+        ]
+      },
+      {
+        "en": "Stable",
+        "ja": "Stable",
+        "ja_typings": [
+          "stable"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03568",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a feature-complete pre-release version offered to wider testers before release?",
+      "ja": "リリース前に広範な利用者に提供される機能ほぼ完成版の試験版は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Blue-Green Deployment",
+        "ja": "Blue-Green Deployment",
+        "ja_typings": [
+          "blue-green deployment"
+        ]
+      },
+      {
+        "en": "Rolling Update",
+        "ja": "Rolling Update",
+        "ja_typings": [
+          "rolling update"
+        ]
+      },
+      {
+        "en": "Canary Release",
+        "ja": "Canary Release",
+        "ja_typings": [
+          "canary release"
+        ]
+      },
+      {
+        "en": "Shadow Deployment",
+        "ja": "Shadow Deployment",
+        "ja_typings": [
+          "shadow deployment"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03569",
+    "image_path": null,
+    "question_text": {
+      "en": "Which deployment switches traffic between two identical environments to minimize downtime?",
+      "ja": "二つの同一環境を切り替えてダウンタイムを最小化するデプロイ手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CNCF",
+        "ja": "CNCF",
+        "ja_typings": [
+          "cncf"
+        ]
+      },
+      {
+        "en": "ASF",
+        "ja": "ASF",
+        "ja_typings": [
+          "asf"
+        ]
+      },
+      {
+        "en": "OSI",
+        "ja": "OSI",
+        "ja_typings": [
+          "osi"
+        ]
+      },
+      {
+        "en": "FSF",
+        "ja": "FSF",
+        "ja_typings": [
+          "fsf"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03570",
+    "image_path": null,
+    "question_text": {
+      "en": "Which foundation hosts Kubernetes and other cloud native projects?",
+      "ja": "Kubernetes 等のクラウドネイティブ系プロジェクトをホストする財団は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CR",
+        "ja": "CR",
+        "ja_typings": [
+          "cr"
+        ]
+      },
+      {
+        "en": "PR",
+        "ja": "PR",
+        "ja_typings": [
+          "pr"
+        ]
+      },
+      {
+        "en": "MR",
+        "ja": "MR",
+        "ja_typings": [
+          "mr"
+        ]
+      },
+      {
+        "en": "IR",
+        "ja": "IR",
+        "ja_typings": [
+          "ir"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03571",
+    "image_path": null,
+    "question_text": {
+      "en": "In GitLab, what is the abbreviation for a request to review and integrate code (similar to GitHub PR)?",
+      "ja": "GitLab で GitHub の PR に相当する変更取り込み要求の略称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CloudFront",
+        "ja": "CloudFront",
+        "ja_typings": [
+          "cloudfront"
+        ]
+      },
+      {
+        "en": "Route 53",
+        "ja": "Route 53",
+        "ja_typings": [
+          "route 53"
+        ]
+      },
+      {
+        "en": "S3",
+        "ja": "S3",
+        "ja_typings": [
+          "s3"
+        ]
+      },
+      {
+        "en": "Lambda",
+        "ja": "Lambda",
+        "ja_typings": [
+          "lambda"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03572",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS service is a global content delivery network (CDN)?",
+      "ja": "AWS のグローバル CDN サービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DNS",
+        "ja": "DNS",
+        "ja_typings": [
+          "dns"
+        ]
+      },
+      {
+        "en": "DHCP",
+        "ja": "DHCP",
+        "ja_typings": [
+          "dhcp"
+        ]
+      },
+      {
+        "en": "ARP",
+        "ja": "ARP",
+        "ja_typings": [
+          "arp"
+        ]
+      },
+      {
+        "en": "NAT",
+        "ja": "NAT",
+        "ja_typings": [
+          "nat"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03573",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol translates human-readable domain names into IP addresses?",
+      "ja": "ドメイン名を IP アドレスに変換する仕組みは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Deployment",
+        "ja": "Deployment",
+        "ja_typings": [
+          "deployment"
+        ]
+      },
+      {
+        "en": "Service",
+        "ja": "Service",
+        "ja_typings": [
+          "service"
+        ]
+      },
+      {
+        "en": "Node",
+        "ja": "Node",
+        "ja_typings": [
+          "node"
+        ]
+      },
+      {
+        "en": "ConfigMap",
+        "ja": "ConfigMap",
+        "ja_typings": [
+          "configmap"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03574",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Kubernetes resource manages a replicated set of stateless Pods?",
+      "ja": "ステートレスな Pod のレプリカを管理する Kubernetes リソースは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Direct Connect",
+        "ja": "Direct Connect",
+        "ja_typings": [
+          "direct connect"
+        ]
+      },
+      {
+        "en": "VPN",
+        "ja": "VPN",
+        "ja_typings": [
+          "vpn"
+        ]
+      },
+      {
+        "en": "Transit Gateway",
+        "ja": "Transit Gateway",
+        "ja_typings": [
+          "transit gateway"
+        ]
+      },
+      {
+        "en": "PrivateLink",
+        "ja": "PrivateLink",
+        "ja_typings": [
+          "privatelink"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03575",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS service provides a dedicated private network connection to AWS?",
+      "ja": "オンプレと AWS を専用線で接続する AWS サービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Epic",
+        "ja": "Epic",
+        "ja_typings": [
+          "epic"
+        ]
+      },
+      {
+        "en": "Story",
+        "ja": "Story",
+        "ja_typings": [
+          "story"
+        ]
+      },
+      {
+        "en": "Task",
+        "ja": "Task",
+        "ja_typings": [
+          "task"
+        ]
+      },
+      {
+        "en": "Sprint",
+        "ja": "Sprint",
+        "ja_typings": [
+          "sprint"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03576",
+    "image_path": null,
+    "question_text": {
+      "en": "In agile, what is a large body of work that is broken down into multiple stories?",
+      "ja": "アジャイルで複数のストーリーに分割される大きな作業単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Event-Driven Architecture",
+        "ja": "Event-Driven Architecture",
+        "ja_typings": [
+          "event-driven architecture"
+        ]
+      },
+      {
+        "en": "Service-Oriented Architecture",
+        "ja": "Service-Oriented Architecture",
+        "ja_typings": [
+          "service-oriented architecture"
+        ]
+      },
+      {
+        "en": "Layered Architecture",
+        "ja": "Layered Architecture",
+        "ja_typings": [
+          "layered architecture"
+        ]
+      },
+      {
+        "en": "Monolith",
+        "ja": "Monolith",
+        "ja_typings": [
+          "monolith"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03577",
+    "image_path": null,
+    "question_text": {
+      "en": "Which architecture style produces and consumes events asynchronously between components?",
+      "ja": "コンポーネント間でイベントを非同期にやり取りするアーキテクチャは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FIPS 140",
+        "ja": "FIPS 140",
+        "ja_typings": [
+          "fips 140"
+        ]
+      },
+      {
+        "en": "ISO 27001",
+        "ja": "ISO 27001",
+        "ja_typings": [
+          "iso 27001"
+        ]
+      },
+      {
+        "en": "SOC 2",
+        "ja": "SOC 2",
+        "ja_typings": [
+          "soc 2"
+        ]
+      },
+      {
+        "en": "PCI DSS",
+        "ja": "PCI DSS",
+        "ja_typings": [
+          "pci dss"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03578",
+    "image_path": null,
+    "question_text": {
+      "en": "Which US government standard specifies security requirements for cryptographic modules?",
+      "ja": "暗号モジュールのセキュリティ要件を定めた米国政府の規格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "GNU Manifesto",
+        "ja": "GNU Manifesto",
+        "ja_typings": [
+          "gnu manifesto"
+        ]
+      },
+      {
+        "en": "Hacker Manifesto",
+        "ja": "Hacker Manifesto",
+        "ja_typings": [
+          "hacker manifesto"
+        ]
+      },
+      {
+        "en": "Open Source Definition",
+        "ja": "Open Source Definition",
+        "ja_typings": [
+          "open source definition"
+        ]
+      },
+      {
+        "en": "Cathedral and the Bazaar",
+        "ja": "Cathedral and the Bazaar",
+        "ja_typings": [
+          "cathedral and the bazaar"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03579",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1985 document by Richard Stallman declared the philosophy of free software?",
+      "ja": "1985 年にストールマンがフリーソフトウェアの理念を宣言した文書は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "GPLv3",
+        "ja": "GPLv3",
+        "ja_typings": [
+          "gplv3"
+        ]
+      },
+      {
+        "en": "GPLv2",
+        "ja": "GPLv2",
+        "ja_typings": [
+          "gplv2"
+        ]
+      },
+      {
+        "en": "LGPL",
+        "ja": "LGPL",
+        "ja_typings": [
+          "lgpl"
+        ]
+      },
+      {
+        "en": "AGPL",
+        "ja": "AGPL",
+        "ja_typings": [
+          "agpl"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03580",
+    "image_path": null,
+    "question_text": {
+      "en": "Which version of the GNU General Public License was released in 2007 with patent provisions?",
+      "ja": "2007 年にリリースされ特許条項を含む GPL のバージョンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hacker Manifesto",
+        "ja": "Hacker Manifesto",
+        "ja_typings": [
+          "hacker manifesto"
+        ]
+      },
+      {
+        "en": "GNU Manifesto",
+        "ja": "GNU Manifesto",
+        "ja_typings": [
+          "gnu manifesto"
+        ]
+      },
+      {
+        "en": "Cypherpunk Manifesto",
+        "ja": "Cypherpunk Manifesto",
+        "ja_typings": [
+          "cypherpunk manifesto"
+        ]
+      },
+      {
+        "en": "Open Source Definition",
+        "ja": "Open Source Definition",
+        "ja_typings": [
+          "open source definition"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03581",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1986 essay by The Mentor became iconic in hacker culture?",
+      "ja": "ハッカー文化の象徴となった 1986 年のメンターによる文書は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "IETF",
+        "ja": "IETF",
+        "ja_typings": [
+          "ietf"
+        ]
+      },
+      {
+        "en": "IEEE",
+        "ja": "IEEE",
+        "ja_typings": [
+          "ieee"
+        ]
+      },
+      {
+        "en": "W3C",
+        "ja": "W3C",
+        "ja_typings": [
+          "w3c"
+        ]
+      },
+      {
+        "en": "ISO",
+        "ja": "ISO",
+        "ja_typings": [
+          "iso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03582",
+    "image_path": null,
+    "question_text": {
+      "en": "Which organization develops and promotes voluntary Internet standards like TCP/IP and HTTP?",
+      "ja": "TCP/IP や HTTP 等のインターネット標準を策定する組織は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "IR",
+        "ja": "IR",
+        "ja_typings": [
+          "ir"
+        ]
+      },
+      {
+        "en": "AST",
+        "ja": "AST",
+        "ja_typings": [
+          "ast"
+        ]
+      },
+      {
+        "en": "CFG",
+        "ja": "CFG",
+        "ja_typings": [
+          "cfg"
+        ]
+      },
+      {
+        "en": "SSA",
+        "ja": "SSA",
+        "ja_typings": [
+          "ssa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03583",
+    "image_path": null,
+    "question_text": {
+      "en": "In compilers, what is the abbreviation for the intermediate representation of code?",
+      "ja": "コンパイラで中間表現を指す略称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ISO 27001",
+        "ja": "ISO 27001",
+        "ja_typings": [
+          "iso 27001"
+        ]
+      },
+      {
+        "en": "ISO 9001",
+        "ja": "ISO 9001",
+        "ja_typings": [
+          "iso 9001"
+        ]
+      },
+      {
+        "en": "SOC 2",
+        "ja": "SOC 2",
+        "ja_typings": [
+          "soc 2"
+        ]
+      },
+      {
+        "en": "FIPS 140",
+        "ja": "FIPS 140",
+        "ja_typings": [
+          "fips 140"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03584",
+    "image_path": null,
+    "question_text": {
+      "en": "Which international standard specifies requirements for an information security management system (ISMS)?",
+      "ja": "情報セキュリティマネジメントシステム(ISMS)の要件を定めた国際規格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "LGPL",
+        "ja": "LGPL",
+        "ja_typings": [
+          "lgpl"
+        ]
+      },
+      {
+        "en": "GPLv3",
+        "ja": "GPLv3",
+        "ja_typings": [
+          "gplv3"
+        ]
+      },
+      {
+        "en": "AGPL",
+        "ja": "AGPL",
+        "ja_typings": [
+          "agpl"
+        ]
+      },
+      {
+        "en": "MPL",
+        "ja": "MPL",
+        "ja_typings": [
+          "mpl"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03585",
+    "image_path": null,
+    "question_text": {
+      "en": "Which GNU license allows linking with proprietary software, often used for libraries?",
+      "ja": "ライブラリ向けで、プロプライエタリと動的リンク可能な GNU 系ライセンスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MR",
+        "ja": "MR",
+        "ja_typings": [
+          "mr"
+        ]
+      },
+      {
+        "en": "PR",
+        "ja": "PR",
+        "ja_typings": [
+          "pr"
+        ]
+      },
+      {
+        "en": "CR",
+        "ja": "CR",
+        "ja_typings": [
+          "cr"
+        ]
+      },
+      {
+        "en": "IR",
+        "ja": "IR",
+        "ja_typings": [
+          "ir"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03586",
+    "image_path": null,
+    "question_text": {
+      "en": "In GitLab terminology, what is the abbreviation for a Merge Request?",
+      "ja": "GitLab でマージリクエストを意味する略称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Monolith",
+        "ja": "Monolith",
+        "ja_typings": [
+          "monolith"
+        ]
+      },
+      {
+        "en": "Microservices",
+        "ja": "Microservices",
+        "ja_typings": [
+          "microservices"
+        ]
+      },
+      {
+        "en": "Serverless",
+        "ja": "Serverless",
+        "ja_typings": [
+          "serverless"
+        ]
+      },
+      {
+        "en": "Event-Driven Architecture",
+        "ja": "Event-Driven Architecture",
+        "ja_typings": [
+          "event-driven architecture"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03587",
+    "image_path": null,
+    "question_text": {
+      "en": "Which architecture deploys an application as a single, tightly coupled unit?",
+      "ja": "アプリ全体を単一の密結合な単位として配備するアーキテクチャは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NAT",
+        "ja": "NAT",
+        "ja_typings": [
+          "nat"
+        ]
+      },
+      {
+        "en": "DNS",
+        "ja": "DNS",
+        "ja_typings": [
+          "dns"
+        ]
+      },
+      {
+        "en": "VPN",
+        "ja": "VPN",
+        "ja_typings": [
+          "vpn"
+        ]
+      },
+      {
+        "en": "DHCP",
+        "ja": "DHCP",
+        "ja_typings": [
+          "dhcp"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03588",
+    "image_path": null,
+    "question_text": {
+      "en": "Which technique remaps IP addresses by translating them between private and public networks?",
+      "ja": "プライベートとパブリックネットワーク間で IP を変換する技術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nightly Build",
+        "ja": "Nightly Build",
+        "ja_typings": [
+          "nightly build"
+        ]
+      },
+      {
+        "en": "Release Build",
+        "ja": "Release Build",
+        "ja_typings": [
+          "release build"
+        ]
+      },
+      {
+        "en": "Debug Build",
+        "ja": "Debug Build",
+        "ja_typings": [
+          "debug build"
+        ]
+      },
+      {
+        "en": "Snapshot",
+        "ja": "Snapshot",
+        "ja_typings": [
+          "snapshot"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03589",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a build automatically produced every night from the latest source code called?",
+      "ja": "毎晩最新ソースから自動生成されるビルドを何と呼ぶ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Node",
+        "ja": "Node",
+        "ja_typings": [
+          "node"
+        ]
+      },
+      {
+        "en": "Pod",
+        "ja": "Pod",
+        "ja_typings": [
+          "pod"
+        ]
+      },
+      {
+        "en": "Cluster",
+        "ja": "Cluster",
+        "ja_typings": [
+          "cluster"
+        ]
+      },
+      {
+        "en": "Service",
+        "ja": "Service",
+        "ja_typings": [
+          "service"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03590",
+    "image_path": null,
+    "question_text": {
+      "en": "In Kubernetes, what term refers to a worker machine (VM or physical) that runs Pods?",
+      "ja": "Kubernetes で Pod を実行するワーカーマシンを何と呼ぶ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "OWASP",
+        "ja": "OWASP",
+        "ja_typings": [
+          "owasp"
+        ]
+      },
+      {
+        "en": "CNCF",
+        "ja": "CNCF",
+        "ja_typings": [
+          "cncf"
+        ]
+      },
+      {
+        "en": "IETF",
+        "ja": "IETF",
+        "ja_typings": [
+          "ietf"
+        ]
+      },
+      {
+        "en": "ISO",
+        "ja": "ISO",
+        "ja_typings": [
+          "iso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03591",
+    "image_path": null,
+    "question_text": {
+      "en": "Which non-profit publishes the Top 10 list of web application security risks?",
+      "ja": "Web アプリのセキュリティリスク Top 10 を公開している非営利団体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Open Source Definition",
+        "ja": "Open Source Definition",
+        "ja_typings": [
+          "open source definition"
+        ]
+      },
+      {
+        "en": "GNU Manifesto",
+        "ja": "GNU Manifesto",
+        "ja_typings": [
+          "gnu manifesto"
+        ]
+      },
+      {
+        "en": "Hacker Manifesto",
+        "ja": "Hacker Manifesto",
+        "ja_typings": [
+          "hacker manifesto"
+        ]
+      },
+      {
+        "en": "Free Software Definition",
+        "ja": "Free Software Definition",
+        "ja_typings": [
+          "free software definition"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03592",
+    "image_path": null,
+    "question_text": {
+      "en": "Which document published by OSI defines the criteria a license must meet to be \"open source\"?",
+      "ja": "OSI が公開する、オープンソースライセンスの定義文書は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PR",
+        "ja": "PR",
+        "ja_typings": [
+          "pr"
+        ]
+      },
+      {
+        "en": "MR",
+        "ja": "MR",
+        "ja_typings": [
+          "mr"
+        ]
+      },
+      {
+        "en": "CR",
+        "ja": "CR",
+        "ja_typings": [
+          "cr"
+        ]
+      },
+      {
+        "en": "IR",
+        "ja": "IR",
+        "ja_typings": [
+          "ir"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03593",
+    "image_path": null,
+    "question_text": {
+      "en": "On GitHub, what is the abbreviation for a request to merge a branch's changes?",
+      "ja": "GitHub でブランチの変更をマージ要求する仕組みの略称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PaaS",
+        "ja": "PaaS",
+        "ja_typings": [
+          "paas"
+        ]
+      },
+      {
+        "en": "IaaS",
+        "ja": "IaaS",
+        "ja_typings": [
+          "iaas"
+        ]
+      },
+      {
+        "en": "SaaS",
+        "ja": "SaaS",
+        "ja_typings": [
+          "saas"
+        ]
+      },
+      {
+        "en": "FaaS",
+        "ja": "FaaS",
+        "ja_typings": [
+          "faas"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03594",
+    "image_path": null,
+    "question_text": {
+      "en": "Which cloud service model provides a managed runtime and platform for deploying apps?",
+      "ja": "アプリ実行用のマネージドなプラットフォームを提供するクラウド形態は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Planning Poker",
+        "ja": "Planning Poker",
+        "ja_typings": [
+          "planning poker"
+        ]
+      },
+      {
+        "en": "Story Mapping",
+        "ja": "Story Mapping",
+        "ja_typings": [
+          "story mapping"
+        ]
+      },
+      {
+        "en": "T-shirt Sizing",
+        "ja": "T-shirt Sizing",
+        "ja_typings": [
+          "t-shirt sizing"
+        ]
+      },
+      {
+        "en": "Delphi Method",
+        "ja": "Delphi Method",
+        "ja_typings": [
+          "delphi method"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03595",
+    "image_path": null,
+    "question_text": {
+      "en": "Which agile estimation technique uses cards with Fibonacci-like numbers?",
+      "ja": "フィボナッチ風の数字カードで規模見積りを行うアジャイル手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "RDS",
+        "ja": "RDS",
+        "ja_typings": [
+          "rds"
+        ]
+      },
+      {
+        "en": "DynamoDB",
+        "ja": "DynamoDB",
+        "ja_typings": [
+          "dynamodb"
+        ]
+      },
+      {
+        "en": "Aurora Serverless",
+        "ja": "Aurora Serverless",
+        "ja_typings": [
+          "aurora serverless"
+        ]
+      },
+      {
+        "en": "ElastiCache",
+        "ja": "ElastiCache",
+        "ja_typings": [
+          "elasticache"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03596",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS service provides a managed relational database?",
+      "ja": "リレーショナルDBをマネージドで提供する AWS サービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rolling Update",
+        "ja": "Rolling Update",
+        "ja_typings": [
+          "rolling update"
+        ]
+      },
+      {
+        "en": "Blue-Green Deployment",
+        "ja": "Blue-Green Deployment",
+        "ja_typings": [
+          "blue-green deployment"
+        ]
+      },
+      {
+        "en": "Canary Release",
+        "ja": "Canary Release",
+        "ja_typings": [
+          "canary release"
+        ]
+      },
+      {
+        "en": "Shadow Deployment",
+        "ja": "Shadow Deployment",
+        "ja_typings": [
+          "shadow deployment"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03597",
+    "image_path": null,
+    "question_text": {
+      "en": "Which deployment gradually replaces instances of the old version with the new one?",
+      "ja": "旧版のインスタンスを順次新版へ置き換えていくデプロイ手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SOC 2",
+        "ja": "SOC 2",
+        "ja_typings": [
+          "soc 2"
+        ]
+      },
+      {
+        "en": "ISO 27001",
+        "ja": "ISO 27001",
+        "ja_typings": [
+          "iso 27001"
+        ]
+      },
+      {
+        "en": "FIPS 140",
+        "ja": "FIPS 140",
+        "ja_typings": [
+          "fips 140"
+        ]
+      },
+      {
+        "en": "PCI DSS",
+        "ja": "PCI DSS",
+        "ja_typings": [
+          "pci dss"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03598",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AICPA audit report focuses on service organizations' security and availability controls?",
+      "ja": "サービス事業者のセキュリティ・可用性統制を評価する AICPA の監査報告書は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Service",
+        "ja": "Service",
+        "ja_typings": [
+          "service"
+        ]
+      },
+      {
+        "en": "Deployment",
+        "ja": "Deployment",
+        "ja_typings": [
+          "deployment"
+        ]
+      },
+      {
+        "en": "Node",
+        "ja": "Node",
+        "ja_typings": [
+          "node"
+        ]
+      },
+      {
+        "en": "Ingress",
+        "ja": "Ingress",
+        "ja_typings": [
+          "ingress"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03599",
+    "image_path": null,
+    "question_text": {
+      "en": "In Kubernetes, which resource provides stable network access to a set of Pods?",
+      "ja": "Kubernetes で Pod 群への安定したネットワークアクセスを提供するリソースは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Service-Oriented Architecture",
+        "ja": "Service-Oriented Architecture",
+        "ja_typings": [
+          "service-oriented architecture"
+        ]
+      },
+      {
+        "en": "Event-Driven Architecture",
+        "ja": "Event-Driven Architecture",
+        "ja_typings": [
+          "event-driven architecture"
+        ]
+      },
+      {
+        "en": "Monolith",
+        "ja": "Monolith",
+        "ja_typings": [
+          "monolith"
+        ]
+      },
+      {
+        "en": "Layered Architecture",
+        "ja": "Layered Architecture",
+        "ja_typings": [
+          "layered architecture"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03600",
+    "image_path": null,
+    "question_text": {
+      "en": "Which architecture organizes functionality as reusable services communicating over a network?",
+      "ja": "機能をネットワーク経由で再利用可能なサービス群として組むアーキテクチャは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shadow Deployment",
+        "ja": "Shadow Deployment",
+        "ja_typings": [
+          "shadow deployment"
+        ]
+      },
+      {
+        "en": "Blue-Green Deployment",
+        "ja": "Blue-Green Deployment",
+        "ja_typings": [
+          "blue-green deployment"
+        ]
+      },
+      {
+        "en": "Rolling Update",
+        "ja": "Rolling Update",
+        "ja_typings": [
+          "rolling update"
+        ]
+      },
+      {
+        "en": "Canary Release",
+        "ja": "Canary Release",
+        "ja_typings": [
+          "canary release"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03601",
+    "image_path": null,
+    "question_text": {
+      "en": "Which deployment sends a copy of live traffic to a new version without affecting users?",
+      "ja": "本番トラフィックを複製して新版に流し、利用者に影響を与えない検証手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Task",
+        "ja": "Task",
+        "ja_typings": [
+          "task"
+        ]
+      },
+      {
+        "en": "Story",
+        "ja": "Story",
+        "ja_typings": [
+          "story"
+        ]
+      },
+      {
+        "en": "Epic",
+        "ja": "Epic",
+        "ja_typings": [
+          "epic"
+        ]
+      },
+      {
+        "en": "Sprint",
+        "ja": "Sprint",
+        "ja_typings": [
+          "sprint"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03602",
+    "image_path": null,
+    "question_text": {
+      "en": "In agile, what is the smallest unit of work assigned to a developer?",
+      "ja": "アジャイルで開発者にアサインされる最小の作業単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Use Case",
+        "ja": "Use Case",
+        "ja_typings": [
+          "use case"
+        ]
+      },
+      {
+        "en": "User Story",
+        "ja": "User Story",
+        "ja_typings": [
+          "user story"
+        ]
+      },
+      {
+        "en": "Epic",
+        "ja": "Epic",
+        "ja_typings": [
+          "epic"
+        ]
+      },
+      {
+        "en": "Scenario Map",
+        "ja": "Scenario Map",
+        "ja_typings": [
+          "scenario map"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03603",
+    "image_path": null,
+    "question_text": {
+      "en": "In requirements engineering, what describes a sequence of interactions between user and system?",
+      "ja": "要件定義で利用者とシステムのやり取りの流れを記述するものは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "VPN",
+        "ja": "VPN",
+        "ja_typings": [
+          "vpn"
+        ]
+      },
+      {
+        "en": "NAT",
+        "ja": "NAT",
+        "ja_typings": [
+          "nat"
+        ]
+      },
+      {
+        "en": "DNS",
+        "ja": "DNS",
+        "ja_typings": [
+          "dns"
+        ]
+      },
+      {
+        "en": "Direct Connect",
+        "ja": "Direct Connect",
+        "ja_typings": [
+          "direct connect"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03604",
+    "image_path": null,
+    "question_text": {
+      "en": "Which technology creates an encrypted tunnel over a public network to access a private one?",
+      "ja": "公衆網上に暗号化トンネルを張りプライベート網へアクセスする技術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Affix",
+        "ja": "接辞",
+        "ja_typings": [
+          "setsuji"
+        ]
+      },
+      {
+        "en": "Stem",
+        "ja": "語幹",
+        "ja_typings": [
+          "gokan"
+        ]
+      },
+      {
+        "en": "Ending",
+        "ja": "語尾",
+        "ja_typings": [
+          "gobi"
+        ]
+      },
+      {
+        "en": "Particle",
+        "ja": "助詞",
+        "ja_typings": [
+          "joshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03605",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the linguistic term for a bound morpheme attached to a word stem (prefix, suffix, infix)?",
+      "ja": "語幹に付加される接頭辞・接尾辞などの拘束形態素を指す言語学用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Afro-Asiatic",
+        "ja": "アフロ・アジア語族",
+        "ja_typings": [
+          "afuro ajia gozoku"
+        ]
+      },
+      {
+        "en": "Indo-European",
+        "ja": "インド・ヨーロッパ語族",
+        "ja_typings": [
+          "indo yo-roppa gozoku"
+        ]
+      },
+      {
+        "en": "Sino-Tibetan",
+        "ja": "シナ・チベット語族",
+        "ja_typings": [
+          "shina chibetto gozoku"
+        ]
+      },
+      {
+        "en": "Niger-Congo",
+        "ja": "ニジェール・コンゴ語族",
+        "ja_typings": [
+          "nijie-ru kongo gozoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03606",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language family includes Arabic, Hebrew, and ancient Egyptian?",
+      "ja": "アラビア語・ヘブライ語・古代エジプト語を含む語族は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Auxiliary verb",
+        "ja": "助動詞",
+        "ja_typings": [
+          "jodoushi"
+        ]
+      },
+      {
+        "en": "Particle",
+        "ja": "助詞",
+        "ja_typings": [
+          "joshi"
+        ]
+      },
+      {
+        "en": "Adverb",
+        "ja": "副詞",
+        "ja_typings": [
+          "fukushi"
+        ]
+      },
+      {
+        "en": "Conjunction",
+        "ja": "接続詞",
+        "ja_typings": [
+          "setsuzokushi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03607",
+    "image_path": null,
+    "question_text": {
+      "en": "Which part of speech in English includes \"can,\" \"will,\" \"must,\" and \"may\"?",
+      "ja": "英語で can / will / must / may を含む品詞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bottom to top",
+        "ja": "下から上",
+        "ja_typings": [
+          "shita kara ue"
+        ]
+      },
+      {
+        "en": "Top to bottom",
+        "ja": "上から下",
+        "ja_typings": [
+          "ue kara shita"
+        ]
+      },
+      {
+        "en": "Left to right",
+        "ja": "左から右",
+        "ja_typings": [
+          "hidari kara migi"
+        ]
+      },
+      {
+        "en": "Right to left",
+        "ja": "右から左",
+        "ja_typings": [
+          "migi kara hidari"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03608",
+    "image_path": null,
+    "question_text": {
+      "en": "In Japanese kanji learning order, which direction is sometimes used in stroke order references?",
+      "ja": "漢字の筆順の説明で、下から上へ書く方向性を指す表現は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Causative voice",
+        "ja": "使役態",
+        "ja_typings": [
+          "shiekitai"
+        ]
+      },
+      {
+        "en": "Passive voice",
+        "ja": "受動態",
+        "ja_typings": [
+          "judoutai"
+        ]
+      },
+      {
+        "en": "Active voice",
+        "ja": "能動態",
+        "ja_typings": [
+          "noudoutai"
+        ]
+      },
+      {
+        "en": "Middle voice",
+        "ja": "中動態",
+        "ja_typings": [
+          "chuudoutai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03609",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice expresses that the subject causes someone or something else to perform an action?",
+      "ja": "主語が他者に動作を行わせることを表す態(ヴォイス)は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chinese characters",
+        "ja": "漢字",
+        "ja_typings": [
+          "kanji"
+        ]
+      },
+      {
+        "en": "Kana",
+        "ja": "仮名",
+        "ja_typings": [
+          "kana"
+        ]
+      },
+      {
+        "en": "Hiragana",
+        "ja": "ひらがな",
+        "ja_typings": [
+          "hiragana"
+        ]
+      },
+      {
+        "en": "Katakana",
+        "ja": "カタカナ",
+        "ja_typings": [
+          "katakana"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03610",
+    "image_path": null,
+    "question_text": {
+      "en": "What are the logographic characters borrowed from China and used in Japanese called in English?",
+      "ja": "日本語で中国由来の表意文字である漢字を英語で何と呼ぶ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Customary reading",
+        "ja": "慣用読み",
+        "ja_typings": [
+          "kanyouyomi"
+        ]
+      },
+      {
+        "en": "On reading",
+        "ja": "音読み",
+        "ja_typings": [
+          "onyomi"
+        ]
+      },
+      {
+        "en": "Kun reading",
+        "ja": "訓読み",
+        "ja_typings": [
+          "kunyomi"
+        ]
+      },
+      {
+        "en": "Nanori reading",
+        "ja": "名乗り読み",
+        "ja_typings": [
+          "nanoriyomi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03611",
+    "image_path": null,
+    "question_text": {
+      "en": "Which kanji reading is based on traditional convention rather than standard on/kun readings?",
+      "ja": "音読み・訓読みの標準的な規則ではなく慣習に基づく漢字の読み方は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cyrillic",
+        "ja": "キリル文字",
+        "ja_typings": [
+          "kiriru moji"
+        ]
+      },
+      {
+        "en": "Latin alphabet",
+        "ja": "ラテン文字",
+        "ja_typings": [
+          "raten moji"
+        ]
+      },
+      {
+        "en": "Greek alphabet",
+        "ja": "ギリシャ文字",
+        "ja_typings": [
+          "girisha moji"
+        ]
+      },
+      {
+        "en": "Arabic script",
+        "ja": "アラビア文字",
+        "ja_typings": [
+          "arabia moji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03612",
+    "image_path": null,
+    "question_text": {
+      "en": "Which alphabet is used for Russian, Bulgarian, and Serbian?",
+      "ja": "ロシア語・ブルガリア語・セルビア語で用いられる文字体系は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Eight",
+        "ja": "8",
+        "ja_typings": [
+          "8",
+          "hachi"
+        ]
+      },
+      {
+        "en": "Six",
+        "ja": "6",
+        "ja_typings": [
+          "6",
+          "roku"
+        ]
+      },
+      {
+        "en": "Two",
+        "ja": "2",
+        "ja_typings": [
+          "2",
+          "ni"
+        ]
+      },
+      {
+        "en": "Ten",
+        "ja": "10",
+        "ja_typings": [
+          "10",
+          "juu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03613",
+    "image_path": null,
+    "question_text": {
+      "en": "Which number is \"eight\" in English?",
+      "ja": "英語で eight が表す数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ellipsis",
+        "ja": "省略法",
+        "ja_typings": [
+          "shouryakuhou"
+        ]
+      },
+      {
+        "en": "Repetition",
+        "ja": "反復法",
+        "ja_typings": [
+          "hanpukuhou"
+        ]
+      },
+      {
+        "en": "Inversion",
+        "ja": "倒置法",
+        "ja_typings": [
+          "touchihou"
+        ]
+      },
+      {
+        "en": "Metaphor",
+        "ja": "隠喩",
+        "ja_typings": [
+          "inyu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03614",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the rhetorical device of omitting words that are understood from context?",
+      "ja": "文脈から自明な語を省略する修辞技法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ending",
+        "ja": "語尾",
+        "ja_typings": [
+          "gobi"
+        ]
+      },
+      {
+        "en": "Stem",
+        "ja": "語幹",
+        "ja_typings": [
+          "gokan"
+        ]
+      },
+      {
+        "en": "Affix",
+        "ja": "接辞",
+        "ja_typings": [
+          "setsuji"
+        ]
+      },
+      {
+        "en": "Particle",
+        "ja": "助詞",
+        "ja_typings": [
+          "joshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03615",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the final part of a Japanese conjugated word called?",
+      "ja": "日本語の活用語の末尾(活用語尾)を指す語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hepburn romanization",
+        "ja": "ヘボン式ローマ字",
+        "ja_typings": [
+          "hebon shiki ro-maji"
+        ]
+      },
+      {
+        "en": "Kunrei-shiki",
+        "ja": "訓令式",
+        "ja_typings": [
+          "kunrei shiki"
+        ]
+      },
+      {
+        "en": "Nihon-shiki",
+        "ja": "日本式",
+        "ja_typings": [
+          "nihon shiki"
+        ]
+      },
+      {
+        "en": "Wapuro romaji",
+        "ja": "ワープロローマ字",
+        "ja_typings": [
+          "wa-puro ro-maji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03616",
+    "image_path": null,
+    "question_text": {
+      "en": "Which romanization system for Japanese was popularized by an American missionary's dictionary?",
+      "ja": "米国人宣教師の辞典で普及した日本語のローマ字表記法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Indo-European",
+        "ja": "インド・ヨーロッパ語族",
+        "ja_typings": [
+          "indo yo-roppa gozoku"
+        ]
+      },
+      {
+        "en": "Afro-Asiatic",
+        "ja": "アフロ・アジア語族",
+        "ja_typings": [
+          "afuro ajia gozoku"
+        ]
+      },
+      {
+        "en": "Sino-Tibetan",
+        "ja": "シナ・チベット語族",
+        "ja_typings": [
+          "shina chibetto gozoku"
+        ]
+      },
+      {
+        "en": "Uralic",
+        "ja": "ウラル語族",
+        "ja_typings": [
+          "uraru gozoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03617",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language family includes English, Hindi, Russian, and Greek?",
+      "ja": "英語・ヒンディー語・ロシア語・ギリシャ語を含む語族は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Inversion",
+        "ja": "倒置法",
+        "ja_typings": [
+          "touchihou"
+        ]
+      },
+      {
+        "en": "Ellipsis",
+        "ja": "省略法",
+        "ja_typings": [
+          "shouryakuhou"
+        ]
+      },
+      {
+        "en": "Repetition",
+        "ja": "反復法",
+        "ja_typings": [
+          "hanpukuhou"
+        ]
+      },
+      {
+        "en": "Personification",
+        "ja": "擬人法",
+        "ja_typings": [
+          "gijinhou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03618",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the rhetorical device of reversing the usual word order for emphasis?",
+      "ja": "強調のために通常の語順を入れ替える修辞技法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Khmer script",
+        "ja": "クメール文字",
+        "ja_typings": [
+          "kume-ru moji"
+        ]
+      },
+      {
+        "en": "Thai script",
+        "ja": "タイ文字",
+        "ja_typings": [
+          "tai moji"
+        ]
+      },
+      {
+        "en": "Lao script",
+        "ja": "ラオ文字",
+        "ja_typings": [
+          "rao moji"
+        ]
+      },
+      {
+        "en": "Burmese script",
+        "ja": "ビルマ文字",
+        "ja_typings": [
+          "biruma moji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03619",
+    "image_path": null,
+    "question_text": {
+      "en": "Which script is used to write the Khmer language of Cambodia?",
+      "ja": "カンボジアのクメール語を書き表す文字は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Latin alphabet",
+        "ja": "ラテン文字",
+        "ja_typings": [
+          "raten moji"
+        ]
+      },
+      {
+        "en": "Cyrillic",
+        "ja": "キリル文字",
+        "ja_typings": [
+          "kiriru moji"
+        ]
+      },
+      {
+        "en": "Greek alphabet",
+        "ja": "ギリシャ文字",
+        "ja_typings": [
+          "girisha moji"
+        ]
+      },
+      {
+        "en": "Arabic script",
+        "ja": "アラビア文字",
+        "ja_typings": [
+          "arabia moji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03620",
+    "image_path": null,
+    "question_text": {
+      "en": "Which alphabet is used for English, French, Spanish, and most European languages?",
+      "ja": "英語・フランス語・スペイン語など多くの欧州言語で使われる文字体系は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Metaphor",
+        "ja": "隠喩",
+        "ja_typings": [
+          "inyu"
+        ]
+      },
+      {
+        "en": "Simile",
+        "ja": "直喩",
+        "ja_typings": [
+          "chokuyu"
+        ]
+      },
+      {
+        "en": "Metonymy",
+        "ja": "換喩",
+        "ja_typings": [
+          "kanyu"
+        ]
+      },
+      {
+        "en": "Personification",
+        "ja": "擬人法",
+        "ja_typings": [
+          "gijinhou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03621",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the rhetorical device of describing one thing as if it were another (e.g., \"Time is money\")?",
+      "ja": "あるものを別のものに見立てて表現する修辞技法(例: 時は金なり)は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Metonymy",
+        "ja": "換喩",
+        "ja_typings": [
+          "kanyu"
+        ]
+      },
+      {
+        "en": "Metaphor",
+        "ja": "隠喩",
+        "ja_typings": [
+          "inyu"
+        ]
+      },
+      {
+        "en": "Synecdoche",
+        "ja": "提喩",
+        "ja_typings": [
+          "teiyu"
+        ]
+      },
+      {
+        "en": "Personification",
+        "ja": "擬人法",
+        "ja_typings": [
+          "gijinhou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03622",
+    "image_path": null,
+    "question_text": {
+      "en": "Which rhetorical device substitutes a related concept for the name of a thing (e.g., \"the crown\" for monarchy)?",
+      "ja": "事物の名を関連概念で置き換える修辞技法(例: 王冠が王権を指す)は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Noun ending",
+        "ja": "体言止め",
+        "ja_typings": [
+          "taigendome"
+        ]
+      },
+      {
+        "en": "Auxiliary verb",
+        "ja": "助動詞",
+        "ja_typings": [
+          "jodoushi"
+        ]
+      },
+      {
+        "en": "Particle",
+        "ja": "助詞",
+        "ja_typings": [
+          "joshi"
+        ]
+      },
+      {
+        "en": "Adverbial",
+        "ja": "連用形",
+        "ja_typings": [
+          "renyoukei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03623",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the final part of a Japanese noun's conjugational form called?",
+      "ja": "日本語で名詞活用の語尾部分を指す用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Particle",
+        "ja": "助詞",
+        "ja_typings": [
+          "joshi"
+        ]
+      },
+      {
+        "en": "Auxiliary verb",
+        "ja": "助動詞",
+        "ja_typings": [
+          "jodoushi"
+        ]
+      },
+      {
+        "en": "Conjunction",
+        "ja": "接続詞",
+        "ja_typings": [
+          "setsuzokushi"
+        ]
+      },
+      {
+        "en": "Adverb",
+        "ja": "副詞",
+        "ja_typings": [
+          "fukushi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03624",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese part of speech marks grammatical relations like subject, object, and topic?",
+      "ja": "主語・目的語・主題などの文法関係を示す日本語の品詞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Passive voice",
+        "ja": "受動態",
+        "ja_typings": [
+          "judoutai"
+        ]
+      },
+      {
+        "en": "Active voice",
+        "ja": "能動態",
+        "ja_typings": [
+          "noudoutai"
+        ]
+      },
+      {
+        "en": "Causative voice",
+        "ja": "使役態",
+        "ja_typings": [
+          "shiekitai"
+        ]
+      },
+      {
+        "en": "Middle voice",
+        "ja": "中動態",
+        "ja_typings": [
+          "chuudoutai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03625",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice expresses that the subject receives the action of the verb?",
+      "ja": "主語が動作の受け手であることを表す態(ヴォイス)は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Personification",
+        "ja": "擬人法",
+        "ja_typings": [
+          "gijinhou"
+        ]
+      },
+      {
+        "en": "Metaphor",
+        "ja": "隠喩",
+        "ja_typings": [
+          "inyu"
+        ]
+      },
+      {
+        "en": "Metonymy",
+        "ja": "換喩",
+        "ja_typings": [
+          "kanyu"
+        ]
+      },
+      {
+        "en": "Synecdoche",
+        "ja": "提喩",
+        "ja_typings": [
+          "teiyu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03626",
+    "image_path": null,
+    "question_text": {
+      "en": "What rhetorical device gives human qualities to non-human things?",
+      "ja": "人ではないものに人間的性質を与える修辞技法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Polite language",
+        "ja": "丁寧語",
+        "ja_typings": [
+          "teineigo"
+        ]
+      },
+      {
+        "en": "Respectful language",
+        "ja": "尊敬語",
+        "ja_typings": [
+          "sonkeigo"
+        ]
+      },
+      {
+        "en": "Humble language",
+        "ja": "謙譲語",
+        "ja_typings": [
+          "kenjougo"
+        ]
+      },
+      {
+        "en": "Honorific language",
+        "ja": "敬語",
+        "ja_typings": [
+          "keigo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03627",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the polite style of Japanese using forms like \"desu\" and \"masu\" called?",
+      "ja": "「です」「ます」を用いる日本語の丁寧な文体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Portuguese",
+        "ja": "ポルトガル語",
+        "ja_typings": [
+          "porutogarugo"
+        ]
+      },
+      {
+        "en": "Spanish",
+        "ja": "スペイン語",
+        "ja_typings": [
+          "supeingo"
+        ]
+      },
+      {
+        "en": "Italian",
+        "ja": "イタリア語",
+        "ja_typings": [
+          "itariago"
+        ]
+      },
+      {
+        "en": "French",
+        "ja": "フランス語",
+        "ja_typings": [
+          "furansugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03628",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Romance language is the official language of Portugal and Brazil?",
+      "ja": "ポルトガルとブラジルの公用語であるロマンス諸語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pragmatics",
+        "ja": "語用論",
+        "ja_typings": [
+          "goyouron"
+        ]
+      },
+      {
+        "en": "Semantics",
+        "ja": "意味論",
+        "ja_typings": [
+          "imiron"
+        ]
+      },
+      {
+        "en": "Syntax",
+        "ja": "統語論",
+        "ja_typings": [
+          "tougoron"
+        ]
+      },
+      {
+        "en": "Phonology",
+        "ja": "音韻論",
+        "ja_typings": [
+          "onninron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03629",
+    "image_path": null,
+    "question_text": {
+      "en": "Which subfield of linguistics studies how context contributes to meaning?",
+      "ja": "文脈が意味に与える影響を研究する言語学の下位分野は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Psycholinguistics",
+        "ja": "心理言語学",
+        "ja_typings": [
+          "shinrigengogaku"
+        ]
+      },
+      {
+        "en": "Sociolinguistics",
+        "ja": "社会言語学",
+        "ja_typings": [
+          "shakaigengogaku"
+        ]
+      },
+      {
+        "en": "Neurolinguistics",
+        "ja": "神経言語学",
+        "ja_typings": [
+          "shinkeigengogaku"
+        ]
+      },
+      {
+        "en": "Pragmatics",
+        "ja": "語用論",
+        "ja_typings": [
+          "goyouron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03630",
+    "image_path": null,
+    "question_text": {
+      "en": "Which interdisciplinary field studies the mental processes involved in language use?",
+      "ja": "言語使用に関わる心的過程を研究する学際分野は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rendaku",
+        "ja": "連濁",
+        "ja_typings": [
+          "rendaku"
+        ]
+      },
+      {
+        "en": "Gemination",
+        "ja": "促音",
+        "ja_typings": [
+          "sokuon"
+        ]
+      },
+      {
+        "en": "Vowel devoicing",
+        "ja": "母音の無声化",
+        "ja_typings": [
+          "boin no museika"
+        ]
+      },
+      {
+        "en": "Sandhi",
+        "ja": "連声",
+        "ja_typings": [
+          "renjou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03631",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Japanese phonological phenomenon where a voiceless consonant becomes voiced in compounds (e.g., hito + hito = hitobito)?",
+      "ja": "複合語で清音が濁音化する日本語の音韻現象(例: ひと+ひと=ひとびと)は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Repetition",
+        "ja": "反復法",
+        "ja_typings": [
+          "hanpukuhou"
+        ]
+      },
+      {
+        "en": "Inversion",
+        "ja": "倒置法",
+        "ja_typings": [
+          "touchihou"
+        ]
+      },
+      {
+        "en": "Ellipsis",
+        "ja": "省略法",
+        "ja_typings": [
+          "shouryakuhou"
+        ]
+      },
+      {
+        "en": "Metaphor",
+        "ja": "隠喩",
+        "ja_typings": [
+          "inyu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03632",
+    "image_path": null,
+    "question_text": {
+      "en": "Which rhetorical device repeats words or phrases for emphasis?",
+      "ja": "強調のために語句を繰り返す修辞技法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Respectful language",
+        "ja": "尊敬語",
+        "ja_typings": [
+          "sonkeigo"
+        ]
+      },
+      {
+        "en": "Humble language",
+        "ja": "謙譲語",
+        "ja_typings": [
+          "kenjougo"
+        ]
+      },
+      {
+        "en": "Polite language",
+        "ja": "丁寧語",
+        "ja_typings": [
+          "teineigo"
+        ]
+      },
+      {
+        "en": "Honorific language",
+        "ja": "敬語",
+        "ja_typings": [
+          "keigo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03633",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Japanese honorific style used to elevate the listener or referent called?",
+      "ja": "聞き手や話題の人物を高める日本語の敬語スタイルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Six",
+        "ja": "6",
+        "ja_typings": [
+          "6",
+          "roku"
+        ]
+      },
+      {
+        "en": "Eight",
+        "ja": "8",
+        "ja_typings": [
+          "8",
+          "hachi"
+        ]
+      },
+      {
+        "en": "Two",
+        "ja": "2",
+        "ja_typings": [
+          "2",
+          "ni"
+        ]
+      },
+      {
+        "en": "Nine",
+        "ja": "9",
+        "ja_typings": [
+          "9",
+          "kyuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03634",
+    "image_path": null,
+    "question_text": {
+      "en": "Which number is \"six\" in English?",
+      "ja": "英語で six が表す数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sociolinguistics",
+        "ja": "社会言語学",
+        "ja_typings": [
+          "shakaigengogaku"
+        ]
+      },
+      {
+        "en": "Psycholinguistics",
+        "ja": "心理言語学",
+        "ja_typings": [
+          "shinrigengogaku"
+        ]
+      },
+      {
+        "en": "Pragmatics",
+        "ja": "語用論",
+        "ja_typings": [
+          "goyouron"
+        ]
+      },
+      {
+        "en": "Semantics",
+        "ja": "意味論",
+        "ja_typings": [
+          "imiron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03635",
+    "image_path": null,
+    "question_text": {
+      "en": "Which subfield of linguistics studies the relationship between language and society?",
+      "ja": "言語と社会の関係を研究する言語学の下位分野は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Spanish",
+        "ja": "スペイン語",
+        "ja_typings": [
+          "supeingo"
+        ]
+      },
+      {
+        "en": "Portuguese",
+        "ja": "ポルトガル語",
+        "ja_typings": [
+          "porutogarugo"
+        ]
+      },
+      {
+        "en": "Italian",
+        "ja": "イタリア語",
+        "ja_typings": [
+          "itariago"
+        ]
+      },
+      {
+        "en": "French",
+        "ja": "フランス語",
+        "ja_typings": [
+          "furansugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03636",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Romance language is the official language of Spain and most of Latin America?",
+      "ja": "スペインおよびラテンアメリカの多くの国の公用語であるロマンス諸語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Stem",
+        "ja": "語幹",
+        "ja_typings": [
+          "gokan"
+        ]
+      },
+      {
+        "en": "Ending",
+        "ja": "語尾",
+        "ja_typings": [
+          "gobi"
+        ]
+      },
+      {
+        "en": "Affix",
+        "ja": "接辞",
+        "ja_typings": [
+          "setsuji"
+        ]
+      },
+      {
+        "en": "Particle",
+        "ja": "助詞",
+        "ja_typings": [
+          "joshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03637",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the unchanging core part of a Japanese conjugated word called?",
+      "ja": "日本語の活用語で変化しない中心部分を指す語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Synecdoche",
+        "ja": "提喩",
+        "ja_typings": [
+          "teiyu"
+        ]
+      },
+      {
+        "en": "Metonymy",
+        "ja": "換喩",
+        "ja_typings": [
+          "kanyu"
+        ]
+      },
+      {
+        "en": "Metaphor",
+        "ja": "隠喩",
+        "ja_typings": [
+          "inyu"
+        ]
+      },
+      {
+        "en": "Personification",
+        "ja": "擬人法",
+        "ja_typings": [
+          "gijinhou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03638",
+    "image_path": null,
+    "question_text": {
+      "en": "Which rhetorical device uses a part to represent the whole, or vice versa (e.g., \"all hands on deck\")?",
+      "ja": "部分で全体を、あるいは全体で部分を表す修辞技法(例: \"all hands\" が船員を指す)は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Syntax",
+        "ja": "統語論",
+        "ja_typings": [
+          "tougoron"
+        ]
+      },
+      {
+        "en": "Semantics",
+        "ja": "意味論",
+        "ja_typings": [
+          "imiron"
+        ]
+      },
+      {
+        "en": "Phonology",
+        "ja": "音韻論",
+        "ja_typings": [
+          "onninron"
+        ]
+      },
+      {
+        "en": "Pragmatics",
+        "ja": "語用論",
+        "ja_typings": [
+          "goyouron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03639",
+    "image_path": null,
+    "question_text": {
+      "en": "Which subfield of linguistics studies the rules governing sentence structure?",
+      "ja": "文の構造を規定する規則を研究する言語学の下位分野は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thai script",
+        "ja": "タイ文字",
+        "ja_typings": [
+          "tai moji"
+        ]
+      },
+      {
+        "en": "Khmer script",
+        "ja": "クメール文字",
+        "ja_typings": [
+          "kume-ru moji"
+        ]
+      },
+      {
+        "en": "Lao script",
+        "ja": "ラオ文字",
+        "ja_typings": [
+          "rao moji"
+        ]
+      },
+      {
+        "en": "Burmese script",
+        "ja": "ビルマ文字",
+        "ja_typings": [
+          "biruma moji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03640",
+    "image_path": null,
+    "question_text": {
+      "en": "Which script is used to write the Thai language?",
+      "ja": "タイ語を書き表す文字は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Two",
+        "ja": "2",
+        "ja_typings": [
+          "2",
+          "ni"
+        ]
+      },
+      {
+        "en": "Six",
+        "ja": "6",
+        "ja_typings": [
+          "6",
+          "roku"
+        ]
+      },
+      {
+        "en": "Eight",
+        "ja": "8",
+        "ja_typings": [
+          "8",
+          "hachi"
+        ]
+      },
+      {
+        "en": "Three",
+        "ja": "3",
+        "ja_typings": [
+          "3",
+          "san"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03641",
+    "image_path": null,
+    "question_text": {
+      "en": "Which number is \"two\" in English?",
+      "ja": "英語で two が表す数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Akira Toriyama",
+        "ja": "鳥山明",
+        "ja_typings": [
+          "toriyama akira"
+        ]
+      },
+      {
+        "en": "Masashi Kishimoto",
+        "ja": "岸本斉史",
+        "ja_typings": [
+          "kishimoto masashi"
+        ]
+      },
+      {
+        "en": "Eiichiro Oda",
+        "ja": "尾田栄一郎",
+        "ja_typings": [
+          "oda eiichirou"
+        ]
+      },
+      {
+        "en": "Tite Kubo",
+        "ja": "久保帯人",
+        "ja_typings": [
+          "kubo taito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03642",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created the manga \"Dragon Ball\"?",
+      "ja": "漫画『ドラゴンボール』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Eiichiro Oda",
+        "ja": "尾田栄一郎",
+        "ja_typings": [
+          "oda eiichirou"
+        ]
+      },
+      {
+        "en": "Akira Toriyama",
+        "ja": "鳥山明",
+        "ja_typings": [
+          "toriyama akira"
+        ]
+      },
+      {
+        "en": "Masashi Kishimoto",
+        "ja": "岸本斉史",
+        "ja_typings": [
+          "kishimoto masashi"
+        ]
+      },
+      {
+        "en": "Tite Kubo",
+        "ja": "久保帯人",
+        "ja_typings": [
+          "kubo taito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03643",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created the manga \"One Piece\"?",
+      "ja": "漫画『ONE PIECE』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fujiko F. Fujio",
+        "ja": "藤子・F・不二雄",
+        "ja_typings": [
+          "fujiko f fujio"
+        ]
+      },
+      {
+        "en": "Fujiko Fujio A",
+        "ja": "藤子不二雄A",
+        "ja_typings": [
+          "fujiko fujio a"
+        ]
+      },
+      {
+        "en": "Osamu Tezuka",
+        "ja": "手塚治虫",
+        "ja_typings": [
+          "tezuka osamu"
+        ]
+      },
+      {
+        "en": "Shotaro Ishinomori",
+        "ja": "石ノ森章太郎",
+        "ja_typings": [
+          "ishinomori shoutarou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03644",
+    "image_path": null,
+    "question_text": {
+      "en": "Which pen name was used by the duo behind \"Doraemon\"?",
+      "ja": "『ドラえもん』を生んだコンビが用いたペンネームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Futabasha",
+        "ja": "双葉社",
+        "ja_typings": [
+          "futabasha"
+        ]
+      },
+      {
+        "en": "Shueisha",
+        "ja": "集英社",
+        "ja_typings": [
+          "shueisha"
+        ]
+      },
+      {
+        "en": "Kodansha",
+        "ja": "講談社",
+        "ja_typings": [
+          "koudansha"
+        ]
+      },
+      {
+        "en": "Hakusensha",
+        "ja": "白泉社",
+        "ja_typings": [
+          "hakusensha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03645",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese publisher issues \"Weekly Manga Action\" and \"Manga Town\"?",
+      "ja": "『漫画アクション』『漫画タウン』を発行する日本の出版社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hakusensha",
+        "ja": "白泉社",
+        "ja_typings": [
+          "hakusensha"
+        ]
+      },
+      {
+        "en": "Shueisha",
+        "ja": "集英社",
+        "ja_typings": [
+          "shueisha"
+        ]
+      },
+      {
+        "en": "Kodansha",
+        "ja": "講談社",
+        "ja_typings": [
+          "koudansha"
+        ]
+      },
+      {
+        "en": "Futabasha",
+        "ja": "双葉社",
+        "ja_typings": [
+          "futabasha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03646",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese publisher issues \"Hana to Yume\" and \"LaLa\"?",
+      "ja": "『花とゆめ』『LaLa』を発行する日本の出版社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kadokawa Shoten",
+        "ja": "角川書店",
+        "ja_typings": [
+          "kadokawa shoten"
+        ]
+      },
+      {
+        "en": "Shueisha",
+        "ja": "集英社",
+        "ja_typings": [
+          "shueisha"
+        ]
+      },
+      {
+        "en": "Kodansha",
+        "ja": "講談社",
+        "ja_typings": [
+          "koudansha"
+        ]
+      },
+      {
+        "en": "Hakusensha",
+        "ja": "白泉社",
+        "ja_typings": [
+          "hakusensha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03647",
+    "image_path": null,
+    "question_text": {
+      "en": "Which publisher issues \"Monthly Shonen Ace\" and is a major light novel publisher?",
+      "ja": "『月刊少年エース』を発行しライトノベルでも大手の出版社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Katsuhiro Otomo",
+        "ja": "大友克洋",
+        "ja_typings": [
+          "ootomo katsuhiro"
+        ]
+      },
+      {
+        "en": "Masamune Shirow",
+        "ja": "士郎正宗",
+        "ja_typings": [
+          "shirou masamune"
+        ]
+      },
+      {
+        "en": "Hirohiko Araki",
+        "ja": "荒木飛呂彦",
+        "ja_typings": [
+          "araki hirohiko"
+        ]
+      },
+      {
+        "en": "Kentaro Miura",
+        "ja": "三浦建太郎",
+        "ja_typings": [
+          "miura kentarou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03648",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created \"Akira\"?",
+      "ja": "漫画『AKIRA』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kentaro Miura",
+        "ja": "三浦建太郎",
+        "ja_typings": [
+          "miura kentarou"
+        ]
+      },
+      {
+        "en": "Hirohiko Araki",
+        "ja": "荒木飛呂彦",
+        "ja_typings": [
+          "araki hirohiko"
+        ]
+      },
+      {
+        "en": "Katsuhiro Otomo",
+        "ja": "大友克洋",
+        "ja_typings": [
+          "ootomo katsuhiro"
+        ]
+      },
+      {
+        "en": "Yoshihiro Togashi",
+        "ja": "冨樫義博",
+        "ja_typings": [
+          "togashi yoshihiro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03649",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created \"Berserk\"?",
+      "ja": "漫画『ベルセルク』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Masamune Shirow",
+        "ja": "士郎正宗",
+        "ja_typings": [
+          "shirou masamune"
+        ]
+      },
+      {
+        "en": "Katsuhiro Otomo",
+        "ja": "大友克洋",
+        "ja_typings": [
+          "ootomo katsuhiro"
+        ]
+      },
+      {
+        "en": "Hirohiko Araki",
+        "ja": "荒木飛呂彦",
+        "ja_typings": [
+          "araki hirohiko"
+        ]
+      },
+      {
+        "en": "Kentaro Miura",
+        "ja": "三浦建太郎",
+        "ja_typings": [
+          "miura kentarou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03650",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created \"Ghost in the Shell\"?",
+      "ja": "『攻殻機動隊』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Masumi Hayami",
+        "ja": "速水真澄",
+        "ja_typings": [
+          "hayami masumi"
+        ]
+      },
+      {
+        "en": "Maya Kitajima",
+        "ja": "北島マヤ",
+        "ja_typings": [
+          "kitajima maya"
+        ]
+      },
+      {
+        "en": "Ayumi Himekawa",
+        "ja": "姫川亜弓",
+        "ja_typings": [
+          "himekawa ayumi"
+        ]
+      },
+      {
+        "en": "Chigusa Tsukikage",
+        "ja": "月影千草",
+        "ja_typings": [
+          "tsukikage chigusa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03651",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the protagonist artist character of \"Glass Mask\" (Garasu no Kamen)?",
+      "ja": "『ガラスの仮面』に登場する天才舞台女優のライバルの名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nikkei",
+        "ja": "日本経済新聞",
+        "ja_typings": [
+          "nihon keizai shinbun"
+        ]
+      },
+      {
+        "en": "The Yomiuri Shimbun",
+        "ja": "読売新聞",
+        "ja_typings": [
+          "yomiuri shinbun"
+        ]
+      },
+      {
+        "en": "The Mainichi Shimbun",
+        "ja": "毎日新聞",
+        "ja_typings": [
+          "mainichi shinbun"
+        ]
+      },
+      {
+        "en": "The Asahi Shimbun",
+        "ja": "朝日新聞",
+        "ja_typings": [
+          "asahi shinbun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03652",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese newspaper company is known for its economic and business news?",
+      "ja": "経済・ビジネスニュースで知られる日本の新聞社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Takeshi Obata",
+        "ja": "小畑健",
+        "ja_typings": [
+          "obata takeshi"
+        ]
+      },
+      {
+        "en": "Tsugumi Ohba",
+        "ja": "大場つぐみ",
+        "ja_typings": [
+          "ooba tsugumi"
+        ]
+      },
+      {
+        "en": "Tite Kubo",
+        "ja": "久保帯人",
+        "ja_typings": [
+          "kubo taito"
+        ]
+      },
+      {
+        "en": "Masashi Kishimoto",
+        "ja": "岸本斉史",
+        "ja_typings": [
+          "kishimoto masashi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03653",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the illustrator of \"Death Note\" and \"Bakuman\"?",
+      "ja": "『DEATH NOTE』『バクマン。』の作画担当は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tatsuki Fujimoto",
+        "ja": "藤本タツキ",
+        "ja_typings": [
+          "fujimoto tatsuki"
+        ]
+      },
+      {
+        "en": "Gege Akutami",
+        "ja": "芥見下々",
+        "ja_typings": [
+          "akutami gege"
+        ]
+      },
+      {
+        "en": "Kohei Horikoshi",
+        "ja": "堀越耕平",
+        "ja_typings": [
+          "horikoshi kouhei"
+        ]
+      },
+      {
+        "en": "Koyoharu Gotouge",
+        "ja": "吾峠呼世晴",
+        "ja_typings": [
+          "gotouge koyoharu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03654",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created \"Chainsaw Man\"?",
+      "ja": "『チェンソーマン』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tetsuo Hara",
+        "ja": "原哲夫",
+        "ja_typings": [
+          "hara tetsuo"
+        ]
+      },
+      {
+        "en": "Buronson",
+        "ja": "武論尊",
+        "ja_typings": [
+          "buronson"
+        ]
+      },
+      {
+        "en": "Yasuhisa Hara",
+        "ja": "原泰久",
+        "ja_typings": [
+          "hara yasuhisa"
+        ]
+      },
+      {
+        "en": "Takeshi Obata",
+        "ja": "小畑健",
+        "ja_typings": [
+          "obata takeshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03655",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created \"Fist of the North Star\" as the artist?",
+      "ja": "『北斗の拳』の作画担当は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Mainichi Shimbun",
+        "ja": "毎日新聞",
+        "ja_typings": [
+          "mainichi shinbun"
+        ]
+      },
+      {
+        "en": "The Yomiuri Shimbun",
+        "ja": "読売新聞",
+        "ja_typings": [
+          "yomiuri shinbun"
+        ]
+      },
+      {
+        "en": "The Asahi Shimbun",
+        "ja": "朝日新聞",
+        "ja_typings": [
+          "asahi shinbun"
+        ]
+      },
+      {
+        "en": "Nikkei",
+        "ja": "日本経済新聞",
+        "ja_typings": [
+          "nihon keizai shinbun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03656",
+    "image_path": null,
+    "question_text": {
+      "en": "Which national daily Japanese newspaper is published by Mainichi Shimbun Holdings?",
+      "ja": "毎日新聞社が発行する日本の全国紙は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Yomiuri Shimbun",
+        "ja": "読売新聞",
+        "ja_typings": [
+          "yomiuri shinbun"
+        ]
+      },
+      {
+        "en": "The Asahi Shimbun",
+        "ja": "朝日新聞",
+        "ja_typings": [
+          "asahi shinbun"
+        ]
+      },
+      {
+        "en": "The Mainichi Shimbun",
+        "ja": "毎日新聞",
+        "ja_typings": [
+          "mainichi shinbun"
+        ]
+      },
+      {
+        "en": "Nikkei",
+        "ja": "日本経済新聞",
+        "ja_typings": [
+          "nihon keizai shinbun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03657",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese daily newspaper has the largest circulation, published by The Yomiuri Shimbun Holdings?",
+      "ja": "発行部数が日本最大級の、読売新聞社が発行する全国紙は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tsugumi Ohba",
+        "ja": "大場つぐみ",
+        "ja_typings": [
+          "ooba tsugumi"
+        ]
+      },
+      {
+        "en": "Takeshi Obata",
+        "ja": "小畑健",
+        "ja_typings": [
+          "obata takeshi"
+        ]
+      },
+      {
+        "en": "Tite Kubo",
+        "ja": "久保帯人",
+        "ja_typings": [
+          "kubo taito"
+        ]
+      },
+      {
+        "en": "Masashi Kishimoto",
+        "ja": "岸本斉史",
+        "ja_typings": [
+          "kishimoto masashi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03658",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the writer of \"Death Note\" and \"Bakuman\"?",
+      "ja": "『DEATH NOTE』『バクマン。』の原作担当は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Weekly Shonen Sunday",
+        "ja": "週刊少年サンデー",
+        "ja_typings": [
+          "shuukan shounen sandee"
+        ]
+      },
+      {
+        "en": "Weekly Shonen Jump",
+        "ja": "週刊少年ジャンプ",
+        "ja_typings": [
+          "shuukan shounen janpu"
+        ]
+      },
+      {
+        "en": "Weekly Shonen Magazine",
+        "ja": "週刊少年マガジン",
+        "ja_typings": [
+          "shuukan shounen magajin"
+        ]
+      },
+      {
+        "en": "Weekly Shonen Champion",
+        "ja": "週刊少年チャンピオン",
+        "ja_typings": [
+          "shuukan shounen chanpion"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03659",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Shogakukan magazine serialized \"InuYasha\" and \"Detective Conan\"?",
+      "ja": "『犬夜叉』『名探偵コナン』を連載する小学館の漫画雑誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yasuhisa Hara",
+        "ja": "原泰久",
+        "ja_typings": [
+          "hara yasuhisa"
+        ]
+      },
+      {
+        "en": "Tetsuo Hara",
+        "ja": "原哲夫",
+        "ja_typings": [
+          "hara tetsuo"
+        ]
+      },
+      {
+        "en": "Hajime Isayama",
+        "ja": "諫山創",
+        "ja_typings": [
+          "isayama hajime"
+        ]
+      },
+      {
+        "en": "Kentaro Miura",
+        "ja": "三浦建太郎",
+        "ja_typings": [
+          "miura kentarou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03660",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created \"Kingdom\"?",
+      "ja": "漫画『キングダム』の作者は?"
     }
   }
 ]

--- a/data/questions_en.json
+++ b/data/questions_en.json
@@ -143110,24 +143110,24 @@
         ]
       },
       {
-        "en": "Flamenco",
-        "ja": "フラメンコ",
+        "en": "Samba",
+        "ja": "サンバ",
         "ja_typings": [
-          "furamenko"
+          "sanba"
         ]
       },
       {
-        "en": "Krav Maga",
-        "ja": "クラヴマガ",
+        "en": "Tango",
+        "ja": "タンゴ",
         "ja_typings": [
-          "kuravumaga"
+          "tango"
         ]
       },
       {
-        "en": "Taekwondo",
-        "ja": "テコンドー",
+        "en": "Salsa",
+        "ja": "サルサ",
         "ja_typings": [
-          "tekondo-"
+          "sarusa"
         ]
       }
     ],
@@ -143164,10 +143164,10 @@
         ]
       },
       {
-        "en": "Eiffel Tower",
-        "ja": "エッフェル塔",
+        "en": "Ganges River",
+        "ja": "ガンジス川",
         "ja_typings": [
-          "efferutou"
+          "ganjisugawa"
         ]
       }
     ],
@@ -143391,24 +143391,24 @@
         ]
       },
       {
-        "en": "Bossa Nova",
-        "ja": "ボサノバ",
+        "en": "Bolero",
+        "ja": "ボレロ",
         "ja_typings": [
-          "bosanoba"
+          "borero"
         ]
       },
       {
-        "en": "Krav Maga",
-        "ja": "クラヴマガ",
+        "en": "Sevillanas",
+        "ja": "セビジャーナス",
         "ja_typings": [
-          "kuravumaga"
+          "sebija-nasu"
         ]
       },
       {
-        "en": "Taekwondo",
-        "ja": "テコンドー",
+        "en": "Jota",
+        "ja": "ホタ",
         "ja_typings": [
-          "tekondo-"
+          "hota"
         ]
       }
     ],
@@ -143803,17 +143803,17 @@
         ]
       },
       {
-        "en": "Flamenco",
-        "ja": "フラメンコ",
+        "en": "Judo",
+        "ja": "柔道",
         "ja_typings": [
-          "furamenko"
+          "juudou"
         ]
       },
       {
-        "en": "Bossa Nova",
-        "ja": "ボサノバ",
+        "en": "Sambo",
+        "ja": "サンボ",
         "ja_typings": [
-          "bosanoba"
+          "sanbo"
         ]
       }
     ],
@@ -144441,24 +144441,24 @@
         ]
       },
       {
-        "en": "Krav Maga",
-        "ja": "クラヴマガ",
+        "en": "Karate",
+        "ja": "空手",
         "ja_typings": [
-          "kuravumaga"
+          "karate"
         ]
       },
       {
-        "en": "Flamenco",
-        "ja": "フラメンコ",
+        "en": "Hapkido",
+        "ja": "ハプキドー",
         "ja_typings": [
-          "furamenko"
+          "hapukido-"
         ]
       },
       {
-        "en": "Bossa Nova",
-        "ja": "ボサノバ",
+        "en": "Wushu",
+        "ja": "武術",
         "ja_typings": [
-          "bosanoba"
+          "bujutsu"
         ]
       }
     ],
@@ -144735,10 +144735,10 @@
         ]
       },
       {
-        "en": "Eiffel Tower",
-        "ja": "エッフェル塔",
+        "en": "Sarasvati River",
+        "ja": "サラスヴァティー川",
         "ja_typings": [
-          "efferutou"
+          "sarasuvati-gawa"
         ]
       }
     ],
@@ -146501,7 +146501,7 @@
         "en": "Niger-Congo",
         "ja": "ニジェール・コンゴ語族",
         "ja_typings": [
-          "nijie-ru kongo gozoku"
+          "nije-ru kongo gozoku"
         ]
       }
     ],
@@ -148358,7 +148358,7 @@
       }
     ],
     "correct_answer_index": 0,
-    "genre": "manga",
+    "genre": "general_knowledge",
     "id": "q03652",
     "image_path": null,
     "question_text": {
@@ -148518,7 +148518,7 @@
       }
     ],
     "correct_answer_index": 0,
-    "genre": "manga",
+    "genre": "general_knowledge",
     "id": "q03656",
     "image_path": null,
     "question_text": {
@@ -148558,7 +148558,7 @@
       }
     ],
     "correct_answer_index": 0,
-    "genre": "manga",
+    "genre": "general_knowledge",
     "id": "q03657",
     "image_path": null,
     "question_text": {

--- a/data/questions_ja.json
+++ b/data/questions_ja.json
@@ -108749,28 +108749,30 @@
         "en": "O(n log n)",
         "ja": "O(n log n)",
         "ja_typings": [
-          "O(nlogn)"
+          "o(nlogn)",
+          "o(n log n)"
         ]
       },
       {
         "en": "O(n)",
         "ja": "O(n)",
         "ja_typings": [
-          "O(n)"
+          "o(n)"
         ]
       },
       {
         "en": "O(n^2)",
         "ja": "O(n^2)",
         "ja_typings": [
-          "O(n^2)"
+          "o(n^2)"
         ]
       },
       {
         "en": "O(log n)",
         "ja": "O(log n)",
         "ja_typings": [
-          "O(logn)"
+          "o(logn)",
+          "o(log n)"
         ]
       }
     ],
@@ -114359,21 +114361,24 @@
         "en": "`==`",
         "ja": "イコール2つ",
         "ja_typings": [
-          "ikooru2tsu"
+          "ikooru2tsu",
+          "iko-ru2tsu"
         ]
       },
       {
         "en": "`===`",
         "ja": "イコール3つ",
         "ja_typings": [
-          "ikooru3tsu"
+          "ikooru3tsu",
+          "iko-ru3tsu"
         ]
       },
       {
         "en": "`=`",
         "ja": "イコール1つ",
         "ja_typings": [
-          "ikooru1tsu"
+          "ikooru1tsu",
+          "iko-ru1tsu"
         ]
       }
     ],
@@ -114632,14 +114637,16 @@
         "en": "`==`",
         "ja": "イコール2つ",
         "ja_typings": [
-          "ikooru2tsu"
+          "ikooru2tsu",
+          "iko-ru2tsu"
         ]
       },
       {
         "en": "`===`",
         "ja": "イコール3つ",
         "ja_typings": [
-          "ikooru3tsu"
+          "ikooru3tsu",
+          "iko-ru3tsu"
         ]
       },
       {
@@ -114654,7 +114661,8 @@
         "en": "`=`",
         "ja": "イコール1つ",
         "ja_typings": [
-          "ikooru1tsu"
+          "ikooru1tsu",
+          "iko-ru1tsu"
         ]
       }
     ],
@@ -114673,21 +114681,24 @@
         "en": "`=`",
         "ja": "イコール1つ",
         "ja_typings": [
-          "ikooru1tsu"
+          "ikooru1tsu",
+          "iko-ru1tsu"
         ]
       },
       {
         "en": "`==`",
         "ja": "イコール2つ",
         "ja_typings": [
-          "ikooru2tsu"
+          "ikooru2tsu",
+          "iko-ru2tsu"
         ]
       },
       {
         "en": "`===`",
         "ja": "イコール3つ",
         "ja_typings": [
-          "ikooru3tsu"
+          "ikooru3tsu",
+          "iko-ru3tsu"
         ]
       },
       {
@@ -132379,7 +132390,8 @@
         "en": "2",
         "ja": "2つ",
         "ja_typings": [
-          "futatsu"
+          "futatsu",
+          "2tsu"
         ]
       },
       {
@@ -132820,7 +132832,8 @@
         "en": "Mark Twain",
         "ja": "マーク・トウェイン",
         "ja_typings": [
-          "maa-ku/touxein"
+          "maa-ku/touxein",
+          "ma-ku/towein"
         ]
       },
       {
@@ -133094,7 +133107,8 @@
         "en": "Venice",
         "ja": "ヴェネツィア",
         "ja_typings": [
-          "venetsuxia"
+          "venetsuxia",
+          "venetsia"
         ]
       }
     ],
@@ -133739,7 +133753,8 @@
         "en": "Beetroot",
         "ja": "ビーツ",
         "ja_typings": [
-          "bii-tsu"
+          "bii-tsu",
+          "bi-tsu"
         ]
       }
     ],
@@ -133781,7 +133796,8 @@
         "en": "Beetroot",
         "ja": "ビーツ",
         "ja_typings": [
-          "bii-tsu"
+          "bii-tsu",
+          "bi-tsu"
         ]
       }
     ],
@@ -135054,6 +135070,13620 @@
     "question_text": {
       "en": "What does an arrow leave behind in flight, often used as an idiom?",
       "ja": "矢が飛んだ後に残るとされる、慣用句にもなるものはどれ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "128 bits",
+        "ja": "128ビット",
+        "ja_typings": [
+          "128bitto"
+        ]
+      },
+      {
+        "en": "64 bits",
+        "ja": "64ビット",
+        "ja_typings": [
+          "64bitto"
+        ]
+      },
+      {
+        "en": "32 bits",
+        "ja": "32ビット",
+        "ja_typings": [
+          "32bitto"
+        ]
+      },
+      {
+        "en": "256 bits",
+        "ja": "256ビット",
+        "ja_typings": [
+          "256bitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03322",
+    "image_path": null,
+    "question_text": {
+      "en": "Which bit width can represent IPv6 addresses?",
+      "ja": "IPv6アドレスを表現できるビット幅は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "2 bits",
+        "ja": "2ビット",
+        "ja_typings": [
+          "2bitto"
+        ]
+      },
+      {
+        "en": "4 bits",
+        "ja": "4ビット",
+        "ja_typings": [
+          "4bitto"
+        ]
+      },
+      {
+        "en": "8 bits",
+        "ja": "8ビット",
+        "ja_typings": [
+          "8bitto"
+        ]
+      },
+      {
+        "en": "16 bits",
+        "ja": "16ビット",
+        "ja_typings": [
+          "16bitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03323",
+    "image_path": null,
+    "question_text": {
+      "en": "Which bit width can represent only two values, 0 and 1?",
+      "ja": "0と1の2値しか表現できないビット幅は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "4 bits",
+        "ja": "4ビット",
+        "ja_typings": [
+          "4bitto"
+        ]
+      },
+      {
+        "en": "8 bits",
+        "ja": "8ビット",
+        "ja_typings": [
+          "8bitto"
+        ]
+      },
+      {
+        "en": "2 bits",
+        "ja": "2ビット",
+        "ja_typings": [
+          "2bitto"
+        ]
+      },
+      {
+        "en": "16 bits",
+        "ja": "16ビット",
+        "ja_typings": [
+          "16bitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03324",
+    "image_path": null,
+    "question_text": {
+      "en": "Which bit width is called a nibble?",
+      "ja": "ニブルと呼ばれるビット幅は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "8 bits",
+        "ja": "8ビット",
+        "ja_typings": [
+          "8bitto"
+        ]
+      },
+      {
+        "en": "4 bits",
+        "ja": "4ビット",
+        "ja_typings": [
+          "4bitto"
+        ]
+      },
+      {
+        "en": "16 bits",
+        "ja": "16ビット",
+        "ja_typings": [
+          "16bitto"
+        ]
+      },
+      {
+        "en": "2 bits",
+        "ja": "2ビット",
+        "ja_typings": [
+          "2bitto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03325",
+    "image_path": null,
+    "question_text": {
+      "en": "Which bit width equals one byte?",
+      "ja": "1バイトに相当するビット幅は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ALTAIR",
+        "ja": "アルテア",
+        "ja_typings": [
+          "arutea"
+        ]
+      },
+      {
+        "en": "ENIAC",
+        "ja": "エニアック",
+        "ja_typings": [
+          "eniakku"
+        ]
+      },
+      {
+        "en": "PDP-8",
+        "ja": "ピーディーピー8",
+        "ja_typings": [
+          "pi-di-pi-8"
+        ]
+      },
+      {
+        "en": "IBM 5100",
+        "ja": "アイビーエム5100",
+        "ja_typings": [
+          "aibi-emu5100"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03326",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the famous early microcomputer kit released in 1975?",
+      "ja": "1975年に発売された有名な初期マイコンキットは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ARM",
+        "ja": "アーム",
+        "ja_typings": [
+          "a-mu"
+        ]
+      },
+      {
+        "en": "x86",
+        "ja": "エックス86",
+        "ja_typings": [
+          "ekkusu86"
+        ]
+      },
+      {
+        "en": "MIPS",
+        "ja": "ミップス",
+        "ja_typings": [
+          "mippusu"
+        ]
+      },
+      {
+        "en": "SPARC",
+        "ja": "スパーク",
+        "ja_typings": [
+          "supa-ku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03327",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CPU architecture is widely used in smartphones?",
+      "ja": "スマートフォンで広く使われているCPUアーキテクチャは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Apple",
+        "ja": "アップル",
+        "ja_typings": [
+          "appuru"
+        ]
+      },
+      {
+        "en": "Samsung",
+        "ja": "サムスン",
+        "ja_typings": [
+          "samusun"
+        ]
+      },
+      {
+        "en": "Google",
+        "ja": "グーグル",
+        "ja_typings": [
+          "gu-guru"
+        ]
+      },
+      {
+        "en": "Sony",
+        "ja": "ソニー",
+        "ja_typings": [
+          "soni-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03328",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company makes the iPhone?",
+      "ja": "iPhoneを製造している企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "BIOS",
+        "ja": "バイオス",
+        "ja_typings": [
+          "baiosu"
+        ]
+      },
+      {
+        "en": "UEFI",
+        "ja": "ユーイーエフアイ",
+        "ja_typings": [
+          "yu-i-efuai"
+        ]
+      },
+      {
+        "en": "GRUB",
+        "ja": "グラブ",
+        "ja_typings": [
+          "gurabu"
+        ]
+      },
+      {
+        "en": "POST",
+        "ja": "ポスト",
+        "ja_typings": [
+          "posuto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03329",
+    "image_path": null,
+    "question_text": {
+      "en": "Which firmware initializes hardware at PC boot?",
+      "ja": "PC起動時にハードウェアを初期化するファームウェアは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bluetooth",
+        "ja": "ブルートゥース",
+        "ja_typings": [
+          "buru-tu-su"
+        ]
+      },
+      {
+        "en": "Wi-Fi",
+        "ja": "ワイファイ",
+        "ja_typings": [
+          "waifai"
+        ]
+      },
+      {
+        "en": "Zigbee",
+        "ja": "ジグビー",
+        "ja_typings": [
+          "jigubi-"
+        ]
+      },
+      {
+        "en": "NFC",
+        "ja": "エヌエフシー",
+        "ja_typings": [
+          "enuefushi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03330",
+    "image_path": null,
+    "question_text": {
+      "en": "Which short-range wireless standard is used for headsets?",
+      "ja": "ヘッドセットなどで使われる近距離無線規格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Buffer",
+        "ja": "バッファ",
+        "ja_typings": [
+          "baffa"
+        ]
+      },
+      {
+        "en": "Cache",
+        "ja": "キャッシュ",
+        "ja_typings": [
+          "kyasshu"
+        ]
+      },
+      {
+        "en": "Queue",
+        "ja": "キュー",
+        "ja_typings": [
+          "kyu-"
+        ]
+      },
+      {
+        "en": "Stack",
+        "ja": "スタック",
+        "ja_typings": [
+          "sutakku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03331",
+    "image_path": null,
+    "question_text": {
+      "en": "Which temporary storage smooths the speed gap between devices?",
+      "ja": "機器間の速度差を吸収する一時記憶領域は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CPU",
+        "ja": "シーピーユー",
+        "ja_typings": [
+          "shi-pi-yu-"
+        ]
+      },
+      {
+        "en": "GPU",
+        "ja": "ジーピーユー",
+        "ja_typings": [
+          "ji-pi-yu-"
+        ]
+      },
+      {
+        "en": "RAM",
+        "ja": "ラム",
+        "ja_typings": [
+          "ramu"
+        ]
+      },
+      {
+        "en": "SSD",
+        "ja": "エスエスディー",
+        "ja_typings": [
+          "esuesudi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03332",
+    "image_path": null,
+    "question_text": {
+      "en": "Which component is the brain of a computer?",
+      "ja": "コンピュータの頭脳に相当する部品は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CRC32",
+        "ja": "シーアールシー32",
+        "ja_typings": [
+          "shi-a-rushi-32"
+        ]
+      },
+      {
+        "en": "MD5",
+        "ja": "エムディー5",
+        "ja_typings": [
+          "emudi-5"
+        ]
+      },
+      {
+        "en": "SHA1",
+        "ja": "シャー1",
+        "ja_typings": [
+          "sha-1"
+        ]
+      },
+      {
+        "en": "Adler32",
+        "ja": "アドラー32",
+        "ja_typings": [
+          "adora-32"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03333",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 32-bit cyclic redundancy check is widely used for error detection?",
+      "ja": "エラー検出に広く使われる32ビットの巡回冗長検査は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cache memory",
+        "ja": "キャッシュメモリ",
+        "ja_typings": [
+          "kyasshumemori"
+        ]
+      },
+      {
+        "en": "Virtual memory",
+        "ja": "仮想メモリ",
+        "ja_typings": [
+          "kasoumemori"
+        ]
+      },
+      {
+        "en": "Swap memory",
+        "ja": "スワップメモリ",
+        "ja_typings": [
+          "suwappumemori"
+        ]
+      },
+      {
+        "en": "Flash memory",
+        "ja": "フラッシュメモリ",
+        "ja_typings": [
+          "furasshumemori"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03334",
+    "image_path": null,
+    "question_text": {
+      "en": "Which high-speed memory sits between the CPU and main memory?",
+      "ja": "CPUと主記憶の間にある高速メモリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cisco",
+        "ja": "シスコ",
+        "ja_typings": [
+          "shisuko"
+        ]
+      },
+      {
+        "en": "Juniper",
+        "ja": "ジュニパー",
+        "ja_typings": [
+          "junipa-"
+        ]
+      },
+      {
+        "en": "Arista",
+        "ja": "アリスタ",
+        "ja_typings": [
+          "arisuta"
+        ]
+      },
+      {
+        "en": "Huawei",
+        "ja": "ファーウェイ",
+        "ja_typings": [
+          "fa-wei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03335",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company is a major networking equipment vendor?",
+      "ja": "大手ネットワーク機器ベンダーは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DDR",
+        "ja": "ディーディーアール",
+        "ja_typings": [
+          "di-di-a-ru"
+        ]
+      },
+      {
+        "en": "SDR",
+        "ja": "エスディーアール",
+        "ja_typings": [
+          "esudi-a-ru"
+        ]
+      },
+      {
+        "en": "RDRAM",
+        "ja": "アールディーラム",
+        "ja_typings": [
+          "a-rudi-ramu"
+        ]
+      },
+      {
+        "en": "EDO",
+        "ja": "イーディーオー",
+        "ja_typings": [
+          "i-di-o-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03336",
+    "image_path": null,
+    "question_text": {
+      "en": "Which memory standard is commonly used in modern PCs?",
+      "ja": "現代のPCで広く使われるメモリ規格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DHCP",
+        "ja": "ディーエイチシーピー",
+        "ja_typings": [
+          "di-eichishi-pi-"
+        ]
+      },
+      {
+        "en": "DNS",
+        "ja": "ディーエヌエス",
+        "ja_typings": [
+          "di-enuesu"
+        ]
+      },
+      {
+        "en": "ARP",
+        "ja": "エーアールピー",
+        "ja_typings": [
+          "e-a-rupi-"
+        ]
+      },
+      {
+        "en": "NAT",
+        "ja": "エヌエーティー",
+        "ja_typings": [
+          "enue-ti-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03337",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol automatically assigns IP addresses to hosts?",
+      "ja": "ホストにIPアドレスを自動配布するプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DNS",
+        "ja": "ディーエヌエス",
+        "ja_typings": [
+          "di-enuesu"
+        ]
+      },
+      {
+        "en": "DHCP",
+        "ja": "ディーエイチシーピー",
+        "ja_typings": [
+          "di-eichishi-pi-"
+        ]
+      },
+      {
+        "en": "NAT",
+        "ja": "エヌエーティー",
+        "ja_typings": [
+          "enue-ti-"
+        ]
+      },
+      {
+        "en": "ARP",
+        "ja": "エーアールピー",
+        "ja_typings": [
+          "e-a-rupi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03338",
+    "image_path": null,
+    "question_text": {
+      "en": "Which system resolves domain names to IP addresses?",
+      "ja": "ドメイン名をIPアドレスに解決する仕組みは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "EEPROM",
+        "ja": "イーイーピーロム",
+        "ja_typings": [
+          "i-i-pi-romu"
+        ]
+      },
+      {
+        "en": "DRAM",
+        "ja": "ディーラム",
+        "ja_typings": [
+          "di-ramu"
+        ]
+      },
+      {
+        "en": "SRAM",
+        "ja": "エスラム",
+        "ja_typings": [
+          "esuramu"
+        ]
+      },
+      {
+        "en": "ROM",
+        "ja": "ロム",
+        "ja_typings": [
+          "romu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03339",
+    "image_path": null,
+    "question_text": {
+      "en": "Which non-volatile memory can be electrically erased and rewritten?",
+      "ja": "電気的に消去・書き換え可能な不揮発性メモリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FAT32",
+        "ja": "ファット32",
+        "ja_typings": [
+          "fatto32"
+        ]
+      },
+      {
+        "en": "NTFS",
+        "ja": "エヌティーエフエス",
+        "ja_typings": [
+          "enuti-efuesu"
+        ]
+      },
+      {
+        "en": "ext4",
+        "ja": "イーエックスティー4",
+        "ja_typings": [
+          "i-ekkusuti-4"
+        ]
+      },
+      {
+        "en": "HFS",
+        "ja": "エイチエフエス",
+        "ja_typings": [
+          "eichiefuesu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03340",
+    "image_path": null,
+    "question_text": {
+      "en": "Which file system was widely used in older Windows versions?",
+      "ja": "古いWindowsで広く使われたファイルシステムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Flash",
+        "ja": "フラッシュ",
+        "ja_typings": [
+          "furasshu"
+        ]
+      },
+      {
+        "en": "DRAM",
+        "ja": "ディーラム",
+        "ja_typings": [
+          "di-ramu"
+        ]
+      },
+      {
+        "en": "SRAM",
+        "ja": "エスラム",
+        "ja_typings": [
+          "esuramu"
+        ]
+      },
+      {
+        "en": "EEPROM",
+        "ja": "イーイーピーロム",
+        "ja_typings": [
+          "i-i-pi-romu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03341",
+    "image_path": null,
+    "question_text": {
+      "en": "Which type of non-volatile memory is used in USB drives?",
+      "ja": "USBメモリに使われる不揮発性メモリの種類は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FreeBSD",
+        "ja": "フリービーエスディー",
+        "ja_typings": [
+          "furi-bi-esudi-"
+        ]
+      },
+      {
+        "en": "Linux",
+        "ja": "リナックス",
+        "ja_typings": [
+          "rinakkusu"
+        ]
+      },
+      {
+        "en": "Minix",
+        "ja": "ミニックス",
+        "ja_typings": [
+          "minikkusu"
+        ]
+      },
+      {
+        "en": "Solaris",
+        "ja": "ソラリス",
+        "ja_typings": [
+          "sorarisu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03342",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Unix-like OS evolved from the Berkeley Software Distribution?",
+      "ja": "BSDから派生したUnix系OSは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "GPU",
+        "ja": "ジーピーユー",
+        "ja_typings": [
+          "ji-pi-yu-"
+        ]
+      },
+      {
+        "en": "CPU",
+        "ja": "シーピーユー",
+        "ja_typings": [
+          "shi-pi-yu-"
+        ]
+      },
+      {
+        "en": "DSP",
+        "ja": "ディーエスピー",
+        "ja_typings": [
+          "di-esupi-"
+        ]
+      },
+      {
+        "en": "FPGA",
+        "ja": "エフピージーエー",
+        "ja_typings": [
+          "efupi-ji-e-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03343",
+    "image_path": null,
+    "question_text": {
+      "en": "Which processor specializes in parallel graphics computation?",
+      "ja": "並列グラフィクス演算に特化したプロセッサは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Google",
+        "ja": "グーグル",
+        "ja_typings": [
+          "gu-guru"
+        ]
+      },
+      {
+        "en": "Apple",
+        "ja": "アップル",
+        "ja_typings": [
+          "appuru"
+        ]
+      },
+      {
+        "en": "Microsoft",
+        "ja": "マイクロソフト",
+        "ja_typings": [
+          "maikurosofuto"
+        ]
+      },
+      {
+        "en": "Samsung",
+        "ja": "サムスン",
+        "ja_typings": [
+          "samusun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03344",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed the Android operating system?",
+      "ja": "Android OSを開発した企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HDD",
+        "ja": "エイチディーディー",
+        "ja_typings": [
+          "eichidi-di-"
+        ]
+      },
+      {
+        "en": "SSD",
+        "ja": "エスエスディー",
+        "ja_typings": [
+          "esuesudi-"
+        ]
+      },
+      {
+        "en": "USB",
+        "ja": "ユーエスビー",
+        "ja_typings": [
+          "yu-esubi-"
+        ]
+      },
+      {
+        "en": "NAS",
+        "ja": "エヌエーエス",
+        "ja_typings": [
+          "enue-esu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03345",
+    "image_path": null,
+    "question_text": {
+      "en": "Which magnetic storage device uses spinning platters?",
+      "ja": "回転するプラッタを使う磁気記憶装置は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HDMI",
+        "ja": "エイチディーエムアイ",
+        "ja_typings": [
+          "eichidi-emuai"
+        ]
+      },
+      {
+        "en": "VGA",
+        "ja": "ブイジーエー",
+        "ja_typings": [
+          "buiji-e-"
+        ]
+      },
+      {
+        "en": "DVI",
+        "ja": "ディーブイアイ",
+        "ja_typings": [
+          "di-buiai"
+        ]
+      },
+      {
+        "en": "DisplayPort",
+        "ja": "ディスプレイポート",
+        "ja_typings": [
+          "disupureipo-to"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03346",
+    "image_path": null,
+    "question_text": {
+      "en": "Which digital audio-video interface is common on TVs?",
+      "ja": "テレビで広く使われるデジタル映像音声端子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HFS",
+        "ja": "エイチエフエス",
+        "ja_typings": [
+          "eichiefuesu"
+        ]
+      },
+      {
+        "en": "NTFS",
+        "ja": "エヌティーエフエス",
+        "ja_typings": [
+          "enuti-efuesu"
+        ]
+      },
+      {
+        "en": "FAT32",
+        "ja": "ファット32",
+        "ja_typings": [
+          "fatto32"
+        ]
+      },
+      {
+        "en": "ext4",
+        "ja": "イーエックスティー4",
+        "ja_typings": [
+          "i-ekkusuti-4"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03347",
+    "image_path": null,
+    "question_text": {
+      "en": "Which file system was developed by Apple?",
+      "ja": "Appleが開発したファイルシステムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "HTTP",
+        "ja": "エイチティーティーピー",
+        "ja_typings": [
+          "eichiti-ti-pi-"
+        ]
+      },
+      {
+        "en": "FTP",
+        "ja": "エフティーピー",
+        "ja_typings": [
+          "efuti-pi-"
+        ]
+      },
+      {
+        "en": "SMTP",
+        "ja": "エスエムティーピー",
+        "ja_typings": [
+          "esuemuti-pi-"
+        ]
+      },
+      {
+        "en": "SSH",
+        "ja": "エスエスエイチ",
+        "ja_typings": [
+          "esuesueichi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03348",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol is the foundation of the World Wide Web?",
+      "ja": "World Wide Webの基礎となるプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hash function",
+        "ja": "ハッシュ関数",
+        "ja_typings": [
+          "hasshukansuu"
+        ]
+      },
+      {
+        "en": "Sort function",
+        "ja": "ソート関数",
+        "ja_typings": [
+          "so-tokansuu"
+        ]
+      },
+      {
+        "en": "Search function",
+        "ja": "検索関数",
+        "ja_typings": [
+          "kennsakukansuu"
+        ]
+      },
+      {
+        "en": "Filter function",
+        "ja": "フィルタ関数",
+        "ja_typings": [
+          "firutakansuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03349",
+    "image_path": null,
+    "question_text": {
+      "en": "Which function maps arbitrary data to a fixed-size value?",
+      "ja": "任意のデータを固定長の値に変換する関数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "IBM",
+        "ja": "アイビーエム",
+        "ja_typings": [
+          "aibi-emu"
+        ]
+      },
+      {
+        "en": "DEC",
+        "ja": "ディーイーシー",
+        "ja_typings": [
+          "di-i-shi-"
+        ]
+      },
+      {
+        "en": "HP",
+        "ja": "エイチピー",
+        "ja_typings": [
+          "eichipi-"
+        ]
+      },
+      {
+        "en": "Cray",
+        "ja": "クレイ",
+        "ja_typings": [
+          "kurei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03350",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company built the System/360 mainframe family?",
+      "ja": "System/360メインフレームを生み出した企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "IDE",
+        "ja": "アイディーイー",
+        "ja_typings": [
+          "aidi-i-"
+        ]
+      },
+      {
+        "en": "SCSI",
+        "ja": "スカジー",
+        "ja_typings": [
+          "sukaji-"
+        ]
+      },
+      {
+        "en": "SATA",
+        "ja": "サタ",
+        "ja_typings": [
+          "sata"
+        ]
+      },
+      {
+        "en": "NVMe",
+        "ja": "エヌブイエムイー",
+        "ja_typings": [
+          "enubuiemui-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03351",
+    "image_path": null,
+    "question_text": {
+      "en": "Which parallel interface was once common for connecting hard drives?",
+      "ja": "かつてHDD接続に広く使われたパラレル規格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kernel",
+        "ja": "カーネル",
+        "ja_typings": [
+          "ka-neru"
+        ]
+      },
+      {
+        "en": "Shell",
+        "ja": "シェル",
+        "ja_typings": [
+          "sheru"
+        ]
+      },
+      {
+        "en": "Driver",
+        "ja": "ドライバ",
+        "ja_typings": [
+          "doraiba"
+        ]
+      },
+      {
+        "en": "Library",
+        "ja": "ライブラリ",
+        "ja_typings": [
+          "raiburari"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03352",
+    "image_path": null,
+    "question_text": {
+      "en": "Which core part of an operating system manages resources?",
+      "ja": "OSの中核としてリソースを管理する部分は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "LTE",
+        "ja": "エルティーイー",
+        "ja_typings": [
+          "eruti-i-"
+        ]
+      },
+      {
+        "en": "HSPA",
+        "ja": "エイチエスピーエー",
+        "ja_typings": [
+          "eichiesupi-e-"
+        ]
+      },
+      {
+        "en": "GSM",
+        "ja": "ジーエスエム",
+        "ja_typings": [
+          "ji-esuemu"
+        ]
+      },
+      {
+        "en": "CDMA",
+        "ja": "シーディーエムエー",
+        "ja_typings": [
+          "shi-di-emue-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03353",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 4G mobile communication standard succeeded 3G?",
+      "ja": "3Gの次世代となった4G移動通信規格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "LVM",
+        "ja": "エルブイエム",
+        "ja_typings": [
+          "erubuiemu"
+        ]
+      },
+      {
+        "en": "RAID",
+        "ja": "レイド",
+        "ja_typings": [
+          "reido"
+        ]
+      },
+      {
+        "en": "ZFS",
+        "ja": "ゼットエフエス",
+        "ja_typings": [
+          "zettoefuesu"
+        ]
+      },
+      {
+        "en": "Btrfs",
+        "ja": "ビーティーアールエフエス",
+        "ja_typings": [
+          "bi-ti-a-ruefuesu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03354",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Linux disk management abstraction allows flexible volumes?",
+      "ja": "柔軟なボリューム管理を行うLinuxの仕組みは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Load balancer",
+        "ja": "ロードバランサ",
+        "ja_typings": [
+          "ro-dobaransa"
+        ]
+      },
+      {
+        "en": "Router",
+        "ja": "ルータ",
+        "ja_typings": [
+          "ru-ta"
+        ]
+      },
+      {
+        "en": "Switch",
+        "ja": "スイッチ",
+        "ja_typings": [
+          "suitchi"
+        ]
+      },
+      {
+        "en": "Firewall",
+        "ja": "ファイアウォール",
+        "ja_typings": [
+          "faiawo-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03355",
+    "image_path": null,
+    "question_text": {
+      "en": "Which device distributes traffic across multiple servers?",
+      "ja": "複数サーバへ通信を分散する装置は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MARK I",
+        "ja": "マーク1",
+        "ja_typings": [
+          "ma-ku1"
+        ]
+      },
+      {
+        "en": "ENIAC",
+        "ja": "エニアック",
+        "ja_typings": [
+          "eniakku"
+        ]
+      },
+      {
+        "en": "UNIVAC",
+        "ja": "ユニバック",
+        "ja_typings": [
+          "yunibakku"
+        ]
+      },
+      {
+        "en": "EDVAC",
+        "ja": "エドバック",
+        "ja_typings": [
+          "edobakku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03356",
+    "image_path": null,
+    "question_text": {
+      "en": "Which early Harvard relay-based computer was completed in 1944?",
+      "ja": "1944年に完成したハーバードのリレー式初期コンピュータは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Main memory",
+        "ja": "主記憶",
+        "ja_typings": [
+          "shukioku"
+        ]
+      },
+      {
+        "en": "Cache memory",
+        "ja": "キャッシュメモリ",
+        "ja_typings": [
+          "kyasshumemori"
+        ]
+      },
+      {
+        "en": "Virtual memory",
+        "ja": "仮想メモリ",
+        "ja_typings": [
+          "kasoumemori"
+        ]
+      },
+      {
+        "en": "Flash memory",
+        "ja": "フラッシュメモリ",
+        "ja_typings": [
+          "furasshumemori"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03357",
+    "image_path": null,
+    "question_text": {
+      "en": "Which memory directly accessed by the CPU during execution?",
+      "ja": "CPUが実行中に直接アクセスする記憶領域は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Meta",
+        "ja": "メタ",
+        "ja_typings": [
+          "meta"
+        ]
+      },
+      {
+        "en": "Google",
+        "ja": "グーグル",
+        "ja_typings": [
+          "gu-guru"
+        ]
+      },
+      {
+        "en": "Apple",
+        "ja": "アップル",
+        "ja_typings": [
+          "appuru"
+        ]
+      },
+      {
+        "en": "Amazon",
+        "ja": "アマゾン",
+        "ja_typings": [
+          "amazon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03358",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company owns Facebook and Instagram?",
+      "ja": "FacebookとInstagramを保有する企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Microsoft",
+        "ja": "マイクロソフト",
+        "ja_typings": [
+          "maikurosofuto"
+        ]
+      },
+      {
+        "en": "Apple",
+        "ja": "アップル",
+        "ja_typings": [
+          "appuru"
+        ]
+      },
+      {
+        "en": "IBM",
+        "ja": "アイビーエム",
+        "ja_typings": [
+          "aibi-emu"
+        ]
+      },
+      {
+        "en": "Google",
+        "ja": "グーグル",
+        "ja_typings": [
+          "gu-guru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03359",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company developed the Windows operating system?",
+      "ja": "Windows OSを開発した企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NAS",
+        "ja": "エヌエーエス",
+        "ja_typings": [
+          "enue-esu"
+        ]
+      },
+      {
+        "en": "SAN",
+        "ja": "エスエーエヌ",
+        "ja_typings": [
+          "esue-enu"
+        ]
+      },
+      {
+        "en": "HDD",
+        "ja": "エイチディーディー",
+        "ja_typings": [
+          "eichidi-di-"
+        ]
+      },
+      {
+        "en": "SSD",
+        "ja": "エスエスディー",
+        "ja_typings": [
+          "esuesudi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03360",
+    "image_path": null,
+    "question_text": {
+      "en": "Which storage device is dedicated to file sharing over a network?",
+      "ja": "ネットワーク経由でファイル共有する専用ストレージは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NAT",
+        "ja": "エヌエーティー",
+        "ja_typings": [
+          "enue-ti-"
+        ]
+      },
+      {
+        "en": "DNS",
+        "ja": "ディーエヌエス",
+        "ja_typings": [
+          "di-enuesu"
+        ]
+      },
+      {
+        "en": "DHCP",
+        "ja": "ディーエイチシーピー",
+        "ja_typings": [
+          "di-eichishi-pi-"
+        ]
+      },
+      {
+        "en": "ARP",
+        "ja": "エーアールピー",
+        "ja_typings": [
+          "e-a-rupi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03361",
+    "image_path": null,
+    "question_text": {
+      "en": "Which technology translates private and public IP addresses?",
+      "ja": "プライベートとグローバルIPを変換する技術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NFC",
+        "ja": "エヌエフシー",
+        "ja_typings": [
+          "enuefushi-"
+        ]
+      },
+      {
+        "en": "Bluetooth",
+        "ja": "ブルートゥース",
+        "ja_typings": [
+          "buru-tu-su"
+        ]
+      },
+      {
+        "en": "Zigbee",
+        "ja": "ジグビー",
+        "ja_typings": [
+          "jigubi-"
+        ]
+      },
+      {
+        "en": "Wi-Fi",
+        "ja": "ワイファイ",
+        "ja_typings": [
+          "waifai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03362",
+    "image_path": null,
+    "question_text": {
+      "en": "Which very short range wireless tech is used for contactless payment?",
+      "ja": "非接触決済で使われるごく短距離無線技術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NTFS",
+        "ja": "エヌティーエフエス",
+        "ja_typings": [
+          "enuti-efuesu"
+        ]
+      },
+      {
+        "en": "FAT32",
+        "ja": "ファット32",
+        "ja_typings": [
+          "fatto32"
+        ]
+      },
+      {
+        "en": "HFS",
+        "ja": "エイチエフエス",
+        "ja_typings": [
+          "eichiefuesu"
+        ]
+      },
+      {
+        "en": "ext4",
+        "ja": "イーエックスティー4",
+        "ja_typings": [
+          "i-ekkusuti-4"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03363",
+    "image_path": null,
+    "question_text": {
+      "en": "Which file system is the default for modern Windows?",
+      "ja": "現代のWindowsで標準のファイルシステムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Oracle",
+        "ja": "オラクル",
+        "ja_typings": [
+          "orakuru"
+        ]
+      },
+      {
+        "en": "Microsoft",
+        "ja": "マイクロソフト",
+        "ja_typings": [
+          "maikurosofuto"
+        ]
+      },
+      {
+        "en": "IBM",
+        "ja": "アイビーエム",
+        "ja_typings": [
+          "aibi-emu"
+        ]
+      },
+      {
+        "en": "SAP",
+        "ja": "エスエーピー",
+        "ja_typings": [
+          "esue-pi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03364",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company is famous for enterprise database products?",
+      "ja": "企業向けデータベースで知られる企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PCIe",
+        "ja": "ピーシーアイイー",
+        "ja_typings": [
+          "pi-shi-aii-"
+        ]
+      },
+      {
+        "en": "PCI",
+        "ja": "ピーシーアイ",
+        "ja_typings": [
+          "pi-shi-ai"
+        ]
+      },
+      {
+        "en": "ISA",
+        "ja": "アイエスエー",
+        "ja_typings": [
+          "aiesue-"
+        ]
+      },
+      {
+        "en": "AGP",
+        "ja": "エージーピー",
+        "ja_typings": [
+          "e-ji-pi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03365",
+    "image_path": null,
+    "question_text": {
+      "en": "Which high-speed serial expansion bus is used inside modern PCs?",
+      "ja": "現代PC内部の高速シリアル拡張バスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PS/2",
+        "ja": "ピーエス2",
+        "ja_typings": [
+          "pi-esu2"
+        ]
+      },
+      {
+        "en": "USB",
+        "ja": "ユーエスビー",
+        "ja_typings": [
+          "yu-esubi-"
+        ]
+      },
+      {
+        "en": "RS-232C",
+        "ja": "アールエス232シー",
+        "ja_typings": [
+          "a-ruesu232shi-"
+        ]
+      },
+      {
+        "en": "DIN",
+        "ja": "ディン",
+        "ja_typings": [
+          "din"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03366",
+    "image_path": null,
+    "question_text": {
+      "en": "Which old round connector was used for keyboards and mice?",
+      "ja": "キーボードやマウスに使われた古い丸型コネクタは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Process",
+        "ja": "プロセス",
+        "ja_typings": [
+          "purosesu"
+        ]
+      },
+      {
+        "en": "Thread",
+        "ja": "スレッド",
+        "ja_typings": [
+          "sureddo"
+        ]
+      },
+      {
+        "en": "Kernel",
+        "ja": "カーネル",
+        "ja_typings": [
+          "ka-neru"
+        ]
+      },
+      {
+        "en": "Daemon",
+        "ja": "デーモン",
+        "ja_typings": [
+          "de-mon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03367",
+    "image_path": null,
+    "question_text": {
+      "en": "Which OS abstraction represents a running program?",
+      "ja": "実行中のプログラムを表すOSの抽象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Proxy",
+        "ja": "プロキシ",
+        "ja_typings": [
+          "purokishi"
+        ]
+      },
+      {
+        "en": "Gateway",
+        "ja": "ゲートウェイ",
+        "ja_typings": [
+          "ge-towei"
+        ]
+      },
+      {
+        "en": "Router",
+        "ja": "ルータ",
+        "ja_typings": [
+          "ru-ta"
+        ]
+      },
+      {
+        "en": "Firewall",
+        "ja": "ファイアウォール",
+        "ja_typings": [
+          "faiawo-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03368",
+    "image_path": null,
+    "question_text": {
+      "en": "Which server relays client requests to other servers?",
+      "ja": "クライアントの要求を他サーバへ中継するサーバは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Qualcomm",
+        "ja": "クアルコム",
+        "ja_typings": [
+          "kuarukomu"
+        ]
+      },
+      {
+        "en": "MediaTek",
+        "ja": "メディアテック",
+        "ja_typings": [
+          "mediatekku"
+        ]
+      },
+      {
+        "en": "Broadcom",
+        "ja": "ブロードコム",
+        "ja_typings": [
+          "buro-dokomu"
+        ]
+      },
+      {
+        "en": "Marvell",
+        "ja": "マーベル",
+        "ja_typings": [
+          "ma-beru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03369",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company is known for the Snapdragon mobile SoC?",
+      "ja": "Snapdragonモバイル向けSoCで知られる企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "RAM",
+        "ja": "ラム",
+        "ja_typings": [
+          "ramu"
+        ]
+      },
+      {
+        "en": "ROM",
+        "ja": "ロム",
+        "ja_typings": [
+          "romu"
+        ]
+      },
+      {
+        "en": "HDD",
+        "ja": "エイチディーディー",
+        "ja_typings": [
+          "eichidi-di-"
+        ]
+      },
+      {
+        "en": "SSD",
+        "ja": "エスエスディー",
+        "ja_typings": [
+          "esuesudi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03370",
+    "image_path": null,
+    "question_text": {
+      "en": "Which volatile memory holds data while a computer is running?",
+      "ja": "稼働中のPCでデータを保持する揮発性メモリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "RJ-45",
+        "ja": "アールジェイ45",
+        "ja_typings": [
+          "a-rujei45"
+        ]
+      },
+      {
+        "en": "RJ-11",
+        "ja": "アールジェイ11",
+        "ja_typings": [
+          "a-rujei11"
+        ]
+      },
+      {
+        "en": "BNC",
+        "ja": "ビーエヌシー",
+        "ja_typings": [
+          "bi-enushi-"
+        ]
+      },
+      {
+        "en": "SC",
+        "ja": "エスシー",
+        "ja_typings": [
+          "esushi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03371",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 8-pin modular connector is standard for Ethernet?",
+      "ja": "イーサネットで標準的な8ピンモジュラ端子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ROT13",
+        "ja": "ロット13",
+        "ja_typings": [
+          "rotto13"
+        ]
+      },
+      {
+        "en": "ROT47",
+        "ja": "ロット47",
+        "ja_typings": [
+          "rotto47"
+        ]
+      },
+      {
+        "en": "Caesar",
+        "ja": "シーザー",
+        "ja_typings": [
+          "shi-za-"
+        ]
+      },
+      {
+        "en": "Vigenere",
+        "ja": "ビジュネル",
+        "ja_typings": [
+          "bijuneru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03372",
+    "image_path": null,
+    "question_text": {
+      "en": "Which simple cipher shifts letters by 13 positions?",
+      "ja": "アルファベットを13文字ずらす単純な暗号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "RS-232C",
+        "ja": "アールエス232シー",
+        "ja_typings": [
+          "a-ruesu232shi-"
+        ]
+      },
+      {
+        "en": "USB",
+        "ja": "ユーエスビー",
+        "ja_typings": [
+          "yu-esubi-"
+        ]
+      },
+      {
+        "en": "PS/2",
+        "ja": "ピーエス2",
+        "ja_typings": [
+          "pi-esu2"
+        ]
+      },
+      {
+        "en": "IrDA",
+        "ja": "アイアールディーエー",
+        "ja_typings": [
+          "aia-rudi-e-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03373",
+    "image_path": null,
+    "question_text": {
+      "en": "Which serial interface standard was once common on PCs?",
+      "ja": "かつてPCで一般的だったシリアル通信規格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "RSA",
+        "ja": "アールエスエー",
+        "ja_typings": [
+          "a-ruesue-"
+        ]
+      },
+      {
+        "en": "DSA",
+        "ja": "ディーエスエー",
+        "ja_typings": [
+          "di-esue-"
+        ]
+      },
+      {
+        "en": "ECC",
+        "ja": "イーシーシー",
+        "ja_typings": [
+          "i-shi-shi-"
+        ]
+      },
+      {
+        "en": "AES",
+        "ja": "エーイーエス",
+        "ja_typings": [
+          "e-i-esu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03374",
+    "image_path": null,
+    "question_text": {
+      "en": "Which public-key cryptosystem is named after its three inventors?",
+      "ja": "発明者3人の頭文字を取った公開鍵暗号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Register",
+        "ja": "レジスタ",
+        "ja_typings": [
+          "rejisuta"
+        ]
+      },
+      {
+        "en": "Cache",
+        "ja": "キャッシュ",
+        "ja_typings": [
+          "kyasshu"
+        ]
+      },
+      {
+        "en": "RAM",
+        "ja": "ラム",
+        "ja_typings": [
+          "ramu"
+        ]
+      },
+      {
+        "en": "Stack",
+        "ja": "スタック",
+        "ja_typings": [
+          "sutakku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03375",
+    "image_path": null,
+    "question_text": {
+      "en": "Which CPU component holds small, fast data for immediate use?",
+      "ja": "CPU内部で即時利用される小さく高速な記憶領域は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Reverse shell",
+        "ja": "リバースシェル",
+        "ja_typings": [
+          "riba-susheru"
+        ]
+      },
+      {
+        "en": "Bind shell",
+        "ja": "バインドシェル",
+        "ja_typings": [
+          "baindosheru"
+        ]
+      },
+      {
+        "en": "Web shell",
+        "ja": "ウェブシェル",
+        "ja_typings": [
+          "webusheru"
+        ]
+      },
+      {
+        "en": "Root shell",
+        "ja": "ルートシェル",
+        "ja_typings": [
+          "ru-tosheru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03376",
+    "image_path": null,
+    "question_text": {
+      "en": "Which attack makes a victim host connect back to the attacker?",
+      "ja": "被害ホストから攻撃者へ接続させる攻撃手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SAN",
+        "ja": "エスエーエヌ",
+        "ja_typings": [
+          "esue-enu"
+        ]
+      },
+      {
+        "en": "NAS",
+        "ja": "エヌエーエス",
+        "ja_typings": [
+          "enue-esu"
+        ]
+      },
+      {
+        "en": "LAN",
+        "ja": "ラン",
+        "ja_typings": [
+          "ran"
+        ]
+      },
+      {
+        "en": "WAN",
+        "ja": "ワン",
+        "ja_typings": [
+          "wan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03377",
+    "image_path": null,
+    "question_text": {
+      "en": "Which network is dedicated to high-speed block storage access?",
+      "ja": "高速ブロックストレージ専用のネットワークは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SRAM",
+        "ja": "エスラム",
+        "ja_typings": [
+          "esuramu"
+        ]
+      },
+      {
+        "en": "DRAM",
+        "ja": "ディーラム",
+        "ja_typings": [
+          "di-ramu"
+        ]
+      },
+      {
+        "en": "SDRAM",
+        "ja": "エスディーラム",
+        "ja_typings": [
+          "esudi-ramu"
+        ]
+      },
+      {
+        "en": "VRAM",
+        "ja": "ブイラム",
+        "ja_typings": [
+          "buiramu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03378",
+    "image_path": null,
+    "question_text": {
+      "en": "Which type of RAM uses flip-flops and needs no refresh?",
+      "ja": "フリップフロップで構成しリフレッシュ不要なRAMは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SSD",
+        "ja": "エスエスディー",
+        "ja_typings": [
+          "esuesudi-"
+        ]
+      },
+      {
+        "en": "HDD",
+        "ja": "エイチディーディー",
+        "ja_typings": [
+          "eichidi-di-"
+        ]
+      },
+      {
+        "en": "NAS",
+        "ja": "エヌエーエス",
+        "ja_typings": [
+          "enue-esu"
+        ]
+      },
+      {
+        "en": "DVD",
+        "ja": "ディーブイディー",
+        "ja_typings": [
+          "di-buidi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03379",
+    "image_path": null,
+    "question_text": {
+      "en": "Which storage uses flash memory and has no moving parts?",
+      "ja": "フラッシュメモリを使い可動部品が無いストレージは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SSH",
+        "ja": "エスエスエイチ",
+        "ja_typings": [
+          "esuesueichi"
+        ]
+      },
+      {
+        "en": "Telnet",
+        "ja": "テルネット",
+        "ja_typings": [
+          "terunetto"
+        ]
+      },
+      {
+        "en": "FTP",
+        "ja": "エフティーピー",
+        "ja_typings": [
+          "efuti-pi-"
+        ]
+      },
+      {
+        "en": "HTTP",
+        "ja": "エイチティーティーピー",
+        "ja_typings": [
+          "eichiti-ti-pi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03380",
+    "image_path": null,
+    "question_text": {
+      "en": "Which encrypted protocol is used for secure remote shell?",
+      "ja": "暗号化された遠隔シェルで使うプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Samsung",
+        "ja": "サムスン",
+        "ja_typings": [
+          "samusun"
+        ]
+      },
+      {
+        "en": "LG",
+        "ja": "エルジー",
+        "ja_typings": [
+          "eruji-"
+        ]
+      },
+      {
+        "en": "Apple",
+        "ja": "アップル",
+        "ja_typings": [
+          "appuru"
+        ]
+      },
+      {
+        "en": "Sony",
+        "ja": "ソニー",
+        "ja_typings": [
+          "soni-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03381",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Korean conglomerate is a major smartphone maker?",
+      "ja": "大手スマートフォンメーカーの韓国系コングロマリットは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Swap",
+        "ja": "スワップ",
+        "ja_typings": [
+          "suwappu"
+        ]
+      },
+      {
+        "en": "Cache",
+        "ja": "キャッシュ",
+        "ja_typings": [
+          "kyasshu"
+        ]
+      },
+      {
+        "en": "Buffer",
+        "ja": "バッファ",
+        "ja_typings": [
+          "baffa"
+        ]
+      },
+      {
+        "en": "Paging",
+        "ja": "ページング",
+        "ja_typings": [
+          "pe-jingu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03382",
+    "image_path": null,
+    "question_text": {
+      "en": "Which mechanism moves memory pages between RAM and disk?",
+      "ja": "RAMとディスク間でメモリページを退避する仕組みは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "TCP",
+        "ja": "ティーシーピー",
+        "ja_typings": [
+          "ti-shi-pi-"
+        ]
+      },
+      {
+        "en": "UDP",
+        "ja": "ユーディーピー",
+        "ja_typings": [
+          "yu-di-pi-"
+        ]
+      },
+      {
+        "en": "IP",
+        "ja": "アイピー",
+        "ja_typings": [
+          "aipi-"
+        ]
+      },
+      {
+        "en": "ICMP",
+        "ja": "アイシーエムピー",
+        "ja_typings": [
+          "aishi-emupi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03383",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol provides reliable, ordered data delivery on the Internet?",
+      "ja": "信頼性のある順序付き配送を提供するインターネットプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Telnet",
+        "ja": "テルネット",
+        "ja_typings": [
+          "terunetto"
+        ]
+      },
+      {
+        "en": "SSH",
+        "ja": "エスエスエイチ",
+        "ja_typings": [
+          "esuesueichi"
+        ]
+      },
+      {
+        "en": "FTP",
+        "ja": "エフティーピー",
+        "ja_typings": [
+          "efuti-pi-"
+        ]
+      },
+      {
+        "en": "HTTP",
+        "ja": "エイチティーティーピー",
+        "ja_typings": [
+          "eichiti-ti-pi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03384",
+    "image_path": null,
+    "question_text": {
+      "en": "Which old plaintext protocol is used for remote terminal access?",
+      "ja": "古い平文の遠隔端末アクセスプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "UDP",
+        "ja": "ユーディーピー",
+        "ja_typings": [
+          "yu-di-pi-"
+        ]
+      },
+      {
+        "en": "TCP",
+        "ja": "ティーシーピー",
+        "ja_typings": [
+          "ti-shi-pi-"
+        ]
+      },
+      {
+        "en": "IP",
+        "ja": "アイピー",
+        "ja_typings": [
+          "aipi-"
+        ]
+      },
+      {
+        "en": "ARP",
+        "ja": "エーアールピー",
+        "ja_typings": [
+          "e-a-rupi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03385",
+    "image_path": null,
+    "question_text": {
+      "en": "Which connectionless protocol prioritizes speed over reliability?",
+      "ja": "信頼性より速度を優先するコネクションレスプロトコルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "UNIVAC",
+        "ja": "ユニバック",
+        "ja_typings": [
+          "yunibakku"
+        ]
+      },
+      {
+        "en": "MARK I",
+        "ja": "マーク1",
+        "ja_typings": [
+          "ma-ku1"
+        ]
+      },
+      {
+        "en": "EDVAC",
+        "ja": "エドバック",
+        "ja_typings": [
+          "edobakku"
+        ]
+      },
+      {
+        "en": "ALTAIR",
+        "ja": "アルテア",
+        "ja_typings": [
+          "arutea"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03386",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1951 commercial computer succeeded the ENIAC line?",
+      "ja": "ENIAC系を継いだ1951年の商用コンピュータは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "USB",
+        "ja": "ユーエスビー",
+        "ja_typings": [
+          "yu-esubi-"
+        ]
+      },
+      {
+        "en": "PS/2",
+        "ja": "ピーエス2",
+        "ja_typings": [
+          "pi-esu2"
+        ]
+      },
+      {
+        "en": "RS-232C",
+        "ja": "アールエス232シー",
+        "ja_typings": [
+          "a-ruesu232shi-"
+        ]
+      },
+      {
+        "en": "FireWire",
+        "ja": "ファイアワイヤ",
+        "ja_typings": [
+          "faiawaiya"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03387",
+    "image_path": null,
+    "question_text": {
+      "en": "Which serial bus is most common for connecting peripherals?",
+      "ja": "周辺機器接続で最も一般的なシリアルバスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Virtual memory",
+        "ja": "仮想メモリ",
+        "ja_typings": [
+          "kasoumemori"
+        ]
+      },
+      {
+        "en": "Main memory",
+        "ja": "主記憶",
+        "ja_typings": [
+          "shukioku"
+        ]
+      },
+      {
+        "en": "Cache memory",
+        "ja": "キャッシュメモリ",
+        "ja_typings": [
+          "kyasshumemori"
+        ]
+      },
+      {
+        "en": "Flash memory",
+        "ja": "フラッシュメモリ",
+        "ja_typings": [
+          "furasshumemori"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03388",
+    "image_path": null,
+    "question_text": {
+      "en": "Which OS technique uses disk to extend addressable memory?",
+      "ja": "ディスクを使って利用可能なメモリを拡張するOSの仕組みは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Windows",
+        "ja": "ウィンドウズ",
+        "ja_typings": [
+          "windozu",
+          "windouzu"
+        ]
+      },
+      {
+        "en": "macOS",
+        "ja": "マックオーエス",
+        "ja_typings": [
+          "makkuo-esu"
+        ]
+      },
+      {
+        "en": "Linux",
+        "ja": "リナックス",
+        "ja_typings": [
+          "rinakkusu"
+        ]
+      },
+      {
+        "en": "Chrome OS",
+        "ja": "クロームオーエス",
+        "ja_typings": [
+          "kuro-muo-esu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03389",
+    "image_path": null,
+    "question_text": {
+      "en": "Which OS is developed by Microsoft for personal computers?",
+      "ja": "Microsoftが開発するPC向けOSは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Zigbee",
+        "ja": "ジグビー",
+        "ja_typings": [
+          "jigubi-"
+        ]
+      },
+      {
+        "en": "Bluetooth",
+        "ja": "ブルートゥース",
+        "ja_typings": [
+          "buru-tu-su"
+        ]
+      },
+      {
+        "en": "Wi-Fi",
+        "ja": "ワイファイ",
+        "ja_typings": [
+          "waifai"
+        ]
+      },
+      {
+        "en": "LTE",
+        "ja": "エルティーイー",
+        "ja_typings": [
+          "eruti-i-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03390",
+    "image_path": null,
+    "question_text": {
+      "en": "Which low-power mesh wireless standard is used in IoT?",
+      "ja": "IoTで使われる低消費電力のメッシュ無線規格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ext4",
+        "ja": "イーエックスティー4",
+        "ja_typings": [
+          "i-ekkusuti-4"
+        ]
+      },
+      {
+        "en": "NTFS",
+        "ja": "エヌティーエフエス",
+        "ja_typings": [
+          "enuti-efuesu"
+        ]
+      },
+      {
+        "en": "FAT32",
+        "ja": "ファット32",
+        "ja_typings": [
+          "fatto32"
+        ]
+      },
+      {
+        "en": "HFS",
+        "ja": "エイチエフエス",
+        "ja_typings": [
+          "eichiefuesu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03391",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is a modern default journaling file system on Linux?",
+      "ja": "現代のLinuxで標準的なジャーナリングファイルシステムは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "macOS",
+        "ja": "マックオーエス",
+        "ja_typings": [
+          "makkuo-esu"
+        ]
+      },
+      {
+        "en": "Windows",
+        "ja": "ウィンドウズ",
+        "ja_typings": [
+          "windozu",
+          "windouzu"
+        ]
+      },
+      {
+        "en": "Linux",
+        "ja": "リナックス",
+        "ja_typings": [
+          "rinakkusu"
+        ]
+      },
+      {
+        "en": "FreeBSD",
+        "ja": "フリービーエスディー",
+        "ja_typings": [
+          "furi-bi-esudi-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "technology",
+    "id": "q03392",
+    "image_path": null,
+    "question_text": {
+      "en": "Which OS is developed by Apple for Macintosh computers?",
+      "ja": "AppleがMacintosh向けに開発するOSは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "-100 degrees",
+        "ja": "マイナス100度",
+        "ja_typings": [
+          "mainasu100do"
+        ]
+      },
+      {
+        "en": "-20 degrees",
+        "ja": "マイナス20度",
+        "ja_typings": [
+          "mainasu20do"
+        ]
+      },
+      {
+        "en": "0 degrees",
+        "ja": "0度",
+        "ja_typings": [
+          "0do"
+        ]
+      },
+      {
+        "en": "-500 degrees",
+        "ja": "マイナス500度",
+        "ja_typings": [
+          "mainasu500do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03393",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is roughly the average winter temperature at the South Pole?",
+      "ja": "南極の冬の平均気温に近いのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "-500 degrees",
+        "ja": "マイナス500度",
+        "ja_typings": [
+          "mainasu500do"
+        ]
+      },
+      {
+        "en": "-100 degrees",
+        "ja": "マイナス100度",
+        "ja_typings": [
+          "mainasu100do"
+        ]
+      },
+      {
+        "en": "-50 degrees",
+        "ja": "マイナス50度",
+        "ja_typings": [
+          "mainasu50do"
+        ]
+      },
+      {
+        "en": "-200 degrees",
+        "ja": "マイナス200度",
+        "ja_typings": [
+          "mainasu200do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03394",
+    "image_path": null,
+    "question_text": {
+      "en": "Which temperature is physically impossible since absolute zero is -273 degrees?",
+      "ja": "絶対零度がマイナス273度であるため物理的にあり得ない温度は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "0 degrees",
+        "ja": "0度",
+        "ja_typings": [
+          "0do"
+        ]
+      },
+      {
+        "en": "4 degrees",
+        "ja": "4度",
+        "ja_typings": [
+          "4do"
+        ]
+      },
+      {
+        "en": "-10 degrees",
+        "ja": "マイナス10度",
+        "ja_typings": [
+          "mainasu10do"
+        ]
+      },
+      {
+        "en": "100 degrees",
+        "ja": "100度",
+        "ja_typings": [
+          "100do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03395",
+    "image_path": null,
+    "question_text": {
+      "en": "At which Celsius temperature does pure water freeze at 1 atm?",
+      "ja": "1気圧で純水が凍る摂氏温度は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "25 degrees",
+        "ja": "25度",
+        "ja_typings": [
+          "25do"
+        ]
+      },
+      {
+        "en": "0 degrees",
+        "ja": "0度",
+        "ja_typings": [
+          "0do"
+        ]
+      },
+      {
+        "en": "40 degrees",
+        "ja": "40度",
+        "ja_typings": [
+          "40do"
+        ]
+      },
+      {
+        "en": "-10 degrees",
+        "ja": "マイナス10度",
+        "ja_typings": [
+          "mainasu10do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03396",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Celsius temperature is typical for a comfortable room?",
+      "ja": "快適な室温として典型的な摂氏温度は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "30 degrees",
+        "ja": "30度",
+        "ja_typings": [
+          "30do"
+        ]
+      },
+      {
+        "en": "0 degrees",
+        "ja": "0度",
+        "ja_typings": [
+          "0do"
+        ]
+      },
+      {
+        "en": "15 degrees",
+        "ja": "15度",
+        "ja_typings": [
+          "15do"
+        ]
+      },
+      {
+        "en": "-5 degrees",
+        "ja": "マイナス5度",
+        "ja_typings": [
+          "mainasu5do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03397",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Celsius temperature is considered a hot summer day in Japan?",
+      "ja": "日本で真夏日の目安となる摂氏温度は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "40 degrees",
+        "ja": "40度",
+        "ja_typings": [
+          "40do"
+        ]
+      },
+      {
+        "en": "25 degrees",
+        "ja": "25度",
+        "ja_typings": [
+          "25do"
+        ]
+      },
+      {
+        "en": "10 degrees",
+        "ja": "10度",
+        "ja_typings": [
+          "10do"
+        ]
+      },
+      {
+        "en": "0 degrees",
+        "ja": "0度",
+        "ja_typings": [
+          "0do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03398",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Celsius temperature is classified as an extremely hot day in Japan?",
+      "ja": "日本で猛暑日と分類される摂氏温度の目安は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "A type",
+        "ja": "A型",
+        "ja_typings": [
+          "agata"
+        ]
+      },
+      {
+        "en": "B type",
+        "ja": "B型",
+        "ja_typings": [
+          "bgata"
+        ]
+      },
+      {
+        "en": "O type",
+        "ja": "O型",
+        "ja_typings": [
+          "ogata"
+        ]
+      },
+      {
+        "en": "AB type",
+        "ja": "AB型",
+        "ja_typings": [
+          "abgata"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03399",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ABO blood type has antigen A on red blood cells?",
+      "ja": "赤血球にA抗原を持つABO式血液型は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aluminum",
+        "ja": "アルミニウム",
+        "ja_typings": [
+          "aruminiumu"
+        ]
+      },
+      {
+        "en": "Iron",
+        "ja": "鉄",
+        "ja_typings": [
+          "tetsu"
+        ]
+      },
+      {
+        "en": "Copper",
+        "ja": "銅",
+        "ja_typings": [
+          "dou"
+        ]
+      },
+      {
+        "en": "Magnesium",
+        "ja": "マグネシウム",
+        "ja_typings": [
+          "maguneshiumu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03400",
+    "image_path": null,
+    "question_text": {
+      "en": "Which lightweight metal has atomic number 13?",
+      "ja": "原子番号13番の軽い金属は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Archimedes",
+        "ja": "アルキメデス",
+        "ja_typings": [
+          "arukimedesu"
+        ]
+      },
+      {
+        "en": "Pythagoras",
+        "ja": "ピタゴラス",
+        "ja_typings": [
+          "pitagorasu"
+        ]
+      },
+      {
+        "en": "Euclid",
+        "ja": "ユークリッド",
+        "ja_typings": [
+          "yu-kuriddo"
+        ]
+      },
+      {
+        "en": "Aristotle",
+        "ja": "アリストテレス",
+        "ja_typings": [
+          "arisutoteresu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03401",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Greek scholar discovered the principle of buoyancy?",
+      "ja": "浮力の原理を発見した古代ギリシアの学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Au",
+        "ja": "エーユー",
+        "ja_typings": [
+          "e-yu-"
+        ]
+      },
+      {
+        "en": "Ag",
+        "ja": "エージー",
+        "ja_typings": [
+          "e-ji-"
+        ]
+      },
+      {
+        "en": "Cu",
+        "ja": "シーユー",
+        "ja_typings": [
+          "shi-yu-"
+        ]
+      },
+      {
+        "en": "Fe",
+        "ja": "エフイー",
+        "ja_typings": [
+          "efui-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03402",
+    "image_path": null,
+    "question_text": {
+      "en": "Which element symbol represents gold?",
+      "ja": "金を表す元素記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aurora",
+        "ja": "オーロラ",
+        "ja_typings": [
+          "o-rora"
+        ]
+      },
+      {
+        "en": "Mirage",
+        "ja": "蜃気楼",
+        "ja_typings": [
+          "shinkirou"
+        ]
+      },
+      {
+        "en": "Rainbow",
+        "ja": "虹",
+        "ja_typings": [
+          "niji"
+        ]
+      },
+      {
+        "en": "Halo",
+        "ja": "ハロ",
+        "ja_typings": [
+          "haro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03403",
+    "image_path": null,
+    "question_text": {
+      "en": "Which polar atmospheric phenomenon shows colorful curtains of light?",
+      "ja": "極地で色とりどりの光のカーテンが見える大気現象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "B type",
+        "ja": "B型",
+        "ja_typings": [
+          "bgata"
+        ]
+      },
+      {
+        "en": "A type",
+        "ja": "A型",
+        "ja_typings": [
+          "agata"
+        ]
+      },
+      {
+        "en": "O type",
+        "ja": "O型",
+        "ja_typings": [
+          "ogata"
+        ]
+      },
+      {
+        "en": "AB type",
+        "ja": "AB型",
+        "ja_typings": [
+          "abgata"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03404",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ABO blood type has antigen B on red blood cells?",
+      "ja": "赤血球にB抗原を持つABO式血液型は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "BMI",
+        "ja": "ビーエムアイ",
+        "ja_typings": [
+          "bi-emuai"
+        ]
+      },
+      {
+        "en": "IQ",
+        "ja": "アイキュー",
+        "ja_typings": [
+          "aikyu-"
+        ]
+      },
+      {
+        "en": "EQ",
+        "ja": "イーキュー",
+        "ja_typings": [
+          "i-kyu-"
+        ]
+      },
+      {
+        "en": "BMR",
+        "ja": "ビーエムアール",
+        "ja_typings": [
+          "bi-emua-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03405",
+    "image_path": null,
+    "question_text": {
+      "en": "Which index combines weight and height to estimate body fat?",
+      "ja": "体重と身長から肥満度を推定する指数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Becquerel",
+        "ja": "ベクレル",
+        "ja_typings": [
+          "bekureru"
+        ]
+      },
+      {
+        "en": "Curie",
+        "ja": "キュリー",
+        "ja_typings": [
+          "kyuri-"
+        ]
+      },
+      {
+        "en": "Roentgen",
+        "ja": "レントゲン",
+        "ja_typings": [
+          "rentogen"
+        ]
+      },
+      {
+        "en": "Rutherford",
+        "ja": "ラザフォード",
+        "ja_typings": [
+          "razafo-do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03406",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French physicist discovered natural radioactivity in 1896?",
+      "ja": "1896年に天然放射能を発見したフランスの物理学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Carbon",
+        "ja": "炭素",
+        "ja_typings": [
+          "tannso"
+        ]
+      },
+      {
+        "en": "Oxygen",
+        "ja": "酸素",
+        "ja_typings": [
+          "sannso"
+        ]
+      },
+      {
+        "en": "Hydrogen",
+        "ja": "水素",
+        "ja_typings": [
+          "suiso"
+        ]
+      },
+      {
+        "en": "Nitrogen",
+        "ja": "窒素",
+        "ja_typings": [
+          "chissoso",
+          "chisso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03407",
+    "image_path": null,
+    "question_text": {
+      "en": "Which element with symbol C is the basis of organic chemistry?",
+      "ja": "有機化学の基盤となる元素記号Cの元素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Coal",
+        "ja": "石炭",
+        "ja_typings": [
+          "sekitan"
+        ]
+      },
+      {
+        "en": "Oil",
+        "ja": "石油",
+        "ja_typings": [
+          "sekiyu"
+        ]
+      },
+      {
+        "en": "Natural gas",
+        "ja": "天然ガス",
+        "ja_typings": [
+          "tennenngasu"
+        ]
+      },
+      {
+        "en": "Peat",
+        "ja": "泥炭",
+        "ja_typings": [
+          "deitan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03408",
+    "image_path": null,
+    "question_text": {
+      "en": "Which fossil fuel is a black sedimentary rock burned for energy?",
+      "ja": "黒い堆積岩でエネルギー源として燃やされる化石燃料は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Combustion",
+        "ja": "燃焼",
+        "ja_typings": [
+          "nennshou"
+        ]
+      },
+      {
+        "en": "Oxidation",
+        "ja": "酸化",
+        "ja_typings": [
+          "sannka"
+        ]
+      },
+      {
+        "en": "Reduction",
+        "ja": "還元",
+        "ja_typings": [
+          "kanngen"
+        ]
+      },
+      {
+        "en": "Electrolysis",
+        "ja": "電気分解",
+        "ja_typings": [
+          "dennkibunnkai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03409",
+    "image_path": null,
+    "question_text": {
+      "en": "Which chemical reaction with oxygen produces heat and light?",
+      "ja": "酸素と反応して熱と光を出す化学反応は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Coulomb",
+        "ja": "クーロン",
+        "ja_typings": [
+          "ku-ron"
+        ]
+      },
+      {
+        "en": "Volta",
+        "ja": "ボルタ",
+        "ja_typings": [
+          "boruta"
+        ]
+      },
+      {
+        "en": "Ampere",
+        "ja": "アンペール",
+        "ja_typings": [
+          "anpe-ru"
+        ]
+      },
+      {
+        "en": "Ohm",
+        "ja": "オーム",
+        "ja_typings": [
+          "o-mu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03410",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French physicist gave his name to the SI unit of electric charge?",
+      "ja": "電荷のSI単位に名を残すフランスの物理学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Decibel",
+        "ja": "デシベル",
+        "ja_typings": [
+          "deshiberu"
+        ]
+      },
+      {
+        "en": "Hertz",
+        "ja": "ヘルツ",
+        "ja_typings": [
+          "herutsu"
+        ]
+      },
+      {
+        "en": "Pascal",
+        "ja": "パスカル",
+        "ja_typings": [
+          "pasukaru"
+        ]
+      },
+      {
+        "en": "Watt",
+        "ja": "ワット",
+        "ja_typings": [
+          "watto"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03411",
+    "image_path": null,
+    "question_text": {
+      "en": "Which logarithmic unit expresses sound pressure level?",
+      "ja": "音圧レベルを対数で表す単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Einstein",
+        "ja": "アインシュタイン",
+        "ja_typings": [
+          "ainshutain"
+        ]
+      },
+      {
+        "en": "Bohr",
+        "ja": "ボーア",
+        "ja_typings": [
+          "bo-a"
+        ]
+      },
+      {
+        "en": "Planck",
+        "ja": "プランク",
+        "ja_typings": [
+          "puranku"
+        ]
+      },
+      {
+        "en": "Heisenberg",
+        "ja": "ハイゼンベルク",
+        "ja_typings": [
+          "haizenberuku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03412",
+    "image_path": null,
+    "question_text": {
+      "en": "Which physicist published the theory of relativity in 1905 and 1915?",
+      "ja": "1905年と1915年に相対性理論を発表した物理学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Electromagnetic force",
+        "ja": "電磁気力",
+        "ja_typings": [
+          "dennjikiryoku"
+        ]
+      },
+      {
+        "en": "Gravity",
+        "ja": "重力",
+        "ja_typings": [
+          "juuryoku"
+        ]
+      },
+      {
+        "en": "Strong force",
+        "ja": "強い力",
+        "ja_typings": [
+          "tsuyoichikara"
+        ]
+      },
+      {
+        "en": "Weak force",
+        "ja": "弱い力",
+        "ja_typings": [
+          "yowaichikara"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03413",
+    "image_path": null,
+    "question_text": {
+      "en": "Which fundamental force acts between electrically charged particles?",
+      "ja": "電荷を持つ粒子の間に働く基本相互作用は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fe",
+        "ja": "エフイー",
+        "ja_typings": [
+          "efui-"
+        ]
+      },
+      {
+        "en": "Au",
+        "ja": "エーユー",
+        "ja_typings": [
+          "e-yu-"
+        ]
+      },
+      {
+        "en": "Ag",
+        "ja": "エージー",
+        "ja_typings": [
+          "e-ji-"
+        ]
+      },
+      {
+        "en": "Cu",
+        "ja": "シーユー",
+        "ja_typings": [
+          "shi-yu-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03414",
+    "image_path": null,
+    "question_text": {
+      "en": "Which element symbol represents iron?",
+      "ja": "鉄を表す元素記号は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fleming",
+        "ja": "フレミング",
+        "ja_typings": [
+          "furemingu"
+        ]
+      },
+      {
+        "en": "Faraday",
+        "ja": "ファラデー",
+        "ja_typings": [
+          "farade-"
+        ]
+      },
+      {
+        "en": "Maxwell",
+        "ja": "マクスウェル",
+        "ja_typings": [
+          "makusuweru"
+        ]
+      },
+      {
+        "en": "Ampere",
+        "ja": "アンペール",
+        "ja_typings": [
+          "anpe-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03415",
+    "image_path": null,
+    "question_text": {
+      "en": "Which British scientist formulated rules for the direction of induced current?",
+      "ja": "誘導電流の向きに関する法則を定めた英国の科学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Friction",
+        "ja": "摩擦",
+        "ja_typings": [
+          "masatsu"
+        ]
+      },
+      {
+        "en": "Gravity",
+        "ja": "重力",
+        "ja_typings": [
+          "juuryoku"
+        ]
+      },
+      {
+        "en": "Tension",
+        "ja": "張力",
+        "ja_typings": [
+          "chouryoku"
+        ]
+      },
+      {
+        "en": "Buoyancy",
+        "ja": "浮力",
+        "ja_typings": [
+          "furyoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03416",
+    "image_path": null,
+    "question_text": {
+      "en": "Which force resists motion between surfaces in contact?",
+      "ja": "接触する面の運動を妨げる力は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Galileo",
+        "ja": "ガリレオ",
+        "ja_typings": [
+          "garireo"
+        ]
+      },
+      {
+        "en": "Copernicus",
+        "ja": "コペルニクス",
+        "ja_typings": [
+          "koperunikusu"
+        ]
+      },
+      {
+        "en": "Kepler",
+        "ja": "ケプラー",
+        "ja_typings": [
+          "kepura-"
+        ]
+      },
+      {
+        "en": "Newton",
+        "ja": "ニュートン",
+        "ja_typings": [
+          "nyu-ton"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03417",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian astronomer first observed Jupiter's four largest moons?",
+      "ja": "木星の四大衛星を最初に観測したイタリアの天文学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gravity",
+        "ja": "重力",
+        "ja_typings": [
+          "juuryoku"
+        ]
+      },
+      {
+        "en": "Friction",
+        "ja": "摩擦",
+        "ja_typings": [
+          "masatsu"
+        ]
+      },
+      {
+        "en": "Magnetism",
+        "ja": "磁力",
+        "ja_typings": [
+          "jiryoku"
+        ]
+      },
+      {
+        "en": "Tension",
+        "ja": "張力",
+        "ja_typings": [
+          "chouryoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03418",
+    "image_path": null,
+    "question_text": {
+      "en": "Which attractive force pulls objects toward the Earth?",
+      "ja": "地球が物体を引き寄せる力は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hideyo Noguchi",
+        "ja": "野口英世",
+        "ja_typings": [
+          "noguchihideyo"
+        ]
+      },
+      {
+        "en": "Shibasaburo Kitasato",
+        "ja": "北里柴三郎",
+        "ja_typings": [
+          "kitazatoshibasaburou",
+          "kitasatoshibasaburou"
+        ]
+      },
+      {
+        "en": "Hachiro Hata",
+        "ja": "秦佐八郎",
+        "ja_typings": [
+          "hatasahachirou"
+        ]
+      },
+      {
+        "en": "Umetaro Suzuki",
+        "ja": "鈴木梅太郎",
+        "ja_typings": [
+          "suzukiumetarou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03419",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese bacteriologist studied yellow fever and is on the 1000 yen note?",
+      "ja": "黄熱病を研究し千円札の肖像にもなった日本の細菌学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hooke",
+        "ja": "フック",
+        "ja_typings": [
+          "fukku"
+        ]
+      },
+      {
+        "en": "Newton",
+        "ja": "ニュートン",
+        "ja_typings": [
+          "nyu-ton"
+        ]
+      },
+      {
+        "en": "Boyle",
+        "ja": "ボイル",
+        "ja_typings": [
+          "boiru"
+        ]
+      },
+      {
+        "en": "Cavendish",
+        "ja": "キャベンディッシュ",
+        "ja_typings": [
+          "kyabendisshu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03420",
+    "image_path": null,
+    "question_text": {
+      "en": "Which English scientist formulated the law of elasticity for springs?",
+      "ja": "ばねの弾性に関する法則を定めた英国の科学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hubble",
+        "ja": "ハッブル",
+        "ja_typings": [
+          "habburu"
+        ]
+      },
+      {
+        "en": "Sagan",
+        "ja": "セーガン",
+        "ja_typings": [
+          "se-gan"
+        ]
+      },
+      {
+        "en": "Galileo",
+        "ja": "ガリレオ",
+        "ja_typings": [
+          "garireo"
+        ]
+      },
+      {
+        "en": "Kepler",
+        "ja": "ケプラー",
+        "ja_typings": [
+          "kepura-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03421",
+    "image_path": null,
+    "question_text": {
+      "en": "Which American astronomer found that distant galaxies are receding?",
+      "ja": "遠方銀河が後退していることを発見した米国の天文学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hydrogen",
+        "ja": "水素",
+        "ja_typings": [
+          "suiso"
+        ]
+      },
+      {
+        "en": "Helium",
+        "ja": "ヘリウム",
+        "ja_typings": [
+          "heriumu"
+        ]
+      },
+      {
+        "en": "Oxygen",
+        "ja": "酸素",
+        "ja_typings": [
+          "sannso"
+        ]
+      },
+      {
+        "en": "Nitrogen",
+        "ja": "窒素",
+        "ja_typings": [
+          "chissoso",
+          "chisso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03422",
+    "image_path": null,
+    "question_text": {
+      "en": "Which element has atomic number 1 and symbol H?",
+      "ja": "原子番号1番で記号Hの元素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "IQ",
+        "ja": "アイキュー",
+        "ja_typings": [
+          "aikyu-"
+        ]
+      },
+      {
+        "en": "BMI",
+        "ja": "ビーエムアイ",
+        "ja_typings": [
+          "bi-emuai"
+        ]
+      },
+      {
+        "en": "EQ",
+        "ja": "イーキュー",
+        "ja_typings": [
+          "i-kyu-"
+        ]
+      },
+      {
+        "en": "GPA",
+        "ja": "ジーピーエー",
+        "ja_typings": [
+          "ji-pi-e-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03423",
+    "image_path": null,
+    "question_text": {
+      "en": "Which score is a numerical estimate of intelligence?",
+      "ja": "知能を数値化した指標は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Interference",
+        "ja": "干渉",
+        "ja_typings": [
+          "kannshou"
+        ]
+      },
+      {
+        "en": "Diffraction",
+        "ja": "回折",
+        "ja_typings": [
+          "kaisetsu"
+        ]
+      },
+      {
+        "en": "Reflection",
+        "ja": "反射",
+        "ja_typings": [
+          "hannsha"
+        ]
+      },
+      {
+        "en": "Refraction",
+        "ja": "屈折",
+        "ja_typings": [
+          "kussetsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03424",
+    "image_path": null,
+    "question_text": {
+      "en": "Which wave phenomenon results from superposition producing reinforcement and cancellation?",
+      "ja": "波の重ね合わせで強め合いや打ち消しが起きる現象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jenner",
+        "ja": "ジェンナー",
+        "ja_typings": [
+          "jennna-"
+        ]
+      },
+      {
+        "en": "Pasteur",
+        "ja": "パスツール",
+        "ja_typings": [
+          "pasutsu-ru"
+        ]
+      },
+      {
+        "en": "Koch",
+        "ja": "コッホ",
+        "ja_typings": [
+          "kohho"
+        ]
+      },
+      {
+        "en": "Lister",
+        "ja": "リスター",
+        "ja_typings": [
+          "risuta-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03425",
+    "image_path": null,
+    "question_text": {
+      "en": "Which English doctor developed the first smallpox vaccine?",
+      "ja": "天然痘の世界初のワクチンを開発した英国の医師は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Jurassic",
+        "ja": "ジュラ紀",
+        "ja_typings": [
+          "juraki"
+        ]
+      },
+      {
+        "en": "Triassic",
+        "ja": "三畳紀",
+        "ja_typings": [
+          "sannjouki"
+        ]
+      },
+      {
+        "en": "Cretaceous",
+        "ja": "白亜紀",
+        "ja_typings": [
+          "hakuaki"
+        ]
+      },
+      {
+        "en": "Cambrian",
+        "ja": "カンブリア紀",
+        "ja_typings": [
+          "kannburiaki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03426",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mesozoic geological period is famous for large dinosaurs?",
+      "ja": "大型恐竜で有名な中生代の地質時代は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Leeuwenhoek",
+        "ja": "レーウェンフック",
+        "ja_typings": [
+          "re-wenfukku"
+        ]
+      },
+      {
+        "en": "Hooke",
+        "ja": "フック",
+        "ja_typings": [
+          "fukku"
+        ]
+      },
+      {
+        "en": "Pasteur",
+        "ja": "パスツール",
+        "ja_typings": [
+          "pasutsu-ru"
+        ]
+      },
+      {
+        "en": "Koch",
+        "ja": "コッホ",
+        "ja_typings": [
+          "kohho"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03427",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Dutch pioneer first observed microorganisms with a microscope?",
+      "ja": "顕微鏡で初めて微生物を観察したオランダの先駆者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Magnetic storm",
+        "ja": "磁気嵐",
+        "ja_typings": [
+          "jikiarashi"
+        ]
+      },
+      {
+        "en": "Aurora",
+        "ja": "オーロラ",
+        "ja_typings": [
+          "o-rora"
+        ]
+      },
+      {
+        "en": "Solar flare",
+        "ja": "太陽フレア",
+        "ja_typings": [
+          "taiyoufurea"
+        ]
+      },
+      {
+        "en": "Mirage",
+        "ja": "蜃気楼",
+        "ja_typings": [
+          "shinkirou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03428",
+    "image_path": null,
+    "question_text": {
+      "en": "Which disturbance of Earth's magnetic field is caused by solar wind?",
+      "ja": "太陽風によって生じる地球磁場の擾乱は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mirage",
+        "ja": "蜃気楼",
+        "ja_typings": [
+          "shinkirou"
+        ]
+      },
+      {
+        "en": "Rainbow",
+        "ja": "虹",
+        "ja_typings": [
+          "niji"
+        ]
+      },
+      {
+        "en": "Aurora",
+        "ja": "オーロラ",
+        "ja_typings": [
+          "o-rora"
+        ]
+      },
+      {
+        "en": "Halo",
+        "ja": "ハロ",
+        "ja_typings": [
+          "haro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03429",
+    "image_path": null,
+    "question_text": {
+      "en": "Which optical phenomenon makes distant objects appear distorted over hot ground?",
+      "ja": "熱い地面の上で遠くの物体が歪んで見える光学現象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NaOH",
+        "ja": "エヌエーオーエイチ",
+        "ja_typings": [
+          "enue-o-eichi"
+        ]
+      },
+      {
+        "en": "HCl",
+        "ja": "エイチシーエル",
+        "ja_typings": [
+          "eichishi-eru"
+        ]
+      },
+      {
+        "en": "H2SO4",
+        "ja": "エイチ2エスオー4",
+        "ja_typings": [
+          "eichi2esuo-4"
+        ]
+      },
+      {
+        "en": "NH3",
+        "ja": "エヌエイチ3",
+        "ja_typings": [
+          "enueichi3"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03430",
+    "image_path": null,
+    "question_text": {
+      "en": "Which chemical formula represents sodium hydroxide?",
+      "ja": "水酸化ナトリウムを表す化学式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Natural gas",
+        "ja": "天然ガス",
+        "ja_typings": [
+          "tennenngasu"
+        ]
+      },
+      {
+        "en": "Coal",
+        "ja": "石炭",
+        "ja_typings": [
+          "sekitan"
+        ]
+      },
+      {
+        "en": "Oil",
+        "ja": "石油",
+        "ja_typings": [
+          "sekiyu"
+        ]
+      },
+      {
+        "en": "Peat",
+        "ja": "泥炭",
+        "ja_typings": [
+          "deitan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03431",
+    "image_path": null,
+    "question_text": {
+      "en": "Which fossil fuel is primarily composed of methane?",
+      "ja": "主にメタンからなる化石燃料は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Neutron",
+        "ja": "中性子",
+        "ja_typings": [
+          "chuuseishi"
+        ]
+      },
+      {
+        "en": "Proton",
+        "ja": "陽子",
+        "ja_typings": [
+          "youshi"
+        ]
+      },
+      {
+        "en": "Electron",
+        "ja": "電子",
+        "ja_typings": [
+          "denshi"
+        ]
+      },
+      {
+        "en": "Photon",
+        "ja": "光子",
+        "ja_typings": [
+          "koushi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03432",
+    "image_path": null,
+    "question_text": {
+      "en": "Which electrically neutral subatomic particle is found in atomic nuclei?",
+      "ja": "原子核に含まれる電気的に中性の粒子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nuclear reaction",
+        "ja": "核反応",
+        "ja_typings": [
+          "kakuhannnou",
+          "kakuhannou"
+        ]
+      },
+      {
+        "en": "Chemical reaction",
+        "ja": "化学反応",
+        "ja_typings": [
+          "kagakuhannnou",
+          "kagakuhannou"
+        ]
+      },
+      {
+        "en": "Combustion",
+        "ja": "燃焼",
+        "ja_typings": [
+          "nennshou"
+        ]
+      },
+      {
+        "en": "Electrolysis",
+        "ja": "電気分解",
+        "ja_typings": [
+          "dennkibunnkai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03433",
+    "image_path": null,
+    "question_text": {
+      "en": "Which type of reaction occurs in the Sun's core?",
+      "ja": "太陽の中心で起きている反応の種類は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "O type",
+        "ja": "O型",
+        "ja_typings": [
+          "ogata"
+        ]
+      },
+      {
+        "en": "A type",
+        "ja": "A型",
+        "ja_typings": [
+          "agata"
+        ]
+      },
+      {
+        "en": "B type",
+        "ja": "B型",
+        "ja_typings": [
+          "bgata"
+        ]
+      },
+      {
+        "en": "AB type",
+        "ja": "AB型",
+        "ja_typings": [
+          "abgata"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03434",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ABO blood type has neither A nor B antigen?",
+      "ja": "A抗原もB抗原も持たないABO式血液型は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ohm",
+        "ja": "オーム",
+        "ja_typings": [
+          "o-mu"
+        ]
+      },
+      {
+        "en": "Volta",
+        "ja": "ボルタ",
+        "ja_typings": [
+          "boruta"
+        ]
+      },
+      {
+        "en": "Ampere",
+        "ja": "アンペール",
+        "ja_typings": [
+          "anpe-ru"
+        ]
+      },
+      {
+        "en": "Coulomb",
+        "ja": "クーロン",
+        "ja_typings": [
+          "ku-ron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03435",
+    "image_path": null,
+    "question_text": {
+      "en": "Which German physicist gave his name to the unit of electrical resistance?",
+      "ja": "電気抵抗の単位に名を残すドイツの物理学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Oil",
+        "ja": "石油",
+        "ja_typings": [
+          "sekiyu"
+        ]
+      },
+      {
+        "en": "Coal",
+        "ja": "石炭",
+        "ja_typings": [
+          "sekitan"
+        ]
+      },
+      {
+        "en": "Natural gas",
+        "ja": "天然ガス",
+        "ja_typings": [
+          "tennenngasu"
+        ]
+      },
+      {
+        "en": "Peat",
+        "ja": "泥炭",
+        "ja_typings": [
+          "deitan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03436",
+    "image_path": null,
+    "question_text": {
+      "en": "Which fossil fuel is refined into gasoline and diesel?",
+      "ja": "ガソリンや軽油に精製される化石燃料は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Oxygen",
+        "ja": "酸素",
+        "ja_typings": [
+          "sannso"
+        ]
+      },
+      {
+        "en": "Hydrogen",
+        "ja": "水素",
+        "ja_typings": [
+          "suiso"
+        ]
+      },
+      {
+        "en": "Carbon",
+        "ja": "炭素",
+        "ja_typings": [
+          "tannso"
+        ]
+      },
+      {
+        "en": "Nitrogen",
+        "ja": "窒素",
+        "ja_typings": [
+          "chissoso",
+          "chisso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03437",
+    "image_path": null,
+    "question_text": {
+      "en": "Which element with symbol O is essential for respiration?",
+      "ja": "呼吸に不可欠な記号Oの元素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Paleogene",
+        "ja": "古第三紀",
+        "ja_typings": [
+          "kodaisannki"
+        ]
+      },
+      {
+        "en": "Neogene",
+        "ja": "新第三紀",
+        "ja_typings": [
+          "shinndaisannki"
+        ]
+      },
+      {
+        "en": "Quaternary",
+        "ja": "第四紀",
+        "ja_typings": [
+          "daiyonki"
+        ]
+      },
+      {
+        "en": "Cretaceous",
+        "ja": "白亜紀",
+        "ja_typings": [
+          "hakuaki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03438",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Cenozoic geological period followed the Cretaceous?",
+      "ja": "白亜紀のあとに続く新生代の地質時代は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pasteur",
+        "ja": "パスツール",
+        "ja_typings": [
+          "pasutsu-ru"
+        ]
+      },
+      {
+        "en": "Jenner",
+        "ja": "ジェンナー",
+        "ja_typings": [
+          "jennna-"
+        ]
+      },
+      {
+        "en": "Koch",
+        "ja": "コッホ",
+        "ja_typings": [
+          "kohho"
+        ]
+      },
+      {
+        "en": "Lister",
+        "ja": "リスター",
+        "ja_typings": [
+          "risuta-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03439",
+    "image_path": null,
+    "question_text": {
+      "en": "Which French scientist developed pasteurization and a rabies vaccine?",
+      "ja": "低温殺菌法と狂犬病ワクチンを開発したフランスの科学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Photon",
+        "ja": "光子",
+        "ja_typings": [
+          "koushi"
+        ]
+      },
+      {
+        "en": "Electron",
+        "ja": "電子",
+        "ja_typings": [
+          "denshi"
+        ]
+      },
+      {
+        "en": "Neutron",
+        "ja": "中性子",
+        "ja_typings": [
+          "chuuseishi"
+        ]
+      },
+      {
+        "en": "Proton",
+        "ja": "陽子",
+        "ja_typings": [
+          "youshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03440",
+    "image_path": null,
+    "question_text": {
+      "en": "Which elementary particle is the quantum of light?",
+      "ja": "光の量子に相当する素粒子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Proton",
+        "ja": "陽子",
+        "ja_typings": [
+          "youshi"
+        ]
+      },
+      {
+        "en": "Neutron",
+        "ja": "中性子",
+        "ja_typings": [
+          "chuuseishi"
+        ]
+      },
+      {
+        "en": "Electron",
+        "ja": "電子",
+        "ja_typings": [
+          "denshi"
+        ]
+      },
+      {
+        "en": "Photon",
+        "ja": "光子",
+        "ja_typings": [
+          "koushi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03441",
+    "image_path": null,
+    "question_text": {
+      "en": "Which positively charged particle is found in atomic nuclei?",
+      "ja": "原子核に含まれる正電荷の粒子は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ptolemy",
+        "ja": "プトレマイオス",
+        "ja_typings": [
+          "putoremaiosu"
+        ]
+      },
+      {
+        "en": "Copernicus",
+        "ja": "コペルニクス",
+        "ja_typings": [
+          "koperunikusu"
+        ]
+      },
+      {
+        "en": "Galileo",
+        "ja": "ガリレオ",
+        "ja_typings": [
+          "garireo"
+        ]
+      },
+      {
+        "en": "Kepler",
+        "ja": "ケプラー",
+        "ja_typings": [
+          "kepura-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03442",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Greek astronomer is known for a geocentric model?",
+      "ja": "天動説で知られる古代ギリシアの天文学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Purple",
+        "ja": "紫",
+        "ja_typings": [
+          "murasaki"
+        ]
+      },
+      {
+        "en": "Yellow",
+        "ja": "黄",
+        "ja_typings": [
+          "ki"
+        ]
+      },
+      {
+        "en": "Green",
+        "ja": "緑",
+        "ja_typings": [
+          "midori"
+        ]
+      },
+      {
+        "en": "Orange",
+        "ja": "橙",
+        "ja_typings": [
+          "daidai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03443",
+    "image_path": null,
+    "question_text": {
+      "en": "Which color is produced by mixing red and blue light?",
+      "ja": "赤い光と青い光を混ぜると見える色は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rainbow",
+        "ja": "虹",
+        "ja_typings": [
+          "niji"
+        ]
+      },
+      {
+        "en": "Aurora",
+        "ja": "オーロラ",
+        "ja_typings": [
+          "o-rora"
+        ]
+      },
+      {
+        "en": "Mirage",
+        "ja": "蜃気楼",
+        "ja_typings": [
+          "shinkirou"
+        ]
+      },
+      {
+        "en": "Halo",
+        "ja": "ハロ",
+        "ja_typings": [
+          "haro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03444",
+    "image_path": null,
+    "question_text": {
+      "en": "Which optical phenomenon appears as a colored arc after rain?",
+      "ja": "雨上がりに見える色の弧の光学現象は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Roentgen",
+        "ja": "レントゲン",
+        "ja_typings": [
+          "rentogen"
+        ]
+      },
+      {
+        "en": "Becquerel",
+        "ja": "ベクレル",
+        "ja_typings": [
+          "bekureru"
+        ]
+      },
+      {
+        "en": "Curie",
+        "ja": "キュリー",
+        "ja_typings": [
+          "kyuri-"
+        ]
+      },
+      {
+        "en": "Rutherford",
+        "ja": "ラザフォード",
+        "ja_typings": [
+          "razafo-do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03445",
+    "image_path": null,
+    "question_text": {
+      "en": "Which German physicist discovered X-rays in 1895?",
+      "ja": "1895年にX線を発見したドイツの物理学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Schleiden",
+        "ja": "シュライデン",
+        "ja_typings": [
+          "shuraiden"
+        ]
+      },
+      {
+        "en": "Schwann",
+        "ja": "シュワン",
+        "ja_typings": [
+          "shuwan"
+        ]
+      },
+      {
+        "en": "Virchow",
+        "ja": "ウィルヒョウ",
+        "ja_typings": [
+          "wiruhyo",
+          "wiruhyou"
+        ]
+      },
+      {
+        "en": "Hooke",
+        "ja": "フック",
+        "ja_typings": [
+          "fukku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03446",
+    "image_path": null,
+    "question_text": {
+      "en": "Which German botanist co-founded the cell theory for plants?",
+      "ja": "植物の細胞説を共同で提唱したドイツの植物学者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Seismic intensity",
+        "ja": "震度",
+        "ja_typings": [
+          "shinndo"
+        ]
+      },
+      {
+        "en": "Magnitude",
+        "ja": "マグニチュード",
+        "ja_typings": [
+          "magunichu-do"
+        ]
+      },
+      {
+        "en": "Richter scale",
+        "ja": "リヒタースケール",
+        "ja_typings": [
+          "rihita-suke-ru"
+        ]
+      },
+      {
+        "en": "Mercalli",
+        "ja": "メルカリ",
+        "ja_typings": [
+          "merukari"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03447",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese scale measures the strength of shaking at a location?",
+      "ja": "ある地点での揺れの強さを表す日本の尺度は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Silicon",
+        "ja": "ケイ素",
+        "ja_typings": [
+          "keiso"
+        ]
+      },
+      {
+        "en": "Carbon",
+        "ja": "炭素",
+        "ja_typings": [
+          "tannso"
+        ]
+      },
+      {
+        "en": "Germanium",
+        "ja": "ゲルマニウム",
+        "ja_typings": [
+          "gerumaniumu"
+        ]
+      },
+      {
+        "en": "Gallium",
+        "ja": "ガリウム",
+        "ja_typings": [
+          "gariumu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03448",
+    "image_path": null,
+    "question_text": {
+      "en": "Which element with symbol Si is the main material of semiconductors?",
+      "ja": "半導体の主材料となる記号Siの元素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sirius",
+        "ja": "シリウス",
+        "ja_typings": [
+          "shiriusu"
+        ]
+      },
+      {
+        "en": "Vega",
+        "ja": "ベガ",
+        "ja_typings": [
+          "bega"
+        ]
+      },
+      {
+        "en": "Polaris",
+        "ja": "北極星",
+        "ja_typings": [
+          "hokkyokusei"
+        ]
+      },
+      {
+        "en": "Betelgeuse",
+        "ja": "ベテルギウス",
+        "ja_typings": [
+          "beterugiusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03449",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the brightest star in Earth's night sky?",
+      "ja": "地球の夜空で最も明るく見える恒星は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sulfur",
+        "ja": "硫黄",
+        "ja_typings": [
+          "iou"
+        ]
+      },
+      {
+        "en": "Carbon",
+        "ja": "炭素",
+        "ja_typings": [
+          "tannso"
+        ]
+      },
+      {
+        "en": "Silicon",
+        "ja": "ケイ素",
+        "ja_typings": [
+          "keiso"
+        ]
+      },
+      {
+        "en": "Phosphorus",
+        "ja": "リン",
+        "ja_typings": [
+          "rinn"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03450",
+    "image_path": null,
+    "question_text": {
+      "en": "Which yellow element with symbol S is found near volcanoes?",
+      "ja": "火山周辺で見られる記号Sの黄色い元素は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Triassic",
+        "ja": "三畳紀",
+        "ja_typings": [
+          "sannjouki"
+        ]
+      },
+      {
+        "en": "Jurassic",
+        "ja": "ジュラ紀",
+        "ja_typings": [
+          "juraki"
+        ]
+      },
+      {
+        "en": "Cretaceous",
+        "ja": "白亜紀",
+        "ja_typings": [
+          "hakuaki"
+        ]
+      },
+      {
+        "en": "Permian",
+        "ja": "ペルム紀",
+        "ja_typings": [
+          "perumuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03451",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mesozoic period came right before the Jurassic?",
+      "ja": "ジュラ紀の直前に位置する中生代の地質時代は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "White",
+        "ja": "白",
+        "ja_typings": [
+          "shiro"
+        ]
+      },
+      {
+        "en": "Black",
+        "ja": "黒",
+        "ja_typings": [
+          "kuro"
+        ]
+      },
+      {
+        "en": "Gray",
+        "ja": "灰色",
+        "ja_typings": [
+          "haiiro"
+        ]
+      },
+      {
+        "en": "Silver",
+        "ja": "銀",
+        "ja_typings": [
+          "gin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03452",
+    "image_path": null,
+    "question_text": {
+      "en": "Which color is the result of mixing all visible wavelengths of light equally?",
+      "ja": "可視光のすべての波長を均等に混ぜたときに見える色は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yellow",
+        "ja": "黄",
+        "ja_typings": [
+          "ki"
+        ]
+      },
+      {
+        "en": "Red",
+        "ja": "赤",
+        "ja_typings": [
+          "aka"
+        ]
+      },
+      {
+        "en": "Green",
+        "ja": "緑",
+        "ja_typings": [
+          "midori"
+        ]
+      },
+      {
+        "en": "Purple",
+        "ja": "紫",
+        "ja_typings": [
+          "murasaki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03453",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the color of a ripe lemon?",
+      "ja": "熟したレモンの色は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ppm",
+        "ja": "ピーピーエム",
+        "ja_typings": [
+          "pi-pi-emu"
+        ]
+      },
+      {
+        "en": "ppb",
+        "ja": "ピーピービー",
+        "ja_typings": [
+          "pi-pi-bi-"
+        ]
+      },
+      {
+        "en": "ppt",
+        "ja": "ピーピーティー",
+        "ja_typings": [
+          "pi-pi-ti-"
+        ]
+      },
+      {
+        "en": "phr",
+        "ja": "ピーエイチアール",
+        "ja_typings": [
+          "pi-eichia-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "science",
+    "id": "q03454",
+    "image_path": null,
+    "question_text": {
+      "en": "Which unit expresses concentration as parts per million?",
+      "ja": "100万分のいくつかで濃度を表す単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "AZKi",
+        "ja": "AZKi",
+        "ja_typings": [
+          "azuki",
+          "azki"
+        ]
+      },
+      {
+        "en": "Minato Aqua",
+        "ja": "湊あくあ",
+        "ja_typings": [
+          "minatoakua"
+        ]
+      },
+      {
+        "en": "Nakiri Ayame",
+        "ja": "百鬼あやめ",
+        "ja_typings": [
+          "nakiriayame"
+        ]
+      },
+      {
+        "en": "Shirakami Fubuki",
+        "ja": "白上フブキ",
+        "ja_typings": [
+          "shirakamifubuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03455",
+    "image_path": null,
+    "question_text": {
+      "en": "Which hololive VTuber is known for music activities and is sometimes called the goddess of music?",
+      "ja": "ホロライブで音楽活動を中心にする「ソング・フォー・ユー」を歌うVTuberは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aba",
+        "ja": "アバ",
+        "ja_typings": [
+          "aba"
+        ]
+      },
+      {
+        "en": "Gara",
+        "ja": "ガラ",
+        "ja_typings": [
+          "gara"
+        ]
+      },
+      {
+        "en": "Gomi",
+        "ja": "ゴミ",
+        "ja_typings": [
+          "gomi"
+        ]
+      },
+      {
+        "en": "Zako",
+        "ja": "ザコ",
+        "ja_typings": [
+          "zako"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03456",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the net-slang term for an avatar or anonymous online persona?",
+      "ja": "ネットスラングで匿名のあだ名や仮の名前を指す言葉は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Angry",
+        "ja": "アングリー",
+        "ja_typings": [
+          "anguri-"
+        ]
+      },
+      {
+        "en": "Sorry",
+        "ja": "ソーリー",
+        "ja_typings": [
+          "so-ri-"
+        ]
+      },
+      {
+        "en": "Thanks",
+        "ja": "サンクス",
+        "ja_typings": [
+          "sankusu"
+        ]
+      },
+      {
+        "en": "Bye",
+        "ja": "バイ",
+        "ja_typings": [
+          "bai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03457",
+    "image_path": null,
+    "question_text": {
+      "en": "Which English word is often used in net slang to express frustration?",
+      "ja": "ネットで怒りを表す英単語スラングは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Arashi",
+        "ja": "嵐",
+        "ja_typings": [
+          "arashi"
+        ]
+      },
+      {
+        "en": "Tamashii",
+        "ja": "魂",
+        "ja_typings": [
+          "tamashii"
+        ]
+      },
+      {
+        "en": "Kuromaku",
+        "ja": "黒幕",
+        "ja_typings": [
+          "kuromaku"
+        ]
+      },
+      {
+        "en": "Persona",
+        "ja": "ペルソナ",
+        "ja_typings": [
+          "perusona"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03458",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese word means 'storm' and is also a famous idol group name?",
+      "ja": "「嵐」を意味し有名アイドルグループ名でもある言葉は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "BTW",
+        "ja": "ところで",
+        "ja_typings": [
+          "btw",
+          "tokorode"
+        ]
+      },
+      {
+        "en": "FYI",
+        "ja": "参考までに",
+        "ja_typings": [
+          "fyi"
+        ]
+      },
+      {
+        "en": "TBH",
+        "ja": "正直に言うと",
+        "ja_typings": [
+          "tbh"
+        ]
+      },
+      {
+        "en": "BRB",
+        "ja": "すぐ戻る",
+        "ja_typings": [
+          "brb"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03459",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the net abbreviation 'BTW' stand for?",
+      "ja": "ネット略語「BTW」の意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bimyou",
+        "ja": "微妙",
+        "ja_typings": [
+          "bimyou",
+          "bimyo-"
+        ]
+      },
+      {
+        "en": "Gomi",
+        "ja": "ゴミ",
+        "ja_typings": [
+          "gomi"
+        ]
+      },
+      {
+        "en": "Zako",
+        "ja": "ザコ",
+        "ja_typings": [
+          "zako"
+        ]
+      },
+      {
+        "en": "Gara",
+        "ja": "ガラ",
+        "ja_typings": [
+          "gara"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03460",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese word means 'subtle' or 'so-so'?",
+      "ja": "「微妙」を意味する日本語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bits",
+        "ja": "ビッツ",
+        "ja_typings": [
+          "bittsu"
+        ]
+      },
+      {
+        "en": "Supacha",
+        "ja": "スパチャ",
+        "ja_typings": [
+          "supacha"
+        ]
+      },
+      {
+        "en": "Renkome",
+        "ja": "連コメ",
+        "ja_typings": [
+          "renkome"
+        ]
+      },
+      {
+        "en": "Laicha",
+        "ja": "ライチャ",
+        "ja_typings": [
+          "raicha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03461",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the name of the virtual currency used to cheer on Twitch?",
+      "ja": "Twitchで配信者を応援するために使う仮想通貨は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bushiroad",
+        "ja": "ブシロード",
+        "ja_typings": [
+          "bushiro-do"
+        ]
+      },
+      {
+        "en": "Kadokawa",
+        "ja": "KADOKAWA",
+        "ja_typings": [
+          "kadokawa"
+        ]
+      },
+      {
+        "en": "Dwango",
+        "ja": "ドワンゴ",
+        "ja_typings": [
+          "dowango"
+        ]
+      },
+      {
+        "en": "DeNA",
+        "ja": "DeNA",
+        "ja_typings": [
+          "dena",
+          "deiienue-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03462",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese company produces Bang Dream and Revue Starlight, and runs many TCGs?",
+      "ja": "バンドリやヴァイスシュヴァルツを運営する日本企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bye",
+        "ja": "バイ",
+        "ja_typings": [
+          "bai"
+        ]
+      },
+      {
+        "en": "Sorry",
+        "ja": "ソーリー",
+        "ja_typings": [
+          "so-ri-"
+        ]
+      },
+      {
+        "en": "Thanks",
+        "ja": "サンクス",
+        "ja_typings": [
+          "sankusu"
+        ]
+      },
+      {
+        "en": "Spam",
+        "ja": "スパム",
+        "ja_typings": [
+          "supamu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03463",
+    "image_path": null,
+    "question_text": {
+      "en": "Which English word is commonly used as a parting greeting?",
+      "ja": "英語で別れの挨拶として使われる短い単語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Collab haishin",
+        "ja": "コラボ配信",
+        "ja_typings": [
+          "korabohaishin"
+        ]
+      },
+      {
+        "en": "Mirror haishin",
+        "ja": "ミラー配信",
+        "ja_typings": [
+          "mira-haishin"
+        ]
+      },
+      {
+        "en": "Reaction douga",
+        "ja": "リアクション動画",
+        "ja_typings": [
+          "riakushondouga",
+          "riakushondo-ga"
+        ]
+      },
+      {
+        "en": "Nico Utagassen",
+        "ja": "ニコニコ歌合戦",
+        "ja_typings": [
+          "nikonikoutagassen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03464",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a streaming format where multiple VTubers appear together called?",
+      "ja": "複数のVTuberが一緒に出演する配信形式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cover Corp",
+        "ja": "カバー",
+        "ja_typings": [
+          "kaba-"
+        ]
+      },
+      {
+        "en": "ANYCOLOR",
+        "ja": "ANYCOLOR",
+        "ja_typings": [
+          "anycolor"
+        ]
+      },
+      {
+        "en": "Sony",
+        "ja": "ソニー",
+        "ja_typings": [
+          "soni-"
+        ]
+      },
+      {
+        "en": "DeNA",
+        "ja": "DeNA",
+        "ja_typings": [
+          "dena"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03465",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company runs the Hololive Production VTuber agency?",
+      "ja": "ホロライブプロダクションを運営する会社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Crew",
+        "ja": "クルー",
+        "ja_typings": [
+          "kuru-"
+        ]
+      },
+      {
+        "en": "Staff",
+        "ja": "スタッフ",
+        "ja_typings": [
+          "sutaffu"
+        ]
+      },
+      {
+        "en": "Listener",
+        "ja": "リスナー",
+        "ja_typings": [
+          "risuna-"
+        ]
+      },
+      {
+        "en": "Member",
+        "ja": "メンバー",
+        "ja_typings": [
+          "menba-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03466",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a group of regular fans of a specific streamer or VTuber called in English?",
+      "ja": "特定の配信者の常連ファン集団を英語で何と呼ぶ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DeNA",
+        "ja": "DeNA",
+        "ja_typings": [
+          "dena",
+          "deiienue-"
+        ]
+      },
+      {
+        "en": "Dwango",
+        "ja": "ドワンゴ",
+        "ja_typings": [
+          "dowango"
+        ]
+      },
+      {
+        "en": "Sony",
+        "ja": "ソニー",
+        "ja_typings": [
+          "soni-"
+        ]
+      },
+      {
+        "en": "ANYCOLOR",
+        "ja": "ANYCOLOR",
+        "ja_typings": [
+          "anycolor"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03467",
+    "image_path": null,
+    "question_text": {
+      "en": "Which company is known for the mobile games Pokemon Masters and Mobage platform?",
+      "ja": "モバゲーやポケモンマスターズで知られる日本企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Enja",
+        "ja": "英じゃ",
+        "ja_typings": [
+          "enja"
+        ]
+      },
+      {
+        "en": "Aba",
+        "ja": "アバ",
+        "ja_typings": [
+          "aba"
+        ]
+      },
+      {
+        "en": "Gara",
+        "ja": "ガラ",
+        "ja_typings": [
+          "gara"
+        ]
+      },
+      {
+        "en": "Bimyou",
+        "ja": "微妙",
+        "ja_typings": [
+          "bimyou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03468",
+    "image_path": null,
+    "question_text": {
+      "en": "What net slang refers to the English language or being in English?",
+      "ja": "英語であることを指すネットスラングは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FYI",
+        "ja": "参考までに",
+        "ja_typings": [
+          "fyi"
+        ]
+      },
+      {
+        "en": "BTW",
+        "ja": "ところで",
+        "ja_typings": [
+          "btw",
+          "tokorode"
+        ]
+      },
+      {
+        "en": "TBH",
+        "ja": "正直に言うと",
+        "ja_typings": [
+          "tbh"
+        ]
+      },
+      {
+        "en": "BRB",
+        "ja": "すぐ戻る",
+        "ja_typings": [
+          "brb"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03469",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the net abbreviation 'FYI' stand for?",
+      "ja": "ネット略語「FYI」の意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gara",
+        "ja": "ガラ",
+        "ja_typings": [
+          "gara"
+        ]
+      },
+      {
+        "en": "Aba",
+        "ja": "アバ",
+        "ja_typings": [
+          "aba"
+        ]
+      },
+      {
+        "en": "Gomi",
+        "ja": "ゴミ",
+        "ja_typings": [
+          "gomi"
+        ]
+      },
+      {
+        "en": "Zako",
+        "ja": "ザコ",
+        "ja_typings": [
+          "zako"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03470",
+    "image_path": null,
+    "question_text": {
+      "en": "Which net slang word refers to character traits in Japanese?",
+      "ja": "ネットスラングで「キャラ性」「性格」を指す日本語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gold member",
+        "ja": "ゴールドメンバー",
+        "ja_typings": [
+          "go-rudomenba-"
+        ]
+      },
+      {
+        "en": "Plus member",
+        "ja": "プラスメンバー",
+        "ja_typings": [
+          "purasumenba-"
+        ]
+      },
+      {
+        "en": "Member",
+        "ja": "メンバー",
+        "ja_typings": [
+          "menba-"
+        ]
+      },
+      {
+        "en": "Crew",
+        "ja": "クルー",
+        "ja_typings": [
+          "kuru-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03471",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the top-tier paid YouTube channel membership called?",
+      "ja": "YouTubeチャンネルメンバーシップの最上位プランは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Gomi",
+        "ja": "ゴミ",
+        "ja_typings": [
+          "gomi"
+        ]
+      },
+      {
+        "en": "Zako",
+        "ja": "ザコ",
+        "ja_typings": [
+          "zako"
+        ]
+      },
+      {
+        "en": "Bimyou",
+        "ja": "微妙",
+        "ja_typings": [
+          "bimyou"
+        ]
+      },
+      {
+        "en": "Aba",
+        "ja": "アバ",
+        "ja_typings": [
+          "aba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03472",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese word means 'trash' and is used as net slang?",
+      "ja": "ネットスラングで「ゴミ」を意味する言葉は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Good morning",
+        "ja": "グッドモーニング",
+        "ja_typings": [
+          "guddomo-ningu"
+        ]
+      },
+      {
+        "en": "Bye",
+        "ja": "バイ",
+        "ja_typings": [
+          "bai"
+        ]
+      },
+      {
+        "en": "Sorry",
+        "ja": "ソーリー",
+        "ja_typings": [
+          "so-ri-"
+        ]
+      },
+      {
+        "en": "Thanks",
+        "ja": "サンクス",
+        "ja_typings": [
+          "sankusu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03473",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a typical morning greeting in English?",
+      "ja": "英語で朝の挨拶として使われる定型句は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hololive",
+        "ja": "ホロライブ",
+        "ja_typings": [
+          "hororaibu"
+        ]
+      },
+      {
+        "en": "Nijisanji",
+        "ja": "にじさんじ",
+        "ja_typings": [
+          "nijisanji"
+        ]
+      },
+      {
+        "en": "VSPO!",
+        "ja": "ぶいすぽっ!",
+        "ja_typings": [
+          "buisupo"
+        ]
+      },
+      {
+        "en": "Noripro",
+        "ja": "ノリプロ",
+        "ja_typings": [
+          "noripuro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03474",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is the largest Japanese VTuber agency featuring Pekora and Fubuki?",
+      "ja": "兎田ぺこらや白上フブキが所属するVTuber事務所は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Indonesia",
+        "ja": "インドネシア",
+        "ja_typings": [
+          "indoneshia"
+        ]
+      },
+      {
+        "en": "Korea",
+        "ja": "コリア",
+        "ja_typings": [
+          "koria"
+        ]
+      },
+      {
+        "en": "Japan",
+        "ja": "ジャパン",
+        "ja_typings": [
+          "japan"
+        ]
+      },
+      {
+        "en": "Persona",
+        "ja": "ペルソナ",
+        "ja_typings": [
+          "perusona"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03475",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Southeast Asian country has its own Hololive branch?",
+      "ja": "ホロライブの支部があった東南アジアの国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Inuyama Tamaki",
+        "ja": "犬山たまき",
+        "ja_typings": [
+          "inuyamatamaki"
+        ]
+      },
+      {
+        "en": "Tenkai Tsukasa",
+        "ja": "天開司",
+        "ja_typings": [
+          "tenkaitsukasa"
+        ]
+      },
+      {
+        "en": "Yamato Iori",
+        "ja": "ヤマトイオリ",
+        "ja_typings": [
+          "yamatoiori"
+        ]
+      },
+      {
+        "en": "Robocosan",
+        "ja": "ロボ子さん",
+        "ja_typings": [
+          "robokosan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03476",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nijisanji VTuber is the leader of the 'Iwagumi' generation and has cat ears?",
+      "ja": "にじさんじの「岩組」のリーダーで猫耳のVTuberは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Japan",
+        "ja": "日本",
+        "ja_typings": [
+          "nippon",
+          "nihon",
+          "japan"
+        ]
+      },
+      {
+        "en": "Korea",
+        "ja": "韓国",
+        "ja_typings": [
+          "kankoku",
+          "koria"
+        ]
+      },
+      {
+        "en": "Indonesia",
+        "ja": "インドネシア",
+        "ja_typings": [
+          "indoneshia"
+        ]
+      },
+      {
+        "en": "China",
+        "ja": "中国",
+        "ja_typings": [
+          "chuugoku",
+          "chu-goku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03477",
+    "image_path": null,
+    "question_text": {
+      "en": "Which country is the headquarters of Hololive based in?",
+      "ja": "ホロライブの本社がある国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kadokawa",
+        "ja": "KADOKAWA",
+        "ja_typings": [
+          "kadokawa"
+        ]
+      },
+      {
+        "en": "Dwango",
+        "ja": "ドワンゴ",
+        "ja_typings": [
+          "dowango"
+        ]
+      },
+      {
+        "en": "Sony",
+        "ja": "ソニー",
+        "ja_typings": [
+          "soni-"
+        ]
+      },
+      {
+        "en": "Bushiroad",
+        "ja": "ブシロード",
+        "ja_typings": [
+          "bushiro-do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03478",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese publisher owns Dwango and is famous for light novels?",
+      "ja": "ドワンゴを子会社に持ち、ライトノベルでも有名な日本の出版社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Korea",
+        "ja": "韓国",
+        "ja_typings": [
+          "kankoku",
+          "koria"
+        ]
+      },
+      {
+        "en": "Indonesia",
+        "ja": "インドネシア",
+        "ja_typings": [
+          "indoneshia"
+        ]
+      },
+      {
+        "en": "Japan",
+        "ja": "日本",
+        "ja_typings": [
+          "nihon"
+        ]
+      },
+      {
+        "en": "Persona",
+        "ja": "ペルソナ",
+        "ja_typings": [
+          "perusona"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03479",
+    "image_path": null,
+    "question_text": {
+      "en": "Which East Asian country borders Japan and has its own VTuber scene?",
+      "ja": "日本の隣にあり独自のVTuber文化を持つ東アジアの国は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kuromaku",
+        "ja": "黒幕",
+        "ja_typings": [
+          "kuromaku"
+        ]
+      },
+      {
+        "en": "Tamashii",
+        "ja": "魂",
+        "ja_typings": [
+          "tamashii"
+        ]
+      },
+      {
+        "en": "Persona",
+        "ja": "ペルソナ",
+        "ja_typings": [
+          "perusona"
+        ]
+      },
+      {
+        "en": "Arashi",
+        "ja": "嵐",
+        "ja_typings": [
+          "arashi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03480",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese word means 'mastermind' behind the scenes?",
+      "ja": "陰で操る黒幕を意味する日本語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kuzuha and Kenmochi",
+        "ja": "葛葉と剣持",
+        "ja_typings": [
+          "kuzuhatokenmochi"
+        ]
+      },
+      {
+        "en": "Kuromaku",
+        "ja": "黒幕",
+        "ja_typings": [
+          "kuromaku"
+        ]
+      },
+      {
+        "en": "Tenkai Tsukasa",
+        "ja": "天開司",
+        "ja_typings": [
+          "tenkaitsukasa"
+        ]
+      },
+      {
+        "en": "Inuyama Tamaki",
+        "ja": "犬山たまき",
+        "ja_typings": [
+          "inuyamatamaki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03481",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Nijisanji male duo became hugely popular as the 'ChroNoiR' unit?",
+      "ja": "にじさんじでChroNoiRとして活動する男性デュオは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Supacha",
+        "ja": "スパチャ",
+        "ja_typings": [
+          "supacha"
+        ]
+      },
+      {
+        "en": "Laicha",
+        "ja": "ライチャ",
+        "ja_typings": [
+          "raicha"
+        ]
+      },
+      {
+        "en": "Renkome",
+        "ja": "連コメ",
+        "ja_typings": [
+          "renkome"
+        ]
+      },
+      {
+        "en": "Bits",
+        "ja": "ビッツ",
+        "ja_typings": [
+          "bittsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03482",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the slang term for a stream of paid YouTube Super Chat messages?",
+      "ja": "YouTubeのスーパーチャットの俗称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Listener",
+        "ja": "リスナー",
+        "ja_typings": [
+          "risuna-"
+        ]
+      },
+      {
+        "en": "Member",
+        "ja": "メンバー",
+        "ja_typings": [
+          "menba-"
+        ]
+      },
+      {
+        "en": "Staff",
+        "ja": "スタッフ",
+        "ja_typings": [
+          "sutaffu"
+        ]
+      },
+      {
+        "en": "Crew",
+        "ja": "クルー",
+        "ja_typings": [
+          "kuru-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03483",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call a viewer who watches and comments on streams?",
+      "ja": "配信を見ながらコメントする視聴者を指す言葉は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Member",
+        "ja": "メンバー",
+        "ja_typings": [
+          "menba-"
+        ]
+      },
+      {
+        "en": "Listener",
+        "ja": "リスナー",
+        "ja_typings": [
+          "risuna-"
+        ]
+      },
+      {
+        "en": "Crew",
+        "ja": "クルー",
+        "ja_typings": [
+          "kuru-"
+        ]
+      },
+      {
+        "en": "Staff",
+        "ja": "スタッフ",
+        "ja_typings": [
+          "sutaffu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03484",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a paid YouTube channel supporter called?",
+      "ja": "有料のチャンネル登録者をなんと呼ぶ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Messe",
+        "ja": "メッセ",
+        "ja_typings": [
+          "messe"
+        ]
+      },
+      {
+        "en": "Spam",
+        "ja": "スパム",
+        "ja_typings": [
+          "supamu"
+        ]
+      },
+      {
+        "en": "Persona",
+        "ja": "ペルソナ",
+        "ja_typings": [
+          "perusona"
+        ]
+      },
+      {
+        "en": "Tamashii",
+        "ja": "魂",
+        "ja_typings": [
+          "tamashii"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03485",
+    "image_path": null,
+    "question_text": {
+      "en": "Which English word borrowed into Japanese means 'message'?",
+      "ja": "「メッセージ」を意味するドイツ語由来の言葉で、見本市の意味もある語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Minato Aqua",
+        "ja": "湊あくあ",
+        "ja_typings": [
+          "minatoakua"
+        ]
+      },
+      {
+        "en": "Murasaki Shion",
+        "ja": "紫咲シオン",
+        "ja_typings": [
+          "murasakishion"
+        ]
+      },
+      {
+        "en": "Nakiri Ayame",
+        "ja": "百鬼あやめ",
+        "ja_typings": [
+          "nakiriayame"
+        ]
+      },
+      {
+        "en": "Shirakami Fubuki",
+        "ja": "白上フブキ",
+        "ja_typings": [
+          "shirakamifubuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03486",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive VTuber has blue twintails and is famous for the 'Aqua Crew'?",
+      "ja": "ホロライブで青いツインテールが特徴のVTuberは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Mirror haishin",
+        "ja": "ミラー配信",
+        "ja_typings": [
+          "mira-haishin"
+        ]
+      },
+      {
+        "en": "Collab haishin",
+        "ja": "コラボ配信",
+        "ja_typings": [
+          "korabohaishin"
+        ]
+      },
+      {
+        "en": "Reaction douga",
+        "ja": "リアクション動画",
+        "ja_typings": [
+          "riakushondo-ga"
+        ]
+      },
+      {
+        "en": "Nico Utagassen",
+        "ja": "ニコニコ歌合戦",
+        "ja_typings": [
+          "nikonikoutagassen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03487",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call replaying another streamer's broadcast on your own channel?",
+      "ja": "他人の配信を自分の画面で同時に映す配信形式は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Murasaki Shion",
+        "ja": "紫咲シオン",
+        "ja_typings": [
+          "murasakishion"
+        ]
+      },
+      {
+        "en": "Minato Aqua",
+        "ja": "湊あくあ",
+        "ja_typings": [
+          "minatoakua"
+        ]
+      },
+      {
+        "en": "Nakiri Ayame",
+        "ja": "百鬼あやめ",
+        "ja_typings": [
+          "nakiriayame"
+        ]
+      },
+      {
+        "en": "Shirakami Fubuki",
+        "ja": "白上フブキ",
+        "ja_typings": [
+          "shirakamifubuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03488",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive VTuber has purple hair and is the younger sister of Yozora Mel?",
+      "ja": "ホロライブの紫髪のVTuberで、夜空メルの妹分とされるのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nakiri Ayame",
+        "ja": "百鬼あやめ",
+        "ja_typings": [
+          "nakiriayame"
+        ]
+      },
+      {
+        "en": "Murasaki Shion",
+        "ja": "紫咲シオン",
+        "ja_typings": [
+          "murasakishion"
+        ]
+      },
+      {
+        "en": "Minato Aqua",
+        "ja": "湊あくあ",
+        "ja_typings": [
+          "minatoakua"
+        ]
+      },
+      {
+        "en": "Shirakami Fubuki",
+        "ja": "白上フブキ",
+        "ja_typings": [
+          "shirakamifubuki"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03489",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive VTuber has red oni horns and is part of 'Yo-rappers'?",
+      "ja": "赤い鬼の角が特徴のホロライブVTuberは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nico Utagassen",
+        "ja": "ニコニコ歌合戦",
+        "ja_typings": [
+          "nikonikoutagassen"
+        ]
+      },
+      {
+        "en": "Niconico Festival",
+        "ja": "ニコニコ祭",
+        "ja_typings": [
+          "nikonikomatsuri"
+        ]
+      },
+      {
+        "en": "Nicochu",
+        "ja": "ニコ厨",
+        "ja_typings": [
+          "nikochu",
+          "nikochuu"
+        ]
+      },
+      {
+        "en": "Collab haishin",
+        "ja": "コラボ配信",
+        "ja_typings": [
+          "korabohaishin"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03490",
+    "image_path": null,
+    "question_text": {
+      "en": "What was the name of NHK's traditional New Year's Eve singing contest, parodied on Niconico?",
+      "ja": "NHK紅白歌合戦をパロディしたニコニコ動画の年末イベントは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nicochu",
+        "ja": "ニコ厨",
+        "ja_typings": [
+          "nikochu",
+          "nikochuu"
+        ]
+      },
+      {
+        "en": "Listener",
+        "ja": "リスナー",
+        "ja_typings": [
+          "risuna-"
+        ]
+      },
+      {
+        "en": "Member",
+        "ja": "メンバー",
+        "ja_typings": [
+          "menba-"
+        ]
+      },
+      {
+        "en": "Crew",
+        "ja": "クルー",
+        "ja_typings": [
+          "kuru-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03491",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the slang term for a die-hard Niconico Douga fan?",
+      "ja": "ニコニコ動画に熱中する人を指すスラングは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Niconico Festival",
+        "ja": "ニコニコ超会議",
+        "ja_typings": [
+          "nikonikochoukaigi"
+        ]
+      },
+      {
+        "en": "Nico Utagassen",
+        "ja": "ニコニコ歌合戦",
+        "ja_typings": [
+          "nikonikoutagassen"
+        ]
+      },
+      {
+        "en": "Toukaigi",
+        "ja": "闘会議",
+        "ja_typings": [
+          "toukaigi"
+        ]
+      },
+      {
+        "en": "Messe",
+        "ja": "メッセ",
+        "ja_typings": [
+          "messe"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03492",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the annual Niconico user festival held in Makuhari called?",
+      "ja": "幕張メッセで行われるニコニコ動画のリアルイベントは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Persona",
+        "ja": "ペルソナ",
+        "ja_typings": [
+          "perusona"
+        ]
+      },
+      {
+        "en": "Tamashii",
+        "ja": "魂",
+        "ja_typings": [
+          "tamashii"
+        ]
+      },
+      {
+        "en": "Arashi",
+        "ja": "嵐",
+        "ja_typings": [
+          "arashi"
+        ]
+      },
+      {
+        "en": "Kuromaku",
+        "ja": "黒幕",
+        "ja_typings": [
+          "kuromaku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03493",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Atlus RPG series features Shadows and the Velvet Room?",
+      "ja": "アトラスのRPGで「ベルベットルーム」が登場するシリーズは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Plus member",
+        "ja": "プラスメンバー",
+        "ja_typings": [
+          "purasumenba-"
+        ]
+      },
+      {
+        "en": "Gold member",
+        "ja": "ゴールドメンバー",
+        "ja_typings": [
+          "go-rudomenba-"
+        ]
+      },
+      {
+        "en": "Member",
+        "ja": "メンバー",
+        "ja_typings": [
+          "menba-"
+        ]
+      },
+      {
+        "en": "Listener",
+        "ja": "リスナー",
+        "ja_typings": [
+          "risuna-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03494",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a mid-tier YouTube channel membership plan often called?",
+      "ja": "YouTubeメンバーシップで中位のプラン名としてよく使われるのは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Reaction douga",
+        "ja": "リアクション動画",
+        "ja_typings": [
+          "riakushondo-ga",
+          "riakushondouga"
+        ]
+      },
+      {
+        "en": "Collab haishin",
+        "ja": "コラボ配信",
+        "ja_typings": [
+          "korabohaishin"
+        ]
+      },
+      {
+        "en": "Mirror haishin",
+        "ja": "ミラー配信",
+        "ja_typings": [
+          "mira-haishin"
+        ]
+      },
+      {
+        "en": "Nico Utagassen",
+        "ja": "ニコニコ歌合戦",
+        "ja_typings": [
+          "nikonikoutagassen"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03495",
+    "image_path": null,
+    "question_text": {
+      "en": "What kind of video shows a streamer's responses to other content?",
+      "ja": "他の動画や配信に対する反応を撮った動画は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Renkome",
+        "ja": "連コメ",
+        "ja_typings": [
+          "renkome"
+        ]
+      },
+      {
+        "en": "Supacha",
+        "ja": "スパチャ",
+        "ja_typings": [
+          "supacha"
+        ]
+      },
+      {
+        "en": "Spam",
+        "ja": "スパム",
+        "ja_typings": [
+          "supamu"
+        ]
+      },
+      {
+        "en": "Laicha",
+        "ja": "ライチャ",
+        "ja_typings": [
+          "raicha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03496",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the slang term for spamming the same comment repeatedly?",
+      "ja": "同じコメントを何度も連投することを指すスラングは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Robocosan",
+        "ja": "ロボ子さん",
+        "ja_typings": [
+          "robokosan"
+        ]
+      },
+      {
+        "en": "Yamato Iori",
+        "ja": "ヤマトイオリ",
+        "ja_typings": [
+          "yamatoiori"
+        ]
+      },
+      {
+        "en": "Inuyama Tamaki",
+        "ja": "犬山たまき",
+        "ja_typings": [
+          "inuyamatamaki"
+        ]
+      },
+      {
+        "en": "Tenkai Tsukasa",
+        "ja": "天開司",
+        "ja_typings": [
+          "tenkaitsukasa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03497",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive VTuber is a robot girl voiced as a tinkerer who builds Robohouse?",
+      "ja": "ホロライブのロボット娘で工作好きなVTuberは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shirakami Fubuki",
+        "ja": "白上フブキ",
+        "ja_typings": [
+          "shirakamifubuki"
+        ]
+      },
+      {
+        "en": "Minato Aqua",
+        "ja": "湊あくあ",
+        "ja_typings": [
+          "minatoakua"
+        ]
+      },
+      {
+        "en": "Nakiri Ayame",
+        "ja": "百鬼あやめ",
+        "ja_typings": [
+          "nakiriayame"
+        ]
+      },
+      {
+        "en": "Murasaki Shion",
+        "ja": "紫咲シオン",
+        "ja_typings": [
+          "murasakishion"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03498",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive VTuber is a white fox-girl and 'gamers' group member?",
+      "ja": "ホロライブGAMERSの白い狐のVTuberは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sony",
+        "ja": "ソニー",
+        "ja_typings": [
+          "soni-"
+        ]
+      },
+      {
+        "en": "Kadokawa",
+        "ja": "KADOKAWA",
+        "ja_typings": [
+          "kadokawa"
+        ]
+      },
+      {
+        "en": "DeNA",
+        "ja": "DeNA",
+        "ja_typings": [
+          "dena"
+        ]
+      },
+      {
+        "en": "Bushiroad",
+        "ja": "ブシロード",
+        "ja_typings": [
+          "bushiro-do"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03499",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese global electronics and entertainment giant owns PlayStation?",
+      "ja": "PlayStationを展開する日本の大手電機・エンタメ企業は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sorry",
+        "ja": "ソーリー",
+        "ja_typings": [
+          "so-ri-"
+        ]
+      },
+      {
+        "en": "Thanks",
+        "ja": "サンクス",
+        "ja_typings": [
+          "sankusu"
+        ]
+      },
+      {
+        "en": "Bye",
+        "ja": "バイ",
+        "ja_typings": [
+          "bai"
+        ]
+      },
+      {
+        "en": "Spam",
+        "ja": "スパム",
+        "ja_typings": [
+          "supamu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03500",
+    "image_path": null,
+    "question_text": {
+      "en": "Which English word is used to apologize politely?",
+      "ja": "英語で丁寧に謝罪する一語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Spam",
+        "ja": "スパム",
+        "ja_typings": [
+          "supamu"
+        ]
+      },
+      {
+        "en": "Renkome",
+        "ja": "連コメ",
+        "ja_typings": [
+          "renkome"
+        ]
+      },
+      {
+        "en": "Supacha",
+        "ja": "スパチャ",
+        "ja_typings": [
+          "supacha"
+        ]
+      },
+      {
+        "en": "Bits",
+        "ja": "ビッツ",
+        "ja_typings": [
+          "bittsu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03501",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call unsolicited junk messages on the internet?",
+      "ja": "ネット上の迷惑な大量メッセージのことを何という?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Staff",
+        "ja": "スタッフ",
+        "ja_typings": [
+          "sutaffu"
+        ]
+      },
+      {
+        "en": "Crew",
+        "ja": "クルー",
+        "ja_typings": [
+          "kuru-"
+        ]
+      },
+      {
+        "en": "Listener",
+        "ja": "リスナー",
+        "ja_typings": [
+          "risuna-"
+        ]
+      },
+      {
+        "en": "Member",
+        "ja": "メンバー",
+        "ja_typings": [
+          "menba-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03502",
+    "image_path": null,
+    "question_text": {
+      "en": "What do you call the production team behind the scenes of a stream?",
+      "ja": "配信を支える裏方のスタッフを英語で何と呼ぶ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Supacha",
+        "ja": "スパチャ",
+        "ja_typings": [
+          "supacha"
+        ]
+      },
+      {
+        "en": "Laicha",
+        "ja": "ライチャ",
+        "ja_typings": [
+          "raicha"
+        ]
+      },
+      {
+        "en": "Bits",
+        "ja": "ビッツ",
+        "ja_typings": [
+          "bittsu"
+        ]
+      },
+      {
+        "en": "Renkome",
+        "ja": "renkome",
+        "ja_typings": [
+          "renkome"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03503",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the slang term for a paid Twitch chat similar to Supacha?",
+      "ja": "Twitchの有料コメント機能を指す俗称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "TBH",
+        "ja": "正直に言うと",
+        "ja_typings": [
+          "tbh"
+        ]
+      },
+      {
+        "en": "BTW",
+        "ja": "ところで",
+        "ja_typings": [
+          "btw",
+          "tokorode"
+        ]
+      },
+      {
+        "en": "FYI",
+        "ja": "参考までに",
+        "ja_typings": [
+          "fyi"
+        ]
+      },
+      {
+        "en": "BRB",
+        "ja": "すぐ戻る",
+        "ja_typings": [
+          "brb"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03504",
+    "image_path": null,
+    "question_text": {
+      "en": "What does the net abbreviation 'TBH' stand for?",
+      "ja": "ネット略語「TBH」の意味は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tamashii",
+        "ja": "魂",
+        "ja_typings": [
+          "tamashii"
+        ]
+      },
+      {
+        "en": "Persona",
+        "ja": "ペルソナ",
+        "ja_typings": [
+          "perusona"
+        ]
+      },
+      {
+        "en": "Kuromaku",
+        "ja": "黒幕",
+        "ja_typings": [
+          "kuromaku"
+        ]
+      },
+      {
+        "en": "Gara",
+        "ja": "ガラ",
+        "ja_typings": [
+          "gara"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03505",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese word refers to the 'soul' inside a VTuber avatar?",
+      "ja": "VTuberのアバターの中の人(魂)を指す日本語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tenkai Tsukasa",
+        "ja": "天開司",
+        "ja_typings": [
+          "tenkaitsukasa"
+        ]
+      },
+      {
+        "en": "Inuyama Tamaki",
+        "ja": "犬山たまき",
+        "ja_typings": [
+          "inuyamatamaki"
+        ]
+      },
+      {
+        "en": "Robocosan",
+        "ja": "ロボ子さん",
+        "ja_typings": [
+          "robokosan"
+        ]
+      },
+      {
+        "en": "Yamato Iori",
+        "ja": "ヤマトイオリ",
+        "ja_typings": [
+          "yamatoiori"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03506",
+    "image_path": null,
+    "question_text": {
+      "en": "Which male VTuber is known as the leader of 'Tasokare Hotel' and 774 inc?",
+      "ja": "774inc.に所属し「黄昏ホテル」で知られる男性VTuberは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thanks",
+        "ja": "サンクス",
+        "ja_typings": [
+          "sankusu"
+        ]
+      },
+      {
+        "en": "Sorry",
+        "ja": "ソーリー",
+        "ja_typings": [
+          "so-ri-"
+        ]
+      },
+      {
+        "en": "Bye",
+        "ja": "バイ",
+        "ja_typings": [
+          "bai"
+        ]
+      },
+      {
+        "en": "Spam",
+        "ja": "スパム",
+        "ja_typings": [
+          "supamu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03507",
+    "image_path": null,
+    "question_text": {
+      "en": "Which English word is used to express gratitude?",
+      "ja": "英語で感謝を伝える短い単語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The streamer",
+        "ja": "ストリーマー",
+        "ja_typings": [
+          "sutori-ma-"
+        ]
+      },
+      {
+        "en": "Listener",
+        "ja": "リスナー",
+        "ja_typings": [
+          "risuna-"
+        ]
+      },
+      {
+        "en": "Staff",
+        "ja": "スタッフ",
+        "ja_typings": [
+          "sutaffu"
+        ]
+      },
+      {
+        "en": "Crew",
+        "ja": "クルー",
+        "ja_typings": [
+          "kuru-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03508",
+    "image_path": null,
+    "question_text": {
+      "en": "What term refers to the main personality being broadcast in a stream?",
+      "ja": "配信のメインとなる配信者を英語で何と呼ぶ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "TikTok",
+        "ja": "ティックトック",
+        "ja_typings": [
+          "tikkutokku"
+        ]
+      },
+      {
+        "en": "Twitch",
+        "ja": "ツイッチ",
+        "ja_typings": [
+          "tsuicchi",
+          "tsuitchi"
+        ]
+      },
+      {
+        "en": "YouTube",
+        "ja": "ユーチューブ",
+        "ja_typings": [
+          "yu-chu-bu"
+        ]
+      },
+      {
+        "en": "Nicochu",
+        "ja": "ニコ厨",
+        "ja_typings": [
+          "nikochu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03509",
+    "image_path": null,
+    "question_text": {
+      "en": "Which short-form video app is owned by ByteDance and popular for dance trends?",
+      "ja": "ByteDanceが運営するショート動画アプリは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Toukaigi",
+        "ja": "闘会議",
+        "ja_typings": [
+          "toukaigi"
+        ]
+      },
+      {
+        "en": "Niconico Festival",
+        "ja": "ニコニコ超会議",
+        "ja_typings": [
+          "nikonikochoukaigi"
+        ]
+      },
+      {
+        "en": "Nico Utagassen",
+        "ja": "ニコニコ歌合戦",
+        "ja_typings": [
+          "nikonikoutagassen"
+        ]
+      },
+      {
+        "en": "Messe",
+        "ja": "メッセ",
+        "ja_typings": [
+          "messe"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03510",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the annual Niconico gaming festival called?",
+      "ja": "ニコニコが主催するゲームのリアルイベントは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Twitch",
+        "ja": "ツイッチ",
+        "ja_typings": [
+          "tsuicchi",
+          "tsuitchi"
+        ]
+      },
+      {
+        "en": "TikTok",
+        "ja": "ティックトック",
+        "ja_typings": [
+          "tikkutokku"
+        ]
+      },
+      {
+        "en": "YouTube",
+        "ja": "ユーチューブ",
+        "ja_typings": [
+          "yu-chu-bu"
+        ]
+      },
+      {
+        "en": "Nicochu",
+        "ja": "ニコ厨",
+        "ja_typings": [
+          "nikochu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03511",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Amazon-owned live streaming platform is centered on gaming?",
+      "ja": "Amazon傘下のゲーム配信に強いストリーミングサービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Usada Pekora",
+        "ja": "兎田ぺこら",
+        "ja_typings": [
+          "usadapekora"
+        ]
+      },
+      {
+        "en": "Minato Aqua",
+        "ja": "湊あくあ",
+        "ja_typings": [
+          "minatoakua"
+        ]
+      },
+      {
+        "en": "Shirakami Fubuki",
+        "ja": "白上フブキ",
+        "ja_typings": [
+          "shirakamifubuki"
+        ]
+      },
+      {
+        "en": "Murasaki Shion",
+        "ja": "紫咲シオン",
+        "ja_typings": [
+          "murasakishion"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03512",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Hololive VTuber is a bunny girl famous for 'peko peko peko'?",
+      "ja": "「ぺこぺこぺこ」で有名なホロライブのバニーVTuberは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Voice changer",
+        "ja": "ボイスチェンジャー",
+        "ja_typings": [
+          "boisuchenja-"
+        ]
+      },
+      {
+        "en": "Mirror haishin",
+        "ja": "ミラー配信",
+        "ja_typings": [
+          "mira-haishin"
+        ]
+      },
+      {
+        "en": "Reaction douga",
+        "ja": "リアクション動画",
+        "ja_typings": [
+          "riakushondo-ga"
+        ]
+      },
+      {
+        "en": "Spam",
+        "ja": "スパム",
+        "ja_typings": [
+          "supamu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03513",
+    "image_path": null,
+    "question_text": {
+      "en": "What kind of software changes the pitch or tone of a streamer's voice?",
+      "ja": "配信者の声を加工するソフトウェアの一般名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yamato Iori",
+        "ja": "ヤマトイオリ",
+        "ja_typings": [
+          "yamatoiori"
+        ]
+      },
+      {
+        "en": "Inuyama Tamaki",
+        "ja": "犬山たまき",
+        "ja_typings": [
+          "inuyamatamaki"
+        ]
+      },
+      {
+        "en": "Robocosan",
+        "ja": "ロボ子さん",
+        "ja_typings": [
+          "robokosan"
+        ]
+      },
+      {
+        "en": "Tenkai Tsukasa",
+        "ja": "天開司",
+        "ja_typings": [
+          "tenkaitsukasa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03514",
+    "image_path": null,
+    "question_text": {
+      "en": "Which early .LIVE VTuber is known as a quiet aesthetic singer with long hair?",
+      "ja": "アイドル部の長髪で物静かな歌姫VTuberは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "YouTube",
+        "ja": "ユーチューブ",
+        "ja_typings": [
+          "yu-chu-bu"
+        ]
+      },
+      {
+        "en": "Twitch",
+        "ja": "ツイッチ",
+        "ja_typings": [
+          "tsuicchi",
+          "tsuitchi"
+        ]
+      },
+      {
+        "en": "TikTok",
+        "ja": "ティックトック",
+        "ja_typings": [
+          "tikkutokku"
+        ]
+      },
+      {
+        "en": "Nicochu",
+        "ja": "ニコ厨",
+        "ja_typings": [
+          "nikochu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03515",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Google-owned video platform is the largest in the world?",
+      "ja": "Googleが運営する世界最大の動画共有サイトは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Zako",
+        "ja": "ザコ",
+        "ja_typings": [
+          "zako"
+        ]
+      },
+      {
+        "en": "Gomi",
+        "ja": "ゴミ",
+        "ja_typings": [
+          "gomi"
+        ]
+      },
+      {
+        "en": "Bimyou",
+        "ja": "微妙",
+        "ja_typings": [
+          "bimyou"
+        ]
+      },
+      {
+        "en": "Gara",
+        "ja": "ガラ",
+        "ja_typings": [
+          "gara"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "vtuber_net_culture",
+    "id": "q03516",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese word means 'weakling' and is often shouted by streamers?",
+      "ja": "「雑魚」を意味し配信者がよく叫ぶスラングは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ao Dai",
+        "ja": "アオザイ",
+        "ja_typings": [
+          "aozai"
+        ]
+      },
+      {
+        "en": "Hanbok",
+        "ja": "ハンボク",
+        "ja_typings": [
+          "hanboku"
+        ]
+      },
+      {
+        "en": "Toga",
+        "ja": "トーガ",
+        "ja_typings": [
+          "to-ga"
+        ]
+      },
+      {
+        "en": "Poncho",
+        "ja": "ポンチョ",
+        "ja_typings": [
+          "poncho"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03517",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the traditional long Vietnamese silk tunic dress called?",
+      "ja": "ベトナムの伝統的な長い絹のチュニック衣装は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Arrabbiata",
+        "ja": "アラビアータ",
+        "ja_typings": [
+          "arabia-ta"
+        ]
+      },
+      {
+        "en": "Bolognese",
+        "ja": "ボロネーゼ",
+        "ja_typings": [
+          "borone-ze"
+        ]
+      },
+      {
+        "en": "Pescatore",
+        "ja": "ペスカトーレ",
+        "ja_typings": [
+          "pesukato-re"
+        ]
+      },
+      {
+        "en": "Calzone",
+        "ja": "カルツォーネ",
+        "ja_typings": [
+          "karutso-ne"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03518",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian pasta sauce is made with garlic, chili and tomato, and means 'angry'?",
+      "ja": "ニンニクと唐辛子のトマトソースで「怒り」を意味するイタリア料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aztec civilization",
+        "ja": "アステカ文明",
+        "ja_typings": [
+          "asutekabunmei"
+        ]
+      },
+      {
+        "en": "Maya civilization",
+        "ja": "マヤ文明",
+        "ja_typings": [
+          "mayabunmei"
+        ]
+      },
+      {
+        "en": "Olmec civilization",
+        "ja": "オルメカ文明",
+        "ja_typings": [
+          "orumekabunmei"
+        ]
+      },
+      {
+        "en": "Indus River",
+        "ja": "インダス川",
+        "ja_typings": [
+          "indasugawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03519",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Mesoamerican civilization built Tenochtitlan?",
+      "ja": "テノチティトランを築いた古代メソアメリカ文明は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bible",
+        "ja": "聖書",
+        "ja_typings": [
+          "seisho"
+        ]
+      },
+      {
+        "en": "Torah",
+        "ja": "トーラー",
+        "ja_typings": [
+          "to-ra-"
+        ]
+      },
+      {
+        "en": "Vedas",
+        "ja": "ヴェーダ",
+        "ja_typings": [
+          "ve-da"
+        ]
+      },
+      {
+        "en": "Pesach",
+        "ja": "ペサハ",
+        "ja_typings": [
+          "pesaha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03520",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the central sacred book of Christianity called?",
+      "ja": "キリスト教の聖典は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bolognese",
+        "ja": "ボロネーゼ",
+        "ja_typings": [
+          "borone-ze"
+        ]
+      },
+      {
+        "en": "Arrabbiata",
+        "ja": "アラビアータ",
+        "ja_typings": [
+          "arabia-ta"
+        ]
+      },
+      {
+        "en": "Pescatore",
+        "ja": "ペスカトーレ",
+        "ja_typings": [
+          "pesukato-re"
+        ]
+      },
+      {
+        "en": "Piadina",
+        "ja": "ピアディーナ",
+        "ja_typings": [
+          "piadi-na"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03521",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian pasta sauce comes from a city in Emilia-Romagna and uses ground meat?",
+      "ja": "エミリア=ロマーニャ州の都市発祥のひき肉トマトソースは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bossa Nova",
+        "ja": "ボサノバ",
+        "ja_typings": [
+          "bosanoba"
+        ]
+      },
+      {
+        "en": "Flamenco",
+        "ja": "フラメンコ",
+        "ja_typings": [
+          "furamenko"
+        ]
+      },
+      {
+        "en": "Krav Maga",
+        "ja": "クラヴマガ",
+        "ja_typings": [
+          "kuravumaga"
+        ]
+      },
+      {
+        "en": "Taekwondo",
+        "ja": "テコンドー",
+        "ja_typings": [
+          "tekondo-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03522",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Brazilian music genre is closely associated with 'The Girl from Ipanema'?",
+      "ja": "「イパネマの娘」で有名なブラジル発祥の音楽ジャンルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Brahmaputra River",
+        "ja": "ブラフマプトラ川",
+        "ja_typings": [
+          "burafumaputoragawa"
+        ]
+      },
+      {
+        "en": "Indus River",
+        "ja": "インダス川",
+        "ja_typings": [
+          "indasugawa"
+        ]
+      },
+      {
+        "en": "Yamuna River",
+        "ja": "ヤムナー川",
+        "ja_typings": [
+          "yamuna-gawa"
+        ]
+      },
+      {
+        "en": "Eiffel Tower",
+        "ja": "エッフェル塔",
+        "ja_typings": [
+          "efferutou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03523",
+    "image_path": null,
+    "question_text": {
+      "en": "Which major river flows through Tibet, India and Bangladesh?",
+      "ja": "チベット、インド、バングラデシュを流れる大河は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Brasilia",
+        "ja": "ブラジリア",
+        "ja_typings": [
+          "burajiria"
+        ]
+      },
+      {
+        "en": "Pantheon",
+        "ja": "パンテオン",
+        "ja_typings": [
+          "panteon"
+        ]
+      },
+      {
+        "en": "Eiffel Tower",
+        "ja": "エッフェル塔",
+        "ja_typings": [
+          "efferutou"
+        ]
+      },
+      {
+        "en": "Louvre Museum",
+        "ja": "ルーブル美術館",
+        "ja_typings": [
+          "ru-burubijutsukan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03524",
+    "image_path": null,
+    "question_text": {
+      "en": "Which planned city, designed by Oscar Niemeyer, is the capital of Brazil?",
+      "ja": "オスカー・ニーマイヤー設計のブラジルの計画都市の首都は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Burrito",
+        "ja": "ブリトー",
+        "ja_typings": [
+          "burito-"
+        ]
+      },
+      {
+        "en": "Taco",
+        "ja": "タコス",
+        "ja_typings": [
+          "takosu"
+        ]
+      },
+      {
+        "en": "Enchilada",
+        "ja": "エンチラーダ",
+        "ja_typings": [
+          "enchira-da"
+        ]
+      },
+      {
+        "en": "Calzone",
+        "ja": "カルツォーネ",
+        "ja_typings": [
+          "karutso-ne"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03525",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mexican wrap consists of fillings inside a wheat flour tortilla?",
+      "ja": "小麦粉トルティーヤで具を包んだメキシコ料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Calzone",
+        "ja": "カルツォーネ",
+        "ja_typings": [
+          "karutso-ne"
+        ]
+      },
+      {
+        "en": "Focaccia",
+        "ja": "フォカッチャ",
+        "ja_typings": [
+          "fokaccha",
+          "fokatcha"
+        ]
+      },
+      {
+        "en": "Piadina",
+        "ja": "ピアディーナ",
+        "ja_typings": [
+          "piadi-na"
+        ]
+      },
+      {
+        "en": "Bolognese",
+        "ja": "ボロネーゼ",
+        "ja_typings": [
+          "borone-ze"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03526",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian dish is a folded pizza, baked or fried?",
+      "ja": "二つ折りにして焼くイタリアのピザは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Eiffel Tower",
+        "ja": "エッフェル塔",
+        "ja_typings": [
+          "efferutou"
+        ]
+      },
+      {
+        "en": "Louvre Museum",
+        "ja": "ルーブル美術館",
+        "ja_typings": [
+          "ru-burubijutsukan"
+        ]
+      },
+      {
+        "en": "Pantheon",
+        "ja": "パンテオン",
+        "ja_typings": [
+          "panteon"
+        ]
+      },
+      {
+        "en": "Brasilia",
+        "ja": "ブラジリア",
+        "ja_typings": [
+          "burajiria"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03527",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Parisian iron landmark was built for the 1889 World's Fair?",
+      "ja": "1889年パリ万博のために建てられた鉄の塔は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Enchilada",
+        "ja": "エンチラーダ",
+        "ja_typings": [
+          "enchira-da"
+        ]
+      },
+      {
+        "en": "Burrito",
+        "ja": "ブリトー",
+        "ja_typings": [
+          "burito-"
+        ]
+      },
+      {
+        "en": "Taco",
+        "ja": "タコス",
+        "ja_typings": [
+          "takosu"
+        ]
+      },
+      {
+        "en": "Tabbouleh",
+        "ja": "タブレ",
+        "ja_typings": [
+          "tabure"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03528",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mexican dish involves corn tortillas filled, rolled and covered in chili sauce?",
+      "ja": "トウモロコシのトルティーヤを巻きチリソースをかけたメキシコ料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Flamenco",
+        "ja": "フラメンコ",
+        "ja_typings": [
+          "furamenko"
+        ]
+      },
+      {
+        "en": "Bossa Nova",
+        "ja": "ボサノバ",
+        "ja_typings": [
+          "bosanoba"
+        ]
+      },
+      {
+        "en": "Krav Maga",
+        "ja": "クラヴマガ",
+        "ja_typings": [
+          "kuravumaga"
+        ]
+      },
+      {
+        "en": "Taekwondo",
+        "ja": "テコンドー",
+        "ja_typings": [
+          "tekondo-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03529",
+    "image_path": null,
+    "question_text": {
+      "en": "Which passionate Spanish dance is associated with Andalusia?",
+      "ja": "アンダルシア地方発祥の情熱的なスペインの舞踊は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Focaccia",
+        "ja": "フォカッチャ",
+        "ja_typings": [
+          "fokaccha",
+          "fokatcha"
+        ]
+      },
+      {
+        "en": "Piadina",
+        "ja": "ピアディーナ",
+        "ja_typings": [
+          "piadi-na"
+        ]
+      },
+      {
+        "en": "Calzone",
+        "ja": "カルツォーネ",
+        "ja_typings": [
+          "karutso-ne"
+        ]
+      },
+      {
+        "en": "Pesach",
+        "ja": "ペサハ",
+        "ja_typings": [
+          "pesaha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03530",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian flatbread is topped with olive oil and herbs?",
+      "ja": "オリーブオイルとハーブを使ったイタリアの平焼きパンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Frank Lloyd Wright",
+        "ja": "フランク・ロイド・ライト",
+        "ja_typings": [
+          "furankuroidoraito",
+          "furanku/roido/raito"
+        ]
+      },
+      {
+        "en": "Le Corbusier",
+        "ja": "ル・コルビュジエ",
+        "ja_typings": [
+          "rukorubyujie",
+          "ru/korubyujie"
+        ]
+      },
+      {
+        "en": "Zaha Hadid",
+        "ja": "ザハ・ハディド",
+        "ja_typings": [
+          "zahahadeido",
+          "zaha/hadido"
+        ]
+      },
+      {
+        "en": "Eiffel Tower",
+        "ja": "エッフェル塔",
+        "ja_typings": [
+          "efferutou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03531",
+    "image_path": null,
+    "question_text": {
+      "en": "Which American architect designed Fallingwater and the Guggenheim Museum?",
+      "ja": "落水荘やグッゲンハイム美術館を設計したアメリカの建築家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Geta",
+        "ja": "下駄",
+        "ja_typings": [
+          "geta"
+        ]
+      },
+      {
+        "en": "Sabot",
+        "ja": "サボ",
+        "ja_typings": [
+          "sabo"
+        ]
+      },
+      {
+        "en": "Moccasin",
+        "ja": "モカシン",
+        "ja_typings": [
+          "mokashin"
+        ]
+      },
+      {
+        "en": "Toga",
+        "ja": "トーガ",
+        "ja_typings": [
+          "to-ga"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03532",
+    "image_path": null,
+    "question_text": {
+      "en": "Which traditional Japanese wooden footwear has a raised platform on two 'teeth'?",
+      "ja": "二本歯の台がある日本の伝統的な木の履物は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hanbok",
+        "ja": "ハンボク",
+        "ja_typings": [
+          "hanboku"
+        ]
+      },
+      {
+        "en": "Ao Dai",
+        "ja": "アオザイ",
+        "ja_typings": [
+          "aozai"
+        ]
+      },
+      {
+        "en": "Toga",
+        "ja": "トーガ",
+        "ja_typings": [
+          "to-ga"
+        ]
+      },
+      {
+        "en": "Keffiyeh",
+        "ja": "ケフィエ",
+        "ja_typings": [
+          "kefie"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03533",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the traditional Korean dress, worn during festivals and ceremonies?",
+      "ja": "祝祭で着用される韓国の伝統衣装は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hummus",
+        "ja": "フムス",
+        "ja_typings": [
+          "fumusu"
+        ]
+      },
+      {
+        "en": "Tabbouleh",
+        "ja": "タブレ",
+        "ja_typings": [
+          "tabure"
+        ]
+      },
+      {
+        "en": "Kebab",
+        "ja": "ケバブ",
+        "ja_typings": [
+          "kebabu"
+        ]
+      },
+      {
+        "en": "Pesach",
+        "ja": "ペサハ",
+        "ja_typings": [
+          "pesaha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03534",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Middle Eastern dip is made from chickpeas, tahini and lemon?",
+      "ja": "ひよこ豆とタヒニで作る中東の料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Indus River",
+        "ja": "インダス川",
+        "ja_typings": [
+          "indasugawa"
+        ]
+      },
+      {
+        "en": "Brahmaputra River",
+        "ja": "ブラフマプトラ川",
+        "ja_typings": [
+          "burafumaputoragawa"
+        ]
+      },
+      {
+        "en": "Yamuna River",
+        "ja": "ヤムナー川",
+        "ja_typings": [
+          "yamuna-gawa"
+        ]
+      },
+      {
+        "en": "Bible",
+        "ja": "聖書",
+        "ja_typings": [
+          "seisho"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03535",
+    "image_path": null,
+    "question_text": {
+      "en": "Which major South Asian river gave its name to an ancient civilization in Pakistan?",
+      "ja": "パキスタンを流れ古代文明の名にもなった大河は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kebab",
+        "ja": "ケバブ",
+        "ja_typings": [
+          "kebabu"
+        ]
+      },
+      {
+        "en": "Hummus",
+        "ja": "フムス",
+        "ja_typings": [
+          "fumusu"
+        ]
+      },
+      {
+        "en": "Tabbouleh",
+        "ja": "タブレ",
+        "ja_typings": [
+          "tabure"
+        ]
+      },
+      {
+        "en": "Burrito",
+        "ja": "ブリトー",
+        "ja_typings": [
+          "burito-"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03536",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Middle Eastern grilled meat dish is often served on skewers or in wraps?",
+      "ja": "串焼きや包み焼きにする中東発祥の肉料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Keffiyeh",
+        "ja": "ケフィエ",
+        "ja_typings": [
+          "kefie"
+        ]
+      },
+      {
+        "en": "Turban",
+        "ja": "ターバン",
+        "ja_typings": [
+          "ta-ban"
+        ]
+      },
+      {
+        "en": "Veil",
+        "ja": "ベール",
+        "ja_typings": [
+          "be-ru"
+        ]
+      },
+      {
+        "en": "Hanbok",
+        "ja": "ハンボク",
+        "ja_typings": [
+          "hanboku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03537",
+    "image_path": null,
+    "question_text": {
+      "en": "Which patterned headscarf is associated with traditional Arab dress?",
+      "ja": "アラブ圏で頭に巻く格子模様の伝統的なスカーフは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Komusubi",
+        "ja": "小結",
+        "ja_typings": [
+          "komusubi"
+        ]
+      },
+      {
+        "en": "Sekiwake",
+        "ja": "関脇",
+        "ja_typings": [
+          "sekiwake"
+        ]
+      },
+      {
+        "en": "Ozeki",
+        "ja": "大関",
+        "ja_typings": [
+          "oozeki",
+          "ouzeki"
+        ]
+      },
+      {
+        "en": "Geta",
+        "ja": "下駄",
+        "ja_typings": [
+          "geta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03538",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sumo rank is the fourth-highest, ranked just below Sekiwake?",
+      "ja": "大相撲の番付で関脇のすぐ下の地位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Krav Maga",
+        "ja": "クラヴマガ",
+        "ja_typings": [
+          "kuravumaga"
+        ]
+      },
+      {
+        "en": "Taekwondo",
+        "ja": "テコンドー",
+        "ja_typings": [
+          "tekondo-"
+        ]
+      },
+      {
+        "en": "Flamenco",
+        "ja": "フラメンコ",
+        "ja_typings": [
+          "furamenko"
+        ]
+      },
+      {
+        "en": "Bossa Nova",
+        "ja": "ボサノバ",
+        "ja_typings": [
+          "bosanoba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03539",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Israeli self-defense martial art was developed for military use?",
+      "ja": "イスラエル軍で生まれた自己防衛のための格闘術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Le Corbusier",
+        "ja": "ル・コルビュジエ",
+        "ja_typings": [
+          "rukorubyujie",
+          "ru/korubyujie"
+        ]
+      },
+      {
+        "en": "Frank Lloyd Wright",
+        "ja": "フランク・ロイド・ライト",
+        "ja_typings": [
+          "furankuroidoraito",
+          "furanku/roido/raito"
+        ]
+      },
+      {
+        "en": "Zaha Hadid",
+        "ja": "ザハ・ハディド",
+        "ja_typings": [
+          "zahahadeido",
+          "zaha/hadido"
+        ]
+      },
+      {
+        "en": "Pantheon",
+        "ja": "パンテオン",
+        "ja_typings": [
+          "panteon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03540",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Swiss-French architect designed the Villa Savoye and Unite d'Habitation?",
+      "ja": "サヴォア邸とユニテ・ダビタシオンを設計した建築家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Louvre Museum",
+        "ja": "ルーブル美術館",
+        "ja_typings": [
+          "ru-burubijutsukan"
+        ]
+      },
+      {
+        "en": "Eiffel Tower",
+        "ja": "エッフェル塔",
+        "ja_typings": [
+          "efferutou"
+        ]
+      },
+      {
+        "en": "Pantheon",
+        "ja": "パンテオン",
+        "ja_typings": [
+          "panteon"
+        ]
+      },
+      {
+        "en": "Brasilia",
+        "ja": "ブラジリア",
+        "ja_typings": [
+          "burajiria"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03541",
+    "image_path": null,
+    "question_text": {
+      "en": "Which famous Paris museum houses the Mona Lisa?",
+      "ja": "モナ・リザを所蔵するパリの美術館は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Maya civilization",
+        "ja": "マヤ文明",
+        "ja_typings": [
+          "mayabunmei"
+        ]
+      },
+      {
+        "en": "Aztec civilization",
+        "ja": "アステカ文明",
+        "ja_typings": [
+          "asutekabunmei"
+        ]
+      },
+      {
+        "en": "Olmec civilization",
+        "ja": "オルメカ文明",
+        "ja_typings": [
+          "orumekabunmei"
+        ]
+      },
+      {
+        "en": "Indus River",
+        "ja": "インダス川",
+        "ja_typings": [
+          "indasugawa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03542",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Mesoamerican civilization is known for Chichen Itza and the Long Count calendar?",
+      "ja": "チチェン・イッツァや長期暦で知られる古代メソアメリカ文明は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Moccasin",
+        "ja": "モカシン",
+        "ja_typings": [
+          "mokashin"
+        ]
+      },
+      {
+        "en": "Sabot",
+        "ja": "サボ",
+        "ja_typings": [
+          "sabo"
+        ]
+      },
+      {
+        "en": "Geta",
+        "ja": "下駄",
+        "ja_typings": [
+          "geta"
+        ]
+      },
+      {
+        "en": "Poncho",
+        "ja": "ポンチョ",
+        "ja_typings": [
+          "poncho"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03543",
+    "image_path": null,
+    "question_text": {
+      "en": "Which soft leather shoe is associated with Native American tradition?",
+      "ja": "ネイティブアメリカンの伝統的な柔らかい革靴は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Olmec civilization",
+        "ja": "オルメカ文明",
+        "ja_typings": [
+          "orumekabunmei"
+        ]
+      },
+      {
+        "en": "Maya civilization",
+        "ja": "マヤ文明",
+        "ja_typings": [
+          "mayabunmei"
+        ]
+      },
+      {
+        "en": "Aztec civilization",
+        "ja": "アステカ文明",
+        "ja_typings": [
+          "asutekabunmei"
+        ]
+      },
+      {
+        "en": "Vedas",
+        "ja": "ヴェーダ",
+        "ja_typings": [
+          "ve-da"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03544",
+    "image_path": null,
+    "question_text": {
+      "en": "Which is considered the earliest known major civilization of Mesoamerica, predating the Maya?",
+      "ja": "マヤ文明より古い、メソアメリカ最古とされる文明は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ozeki",
+        "ja": "大関",
+        "ja_typings": [
+          "oozeki",
+          "ouzeki"
+        ]
+      },
+      {
+        "en": "Sekiwake",
+        "ja": "関脇",
+        "ja_typings": [
+          "sekiwake"
+        ]
+      },
+      {
+        "en": "Komusubi",
+        "ja": "小結",
+        "ja_typings": [
+          "komusubi"
+        ]
+      },
+      {
+        "en": "Geta",
+        "ja": "下駄",
+        "ja_typings": [
+          "geta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03545",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sumo rank is the second-highest, just below Yokozuna?",
+      "ja": "大相撲の番付で横綱のすぐ下の地位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pantheon",
+        "ja": "パンテオン",
+        "ja_typings": [
+          "panteon"
+        ]
+      },
+      {
+        "en": "Louvre Museum",
+        "ja": "ルーブル美術館",
+        "ja_typings": [
+          "ru-burubijutsukan"
+        ]
+      },
+      {
+        "en": "Eiffel Tower",
+        "ja": "エッフェル塔",
+        "ja_typings": [
+          "efferutou"
+        ]
+      },
+      {
+        "en": "Brasilia",
+        "ja": "ブラジリア",
+        "ja_typings": [
+          "burajiria"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03546",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Roman temple in Rome has a famous dome and oculus?",
+      "ja": "ローマにあるドームと天窓で有名な古代神殿は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pesach",
+        "ja": "ペサハ",
+        "ja_typings": [
+          "pesaha"
+        ]
+      },
+      {
+        "en": "Torah",
+        "ja": "トーラー",
+        "ja_typings": [
+          "to-ra-"
+        ]
+      },
+      {
+        "en": "Bible",
+        "ja": "聖書",
+        "ja_typings": [
+          "seisho"
+        ]
+      },
+      {
+        "en": "Vedas",
+        "ja": "ヴェーダ",
+        "ja_typings": [
+          "ve-da"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03547",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Jewish holiday commemorates the Exodus from Egypt?",
+      "ja": "ユダヤ教でエジプト脱出を記念する祭りは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pescatore",
+        "ja": "ペスカトーレ",
+        "ja_typings": [
+          "pesukato-re"
+        ]
+      },
+      {
+        "en": "Arrabbiata",
+        "ja": "アラビアータ",
+        "ja_typings": [
+          "arabia-ta"
+        ]
+      },
+      {
+        "en": "Bolognese",
+        "ja": "ボロネーゼ",
+        "ja_typings": [
+          "borone-ze"
+        ]
+      },
+      {
+        "en": "Calzone",
+        "ja": "カルツォーネ",
+        "ja_typings": [
+          "karutso-ne"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03548",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Italian seafood pasta sauce features shellfish and tomato?",
+      "ja": "魚介とトマトで作るイタリアのパスタソースは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Piadina",
+        "ja": "ピアディーナ",
+        "ja_typings": [
+          "piadi-na"
+        ]
+      },
+      {
+        "en": "Focaccia",
+        "ja": "フォカッチャ",
+        "ja_typings": [
+          "fokaccha",
+          "fokatcha"
+        ]
+      },
+      {
+        "en": "Calzone",
+        "ja": "カルツォーネ",
+        "ja_typings": [
+          "karutso-ne"
+        ]
+      },
+      {
+        "en": "Tabbouleh",
+        "ja": "タブレ",
+        "ja_typings": [
+          "tabure"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03549",
+    "image_path": null,
+    "question_text": {
+      "en": "Which flatbread from Emilia-Romagna is similar to a tortilla?",
+      "ja": "エミリア=ロマーニャ州のトルティーヤに似た平焼きパンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Poncho",
+        "ja": "ポンチョ",
+        "ja_typings": [
+          "poncho"
+        ]
+      },
+      {
+        "en": "Toga",
+        "ja": "トーガ",
+        "ja_typings": [
+          "to-ga"
+        ]
+      },
+      {
+        "en": "Hanbok",
+        "ja": "ハンボク",
+        "ja_typings": [
+          "hanboku"
+        ]
+      },
+      {
+        "en": "Ao Dai",
+        "ja": "アオザイ",
+        "ja_typings": [
+          "aozai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03550",
+    "image_path": null,
+    "question_text": {
+      "en": "Which South American garment is a single piece of cloth with a hole for the head?",
+      "ja": "頭を通す穴があいた一枚布の南米の衣服は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sabot",
+        "ja": "サボ",
+        "ja_typings": [
+          "sabo"
+        ]
+      },
+      {
+        "en": "Geta",
+        "ja": "下駄",
+        "ja_typings": [
+          "geta"
+        ]
+      },
+      {
+        "en": "Moccasin",
+        "ja": "モカシン",
+        "ja_typings": [
+          "mokashin"
+        ]
+      },
+      {
+        "en": "Veil",
+        "ja": "ベール",
+        "ja_typings": [
+          "be-ru"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03551",
+    "image_path": null,
+    "question_text": {
+      "en": "Which traditional wooden shoe is associated with France and the Netherlands?",
+      "ja": "フランスやオランダの木製の伝統的な靴は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sekiwake",
+        "ja": "関脇",
+        "ja_typings": [
+          "sekiwake"
+        ]
+      },
+      {
+        "en": "Komusubi",
+        "ja": "小結",
+        "ja_typings": [
+          "komusubi"
+        ]
+      },
+      {
+        "en": "Ozeki",
+        "ja": "大関",
+        "ja_typings": [
+          "oozeki"
+        ]
+      },
+      {
+        "en": "Geta",
+        "ja": "下駄",
+        "ja_typings": [
+          "geta"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03552",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sumo rank is the third-highest, just below Ozeki?",
+      "ja": "大相撲の番付で大関のすぐ下の地位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tabbouleh",
+        "ja": "タブレ",
+        "ja_typings": [
+          "tabure"
+        ]
+      },
+      {
+        "en": "Hummus",
+        "ja": "フムス",
+        "ja_typings": [
+          "fumusu"
+        ]
+      },
+      {
+        "en": "Kebab",
+        "ja": "ケバブ",
+        "ja_typings": [
+          "kebabu"
+        ]
+      },
+      {
+        "en": "Keffiyeh",
+        "ja": "ケフィエ",
+        "ja_typings": [
+          "kefie"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03553",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Levantine salad is made of bulgur, parsley, tomato and mint?",
+      "ja": "ブルグル、パセリ、トマト、ミントで作る中東のサラダは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Taco",
+        "ja": "タコス",
+        "ja_typings": [
+          "takosu"
+        ]
+      },
+      {
+        "en": "Burrito",
+        "ja": "ブリトー",
+        "ja_typings": [
+          "burito-"
+        ]
+      },
+      {
+        "en": "Enchilada",
+        "ja": "エンチラーダ",
+        "ja_typings": [
+          "enchira-da"
+        ]
+      },
+      {
+        "en": "Calzone",
+        "ja": "カルツォーネ",
+        "ja_typings": [
+          "karutso-ne"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03554",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Mexican dish uses a folded corn tortilla with various fillings?",
+      "ja": "コーントルティーヤに具を挟んだメキシコ料理は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Taekwondo",
+        "ja": "テコンドー",
+        "ja_typings": [
+          "tekondo-"
+        ]
+      },
+      {
+        "en": "Krav Maga",
+        "ja": "クラヴマガ",
+        "ja_typings": [
+          "kuravumaga"
+        ]
+      },
+      {
+        "en": "Flamenco",
+        "ja": "フラメンコ",
+        "ja_typings": [
+          "furamenko"
+        ]
+      },
+      {
+        "en": "Bossa Nova",
+        "ja": "ボサノバ",
+        "ja_typings": [
+          "bosanoba"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03555",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Korean martial art is known for its powerful kicks and is an Olympic sport?",
+      "ja": "強力な蹴りで知られ五輪競技にもなった韓国発祥の格闘技は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tartan",
+        "ja": "タータン",
+        "ja_typings": [
+          "ta-tan"
+        ]
+      },
+      {
+        "en": "Keffiyeh",
+        "ja": "ケフィエ",
+        "ja_typings": [
+          "kefie"
+        ]
+      },
+      {
+        "en": "Hanbok",
+        "ja": "ハンボク",
+        "ja_typings": [
+          "hanboku"
+        ]
+      },
+      {
+        "en": "Ao Dai",
+        "ja": "アオザイ",
+        "ja_typings": [
+          "aozai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03556",
+    "image_path": null,
+    "question_text": {
+      "en": "Which checkered woven pattern is associated with Scottish kilts?",
+      "ja": "スコットランドのキルトに使われる格子模様は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Toga",
+        "ja": "トーガ",
+        "ja_typings": [
+          "to-ga"
+        ]
+      },
+      {
+        "en": "Poncho",
+        "ja": "ポンチョ",
+        "ja_typings": [
+          "poncho"
+        ]
+      },
+      {
+        "en": "Ao Dai",
+        "ja": "アオザイ",
+        "ja_typings": [
+          "aozai"
+        ]
+      },
+      {
+        "en": "Hanbok",
+        "ja": "ハンボク",
+        "ja_typings": [
+          "hanboku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03557",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Roman garment was a draped piece of cloth worn by citizens?",
+      "ja": "古代ローマの市民が身につけた、布をまとう衣服は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Torah",
+        "ja": "トーラー",
+        "ja_typings": [
+          "to-ra-"
+        ]
+      },
+      {
+        "en": "Bible",
+        "ja": "聖書",
+        "ja_typings": [
+          "seisho"
+        ]
+      },
+      {
+        "en": "Vedas",
+        "ja": "ヴェーダ",
+        "ja_typings": [
+          "ve-da"
+        ]
+      },
+      {
+        "en": "Pesach",
+        "ja": "ペサハ",
+        "ja_typings": [
+          "pesaha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03558",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sacred Jewish scripture corresponds to the first five books of the Hebrew Bible?",
+      "ja": "ヘブライ語聖書の最初の五書に当たるユダヤ教の聖典は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Turban",
+        "ja": "ターバン",
+        "ja_typings": [
+          "ta-ban"
+        ]
+      },
+      {
+        "en": "Keffiyeh",
+        "ja": "ケフィエ",
+        "ja_typings": [
+          "kefie"
+        ]
+      },
+      {
+        "en": "Veil",
+        "ja": "ベール",
+        "ja_typings": [
+          "be-ru"
+        ]
+      },
+      {
+        "en": "Hanbok",
+        "ja": "ハンボク",
+        "ja_typings": [
+          "hanboku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03559",
+    "image_path": null,
+    "question_text": {
+      "en": "Which wrapped headgear is traditionally worn by Sikh men and others across South Asia?",
+      "ja": "南アジアでシーク教徒の男性などが頭に巻く布は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Vedas",
+        "ja": "ヴェーダ",
+        "ja_typings": [
+          "ve-da"
+        ]
+      },
+      {
+        "en": "Torah",
+        "ja": "トーラー",
+        "ja_typings": [
+          "to-ra-"
+        ]
+      },
+      {
+        "en": "Bible",
+        "ja": "聖書",
+        "ja_typings": [
+          "seisho"
+        ]
+      },
+      {
+        "en": "Pesach",
+        "ja": "ペサハ",
+        "ja_typings": [
+          "pesaha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03560",
+    "image_path": null,
+    "question_text": {
+      "en": "Which ancient Indian sacred texts form the foundation of Hindu scripture?",
+      "ja": "ヒンドゥー教の聖典の基礎となる古代インドの聖典は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Veil",
+        "ja": "ベール",
+        "ja_typings": [
+          "be-ru"
+        ]
+      },
+      {
+        "en": "Turban",
+        "ja": "ターバン",
+        "ja_typings": [
+          "ta-ban"
+        ]
+      },
+      {
+        "en": "Keffiyeh",
+        "ja": "ケフィエ",
+        "ja_typings": [
+          "kefie"
+        ]
+      },
+      {
+        "en": "Tartan",
+        "ja": "タータン",
+        "ja_typings": [
+          "ta-tan"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03561",
+    "image_path": null,
+    "question_text": {
+      "en": "Which thin fabric covering is worn over the face, often in religious or wedding contexts?",
+      "ja": "宗教儀礼や結婚式で顔を覆う薄い布は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yamuna River",
+        "ja": "ヤムナー川",
+        "ja_typings": [
+          "yamuna-gawa"
+        ]
+      },
+      {
+        "en": "Brahmaputra River",
+        "ja": "ブラフマプトラ川",
+        "ja_typings": [
+          "burafumaputoragawa"
+        ]
+      },
+      {
+        "en": "Indus River",
+        "ja": "インダス川",
+        "ja_typings": [
+          "indasugawa"
+        ]
+      },
+      {
+        "en": "Eiffel Tower",
+        "ja": "エッフェル塔",
+        "ja_typings": [
+          "efferutou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03562",
+    "image_path": null,
+    "question_text": {
+      "en": "Which sacred river of India flows through Delhi and joins the Ganges at Prayagraj?",
+      "ja": "デリーを流れプラヤーグラージでガンジス川と合流するインドの聖なる川は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Zaha Hadid",
+        "ja": "ザハ・ハディド",
+        "ja_typings": [
+          "zahahadeido",
+          "zaha/hadido"
+        ]
+      },
+      {
+        "en": "Frank Lloyd Wright",
+        "ja": "フランク・ロイド・ライト",
+        "ja_typings": [
+          "furankuroidoraito",
+          "furanku/roido/raito"
+        ]
+      },
+      {
+        "en": "Le Corbusier",
+        "ja": "ル・コルビュジエ",
+        "ja_typings": [
+          "rukorubyujie",
+          "ru/korubyujie"
+        ]
+      },
+      {
+        "en": "Pantheon",
+        "ja": "パンテオン",
+        "ja_typings": [
+          "panteon"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "culture",
+    "id": "q03563",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Iraqi-British architect designed the Heydar Aliyev Center and the London Aquatics Centre?",
+      "ja": "ヘイダル・アリエフ・センターを設計したイラク出身の建築家は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "AGPL",
+        "ja": "AGPL",
+        "ja_typings": [
+          "agpl"
+        ]
+      },
+      {
+        "en": "MIT",
+        "ja": "MIT",
+        "ja_typings": [
+          "mit"
+        ]
+      },
+      {
+        "en": "BSD",
+        "ja": "BSD",
+        "ja_typings": [
+          "bsd"
+        ]
+      },
+      {
+        "en": "Apache",
+        "ja": "Apache",
+        "ja_typings": [
+          "apache"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03564",
+    "image_path": null,
+    "question_text": {
+      "en": "Which copyleft license requires source disclosure even for network-served software?",
+      "ja": "ネットワーク経由で提供されるソフトウェアにもソース開示を求めるコピーレフトライセンスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "API Gateway",
+        "ja": "API Gateway",
+        "ja_typings": [
+          "api gateway"
+        ]
+      },
+      {
+        "en": "CloudFront",
+        "ja": "CloudFront",
+        "ja_typings": [
+          "cloudfront"
+        ]
+      },
+      {
+        "en": "Route 53",
+        "ja": "Route 53",
+        "ja_typings": [
+          "route 53"
+        ]
+      },
+      {
+        "en": "AppSync",
+        "ja": "AppSync",
+        "ja_typings": [
+          "appsync"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03565",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS service acts as a managed front door for APIs with routing, auth, and throttling?",
+      "ja": "API のルーティングや認証、スロットリングを担う AWS のマネージドサービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Alpha",
+        "ja": "Alpha",
+        "ja_typings": [
+          "alpha"
+        ]
+      },
+      {
+        "en": "Beta",
+        "ja": "Beta",
+        "ja_typings": [
+          "beta"
+        ]
+      },
+      {
+        "en": "RC",
+        "ja": "RC",
+        "ja_typings": [
+          "rc"
+        ]
+      },
+      {
+        "en": "GA",
+        "ja": "GA",
+        "ja_typings": [
+          "ga"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03566",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the term for an early pre-release version used for internal or limited testing?",
+      "ja": "限定的な内部テスト向けに公開される初期段階の試験版を何と呼ぶ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Aurora Serverless",
+        "ja": "Aurora Serverless",
+        "ja_typings": [
+          "aurora serverless"
+        ]
+      },
+      {
+        "en": "DynamoDB",
+        "ja": "DynamoDB",
+        "ja_typings": [
+          "dynamodb"
+        ]
+      },
+      {
+        "en": "Redshift",
+        "ja": "Redshift",
+        "ja_typings": [
+          "redshift"
+        ]
+      },
+      {
+        "en": "ElastiCache",
+        "ja": "ElastiCache",
+        "ja_typings": [
+          "elasticache"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03567",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS service auto-scales relational database capacity on demand?",
+      "ja": "需要に応じてリレーショナルDBの容量を自動スケールする AWS サービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Beta",
+        "ja": "Beta",
+        "ja_typings": [
+          "beta"
+        ]
+      },
+      {
+        "en": "Alpha",
+        "ja": "Alpha",
+        "ja_typings": [
+          "alpha"
+        ]
+      },
+      {
+        "en": "Nightly",
+        "ja": "Nightly",
+        "ja_typings": [
+          "nightly"
+        ]
+      },
+      {
+        "en": "Stable",
+        "ja": "Stable",
+        "ja_typings": [
+          "stable"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03568",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a feature-complete pre-release version offered to wider testers before release?",
+      "ja": "リリース前に広範な利用者に提供される機能ほぼ完成版の試験版は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Blue-Green Deployment",
+        "ja": "Blue-Green Deployment",
+        "ja_typings": [
+          "blue-green deployment"
+        ]
+      },
+      {
+        "en": "Rolling Update",
+        "ja": "Rolling Update",
+        "ja_typings": [
+          "rolling update"
+        ]
+      },
+      {
+        "en": "Canary Release",
+        "ja": "Canary Release",
+        "ja_typings": [
+          "canary release"
+        ]
+      },
+      {
+        "en": "Shadow Deployment",
+        "ja": "Shadow Deployment",
+        "ja_typings": [
+          "shadow deployment"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03569",
+    "image_path": null,
+    "question_text": {
+      "en": "Which deployment switches traffic between two identical environments to minimize downtime?",
+      "ja": "二つの同一環境を切り替えてダウンタイムを最小化するデプロイ手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CNCF",
+        "ja": "CNCF",
+        "ja_typings": [
+          "cncf"
+        ]
+      },
+      {
+        "en": "ASF",
+        "ja": "ASF",
+        "ja_typings": [
+          "asf"
+        ]
+      },
+      {
+        "en": "OSI",
+        "ja": "OSI",
+        "ja_typings": [
+          "osi"
+        ]
+      },
+      {
+        "en": "FSF",
+        "ja": "FSF",
+        "ja_typings": [
+          "fsf"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03570",
+    "image_path": null,
+    "question_text": {
+      "en": "Which foundation hosts Kubernetes and other cloud native projects?",
+      "ja": "Kubernetes 等のクラウドネイティブ系プロジェクトをホストする財団は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CR",
+        "ja": "CR",
+        "ja_typings": [
+          "cr"
+        ]
+      },
+      {
+        "en": "PR",
+        "ja": "PR",
+        "ja_typings": [
+          "pr"
+        ]
+      },
+      {
+        "en": "MR",
+        "ja": "MR",
+        "ja_typings": [
+          "mr"
+        ]
+      },
+      {
+        "en": "IR",
+        "ja": "IR",
+        "ja_typings": [
+          "ir"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03571",
+    "image_path": null,
+    "question_text": {
+      "en": "In GitLab, what is the abbreviation for a request to review and integrate code (similar to GitHub PR)?",
+      "ja": "GitLab で GitHub の PR に相当する変更取り込み要求の略称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "CloudFront",
+        "ja": "CloudFront",
+        "ja_typings": [
+          "cloudfront"
+        ]
+      },
+      {
+        "en": "Route 53",
+        "ja": "Route 53",
+        "ja_typings": [
+          "route 53"
+        ]
+      },
+      {
+        "en": "S3",
+        "ja": "S3",
+        "ja_typings": [
+          "s3"
+        ]
+      },
+      {
+        "en": "Lambda",
+        "ja": "Lambda",
+        "ja_typings": [
+          "lambda"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03572",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS service is a global content delivery network (CDN)?",
+      "ja": "AWS のグローバル CDN サービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "DNS",
+        "ja": "DNS",
+        "ja_typings": [
+          "dns"
+        ]
+      },
+      {
+        "en": "DHCP",
+        "ja": "DHCP",
+        "ja_typings": [
+          "dhcp"
+        ]
+      },
+      {
+        "en": "ARP",
+        "ja": "ARP",
+        "ja_typings": [
+          "arp"
+        ]
+      },
+      {
+        "en": "NAT",
+        "ja": "NAT",
+        "ja_typings": [
+          "nat"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03573",
+    "image_path": null,
+    "question_text": {
+      "en": "Which protocol translates human-readable domain names into IP addresses?",
+      "ja": "ドメイン名を IP アドレスに変換する仕組みは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Deployment",
+        "ja": "Deployment",
+        "ja_typings": [
+          "deployment"
+        ]
+      },
+      {
+        "en": "Service",
+        "ja": "Service",
+        "ja_typings": [
+          "service"
+        ]
+      },
+      {
+        "en": "Node",
+        "ja": "Node",
+        "ja_typings": [
+          "node"
+        ]
+      },
+      {
+        "en": "ConfigMap",
+        "ja": "ConfigMap",
+        "ja_typings": [
+          "configmap"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03574",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Kubernetes resource manages a replicated set of stateless Pods?",
+      "ja": "ステートレスな Pod のレプリカを管理する Kubernetes リソースは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Direct Connect",
+        "ja": "Direct Connect",
+        "ja_typings": [
+          "direct connect"
+        ]
+      },
+      {
+        "en": "VPN",
+        "ja": "VPN",
+        "ja_typings": [
+          "vpn"
+        ]
+      },
+      {
+        "en": "Transit Gateway",
+        "ja": "Transit Gateway",
+        "ja_typings": [
+          "transit gateway"
+        ]
+      },
+      {
+        "en": "PrivateLink",
+        "ja": "PrivateLink",
+        "ja_typings": [
+          "privatelink"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03575",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS service provides a dedicated private network connection to AWS?",
+      "ja": "オンプレと AWS を専用線で接続する AWS サービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Epic",
+        "ja": "Epic",
+        "ja_typings": [
+          "epic"
+        ]
+      },
+      {
+        "en": "Story",
+        "ja": "Story",
+        "ja_typings": [
+          "story"
+        ]
+      },
+      {
+        "en": "Task",
+        "ja": "Task",
+        "ja_typings": [
+          "task"
+        ]
+      },
+      {
+        "en": "Sprint",
+        "ja": "Sprint",
+        "ja_typings": [
+          "sprint"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03576",
+    "image_path": null,
+    "question_text": {
+      "en": "In agile, what is a large body of work that is broken down into multiple stories?",
+      "ja": "アジャイルで複数のストーリーに分割される大きな作業単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Event-Driven Architecture",
+        "ja": "Event-Driven Architecture",
+        "ja_typings": [
+          "event-driven architecture"
+        ]
+      },
+      {
+        "en": "Service-Oriented Architecture",
+        "ja": "Service-Oriented Architecture",
+        "ja_typings": [
+          "service-oriented architecture"
+        ]
+      },
+      {
+        "en": "Layered Architecture",
+        "ja": "Layered Architecture",
+        "ja_typings": [
+          "layered architecture"
+        ]
+      },
+      {
+        "en": "Monolith",
+        "ja": "Monolith",
+        "ja_typings": [
+          "monolith"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03577",
+    "image_path": null,
+    "question_text": {
+      "en": "Which architecture style produces and consumes events asynchronously between components?",
+      "ja": "コンポーネント間でイベントを非同期にやり取りするアーキテクチャは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "FIPS 140",
+        "ja": "FIPS 140",
+        "ja_typings": [
+          "fips 140"
+        ]
+      },
+      {
+        "en": "ISO 27001",
+        "ja": "ISO 27001",
+        "ja_typings": [
+          "iso 27001"
+        ]
+      },
+      {
+        "en": "SOC 2",
+        "ja": "SOC 2",
+        "ja_typings": [
+          "soc 2"
+        ]
+      },
+      {
+        "en": "PCI DSS",
+        "ja": "PCI DSS",
+        "ja_typings": [
+          "pci dss"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03578",
+    "image_path": null,
+    "question_text": {
+      "en": "Which US government standard specifies security requirements for cryptographic modules?",
+      "ja": "暗号モジュールのセキュリティ要件を定めた米国政府の規格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "GNU Manifesto",
+        "ja": "GNU Manifesto",
+        "ja_typings": [
+          "gnu manifesto"
+        ]
+      },
+      {
+        "en": "Hacker Manifesto",
+        "ja": "Hacker Manifesto",
+        "ja_typings": [
+          "hacker manifesto"
+        ]
+      },
+      {
+        "en": "Open Source Definition",
+        "ja": "Open Source Definition",
+        "ja_typings": [
+          "open source definition"
+        ]
+      },
+      {
+        "en": "Cathedral and the Bazaar",
+        "ja": "Cathedral and the Bazaar",
+        "ja_typings": [
+          "cathedral and the bazaar"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03579",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1985 document by Richard Stallman declared the philosophy of free software?",
+      "ja": "1985 年にストールマンがフリーソフトウェアの理念を宣言した文書は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "GPLv3",
+        "ja": "GPLv3",
+        "ja_typings": [
+          "gplv3"
+        ]
+      },
+      {
+        "en": "GPLv2",
+        "ja": "GPLv2",
+        "ja_typings": [
+          "gplv2"
+        ]
+      },
+      {
+        "en": "LGPL",
+        "ja": "LGPL",
+        "ja_typings": [
+          "lgpl"
+        ]
+      },
+      {
+        "en": "AGPL",
+        "ja": "AGPL",
+        "ja_typings": [
+          "agpl"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03580",
+    "image_path": null,
+    "question_text": {
+      "en": "Which version of the GNU General Public License was released in 2007 with patent provisions?",
+      "ja": "2007 年にリリースされ特許条項を含む GPL のバージョンは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hacker Manifesto",
+        "ja": "Hacker Manifesto",
+        "ja_typings": [
+          "hacker manifesto"
+        ]
+      },
+      {
+        "en": "GNU Manifesto",
+        "ja": "GNU Manifesto",
+        "ja_typings": [
+          "gnu manifesto"
+        ]
+      },
+      {
+        "en": "Cypherpunk Manifesto",
+        "ja": "Cypherpunk Manifesto",
+        "ja_typings": [
+          "cypherpunk manifesto"
+        ]
+      },
+      {
+        "en": "Open Source Definition",
+        "ja": "Open Source Definition",
+        "ja_typings": [
+          "open source definition"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03581",
+    "image_path": null,
+    "question_text": {
+      "en": "Which 1986 essay by The Mentor became iconic in hacker culture?",
+      "ja": "ハッカー文化の象徴となった 1986 年のメンターによる文書は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "IETF",
+        "ja": "IETF",
+        "ja_typings": [
+          "ietf"
+        ]
+      },
+      {
+        "en": "IEEE",
+        "ja": "IEEE",
+        "ja_typings": [
+          "ieee"
+        ]
+      },
+      {
+        "en": "W3C",
+        "ja": "W3C",
+        "ja_typings": [
+          "w3c"
+        ]
+      },
+      {
+        "en": "ISO",
+        "ja": "ISO",
+        "ja_typings": [
+          "iso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03582",
+    "image_path": null,
+    "question_text": {
+      "en": "Which organization develops and promotes voluntary Internet standards like TCP/IP and HTTP?",
+      "ja": "TCP/IP や HTTP 等のインターネット標準を策定する組織は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "IR",
+        "ja": "IR",
+        "ja_typings": [
+          "ir"
+        ]
+      },
+      {
+        "en": "AST",
+        "ja": "AST",
+        "ja_typings": [
+          "ast"
+        ]
+      },
+      {
+        "en": "CFG",
+        "ja": "CFG",
+        "ja_typings": [
+          "cfg"
+        ]
+      },
+      {
+        "en": "SSA",
+        "ja": "SSA",
+        "ja_typings": [
+          "ssa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03583",
+    "image_path": null,
+    "question_text": {
+      "en": "In compilers, what is the abbreviation for the intermediate representation of code?",
+      "ja": "コンパイラで中間表現を指す略称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "ISO 27001",
+        "ja": "ISO 27001",
+        "ja_typings": [
+          "iso 27001"
+        ]
+      },
+      {
+        "en": "ISO 9001",
+        "ja": "ISO 9001",
+        "ja_typings": [
+          "iso 9001"
+        ]
+      },
+      {
+        "en": "SOC 2",
+        "ja": "SOC 2",
+        "ja_typings": [
+          "soc 2"
+        ]
+      },
+      {
+        "en": "FIPS 140",
+        "ja": "FIPS 140",
+        "ja_typings": [
+          "fips 140"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03584",
+    "image_path": null,
+    "question_text": {
+      "en": "Which international standard specifies requirements for an information security management system (ISMS)?",
+      "ja": "情報セキュリティマネジメントシステム(ISMS)の要件を定めた国際規格は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "LGPL",
+        "ja": "LGPL",
+        "ja_typings": [
+          "lgpl"
+        ]
+      },
+      {
+        "en": "GPLv3",
+        "ja": "GPLv3",
+        "ja_typings": [
+          "gplv3"
+        ]
+      },
+      {
+        "en": "AGPL",
+        "ja": "AGPL",
+        "ja_typings": [
+          "agpl"
+        ]
+      },
+      {
+        "en": "MPL",
+        "ja": "MPL",
+        "ja_typings": [
+          "mpl"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03585",
+    "image_path": null,
+    "question_text": {
+      "en": "Which GNU license allows linking with proprietary software, often used for libraries?",
+      "ja": "ライブラリ向けで、プロプライエタリと動的リンク可能な GNU 系ライセンスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "MR",
+        "ja": "MR",
+        "ja_typings": [
+          "mr"
+        ]
+      },
+      {
+        "en": "PR",
+        "ja": "PR",
+        "ja_typings": [
+          "pr"
+        ]
+      },
+      {
+        "en": "CR",
+        "ja": "CR",
+        "ja_typings": [
+          "cr"
+        ]
+      },
+      {
+        "en": "IR",
+        "ja": "IR",
+        "ja_typings": [
+          "ir"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03586",
+    "image_path": null,
+    "question_text": {
+      "en": "In GitLab terminology, what is the abbreviation for a Merge Request?",
+      "ja": "GitLab でマージリクエストを意味する略称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Monolith",
+        "ja": "Monolith",
+        "ja_typings": [
+          "monolith"
+        ]
+      },
+      {
+        "en": "Microservices",
+        "ja": "Microservices",
+        "ja_typings": [
+          "microservices"
+        ]
+      },
+      {
+        "en": "Serverless",
+        "ja": "Serverless",
+        "ja_typings": [
+          "serverless"
+        ]
+      },
+      {
+        "en": "Event-Driven Architecture",
+        "ja": "Event-Driven Architecture",
+        "ja_typings": [
+          "event-driven architecture"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03587",
+    "image_path": null,
+    "question_text": {
+      "en": "Which architecture deploys an application as a single, tightly coupled unit?",
+      "ja": "アプリ全体を単一の密結合な単位として配備するアーキテクチャは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "NAT",
+        "ja": "NAT",
+        "ja_typings": [
+          "nat"
+        ]
+      },
+      {
+        "en": "DNS",
+        "ja": "DNS",
+        "ja_typings": [
+          "dns"
+        ]
+      },
+      {
+        "en": "VPN",
+        "ja": "VPN",
+        "ja_typings": [
+          "vpn"
+        ]
+      },
+      {
+        "en": "DHCP",
+        "ja": "DHCP",
+        "ja_typings": [
+          "dhcp"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03588",
+    "image_path": null,
+    "question_text": {
+      "en": "Which technique remaps IP addresses by translating them between private and public networks?",
+      "ja": "プライベートとパブリックネットワーク間で IP を変換する技術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nightly Build",
+        "ja": "Nightly Build",
+        "ja_typings": [
+          "nightly build"
+        ]
+      },
+      {
+        "en": "Release Build",
+        "ja": "Release Build",
+        "ja_typings": [
+          "release build"
+        ]
+      },
+      {
+        "en": "Debug Build",
+        "ja": "Debug Build",
+        "ja_typings": [
+          "debug build"
+        ]
+      },
+      {
+        "en": "Snapshot",
+        "ja": "Snapshot",
+        "ja_typings": [
+          "snapshot"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03589",
+    "image_path": null,
+    "question_text": {
+      "en": "What is a build automatically produced every night from the latest source code called?",
+      "ja": "毎晩最新ソースから自動生成されるビルドを何と呼ぶ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Node",
+        "ja": "Node",
+        "ja_typings": [
+          "node"
+        ]
+      },
+      {
+        "en": "Pod",
+        "ja": "Pod",
+        "ja_typings": [
+          "pod"
+        ]
+      },
+      {
+        "en": "Cluster",
+        "ja": "Cluster",
+        "ja_typings": [
+          "cluster"
+        ]
+      },
+      {
+        "en": "Service",
+        "ja": "Service",
+        "ja_typings": [
+          "service"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03590",
+    "image_path": null,
+    "question_text": {
+      "en": "In Kubernetes, what term refers to a worker machine (VM or physical) that runs Pods?",
+      "ja": "Kubernetes で Pod を実行するワーカーマシンを何と呼ぶ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "OWASP",
+        "ja": "OWASP",
+        "ja_typings": [
+          "owasp"
+        ]
+      },
+      {
+        "en": "CNCF",
+        "ja": "CNCF",
+        "ja_typings": [
+          "cncf"
+        ]
+      },
+      {
+        "en": "IETF",
+        "ja": "IETF",
+        "ja_typings": [
+          "ietf"
+        ]
+      },
+      {
+        "en": "ISO",
+        "ja": "ISO",
+        "ja_typings": [
+          "iso"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03591",
+    "image_path": null,
+    "question_text": {
+      "en": "Which non-profit publishes the Top 10 list of web application security risks?",
+      "ja": "Web アプリのセキュリティリスク Top 10 を公開している非営利団体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Open Source Definition",
+        "ja": "Open Source Definition",
+        "ja_typings": [
+          "open source definition"
+        ]
+      },
+      {
+        "en": "GNU Manifesto",
+        "ja": "GNU Manifesto",
+        "ja_typings": [
+          "gnu manifesto"
+        ]
+      },
+      {
+        "en": "Hacker Manifesto",
+        "ja": "Hacker Manifesto",
+        "ja_typings": [
+          "hacker manifesto"
+        ]
+      },
+      {
+        "en": "Free Software Definition",
+        "ja": "Free Software Definition",
+        "ja_typings": [
+          "free software definition"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03592",
+    "image_path": null,
+    "question_text": {
+      "en": "Which document published by OSI defines the criteria a license must meet to be \"open source\"?",
+      "ja": "OSI が公開する、オープンソースライセンスの定義文書は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PR",
+        "ja": "PR",
+        "ja_typings": [
+          "pr"
+        ]
+      },
+      {
+        "en": "MR",
+        "ja": "MR",
+        "ja_typings": [
+          "mr"
+        ]
+      },
+      {
+        "en": "CR",
+        "ja": "CR",
+        "ja_typings": [
+          "cr"
+        ]
+      },
+      {
+        "en": "IR",
+        "ja": "IR",
+        "ja_typings": [
+          "ir"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03593",
+    "image_path": null,
+    "question_text": {
+      "en": "On GitHub, what is the abbreviation for a request to merge a branch's changes?",
+      "ja": "GitHub でブランチの変更をマージ要求する仕組みの略称は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "PaaS",
+        "ja": "PaaS",
+        "ja_typings": [
+          "paas"
+        ]
+      },
+      {
+        "en": "IaaS",
+        "ja": "IaaS",
+        "ja_typings": [
+          "iaas"
+        ]
+      },
+      {
+        "en": "SaaS",
+        "ja": "SaaS",
+        "ja_typings": [
+          "saas"
+        ]
+      },
+      {
+        "en": "FaaS",
+        "ja": "FaaS",
+        "ja_typings": [
+          "faas"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03594",
+    "image_path": null,
+    "question_text": {
+      "en": "Which cloud service model provides a managed runtime and platform for deploying apps?",
+      "ja": "アプリ実行用のマネージドなプラットフォームを提供するクラウド形態は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Planning Poker",
+        "ja": "Planning Poker",
+        "ja_typings": [
+          "planning poker"
+        ]
+      },
+      {
+        "en": "Story Mapping",
+        "ja": "Story Mapping",
+        "ja_typings": [
+          "story mapping"
+        ]
+      },
+      {
+        "en": "T-shirt Sizing",
+        "ja": "T-shirt Sizing",
+        "ja_typings": [
+          "t-shirt sizing"
+        ]
+      },
+      {
+        "en": "Delphi Method",
+        "ja": "Delphi Method",
+        "ja_typings": [
+          "delphi method"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03595",
+    "image_path": null,
+    "question_text": {
+      "en": "Which agile estimation technique uses cards with Fibonacci-like numbers?",
+      "ja": "フィボナッチ風の数字カードで規模見積りを行うアジャイル手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "RDS",
+        "ja": "RDS",
+        "ja_typings": [
+          "rds"
+        ]
+      },
+      {
+        "en": "DynamoDB",
+        "ja": "DynamoDB",
+        "ja_typings": [
+          "dynamodb"
+        ]
+      },
+      {
+        "en": "Aurora Serverless",
+        "ja": "Aurora Serverless",
+        "ja_typings": [
+          "aurora serverless"
+        ]
+      },
+      {
+        "en": "ElastiCache",
+        "ja": "ElastiCache",
+        "ja_typings": [
+          "elasticache"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03596",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AWS service provides a managed relational database?",
+      "ja": "リレーショナルDBをマネージドで提供する AWS サービスは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rolling Update",
+        "ja": "Rolling Update",
+        "ja_typings": [
+          "rolling update"
+        ]
+      },
+      {
+        "en": "Blue-Green Deployment",
+        "ja": "Blue-Green Deployment",
+        "ja_typings": [
+          "blue-green deployment"
+        ]
+      },
+      {
+        "en": "Canary Release",
+        "ja": "Canary Release",
+        "ja_typings": [
+          "canary release"
+        ]
+      },
+      {
+        "en": "Shadow Deployment",
+        "ja": "Shadow Deployment",
+        "ja_typings": [
+          "shadow deployment"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03597",
+    "image_path": null,
+    "question_text": {
+      "en": "Which deployment gradually replaces instances of the old version with the new one?",
+      "ja": "旧版のインスタンスを順次新版へ置き換えていくデプロイ手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "SOC 2",
+        "ja": "SOC 2",
+        "ja_typings": [
+          "soc 2"
+        ]
+      },
+      {
+        "en": "ISO 27001",
+        "ja": "ISO 27001",
+        "ja_typings": [
+          "iso 27001"
+        ]
+      },
+      {
+        "en": "FIPS 140",
+        "ja": "FIPS 140",
+        "ja_typings": [
+          "fips 140"
+        ]
+      },
+      {
+        "en": "PCI DSS",
+        "ja": "PCI DSS",
+        "ja_typings": [
+          "pci dss"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03598",
+    "image_path": null,
+    "question_text": {
+      "en": "Which AICPA audit report focuses on service organizations' security and availability controls?",
+      "ja": "サービス事業者のセキュリティ・可用性統制を評価する AICPA の監査報告書は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Service",
+        "ja": "Service",
+        "ja_typings": [
+          "service"
+        ]
+      },
+      {
+        "en": "Deployment",
+        "ja": "Deployment",
+        "ja_typings": [
+          "deployment"
+        ]
+      },
+      {
+        "en": "Node",
+        "ja": "Node",
+        "ja_typings": [
+          "node"
+        ]
+      },
+      {
+        "en": "Ingress",
+        "ja": "Ingress",
+        "ja_typings": [
+          "ingress"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03599",
+    "image_path": null,
+    "question_text": {
+      "en": "In Kubernetes, which resource provides stable network access to a set of Pods?",
+      "ja": "Kubernetes で Pod 群への安定したネットワークアクセスを提供するリソースは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Service-Oriented Architecture",
+        "ja": "Service-Oriented Architecture",
+        "ja_typings": [
+          "service-oriented architecture"
+        ]
+      },
+      {
+        "en": "Event-Driven Architecture",
+        "ja": "Event-Driven Architecture",
+        "ja_typings": [
+          "event-driven architecture"
+        ]
+      },
+      {
+        "en": "Monolith",
+        "ja": "Monolith",
+        "ja_typings": [
+          "monolith"
+        ]
+      },
+      {
+        "en": "Layered Architecture",
+        "ja": "Layered Architecture",
+        "ja_typings": [
+          "layered architecture"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03600",
+    "image_path": null,
+    "question_text": {
+      "en": "Which architecture organizes functionality as reusable services communicating over a network?",
+      "ja": "機能をネットワーク経由で再利用可能なサービス群として組むアーキテクチャは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Shadow Deployment",
+        "ja": "Shadow Deployment",
+        "ja_typings": [
+          "shadow deployment"
+        ]
+      },
+      {
+        "en": "Blue-Green Deployment",
+        "ja": "Blue-Green Deployment",
+        "ja_typings": [
+          "blue-green deployment"
+        ]
+      },
+      {
+        "en": "Rolling Update",
+        "ja": "Rolling Update",
+        "ja_typings": [
+          "rolling update"
+        ]
+      },
+      {
+        "en": "Canary Release",
+        "ja": "Canary Release",
+        "ja_typings": [
+          "canary release"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03601",
+    "image_path": null,
+    "question_text": {
+      "en": "Which deployment sends a copy of live traffic to a new version without affecting users?",
+      "ja": "本番トラフィックを複製して新版に流し、利用者に影響を与えない検証手法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Task",
+        "ja": "Task",
+        "ja_typings": [
+          "task"
+        ]
+      },
+      {
+        "en": "Story",
+        "ja": "Story",
+        "ja_typings": [
+          "story"
+        ]
+      },
+      {
+        "en": "Epic",
+        "ja": "Epic",
+        "ja_typings": [
+          "epic"
+        ]
+      },
+      {
+        "en": "Sprint",
+        "ja": "Sprint",
+        "ja_typings": [
+          "sprint"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03602",
+    "image_path": null,
+    "question_text": {
+      "en": "In agile, what is the smallest unit of work assigned to a developer?",
+      "ja": "アジャイルで開発者にアサインされる最小の作業単位は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Use Case",
+        "ja": "Use Case",
+        "ja_typings": [
+          "use case"
+        ]
+      },
+      {
+        "en": "User Story",
+        "ja": "User Story",
+        "ja_typings": [
+          "user story"
+        ]
+      },
+      {
+        "en": "Epic",
+        "ja": "Epic",
+        "ja_typings": [
+          "epic"
+        ]
+      },
+      {
+        "en": "Scenario Map",
+        "ja": "Scenario Map",
+        "ja_typings": [
+          "scenario map"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03603",
+    "image_path": null,
+    "question_text": {
+      "en": "In requirements engineering, what describes a sequence of interactions between user and system?",
+      "ja": "要件定義で利用者とシステムのやり取りの流れを記述するものは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "VPN",
+        "ja": "VPN",
+        "ja_typings": [
+          "vpn"
+        ]
+      },
+      {
+        "en": "NAT",
+        "ja": "NAT",
+        "ja_typings": [
+          "nat"
+        ]
+      },
+      {
+        "en": "DNS",
+        "ja": "DNS",
+        "ja_typings": [
+          "dns"
+        ]
+      },
+      {
+        "en": "Direct Connect",
+        "ja": "Direct Connect",
+        "ja_typings": [
+          "direct connect"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "it_terminology",
+    "id": "q03604",
+    "image_path": null,
+    "question_text": {
+      "en": "Which technology creates an encrypted tunnel over a public network to access a private one?",
+      "ja": "公衆網上に暗号化トンネルを張りプライベート網へアクセスする技術は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Affix",
+        "ja": "接辞",
+        "ja_typings": [
+          "setsuji"
+        ]
+      },
+      {
+        "en": "Stem",
+        "ja": "語幹",
+        "ja_typings": [
+          "gokan"
+        ]
+      },
+      {
+        "en": "Ending",
+        "ja": "語尾",
+        "ja_typings": [
+          "gobi"
+        ]
+      },
+      {
+        "en": "Particle",
+        "ja": "助詞",
+        "ja_typings": [
+          "joshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03605",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the linguistic term for a bound morpheme attached to a word stem (prefix, suffix, infix)?",
+      "ja": "語幹に付加される接頭辞・接尾辞などの拘束形態素を指す言語学用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Afro-Asiatic",
+        "ja": "アフロ・アジア語族",
+        "ja_typings": [
+          "afuro ajia gozoku"
+        ]
+      },
+      {
+        "en": "Indo-European",
+        "ja": "インド・ヨーロッパ語族",
+        "ja_typings": [
+          "indo yo-roppa gozoku"
+        ]
+      },
+      {
+        "en": "Sino-Tibetan",
+        "ja": "シナ・チベット語族",
+        "ja_typings": [
+          "shina chibetto gozoku"
+        ]
+      },
+      {
+        "en": "Niger-Congo",
+        "ja": "ニジェール・コンゴ語族",
+        "ja_typings": [
+          "nijie-ru kongo gozoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03606",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language family includes Arabic, Hebrew, and ancient Egyptian?",
+      "ja": "アラビア語・ヘブライ語・古代エジプト語を含む語族は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Auxiliary verb",
+        "ja": "助動詞",
+        "ja_typings": [
+          "jodoushi"
+        ]
+      },
+      {
+        "en": "Particle",
+        "ja": "助詞",
+        "ja_typings": [
+          "joshi"
+        ]
+      },
+      {
+        "en": "Adverb",
+        "ja": "副詞",
+        "ja_typings": [
+          "fukushi"
+        ]
+      },
+      {
+        "en": "Conjunction",
+        "ja": "接続詞",
+        "ja_typings": [
+          "setsuzokushi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03607",
+    "image_path": null,
+    "question_text": {
+      "en": "Which part of speech in English includes \"can,\" \"will,\" \"must,\" and \"may\"?",
+      "ja": "英語で can / will / must / may を含む品詞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Bottom to top",
+        "ja": "下から上",
+        "ja_typings": [
+          "shita kara ue"
+        ]
+      },
+      {
+        "en": "Top to bottom",
+        "ja": "上から下",
+        "ja_typings": [
+          "ue kara shita"
+        ]
+      },
+      {
+        "en": "Left to right",
+        "ja": "左から右",
+        "ja_typings": [
+          "hidari kara migi"
+        ]
+      },
+      {
+        "en": "Right to left",
+        "ja": "右から左",
+        "ja_typings": [
+          "migi kara hidari"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03608",
+    "image_path": null,
+    "question_text": {
+      "en": "In Japanese kanji learning order, which direction is sometimes used in stroke order references?",
+      "ja": "漢字の筆順の説明で、下から上へ書く方向性を指す表現は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Causative voice",
+        "ja": "使役態",
+        "ja_typings": [
+          "shiekitai"
+        ]
+      },
+      {
+        "en": "Passive voice",
+        "ja": "受動態",
+        "ja_typings": [
+          "judoutai"
+        ]
+      },
+      {
+        "en": "Active voice",
+        "ja": "能動態",
+        "ja_typings": [
+          "noudoutai"
+        ]
+      },
+      {
+        "en": "Middle voice",
+        "ja": "中動態",
+        "ja_typings": [
+          "chuudoutai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03609",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice expresses that the subject causes someone or something else to perform an action?",
+      "ja": "主語が他者に動作を行わせることを表す態(ヴォイス)は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Chinese characters",
+        "ja": "漢字",
+        "ja_typings": [
+          "kanji"
+        ]
+      },
+      {
+        "en": "Kana",
+        "ja": "仮名",
+        "ja_typings": [
+          "kana"
+        ]
+      },
+      {
+        "en": "Hiragana",
+        "ja": "ひらがな",
+        "ja_typings": [
+          "hiragana"
+        ]
+      },
+      {
+        "en": "Katakana",
+        "ja": "カタカナ",
+        "ja_typings": [
+          "katakana"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03610",
+    "image_path": null,
+    "question_text": {
+      "en": "What are the logographic characters borrowed from China and used in Japanese called in English?",
+      "ja": "日本語で中国由来の表意文字である漢字を英語で何と呼ぶ?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Customary reading",
+        "ja": "慣用読み",
+        "ja_typings": [
+          "kanyouyomi"
+        ]
+      },
+      {
+        "en": "On reading",
+        "ja": "音読み",
+        "ja_typings": [
+          "onyomi"
+        ]
+      },
+      {
+        "en": "Kun reading",
+        "ja": "訓読み",
+        "ja_typings": [
+          "kunyomi"
+        ]
+      },
+      {
+        "en": "Nanori reading",
+        "ja": "名乗り読み",
+        "ja_typings": [
+          "nanoriyomi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03611",
+    "image_path": null,
+    "question_text": {
+      "en": "Which kanji reading is based on traditional convention rather than standard on/kun readings?",
+      "ja": "音読み・訓読みの標準的な規則ではなく慣習に基づく漢字の読み方は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Cyrillic",
+        "ja": "キリル文字",
+        "ja_typings": [
+          "kiriru moji"
+        ]
+      },
+      {
+        "en": "Latin alphabet",
+        "ja": "ラテン文字",
+        "ja_typings": [
+          "raten moji"
+        ]
+      },
+      {
+        "en": "Greek alphabet",
+        "ja": "ギリシャ文字",
+        "ja_typings": [
+          "girisha moji"
+        ]
+      },
+      {
+        "en": "Arabic script",
+        "ja": "アラビア文字",
+        "ja_typings": [
+          "arabia moji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03612",
+    "image_path": null,
+    "question_text": {
+      "en": "Which alphabet is used for Russian, Bulgarian, and Serbian?",
+      "ja": "ロシア語・ブルガリア語・セルビア語で用いられる文字体系は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Eight",
+        "ja": "8",
+        "ja_typings": [
+          "8",
+          "hachi"
+        ]
+      },
+      {
+        "en": "Six",
+        "ja": "6",
+        "ja_typings": [
+          "6",
+          "roku"
+        ]
+      },
+      {
+        "en": "Two",
+        "ja": "2",
+        "ja_typings": [
+          "2",
+          "ni"
+        ]
+      },
+      {
+        "en": "Ten",
+        "ja": "10",
+        "ja_typings": [
+          "10",
+          "juu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03613",
+    "image_path": null,
+    "question_text": {
+      "en": "Which number is \"eight\" in English?",
+      "ja": "英語で eight が表す数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ellipsis",
+        "ja": "省略法",
+        "ja_typings": [
+          "shouryakuhou"
+        ]
+      },
+      {
+        "en": "Repetition",
+        "ja": "反復法",
+        "ja_typings": [
+          "hanpukuhou"
+        ]
+      },
+      {
+        "en": "Inversion",
+        "ja": "倒置法",
+        "ja_typings": [
+          "touchihou"
+        ]
+      },
+      {
+        "en": "Metaphor",
+        "ja": "隠喩",
+        "ja_typings": [
+          "inyu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03614",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the rhetorical device of omitting words that are understood from context?",
+      "ja": "文脈から自明な語を省略する修辞技法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Ending",
+        "ja": "語尾",
+        "ja_typings": [
+          "gobi"
+        ]
+      },
+      {
+        "en": "Stem",
+        "ja": "語幹",
+        "ja_typings": [
+          "gokan"
+        ]
+      },
+      {
+        "en": "Affix",
+        "ja": "接辞",
+        "ja_typings": [
+          "setsuji"
+        ]
+      },
+      {
+        "en": "Particle",
+        "ja": "助詞",
+        "ja_typings": [
+          "joshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03615",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the final part of a Japanese conjugated word called?",
+      "ja": "日本語の活用語の末尾(活用語尾)を指す語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hepburn romanization",
+        "ja": "ヘボン式ローマ字",
+        "ja_typings": [
+          "hebon shiki ro-maji"
+        ]
+      },
+      {
+        "en": "Kunrei-shiki",
+        "ja": "訓令式",
+        "ja_typings": [
+          "kunrei shiki"
+        ]
+      },
+      {
+        "en": "Nihon-shiki",
+        "ja": "日本式",
+        "ja_typings": [
+          "nihon shiki"
+        ]
+      },
+      {
+        "en": "Wapuro romaji",
+        "ja": "ワープロローマ字",
+        "ja_typings": [
+          "wa-puro ro-maji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03616",
+    "image_path": null,
+    "question_text": {
+      "en": "Which romanization system for Japanese was popularized by an American missionary's dictionary?",
+      "ja": "米国人宣教師の辞典で普及した日本語のローマ字表記法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Indo-European",
+        "ja": "インド・ヨーロッパ語族",
+        "ja_typings": [
+          "indo yo-roppa gozoku"
+        ]
+      },
+      {
+        "en": "Afro-Asiatic",
+        "ja": "アフロ・アジア語族",
+        "ja_typings": [
+          "afuro ajia gozoku"
+        ]
+      },
+      {
+        "en": "Sino-Tibetan",
+        "ja": "シナ・チベット語族",
+        "ja_typings": [
+          "shina chibetto gozoku"
+        ]
+      },
+      {
+        "en": "Uralic",
+        "ja": "ウラル語族",
+        "ja_typings": [
+          "uraru gozoku"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03617",
+    "image_path": null,
+    "question_text": {
+      "en": "Which language family includes English, Hindi, Russian, and Greek?",
+      "ja": "英語・ヒンディー語・ロシア語・ギリシャ語を含む語族は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Inversion",
+        "ja": "倒置法",
+        "ja_typings": [
+          "touchihou"
+        ]
+      },
+      {
+        "en": "Ellipsis",
+        "ja": "省略法",
+        "ja_typings": [
+          "shouryakuhou"
+        ]
+      },
+      {
+        "en": "Repetition",
+        "ja": "反復法",
+        "ja_typings": [
+          "hanpukuhou"
+        ]
+      },
+      {
+        "en": "Personification",
+        "ja": "擬人法",
+        "ja_typings": [
+          "gijinhou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03618",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the rhetorical device of reversing the usual word order for emphasis?",
+      "ja": "強調のために通常の語順を入れ替える修辞技法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Khmer script",
+        "ja": "クメール文字",
+        "ja_typings": [
+          "kume-ru moji"
+        ]
+      },
+      {
+        "en": "Thai script",
+        "ja": "タイ文字",
+        "ja_typings": [
+          "tai moji"
+        ]
+      },
+      {
+        "en": "Lao script",
+        "ja": "ラオ文字",
+        "ja_typings": [
+          "rao moji"
+        ]
+      },
+      {
+        "en": "Burmese script",
+        "ja": "ビルマ文字",
+        "ja_typings": [
+          "biruma moji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03619",
+    "image_path": null,
+    "question_text": {
+      "en": "Which script is used to write the Khmer language of Cambodia?",
+      "ja": "カンボジアのクメール語を書き表す文字は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Latin alphabet",
+        "ja": "ラテン文字",
+        "ja_typings": [
+          "raten moji"
+        ]
+      },
+      {
+        "en": "Cyrillic",
+        "ja": "キリル文字",
+        "ja_typings": [
+          "kiriru moji"
+        ]
+      },
+      {
+        "en": "Greek alphabet",
+        "ja": "ギリシャ文字",
+        "ja_typings": [
+          "girisha moji"
+        ]
+      },
+      {
+        "en": "Arabic script",
+        "ja": "アラビア文字",
+        "ja_typings": [
+          "arabia moji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03620",
+    "image_path": null,
+    "question_text": {
+      "en": "Which alphabet is used for English, French, Spanish, and most European languages?",
+      "ja": "英語・フランス語・スペイン語など多くの欧州言語で使われる文字体系は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Metaphor",
+        "ja": "隠喩",
+        "ja_typings": [
+          "inyu"
+        ]
+      },
+      {
+        "en": "Simile",
+        "ja": "直喩",
+        "ja_typings": [
+          "chokuyu"
+        ]
+      },
+      {
+        "en": "Metonymy",
+        "ja": "換喩",
+        "ja_typings": [
+          "kanyu"
+        ]
+      },
+      {
+        "en": "Personification",
+        "ja": "擬人法",
+        "ja_typings": [
+          "gijinhou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03621",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the rhetorical device of describing one thing as if it were another (e.g., \"Time is money\")?",
+      "ja": "あるものを別のものに見立てて表現する修辞技法(例: 時は金なり)は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Metonymy",
+        "ja": "換喩",
+        "ja_typings": [
+          "kanyu"
+        ]
+      },
+      {
+        "en": "Metaphor",
+        "ja": "隠喩",
+        "ja_typings": [
+          "inyu"
+        ]
+      },
+      {
+        "en": "Synecdoche",
+        "ja": "提喩",
+        "ja_typings": [
+          "teiyu"
+        ]
+      },
+      {
+        "en": "Personification",
+        "ja": "擬人法",
+        "ja_typings": [
+          "gijinhou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03622",
+    "image_path": null,
+    "question_text": {
+      "en": "Which rhetorical device substitutes a related concept for the name of a thing (e.g., \"the crown\" for monarchy)?",
+      "ja": "事物の名を関連概念で置き換える修辞技法(例: 王冠が王権を指す)は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Noun ending",
+        "ja": "体言止め",
+        "ja_typings": [
+          "taigendome"
+        ]
+      },
+      {
+        "en": "Auxiliary verb",
+        "ja": "助動詞",
+        "ja_typings": [
+          "jodoushi"
+        ]
+      },
+      {
+        "en": "Particle",
+        "ja": "助詞",
+        "ja_typings": [
+          "joshi"
+        ]
+      },
+      {
+        "en": "Adverbial",
+        "ja": "連用形",
+        "ja_typings": [
+          "renyoukei"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03623",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the final part of a Japanese noun's conjugational form called?",
+      "ja": "日本語で名詞活用の語尾部分を指す用語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Particle",
+        "ja": "助詞",
+        "ja_typings": [
+          "joshi"
+        ]
+      },
+      {
+        "en": "Auxiliary verb",
+        "ja": "助動詞",
+        "ja_typings": [
+          "jodoushi"
+        ]
+      },
+      {
+        "en": "Conjunction",
+        "ja": "接続詞",
+        "ja_typings": [
+          "setsuzokushi"
+        ]
+      },
+      {
+        "en": "Adverb",
+        "ja": "副詞",
+        "ja_typings": [
+          "fukushi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03624",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese part of speech marks grammatical relations like subject, object, and topic?",
+      "ja": "主語・目的語・主題などの文法関係を示す日本語の品詞は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Passive voice",
+        "ja": "受動態",
+        "ja_typings": [
+          "judoutai"
+        ]
+      },
+      {
+        "en": "Active voice",
+        "ja": "能動態",
+        "ja_typings": [
+          "noudoutai"
+        ]
+      },
+      {
+        "en": "Causative voice",
+        "ja": "使役態",
+        "ja_typings": [
+          "shiekitai"
+        ]
+      },
+      {
+        "en": "Middle voice",
+        "ja": "中動態",
+        "ja_typings": [
+          "chuudoutai"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03625",
+    "image_path": null,
+    "question_text": {
+      "en": "Which voice expresses that the subject receives the action of the verb?",
+      "ja": "主語が動作の受け手であることを表す態(ヴォイス)は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Personification",
+        "ja": "擬人法",
+        "ja_typings": [
+          "gijinhou"
+        ]
+      },
+      {
+        "en": "Metaphor",
+        "ja": "隠喩",
+        "ja_typings": [
+          "inyu"
+        ]
+      },
+      {
+        "en": "Metonymy",
+        "ja": "換喩",
+        "ja_typings": [
+          "kanyu"
+        ]
+      },
+      {
+        "en": "Synecdoche",
+        "ja": "提喩",
+        "ja_typings": [
+          "teiyu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03626",
+    "image_path": null,
+    "question_text": {
+      "en": "What rhetorical device gives human qualities to non-human things?",
+      "ja": "人ではないものに人間的性質を与える修辞技法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Polite language",
+        "ja": "丁寧語",
+        "ja_typings": [
+          "teineigo"
+        ]
+      },
+      {
+        "en": "Respectful language",
+        "ja": "尊敬語",
+        "ja_typings": [
+          "sonkeigo"
+        ]
+      },
+      {
+        "en": "Humble language",
+        "ja": "謙譲語",
+        "ja_typings": [
+          "kenjougo"
+        ]
+      },
+      {
+        "en": "Honorific language",
+        "ja": "敬語",
+        "ja_typings": [
+          "keigo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03627",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the polite style of Japanese using forms like \"desu\" and \"masu\" called?",
+      "ja": "「です」「ます」を用いる日本語の丁寧な文体は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Portuguese",
+        "ja": "ポルトガル語",
+        "ja_typings": [
+          "porutogarugo"
+        ]
+      },
+      {
+        "en": "Spanish",
+        "ja": "スペイン語",
+        "ja_typings": [
+          "supeingo"
+        ]
+      },
+      {
+        "en": "Italian",
+        "ja": "イタリア語",
+        "ja_typings": [
+          "itariago"
+        ]
+      },
+      {
+        "en": "French",
+        "ja": "フランス語",
+        "ja_typings": [
+          "furansugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03628",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Romance language is the official language of Portugal and Brazil?",
+      "ja": "ポルトガルとブラジルの公用語であるロマンス諸語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Pragmatics",
+        "ja": "語用論",
+        "ja_typings": [
+          "goyouron"
+        ]
+      },
+      {
+        "en": "Semantics",
+        "ja": "意味論",
+        "ja_typings": [
+          "imiron"
+        ]
+      },
+      {
+        "en": "Syntax",
+        "ja": "統語論",
+        "ja_typings": [
+          "tougoron"
+        ]
+      },
+      {
+        "en": "Phonology",
+        "ja": "音韻論",
+        "ja_typings": [
+          "onninron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03629",
+    "image_path": null,
+    "question_text": {
+      "en": "Which subfield of linguistics studies how context contributes to meaning?",
+      "ja": "文脈が意味に与える影響を研究する言語学の下位分野は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Psycholinguistics",
+        "ja": "心理言語学",
+        "ja_typings": [
+          "shinrigengogaku"
+        ]
+      },
+      {
+        "en": "Sociolinguistics",
+        "ja": "社会言語学",
+        "ja_typings": [
+          "shakaigengogaku"
+        ]
+      },
+      {
+        "en": "Neurolinguistics",
+        "ja": "神経言語学",
+        "ja_typings": [
+          "shinkeigengogaku"
+        ]
+      },
+      {
+        "en": "Pragmatics",
+        "ja": "語用論",
+        "ja_typings": [
+          "goyouron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03630",
+    "image_path": null,
+    "question_text": {
+      "en": "Which interdisciplinary field studies the mental processes involved in language use?",
+      "ja": "言語使用に関わる心的過程を研究する学際分野は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Rendaku",
+        "ja": "連濁",
+        "ja_typings": [
+          "rendaku"
+        ]
+      },
+      {
+        "en": "Gemination",
+        "ja": "促音",
+        "ja_typings": [
+          "sokuon"
+        ]
+      },
+      {
+        "en": "Vowel devoicing",
+        "ja": "母音の無声化",
+        "ja_typings": [
+          "boin no museika"
+        ]
+      },
+      {
+        "en": "Sandhi",
+        "ja": "連声",
+        "ja_typings": [
+          "renjou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03631",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Japanese phonological phenomenon where a voiceless consonant becomes voiced in compounds (e.g., hito + hito = hitobito)?",
+      "ja": "複合語で清音が濁音化する日本語の音韻現象(例: ひと+ひと=ひとびと)は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Repetition",
+        "ja": "反復法",
+        "ja_typings": [
+          "hanpukuhou"
+        ]
+      },
+      {
+        "en": "Inversion",
+        "ja": "倒置法",
+        "ja_typings": [
+          "touchihou"
+        ]
+      },
+      {
+        "en": "Ellipsis",
+        "ja": "省略法",
+        "ja_typings": [
+          "shouryakuhou"
+        ]
+      },
+      {
+        "en": "Metaphor",
+        "ja": "隠喩",
+        "ja_typings": [
+          "inyu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03632",
+    "image_path": null,
+    "question_text": {
+      "en": "Which rhetorical device repeats words or phrases for emphasis?",
+      "ja": "強調のために語句を繰り返す修辞技法は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Respectful language",
+        "ja": "尊敬語",
+        "ja_typings": [
+          "sonkeigo"
+        ]
+      },
+      {
+        "en": "Humble language",
+        "ja": "謙譲語",
+        "ja_typings": [
+          "kenjougo"
+        ]
+      },
+      {
+        "en": "Polite language",
+        "ja": "丁寧語",
+        "ja_typings": [
+          "teineigo"
+        ]
+      },
+      {
+        "en": "Honorific language",
+        "ja": "敬語",
+        "ja_typings": [
+          "keigo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03633",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the Japanese honorific style used to elevate the listener or referent called?",
+      "ja": "聞き手や話題の人物を高める日本語の敬語スタイルは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Six",
+        "ja": "6",
+        "ja_typings": [
+          "6",
+          "roku"
+        ]
+      },
+      {
+        "en": "Eight",
+        "ja": "8",
+        "ja_typings": [
+          "8",
+          "hachi"
+        ]
+      },
+      {
+        "en": "Two",
+        "ja": "2",
+        "ja_typings": [
+          "2",
+          "ni"
+        ]
+      },
+      {
+        "en": "Nine",
+        "ja": "9",
+        "ja_typings": [
+          "9",
+          "kyuu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03634",
+    "image_path": null,
+    "question_text": {
+      "en": "Which number is \"six\" in English?",
+      "ja": "英語で six が表す数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Sociolinguistics",
+        "ja": "社会言語学",
+        "ja_typings": [
+          "shakaigengogaku"
+        ]
+      },
+      {
+        "en": "Psycholinguistics",
+        "ja": "心理言語学",
+        "ja_typings": [
+          "shinrigengogaku"
+        ]
+      },
+      {
+        "en": "Pragmatics",
+        "ja": "語用論",
+        "ja_typings": [
+          "goyouron"
+        ]
+      },
+      {
+        "en": "Semantics",
+        "ja": "意味論",
+        "ja_typings": [
+          "imiron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03635",
+    "image_path": null,
+    "question_text": {
+      "en": "Which subfield of linguistics studies the relationship between language and society?",
+      "ja": "言語と社会の関係を研究する言語学の下位分野は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Spanish",
+        "ja": "スペイン語",
+        "ja_typings": [
+          "supeingo"
+        ]
+      },
+      {
+        "en": "Portuguese",
+        "ja": "ポルトガル語",
+        "ja_typings": [
+          "porutogarugo"
+        ]
+      },
+      {
+        "en": "Italian",
+        "ja": "イタリア語",
+        "ja_typings": [
+          "itariago"
+        ]
+      },
+      {
+        "en": "French",
+        "ja": "フランス語",
+        "ja_typings": [
+          "furansugo"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03636",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Romance language is the official language of Spain and most of Latin America?",
+      "ja": "スペインおよびラテンアメリカの多くの国の公用語であるロマンス諸語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Stem",
+        "ja": "語幹",
+        "ja_typings": [
+          "gokan"
+        ]
+      },
+      {
+        "en": "Ending",
+        "ja": "語尾",
+        "ja_typings": [
+          "gobi"
+        ]
+      },
+      {
+        "en": "Affix",
+        "ja": "接辞",
+        "ja_typings": [
+          "setsuji"
+        ]
+      },
+      {
+        "en": "Particle",
+        "ja": "助詞",
+        "ja_typings": [
+          "joshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03637",
+    "image_path": null,
+    "question_text": {
+      "en": "What is the unchanging core part of a Japanese conjugated word called?",
+      "ja": "日本語の活用語で変化しない中心部分を指す語は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Synecdoche",
+        "ja": "提喩",
+        "ja_typings": [
+          "teiyu"
+        ]
+      },
+      {
+        "en": "Metonymy",
+        "ja": "換喩",
+        "ja_typings": [
+          "kanyu"
+        ]
+      },
+      {
+        "en": "Metaphor",
+        "ja": "隠喩",
+        "ja_typings": [
+          "inyu"
+        ]
+      },
+      {
+        "en": "Personification",
+        "ja": "擬人法",
+        "ja_typings": [
+          "gijinhou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03638",
+    "image_path": null,
+    "question_text": {
+      "en": "Which rhetorical device uses a part to represent the whole, or vice versa (e.g., \"all hands on deck\")?",
+      "ja": "部分で全体を、あるいは全体で部分を表す修辞技法(例: \"all hands\" が船員を指す)は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Syntax",
+        "ja": "統語論",
+        "ja_typings": [
+          "tougoron"
+        ]
+      },
+      {
+        "en": "Semantics",
+        "ja": "意味論",
+        "ja_typings": [
+          "imiron"
+        ]
+      },
+      {
+        "en": "Phonology",
+        "ja": "音韻論",
+        "ja_typings": [
+          "onninron"
+        ]
+      },
+      {
+        "en": "Pragmatics",
+        "ja": "語用論",
+        "ja_typings": [
+          "goyouron"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03639",
+    "image_path": null,
+    "question_text": {
+      "en": "Which subfield of linguistics studies the rules governing sentence structure?",
+      "ja": "文の構造を規定する規則を研究する言語学の下位分野は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Thai script",
+        "ja": "タイ文字",
+        "ja_typings": [
+          "tai moji"
+        ]
+      },
+      {
+        "en": "Khmer script",
+        "ja": "クメール文字",
+        "ja_typings": [
+          "kume-ru moji"
+        ]
+      },
+      {
+        "en": "Lao script",
+        "ja": "ラオ文字",
+        "ja_typings": [
+          "rao moji"
+        ]
+      },
+      {
+        "en": "Burmese script",
+        "ja": "ビルマ文字",
+        "ja_typings": [
+          "biruma moji"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03640",
+    "image_path": null,
+    "question_text": {
+      "en": "Which script is used to write the Thai language?",
+      "ja": "タイ語を書き表す文字は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Two",
+        "ja": "2",
+        "ja_typings": [
+          "2",
+          "ni"
+        ]
+      },
+      {
+        "en": "Six",
+        "ja": "6",
+        "ja_typings": [
+          "6",
+          "roku"
+        ]
+      },
+      {
+        "en": "Eight",
+        "ja": "8",
+        "ja_typings": [
+          "8",
+          "hachi"
+        ]
+      },
+      {
+        "en": "Three",
+        "ja": "3",
+        "ja_typings": [
+          "3",
+          "san"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "language",
+    "id": "q03641",
+    "image_path": null,
+    "question_text": {
+      "en": "Which number is \"two\" in English?",
+      "ja": "英語で two が表す数は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Akira Toriyama",
+        "ja": "鳥山明",
+        "ja_typings": [
+          "toriyama akira"
+        ]
+      },
+      {
+        "en": "Masashi Kishimoto",
+        "ja": "岸本斉史",
+        "ja_typings": [
+          "kishimoto masashi"
+        ]
+      },
+      {
+        "en": "Eiichiro Oda",
+        "ja": "尾田栄一郎",
+        "ja_typings": [
+          "oda eiichirou"
+        ]
+      },
+      {
+        "en": "Tite Kubo",
+        "ja": "久保帯人",
+        "ja_typings": [
+          "kubo taito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03642",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created the manga \"Dragon Ball\"?",
+      "ja": "漫画『ドラゴンボール』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Eiichiro Oda",
+        "ja": "尾田栄一郎",
+        "ja_typings": [
+          "oda eiichirou"
+        ]
+      },
+      {
+        "en": "Akira Toriyama",
+        "ja": "鳥山明",
+        "ja_typings": [
+          "toriyama akira"
+        ]
+      },
+      {
+        "en": "Masashi Kishimoto",
+        "ja": "岸本斉史",
+        "ja_typings": [
+          "kishimoto masashi"
+        ]
+      },
+      {
+        "en": "Tite Kubo",
+        "ja": "久保帯人",
+        "ja_typings": [
+          "kubo taito"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03643",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created the manga \"One Piece\"?",
+      "ja": "漫画『ONE PIECE』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Fujiko F. Fujio",
+        "ja": "藤子・F・不二雄",
+        "ja_typings": [
+          "fujiko f fujio"
+        ]
+      },
+      {
+        "en": "Fujiko Fujio A",
+        "ja": "藤子不二雄A",
+        "ja_typings": [
+          "fujiko fujio a"
+        ]
+      },
+      {
+        "en": "Osamu Tezuka",
+        "ja": "手塚治虫",
+        "ja_typings": [
+          "tezuka osamu"
+        ]
+      },
+      {
+        "en": "Shotaro Ishinomori",
+        "ja": "石ノ森章太郎",
+        "ja_typings": [
+          "ishinomori shoutarou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03644",
+    "image_path": null,
+    "question_text": {
+      "en": "Which pen name was used by the duo behind \"Doraemon\"?",
+      "ja": "『ドラえもん』を生んだコンビが用いたペンネームは?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Futabasha",
+        "ja": "双葉社",
+        "ja_typings": [
+          "futabasha"
+        ]
+      },
+      {
+        "en": "Shueisha",
+        "ja": "集英社",
+        "ja_typings": [
+          "shueisha"
+        ]
+      },
+      {
+        "en": "Kodansha",
+        "ja": "講談社",
+        "ja_typings": [
+          "koudansha"
+        ]
+      },
+      {
+        "en": "Hakusensha",
+        "ja": "白泉社",
+        "ja_typings": [
+          "hakusensha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03645",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese publisher issues \"Weekly Manga Action\" and \"Manga Town\"?",
+      "ja": "『漫画アクション』『漫画タウン』を発行する日本の出版社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Hakusensha",
+        "ja": "白泉社",
+        "ja_typings": [
+          "hakusensha"
+        ]
+      },
+      {
+        "en": "Shueisha",
+        "ja": "集英社",
+        "ja_typings": [
+          "shueisha"
+        ]
+      },
+      {
+        "en": "Kodansha",
+        "ja": "講談社",
+        "ja_typings": [
+          "koudansha"
+        ]
+      },
+      {
+        "en": "Futabasha",
+        "ja": "双葉社",
+        "ja_typings": [
+          "futabasha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03646",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese publisher issues \"Hana to Yume\" and \"LaLa\"?",
+      "ja": "『花とゆめ』『LaLa』を発行する日本の出版社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kadokawa Shoten",
+        "ja": "角川書店",
+        "ja_typings": [
+          "kadokawa shoten"
+        ]
+      },
+      {
+        "en": "Shueisha",
+        "ja": "集英社",
+        "ja_typings": [
+          "shueisha"
+        ]
+      },
+      {
+        "en": "Kodansha",
+        "ja": "講談社",
+        "ja_typings": [
+          "koudansha"
+        ]
+      },
+      {
+        "en": "Hakusensha",
+        "ja": "白泉社",
+        "ja_typings": [
+          "hakusensha"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03647",
+    "image_path": null,
+    "question_text": {
+      "en": "Which publisher issues \"Monthly Shonen Ace\" and is a major light novel publisher?",
+      "ja": "『月刊少年エース』を発行しライトノベルでも大手の出版社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Katsuhiro Otomo",
+        "ja": "大友克洋",
+        "ja_typings": [
+          "ootomo katsuhiro"
+        ]
+      },
+      {
+        "en": "Masamune Shirow",
+        "ja": "士郎正宗",
+        "ja_typings": [
+          "shirou masamune"
+        ]
+      },
+      {
+        "en": "Hirohiko Araki",
+        "ja": "荒木飛呂彦",
+        "ja_typings": [
+          "araki hirohiko"
+        ]
+      },
+      {
+        "en": "Kentaro Miura",
+        "ja": "三浦建太郎",
+        "ja_typings": [
+          "miura kentarou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03648",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created \"Akira\"?",
+      "ja": "漫画『AKIRA』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Kentaro Miura",
+        "ja": "三浦建太郎",
+        "ja_typings": [
+          "miura kentarou"
+        ]
+      },
+      {
+        "en": "Hirohiko Araki",
+        "ja": "荒木飛呂彦",
+        "ja_typings": [
+          "araki hirohiko"
+        ]
+      },
+      {
+        "en": "Katsuhiro Otomo",
+        "ja": "大友克洋",
+        "ja_typings": [
+          "ootomo katsuhiro"
+        ]
+      },
+      {
+        "en": "Yoshihiro Togashi",
+        "ja": "冨樫義博",
+        "ja_typings": [
+          "togashi yoshihiro"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03649",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created \"Berserk\"?",
+      "ja": "漫画『ベルセルク』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Masamune Shirow",
+        "ja": "士郎正宗",
+        "ja_typings": [
+          "shirou masamune"
+        ]
+      },
+      {
+        "en": "Katsuhiro Otomo",
+        "ja": "大友克洋",
+        "ja_typings": [
+          "ootomo katsuhiro"
+        ]
+      },
+      {
+        "en": "Hirohiko Araki",
+        "ja": "荒木飛呂彦",
+        "ja_typings": [
+          "araki hirohiko"
+        ]
+      },
+      {
+        "en": "Kentaro Miura",
+        "ja": "三浦建太郎",
+        "ja_typings": [
+          "miura kentarou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03650",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created \"Ghost in the Shell\"?",
+      "ja": "『攻殻機動隊』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Masumi Hayami",
+        "ja": "速水真澄",
+        "ja_typings": [
+          "hayami masumi"
+        ]
+      },
+      {
+        "en": "Maya Kitajima",
+        "ja": "北島マヤ",
+        "ja_typings": [
+          "kitajima maya"
+        ]
+      },
+      {
+        "en": "Ayumi Himekawa",
+        "ja": "姫川亜弓",
+        "ja_typings": [
+          "himekawa ayumi"
+        ]
+      },
+      {
+        "en": "Chigusa Tsukikage",
+        "ja": "月影千草",
+        "ja_typings": [
+          "tsukikage chigusa"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03651",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the protagonist artist character of \"Glass Mask\" (Garasu no Kamen)?",
+      "ja": "『ガラスの仮面』に登場する天才舞台女優のライバルの名は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Nikkei",
+        "ja": "日本経済新聞",
+        "ja_typings": [
+          "nihon keizai shinbun"
+        ]
+      },
+      {
+        "en": "The Yomiuri Shimbun",
+        "ja": "読売新聞",
+        "ja_typings": [
+          "yomiuri shinbun"
+        ]
+      },
+      {
+        "en": "The Mainichi Shimbun",
+        "ja": "毎日新聞",
+        "ja_typings": [
+          "mainichi shinbun"
+        ]
+      },
+      {
+        "en": "The Asahi Shimbun",
+        "ja": "朝日新聞",
+        "ja_typings": [
+          "asahi shinbun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03652",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese newspaper company is known for its economic and business news?",
+      "ja": "経済・ビジネスニュースで知られる日本の新聞社は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Takeshi Obata",
+        "ja": "小畑健",
+        "ja_typings": [
+          "obata takeshi"
+        ]
+      },
+      {
+        "en": "Tsugumi Ohba",
+        "ja": "大場つぐみ",
+        "ja_typings": [
+          "ooba tsugumi"
+        ]
+      },
+      {
+        "en": "Tite Kubo",
+        "ja": "久保帯人",
+        "ja_typings": [
+          "kubo taito"
+        ]
+      },
+      {
+        "en": "Masashi Kishimoto",
+        "ja": "岸本斉史",
+        "ja_typings": [
+          "kishimoto masashi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03653",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the illustrator of \"Death Note\" and \"Bakuman\"?",
+      "ja": "『DEATH NOTE』『バクマン。』の作画担当は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tatsuki Fujimoto",
+        "ja": "藤本タツキ",
+        "ja_typings": [
+          "fujimoto tatsuki"
+        ]
+      },
+      {
+        "en": "Gege Akutami",
+        "ja": "芥見下々",
+        "ja_typings": [
+          "akutami gege"
+        ]
+      },
+      {
+        "en": "Kohei Horikoshi",
+        "ja": "堀越耕平",
+        "ja_typings": [
+          "horikoshi kouhei"
+        ]
+      },
+      {
+        "en": "Koyoharu Gotouge",
+        "ja": "吾峠呼世晴",
+        "ja_typings": [
+          "gotouge koyoharu"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03654",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created \"Chainsaw Man\"?",
+      "ja": "『チェンソーマン』の作者は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tetsuo Hara",
+        "ja": "原哲夫",
+        "ja_typings": [
+          "hara tetsuo"
+        ]
+      },
+      {
+        "en": "Buronson",
+        "ja": "武論尊",
+        "ja_typings": [
+          "buronson"
+        ]
+      },
+      {
+        "en": "Yasuhisa Hara",
+        "ja": "原泰久",
+        "ja_typings": [
+          "hara yasuhisa"
+        ]
+      },
+      {
+        "en": "Takeshi Obata",
+        "ja": "小畑健",
+        "ja_typings": [
+          "obata takeshi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03655",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created \"Fist of the North Star\" as the artist?",
+      "ja": "『北斗の拳』の作画担当は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Mainichi Shimbun",
+        "ja": "毎日新聞",
+        "ja_typings": [
+          "mainichi shinbun"
+        ]
+      },
+      {
+        "en": "The Yomiuri Shimbun",
+        "ja": "読売新聞",
+        "ja_typings": [
+          "yomiuri shinbun"
+        ]
+      },
+      {
+        "en": "The Asahi Shimbun",
+        "ja": "朝日新聞",
+        "ja_typings": [
+          "asahi shinbun"
+        ]
+      },
+      {
+        "en": "Nikkei",
+        "ja": "日本経済新聞",
+        "ja_typings": [
+          "nihon keizai shinbun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03656",
+    "image_path": null,
+    "question_text": {
+      "en": "Which national daily Japanese newspaper is published by Mainichi Shimbun Holdings?",
+      "ja": "毎日新聞社が発行する日本の全国紙は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "The Yomiuri Shimbun",
+        "ja": "読売新聞",
+        "ja_typings": [
+          "yomiuri shinbun"
+        ]
+      },
+      {
+        "en": "The Asahi Shimbun",
+        "ja": "朝日新聞",
+        "ja_typings": [
+          "asahi shinbun"
+        ]
+      },
+      {
+        "en": "The Mainichi Shimbun",
+        "ja": "毎日新聞",
+        "ja_typings": [
+          "mainichi shinbun"
+        ]
+      },
+      {
+        "en": "Nikkei",
+        "ja": "日本経済新聞",
+        "ja_typings": [
+          "nihon keizai shinbun"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03657",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Japanese daily newspaper has the largest circulation, published by The Yomiuri Shimbun Holdings?",
+      "ja": "発行部数が日本最大級の、読売新聞社が発行する全国紙は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Tsugumi Ohba",
+        "ja": "大場つぐみ",
+        "ja_typings": [
+          "ooba tsugumi"
+        ]
+      },
+      {
+        "en": "Takeshi Obata",
+        "ja": "小畑健",
+        "ja_typings": [
+          "obata takeshi"
+        ]
+      },
+      {
+        "en": "Tite Kubo",
+        "ja": "久保帯人",
+        "ja_typings": [
+          "kubo taito"
+        ]
+      },
+      {
+        "en": "Masashi Kishimoto",
+        "ja": "岸本斉史",
+        "ja_typings": [
+          "kishimoto masashi"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03658",
+    "image_path": null,
+    "question_text": {
+      "en": "Who is the writer of \"Death Note\" and \"Bakuman\"?",
+      "ja": "『DEATH NOTE』『バクマン。』の原作担当は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Weekly Shonen Sunday",
+        "ja": "週刊少年サンデー",
+        "ja_typings": [
+          "shuukan shounen sandee"
+        ]
+      },
+      {
+        "en": "Weekly Shonen Jump",
+        "ja": "週刊少年ジャンプ",
+        "ja_typings": [
+          "shuukan shounen janpu"
+        ]
+      },
+      {
+        "en": "Weekly Shonen Magazine",
+        "ja": "週刊少年マガジン",
+        "ja_typings": [
+          "shuukan shounen magajin"
+        ]
+      },
+      {
+        "en": "Weekly Shonen Champion",
+        "ja": "週刊少年チャンピオン",
+        "ja_typings": [
+          "shuukan shounen chanpion"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03659",
+    "image_path": null,
+    "question_text": {
+      "en": "Which Shogakukan magazine serialized \"InuYasha\" and \"Detective Conan\"?",
+      "ja": "『犬夜叉』『名探偵コナン』を連載する小学館の漫画雑誌は?"
+    }
+  },
+  {
+    "choices": [
+      {
+        "en": "Yasuhisa Hara",
+        "ja": "原泰久",
+        "ja_typings": [
+          "hara yasuhisa"
+        ]
+      },
+      {
+        "en": "Tetsuo Hara",
+        "ja": "原哲夫",
+        "ja_typings": [
+          "hara tetsuo"
+        ]
+      },
+      {
+        "en": "Hajime Isayama",
+        "ja": "諫山創",
+        "ja_typings": [
+          "isayama hajime"
+        ]
+      },
+      {
+        "en": "Kentaro Miura",
+        "ja": "三浦建太郎",
+        "ja_typings": [
+          "miura kentarou"
+        ]
+      }
+    ],
+    "correct_answer_index": 0,
+    "genre": "manga",
+    "id": "q03660",
+    "image_path": null,
+    "question_text": {
+      "en": "Who created \"Kingdom\"?",
+      "ja": "漫画『キングダム』の作者は?"
     }
   }
 ]

--- a/data/questions_ja.json
+++ b/data/questions_ja.json
@@ -143110,24 +143110,24 @@
         ]
       },
       {
-        "en": "Flamenco",
-        "ja": "フラメンコ",
+        "en": "Samba",
+        "ja": "サンバ",
         "ja_typings": [
-          "furamenko"
+          "sanba"
         ]
       },
       {
-        "en": "Krav Maga",
-        "ja": "クラヴマガ",
+        "en": "Tango",
+        "ja": "タンゴ",
         "ja_typings": [
-          "kuravumaga"
+          "tango"
         ]
       },
       {
-        "en": "Taekwondo",
-        "ja": "テコンドー",
+        "en": "Salsa",
+        "ja": "サルサ",
         "ja_typings": [
-          "tekondo-"
+          "sarusa"
         ]
       }
     ],
@@ -143164,10 +143164,10 @@
         ]
       },
       {
-        "en": "Eiffel Tower",
-        "ja": "エッフェル塔",
+        "en": "Ganges River",
+        "ja": "ガンジス川",
         "ja_typings": [
-          "efferutou"
+          "ganjisugawa"
         ]
       }
     ],
@@ -143391,24 +143391,24 @@
         ]
       },
       {
-        "en": "Bossa Nova",
-        "ja": "ボサノバ",
+        "en": "Bolero",
+        "ja": "ボレロ",
         "ja_typings": [
-          "bosanoba"
+          "borero"
         ]
       },
       {
-        "en": "Krav Maga",
-        "ja": "クラヴマガ",
+        "en": "Sevillanas",
+        "ja": "セビジャーナス",
         "ja_typings": [
-          "kuravumaga"
+          "sebija-nasu"
         ]
       },
       {
-        "en": "Taekwondo",
-        "ja": "テコンドー",
+        "en": "Jota",
+        "ja": "ホタ",
         "ja_typings": [
-          "tekondo-"
+          "hota"
         ]
       }
     ],
@@ -143803,17 +143803,17 @@
         ]
       },
       {
-        "en": "Flamenco",
-        "ja": "フラメンコ",
+        "en": "Judo",
+        "ja": "柔道",
         "ja_typings": [
-          "furamenko"
+          "juudou"
         ]
       },
       {
-        "en": "Bossa Nova",
-        "ja": "ボサノバ",
+        "en": "Sambo",
+        "ja": "サンボ",
         "ja_typings": [
-          "bosanoba"
+          "sanbo"
         ]
       }
     ],
@@ -144441,24 +144441,24 @@
         ]
       },
       {
-        "en": "Krav Maga",
-        "ja": "クラヴマガ",
+        "en": "Karate",
+        "ja": "空手",
         "ja_typings": [
-          "kuravumaga"
+          "karate"
         ]
       },
       {
-        "en": "Flamenco",
-        "ja": "フラメンコ",
+        "en": "Hapkido",
+        "ja": "ハプキドー",
         "ja_typings": [
-          "furamenko"
+          "hapukido-"
         ]
       },
       {
-        "en": "Bossa Nova",
-        "ja": "ボサノバ",
+        "en": "Wushu",
+        "ja": "武術",
         "ja_typings": [
-          "bosanoba"
+          "bujutsu"
         ]
       }
     ],
@@ -144735,10 +144735,10 @@
         ]
       },
       {
-        "en": "Eiffel Tower",
-        "ja": "エッフェル塔",
+        "en": "Sarasvati River",
+        "ja": "サラスヴァティー川",
         "ja_typings": [
-          "efferutou"
+          "sarasuvati-gawa"
         ]
       }
     ],
@@ -146501,7 +146501,7 @@
         "en": "Niger-Congo",
         "ja": "ニジェール・コンゴ語族",
         "ja_typings": [
-          "nijie-ru kongo gozoku"
+          "nije-ru kongo gozoku"
         ]
       }
     ],
@@ -148358,7 +148358,7 @@
       }
     ],
     "correct_answer_index": 0,
-    "genre": "manga",
+    "genre": "general_knowledge",
     "id": "q03652",
     "image_path": null,
     "question_text": {
@@ -148518,7 +148518,7 @@
       }
     ],
     "correct_answer_index": 0,
-    "genre": "manga",
+    "genre": "general_knowledge",
     "id": "q03656",
     "image_path": null,
     "question_text": {
@@ -148558,7 +148558,7 @@
       }
     ],
     "correct_answer_index": 0,
-    "genre": "manga",
+    "genre": "general_knowledge",
     "id": "q03657",
     "image_path": null,
     "question_text": {


### PR DESCRIPTION
## Summary
Round 4 後に残った 7 ジャンル (technology, vtuber, science, culture, it_term, language, manga) を完遂。

## カバレッジ最終
| 段階 | カバレッジ |
|---|---|
| Round 1 | 8% |
| Round 3 | 38% |
| Round 4 | 81% |
| **Round 5** | **98.5%** |

## ジャンル別最終
| genre | coverage |
|---|---|
| anime, culture, geography, it_terminology, language, science, technology, web_development | **100%** |
| history | 99% |
| math | 99% |
| game | 99% |
| programming | 98% |
| vtuber_net_culture | 97% |
| general_knowledge | 95% |
| manga | 86% |

## 問題数
735 (元) → **3660** (+2925 問)

## Issue #116 目的達成
元の 735 問の誤答ユニーク 1891 件のうち 1863 件 (98.5%) が新規問題の正解として登場するようになり、
「選択肢だけ見て正解を当てる」戦略はほぼ無効化された。

## Test plan
- [x] lint-questions: 0 errors
- [x] cargo test --release: 236 passed
- [x] backfill-ja-typing 通過