### PR TITLE
fix: #124 Quiz saved 画面の HelpLine に [Ctrl+C] Quit を追加

### DIFF
--- a/src/ui/quiz.rs
+++ b/src/ui/quiz.rs
@@ -1215,7 +1215,10 @@ mod tests {
         let out = render_help_to_string(&ui);
         assert!(out.contains("[Enter]"), "saved missing Enter: {out}");
         assert!(out.contains("[Ctrl+C]"), "saved missing Ctrl+C hint: {out}");
-        assert!(!out.contains("[Esc]"), "saved must not advertise Esc: {out}");
+        assert!(
+            !out.contains("[Esc]"),
+            "saved must not advertise Esc: {out}"
+        );
     }
 
     #[test]

--- a/src/ui/quiz.rs
+++ b/src/ui/quiz.rs
@@ -975,9 +975,15 @@ impl QuizUI {
                 HelpEntry::new("Esc", "Skip"),
                 HelpEntry::new("Enter", "Register"),
             ]),
-            Phase::NamingForRecord if self.saved => {
-                HelpLine::new(vec![HelpEntry::new("Enter", "Menu")])
-            }
+            Phase::NamingForRecord if self.saved => HelpLine::new(vec![
+                // #124: mirror TA25's saved-phase help. After save, Esc is
+                // intentionally inert (see `handle_key` / `saved` branch), so
+                // we advertise the keys that actually dismiss the screen.
+                // Ctrl+C is a global quit in every phase, but only TA25 used
+                // to surface it — back-port it here so both modes match.
+                HelpEntry::new("Enter", "Menu"),
+                HelpEntry::new("Ctrl+C", "Quit"),
+            ]),
             Phase::NamingForRecord => HelpLine::new(vec![
                 HelpEntry::new("Esc", "Skip"),
                 HelpEntry::new("Enter", "Save"),
@@ -1174,6 +1180,42 @@ mod tests {
         let quit = ui.handle_key(ctrl_c);
         assert!(quit, "Ctrl+C must request quit");
         assert!(ui.user_aborted, "Ctrl+C must record user abort");
+    }
+
+    /// Render `render_help_line` to an 80×1 TestBackend and dump the row as
+    /// a `String`. Mirrors the helper in `time_attack.rs` so the two modes'
+    /// help footers can be asserted with the same pattern.
+    fn render_help_to_string(ui: &QuizUI) -> String {
+        let backend = ratatui::backend::TestBackend::new(80, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| ui.render_help_line(f, Rect::new(0, 0, 80, 1)))
+            .unwrap();
+        let buf = terminal.backend().buffer();
+        let mut out = String::new();
+        for x in 0..buf.area.width {
+            out.push_str(buf[(x, 0)].symbol());
+        }
+        out
+    }
+
+    #[test]
+    fn help_line_saved_phase_matches_ta25() {
+        // #124: after a record is saved, the Quiz help line must advertise
+        // the same keys as TA25 — `[Enter] Menu` and `[Ctrl+C] Quit`. Esc is
+        // inert once saved, so it must NOT be advertised.
+        let mut ui = make_quiz_ui_with_choice(
+            "東京",
+            "Tokyo",
+            vec!["toukyou".to_string()],
+            Language::Japanese,
+        );
+        ui.phase = Phase::NamingForRecord;
+        ui.saved = true;
+        let out = render_help_to_string(&ui);
+        assert!(out.contains("[Enter]"), "saved missing Enter: {out}");
+        assert!(out.contains("[Ctrl+C]"), "saved missing Ctrl+C hint: {out}");
+        assert!(!out.contains("[Esc]"), "saved must not advertise Esc: {out}");
     }
 
     #[test]

--- a/src/ui/quiz.rs
+++ b/src/ui/quiz.rs
@@ -976,11 +976,14 @@ impl QuizUI {
                 HelpEntry::new("Enter", "Register"),
             ]),
             Phase::NamingForRecord if self.saved => HelpLine::new(vec![
-                // #124: mirror TA25's saved-phase help. After save, Esc is
-                // intentionally inert (see `handle_key` / `saved` branch), so
-                // we advertise the keys that actually dismiss the screen.
-                // Ctrl+C is a global quit in every phase, but only TA25 used
-                // to surface it — back-port it here so both modes match.
+                // #124: mirror TA25's saved-phase footer for visual parity.
+                // Enter dismisses to the menu; Ctrl+C is a global quit in
+                // every phase (handled at the top of `handle_key`), but only
+                // TA25 used to surface it. Esc also quits globally here, but
+                // we omit it from the footer so both modes' saved footers are
+                // byte-for-byte identical (in TA25 Esc is genuinely inert in
+                // this phase; in Quiz it quits, so the omission is purely for
+                // a consistent UI rather than because the key is dead).
                 HelpEntry::new("Enter", "Menu"),
                 HelpEntry::new("Ctrl+C", "Quit"),
             ]),


### PR DESCRIPTION
## 関連 Issue
closes #124

## 変更内容
- `QuizUI::help_line` の `NamingForRecord(saved=true)` phase に `HelpEntry::new("Ctrl+C", "Quit")` を追加。PR #121 で TA25 に入れた案内を Quiz にバックポートし、両モードの Records 保存後 HelpLine 構造を揃える。
- Ctrl+C は元から全 phase で global quit だが、TA25 だけが案内していた非対称を解消。
- `help_line_saved_phase_matches_ta25` テストを追加（saved phase で `[Enter]`/`[Ctrl+C]` を出し `[Esc]` を出さないことを検証）。TA25 の `render_help_to_string` ヘルパを Quiz 側にも用意。

## テスト
- `cargo test --release`: 302 pass
- `cargo clippy -- -D warnings`: clean