### PR TITLE
fix: #122 name 入力の先頭スペースを入力時に拒否 (Quiz/TA25)

### DIFF
--- a/src/ui/quiz.rs
+++ b/src/ui/quiz.rs
@@ -495,7 +495,14 @@ impl QuizUI {
                 if !key
                     .modifiers
                     .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
-                    && self.name_buffer.chars().count() < NAME_MAX_CHARS =>
+                    && self.name_buffer.chars().count() < NAME_MAX_CHARS
+                    // #122: drop a leading Space so a name can never start
+                    // with whitespace. The buffer was only `trim()`-ed at
+                    // save time, so a leading-space name made the "typed"
+                    // and "saved" char counts diverge against NAME_MAX_CHARS.
+                    // Mid-word and trailing spaces are still accepted; the
+                    // save-time trim absorbs trailing ones.
+                    && !(c == ' ' && self.name_buffer.is_empty()) =>
             {
                 self.name_buffer.push(c);
             }
@@ -1183,6 +1190,36 @@ mod tests {
         let quit = ui.handle_key(ctrl_c);
         assert!(quit, "Ctrl+C must request quit");
         assert!(ui.user_aborted, "Ctrl+C must record user abort");
+    }
+
+    #[test]
+    fn handle_key_naming_rejects_leading_space_keeps_inner() {
+        // #122: a leading Space must not enter `name_buffer` (it was only
+        // trimmed at save time). Mid / trailing spaces are still accepted.
+        let mut ui = make_quiz_ui_with_choice(
+            "東京",
+            "Tokyo",
+            vec!["toukyou".to_string()],
+            Language::Japanese,
+        );
+        ui.phase = Phase::NamingForRecord;
+
+        let space = KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE);
+        ui.handle_key(space);
+        assert!(
+            ui.name_buffer.is_empty(),
+            "leading Space must not enter the buffer"
+        );
+        ui.handle_key(space);
+        assert!(ui.name_buffer.is_empty(), "second leading Space dropped");
+
+        for ch in "ab".chars() {
+            ui.handle_key(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE));
+        }
+        ui.handle_key(space);
+        ui.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE));
+        ui.handle_key(space);
+        assert_eq!(ui.name_buffer, "ab c ", "inner/trailing spaces kept");
     }
 
     /// Render `render_help_line` to an 80×1 TestBackend and dump the row as

--- a/src/ui/quiz.rs
+++ b/src/ui/quiz.rs
@@ -1220,6 +1220,19 @@ mod tests {
         ui.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE));
         ui.handle_key(space);
         assert_eq!(ui.name_buffer, "ab c ", "inner/trailing spaces kept");
+
+        // Backspace all the way to empty, then a Space is dropped again —
+        // the guard reads current state every keypress, not a one-shot flag.
+        let bksp = KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE);
+        for _ in 0..ui.name_buffer.chars().count() {
+            ui.handle_key(bksp);
+        }
+        assert!(ui.name_buffer.is_empty(), "buffer emptied via Backspace");
+        ui.handle_key(space);
+        assert!(
+            ui.name_buffer.is_empty(),
+            "Space after Backspace-to-empty must be dropped"
+        );
     }
 
     /// Render `render_help_line` to an 80×1 TestBackend and dump the row as

