### PR TITLE
feat: Hack RPG Phase 1 — 永続化配線 + 状態機械 + 戦闘ログ配線

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -52,20 +52,12 @@ impl Config {
         )
     }
 
-    #[allow(dead_code)]
-    pub fn player_data_file_path(&self) -> String {
-        format!("{}/{}", self.data_dir, self.player_data_file)
-    }
-
     /// Single-file path for the cross-language player progression file
     /// (`player.yaml`). Unlike `records_file_path` this is **not**
     /// language-keyed: RPG progression persists once per user across
-    /// all languages they sample (#32). Currently an alias for
-    /// `player_data_file_path`; kept as a separate accessor so the
-    /// run-loop in `main.rs` reads from the documented #32 name and
-    /// future renames stay local to one helper.
+    /// all languages they sample (#32).
     pub fn player_file_path(&self) -> String {
-        self.player_data_file_path()
+        format!("{}/{}", self.data_dir, self.player_data_file)
     }
 
     pub fn records_file_path(&self, language: &Language) -> String {

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,6 +57,17 @@ impl Config {
         format!("{}/{}", self.data_dir, self.player_data_file)
     }
 
+    /// Single-file path for the cross-language player progression file
+    /// (`player.yaml`). Unlike `records_file_path` this is **not**
+    /// language-keyed: RPG progression persists once per user across
+    /// all languages they sample (#32). Currently an alias for
+    /// `player_data_file_path`; kept as a separate accessor so the
+    /// run-loop in `main.rs` reads from the documented #32 name and
+    /// future renames stay local to one helper.
+    pub fn player_file_path(&self) -> String {
+        self.player_data_file_path()
+    }
+
     pub fn records_file_path(&self, language: &Language) -> String {
         format!(
             "{}/{}",

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -8,6 +8,6 @@ pub use listening::{ListeningSession, SubmissionResult};
 // `listening::is_correct_listening_input`; not re-exported until a
 // non-test caller appears.
 pub use quiz::QuizGame;
-pub use rpg::{ListeningRpgRun, RpgEncounterKind, RPG_RUN_LENGTH};
+pub use rpg::{ListeningRpgRun, RpgEncounterKind, RpgRunPhase, RPG_RUN_LENGTH};
 #[allow(unused_imports)]
 pub use time_attack::{Ta25LocalGame, Ta25Roster, Ta25SeatColor, TA25_RUN_LENGTH};

--- a/src/game/rpg.rs
+++ b/src/game/rpg.rs
@@ -18,9 +18,40 @@ pub struct RpgEncounter {
     pub prompt: ListeningPrompt,
 }
 
+/// Macro-phase of a single RPG run, used by `main::run_listening_rpg`
+/// to drive the loop instead of a bare `for encounter in run.encounters()`.
+///
+/// Phase 1 (#33) deliberately keeps this simple:
+///   Town → Diving → Encounter(1) → ... → Encounter(10) → Return → Town
+///
+/// `Combat / Defeat` are not modelled — the v0.2.0 RPG has *no failure
+/// state* (CLAUDE.md: "失敗概念なし"). Players always finish all 10
+/// encounters and return to town; missed answers only affect future EXP
+/// accounting (Phase 2). The single `Encounter(N)` variant is enough to
+/// represent both regular and boss beats; the encounter table itself
+/// (regular / miniboss / boss) is held by `ListeningRpgRun::encounters`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RpgRunPhase {
+    Town,
+    Diving,
+    /// 1..=`RPG_RUN_LENGTH`. Ordinal matches `RpgEncounter::ordinal`.
+    Encounter(u32),
+    Return,
+}
+
+/// Maximum number of battle-log lines kept on `ListeningRpgRun` in
+/// Phase 1 (#36). The UI clips to the visible pane height; this bound
+/// just prevents unbounded growth across a 10-encounter run.
+pub const BATTLE_LOG_MAX: usize = 64;
+
 #[derive(Debug, Clone)]
 pub struct ListeningRpgRun {
     encounters: Vec<RpgEncounter>,
+    phase: RpgRunPhase,
+    /// Per-run rolling battle log surfaced by the listening UIs (#36).
+    /// Phase 1 only carries Hit / Missed / Plays lines; richer events
+    /// (damage numbers, EXP gain, level-ups) come in Phase 2.
+    battle_log: Vec<String>,
 }
 
 impl ListeningRpgRun {
@@ -118,11 +149,70 @@ impl ListeningRpgRun {
                 .expect("validated boss availability before building run"),
         });
 
-        Ok(Self { encounters })
+        Ok(Self {
+            encounters,
+            phase: RpgRunPhase::Town,
+            battle_log: Vec::new(),
+        })
     }
 
+    #[allow(dead_code)]
     pub fn encounters(&self) -> &[RpgEncounter] {
         &self.encounters
+    }
+
+    pub fn phase(&self) -> RpgRunPhase {
+        self.phase
+    }
+
+    /// Town → Diving. Called once when a run is starting to descend.
+    pub fn enter_diving(&mut self) {
+        self.phase = RpgRunPhase::Diving;
+    }
+
+    /// Advance from Diving (or Encounter(N-1)) to Encounter(N).
+    /// Returns the encounter to play, or `None` once all 10 are done
+    /// (in which case the phase becomes `Return`).
+    ///
+    /// Phase 1 keeps this dumb on purpose — the loop driver in
+    /// `main.rs` calls `advance_to_next_encounter` between beats and
+    /// trusts the returned `Option<&RpgEncounter>` for control flow.
+    pub fn advance_to_next_encounter(&mut self) -> Option<&RpgEncounter> {
+        let next_ordinal = match self.phase {
+            RpgRunPhase::Town | RpgRunPhase::Return => return None,
+            RpgRunPhase::Diving => 1,
+            RpgRunPhase::Encounter(n) => n + 1,
+        };
+
+        if (next_ordinal as usize) > self.encounters.len() {
+            self.phase = RpgRunPhase::Return;
+            return None;
+        }
+
+        self.phase = RpgRunPhase::Encounter(next_ordinal);
+        self.encounters.get((next_ordinal - 1) as usize)
+    }
+
+    /// Force the run back into `Town`. Called once the `Return` beat
+    /// finishes (or by callers that need to abort cleanly).
+    pub fn return_to_town(&mut self) {
+        self.phase = RpgRunPhase::Town;
+    }
+
+    /// Append a line to the run's rolling battle log (#36). Older
+    /// entries are dropped past `BATTLE_LOG_MAX` to keep memory bounded.
+    pub fn push_battle_log<S: Into<String>>(&mut self, entry: S) {
+        self.battle_log.push(entry.into());
+        let len = self.battle_log.len();
+        if len > BATTLE_LOG_MAX {
+            self.battle_log.drain(0..(len - BATTLE_LOG_MAX));
+        }
+    }
+
+    /// Read-only view over the battle log. UIs slice the tail of this
+    /// to fill their log pane.
+    pub fn battle_log(&self) -> &[String] {
+        &self.battle_log
     }
 }
 
