### PR TITLE
[codex] Document records persistence policy

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -62,7 +62,7 @@ Ordinary prompts and replay already use the same runtime pipeline, and future bo
 | TUI | `ratatui` + `crossterm` |
 | Audio | `tts` crate (cross-platform OS TTS) |
 | Animation | [`jiwa`](https://crates.io/crates/jiwa) crate (typewriter + RGB fade), extracted from this repo's former `jiwa_core` module |
-| Storage | local JSON |
+| Storage | local YAML (`player.yaml`, `records_<lang>.yaml`) |
 
 ## Quiz Content
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -90,9 +90,10 @@ v0.1.x の「画面に出た文字列を打つタイピングモード」を **�
 
 > 用語: ローカル自己ベストは Records、世界順位は Ranking（v0.3.0+ Nostralgic Ranking 連携で実現）。混同禁止。
 
-- [x] `records_<lang>.json` データ構造（#26 PR #63 で確定）
+- [x] `records_<lang>.yaml` データ構造（#26 PR #63 で確定、YAML 永続化へ移行済み）
 - [x] スコア永続化（モード別・言語別 Top10、ローカル自己ベスト、#26 PR #63）
 - [x] Records 表示画面 + 最新エントリハイライト（#40）
+- [x] Records 書き込みの atomic replace 化（同一ディレクトリ temp + rename、#123）
 
 ### Epic [TA25] Time Attack 25
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -371,6 +371,8 @@ rpg:
 
 Top 10 per mode per language. This is a local self-best file — never call it a "ranking". World ranking (Nostralgic Ranking) is wired in the v0.3.0+ `type-globe-online` build and submits the same entries to a Nostr-relay-backed feed.
 
+Record saves use an atomic replacement policy in `Storage::save_records`: serialize the full YAML document, write it to a same-directory hidden temp file, `sync_all` the temp file, then `rename` it over `records_<lang>.yaml`. On Unix, the parent directory is also synced after the rename so the replacement directory entry is flushed when the platform allows it. If any step before the rename fails, the existing records file remains untouched and the temp file is cleaned up best-effort.
+
 The Records menu entry opens a read-only browser (`src/ui/records.rs`) that shows three sections — Quiz, Time Attack 25, Listening RPG — with the most recent ts in each section highlighted so the player can spot a just-saved entry without scrolling. Esc / Enter / `q` returns to the menu.
 
 ## Source Architecture (target)

--- a/src/io/storage.rs
+++ b/src/io/storage.rs
@@ -78,6 +78,7 @@ fn atomic_write(file_path: &str, content: &[u8]) -> Result<(), Box<dyn std::erro
         file.sync_all()?;
         drop(file);
         fs::rename(&tmp_path, path)?;
+        sync_parent_directory(path)?;
         Ok(())
     })();
 
@@ -85,6 +86,21 @@ fn atomic_write(file_path: &str, content: &[u8]) -> Result<(), Box<dyn std::erro
         let _ = fs::remove_file(&tmp_path);
     }
     write_result
+}
+
+#[cfg(unix)]
+fn sync_parent_directory(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    fs::File::open(parent)?.sync_all()?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn sync_parent_directory(_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Follow-up review for #130.

- Sync the records parent directory after atomic rename on Unix.
- Document the records atomic replacement policy in the spec.
- Fix stale docs that still described storage as local JSON / records_<lang>.json.
- Mark #123 atomic records writes as completed in the roadmap.

## Review Finding Addressed

The #130 implementation wrote and synced the temp file before rename, which was enough for normal replacement semantics but under-documented for crash/power-loss behavior. This follow-up aligns implementation and docs by flushing the parent directory entry on Unix and spelling out the exact persistence policy.

## Validation

- cargo fmt --check
- cargo test io::storage
- cargo test
- cargo clippy -- -D warnings via commit hook