--- a/src/ui/time_attack.rs
+++ b/src/ui/time_attack.rs
@@ -248,7 +248,13 @@ impl TimeAttack25UI {
                 if !key
                     .modifiers
                     .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
-                    && self.name_buffer.chars().count() < NAME_MAX_CHARS =>
+                    && self.name_buffer.chars().count() < NAME_MAX_CHARS
+                    // #122: drop a leading Space (mirror `QuizUI`). The
+                    // buffer is only `trim()`-ed at save time, so a name
+                    // starting with whitespace made typed-vs-saved char
+                    // counts diverge against NAME_MAX_CHARS. Mid/trailing
+                    // spaces stay allowed; the save-time trim absorbs them.
+                    && !(c == ' ' && self.name_buffer.is_empty()) =>
             {
                 self.name_buffer.push(c);
                 false
@@ -942,6 +948,36 @@ mod tests {
         let before = ui.name_buffer.clone();
         let _ = ui.handle_key(key(KeyCode::Char('q')));
         assert_eq!(ui.name_buffer, before, "17th char must be ignored");
+    }
+
+    // -------------------------------------------------------------------
+    // #122: a leading Space is dropped; mid / trailing spaces are kept.
+    // -------------------------------------------------------------------
+    #[test]
+    fn test_handle_key_naming_rejects_leading_space_keeps_inner() {
+        let mut ui = make_ui();
+        finish_game(&mut ui);
+        ui.phase = Phase::NamingForRecord;
+
+        // Space on an empty buffer is dropped — no leading whitespace.
+        let _ = ui.handle_key(key(KeyCode::Char(' ')));
+        assert!(
+            ui.name_buffer.is_empty(),
+            "leading Space must not enter the buffer"
+        );
+        // Repeated leading Spaces stay dropped (buffer never leaves empty).
+        let _ = ui.handle_key(key(KeyCode::Char(' ')));
+        assert!(ui.name_buffer.is_empty(), "second leading Space dropped");
+
+        // Once there is content, an inner Space is accepted...
+        for ch in "ab".chars() {
+            let _ = ui.handle_key(key(KeyCode::Char(ch)));
+        }
+        let _ = ui.handle_key(key(KeyCode::Char(' ')));
+        let _ = ui.handle_key(key(KeyCode::Char('c')));
+        // ...and a trailing Space is accepted too (trim absorbs it on save).
+        let _ = ui.handle_key(key(KeyCode::Char(' ')));
+        assert_eq!(ui.name_buffer, "ab c ", "inner/trailing spaces kept");
     }
 
     // -------------------------------------------------------------------

--- a/src/ui/time_attack.rs
+++ b/src/ui/time_attack.rs
@@ -978,6 +978,19 @@ mod tests {
         // ...and a trailing Space is accepted too (trim absorbs it on save).
         let _ = ui.handle_key(key(KeyCode::Char(' ')));
         assert_eq!(ui.name_buffer, "ab c ", "inner/trailing spaces kept");
+
+        // Backspace all the way to empty, then a Space is dropped again —
+        // the guard reads current state every keypress, it is not a
+        // one-shot "first character" flag.
+        for _ in 0..ui.name_buffer.chars().count() {
+            let _ = ui.handle_key(key(KeyCode::Backspace));
+        }
+        assert!(ui.name_buffer.is_empty(), "buffer emptied via Backspace");
+        let _ = ui.handle_key(key(KeyCode::Char(' ')));
+        assert!(
+            ui.name_buffer.is_empty(),
+            "Space after Backspace-to-empty must be dropped"
+        );
     }
 
     // -------------------------------------------------------------------


### PR DESCRIPTION
## 関連 Issue
closes #122

## 変更内容
- `QuizUI::handle_key_naming` / `TimeAttack25UI::handle_key_naming` の `KeyCode::Char` ガードに `!(c == ' ' && self.name_buffer.is_empty())` を追加。空状態の Space を drop し、名前が先頭スペースで始まれないようにする。
- name_buffer は元々保存時にしか `trim()` されず、`'   Alice'` のように先頭スペース込みで入力でき、`NAME_MAX_CHARS=16` の『打てる文字数』と『trim 後に保存される文字数』が乖離していた UX 不整合を解消（PR #121 セルフレビュー S5）。
- 中間スペース・末尾スペースは従来通り許可（末尾は保存時 trim で吸収）。
- 両モードに回帰テスト追加（空時 Space 拒否 / 連続先頭 Space 拒否 / 中間・末尾 Space 許可）。

## テスト
- `cargo test --release`: 304 pass
- `cargo clippy -- -D warnings`: clean (pre-commit hook)