@@ -192,6 +282,61 @@ mod tests {
         let prompts: Vec<ListeningPrompt> = (0..8).map(|idx| regular(&format!("r{idx}"))).collect();
         let err = ListeningRpgRun::build(&prompts).expect_err("boss prompt required");
         assert!(err.contains("miniboss") || err.contains("boss"));
+    }
+
+    fn full_pool() -> Vec<ListeningPrompt> {
+        let mut prompts = vec![
+            boss("mini", BossTier::Miniboss),
+            boss("boss", BossTier::Boss),
+        ];
+        for idx in 0..8 {
+            prompts.push(regular(&format!("r{idx}")));
+        }
+        prompts
+    }
+
+    #[test]
+    fn new_run_starts_in_town_with_empty_log() {
+        let run = ListeningRpgRun::build(&full_pool()).expect("build");
+        assert_eq!(run.phase(), RpgRunPhase::Town);
+        assert!(run.battle_log().is_empty());
+    }
+
+    #[test]
+    fn state_machine_visits_all_ten_encounters_then_returns() {
+        let mut run = ListeningRpgRun::build(&full_pool()).expect("build");
+        // Town → can't advance directly.
+        assert!(run.advance_to_next_encounter().is_none());
+
+        run.enter_diving();
+        assert_eq!(run.phase(), RpgRunPhase::Diving);
+
+        for expected in 1..=RPG_RUN_LENGTH as u32 {
+            let encounter = run.advance_to_next_encounter().expect("encounter present");
+            assert_eq!(encounter.ordinal as u32, expected);
+            assert_eq!(run.phase(), RpgRunPhase::Encounter(expected));
+        }
+
+        // After the 10th encounter the next advance flips into Return.
+        assert!(run.advance_to_next_encounter().is_none());
+        assert_eq!(run.phase(), RpgRunPhase::Return);
+
+        run.return_to_town();
+        assert_eq!(run.phase(), RpgRunPhase::Town);
+    }
+
+    #[test]
+    fn battle_log_records_and_caps_entries() {
+        let mut run = ListeningRpgRun::build(&full_pool()).expect("build");
+        for i in 0..(BATTLE_LOG_MAX + 5) {
+            run.push_battle_log(format!("entry {i}"));
+        }
+        assert_eq!(run.battle_log().len(), BATTLE_LOG_MAX);
+        // Oldest dropped, newest preserved.
+        assert_eq!(
+            run.battle_log().last().map(String::as_str),
+            Some(format!("entry {}", BATTLE_LOG_MAX + 4).as_str())
+        );
     }
 
     #[test]

--- a/src/game/rpg.rs
+++ b/src/game/rpg.rs
@@ -156,7 +156,7 @@ impl ListeningRpgRun {
         })
     }
 
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn encounters(&self) -> &[RpgEncounter] {
         &self.encounters
     }

--- a/src/game/rpg.rs
+++ b/src/game/rpg.rs
@@ -35,7 +35,7 @@ pub enum RpgRunPhase {
     Town,
     Diving,
     /// 1..=`RPG_RUN_LENGTH`. Ordinal matches `RpgEncounter::ordinal`.
-    Encounter(u32),
+    Encounter(usize),
     Return,
 }
 
@@ -178,19 +178,19 @@ impl ListeningRpgRun {
     /// `main.rs` calls `advance_to_next_encounter` between beats and
     /// trusts the returned `Option<&RpgEncounter>` for control flow.
     pub fn advance_to_next_encounter(&mut self) -> Option<&RpgEncounter> {
-        let next_ordinal = match self.phase {
+        let next_ordinal: usize = match self.phase {
             RpgRunPhase::Town | RpgRunPhase::Return => return None,
             RpgRunPhase::Diving => 1,
             RpgRunPhase::Encounter(n) => n + 1,
         };
 
-        if (next_ordinal as usize) > self.encounters.len() {
+        if next_ordinal > self.encounters.len() {
             self.phase = RpgRunPhase::Return;
             return None;
         }
 
         self.phase = RpgRunPhase::Encounter(next_ordinal);
-        self.encounters.get((next_ordinal - 1) as usize)
+        self.encounters.get(next_ordinal - 1)
     }
 
     /// Force the run back into `Town`. Called once the `Return` beat
@@ -311,9 +311,9 @@ mod tests {
         run.enter_diving();
         assert_eq!(run.phase(), RpgRunPhase::Diving);
 
-        for expected in 1..=RPG_RUN_LENGTH as u32 {
+        for expected in 1..=RPG_RUN_LENGTH {
             let encounter = run.advance_to_next_encounter().expect("encounter present");
-            assert_eq!(encounter.ordinal as u32, expected);
+            assert_eq!(encounter.ordinal, expected);
             assert_eq!(run.phase(), RpgRunPhase::Encounter(expected));
         }
 

--- a/src/io/storage.rs
+++ b/src/io/storage.rs
@@ -150,6 +150,70 @@ mod tests {
     }
 
     #[test]
+    fn load_player_data_returns_default_when_file_absent() {
+        let path = unique_path("player-missing");
+        let _ = std::fs::remove_file(&path);
+        let player = Storage::load_player_data(&path).expect("load");
+        assert_eq!(player.player_name, "Player");
+        assert_eq!(player.language, "ja");
+        assert_eq!(player.rpg_stats.level, 1);
+        assert_eq!(player.rpg_stats.exp, 0);
+        assert_eq!(player.rpg_stats.hp_max, 100);
+        assert!(player.rpg_stats.titles_unlocked.is_empty());
+    }
+
+    #[test]
+    fn save_then_load_player_data_round_trip() {
+        let path = unique_path("player-roundtrip");
+        let player = crate::types::Player {
+            player_name: "Goku".into(),
+            language: "en".into(),
+            rpg_stats: crate::types::RpgStats {
+                level: 5,
+                exp: 1234,
+                hp_max: 150,
+                titles_unlocked: vec!["Apprentice".into(), "Veteran".into()],
+            },
+        };
+
+        Storage::save_player_data(&path, &player).expect("save");
+
+        let loaded = Storage::load_player_data(&path).expect("load");
+        assert_eq!(loaded.player_name, "Goku");
+        assert_eq!(loaded.language, "en");
+        assert_eq!(loaded.rpg_stats.level, 5);
+        assert_eq!(loaded.rpg_stats.exp, 1234);
+        assert_eq!(loaded.rpg_stats.hp_max, 150);
+        assert_eq!(
+            loaded.rpg_stats.titles_unlocked,
+            vec!["Apprentice".to_string(), "Veteran".to_string()]
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn load_player_data_accepts_legacy_yaml_without_new_fields() {
+        // Legacy player.yaml from before #32 had `rpg_stats: { level, exp }`
+        // only. New fields must default rather than refuse to deserialize.
+        let path = unique_path("player-legacy");
+        std::fs::write(
+            &path,
+            "player_name: Legacy\nlanguage: ja\nrpg_stats:\n  level: 3\n  exp: 200\n",
+        )
+        .expect("write legacy");
+
+        let loaded = Storage::load_player_data(&path).expect("load");
+        assert_eq!(loaded.player_name, "Legacy");
+        assert_eq!(loaded.rpg_stats.level, 3);
+        assert_eq!(loaded.rpg_stats.exp, 200);
+        assert_eq!(loaded.rpg_stats.hp_max, 100);
+        assert!(loaded.rpg_stats.titles_unlocked.is_empty());
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
     fn load_records_file_absent_returns_default() {
         let path = unique_path("absent-yaml");
         // Ensure the file does not exist

--- a/src/io/storage.rs
+++ b/src/io/storage.rs
@@ -214,6 +214,27 @@ mod tests {
     }
 
     #[test]
+    fn load_player_data_accepts_yaml_without_rpg_stats_block() {
+        // n2: legacy player.yaml from before #32 had no `rpg_stats:` block
+        // at all. Struct-level `#[serde(default)]` on `RpgStats` plus
+        // `#[serde(default)]` on `Player::rpg_stats` must fully populate
+        // a `RpgStats::default()` when the block is absent.
+        let path = unique_path("player-no-rpg-stats");
+        std::fs::write(&path, "player_name: Legacy\nlanguage: ja\n").expect("write legacy");
+
+        let loaded = Storage::load_player_data(&path).expect("load");
+        let defaults = crate::types::RpgStats::default();
+        assert_eq!(loaded.player_name, "Legacy");
+        assert_eq!(loaded.language, "ja");
+        assert_eq!(loaded.rpg_stats.level, defaults.level);
+        assert_eq!(loaded.rpg_stats.exp, defaults.exp);
+        assert_eq!(loaded.rpg_stats.hp_max, defaults.hp_max);
+        assert_eq!(loaded.rpg_stats.titles_unlocked, defaults.titles_unlocked);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
     fn load_records_file_absent_returns_default() {
         let path = unique_path("absent-yaml");
         // Ensure the file does not exist

--- a/src/main.rs
+++ b/src/main.rs
@@ -503,6 +503,7 @@ fn run_listening_rpg(
             show_return_to_menu_message(&err)?;
             // Even on early-exit, persist whatever language switch the
             // player made. Failure here is non-fatal (warn only).
+            // Phase 2: 検討 — closure/scopeguard で defer 化
             if let Err(err) = Storage::save_player_data(&player_path, &player) {
                 eprintln!("warning: failed to save player.yaml: {err}");
             }
@@ -517,6 +518,7 @@ fn run_listening_rpg(
             Ok(tts) => Some(tts),
             Err(err) => {
                 show_return_to_menu_message(&tts_unavailable_message(err.as_ref()))?;
+                // Phase 2: 検討 — closure/scopeguard で defer 化
                 if let Err(err) = Storage::save_player_data(&player_path, &player) {
                     eprintln!("warning: failed to save player.yaml: {err}");
                 }
@@ -596,6 +598,7 @@ fn run_listening_rpg(
             RpgEncounterKind::Miniboss => "Miniboss",
             RpgEncounterKind::Boss => "Boss",
         };
+        // TODO(#34): localize once i18n table lands
         if result.is_correct {
             correct += 1;
             run.push_battle_log(format!("▸ {} {}: Hit!", label, encounter.ordinal));
@@ -615,6 +618,7 @@ fn run_listening_rpg(
     // #32: persist progression on the way back to the menu. Phase 1
     // does not mutate level/exp, so this is effectively just a
     // language-write today, but it cements the load→save round-trip.
+    // Phase 2: 検討 — closure/scopeguard で defer 化
     if let Err(err) = Storage::save_player_data(&player_path, &player) {
         eprintln!("warning: failed to save player.yaml: {err}");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -574,6 +574,7 @@ fn run_listening_rpg(
                     language.clone(),
                     encounter.ordinal,
                 );
+                ui.set_battle_log(run.battle_log().to_vec());
                 let result = ui.run()?;
                 tts = ui.take_tts();
                 result
@@ -619,8 +620,20 @@ fn run_listening_rpg(
     }
 
     if !aborted {
+        // q1: surface the tail of the rolling battle log so the player
+        // can see the last few encounters — most importantly the boss
+        // (#10) Hit/Missed line, which otherwise never appears in any UI
+        // because the boss UI exits immediately after its Result phase.
+        const SUMMARY_LOG_TAIL: usize = 6;
+        let log = run.battle_log();
+        let start = log.len().saturating_sub(SUMMARY_LOG_TAIL);
+        let tail = if log.is_empty() {
+            String::new()
+        } else {
+            format!("\n\nRecent log:\n{}", log[start..].join("\n"))
+        };
         show_return_to_menu_message(&format!(
-            "Listening RPG run complete.\nCorrect: {correct}/{RPG_RUN_LENGTH}\nBoss structure: regular 1-4 / miniboss 5 / regular 6-9 / boss 10."
+            "Listening RPG run complete.\nCorrect: {correct}/{RPG_RUN_LENGTH}\nBoss structure: regular 1-4 / miniboss 5 / regular 6-9 / boss 10.{tail}"
         ))?;
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,13 +9,13 @@ use audio::TtsEngine;
 use clap::{Parser, Subcommand};
 use config::Config;
 use game::{
-    ListeningRpgRun, ListeningSession, RpgEncounterKind, Ta25LocalGame, RPG_RUN_LENGTH,
-    TA25_RUN_LENGTH,
+    ListeningRpgRun, ListeningSession, RpgEncounterKind, RpgRunPhase, Ta25LocalGame,
+    RPG_RUN_LENGTH, TA25_RUN_LENGTH,
 };
 use io::{DataLoader, Storage};
 use std::io::{stdin, stdout, Write};
 use std::time::Duration;
-use types::{GameMode, Language, Question};
+use types::{GameMode, Language, Player, Question};
 use ui::{
     tts_unavailable_message, BossListenUI, DemoInputSource, ListenUI, MenuUI, QuizUI, RecordsUI,
     TimeAttack25UI,
@@ -480,10 +480,32 @@ fn run_listening_rpg(
         return Ok(());
     }
 
-    let run = match ListeningRpgRun::build(&prompts) {
+    // #32: load persistent RPG progression up-front, save it on exit.
+    // Phase 1 deliberately does *not* mutate level / exp — the load →
+    // save round-trip is the acceptance criterion. EXP/level wiring lands
+    // in Phase 2 (#34).
+    let player_path = config.player_file_path();
+    let mut player = match Storage::load_player_data(&player_path) {
+        Ok(p) => p,
+        Err(err) => {
+            eprintln!("warning: failed to load player.yaml ({err}); starting from defaults");
+            Player::default()
+        }
+    };
+    // Remember the language the player most recently played, so the
+    // next launch can prefer it. Selection itself stays where it is —
+    // this is only persistence.
+    player.language = language.code().to_string();
+
+    let mut run = match ListeningRpgRun::build(&prompts) {
         Ok(run) => run,
         Err(err) => {
             show_return_to_menu_message(&err)?;
+            // Even on early-exit, persist whatever language switch the
+            // player made. Failure here is non-fatal (warn only).
+            if let Err(err) = Storage::save_player_data(&player_path, &player) {
+                eprintln!("warning: failed to save player.yaml: {err}");
+            }
             return Ok(());
         }
     };
@@ -495,13 +517,36 @@ fn run_listening_rpg(
             Ok(tts) => Some(tts),
             Err(err) => {
                 show_return_to_menu_message(&tts_unavailable_message(err.as_ref()))?;
+                if let Err(err) = Storage::save_player_data(&player_path, &player) {
+                    eprintln!("warning: failed to save player.yaml: {err}");
+                }
                 return Ok(());
             }
         }
     };
 
+    // ----- Phase-driven run loop (#33) ----------------------------------
+    // Town → Diving → Encounter(1..=10) → Return → Town. UI behaviour
+    // matches the previous straight-line for-loop; the explicit state
+    // machine is what Phase 2 (#34/#37) will hang EXP / enemy art off of.
+    run.enter_diving();
     let mut correct = 0usize;
-    for encounter in run.encounters() {
+    let mut aborted = false;
+
+    'run: loop {
+        match run.phase() {
+            RpgRunPhase::Town | RpgRunPhase::Return => break 'run,
+            RpgRunPhase::Diving | RpgRunPhase::Encounter(_) => {}
+        }
+
+        // `advance_to_next_encounter` transitions Diving → Encounter(1)
+        // and Encounter(N) → Encounter(N+1) / Return. When it returns
+        // `None` the run is done.
+        let encounter = match run.advance_to_next_encounter() {
+            Some(encounter) => encounter.clone(),
+            None => break 'run,
+        };
+
         let session = ListeningSession::new(encounter.prompt.clone(), language.clone());
         let result = match encounter.kind {
             RpgEncounterKind::Regular => {
@@ -511,6 +556,7 @@ fn run_listening_rpg(
                     ListenUI::new_without_tts(session, language.clone())
                 };
                 ui.set_run_progress(encounter.ordinal, RPG_RUN_LENGTH);
+                ui.set_battle_log(run.battle_log().to_vec());
                 let result = ui.run()?;
                 tts = ui.take_tts();
                 result
@@ -534,17 +580,49 @@ fn run_listening_rpg(
             }
         };
 
+        // Esc / Ctrl+C inside the UI returns None — abort cleanly but
+        // still persist player state on the way out.
         let Some(result) = result else {
-            return Ok(());
+            aborted = true;
+            break 'run;
+        };
+
+        // #36: Phase 1 battle-log entries. The data layer carries the
+        // strings; ListenUI surfaces the tail on the next encounter's
+        // play pane. Damage / EXP / level-up lines come in Phase 2.
+        let label = match encounter.kind {
+            RpgEncounterKind::Regular => "Encounter",
+            RpgEncounterKind::Miniboss => "Miniboss",
+            RpgEncounterKind::Boss => "Boss",
         };
         if result.is_correct {
             correct += 1;
+            run.push_battle_log(format!("▸ {} {}: Hit!", label, encounter.ordinal));
+        } else {
+            run.push_battle_log(format!("▸ {} {}: Missed.", label, encounter.ordinal));
         }
+        run.push_battle_log(format!("  Expected: {}", encounter.prompt.text_display));
     }
 
-    show_return_to_menu_message(&format!(
-        "Listening RPG run complete.\nCorrect: {correct}/{RPG_RUN_LENGTH}\nBoss structure: regular 1-4 / miniboss 5 / regular 6-9 / boss 10."
-    ))?;
+    // Run finished naturally: transition Return → Town. (If aborted, we
+    // skip this so future Phase-2 introspection can tell apart "ended"
+    // and "bailed".)
+    if !aborted {
+        run.return_to_town();
+    }
+
+    // #32: persist progression on the way back to the menu. Phase 1
+    // does not mutate level/exp, so this is effectively just a
+    // language-write today, but it cements the load→save round-trip.
+    if let Err(err) = Storage::save_player_data(&player_path, &player) {
+        eprintln!("warning: failed to save player.yaml: {err}");
+    }
+
+    if !aborted {
+        show_return_to_menu_message(&format!(
+            "Listening RPG run complete.\nCorrect: {correct}/{RPG_RUN_LENGTH}\nBoss structure: regular 1-4 / miniboss 5 / regular 6-9 / boss 10."
+        ))?;
+    }
     Ok(())
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -179,13 +179,45 @@ impl Serialize for ListeningPrompt {
 pub struct Player {
     pub player_name: String,
     pub language: String,
+    #[serde(default)]
     pub rpg_stats: RpgStats,
 }
 
+/// Per-player RPG progression. Phase 1 (#32) only persists the data —
+/// EXP/level updates and title-unlock logic land in Phase 2 (#34/#35).
+/// `#[serde(default)]` on every field keeps legacy `player.yaml` files
+/// loadable when new columns are added later in the same Phase 1 wave.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct RpgStats {
+    #[serde(default = "RpgStats::default_level")]
     pub level: u32,
+    #[serde(default)]
     pub exp: u32,
+    #[serde(default = "RpgStats::default_hp_max")]
+    pub hp_max: u32,
+    #[serde(default)]
+    pub titles_unlocked: Vec<String>,
+}
+
+impl RpgStats {
+    fn default_level() -> u32 {
+        1
+    }
+
+    fn default_hp_max() -> u32 {
+        100
+    }
+}
+
+impl Default for RpgStats {
+    fn default() -> Self {
+        RpgStats {
+            level: Self::default_level(),
+            exp: 0,
+            hp_max: Self::default_hp_max(),
+            titles_unlocked: Vec::new(),
+        }
+    }
 }
 
 /// One row in a Records list. `ts` is RFC3339 format (e.g. "2025-05-11T12:34:56Z").
@@ -518,7 +550,7 @@ impl Default for Player {
         Player {
             player_name: "Player".to_string(),
             language: "ja".to_string(),
-            rpg_stats: RpgStats { level: 1, exp: 0 },
+            rpg_stats: RpgStats::default(),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -185,36 +185,24 @@ pub struct Player {
 
 /// Per-player RPG progression. Phase 1 (#32) only persists the data —
 /// EXP/level updates and title-unlock logic land in Phase 2 (#34/#35).
-/// `#[serde(default)]` on every field keeps legacy `player.yaml` files
-/// loadable when new columns are added later in the same Phase 1 wave.
+/// Struct-level `#[serde(default)]` delegates per-field defaults to the
+/// `Default` impl below, so legacy `player.yaml` files (with `rpg_stats`
+/// missing or partial) load cleanly without per-field default fns.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
 pub struct RpgStats {
-    #[serde(default = "RpgStats::default_level")]
     pub level: u32,
-    #[serde(default)]
     pub exp: u32,
-    #[serde(default = "RpgStats::default_hp_max")]
     pub hp_max: u32,
-    #[serde(default)]
     pub titles_unlocked: Vec<String>,
-}
-
-impl RpgStats {
-    fn default_level() -> u32 {
-        1
-    }
-
-    fn default_hp_max() -> u32 {
-        100
-    }
 }
 
 impl Default for RpgStats {
     fn default() -> Self {
         RpgStats {
-            level: Self::default_level(),
+            level: 1,
             exp: 0,
-            hp_max: Self::default_hp_max(),
+            hp_max: 100,
             titles_unlocked: Vec::new(),
         }
     }

--- a/src/ui/listen.rs
+++ b/src/ui/listen.rs
@@ -75,7 +75,16 @@ pub struct ListenUI {
     rejected_char: Option<char>,
     reject_flash_until: Option<Instant>,
     run_progress: Option<(usize, usize)>,
+    /// Snapshot of the parent run's rolling battle log (#36). Phase 1
+    /// only displays the tail in the log pane — composition / mutation
+    /// lives on `ListeningRpgRun`.
+    battle_log: Vec<String>,
 }
+
+/// Maximum visible battle-log lines in the play-phase log pane. The pane
+/// usually shows fewer than this; this just bounds the slice we hand to
+/// ratatui when the pane is taller than expected.
+const PLAY_LOG_TAIL_MAX: usize = 8;
 
 impl ListenUI {
     pub fn new(session: ListeningSession, tts: TtsEngine, language: Language) -> Self {
@@ -90,6 +99,7 @@ impl ListenUI {
             rejected_char: None,
             reject_flash_until: None,
             run_progress: None,
+            battle_log: Vec::new(),
         }
     }
 
@@ -107,11 +117,19 @@ impl ListenUI {
             rejected_char: None,
             reject_flash_until: None,
             run_progress: None,
+            battle_log: Vec::new(),
         }
     }
 
     pub fn set_run_progress(&mut self, current: usize, total: usize) {
         self.run_progress = Some((current, total));
+    }
+
+    /// Seed the play-phase log pane with the rolling battle log from
+    /// the parent `ListeningRpgRun` (#36). Pass the *full* log; the UI
+    /// clips to the visible tail.
+    pub fn set_battle_log(&mut self, log: Vec<String>) {
+        self.battle_log = log;
     }
 
     pub fn take_tts(&mut self) -> Option<TtsEngine> {
@@ -388,13 +406,21 @@ impl ListenUI {
 
     fn render_log_pane(&self, f: &mut Frame, area: Rect) {
         let lines: Vec<Line<'static>> = match self.phase {
-            Phase::Playing => vec![
-                Line::from(Span::styled("(no events)", STYLE_DIM)),
-                Line::from(Span::styled(
-                    "Battle log fills in once #32-#37 land.",
-                    STYLE_DIM,
-                )),
-            ],
+            Phase::Playing => {
+                if self.battle_log.is_empty() {
+                    vec![Line::from(Span::styled("(no events yet)", STYLE_DIM))]
+                } else {
+                    // Show the tail of the rolling battle log (#36). Use
+                    // the smaller of `PLAY_LOG_TAIL_MAX` and the visible
+                    // pane height (minus the border).
+                    let visible = (area.height.saturating_sub(2) as usize).min(PLAY_LOG_TAIL_MAX);
+                    let start = self.battle_log.len().saturating_sub(visible.max(1));
+                    self.battle_log[start..]
+                        .iter()
+                        .map(|entry| Line::from(Span::styled(entry.clone(), STYLE_NORMAL)))
+                        .collect()
+                }
+            }
             Phase::Result => match self.session.result() {
                 Some(r) if r.is_correct => {
                     vec![

--- a/src/ui/listen_boss.rs
+++ b/src/ui/listen_boss.rs
@@ -509,10 +509,7 @@ impl BossListenUI {
             let remaining = inner_height.saturating_sub(lines.len()).max(1);
             let start = self.logs.len().saturating_sub(remaining);
             for entry in &self.logs[start..] {
-                lines.push(Line::from(Span::styled(
-                    format!("▸ {entry}"),
-                    STYLE_NORMAL,
-                )));
+                lines.push(Line::from(Span::styled(format!("▸ {entry}"), STYLE_NORMAL)));
             }
         }
 

--- a/src/ui/listen_boss.rs
+++ b/src/ui/listen_boss.rs
@@ -111,7 +111,14 @@ pub struct BossListenUI {
     logs: Vec<String>,
     rejected_char: Option<char>,
     reject_flash_until: Option<Instant>,
+    /// Snapshot of the parent run's rolling battle log (#36). Surfaced as
+    /// extra context lines below the in-encounter event log so the player
+    /// can see Hit/Missed history coming into the boss/miniboss fight.
+    battle_log: Vec<String>,
 }
+
+/// Maximum visible battle-log tail rendered above the per-encounter log.
+const BOSS_LOG_TAIL_MAX: usize = 6;
 
 impl BossListenUI {
     pub fn new(
@@ -136,7 +143,15 @@ impl BossListenUI {
             logs: Vec::new(),
             rejected_char: None,
             reject_flash_until: None,
+            battle_log: Vec::new(),
         }
+    }
+
+    /// Seed the log pane with the rolling battle log from the parent
+    /// `ListeningRpgRun` (#36). Pass the *full* log; the UI clips to the
+    /// visible tail.
+    pub fn set_battle_log(&mut self, log: Vec<String>) {
+        self.battle_log = log;
     }
 
     pub fn take_tts(&mut self) -> Option<TtsEngine> {
@@ -476,18 +491,31 @@ impl BossListenUI {
     }
 
     fn render_log_pane(&self, f: &mut Frame, area: Rect) {
-        let start = self
-            .logs
-            .len()
-            .saturating_sub(area.height.saturating_sub(2) as usize);
-        let lines: Vec<Line<'static>> = if self.logs.is_empty() {
-            vec![Line::from(Span::styled("(no events)", STYLE_DIM))]
+        let mut lines: Vec<Line<'static>> = Vec::new();
+
+        // Surface the tail of the parent run's battle log first (#36 s1),
+        // so boss/miniboss encounters see prior Hit/Missed history.
+        if !self.battle_log.is_empty() {
+            let start = self.battle_log.len().saturating_sub(BOSS_LOG_TAIL_MAX);
+            for entry in &self.battle_log[start..] {
+                lines.push(Line::from(Span::styled(entry.clone(), STYLE_DIM)));
+            }
+        }
+
+        if self.logs.is_empty() && self.battle_log.is_empty() {
+            lines.push(Line::from(Span::styled("(no events)", STYLE_DIM)));
         } else {
-            self.logs[start..]
-                .iter()
-                .map(|entry| Line::from(Span::styled(format!("▸ {entry}"), STYLE_NORMAL)))
-                .collect()
-        };
+            let inner_height = area.height.saturating_sub(2) as usize;
+            let remaining = inner_height.saturating_sub(lines.len()).max(1);
+            let start = self.logs.len().saturating_sub(remaining);
+            for entry in &self.logs[start..] {
+                lines.push(Line::from(Span::styled(
+                    format!("▸ {entry}"),
+                    STYLE_NORMAL,
+                )));
+            }
+        }
+
         let para = Paragraph::new(lines)
             .alignment(Alignment::Left)
             .block(Block::default().title(" Log ").borders(Borders::ALL));


### PR DESCRIPTION
## 関連 Issue

partial #32 (永続化配線)
partial #33 (状態機械)
partial #35 (型のみ)
partial #36 (データ配線)

Phase 2 PR で残りの #34 EXP/Lv、#35 称号テーブル+演出、#37 敵表示、#36 ログ中身充実をやり、その時点で全 6 Issue を close する。

## 概要

Hack-and-Slash RPG (Listening RPG) の骨組み層を Phase 1 として実装。Phase 2 で乗せるロジック (EXP/レベルアップ/称号テーブル/敵表示) の受け皿を確保する。

### Phase 1 で実装した範囲

- **#32 永続化**: `RpgStats` に `hp_max: u32` (default 100) と `titles_unlocked: Vec<String>` (default empty) を追加、`#[serde(default)]` で旧スキーマ後方互換、`Config::player_file_path()` 単一 path 採用、`run_listening_rpg` で load/save 配線
- **#33 状態機械**: `RpgRunPhase` enum (Town / Diving / Encounter(N) / Return)、`ListeningRpgRun.phase` フィールド、`enter_diving` / `advance_to_next_encounter` / `return_to_town` メソッド、main.rs ループを phase 駆動に書き換え。Issue 本文の Combat/Defeat は CLAUDE.md「失敗概念なし」方針に合わせて `Encounter(N)` 一本化
- **#35 型のみ**: `titles_unlocked: Vec<String>` フィールド追加。テーブル/演出は Phase 2
- **#36 戦闘ログ配線**: `ListeningRpgRun.battle_log: Vec<String>` (BATTLE_LOG_MAX = 64)、UI play phase の `(no events)` プレースホルダを末尾 N 件のスクロール表示に変更。中身充実 (Hit X dmg / +Y EXP / Level up) は Phase 2

### Phase 2 に送った項目

- #34 EXP 加算 / レベルアップ計算
- #35 称号テーブル + アンロック演出
- #37 敵表示 (絵文字 / 敵テーブル)
- #36 戦闘ログ充実 (Hit dmg / +EXP / Level up イベント)

## コミット

| Hash | 内容 |
|---|---|
| `efb3a43` | feat: #32 Player スキーマ拡張 |
| `0a2ac0a` | feat: #33 RpgRunPhase 状態機械導入 |
| `975f138` | feat: #32 #33 #36 run_listening_rpg phase 駆動化 + battle_log 配線 |

## 検証結果

- `cargo test --release`: **269 passed (main crate) + lint-questions 60 + backfill-ja-typing 8 = 337 件 全 pass**
- `cargo clippy --all-targets -- -D warnings`: clean
- husky pre-commit (cargo fmt + clippy) 全コミット通過