### PR TITLE
feat: #135 kana/ASCII choice の決定的 auto-review + ja_reviewed バックログ一掃

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libspeechd-dev libasound2-dev
       - name: Run question-data linter
         run: cargo run --bin lint-questions -- data/questions_ja.json data/questions_en.json
+      - name: Verify kana/ASCII ja_typings are canonical (#135)
+        run: cargo run --bin review-ja-typings -- verify data/questions_ja.json
       - name: Set up Python (for IME-strict ja_typings lint)
         uses: actions/setup-python@v5
         with:

--- a/README.md
+++ b/README.md
@@ -197,7 +197,13 @@ uv run python3 scripts/restore_ja_question_texts_with_ollama.py data/questions_j
 # 4. list any stragglers for manual review
 uv run python3 scripts/list_suspect_question_texts.py data/questions_ja.json
 
-# 5. final lint
+# 5. auto-review kana/ASCII typings: canonicalise + confirm ja_reviewed
+#    (verify is the CI gate; apply also flips ja_reviewed on all-kana/ASCII
+#    questions. Kanji-bearing questions are left for the LLM-judge pass.)
+cargo run --bin review-ja-typings -- verify data/questions_ja.json
+cargo run --bin review-ja-typings -- apply data/questions_ja.json
+
+# 6. final lint
 cargo run --bin lint-questions -- data/questions_ja.json data/questions_en.json
 ```
 

--- a/data/questions_ja.json
+++ b/data/questions_ja.json
@@ -2430,8 +2430,7 @@
         "ja": "ソウル",
         "en": "Seoul",
         "ja_typings": [
-          "souru",
-          "soru"
+          "souru"
         ]
       },
       {
@@ -12319,8 +12318,7 @@
         "ja": "プロダクトオーナー",
         "en": "Product Owner",
         "ja_typings": [
-          "purodakutoo-na-",
-          "purodakuto-na-"
+          "purodakutoo-na-"
         ]
       },
       {
@@ -15532,7 +15530,7 @@
         "ja": "ジョルノ・ジョバァーナ",
         "en": "Giorno Giovanna",
         "ja_typings": [
-          "joruno/joba--na"
+          "joruno/jobaa-na"
         ]
       }
     ],
@@ -17486,8 +17484,7 @@
         "ja": "ダークソウル",
         "en": "Dark Souls",
         "ja_typings": [
-          "da-kusouru",
-          "da-kusoru"
+          "da-kusouru"
         ]
       },
       {
@@ -17747,8 +17744,7 @@
         "ja": "シャドウバース",
         "en": "Shadowverse",
         "ja_typings": [
-          "shadouba-su",
-          "shadoba-su"
+          "shadouba-su"
         ]
       }
     ],
@@ -17912,8 +17908,7 @@
         "ja": "スプラトゥーン",
         "en": "Splatoon",
         "ja_typings": [
-          "supuratwu-n",
-          "supuratu-n"
+          "supuratwu-n"
         ]
       }
     ],
@@ -17933,8 +17928,7 @@
         "ja": "スプラトゥーン",
         "en": "Splatoon",
         "ja_typings": [
-          "supuratwu-n",
-          "supuratu-n"
+          "supuratwu-n"
         ]
       },
       {
@@ -20354,8 +20348,7 @@
         "ja": "アウグストゥス",
         "en": "Augustus",
         "ja_typings": [
-          "augusutwusu",
-          "augusutusu"
+          "augusutwusu"
         ]
       },
       {
@@ -25891,8 +25884,7 @@
         "ja": "ラタトゥイユ",
         "en": "Ratatouille",
         "ja_typings": [
-          "ratatwuiyu",
-          "ratatuiyu"
+          "ratatwuiyu"
         ]
       },
       {
@@ -27307,8 +27299,7 @@
         "ja": "ヒョウ",
         "en": "leopard",
         "ja_typings": [
-          "hyou",
-          "hyo"
+          "hyou"
         ]
       }
     ],
@@ -29960,16 +29951,14 @@
         "ja": "ありがとう",
         "en": "Thanks",
         "ja_typings": [
-          "arigatou",
-          "arigato"
+          "arigatou"
         ]
       },
       {
         "ja": "おはよう",
         "en": "Good morning",
         "ja_typings": [
-          "ohayou",
-          "ohayo"
+          "ohayou"
         ]
       },
       {
@@ -30186,7 +30175,8 @@
     "question_text": {
       "en": "Which Git command merges by creating a new commit that combines branch histories without fast-forward?",
       "ja": "ファストフォワードなしで新しいコミットを作ってブランチ履歴をマージする Git コマンドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30226,7 +30216,8 @@
     "question_text": {
       "en": "Which HTTP status code indicates that the requested resource was permanently moved?",
       "ja": "リクエストされたリソースが恒久的に移動したことを示す HTTP ステータスコードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30266,7 +30257,8 @@
     "question_text": {
       "en": "Which design pattern ensures a class has only one instance?",
       "ja": "クラスがただ一つのインスタンスしか持たないことを保証するデザインパターンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30306,7 +30298,8 @@
     "question_text": {
       "en": "Which protocol is used to securely transfer files over SSH?",
       "ja": "SSH 経由で安全にファイルを転送するプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30346,7 +30339,8 @@
     "question_text": {
       "en": "In Kubernetes, what controller maintains a stable set of replica Pods?",
       "ja": "Kubernetes でレプリカ Pod の安定集合を維持するコントローラーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30386,7 +30380,8 @@
     "question_text": {
       "en": "Which AWS service provides a fully managed relational database for PostgreSQL with Aurora compatibility?",
       "ja": "Aurora 互換のマネージドリレーショナル DB を提供する AWS サービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30426,7 +30421,8 @@
     "question_text": {
       "en": "Which CAP theorem property guarantees every read returns the most recent write?",
       "ja": "CAP 定理で、すべての読み出しが最新の書き込みを返すことを保証する性質は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30448,7 +30444,7 @@
         "en": "End-to-end test",
         "ja": "エンドトゥーエンドテスト",
         "ja_typings": [
-          "endotu-endotesuto"
+          "endotwu-endotesuto"
         ]
       },
       {
@@ -30466,7 +30462,8 @@
     "question_text": {
       "en": "Which test type checks the integration of multiple modules working together?",
       "ja": "複数のモジュールが連携して動作することを検証するテストの種類は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30546,7 +30543,8 @@
     "question_text": {
       "en": "Which database concept ensures that committed data survives system failures?",
       "ja": "コミット済みのデータがシステム障害後も残ることを保証する DB の概念は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30586,7 +30584,8 @@
     "question_text": {
       "en": "Which Linux command shows the routing table?",
       "ja": "Linux でルーティングテーブルを表示するコマンドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30626,7 +30625,8 @@
     "question_text": {
       "en": "Which Agile ceremony reviews what the team learned during the sprint to improve processes?",
       "ja": "プロセス改善のためスプリント中の学びを振り返るアジャイルのセレモニーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30666,7 +30666,8 @@
     "question_text": {
       "en": "Which AWS service provides a managed message queue?",
       "ja": "マネージドメッセージキューを提供する AWS サービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30746,7 +30747,8 @@
     "question_text": {
       "en": "Which authentication standard is widely used for federated single sign-on with XML assertions?",
       "ja": "XML アサーションでフェデレーテッド SSO に広く使われる認証規格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30761,7 +30763,7 @@
         "en": "Mean Time to Recover",
         "ja": "ミーンタイムトゥーリカバー",
         "ja_typings": [
-          "mi-ntaimutu-rikaba-"
+          "mi-ntaimutwu-rikaba-"
         ]
       },
       {
@@ -30786,7 +30788,8 @@
     "question_text": {
       "en": "Which DevOps metric measures the time from code commit to production deployment?",
       "ja": "コミットから本番デプロイまでの時間を計測する DevOps メトリクスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30826,7 +30829,8 @@
     "question_text": {
       "en": "Which type of cloud computing service provides ready-to-use applications over the internet?",
       "ja": "利用可能なアプリケーションをインターネット経由で提供するクラウドサービス種別は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30866,7 +30870,8 @@
     "question_text": {
       "en": "Which Japanese particle marks the topic of a sentence?",
       "ja": "日本語で文の主題を示す助詞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31546,7 +31551,8 @@
     "question_text": {
       "en": "Which traditional Korean dish consists of fermented vegetables, typically cabbage?",
       "ja": "発酵野菜、特に白菜を使った韓国の伝統料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31586,7 +31592,8 @@
     "question_text": {
       "en": "Which French dish is a thin pancake filled with savory ingredients, originally from Brittany?",
       "ja": "ブルターニュ地方発祥の塩味の薄焼き菓子料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31666,7 +31673,8 @@
     "question_text": {
       "en": "Which Spanish dish features saffron-flavored rice with seafood or meat?",
       "ja": "サフラン風味の米にシーフードや肉を入れたスペイン料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31786,7 +31794,8 @@
     "question_text": {
       "en": "Which traditional Indian garment is a long unstitched cloth wrapped around the body?",
       "ja": "長く縫っていない布を体に巻くインドの伝統衣装は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31826,7 +31835,8 @@
     "question_text": {
       "en": "Which French dessert is a layered cake with coffee buttercream and chocolate?",
       "ja": "コーヒーバタークリームとチョコレートの層状ケーキはフランスの何という菓子?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31866,7 +31876,8 @@
     "question_text": {
       "en": "Which Turkish coffee preparation involves boiling finely ground coffee in a small pot?",
       "ja": "小さな鍋で細かく挽いたコーヒーを煮詰めるトルコのコーヒー抽出法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31906,7 +31917,8 @@
     "question_text": {
       "en": "Which Scottish bagpipe music style features ornate variations on a theme?",
       "ja": "主題への装飾的変奏が特徴のスコットランドのバグパイプ曲は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31946,7 +31958,8 @@
     "question_text": {
       "en": "Which Argentine dance originated in Buenos Aires and Montevideo in the late 19th century?",
       "ja": "19世紀後半にブエノスアイレスとモンテビデオで生まれたアルゼンチンの舞踊は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31986,7 +31999,8 @@
     "question_text": {
       "en": "Which traditional Russian soup is made with beetroot?",
       "ja": "ビーツを使ったロシアの伝統スープは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32026,7 +32040,8 @@
     "question_text": {
       "en": "Which Italian opera house in Milan opened in 1778?",
       "ja": "1778年に開館したミラノのオペラ劇場は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32041,7 +32056,7 @@
         "en": "Vale tudo",
         "ja": "バーリトゥード",
         "ja_typings": [
-          "ba-ritu-do"
+          "ba-ritwu-do"
         ]
       },
       {
@@ -32066,7 +32081,8 @@
     "question_text": {
       "en": "Which Brazilian martial art combines dance, acrobatics, and music?",
       "ja": "ダンス、アクロバット、音楽を組み合わせたブラジルの武術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32106,7 +32122,8 @@
     "question_text": {
       "en": "Which Greek philosophical drinking party was the subject of works by Plato and Xenophon?",
       "ja": "プラトンとクセノフォンの著作の主題となったギリシャの哲学的宴会は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32186,7 +32203,8 @@
     "question_text": {
       "en": "Which Brazilian dance is the signature of the Rio Carnival?",
       "ja": "リオのカーニバルを代表するブラジルのダンスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32306,7 +32324,8 @@
     "question_text": {
       "en": "Which Spanish festival is famous for the running of the bulls in Pamplona?",
       "ja": "パンプローナでの牛追いで有名なスペインの祭りは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32346,7 +32365,8 @@
     "question_text": {
       "en": "Which Cuban-origin dance is known for its quick step patterns and is popular worldwide?",
       "ja": "キューバ発祥で速いステップで世界的に普及している舞踊は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32386,7 +32406,8 @@
     "question_text": {
       "en": "Which Hindu festival of lights is celebrated in autumn?",
       "ja": "秋に祝われるヒンドゥー教の光の祭りは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32746,7 +32767,8 @@
     "question_text": {
       "en": "Which AWS service provides serverless container compute that runs without managing servers?",
       "ja": "サーバー管理不要でコンテナ実行環境を提供する AWS サービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32786,7 +32808,8 @@
     "question_text": {
       "en": "Which type of cloud computing provides raw virtualized hardware resources?",
       "ja": "生の仮想化ハードウェアリソースを提供するクラウドの種類は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32826,7 +32849,8 @@
     "question_text": {
       "en": "Which cloud computing model executes code in response to events without managing infrastructure?",
       "ja": "インフラ管理不要でイベント応答コード実行をするクラウドモデルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32866,7 +32890,8 @@
     "question_text": {
       "en": "Which AWS service is a fully managed NoSQL key-value database?",
       "ja": "マネージドな NoSQL キーバリュー DB である AWS サービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32906,7 +32931,8 @@
     "question_text": {
       "en": "Which AWS service is a petabyte-scale data warehouse?",
       "ja": "ペタバイト規模のデータウェアハウスである AWS サービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32946,7 +32972,8 @@
     "question_text": {
       "en": "Which open-source IaC tool by HashiCorp uses HCL to define cloud infrastructure?",
       "ja": "HashiCorp 製で HCL でクラウドインフラを定義する IaC ツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32986,7 +33013,8 @@
     "question_text": {
       "en": "Which open-source configuration management tool uses YAML playbooks?",
       "ja": "YAML プレイブックを使う構成管理ツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33026,7 +33054,8 @@
     "question_text": {
       "en": "In Scrum, which ceremony lets the team demo completed work to stakeholders?",
       "ja": "Scrum でステークホルダーに完了作業をデモするセレモニーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33066,7 +33095,8 @@
     "question_text": {
       "en": "Which German astronomer formulated the laws of planetary motion?",
       "ja": "惑星運動の法則を定式化したドイツの天文学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33106,7 +33136,8 @@
     "question_text": {
       "en": "Which German physician proved that specific microorganisms cause specific diseases?",
       "ja": "特定の微生物が特定の病気を引き起こすことを証明したドイツの医師は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33226,7 +33257,8 @@
     "question_text": {
       "en": "Which unit of electric potential difference is named after an Italian physicist?",
       "ja": "イタリア人物理学者にちなんだ電位差の単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33266,7 +33298,8 @@
     "question_text": {
       "en": "Which SI unit of power equals one joule per second?",
       "ja": "毎秒1ジュールに相当する SI 単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33306,7 +33339,8 @@
     "question_text": {
       "en": "Which physicist discovered the atomic nucleus through the gold foil experiment?",
       "ja": "金箔実験で原子核を発見した物理学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33346,7 +33380,8 @@
     "question_text": {
       "en": "Which unit of pressure equals one newton per square meter?",
       "ja": "平方メートルあたり1ニュートンの圧力単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33375,7 +33410,7 @@
         "en": "Commodus",
         "ja": "コンモドゥス",
         "ja_typings": [
-          "konmodusu"
+          "konmodwusu"
         ]
       }
     ],
@@ -33386,7 +33421,8 @@
     "question_text": {
       "en": "Which Roman emperor is infamous for allegedly playing music while Rome burned?",
       "ja": "ローマ市街炎上中に演奏したと言われる悪名高いローマ皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33426,7 +33462,8 @@
     "question_text": {
       "en": "Which Roman emperor built a famous wall across northern Britain?",
       "ja": "北ブリテンに有名な城壁を築いたローマ皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33546,7 +33583,8 @@
     "question_text": {
       "en": "Which Italian explorer's first name became the basis for the name 'America'?",
       "ja": "「アメリカ」の語源となったイタリア人探検家の名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33586,7 +33624,8 @@
     "question_text": {
       "en": "Which Portuguese-born explorer led the first expedition to circumnavigate the globe?",
       "ja": "世界一周航海の最初の遠征を率いたポルトガル出身の探検家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33626,7 +33665,8 @@
     "question_text": {
       "en": "Which country has Hanoi as its capital?",
       "ja": "ハノイを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33666,7 +33706,8 @@
     "question_text": {
       "en": "Which country has Jakarta as its capital?",
       "ja": "ジャカルタを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33706,7 +33747,8 @@
     "question_text": {
       "en": "Which country has Ankara as its capital?",
       "ja": "アンカラを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33746,7 +33788,8 @@
     "question_text": {
       "en": "Which country has Lisbon as its capital?",
       "ja": "リスボンを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33786,7 +33829,8 @@
     "question_text": {
       "en": "Which country has Helsinki as its capital?",
       "ja": "ヘルシンキを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33826,7 +33870,8 @@
     "question_text": {
       "en": "Which country has Oslo as its capital?",
       "ja": "オスロを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33866,7 +33911,8 @@
     "question_text": {
       "en": "Which country has Vienna as its capital?",
       "ja": "ウィーンを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33906,7 +33952,8 @@
     "question_text": {
       "en": "Which country has Prague as its capital?",
       "ja": "プラハを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33946,7 +33993,8 @@
     "question_text": {
       "en": "Which country has Warsaw as its capital?",
       "ja": "ワルシャワを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33986,7 +34034,8 @@
     "question_text": {
       "en": "Which country has Buenos Aires as its capital?",
       "ja": "ブエノスアイレスを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34026,7 +34075,8 @@
     "question_text": {
       "en": "Which country has Lima as its capital?",
       "ja": "リマを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34066,7 +34116,8 @@
     "question_text": {
       "en": "Which country has Nairobi as its capital?",
       "ja": "ナイロビを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34106,7 +34157,8 @@
     "question_text": {
       "en": "Which country has Cairo as its capital?",
       "ja": "カイロを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34146,7 +34198,8 @@
     "question_text": {
       "en": "Which country has Wellington as its capital?",
       "ja": "ウェリントンを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34186,7 +34239,8 @@
     "question_text": {
       "en": "Which country has Canberra as its capital?",
       "ja": "キャンベラを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34226,7 +34280,8 @@
     "question_text": {
       "en": "Which country has Ottawa as its capital?",
       "ja": "オタワを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34866,7 +34921,8 @@
     "question_text": {
       "en": "Which continent is Egypt located in?",
       "ja": "エジプトが属する大陸は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34986,7 +35042,8 @@
     "question_text": {
       "en": "Which city is known as the Eternal City?",
       "ja": "永遠の都と呼ばれる都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35066,7 +35123,8 @@
     "question_text": {
       "en": "Who founded the Mongol Empire?",
       "ja": "モンゴル帝国を建国したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35106,7 +35164,8 @@
     "question_text": {
       "en": "Who was the queen of ancient Egypt famous for relations with Rome?",
       "ja": "ローマと関係したことで有名な古代エジプトの女王は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35146,7 +35205,8 @@
     "question_text": {
       "en": "Who was the first president of independent India?",
       "ja": "インド独立後の初代大統領は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35186,7 +35246,8 @@
     "question_text": {
       "en": "Who led India's independence movement nonviolently?",
       "ja": "非暴力でインド独立運動を率いたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35226,7 +35287,8 @@
     "question_text": {
       "en": "Who was the British Prime Minister during WWII?",
       "ja": "第二次大戦中のイギリス首相は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35266,7 +35328,8 @@
     "question_text": {
       "en": "Who was the leader of Nazi Germany?",
       "ja": "ナチスドイツの指導者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35306,7 +35369,8 @@
     "question_text": {
       "en": "Who led the Soviet Union during WWII?",
       "ja": "第二次大戦中のソ連を率いたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35346,7 +35410,8 @@
     "question_text": {
       "en": "Who founded the Soviet Union?",
       "ja": "ソ連を建国したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35386,7 +35451,8 @@
     "question_text": {
       "en": "Who wrote The Communist Manifesto with Engels?",
       "ja": "エンゲルスと共産党宣言を書いたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35426,7 +35492,8 @@
     "question_text": {
       "en": "Who was the first US president to be assassinated?",
       "ja": "暗殺された最初のアメリカ大統領は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35466,7 +35533,8 @@
     "question_text": {
       "en": "Who was the US president during the Cuban Missile Crisis?",
       "ja": "キューバ危機時のアメリカ大統領は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35506,7 +35574,8 @@
     "question_text": {
       "en": "Who discovered the Americas in 1492?",
       "ja": "1492年に新大陸に到達したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35586,7 +35655,8 @@
     "question_text": {
       "en": "Who painted the Mona Lisa?",
       "ja": "モナリザを描いたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35626,7 +35696,8 @@
     "question_text": {
       "en": "Who proposed heliocentrism in the 16th century?",
       "ja": "16世紀に地動説を唱えたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35666,7 +35737,8 @@
     "question_text": {
       "en": "Who founded the Mughal Empire in India?",
       "ja": "インドのムガル帝国を建国したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35706,7 +35778,8 @@
     "question_text": {
       "en": "Who built the Taj Mahal?",
       "ja": "タージマハルを建てたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36026,7 +36099,8 @@
     "question_text": {
       "en": "Which civilization built Machu Picchu?",
       "ja": "マチュピチュを築いた文明は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36066,7 +36140,8 @@
     "question_text": {
       "en": "Which civilization built Chichen Itza?",
       "ja": "チチェンイツァを築いた文明は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36106,7 +36181,8 @@
     "question_text": {
       "en": "Which civilization was centered at Tenochtitlan?",
       "ja": "テノチティトランを首都とした文明は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36186,7 +36262,8 @@
     "question_text": {
       "en": "Who is regarded as the father of modern Turkey?",
       "ja": "近代トルコの父と呼ばれるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36426,7 +36503,8 @@
     "question_text": {
       "en": "What is the chemical symbol for silver?",
       "ja": "銀の元素記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36466,7 +36544,8 @@
     "question_text": {
       "en": "What is the chemical symbol for sodium?",
       "ja": "ナトリウムの元素記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36506,7 +36585,8 @@
     "question_text": {
       "en": "What is the chemical symbol for potassium?",
       "ja": "カリウムの元素記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36826,7 +36906,8 @@
     "question_text": {
       "en": "Who formulated the three laws of motion?",
       "ja": "運動の三法則を定式化したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36866,7 +36947,8 @@
     "question_text": {
       "en": "Who proposed the theory of evolution by natural selection?",
       "ja": "自然選択による進化論を唱えたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36906,7 +36988,8 @@
     "question_text": {
       "en": "Who is regarded as the father of genetics?",
       "ja": "遺伝学の父と呼ばれるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36946,7 +37029,8 @@
     "question_text": {
       "en": "Who discovered radium together with Pierre Curie?",
       "ja": "ピエールキュリーと共にラジウムを発見したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37266,7 +37350,8 @@
     "question_text": {
       "en": "What is the speed unit named after a Scottish engineer?",
       "ja": "スコットランドの技術者にちなんだ仕事率の単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37386,7 +37471,8 @@
     "question_text": {
       "en": "Which Python framework is known as a microframework?",
       "ja": "Python のマイクロフレームワークと呼ばれるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37426,7 +37512,8 @@
     "question_text": {
       "en": "Which Python framework is async-first and based on type hints?",
       "ja": "型ヒントベースで非同期前提の Python フレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37466,7 +37553,8 @@
     "question_text": {
       "en": "Which Python library is the de facto standard for numerical arrays?",
       "ja": "Python の数値配列の事実上の標準ライブラリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37506,7 +37594,8 @@
     "question_text": {
       "en": "Which Python library is the standard for DataFrames?",
       "ja": "Python のデータフレームの標準ライブラリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37546,7 +37635,8 @@
     "question_text": {
       "en": "Which Python deep learning framework was developed by Meta?",
       "ja": "Meta が開発した Python の深層学習フレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37586,7 +37676,8 @@
     "question_text": {
       "en": "Which Python web framework is full-stack and batteries-included?",
       "ja": "フルスタックでバッテリー同梱型の Python Web フレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37626,7 +37717,8 @@
     "question_text": {
       "en": "Which extremely fast Python package manager is written in Rust?",
       "ja": "Rust で書かれた高速な Python パッケージマネージャーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37666,7 +37758,8 @@
     "question_text": {
       "en": "Which Python tool combines a fast linter and formatter in Rust?",
       "ja": "Rust 製の高速な Python のリンター兼フォーマッターは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37706,7 +37799,8 @@
     "question_text": {
       "en": "Which Rust trait represents types that own a clone operation?",
       "ja": "複製操作を表す Rust のトレイトは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37746,7 +37840,8 @@
     "question_text": {
       "en": "Which Rust trait marks types that are bitwise-copyable?",
       "ja": "ビット単位でコピー可能な型を示す Rust のトレイトは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37786,7 +37881,8 @@
     "question_text": {
       "en": "Which Rust macro formats a string without printing it?",
       "ja": "出力せずに文字列を整形する Rust のマクロは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37826,7 +37922,8 @@
     "question_text": {
       "en": "Which Rust attribute auto-implements common traits?",
       "ja": "一般的なトレイトを自動実装する Rust の属性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37866,7 +37963,8 @@
     "question_text": {
       "en": "Which Rust async runtime is most widely used?",
       "ja": "Rust で最も広く使われている非同期ランタイムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37906,7 +38004,8 @@
     "question_text": {
       "en": "Which Rust web framework is built on top of tokio and hyper?",
       "ja": "tokio と hyper の上に構築された Rust の Web フレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37946,7 +38045,8 @@
     "question_text": {
       "en": "Which JavaScript runtime was created by Ryan Dahl after Node.js?",
       "ja": "Ryan Dahl が Node.js の後に作った JavaScript ランタイムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37986,7 +38086,8 @@
     "question_text": {
       "en": "Which JavaScript runtime is written in Zig and focuses on speed?",
       "ja": "Zig で書かれた高速志向の JavaScript ランタイムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38026,7 +38127,8 @@
     "question_text": {
       "en": "Which company developed TypeScript?",
       "ja": "TypeScript を開発した企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38066,7 +38168,8 @@
     "question_text": {
       "en": "Which JavaScript bundler is known for zero-config and being extremely fast?",
       "ja": "ゼロ設定で高速な JavaScript バンドラーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38106,7 +38209,8 @@
     "question_text": {
       "en": "Which JavaScript dev server is built on top of esbuild and Rollup by Evan You?",
       "ja": "Evan You が作った esbuild と Rollup ベースの開発サーバーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38146,7 +38250,8 @@
     "question_text": {
       "en": "Which test runner ships with Jest-compatible API and is by Vite team?",
       "ja": "Vite チームの Jest 互換テストランナーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38186,7 +38291,8 @@
     "question_text": {
       "en": "Which functional language runs on the BEAM VM and is Erlang-based?",
       "ja": "BEAM 仮想マシン上で動く Erlang 系の関数型言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38226,7 +38332,8 @@
     "question_text": {
       "en": "Which JVM language emphasizes immutability and is a Lisp dialect?",
       "ja": "不変性重視で Lisp 方言の JVM 言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38266,7 +38373,8 @@
     "question_text": {
       "en": "Which language is the official language for Android development today?",
       "ja": "現在の Android 開発の公式言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38306,7 +38414,8 @@
     "question_text": {
       "en": "Which language powers the Flutter framework?",
       "ja": "Flutter フレームワークの言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38346,7 +38455,8 @@
     "question_text": {
       "en": "Which scripting language is embedded in many games and apps?",
       "ja": "ゲームやアプリに組み込まれることが多いスクリプト言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38386,7 +38496,8 @@
     "question_text": {
       "en": "Which statically typed functional language is from Microsoft Research?",
       "ja": "Microsoft Research 発の静的型付け関数型言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38426,7 +38537,8 @@
     "question_text": {
       "en": "Which language is the spiritual successor to Objective-C on Apple platforms?",
       "ja": "Apple プラットフォームでの Objective-C の後継言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38466,7 +38578,8 @@
     "question_text": {
       "en": "Which language was created at Mozilla for systems programming?",
       "ja": "Mozilla がシステムプログラミング向けに作った言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38506,7 +38619,8 @@
     "question_text": {
       "en": "Which language emphasizes manual memory management as a C replacement?",
       "ja": "C の代替を意識した手動メモリ管理重視の言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38546,7 +38660,8 @@
     "question_text": {
       "en": "Which sorting algorithm is stable and runs in O(n log n) worst case?",
       "ja": "最悪 O(n log n) で安定なソートアルゴリズムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38626,7 +38741,8 @@
     "question_text": {
       "en": "Which data structure provides efficient prefix string search?",
       "ja": "プレフィックス検索に効率的なデータ構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38648,7 +38764,6 @@
         "en": "Post-order",
         "ja": "ポストオーダー",
         "ja_typings": [
-          "posuto-da-",
           "posutoo-da-"
         ]
       },
@@ -38667,7 +38782,8 @@
     "question_text": {
       "en": "Which traversal visits a binary tree in left-root-right order?",
       "ja": "二分木を左-根-右の順で巡回するのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38707,7 +38823,8 @@
     "question_text": {
       "en": "Which algorithm finds shortest paths from all sources to all destinations?",
       "ja": "全頂点対の最短経路を求めるアルゴリズムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38827,7 +38944,8 @@
     "question_text": {
       "en": "Which container image format is the OCI industry standard?",
       "ja": "OCI 業界標準のコンテナイメージ形式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38867,7 +38985,8 @@
     "question_text": {
       "en": "Which command-line tool is the standard for HTTP transfers in scripts?",
       "ja": "スクリプトで HTTP 通信を行う標準的な CLI ツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38907,7 +39026,8 @@
     "question_text": {
       "en": "Which version control system is centralized rather than distributed?",
       "ja": "分散型ではなく集中型のバージョン管理システムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38947,7 +39067,8 @@
     "question_text": {
       "en": "Which CI service is built into GitHub itself?",
       "ja": "GitHub に組み込まれている CI サービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38987,7 +39108,8 @@
     "question_text": {
       "en": "Which markup language is commonly used for README files on GitHub?",
       "ja": "GitHub の README で使われるマークアップは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39027,7 +39149,8 @@
     "question_text": {
       "en": "Which serialization format is line-oriented and key-value-like for configs?",
       "ja": "設定用のキーバリュー型シリアライズ形式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39067,7 +39190,8 @@
     "question_text": {
       "en": "Which data format is whitespace-significant and widely used in CI configs?",
       "ja": "インデントに意味があり CI 設定で多用されるデータ形式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39107,7 +39231,8 @@
     "question_text": {
       "en": "Who created the Pascal language and Turbo Pascal?",
       "ja": "Pascal と Turbo Pascal を作ったのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39147,7 +39272,8 @@
     "question_text": {
       "en": "Who is the lead architect of TypeScript and C#?",
       "ja": "TypeScript と C# の主任設計者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39187,7 +39313,8 @@
     "question_text": {
       "en": "Who designed the Java language?",
       "ja": "Java 言語を設計したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39227,7 +39354,8 @@
     "question_text": {
       "en": "Who is famous for The Art of Computer Programming and TeX?",
       "ja": "The Art of Computer Programming と TeX で有名な人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39267,7 +39395,8 @@
     "question_text": {
       "en": "Who is credited with creating Lisp?",
       "ja": "Lisp を生み出した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39307,7 +39436,8 @@
     "question_text": {
       "en": "Who is credited with creating Smalltalk and coining 'object-oriented'?",
       "ja": "Smalltalk を作りオブジェクト指向の語を定着させたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39467,7 +39597,8 @@
     "question_text": {
       "en": "Which HTML5 tag represents a self-contained article?",
       "ja": "自己完結した記事を表す HTML5 タグは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39507,7 +39638,8 @@
     "question_text": {
       "en": "Which HTML5 tag groups thematically related content?",
       "ja": "テーマで関連する内容をまとめる HTML5 タグは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39547,7 +39679,8 @@
     "question_text": {
       "en": "Which HTML5 tag represents tangentially related content like a sidebar?",
       "ja": "サイドバー等の補足的内容を表す HTML5 タグは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39587,7 +39720,8 @@
     "question_text": {
       "en": "Which HTML element is used to embed scalable vector graphics?",
       "ja": "ベクター画像を埋め込む HTML 要素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39627,7 +39761,8 @@
     "question_text": {
       "en": "Which HTML element provides scriptable bitmap drawing?",
       "ja": "スクリプトでビットマップ描画できる HTML 要素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39667,7 +39802,8 @@
     "question_text": {
       "en": "Which HTML attribute enables a drop-down list bound to an input?",
       "ja": "input に紐づく候補リストを実現する HTML 属性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39707,7 +39843,8 @@
     "question_text": {
       "en": "Which HTML input type provides a native color picker?",
       "ja": "ネイティブのカラーピッカーを表示する input type は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39729,7 +39866,6 @@
         "en": "`:first-of-type`",
         "ja": "ファーストオブタイプ",
         "ja_typings": [
-          "fa-sutobutaipu",
           "fa-sutoobutaipu"
         ]
       },
@@ -39748,7 +39884,8 @@
     "question_text": {
       "en": "Which CSS pseudo-class targets the first child element?",
       "ja": "最初の子要素を選択する CSS 疑似クラスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39788,7 +39925,8 @@
     "question_text": {
       "en": "Which CSS unit is relative to the root font-size?",
       "ja": "ルートフォントサイズに対する CSS の単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39828,7 +39966,8 @@
     "question_text": {
       "en": "Which CSS unit equals one percent of the viewport width?",
       "ja": "ビューポート幅の 1% を表す CSS の単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39868,7 +40007,8 @@
     "question_text": {
       "en": "Which CSS property controls stacking order along the z-axis?",
       "ja": "Z 軸方向の重なり順を制御する CSS プロパティは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39908,7 +40048,8 @@
     "question_text": {
       "en": "Which CSS function performs simple arithmetic with mixed units?",
       "ja": "異なる単位の四則演算を行う CSS 関数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39948,7 +40089,8 @@
     "question_text": {
       "en": "Which CSS at-rule defines media-query-based styles?",
       "ja": "メディアクエリに基づくスタイルを定義する CSS の at-rule は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39988,7 +40130,8 @@
     "question_text": {
       "en": "Which CSS at-rule scopes styles by container queries?",
       "ja": "コンテナクエリでスタイルをスコープする at-rule は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40028,7 +40171,8 @@
     "question_text": {
       "en": "Which CSS property smoothly animates between value changes?",
       "ja": "値の変化を滑らかに補間する CSS プロパティは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40068,7 +40212,8 @@
     "question_text": {
       "en": "Which CSS property applies blur, grayscale, and similar effects?",
       "ja": "ぼかしやグレースケール等の効果を適用する CSS プロパティは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40108,7 +40253,8 @@
     "question_text": {
       "en": "Which method selects the first element matching a CSS selector?",
       "ja": "CSS セレクタに合う最初の要素を取得する DOM メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40148,7 +40294,8 @@
     "question_text": {
       "en": "Which DOM API replaces XMLHttpRequest in modern code?",
       "ja": "XMLHttpRequest に代わる現代の DOM API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40188,7 +40335,8 @@
     "question_text": {
       "en": "Which Web API observes elements crossing the viewport?",
       "ja": "ビューポート交差を監視する Web API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40228,7 +40376,8 @@
     "question_text": {
       "en": "Which Web API watches changes to the DOM tree?",
       "ja": "DOM ツリーの変化を監視する Web API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40268,7 +40417,8 @@
     "question_text": {
       "en": "Which Web API monitors element size changes?",
       "ja": "要素サイズの変化を監視する Web API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40308,7 +40458,8 @@
     "question_text": {
       "en": "Which JavaScript timer schedules a callback for the next animation frame?",
       "ja": "次の描画フレームでコールバックを呼ぶ JavaScript のタイマーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40348,7 +40499,8 @@
     "question_text": {
       "en": "Which JavaScript construct represents a one-time async value?",
       "ja": "1 回限りの非同期値を表す JavaScript の構文は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40388,7 +40540,8 @@
     "question_text": {
       "en": "Which HTTP status code indicates a temporary redirect?",
       "ja": "一時的リダイレクトを示す HTTP ステータスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40428,7 +40581,8 @@
     "question_text": {
       "en": "Which HTTP status code indicates the server is temporarily unavailable?",
       "ja": "サーバーが一時的に利用不能であることを示す HTTP ステータスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40468,7 +40622,8 @@
     "question_text": {
       "en": "Which HTTP status code indicates the request body exceeds the server limit?",
       "ja": "リクエストボディがサーバー制限を超えたことを示す HTTP ステータスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40508,7 +40663,8 @@
     "question_text": {
       "en": "Which HTTP status indicates the resource has not been modified?",
       "ja": "リソースが未更新であることを示す HTTP ステータスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40548,7 +40704,8 @@
     "question_text": {
       "en": "Which HTTP header sends authentication credentials with the request?",
       "ja": "リクエストに認証情報を載せる HTTP ヘッダーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40588,7 +40745,8 @@
     "question_text": {
       "en": "Which HTTP header indicates the format of the request body?",
       "ja": "リクエストボディの形式を示す HTTP ヘッダーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40628,7 +40786,8 @@
     "question_text": {
       "en": "Which HTTP header declares acceptable response media types?",
       "ja": "受け入れ可能なレスポンス形式を宣言する HTTP ヘッダーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40668,7 +40827,8 @@
     "question_text": {
       "en": "Which HTTP header is used by browsers to identify the client software?",
       "ja": "クライアントソフトを識別する HTTP ヘッダーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40708,7 +40868,8 @@
     "question_text": {
       "en": "Which attack manipulates database queries via unsanitized input?",
       "ja": "未検証の入力で DB クエリを改ざんする攻撃は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40748,7 +40909,8 @@
     "question_text": {
       "en": "Which attack reads files outside the intended directory?",
       "ja": "意図したディレクトリ外のファイルを読む攻撃は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40788,7 +40950,8 @@
     "question_text": {
       "en": "Which attack overlays an invisible UI to trick clicks?",
       "ja": "見えない UI を被せてクリックを誘う攻撃は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40828,7 +40991,8 @@
     "question_text": {
       "en": "Which HTTP header forbids embedding the page in a frame?",
       "ja": "ページをフレームに埋め込むことを禁じる HTTP ヘッダーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40868,7 +41032,8 @@
     "question_text": {
       "en": "Which HTTP header forces browsers to use HTTPS for a period?",
       "ja": "一定期間 HTTPS 強制を伝える HTTP ヘッダーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40908,7 +41073,8 @@
     "question_text": {
       "en": "Which state management library is most associated with React?",
       "ja": "React と最も結びつく状態管理ライブラリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40948,7 +41114,8 @@
     "question_text": {
       "en": "Which CSS-in-JS library popularized tagged template literals for styles?",
       "ja": "タグ付きテンプレートリテラルによる CSS-in-JS を広めたライブラリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40988,7 +41155,8 @@
     "question_text": {
       "en": "Which framework introduced the Islands Architecture concept?",
       "ja": "アイランズアーキテクチャを広めたフレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41028,7 +41196,8 @@
     "question_text": {
       "en": "Which fine-grained reactive framework was created by Ryan Carniato?",
       "ja": "Ryan Carniato による細粒度リアクティブなフレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41068,7 +41237,8 @@
     "question_text": {
       "en": "Which framework focuses on resumability instead of hydration?",
       "ja": "ハイドレーションではなく resumability を志向するフレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41097,7 +41267,6 @@
         "en": "Redwood",
         "ja": "レッドウッド",
         "ja_typings": [
-          "reddoddo",
           "reddouddo"
         ]
       }
@@ -41109,7 +41278,8 @@
     "question_text": {
       "en": "Which React framework focuses on web fundamentals and is by Shopify now?",
       "ja": "Web 基礎重視で現在は Shopify が運用する React フレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41149,7 +41319,8 @@
     "question_text": {
       "en": "Which standards body publishes HTML specifications today?",
       "ja": "現在 HTML 仕様を発行している標準化団体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41189,7 +41360,8 @@
     "question_text": {
       "en": "Which group standardizes JavaScript (ECMAScript)?",
       "ja": "JavaScript すなわち ECMAScript を標準化する団体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41229,7 +41401,8 @@
     "question_text": {
       "en": "Which rendering engine powers Safari and WebKit-based browsers?",
       "ja": "Safari や WebKit 系ブラウザのレンダリングエンジンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41269,7 +41442,8 @@
     "question_text": {
       "en": "Which rendering engine powers Firefox?",
       "ja": "Firefox のレンダリングエンジンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41309,7 +41483,8 @@
     "question_text": {
       "en": "Which engine powers Chrome and modern Edge?",
       "ja": "Chrome と現行 Edge のエンジンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41349,7 +41524,8 @@
     "question_text": {
       "en": "Which technology lets browsers run near-native compiled code?",
       "ja": "ブラウザでネイティブ近い速度のコンパイル済みコードを動かす技術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41389,7 +41565,8 @@
     "question_text": {
       "en": "Which file makes a website installable as a PWA?",
       "ja": "サイトを PWA としてインストール可能にするファイルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41429,7 +41606,8 @@
     "question_text": {
       "en": "Which file directs crawlers about allowed and disallowed paths?",
       "ja": "クローラーに巡回可否を伝えるファイルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41469,7 +41647,8 @@
     "question_text": {
       "en": "Which file lists URLs for search engines to index?",
       "ja": "検索エンジンが巡回すべき URL を列挙するファイルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41509,7 +41688,8 @@
     "question_text": {
       "en": "Which standard defines real-time peer-to-peer media in browsers?",
       "ja": "ブラウザのリアルタイム P2P メディア通信を定める標準は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41549,7 +41729,8 @@
     "question_text": {
       "en": "Which mechanism pushes server-sent events over a long-lived HTTP response?",
       "ja": "長時間 HTTP 応答上でサーバー発のイベントを配信する仕組みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41557,7 +41738,6 @@
         "en": "1024",
         "ja": "センニジュウヨン",
         "ja_typings": [
-          "sennijuuyon",
           "sennnijuuyon"
         ]
       },
@@ -41572,7 +41752,6 @@
         "en": "2048",
         "ja": "ニセンヨンジュウハチ",
         "ja_typings": [
-          "nisenyonjuuhachi",
           "nisennyonjuuhachi"
         ]
       },
@@ -41591,7 +41770,8 @@
     "question_text": {
       "en": "What is 2 to the power of 10?",
       "ja": "2の10乗はいくつ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41631,7 +41811,8 @@
     "question_text": {
       "en": "What is the square root of 144?",
       "ja": "144の平方根はいくつ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41671,7 +41852,8 @@
     "question_text": {
       "en": "What is the factorial of 5?",
       "ja": "5の階乗はいくつ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41711,7 +41893,8 @@
     "question_text": {
       "en": "What is the value of e to one decimal place?",
       "ja": "ネイピア数を小数点以下1桁で表すと?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41751,7 +41934,8 @@
     "question_text": {
       "en": "Which is a prime number?",
       "ja": "次のうち素数はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41759,7 +41943,6 @@
         "en": "pi r squared",
         "ja": "パイアールジジョウ",
         "ja_typings": [
-          "paia-rujijo",
           "paia-rujijou"
         ]
       },
@@ -41781,7 +41964,6 @@
         "en": "four pi r squared",
         "ja": "ヨンパイアールジジョウ",
         "ja_typings": [
-          "yonpaia-rujijo",
           "yonpaia-rujijou"
         ]
       }
@@ -41793,7 +41975,8 @@
     "question_text": {
       "en": "What is the area formula for a circle?",
       "ja": "円の面積を求める公式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41833,7 +42016,8 @@
     "question_text": {
       "en": "What is the sum of angles in a quadrilateral?",
       "ja": "四角形の内角の和は何度?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41873,7 +42057,8 @@
     "question_text": {
       "en": "What is 7 times 8?",
       "ja": "7かける8はいくつ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41881,7 +42066,6 @@
         "en": "1/6",
         "ja": "ロクブンノイチ",
         "ja_typings": [
-          "rokubunnoichi",
           "rokubunnnoichi"
         ]
       },
@@ -41889,7 +42073,6 @@
         "en": "1/3",
         "ja": "サンブンノイチ",
         "ja_typings": [
-          "sanbunnoichi",
           "sanbunnnoichi"
         ]
       },
@@ -41897,7 +42080,6 @@
         "en": "1/2",
         "ja": "ニブンノイチ",
         "ja_typings": [
-          "nibunnoichi",
           "nibunnnoichi"
         ]
       },
@@ -41905,7 +42087,6 @@
         "en": "1/12",
         "ja": "ジュウニブンノイチ",
         "ja_typings": [
-          "juunibunnoichi",
           "juunibunnnoichi"
         ]
       }
@@ -41917,7 +42098,8 @@
     "question_text": {
       "en": "What is the probability of rolling a 6 on a fair die?",
       "ja": "サイコロで6が出る確率は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41957,7 +42139,8 @@
     "question_text": {
       "en": "What is the next number: 2, 4, 8, 16, ?",
       "ja": "次の数列の次は: 2, 4, 8, 16, ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41997,7 +42180,8 @@
     "question_text": {
       "en": "What is the mean of 2, 4, 6, 8, 10?",
       "ja": "2, 4, 6, 8, 10の平均は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42005,7 +42189,6 @@
         "en": "middle value",
         "ja": "マンナカノアタイ",
         "ja_typings": [
-          "mannakanoatai",
           "mannnakanoatai"
         ]
       },
@@ -42027,8 +42210,7 @@
         "en": "total sum",
         "ja": "ゴウケイ",
         "ja_typings": [
-          "goukei",
-          "gokei"
+          "goukei"
         ]
       }
     ],
@@ -42039,7 +42221,8 @@
     "question_text": {
       "en": "What does the median represent?",
       "ja": "中央値とは何か?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42047,8 +42230,7 @@
         "en": "cube",
         "ja": "リッポウタイ",
         "ja_typings": [
-          "rippoutai",
-          "rippotai"
+          "rippoutai"
         ]
       },
       {
@@ -42080,7 +42262,8 @@
     "question_text": {
       "en": "What shape has 6 faces?",
       "ja": "面が6つある立体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42120,7 +42303,8 @@
     "question_text": {
       "en": "How many edges does a cube have?",
       "ja": "立方体の辺の数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42149,8 +42333,7 @@
         "en": "squared sum",
         "ja": "ジジョウワ",
         "ja_typings": [
-          "jijouwa",
-          "jijowa"
+          "jijouwa"
         ]
       }
     ],
@@ -42161,7 +42344,8 @@
     "question_text": {
       "en": "What is the slope formula?",
       "ja": "傾きを求める公式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42201,7 +42385,8 @@
     "question_text": {
       "en": "What is the value of log base 10 of 1000?",
       "ja": "10を底とする1000の対数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42241,7 +42426,8 @@
     "question_text": {
       "en": "What is 15 percent of 200?",
       "ja": "200の15パーセントはいくつ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42281,7 +42467,8 @@
     "question_text": {
       "en": "What is the diagonal of a unit square?",
       "ja": "1辺1の正方形の対角線の長さは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42321,7 +42508,8 @@
     "question_text": {
       "en": "What is the binary representation of 5?",
       "ja": "10進数の5を2進数で表すと?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42329,7 +42517,6 @@
         "en": "1/2",
         "ja": "ニブンノイチ",
         "ja_typings": [
-          "nibunnoichi",
           "nibunnnoichi"
         ]
       },
@@ -42337,7 +42524,6 @@
         "en": "root 3 over 2",
         "ja": "ルートサンブンノニ",
         "ja_typings": [
-          "ru-tosanbunnoni",
           "ru-tosanbunnnoni"
         ]
       },
@@ -42345,7 +42531,6 @@
         "en": "root 2 over 2",
         "ja": "ルートニブンノニ",
         "ja_typings": [
-          "ru-tonibunnoni",
           "ru-tonibunnnoni"
         ]
       },
@@ -42364,7 +42549,8 @@
     "question_text": {
       "en": "What is sin of 30 degrees?",
       "ja": "サイン30度の値は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42386,8 +42572,7 @@
         "en": "x cubed",
         "ja": "エックスサンジョウ",
         "ja_typings": [
-          "ekkususanjou",
-          "ekkususanjo"
+          "ekkususanjou"
         ]
       },
       {
@@ -42405,7 +42590,8 @@
     "question_text": {
       "en": "What is the derivative of x squared?",
       "ja": "xの2乗の微分は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42420,16 +42606,14 @@
         "en": "x squared",
         "ja": "エックスニジョウ",
         "ja_typings": [
-          "ekkusunijou",
-          "ekkusunijo"
+          "ekkusunijou"
         ]
       },
       {
         "en": "e to the x",
         "ja": "イーノエックスジョウ",
         "ja_typings": [
-          "i-noekkusujou",
-          "i-noekkusujo"
+          "i-noekkusujou"
         ]
       },
       {
@@ -42447,7 +42631,8 @@
     "question_text": {
       "en": "What is the integral of 1 over x?",
       "ja": "xぶんの1の積分は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42487,7 +42672,8 @@
     "question_text": {
       "en": "What is 10 squared minus 9 squared?",
       "ja": "10の2乗ひく9の2乗は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42527,7 +42713,8 @@
     "question_text": {
       "en": "What is the smallest perfect number?",
       "ja": "最小の完全数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42567,7 +42754,8 @@
     "question_text": {
       "en": "What does ATM stand for?",
       "ja": "ATMは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42607,7 +42795,8 @@
     "question_text": {
       "en": "How many bones are in the adult human body?",
       "ja": "成人の人間の骨の数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42615,24 +42804,20 @@
         "en": "3600 seconds",
         "ja": "サンゼンロッピャクビョウ",
         "ja_typings": [
-          "sanzenroppyakubyou",
-          "sanzenroppyakubyo"
+          "sanzenroppyakubyou"
         ]
       },
       {
         "en": "60 seconds",
         "ja": "ロクジュウビョウ",
         "ja_typings": [
-          "rokujuubyou",
-          "rokujuubyo"
+          "rokujuubyou"
         ]
       },
       {
         "en": "7200 seconds",
         "ja": "ナナセンニヒャクビョウ",
         "ja_typings": [
-          "nanasennihyakubyou",
-          "nanasennnihyakubyo",
           "nanasennnihyakubyou"
         ]
       },
@@ -42640,8 +42825,7 @@
         "en": "1800 seconds",
         "ja": "センハッピャクビョウ",
         "ja_typings": [
-          "senhappyakubyou",
-          "senhappyakubyo"
+          "senhappyakubyou"
         ]
       }
     ],
@@ -42652,7 +42836,8 @@
     "question_text": {
       "en": "How many seconds are in an hour?",
       "ja": "1時間は何秒?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42660,32 +42845,28 @@
         "en": "300000 km per second",
         "ja": "サンジュウマンキロメートルマイビョウ",
         "ja_typings": [
-          "sanjuumankirome-torumaibyou",
-          "sanjuumankirome-torumaibyo"
+          "sanjuumankirome-torumaibyou"
         ]
       },
       {
         "en": "30000 km per second",
         "ja": "サンマンキロメートルマイビョウ",
         "ja_typings": [
-          "sanmankirome-torumaibyou",
-          "sanmankirome-torumaibyo"
+          "sanmankirome-torumaibyou"
         ]
       },
       {
         "en": "3 million km per second",
         "ja": "サンビャクマンキロメートルマイビョウ",
         "ja_typings": [
-          "sanbyakumankirome-torumaibyou",
-          "sanbyakumankirome-torumaibyo"
+          "sanbyakumankirome-torumaibyou"
         ]
       },
       {
         "en": "3000 km per second",
         "ja": "サンゼンキロメートルマイビョウ",
         "ja_typings": [
-          "sanzenkirome-torumaibyou",
-          "sanzenkirome-torumaibyo"
+          "sanzenkirome-torumaibyou"
         ]
       }
     ],
@@ -42696,7 +42877,8 @@
     "question_text": {
       "en": "What is the speed of light approximately?",
       "ja": "光の速さはおよそ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42736,7 +42918,8 @@
     "question_text": {
       "en": "What does CEO stand for?",
       "ja": "CEOは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42776,7 +42959,8 @@
     "question_text": {
       "en": "How many planets are in our solar system?",
       "ja": "太陽系の惑星の数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42784,24 +42968,21 @@
         "en": "Pacific Ocean",
         "ja": "タイヘイヨウ",
         "ja_typings": [
-          "taiheiyou",
-          "taiheiyo"
+          "taiheiyou"
         ]
       },
       {
         "en": "Atlantic Ocean",
         "ja": "タイセイヨウ",
         "ja_typings": [
-          "taiseiyou",
-          "taiseiyo"
+          "taiseiyou"
         ]
       },
       {
         "en": "Indian Ocean",
         "ja": "インドヨウ",
         "ja_typings": [
-          "indoyou",
-          "indoyo"
+          "indoyou"
         ]
       },
       {
@@ -42819,7 +43000,8 @@
     "question_text": {
       "en": "What is the largest ocean?",
       "ja": "世界最大の海は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42859,7 +43041,8 @@
     "question_text": {
       "en": "What is the tallest mountain in the world?",
       "ja": "世界一高い山は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42899,7 +43082,8 @@
     "question_text": {
       "en": "Which country has the longest coastline?",
       "ja": "海岸線が世界一長い国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42939,7 +43123,8 @@
     "question_text": {
       "en": "What does GPS stand for?",
       "ja": "GPSは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42979,7 +43164,8 @@
     "question_text": {
       "en": "What is the origin of the word robot?",
       "ja": "ロボットの語源となった言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43019,7 +43205,8 @@
     "question_text": {
       "en": "What unit measures pressure?",
       "ja": "圧力の単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43059,7 +43246,8 @@
     "question_text": {
       "en": "How many strings does a standard guitar have?",
       "ja": "標準的なギターの弦の数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43067,8 +43255,7 @@
         "en": "distress signal",
         "ja": "ソウナンシンゴウ",
         "ja_typings": [
-          "sounanshingou",
-          "sonanshingo"
+          "sounanshingou"
         ]
       },
       {
@@ -43089,7 +43276,6 @@
         "en": "standard order set",
         "ja": "スタンダードオーダーセット",
         "ja_typings": [
-          "sutanda-do-da-setto-",
           "sutanda-doo-da-setto"
         ]
       }
@@ -43101,7 +43287,8 @@
     "question_text": {
       "en": "What does SOS represent?",
       "ja": "SOSは何を表すか?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43141,7 +43328,8 @@
     "question_text": {
       "en": "What does VIP stand for?",
       "ja": "VIPは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43181,7 +43369,8 @@
     "question_text": {
       "en": "How many continents are there?",
       "ja": "大陸はいくつある?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43221,7 +43410,8 @@
     "question_text": {
       "en": "What is the smallest country in the world?",
       "ja": "世界で一番小さい国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43261,7 +43451,8 @@
     "question_text": {
       "en": "What does PDF stand for?",
       "ja": "PDFは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43301,7 +43492,8 @@
     "question_text": {
       "en": "What is the boiling point of water at sea level?",
       "ja": "海面における水の沸点は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43341,7 +43533,8 @@
     "question_text": {
       "en": "How many colors are in a rainbow?",
       "ja": "虹の色の数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43381,7 +43574,8 @@
     "question_text": {
       "en": "What does GG mean in gaming?",
       "ja": "ゲームで使われるGGの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43421,7 +43615,8 @@
     "question_text": {
       "en": "What does AFK stand for?",
       "ja": "AFKは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43461,7 +43656,8 @@
     "question_text": {
       "en": "What does the slang 'kusa' mean?",
       "ja": "ネットスラング草の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43501,7 +43697,8 @@
     "question_text": {
       "en": "What is a VTuber's avatar called?",
       "ja": "VTuberが使うアバターの呼び方は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43509,16 +43706,14 @@
         "en": "paid comment",
         "ja": "ユウリョウコメント",
         "ja_typings": [
-          "yuuryoukomento",
-          "yuuryokomento"
+          "yuuryoukomento"
         ]
       },
       {
         "en": "free comment",
         "ja": "ムリョウコメント",
         "ja_typings": [
-          "muryoukomento",
-          "muryokomento"
+          "muryoukomento"
         ]
       },
       {
@@ -43543,7 +43738,8 @@
     "question_text": {
       "en": "What does superchat mean on YouTube?",
       "ja": "YouTubeのスパチャの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43583,7 +43779,8 @@
     "question_text": {
       "en": "What does GLHF mean?",
       "ja": "GLHFの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43598,8 +43795,7 @@
         "en": "expert",
         "ja": "ジョウキュウシャ",
         "ja_typings": [
-          "joukyuusha",
-          "jokyuusha"
+          "joukyuusha"
         ]
       },
       {
@@ -43624,7 +43820,8 @@
     "question_text": {
       "en": "What is a 'noob' in gaming?",
       "ja": "ゲームでnoobの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43664,7 +43861,8 @@
     "question_text": {
       "en": "What does 'tryhard' refer to?",
       "ja": "tryhardが指す意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43672,8 +43870,7 @@
         "en": "excitement",
         "ja": "コウフン",
         "ja_typings": [
-          "koufun",
-          "kofun"
+          "koufun"
         ]
       },
       {
@@ -43694,8 +43891,7 @@
         "en": "regret",
         "ja": "コウカイ",
         "ja_typings": [
-          "koukai",
-          "kokai"
+          "koukai"
         ]
       }
     ],
@@ -43706,7 +43902,8 @@
     "question_text": {
       "en": "What is the meaning of 'pog'?",
       "ja": "pogの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43714,8 +43911,7 @@
         "en": "most effective tactic",
         "ja": "サイコウセンリャク",
         "ja_typings": [
-          "saikousenryaku",
-          "saikosenryaku"
+          "saikousenryaku"
         ]
       },
       {
@@ -43747,7 +43943,8 @@
     "question_text": {
       "en": "What does 'meta' mean in games?",
       "ja": "ゲーム用語のメタの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43787,7 +43984,8 @@
     "question_text": {
       "en": "What is the origin of meme?",
       "ja": "ミームの語源は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43795,8 +43993,7 @@
         "en": "low quality post",
         "ja": "ヒンシツノヒクイトウコウ",
         "ja_typings": [
-          "hinshitsunohikuitoukou",
-          "hinshitsunohikuitoko"
+          "hinshitsunohikuitoukou"
         ]
       },
       {
@@ -43810,16 +44007,14 @@
         "en": "paid sponsorship",
         "ja": "ユウリョウスポンサー",
         "ja_typings": [
-          "yuuryousuponsa-",
-          "yuuryosuponsa-"
+          "yuuryousuponsa-"
         ]
       },
       {
         "en": "legal notice",
         "ja": "ホウテキツウチ",
         "ja_typings": [
-          "houtekitsuuchi",
-          "hotekitsuuchi"
+          "houtekitsuuchi"
         ]
       }
     ],
@@ -43830,7 +44025,8 @@
     "question_text": {
       "en": "What is shitposting?",
       "ja": "シットポストとは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43838,8 +44034,7 @@
         "en": "silent viewer",
         "ja": "ムゲンシチョウシャ",
         "ja_typings": [
-          "mugenshichousha",
-          "mugenshichosha"
+          "mugenshichousha"
         ]
       },
       {
@@ -43853,16 +44048,14 @@
         "en": "paid member",
         "ja": "ユウリョウメンバー",
         "ja_typings": [
-          "yuuryoumenba-",
-          "yuuryomenba-"
+          "yuuryoumenba-"
         ]
       },
       {
         "en": "auto bot",
         "ja": "ジドウボット",
         "ja_typings": [
-          "jidoubotto",
-          "jidobotto"
+          "jidoubotto"
         ]
       }
     ],
@@ -43873,7 +44066,8 @@
     "question_text": {
       "en": "What does 'lurker' mean in livestreams?",
       "ja": "配信用語のlurkerの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43881,16 +44075,14 @@
         "en": "leaking personal info",
         "ja": "コジンジョウホウバクロ",
         "ja_typings": [
-          "kojinjouhoubakuro",
-          "kojinjohobakuro"
+          "kojinjouhoubakuro"
         ]
       },
       {
         "en": "sharing memes",
         "ja": "ミームキョウユウ",
         "ja_typings": [
-          "mi-mukyouyuu",
-          "mi-mukyoyuu"
+          "mi-mukyouyuu"
         ]
       },
       {
@@ -43904,8 +44096,7 @@
         "en": "posting reviews",
         "ja": "レビュートウコウ",
         "ja_typings": [
-          "rebyu-toukou",
-          "rebyu-toko"
+          "rebyu-toukou"
         ]
       }
     ],
@@ -43916,7 +44107,8 @@
     "question_text": {
       "en": "What is meant by 'doxxing'?",
       "ja": "ドキシングの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43956,7 +44148,8 @@
     "question_text": {
       "en": "What does FPS stand for in gaming?",
       "ja": "ゲーム用語のFPSは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43964,8 +44157,7 @@
         "en": "clearing a game as fast as possible",
         "ja": "ゲームサイソクコウリャク",
         "ja_typings": [
-          "ge-musaisokukouryaku",
-          "ge-musaisokukoryaku"
+          "ge-musaisokukouryaku"
         ]
       },
       {
@@ -43997,7 +44189,8 @@
     "question_text": {
       "en": "What is a 'speedrun'?",
       "ja": "スピードランとは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44005,8 +44198,6 @@
         "en": "sending viewers to another channel",
         "ja": "ベツチャンネルニシチョウシャヲオクル",
         "ja_typings": [
-          "betsuchannnerunishichoushawookuru",
-          "betsuchannnerunishichoshaokuru",
           "betsuchannnerunishichoushaookuru"
         ]
       },
@@ -44014,8 +44205,7 @@
         "en": "hacking attack",
         "ja": "ハッキングコウゲキ",
         "ja_typings": [
-          "hakkingukougeki",
-          "hakkingukogeki"
+          "hakkingukougeki"
         ]
       },
       {
@@ -44040,7 +44230,8 @@
     "question_text": {
       "en": "What is the meaning of 'raid' on streaming sites?",
       "ja": "配信サイトのレイドの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44069,8 +44260,7 @@
         "en": "ad song",
         "ja": "コウコクキョク",
         "ja_typings": [
-          "koukokukyoku",
-          "kokokukyoku"
+          "koukokukyoku"
         ]
       }
     ],
@@ -44081,7 +44271,8 @@
     "question_text": {
       "en": "What is a 'banger' track?",
       "ja": "bangerトラックの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44121,7 +44312,8 @@
     "question_text": {
       "en": "What is the meaning of 'salt' in gaming?",
       "ja": "ゲームのsaltの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44143,16 +44335,14 @@
         "en": "calm goodbye",
         "ja": "オダヤカナサヨウナラ",
         "ja_typings": [
-          "odayakanasayounara",
-          "odayakanasayonara"
+          "odayakanasayounara"
         ]
       },
       {
         "en": "auto save",
         "ja": "ジドウホゾン",
         "ja_typings": [
-          "jidouhozon",
-          "jidohozon"
+          "jidouhozon"
         ]
       }
     ],
@@ -44163,7 +44353,8 @@
     "question_text": {
       "en": "What is the meaning of 'rage quit'?",
       "ja": "rage quitの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44203,7 +44394,8 @@
     "question_text": {
       "en": "What does PvP mean?",
       "ja": "PvPの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44211,8 +44403,7 @@
         "en": "embarrassment",
         "ja": "キョウシュク",
         "ja_typings": [
-          "kyoushuku",
-          "kyoshuku"
+          "kyoushuku"
         ]
       },
       {
@@ -44244,7 +44435,8 @@
     "question_text": {
       "en": "What does 'cringe' describe?",
       "ja": "cringeが表す感情は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44252,16 +44444,14 @@
         "en": "indecent content",
         "ja": "セイテキナナイヨウ",
         "ja_typings": [
-          "seitekinanaiyou",
-          "seitekinanaiyo"
+          "seitekinanaiyou"
         ]
       },
       {
         "en": "educational topic",
         "ja": "キョウイクテーマ",
         "ja_typings": [
-          "kyouikute-ma",
-          "kyoikute-ma"
+          "kyouikute-ma"
         ]
       },
       {
@@ -44286,7 +44476,8 @@
     "question_text": {
       "en": "What does 'lewd' refer to?",
       "ja": "lewdの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44294,32 +44485,28 @@
         "en": "very funny",
         "ja": "オオワライ",
         "ja_typings": [
-          "oowarai",
-          "owarai"
+          "oowarai"
         ]
       },
       {
         "en": "very sad",
         "ja": "オオナキ",
         "ja_typings": [
-          "oonaki",
-          "onaki"
+          "oonaki"
         ]
       },
       {
         "en": "very angry",
         "ja": "オオイカリ",
         "ja_typings": [
-          "ooikari",
-          "oikari"
+          "ooikari"
         ]
       },
       {
         "en": "very scared",
         "ja": "オオオビエ",
         "ja_typings": [
-          "ooobie",
-          "oobie"
+          "ooobie"
         ]
       }
     ],
@@ -44330,7 +44517,8 @@
     "question_text": {
       "en": "What is the meaning of '草生える'?",
       "ja": "草生えるの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44338,32 +44526,28 @@
         "en": "clip video",
         "ja": "クリップドウガ",
         "ja_typings": [
-          "kurippudouga",
-          "kurippudoga"
+          "kurippudouga"
         ]
       },
       {
         "en": "trim video",
         "ja": "トリムドウガ",
         "ja_typings": [
-          "torimudouga",
-          "torimudoga"
+          "torimudouga"
         ]
       },
       {
         "en": "snippet video",
         "ja": "スニペットドウガ",
         "ja_typings": [
-          "sunipettodouga",
-          "sunipettodoga"
+          "sunipettodouga"
         ]
       },
       {
         "en": "flash video",
         "ja": "フラッシュドウガ",
         "ja_typings": [
-          "furasshudouga",
-          "furasshudoga"
+          "furasshudouga"
         ]
       }
     ],
@@ -44374,7 +44558,8 @@
     "question_text": {
       "en": "What is the term for a clipped highlight?",
       "ja": "切り抜き動画の英語呼称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44414,7 +44599,8 @@
     "question_text": {
       "en": "What does CPU stand for?",
       "ja": "CPUは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44454,7 +44640,8 @@
     "question_text": {
       "en": "What does RAM stand for?",
       "ja": "RAMは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44494,7 +44681,8 @@
     "question_text": {
       "en": "What port does SSH typically use?",
       "ja": "SSHが通常使うポート番号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44534,7 +44722,8 @@
     "question_text": {
       "en": "What does SSD stand for?",
       "ja": "SSDは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44574,7 +44763,8 @@
     "question_text": {
       "en": "What does API stand for?",
       "ja": "APIは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44582,7 +44772,6 @@
         "en": "443",
         "ja": "ヨンヨンサン",
         "ja_typings": [
-          "yonyonsan",
           "yonnyonsan"
         ]
       },
@@ -44615,7 +44804,8 @@
     "question_text": {
       "en": "What is the default port for HTTPS?",
       "ja": "HTTPSのデフォルトポート番号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44655,7 +44845,8 @@
     "question_text": {
       "en": "What does USB stand for?",
       "ja": "USBは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44695,7 +44886,8 @@
     "question_text": {
       "en": "What is IPv4 address length in bits?",
       "ja": "IPv4アドレスのビット長は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44735,7 +44927,8 @@
     "question_text": {
       "en": "What does AWS stand for?",
       "ja": "AWSは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44775,7 +44968,8 @@
     "question_text": {
       "en": "What does GPU stand for?",
       "ja": "GPUは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44815,7 +45009,8 @@
     "question_text": {
       "en": "What is the base of hexadecimal?",
       "ja": "16進数の基数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44855,7 +45050,8 @@
     "question_text": {
       "en": "What does HTML stand for?",
       "ja": "HTMLは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44895,7 +45091,8 @@
     "question_text": {
       "en": "What is the size of a standard MAC address in bits?",
       "ja": "MACアドレスのビット長は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44935,7 +45132,8 @@
     "question_text": {
       "en": "What is the default port for FTP?",
       "ja": "FTPのデフォルトポート番号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44975,7 +45173,8 @@
     "question_text": {
       "en": "What does VPN stand for?",
       "ja": "VPNは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45015,7 +45214,8 @@
     "question_text": {
       "en": "What does CSS stand for?",
       "ja": "CSSは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45055,7 +45255,8 @@
     "question_text": {
       "en": "What protocol is used to send email?",
       "ja": "電子メール送信に使うプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45063,7 +45264,6 @@
         "en": "1024 bytes",
         "ja": "センニジュウヨンバイト",
         "ja_typings": [
-          "sennijuuyonbaito",
           "sennnijuuyonbaito"
         ]
       },
@@ -45085,7 +45285,6 @@
         "en": "2048 bytes",
         "ja": "ニセンヨンジュウハチバイト",
         "ja_typings": [
-          "nisenyonjuuhachibaito",
           "nisennyonjuuhachibaito"
         ]
       }
@@ -45097,7 +45296,8 @@
     "question_text": {
       "en": "What is a kilobyte equal to?",
       "ja": "1キロバイトは何バイト?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45137,7 +45337,8 @@
     "question_text": {
       "en": "What does SQL stand for?",
       "ja": "SQLは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45177,7 +45378,8 @@
     "question_text": {
       "en": "What is the default port for SMTP?",
       "ja": "SMTPのデフォルトポート番号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45217,7 +45419,8 @@
     "question_text": {
       "en": "What does the acronym RGB represent?",
       "ja": "RGBは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45257,7 +45460,8 @@
     "question_text": {
       "en": "What is the smallest unit of digital information?",
       "ja": "デジタル情報の最小単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45297,7 +45501,8 @@
     "question_text": {
       "en": "What is the binary value of decimal 10?",
       "ja": "10進数10の2進数表現は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45337,7 +45542,8 @@
     "question_text": {
       "en": "What does RAID stand for in storage?",
       "ja": "ストレージのRAIDは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45417,7 +45623,8 @@
     "question_text": {
       "en": "Which anime is set in a virtual MMORPG where players are trapped?",
       "ja": "仮想MMORPGに閉じ込められるアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45457,7 +45664,8 @@
     "question_text": {
       "en": "Which anime features a boy aiming to be Hokage?",
       "ja": "火影を目指す少年のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45545,7 +45753,6 @@
         "en": "Soul Eater",
         "ja": "ソウルイーター",
         "ja_typings": [
-          "sorui-ta-",
           "sourui-ta-"
         ]
       },
@@ -45680,7 +45887,6 @@
         "en": "Ace of Diamond",
         "ja": "ダイヤのA",
         "ja_typings": [
-          "daiyanoeesu",
           "daiyanoa"
         ]
       },
@@ -45739,7 +45945,8 @@
     "question_text": {
       "en": "Which anime is set in the fictional city of Ikebukuro with gang wars?",
       "ja": "池袋を舞台にした抗争アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45779,7 +45986,8 @@
     "question_text": {
       "en": "Which anime features the school idol group μ's?",
       "ja": "μ'sが登場するアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45940,7 +46148,8 @@
     "question_text": {
       "en": "Which anime features Spike Spiegel as a bounty hunter?",
       "ja": "スパイク・スピーゲルが賞金稼ぎとして登場するアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46100,7 +46309,8 @@
     "question_text": {
       "en": "Which anime is about a high school light music club?",
       "ja": "高校の軽音部が舞台のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46180,7 +46390,8 @@
     "question_text": {
       "en": "Which anime features a girl named Asuna in a virtual world?",
       "ja": "アスナという少女が仮想世界で活躍するアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46500,7 +46711,8 @@
     "question_text": {
       "en": "Which anime features a time-traveling microwave?",
       "ja": "電子レンジで時間移動するアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46540,7 +46752,8 @@
     "question_text": {
       "en": "Which anime studio produced 'Demon Slayer'?",
       "ja": "『鬼滅の刃』を制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46595,7 +46808,6 @@
         "en": "Ace of Diamond",
         "ja": "ダイヤのA",
         "ja_typings": [
-          "daiyanoeesu",
           "daiyanoa"
         ]
       },
@@ -47221,7 +47433,8 @@
     "question_text": {
       "en": "Which manga is about a boy who can stretch his body?",
       "ja": "体を伸ばせる少年の漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47261,7 +47474,8 @@
     "question_text": {
       "en": "Which manga features a serial killer note?",
       "ja": "殺人ノートが登場する漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47621,7 +47835,8 @@
     "question_text": {
       "en": "Which manga features the Yagami family?",
       "ja": "夜神家が登場する漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47661,7 +47876,8 @@
     "question_text": {
       "en": "Which manga is about a boy who becomes a pirate king?",
       "ja": "海賊王を目指す少年の漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47701,7 +47917,8 @@
     "question_text": {
       "en": "Which manga magazine publishes 'Berserk'?",
       "ja": "『ベルセルク』を連載している雑誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47901,7 +48118,8 @@
     "question_text": {
       "en": "Which manga is about wizards at Fairy Tail guild?",
       "ja": "妖精の尻尾ギルドの魔法使いの漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47981,7 +48199,8 @@
     "question_text": {
       "en": "Which company developed 'Monster Hunter'?",
       "ja": "『モンスターハンター』を開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48003,7 +48222,6 @@
         "en": "Soul Reaver",
         "ja": "ソウルリーバー",
         "ja_typings": [
-          "soruri-ba-",
           "soururi-ba-"
         ]
       },
@@ -48062,7 +48280,8 @@
     "question_text": {
       "en": "Which company developed 'Persona 5'?",
       "ja": "『ペルソナ5』を開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48102,7 +48321,8 @@
     "question_text": {
       "en": "Which game features Cloud Strife as the protagonist?",
       "ja": "クラウド・ストライフが主人公のゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48142,7 +48362,8 @@
     "question_text": {
       "en": "Which company developed 'Dark Souls'?",
       "ja": "『ダークソウル』を開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48157,7 +48378,6 @@
         "en": "Dark Souls",
         "ja": "ダークソウル",
         "ja_typings": [
-          "da-kusoru",
           "da-kusouru"
         ]
       },
@@ -48303,7 +48523,8 @@
     "question_text": {
       "en": "Which stealth game series features Sam Fisher?",
       "ja": "サム・フィッシャーが主人公のステルスゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48343,7 +48564,8 @@
     "question_text": {
       "en": "Which game features the protagonist Aloy in a post-apocalyptic world?",
       "ja": "アーロイが主人公のポストアポカリプスゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48383,7 +48605,8 @@
     "question_text": {
       "en": "Which company developed 'Yakuza' (Ryu ga Gotoku) series?",
       "ja": "『龍が如く』を開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48543,7 +48766,8 @@
     "question_text": {
       "en": "Which game features a plumber's brother named Luigi?",
       "ja": "ルイージが登場するゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48583,7 +48807,8 @@
     "question_text": {
       "en": "Which company developed 'Street Fighter'?",
       "ja": "『ストリートファイター』を開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48638,7 +48863,6 @@
         "en": "Soulcalibur",
         "ja": "ソウルキャリバー",
         "ja_typings": [
-          "sorukyariba-",
           "sourukyariba-"
         ]
       },
@@ -48704,7 +48928,8 @@
     "question_text": {
       "en": "Which game features building with blocks named NOT Minecraft?",
       "ja": "ブロックを積むゲームでマインクラフトではないのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48744,7 +48969,8 @@
     "question_text": {
       "en": "Which game features the protagonist Kratos?",
       "ja": "クレイトスが主人公のゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48784,7 +49010,8 @@
     "question_text": {
       "en": "Which company developed 'Phantasy Star Online'?",
       "ja": "『ファンタシースターオンライン』を開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48824,7 +49051,8 @@
     "question_text": {
       "en": "Which game features Geralt of Rivia?",
       "ja": "リヴィアのゲラルトが主人公のゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48904,7 +49132,8 @@
     "question_text": {
       "en": "Which game features Sonic the hedgehog?",
       "ja": "ソニックが登場するゲームシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48944,7 +49173,8 @@
     "question_text": {
       "en": "Which company developed 'Kingdom Hearts'?",
       "ja": "『キングダムハーツ』を開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48984,7 +49214,8 @@
     "question_text": {
       "en": "Which game features Sora wielding a Keyblade?",
       "ja": "ソラがキーブレードを使うゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49064,7 +49295,8 @@
     "question_text": {
       "en": "Which game features pilots and Titans in combat?",
       "ja": "パイロットとタイタンが戦うゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49144,7 +49376,8 @@
     "question_text": {
       "en": "Which game features a girl named 2B fighting machines?",
       "ja": "2Bが機械生命体と戦うゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49184,7 +49417,8 @@
     "question_text": {
       "en": "What is the Python module for ordered dictionaries (insertion-ordered) added in 3.7 as guaranteed?",
       "ja": "Python 3.7 で挿入順序が保証された辞書の特殊型を提供するモジュールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49224,7 +49458,8 @@
     "question_text": {
       "en": "Which Python decorator caches return values based on arguments?",
       "ja": "Python で引数に基づいて戻り値をキャッシュするデコレーターは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49264,7 +49499,8 @@
     "question_text": {
       "en": "What Python statement creates a context manager inline?",
       "ja": "Python でコンテキストマネージャをインラインで作成する文は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49304,7 +49540,8 @@
     "question_text": {
       "en": "Which Python builtin returns an iterator of tuples pairing index and value?",
       "ja": "インデックスと値をペアにしたタプルのイテレータを返す Python 組み込み関数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49344,7 +49581,8 @@
     "question_text": {
       "en": "Which Python keyword defines a coroutine function?",
       "ja": "Python でコルーチン関数を定義するキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49384,7 +49622,8 @@
     "question_text": {
       "en": "What is Python's walrus operator?",
       "ja": "Python のセイウチ演算子はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49424,7 +49663,8 @@
     "question_text": {
       "en": "Which Python module provides abstract base classes for containers?",
       "ja": "コンテナの抽象基底クラスを提供する Python モジュールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49464,7 +49704,8 @@
     "question_text": {
       "en": "What does Python's GIL stand for?",
       "ja": "Python の GIL の正式名称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49504,7 +49745,8 @@
     "question_text": {
       "en": "Which Rust attribute marks a function for compile-time evaluation?",
       "ja": "Rust でコンパイル時評価のために関数をマークする属性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49544,7 +49786,8 @@
     "question_text": {
       "en": "What Rust smart pointer enables interior mutability with runtime borrow checking?",
       "ja": "実行時借用チェックで内部可変性を可能にする Rust のスマートポインタは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49584,7 +49827,8 @@
     "question_text": {
       "en": "Which Rust macro derives Debug formatting?",
       "ja": "Rust で Debug フォーマットを派生させるマクロは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49664,7 +49908,8 @@
     "question_text": {
       "en": "Which Rust keyword introduces a trait bound on a generic?",
       "ja": "Rust でジェネリクスにトレイト境界を導入するキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49704,7 +49949,8 @@
     "question_text": {
       "en": "What Rust feature allows pattern matching on enum variants?",
       "ja": "Rust で enum バリアントへのパターンマッチを可能にする機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49744,7 +49990,8 @@
     "question_text": {
       "en": "Which JavaScript method creates a shallow copy of an array?",
       "ja": "配列の浅いコピーを作成する JavaScript のメソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49784,7 +50031,8 @@
     "question_text": {
       "en": "What JavaScript operator performs nullish coalescing?",
       "ja": "JavaScript で null 合体演算を行う演算子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49806,7 +50054,6 @@
         "en": "Readonly",
         "ja": "リードオンリー",
         "ja_typings": [
-          "ri-donri-",
           "ri-doonri-"
         ]
       },
@@ -49825,7 +50072,8 @@
     "question_text": {
       "en": "Which TypeScript utility type makes all properties optional?",
       "ja": "全プロパティを省略可能にする TypeScript ユーティリティ型は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49847,7 +50095,6 @@
         "en": "unknown",
         "ja": "アンノウン",
         "ja_typings": [
-          "annnon",
           "annnoun"
         ]
       },
@@ -49866,7 +50113,8 @@
     "question_text": {
       "en": "What TypeScript feature represents a value that never occurs?",
       "ja": "決して発生しない値を表す TypeScript の機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49906,7 +50154,8 @@
     "question_text": {
       "en": "Which JavaScript API provides a way to run code in a separate thread?",
       "ja": "別スレッドでコードを実行する方法を提供する JavaScript の API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49946,7 +50195,8 @@
     "question_text": {
       "en": "What does JavaScript's Symbol.iterator define?",
       "ja": "JavaScript の Symbol.iterator が定義するものは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49986,7 +50236,8 @@
     "question_text": {
       "en": "Which JavaScript expression freezes an object?",
       "ja": "オブジェクトを凍結する JavaScript の式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50026,7 +50277,8 @@
     "question_text": {
       "en": "What Go keyword starts a lightweight thread?",
       "ja": "軽量スレッドを開始する Go のキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50066,7 +50318,8 @@
     "question_text": {
       "en": "Which Go construct enables typed channel communication selection?",
       "ja": "型付きチャネル通信の選択を可能にする Go の構文は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50106,7 +50359,8 @@
     "question_text": {
       "en": "What Go feature is used for deferred function execution at scope end?",
       "ja": "スコープ末尾での関数実行を遅延する Go の機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50146,7 +50400,8 @@
     "question_text": {
       "en": "Which Go package provides synchronization primitives?",
       "ja": "同期プリミティブを提供する Go のパッケージは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50186,7 +50441,8 @@
     "question_text": {
       "en": "Which C++ smart pointer represents exclusive ownership?",
       "ja": "排他的所有権を表す C++ のスマートポインタは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50226,7 +50482,8 @@
     "question_text": {
       "en": "What C++ keyword prevents implicit conversions for constructors?",
       "ja": "コンストラクタの暗黙変換を防ぐ C++ のキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50266,7 +50523,8 @@
     "question_text": {
       "en": "Which C++ feature enables compile-time computation?",
       "ja": "コンパイル時計算を可能にする C++ の機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50306,7 +50564,8 @@
     "question_text": {
       "en": "What C++ standard introduced concepts?",
       "ja": "concepts を導入した C++ 標準は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50346,7 +50605,8 @@
     "question_text": {
       "en": "Which C++ cast performs runtime type checking?",
       "ja": "実行時型チェックを行う C++ のキャストは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50386,7 +50646,8 @@
     "question_text": {
       "en": "Which Kotlin keyword declares a singleton object?",
       "ja": "Kotlin でシングルトンオブジェクトを宣言するキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50426,7 +50687,8 @@
     "question_text": {
       "en": "What Kotlin function-like type allows null-safe call chaining?",
       "ja": "null 安全なチェーンを可能にする Kotlin の演算子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50466,7 +50728,8 @@
     "question_text": {
       "en": "Which Swift keyword declares an immutable binding?",
       "ja": "Swift で不変束縛を宣言するキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50506,7 +50769,8 @@
     "question_text": {
       "en": "What Swift feature handles optional values with default fallback?",
       "ja": "省略可能値をデフォルトでフォールバックする Swift の機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50554,7 +50818,6 @@
         "en": "O(n^2)",
         "ja": "オーエヌジジョウ",
         "ja_typings": [
-          "o-enujijo",
           "o-enujijou"
         ]
       },
@@ -50587,7 +50850,8 @@
     "question_text": {
       "en": "What is the worst-case time complexity of quicksort?",
       "ja": "クイックソートの最悪計算量は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50627,7 +50891,8 @@
     "question_text": {
       "en": "Which tree is self-balancing with red and black node coloring?",
       "ja": "赤黒ノード彩色で自己平衡する木は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50667,7 +50932,8 @@
     "question_text": {
       "en": "What algorithm finds shortest paths from all pairs in a graph?",
       "ja": "グラフの全頂点間最短路を求めるアルゴリズムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50827,7 +51093,8 @@
     "question_text": {
       "en": "What is the name of the algorithm matching strings with KMP failure function?",
       "ja": "KMP の失敗関数で文字列照合するアルゴリズムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50867,7 +51134,8 @@
     "question_text": {
       "en": "Which GC algorithm uses two semispaces and copies live objects?",
       "ja": "2 つの半空間を使い生存オブジェクトをコピーする GC は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50947,7 +51215,8 @@
     "question_text": {
       "en": "Which low-level technique uses pointer tagging to encode types?",
       "ja": "ポインタタグ付けで型をエンコードする低レベル技法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50987,7 +51256,8 @@
     "question_text": {
       "en": "What concurrency primitive allows multiple readers or one writer?",
       "ja": "複数読者または単一書き手を許す並行プリミティブは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51027,7 +51297,8 @@
     "question_text": {
       "en": "Which pattern uses message passing between actors?",
       "ja": "アクター間でメッセージパッシングを行うパターンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51067,7 +51338,8 @@
     "question_text": {
       "en": "What is the term for a deadlock-like state where threads keep yielding?",
       "ja": "スレッドが譲り合い続けるデッドロック類似状態は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51107,7 +51379,8 @@
     "question_text": {
       "en": "Which Java construct provides lock-free atomic operations?",
       "ja": "ロックフリーなアトミック操作を提供する Java 構文は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51147,7 +51420,8 @@
     "question_text": {
       "en": "What is the term for ensuring memory ordering across threads?",
       "ja": "スレッド間のメモリ順序を保証する用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51227,7 +51501,8 @@
     "question_text": {
       "en": "What is a monad's binding operation commonly named?",
       "ja": "モナドの束縛操作の一般的な名前は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51267,7 +51542,8 @@
     "question_text": {
       "en": "Which higher-order function reduces a list to a single value?",
       "ja": "リストを単一値に畳み込む高階関数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51307,7 +51583,8 @@
     "question_text": {
       "en": "What is the term for treating functions as first-class values?",
       "ja": "関数をファーストクラス値として扱う用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51336,7 +51613,6 @@
         "en": "Row polymorphism",
         "ja": "ロウポリモーフィズム",
         "ja_typings": [
-          "roporimo-fizumu",
           "rouporimo-fizumu"
         ]
       }
@@ -51348,7 +51624,8 @@
     "question_text": {
       "en": "Which type system feature describes Haskell's typeclasses?",
       "ja": "Haskell の型クラスを表現する型システム機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51388,7 +51665,8 @@
     "question_text": {
       "en": "What is tail call optimization commonly abbreviated as?",
       "ja": "末尾呼び出し最適化の略称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51428,7 +51706,8 @@
     "question_text": {
       "en": "Which compilation step converts source to an intermediate representation?",
       "ja": "ソースを中間表現に変換するコンパイル工程は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51508,7 +51787,8 @@
     "question_text": {
       "en": "Which feature allows mixing code at runtime with reflection-style APIs?",
       "ja": "リフレクション風 API で実行時にコードを差し込む機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51548,7 +51828,8 @@
     "question_text": {
       "en": "What term describes calling C functions from another language?",
       "ja": "他言語から C 関数を呼び出すことを指す用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51628,7 +51909,8 @@
     "question_text": {
       "en": "What is the convention for naming constants in many languages?",
       "ja": "多くの言語で定数を命名する慣習は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51668,7 +51950,8 @@
     "question_text": {
       "en": "Which is a structural typing system feature?",
       "ja": "構造的型付けシステムの特徴は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51748,7 +52031,8 @@
     "question_text": {
       "en": "Which dispatch mechanism resolves method calls at runtime via vtables?",
       "ja": "vtable で実行時にメソッド呼び出しを解決する機構は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51788,7 +52072,8 @@
     "question_text": {
       "en": "Which CSS function clamps a value between min and max?",
       "ja": "値を最小値と最大値で挟む CSS 関数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51828,7 +52113,8 @@
     "question_text": {
       "en": "What CSS property enables logical inline-start margin?",
       "ja": "論理的なインライン開始マージンを設定する CSS プロパティは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51868,7 +52154,8 @@
     "question_text": {
       "en": "Which CSS unit is relative to the smaller of viewport width/height?",
       "ja": "ビューポートの幅と高さの小さい方に対する CSS 単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51908,7 +52195,8 @@
     "question_text": {
       "en": "What CSS at-rule defines a font from a remote source?",
       "ja": "リモートソースからフォントを定義する CSS の at-rule は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51948,7 +52236,8 @@
     "question_text": {
       "en": "Which CSS property creates a stacking context without z-index?",
       "ja": "z-index なしでスタッキングコンテキストを作る CSS プロパティは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51988,7 +52277,8 @@
     "question_text": {
       "en": "What CSS feature allows scoping styles with @scope?",
       "ja": "@scope でスタイルをスコープ化する CSS 機能の名称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52028,7 +52318,8 @@
     "question_text": {
       "en": "Which CSS pseudo-class matches an element that has focus within its tree?",
       "ja": "要素ツリー内にフォーカスがある要素にマッチする CSS 疑似クラスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52068,7 +52359,8 @@
     "question_text": {
       "en": "What CSS property defines named grid areas?",
       "ja": "名前付きグリッドエリアを定義する CSS プロパティは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52108,7 +52400,8 @@
     "question_text": {
       "en": "Which HTML element represents a disclosure widget?",
       "ja": "開閉式ウィジェットを表す HTML 要素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52148,7 +52441,8 @@
     "question_text": {
       "en": "What HTML attribute enables drag-and-drop on any element?",
       "ja": "任意の要素でドラッグアンドドロップを有効にする HTML 属性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52188,7 +52482,8 @@
     "question_text": {
       "en": "Which HTML input type provides a color picker?",
       "ja": "カラーピッカーを提供する HTML input type は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52228,7 +52523,8 @@
     "question_text": {
       "en": "What HTML element groups labeled form controls?",
       "ja": "ラベル付きフォーム部品をグループ化する HTML 要素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52268,7 +52564,8 @@
     "question_text": {
       "en": "Which HTML5 API allows offline storage of structured data?",
       "ja": "構造化データのオフライン保存を可能にする HTML5 API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52308,7 +52605,8 @@
     "question_text": {
       "en": "Which HTTP status indicates a request conflict?",
       "ja": "リクエストの競合を示す HTTP ステータスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52323,7 +52621,7 @@
         "en": "Forbidden",
         "ja": "フォービドゥン",
         "ja_typings": [
-          "fo-bidun"
+          "fo-bidwun"
         ]
       },
       {
@@ -52348,7 +52646,8 @@
     "question_text": {
       "en": "What HTTP status means the resource is permanently gone?",
       "ja": "リソースが恒久的に消えたことを示す HTTP ステータスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52363,7 +52662,6 @@
         "en": "Access-Control-Allow-Origin",
         "ja": "アクセスコントロールアロウオリジン",
         "ja_typings": [
-          "akusesukontoro-ruaroorijin",
           "akusesukontoro-ruarouorijin"
         ]
       },
@@ -52389,7 +52687,8 @@
     "question_text": {
       "en": "Which HTTP header controls how long a preflight response is cached?",
       "ja": "プリフライト応答のキャッシュ期間を制御する HTTP ヘッダーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52429,7 +52728,8 @@
     "question_text": {
       "en": "What HTTP header indicates the original request scheme behind a proxy?",
       "ja": "プロキシ越しに元のリクエストスキームを示す HTTP ヘッダーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52469,7 +52769,8 @@
     "question_text": {
       "en": "Which HTTP response header tells browsers to enforce HTTPS?",
       "ja": "ブラウザに HTTPS を強制させる HTTP 応答ヘッダーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52509,7 +52810,8 @@
     "question_text": {
       "en": "What HTTP method is used to retrieve metadata only?",
       "ja": "メタデータのみを取得する HTTP メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52549,7 +52851,8 @@
     "question_text": {
       "en": "Which Web API observes element resize events?",
       "ja": "要素のリサイズイベントを監視する Web API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52571,7 +52874,6 @@
         "en": "Viewport Observer",
         "ja": "ビューポートオブザーバー",
         "ja_typings": [
-          "byu-po-tobuza-ba-",
           "byu-po-toobuza-ba-"
         ]
       },
@@ -52590,7 +52892,8 @@
     "question_text": {
       "en": "What Web API detects when an element enters the viewport?",
       "ja": "要素がビューポートに入ったことを検出する Web API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52630,7 +52933,8 @@
     "question_text": {
       "en": "Which Web API enables push notifications?",
       "ja": "プッシュ通知を可能にする Web API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52670,7 +52974,8 @@
     "question_text": {
       "en": "What Web API persists data using a key-value pair with promises?",
       "ja": "Promise でキーバリュー保存する Web API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52710,7 +53015,8 @@
     "question_text": {
       "en": "Which API lets pages register handlers for share targets?",
       "ja": "共有先ハンドラを登録できる API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52750,7 +53056,8 @@
     "question_text": {
       "en": "What API exposes high-resolution monotonic timestamps?",
       "ja": "高解像度の単調タイムスタンプを提供する API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52790,7 +53097,8 @@
     "question_text": {
       "en": "Which API allows speech-to-text in the browser?",
       "ja": "ブラウザで音声を文字起こしする API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52830,7 +53138,8 @@
     "question_text": {
       "en": "Which React hook subscribes to an external store with concurrent safety?",
       "ja": "並行性安全に外部ストア購読する React フックは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52870,7 +53179,8 @@
     "question_text": {
       "en": "What Vue 3 macro defines props in script setup?",
       "ja": "script setup で props を定義する Vue 3 マクロは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52899,7 +53209,6 @@
         "en": "event:on",
         "ja": "イベントオン",
         "ja_typings": [
-          "ibenton",
           "ibentoon"
         ]
       }
@@ -52911,7 +53220,8 @@
     "question_text": {
       "en": "Which Svelte directive listens to DOM events?",
       "ja": "DOM イベントを購読する Svelte ディレクティブは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52951,7 +53261,8 @@
     "question_text": {
       "en": "What is the term for rendering on the server at request time?",
       "ja": "リクエスト時にサーバーでレンダリングすることを指す用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52991,7 +53302,8 @@
     "question_text": {
       "en": "Which Next.js feature regenerates static pages on demand?",
       "ja": "オンデマンドで静的ページを再生成する Next.js の機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53031,7 +53343,8 @@
     "question_text": {
       "en": "What Astro feature ships zero JS to the client by default?",
       "ja": "デフォルトでクライアントに JS を送らない Astro の機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53071,7 +53384,8 @@
     "question_text": {
       "en": "Which browser process step computes element geometry?",
       "ja": "要素の幾何を計算するブラウザ処理工程は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53111,7 +53425,8 @@
     "question_text": {
       "en": "What is the term for the browser combining painted layers?",
       "ja": "ペイントしたレイヤーをブラウザが合成することを指す用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53151,7 +53466,8 @@
     "question_text": {
       "en": "Which event fires after DOM is parsed but before all assets load?",
       "ja": "DOM 解析後・全アセット読み込み前に発火するイベントは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53191,7 +53507,8 @@
     "question_text": {
       "en": "What browser feature isolates iframes in separate processes?",
       "ja": "iframe を別プロセスに隔離するブラウザ機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53231,7 +53548,8 @@
     "question_text": {
       "en": "Which API enables sharing memory between threads with locks?",
       "ja": "ロック付きでスレッド間メモリ共有を可能にする API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53271,7 +53589,8 @@
     "question_text": {
       "en": "Which attack tricks users into clicking hidden UI elements?",
       "ja": "隠された UI 要素をクリックさせる攻撃は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53340,7 +53659,6 @@
         "en": "X-Download-Options",
         "ja": "エックスダウンロードオプションズ",
         "ja_typings": [
-          "ekkusudaunro-dopushonzu",
           "ekkusudaunro-doopushonzu"
         ]
       }
@@ -53352,7 +53670,8 @@
     "question_text": {
       "en": "Which header prevents MIME-type sniffing?",
       "ja": "MIME タイプ推測を防ぐヘッダーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53392,7 +53711,8 @@
     "question_text": {
       "en": "What attack exploits trust in cached DNS responses?",
       "ja": "キャッシュ済み DNS 応答の信頼を悪用する攻撃は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53414,7 +53734,6 @@
         "en": "X-Embed-Options",
         "ja": "エックスエンベッドオプションズ",
         "ja_typings": [
-          "ekkusuenbeddopushonzu",
           "ekkusuenbeddoopushonzu"
         ]
       },
@@ -53433,7 +53752,8 @@
     "question_text": {
       "en": "Which feature lets servers opt out of being framed?",
       "ja": "サーバーがフレーム化拒否を表明する機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53473,7 +53793,8 @@
     "question_text": {
       "en": "What is the term for embedding tokens to verify form origin?",
       "ja": "フォーム送信元検証のためにトークンを埋め込むことを指す用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53513,7 +53834,8 @@
     "question_text": {
       "en": "Which ARIA attribute announces dynamic content politely?",
       "ja": "動的コンテンツを丁寧に通知する ARIA 属性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53553,7 +53875,8 @@
     "question_text": {
       "en": "What ARIA role marks the main content area?",
       "ja": "メインコンテンツ領域を示す ARIA ロールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53561,7 +53884,7 @@
         "en": "aria-hidden",
         "ja": "アリアヒドゥン",
         "ja_typings": [
-          "ariahidun"
+          "ariahidwun"
         ]
       },
       {
@@ -53593,7 +53916,8 @@
     "question_text": {
       "en": "Which attribute hides decorative elements from assistive tech?",
       "ja": "支援技術から装飾要素を隠す属性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53633,7 +53957,8 @@
     "question_text": {
       "en": "What WCAG contrast ratio is required for normal text AA?",
       "ja": "通常テキスト AA に必要な WCAG コントラスト比は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53673,7 +53998,8 @@
     "question_text": {
       "en": "Which Core Web Vital measures input responsiveness?",
       "ja": "入力応答性を測る Core Web Vital は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53713,7 +54039,8 @@
     "question_text": {
       "en": "What Core Web Vital tracks layout stability?",
       "ja": "レイアウト安定性を追跡する Core Web Vital は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53753,7 +54080,8 @@
     "question_text": {
       "en": "Which technique loads JS chunks only when needed?",
       "ja": "必要時のみ JS チャンクを読み込む技法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53793,7 +54121,8 @@
     "question_text": {
       "en": "What HTML attribute hints the browser to preload a resource?",
       "ja": "ブラウザにリソースの事前読み込みを指示する HTML 属性値は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53833,7 +54162,8 @@
     "question_text": {
       "en": "Which image format uses AV1 video codec for compression?",
       "ja": "AV1 動画コーデックを使う画像形式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53873,7 +54203,8 @@
     "question_text": {
       "en": "What technique sends critical CSS in the HTML to reduce render-blocking?",
       "ja": "レンダーブロッキング軽減のため HTML に CSS を埋め込む技法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53902,7 +54233,6 @@
         "en": "WebTransport over TCP",
         "ja": "ウェブトランスポートオーバーティーシーピー",
         "ja_typings": [
-          "webutoransupo-to-ba-thi-shi-pi-",
           "webutoransupo-too-ba-thi-shi-pi-"
         ]
       }
@@ -53914,7 +54244,8 @@
     "question_text": {
       "en": "Which protocol multiplexes streams over QUIC?",
       "ja": "QUIC 上でストリームを多重化するプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53954,7 +54285,8 @@
     "question_text": {
       "en": "What standard defines URL parsing across browsers?",
       "ja": "ブラウザ間で URL 解析を定義する標準は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53994,7 +54326,8 @@
     "question_text": {
       "en": "Which DOM method creates a document fragment?",
       "ja": "ドキュメントフラグメントを作成する DOM メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54034,7 +54367,8 @@
     "question_text": {
       "en": "What feature lets web apps install like native apps?",
       "ja": "Web アプリをネイティブのようにインストール可能にする機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54074,7 +54408,8 @@
     "question_text": {
       "en": "Which encoding represents binary data as ASCII text in URLs?",
       "ja": "URL でバイナリデータを ASCII テキストとして表現するエンコードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54114,7 +54449,8 @@
     "question_text": {
       "en": "What CSS property controls how an element is contained for performance?",
       "ja": "パフォーマンスのために要素の含意を制御する CSS プロパティは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54154,7 +54490,8 @@
     "question_text": {
       "en": "Which DOM event fires when a CSS transition completes?",
       "ja": "CSS トランジション完了時に発火する DOM イベントは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54529,7 +54866,6 @@
         "en": "Gunbuster",
         "ja": "トップをねらえ!",
         "ja_typings": [
-          "toppuwonerae",
           "toppuonerae"
         ]
       },
@@ -54563,7 +54899,6 @@
         "en": "Gunbuster",
         "ja": "トップをねらえ!",
         "ja_typings": [
-          "toppuwonerae",
           "toppuonerae"
         ]
       },
@@ -54916,7 +55251,8 @@
     "question_text": {
       "en": "Which 2021 Madhouse anime features high schoolers stranded on a deserted island?",
       "ja": "無人島に漂流する高校生が主人公の2021年マッドハウス制作アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54956,7 +55292,8 @@
     "question_text": {
       "en": "Which 2023 anime is about a girl band formed at SHIMOKITAZAWA?",
       "ja": "下北沢で結成された女子バンドを描く2023年のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55076,7 +55413,8 @@
     "question_text": {
       "en": "Which 2019 anime adapts Makoto Yukimura's Viking epic?",
       "ja": "幸村誠のヴァイキング叙事詩を原作とする2019年のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55356,7 +55694,8 @@
     "question_text": {
       "en": "Which studio produced Made in Abyss?",
       "ja": "メイドインアビスを制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55396,7 +55735,8 @@
     "question_text": {
       "en": "Which studio is famous for Mob Psycho 100 and One-Punch Man season 1?",
       "ja": "モブサイコ100とワンパンマン1期で有名なスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55516,7 +55856,8 @@
     "question_text": {
       "en": "Which studio is famous for Kill la Kill and SSSS.GRIDMAN?",
       "ja": "キルラキル・SSSS.GRIDMANで有名なスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55756,7 +56097,8 @@
     "question_text": {
       "en": "Which 2004 anime by Shinichiro Watanabe is set in Edo-period Japan with hip-hop?",
       "ja": "江戸時代にヒップホップを融合した2004年渡辺信一郎作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55796,7 +56138,8 @@
     "question_text": {
       "en": "Which 1998 anime features bounty hunter Spike Spiegel?",
       "ja": "賞金稼ぎのスパイク・スピーゲルが主人公の1998年アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55836,7 +56179,8 @@
     "question_text": {
       "en": "Which 1998 anime features Vash the Stampede on a desert planet?",
       "ja": "砂漠の惑星でヴァッシュ・ザ・スタンピードが活躍する1998年アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57636,7 +57980,8 @@
     "question_text": {
       "en": "Which company developed the 'Yakuza' (Like a Dragon) series?",
       "ja": "『龍が如く』シリーズを開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57676,7 +58021,8 @@
     "question_text": {
       "en": "Which company developed Dark Souls and Bloodborne?",
       "ja": "ダークソウルとブラッドボーンを開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57716,7 +58062,8 @@
     "question_text": {
       "en": "Which company developed the 'Dragon Quest' series?",
       "ja": "『ドラゴンクエスト』シリーズを開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57756,7 +58103,8 @@
     "question_text": {
       "en": "Which company developed Dynasty Warriors?",
       "ja": "真・三國無双を開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57796,7 +58144,8 @@
     "question_text": {
       "en": "Which company developed Tales of series?",
       "ja": "テイルズオブシリーズを開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57836,7 +58185,8 @@
     "question_text": {
       "en": "Which company developed Phantasy Star Online?",
       "ja": "ファンタシースターオンラインを開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57876,7 +58226,8 @@
     "question_text": {
       "en": "Which studio created Nier Automata?",
       "ja": "ニーアオートマタを開発したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57916,7 +58267,8 @@
     "question_text": {
       "en": "Which studio developed Bayonetta?",
       "ja": "ベヨネッタを開発したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57956,7 +58308,8 @@
     "question_text": {
       "en": "Which company developed Persona Q and Etrian Odyssey?",
       "ja": "ペルソナQと世界樹の迷宮を開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58116,7 +58469,8 @@
     "question_text": {
       "en": "Which 1986 Sega arcade game features pilot Harrier?",
       "ja": "1986年のセガアーケード作品でハリアーが主人公の作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58156,7 +58510,8 @@
     "question_text": {
       "en": "Which 1986 Sega arcade game is a coastal driving game?",
       "ja": "1986年のセガアーケードの海岸線ドライブゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58196,7 +58551,8 @@
     "question_text": {
       "en": "Which 1985 Sega arcade game features motorcycle racing?",
       "ja": "1985年のセガのバイクレースアーケードゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58385,7 +58741,6 @@
         "en": "Soul Blazer",
         "ja": "ソウルブレイダー",
         "ja_typings": [
-          "sorubureida-",
           "sourubureida-"
         ]
       }
@@ -58412,7 +58767,6 @@
         "en": "Soul Blazer",
         "ja": "ソウルブレイダー",
         "ja_typings": [
-          "sorubureida-",
           "sourubureida-"
         ]
       },
@@ -58518,7 +58872,8 @@
     "question_text": {
       "en": "Which 1994 Capcom 2D fighter starts the Darkstalkers series?",
       "ja": "1994年カプコンの2D格闘ゲームでヴァンパイアシリーズ第1作は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58718,7 +59073,8 @@
     "question_text": {
       "en": "Which platform was released by SEGA in 1998 as a successor to the Saturn?",
       "ja": "1998年セガがサターンの後継機として発売したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58758,7 +59114,8 @@
     "question_text": {
       "en": "Which platform was released by SNK in 1990?",
       "ja": "1990年にSNKが発売した家庭用ゲーム機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58798,7 +59155,8 @@
     "question_text": {
       "en": "Which platform was released by NEC in 1987?",
       "ja": "1987年にNECが発売した家庭用ゲーム機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58838,7 +59196,8 @@
     "question_text": {
       "en": "Which handheld was released by Bandai in 1999?",
       "ja": "1999年にバンダイが発売した携帯ゲーム機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58878,7 +59237,8 @@
     "question_text": {
       "en": "Which handheld was released by SNK in 1998?",
       "ja": "1998年にSNKが発売した携帯ゲーム機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58918,7 +59278,8 @@
     "question_text": {
       "en": "Which 2017 indie game features Madeline climbing a mountain?",
       "ja": "マデリーンが山を登る2017年のインディーゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58958,7 +59319,8 @@
     "question_text": {
       "en": "Which 2020 Supergiant indie game features Zagreus escaping the Underworld?",
       "ja": "ザグレウスが冥界脱出を目指す2020年のスーパージャイアント作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58998,7 +59360,8 @@
     "question_text": {
       "en": "Which 2017 run-and-gun indie features 1930s cartoon aesthetics?",
       "ja": "1930年代カートゥーン風の2017年ラン&ガンインディーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59038,7 +59401,8 @@
     "question_text": {
       "en": "Which 2014 indie crowdfunded retro platformer features a digging knight?",
       "ja": "2014年クラウドファンディング発のレトロ調アクションで掘る騎士が主人公の作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59078,7 +59442,8 @@
     "question_text": {
       "en": "Which 1998 SquareSoft RPG features Serge and Kid?",
       "ja": "セルジュとキッドが登場する1998年スクウェアのRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59118,7 +59483,8 @@
     "question_text": {
       "en": "Which 1998 Square RPG by Tetsuya Takahashi features Fei Fong Wong?",
       "ja": "1998年スクウェアの高橋哲哉作でフェイ・フォン・ウォンが主人公のRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59158,7 +59524,8 @@
     "question_text": {
       "en": "Which 2000 Square PS1 game by Yasumi Matsuno features Ashley Riot?",
       "ja": "2000年スクウェアの松野泰己作品でアシュレイ・ライオットが主人公のPS1作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59198,7 +59565,8 @@
     "question_text": {
       "en": "Which country has Athens as its capital?",
       "ja": "アテネを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59238,7 +59606,8 @@
     "question_text": {
       "en": "Which country has Budapest as its capital?",
       "ja": "ブダペストを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59278,7 +59647,8 @@
     "question_text": {
       "en": "Which country has Bern as its capital?",
       "ja": "ベルンを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59318,7 +59688,8 @@
     "question_text": {
       "en": "Which country has Dublin as its capital?",
       "ja": "ダブリンを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59438,7 +59809,8 @@
     "question_text": {
       "en": "Which country has Manila as its capital?",
       "ja": "マニラを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59478,7 +59850,8 @@
     "question_text": {
       "en": "Which country has Tehran as its capital?",
       "ja": "テヘランを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59558,7 +59931,8 @@
     "question_text": {
       "en": "Which country has Addis Ababa as its capital?",
       "ja": "アディスアベバを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59598,7 +59972,8 @@
     "question_text": {
       "en": "Which country has Santiago as its capital?",
       "ja": "サンティアゴを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59638,7 +60013,8 @@
     "question_text": {
       "en": "Which country has Bogota as its capital?",
       "ja": "ボゴタを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60240,7 +60616,8 @@
     "question_text": {
       "en": "Which is the largest country by area in Africa?",
       "ja": "アフリカで面積最大の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60440,7 +60817,8 @@
     "question_text": {
       "en": "Who was the first President of the French Republic?",
       "ja": "フランス第二共和政の初代大統領は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60520,7 +60898,8 @@
     "question_text": {
       "en": "Who led the Soviet Union during World War II?",
       "ja": "第二次大戦中のソ連指導者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60560,7 +60939,8 @@
     "question_text": {
       "en": "Who was the British Prime Minister during most of WWII?",
       "ja": "第二次大戦中の英首相は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60600,7 +60980,8 @@
     "question_text": {
       "en": "Who was the US President during WWII?",
       "ja": "第二次大戦中の米大統領は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60640,7 +61021,8 @@
     "question_text": {
       "en": "Who was the first Chancellor of Nazi Germany?",
       "ja": "ナチス・ドイツの最初の首相は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60680,7 +61062,8 @@
     "question_text": {
       "en": "Who led India's independence movement?",
       "ja": "インド独立運動を率いたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60720,7 +61103,8 @@
     "question_text": {
       "en": "Who became the first Prime Minister of independent India?",
       "ja": "インド独立後の初代首相は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60760,7 +61144,8 @@
     "question_text": {
       "en": "Who was the first President of South Africa after apartheid?",
       "ja": "南アフリカでアパルトヘイト後初の大統領は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60782,7 +61167,7 @@
         "en": "Boris Godunov",
         "ja": "ゴドゥノフ",
         "ja_typings": [
-          "godunofu"
+          "godwunofu"
         ]
       },
       {
@@ -60920,7 +61305,8 @@
     "question_text": {
       "en": "Who led the Cuban Revolution?",
       "ja": "キューバ革命を率いたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60928,7 +61314,7 @@
         "en": "Augustus",
         "ja": "アウグストゥス",
         "ja_typings": [
-          "augusutusu"
+          "augusutwusu"
         ]
       },
       {
@@ -60960,7 +61346,8 @@
     "question_text": {
       "en": "Who was the first Emperor of Rome?",
       "ja": "ローマ初代皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61000,7 +61387,8 @@
     "question_text": {
       "en": "Who was the Carthaginian general who crossed the Alps?",
       "ja": "アルプスを越えたカルタゴの将軍は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61562,7 +61950,8 @@
     "question_text": {
       "en": "Who invented the printing press in Europe?",
       "ja": "ヨーロッパで活版印刷を発明したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61602,7 +61991,8 @@
     "question_text": {
       "en": "Who invented the telephone?",
       "ja": "電話を発明したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61642,7 +62032,8 @@
     "question_text": {
       "en": "Who invented the light bulb commercially?",
       "ja": "白熱電球を商用化したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61682,7 +62073,8 @@
     "question_text": {
       "en": "Who invented dynamite?",
       "ja": "ダイナマイトを発明したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61722,7 +62114,8 @@
     "question_text": {
       "en": "Which religious reformer launched the Protestant Reformation in 1517?",
       "ja": "1517年に宗教改革を始めたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61824,7 +62217,7 @@
         "en": "Batu Khan",
         "ja": "バトゥ",
         "ja_typings": [
-          "batu"
+          "batwu"
         ]
       },
       {
@@ -61842,7 +62235,8 @@
     "question_text": {
       "en": "Which Mongol leader conquered Baghdad in 1258?",
       "ja": "1258年にバグダードを陥落させたモンゴル指導者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62002,7 +62396,8 @@
     "question_text": {
       "en": "What is the chemical symbol for tungsten?",
       "ja": "タングステンの元素記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62122,7 +62517,8 @@
     "question_text": {
       "en": "What is the lightest metal?",
       "ja": "最も軽い金属は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62322,7 +62718,8 @@
     "question_text": {
       "en": "Which is the largest moon in the solar system?",
       "ja": "太陽系最大の衛星は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62337,7 +62734,7 @@
         "en": "Enceladus",
         "ja": "エンケラドゥス",
         "ja_typings": [
-          "enkeradusu"
+          "enkeradwusu"
         ]
       },
       {
@@ -62362,7 +62759,8 @@
     "question_text": {
       "en": "Which moon of Saturn has a thick atmosphere?",
       "ja": "厚い大気を持つ土星の衛星は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62402,7 +62800,8 @@
     "question_text": {
       "en": "Who proposed the heliocentric model of the solar system?",
       "ja": "地動説を唱えたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62442,7 +62841,8 @@
     "question_text": {
       "en": "Who formulated the three laws of planetary motion?",
       "ja": "惑星運動の三法則を導いたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62482,7 +62882,8 @@
     "question_text": {
       "en": "Who proposed that current flows in a magnetic field induces force?",
       "ja": "電流に磁場が力を及ぼすことを示したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62522,7 +62923,8 @@
     "question_text": {
       "en": "Who discovered electromagnetic induction?",
       "ja": "電磁誘導を発見したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62562,7 +62964,8 @@
     "question_text": {
       "en": "Who unified electricity and magnetism into a single theory?",
       "ja": "電気と磁気を統一理論にまとめたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62602,7 +63005,8 @@
     "question_text": {
       "en": "Who discovered the structure of DNA along with Watson?",
       "ja": "ワトソンとともにDNA構造を解明したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62642,7 +63046,8 @@
     "question_text": {
       "en": "Who is considered the father of modern chemistry?",
       "ja": "近代化学の父と呼ばれるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62682,7 +63087,8 @@
     "question_text": {
       "en": "Who created the periodic table of elements?",
       "ja": "元素周期表を作ったのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62722,7 +63128,8 @@
     "question_text": {
       "en": "Who developed the atomic theory of matter?",
       "ja": "原子論を提唱したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62762,7 +63169,8 @@
     "question_text": {
       "en": "Who discovered the electron?",
       "ja": "電子を発見したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62802,7 +63210,8 @@
     "question_text": {
       "en": "Who discovered the atomic nucleus?",
       "ja": "原子核を発見したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62842,7 +63251,8 @@
     "question_text": {
       "en": "Who discovered the neutron?",
       "ja": "中性子を発見したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62882,7 +63292,8 @@
     "question_text": {
       "en": "What is the SI unit of electric current?",
       "ja": "電流のSI単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62922,7 +63333,8 @@
     "question_text": {
       "en": "What is the SI unit of frequency?",
       "ja": "周波数のSI単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62962,7 +63374,8 @@
     "question_text": {
       "en": "What is the SI unit of pressure?",
       "ja": "圧力のSI単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63002,7 +63415,8 @@
     "question_text": {
       "en": "What is the SI unit of energy?",
       "ja": "エネルギーのSI単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63042,7 +63456,8 @@
     "question_text": {
       "en": "What is the SI unit of force?",
       "ja": "力のSI単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63242,7 +63657,8 @@
     "question_text": {
       "en": "What is the smallest non-abelian group?",
       "ja": "最小の非可換群はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63604,7 +64020,8 @@
     "question_text": {
       "en": "What is the cardinality of the continuum?",
       "ja": "連続体の濃度の記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64404,7 +64821,8 @@
     "question_text": {
       "en": "Which paradox involves a set of all sets?",
       "ja": "全集合の集合に関するパラドックスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64524,7 +64942,8 @@
     "question_text": {
       "en": "What unit measures luminous intensity?",
       "ja": "光度の単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64644,7 +65063,8 @@
     "question_text": {
       "en": "What is the SI unit of magnetic flux?",
       "ja": "磁束のSI単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64804,7 +65224,8 @@
     "question_text": {
       "en": "What unit measures sound intensity level?",
       "ja": "音の強さレベルの単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64964,7 +65385,8 @@
     "question_text": {
       "en": "Which heraldic charge represents a lion standing?",
       "ja": "立ち上がるライオンを表す紋章用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65004,7 +65426,8 @@
     "question_text": {
       "en": "What unit measures radiation exposure?",
       "ja": "放射線被曝量の単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65106,7 +65529,7 @@
         "en": "Arcturus",
         "ja": "アルクトゥルス",
         "ja_typings": [
-          "arukuturusu"
+          "arukutwurusu"
         ]
       },
       {
@@ -65124,7 +65547,8 @@
     "question_text": {
       "en": "Which star is the brightest in the night sky?",
       "ja": "夜空で最も明るい恒星は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65204,7 +65628,8 @@
     "question_text": {
       "en": "Which unit measures atmospheric pressure?",
       "ja": "気圧の単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65364,7 +65789,8 @@
     "question_text": {
       "en": "What unit measures the speed of computer operations?",
       "ja": "コンピュータ演算速度の単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65524,7 +65950,8 @@
     "question_text": {
       "en": "Which mineral has hardness 10 on the Mohs scale?",
       "ja": "モース硬度10の鉱物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65644,7 +66071,8 @@
     "question_text": {
       "en": "Which VTuber agency is operated by Anycolor?",
       "ja": "Anycolor運営のVTuber事務所は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65764,7 +66192,8 @@
     "question_text": {
       "en": "Which term means 'lurker' in Twitch chat?",
       "ja": "Twitchチャットで『見るだけの人』を意味するのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65844,7 +66273,8 @@
     "question_text": {
       "en": "Which Discord bot is famous for music streaming (before shutdown)?",
       "ja": "音楽配信で有名だったDiscordボット(閉鎖済)は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65964,7 +66394,8 @@
     "question_text": {
       "en": "Which slang phrase originated from 2channel for 'has been a while'?",
       "ja": "2ちゃん発祥の『久しぶり』系スラングは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66124,7 +66555,8 @@
     "question_text": {
       "en": "Which term refers to a Twitch streamer's loyal viewers?",
       "ja": "Twitch配信者の常連視聴者を指す語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66204,7 +66636,8 @@
     "question_text": {
       "en": "Which slang means 'crying with laughter' as kaomoji-like?",
       "ja": "笑い泣きを表す日本のネット表現は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66332,7 +66765,6 @@
         "en": "5channel",
         "ja": "5ちゃんねる",
         "ja_typings": [
-          "gochanneru",
           "5channneru"
         ]
       },
@@ -66685,7 +67117,8 @@
     "question_text": {
       "en": "Which Discord feature allows server moderation?",
       "ja": "Discordでサーバー管理に使う機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66765,7 +67198,8 @@
     "question_text": {
       "en": "Which Hololive branch is JP-based original first gen?",
       "ja": "ホロライブJP初代1期生に属するのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66805,7 +67239,8 @@
     "question_text": {
       "en": "Which protocol is the successor of HTTP/2 over QUIC?",
       "ja": "QUICベースのHTTP後継プロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66845,7 +67280,8 @@
     "question_text": {
       "en": "Which routing protocol uses link-state?",
       "ja": "リンクステート方式のルーティングプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66885,7 +67321,8 @@
     "question_text": {
       "en": "Which storage interface is replacing SATA SSDs?",
       "ja": "SATA SSDを置き換えつつある規格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66925,7 +67362,8 @@
     "question_text": {
       "en": "Which port standard supports Thunderbolt 4?",
       "ja": "Thunderbolt 4が使う物理コネクタは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66965,7 +67403,8 @@
     "question_text": {
       "en": "Which display interface supports 8K at 60Hz?",
       "ja": "8K60Hz対応のディスプレイ規格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67005,7 +67444,8 @@
     "question_text": {
       "en": "Which protocol resolves MAC from IP?",
       "ja": "IPからMACを解決するプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67045,7 +67485,8 @@
     "question_text": {
       "en": "Which protocol carries ping packets?",
       "ja": "pingが使うプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67085,7 +67526,8 @@
     "question_text": {
       "en": "Which CPU architecture is open source?",
       "ja": "オープンソースなCPUアーキテクチャは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67125,7 +67567,8 @@
     "question_text": {
       "en": "Which GPU API is from Khronos for low-overhead access?",
       "ja": "Khronos策定の低オーバーヘッドGPU APIは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67205,7 +67648,8 @@
     "question_text": {
       "en": "Which Bluetooth profile is used for hands-free calls?",
       "ja": "ハンズフリー通話のBluetoothプロファイルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67245,7 +67689,8 @@
     "question_text": {
       "en": "Which encryption algorithm replaced DES?",
       "ja": "DESを置き換えた暗号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67285,7 +67730,8 @@
     "question_text": {
       "en": "Which key exchange uses elliptic curves?",
       "ja": "楕円曲線を使う鍵交換は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67325,7 +67771,8 @@
     "question_text": {
       "en": "Which protocol enables peer-to-peer browser communication?",
       "ja": "ブラウザ間P2P通信を可能にするのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67365,7 +67812,8 @@
     "question_text": {
       "en": "Which input device uses pressure-sensitive stylus?",
       "ja": "筆圧感知ペンを使う入力機器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67405,7 +67853,8 @@
     "question_text": {
       "en": "Which file system is default on modern macOS?",
       "ja": "現代のmacOSの標準ファイルシステムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67445,7 +67894,8 @@
     "question_text": {
       "en": "Which RAID level provides striping with parity?",
       "ja": "ストライピング+パリティのRAIDレベルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67485,7 +67935,8 @@
     "question_text": {
       "en": "Which BGP attribute determines best path?",
       "ja": "BGP最適経路を決める属性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67525,7 +67976,8 @@
     "question_text": {
       "en": "Which display tech uses self-emitting pixels?",
       "ja": "自発光画素を使うディスプレイは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67565,7 +68017,8 @@
     "question_text": {
       "en": "Which BIOS replacement uses GPT partitions?",
       "ja": "GPTパーティションを使うBIOS後継は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67605,7 +68058,8 @@
     "question_text": {
       "en": "Which protocol is used for time synchronization?",
       "ja": "時刻同期に使うプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67645,7 +68099,8 @@
     "question_text": {
       "en": "Which network device operates at OSI layer 3?",
       "ja": "OSI第3層で動作する機器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67725,7 +68180,8 @@
     "question_text": {
       "en": "Which CPU instruction set is used in Apple Silicon?",
       "ja": "Apple Siliconが採用する命令セットは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67765,7 +68221,8 @@
     "question_text": {
       "en": "Which hash function is part of SHA-3?",
       "ja": "SHA-3の基礎関数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67845,7 +68302,8 @@
     "question_text": {
       "en": "Which container format is OCI standard?",
       "ja": "OCI標準のコンテナ形式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67885,7 +68343,8 @@
     "question_text": {
       "en": "Which GPU vendor created CUDA?",
       "ja": "CUDAを開発したGPUベンダは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67925,7 +68384,8 @@
     "question_text": {
       "en": "Which key concept allows VLANs over WAN?",
       "ja": "WAN越しにVLANを実現する技術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67965,7 +68425,8 @@
     "question_text": {
       "en": "Which CPU feature accelerates virtualization?",
       "ja": "仮想化を加速するCPU機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68005,7 +68466,8 @@
     "question_text": {
       "en": "Which GitOps tool is part of CNCF?",
       "ja": "CNCFのGitOpsツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68045,7 +68507,8 @@
     "question_text": {
       "en": "Which service mesh is created by Buoyant?",
       "ja": "Buoyant社のサービスメッシュは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68085,7 +68548,8 @@
     "question_text": {
       "en": "Which standard unifies observability data?",
       "ja": "可観測性データを統一する標準は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68125,7 +68589,8 @@
     "question_text": {
       "en": "Which Linux feature allows safe kernel programmability?",
       "ja": "Linuxカーネルを安全に拡張する機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68205,7 +68670,8 @@
     "question_text": {
       "en": "Which agile framework uses sprints?",
       "ja": "スプリントを使うアジャイル手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68325,7 +68791,8 @@
     "question_text": {
       "en": "Which serverless runtime is by AWS?",
       "ja": "AWSのサーバーレス基盤は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68405,7 +68872,8 @@
     "question_text": {
       "en": "Which methodology emphasizes blameless postmortems?",
       "ja": "ブレームレスを重視する手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68445,7 +68913,8 @@
     "question_text": {
       "en": "Which CI/CD service is built into GitHub?",
       "ja": "GitHub内蔵のCI/CDは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68525,7 +68994,8 @@
     "question_text": {
       "en": "Which container orchestrator was open-sourced by Google?",
       "ja": "Google発のコンテナオーケストレータは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68565,7 +69035,8 @@
     "question_text": {
       "en": "Which DevOps pattern reduces deployment risk by gradual rollout?",
       "ja": "段階的展開でリスク低減するパターンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68605,7 +69076,8 @@
     "question_text": {
       "en": "Which IaC tool uses HCL?",
       "ja": "HCLを使うIaCツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68725,7 +69197,8 @@
     "question_text": {
       "en": "Which retrospective format uses ports?",
       "ja": "ポート(港)を使うレトロスペクティブは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68885,7 +69358,8 @@
     "question_text": {
       "en": "Which platform offers managed K8s by Google?",
       "ja": "Google提供のマネージドK8sは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68954,7 +69428,6 @@
         "en": "shadow deployment",
         "ja": "シャドウデプロイ",
         "ja_typings": [
-          "shadodepuroi",
           "shadoudepuroi"
         ]
       }
@@ -69006,7 +69479,8 @@
     "question_text": {
       "en": "Which architecture decomposes apps into small services?",
       "ja": "アプリを小サービスに分解する設計は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69126,7 +69600,8 @@
     "question_text": {
       "en": "Which manifest tool packages K8s apps?",
       "ja": "K8sアプリをパッケージ化するツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70286,7 +70761,8 @@
     "question_text": {
       "en": "Which speech sound is a fricative?",
       "ja": "摩擦音はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70326,7 +70802,8 @@
     "question_text": {
       "en": "Which constructed language is most spoken?",
       "ja": "最も話される人工言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70406,7 +70883,8 @@
     "question_text": {
       "en": "Which traditional Spanish dish is from Valencia, rice based with rabbit?",
       "ja": "ウサギ肉入りバレンシア発祥の伝統米料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70421,7 +70899,7 @@
         "en": "Vale Tudo",
         "ja": "バーリトゥード",
         "ja_typings": [
-          "ba-ritu-do"
+          "ba-ritwu-do"
         ]
       },
       {
@@ -70526,7 +71004,8 @@
     "question_text": {
       "en": "Which Indian instrument has sympathetic strings?",
       "ja": "共鳴弦を持つインドの弦楽器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70566,7 +71045,8 @@
     "question_text": {
       "en": "Which Norse mythology figure is the trickster god?",
       "ja": "北欧神話のいたずら神は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70606,7 +71086,8 @@
     "question_text": {
       "en": "Which Mongolian traditional dwelling is round and portable?",
       "ja": "丸く可搬なモンゴル伝統住居は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70646,7 +71127,8 @@
     "question_text": {
       "en": "Which Spanish flamenco rhythm is sad and slow?",
       "ja": "悲しくゆっくりなフラメンコのリズムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70661,7 +71143,7 @@
         "en": "dunun",
         "ja": "ドゥヌン",
         "ja_typings": [
-          "dunun"
+          "dwunun"
         ]
       },
       {
@@ -70686,7 +71168,8 @@
     "question_text": {
       "en": "Which Senegalese drum is goblet-shaped?",
       "ja": "ゴブレット型のセネガル太鼓は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70806,7 +71289,8 @@
     "question_text": {
       "en": "Which Indonesian shadow puppet theater is UNESCO listed?",
       "ja": "ユネスコ登録のインドネシア影絵芝居は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70886,7 +71370,8 @@
     "question_text": {
       "en": "Which Greek instrument is a bouzouki ancestor?",
       "ja": "ブズーキの祖先となるギリシャ楽器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70926,7 +71411,8 @@
     "question_text": {
       "en": "Which Andean instrument is a panpipe?",
       "ja": "アンデスのパンパイプは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70966,7 +71452,8 @@
     "question_text": {
       "en": "Which Ethiopian bread is spongy and sour?",
       "ja": "スポンジ状で酸味のあるエチオピアのパンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71006,7 +71493,8 @@
     "question_text": {
       "en": "Which Egyptian mythological creature has lion body and human head?",
       "ja": "ライオン体に人頭のエジプト神話の生物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71061,7 +71549,7 @@
         "en": "Vodun",
         "ja": "ヴォドゥン",
         "ja_typings": [
-          "vodun"
+          "vodwun"
         ]
       },
       {
@@ -71126,7 +71614,8 @@
     "question_text": {
       "en": "Which Italian dance is fast paced from Naples?",
       "ja": "ナポリ発祥の速いイタリア舞踊は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71134,7 +71623,7 @@
         "en": "dungchen",
         "ja": "ドゥンチェン",
         "ja_typings": [
-          "dunchen"
+          "dwunchen"
         ]
       },
       {
@@ -71166,7 +71655,8 @@
     "question_text": {
       "en": "Which Tibetan instrument is a long horn?",
       "ja": "チベットの長い角笛は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71206,7 +71696,8 @@
     "question_text": {
       "en": "Which Polish dance is in triple meter and elegant?",
       "ja": "三拍子で優雅なポーランド舞踊は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71246,7 +71737,8 @@
     "question_text": {
       "en": "Which Persian poetic form has couplets?",
       "ja": "対句で構成されるペルシア詩形は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71286,7 +71778,8 @@
     "question_text": {
       "en": "Which Indian sweet is made from milk solids?",
       "ja": "ミルク固形分から作るインドの菓子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71308,7 +71801,6 @@
         "en": "bodhran",
         "ja": "ボウラン",
         "ja_typings": [
-          "boran",
           "bouran"
         ]
       },
@@ -71327,7 +71819,8 @@
     "question_text": {
       "en": "Which Scottish instrument has bag and drones?",
       "ja": "袋とドローンを持つスコットランド楽器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71407,7 +71900,8 @@
     "question_text": {
       "en": "Which Native American structure is a conical tent?",
       "ja": "円錐形のネイティブアメリカン住居は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71447,7 +71941,8 @@
     "question_text": {
       "en": "Which Hawaiian dance tells stories with hands?",
       "ja": "手で物語を表すハワイの舞踊は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71487,7 +71982,8 @@
     "question_text": {
       "en": "Which Belgian dish is mussels with fries?",
       "ja": "ムール貝とフライドポテトのベルギー料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71527,7 +72023,8 @@
     "question_text": {
       "en": "Which Aztec god is the feathered serpent?",
       "ja": "羽毛の蛇のアステカ神は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71567,7 +72064,8 @@
     "question_text": {
       "en": "Which Vietnamese soup is broth-based with herbs?",
       "ja": "ハーブを使うベトナム麺スープは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72327,7 +72825,8 @@
     "question_text": {
       "en": "Which studio produced Ghost in the Shell: Stand Alone Complex?",
       "ja": "『攻殻機動隊 STAND ALONE COMPLEX』を制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72367,7 +72866,8 @@
     "question_text": {
       "en": "Which studio produced Death Note and One-Punch Man (Season 1)?",
       "ja": "『デスノート』『ワンパンマン』(1期) を制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72407,7 +72907,8 @@
     "question_text": {
       "en": "Which studio produced Attack on Titan (Seasons 1-3)?",
       "ja": "『進撃の巨人』(1-3期) を制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72447,7 +72948,8 @@
     "question_text": {
       "en": "Which studio produced Sword Art Online and Fairy Tail?",
       "ja": "『ソードアート・オンライン』『フェアリーテイル』を制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72487,7 +72989,8 @@
     "question_text": {
       "en": "Which studio produced Naruto and Bleach?",
       "ja": "『NARUTO』『BLEACH』を制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72527,7 +73030,8 @@
     "question_text": {
       "en": "Which anime follows Aladdin and Alibaba exploring mysterious dungeons?",
       "ja": "アラジンとアリババがダンジョンに挑む冒険アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72727,7 +73231,8 @@
     "question_text": {
       "en": "Which anime, based on Mamare Touno's novels, traps players inside an MMORPG world?",
       "ja": "橙乃ままれ原作で MMO 世界に閉じ込められる作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72767,7 +73272,8 @@
     "question_text": {
       "en": "Which Shonen Jump anime follows Asta, a magicless boy in a magical kingdom?",
       "ja": "魔法が使えない少年アスタを描くジャンプアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72847,7 +73353,8 @@
     "question_text": {
       "en": "Which Katsura Hoshino anime follows exorcists fighting Akuma with Innocence?",
       "ja": "星野桂原作、イノセンスでアクマと戦うエクソシストたちの物語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73422,7 +73929,6 @@
         "en": "Chimera Shadow Garden",
         "ja": "キメラ・シャドウガーデン",
         "ja_typings": [
-          "kimera/shadoga-den",
           "kimera/shadouga-den"
         ]
       },
@@ -73448,7 +73954,8 @@
     "question_text": {
       "en": "What is the name of Saitama's S-Class hero disciple in One-Punch Man?",
       "ja": "『ワンパンマン』でサイタマの弟子となる S級ヒーローの名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73768,7 +74275,8 @@
     "question_text": {
       "en": "Which manga features Akira Yuki training under his master in Edo-era Japan?",
       "ja": "アスタが魔法の国で修行する少年漫画は? (誤) — 正: アラジンとアリババがダンジョンに挑む小学館連載作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73808,7 +74316,8 @@
     "question_text": {
       "en": "Which Yuki Tabata manga follows Asta in the Clover Kingdom?",
       "ja": "田畠裕基の漫画で、アスタがクローバー王国で活躍する作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73848,7 +74357,8 @@
     "question_text": {
       "en": "Which Tsugumi Ohba & Takeshi Obata manga follows two boys aiming to become manga artists?",
       "ja": "大場つぐみ・小畑健で、漫画家を目指す二人の少年の物語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73888,7 +74398,8 @@
     "question_text": {
       "en": "Which Ohba & Obata manga features a boy chosen by an angel competing to become god?",
       "ja": "大場つぐみ・小畑健で、天使に選ばれた少年が神を目指す作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75528,7 +76039,8 @@
     "question_text": {
       "en": "Which Japanese game company developed the Metal Gear and Castlevania series?",
       "ja": "『メタルギア』『悪魔城ドラキュラ』を開発した日本のゲーム会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75608,7 +76120,8 @@
     "question_text": {
       "en": "Which Japanese developer is known for Star Ocean and Valkyrie Profile?",
       "ja": "『スターオーシャン』『ヴァルキリープロファイル』で知られるデベロッパーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75728,7 +76241,8 @@
     "question_text": {
       "en": "Which Sega 3D fighting series began in 1993 starring Akira Yuki?",
       "ja": "1993年に始まったセガの3D格闘ゲームシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75750,7 +76264,6 @@
         "en": "Dark Souls",
         "ja": "ダークソウル",
         "ja_typings": [
-          "da-kusoru",
           "da-kusouru"
         ]
       },
@@ -75769,7 +76282,8 @@
     "question_text": {
       "en": "Which BioWare RPG series features Grey Wardens fighting darkspawn?",
       "ja": "BioWare 製、灰色の守人がダークスポーンと戦うRPGシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75798,7 +76312,6 @@
         "en": "Dark Souls",
         "ja": "ダークソウル",
         "ja_typings": [
-          "da-kusoru",
           "da-kusouru"
         ]
       }
@@ -75890,7 +76403,8 @@
     "question_text": {
       "en": "Which Sega 16-bit home console competed with the Super Famicom in the early 1990s?",
       "ja": "1990年代初頭にスーパーファミコンと競合したセガの16ビット家庭用機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75930,7 +76444,8 @@
     "question_text": {
       "en": "Which Sega handheld competed with the Game Boy?",
       "ja": "ゲームボーイと競合したセガの携帯ゲーム機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75959,7 +76474,6 @@
         "en": "Soul Blazer",
         "ja": "ソウルブレイダー",
         "ja_typings": [
-          "sorubureida-",
           "sourubureida-"
         ]
       }
@@ -76080,7 +76594,6 @@
         "en": "Dark Souls",
         "ja": "ダークソウル",
         "ja_typings": [
-          "da-kusoru",
           "da-kusouru"
         ]
       }
@@ -76132,7 +76645,8 @@
     "question_text": {
       "en": "Which Hi-Rez Studios free-to-play hero shooter features Champions?",
       "ja": "Hi-Rez Studios 製、チャンピオンが戦う基本無料ヒーローシューターは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76154,7 +76668,6 @@
         "en": "Dark Souls",
         "ja": "ダークソウル",
         "ja_typings": [
-          "da-kusoru",
           "da-kusouru"
         ]
       },
@@ -76173,7 +76686,8 @@
     "question_text": {
       "en": "Which BioWare sci-fi RPG series stars Commander Shepard?",
       "ja": "BioWare 製、シェパード司令官が主人公のSF RPGシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76181,7 +76695,6 @@
         "en": "Dark Souls",
         "ja": "ダークソウル",
         "ja_typings": [
-          "da-kusoru",
           "da-kusouru"
         ]
       },
@@ -76414,7 +76927,8 @@
     "question_text": {
       "en": "Which game genre is exemplified by StarCraft and Age of Empires?",
       "ja": "『スタークラフト』『エイジ・オブ・エンパイア』に代表されるジャンルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76454,7 +76968,8 @@
     "question_text": {
       "en": "Which 1988 Sega arcade racing game features tilting cockpit cabinets?",
       "ja": "1988年セガのアーケードレース、可動筐体が特徴の作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76542,7 +77057,6 @@
         "en": "Soul Blazer",
         "ja": "ソウルブレイダー",
         "ja_typings": [
-          "sorubureida-",
           "sourubureida-"
         ]
       },
@@ -76575,7 +77089,8 @@
     "question_text": {
       "en": "Which Enix Super Famicom action RPG by Quintet has you reviving the world?",
       "ja": "クインテット製スーファミの、世界を蘇らせるエニックスのアクションRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76615,7 +77130,8 @@
     "question_text": {
       "en": "Which SNK weapon-based fighting game series spun off from Samurai Shodown?",
       "ja": "『サムライスピリッツ』から派生した武器対戦格闘ゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76655,7 +77171,8 @@
     "question_text": {
       "en": "Which NEC handheld is a portable PC Engine with a color LCD?",
       "ja": "PCエンジン互換のNEC製カラー液晶携帯機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76695,7 +77212,8 @@
     "question_text": {
       "en": "Which Nintendo series stars bounty hunter Samus Aran?",
       "ja": "サムス・アランが活躍する任天堂のシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76895,7 +77413,8 @@
     "question_text": {
       "en": "Which 2001 PS2 JRPG features Tidus and the world of Spira?",
       "ja": "2001年のPS2 JRPGで、ティーダとスピラの世界を描く作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77055,7 +77574,8 @@
     "question_text": {
       "en": "Which user-generated online platform lets kids create and play 3D worlds?",
       "ja": "ユーザー作成の3D世界を遊ぶオンラインプラットフォームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77084,7 +77604,6 @@
         "en": "Saints Row",
         "ja": "セインツロウ",
         "ja_typings": [
-          "seintsuro",
           "seintsurou"
         ]
       }
@@ -77104,7 +77623,6 @@
         "en": "Saints Row",
         "ja": "セインツロウ",
         "ja_typings": [
-          "seintsuro",
           "seintsurou"
         ]
       },
@@ -77137,7 +77655,8 @@
     "question_text": {
       "en": "Which Volition open-world series follows the 3rd Street Saints gang?",
       "ja": "Volition 製、3rdストリートセインツのギャングを描くオープンワールドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77152,7 +77671,6 @@
         "en": "Saints Row",
         "ja": "セインツロウ",
         "ja_typings": [
-          "seintsuro",
           "seintsurou"
         ]
       },
@@ -77178,7 +77696,8 @@
     "question_text": {
       "en": "Which Ubisoft open-world hacker series began in 2014?",
       "ja": "2014年に始まったユービーアイのハッカー系オープンワールドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77200,7 +77719,6 @@
         "en": "Saints Row",
         "ja": "セインツロウ",
         "ja_typings": [
-          "seintsuro",
           "seintsurou"
         ]
       },
@@ -77219,7 +77737,8 @@
     "question_text": {
       "en": "Which 2K open-world series began with Tommy Angelo in 1930s Lost Heaven?",
       "ja": "1930年代ロスト・ヘブンのトミー・アンジェロが主人公の2Kオープンワールドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77259,7 +77778,8 @@
     "question_text": {
       "en": "Which 2017 Krafton battle royale popularized the genre on PC?",
       "ja": "2017年クラフトン製でバトロワを大流行させたPCゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77299,7 +77819,8 @@
     "question_text": {
       "en": "Which free-to-play battle royale is part of the Call of Duty franchise?",
       "ja": "CoD シリーズの基本無料バトロワは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77339,7 +77860,8 @@
     "question_text": {
       "en": "Which 1990 Nintendo 16-bit console succeeded the Famicom in Japan?",
       "ja": "ファミコンの後継として1990年に発売された任天堂の16ビット機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77379,7 +77901,8 @@
     "question_text": {
       "en": "Which 1989 Nintendo handheld popularized portable gaming with Tetris?",
       "ja": "1989年テトリスで携帯ゲームを普及させた任天堂の携帯機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77419,7 +77942,8 @@
     "question_text": {
       "en": "Which 1996 Nintendo 64-bit console launched with Super Mario 64?",
       "ja": "1996年スーパーマリオ64と共に発売された任天堂の64ビット機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77459,7 +77983,8 @@
     "question_text": {
       "en": "Which 1994 Sega 32-bit console competed with the PlayStation in Japan?",
       "ja": "1994年プレイステーションと競った32ビットのセガ家庭用機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77499,7 +78024,8 @@
     "question_text": {
       "en": "Which 2017 Nintendo hybrid console plays both docked and handheld?",
       "ja": "2017年発売、据置と携帯を両立する任天堂のハイブリッド機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77579,7 +78105,8 @@
     "question_text": {
       "en": "Which markup language uses customizable tags to describe structured data?",
       "ja": "ユーザー定義タグで構造化データを記述するマークアップ言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77661,7 +78188,8 @@
     "question_text": {
       "en": "Which spreadsheet term refers to a single unit at the intersection of a row and column?",
       "ja": "表計算で行と列の交点にある一つの枠を指す用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77741,7 +78269,8 @@
     "question_text": {
       "en": "In Perl, which keyword defines a subroutine?",
       "ja": "Perl でサブルーチンを定義するキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77781,7 +78310,8 @@
     "question_text": {
       "en": "Who co-created Unix and the B programming language at Bell Labs?",
       "ja": "ベル研で Unix と B 言語を共同開発した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77821,7 +78351,8 @@
     "question_text": {
       "en": "Which company created the Swift programming language?",
       "ja": "プログラミング言語 Swift を開発した企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77901,7 +78432,8 @@
     "question_text": {
       "en": "Which package manager is bundled with Node.js by default?",
       "ja": "Node.js に既定で同梱されるパッケージマネージャは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77941,7 +78473,8 @@
     "question_text": {
       "en": "Which Groovy-based build automation tool is standard for Android?",
       "ja": "Android 開発で標準的に使われる Groovy ベースのビルドツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77981,7 +78514,8 @@
     "question_text": {
       "en": "Which classic Unix build tool reads a Makefile?",
       "ja": "Makefile を読み込む古典的な Unix のビルドツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78021,7 +78555,8 @@
     "question_text": {
       "en": "Which dynamic JVM language is often used with Gradle scripts?",
       "ja": "Gradle スクリプトで使われる動的な JVM 言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78061,7 +78596,8 @@
     "question_text": {
       "en": "Which classic synchronization primitive uses a counter to control resource access?",
       "ja": "カウンタで資源アクセスを制御する古典的な同期プリミティブは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78101,7 +78637,8 @@
     "question_text": {
       "en": "Which JavaScript keyword declares a regular function?",
       "ja": "JavaScript で通常の関数を宣言するキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78141,7 +78678,8 @@
     "question_text": {
       "en": "Which company developed the original PC compatible architecture and OS/2?",
       "ja": "PC 互換機と OS/2 を生み出した企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78261,7 +78799,8 @@
     "question_text": {
       "en": "Which comparison sort builds a binary heap to extract elements in order?",
       "ja": "二分ヒープを構築して要素を順に取り出す比較ソートは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78341,7 +78880,8 @@
     "question_text": {
       "en": "Which lightweight data interchange format is based on JavaScript object syntax?",
       "ja": "JavaScript のオブジェクト構文に基づく軽量データ交換形式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78381,7 +78921,8 @@
     "question_text": {
       "en": "Which JavaScript bundler is known for ES module-first design?",
       "ja": "ES モジュール優先の設計で知られる JavaScript バンドラは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78421,7 +78962,8 @@
     "question_text": {
       "en": "Which zero-configuration JavaScript bundler is famous for being beginner-friendly?",
       "ja": "ゼロ設定で初心者にも優しいことで知られる JavaScript バンドラは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78461,7 +79003,8 @@
     "question_text": {
       "en": "Which HTTP method requests data without modifying the server state?",
       "ja": "サーバの状態を変えずにデータを取得する HTTP メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78501,7 +79044,8 @@
     "question_text": {
       "en": "Which language runs on the JVM and was originally developed by Sun?",
       "ja": "サンが開発し JVM 上で動作する言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78581,7 +79125,8 @@
     "question_text": {
       "en": "Which JavaScript runtime built on V8 enables server-side scripting?",
       "ja": "V8 上に作られたサーバサイド JavaScript ランタイムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78702,7 +79247,8 @@
     "question_text": {
       "en": "Which algorithm finds shortest paths and detects negative-weight cycles?",
       "ja": "負の重みの閉路も検出できる最短経路アルゴリズムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78822,7 +79368,8 @@
     "question_text": {
       "en": "Who proposed the famous shortest path algorithm in 1956?",
       "ja": "1956 年に有名な最短経路アルゴリズムを提案した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78862,7 +79409,8 @@
     "question_text": {
       "en": "Which JavaScript keyword marks a function that returns a Promise?",
       "ja": "Promise を返す関数を示す JavaScript のキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78982,7 +79530,8 @@
     "question_text": {
       "en": "In C, which storage class limits a variable's visibility to its file?",
       "ja": "C 言語で変数の可視性をファイル内に限定する記憶クラスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79264,7 +79813,8 @@
     "question_text": {
       "en": "Which structural design pattern bridges incompatible interfaces?",
       "ja": "互換性のないインタフェースを橋渡しする構造的デザインパターンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79304,7 +79854,8 @@
     "question_text": {
       "en": "Which behavioral pattern lets algorithms vary independently from clients?",
       "ja": "アルゴリズムをクライアントから独立に切り替えられる振る舞い系パターンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79344,7 +79895,8 @@
     "question_text": {
       "en": "Which structural pattern wraps an object to add behavior dynamically?",
       "ja": "オブジェクトを包んで動的に振る舞いを追加する構造パターンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79384,7 +79936,8 @@
     "question_text": {
       "en": "Which structural pattern provides a surrogate to control access to an object?",
       "ja": "オブジェクトへのアクセスを制御する代理を提供する構造パターンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79424,7 +79977,8 @@
     "question_text": {
       "en": "Which pattern lets clients treat individual objects and compositions uniformly?",
       "ja": "個々の要素と複合要素を一様に扱える構造パターンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79464,7 +80018,8 @@
     "question_text": {
       "en": "Which behavioral pattern adds operations without changing element classes?",
       "ja": "要素クラスを変えずに操作を追加できる振る舞いパターンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79544,7 +80099,8 @@
     "question_text": {
       "en": "Which HTTP header controls how much referrer information is sent with requests?",
       "ja": "リクエストに含めるリファラ情報の量を制御する HTTP ヘッダは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79584,7 +80140,8 @@
     "question_text": {
       "en": "Which Web Vitals metric measures the delay until the first user interaction is processed?",
       "ja": "最初のユーザー操作が処理されるまでの遅延を計る Web Vitals 指標は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79624,7 +80181,8 @@
     "question_text": {
       "en": "Which Web API observes performance-related events such as paint and longtask?",
       "ja": "ペイントやロングタスク等のパフォーマンス事象を観測する Web API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79646,7 +80204,7 @@
         "en": "Forbidden",
         "ja": "フォービドゥン",
         "ja_typings": [
-          "fo-bidun"
+          "fo-bidwun"
         ]
       },
       {
@@ -79664,7 +80222,8 @@
     "question_text": {
       "en": "Which HTTP status indicates the server cannot process due to client-side error?",
       "ja": "クライアント側の誤りで処理できないことを示す HTTP ステータスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79704,7 +80263,8 @@
     "question_text": {
       "en": "Which HTTP method submits data to be processed to a specified resource?",
       "ja": "指定リソースに処理用データを送信する HTTP メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79744,7 +80304,8 @@
     "question_text": {
       "en": "Which CSS framework is built with Sass and based on Flexbox?",
       "ja": "Sass で作られ Flexbox を基礎にした CSS フレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79784,7 +80345,8 @@
     "question_text": {
       "en": "Which responsive front-end framework was originally created by ZURB?",
       "ja": "ZURB が生み出したレスポンシブなフロントエンドフレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79824,7 +80386,8 @@
     "question_text": {
       "en": "Which RxJS primitive represents a push-based stream of values over time?",
       "ja": "時間経過に伴う値のプッシュ型ストリームを表す RxJS のプリミティブは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79864,7 +80427,8 @@
     "question_text": {
       "en": "Which Unix-style command in shells locates files by name?",
       "ja": "シェルで名前からファイルを探す Unix 系コマンドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79904,7 +80468,8 @@
     "question_text": {
       "en": "Which Vue-based meta-framework supports SSR and static generation?",
       "ja": "SSR と静的生成に対応する Vue ベースのメタフレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79944,7 +80509,8 @@
     "question_text": {
       "en": "Which React-based static site generator pulls data via GraphQL?",
       "ja": "GraphQL でデータを取り込む React ベースの静的サイトジェネレータは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79984,7 +80550,8 @@
     "question_text": {
       "en": "Which GraphQL operation type pushes server updates to clients over time?",
       "ja": "サーバの更新を時系列でクライアントに送る GraphQL の操作型は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80024,7 +80591,8 @@
     "question_text": {
       "en": "Which XML-based open standard exchanges authentication and authorization data?",
       "ja": "認証認可情報を交換する XML ベースのオープン標準は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80064,7 +80632,8 @@
     "question_text": {
       "en": "Which Next.js rendering mode regenerates static pages on demand after deploy?",
       "ja": "デプロイ後にオンデマンドで静的ページを再生成する Next.js のレンダリング方式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80104,7 +80673,8 @@
     "question_text": {
       "en": "Which Web Vitals metric measures when the first content is painted on screen?",
       "ja": "画面に最初のコンテンツが描画されたタイミングを示す Web Vitals 指標は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80144,7 +80714,8 @@
     "question_text": {
       "en": "Which web technology pushes events from server to browser over a single HTTP connection?",
       "ja": "単一の HTTP 接続でサーバからブラウザへイベントを送る技術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80184,7 +80755,8 @@
     "question_text": {
       "en": "Which browser storage persists key-value pairs without expiration on the same origin?",
       "ja": "同一オリジン上でキー値ペアを期限なく保持するブラウザストレージは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80304,7 +80876,8 @@
     "question_text": {
       "en": "Which HTTP header controls access to browser features like camera and geolocation?",
       "ja": "カメラや位置情報など端末機能へのアクセスを制御する HTTP ヘッダは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80344,7 +80917,8 @@
     "question_text": {
       "en": "Which consortium maintains HTML, CSS, and other web standards led by Tim Berners-Lee?",
       "ja": "ティム・バーナーズ＝リーが率いる HTML や CSS の標準化団体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80384,7 +80958,8 @@
     "question_text": {
       "en": "Which organization standardizes Internet protocols such as HTTP and TLS?",
       "ja": "HTTP や TLS などインターネットプロトコルを標準化する組織は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80424,7 +80999,8 @@
     "question_text": {
       "en": "Which HTTP mechanism instructs the client to fetch a different URL?",
       "ja": "別の URL を取得するようクライアントに指示する HTTP の仕組みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80464,7 +81040,8 @@
     "question_text": {
       "en": "Which HTTP status indicates a temporary redirect that should preserve the method?",
       "ja": "メソッドを保持したまま一時的にリダイレクトすることを示す HTTP ステータスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80504,7 +81081,8 @@
     "question_text": {
       "en": "Which HTTP status indicates the server is temporarily unable to handle the request?",
       "ja": "サーバが一時的にリクエストを処理できないことを示す HTTP ステータスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80544,7 +81122,8 @@
     "question_text": {
       "en": "Which HTTP method removes the specified resource?",
       "ja": "指定リソースを削除する HTTP メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80584,7 +81163,8 @@
     "question_text": {
       "en": "Which HTTP method returns only headers for a resource?",
       "ja": "リソースのヘッダだけを返す HTTP メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80624,7 +81204,8 @@
     "question_text": {
       "en": "Which HTTP method describes the communication options for the target resource?",
       "ja": "対象リソースに対する通信オプションを取得する HTTP メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80653,8 +81234,7 @@
         "en": "`<article>` tag",
         "ja": "アーティクルタグ",
         "ja_typings": [
-          "a-thikurutagu",
-          "a-thikulutagu"
+          "a-thikurutagu"
         ]
       }
     ],
@@ -80665,7 +81245,8 @@
     "question_text": {
       "en": "Which HTML element represents self-contained content like illustrations?",
       "ja": "挿絵など自己完結したコンテンツを表す HTML 要素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80705,7 +81286,8 @@
     "question_text": {
       "en": "Which HTML element provides a drawable region for graphics via scripting?",
       "ja": "スクリプトで描画する領域を提供する HTML 要素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80865,7 +81447,8 @@
     "question_text": {
       "en": "Which HTML element references external resources such as stylesheets?",
       "ja": "スタイルシートなど外部リソースを参照する HTML 要素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80905,7 +81488,8 @@
     "question_text": {
       "en": "Which HTML element groups navigation links?",
       "ja": "ナビゲーション用のリンクをまとめる HTML 要素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80945,7 +81529,8 @@
     "question_text": {
       "en": "Which of the following is NOT a real HTML element name?",
       "ja": "実在しない HTML 要素名はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80985,7 +81570,8 @@
     "question_text": {
       "en": "Which of the following is NOT a valid HTML tag?",
       "ja": "正しい HTML タグでないものはどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81000,7 +81586,7 @@
         "en": "`<picture>` tag",
         "ja": "ピクチャタグ",
         "ja_typings": [
-          "pikutyatagu"
+          "pikuchatagu"
         ]
       },
       {
@@ -81025,7 +81611,8 @@
     "question_text": {
       "en": "Which of these tag names does NOT exist in HTML?",
       "ja": "HTML に存在しないタグ名はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81054,7 +81641,6 @@
         "en": "`<applet>` tag",
         "ja": "アプレットタグ",
         "ja_typings": [
-          "aapurettotagu",
           "apurettotagu"
         ]
       }
@@ -81066,7 +81652,8 @@
     "question_text": {
       "en": "Which HTML element embeds external content such as plugins or media?",
       "ja": "プラグインやメディアなど外部コンテンツを埋め込む HTML 要素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81106,7 +81693,8 @@
     "question_text": {
       "en": "Which CSS display value lays out children in a two-dimensional grid?",
       "ja": "子要素を 2 次元グリッドに配置する CSS の display 値は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81146,7 +81734,8 @@
     "question_text": {
       "en": "Which CSS display value makes the element start on a new line and take full width?",
       "ja": "要素を改行して横幅いっぱいに広げる CSS の display 値は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81175,7 +81764,6 @@
         "en": "`display: run-in`",
         "ja": "ランインディスプレイ",
         "ja_typings": [
-          "ranindhisupurei",
           "rannindhisupurei"
         ]
       }
@@ -81187,7 +81775,8 @@
     "question_text": {
       "en": "Which CSS display value flows the element within text without line breaks?",
       "ja": "要素を改行せずテキスト中に流す CSS の display 値は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81209,8 +81798,6 @@
         "en": "Table",
         "ja": "テーブルレイアウト",
         "ja_typings": [
-          "te-bururereiauto",
-          "te-bureiauto",
           "te-burureiauto"
         ]
       },
@@ -81229,7 +81816,8 @@
     "question_text": {
       "en": "Which CSS layout module arranges items in a single dimension with flexible sizing?",
       "ja": "アイテムを 1 次元に柔軟なサイズで並べる CSS レイアウトモジュールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81269,7 +81857,8 @@
     "question_text": {
       "en": "Which legacy CSS property removes an element from normal flow to the side?",
       "ja": "通常フローから要素を外して横に寄せる古典的な CSS プロパティは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81309,7 +81898,8 @@
     "question_text": {
       "en": "Which CSS property sets how an element is positioned in the document?",
       "ja": "要素の配置方法を指定する CSS プロパティは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81349,7 +81939,8 @@
     "question_text": {
       "en": "Which continent contains France, Germany, and Italy?",
       "ja": "フランス・ドイツ・イタリアを含む大陸は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81589,7 +82180,8 @@
     "question_text": {
       "en": "Which South American country has La Paz as one of its capitals?",
       "ja": "ラパスを首都の一つとする南米の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81629,7 +82221,8 @@
     "question_text": {
       "en": "Which African country has Khartoum as its capital?",
       "ja": "ハルツームを首都とするアフリカの国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81869,7 +82462,8 @@
     "question_text": {
       "en": "Which is the largest city of Turkey, straddling Europe and Asia?",
       "ja": "ヨーロッパとアジアにまたがるトルコ最大の都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81949,7 +82543,8 @@
     "question_text": {
       "en": "Which Scandinavian country has Copenhagen as its capital?",
       "ja": "コペンハーゲンを首都とする北欧の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82029,7 +82624,8 @@
     "question_text": {
       "en": "Which country has Mexico City as its capital?",
       "ja": "メキシコシティを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82069,7 +82665,8 @@
     "question_text": {
       "en": "Which South American country has Caracas as its capital?",
       "ja": "カラカスを首都とする南米の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82109,7 +82706,8 @@
     "question_text": {
       "en": "Which Southeast Asian country has Vientiane as its capital?",
       "ja": "ヴィエンチャンを首都とする東南アジアの国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82149,7 +82747,8 @@
     "question_text": {
       "en": "Which Southeast Asian country has Phnom Penh as its capital?",
       "ja": "プノンペンを首都とする東南アジアの国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82189,7 +82788,8 @@
     "question_text": {
       "en": "Which Southeast Asian country has Naypyidaw as its capital?",
       "ja": "ネピドーを首都とする東南アジアの国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82229,7 +82829,8 @@
     "question_text": {
       "en": "Which Balkan country has Sofia as its capital?",
       "ja": "ソフィアを首都とするバルカンの国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82269,7 +82870,8 @@
     "question_text": {
       "en": "Which Eastern European country has Bucharest as its capital?",
       "ja": "ブカレストを首都とする東欧の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82309,7 +82911,8 @@
     "question_text": {
       "en": "Which Scandinavian country has Stockholm as its capital?",
       "ja": "ストックホルムを首都とする北欧の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82349,7 +82952,8 @@
     "question_text": {
       "en": "Which South American country has Montevideo as its capital?",
       "ja": "モンテビデオを首都とする南米の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82389,7 +82993,8 @@
     "question_text": {
       "en": "Which South American country has Asuncion as its capital?",
       "ja": "アスンシオンを首都とする南米の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82429,7 +83034,8 @@
     "question_text": {
       "en": "Which North African country has Tripoli as its capital?",
       "ja": "トリポリを首都とする北アフリカの国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82469,7 +83075,8 @@
     "question_text": {
       "en": "Which Pacific island country has Suva as its capital?",
       "ja": "スバを首都とする太平洋の島国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82909,7 +83516,8 @@
     "question_text": {
       "en": "Which microstate on the French Riviera is famous for its casino?",
       "ja": "フレンチリヴィエラにある、カジノで有名な小国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82949,7 +83557,8 @@
     "question_text": {
       "en": "Which microstate lies between Switzerland and Austria?",
       "ja": "スイスとオーストリアの間にある小国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83069,7 +83678,8 @@
     "question_text": {
       "en": "Which island country in the eastern Mediterranean has Nicosia as its capital?",
       "ja": "東地中海にあるニコシアを首都とする島国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83109,7 +83719,8 @@
     "question_text": {
       "en": "Which Mediterranean island country has Valletta as its capital?",
       "ja": "ヴァレッタを首都とする地中海の島国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83189,7 +83800,8 @@
     "question_text": {
       "en": "Which is the most populous city in Australia?",
       "ja": "オーストラリアで最も人口の多い都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83229,7 +83841,8 @@
     "question_text": {
       "en": "Which Australian city hosts the famous Melbourne Cup horse race?",
       "ja": "メルボルンカップ競馬が開催されるオーストラリアの都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83269,7 +83882,8 @@
     "question_text": {
       "en": "Which is the capital of Western Australia?",
       "ja": "西オーストラリア州の州都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83309,7 +83923,8 @@
     "question_text": {
       "en": "Which is the second-highest mountain in the world?",
       "ja": "世界で2番目に高い山は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83349,7 +83964,8 @@
     "question_text": {
       "en": "Which Mongol emperor founded the Yuan dynasty?",
       "ja": "元朝を建てたモンゴル皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83429,7 +84045,8 @@
     "question_text": {
       "en": "Which Indian revolutionary led the Indian National Army during WWII?",
       "ja": "第二次大戦中にインド国民軍を率いた独立運動家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83469,7 +84086,8 @@
     "question_text": {
       "en": "Which Soviet revolutionary founded the Red Army and was later exiled by Stalin?",
       "ja": "赤軍を創設し後にスターリンに追放されたソ連の革命家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83589,7 +84207,8 @@
     "question_text": {
       "en": "Which Serbian-American inventor pioneered alternating-current electrical systems?",
       "ja": "交流電力システムを開拓したセルビア系米国人発明家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83597,7 +84216,6 @@
         "en": "Thermidorian Reaction",
         "ja": "テルミドールのクーデター",
         "ja_typings": [
-          "terumido-ru/no/ku-deta-",
           "terumido-runoku-deta-"
         ]
       },
@@ -83619,7 +84237,6 @@
         "en": "Brumaire Coup",
         "ja": "ブリュメールのクーデター",
         "ja_typings": [
-          "buryume-ru/no/ku-deta-",
           "buryume-runoku-deta-"
         ]
       }
@@ -83711,7 +84328,8 @@
     "question_text": {
       "en": "Which Renaissance artist painted the Sistine Chapel ceiling?",
       "ja": "システィーナ礼拝堂の天井画を描いたルネサンスの芸術家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83751,7 +84369,8 @@
     "question_text": {
       "en": "Which Renaissance painter created 'The School of Athens'?",
       "ja": "「アテネの学堂」を描いたルネサンスの画家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83791,7 +84410,8 @@
     "question_text": {
       "en": "Which Renaissance painter created 'The Birth of Venus'?",
       "ja": "「ヴィーナスの誕生」を描いたルネサンスの画家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83820,7 +84440,6 @@
         "en": "Vallabhbhai Patel",
         "ja": "ヴァッラブバーイー・パテール",
         "ja_typings": [
-          "varrabu/ba-i-/pate-ru",
           "varrabuba-i-/pate-ru"
         ]
       }
@@ -83832,7 +84451,8 @@
     "question_text": {
       "en": "Who was the first Prime Minister of independent India?",
       "ja": "独立インドの初代首相は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83872,7 +84492,8 @@
     "question_text": {
       "en": "Which Mongol Great Khan succeeded Genghis Khan?",
       "ja": "チンギス・ハンの後を継いだモンゴル帝国の大ハーンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83941,7 +84562,7 @@
         "en": "Commodus",
         "ja": "コンモドゥス",
         "ja_typings": [
-          "konmodusu"
+          "konmodwusu"
         ]
       }
     ],
@@ -83952,7 +84573,8 @@
     "question_text": {
       "en": "Which Roman emperor was infamous for cruelty and was assassinated in 41 AD?",
       "ja": "残虐で知られ41年に暗殺されたローマ皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84032,7 +84654,8 @@
     "question_text": {
       "en": "Which British PM is associated with the Munich Agreement appeasing Hitler in 1938?",
       "ja": "1938年のミュンヘン協定でヒトラーに宥和したイギリス首相は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84072,7 +84695,8 @@
     "question_text": {
       "en": "Which British Labour PM led postwar reforms including the NHS?",
       "ja": "NHS創設など戦後改革を進めたイギリス労働党の首相は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84112,7 +84736,8 @@
     "question_text": {
       "en": "Which British PM led Britain during the 1956 Suez Crisis?",
       "ja": "1956年のスエズ危機時のイギリス首相は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84152,7 +84777,8 @@
     "question_text": {
       "en": "Which Nazi leader headed the SS and organized the Holocaust?",
       "ja": "親衛隊を率いホロコーストを組織したナチ指導者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84192,7 +84818,8 @@
     "question_text": {
       "en": "Which Nazi leader served as Minister of Propaganda?",
       "ja": "ナチス・ドイツの宣伝大臣を務めた人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84232,7 +84859,8 @@
     "question_text": {
       "en": "Which Nazi leader founded the Luftwaffe and the Gestapo?",
       "ja": "ルフトヴァッフェとゲシュタポを創設したナチ指導者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84272,7 +84900,8 @@
     "question_text": {
       "en": "Which Soviet leader denounced Stalin in 1956 and led during the Cuban Missile Crisis?",
       "ja": "1956年にスターリン批判を行いキューバ危機を経験したソ連指導者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84312,7 +84941,8 @@
     "question_text": {
       "en": "Which US president and WWII general served from 1953 to 1961?",
       "ja": "1953〜1961年に在任した第二次大戦の将軍出身の米大統領は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84352,7 +84982,8 @@
     "question_text": {
       "en": "Which Mughal emperor known for religious tolerance ruled India in the 16th century?",
       "ja": "宗教的寛容で知られる16世紀インドのムガル皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84392,7 +85023,8 @@
     "question_text": {
       "en": "Which Mughal emperor was known for orthodox Islamic rule and expansion in the late 17th century?",
       "ja": "17世紀後半に厳格なイスラム統治と領土拡大を行ったムガル皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84472,7 +85104,8 @@
     "question_text": {
       "en": "Which ancient Mesoamerican civilization is known for colossal stone heads?",
       "ja": "巨大な石頭像で知られる古代メソアメリカ文明は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84512,7 +85145,8 @@
     "question_text": {
       "en": "Which ancient civilization built the pyramids of Giza?",
       "ja": "ギザのピラミッドを築いた古代文明は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84880,7 +85514,6 @@
         "en": "Julius Caesar",
         "ja": "ユリウス・カエサル",
         "ja_typings": [
-          "uriusu/kaesaru",
           "yuriusu/kaesaru"
         ]
       },
@@ -84913,7 +85546,8 @@
     "question_text": {
       "en": "Which Roman general crossed the Rubicon in 49 BC?",
       "ja": "紀元前49年にルビコン川を渡ったローマの将軍は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85353,7 +85987,8 @@
     "question_text": {
       "en": "Which Danish physicist proposed a model of the hydrogen atom with quantized orbits in 1913?",
       "ja": "1913年に量子化された軌道を持つ水素原子モデルを提唱したデンマークの物理学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85433,7 +86068,8 @@
     "question_text": {
       "en": "Which noble gas is the third most abundant gas in Earth's atmosphere?",
       "ja": "地球大気で3番目に多い希ガスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85593,7 +86229,8 @@
     "question_text": {
       "en": "Which French naturalist proposed an early theory of inheritance of acquired characteristics?",
       "ja": "獲得形質の遺伝説を提唱したフランスの博物学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85633,7 +86270,8 @@
     "question_text": {
       "en": "Which Polish-French scientist discovered polonium and radium?",
       "ja": "ポロニウムとラジウムを発見したポーランド系フランス人科学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85753,7 +86391,8 @@
     "question_text": {
       "en": "Which Danish astronomer made precise pre-telescope observations used by Kepler?",
       "ja": "ケプラーが利用した精密な肉眼観測を残したデンマークの天文学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85833,7 +86472,8 @@
     "question_text": {
       "en": "Which gas, CH4, is the main component of natural gas?",
       "ja": "化学式CH4で天然ガスの主成分である気体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86233,7 +86873,8 @@
     "question_text": {
       "en": "Approximately what is the circumference of the Earth at the equator?",
       "ja": "地球の赤道周長は約何kmか?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86273,7 +86914,8 @@
     "question_text": {
       "en": "Approximately what is the distance from the Earth to the Moon?",
       "ja": "地球から月までの距離は約何kmか?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86313,7 +86955,8 @@
     "question_text": {
       "en": "Approximately what is the diameter of the Moon?",
       "ja": "月の直径は約何kmか?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86353,7 +86996,8 @@
     "question_text": {
       "en": "Which British physicist proposed that black holes emit radiation?",
       "ja": "ブラックホールが放射を発するという理論を提唱したイギリスの物理学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86521,7 +87165,6 @@
         "en": "Mendel and Darwin",
         "ja": "メンデルとダーウィン",
         "ja_typings": [
-          "menderu/to/da-win",
           "menderutoda-win"
         ]
       },
@@ -86529,7 +87172,6 @@
         "en": "Pasteur and Koch",
         "ja": "パスツールとコッホ",
         "ja_typings": [
-          "pasutsu-ru/to/kohho",
           "pasutsu-rutokohho"
         ]
       },
@@ -86537,7 +87179,6 @@
         "en": "Lamarck and Linnaeus",
         "ja": "ラマルクとリンネ",
         "ja_typings": [
-          "ramaruku/to/rinne",
           "ramarukutorinnne"
         ]
       },
@@ -86545,7 +87186,6 @@
         "en": "Watson and Crick",
         "ja": "ワトソンとクリック",
         "ja_typings": [
-          "watoson/to/kurikku",
           "watosontokurikku"
         ]
       }
@@ -86557,7 +87197,8 @@
     "question_text": {
       "en": "Who are the two 19th-century scientists most often cited as founders of evolution and modern genetics?",
       "ja": "進化論と近代遺伝学の創始者としてよく挙げられる19世紀の2人の科学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86565,7 +87206,6 @@
         "en": "Pasteur and Koch",
         "ja": "パスツールとコッホ",
         "ja_typings": [
-          "pasutsu-ru/to/kohho",
           "pasutsu-rutokohho"
         ]
       },
@@ -86573,7 +87213,6 @@
         "en": "Mendel and Darwin",
         "ja": "メンデルとダーウィン",
         "ja_typings": [
-          "menderu/to/da-win",
           "menderutoda-win"
         ]
       },
@@ -86581,7 +87220,6 @@
         "en": "Lamarck and Linnaeus",
         "ja": "ラマルクとリンネ",
         "ja_typings": [
-          "ramaruku/to/rinne",
           "ramarukutorinnne"
         ]
       },
@@ -86589,7 +87227,6 @@
         "en": "Watson and Crick",
         "ja": "ワトソンとクリック",
         "ja_typings": [
-          "watoson/to/kurikku",
           "watosontokurikku"
         ]
       }
@@ -86601,7 +87238,8 @@
     "question_text": {
       "en": "Who are the two 19th-century scientists most associated with the founding of microbiology?",
       "ja": "微生物学の創始に深く関わった19世紀の2人の科学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86609,7 +87247,6 @@
         "en": "Lamarck and Linnaeus",
         "ja": "ラマルクとリンネ",
         "ja_typings": [
-          "ramaruku/to/rinne",
           "ramarukutorinnne"
         ]
       },
@@ -86617,7 +87254,6 @@
         "en": "Mendel and Darwin",
         "ja": "メンデルとダーウィン",
         "ja_typings": [
-          "menderu/to/da-win",
           "menderutoda-win"
         ]
       },
@@ -86625,7 +87261,6 @@
         "en": "Pasteur and Koch",
         "ja": "パスツールとコッホ",
         "ja_typings": [
-          "pasutsu-ru/to/kohho",
           "pasutsu-rutokohho"
         ]
       },
@@ -86633,7 +87268,6 @@
         "en": "Watson and Crick",
         "ja": "ワトソンとクリック",
         "ja_typings": [
-          "watoson/to/kurikku",
           "watosontokurikku"
         ]
       }
@@ -86645,7 +87279,8 @@
     "question_text": {
       "en": "Who are the two pre-Darwinian naturalists associated with early classification and inheritance theory?",
       "ja": "ダーウィン以前の分類学・進化思想に関わった2人の博物学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86685,7 +87320,8 @@
     "question_text": {
       "en": "Which 18th-century Swedish naturalist established the modern binomial nomenclature?",
       "ja": "二名法を確立した18世紀スウェーデンの博物学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86725,7 +87361,8 @@
     "question_text": {
       "en": "What is the sum of the interior angles of a triangle in Euclidean geometry?",
       "ja": "ユークリッド幾何で三角形の内角の和は何度か?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86765,7 +87402,8 @@
     "question_text": {
       "en": "If an isoceles triangle has a vertex angle of 20 degrees, each base angle measures how many degrees?",
       "ja": "頂角20度の二等辺三角形の底角はそれぞれ何度か?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86805,7 +87443,8 @@
     "question_text": {
       "en": "Each interior angle of a regular hexagon measures how many degrees?",
       "ja": "正六角形の1つの内角は何度か?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86845,7 +87484,8 @@
     "question_text": {
       "en": "Approximately how long is a standard Olympic sprint track in meters for the 100m dash?",
       "ja": "オリンピックの100m走の距離は何mか?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86885,7 +87525,8 @@
     "question_text": {
       "en": "How long is a standard track distance for the 1km run in meters?",
       "ja": "1km走の距離はメートル換算で何mか?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86925,7 +87566,8 @@
     "question_text": {
       "en": "How many meters is a 3km running event?",
       "ja": "3km走は何mか?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87165,7 +87807,8 @@
     "question_text": {
       "en": "Which star, near the celestial north pole, is used for navigation?",
       "ja": "天の北極付近にあり航法に使われる恒星は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87205,7 +87848,8 @@
     "question_text": {
       "en": "Which red supergiant star marks the shoulder of Orion?",
       "ja": "オリオン座の肩を成す赤色超巨星は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87365,7 +88009,8 @@
     "question_text": {
       "en": "Who proposed 23 famous unsolved problems in 1900?",
       "ja": "1900年に23の未解決問題を提示した数学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87405,7 +88050,8 @@
     "question_text": {
       "en": "Whose name is associated with the integral formula for analytic functions on a closed contour?",
       "ja": "閉曲線上の解析関数の積分公式に名を残す数学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87445,7 +88091,8 @@
     "question_text": {
       "en": "Whose hypothesis about the zeros of the zeta function is a Millennium Prize problem?",
       "ja": "ゼータ関数の零点に関する仮説で知られミレニアム懸賞問題となっている数学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87485,7 +88132,8 @@
     "question_text": {
       "en": "Which Norwegian mathematician proved the impossibility of solving the general quintic by radicals?",
       "ja": "一般5次方程式が代数的に解けないことを示したノルウェーの数学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87645,7 +88293,8 @@
     "question_text": {
       "en": "What is 10 squared?",
       "ja": "10の2乗は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87685,7 +88334,8 @@
     "question_text": {
       "en": "What is 3 multiplied by 7?",
       "ja": "3×7はいくつ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87725,7 +88375,8 @@
     "question_text": {
       "en": "What is 2 to the third power?",
       "ja": "2の3乗は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87806,7 +88457,8 @@
     "question_text": {
       "en": "What is the only even prime number?",
       "ja": "唯一の偶数の素数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87846,7 +88498,8 @@
     "question_text": {
       "en": "What is 2 squared?",
       "ja": "2の2乗は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87886,7 +88539,8 @@
     "question_text": {
       "en": "Whose conjecture says every even integer greater than 2 is the sum of two primes?",
       "ja": "2より大きい偶数はすべて2つの素数の和で表せるという予想を提唱したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88006,7 +88660,8 @@
     "question_text": {
       "en": "Which Greek letter is often used to denote the golden ratio?",
       "ja": "黄金比を表すのによく使われるギリシャ文字は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88046,7 +88701,8 @@
     "question_text": {
       "en": "Which Greek letter is commonly used to denote an angle?",
       "ja": "角度を表すのによく使われるギリシャ文字は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88086,7 +88742,8 @@
     "question_text": {
       "en": "Whose family produced multiple Swiss mathematicians known for probability and fluid dynamics?",
       "ja": "確率や流体力学で知られるスイスの数学者一族の名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88126,7 +88783,8 @@
     "question_text": {
       "en": "Who is known for the construction of real numbers via cuts of rationals?",
       "ja": "有理数の切断で実数を構成したことで知られる数学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88166,7 +88824,8 @@
     "question_text": {
       "en": "Which French mathematician's conjecture on 3-manifolds was solved by Perelman?",
       "ja": "3次元多様体に関する予想がペレルマンに解かれたフランスの数学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88206,7 +88865,8 @@
     "question_text": {
       "en": "Who developed the calculus of variations and a theorem on subgroup order in group theory?",
       "ja": "変分法を発展させ群論で部分群の位数の定理にも名を残す数学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89046,7 +89706,8 @@
     "question_text": {
       "en": "What do you call a multi-dimensional generalization of vectors and matrices?",
       "ja": "ベクトルや行列を多次元に一般化した量は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89166,7 +89827,8 @@
     "question_text": {
       "en": "Which French mathematician's triangle gives binomial coefficients?",
       "ja": "二項係数を並べた三角形に名を残すフランスの数学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89206,7 +89868,8 @@
     "question_text": {
       "en": "Which ancient Greek mathematician's theorem relates the sides of a right triangle?",
       "ja": "直角三角形の辺の関係に名を残す古代ギリシャの数学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89246,7 +89909,8 @@
     "question_text": {
       "en": "Which ancient Greek philosopher is credited with one of the first geometric theorems about angles in a semicircle?",
       "ja": "半円に内接する角に関する定理で知られる古代ギリシャの哲学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89286,7 +89950,8 @@
     "question_text": {
       "en": "Which Greek philosopher is associated with five regular polyhedra called the 'solids'?",
       "ja": "5種類の正多面体に名を残すギリシャの哲学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89326,7 +89991,8 @@
     "question_text": {
       "en": "Which country is the Eiffel Tower located in?",
       "ja": "エッフェル塔がある国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89366,7 +90032,8 @@
     "question_text": {
       "en": "Who is the Italian inventor credited with the first long-distance radio transmission?",
       "ja": "長距離無線通信を初めて成功させたイタリアの発明家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89406,7 +90073,8 @@
     "question_text": {
       "en": "Which country has London as its capital?",
       "ja": "ロンドンを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89486,7 +90154,8 @@
     "question_text": {
       "en": "Which country is shaped like a boot and known for pasta and pizza?",
       "ja": "長靴の形をしておりパスタやピザで有名な国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89566,7 +90235,8 @@
     "question_text": {
       "en": "Which SI unit measures frequency, in cycles per second?",
       "ja": "周波数のSI単位(毎秒の振動回数)は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89646,7 +90316,8 @@
     "question_text": {
       "en": "In baseball, what term means a successful safe hit on the ball into fair territory?",
       "ja": "野球で打球がフェア地域に飛び出塁できた打撃を何という?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89686,7 +90357,8 @@
     "question_text": {
       "en": "In baseball, what term means the ball was hit outside the fair territory lines?",
       "ja": "野球で打球がフェア地域の外に飛ぶことを何という?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89846,7 +90518,8 @@
     "question_text": {
       "en": "Who was the 7th president of the International Olympic Committee, serving 1980-2001?",
       "ja": "1980年から2001年までIOC会長を務めたスペイン人は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89886,7 +90559,8 @@
     "question_text": {
       "en": "Who was the 8th president of the IOC, serving 2001-2013?",
       "ja": "2001年から2013年までIOC会長を務めたベルギー人は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89926,7 +90600,8 @@
     "question_text": {
       "en": "Who became the 9th president of the IOC in 2013?",
       "ja": "2013年にIOC会長となったドイツ人は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89966,7 +90641,8 @@
     "question_text": {
       "en": "Which Serbian-American inventor is known for AC electrical systems?",
       "ja": "交流送電で知られるセルビア系アメリカ人の発明家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90006,7 +90682,8 @@
     "question_text": {
       "en": "Who was the Polish-French physicist who won Nobel Prizes in both physics and chemistry for work on radioactivity?",
       "ja": "放射線の研究で物理学賞と化学賞の両方を受賞したポーランド系フランス人の物理学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90046,7 +90723,8 @@
     "question_text": {
       "en": "In which year did Melbourne host the Summer Olympics?",
       "ja": "メルボルン夏季オリンピックが開催された年は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90086,7 +90764,8 @@
     "question_text": {
       "en": "In which year did Mexico City host the Summer Olympics?",
       "ja": "メキシコシティ夏季オリンピックが開催された年は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90126,7 +90805,8 @@
     "question_text": {
       "en": "In which year did Munich host the Summer Olympics?",
       "ja": "ミュンヘン夏季オリンピックが開催された年は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90286,7 +90966,8 @@
     "question_text": {
       "en": "Who wrote 'The Grapes of Wrath' and won the Nobel Prize in Literature in 1962?",
       "ja": "「怒りの葡萄」を書き1962年にノーベル文学賞を受賞した米国人作家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90326,7 +91007,8 @@
     "question_text": {
       "en": "Who wrote 'The Sound and the Fury' and won the Nobel Prize in Literature in 1949?",
       "ja": "「響きと怒り」を書き1949年にノーベル文学賞を受賞した米国人作家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90366,7 +91048,8 @@
     "question_text": {
       "en": "Who wrote 'The Great Gatsby'?",
       "ja": "「グレート ギャツビー」の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90406,7 +91089,8 @@
     "question_text": {
       "en": "Who directed 'Jaws', 'E.T.', and 'Jurassic Park'?",
       "ja": "「ジョーズ」「E.T.」「ジュラシック パーク」を監督した米国人は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90446,7 +91130,8 @@
     "question_text": {
       "en": "Who directed 'Taxi Driver' and 'Goodfellas'?",
       "ja": "「タクシードライバー」「グッドフェローズ」を監督した米国人は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90486,7 +91171,8 @@
     "question_text": {
       "en": "Who directed 'Alien', 'Blade Runner', and 'Gladiator'?",
       "ja": "「エイリアン」「ブレードランナー」「グラディエーター」を監督した英国人は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90541,7 +91227,6 @@
         "en": "leopard",
         "ja": "ヒョウ",
         "ja_typings": [
-          "hyo",
           "hyou"
         ]
       },
@@ -90567,7 +91252,8 @@
     "question_text": {
       "en": "Which large cat is known as the 'king of the savannah' and lives in prides?",
       "ja": "サバンナの王者と呼ばれ群れを作る大型のネコ科動物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90607,7 +91293,8 @@
     "question_text": {
       "en": "Which slender African antelope is famous for its leaping bounds?",
       "ja": "跳躍で有名なアフリカの細身の動物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90615,7 +91302,6 @@
         "en": "leopard",
         "ja": "ヒョウ",
         "ja_typings": [
-          "hyo",
           "hyou"
         ]
       },
@@ -90648,7 +91334,8 @@
     "question_text": {
       "en": "Which spotted big cat is known for dragging prey up into trees?",
       "ja": "獲物を木の上に運ぶことで知られる斑点模様の大型ネコ科動物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90808,7 +91495,8 @@
     "question_text": {
       "en": "Who is the English inventor of the early atmospheric steam engine in 1712?",
       "ja": "1712年に大気圧蒸気機関を実用化した英国の発明家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90848,7 +91536,8 @@
     "question_text": {
       "en": "Who built the early steam locomotive 'Rocket' in England?",
       "ja": "英国で蒸気機関車「ロケット号」を製作した技術者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90888,7 +91577,8 @@
     "question_text": {
       "en": "Who is the American engineer who developed the first commercially successful steamboat?",
       "ja": "商業的に成功した最初の蒸気船を開発した米国人は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90928,7 +91618,8 @@
     "question_text": {
       "en": "Which large stinging insect builds papery nests and is more aggressive than honeybees?",
       "ja": "ミツバチより攻撃的で紙状の巣を作る大型の刺す昆虫は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90968,7 +91659,8 @@
     "question_text": {
       "en": "Which slender wasp builds open umbrella-shaped nests?",
       "ja": "細身で傘状の巣を作るハチは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91008,7 +91700,8 @@
     "question_text": {
       "en": "Which large solitary black bee bores into wood to make nests?",
       "ja": "木に穴を開けて巣を作る大きな黒い単独行動の蜂は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91183,7 +91876,6 @@
         "en": "VShojo",
         "ja": "ブイショウジョ",
         "ja_typings": [
-          "buishojo",
           "buishoujo"
         ]
       },
@@ -91209,7 +91901,8 @@
     "question_text": {
       "en": "Which VTuber agency manages stylish 'Noripro' talents in Japan?",
       "ja": "ののかみらいなど「のりプロ」の所属タレントを抱える事務所は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91217,7 +91910,6 @@
         "en": "VShojo",
         "ja": "ブイショウジョ",
         "ja_typings": [
-          "buishojo",
           "buishoujo"
         ]
       },
@@ -91250,7 +91942,8 @@
     "question_text": {
       "en": "Which English-language VTuber agency includes Ironmouse and Projekt Melody?",
       "ja": "アイアンマウスやプロジェクトメロディなどが所属する英語圏VTuber事務所は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91330,7 +92023,8 @@
     "question_text": {
       "en": "Which Japanese internet company is the parent of Nijisanji's operator Anycolor's predecessor relationships and also runs AbemaTV?",
       "ja": "AbemaTVを運営する日本のインターネット企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91370,7 +92064,8 @@
     "question_text": {
       "en": "What live streaming community term refers to the meme cat 'chato' that became iconic in early Japanese VTuber chats?",
       "ja": "初期VTuber配信のコメント文化で象徴的になった猫「ちゃと」を指す言葉は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91465,7 +92160,6 @@
         "en": "VShojo",
         "ja": "ブイショウジョ",
         "ja_typings": [
-          "buishojo",
           "buishoujo"
         ]
       },
@@ -91491,7 +92185,8 @@
     "question_text": {
       "en": "Which VTuber group focuses on competitive FPS and esports under Brave Group?",
       "ja": "ブレイブグループ傘下でFPS・eスポーツを中心とするVTuberグループは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91520,7 +92215,6 @@
         "en": "VShojo",
         "ja": "ブイショウジョ",
         "ja_typings": [
-          "buishojo",
           "buishoujo"
         ]
       }
@@ -91532,7 +92226,8 @@
     "question_text": {
       "en": "Which early Japanese VTuber group included Dennou Shoujo Siro and Mononobe no Alice?",
       "ja": "電脳少女シロや物述有栖が所属していた初期VTuberグループは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91572,7 +92267,8 @@
     "question_text": {
       "en": "Which Japanese company is famous for Weiss Schwarz card games and pro wrestling promotion?",
       "ja": "ヴァイスシュヴァルツやプロレス興行で知られる日本企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91612,7 +92308,8 @@
     "question_text": {
       "en": "Which Japanese electronics company makes the PlayStation?",
       "ja": "プレイステーションを製造する日本企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91634,8 +92331,7 @@
         "en": "kusa haeru",
         "ja": "ありがとう",
         "ja_typings": [
-          "arigatou",
-          "arigato"
+          "arigatou"
         ]
       },
       {
@@ -92093,7 +92789,8 @@
     "question_text": {
       "en": "Which premium in-app currency is often represented as a shining stone?",
       "ja": "光る宝石として描かれる高価なアプリ内通貨は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92373,7 +93070,8 @@
     "question_text": {
       "en": "Which Japanese character ending sound is associated with cute cat-like speech?",
       "ja": "猫っぽい可愛い語尾としてキャラに使われるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92413,7 +93111,8 @@
     "question_text": {
       "en": "Which Japanese sentence-ending emphasis word means roughly 'you know'?",
       "ja": "強調や念押しで使う「ぞ」を含む語尾は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92453,7 +93152,8 @@
     "question_text": {
       "en": "Which Japanese assertive sentence-ending phrase often used by anime characters means roughly 'it is so'?",
       "ja": "アニメキャラがよく使う「断定」の語尾で「のだ」となるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92493,7 +93193,8 @@
     "question_text": {
       "en": "Which Hololive branch is based in Indonesia?",
       "ja": "ホロライブのインドネシア拠点支部は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92533,7 +93234,8 @@
     "question_text": {
       "en": "Which Hololive branch is the original Japanese division?",
       "ja": "ホロライブの本家日本支部は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92573,7 +93275,8 @@
     "question_text": {
       "en": "Which Hololive branch operated in mainland China before its 2020 closure?",
       "ja": "2020年に活動終了したホロライブの中国大陸支部は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95104,7 +95807,8 @@
     "question_text": {
       "en": "Which Valencia festival burns giant satirical figures in March?",
       "ja": "3月にバレンシアで巨大な人形を焼くスペインの祭りは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95184,7 +95888,8 @@
     "question_text": {
       "en": "Which nine-night Hindu festival worships the goddess Durga?",
       "ja": "ドゥルガー女神を祀る9夜にわたるヒンドゥー教の祭は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95224,7 +95929,8 @@
     "question_text": {
       "en": "Which Tamil harvest festival celebrates the sun in January?",
       "ja": "1月に太陽神を祝うタミル人の収穫祭は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95264,7 +95970,8 @@
     "question_text": {
       "en": "What is the traditional Indian male garment wrapped around the waist?",
       "ja": "腰に巻くインドの伝統的な男性用の衣装は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95304,7 +96011,8 @@
     "question_text": {
       "en": "Which Dominican music and dance style features romantic guitar?",
       "ja": "ロマンチックなギターが特徴のドミニカ共和国の音楽は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95344,7 +96052,8 @@
     "question_text": {
       "en": "Which Seville festival features flamenco and casetas after Holy Week?",
       "ja": "聖週間後にセビリアで開かれるフラメンコの祭りは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95384,7 +96093,8 @@
     "question_text": {
       "en": "Which large communal dwelling housed several families in Native American cultures?",
       "ja": "複数の家族が暮らした北米先住民の細長い共同住居は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95551,7 +96261,8 @@
     "question_text": {
       "en": "Which is the largest city in Brazil?",
       "ja": "ブラジル最大の都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95591,7 +96302,8 @@
     "question_text": {
       "en": "Which Brazilian city was the country's first capital and is known for Afro-Brazilian culture?",
       "ja": "ブラジル最初の首都で、アフロ・ブラジル文化の中心地は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95671,7 +96383,8 @@
     "question_text": {
       "en": "Which Italian carnival is famous for elaborate masks?",
       "ja": "華やかな仮面で知られるイタリアの謝肉祭は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95711,7 +96424,8 @@
     "question_text": {
       "en": "Which Brazilian music festival is one of the largest in the world?",
       "ja": "ブラジルで開かれる世界最大級の音楽フェスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95876,7 +96590,8 @@
     "question_text": {
       "en": "Which Islamic month commemorates the martyrdom of Husayn ibn Ali?",
       "ja": "フサイン・イブン・アリーの殉教を悼むイスラム暦の月は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95916,7 +96631,8 @@
     "question_text": {
       "en": "Which Islamic month follows Ramadan and starts with Eid al-Fitr?",
       "ja": "ラマダーン明けでイード・アル＝フィトルから始まるイスラム暦の月は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95956,7 +96672,8 @@
     "question_text": {
       "en": "Which is the seventh month of the Islamic calendar, considered sacred?",
       "ja": "イスラム暦の第7月で神聖月とされるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95996,7 +96713,8 @@
     "question_text": {
       "en": "Which Italian coffee drink tops espresso with foamed milk in equal layers?",
       "ja": "エスプレッソに泡立てミルクを等量に重ねるイタリアのコーヒーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96036,7 +96754,8 @@
     "question_text": {
       "en": "Which Italian coffee is espresso 'stained' with a small amount of milk?",
       "ja": "エスプレッソに少量のミルクを加えたイタリアのコーヒーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96076,7 +96795,8 @@
     "question_text": {
       "en": "Which coffee is espresso diluted with hot water?",
       "ja": "エスプレッソをお湯で薄めたコーヒーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96116,7 +96836,8 @@
     "question_text": {
       "en": "Which Spanish Holy Week celebration features hooded processions?",
       "ja": "とんがり頭巾の行列が特徴のスペイン聖週間の祝祭は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96271,7 +96992,7 @@
         "en": "Ratatouille",
         "ja": "ラタトゥイユ",
         "ja_typings": [
-          "ratatuiyu"
+          "ratatwuiyu"
         ]
       }
     ],
@@ -96282,7 +97003,8 @@
     "question_text": {
       "en": "Which Provencal fish stew is from Marseille?",
       "ja": "マルセイユ発祥のプロヴァンス風魚介スープは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96322,7 +97044,8 @@
     "question_text": {
       "en": "Which French slow-cooked stew of beans and meat is from Languedoc?",
       "ja": "ラングドック地方の豆と肉の煮込み料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96351,7 +97074,7 @@
         "en": "Ratatouille",
         "ja": "ラタトゥイユ",
         "ja_typings": [
-          "ratatuiyu"
+          "ratatwuiyu"
         ]
       }
     ],
@@ -96362,7 +97085,8 @@
     "question_text": {
       "en": "Which classic French dish is a boiled beef and vegetable stew?",
       "ja": "牛肉と野菜を煮込んだフランスの伝統料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96402,7 +97126,8 @@
     "question_text": {
       "en": "Which long collarless shirt is worn across South Asia?",
       "ja": "南アジアで広く着用される襟なしの長いシャツは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96442,7 +97167,8 @@
     "question_text": {
       "en": "Which loose trousers are paired with a kameez in South Asia?",
       "ja": "南アジアでカミーズと合わせる、ゆったりしたズボンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96482,7 +97208,8 @@
     "question_text": {
       "en": "Which non-mandatory Islamic pilgrimage to Mecca can be performed any time of year?",
       "ja": "メッカへの随時可能な小巡礼は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96522,7 +97249,8 @@
     "question_text": {
       "en": "Which is the Islamic ritual prayer performed five times a day?",
       "ja": "1日5回行うイスラム教の礼拝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96562,7 +97290,8 @@
     "question_text": {
       "en": "Which Islamic pillar is the obligatory almsgiving?",
       "ja": "イスラム教における義務的な喜捨は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96602,7 +97331,8 @@
     "question_text": {
       "en": "Which Russian word names the traditional grandmother's headscarf or nesting doll?",
       "ja": "ロシアの伝統的なおばあさんの頭巾や入れ子人形を指す語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96642,7 +97372,8 @@
     "question_text": {
       "en": "Which Russian small baked or fried bun is filled with meat or potatoes?",
       "ja": "肉や芋を詰めて焼くロシアの小さなパンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96682,7 +97413,8 @@
     "question_text": {
       "en": "Which Russian folk painting uses red, black and gold on wooden tableware?",
       "ja": "赤・黒・金で木製食器を彩るロシアの民芸絵付けは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96986,7 +97718,8 @@
     "question_text": {
       "en": "What is the national embroidered formal shirt of the Philippines for men?",
       "ja": "フィリピンの男性正装である刺繍シャツは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97074,7 +97807,6 @@
         "en": "ECS",
         "ja": "ECS",
         "ja_typings": [
-          "i-shi-esu",
           "ecs"
         ]
       },
@@ -97082,7 +97814,6 @@
         "en": "EKS",
         "ja": "EKS",
         "ja_typings": [
-          "i-kei-esu",
           "eks"
         ]
       },
@@ -97108,7 +97839,8 @@
     "question_text": {
       "en": "Which AWS service runs Docker containers without Kubernetes?",
       "ja": "Kubernetes を使わず Docker コンテナを動かす AWS のサービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97116,7 +97848,6 @@
         "en": "EKS",
         "ja": "EKS",
         "ja_typings": [
-          "i-kei-esu",
           "eks"
         ]
       },
@@ -97124,7 +97855,6 @@
         "en": "ECS",
         "ja": "ECS",
         "ja_typings": [
-          "i-shi-esu",
           "ecs"
         ]
       },
@@ -97132,7 +97862,6 @@
         "en": "AKS",
         "ja": "AKS",
         "ja_typings": [
-          "e-kei-esu",
           "aks"
         ]
       },
@@ -97140,7 +97869,6 @@
         "en": "GKE",
         "ja": "GKE",
         "ja_typings": [
-          "ji-kei-i-",
           "gke"
         ]
       }
@@ -97152,7 +97880,8 @@
     "question_text": {
       "en": "Which is AWS's managed Kubernetes service?",
       "ja": "AWS が提供するマネージド Kubernetes は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97160,7 +97889,6 @@
         "en": "QA",
         "ja": "QA",
         "ja_typings": [
-          "kyu-e-",
           "qa"
         ]
       },
@@ -97168,7 +97896,6 @@
         "en": "UA",
         "ja": "UA",
         "ja_typings": [
-          "yu-e-",
           "ua"
         ]
       },
@@ -97176,7 +97903,6 @@
         "en": "DA",
         "ja": "DA",
         "ja_typings": [
-          "di-e-",
           "da"
         ]
       },
@@ -97184,7 +97910,6 @@
         "en": "PA",
         "ja": "PA",
         "ja_typings": [
-          "pi-e-",
           "pa"
         ]
       }
@@ -97196,7 +97921,8 @@
     "question_text": {
       "en": "Which abbreviation refers to quality assurance in software?",
       "ja": "ソフトウェアの品質保証を意味する略語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97204,7 +97930,6 @@
         "en": "OCI",
         "ja": "OCI",
         "ja_typings": [
-          "o-shi-ai",
           "oci"
         ]
       },
@@ -97212,7 +97937,6 @@
         "en": "CRI",
         "ja": "CRI",
         "ja_typings": [
-          "shi-a-ru-ai",
           "cri"
         ]
       },
@@ -97220,7 +97944,6 @@
         "en": "CNI",
         "ja": "CNI",
         "ja_typings": [
-          "shi-enu-ai",
           "cni"
         ]
       },
@@ -97228,7 +97951,6 @@
         "en": "OPA",
         "ja": "OPA",
         "ja_typings": [
-          "o-pi-e-",
           "opa"
         ]
       }
@@ -97240,7 +97962,8 @@
     "question_text": {
       "en": "Which open standard defines container runtimes and image format?",
       "ja": "コンテナランタイムとイメージ形式のオープン標準は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97290,7 +98013,6 @@
         "en": "AKS",
         "ja": "AKS",
         "ja_typings": [
-          "e-kei-esu",
           "aks"
         ]
       },
@@ -97298,7 +98020,6 @@
         "en": "EKS",
         "ja": "EKS",
         "ja_typings": [
-          "i-kei-esu",
           "eks"
         ]
       },
@@ -97306,7 +98027,6 @@
         "en": "GKE",
         "ja": "GKE",
         "ja_typings": [
-          "ji-kei-i-",
           "gke"
         ]
       },
@@ -97314,7 +98034,6 @@
         "en": "OKE",
         "ja": "OKE",
         "ja_typings": [
-          "o-kei-i-",
           "oke"
         ]
       }
@@ -97326,7 +98045,8 @@
     "question_text": {
       "en": "Which is Microsoft Azure's managed Kubernetes service?",
       "ja": "Microsoft Azure のマネージド Kubernetes は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97334,7 +98054,6 @@
         "en": "OKE",
         "ja": "OKE",
         "ja_typings": [
-          "o-kei-i-",
           "oke"
         ]
       },
@@ -97342,7 +98061,6 @@
         "en": "AKS",
         "ja": "AKS",
         "ja_typings": [
-          "e-kei-esu",
           "aks"
         ]
       },
@@ -97350,7 +98068,6 @@
         "en": "EKS",
         "ja": "EKS",
         "ja_typings": [
-          "i-kei-esu",
           "eks"
         ]
       },
@@ -97358,7 +98075,6 @@
         "en": "GKE",
         "ja": "GKE",
         "ja_typings": [
-          "ji-kei-i-",
           "gke"
         ]
       }
@@ -97370,7 +98086,8 @@
     "question_text": {
       "en": "Which is Oracle Cloud's managed Kubernetes service?",
       "ja": "Oracle Cloud のマネージド Kubernetes は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97378,7 +98095,6 @@
         "en": "ITIL",
         "ja": "ITIL",
         "ja_typings": [
-          "aitiru",
           "itil"
         ]
       },
@@ -97386,7 +98102,6 @@
         "en": "COBIT",
         "ja": "COBIT",
         "ja_typings": [
-          "kobitto",
           "cobit"
         ]
       },
@@ -97394,7 +98109,6 @@
         "en": "TOGAF",
         "ja": "TOGAF",
         "ja_typings": [
-          "to-gafu",
           "togaf"
         ]
       },
@@ -97402,7 +98116,6 @@
         "en": "PMBOK",
         "ja": "PMBOK",
         "ja_typings": [
-          "pinbokku",
           "pmbok"
         ]
       }
@@ -97414,7 +98127,8 @@
     "question_text": {
       "en": "Which framework standardizes IT service management practices?",
       "ja": "IT サービスマネジメントのベストプラクティス集は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97454,7 +98168,8 @@
     "question_text": {
       "en": "Which Scrum event begins a sprint by selecting backlog items?",
       "ja": "バックログを選んでスプリントを開始する Scrum のイベントは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97494,7 +98209,8 @@
     "question_text": {
       "en": "Which Ruby-based configuration management tool defines infrastructure as recipes?",
       "ja": "Ruby ベースでレシピを書く構成管理ツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97534,7 +98250,8 @@
     "question_text": {
       "en": "Which configuration management tool uses a declarative DSL and a pull model?",
       "ja": "宣言的 DSL とプル型を採用する構成管理ツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97556,7 +98273,6 @@
         "en": "QA",
         "ja": "QA",
         "ja_typings": [
-          "kyu-e-",
           "qa"
         ]
       },
@@ -97564,7 +98280,6 @@
         "en": "BA",
         "ja": "BA",
         "ja_typings": [
-          "bi-e-",
           "ba"
         ]
       }
@@ -97616,7 +98331,8 @@
     "question_text": {
       "en": "Which HashiCorp tool manages reproducible developer VMs?",
       "ja": "再現可能な開発用 VM を管理する HashiCorp のツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97624,7 +98340,6 @@
         "en": "EBS",
         "ja": "EBS",
         "ja_typings": [
-          "i-bi-esu",
           "ebs"
         ]
       },
@@ -97632,7 +98347,6 @@
         "en": "EFS",
         "ja": "EFS",
         "ja_typings": [
-          "i-efu-esu",
           "efs"
         ]
       },
@@ -97640,7 +98354,6 @@
         "en": "S3",
         "ja": "S3",
         "ja_typings": [
-          "esu-su-ri-",
           "s3"
         ]
       },
@@ -97659,7 +98372,8 @@
     "question_text": {
       "en": "Which AWS service provides block storage volumes for EC2?",
       "ja": "EC2 にブロックストレージボリュームを提供する AWS のサービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97667,7 +98381,6 @@
         "en": "EFS",
         "ja": "EFS",
         "ja_typings": [
-          "i-efu-esu",
           "efs"
         ]
       },
@@ -97675,7 +98388,6 @@
         "en": "EBS",
         "ja": "EBS",
         "ja_typings": [
-          "i-bi-esu",
           "ebs"
         ]
       },
@@ -97683,7 +98395,6 @@
         "en": "S3",
         "ja": "S3",
         "ja_typings": [
-          "esu-su-ri-",
           "s3"
         ]
       },
@@ -97691,7 +98402,6 @@
         "en": "FSx",
         "ja": "FSx",
         "ja_typings": [
-          "efu-esu-ekkusu",
           "fsx"
         ]
       }
@@ -97703,7 +98413,8 @@
     "question_text": {
       "en": "Which AWS service provides scalable shared file storage (NFS)?",
       "ja": "AWS で NFS 互換の共有ファイルストレージを提供するサービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97743,7 +98454,8 @@
     "question_text": {
       "en": "Which AWS PaaS deploys apps and handles capacity, load balancing, scaling?",
       "ja": "AWS でアプリ展開と負荷分散・スケーリングを自動化する PaaS は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97773,7 +98485,6 @@
         "en": "F1 score",
         "ja": "F1スコア",
         "ja_typings": [
-          "efuwansukoa",
           "f1sukoa"
         ]
       }
@@ -97959,7 +98670,6 @@
         "en": "DaaS",
         "ja": "DaaS",
         "ja_typings": [
-          "da-su",
           "daas"
         ]
       },
@@ -97967,7 +98677,6 @@
         "en": "IaaS",
         "ja": "IaaS",
         "ja_typings": [
-          "aia-su",
           "iaas"
         ]
       },
@@ -97975,7 +98684,6 @@
         "en": "PaaS",
         "ja": "PaaS",
         "ja_typings": [
-          "pa-su",
           "paas"
         ]
       },
@@ -97983,7 +98691,6 @@
         "en": "SaaS",
         "ja": "SaaS",
         "ja_typings": [
-          "sa-su",
           "saas"
         ]
       }
@@ -97995,7 +98702,8 @@
     "question_text": {
       "en": "Which cloud delivery model provides virtual desktops?",
       "ja": "仮想デスクトップを提供するクラウドモデルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98035,7 +98743,8 @@
     "question_text": {
       "en": "Which Agile term refers to one timeboxed cycle of work?",
       "ja": "アジャイルで時間枠を区切った1サイクルの作業を指すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98115,7 +98824,8 @@
     "question_text": {
       "en": "Which event makes a new version of software available to users?",
       "ja": "ソフトウェアの新版を利用者へ提供することを指すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98123,7 +98833,6 @@
         "en": "Product Owner",
         "ja": "プロダクトオーナー",
         "ja_typings": [
-          "purodakuto-na-",
           "purodakutoo-na-"
         ]
       },
@@ -98156,7 +98865,8 @@
     "question_text": {
       "en": "Which Scrum role owns the product backlog and prioritization?",
       "ja": "プロダクトバックログと優先順位を所有する Scrum の役割は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98171,7 +98881,6 @@
         "en": "Product Owner",
         "ja": "プロダクトオーナー",
         "ja_typings": [
-          "purodakuto-na-",
           "purodakutoo-na-"
         ]
       },
@@ -98197,7 +98906,8 @@
     "question_text": {
       "en": "Which engineering role leads technical decisions in a team?",
       "ja": "チームの技術的意思決定を主導するエンジニアの役職は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98212,7 +98922,6 @@
         "en": "Product Owner",
         "ja": "プロダクトオーナー",
         "ja_typings": [
-          "purodakuto-na-",
           "purodakutoo-na-"
         ]
       },
@@ -98238,7 +98947,8 @@
     "question_text": {
       "en": "Which role manages scope, schedule, and budget of a project?",
       "ja": "プロジェクトの範囲・予定・予算を管理する役割は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98246,7 +98956,6 @@
         "en": "MIT",
         "ja": "MITライセンス",
         "ja_typings": [
-          "emuaiti-raisensu",
           "mitraisensu"
         ]
       },
@@ -98254,7 +98963,6 @@
         "en": "BSD",
         "ja": "BSDライセンス",
         "ja_typings": [
-          "bi-esudi-raisensu",
           "bsdraisensu"
         ]
       },
@@ -98262,7 +98970,6 @@
         "en": "Apache",
         "ja": "Apacheライセンス",
         "ja_typings": [
-          "apatchiraisensu",
           "apacheraisensu"
         ]
       },
@@ -98270,7 +98977,6 @@
         "en": "GPL",
         "ja": "GPL",
         "ja_typings": [
-          "ji-pi-eru",
           "gpl"
         ]
       }
@@ -98282,7 +98988,8 @@
     "question_text": {
       "en": "Which permissive open source license is associated with the X Window System?",
       "ja": "X Window System に由来する寛容なオープンソースライセンスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98290,7 +98997,6 @@
         "en": "BSD",
         "ja": "BSDライセンス",
         "ja_typings": [
-          "bi-esudi-raisensu",
           "bsdraisensu"
         ]
       },
@@ -98298,7 +99004,6 @@
         "en": "MIT",
         "ja": "MITライセンス",
         "ja_typings": [
-          "emuaiti-raisensu",
           "mitraisensu"
         ]
       },
@@ -98306,7 +99011,6 @@
         "en": "Apache",
         "ja": "Apacheライセンス",
         "ja_typings": [
-          "apatchiraisensu",
           "apacheraisensu"
         ]
       },
@@ -98314,7 +99018,6 @@
         "en": "MPL",
         "ja": "MPL",
         "ja_typings": [
-          "emupi-eru",
           "mpl"
         ]
       }
@@ -98326,7 +99029,8 @@
     "question_text": {
       "en": "Which open source license originated with the Berkeley Unix distribution?",
       "ja": "Berkeley Unix 由来のオープンソースライセンスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98334,7 +99038,6 @@
         "en": "Apache",
         "ja": "Apacheライセンス",
         "ja_typings": [
-          "apatchiraisensu",
           "apacheraisensu"
         ]
       },
@@ -98342,7 +99045,6 @@
         "en": "MIT",
         "ja": "MITライセンス",
         "ja_typings": [
-          "emuaiti-raisensu",
           "mitraisensu"
         ]
       },
@@ -98350,7 +99052,6 @@
         "en": "BSD",
         "ja": "BSDライセンス",
         "ja_typings": [
-          "bi-esudi-raisensu",
           "bsdraisensu"
         ]
       },
@@ -98358,7 +99059,6 @@
         "en": "GPL",
         "ja": "GPL",
         "ja_typings": [
-          "ji-pi-eru",
           "gpl"
         ]
       }
@@ -98370,7 +99070,8 @@
     "question_text": {
       "en": "Which open source license version 2.0 has an explicit patent grant?",
       "ja": "明示的な特許許諾条項を含むオープンソースライセンス2.0は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98378,7 +99079,6 @@
         "en": "AWS",
         "ja": "AWS",
         "ja_typings": [
-          "e-daburyu-esu",
           "aws"
         ]
       },
@@ -98386,7 +99086,6 @@
         "en": "GCP",
         "ja": "GCP",
         "ja_typings": [
-          "ji-shi-pi-",
           "gcp"
         ]
       },
@@ -98401,7 +99100,6 @@
         "en": "OCI",
         "ja": "OCI",
         "ja_typings": [
-          "o-shi-ai",
           "oci"
         ]
       }
@@ -98413,7 +99111,8 @@
     "question_text": {
       "en": "Which is the largest public cloud provider, run by Amazon?",
       "ja": "Amazon が運営する最大手のパブリッククラウドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98421,7 +99120,6 @@
         "en": "GCP",
         "ja": "GCP",
         "ja_typings": [
-          "ji-shi-pi-",
           "gcp"
         ]
       },
@@ -98429,7 +99127,6 @@
         "en": "AWS",
         "ja": "AWS",
         "ja_typings": [
-          "e-daburyu-esu",
           "aws"
         ]
       },
@@ -98444,7 +99141,6 @@
         "en": "OCI",
         "ja": "OCI",
         "ja_typings": [
-          "o-shi-ai",
           "oci"
         ]
       }
@@ -98456,7 +99152,8 @@
     "question_text": {
       "en": "Which Google public cloud platform competes with AWS and Azure?",
       "ja": "AWS や Azure と競合する Google のパブリッククラウドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98504,7 +99201,6 @@
         "en": "NDA",
         "ja": "NDA",
         "ja_typings": [
-          "enudi-e-",
           "nda"
         ]
       },
@@ -98512,7 +99208,6 @@
         "en": "MOU",
         "ja": "MOU",
         "ja_typings": [
-          "emuo-yu-",
           "mou"
         ]
       },
@@ -98520,7 +99215,6 @@
         "en": "EULA",
         "ja": "EULA",
         "ja_typings": [
-          "yu-ra",
           "eula"
         ]
       },
@@ -98528,7 +99222,6 @@
         "en": "SLA",
         "ja": "SLA",
         "ja_typings": [
-          "esuerue-",
           "sla"
         ]
       }
@@ -98540,7 +99233,8 @@
     "question_text": {
       "en": "Which legal agreement prevents disclosure of confidential info?",
       "ja": "機密情報の開示を禁じる契約は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98548,7 +99242,6 @@
         "en": "MOU",
         "ja": "MOU",
         "ja_typings": [
-          "emuo-yu-",
           "mou"
         ]
       },
@@ -98556,7 +99249,6 @@
         "en": "NDA",
         "ja": "NDA",
         "ja_typings": [
-          "enudi-e-",
           "nda"
         ]
       },
@@ -98564,7 +99256,6 @@
         "en": "EULA",
         "ja": "EULA",
         "ja_typings": [
-          "yu-ra",
           "eula"
         ]
       },
@@ -98572,7 +99263,6 @@
         "en": "SLA",
         "ja": "SLA",
         "ja_typings": [
-          "esuerue-",
           "sla"
         ]
       }
@@ -98584,7 +99274,8 @@
     "question_text": {
       "en": "Which non-binding agreement outlines mutual intent between parties?",
       "ja": "当事者間の意思を確認するための法的拘束力のない覚書は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98592,7 +99283,6 @@
         "en": "EULA",
         "ja": "EULA",
         "ja_typings": [
-          "yu-ra",
           "eula"
         ]
       },
@@ -98600,7 +99290,6 @@
         "en": "MOU",
         "ja": "MOU",
         "ja_typings": [
-          "emuo-yu-",
           "mou"
         ]
       },
@@ -98608,7 +99297,6 @@
         "en": "NDA",
         "ja": "NDA",
         "ja_typings": [
-          "enudi-e-",
           "nda"
         ]
       },
@@ -98616,7 +99304,6 @@
         "en": "SLA",
         "ja": "SLA",
         "ja_typings": [
-          "esuerue-",
           "sla"
         ]
       }
@@ -98628,7 +99315,8 @@
     "question_text": {
       "en": "Which contract is presented to end users for software use?",
       "ja": "ソフトウェア使用にあたりエンドユーザーに提示される契約は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98668,7 +99356,8 @@
     "question_text": {
       "en": "Which culture unites development and operations teams?",
       "ja": "開発と運用を統合する文化・運動は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98676,7 +99365,6 @@
         "en": "CaC",
         "ja": "CaC",
         "ja_typings": [
-          "shi-e-shi-",
           "cac"
         ]
       },
@@ -98684,7 +99372,6 @@
         "en": "PaC",
         "ja": "PaC",
         "ja_typings": [
-          "pi-e-shi-",
           "pac"
         ]
       },
@@ -98692,7 +99379,6 @@
         "en": "DaC",
         "ja": "DaC",
         "ja_typings": [
-          "di-e-shi-",
           "dac"
         ]
       },
@@ -98700,7 +99386,6 @@
         "en": "IaC",
         "ja": "IaC",
         "ja_typings": [
-          "aia-shi-",
           "iac"
         ]
       }
@@ -98712,7 +99397,8 @@
     "question_text": {
       "en": "Which practice manages configurations declaratively as code?",
       "ja": "構成情報をコードとして宣言的に管理する手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98720,7 +99406,6 @@
         "en": "PaC",
         "ja": "PaC",
         "ja_typings": [
-          "pi-e-shi-",
           "pac"
         ]
       },
@@ -98728,7 +99413,6 @@
         "en": "CaC",
         "ja": "CaC",
         "ja_typings": [
-          "shi-e-shi-",
           "cac"
         ]
       },
@@ -98736,7 +99420,6 @@
         "en": "DaC",
         "ja": "DaC",
         "ja_typings": [
-          "di-e-shi-",
           "dac"
         ]
       },
@@ -98744,7 +99427,6 @@
         "en": "IaC",
         "ja": "IaC",
         "ja_typings": [
-          "aia-shi-",
           "iac"
         ]
       }
@@ -98756,7 +99438,8 @@
     "question_text": {
       "en": "Which practice expresses security policies as code (e.g., OPA)?",
       "ja": "OPA 等でポリシーをコードとして書く手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98764,7 +99447,6 @@
         "en": "DaC",
         "ja": "DaC",
         "ja_typings": [
-          "di-e-shi-",
           "dac"
         ]
       },
@@ -98772,7 +99454,6 @@
         "en": "CaC",
         "ja": "CaC",
         "ja_typings": [
-          "shi-e-shi-",
           "cac"
         ]
       },
@@ -98780,7 +99461,6 @@
         "en": "PaC",
         "ja": "PaC",
         "ja_typings": [
-          "pi-e-shi-",
           "pac"
         ]
       },
@@ -98788,7 +99468,6 @@
         "en": "IaC",
         "ja": "IaC",
         "ja_typings": [
-          "aia-shi-",
           "iac"
         ]
       }
@@ -98800,7 +99479,8 @@
     "question_text": {
       "en": "Which practice manages documentation as code in repositories?",
       "ja": "ドキュメントをコードのようにリポジトリ管理する手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98840,7 +99520,8 @@
     "question_text": {
       "en": "Which DB object executes a procedure when a table changes?",
       "ja": "テーブル変更時に処理を実行する DB オブジェクトは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98880,7 +99561,8 @@
     "question_text": {
       "en": "Which DB object is a virtual table from a stored query?",
       "ja": "クエリから生成される仮想表である DB オブジェクトは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98920,7 +99602,8 @@
     "question_text": {
       "en": "Which DB term names the overall structure of tables and relations?",
       "ja": "テーブルと関係の全体構造を示す DB 用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98928,7 +99611,6 @@
         "en": "NewSQL",
         "ja": "NewSQL",
         "ja_typings": [
-          "nyu-esukyu-eru",
           "newsql"
         ]
       },
@@ -98936,7 +99618,6 @@
         "en": "NoSQL",
         "ja": "NoSQL",
         "ja_typings": [
-          "no-esukyu-eru",
           "nosql"
         ]
       },
@@ -98944,7 +99625,6 @@
         "en": "OLAP",
         "ja": "OLAP",
         "ja_typings": [
-          "o-rappu",
           "olap"
         ]
       },
@@ -98952,7 +99632,6 @@
         "en": "OLTP",
         "ja": "OLTP",
         "ja_typings": [
-          "o-rutipi-",
           "oltp"
         ]
       }
@@ -98964,7 +99643,8 @@
     "question_text": {
       "en": "Which class of databases combines SQL with horizontal scalability?",
       "ja": "SQL と水平スケールを両立させる新世代 DB は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98972,7 +99652,6 @@
         "en": "OLAP",
         "ja": "OLAP",
         "ja_typings": [
-          "o-rappu",
           "olap"
         ]
       },
@@ -98980,7 +99659,6 @@
         "en": "OLTP",
         "ja": "OLTP",
         "ja_typings": [
-          "o-rutipi-",
           "oltp"
         ]
       },
@@ -98988,7 +99666,6 @@
         "en": "NewSQL",
         "ja": "NewSQL",
         "ja_typings": [
-          "nyu-esukyu-eru",
           "newsql"
         ]
       },
@@ -98996,7 +99673,6 @@
         "en": "NoSQL",
         "ja": "NoSQL",
         "ja_typings": [
-          "no-esukyu-eru",
           "nosql"
         ]
       }
@@ -99008,7 +99684,8 @@
     "question_text": {
       "en": "Which workload type emphasizes analytical multi-dimensional queries?",
       "ja": "多次元分析クエリ向けのワークロード種別は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99016,7 +99693,6 @@
         "en": "OLTP",
         "ja": "OLTP",
         "ja_typings": [
-          "o-rutipi-",
           "oltp"
         ]
       },
@@ -99024,7 +99700,6 @@
         "en": "OLAP",
         "ja": "OLAP",
         "ja_typings": [
-          "o-rappu",
           "olap"
         ]
       },
@@ -99032,7 +99707,6 @@
         "en": "NewSQL",
         "ja": "NewSQL",
         "ja_typings": [
-          "nyu-esukyu-eru",
           "newsql"
         ]
       },
@@ -99040,7 +99714,6 @@
         "en": "NoSQL",
         "ja": "NoSQL",
         "ja_typings": [
-          "no-esukyu-eru",
           "nosql"
         ]
       }
@@ -99052,7 +99725,8 @@
     "question_text": {
       "en": "Which workload type handles many short, transactional operations?",
       "ja": "短時間のトランザクション処理を多数こなすワークロードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99060,7 +99734,6 @@
         "en": "HIPAA",
         "ja": "HIPAA",
         "ja_typings": [
-          "hipa-",
           "hipaa"
         ]
       },
@@ -99068,7 +99741,6 @@
         "en": "CCPA",
         "ja": "CCPA",
         "ja_typings": [
-          "shi-shi-pi-e-",
           "ccpa"
         ]
       },
@@ -99076,7 +99748,6 @@
         "en": "SOX",
         "ja": "SOX",
         "ja_typings": [
-          "sokkusu",
           "sox"
         ]
       },
@@ -99084,7 +99755,6 @@
         "en": "GDPR",
         "ja": "GDPR",
         "ja_typings": [
-          "ji-di-pi-a-ru",
           "gdpr"
         ]
       }
@@ -99096,7 +99766,8 @@
     "question_text": {
       "en": "Which US law protects health information privacy?",
       "ja": "アメリカで医療情報のプライバシーを守る法律は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99104,7 +99775,6 @@
         "en": "CCPA",
         "ja": "CCPA",
         "ja_typings": [
-          "shi-shi-pi-e-",
           "ccpa"
         ]
       },
@@ -99112,7 +99782,6 @@
         "en": "HIPAA",
         "ja": "HIPAA",
         "ja_typings": [
-          "hipa-",
           "hipaa"
         ]
       },
@@ -99120,7 +99789,6 @@
         "en": "SOX",
         "ja": "SOX",
         "ja_typings": [
-          "sokkusu",
           "sox"
         ]
       },
@@ -99128,7 +99796,6 @@
         "en": "GDPR",
         "ja": "GDPR",
         "ja_typings": [
-          "ji-di-pi-a-ru",
           "gdpr"
         ]
       }
@@ -99140,7 +99807,8 @@
     "question_text": {
       "en": "Which California law protects consumer data rights?",
       "ja": "カリフォルニア州の消費者データ保護法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99148,7 +99816,6 @@
         "en": "SOX",
         "ja": "SOX",
         "ja_typings": [
-          "sokkusu",
           "sox"
         ]
       },
@@ -99156,7 +99823,6 @@
         "en": "HIPAA",
         "ja": "HIPAA",
         "ja_typings": [
-          "hipa-",
           "hipaa"
         ]
       },
@@ -99164,7 +99830,6 @@
         "en": "CCPA",
         "ja": "CCPA",
         "ja_typings": [
-          "shi-shi-pi-e-",
           "ccpa"
         ]
       },
@@ -99172,7 +99837,6 @@
         "en": "GDPR",
         "ja": "GDPR",
         "ja_typings": [
-          "ji-di-pi-a-ru",
           "gdpr"
         ]
       }
@@ -99184,7 +99848,8 @@
     "question_text": {
       "en": "Which US law tightens corporate financial reporting after Enron?",
       "ja": "エンロン事件後に施行されたアメリカの企業会計改革法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99192,7 +99857,6 @@
         "en": "FTP",
         "ja": "FTP",
         "ja_typings": [
-          "efuti-pi-",
           "ftp"
         ]
       },
@@ -99200,7 +99864,6 @@
         "en": "SFTP",
         "ja": "SFTP",
         "ja_typings": [
-          "esuefuti-pi-",
           "sftp"
         ]
       },
@@ -99208,7 +99871,6 @@
         "en": "FTPS",
         "ja": "FTPS",
         "ja_typings": [
-          "efuti-pi-esu",
           "ftps"
         ]
       },
@@ -99216,7 +99878,6 @@
         "en": "TFTP",
         "ja": "TFTP",
         "ja_typings": [
-          "thi-efuthi-pi-",
           "tftp"
         ]
       }
@@ -99228,7 +99889,8 @@
     "question_text": {
       "en": "Which file transfer protocol uses plain text and ports 20/21?",
       "ja": "ポート20/21を使う平文ファイル転送プロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99236,7 +99898,6 @@
         "en": "16 bits",
         "ja": "16ビット",
         "ja_typings": [
-          "ju-rokubitto",
           "16bitto"
         ]
       },
@@ -99244,7 +99905,6 @@
         "en": "8 bits",
         "ja": "8ビット",
         "ja_typings": [
-          "hachibitto",
           "8bitto"
         ]
       },
@@ -99252,7 +99912,6 @@
         "en": "32 bits",
         "ja": "32ビット",
         "ja_typings": [
-          "sanju-nibitto",
           "32bitto"
         ]
       },
@@ -99260,7 +99919,6 @@
         "en": "64 bits",
         "ja": "64ビット",
         "ja_typings": [
-          "rokuju-yonbitto",
           "64bitto"
         ]
       }
@@ -99272,7 +99930,8 @@
     "question_text": {
       "en": "Which CPU register width was standard for Intel 8086?",
       "ja": "Intel 8086 の標準的なレジスタ幅は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99280,7 +99939,6 @@
         "en": "64 bits",
         "ja": "64ビット",
         "ja_typings": [
-          "rokuju-yonbitto",
           "64bitto"
         ]
       },
@@ -99288,7 +99946,6 @@
         "en": "32 bits",
         "ja": "32ビット",
         "ja_typings": [
-          "sanju-nibitto",
           "32bitto"
         ]
       },
@@ -99296,7 +99953,6 @@
         "en": "16 bits",
         "ja": "16ビット",
         "ja_typings": [
-          "ju-rokubitto",
           "16bitto"
         ]
       },
@@ -99304,7 +99960,6 @@
         "en": "128 bits",
         "ja": "128ビット",
         "ja_typings": [
-          "hyakunijuhachibitto",
           "128bitto"
         ]
       }
@@ -99316,7 +99971,8 @@
     "question_text": {
       "en": "Which CPU register width is standard for modern x86_64 / ARM64?",
       "ja": "現代の x86_64 や ARM64 で標準のレジスタ幅は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99324,7 +99980,6 @@
         "en": "MD5",
         "ja": "MD5",
         "ja_typings": [
-          "emudi-go",
           "md5"
         ]
       },
@@ -99332,7 +99987,6 @@
         "en": "SHA-1",
         "ja": "SHA-1",
         "ja_typings": [
-          "esuetchie-ichi",
           "sha-1"
         ]
       },
@@ -99340,7 +99994,6 @@
         "en": "SHA-256",
         "ja": "SHA-256",
         "ja_typings": [
-          "esuetchie-nigorokuju-roku",
           "sha-256"
         ]
       },
@@ -99348,7 +100001,6 @@
         "en": "CRC32",
         "ja": "CRC32",
         "ja_typings": [
-          "shi-a-ru-shi-sanjuni",
           "crc32"
         ]
       }
@@ -99360,7 +100012,8 @@
     "question_text": {
       "en": "Which 128-bit hash function is now considered broken?",
       "ja": "現在では衝突攻撃に弱い128ビットのハッシュ関数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99368,7 +100021,6 @@
         "en": "POP3",
         "ja": "POP3",
         "ja_typings": [
-          "popputsuri-",
           "pop3"
         ]
       },
@@ -99376,7 +100028,6 @@
         "en": "IMAP",
         "ja": "IMAP",
         "ja_typings": [
-          "aimappu",
           "imap"
         ]
       },
@@ -99384,7 +100035,6 @@
         "en": "SMTP",
         "ja": "SMTP",
         "ja_typings": [
-          "esuemuti-pi-",
           "smtp"
         ]
       },
@@ -99403,7 +100053,8 @@
     "question_text": {
       "en": "Which protocol retrieves email by downloading from server (legacy)?",
       "ja": "メールをダウンロードして取得する旧来の受信プロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99418,7 +100069,6 @@
         "en": "SCSI",
         "ja": "SCSI",
         "ja_typings": [
-          "sukajii",
           "scsi"
         ]
       },
@@ -99433,7 +100083,6 @@
         "en": "eSATA",
         "ja": "eSATA",
         "ja_typings": [
-          "i-sata",
           "esata"
         ]
       }
@@ -99445,7 +100094,8 @@
     "question_text": {
       "en": "Which serial interface connects hard drives in PCs?",
       "ja": "PC で HDD を接続する内蔵シリアルインタフェースは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99453,7 +100103,6 @@
         "en": "22",
         "ja": "ポート22",
         "ja_typings": [
-          "po-toniju-ni",
           "po-to22"
         ]
       },
@@ -99461,7 +100110,6 @@
         "en": "21",
         "ja": "ポート21",
         "ja_typings": [
-          "po-tonijuichi",
           "po-to21"
         ]
       },
@@ -99469,7 +100117,6 @@
         "en": "23",
         "ja": "ポート23",
         "ja_typings": [
-          "po-toniju-san",
           "po-to23"
         ]
       },
@@ -99477,7 +100124,6 @@
         "en": "25",
         "ja": "ポート25",
         "ja_typings": [
-          "po-tonijugo",
           "po-to25"
         ]
       }
@@ -99489,7 +100135,8 @@
     "question_text": {
       "en": "Which TCP port does SSH use by default?",
       "ja": "SSH が既定で使う TCP ポートは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99497,7 +100144,6 @@
         "en": "ROM",
         "ja": "ROM",
         "ja_typings": [
-          "romu",
           "rom"
         ]
       },
@@ -99505,7 +100151,6 @@
         "en": "RAM",
         "ja": "RAM",
         "ja_typings": [
-          "ramu",
           "ram"
         ]
       },
@@ -99531,7 +100176,8 @@
     "question_text": {
       "en": "Which memory type can only be read, not modified at runtime?",
       "ja": "実行時に書き換えできず読み出し専用のメモリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99571,7 +100217,8 @@
     "question_text": {
       "en": "Which OS component provides a command-line interface?",
       "ja": "コマンドライン操作を提供する OS の構成要素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99579,7 +100226,6 @@
         "en": "VPN",
         "ja": "VPN",
         "ja_typings": [
-          "bui-pi-enu",
           "vpn"
         ]
       },
@@ -99587,7 +100233,6 @@
         "en": "DNS",
         "ja": "DNS",
         "ja_typings": [
-          "di-enu-esu",
           "dns"
         ]
       },
@@ -99595,7 +100240,6 @@
         "en": "VLAN",
         "ja": "VLAN",
         "ja_typings": [
-          "buiran",
           "vlan"
         ]
       },
@@ -99603,7 +100247,6 @@
         "en": "NAT",
         "ja": "NAT",
         "ja_typings": [
-          "natto",
           "nat"
         ]
       }
@@ -99615,7 +100258,8 @@
     "question_text": {
       "en": "Which technology creates an encrypted tunnel over a public network?",
       "ja": "公衆網上に暗号化トンネルを作る技術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99623,7 +100267,6 @@
         "en": "SNMP",
         "ja": "SNMP",
         "ja_typings": [
-          "esuenuemupi-",
           "snmp"
         ]
       },
@@ -99631,7 +100274,6 @@
         "en": "SMTP",
         "ja": "SMTP",
         "ja_typings": [
-          "esuemuti-pi-",
           "smtp"
         ]
       },
@@ -99639,7 +100281,6 @@
         "en": "ICMP",
         "ja": "ICMP",
         "ja_typings": [
-          "aishi-emupi-",
           "icmp"
         ]
       },
@@ -99647,7 +100288,6 @@
         "en": "NTP",
         "ja": "NTP",
         "ja_typings": [
-          "enuti-pi-",
           "ntp"
         ]
       }
@@ -99659,7 +100299,8 @@
     "question_text": {
       "en": "Which protocol monitors and manages network devices?",
       "ja": "ネットワーク機器の監視・管理に使うプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99667,7 +100308,6 @@
         "en": "ECC",
         "ja": "ECCメモリ",
         "ja_typings": [
-          "i-shi-shi-memori",
           "eccmemori"
         ]
       },
@@ -99675,7 +100315,6 @@
         "en": "DDR",
         "ja": "DDRメモリ",
         "ja_typings": [
-          "di-di-a-rumemori",
           "ddrmemori"
         ]
       },
@@ -99683,7 +100322,6 @@
         "en": "SRAM",
         "ja": "SRAM",
         "ja_typings": [
-          "esuramu",
           "sram"
         ]
       },
@@ -99691,7 +100329,6 @@
         "en": "Flash",
         "ja": "Flashメモリ",
         "ja_typings": [
-          "furasshumemori",
           "flashmemori"
         ]
       }
@@ -99703,7 +100340,8 @@
     "question_text": {
       "en": "Which memory technology detects and corrects single-bit errors?",
       "ja": "1ビット誤りを検出・訂正できるメモリ技術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99711,7 +100349,6 @@
         "en": "ZFS",
         "ja": "ZFS",
         "ja_typings": [
-          "zetto-efu-esu",
           "zfs"
         ]
       },
@@ -99719,7 +100356,6 @@
         "en": "Btrfs",
         "ja": "Btrfs",
         "ja_typings": [
-          "bata-efu-esu",
           "btrfs"
         ]
       },
@@ -99727,7 +100363,6 @@
         "en": "XFS",
         "ja": "XFS",
         "ja_typings": [
-          "ekkusu-efu-esu",
           "xfs"
         ]
       },
@@ -99735,7 +100370,6 @@
         "en": "ext4",
         "ja": "ext4",
         "ja_typings": [
-          "ikusutoyon",
           "ext4"
         ]
       }
@@ -99747,7 +100381,8 @@
     "question_text": {
       "en": "Which Sun-originated filesystem features copy-on-write and snapshots?",
       "ja": "Sun 発のコピーオンライトとスナップショットを持つファイルシステムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99755,7 +100390,6 @@
         "en": "exFAT",
         "ja": "exFAT",
         "ja_typings": [
-          "ekkusufatto",
           "exfat"
         ]
       },
@@ -99763,7 +100397,6 @@
         "en": "FAT32",
         "ja": "FAT32",
         "ja_typings": [
-          "fattosanjuni",
           "fat32"
         ]
       },
@@ -99771,7 +100404,6 @@
         "en": "NTFS",
         "ja": "NTFS",
         "ja_typings": [
-          "enuti-efu-esu",
           "ntfs"
         ]
       },
@@ -99779,7 +100411,6 @@
         "en": "ext4",
         "ja": "ext4",
         "ja_typings": [
-          "ikusutoyon",
           "ext4"
         ]
       }
@@ -99791,7 +100422,8 @@
     "question_text": {
       "en": "Which filesystem extends FAT for large flash drives beyond 32GB?",
       "ja": "32GB を超える大型フラッシュ向けに FAT を拡張したファイルシステムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99799,7 +100431,6 @@
         "en": "Intel",
         "ja": "Intel",
         "ja_typings": [
-          "interu",
           "intel"
         ]
       },
@@ -99807,7 +100438,6 @@
         "en": "AMD",
         "ja": "AMD",
         "ja_typings": [
-          "e-emudi-",
           "amd"
         ]
       },
@@ -99815,7 +100445,6 @@
         "en": "VIA",
         "ja": "VIA",
         "ja_typings": [
-          "bia",
           "via"
         ]
       },
@@ -99823,7 +100452,6 @@
         "en": "Cyrix",
         "ja": "Cyrix",
         "ja_typings": [
-          "sairikkusu",
           "cyrix"
         ]
       }
@@ -99835,7 +100463,8 @@
     "question_text": {
       "en": "Which is the largest x86 CPU vendor with brands like Core and Xeon?",
       "ja": "Core や Xeon を擁する最大の x86 CPU メーカーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99843,7 +100472,6 @@
         "en": "x86",
         "ja": "x86",
         "ja_typings": [
-          "ekkusuhachiroku",
           "x86"
         ]
       },
@@ -99851,7 +100479,6 @@
         "en": "ARM",
         "ja": "ARM",
         "ja_typings": [
-          "a-mu",
           "arm"
         ]
       },
@@ -99859,7 +100486,6 @@
         "en": "MIPS",
         "ja": "MIPS",
         "ja_typings": [
-          "mippusu",
           "mips"
         ]
       },
@@ -99867,8 +100493,6 @@
         "en": "RISC-V",
         "ja": "RISC-V",
         "ja_typings": [
-          "risukubu~i",
-          "risukubui-",
           "risc-v"
         ]
       }
@@ -99880,7 +100504,8 @@
     "question_text": {
       "en": "Which CISC instruction set architecture is used by Intel and AMD?",
       "ja": "Intel や AMD が採用する CISC 命令セットアーキテクチャは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99888,7 +100513,6 @@
         "en": "MIPS",
         "ja": "MIPS",
         "ja_typings": [
-          "mippusu",
           "mips"
         ]
       },
@@ -99896,7 +100520,6 @@
         "en": "SPARC",
         "ja": "SPARC",
         "ja_typings": [
-          "supa-ku",
           "sparc"
         ]
       },
@@ -99904,7 +100527,6 @@
         "en": "PowerPC",
         "ja": "PowerPC",
         "ja_typings": [
-          "pawa-pi-shi-",
           "powerpc"
         ]
       },
@@ -99912,7 +100534,6 @@
         "en": "Alpha",
         "ja": "Alpha",
         "ja_typings": [
-          "arufa",
           "alpha"
         ]
       }
@@ -99924,7 +100545,8 @@
     "question_text": {
       "en": "Which RISC architecture originated at Stanford in the 1980s?",
       "ja": "1980年代にスタンフォードで生まれた RISC アーキテクチャは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99932,7 +100554,6 @@
         "en": "SPARC",
         "ja": "SPARC",
         "ja_typings": [
-          "supa-ku",
           "sparc"
         ]
       },
@@ -99940,7 +100561,6 @@
         "en": "MIPS",
         "ja": "MIPS",
         "ja_typings": [
-          "mippusu",
           "mips"
         ]
       },
@@ -99948,7 +100568,6 @@
         "en": "PowerPC",
         "ja": "PowerPC",
         "ja_typings": [
-          "pawa-pi-shi-",
           "powerpc"
         ]
       },
@@ -99956,7 +100575,6 @@
         "en": "Alpha",
         "ja": "Alpha",
         "ja_typings": [
-          "arufa",
           "alpha"
         ]
       }
@@ -99968,7 +100586,8 @@
     "question_text": {
       "en": "Which RISC architecture was developed by Sun Microsystems?",
       "ja": "Sun Microsystems が開発した RISC アーキテクチャは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99976,7 +100595,6 @@
         "en": "VGA",
         "ja": "VGA",
         "ja_typings": [
-          "bui-ji-e-",
           "vga"
         ]
       },
@@ -99984,7 +100602,6 @@
         "en": "XGA",
         "ja": "XGA",
         "ja_typings": [
-          "ekkusuji-e-",
           "xga"
         ]
       },
@@ -99992,7 +100609,6 @@
         "en": "SVGA",
         "ja": "SVGA",
         "ja_typings": [
-          "esubui-ji-e-",
           "svga"
         ]
       },
@@ -100000,7 +100616,6 @@
         "en": "CGA",
         "ja": "CGA",
         "ja_typings": [
-          "shi-ji-e-",
           "cga"
         ]
       }
@@ -100012,7 +100627,8 @@
     "question_text": {
       "en": "Which video display standard introduced 640x480 resolution on PCs?",
       "ja": "PC で 640x480 解像度を一般化したビデオ規格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100020,7 +100636,6 @@
         "en": "Wi-Fi",
         "ja": "Wi-Fi",
         "ja_typings": [
-          "waifai",
           "wi-fi"
         ]
       },
@@ -100028,7 +100643,6 @@
         "en": "Bluetooth",
         "ja": "Bluetooth",
         "ja_typings": [
-          "buru-twu-su",
           "bluetooth"
         ]
       },
@@ -100036,7 +100650,6 @@
         "en": "Zigbee",
         "ja": "Zigbee",
         "ja_typings": [
-          "jigubi-",
           "zigbee"
         ]
       },
@@ -100044,7 +100657,6 @@
         "en": "LTE",
         "ja": "LTE",
         "ja_typings": [
-          "eruti-i-",
           "lte"
         ]
       }
@@ -100056,7 +100668,8 @@
     "question_text": {
       "en": "Which wireless standard is based on IEEE 802.11?",
       "ja": "IEEE 802.11 を基にした無線 LAN 規格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100064,7 +100677,6 @@
         "en": "IMAP",
         "ja": "IMAP",
         "ja_typings": [
-          "aimappu",
           "imap"
         ]
       },
@@ -100072,7 +100684,6 @@
         "en": "POP3",
         "ja": "POP3",
         "ja_typings": [
-          "popputsuri-",
           "pop3"
         ]
       },
@@ -100080,7 +100691,6 @@
         "en": "SMTP",
         "ja": "SMTP",
         "ja_typings": [
-          "esuemuti-pi-",
           "smtp"
         ]
       },
@@ -100099,7 +100709,8 @@
     "question_text": {
       "en": "Which mail protocol synchronizes messages across multiple devices?",
       "ja": "複数端末でメッセージを同期するメール受信プロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100107,7 +100718,6 @@
         "en": "SCSI",
         "ja": "SCSI",
         "ja_typings": [
-          "sukajii",
           "scsi"
         ]
       },
@@ -100129,7 +100739,6 @@
         "en": "PCIe",
         "ja": "PCIe",
         "ja_typings": [
-          "pi-shi-ai-i-",
           "pcie"
         ]
       }
@@ -100141,7 +100750,8 @@
     "question_text": {
       "en": "Which parallel interface historically connected enterprise disks and scanners?",
       "ja": "業務用ディスクやスキャナを接続したパラレルインタフェースは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100149,7 +100759,6 @@
         "en": "port 21",
         "ja": "ポート21",
         "ja_typings": [
-          "po-tonijuichi",
           "po-to21"
         ]
       },
@@ -100157,7 +100766,6 @@
         "en": "port 22",
         "ja": "ポート22",
         "ja_typings": [
-          "po-toniju-ni",
           "po-to22"
         ]
       },
@@ -100165,7 +100773,6 @@
         "en": "port 23",
         "ja": "ポート23",
         "ja_typings": [
-          "po-toniju-san",
           "po-to23"
         ]
       },
@@ -100173,7 +100780,6 @@
         "en": "port 25",
         "ja": "ポート25",
         "ja_typings": [
-          "po-tonijugo",
           "po-to25"
         ]
       }
@@ -100185,7 +100791,8 @@
     "question_text": {
       "en": "Which TCP port is used for the FTP control connection?",
       "ja": "FTP の制御コネクションに使われる TCP ポートは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100193,7 +100800,6 @@
         "en": "23",
         "ja": "ポート23",
         "ja_typings": [
-          "po-toniju-san",
           "po-to23"
         ]
       },
@@ -100201,7 +100807,6 @@
         "en": "22",
         "ja": "ポート22",
         "ja_typings": [
-          "po-toniju-ni",
           "po-to22"
         ]
       },
@@ -100209,7 +100814,6 @@
         "en": "21",
         "ja": "ポート21",
         "ja_typings": [
-          "po-tonijuichi",
           "po-to21"
         ]
       },
@@ -100217,7 +100821,6 @@
         "en": "25",
         "ja": "ポート25",
         "ja_typings": [
-          "po-tonijugo",
           "po-to25"
         ]
       }
@@ -100229,7 +100832,8 @@
     "question_text": {
       "en": "Which TCP port does Telnet use by default?",
       "ja": "Telnet が既定で使う TCP ポートは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100244,7 +100848,6 @@
         "en": "HTTP",
         "ja": "HTTP",
         "ja_typings": [
-          "etchi-thi-thi-pi-",
           "http"
         ]
       },
@@ -100252,7 +100855,6 @@
         "en": "gRPC",
         "ja": "gRPC",
         "ja_typings": [
-          "ji-a-ru-pi-shi-",
           "grpc"
         ]
       },
@@ -100260,7 +100862,6 @@
         "en": "MQTT",
         "ja": "MQTT",
         "ja_typings": [
-          "emukyu-thi-thi-",
           "mqtt"
         ]
       }
@@ -100272,7 +100873,8 @@
     "question_text": {
       "en": "Which protocol enables full-duplex communication over a single TCP connection?",
       "ja": "単一の TCP 接続で全二重通信を行うプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100280,7 +100882,6 @@
         "en": "TPU",
         "ja": "TPU",
         "ja_typings": [
-          "thi-pi-yu-",
           "tpu"
         ]
       },
@@ -100288,7 +100889,6 @@
         "en": "GPU",
         "ja": "GPU",
         "ja_typings": [
-          "ji-pi-yu-",
           "gpu"
         ]
       },
@@ -100296,7 +100896,6 @@
         "en": "CPU",
         "ja": "CPU",
         "ja_typings": [
-          "shi-pi-yu-",
           "cpu"
         ]
       },
@@ -100304,7 +100903,6 @@
         "en": "FPGA",
         "ja": "FPGA",
         "ja_typings": [
-          "efupi-ji-e-",
           "fpga"
         ]
       }
@@ -100316,7 +100914,8 @@
     "question_text": {
       "en": "Which Google chip accelerates tensor computations for ML?",
       "ja": "Google が機械学習用に開発したテンソル演算アクセラレータは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100324,7 +100923,6 @@
         "en": "DSP",
         "ja": "DSP",
         "ja_typings": [
-          "di-esu-pi-",
           "dsp"
         ]
       },
@@ -100332,7 +100930,6 @@
         "en": "GPU",
         "ja": "GPU",
         "ja_typings": [
-          "ji-pi-yu-",
           "gpu"
         ]
       },
@@ -100340,7 +100937,6 @@
         "en": "CPU",
         "ja": "CPU",
         "ja_typings": [
-          "shi-pi-yu-",
           "cpu"
         ]
       },
@@ -100348,7 +100944,6 @@
         "en": "MCU",
         "ja": "MCU",
         "ja_typings": [
-          "emu-shi-yu-",
           "mcu"
         ]
       }
@@ -100360,7 +100955,8 @@
     "question_text": {
       "en": "Which specialized processor handles signal processing tasks?",
       "ja": "信号処理に特化した専用プロセッサは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100368,7 +100964,6 @@
         "en": "USB flash drive",
         "ja": "USBメモリ",
         "ja_typings": [
-          "yu-esubi-memori",
           "usbmemori"
         ]
       },
@@ -100383,7 +100978,6 @@
         "en": "FDD",
         "ja": "FDD",
         "ja_typings": [
-          "efu-di-di-",
           "fdd"
         ]
       },
@@ -100391,7 +100985,6 @@
         "en": "MO",
         "ja": "MO",
         "ja_typings": [
-          "emu-o-",
           "mo"
         ]
       }
@@ -100418,7 +101011,6 @@
         "en": "USB flash drive",
         "ja": "USBメモリ",
         "ja_typings": [
-          "yu-esubi-memori",
           "usbmemori"
         ]
       },
@@ -100426,7 +101018,6 @@
         "en": "FDD",
         "ja": "FDD",
         "ja_typings": [
-          "efu-di-di-",
           "fdd"
         ]
       },
@@ -100434,7 +101025,6 @@
         "en": "HDD",
         "ja": "HDD",
         "ja_typings": [
-          "etchi-di-di-",
           "hdd"
         ]
       }
@@ -100454,7 +101044,6 @@
         "en": "FDD",
         "ja": "FDD",
         "ja_typings": [
-          "efu-di-di-",
           "fdd"
         ]
       },
@@ -100462,7 +101051,6 @@
         "en": "HDD",
         "ja": "HDD",
         "ja_typings": [
-          "etchi-di-di-",
           "hdd"
         ]
       },
@@ -100470,7 +101058,6 @@
         "en": "MO",
         "ja": "MO",
         "ja_typings": [
-          "emu-o-",
           "mo"
         ]
       },
@@ -100478,7 +101065,6 @@
         "en": "ZIP",
         "ja": "ZIP",
         "ja_typings": [
-          "jippu",
           "zip"
         ]
       }
@@ -100490,7 +101076,8 @@
     "question_text": {
       "en": "Which legacy 3.5-inch removable magnetic storage was common in the 90s?",
       "ja": "90年代に普及した3.5インチの磁気フロッピーディスク装置は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100498,7 +101085,6 @@
         "en": "MO",
         "ja": "MO",
         "ja_typings": [
-          "emu-o-",
           "mo"
         ]
       },
@@ -100506,7 +101092,6 @@
         "en": "FDD",
         "ja": "FDD",
         "ja_typings": [
-          "efu-di-di-",
           "fdd"
         ]
       },
@@ -100514,7 +101099,6 @@
         "en": "ZIP",
         "ja": "ZIP",
         "ja_typings": [
-          "jippu",
           "zip"
         ]
       },
@@ -100522,7 +101106,6 @@
         "en": "DAT",
         "ja": "DAT",
         "ja_typings": [
-          "datto",
           "dat"
         ]
       }
@@ -100534,7 +101117,8 @@
     "question_text": {
       "en": "Which magneto-optical removable disc was popular in Japan in the 90s?",
       "ja": "90年代の日本で普及した光磁気ディスクは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100574,7 +101158,8 @@
     "question_text": {
       "en": "Which software lets the OS communicate with hardware devices?",
       "ja": "OS がハードウェアと通信するためのソフトウェアは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100614,7 +101199,8 @@
     "question_text": {
       "en": "Which reusable code collection can be linked into programs?",
       "ja": "プログラムにリンクして再利用するコードの集合は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100654,7 +101240,8 @@
     "question_text": {
       "en": "Which Unix term names a background service process?",
       "ja": "Unix でバックグラウンドサービスを指す用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100694,7 +101281,8 @@
     "question_text": {
       "en": "Which tool translates source code into machine code?",
       "ja": "ソースコードを機械語に変換するツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100734,7 +101322,8 @@
     "question_text": {
       "en": "Which Git term names a storage location for project history?",
       "ja": "Git でプロジェクト履歴を格納する場所を指す用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100774,7 +101363,8 @@
     "question_text": {
       "en": "Which tool steps through code to find bugs?",
       "ja": "プログラムを段階実行してバグを見つけるツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100830,7 +101420,6 @@
         "en": "VM",
         "ja": "VM",
         "ja_typings": [
-          "bui-emu",
           "vm"
         ]
       },
@@ -100856,7 +101445,8 @@
     "question_text": {
       "en": "Which OS-level virtualization unit packages an app with its deps?",
       "ja": "アプリと依存関係をまとめる OS レベル仮想化の単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100896,7 +101486,8 @@
     "question_text": {
       "en": "Which Ethernet device forwards frames using MAC addresses?",
       "ja": "MAC アドレスでフレームを転送するイーサネット機器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100936,7 +101527,8 @@
     "question_text": {
       "en": "Which legacy device broadcasts all incoming traffic to every port?",
       "ja": "受信した信号を全ポートに送出する旧式の機器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100976,7 +101568,8 @@
     "question_text": {
       "en": "Which device regenerates signals to extend a network's reach?",
       "ja": "信号を増幅・整形してネットワーク到達距離を伸ばす機器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100984,7 +101577,6 @@
         "en": "256 bits",
         "ja": "256ビット",
         "ja_typings": [
-          "nigorokuju-rokubitto",
           "256bitto"
         ]
       },
@@ -100992,7 +101584,6 @@
         "en": "128 bits",
         "ja": "128ビット",
         "ja_typings": [
-          "hyakunijuhachibitto",
           "128bitto"
         ]
       },
@@ -101000,7 +101591,6 @@
         "en": "192 bits",
         "ja": "192ビット",
         "ja_typings": [
-          "hyakukyuju-nibitto",
           "192bitto"
         ]
       },
@@ -101008,7 +101598,6 @@
         "en": "512 bits",
         "ja": "512ビット",
         "ja_typings": [
-          "gohyakuju-nibitto",
           "512bitto"
         ]
       }
@@ -101020,7 +101609,8 @@
     "question_text": {
       "en": "Which key length is standard for AES-256?",
       "ja": "AES-256 で使われる鍵長は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101112,7 +101702,6 @@
         "en": "DES",
         "ja": "DES",
         "ja_typings": [
-          "di-i-esu",
           "des"
         ]
       },
@@ -101120,7 +101709,6 @@
         "en": "AES",
         "ja": "AES",
         "ja_typings": [
-          "e-i-esu",
           "aes"
         ]
       },
@@ -101128,7 +101716,6 @@
         "en": "RSA",
         "ja": "RSA",
         "ja_typings": [
-          "a-ru-esu-e-",
           "rsa"
         ]
       },
@@ -101147,7 +101734,8 @@
     "question_text": {
       "en": "Which now-deprecated symmetric block cipher uses a 56-bit key?",
       "ja": "56ビット鍵を使う旧式の対称ブロック暗号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101155,7 +101743,6 @@
         "en": "SHA",
         "ja": "SHA",
         "ja_typings": [
-          "esuetchie-",
           "sha"
         ]
       },
@@ -101163,7 +101750,6 @@
         "en": "MD5",
         "ja": "MD5",
         "ja_typings": [
-          "emudi-go",
           "md5"
         ]
       },
@@ -101171,7 +101757,6 @@
         "en": "CRC",
         "ja": "CRC",
         "ja_typings": [
-          "shi-a-ru-shi-",
           "crc"
         ]
       },
@@ -101179,7 +101764,6 @@
         "en": "HMAC",
         "ja": "HMAC",
         "ja_typings": [
-          "etchi-makku",
           "hmac"
         ]
       }
@@ -101191,7 +101775,8 @@
     "question_text": {
       "en": "Which family of cryptographic hash functions includes -1, -256, -512?",
       "ja": "-1 や -256 などのバリアントを持つ暗号ハッシュ関数群は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101355,7 +101940,8 @@
     "question_text": {
       "en": "Which Egyptian city on the Mediterranean coast was home to a famous ancient library?",
       "ja": "エジプトの地中海沿岸に位置し、古代に大図書館があった都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101519,7 +102105,8 @@
     "question_text": {
       "en": "Which is the largest continent in the world?",
       "ja": "世界で最も広い大陸は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101559,7 +102146,8 @@
     "question_text": {
       "en": "What is the capital of Paraguay?",
       "ja": "パラグアイの首都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101679,7 +102267,8 @@
     "question_text": {
       "en": "Which Indian city is known as the center of the IT industry?",
       "ja": "インドのIT産業の中心地として知られる都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101719,7 +102308,8 @@
     "question_text": {
       "en": "Which city in northeastern Spain is home to the Sagrada Familia?",
       "ja": "サグラダ・ファミリアがあるスペイン北東部の都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101759,7 +102349,8 @@
     "question_text": {
       "en": "What is the capital of Germany?",
       "ja": "ドイツの首都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101799,7 +102390,8 @@
     "question_text": {
       "en": "Which Himalayan country is known for its focus on Gross National Happiness?",
       "ja": "ヒマラヤ山脈にある「幸福度」で知られる国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101883,7 +102475,8 @@
     "question_text": {
       "en": "Iguazu Falls lies on the border between which two countries?",
       "ja": "イグアスの滝が国境にある国の組み合わせは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101923,7 +102516,8 @@
     "question_text": {
       "en": "What is the capital of Argentina?",
       "ja": "アルゼンチンの首都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101963,7 +102557,8 @@
     "question_text": {
       "en": "Which northwestern Turkish city was a former capital of the Ottoman Empire?",
       "ja": "トルコ北西部の旧オスマン帝国首都として知られる都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102003,7 +102598,8 @@
     "question_text": {
       "en": "Which is South Korea's second largest city and a major southeastern port?",
       "ja": "韓国第2の都市で南東部の主要港湾都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102043,7 +102639,8 @@
     "question_text": {
       "en": "Which resort city is on Mexico's Yucatan Peninsula?",
       "ja": "メキシコ・ユカタン半島のリゾート都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102163,7 +102760,8 @@
     "question_text": {
       "en": "Which U.S. city is located on the shore of Lake Michigan?",
       "ja": "アメリカ五大湖のミシガン湖畔に位置する都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102203,7 +102801,8 @@
     "question_text": {
       "en": "Which ancient Greek city stood at the isthmus of the Peloponnese?",
       "ja": "ペロポネソス半島の付け根にある古代ギリシャの都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102243,7 +102842,8 @@
     "question_text": {
       "en": "Which city is a major port in central Vietnam?",
       "ja": "ベトナム中部の主要港湾都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102283,7 +102883,8 @@
     "question_text": {
       "en": "What is the capital of Ireland?",
       "ja": "アイルランドの首都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102323,7 +102924,8 @@
     "question_text": {
       "en": "What is the capital of Scotland?",
       "ja": "スコットランドの首都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102363,7 +102965,8 @@
     "question_text": {
       "en": "Which Tuscan city is known as the birthplace of the Renaissance?",
       "ja": "イタリアのトスカーナ州の州都でルネサンス発祥の地は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102403,7 +103006,8 @@
     "question_text": {
       "en": "Which German city is the country's financial center?",
       "ja": "ドイツの金融の中心地として知られる都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102483,7 +103087,8 @@
     "question_text": {
       "en": "Which Egyptian city is home to the pyramids and the Sphinx?",
       "ja": "ピラミッドとスフィンクスがあるエジプトの都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102565,7 +103170,8 @@
     "question_text": {
       "en": "Which Mexican city is famous as the home of tequila?",
       "ja": "メキシコ第2の都市でテキーラの産地として有名な都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102645,7 +103251,8 @@
     "question_text": {
       "en": "Which city is a major northern German port?",
       "ja": "ドイツ北部の主要港湾都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102685,7 +103292,8 @@
     "question_text": {
       "en": "What is the capital of Vietnam?",
       "ja": "ベトナムの首都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102725,7 +103333,8 @@
     "question_text": {
       "en": "Which is the largest city in southern Vietnam?",
       "ja": "ベトナム南部最大の都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102805,7 +103414,8 @@
     "question_text": {
       "en": "Which central Vietnamese city was the imperial capital under the Nguyen dynasty?",
       "ja": "ベトナム中部の旧王朝の都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102845,7 +103455,8 @@
     "question_text": {
       "en": "Which port city near Seoul hosts South Korea's main international airport?",
       "ja": "韓国の国際空港があるソウル近郊の港湾都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102885,7 +103496,8 @@
     "question_text": {
       "en": "Which is the most populous country in South Asia?",
       "ja": "南アジアで人口最多の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103050,7 +103662,8 @@
     "question_text": {
       "en": "Which is Turkey's third largest city, a port on the Aegean coast?",
       "ja": "トルコ第3の都市でエーゲ海沿岸の港湾都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103090,7 +103703,8 @@
     "question_text": {
       "en": "Which is Saudi Arabia's main city on the Red Sea coast?",
       "ja": "サウジアラビアの紅海沿岸の主要都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103211,7 +103825,8 @@
     "question_text": {
       "en": "Which large eastern Indian city was formerly called Calcutta?",
       "ja": "インド東部の大都市で旧称カルカッタの都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103451,7 +104066,8 @@
     "question_text": {
       "en": "Which is the largest city in Southern California?",
       "ja": "アメリカ・カリフォルニア州南部の大都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103491,7 +104107,8 @@
     "question_text": {
       "en": "Which southern Egyptian city is famous for the Karnak Temple?",
       "ja": "エジプト南部にあるカルナック神殿で有名な都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103573,7 +104190,8 @@
     "question_text": {
       "en": "What is the capital of Spain?",
       "ja": "スペインの首都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103613,7 +104231,8 @@
     "question_text": {
       "en": "Which northwestern English industrial city is famous for football?",
       "ja": "イギリス北西部の工業都市でサッカーが盛んな都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103653,7 +104272,8 @@
     "question_text": {
       "en": "Which Saudi Arabian city is Islam's holiest site?",
       "ja": "イスラム教最大の聖地はサウジアラビアの?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103693,7 +104313,8 @@
     "question_text": {
       "en": "Which city is Islam's second holiest, home to the Prophet Muhammad's tomb?",
       "ja": "イスラム教第2の聖地で預言者ムハンマドの墓がある都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103773,7 +104394,8 @@
     "question_text": {
       "en": "Which northern Italian city is its economic and fashion capital?",
       "ja": "イタリア北部の経済の中心地でファッションの都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103857,7 +104479,8 @@
     "question_text": {
       "en": "Which northern Mexican city is a major industrial center?",
       "ja": "メキシコ北部の工業都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103897,7 +104520,8 @@
     "question_text": {
       "en": "What is the capital of Uruguay?",
       "ja": "ウルグアイの首都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103937,7 +104561,8 @@
     "question_text": {
       "en": "Which is the largest city in Quebec, Canada?",
       "ja": "カナダ・ケベック州の最大都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104217,7 +104842,8 @@
     "question_text": {
       "en": "Which is India's largest city, formerly known as Bombay?",
       "ja": "インド最大の都市で旧称ボンベイは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104257,7 +104883,8 @@
     "question_text": {
       "en": "What is the capital of Bavaria, Germany?",
       "ja": "ドイツ・バイエルン州の州都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104377,7 +105004,8 @@
     "question_text": {
       "en": "Which landlocked South Asian country is home to Mount Everest?",
       "ja": "エベレストがある南アジアの内陸国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104417,7 +105045,8 @@
     "question_text": {
       "en": "Which European country has Amsterdam as its capital?",
       "ja": "アムステルダムを首都とするヨーロッパの国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104500,7 +105129,8 @@
     "question_text": {
       "en": "Which is the U.S. east coast's global city?",
       "ja": "アメリカ東海岸の世界都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104540,7 +105170,8 @@
     "question_text": {
       "en": "Which is the largest city in Siberia?",
       "ja": "シベリア最大の都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104580,7 +105211,8 @@
     "question_text": {
       "en": "What is the capital of Cambodia?",
       "ja": "カンボジアの首都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104595,7 +105227,6 @@
         "en": "Seoul",
         "ja": "ソウル",
         "ja_typings": [
-          "soru",
           "souru"
         ]
       },
@@ -104621,7 +105252,8 @@
     "question_text": {
       "en": "What is the capital of North Korea?",
       "ja": "北朝鮮の首都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104702,7 +105334,8 @@
     "question_text": {
       "en": "Which Brazilian city is famous for the Christ the Redeemer statue?",
       "ja": "ブラジルでコルコバードのキリスト像で有名な都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104742,7 +105375,8 @@
     "question_text": {
       "en": "Which Dutch port city houses Europoort, one of Europe's largest ports?",
       "ja": "オランダの主要港湾都市でユーロポートを擁するのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104782,7 +105416,8 @@
     "question_text": {
       "en": "Which is Russia's former capital on the Baltic coast?",
       "ja": "ロシアの旧首都でバルト海沿岸の都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104822,7 +105457,8 @@
     "question_text": {
       "en": "What is the capital of Chile?",
       "ja": "チリの首都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104862,7 +105498,8 @@
     "question_text": {
       "en": "Which is the largest city in Brazil?",
       "ja": "ブラジル最大の都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104902,7 +105539,8 @@
     "question_text": {
       "en": "What is the capital of Andalusia in southern Spain?",
       "ja": "スペイン南部アンダルシア州の州都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105102,7 +105740,8 @@
     "question_text": {
       "en": "Which ancient Greek city-state was famous for its military?",
       "ja": "古代ギリシャの軍事都市国家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105186,7 +105825,8 @@
     "question_text": {
       "en": "Which Dutch city is home to the International Court of Justice?",
       "ja": "国際司法裁判所が置かれるオランダの都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105226,7 +105866,8 @@
     "question_text": {
       "en": "Which is Greece's second largest city?",
       "ja": "ギリシャ第2の都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105351,7 +105992,8 @@
     "question_text": {
       "en": "Which is the largest city in Canada?",
       "ja": "カナダ最大の都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105431,7 +106073,8 @@
     "question_text": {
       "en": "The Rio Grande forms the border between which two countries?",
       "ja": "リオ・グランデ川が国境を流れている国の組み合わせは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105471,7 +106114,8 @@
     "question_text": {
       "en": "Which Dutch central city is a major university town?",
       "ja": "オランダ中央部の大学都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105511,7 +106155,8 @@
     "question_text": {
       "en": "Which eastern Spanish city on the Mediterranean is the birthplace of paella?",
       "ja": "スペイン東部地中海沿岸の都市でパエリア発祥地は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105551,7 +106196,8 @@
     "question_text": {
       "en": "Which is Canada's main west coast port city?",
       "ja": "カナダ西海岸の港湾都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105591,7 +106237,8 @@
     "question_text": {
       "en": "Which northeastern Italian city is famous for its canals?",
       "ja": "イタリア北東部の運河の街は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105631,7 +106278,8 @@
     "question_text": {
       "en": "What is the capital of Laos?",
       "ja": "ラオスの首都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105671,7 +106319,8 @@
     "question_text": {
       "en": "Which is the largest city in the Russian Far East?",
       "ja": "ロシア極東の最大都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105754,7 +106403,8 @@
     "question_text": {
       "en": "Victoria Falls lies on the border between which two countries?",
       "ja": "ビクトリアの滝が国境にある国の組み合わせは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105794,7 +106444,8 @@
     "question_text": {
       "en": "Which is one of the typical default maximum TTL values used in IPv4?",
       "ja": "IPv4でルータが特別な用途で予約しているTTLのデフォルト最大値の1つは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105834,7 +106485,8 @@
     "question_text": {
       "en": "What is the maximum value of an 8-bit unsigned integer?",
       "ja": "8ビット符号なし整数で表せる最大値は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105874,7 +106526,8 @@
     "question_text": {
       "en": "How many bits does C's short type typically have?",
       "ja": "C言語のshort型で多くの環境におけるビット数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105954,7 +106607,8 @@
     "question_text": {
       "en": "How many bits wide is a general purpose register in x86_64?",
       "ja": "x86_64アーキテクチャでの汎用レジスタの幅は何ビット?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105994,7 +106648,8 @@
     "question_text": {
       "en": "How many bits is one octet in IPv4?",
       "ja": "IPv4の1オクテットは何ビット?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106034,7 +106689,8 @@
     "question_text": {
       "en": "Which protocol resolves IP addresses to MAC addresses?",
       "ja": "IPアドレスからMACアドレスを解決するプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106074,7 +106730,8 @@
     "question_text": {
       "en": "Which agentless configuration management tool uses YAML playbooks?",
       "ja": "サーバ構成管理ツールでYAMLで定義しエージェントレスで動作するのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106114,7 +106771,8 @@
     "question_text": {
       "en": "Which old XML-based build tool is used for Java projects?",
       "ja": "Javaのビルドツールで古くから使われているXMLベースのものは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106154,7 +106812,8 @@
     "question_text": {
       "en": "Which browser was made by The Browser Company with a focus on tabs and workflows?",
       "ja": "Mozillaが開発したJavaScriptランタイム向けの新ブラウザは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106194,7 +106853,8 @@
     "question_text": {
       "en": "Which program translates assembly language into machine code?",
       "ja": "アセンブリ言語を機械語に変換するプログラムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106394,7 +107054,8 @@
     "question_text": {
       "en": "Which unit represents bits transferred per second?",
       "ja": "ビットレートの単位で1秒間のビット数を表すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106402,16 +107063,14 @@
         "en": "Bad Request",
         "ja": "Bad Request",
         "ja_typings": [
-          "bad request",
-          "badrequest"
+          "bad request"
         ]
       },
       {
         "en": "Not Found",
         "ja": "Not Found",
         "ja_typings": [
-          "not found",
-          "notfound"
+          "not found"
         ]
       },
       {
@@ -106436,7 +107095,8 @@
     "question_text": {
       "en": "What does HTTP status code 400 indicate?",
       "ja": "HTTPステータスコード400が示すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106476,7 +107136,8 @@
     "question_text": {
       "en": "Which is the standard shell on most Linux distributions?",
       "ja": "Linuxで標準的に使われるシェルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106484,32 +107145,28 @@
         "en": "Bill Joy",
         "ja": "Bill Joy",
         "ja_typings": [
-          "bill joy",
-          "billjoy"
+          "bill joy"
         ]
       },
       {
         "en": "Bjarne Stroustrup",
         "ja": "Bjarne Stroustrup",
         "ja_typings": [
-          "bjarne stroustrup",
-          "bjarnestroustrup"
+          "bjarne stroustrup"
         ]
       },
       {
         "en": "Linus Torvalds",
         "ja": "Linus Torvalds",
         "ja_typings": [
-          "linus torvalds",
-          "linustorvalds"
+          "linus torvalds"
         ]
       },
       {
         "en": "Richard Stallman",
         "ja": "Richard Stallman",
         "ja_typings": [
-          "richard stallman",
-          "richardstallman"
+          "richard stallman"
         ]
       }
     ],
@@ -106520,7 +107177,8 @@
     "question_text": {
       "en": "Who is the author of the vi editor?",
       "ja": "viエディタを開発した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106568,32 +107226,28 @@
         "en": "Bjarne Stroustrup",
         "ja": "Bjarne Stroustrup",
         "ja_typings": [
-          "bjarne stroustrup",
-          "bjarnestroustrup"
+          "bjarne stroustrup"
         ]
       },
       {
         "en": "Dennis Ritchie",
         "ja": "Dennis Ritchie",
         "ja_typings": [
-          "dennis ritchie",
-          "dennisritchie"
+          "dennis ritchie"
         ]
       },
       {
         "en": "Bill Joy",
         "ja": "Bill Joy",
         "ja_typings": [
-          "bill joy",
-          "billjoy"
+          "bill joy"
         ]
       },
       {
         "en": "Brian Kernighan",
         "ja": "Brian Kernighan",
         "ja_typings": [
-          "brian kernighan",
-          "briankernighan"
+          "brian kernighan"
         ]
       }
     ],
@@ -106604,7 +107258,8 @@
     "question_text": {
       "en": "Who designed the C++ programming language?",
       "ja": "C++を設計した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106644,7 +107299,8 @@
     "question_text": {
       "en": "Which Rust smart pointer places a single value on the heap?",
       "ja": "Rustのヒープに値を1つ置くスマートポインタ型は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106652,32 +107308,28 @@
         "en": "Brendan Eich",
         "ja": "Brendan Eich",
         "ja_typings": [
-          "brendan eich",
-          "brendaneich"
+          "brendan eich"
         ]
       },
       {
         "en": "Guido van Rossum",
         "ja": "Guido van Rossum",
         "ja_typings": [
-          "guido van rossum",
-          "guidovanrossum"
+          "guido van rossum"
         ]
       },
       {
         "en": "Larry Wall",
         "ja": "Larry Wall",
         "ja_typings": [
-          "larry wall",
-          "larrywall"
+          "larry wall"
         ]
       },
       {
         "en": "Yukihiro Matsumoto",
         "ja": "Yukihiro Matsumoto",
         "ja_typings": [
-          "yukihiro matsumoto",
-          "yukihiromatsumoto"
+          "yukihiro matsumoto"
         ]
       }
     ],
@@ -106688,7 +107340,8 @@
     "question_text": {
       "en": "Who designed JavaScript?",
       "ja": "JavaScriptを設計した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106696,32 +107349,28 @@
         "en": "Brian Kernighan",
         "ja": "Brian Kernighan",
         "ja_typings": [
-          "brian kernighan",
-          "briankernighan"
+          "brian kernighan"
         ]
       },
       {
         "en": "Dennis Ritchie",
         "ja": "Dennis Ritchie",
         "ja_typings": [
-          "dennis ritchie",
-          "dennisritchie"
+          "dennis ritchie"
         ]
       },
       {
         "en": "Bjarne Stroustrup",
         "ja": "Bjarne Stroustrup",
         "ja_typings": [
-          "bjarne stroustrup",
-          "bjarnestroustrup"
+          "bjarne stroustrup"
         ]
       },
       {
         "en": "Bill Joy",
         "ja": "Bill Joy",
         "ja_typings": [
-          "bill joy",
-          "billjoy"
+          "bill joy"
         ]
       }
     ],
@@ -106732,7 +107381,8 @@
     "question_text": {
       "en": "Who co-authored 'The C Programming Language' and co-created AWK?",
       "ja": "AWKの開発者の1人で『プログラミング言語C』の共著者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106812,7 +107462,8 @@
     "question_text": {
       "en": "What is the abbreviation for .NET's common language runtime?",
       "ja": ".NETの共通言語ランタイムの略称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106892,7 +107543,8 @@
     "question_text": {
       "en": "Which language styles HTML documents?",
       "ja": "HTMLの見た目を装飾する言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106932,7 +107584,8 @@
     "question_text": {
       "en": "What is Rust's package manager and build tool called?",
       "ja": "Rustのパッケージマネージャ兼ビルドツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106972,7 +107625,8 @@
     "question_text": {
       "en": "Which distributed NoSQL database uses a column-family store?",
       "ja": "分散NoSQLデータベースの1つで列指向ストアなのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107052,7 +107706,8 @@
     "question_text": {
       "en": "Which software translates source code into machine code?",
       "ja": "ソースコードを機械語などに翻訳するソフトウェアは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107132,7 +107787,8 @@
     "question_text": {
       "en": "Which gaming metric measures damage dealt per second?",
       "ja": "1秒間に与えるダメージ量の指標は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107172,7 +107828,8 @@
     "question_text": {
       "en": "Which tool lets you step through code and inspect variables?",
       "ja": "プログラムをステップ実行・変数監視できるツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107224,32 +107881,28 @@
         "en": "Dennis Ritchie",
         "ja": "Dennis Ritchie",
         "ja_typings": [
-          "dennis ritchie",
-          "dennisritchie"
+          "dennis ritchie"
         ]
       },
       {
         "en": "Brian Kernighan",
         "ja": "Brian Kernighan",
         "ja_typings": [
-          "brian kernighan",
-          "briankernighan"
+          "brian kernighan"
         ]
       },
       {
         "en": "Bjarne Stroustrup",
         "ja": "Bjarne Stroustrup",
         "ja_typings": [
-          "bjarne stroustrup",
-          "bjarnestroustrup"
+          "bjarne stroustrup"
         ]
       },
       {
         "en": "Bill Joy",
         "ja": "Bill Joy",
         "ja_typings": [
-          "bill joy",
-          "billjoy"
+          "bill joy"
         ]
       }
     ],
@@ -107260,7 +107913,8 @@
     "question_text": {
       "en": "Who developed the C programming language?",
       "ja": "C言語を開発した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107268,8 +107922,7 @@
         "en": "Docker Compose",
         "ja": "Docker Compose",
         "ja_typings": [
-          "docker compose",
-          "dockercompose"
+          "docker compose"
         ]
       },
       {
@@ -107301,7 +107954,8 @@
     "question_text": {
       "en": "Which tool runs multi-container Docker applications via YAML?",
       "ja": "複数のコンテナをまとめて定義・起動するツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107421,7 +108075,8 @@
     "question_text": {
       "en": "Which SQL statement retrieves rows from a cursor?",
       "ja": "SQLでデータを取得するために使われるカーソル操作の文は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107461,7 +108116,8 @@
     "question_text": {
       "en": "Which fast file system was developed for BSD UNIX?",
       "ja": "BSD系UNIXで使われた高速ファイルシステムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107501,7 +108157,8 @@
     "question_text": {
       "en": "Which classic protocol is used to transfer files?",
       "ja": "ファイルを転送する古典的なプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107516,7 +108173,6 @@
         "en": "Singleton",
         "ja": "シングルトン",
         "ja_typings": [
-          "shingoruton",
           "shinguruton"
         ]
       },
@@ -107542,7 +108198,8 @@
     "question_text": {
       "en": "Which is one of the GoF creational design patterns?",
       "ja": "GoFのデザインパターンで生成系の1つは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107582,7 +108239,8 @@
     "question_text": {
       "en": "Which term refers to lightweight threads scheduled by a runtime?",
       "ja": "軽量スレッドのことを指す概念は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107604,16 +108262,14 @@
         "en": "Not Found",
         "ja": "Not Found",
         "ja_typings": [
-          "not found",
-          "notfound"
+          "not found"
         ]
       },
       {
         "en": "Bad Request",
         "ja": "Bad Request",
         "ja_typings": [
-          "bad request",
-          "badrequest"
+          "bad request"
         ]
       }
     ],
@@ -107624,7 +108280,8 @@
     "question_text": {
       "en": "What does HTTP status code 403 indicate?",
       "ja": "HTTPステータスコード403が示すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107664,7 +108321,8 @@
     "question_text": {
       "en": "Which language was created in 1957 for scientific computation?",
       "ja": "科学計算用に1957年に作られた言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107704,7 +108362,8 @@
     "question_text": {
       "en": "Which SQL clause aggregates rows by column values?",
       "ja": "SQLで列ごとに集計するための句は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107744,7 +108403,8 @@
     "question_text": {
       "en": "Which Google-designed statically typed language emphasizes concurrency?",
       "ja": "Googleが開発した静的型付きの並行処理向け言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107792,32 +108452,28 @@
         "en": "Guido van Rossum",
         "ja": "Guido van Rossum",
         "ja_typings": [
-          "guido van rossum",
-          "guidovanrossum"
+          "guido van rossum"
         ]
       },
       {
         "en": "Brendan Eich",
         "ja": "Brendan Eich",
         "ja_typings": [
-          "brendan eich",
-          "brendaneich"
+          "brendan eich"
         ]
       },
       {
         "en": "Larry Wall",
         "ja": "Larry Wall",
         "ja_typings": [
-          "larry wall",
-          "larrywall"
+          "larry wall"
         ]
       },
       {
         "en": "Yukihiro Matsumoto",
         "ja": "Yukihiro Matsumoto",
         "ja_typings": [
-          "yukihiro matsumoto",
-          "yukihiromatsumoto"
+          "yukihiro matsumoto"
         ]
       }
     ],
@@ -107828,7 +108484,8 @@
     "question_text": {
       "en": "Who designed the Python programming language?",
       "ja": "Pythonを設計した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107868,7 +108525,8 @@
     "question_text": {
       "en": "Which HTTP method fetches only headers without a body?",
       "ja": "HTTPでヘッダだけ取得するメソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107908,7 +108566,8 @@
     "question_text": {
       "en": "Which markup language describes the structure of a web page?",
       "ja": "Webページの構造を記述するマークアップ言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107992,7 +108651,8 @@
     "question_text": {
       "en": "Which IP control message protocol does ping use?",
       "ja": "pingで使われるIP制御メッセージプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108040,24 +108700,21 @@
         "en": "Internal Server Error",
         "ja": "Internal Server Error",
         "ja_typings": [
-          "internal server error",
-          "internalservererror"
+          "internal server error"
         ]
       },
       {
         "en": "Bad Request",
         "ja": "Bad Request",
         "ja_typings": [
-          "bad request",
-          "badrequest"
+          "bad request"
         ]
       },
       {
         "en": "Not Found",
         "ja": "Not Found",
         "ja_typings": [
-          "not found",
-          "notfound"
+          "not found"
         ]
       },
       {
@@ -108075,7 +108732,8 @@
     "question_text": {
       "en": "What does HTTP status code 500 indicate?",
       "ja": "HTTPステータスコード500が示すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108115,7 +108773,8 @@
     "question_text": {
       "en": "Which software executes source code line by line?",
       "ja": "ソースコードを逐次解釈実行するソフトウェアは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108275,7 +108934,8 @@
     "question_text": {
       "en": "Which is a common (incorrect) fake expansion of JSON?",
       "ja": "JSONのフルネームの誤った候補として混同されがちなのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108315,7 +108975,8 @@
     "question_text": {
       "en": "Which dynamic language runs in web browsers?",
       "ja": "ブラウザで動く動的言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108355,7 +109016,8 @@
     "question_text": {
       "en": "Which is another common false expansion of JSON?",
       "ja": "JSONの正式名称として誤って語られがちなのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108395,7 +109057,8 @@
     "question_text": {
       "en": "Which is another false expansion sometimes given for JSON?",
       "ja": "JSONの誤った命名候補としてしばしば挙げられるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108403,32 +109066,28 @@
         "en": "Junio Hamano",
         "ja": "Junio Hamano",
         "ja_typings": [
-          "junio hamano",
-          "juniohamano"
+          "junio hamano"
         ]
       },
       {
         "en": "Yukihiro Matsumoto",
         "ja": "Yukihiro Matsumoto",
         "ja_typings": [
-          "yukihiro matsumoto",
-          "yukihiromatsumoto"
+          "yukihiro matsumoto"
         ]
       },
       {
         "en": "Linus Torvalds",
         "ja": "Linus Torvalds",
         "ja_typings": [
-          "linus torvalds",
-          "linustorvalds"
+          "linus torvalds"
         ]
       },
       {
         "en": "Brian Kernighan",
         "ja": "Brian Kernighan",
         "ja_typings": [
-          "brian kernighan",
-          "briankernighan"
+          "brian kernighan"
         ]
       }
     ],
@@ -108439,7 +109098,8 @@
     "question_text": {
       "en": "Which Japanese developer maintains Git?",
       "ja": "Gitの現在のメンテナを務める日本人開発者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108479,7 +109139,8 @@
     "question_text": {
       "en": "Which compiler infrastructure is used by Clang and Swift?",
       "ja": "Clang/Swiftなどが利用するコンパイラ基盤は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108487,32 +109148,28 @@
         "en": "Larry Wall",
         "ja": "Larry Wall",
         "ja_typings": [
-          "larry wall",
-          "larrywall"
+          "larry wall"
         ]
       },
       {
         "en": "Guido van Rossum",
         "ja": "Guido van Rossum",
         "ja_typings": [
-          "guido van rossum",
-          "guidovanrossum"
+          "guido van rossum"
         ]
       },
       {
         "en": "Brendan Eich",
         "ja": "Brendan Eich",
         "ja_typings": [
-          "brendan eich",
-          "brendaneich"
+          "brendan eich"
         ]
       },
       {
         "en": "Yukihiro Matsumoto",
         "ja": "Yukihiro Matsumoto",
         "ja_typings": [
-          "yukihiro matsumoto",
-          "yukihiromatsumoto"
+          "yukihiro matsumoto"
         ]
       }
     ],
@@ -108523,7 +109180,8 @@
     "question_text": {
       "en": "Who designed the Perl programming language?",
       "ja": "Perlを設計した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108563,7 +109221,8 @@
     "question_text": {
       "en": "Which tool combines object files into an executable?",
       "ja": "オブジェクトファイルをまとめて実行ファイルを作るのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108571,32 +109230,28 @@
         "en": "Linus Torvalds",
         "ja": "Linus Torvalds",
         "ja_typings": [
-          "linus torvalds",
-          "linustorvalds"
+          "linus torvalds"
         ]
       },
       {
         "en": "Richard Stallman",
         "ja": "Richard Stallman",
         "ja_typings": [
-          "richard stallman",
-          "richardstallman"
+          "richard stallman"
         ]
       },
       {
         "en": "Dennis Ritchie",
         "ja": "Dennis Ritchie",
         "ja_typings": [
-          "dennis ritchie",
-          "dennisritchie"
+          "dennis ritchie"
         ]
       },
       {
         "en": "Brian Kernighan",
         "ja": "Brian Kernighan",
         "ja_typings": [
-          "brian kernighan",
-          "briankernighan"
+          "brian kernighan"
         ]
       }
     ],
@@ -108607,7 +109262,8 @@
     "question_text": {
       "en": "Who originally developed the Linux kernel?",
       "ja": "Linuxカーネルを最初に開発した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108655,7 +109311,6 @@
         "en": "O(n log n)",
         "ja": "O(n log n)",
         "ja_typings": [
-          "o(nlogn)",
           "o(n log n)"
         ]
       },
@@ -108677,7 +109332,6 @@
         "en": "O(log n)",
         "ja": "O(log n)",
         "ja_typings": [
-          "o(logn)",
           "o(log n)"
         ]
       }
@@ -108689,7 +109343,8 @@
     "question_text": {
       "en": "What is the proven lower bound of complexity for comparison-based sorting?",
       "ja": "比較ソートで証明されている計算量の下限は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108729,7 +109384,8 @@
     "question_text": {
       "en": "Which SQL statement combines INSERT and UPDATE in one operation?",
       "ja": "SQLでINSERT/UPDATEを一度に行う命令は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108809,7 +109465,8 @@
     "question_text": {
       "en": "Which Java build tool uses pom.xml configuration?",
       "ja": "JavaのXMLベースのビルドツールでpom.xmlを使うのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108817,7 +109474,6 @@
         "en": "Memory Leak",
         "ja": "メモリリーク",
         "ja_typings": [
-          "memori-ri-ku",
           "memoriri-ku"
         ]
       },
@@ -108970,7 +109626,8 @@
     "question_text": {
       "en": "Which is a leading document-oriented NoSQL database?",
       "ja": "ドキュメント指向NoSQLの代表例は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109010,7 +109667,8 @@
     "question_text": {
       "en": "Which primitive ensures only one thread accesses a resource at a time?",
       "ja": "複数スレッドが同時にアクセスしないよう制御する仕組みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109050,7 +109708,8 @@
     "question_text": {
       "en": "Which popular open-source relational database starts with 'M'?",
       "ja": "オープンソースの代表的なリレーショナルDBで「m」で始まるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109090,7 +109749,8 @@
     "question_text": {
       "en": "Which is a leading graph database?",
       "ja": "グラフ型データベースの代表は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109098,8 +109758,7 @@
         "en": "Not Found",
         "ja": "Not Found",
         "ja_typings": [
-          "not found",
-          "notfound"
+          "not found"
         ]
       },
       {
@@ -109113,8 +109772,7 @@
         "en": "Bad Request",
         "ja": "Bad Request",
         "ja_typings": [
-          "bad request",
-          "badrequest"
+          "bad request"
         ]
       },
       {
@@ -109132,7 +109790,8 @@
     "question_text": {
       "en": "What does HTTP status code 404 indicate?",
       "ja": "HTTPステータスコード404が示すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109172,7 +109831,8 @@
     "question_text": {
       "en": "What is the average-case lookup complexity of a hash table?",
       "ja": "ハッシュテーブルの平均的な検索計算量は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109212,7 +109872,8 @@
     "question_text": {
       "en": "What is the time complexity of binary search?",
       "ja": "二分探索の計算量は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109252,7 +109913,8 @@
     "question_text": {
       "en": "What is the best achievable complexity for comparison sorting?",
       "ja": "比較ソートの最良計算量は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109292,7 +109954,8 @@
     "question_text": {
       "en": "What is the time complexity of a single-pass linear search?",
       "ja": "配列を1度走査する線形探索の計算量は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109307,16 +109970,14 @@
         "en": "Bad Request",
         "ja": "Bad Request",
         "ja_typings": [
-          "bad request",
-          "badrequest"
+          "bad request"
         ]
       },
       {
         "en": "Not Found",
         "ja": "Not Found",
         "ja_typings": [
-          "not found",
-          "notfound"
+          "not found"
         ]
       },
       {
@@ -109334,7 +109995,8 @@
     "question_text": {
       "en": "What does HTTP status code 200 indicate?",
       "ja": "HTTPステータスコード200が示すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109349,7 +110011,6 @@
         "en": "Singleton",
         "ja": "シングルトン",
         "ja_typings": [
-          "shingoruton",
           "shinguruton"
         ]
       },
@@ -109375,7 +110036,8 @@
     "question_text": {
       "en": "Which GoF pattern notifies subscribers of state changes?",
       "ja": "GoFパターンで状態変化を購読者に通知するのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109459,7 +110121,8 @@
     "question_text": {
       "en": "Which HTTP method represents a partial update of a resource?",
       "ja": "HTTPでリソースの一部更新を表すメソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109499,7 +110162,8 @@
     "question_text": {
       "en": "Which server-side language is widely used for generating dynamic web pages?",
       "ja": "サーバサイドで動的Webページを生成する人気言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109539,7 +110203,8 @@
     "question_text": {
       "en": "Which HTTP method commonly submits data to the server?",
       "ja": "HTTPでデータをサーバに送信する代表的なメソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109579,7 +110244,8 @@
     "question_text": {
       "en": "Which HTTP method replaces a resource entirely?",
       "ja": "HTTPでリソース全体を置き換えるメソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109619,7 +110285,8 @@
     "question_text": {
       "en": "Which educational language was designed by Niklaus Wirth?",
       "ja": "Niklaus Wirthが設計した教育用言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109699,7 +110366,8 @@
     "question_text": {
       "en": "Which is a feature-rich, extensible open-source RDBMS?",
       "ja": "高機能で拡張性に優れたオープンソースRDBは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109739,7 +110407,8 @@
     "question_text": {
       "en": "Which OS-managed execution unit has its own memory space?",
       "ja": "OSが管理する実行単位でメモリ空間を独立して持つのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109779,7 +110448,8 @@
     "question_text": {
       "en": "Which tool measures and analyzes a program's performance?",
       "ja": "プログラムの性能を測定し分析するツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109859,7 +110529,8 @@
     "question_text": {
       "en": "Which Rust smart pointer is a single-threaded reference counter?",
       "ja": "Rustのシングルスレッド向け参照カウントスマートポインタは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109907,32 +110578,28 @@
         "en": "Richard Stallman",
         "ja": "Richard Stallman",
         "ja_typings": [
-          "richard stallman",
-          "richardstallman"
+          "richard stallman"
         ]
       },
       {
         "en": "Linus Torvalds",
         "ja": "Linus Torvalds",
         "ja_typings": [
-          "linus torvalds",
-          "linustorvalds"
+          "linus torvalds"
         ]
       },
       {
         "en": "Bill Joy",
         "ja": "Bill Joy",
         "ja_typings": [
-          "bill joy",
-          "billjoy"
+          "bill joy"
         ]
       },
       {
         "en": "Dennis Ritchie",
         "ja": "Dennis Ritchie",
         "ja_typings": [
-          "dennis ritchie",
-          "dennisritchie"
+          "dennis ritchie"
         ]
       }
     ],
@@ -109943,7 +110610,8 @@
     "question_text": {
       "en": "Who founded the GNU Project?",
       "ja": "GNUプロジェクトを創設した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109983,7 +110651,8 @@
     "question_text": {
       "en": "Which protocol is used to send emails?",
       "ja": "メール送信に使われるプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110023,7 +110692,8 @@
     "question_text": {
       "en": "Which standard language manipulates relational databases?",
       "ja": "リレーショナルDBを操作する標準言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110063,7 +110733,8 @@
     "question_text": {
       "en": "Which lightweight embedded RDBMS stores data in a single file?",
       "ja": "ファイル1つで動く軽量な組み込みRDBは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110078,7 +110749,6 @@
         "en": "Memory Leak",
         "ja": "メモリリーク",
         "ja_typings": [
-          "memori-ri-ku",
           "memoriri-ku"
         ]
       },
@@ -110093,8 +110763,7 @@
         "en": "Bad Request",
         "ja": "Bad Request",
         "ja_typings": [
-          "bad request",
-          "badrequest"
+          "bad request"
         ]
       }
     ],
@@ -110145,7 +110814,8 @@
     "question_text": {
       "en": "Which Unix mechanism sends notifications to processes?",
       "ja": "Unixでプロセスに送る通知の仕組みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110153,7 +110823,6 @@
         "en": "Singleton",
         "ja": "シングルトン",
         "ja_typings": [
-          "shingoruton",
           "shinguruton"
         ]
       },
@@ -110186,7 +110855,8 @@
     "question_text": {
       "en": "Which GoF pattern restricts a class to a single instance?",
       "ja": "GoFパターンでインスタンスを1つに制限するのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110201,7 +110871,6 @@
         "en": "Memory Leak",
         "ja": "メモリリーク",
         "ja_typings": [
-          "memori-ri-ku",
           "memoriri-ku"
         ]
       },
@@ -110282,7 +110951,6 @@
         "en": "Memory Leak",
         "ja": "メモリリーク",
         "ja_typings": [
-          "memori-ri-ku",
           "memoriri-ku"
         ]
       },
@@ -110428,7 +111096,8 @@
     "question_text": {
       "en": "Which old remote-login protocol transmits data unencrypted?",
       "ja": "古くからある暗号化されないリモートログインプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110450,8 +111119,7 @@
         "en": "Docker Compose",
         "ja": "Docker Compose",
         "ja_typings": [
-          "docker compose",
-          "dockercompose"
+          "docker compose"
         ]
       },
       {
@@ -110469,7 +111137,8 @@
     "question_text": {
       "en": "Which HashiCorp tool provisions infrastructure declaratively?",
       "ja": "HashiCorpが開発するインフラ宣言型ツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110509,7 +111178,8 @@
     "question_text": {
       "en": "Which execution unit runs in a process and shares its memory?",
       "ja": "プロセス内で並行実行されメモリ空間を共有する単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110517,32 +111187,28 @@
         "en": "Tim Berners-Lee",
         "ja": "Tim Berners-Lee",
         "ja_typings": [
-          "tim berners-lee",
-          "timberners-lee"
+          "tim berners-lee"
         ]
       },
       {
         "en": "Linus Torvalds",
         "ja": "Linus Torvalds",
         "ja_typings": [
-          "linus torvalds",
-          "linustorvalds"
+          "linus torvalds"
         ]
       },
       {
         "en": "Brendan Eich",
         "ja": "Brendan Eich",
         "ja_typings": [
-          "brendan eich",
-          "brendaneich"
+          "brendan eich"
         ]
       },
       {
         "en": "Dennis Ritchie",
         "ja": "Dennis Ritchie",
         "ja_typings": [
-          "dennis ritchie",
-          "dennisritchie"
+          "dennis ritchie"
         ]
       }
     ],
@@ -110553,7 +111219,8 @@
     "question_text": {
       "en": "Who invented the World Wide Web?",
       "ja": "World Wide Webを発明した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110633,7 +111300,8 @@
     "question_text": {
       "en": "Which transport protocol is connectionless and unreliable?",
       "ja": "コネクションレスで信頼性を保証しないトランスポート層プロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110655,16 +111323,14 @@
         "en": "Bad Request",
         "ja": "Bad Request",
         "ja_typings": [
-          "bad request",
-          "badrequest"
+          "bad request"
         ]
       },
       {
         "en": "Not Found",
         "ja": "Not Found",
         "ja_typings": [
-          "not found",
-          "notfound"
+          "not found"
         ]
       }
     ],
@@ -110675,7 +111341,8 @@
     "question_text": {
       "en": "What does HTTP status code 401 indicate?",
       "ja": "HTTPステータスコード401が示すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110715,7 +111382,8 @@
     "question_text": {
       "en": "Which JavaScript engine powers Google Chrome?",
       "ja": "GoogleのChromeなどで動くJavaScriptエンジンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110755,7 +111423,8 @@
     "question_text": {
       "en": "Which highly extensible terminal text editor is beloved by Linux users?",
       "ja": "Linuxユーザに愛される高機能テキストエディタは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110795,7 +111464,8 @@
     "question_text": {
       "en": "Which OGC service provides geospatial vector features over the web?",
       "ja": "OGC仕様の地理空間ベクタフィーチャ取得サービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110803,32 +111473,28 @@
         "en": "Yukihiro Matsumoto",
         "ja": "Yukihiro Matsumoto",
         "ja_typings": [
-          "yukihiro matsumoto",
-          "yukihiromatsumoto"
+          "yukihiro matsumoto"
         ]
       },
       {
         "en": "Guido van Rossum",
         "ja": "Guido van Rossum",
         "ja_typings": [
-          "guido van rossum",
-          "guidovanrossum"
+          "guido van rossum"
         ]
       },
       {
         "en": "Brendan Eich",
         "ja": "Brendan Eich",
         "ja_typings": [
-          "brendan eich",
-          "brendaneich"
+          "brendan eich"
         ]
       },
       {
         "en": "Larry Wall",
         "ja": "Larry Wall",
         "ja_typings": [
-          "larry wall",
-          "larrywall"
+          "larry wall"
         ]
       }
     ],
@@ -110839,7 +111505,8 @@
     "question_text": {
       "en": "Who designed the Ruby programming language?",
       "ja": "Rubyを設計した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110847,7 +111514,6 @@
         "en": "`#`",
         "ja": "`#`",
         "ja_typings": [
-          "#",
           "`#`"
         ]
       },
@@ -110855,7 +111521,6 @@
         "en": "`$`",
         "ja": "`$`",
         "ja_typings": [
-          "$",
           "`$`"
         ]
       },
@@ -110863,7 +111528,6 @@
         "en": "`%`",
         "ja": "`%`",
         "ja_typings": [
-          "%",
           "`%`"
         ]
       },
@@ -110871,7 +111535,6 @@
         "en": "`@`",
         "ja": "`@`",
         "ja_typings": [
-          "@",
           "`@`"
         ]
       }
@@ -110883,7 +111546,8 @@
     "question_text": {
       "en": "Which character commonly starts a line comment in many languages?",
       "ja": "多くの言語でコメント開始を表す記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110891,7 +111555,6 @@
         "en": "`$`",
         "ja": "`$`",
         "ja_typings": [
-          "$",
           "`$`"
         ]
       },
@@ -110899,7 +111562,6 @@
         "en": "`#`",
         "ja": "`#`",
         "ja_typings": [
-          "#",
           "`#`"
         ]
       },
@@ -110907,7 +111569,6 @@
         "en": "`%`",
         "ja": "`%`",
         "ja_typings": [
-          "%",
           "`%`"
         ]
       },
@@ -110915,7 +111576,6 @@
         "en": "`&`",
         "ja": "`&`",
         "ja_typings": [
-          "&",
           "`&`"
         ]
       }
@@ -110927,7 +111587,8 @@
     "question_text": {
       "en": "Which character is used to reference shell variables?",
       "ja": "シェルで変数を参照するときに使う記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110935,7 +111596,6 @@
         "en": "`%`",
         "ja": "`%`",
         "ja_typings": [
-          "%",
           "`%`"
         ]
       },
@@ -110943,7 +111603,6 @@
         "en": "`*`",
         "ja": "`*`",
         "ja_typings": [
-          "*",
           "`*`"
         ]
       },
@@ -110951,7 +111610,6 @@
         "en": "`#`",
         "ja": "`#`",
         "ja_typings": [
-          "#",
           "`#`"
         ]
       },
@@ -110959,7 +111617,6 @@
         "en": "`$`",
         "ja": "`$`",
         "ja_typings": [
-          "$",
           "`$`"
         ]
       }
@@ -110971,7 +111628,8 @@
     "question_text": {
       "en": "Which operator represents modulo in C-like languages?",
       "ja": "C系言語で剰余演算を表す記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110979,7 +111637,6 @@
         "en": "`&`",
         "ja": "`&`",
         "ja_typings": [
-          "&",
           "`&`"
         ]
       },
@@ -110987,7 +111644,6 @@
         "en": "`*`",
         "ja": "`*`",
         "ja_typings": [
-          "*",
           "`*`"
         ]
       },
@@ -110995,7 +111651,6 @@
         "en": "`@`",
         "ja": "`@`",
         "ja_typings": [
-          "@",
           "`@`"
         ]
       },
@@ -111003,7 +111658,6 @@
         "en": "`#`",
         "ja": "`#`",
         "ja_typings": [
-          "#",
           "`#`"
         ]
       }
@@ -111015,7 +111669,8 @@
     "question_text": {
       "en": "Which shell character runs a command in the background?",
       "ja": "シェルでコマンドをバックグラウンド実行する記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111023,7 +111678,6 @@
         "en": "`*`",
         "ja": "`*`",
         "ja_typings": [
-          "*",
           "`*`"
         ]
       },
@@ -111031,7 +111685,6 @@
         "en": "`&`",
         "ja": "`&`",
         "ja_typings": [
-          "&",
           "`&`"
         ]
       },
@@ -111039,7 +111692,6 @@
         "en": "`%`",
         "ja": "`%`",
         "ja_typings": [
-          "%",
           "`%`"
         ]
       },
@@ -111047,7 +111699,6 @@
         "en": "`#`",
         "ja": "`#`",
         "ja_typings": [
-          "#",
           "`#`"
         ]
       }
@@ -111059,7 +111710,8 @@
     "question_text": {
       "en": "Which operator dereferences pointers or denotes multiplication in C?",
       "ja": "C系言語でポインタの参照外しや乗算を表す記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111067,7 +111719,6 @@
         "en": "`@`",
         "ja": "`@`",
         "ja_typings": [
-          "@",
           "`@`"
         ]
       },
@@ -111075,7 +111726,6 @@
         "en": "`#`",
         "ja": "`#`",
         "ja_typings": [
-          "#",
           "`#`"
         ]
       },
@@ -111083,7 +111733,6 @@
         "en": "`$`",
         "ja": "`$`",
         "ja_typings": [
-          "$",
           "`$`"
         ]
       },
@@ -111091,7 +111740,6 @@
         "en": "`&`",
         "ja": "`&`",
         "ja_typings": [
-          "&",
           "`&`"
         ]
       }
@@ -111103,7 +111751,8 @@
     "question_text": {
       "en": "Which character marks a decorator in Python?",
       "ja": "Pythonでデコレータを表す記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111111,7 +111760,6 @@
         "en": "`await`",
         "ja": "`await`",
         "ja_typings": [
-          "await",
           "`await`"
         ]
       },
@@ -111119,7 +111767,6 @@
         "en": "`yield`",
         "ja": "`yield`",
         "ja_typings": [
-          "yield",
           "`yield`"
         ]
       },
@@ -111127,7 +111774,6 @@
         "en": "`return`",
         "ja": "`return`",
         "ja_typings": [
-          "return",
           "`return`"
         ]
       },
@@ -111135,7 +111781,6 @@
         "en": "`defer`",
         "ja": "`defer`",
         "ja_typings": [
-          "defer",
           "`defer`"
         ]
       }
@@ -111147,7 +111792,8 @@
     "question_text": {
       "en": "Which keyword in Python and JS waits for an async result?",
       "ja": "非同期関数の完了を待つPython/JSのキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111155,7 +111801,6 @@
         "en": "`def`",
         "ja": "`def`",
         "ja_typings": [
-          "def",
           "`def`"
         ]
       },
@@ -111163,7 +111808,6 @@
         "en": "`fn`",
         "ja": "`fn`",
         "ja_typings": [
-          "fn",
           "`fn`"
         ]
       },
@@ -111171,7 +111815,6 @@
         "en": "`return`",
         "ja": "`return`",
         "ja_typings": [
-          "return",
           "`return`"
         ]
       },
@@ -111179,7 +111822,6 @@
         "en": "`yield`",
         "ja": "`yield`",
         "ja_typings": [
-          "yield",
           "`yield`"
         ]
       }
@@ -111191,7 +111833,8 @@
     "question_text": {
       "en": "Which Python keyword defines a function?",
       "ja": "Pythonで関数を定義するキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111199,7 +111842,6 @@
         "en": "`defer`",
         "ja": "`defer`",
         "ja_typings": [
-          "defer",
           "`defer`"
         ]
       },
@@ -111207,7 +111849,6 @@
         "en": "`await`",
         "ja": "`await`",
         "ja_typings": [
-          "await",
           "`await`"
         ]
       },
@@ -111215,7 +111856,6 @@
         "en": "`yield`",
         "ja": "`yield`",
         "ja_typings": [
-          "yield",
           "`yield`"
         ]
       },
@@ -111223,7 +111863,6 @@
         "en": "`return`",
         "ja": "`return`",
         "ja_typings": [
-          "return",
           "`return`"
         ]
       }
@@ -111235,7 +111874,8 @@
     "question_text": {
       "en": "Which Go keyword schedules a call to run when the function returns?",
       "ja": "Goで関数終了時に処理を予約するキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111243,7 +111883,6 @@
         "en": "`fn`",
         "ja": "`fn`",
         "ja_typings": [
-          "fn",
           "`fn`"
         ]
       },
@@ -111251,7 +111890,6 @@
         "en": "`def`",
         "ja": "`def`",
         "ja_typings": [
-          "def",
           "`def`"
         ]
       },
@@ -111259,7 +111897,6 @@
         "en": "`return`",
         "ja": "`return`",
         "ja_typings": [
-          "return",
           "`return`"
         ]
       },
@@ -111267,7 +111904,6 @@
         "en": "`yield`",
         "ja": "`yield`",
         "ja_typings": [
-          "yield",
           "`yield`"
         ]
       }
@@ -111279,7 +111915,8 @@
     "question_text": {
       "en": "Which Rust keyword defines a function?",
       "ja": "Rustで関数を定義するキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111287,7 +111924,6 @@
         "en": "`return`",
         "ja": "`return`",
         "ja_typings": [
-          "return",
           "`return`"
         ]
       },
@@ -111295,7 +111931,6 @@
         "en": "`yield`",
         "ja": "`yield`",
         "ja_typings": [
-          "yield",
           "`yield`"
         ]
       },
@@ -111303,7 +111938,6 @@
         "en": "`await`",
         "ja": "`await`",
         "ja_typings": [
-          "await",
           "`await`"
         ]
       },
@@ -111311,7 +111945,6 @@
         "en": "`defer`",
         "ja": "`defer`",
         "ja_typings": [
-          "defer",
           "`defer`"
         ]
       }
@@ -111323,7 +111956,8 @@
     "question_text": {
       "en": "Which keyword returns a value from a function in most languages?",
       "ja": "関数から値を返すための多くの言語で共通のキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111331,7 +111965,6 @@
         "en": "`yield`",
         "ja": "`yield`",
         "ja_typings": [
-          "yield",
           "`yield`"
         ]
       },
@@ -111339,7 +111972,6 @@
         "en": "`return`",
         "ja": "`return`",
         "ja_typings": [
-          "return",
           "`return`"
         ]
       },
@@ -111347,7 +111979,6 @@
         "en": "`await`",
         "ja": "`await`",
         "ja_typings": [
-          "await",
           "`await`"
         ]
       },
@@ -111355,7 +111986,6 @@
         "en": "`defer`",
         "ja": "`defer`",
         "ja_typings": [
-          "defer",
           "`defer`"
         ]
       }
@@ -111367,7 +111997,8 @@
     "question_text": {
       "en": "Which keyword produces values one at a time from a generator?",
       "ja": "ジェネレータで値を1つずつ生成するキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111407,7 +112038,8 @@
     "question_text": {
       "en": "Which is the standard package installer for Python?",
       "ja": "Pythonのパッケージインストーラは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111447,7 +112079,8 @@
     "question_text": {
       "en": "Which credential string identifies a client to a web API?",
       "ja": "Web API でクライアントを識別する資格情報文字列は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111487,7 +112120,8 @@
     "question_text": {
       "en": "Which Google-backed SPA framework uses TypeScript and decorators?",
       "ja": "Google が開発した TypeScript ベースの SPA フレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111567,7 +112201,8 @@
     "question_text": {
       "en": "Which early MVC JavaScript framework popularized models and collections?",
       "ja": "モデルとコレクションで知られた初期の MVC 系 JS フレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111647,7 +112282,8 @@
     "question_text": {
       "en": "Which CSS framework popularized grid systems and component classes from Twitter?",
       "ja": "Twitter 発のグリッドとコンポーネントクラスを広めた CSS フレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111727,7 +112363,8 @@
     "question_text": {
       "en": "What collective name covers tools like webpack, Rollup, and Vite?",
       "ja": "webpack や Rollup、Vite などをまとめて指す呼称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111767,7 +112404,8 @@
     "question_text": {
       "en": "Which HTTP header lets a server declare allowed script sources?",
       "ja": "許可するスクリプト配信元をサーバーが宣言するための HTTP ヘッダの略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111807,7 +112445,8 @@
     "question_text": {
       "en": "Which rendering strategy generates HTML on the server per request?",
       "ja": "リクエストごとにサーバーで HTML を生成する描画方式の略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111847,7 +112486,8 @@
     "question_text": {
       "en": "Which attack tricks a logged-in user into submitting unwanted requests?",
       "ja": "ログイン中のユーザーに意図しないリクエストを送らせる攻撃の略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111927,7 +112567,8 @@
     "question_text": {
       "en": "Which Service Worker API caches HTTP request/response pairs?",
       "ja": "Service Worker でリクエストとレスポンスのペアをキャッシュする API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111967,7 +112608,8 @@
     "question_text": {
       "en": "Which JavaScript pattern passes a function to be executed later?",
       "ja": "後で実行される関数を引数として渡す JS のパターンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112007,7 +112649,8 @@
     "question_text": {
       "en": "Which small piece of data does a server store in the user's browser?",
       "ja": "サーバーがユーザーのブラウザに保存する小さなデータは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112047,7 +112690,8 @@
     "question_text": {
       "en": "Which attack floods a service with traffic from many sources?",
       "ja": "多数のソースから大量のトラフィックでサービスを麻痺させる攻撃の略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112087,7 +112731,8 @@
     "question_text": {
       "en": "Which step resolves a domain name into an IP address?",
       "ja": "ドメイン名を IP アドレスに解決する手順は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112102,7 +112747,6 @@
         "en": "Document Object Model",
         "ja": "ドキュメントオブジェクトモデル",
         "ja_typings": [
-          "dokyumentobujekutomoderu",
           "dokyumentoobujekutomoderu"
         ]
       },
@@ -112128,7 +112772,8 @@
     "question_text": {
       "en": "Which option is a decoy expansion sometimes confused with DOM?",
       "ja": "DOM と紛らわしいダミーの展開語はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112183,7 +112828,6 @@
         "en": "Document Object Model",
         "ja": "ドキュメントオブジェクトモデル",
         "ja_typings": [
-          "dokyumentobujekutomoderu",
           "dokyumentoobujekutomoderu"
         ]
       },
@@ -112209,7 +112853,8 @@
     "question_text": {
       "en": "Which DOM expansion is also a decoy display-oriented term?",
       "ja": "DOM に似せたディスプレイ系の誤答候補はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112238,7 +112883,6 @@
         "en": "Document Object Model",
         "ja": "ドキュメントオブジェクトモデル",
         "ja_typings": [
-          "dokyumentobujekutomoderu",
           "dokyumentoobujekutomoderu"
         ]
       }
@@ -112250,7 +112894,8 @@
     "question_text": {
       "en": "Which DOM-like decoy uses the word 'Module' instead of 'Model'?",
       "ja": "Model ではなく Module を使った DOM 風の誤答候補は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112290,7 +112935,8 @@
     "question_text": {
       "en": "Which Chrome DevTools tab shows the live DOM tree of a page?",
       "ja": "Chrome DevTools でページの DOM ツリーを表示するタブは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112330,7 +112976,8 @@
     "question_text": {
       "en": "Which early MVC framework was built on top of Handlebars?",
       "ja": "Handlebars を採用した初期の MVC 系 JS フレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112410,7 +113057,8 @@
     "question_text": {
       "en": "Which URL part follows a `#` and is not sent to the server?",
       "ja": "URL の `#` 以降にあたり、サーバーに送られない部分は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112450,7 +113098,8 @@
     "question_text": {
       "en": "Which HTTP method retrieves a resource without modifying it?",
       "ja": "リソースを変更せず取得する HTTP メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112490,7 +113139,8 @@
     "question_text": {
       "en": "Which markup language describes the structure of a web page?",
       "ja": "Web ページの構造を記述するマークアップ言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112530,7 +113180,8 @@
     "question_text": {
       "en": "Which HTTP version introduced persistent connections by default?",
       "ja": "持続的接続を既定で導入した HTTP のバージョンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112570,7 +113221,8 @@
     "question_text": {
       "en": "Which browser API stores large structured data with key-based access?",
       "ja": "キーで大きな構造化データを保存するブラウザ API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112650,7 +113302,8 @@
     "question_text": {
       "en": "Which lightweight text format is widely used for web APIs?",
       "ja": "Web API で広く使われる軽量テキスト形式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112690,7 +113343,8 @@
     "question_text": {
       "en": "What collective term covers Node.js, Deno, and Bun?",
       "ja": "Node.js や Deno、Bun の総称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112730,7 +113384,8 @@
     "question_text": {
       "en": "Which network authentication protocol uses tickets and a KDC?",
       "ja": "チケットと KDC を使うネットワーク認証プロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112770,7 +113425,8 @@
     "question_text": {
       "en": "Which Core Web Vitals metric measures the largest visible content paint time?",
       "ja": "最大の可視コンテンツ描画時間を測る Core Web Vitals 指標の略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112810,7 +113466,8 @@
     "question_text": {
       "en": "Which directory access protocol underpins many enterprise auth systems?",
       "ja": "多くの企業認証の基盤になるディレクトリアクセスプロトコルの略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112890,7 +113547,8 @@
     "question_text": {
       "en": "Which standard labels content types like text/html and image/png?",
       "ja": "text/html や image/png のようにコンテンツ種別を表す標準は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112970,7 +113628,8 @@
     "question_text": {
       "en": "In GraphQL, which root operation type changes server-side data?",
       "ja": "GraphQL でサーバーのデータを変更するルート操作タイプは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113010,7 +113669,8 @@
     "question_text": {
       "en": "Which Chrome DevTools tab shows HTTP requests made by the page?",
       "ja": "ページが行った HTTP リクエストを表示する DevTools のタブは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113050,7 +113710,8 @@
     "question_text": {
       "en": "Which one-syllable word names the React-based meta-framework by Vercel?",
       "ja": "Vercel が作る React ベースのメタフレームワークの省略形は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113090,7 +113751,8 @@
     "question_text": {
       "en": "Which framework's full name pairs Next with the `.js` suffix?",
       "ja": "Next にファイル拡張子 `.js` を付けた正式名のフレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113130,7 +113792,8 @@
     "question_text": {
       "en": "Which HTTP method applies a partial update to a resource?",
       "ja": "リソースに部分的な更新を適用する HTTP メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113170,7 +113833,8 @@
     "question_text": {
       "en": "Which HTTP method replaces a resource at a given URL?",
       "ja": "指定 URL のリソースを丸ごと置き換える HTTP メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113210,7 +113874,8 @@
     "question_text": {
       "en": "Which acronym describes installable, offline-capable web apps?",
       "ja": "インストール可能でオフライン対応の Web アプリの略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113250,7 +113915,8 @@
     "question_text": {
       "en": "In GraphQL, which root operation type reads data without changing it?",
       "ja": "GraphQL でデータを変更せず読み取るルート操作タイプは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113290,7 +113956,8 @@
     "question_text": {
       "en": "Which architectural style uses URIs, verbs, and stateless servers?",
       "ja": "URI と HTTP 動詞、ステートレスサーバを用いる API アーキテクチャは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113330,7 +113997,8 @@
     "question_text": {
       "en": "Which Meta-developed UI library popularized the virtual DOM?",
       "ja": "仮想 DOM を広めた Meta 製の UI ライブラリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113450,7 +114118,8 @@
     "question_text": {
       "en": "Which IETF transport protocol provides message-oriented streams?",
       "ja": "メッセージ指向のストリームを提供する IETF のトランスポートプロトコルの略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113490,7 +114159,8 @@
     "question_text": {
       "en": "Which XML-based RPC protocol pre-dates REST in enterprise services?",
       "ja": "企業向けで REST 以前に広まった XML ベースの RPC プロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113530,7 +114200,8 @@
     "question_text": {
       "en": "Which browser policy restricts cross-origin scripting access by default?",
       "ja": "クロスオリジンのスクリプトアクセスを既定で制限するブラウザの方針の略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113570,7 +114241,8 @@
     "question_text": {
       "en": "Which acronym describes a client-side app that updates one HTML shell?",
       "ja": "1 枚の HTML を更新し続けるクライアント側アプリの略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113610,7 +114282,8 @@
     "question_text": {
       "en": "Which rendering strategy builds all pages at build time?",
       "ja": "ビルド時にすべてのページを生成する描画方式の略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113650,7 +114323,8 @@
     "question_text": {
       "en": "In GraphQL, which document defines the available types and fields?",
       "ja": "GraphQL で利用可能な型とフィールドを定義する文書は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113690,7 +114364,8 @@
     "question_text": {
       "en": "Which identifier ties subsequent HTTP requests to one user session?",
       "ja": "後続の HTTP リクエストを 1 つのユーザーセッションに紐づける識別子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113771,7 +114446,8 @@
     "question_text": {
       "en": "Which Web Worker variant can be reached from multiple browsing contexts?",
       "ja": "複数のブラウジングコンテキストから利用できる Web Worker は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113811,7 +114487,8 @@
     "question_text": {
       "en": "Which Chrome DevTools tab shows the original JavaScript sources?",
       "ja": "オリジナルの JavaScript ソースを表示する DevTools のタブは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113851,7 +114528,8 @@
     "question_text": {
       "en": "Which framework compiles components to plain JS at build time?",
       "ja": "コンポーネントをビルド時に素の JS にコンパイルするフレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113891,7 +114569,8 @@
     "question_text": {
       "en": "Which transport protocol provides reliable, ordered byte streams?",
       "ja": "信頼性のある順序付きバイトストリームを提供するトランスポートは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113931,7 +114610,8 @@
     "question_text": {
       "en": "Which protocol encrypts HTTP between browser and server?",
       "ja": "ブラウザとサーバ間の HTTP を暗号化するプロトコルの略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113971,7 +114651,8 @@
     "question_text": {
       "en": "Which Web Vitals metric measures the time to the first response byte?",
       "ja": "最初のレスポンスバイトまでの時間を測る Web Vitals 指標の略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114011,7 +114692,8 @@
     "question_text": {
       "en": "Which utility-first CSS framework uses class names like `flex` and `gap-4`?",
       "ja": "`flex` や `gap-4` のようなユーティリティクラス中心の CSS フレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114091,7 +114773,8 @@
     "question_text": {
       "en": "Which unit of execution is scheduled by the OS within a process?",
       "ja": "プロセス内で OS がスケジュールする実行単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114131,7 +114814,8 @@
     "question_text": {
       "en": "Which progressive JS framework was created by Evan You?",
       "ja": "Evan You が作った漸進的に採用できる JS フレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114171,7 +114855,8 @@
     "question_text": {
       "en": "Which worker type lets web pages run scripts off the main thread?",
       "ja": "メインスレッド外でスクリプトを実行できるワーカーの基本形は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114211,7 +114896,8 @@
     "question_text": {
       "en": "Which protocol gives full-duplex communication over a single TCP connection?",
       "ja": "1 本の TCP 接続で全二重通信を提供するプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114251,7 +114937,8 @@
     "question_text": {
       "en": "Which attack injects malicious scripts that run in other users' browsers?",
       "ja": "他ユーザーのブラウザで悪意あるスクリプトを実行させる攻撃の略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114291,7 +114978,8 @@
     "question_text": {
       "en": "Which JavaScript operator tests for strict inequality?",
       "ja": "厳密な不等価を判定する JavaScript 演算子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114331,7 +115019,8 @@
     "question_text": {
       "en": "Which symbol starts a URL fragment identifier?",
       "ja": "URL のフラグメント識別子の先頭に来る記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114371,7 +115060,8 @@
     "question_text": {
       "en": "Which symbol separates query parameters in a URL?",
       "ja": "URL のクエリパラメータを区切る記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114411,7 +115101,8 @@
     "question_text": {
       "en": "Which CSS selector matches any element?",
       "ja": "任意の要素にマッチする CSS セレクタ記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114451,7 +115142,8 @@
     "question_text": {
       "en": "Which CSS selector prefix matches by class name?",
       "ja": "クラス名で一致させる CSS セレクタの先頭記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114491,7 +115183,8 @@
     "question_text": {
       "en": "Which CSS character prefixes a pseudo-class like `:hover`?",
       "ja": "`:hover` のような擬似クラスの先頭に置かれる CSS の文字は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114531,7 +115224,8 @@
     "question_text": {
       "en": "Which HTML element serves responsive images via multiple `<source>` children?",
       "ja": "複数の `<source>` でレスポンシブ画像を提供する HTML 要素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114571,7 +115265,8 @@
     "question_text": {
       "en": "Which JavaScript operator tests for loose equality with type coercion?",
       "ja": "型変換ありで等価を判定する JavaScript 演算子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114611,7 +115306,8 @@
     "question_text": {
       "en": "Which JavaScript operator assigns a value to a variable?",
       "ja": "JavaScript で変数に値を代入する演算子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114651,7 +115347,8 @@
     "question_text": {
       "en": "Which symbol separates a user name from a host in an email address?",
       "ja": "メールアドレスでユーザー名とホストを区切る記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114691,7 +115388,8 @@
     "question_text": {
       "en": "Which CSS shorthand property sets all four borders at once?",
       "ja": "4 辺のボーダーを一括で指定する CSS のショートハンドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114731,7 +115429,8 @@
     "question_text": {
       "en": "Which Java/Dart keyword prevents reassignment of a variable?",
       "ja": "Java や Dart で再代入を禁じる変数宣言キーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114771,7 +115470,8 @@
     "question_text": {
       "en": "Which JavaScript array method executes a callback for each element without returning a new array?",
       "ja": "新しい配列を返さず各要素にコールバックを実行する JS の配列メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114811,7 +115511,8 @@
     "question_text": {
       "en": "Which modern CSS property sets spacing between flex or grid items?",
       "ja": "Flex/Grid 項目間の間隔を指定する現代的な CSS プロパティは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114851,7 +115552,8 @@
     "question_text": {
       "en": "Which CSS shorthand sets top/right/bottom/left for positioned elements?",
       "ja": "配置済み要素の上下左右オフセットを一括指定する CSS プロパティは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114891,7 +115593,8 @@
     "question_text": {
       "en": "Which JavaScript keyword declares a block-scoped mutable variable?",
       "ja": "ブロックスコープで可変な変数を宣言する JS キーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114931,7 +115634,8 @@
     "question_text": {
       "en": "Which JavaScript array method returns a new array with each element transformed?",
       "ja": "各要素を変換した新しい配列を返す JS の配列メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114971,7 +115675,8 @@
     "question_text": {
       "en": "Which CSS shorthand sets the outer space around an element?",
       "ja": "要素の外側の余白を一括指定する CSS のショートハンドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115011,7 +115716,8 @@
     "question_text": {
       "en": "Which CSS shorthand sets the inner space inside an element's border?",
       "ja": "要素の内側の余白を一括指定する CSS のショートハンドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115051,7 +115757,8 @@
     "question_text": {
       "en": "Which JavaScript array method reduces values to a single accumulated result?",
       "ja": "配列の値を 1 つの累積値にまとめる JS の配列メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115091,7 +115798,8 @@
     "question_text": {
       "en": "Which JavaScript array method checks whether at least one element passes a test?",
       "ja": "少なくとも 1 要素が条件を満たすかを判定する JS の配列メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115131,7 +115839,8 @@
     "question_text": {
       "en": "Which Tailwind-style class word is used for inter-item gap utilities?",
       "ja": "Tailwind 系で要素間の間隔ユーティリティに使われる語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115171,7 +115880,8 @@
     "question_text": {
       "en": "Which legacy JavaScript keyword declares a function-scoped variable?",
       "ja": "関数スコープで変数を宣言する従来からの JS キーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115211,7 +115921,8 @@
     "question_text": {
       "en": "Which all-in-one JavaScript runtime by Jarred Sumner ships its own bundler?",
       "ja": "Jarred Sumner が作るバンドラ同梱の JS ランタイムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115251,7 +115962,8 @@
     "question_text": {
       "en": "Which Google-made high-performance RPC framework uses HTTP/2 and protobuf?",
       "ja": "HTTP/2 と Protocol Buffers を使う Google 製の高性能 RPC は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115291,7 +116003,8 @@
     "question_text": {
       "en": "Which package manager stores dependencies in a content-addressable store with hard links?",
       "ja": "コンテンツアドレス指定のストアとハードリンクで依存を管理する Node のパッケージマネージャは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115331,7 +116044,8 @@
     "question_text": {
       "en": "Which Web Storage API persists key/value pairs only until the tab closes?",
       "ja": "タブを閉じるまでキー/値を保持する Web Storage API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115371,7 +116085,8 @@
     "question_text": {
       "en": "Which Node package manager was originally created by Facebook?",
       "ja": "Facebook が最初に作った Node のパッケージマネージャは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115492,7 +116207,8 @@
     "question_text": {
       "en": "Which Symbol of Peace is the No.1 hero in My Hero Academia?",
       "ja": "ヒロアカで「平和の象徴」と呼ばれる No.1 ヒーローは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115532,7 +116248,8 @@
     "question_text": {
       "en": "Which younger Elric brother has his soul bound to a suit of armor?",
       "ja": "魂を鎧に定着させた弟のエルリック兄弟は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115572,7 +116289,8 @@
     "question_text": {
       "en": "Which pink-haired telepath is the daughter in the Forger family?",
       "ja": "フォージャー家のピンク髪の超能力少女は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115612,7 +116330,8 @@
     "question_text": {
       "en": "Which short blond strategist of the Survey Corps is Eren's friend?",
       "ja": "調査兵団でエレンの友人にあたる金髪の戦略家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115734,7 +116453,8 @@
     "question_text": {
       "en": "Which masked blond Zeon ace is also known as 'the Red Comet'?",
       "ja": "「赤い彗星」と呼ばれる仮面のジオンのエースは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115942,7 +116662,7 @@
         "en": "Giorno Giovanna",
         "ja": "ジョルノ・ジョバァーナ",
         "ja_typings": [
-          "joruno/joba--na"
+          "joruno/jobaa-na"
         ]
       },
       {
@@ -116163,7 +116883,7 @@
         "en": "Giorno Giovanna",
         "ja": "ジョルノ・ジョバァーナ",
         "ja_typings": [
-          "joruno/joba--na"
+          "joruno/jobaa-na"
         ]
       }
     ],
@@ -116189,7 +116909,7 @@
         "en": "Giorno Giovanna",
         "ja": "ジョルノ・ジョバァーナ",
         "ja_typings": [
-          "joruno/joba--na"
+          "joruno/jobaa-na"
         ]
       },
       {
@@ -116254,7 +116974,8 @@
     "question_text": {
       "en": "Which protagonist of Zeta Gundam's sequel ZZ pilots the Double Zeta Gundam?",
       "ja": "機動戦士ガンダムZZでΖΖガンダムに乗る主人公は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116374,7 +117095,8 @@
     "question_text": {
       "en": "Which moody Newtype pilots the Zeta Gundam in its title series?",
       "ja": "機動戦士Ζガンダムで Ζガンダムに乗るニュータイプは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116657,7 +117379,8 @@
     "question_text": {
       "en": "Which short, bald Z-Fighter is one of Goku's oldest friends?",
       "ja": "悟空の最古参の親友にあたる坊主頭の Z 戦士は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116737,7 +117460,8 @@
     "question_text": {
       "en": "Which Survey Corps captain is humanity's strongest soldier?",
       "ja": "人類最強の兵士と呼ばれる調査兵団の兵長は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116777,7 +117501,8 @@
     "question_text": {
       "en": "Which Chainsaw Man character is a control devil who recruits Denji?",
       "ja": "チェンソーマンでデンジを勧誘する支配の悪魔の姿の女性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117137,7 +117862,8 @@
     "question_text": {
       "en": "Which black-haired Ackerman is Eren's adoptive sister and a top soldier?",
       "ja": "エレンの義妹で最強クラスの兵士、アッカーマン家の黒髪少女は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117298,7 +118024,8 @@
     "question_text": {
       "en": "Which orange-haired navigator of the Straw Hat Pirates loves money?",
       "ja": "麦わら海賊団の航海士で金が大好きなオレンジ髪の女性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117539,7 +118266,8 @@
     "question_text": {
       "en": "Which green-skinned Namekian is Goku's former rival turned ally?",
       "ja": "悟空の元ライバルで仲間になった緑の肌のナメック星人は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117579,7 +118307,8 @@
     "question_text": {
       "en": "Which Chainsaw Man devil is Aki Hayakawa's blood-loving partner?",
       "ja": "チェンソーマンで早川アキの相棒となる血を好む悪魔は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117700,7 +118429,8 @@
     "question_text": {
       "en": "Which green-haired swordsman of the Straw Hats uses three swords at once?",
       "ja": "麦わら海賊団で三刀流を使う緑髪の剣士は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117740,7 +118470,8 @@
     "question_text": {
       "en": "Which Flame Alchemist colonel in FMA can snap fire from his fingers?",
       "ja": "鋼の錬金術師で指を鳴らして炎を操る大佐は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117860,7 +118591,8 @@
     "question_text": {
       "en": "Which chivalrous, kicking-only chef of the Straw Hats has a curly eyebrow?",
       "ja": "麦わら海賊団で蹴り技専門のコック、ぐるぐる眉毛のキャラは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118020,7 +118752,8 @@
     "question_text": {
       "en": "Which studio is known for Bakemonogatari and the Monogatari series?",
       "ja": "化物語など〈物語〉シリーズで知られる制作スタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118301,7 +119034,8 @@
     "question_text": {
       "en": "Which studio is led by Hideaki Anno and produced the Rebuild of Evangelion films?",
       "ja": "庵野秀明が率い、新劇場版エヴァンゲリオンを制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118782,7 +119516,8 @@
     "question_text": {
       "en": "Which proud Saiyan prince is Goku's longtime rival and ally?",
       "ja": "悟空のライバルにして仲間となる誇り高きサイヤ人の王子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118862,7 +119597,8 @@
     "question_text": {
       "en": "Which blonde automail mechanic in FMA grew up with the Elric brothers?",
       "ja": "鋼の錬金術師でエルリック兄弟と幼馴染の機械鎧技師は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118942,7 +119678,8 @@
     "question_text": {
       "en": "Which dark-haired Spy x Family mother is secretly the assassin 'Thorn Princess'?",
       "ja": "スパイファミリーの母親で正体が殺し屋「いばら姫」の女性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119022,7 +119759,8 @@
     "question_text": {
       "en": "Which sister-obsessed State Security officer is Yor's younger brother?",
       "ja": "スパイファミリーでヨルを溺愛する弟・国家保安局員は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119102,7 +119840,8 @@
     "question_text": {
       "en": "Which studio is known for high-quality battle animation in Demon Slayer and Fate/Zero?",
       "ja": "鬼滅の刃や Fate/Zero の戦闘作画で知られるスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119117,7 +119856,7 @@
         "en": "Splatoon",
         "ja": "スプラトゥーン",
         "ja_typings": [
-          "supuratu-n"
+          "supuratwu-n"
         ]
       },
       {
@@ -119142,7 +119881,8 @@
     "question_text": {
       "en": "Which Nintendo Switch fighting game uses extendable arms?",
       "ja": "ニンテンドースイッチで腕が伸びる格闘ゲームはどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119182,7 +119922,8 @@
     "question_text": {
       "en": "Which company publishes Call of Duty?",
       "ja": "コール オブ デューティを発売している会社はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119302,7 +120043,8 @@
     "question_text": {
       "en": "Which Respawn battle royale features Legends with unique abilities?",
       "ja": "リスポーンのバトルロイヤルでレジェンドが登場する作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119331,7 +120073,6 @@
         "en": "Shadowverse",
         "ja": "シャドウバース",
         "ja_typings": [
-          "shadoba-su",
           "shadouba-su"
         ]
       }
@@ -119343,7 +120084,8 @@
     "question_text": {
       "en": "Which mobile game features anthropomorphized warship girls?",
       "ja": "艦船を擬人化したモバイルゲームはどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119383,7 +120125,8 @@
     "question_text": {
       "en": "Which EA first-person shooter series competes with Call of Duty?",
       "ja": "EAが出すCoDのライバルとなるFPSシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119423,7 +120166,8 @@
     "question_text": {
       "en": "Which studio makes The Elder Scrolls and Fallout?",
       "ja": "エルダースクロールズやフォールアウトを作る会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119445,8 +120189,6 @@
         "en": "Guild Wars 2",
         "ja": "ギルドウォーズ2",
         "ja_typings": [
-          "girudouo-zu2",
-          "girudouo-zutsu-",
           "girudowo-zu2"
         ]
       },
@@ -119505,7 +120247,8 @@
     "question_text": {
       "en": "Which Hudson classic features a character planting bombs in a maze?",
       "ja": "ハドソンの爆弾を置く迷路ゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119545,7 +120288,8 @@
     "question_text": {
       "en": "Which Supercell game has players raiding tropical beaches?",
       "ja": "スーパーセル社の南の島を攻略するゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119560,7 +120304,7 @@
         "en": "Doom",
         "ja": "ドゥーム",
         "ja_typings": [
-          "du-mu"
+          "dwu-mu"
         ]
       },
       {
@@ -119585,7 +120329,8 @@
     "question_text": {
       "en": "Which 2K loot-shooter series features cel-shaded graphics on Pandora?",
       "ja": "2Kのトゥーン調FPSでパンドラ星を舞台にする作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119625,7 +120370,8 @@
     "question_text": {
       "en": "Which Supercell mobile game features 3v3 team brawls?",
       "ja": "スーパーセルの3対3のチーム対戦モバイルゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119665,7 +120411,8 @@
     "question_text": {
       "en": "Which Atari classic involves bouncing a ball to break bricks?",
       "ja": "ボールでブロックを崩すアタリのゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119705,7 +120452,8 @@
     "question_text": {
       "en": "Which studio created Destiny and Halo?",
       "ja": "ヘイローやデスティニーを作ったスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119745,7 +120493,8 @@
     "question_text": {
       "en": "Which competitive FPS is short for Counter-Strike: Global Offensive?",
       "ja": "カウンターストライクの略称で語られる対戦FPSは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119774,7 +120523,7 @@
         "en": "Doom",
         "ja": "ドゥーム",
         "ja_typings": [
-          "du-mu"
+          "dwu-mu"
         ]
       }
     ],
@@ -119785,7 +120534,8 @@
     "question_text": {
       "en": "Which Activision FPS series has Modern Warfare entries?",
       "ja": "モダンウォーフェアを含むアクティビジョンのFPSは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119825,7 +120575,8 @@
     "question_text": {
       "en": "Which Sega puzzle game involves matching colored stones in columns?",
       "ja": "セガの落ちもの宝石パズルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119865,7 +120616,8 @@
     "question_text": {
       "en": "Which CD Projekt RED dystopian RPG was released in 2020?",
       "ja": "CDプロジェクト製の2020年発売SF RPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119905,7 +120657,8 @@
     "question_text": {
       "en": "Which Sony post-apocalyptic biker game features Deacon St. John?",
       "ja": "ディーコンが主人公のソニーのバイクゾンビゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119975,7 +120728,7 @@
         "en": "Doom",
         "ja": "ドゥーム",
         "ja_typings": [
-          "du-mu"
+          "dwu-mu"
         ]
       }
     ],
@@ -119986,7 +120739,8 @@
     "question_text": {
       "en": "Which Quantic Dream game depicts a society of sentient androids?",
       "ja": "クアンティック・ドリームのアンドロイドが主役の作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120008,7 +120762,6 @@
         "en": "Shadowrun",
         "ja": "シャドウラン",
         "ja_typings": [
-          "shadoran",
           "shadouran"
         ]
       },
@@ -120027,7 +120780,8 @@
     "question_text": {
       "en": "Which cyberpunk RPG series features augmented agent Adam Jensen?",
       "ja": "アダム・ジェンセンが主人公のサイバーパンクRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120067,7 +120821,8 @@
     "question_text": {
       "en": "Which Namco classic involves a character pumping up underground monsters?",
       "ja": "地中の敵を膨らませて倒すナムコのゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120075,7 +120830,7 @@
         "en": "Doom",
         "ja": "ドゥーム",
         "ja_typings": [
-          "du-mu"
+          "dwu-mu"
         ]
       },
       {
@@ -120107,7 +120862,8 @@
     "question_text": {
       "en": "Which id Software FPS features a Space Marine fighting demons?",
       "ja": "id Softwareの悪魔を倒す宇宙海兵FPSは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120115,8 +120871,7 @@
         "en": "Dota 2",
         "ja": "ドータ2",
         "ja_typings": [
-          "do-ta2",
-          "do-tatsu-"
+          "do-ta2"
         ]
       },
       {
@@ -120148,7 +120903,8 @@
     "question_text": {
       "en": "Which Valve MOBA features heroes battling for ancients?",
       "ja": "Valveのエンシェントを破壊するMOBAは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120188,7 +120944,8 @@
     "question_text": {
       "en": "Which Game Boy puzzle game has Mario throwing pills at viruses?",
       "ja": "マリオがウイルスを薬で倒すゲームボーイのパズルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120196,32 +120953,28 @@
         "en": "Dragon Quest X",
         "ja": "ドラゴンクエストX",
         "ja_typings": [
-          "doragonkuesutox",
-          "doragonkuesutoten"
+          "doragonkuesutox"
         ]
       },
       {
         "en": "Dragon Quest IX",
         "ja": "ドラゴンクエストIX",
         "ja_typings": [
-          "doragonkuesutoix",
-          "doragonkuesutonain"
+          "doragonkuesutoix"
         ]
       },
       {
         "en": "Dragon Quest XI",
         "ja": "ドラゴンクエストXI",
         "ja_typings": [
-          "doragonkuesutoxi",
-          "doragonkuesutoirebun"
+          "doragonkuesutoxi"
         ]
       },
       {
         "en": "Dragon Quest VIII",
         "ja": "ドラゴンクエストVIII",
         "ja_typings": [
-          "doragonkuesutoviii",
-          "doragonkuesutoeito"
+          "doragonkuesutoviii"
         ]
       }
     ],
@@ -120232,7 +120985,8 @@
     "question_text": {
       "en": "Which Dragon Quest entry is the MMORPG numbered ten?",
       "ja": "ドラクエシリーズで唯一のMMORPGの番号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120272,7 +121026,8 @@
     "question_text": {
       "en": "Which company makes Unreal Engine and Fortnite?",
       "ja": "アンリアルエンジンとフォートナイトの会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120294,8 +121049,6 @@
         "en": "Guild Wars 2",
         "ja": "ギルドウォーズ2",
         "ja_typings": [
-          "girudouo-zu2",
-          "girudouo-zutsu-",
           "girudowo-zu2"
         ]
       },
@@ -120354,7 +121107,8 @@
     "question_text": {
       "en": "Which Bethesda post-apocalyptic RPG features Vault Boy?",
       "ja": "ベセスダのVault Boyが象徴のポストアポカリプスRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120434,7 +121188,8 @@
     "question_text": {
       "en": "Which Namco shooter has insects forming attack formations?",
       "ja": "編隊で攻撃してくるナムコのシューティングは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120474,7 +121229,8 @@
     "question_text": {
       "en": "Which Namco shooter from 1979 preceded Galaga?",
       "ja": "ギャラガの前作にあたる1979年のナムコ作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120617,7 +121373,6 @@
         "en": "Shadowverse",
         "ja": "シャドウバース",
         "ja_typings": [
-          "shadoba-su",
           "shadouba-su"
         ]
       },
@@ -120636,7 +121391,8 @@
     "question_text": {
       "en": "Which Cygames fantasy mobile RPG features sky-faring adventurers?",
       "ja": "サイゲームスの空の旅を描くファンタジーRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120644,8 +121400,6 @@
         "en": "Guild Wars 2",
         "ja": "ギルドウォーズ2",
         "ja_typings": [
-          "girudouo-zu2",
-          "girudouo-zutsu-",
           "girudowo-zu2"
         ]
       },
@@ -120678,7 +121432,8 @@
     "question_text": {
       "en": "Which ArenaNet MMORPG sequel released in 2012 has no monthly fee?",
       "ja": "アリーナネットの月額無料MMORPG続編は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120853,8 +121608,7 @@
         "en": "Dota 2",
         "ja": "ドータ2",
         "ja_typings": [
-          "do-ta2",
-          "do-tatsu-"
+          "do-ta2"
         ]
       },
       {
@@ -120879,7 +121633,8 @@
     "question_text": {
       "en": "Which Blizzard MOBA features characters from across its franchises?",
       "ja": "ブリザード全作品のキャラが集うMOBAは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121308,8 +122063,6 @@
         "en": "Guild Wars 2",
         "ja": "ギルドウォーズ2",
         "ja_typings": [
-          "girudouo-zu2",
-          "girudouo-zutsu-",
           "girudowo-zu2"
         ]
       }
@@ -121361,7 +122114,8 @@
     "question_text": {
       "en": "Which genre includes League of Legends and Dota 2?",
       "ja": "LoLやDota 2のジャンル名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121401,7 +122155,8 @@
     "question_text": {
       "en": "Which Nintendo racing series features banana peels and shells?",
       "ja": "甲羅やバナナを投げる任天堂レースゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121503,7 +122258,7 @@
         "en": "Doom",
         "ja": "ドゥーム",
         "ja_typings": [
-          "du-mu"
+          "dwu-mu"
         ]
       },
       {
@@ -121521,7 +122276,8 @@
     "question_text": {
       "en": "Which EA WWII FPS series competed with early Call of Duty?",
       "ja": "EAの第二次大戦FPSで初期CoDの競合は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121682,7 +122438,8 @@
     "question_text": {
       "en": "Which 1980 Nichibutsu shooter sequel to Cosmos features docking?",
       "ja": "三段ロケットがドッキングする日物のシューティングは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121730,16 +122487,14 @@
         "en": "Nintendo 3DS",
         "ja": "ニンテンドー3DS",
         "ja_typings": [
-          "nintendo-3ds",
-          "nintendo-suri-dei-esu"
+          "nintendo-3ds"
         ]
       },
       {
         "en": "Nintendo DS",
         "ja": "ニンテンドーDS",
         "ja_typings": [
-          "nintendo-ds",
-          "nintendo-dei-esu"
+          "nintendo-ds"
         ]
       },
       {
@@ -121764,7 +122519,8 @@
     "question_text": {
       "en": "Which Nintendo handheld introduced stereoscopic 3D without glasses?",
       "ja": "裸眼3D表示を搭載した任天堂の携帯機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121772,16 +122528,14 @@
         "en": "Nintendo DS",
         "ja": "ニンテンドーDS",
         "ja_typings": [
-          "nintendo-ds",
-          "nintendo-dei-esu"
+          "nintendo-ds"
         ]
       },
       {
         "en": "Nintendo 3DS",
         "ja": "ニンテンドー3DS",
         "ja_typings": [
-          "nintendo-3ds",
-          "nintendo-suri-dei-esu"
+          "nintendo-3ds"
         ]
       },
       {
@@ -121806,7 +122560,8 @@
     "question_text": {
       "en": "Which Nintendo dual-screen handheld launched in 2004?",
       "ja": "2004年発売の任天堂二画面携帯機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121846,7 +122601,8 @@
     "question_text": {
       "en": "Which Blizzard hero shooter features Tracer and Reinhardt?",
       "ja": "トレーサーやラインハルトが登場するブリザードのFPSは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121886,7 +122642,8 @@
     "question_text": {
       "en": "Which Mario spin-off RPG uses 2D paper visuals?",
       "ja": "紙のような2D表現を使うマリオRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121908,7 +122665,7 @@
         "en": "Splatoon",
         "ja": "スプラトゥーン",
         "ja_typings": [
-          "supuratu-n"
+          "supuratwu-n"
         ]
       },
       {
@@ -121926,7 +122683,8 @@
     "question_text": {
       "en": "Which Miyamoto strategy series has players directing tiny plant creatures?",
       "ja": "宮本茂作の植物人間を率いる戦略アクションは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122006,7 +122764,8 @@
     "question_text": {
       "en": "Which Sony game console brand started in 1994?",
       "ja": "1994年発売のソニー据置ゲーム機ブランドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122046,7 +122805,8 @@
     "question_text": {
       "en": "Which Sony streaming handheld plays PS5 games over Wi-Fi?",
       "ja": "PS5の映像をWi-Fi越しに遊ぶソニーの携帯端末は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122075,7 +122835,7 @@
         "en": "Doom",
         "ja": "ドゥーム",
         "ja_typings": [
-          "du-mu"
+          "dwu-mu"
         ]
       }
     ],
@@ -122086,7 +122846,8 @@
     "question_text": {
       "en": "Which Valve puzzle game features a portal-creating gun?",
       "ja": "ポータルを撃つValveのパズルゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122115,7 +122876,6 @@
         "en": "Shadowverse",
         "ja": "シャドウバース",
         "ja_typings": [
-          "shadoba-su",
           "shadouba-su"
         ]
       }
@@ -122127,7 +122887,8 @@
     "question_text": {
       "en": "Which Cygames anime-style mobile RPG features a guild of girls?",
       "ja": "サイゲームスの美少女ギルド系モバイルRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122247,7 +123008,8 @@
     "question_text": {
       "en": "Which Compile/Sega puzzle game features chain-clearing colored blobs?",
       "ja": "連鎖で消すコンパイル/セガのカラフルパズルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122262,7 +123024,7 @@
         "en": "Doom",
         "ja": "ドゥーム",
         "ja_typings": [
-          "du-mu"
+          "dwu-mu"
         ]
       },
       {
@@ -122287,7 +123049,8 @@
     "question_text": {
       "en": "Which id Software FPS succeeded Doom with full 3D graphics?",
       "ja": "ドゥームに続くid Softwareの3D FPSは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122327,7 +123090,8 @@
     "question_text": {
       "en": "Which ASUS Windows handheld competes with Steam Deck?",
       "ja": "Steam Deckの競合となるASUSのWindows携帯機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122367,7 +123131,8 @@
     "question_text": {
       "en": "Which genre includes Final Fantasy and Dragon Quest?",
       "ja": "FFやドラクエが代表するジャンル名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122447,7 +123212,8 @@
     "question_text": {
       "en": "Which Ubisoft tactical shooter is named after Tom Clancy's novel?",
       "ja": "トム・クランシー原作のユービーアイ戦術シューターは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122487,7 +123253,8 @@
     "question_text": {
       "en": "Which 2015 Ubisoft 5v5 attack-defend shooter became an esports staple?",
       "ja": "2015年発売の5対5攻防シューター(R6)は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122556,8 +123323,7 @@
         "en": "Dota 2",
         "ja": "ドータ2",
         "ja_typings": [
-          "do-ta2",
-          "do-tatsu-"
+          "do-ta2"
         ]
       }
     ],
@@ -122568,7 +123334,8 @@
     "question_text": {
       "en": "Which Psyonix game combines soccer with rocket-powered cars?",
       "ja": "ロケット推進の車でサッカーをするPsyonixのゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122857,7 +123624,6 @@
         "en": "Shadowrun",
         "ja": "シャドウラン",
         "ja_typings": [
-          "shadoran",
           "shadouran"
         ]
       },
@@ -122865,7 +123631,6 @@
         "en": "Shadowverse",
         "ja": "シャドウバース",
         "ja_typings": [
-          "shadoba-su",
           "shadouba-su"
         ]
       },
@@ -122891,7 +123656,8 @@
     "question_text": {
       "en": "Which tabletop-origin RPG mixes cyberpunk with fantasy races?",
       "ja": "サイバーパンクとファンタジー種族が混ざるテーブルトークRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122899,7 +123665,6 @@
         "en": "Shadowverse",
         "ja": "シャドウバース",
         "ja_typings": [
-          "shadoba-su",
           "shadouba-su"
         ]
       },
@@ -122907,7 +123672,6 @@
         "en": "Shadowrun",
         "ja": "シャドウラン",
         "ja_typings": [
-          "shadoran",
           "shadouran"
         ]
       },
@@ -122933,7 +123697,8 @@
     "question_text": {
       "en": "Which Cygames digital card battler launched in 2016?",
       "ja": "サイゲームスの2016年デジタルカードゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122988,8 +123753,7 @@
         "en": "Dota 2",
         "ja": "ドータ2",
         "ja_typings": [
-          "do-ta2",
-          "do-tatsu-"
+          "do-ta2"
         ]
       },
       {
@@ -123014,7 +123778,8 @@
     "question_text": {
       "en": "Which MOBA features gods and mythological figures in third-person view?",
       "ja": "神話のキャラがTPS視点で戦うMOBAは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123054,7 +123819,8 @@
     "question_text": {
       "en": "Which 1978 Taito arcade game popularized the shooter genre?",
       "ja": "1978年タイトーの和製シューティングの金字塔は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123062,7 +123828,7 @@
         "en": "Splatoon",
         "ja": "スプラトゥーン",
         "ja_typings": [
-          "supuratu-n"
+          "supuratwu-n"
         ]
       },
       {
@@ -123094,7 +123860,8 @@
     "question_text": {
       "en": "Which Nintendo shooter has squids inking turf?",
       "ja": "イカが街にインクを塗る任天堂のシューターは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123109,7 +123876,7 @@
         "en": "Splatoon",
         "ja": "スプラトゥーン",
         "ja_typings": [
-          "supuratu-n"
+          "supuratwu-n"
         ]
       },
       {
@@ -123134,7 +123901,8 @@
     "question_text": {
       "en": "Which Nintendo on-rails shooter stars a fox pilot?",
       "ja": "キツネのパイロットが宇宙を飛ぶ任天堂作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123174,7 +123942,8 @@
     "question_text": {
       "en": "Which Valve handheld runs SteamOS and launched in 2022?",
       "ja": "SteamOSを搭載する2022年Valveの携帯機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123254,7 +124023,8 @@
     "question_text": {
       "en": "Which company owns Rockstar Games and 2K?",
       "ja": "ロックスターと2Kを傘下に持つ会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123294,7 +124064,8 @@
     "question_text": {
       "en": "Which Valve class-based shooter is famous for the Sandvich?",
       "ja": "サンドビッチで知られるValveのクラスFPSは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123374,7 +124145,8 @@
     "question_text": {
       "en": "Which Bethesda fantasy RPG series includes Skyrim and Oblivion?",
       "ja": "スカイリムやオブリビオンを擁するベセスダのRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123735,7 +124507,8 @@
     "question_text": {
       "en": "Which French publisher makes Assassin's Creed?",
       "ja": "アサシンクリードのフランスの発売会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123775,7 +124548,8 @@
     "question_text": {
       "en": "Which Naughty Dog series stars treasure hunter Nathan Drake?",
       "ja": "ネイサン・ドレイクが活躍するノーティードッグ作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123815,7 +124589,8 @@
     "question_text": {
       "en": "Which Riot Games tactical 5v5 shooter launched in 2020?",
       "ja": "2020年公開のライオット製5対5戦術FPSは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123855,7 +124630,8 @@
     "question_text": {
       "en": "Which narrative game genre features text and character art (NVL)?",
       "ja": "立ち絵とテキストで物語を進めるADVのジャンル名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123877,8 +124653,7 @@
         "en": "Nintendo 3DS",
         "ja": "ニンテンドー3DS",
         "ja_typings": [
-          "nintendo-3ds",
-          "nintendo-suri-dei-esu"
+          "nintendo-3ds"
         ]
       },
       {
@@ -123896,7 +124671,8 @@
     "question_text": {
       "en": "Which Nintendo home console launched in 2012 had a tablet controller?",
       "ja": "タブレット型コントローラの2012年任天堂据置機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123976,7 +124752,8 @@
     "question_text": {
       "en": "Which CD Projekt RED series follows Geralt of Rivia?",
       "ja": "ゲラルトが主人公のCD Projekt RPGシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123998,8 +124775,6 @@
         "en": "Guild Wars 2",
         "ja": "ギルドウォーズ2",
         "ja_typings": [
-          "girudouo-zu2",
-          "girudouo-zutsu-",
           "girudowo-zu2"
         ]
       },
@@ -124018,7 +124793,8 @@
     "question_text": {
       "en": "Which Blizzard MMORPG launched in 2004 and dominated the genre?",
       "ja": "2004年公開のブリザード製MMORPGの代名詞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124058,7 +124834,8 @@
     "question_text": {
       "en": "Which Namco 1982 vertical-scrolling shooter features Solvalou?",
       "ja": "ソルバルウが主人公の1982年ナムコ縦シューは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124379,7 +125156,8 @@
     "question_text": {
       "en": "Who led Nazi Germany during World War II?",
       "ja": "第二次大戦時のナチス・ドイツの指導者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124419,7 +125197,8 @@
     "question_text": {
       "en": "Who was the first US Secretary of the Treasury?",
       "ja": "アメリカ初代財務長官は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124459,7 +125238,8 @@
     "question_text": {
       "en": "Who led Russia's Provisional Government in 1917 before the Bolsheviks?",
       "ja": "1917年ロシア臨時政府を率いた人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124619,7 +125399,8 @@
     "question_text": {
       "en": "Who flew a kite during a thunderstorm and signed the Declaration of Independence?",
       "ja": "雷雨に凧を上げ独立宣言にも署名した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124659,7 +125440,8 @@
     "question_text": {
       "en": "Which B-29 dropped the atomic bomb on Nagasaki?",
       "ja": "長崎に原爆を投下したB-29の機名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124739,7 +125521,8 @@
     "question_text": {
       "en": "Who was the second American to walk on the Moon, after Armstrong?",
       "ja": "アームストロングに次いで月面に立ったアメリカ人は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124754,7 +125537,6 @@
         "en": "Crossbow",
         "ja": "クロスボウ",
         "ja_typings": [
-          "kurosubo",
           "kurosubou"
         ]
       },
@@ -124842,7 +125624,6 @@
         "en": "Crossbow",
         "ja": "クロスボウ",
         "ja_typings": [
-          "kurosubo",
           "kurosubou"
         ]
       },
@@ -124901,7 +125682,8 @@
     "question_text": {
       "en": "Who was the Italian-born queen of France during the Wars of Religion?",
       "ja": "宗教戦争期のフランス王妃でイタリア出身の女性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125031,7 +125813,6 @@
         "en": "Crossbow",
         "ja": "クロスボウ",
         "ja_typings": [
-          "kurosubo",
           "kurosubou"
         ]
       },
@@ -125224,7 +126005,8 @@
     "question_text": {
       "en": "Who was the 12th-century queen consort of both France and England?",
       "ja": "12世紀にフランスとイングランド両国の王妃となった女性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125264,7 +126046,8 @@
     "question_text": {
       "en": "Which Dutch humanist wrote 'In Praise of Folly'?",
       "ja": "『痴愚神礼讃』を書いたオランダの人文主義者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125344,7 +126127,8 @@
     "question_text": {
       "en": "Who ruled Spain as dictator from 1939 to 1975?",
       "ja": "1939年から1975年までスペインを独裁したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125384,7 +126168,8 @@
     "question_text": {
       "en": "Which Italian astronomer was tried by the Inquisition for heliocentrism?",
       "ja": "地動説で異端審問にかけられたイタリアの天文学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125424,7 +126209,8 @@
     "question_text": {
       "en": "Who was the first president of the United States?",
       "ja": "アメリカ合衆国の初代大統領は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125464,7 +126250,8 @@
     "question_text": {
       "en": "Which European country was reunited in 1990?",
       "ja": "1990年に再統一されたヨーロッパの国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125504,7 +126291,8 @@
     "question_text": {
       "en": "Who was the first female Prime Minister of Israel?",
       "ja": "イスラエル初の女性首相は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125559,8 +126347,7 @@
         "en": "Malcolm X",
         "ja": "マルコムX",
         "ja_typings": [
-          "marukomux",
-          "marukomuekusu"
+          "marukomux"
         ]
       },
       {
@@ -125707,7 +126494,8 @@
     "question_text": {
       "en": "Which Greek poet wrote 'Works and Days'?",
       "ja": "『労働と日々』を書いたギリシャの詩人は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125729,7 +126517,6 @@
         "en": "Thucydides",
         "ja": "トゥキディデス",
         "ja_typings": [
-          "twukidhideesu",
           "twukidhidesu"
         ]
       },
@@ -125748,7 +126535,8 @@
     "question_text": {
       "en": "Which legendary Greek poet wrote the Iliad and Odyssey?",
       "ja": "『イリアス』『オデュッセイア』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125788,7 +126576,8 @@
     "question_text": {
       "en": "Which Swiss reformer led the Reformation in Zurich?",
       "ja": "チューリヒで宗教改革を進めたスイスの改革者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125908,7 +126697,8 @@
     "question_text": {
       "en": "Who formulated the law of universal gravitation?",
       "ja": "万有引力の法則を定式化した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126068,7 +126858,8 @@
     "question_text": {
       "en": "Who was the second president of the United States?",
       "ja": "アメリカ合衆国の第2代大統領は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126148,7 +126939,8 @@
     "question_text": {
       "en": "Who was the first American to orbit Earth?",
       "ja": "アメリカ人で初めて地球周回飛行をしたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126228,7 +127020,8 @@
     "question_text": {
       "en": "What was the codename of the atomic bomb dropped on Hiroshima?",
       "ja": "広島に投下された原爆のコードネームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126276,8 +127069,7 @@
         "en": "Malcolm X",
         "ja": "マルコムX",
         "ja_typings": [
-          "marukomux",
-          "marukomuekusu"
+          "marukomux"
         ]
       },
       {
@@ -126349,7 +127141,8 @@
     "question_text": {
       "en": "Who was the queen guillotined during the French Revolution?",
       "ja": "フランス革命で処刑された王妃は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126405,8 +127198,7 @@
         "en": "Malcolm X",
         "ja": "マルコムX",
         "ja_typings": [
-          "marukomux",
-          "marukomuekusu"
+          "marukomux"
         ]
       },
       {
@@ -126512,7 +127304,8 @@
     "question_text": {
       "en": "Which B-17 bomber became famous for completing 25 WWII missions?",
       "ja": "第二次大戦で25回出撃を生き延びた有名なB-17は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126541,7 +127334,6 @@
         "en": "Muhammad Ali Jinnah",
         "ja": "ジンナー",
         "ja_typings": [
-          "jinna-",
           "jinnna-"
         ]
       }
@@ -126553,7 +127345,8 @@
     "question_text": {
       "en": "Who was the Likud Prime Minister of Israel who signed Camp David?",
       "ja": "キャンプ・デービッド合意を結んだイスラエルのリクード首相は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126593,7 +127386,8 @@
     "question_text": {
       "en": "Who discovered electromagnetic induction in 1831?",
       "ja": "1831年に電磁誘導を発見した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126681,7 +127475,6 @@
         "en": "Muhammad Ali Jinnah",
         "ja": "ジンナー",
         "ja_typings": [
-          "jinna-",
           "jinnna-"
         ]
       },
@@ -126875,7 +127668,8 @@
     "question_text": {
       "en": "Who proposed the heliocentric model of the solar system in the 16th century?",
       "ja": "16世紀に太陽中心説を唱えた人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127188,7 +127982,6 @@
         "en": "Thucydides",
         "ja": "トゥキディデス",
         "ja_typings": [
-          "twukidhideesu",
           "twukidhidesu"
         ]
       }
@@ -127200,7 +127993,8 @@
     "question_text": {
       "en": "Which Greek philosopher founded the Academy and wrote 'The Republic'?",
       "ja": "アカデメイアを開き『国家』を著したギリシャの哲学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127280,7 +128074,8 @@
     "question_text": {
       "en": "Which Greek mathematician is famous for a theorem about right triangles?",
       "ja": "直角三角形の定理で知られるギリシャの数学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127295,7 +128090,6 @@
         "en": "Muhammad Ali Jinnah",
         "ja": "ジンナー",
         "ja_typings": [
-          "jinna-",
           "jinnna-"
         ]
       },
@@ -127321,7 +128115,8 @@
     "question_text": {
       "en": "Who was the Bengali poet who won the 1913 Nobel Prize in Literature?",
       "ja": "1913年にノーベル文学賞を受けたベンガルの詩人は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127481,7 +128276,8 @@
     "question_text": {
       "en": "Who ruled Portugal as authoritarian leader during Estado Novo?",
       "ja": "エスタド・ノヴォ体制下でポルトガルを統治したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127601,7 +128397,8 @@
     "question_text": {
       "en": "Which Greek philosopher was tried and executed in Athens?",
       "ja": "アテネで死刑に処されたギリシャの哲学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127882,7 +128679,8 @@
     "question_text": {
       "en": "Who invented the practical incandescent light bulb?",
       "ja": "実用的な白熱電球を発明した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127922,7 +128720,8 @@
     "question_text": {
       "en": "Who authored the US Declaration of Independence and became 3rd president?",
       "ja": "米独立宣言を起草し第3代大統領となったのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127930,7 +128729,6 @@
         "en": "Thucydides",
         "ja": "トゥキディデス",
         "ja_typings": [
-          "twukidhideesu",
           "twukidhidesu"
         ]
       },
@@ -127963,7 +128761,8 @@
     "question_text": {
       "en": "Which Greek historian wrote 'History of the Peloponnesian War'?",
       "ja": "『ペロポネソス戦争史』を書いたギリシャの歴史家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128124,7 +128923,8 @@
     "question_text": {
       "en": "Who was the first US consul to Japan in 1856?",
       "ja": "1856年に初代米国総領事として来日した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128404,7 +129204,8 @@
     "question_text": {
       "en": "Who was the Union general and 18th US President?",
       "ja": "南北戦争の北軍将軍で第18代米大統領は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128674,7 +129475,6 @@
         "en": "Muhammad Ali Jinnah",
         "ja": "ジンナー",
         "ja_typings": [
-          "jinna-",
           "jinnna-"
         ]
       }
@@ -128686,7 +129486,8 @@
     "question_text": {
       "en": "Who was the Israeli PM assassinated in 1995 after signing Oslo Accords?",
       "ja": "オスロ合意後の1995年に暗殺されたイスラエル首相は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128766,7 +129567,8 @@
     "question_text": {
       "en": "Who was the first human to journey into outer space in 1961?",
       "ja": "1961年に人類初の宇宙飛行を達成したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128984,7 +129786,7 @@
         "en": "Euclid",
         "ja": "ユークリッド",
         "ja_typings": [
-          "yu-kuriltudo"
+          "yu-kuriddo"
         ]
       },
       {
@@ -129009,7 +129811,8 @@
     "question_text": {
       "en": "Which ancient Greek mathematician is known for the law of buoyancy?",
       "ja": "浮力の原理で知られる古代ギリシャの数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129049,7 +129852,8 @@
     "question_text": {
       "en": "Which ancient Greek philosopher wrote on logic and natural science?",
       "ja": "論理学や自然学の著作を残した古代ギリシャの哲学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129057,7 +129861,6 @@
         "en": "Babbage",
         "ja": "バベッジ",
         "ja_typings": [
-          "bayatuji",
           "babejji"
         ]
       },
@@ -129065,7 +129868,7 @@
         "en": "Turing",
         "ja": "チューリング",
         "ja_typings": [
-          "chixyu-ringu"
+          "chu-ringu"
         ]
       },
       {
@@ -129090,7 +129893,8 @@
     "question_text": {
       "en": "Who designed the Analytical Engine, a forerunner of the computer?",
       "ja": "解析機関を設計した、コンピュータの先駆者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129185,8 +129989,6 @@
         "en": "Fermi",
         "ja": "フェルミ",
         "ja_typings": [
-          "herumi",
-          "felumi",
           "ferumi"
         ]
       },
@@ -129194,8 +129996,6 @@
         "en": "Dirac",
         "ja": "ディラック",
         "ja_typings": [
-          "dexiratuku",
-          "dhilatuku",
           "dhirakku"
         ]
       },
@@ -129214,7 +130014,8 @@
     "question_text": {
       "en": "Which Indian physicist gave his name to particles called bosons?",
       "ja": "ボース粒子（ボソン）に名を残したインドの物理学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129236,7 +130037,6 @@
         "en": "Russell",
         "ja": "ラッセル",
         "ja_typings": [
-          "ratuseru",
           "rasseru"
         ]
       },
@@ -129255,7 +130055,8 @@
     "question_text": {
       "en": "Who founded modern set theory and the theory of transfinite numbers?",
       "ja": "近代集合論と超限数の理論を築いた数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129284,8 +130085,6 @@
         "en": "David Hilbert",
         "ja": "ダフィット・ヒルベルト",
         "ja_typings": [
-          "dahuxituto/hiruberuto",
-          "dafuxitto/hiluberuto",
           "dafitto/hiruberuto"
         ]
       }
@@ -129297,7 +130096,8 @@
     "question_text": {
       "en": "Who is the German mathematician called the prince of mathematicians?",
       "ja": "「数学者の王」と呼ばれたドイツの大数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129305,8 +130105,6 @@
         "en": "Chandrasekhar",
         "ja": "チャンドラセカール",
         "ja_typings": [
-          "chiyandorasekaa-ru",
-          "tyandolasekaa-lu",
           "chandoraseka-ru"
         ]
       },
@@ -129328,7 +130126,7 @@
         "en": "Eddington",
         "ja": "エディントン",
         "ja_typings": [
-          "edexinton"
+          "edhinton"
         ]
       }
     ],
@@ -129339,7 +130137,8 @@
     "question_text": {
       "en": "Which Indian-American astrophysicist's name labels a stellar mass limit?",
       "ja": "恒星の質量限界に名を残したインド系の天体物理学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129482,15 +130281,13 @@
         "en": "Nabla",
         "ja": "ナブラ",
         "ja_typings": [
-          "nabura",
-          "nabula"
+          "nabura"
         ]
       },
       {
         "en": "Hessian",
         "ja": "ヘッシアン",
         "ja_typings": [
-          "hetusian",
           "hesshian"
         ]
       }
@@ -129502,7 +130299,8 @@
     "question_text": {
       "en": "Which operator, used in relativity, is the wave operator in 4-dimensional spacetime?",
       "ja": "相対論で4次元時空の波動を表す微分作用素はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129510,8 +130308,7 @@
         "en": "Delta",
         "ja": "デルタ",
         "ja_typings": [
-          "deruta",
-          "deluta"
+          "deruta"
         ]
       },
       {
@@ -129532,8 +130329,7 @@
         "en": "Lambda",
         "ja": "ラムダ",
         "ja_typings": [
-          "ramuda",
-          "lamuda"
+          "ramuda"
         ]
       }
     ],
@@ -129544,7 +130340,8 @@
     "question_text": {
       "en": "Which Greek letter is often used to denote a small change in mathematics?",
       "ja": "数学で微小な変化を表すのによく使うギリシャ文字はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129592,16 +130389,14 @@
         "en": "Descartes",
         "ja": "デカルト",
         "ja_typings": [
-          "dekaruto",
-          "dekaluto"
+          "dekaruto"
         ]
       },
       {
         "en": "Pascal",
         "ja": "パスカル",
         "ja_typings": [
-          "pasukaru",
-          "pasukalu"
+          "pasukaru"
         ]
       },
       {
@@ -129615,8 +130410,6 @@
         "en": "Leibniz",
         "ja": "ライプニッツ",
         "ja_typings": [
-          "raipunitutu",
-          "laipunittu",
           "raipunittsu"
         ]
       }
@@ -129628,7 +130421,8 @@
     "question_text": {
       "en": "Which 17th-century French philosopher introduced analytic geometry?",
       "ja": "解析幾何学を創始した17世紀フランスの哲学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129636,7 +130430,7 @@
         "en": "Euclid",
         "ja": "ユークリッド",
         "ja_typings": [
-          "yu-kuriltudo"
+          "yu-kuriddo"
         ]
       },
       {
@@ -129657,8 +130451,7 @@
         "en": "Apollonius",
         "ja": "アポロニウス",
         "ja_typings": [
-          "aporoniusu",
-          "apoloniusu"
+          "aporoniusu"
         ]
       }
     ],
@@ -129669,7 +130462,8 @@
     "question_text": {
       "en": "Who wrote the Elements, the foundational text of geometry?",
       "ja": "幾何学の基礎となる『原論』を著したのは誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129684,8 +130478,7 @@
         "en": "Bernoulli",
         "ja": "ベルヌーイ",
         "ja_typings": [
-          "berunu-i",
-          "belunu-i"
+          "berunu-i"
         ]
       },
       {
@@ -129699,8 +130492,6 @@
         "en": "Lagrange",
         "ja": "ラグランジュ",
         "ja_typings": [
-          "raguranjixu",
-          "lagulanju",
           "raguranju"
         ]
       }
@@ -129712,7 +130503,8 @@
     "question_text": {
       "en": "Which Swiss mathematician introduced the constant e and much modern notation?",
       "ja": "定数 e を導入し、近代数学記法を整備したスイスの数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129781,8 +130573,7 @@
         "en": "Galois",
         "ja": "ガロア",
         "ja_typings": [
-          "garoa",
-          "galoa"
+          "garoa"
         ]
       }
     ],
@@ -129793,7 +130584,8 @@
     "question_text": {
       "en": "Whose Last Theorem about x^n+y^n=z^n was proved by Andrew Wiles?",
       "ja": "ワイルズが証明した「最終定理」を残した数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129808,7 +130600,6 @@
         "en": "Russell",
         "ja": "ラッセル",
         "ja_typings": [
-          "ratuseru",
           "rasseru"
         ]
       },
@@ -129816,8 +130607,6 @@
         "en": "Wittgenstein",
         "ja": "ウィトゲンシュタイン",
         "ja_typings": [
-          "uxitogensiyutain",
-          "wxitogenshutain",
           "witogenshutain"
         ]
       },
@@ -129825,8 +130614,7 @@
         "en": "Gödel",
         "ja": "ゲーデル",
         "ja_typings": [
-          "ge-deru",
-          "ge-delu"
+          "ge-deru"
         ]
       }
     ],
@@ -129837,7 +130625,8 @@
     "question_text": {
       "en": "Which German logician founded modern logic with his Begriffsschrift?",
       "ja": "『概念記法』で近代論理学を築いたドイツの論理学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129886,23 +130675,20 @@
         "en": "Galois",
         "ja": "ガロア",
         "ja_typings": [
-          "garoa",
-          "galoa"
+          "garoa"
         ]
       },
       {
         "en": "Abel",
         "ja": "アーベル",
         "ja_typings": [
-          "a-beru",
-          "a-belu"
+          "a-beru"
         ]
       },
       {
         "en": "Cauchy",
         "ja": "コーシー",
         "ja_typings": [
-          "ko-shi--",
           "ko-shi-"
         ]
       },
@@ -129921,7 +130707,8 @@
     "question_text": {
       "en": "Which young French mathematician founded group theory before dying in a duel?",
       "ja": "決闘で若くして亡くなり、群論を築いたフランスの数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129983,16 +130770,14 @@
         "en": "Laplace",
         "ja": "ラプラス",
         "ja_typings": [
-          "rapurasu",
-          "lapulasu"
+          "rapurasu"
         ]
       },
       {
         "en": "Bernoulli",
         "ja": "ベルヌーイ",
         "ja_typings": [
-          "berunu-i",
-          "belunu-i"
+          "berunu-i"
         ]
       }
     ],
@@ -130003,7 +130788,8 @@
     "question_text": {
       "en": "Which mathematician's name labels the normal distribution's bell curve?",
       "ja": "正規分布の釣鐘型曲線に名を残した数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130011,16 +130797,13 @@
         "en": "Georg Cantor",
         "ja": "ゲオルク・カントール",
         "ja_typings": [
-          "georuku/kanto-ru",
-          "geoluku/kanto-lu"
+          "georuku/kanto-ru"
         ]
       },
       {
         "en": "Richard Dedekind",
         "ja": "リヒャルト・デデキント",
         "ja_typings": [
-          "rihiyaruto/dedekinto",
-          "lihyaluto/dedekinto",
           "rihyaruto/dedekinto"
         ]
       },
@@ -130028,7 +130811,6 @@
         "en": "David Hilbert",
         "ja": "ダフィット・ヒルベルト",
         "ja_typings": [
-          "dahuxituto/hiruberuto",
           "dafitto/hiruberuto"
         ]
       },
@@ -130036,8 +130818,7 @@
         "en": "Henri Poincaré",
         "ja": "アンリ・ポアンカレ",
         "ja_typings": [
-          "anri/poankare",
-          "anli/poankale"
+          "anri/poankare"
         ]
       }
     ],
@@ -130048,7 +130829,8 @@
     "question_text": {
       "en": "Who founded set theory and proved different sizes of infinity?",
       "ja": "集合論を創り、無限に大小があることを示した数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130151,7 +130933,6 @@
         "en": "John Nash",
         "ja": "ジョン・ナッシュ",
         "ja_typings": [
-          "jiyon/natusiyu",
           "jon/nasshu"
         ]
       },
@@ -130159,7 +130940,6 @@
         "en": "Andrew Wiles",
         "ja": "アンドリュー・ワイルズ",
         "ja_typings": [
-          "andoriyu-/wairuzu",
           "andoryu-/wairuzu"
         ]
       }
@@ -130171,7 +130951,8 @@
     "question_text": {
       "en": "Who proved the Poincaré conjecture and declined the Fields Medal?",
       "ja": "ポアンカレ予想を証明しフィールズ賞を辞退した数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130179,16 +130960,14 @@
         "en": "Gödel",
         "ja": "ゲーデル",
         "ja_typings": [
-          "ge-deru",
-          "ge-delu"
+          "ge-deru"
         ]
       },
       {
         "en": "Tarski",
         "ja": "タルスキ",
         "ja_typings": [
-          "tarusuki",
-          "talusuki"
+          "tarusuki"
         ]
       },
       {
@@ -130202,7 +130981,6 @@
         "en": "Russell",
         "ja": "ラッセル",
         "ja_typings": [
-          "ratuseru",
           "rasseru"
         ]
       }
@@ -130214,7 +130992,8 @@
     "question_text": {
       "en": "Who proved the incompleteness theorems of formal arithmetic?",
       "ja": "形式的算術の不完全性定理を証明した数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130222,15 +131001,13 @@
         "en": "Hardy",
         "ja": "ハーディ",
         "ja_typings": [
-          "ha-dexi"
+          "ha-dhi"
         ]
       },
       {
         "en": "Littlewood",
         "ja": "リトルウッド",
         "ja_typings": [
-          "riturouxtudo",
-          "litoluuxtudo",
           "ritoruuddo"
         ]
       },
@@ -130238,7 +131015,6 @@
         "en": "Russell",
         "ja": "ラッセル",
         "ja_typings": [
-          "ratuseru",
           "rasseru"
         ]
       },
@@ -130246,7 +131022,7 @@
         "en": "Turing",
         "ja": "チューリング",
         "ja_typings": [
-          "chixyu-ringu"
+          "chu-ringu"
         ]
       }
     ],
@@ -130257,7 +131033,8 @@
     "question_text": {
       "en": "Which English mathematician collaborated extensively with Ramanujan?",
       "ja": "ラマヌジャンと長く共同研究したイギリスの数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130346,7 +131123,6 @@
         "en": "John Nash",
         "ja": "ジョン・ナッシュ",
         "ja_typings": [
-          "jiyon/natusiyu",
           "jon/nasshu"
         ]
       },
@@ -130354,8 +131130,6 @@
         "en": "John von Neumann",
         "ja": "ジョン・フォン・ノイマン",
         "ja_typings": [
-          "jiyon/fuxon/noiman",
-          "jon/foxn/noiman",
           "jon/fon/noiman"
         ]
       },
@@ -130363,8 +131137,6 @@
         "en": "Lloyd Shapley",
         "ja": "ロイド・シャプレー",
         "ja_typings": [
-          "roido/shiyapure-",
-          "loido/shaple-",
           "roido/shapure-"
         ]
       },
@@ -130372,8 +131144,7 @@
         "en": "Reinhard Selten",
         "ja": "ラインハルト・ゼルテン",
         "ja_typings": [
-          "rainharuto/zeruten",
-          "lainhaluto/zeluten"
+          "rainharuto/zeruten"
         ]
       }
     ],
@@ -130384,7 +131155,8 @@
     "question_text": {
       "en": "Which American mathematician won a Nobel Prize for game theory?",
       "ja": "ゲーム理論でノーベル経済学賞を受けたアメリカの数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130392,14 +131164,13 @@
         "en": "Kolmogorov",
         "ja": "コルモゴロフ",
         "ja_typings": [
-          "korumogorohu"
+          "korumogorofu"
         ]
       },
       {
         "en": "Chebyshev",
         "ja": "チェビシェフ",
         "ja_typings": [
-          "chiebisiehu",
           "chebishefu"
         ]
       },
@@ -130407,8 +131178,6 @@
         "en": "Lobachevsky",
         "ja": "ロバチェフスキー",
         "ja_typings": [
-          "robatiehusuki-",
-          "lobatiehusuki-",
           "robachefusuki-"
         ]
       },
@@ -130416,7 +131185,7 @@
         "en": "Markov",
         "ja": "マルコフ",
         "ja_typings": [
-          "marukohu"
+          "marukofu"
         ]
       }
     ],
@@ -130427,7 +131196,8 @@
     "question_text": {
       "en": "Which Russian mathematician axiomatized probability theory in 1933?",
       "ja": "1933年に確率論を公理化したロシアの数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130435,15 +131205,13 @@
         "en": "Lambda",
         "ja": "ラムダ",
         "ja_typings": [
-          "ramuda",
-          "lamuda"
+          "ramuda"
         ]
       },
       {
         "en": "Mu",
         "ja": "ミュー",
         "ja_typings": [
-          "miyu-",
           "myu-"
         ]
       },
@@ -130451,7 +131219,6 @@
         "en": "Nu",
         "ja": "ニュー",
         "ja_typings": [
-          "niyu-",
           "nyu-"
         ]
       },
@@ -130459,7 +131226,6 @@
         "en": "Kappa",
         "ja": "カッパ",
         "ja_typings": [
-          "katupa",
           "kappa"
         ]
       }
@@ -130471,7 +131237,8 @@
     "question_text": {
       "en": "Which Greek letter is the 11th and often denotes wavelength or eigenvalue?",
       "ja": "波長や固有値を表すのによく使うギリシャ文字（第11字）はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130493,15 +131260,13 @@
         "en": "Nabla",
         "ja": "ナブラ",
         "ja_typings": [
-          "nabura",
-          "nabula"
+          "nabura"
         ]
       },
       {
         "en": "Hessian",
         "ja": "ヘッシアン",
         "ja_typings": [
-          "hetusian",
           "hesshian"
         ]
       }
@@ -130513,7 +131278,8 @@
     "question_text": {
       "en": "Which differential operator is the divergence of the gradient?",
       "ja": "勾配の発散として定義される微分作用素はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130561,8 +131327,6 @@
         "en": "Leibniz",
         "ja": "ライプニッツ",
         "ja_typings": [
-          "raipunitutu",
-          "laipunittu",
           "raipunittsu"
         ]
       },
@@ -130570,7 +131334,6 @@
         "en": "Newton",
         "ja": "ニュートン",
         "ja_typings": [
-          "niyu-ton",
           "nyu-ton"
         ]
       },
@@ -130585,8 +131348,7 @@
         "en": "Bernoulli",
         "ja": "ベルヌーイ",
         "ja_typings": [
-          "berunu-i",
-          "belunu-i"
+          "berunu-i"
         ]
       }
     ],
@@ -130597,7 +131359,8 @@
     "question_text": {
       "en": "Which German philosopher-mathematician independently invented calculus?",
       "ja": "微積分を独立に発見したドイツの哲学者・数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130646,8 +131409,6 @@
         "en": "Lobachevsky",
         "ja": "ロバチェフスキー",
         "ja_typings": [
-          "robatiehusuki-",
-          "lobatiehusuki-",
           "robachefusuki-"
         ]
       },
@@ -130680,7 +131441,8 @@
     "question_text": {
       "en": "Which Russian mathematician developed non-Euclidean hyperbolic geometry?",
       "ja": "双曲幾何学を生んだロシアの数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130769,16 +131531,14 @@
         "en": "Nabla",
         "ja": "ナブラ",
         "ja_typings": [
-          "nabura",
-          "nabula"
+          "nabura"
         ]
       },
       {
         "en": "Delta",
         "ja": "デルタ",
         "ja_typings": [
-          "deruta",
-          "deluta"
+          "deruta"
         ]
       },
       {
@@ -130803,7 +131563,8 @@
     "question_text": {
       "en": "Which symbol ∇ is used for the gradient operator?",
       "ja": "勾配を表す記号 ∇ の名前はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130858,8 +131619,6 @@
         "en": "Alpha",
         "ja": "アルファ",
         "ja_typings": [
-          "aruhua",
-          "alufa",
           "arufa"
         ]
       },
@@ -130885,7 +131644,8 @@
     "question_text": {
       "en": "Which is the last letter of the Greek alphabet?",
       "ja": "ギリシャ文字の最後の文字はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130974,16 +131734,14 @@
         "en": "Poincaré",
         "ja": "ポアンカレ",
         "ja_typings": [
-          "poankare",
-          "poankale"
+          "poankare"
         ]
       },
       {
         "en": "Galois",
         "ja": "ガロア",
         "ja_typings": [
-          "garoa",
-          "galoa"
+          "garoa"
         ]
       },
       {
@@ -130997,7 +131755,6 @@
         "en": "Cauchy",
         "ja": "コーシー",
         "ja_typings": [
-          "ko-shi--",
           "ko-shi-"
         ]
       }
@@ -131009,7 +131766,8 @@
     "question_text": {
       "en": "Which French polymath stated a famous topology conjecture about 3-spheres?",
       "ja": "3次元球面に関する有名な位相幾何の予想を残したフランスの数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131057,8 +131815,6 @@
         "en": "Ramanujan",
         "ja": "ラマヌジャン",
         "ja_typings": [
-          "ramanujiyan",
-          "lamanujan",
           "ramanujan"
         ]
       },
@@ -131073,8 +131829,6 @@
         "en": "Chandrasekhar",
         "ja": "チャンドラセカール",
         "ja_typings": [
-          "chiyandorasekaa-ru",
-          "tyandolasekaa-lu",
           "chandoraseka-ru"
         ]
       },
@@ -131082,8 +131836,7 @@
         "en": "Aryabhata",
         "ja": "アーリヤバタ",
         "ja_typings": [
-          "a-riyabata",
-          "a-liyabata"
+          "a-riyabata"
         ]
       }
     ],
@@ -131094,7 +131847,8 @@
     "question_text": {
       "en": "Which Indian mathematician was famous for self-taught genius and infinite series?",
       "ja": "独学の天才で無限級数の研究で知られるインドの数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131143,7 +131897,6 @@
         "en": "Russell",
         "ja": "ラッセル",
         "ja_typings": [
-          "ratuseru",
           "rasseru"
         ]
       },
@@ -131158,7 +131911,6 @@
         "en": "Wittgenstein",
         "ja": "ウィトゲンシュタイン",
         "ja_typings": [
-          "uxitogensiyutain",
           "witogenshutain"
         ]
       },
@@ -131166,7 +131918,6 @@
         "en": "Moore",
         "ja": "ムーア",
         "ja_typings": [
-          "mu--a",
           "mu-a"
         ]
       }
@@ -131178,7 +131929,8 @@
     "question_text": {
       "en": "Which British philosopher co-wrote Principia Mathematica with Whitehead?",
       "ja": "ホワイトヘッドと『プリンキピア・マテマティカ』を著した英国の哲学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131193,7 +131945,7 @@
         "en": "Turing",
         "ja": "チューリング",
         "ja_typings": [
-          "chixyu-ringu"
+          "chu-ringu"
         ]
       },
       {
@@ -131207,7 +131959,7 @@
         "en": "Wiener",
         "ja": "ウィーナー",
         "ja_typings": [
-          "uxi-na-"
+          "wi-na-"
         ]
       }
     ],
@@ -131218,7 +131970,8 @@
     "question_text": {
       "en": "Which American mathematician founded information theory?",
       "ja": "情報理論を創始したアメリカの数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131240,16 +131993,14 @@
         "en": "Delta",
         "ja": "デルタ",
         "ja_typings": [
-          "deruta",
-          "deluta"
+          "deruta"
         ]
       },
       {
         "en": "Lambda",
         "ja": "ラムダ",
         "ja_typings": [
-          "ramuda",
-          "lamuda"
+          "ramuda"
         ]
       }
     ],
@@ -131260,7 +132011,8 @@
     "question_text": {
       "en": "Which Greek letter Σ denotes summation in mathematics?",
       "ja": "総和を表すギリシャ文字Σはどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131348,16 +132100,14 @@
         "en": "Tarski",
         "ja": "タルスキ",
         "ja_typings": [
-          "tarusuki",
-          "talusuki"
+          "tarusuki"
         ]
       },
       {
         "en": "Gödel",
         "ja": "ゲーデル",
         "ja_typings": [
-          "ge-deru",
-          "ge-delu"
+          "ge-deru"
         ]
       },
       {
@@ -131371,8 +132121,7 @@
         "en": "Kleene",
         "ja": "クリーネ",
         "ja_typings": [
-          "kuri-ne",
-          "kuli-ne"
+          "kuri-ne"
         ]
       }
     ],
@@ -131383,7 +132132,8 @@
     "question_text": {
       "en": "Which Polish-American logician is known for the definition of truth in formal languages?",
       "ja": "形式言語における真理の定義で知られるポーランド系米国の論理学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131423,7 +132173,8 @@
     "question_text": {
       "en": "Which Australian-American mathematician received the Fields Medal in 2006?",
       "ja": "2006年にフィールズ賞を受賞した豪州系米国の数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131471,16 +132222,13 @@
         "en": "Vector",
         "ja": "ベクトル",
         "ja_typings": [
-          "bekutoru",
-          "bekutolu"
+          "bekutoru"
         ]
       },
       {
         "en": "Scalar",
         "ja": "スカラー",
         "ja_typings": [
-          "sukara--",
-          "sukalaa-",
           "sukara-"
         ]
       },
@@ -131488,8 +132236,7 @@
         "en": "Tensor",
         "ja": "テンソル",
         "ja_typings": [
-          "tensoru",
-          "tensolu"
+          "tensoru"
         ]
       },
       {
@@ -131523,14 +132270,13 @@
         "en": "Turing",
         "ja": "チューリング",
         "ja_typings": [
-          "chixyu-ringu"
+          "chu-ringu"
         ]
       },
       {
         "en": "Babbage",
         "ja": "バベッジ",
         "ja_typings": [
-          "bayatuji",
           "babejji"
         ]
       },
@@ -131549,7 +132295,8 @@
     "question_text": {
       "en": "Who is the Hungarian-American polymath who pioneered modern computer architecture?",
       "ja": "現代コンピュータ・アーキテクチャを築いたハンガリー系米国の万能学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131950,7 +132697,6 @@
         "en": "2",
         "ja": "2つ",
         "ja_typings": [
-          "futatsu",
           "2tsu"
         ]
       },
@@ -131976,7 +132722,8 @@
     "question_text": {
       "en": "How many seasons are there in a year?",
       "ja": "1年の季節はいくつ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132122,8 +132869,7 @@
         "en": "Alexander Graham Bell",
         "ja": "アレクサンダー・グラハム・ベル",
         "ja_typings": [
-          "arekusanda-/gurahamu/beru",
-          "alekusanda-/gulahamu/belu"
+          "arekusanda-/gurahamu/beru"
         ]
       },
       {
@@ -132137,8 +132883,6 @@
         "en": "Samuel Morse",
         "ja": "サミュエル・モールス",
         "ja_typings": [
-          "samiyueru/mo-rusu",
-          "samyueru/mo-lusu",
           "samyueru/mo-rusu"
         ]
       },
@@ -132146,8 +132890,7 @@
         "en": "Nikola Tesla",
         "ja": "ニコラ・テスラ",
         "ja_typings": [
-          "nikora/tesura",
-          "nikola/tesula"
+          "nikora/tesura"
         ]
       }
     ],
@@ -132158,7 +132901,8 @@
     "question_text": {
       "en": "Who is credited with inventing the telephone in 1876?",
       "ja": "1876年に電話を発明したとされる人物は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132166,7 +132910,6 @@
         "en": "Anton Chekhov",
         "ja": "アントン・チェーホフ",
         "ja_typings": [
-          "anton/chie-hohu",
           "anton/che-hofu"
         ]
       },
@@ -132188,7 +132931,7 @@
         "en": "Fyodor Dostoevsky",
         "ja": "ドストエフスキー",
         "ja_typings": [
-          "dosutoehusuki-"
+          "dosutoefusuki-"
         ]
       }
     ],
@@ -132199,7 +132942,8 @@
     "question_text": {
       "en": "Who is the Russian playwright that wrote The Cherry Orchard?",
       "ja": "『桜の園』を書いたロシアの劇作家は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132207,24 +132951,20 @@
         "en": "Belle",
         "ja": "ベル",
         "ja_typings": [
-          "beru",
-          "belu"
+          "beru"
         ]
       },
       {
         "en": "Ariel",
         "ja": "アリエル",
         "ja_typings": [
-          "arieru",
-          "alielu"
+          "arieru"
         ]
       },
       {
         "en": "Cinderella",
         "ja": "シンデレラ",
         "ja_typings": [
-          "shindererera",
-          "shindelelela",
           "shinderera"
         ]
       },
@@ -132232,7 +132972,6 @@
         "en": "Jasmine",
         "ja": "ジャスミン",
         "ja_typings": [
-          "jiyasumin",
           "jasumin"
         ]
       }
@@ -132244,7 +132983,8 @@
     "question_text": {
       "en": "Who is the heroine of Disney's Beauty and the Beast?",
       "ja": "ディズニー『美女と野獣』のヒロインは誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132259,7 +132999,6 @@
         "en": "Steve Jobs",
         "ja": "スティーブ・ジョブズ",
         "ja_typings": [
-          "sutexi-bu/jiyobuzu",
           "suthi-bu/jobuzu"
         ]
       },
@@ -132267,7 +133006,6 @@
         "en": "Steve Wozniak",
         "ja": "スティーブ・ウォズニアック",
         "ja_typings": [
-          "sutexi-bu/uxozuniatuku",
           "suthi-bu/wozuniakku"
         ]
       },
@@ -132275,8 +133013,7 @@
         "en": "Larry Page",
         "ja": "ラリー・ペイジ",
         "ja_typings": [
-          "rari-/peiji",
-          "lali-/peiji"
+          "rari-/peiji"
         ]
       }
     ],
@@ -132287,7 +133024,8 @@
     "question_text": {
       "en": "Who co-founded Microsoft with Paul Allen?",
       "ja": "ポール・アレンとマイクロソフトを共同創業したのは誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132295,8 +133033,7 @@
         "en": "Brazil",
         "ja": "ブラジル",
         "ja_typings": [
-          "burajiru",
-          "bulajiru"
+          "burajiru"
         ]
       },
       {
@@ -132317,8 +133054,7 @@
         "en": "Colombia",
         "ja": "コロンビア",
         "ja_typings": [
-          "koronbia",
-          "kolonbia"
+          "koronbia"
         ]
       }
     ],
@@ -132329,7 +133065,8 @@
     "question_text": {
       "en": "Which country's flag features a yellow lozenge on a green field?",
       "ja": "緑地に黄色のひし形がある国旗はどこの国?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132337,24 +133074,20 @@
         "en": "C. S. Lewis",
         "ja": "C.S.ルイス",
         "ja_typings": [
-          "c.s.ruisu",
-          "shi-esuruisu"
+          "c.s.ruisu"
         ]
       },
       {
         "en": "J. R. R. Tolkien",
         "ja": "J.R.R.トールキン",
         "ja_typings": [
-          "j.r.r.to-rukin",
-          "jeia-rua-ruto-rukin"
+          "j.r.r.to-rukin"
         ]
       },
       {
         "en": "Roald Dahl",
         "ja": "ロアルド・ダール",
         "ja_typings": [
-          "roarudo/da--ru",
-          "loaludo/daa-lu",
           "roarudo/da-ru"
         ]
       },
@@ -132362,8 +133095,6 @@
         "en": "Lewis Carroll",
         "ja": "ルイス・キャロル",
         "ja_typings": [
-          "ruisu/kiyaroru",
-          "luisu/kyalolu",
           "ruisu/kyaroru"
         ]
       }
@@ -132375,7 +133106,8 @@
     "question_text": {
       "en": "Who wrote The Chronicles of Narnia?",
       "ja": "『ナルニア国物語』を書いた作家は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132383,8 +133115,6 @@
         "en": "Charles Dickens",
         "ja": "チャールズ・ディケンズ",
         "ja_typings": [
-          "chiya-ruzu/dexikenzu",
-          "cha-luzu/dhikenzu",
           "cha-ruzu/dhikenzu"
         ]
       },
@@ -132392,7 +133122,6 @@
         "en": "Mark Twain",
         "ja": "マーク・トウェイン",
         "ja_typings": [
-          "ma--ku/touxein",
           "ma-ku/towein"
         ]
       },
@@ -132400,8 +133129,6 @@
         "en": "Oscar Wilde",
         "ja": "オスカー・ワイルド",
         "ja_typings": [
-          "osuka--/wairudo",
-          "osuka--/wailudo",
           "osuka-/wairudo"
         ]
       },
@@ -132409,7 +133136,6 @@
         "en": "Jane Austen",
         "ja": "ジェーン・オースティン",
         "ja_typings": [
-          "jixe-n/oo-sutexin",
           "je-n/o-suthin"
         ]
       }
@@ -132421,7 +133147,8 @@
     "question_text": {
       "en": "Who wrote A Christmas Carol and Oliver Twist?",
       "ja": "『クリスマス・キャロル』『オリバー・ツイスト』を書いた英国の作家は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132476,7 +133203,6 @@
         "en": "Bessie",
         "ja": "ベッシー",
         "ja_typings": [
-          "betusi-",
           "besshi-"
         ]
       },
@@ -132484,8 +133210,6 @@
         "en": "Buttercup",
         "ja": "バターカップ",
         "ja_typings": [
-          "bata--katupu",
-          "bata--kappu",
           "bata-kappu"
         ]
       },
@@ -132493,8 +133217,6 @@
         "en": "Clover",
         "ja": "クローバー",
         "ja_typings": [
-          "kuro--ba--",
-          "kuloo-baa-",
           "kuro-ba-"
         ]
       }
@@ -132506,7 +133228,8 @@
     "question_text": {
       "en": "Which is a common pet name often associated with cows in English?",
       "ja": "英語圏で乳牛によく付けられる名前はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132563,7 +133286,6 @@
         "en": "Sudan",
         "ja": "スーダン",
         "ja_typings": [
-          "su--dan",
           "su-dan"
         ]
       },
@@ -132571,16 +133293,14 @@
         "en": "Libya",
         "ja": "リビア",
         "ja_typings": [
-          "ribia",
-          "libia"
+          "ribia"
         ]
       },
       {
         "en": "Iraq",
         "ja": "イラク",
         "ja_typings": [
-          "iraku",
-          "ilaku"
+          "iraku"
         ]
       }
     ],
@@ -132591,7 +133311,8 @@
     "question_text": {
       "en": "In which country are the Pyramids of Giza located?",
       "ja": "ギザのピラミッドがある国はどこ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132641,8 +133362,6 @@
         "en": "Florence",
         "ja": "フィレンツェ",
         "ja_typings": [
-          "fuxirentue",
-          "filentse",
           "firentse"
         ]
       },
@@ -132650,16 +133369,13 @@
         "en": "Milan",
         "ja": "ミラノ",
         "ja_typings": [
-          "mirano",
-          "milano"
+          "mirano"
         ]
       },
       {
         "en": "Rome",
         "ja": "ローマ",
         "ja_typings": [
-          "ro--ma",
-          "loo-ma",
           "ro-ma"
         ]
       },
@@ -132667,7 +133383,6 @@
         "en": "Venice",
         "ja": "ヴェネツィア",
         "ja_typings": [
-          "venetsuxia",
           "venetsia"
         ]
       }
@@ -132679,7 +133394,8 @@
     "question_text": {
       "en": "Which Italian city is famous as the cradle of the Renaissance?",
       "ja": "ルネサンス発祥の地として知られるイタリアの都市はどこ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132687,7 +133403,6 @@
         "en": "Frances Hodgson Burnett",
         "ja": "バーネット",
         "ja_typings": [
-          "ba--netuto",
           "ba-netto"
         ]
       },
@@ -132695,8 +133410,6 @@
         "en": "Louisa May Alcott",
         "ja": "オルコット",
         "ja_typings": [
-          "orukotuto",
-          "olukotto",
           "orukotto"
         ]
       },
@@ -132704,7 +133417,6 @@
         "en": "Beatrix Potter",
         "ja": "ポター",
         "ja_typings": [
-          "pota--",
           "pota-"
         ]
       },
@@ -132712,8 +133424,7 @@
         "en": "Lucy Maud Montgomery",
         "ja": "モンゴメリ",
         "ja_typings": [
-          "mongomeri",
-          "mongomeli"
+          "mongomeri"
         ]
       }
     ],
@@ -132724,7 +133435,8 @@
     "question_text": {
       "en": "Who wrote The Secret Garden and A Little Princess?",
       "ja": "『秘密の花園』『小公女』を書いた英米の作家は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132732,7 +133444,7 @@
         "en": "Fyodor Dostoevsky",
         "ja": "ドストエフスキー",
         "ja_typings": [
-          "dosutoehusuki-"
+          "dosutoefusuki-"
         ]
       },
       {
@@ -132746,7 +133458,6 @@
         "en": "Anton Chekhov",
         "ja": "アントン・チェーホフ",
         "ja_typings": [
-          "anton/chie-hohu",
           "anton/che-hofu"
         ]
       },
@@ -132765,7 +133476,8 @@
     "question_text": {
       "en": "Who wrote Crime and Punishment and The Brothers Karamazov?",
       "ja": "『罪と罰』『カラマーゾフの兄弟』を書いた作家は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132780,8 +133492,6 @@
         "en": "Austria",
         "ja": "オーストリア",
         "ja_typings": [
-          "o--sutoria",
-          "o--sutolia",
           "o-sutoria"
         ]
       },
@@ -132796,8 +133506,7 @@
         "en": "Netherlands",
         "ja": "オランダ",
         "ja_typings": [
-          "oranda",
-          "olanda"
+          "oranda"
         ]
       }
     ],
@@ -132808,7 +133517,8 @@
     "question_text": {
       "en": "In which country is the city Munich located?",
       "ja": "ミュンヘンがある国はどこ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132872,7 +133582,6 @@
         "en": "George R. R. Martin",
         "ja": "ジョージ・R.R.マーティン",
         "ja_typings": [
-          "jiyo-ji/r.r.maa-texin",
           "jo-ji/r.r.ma-thin"
         ]
       },
@@ -132880,8 +133589,6 @@
         "en": "Terry Pratchett",
         "ja": "テリー・プラチェット",
         "ja_typings": [
-          "teri-/puratietuto",
-          "teli-/pulachetto",
           "teri-/purachetto"
         ]
       }
@@ -132893,7 +133600,8 @@
     "question_text": {
       "en": "Who wrote The Lord of the Rings?",
       "ja": "『指輪物語』を書いた英国の作家は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132984,16 +133692,13 @@
         "en": "Los Angeles",
         "ja": "ロサンゼルス",
         "ja_typings": [
-          "rosanzerusu",
-          "losanzelusu"
+          "rosanzerusu"
         ]
       },
       {
         "en": "New York",
         "ja": "ニューヨーク",
         "ja_typings": [
-          "niyuu-yoo-ku",
-          "nyu--yo--ku",
           "nyu-yo-ku"
         ]
       },
@@ -133019,7 +133724,8 @@
     "question_text": {
       "en": "Which American city is the heart of the U.S. film industry (Hollywood)?",
       "ja": "ハリウッドがある、米国映画産業の中心都市はどこ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133069,16 +133775,13 @@
         "en": "Melanie",
         "ja": "メラニー",
         "ja_typings": [
-          "merani-",
-          "melani-"
+          "merani-"
         ]
       },
       {
         "en": "Scarlett",
         "ja": "スカーレット",
         "ja_typings": [
-          "suka--retuto",
-          "suka--letto",
           "suka-retto"
         ]
       },
@@ -133086,8 +133789,6 @@
         "en": "Suellen",
         "ja": "スーエレン",
         "ja_typings": [
-          "su--eren",
-          "su--elen",
           "su-eren"
         ]
       },
@@ -133106,7 +133807,8 @@
     "question_text": {
       "en": "Which character is the antagonist's sister in Gone with the Wind?",
       "ja": "『風と共に去りぬ』に登場するアシュレーの妻の名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133114,16 +133816,13 @@
         "en": "Milan",
         "ja": "ミラノ",
         "ja_typings": [
-          "mirano",
-          "milano"
+          "mirano"
         ]
       },
       {
         "en": "Rome",
         "ja": "ローマ",
         "ja_typings": [
-          "ro--ma",
-          "loo-ma",
           "ro-ma"
         ]
       },
@@ -133131,7 +133830,6 @@
         "en": "Florence",
         "ja": "フィレンツェ",
         "ja_typings": [
-          "fuxirentue",
           "firentse"
         ]
       },
@@ -133139,8 +133837,7 @@
         "en": "Naples",
         "ja": "ナポリ",
         "ja_typings": [
-          "napori",
-          "napoli"
+          "napori"
         ]
       }
     ],
@@ -133151,7 +133848,8 @@
     "question_text": {
       "en": "Which Italian city is famous for fashion and the La Scala opera house?",
       "ja": "ファッションとスカラ座で有名なイタリアの都市はどこ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133159,8 +133857,6 @@
         "en": "New York",
         "ja": "ニューヨーク",
         "ja_typings": [
-          "niyuu-yoo-ku",
-          "nyu--yo--ku",
           "nyu-yo-ku"
         ]
       },
@@ -133193,7 +133889,8 @@
     "question_text": {
       "en": "Which American city is home to the Statue of Liberty?",
       "ja": "自由の女神像があるアメリカの都市はどこ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133201,15 +133898,13 @@
         "en": "Nikolai Gogol",
         "ja": "ニコライ・ゴーゴリ",
         "ja_typings": [
-          "nikorai/go-gori",
-          "nikolai/go-goli"
+          "nikorai/go-gori"
         ]
       },
       {
         "en": "Anton Chekhov",
         "ja": "アントン・チェーホフ",
         "ja_typings": [
-          "anton/chie-hohu",
           "anton/che-hofu"
         ]
       },
@@ -133217,7 +133912,7 @@
         "en": "Fyodor Dostoevsky",
         "ja": "ドストエフスキー",
         "ja_typings": [
-          "dosutoehusuki-"
+          "dosutoefusuki-"
         ]
       },
       {
@@ -133235,7 +133930,8 @@
     "question_text": {
       "en": "Who wrote the Russian short story The Overcoat?",
       "ja": "『外套』を書いたロシアの作家は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133243,8 +133939,6 @@
         "en": "Oscar Wilde",
         "ja": "オスカー・ワイルド",
         "ja_typings": [
-          "osuka--/wairudo",
-          "osuka--/wailudo",
           "osuka-/wairudo"
         ]
       },
@@ -133252,7 +133946,6 @@
         "en": "Charles Dickens",
         "ja": "チャールズ・ディケンズ",
         "ja_typings": [
-          "chiya-ruzu/dexikenzu",
           "cha-ruzu/dhikenzu"
         ]
       },
@@ -133260,8 +133953,6 @@
         "en": "Bram Stoker",
         "ja": "ブラム・ストーカー",
         "ja_typings": [
-          "buramu/suto--ka--",
-          "bulamu/sutoo-kaa-",
           "buramu/suto-ka-"
         ]
       },
@@ -133280,7 +133971,8 @@
     "question_text": {
       "en": "Who wrote The Picture of Dorian Gray?",
       "ja": "『ドリアン・グレイの肖像』を書いた作家は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133296,8 +133988,6 @@
         "en": "Red radish",
         "ja": "ラディッシュ",
         "ja_typings": [
-          "radexitusiyu",
-          "radhixisshu",
           "radhisshu"
         ]
       },
@@ -133312,7 +134002,6 @@
         "en": "Beetroot",
         "ja": "ビーツ",
         "ja_typings": [
-          "bi--tsu",
           "bi-tsu"
         ]
       }
@@ -133332,8 +134021,6 @@
         "en": "Red radish",
         "ja": "ラディッシュ",
         "ja_typings": [
-          "radexitusiyu",
-          "radhixisshu",
           "radhisshu"
         ]
       },
@@ -133355,7 +134042,6 @@
         "en": "Beetroot",
         "ja": "ビーツ",
         "ja_typings": [
-          "bi--tsu",
           "bi-tsu"
         ]
       }
@@ -133375,8 +134061,6 @@
         "en": "Roald Dahl",
         "ja": "ロアルド・ダール",
         "ja_typings": [
-          "roarudo/da--ru",
-          "loaludo/daa-lu",
           "roarudo/da-ru"
         ]
       },
@@ -133384,7 +134068,6 @@
         "en": "J. K. Rowling",
         "ja": "J.K.ローリング",
         "ja_typings": [
-          "j.k.ro--ringu",
           "j.k.ro-ringu"
         ]
       },
@@ -133399,7 +134082,6 @@
         "en": "Lewis Carroll",
         "ja": "ルイス・キャロル",
         "ja_typings": [
-          "ruisu/kiyaroru",
           "ruisu/kyaroru"
         ]
       }
@@ -133411,7 +134093,8 @@
     "question_text": {
       "en": "Who wrote Charlie and the Chocolate Factory?",
       "ja": "『チョコレート工場の秘密』を書いた作家は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133419,8 +134102,6 @@
         "en": "Rome",
         "ja": "ローマ",
         "ja_typings": [
-          "ro--ma",
-          "loo-ma",
           "ro-ma"
         ]
       },
@@ -133428,15 +134109,13 @@
         "en": "Milan",
         "ja": "ミラノ",
         "ja_typings": [
-          "mirano",
-          "milano"
+          "mirano"
         ]
       },
       {
         "en": "Florence",
         "ja": "フィレンツェ",
         "ja_typings": [
-          "fuxirentue",
           "firentse"
         ]
       },
@@ -133444,7 +134123,6 @@
         "en": "Venice",
         "ja": "ヴェネツィア",
         "ja_typings": [
-          "vuxenetuxia",
           "venetsia"
         ]
       }
@@ -133456,7 +134134,8 @@
     "question_text": {
       "en": "Which is the capital of Italy?",
       "ja": "イタリアの首都はどこ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133464,8 +134143,6 @@
         "en": "Samuel Morse",
         "ja": "サミュエル・モールス",
         "ja_typings": [
-          "samiyueru/mo-rusu",
-          "samyueru/mo-lusu",
           "samyueru/mo-rusu"
         ]
       },
@@ -133498,7 +134175,8 @@
     "question_text": {
       "en": "Who invented the famous telegraph code of dots and dashes?",
       "ja": "点と線の電信符号を発明した米国の発明家は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133520,15 +134198,14 @@
         "en": "San Diego",
         "ja": "サンディエゴ",
         "ja_typings": [
-          "sandexiego"
+          "sandhiego"
         ]
       },
       {
         "en": "Sacramento",
         "ja": "サクラメント",
         "ja_typings": [
-          "sakuramento",
-          "sakulamento"
+          "sakuramento"
         ]
       }
     ],
@@ -133539,7 +134216,8 @@
     "question_text": {
       "en": "Which Californian city is famous for the Golden Gate Bridge?",
       "ja": "ゴールデンゲートブリッジで有名なカリフォルニアの都市はどこ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133547,7 +134225,6 @@
         "en": "Steve Wozniak",
         "ja": "スティーブ・ウォズニアック",
         "ja_typings": [
-          "sutexi-bu/uxozuniatuku",
           "suthi-bu/wozuniakku"
         ]
       },
@@ -133562,7 +134239,6 @@
         "en": "Tim Cook",
         "ja": "ティム・クック",
         "ja_typings": [
-          "teximu/kutuku",
           "thimu/kukku"
         ]
       },
@@ -133581,7 +134257,8 @@
     "question_text": {
       "en": "Who co-founded Apple Computer with Steve Jobs in 1976?",
       "ja": "1976年にスティーブ・ジョブズとアップルを共同創業したのは誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133652,8 +134329,7 @@
         "en": "Laos",
         "ja": "ラオス",
         "ja_typings": [
-          "raosu",
-          "laosu"
+          "raosu"
         ]
       }
     ],
@@ -133664,7 +134340,8 @@
     "question_text": {
       "en": "In which country is Bangkok the capital?",
       "ja": "首都がバンコクの国はどこ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133712,7 +134389,6 @@
         "en": "Tim Cook",
         "ja": "ティム・クック",
         "ja_typings": [
-          "teximu/kutuku",
           "thimu/kukku"
         ]
       },
@@ -133720,7 +134396,6 @@
         "en": "Jonathan Ive",
         "ja": "ジョナサン・アイブ",
         "ja_typings": [
-          "jiyonasan/aibu",
           "jonasan/aibu"
         ]
       },
@@ -133728,8 +134403,6 @@
         "en": "Eddy Cue",
         "ja": "エディ・キュー",
         "ja_typings": [
-          "edexi-/kiyuu-",
-          "edhii-/kyu--",
           "edhi/kyu-"
         ]
       },
@@ -133737,8 +134410,6 @@
         "en": "Craig Federighi",
         "ja": "クレイグ・フェデリギ",
         "ja_typings": [
-          "kureigu/fuederigi",
-          "kuleigu/federigi",
           "kureigu/federigi"
         ]
       }
@@ -133750,7 +134421,8 @@
     "question_text": {
       "en": "Who succeeded Steve Jobs as CEO of Apple?",
       "ja": "スティーブ・ジョブズの後を継ぎアップルCEOになったのは誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133758,16 +134430,13 @@
         "en": "Turkey",
         "ja": "トルコ",
         "ja_typings": [
-          "toruko",
-          "toluko"
+          "toruko"
         ]
       },
       {
         "en": "Greece",
         "ja": "ギリシャ",
         "ja_typings": [
-          "girisiya",
-          "gilisya",
           "girisha"
         ]
       },
@@ -133775,8 +134444,7 @@
         "en": "Bulgaria",
         "ja": "ブルガリア",
         "ja_typings": [
-          "burugaria",
-          "bulugalia"
+          "burugaria"
         ]
       },
       {
@@ -133794,7 +134462,8 @@
     "question_text": {
       "en": "In which country is the city Istanbul located?",
       "ja": "イスタンブールがある国はどこ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133823,8 +134492,7 @@
         "en": "United Kingdom",
         "ja": "イギリス",
         "ja_typings": [
-          "igirisu",
-          "igilisu"
+          "igirisu"
         ]
       }
     ],
@@ -133850,7 +134518,6 @@
         "en": "Oman",
         "ja": "オマーン",
         "ja_typings": [
-          "oma--n",
           "oma-n"
         ]
       },
@@ -133858,8 +134525,6 @@
         "en": "Qatar",
         "ja": "カタール",
         "ja_typings": [
-          "kata--ru",
-          "kata--lu",
           "kata-ru"
         ]
       },
@@ -133867,8 +134532,6 @@
         "en": "Bahrain",
         "ja": "バーレーン",
         "ja_typings": [
-          "ba--re-n",
-          "ba--le-n",
           "ba-re-n"
         ]
       }
@@ -133880,7 +134543,8 @@
     "question_text": {
       "en": "Which country's capital is Sana'a in the Arabian Peninsula?",
       "ja": "首都がサヌアであるアラビア半島の国はどこ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134018,7 +134682,6 @@
         "en": "flash of a camera",
         "ja": "カメラのフラッシュ",
         "ja_typings": [
-          "kameranohuratusiyu",
           "kameranofurasshu"
         ]
       },
@@ -134100,8 +134763,6 @@
         "en": "cycle hit",
         "ja": "サイクルヒット",
         "ja_typings": [
-          "saikuruhitututo",
-          "saikuluhitto",
           "saikuruhitto"
         ]
       },
@@ -134116,7 +134777,6 @@
         "en": "perfect day",
         "ja": "パーフェクトデー",
         "ja_typings": [
-          "pa--fuxekutode-",
           "pa-fekutode-"
         ]
       }
@@ -134157,7 +134817,6 @@
         "en": "cycle hit",
         "ja": "サイクルヒット",
         "ja_typings": [
-          "saikuruhitututo",
           "saikuruhitto"
         ]
       }
@@ -134177,25 +134836,21 @@
         "en": "frog",
         "ja": "カエル",
         "ja_typings": [
-          "kaeru",
-          "kaelu"
+          "kaeru"
         ]
       },
       {
         "en": "salamander",
         "ja": "サンショウウオ",
         "ja_typings": [
-          "sansiyouuo",
-          "sanshouuo",
-          "sanshouo"
+          "sanshouuo"
         ]
       },
       {
         "en": "newt",
         "ja": "イモリ",
         "ja_typings": [
-          "imori",
-          "imoli"
+          "imori"
         ]
       },
       {
@@ -134213,7 +134868,8 @@
     "question_text": {
       "en": "Which amphibian is known for metamorphosing from a tadpole?",
       "ja": "オタマジャクシから変態することで知られる両生類はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134392,8 +135048,7 @@
         "en": "crow",
         "ja": "カラス",
         "ja_typings": [
-          "karasu",
-          "kalasu"
+          "karasu"
         ]
       },
       {
@@ -134418,7 +135073,8 @@
     "question_text": {
       "en": "Which bird is famous for its homing ability and is often white in symbolism?",
       "ja": "帰巣本能で知られ、平和の象徴とされる鳥はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134433,24 +135089,20 @@
         "en": "hare",
         "ja": "ノウサギ",
         "ja_typings": [
-          "nousagi",
-          "nosagi"
+          "nousagi"
         ]
       },
       {
         "en": "squirrel",
         "ja": "リス",
         "ja_typings": [
-          "risu",
-          "lisu"
+          "risu"
         ]
       },
       {
         "en": "guinea pig",
         "ja": "モルモット",
         "ja_typings": [
-          "morumotutoto",
-          "molumotto",
           "morumotto"
         ]
       }
@@ -134462,7 +135114,8 @@
     "question_text": {
       "en": "Which mammal is famous for long ears and rapid reproduction?",
       "ja": "長い耳と繁殖力で知られる哺乳類はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134568,7 +135221,6 @@
         "en": "immaculate inning",
         "ja": "イマキュレートイニング",
         "ja_typings": [
-          "imakiyure-toiningu",
           "imakyure-toiningu"
         ]
       },
@@ -134576,8 +135228,6 @@
         "en": "no-hitter",
         "ja": "ノーヒッター",
         "ja_typings": [
-          "no--hituta--",
-          "no--hitta--",
           "no-hitta-"
         ]
       }
@@ -134669,7 +135319,8 @@
     "question_text": {
       "en": "Which bit width can represent IPv6 addresses?",
       "ja": "IPv6アドレスを表現できるビット幅は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134709,7 +135360,8 @@
     "question_text": {
       "en": "Which bit width can represent only two values, 0 and 1?",
       "ja": "0と1の2値しか表現できないビット幅は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134749,7 +135401,8 @@
     "question_text": {
       "en": "Which bit width is called a nibble?",
       "ja": "ニブルと呼ばれるビット幅は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134789,7 +135442,8 @@
     "question_text": {
       "en": "Which bit width equals one byte?",
       "ja": "1バイトに相当するビット幅は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134829,7 +135483,8 @@
     "question_text": {
       "en": "Which is the famous early microcomputer kit released in 1975?",
       "ja": "1975年に発売された有名な初期マイコンキットは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134869,7 +135524,8 @@
     "question_text": {
       "en": "Which CPU architecture is widely used in smartphones?",
       "ja": "スマートフォンで広く使われているCPUアーキテクチャは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134909,7 +135565,8 @@
     "question_text": {
       "en": "Which company makes the iPhone?",
       "ja": "iPhoneを製造している企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134949,7 +135606,8 @@
     "question_text": {
       "en": "Which firmware initializes hardware at PC boot?",
       "ja": "PC起動時にハードウェアを初期化するファームウェアは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134989,7 +135647,8 @@
     "question_text": {
       "en": "Which short-range wireless standard is used for headsets?",
       "ja": "ヘッドセットなどで使われる近距離無線規格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135029,7 +135688,8 @@
     "question_text": {
       "en": "Which temporary storage smooths the speed gap between devices?",
       "ja": "機器間の速度差を吸収する一時記憶領域は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135069,7 +135729,8 @@
     "question_text": {
       "en": "Which component is the brain of a computer?",
       "ja": "コンピュータの頭脳に相当する部品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135109,7 +135770,8 @@
     "question_text": {
       "en": "Which 32-bit cyclic redundancy check is widely used for error detection?",
       "ja": "エラー検出に広く使われる32ビットの巡回冗長検査は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135189,7 +135851,8 @@
     "question_text": {
       "en": "Which company is a major networking equipment vendor?",
       "ja": "大手ネットワーク機器ベンダーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135229,7 +135892,8 @@
     "question_text": {
       "en": "Which memory standard is commonly used in modern PCs?",
       "ja": "現代のPCで広く使われるメモリ規格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135269,7 +135933,8 @@
     "question_text": {
       "en": "Which protocol automatically assigns IP addresses to hosts?",
       "ja": "ホストにIPアドレスを自動配布するプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135309,7 +135974,8 @@
     "question_text": {
       "en": "Which system resolves domain names to IP addresses?",
       "ja": "ドメイン名をIPアドレスに解決する仕組みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135349,7 +136015,8 @@
     "question_text": {
       "en": "Which non-volatile memory can be electrically erased and rewritten?",
       "ja": "電気的に消去・書き換え可能な不揮発性メモリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135389,7 +136056,8 @@
     "question_text": {
       "en": "Which file system was widely used in older Windows versions?",
       "ja": "古いWindowsで広く使われたファイルシステムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135429,7 +136097,8 @@
     "question_text": {
       "en": "Which type of non-volatile memory is used in USB drives?",
       "ja": "USBメモリに使われる不揮発性メモリの種類は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135469,7 +136138,8 @@
     "question_text": {
       "en": "Which Unix-like OS evolved from the Berkeley Software Distribution?",
       "ja": "BSDから派生したUnix系OSは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135509,7 +136179,8 @@
     "question_text": {
       "en": "Which processor specializes in parallel graphics computation?",
       "ja": "並列グラフィクス演算に特化したプロセッサは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135549,7 +136220,8 @@
     "question_text": {
       "en": "Which company developed the Android operating system?",
       "ja": "Android OSを開発した企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135589,7 +136261,8 @@
     "question_text": {
       "en": "Which magnetic storage device uses spinning platters?",
       "ja": "回転するプラッタを使う磁気記憶装置は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135629,7 +136302,8 @@
     "question_text": {
       "en": "Which digital audio-video interface is common on TVs?",
       "ja": "テレビで広く使われるデジタル映像音声端子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135669,7 +136343,8 @@
     "question_text": {
       "en": "Which file system was developed by Apple?",
       "ja": "Appleが開発したファイルシステムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135709,7 +136384,8 @@
     "question_text": {
       "en": "Which protocol is the foundation of the World Wide Web?",
       "ja": "World Wide Webの基礎となるプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135789,7 +136465,8 @@
     "question_text": {
       "en": "Which company built the System/360 mainframe family?",
       "ja": "System/360メインフレームを生み出した企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135829,7 +136506,8 @@
     "question_text": {
       "en": "Which parallel interface was once common for connecting hard drives?",
       "ja": "かつてHDD接続に広く使われたパラレル規格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135869,7 +136547,8 @@
     "question_text": {
       "en": "Which core part of an operating system manages resources?",
       "ja": "OSの中核としてリソースを管理する部分は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135909,7 +136588,8 @@
     "question_text": {
       "en": "Which 4G mobile communication standard succeeded 3G?",
       "ja": "3Gの次世代となった4G移動通信規格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135949,7 +136629,8 @@
     "question_text": {
       "en": "Which Linux disk management abstraction allows flexible volumes?",
       "ja": "柔軟なボリューム管理を行うLinuxの仕組みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135989,7 +136670,8 @@
     "question_text": {
       "en": "Which device distributes traffic across multiple servers?",
       "ja": "複数サーバへ通信を分散する装置は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136029,7 +136711,8 @@
     "question_text": {
       "en": "Which early Harvard relay-based computer was completed in 1944?",
       "ja": "1944年に完成したハーバードのリレー式初期コンピュータは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136109,7 +136792,8 @@
     "question_text": {
       "en": "Which company owns Facebook and Instagram?",
       "ja": "FacebookとInstagramを保有する企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136149,7 +136833,8 @@
     "question_text": {
       "en": "Which company developed the Windows operating system?",
       "ja": "Windows OSを開発した企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136189,7 +136874,8 @@
     "question_text": {
       "en": "Which storage device is dedicated to file sharing over a network?",
       "ja": "ネットワーク経由でファイル共有する専用ストレージは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136229,7 +136915,8 @@
     "question_text": {
       "en": "Which technology translates private and public IP addresses?",
       "ja": "プライベートとグローバルIPを変換する技術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136269,7 +136956,8 @@
     "question_text": {
       "en": "Which very short range wireless tech is used for contactless payment?",
       "ja": "非接触決済で使われるごく短距離無線技術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136309,7 +136997,8 @@
     "question_text": {
       "en": "Which file system is the default for modern Windows?",
       "ja": "現代のWindowsで標準のファイルシステムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136349,7 +137038,8 @@
     "question_text": {
       "en": "Which company is famous for enterprise database products?",
       "ja": "企業向けデータベースで知られる企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136389,7 +137079,8 @@
     "question_text": {
       "en": "Which high-speed serial expansion bus is used inside modern PCs?",
       "ja": "現代PC内部の高速シリアル拡張バスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136429,7 +137120,8 @@
     "question_text": {
       "en": "Which old round connector was used for keyboards and mice?",
       "ja": "キーボードやマウスに使われた古い丸型コネクタは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136469,7 +137161,8 @@
     "question_text": {
       "en": "Which OS abstraction represents a running program?",
       "ja": "実行中のプログラムを表すOSの抽象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136509,7 +137202,8 @@
     "question_text": {
       "en": "Which server relays client requests to other servers?",
       "ja": "クライアントの要求を他サーバへ中継するサーバは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136549,7 +137243,8 @@
     "question_text": {
       "en": "Which company is known for the Snapdragon mobile SoC?",
       "ja": "Snapdragonモバイル向けSoCで知られる企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136589,7 +137284,8 @@
     "question_text": {
       "en": "Which volatile memory holds data while a computer is running?",
       "ja": "稼働中のPCでデータを保持する揮発性メモリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136629,7 +137325,8 @@
     "question_text": {
       "en": "Which 8-pin modular connector is standard for Ethernet?",
       "ja": "イーサネットで標準的な8ピンモジュラ端子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136669,7 +137366,8 @@
     "question_text": {
       "en": "Which simple cipher shifts letters by 13 positions?",
       "ja": "アルファベットを13文字ずらす単純な暗号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136709,7 +137407,8 @@
     "question_text": {
       "en": "Which serial interface standard was once common on PCs?",
       "ja": "かつてPCで一般的だったシリアル通信規格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136749,7 +137448,8 @@
     "question_text": {
       "en": "Which public-key cryptosystem is named after its three inventors?",
       "ja": "発明者3人の頭文字を取った公開鍵暗号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136789,7 +137489,8 @@
     "question_text": {
       "en": "Which CPU component holds small, fast data for immediate use?",
       "ja": "CPU内部で即時利用される小さく高速な記憶領域は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136829,7 +137530,8 @@
     "question_text": {
       "en": "Which attack makes a victim host connect back to the attacker?",
       "ja": "被害ホストから攻撃者へ接続させる攻撃手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136869,7 +137571,8 @@
     "question_text": {
       "en": "Which network is dedicated to high-speed block storage access?",
       "ja": "高速ブロックストレージ専用のネットワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136909,7 +137612,8 @@
     "question_text": {
       "en": "Which type of RAM uses flip-flops and needs no refresh?",
       "ja": "フリップフロップで構成しリフレッシュ不要なRAMは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136949,7 +137653,8 @@
     "question_text": {
       "en": "Which storage uses flash memory and has no moving parts?",
       "ja": "フラッシュメモリを使い可動部品が無いストレージは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136989,7 +137694,8 @@
     "question_text": {
       "en": "Which encrypted protocol is used for secure remote shell?",
       "ja": "暗号化された遠隔シェルで使うプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137029,7 +137735,8 @@
     "question_text": {
       "en": "Which Korean conglomerate is a major smartphone maker?",
       "ja": "大手スマートフォンメーカーの韓国系コングロマリットは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137069,7 +137776,8 @@
     "question_text": {
       "en": "Which mechanism moves memory pages between RAM and disk?",
       "ja": "RAMとディスク間でメモリページを退避する仕組みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137109,7 +137817,8 @@
     "question_text": {
       "en": "Which protocol provides reliable, ordered data delivery on the Internet?",
       "ja": "信頼性のある順序付き配送を提供するインターネットプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137149,7 +137858,8 @@
     "question_text": {
       "en": "Which old plaintext protocol is used for remote terminal access?",
       "ja": "古い平文の遠隔端末アクセスプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137189,7 +137899,8 @@
     "question_text": {
       "en": "Which connectionless protocol prioritizes speed over reliability?",
       "ja": "信頼性より速度を優先するコネクションレスプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137229,7 +137940,8 @@
     "question_text": {
       "en": "Which 1951 commercial computer succeeded the ENIAC line?",
       "ja": "ENIAC系を継いだ1951年の商用コンピュータは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137269,7 +137981,8 @@
     "question_text": {
       "en": "Which serial bus is most common for connecting peripherals?",
       "ja": "周辺機器接続で最も一般的なシリアルバスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137317,7 +138030,6 @@
         "en": "Windows",
         "ja": "ウィンドウズ",
         "ja_typings": [
-          "windozu",
           "windouzu"
         ]
       },
@@ -137350,7 +138062,8 @@
     "question_text": {
       "en": "Which OS is developed by Microsoft for personal computers?",
       "ja": "Microsoftが開発するPC向けOSは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137390,7 +138103,8 @@
     "question_text": {
       "en": "Which low-power mesh wireless standard is used in IoT?",
       "ja": "IoTで使われる低消費電力のメッシュ無線規格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137430,7 +138144,8 @@
     "question_text": {
       "en": "Which is a modern default journaling file system on Linux?",
       "ja": "現代のLinuxで標準的なジャーナリングファイルシステムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137445,7 +138160,6 @@
         "en": "Windows",
         "ja": "ウィンドウズ",
         "ja_typings": [
-          "windozu",
           "windouzu"
         ]
       },
@@ -137471,7 +138185,8 @@
     "question_text": {
       "en": "Which OS is developed by Apple for Macintosh computers?",
       "ja": "AppleがMacintosh向けに開発するOSは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137831,7 +138546,8 @@
     "question_text": {
       "en": "Which ancient Greek scholar discovered the principle of buoyancy?",
       "ja": "浮力の原理を発見した古代ギリシアの学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137871,7 +138587,8 @@
     "question_text": {
       "en": "Which element symbol represents gold?",
       "ja": "金を表す元素記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137991,7 +138708,8 @@
     "question_text": {
       "en": "Which index combines weight and height to estimate body fat?",
       "ja": "体重と身長から肥満度を推定する指数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138031,7 +138749,8 @@
     "question_text": {
       "en": "Which French physicist discovered natural radioactivity in 1896?",
       "ja": "1896年に天然放射能を発見したフランスの物理学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138046,7 +138765,7 @@
         "en": "Oxygen",
         "ja": "酸素",
         "ja_typings": [
-          "sannso"
+          "sanso"
         ]
       },
       {
@@ -138192,7 +138911,8 @@
     "question_text": {
       "en": "Which French physicist gave his name to the SI unit of electric charge?",
       "ja": "電荷のSI単位に名を残すフランスの物理学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138232,7 +138952,8 @@
     "question_text": {
       "en": "Which logarithmic unit expresses sound pressure level?",
       "ja": "音圧レベルを対数で表す単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138272,7 +138993,8 @@
     "question_text": {
       "en": "Which physicist published the theory of relativity in 1905 and 1915?",
       "ja": "1905年と1915年に相対性理論を発表した物理学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138352,7 +139074,8 @@
     "question_text": {
       "en": "Which element symbol represents iron?",
       "ja": "鉄を表す元素記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138392,7 +139115,8 @@
     "question_text": {
       "en": "Which British scientist formulated rules for the direction of induced current?",
       "ja": "誘導電流の向きに関する法則を定めた英国の科学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138472,7 +139196,8 @@
     "question_text": {
       "en": "Which Italian astronomer first observed Jupiter's four largest moons?",
       "ja": "木星の四大衛星を最初に観測したイタリアの天文学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138593,7 +139318,8 @@
     "question_text": {
       "en": "Which English scientist formulated the law of elasticity for springs?",
       "ja": "ばねの弾性に関する法則を定めた英国の科学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138633,7 +139359,8 @@
     "question_text": {
       "en": "Which American astronomer found that distant galaxies are receding?",
       "ja": "遠方銀河が後退していることを発見した米国の天文学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138655,7 +139382,7 @@
         "en": "Oxygen",
         "ja": "酸素",
         "ja_typings": [
-          "sannso"
+          "sanso"
         ]
       },
       {
@@ -138714,7 +139441,8 @@
     "question_text": {
       "en": "Which score is a numerical estimate of intelligence?",
       "ja": "知能を数値化した指標は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138794,7 +139522,8 @@
     "question_text": {
       "en": "Which English doctor developed the first smallpox vaccine?",
       "ja": "天然痘の世界初のワクチンを開発した英国の医師は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138874,7 +139603,8 @@
     "question_text": {
       "en": "Which Dutch pioneer first observed microorganisms with a microscope?",
       "ja": "顕微鏡で初めて微生物を観察したオランダの先駆者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138994,7 +139724,8 @@
     "question_text": {
       "en": "Which chemical formula represents sodium hydroxide?",
       "ja": "水酸化ナトリウムを表す化学式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139196,7 +139927,8 @@
     "question_text": {
       "en": "Which German physicist gave his name to the unit of electrical resistance?",
       "ja": "電気抵抗の単位に名を残すドイツの物理学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139244,7 +139976,7 @@
         "en": "Oxygen",
         "ja": "酸素",
         "ja_typings": [
-          "sannso"
+          "sanso"
         ]
       },
       {
@@ -139357,7 +140089,8 @@
     "question_text": {
       "en": "Which French scientist developed pasteurization and a rabies vaccine?",
       "ja": "低温殺菌法と狂犬病ワクチンを開発したフランスの科学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139477,7 +140210,8 @@
     "question_text": {
       "en": "Which ancient Greek astronomer is known for a geocentric model?",
       "ja": "天動説で知られる古代ギリシアの天文学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139597,7 +140331,8 @@
     "question_text": {
       "en": "Which German physicist discovered X-rays in 1895?",
       "ja": "1895年にX線を発見したドイツの物理学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139619,7 +140354,6 @@
         "en": "Virchow",
         "ja": "ウィルヒョウ",
         "ja_typings": [
-          "wiruhyo",
           "wiruhyou"
         ]
       },
@@ -139638,7 +140372,8 @@
     "question_text": {
       "en": "Which German botanist co-founded the cell theory for plants?",
       "ja": "植物の細胞説を共同で提唱したドイツの植物学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139787,7 +140522,7 @@
         "en": "Phosphorus",
         "ja": "リン",
         "ja_typings": [
-          "rinn"
+          "rin"
         ]
       }
     ],
@@ -139958,7 +140693,8 @@
     "question_text": {
       "en": "Which unit expresses concentration as parts per million?",
       "ja": "100万分のいくつかで濃度を表す単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139966,7 +140702,6 @@
         "en": "AZKi",
         "ja": "AZKi",
         "ja_typings": [
-          "azuki",
           "azki"
         ]
       },
@@ -140039,7 +140774,8 @@
     "question_text": {
       "en": "What is the net-slang term for an avatar or anonymous online persona?",
       "ja": "ネットスラングで匿名のあだ名や仮の名前を指す言葉は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140079,7 +140815,8 @@
     "question_text": {
       "en": "Which English word is often used in net slang to express frustration?",
       "ja": "ネットで怒りを表す英単語スラングは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140127,7 +140864,6 @@
         "en": "BTW",
         "ja": "ところで",
         "ja_typings": [
-          "btw",
           "tokorode"
         ]
       },
@@ -140270,8 +141006,7 @@
         "en": "DeNA",
         "ja": "DeNA",
         "ja_typings": [
-          "dena",
-          "deiienue-"
+          "dena"
         ]
       }
     ],
@@ -140282,7 +141017,8 @@
     "question_text": {
       "en": "Which Japanese company produces Bang Dream and Revue Starlight, and runs many TCGs?",
       "ja": "バンドリやヴァイスシュヴァルツを運営する日本企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140322,7 +141058,8 @@
     "question_text": {
       "en": "Which English word is commonly used as a parting greeting?",
       "ja": "英語で別れの挨拶として使われる短い単語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140403,7 +141140,8 @@
     "question_text": {
       "en": "Which company runs the Hololive Production VTuber agency?",
       "ja": "ホロライブプロダクションを運営する会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140443,7 +141181,8 @@
     "question_text": {
       "en": "What is a group of regular fans of a specific streamer or VTuber called in English?",
       "ja": "特定の配信者の常連ファン集団を英語で何と呼ぶ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140451,8 +141190,7 @@
         "en": "DeNA",
         "ja": "DeNA",
         "ja_typings": [
-          "dena",
-          "deiienue-"
+          "dena"
         ]
       },
       {
@@ -140484,7 +141222,8 @@
     "question_text": {
       "en": "Which company is known for the mobile games Pokemon Masters and Mobage platform?",
       "ja": "モバゲーやポケモンマスターズで知られる日本企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140539,7 +141278,6 @@
         "en": "BTW",
         "ja": "ところで",
         "ja_typings": [
-          "btw",
           "tokorode"
         ]
       },
@@ -140605,7 +141343,8 @@
     "question_text": {
       "en": "Which net slang word refers to character traits in Japanese?",
       "ja": "ネットスラングで「キャラ性」「性格」を指す日本語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140645,7 +141384,8 @@
     "question_text": {
       "en": "What is the top-tier paid YouTube channel membership called?",
       "ja": "YouTubeチャンネルメンバーシップの最上位プランは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140725,7 +141465,8 @@
     "question_text": {
       "en": "What is a typical morning greeting in English?",
       "ja": "英語で朝の挨拶として使われる定型句は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140765,7 +141506,8 @@
     "question_text": {
       "en": "Which is the largest Japanese VTuber agency featuring Pekora and Fubuki?",
       "ja": "兎田ぺこらや白上フブキが所属するVTuber事務所は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140805,7 +141547,8 @@
     "question_text": {
       "en": "Which Southeast Asian country has its own Hololive branch?",
       "ja": "ホロライブの支部があった東南アジアの国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140929,7 +141672,8 @@
     "question_text": {
       "en": "Which Japanese publisher owns Dwango and is famous for light novels?",
       "ja": "ドワンゴを子会社に持ち、ライトノベルでも有名な日本の出版社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141130,7 +141874,8 @@
     "question_text": {
       "en": "What do you call a viewer who watches and comments on streams?",
       "ja": "配信を見ながらコメントする視聴者を指す言葉は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141170,7 +141915,8 @@
     "question_text": {
       "en": "What is a paid YouTube channel supporter called?",
       "ja": "有料のチャンネル登録者をなんと呼ぶ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141572,7 +142318,8 @@
     "question_text": {
       "en": "What is a mid-tier YouTube channel membership plan often called?",
       "ja": "YouTubeメンバーシップで中位のプラン名としてよく使われるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141773,7 +142520,8 @@
     "question_text": {
       "en": "Which Japanese global electronics and entertainment giant owns PlayStation?",
       "ja": "PlayStationを展開する日本の大手電機・エンタメ企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141813,7 +142561,8 @@
     "question_text": {
       "en": "Which English word is used to apologize politely?",
       "ja": "英語で丁寧に謝罪する一語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141893,7 +142642,8 @@
     "question_text": {
       "en": "What do you call the production team behind the scenes of a stream?",
       "ja": "配信を支える裏方のスタッフを英語で何と呼ぶ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141933,7 +142683,8 @@
     "question_text": {
       "en": "What is the slang term for a paid Twitch chat similar to Supacha?",
       "ja": "Twitchの有料コメント機能を指す俗称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141948,7 +142699,6 @@
         "en": "BTW",
         "ja": "ところで",
         "ja_typings": [
-          "btw",
           "tokorode"
         ]
       },
@@ -142094,7 +142844,8 @@
     "question_text": {
       "en": "Which English word is used to express gratitude?",
       "ja": "英語で感謝を伝える短い単語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142134,7 +142885,8 @@
     "question_text": {
       "en": "What term refers to the main personality being broadcast in a stream?",
       "ja": "配信のメインとなる配信者を英語で何と呼ぶ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142149,7 +142901,6 @@
         "en": "Twitch",
         "ja": "ツイッチ",
         "ja_typings": [
-          "tsuicchi",
           "tsuitchi"
         ]
       },
@@ -142223,7 +142974,6 @@
         "en": "Twitch",
         "ja": "ツイッチ",
         "ja_typings": [
-          "tsuicchi",
           "tsuitchi"
         ]
       },
@@ -142391,7 +143141,6 @@
         "en": "Twitch",
         "ja": "ツイッチ",
         "ja_typings": [
-          "tsuicchi",
           "tsuitchi"
         ]
       },
@@ -142497,7 +143246,8 @@
     "question_text": {
       "en": "What is the traditional long Vietnamese silk tunic dress called?",
       "ja": "ベトナムの伝統的な長い絹のチュニック衣装は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142537,7 +143287,8 @@
     "question_text": {
       "en": "Which Italian pasta sauce is made with garlic, chili and tomato, and means 'angry'?",
       "ja": "ニンニクと唐辛子のトマトソースで「怒り」を意味するイタリア料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142657,7 +143408,8 @@
     "question_text": {
       "en": "Which Italian pasta sauce comes from a city in Emilia-Romagna and uses ground meat?",
       "ja": "エミリア=ロマーニャ州の都市発祥のひき肉トマトソースは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142697,7 +143449,8 @@
     "question_text": {
       "en": "Which Brazilian music genre is closely associated with 'The Girl from Ipanema'?",
       "ja": "「イパネマの娘」で有名なブラジル発祥の音楽ジャンルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142817,7 +143570,8 @@
     "question_text": {
       "en": "Which Mexican wrap consists of fillings inside a wheat flour tortilla?",
       "ja": "小麦粉トルティーヤで具を包んだメキシコ料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142832,7 +143586,6 @@
         "en": "Focaccia",
         "ja": "フォカッチャ",
         "ja_typings": [
-          "fokaccha",
           "fokatcha"
         ]
       },
@@ -142858,7 +143611,8 @@
     "question_text": {
       "en": "Which Italian dish is a folded pizza, baked or fried?",
       "ja": "二つ折りにして焼くイタリアのピザは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142938,7 +143692,8 @@
     "question_text": {
       "en": "Which Mexican dish involves corn tortillas filled, rolled and covered in chili sauce?",
       "ja": "トウモロコシのトルティーヤを巻きチリソースをかけたメキシコ料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142978,7 +143733,8 @@
     "question_text": {
       "en": "Which passionate Spanish dance is associated with Andalusia?",
       "ja": "アンダルシア地方発祥の情熱的なスペインの舞踊は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142986,7 +143742,6 @@
         "en": "Focaccia",
         "ja": "フォカッチャ",
         "ja_typings": [
-          "fokaccha",
           "fokatcha"
         ]
       },
@@ -143019,7 +143774,8 @@
     "question_text": {
       "en": "Which Italian flatbread is topped with olive oil and herbs?",
       "ja": "オリーブオイルとハーブを使ったイタリアの平焼きパンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143027,7 +143783,6 @@
         "en": "Frank Lloyd Wright",
         "ja": "フランク・ロイド・ライト",
         "ja_typings": [
-          "furankuroidoraito",
           "furanku/roido/raito"
         ]
       },
@@ -143035,7 +143790,6 @@
         "en": "Le Corbusier",
         "ja": "ル・コルビュジエ",
         "ja_typings": [
-          "rukorubyujie",
           "ru/korubyujie"
         ]
       },
@@ -143043,7 +143797,6 @@
         "en": "Zaha Hadid",
         "ja": "ザハ・ハディド",
         "ja_typings": [
-          "zahahadeido",
           "zaha/hadhido"
         ]
       },
@@ -143142,7 +143895,8 @@
     "question_text": {
       "en": "What is the traditional Korean dress, worn during festivals and ceremonies?",
       "ja": "祝祭で着用される韓国の伝統衣装は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143182,7 +143936,8 @@
     "question_text": {
       "en": "Which Middle Eastern dip is made from chickpeas, tahini and lemon?",
       "ja": "ひよこ豆とタヒニで作る中東の料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143262,7 +144017,8 @@
     "question_text": {
       "en": "Which Middle Eastern grilled meat dish is often served on skewers or in wraps?",
       "ja": "串焼きや包み焼きにする中東発祥の肉料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143302,7 +144058,8 @@
     "question_text": {
       "en": "Which patterned headscarf is associated with traditional Arab dress?",
       "ja": "アラブ圏で頭に巻く格子模様の伝統的なスカーフは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143391,7 +144148,6 @@
         "en": "Le Corbusier",
         "ja": "ル・コルビュジエ",
         "ja_typings": [
-          "rukorubyujie",
           "ru/korubyujie"
         ]
       },
@@ -143399,7 +144155,6 @@
         "en": "Frank Lloyd Wright",
         "ja": "フランク・ロイド・ライト",
         "ja_typings": [
-          "furankuroidoraito",
           "furanku/roido/raito"
         ]
       },
@@ -143407,7 +144162,6 @@
         "en": "Zaha Hadid",
         "ja": "ザハ・ハディド",
         "ja_typings": [
-          "zahahadeido",
           "zaha/hadhido"
         ]
       },
@@ -143426,7 +144180,8 @@
     "question_text": {
       "en": "Which Swiss-French architect designed the Villa Savoye and Unite d'Habitation?",
       "ja": "サヴォア邸とユニテ・ダビタシオンを設計した建築家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143747,7 +144502,8 @@
     "question_text": {
       "en": "Which Italian seafood pasta sauce features shellfish and tomato?",
       "ja": "魚介とトマトで作るイタリアのパスタソースは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143762,7 +144518,6 @@
         "en": "Focaccia",
         "ja": "フォカッチャ",
         "ja_typings": [
-          "fokaccha",
           "fokatcha"
         ]
       },
@@ -143788,7 +144543,8 @@
     "question_text": {
       "en": "Which flatbread from Emilia-Romagna is similar to a tortilla?",
       "ja": "エミリア=ロマーニャ州のトルティーヤに似た平焼きパンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143828,7 +144584,8 @@
     "question_text": {
       "en": "Which South American garment is a single piece of cloth with a hole for the head?",
       "ja": "頭を通す穴があいた一枚布の南米の衣服は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143948,7 +144705,8 @@
     "question_text": {
       "en": "Which Levantine salad is made of bulgur, parsley, tomato and mint?",
       "ja": "ブルグル、パセリ、トマト、ミントで作る中東のサラダは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143988,7 +144746,8 @@
     "question_text": {
       "en": "Which Mexican dish uses a folded corn tortilla with various fillings?",
       "ja": "コーントルティーヤに具を挟んだメキシコ料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144068,7 +144827,8 @@
     "question_text": {
       "en": "Which checkered woven pattern is associated with Scottish kilts?",
       "ja": "スコットランドのキルトに使われる格子模様は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144108,7 +144868,8 @@
     "question_text": {
       "en": "Which ancient Roman garment was a draped piece of cloth worn by citizens?",
       "ja": "古代ローマの市民が身につけた、布をまとう衣服は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144188,7 +144949,8 @@
     "question_text": {
       "en": "Which wrapped headgear is traditionally worn by Sikh men and others across South Asia?",
       "ja": "南アジアでシーク教徒の男性などが頭に巻く布は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144268,7 +145030,8 @@
     "question_text": {
       "en": "Which thin fabric covering is worn over the face, often in religious or wedding contexts?",
       "ja": "宗教儀礼や結婚式で顔を覆う薄い布は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144316,7 +145079,6 @@
         "en": "Zaha Hadid",
         "ja": "ザハ・ハディド",
         "ja_typings": [
-          "zahahadeido",
           "zaha/hadhido"
         ]
       },
@@ -144324,7 +145086,6 @@
         "en": "Frank Lloyd Wright",
         "ja": "フランク・ロイド・ライト",
         "ja_typings": [
-          "furankuroidoraito",
           "furanku/roido/raito"
         ]
       },
@@ -144332,7 +145093,6 @@
         "en": "Le Corbusier",
         "ja": "ル・コルビュジエ",
         "ja_typings": [
-          "rukorubyujie",
           "ru/korubyujie"
         ]
       },
@@ -144351,7 +145111,8 @@
     "question_text": {
       "en": "Which Iraqi-British architect designed the Heydar Aliyev Center and the London Aquatics Centre?",
       "ja": "ヘイダル・アリエフ・センターを設計したイラク出身の建築家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144391,7 +145152,8 @@
     "question_text": {
       "en": "Which copyleft license requires source disclosure even for network-served software?",
       "ja": "ネットワーク経由で提供されるソフトウェアにもソース開示を求めるコピーレフトライセンスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144431,7 +145193,8 @@
     "question_text": {
       "en": "Which AWS service acts as a managed front door for APIs with routing, auth, and throttling?",
       "ja": "API のルーティングや認証、スロットリングを担う AWS のマネージドサービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144471,7 +145234,8 @@
     "question_text": {
       "en": "What is the term for an early pre-release version used for internal or limited testing?",
       "ja": "限定的な内部テスト向けに公開される初期段階の試験版を何と呼ぶ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144511,7 +145275,8 @@
     "question_text": {
       "en": "Which AWS service auto-scales relational database capacity on demand?",
       "ja": "需要に応じてリレーショナルDBの容量を自動スケールする AWS サービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144551,7 +145316,8 @@
     "question_text": {
       "en": "What is a feature-complete pre-release version offered to wider testers before release?",
       "ja": "リリース前に広範な利用者に提供される機能ほぼ完成版の試験版は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144591,7 +145357,8 @@
     "question_text": {
       "en": "Which deployment switches traffic between two identical environments to minimize downtime?",
       "ja": "二つの同一環境を切り替えてダウンタイムを最小化するデプロイ手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144631,7 +145398,8 @@
     "question_text": {
       "en": "Which foundation hosts Kubernetes and other cloud native projects?",
       "ja": "Kubernetes 等のクラウドネイティブ系プロジェクトをホストする財団は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144671,7 +145439,8 @@
     "question_text": {
       "en": "In GitLab, what is the abbreviation for a request to review and integrate code (similar to GitHub PR)?",
       "ja": "GitLab で GitHub の PR に相当する変更取り込み要求の略称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144711,7 +145480,8 @@
     "question_text": {
       "en": "Which AWS service is a global content delivery network (CDN)?",
       "ja": "AWS のグローバル CDN サービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144751,7 +145521,8 @@
     "question_text": {
       "en": "Which protocol translates human-readable domain names into IP addresses?",
       "ja": "ドメイン名を IP アドレスに変換する仕組みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144791,7 +145562,8 @@
     "question_text": {
       "en": "Which Kubernetes resource manages a replicated set of stateless Pods?",
       "ja": "ステートレスな Pod のレプリカを管理する Kubernetes リソースは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144831,7 +145603,8 @@
     "question_text": {
       "en": "Which AWS service provides a dedicated private network connection to AWS?",
       "ja": "オンプレと AWS を専用線で接続する AWS サービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144871,7 +145644,8 @@
     "question_text": {
       "en": "In agile, what is a large body of work that is broken down into multiple stories?",
       "ja": "アジャイルで複数のストーリーに分割される大きな作業単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144911,7 +145685,8 @@
     "question_text": {
       "en": "Which architecture style produces and consumes events asynchronously between components?",
       "ja": "コンポーネント間でイベントを非同期にやり取りするアーキテクチャは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144951,7 +145726,8 @@
     "question_text": {
       "en": "Which US government standard specifies security requirements for cryptographic modules?",
       "ja": "暗号モジュールのセキュリティ要件を定めた米国政府の規格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144991,7 +145767,8 @@
     "question_text": {
       "en": "Which 1985 document by Richard Stallman declared the philosophy of free software?",
       "ja": "1985 年にストールマンがフリーソフトウェアの理念を宣言した文書は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145031,7 +145808,8 @@
     "question_text": {
       "en": "Which version of the GNU General Public License was released in 2007 with patent provisions?",
       "ja": "2007 年にリリースされ特許条項を含む GPL のバージョンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145071,7 +145849,8 @@
     "question_text": {
       "en": "Which 1986 essay by The Mentor became iconic in hacker culture?",
       "ja": "ハッカー文化の象徴となった 1986 年のメンターによる文書は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145111,7 +145890,8 @@
     "question_text": {
       "en": "Which organization develops and promotes voluntary Internet standards like TCP/IP and HTTP?",
       "ja": "TCP/IP や HTTP 等のインターネット標準を策定する組織は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145151,7 +145931,8 @@
     "question_text": {
       "en": "In compilers, what is the abbreviation for the intermediate representation of code?",
       "ja": "コンパイラで中間表現を指す略称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145191,7 +145972,8 @@
     "question_text": {
       "en": "Which international standard specifies requirements for an information security management system (ISMS)?",
       "ja": "情報セキュリティマネジメントシステム(ISMS)の要件を定めた国際規格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145231,7 +146013,8 @@
     "question_text": {
       "en": "Which GNU license allows linking with proprietary software, often used for libraries?",
       "ja": "ライブラリ向けで、プロプライエタリと動的リンク可能な GNU 系ライセンスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145271,7 +146054,8 @@
     "question_text": {
       "en": "In GitLab terminology, what is the abbreviation for a Merge Request?",
       "ja": "GitLab でマージリクエストを意味する略称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145311,7 +146095,8 @@
     "question_text": {
       "en": "Which architecture deploys an application as a single, tightly coupled unit?",
       "ja": "アプリ全体を単一の密結合な単位として配備するアーキテクチャは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145351,7 +146136,8 @@
     "question_text": {
       "en": "Which technique remaps IP addresses by translating them between private and public networks?",
       "ja": "プライベートとパブリックネットワーク間で IP を変換する技術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145391,7 +146177,8 @@
     "question_text": {
       "en": "What is a build automatically produced every night from the latest source code called?",
       "ja": "毎晩最新ソースから自動生成されるビルドを何と呼ぶ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145431,7 +146218,8 @@
     "question_text": {
       "en": "In Kubernetes, what term refers to a worker machine (VM or physical) that runs Pods?",
       "ja": "Kubernetes で Pod を実行するワーカーマシンを何と呼ぶ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145471,7 +146259,8 @@
     "question_text": {
       "en": "Which non-profit publishes the Top 10 list of web application security risks?",
       "ja": "Web アプリのセキュリティリスク Top 10 を公開している非営利団体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145511,7 +146300,8 @@
     "question_text": {
       "en": "Which document published by OSI defines the criteria a license must meet to be \"open source\"?",
       "ja": "OSI が公開する、オープンソースライセンスの定義文書は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145551,7 +146341,8 @@
     "question_text": {
       "en": "On GitHub, what is the abbreviation for a request to merge a branch's changes?",
       "ja": "GitHub でブランチの変更をマージ要求する仕組みの略称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145591,7 +146382,8 @@
     "question_text": {
       "en": "Which cloud service model provides a managed runtime and platform for deploying apps?",
       "ja": "アプリ実行用のマネージドなプラットフォームを提供するクラウド形態は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145631,7 +146423,8 @@
     "question_text": {
       "en": "Which agile estimation technique uses cards with Fibonacci-like numbers?",
       "ja": "フィボナッチ風の数字カードで規模見積りを行うアジャイル手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145671,7 +146464,8 @@
     "question_text": {
       "en": "Which AWS service provides a managed relational database?",
       "ja": "リレーショナルDBをマネージドで提供する AWS サービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145711,7 +146505,8 @@
     "question_text": {
       "en": "Which deployment gradually replaces instances of the old version with the new one?",
       "ja": "旧版のインスタンスを順次新版へ置き換えていくデプロイ手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145751,7 +146546,8 @@
     "question_text": {
       "en": "Which AICPA audit report focuses on service organizations' security and availability controls?",
       "ja": "サービス事業者のセキュリティ・可用性統制を評価する AICPA の監査報告書は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145791,7 +146587,8 @@
     "question_text": {
       "en": "In Kubernetes, which resource provides stable network access to a set of Pods?",
       "ja": "Kubernetes で Pod 群への安定したネットワークアクセスを提供するリソースは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145831,7 +146628,8 @@
     "question_text": {
       "en": "Which architecture organizes functionality as reusable services communicating over a network?",
       "ja": "機能をネットワーク経由で再利用可能なサービス群として組むアーキテクチャは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145871,7 +146669,8 @@
     "question_text": {
       "en": "Which deployment sends a copy of live traffic to a new version without affecting users?",
       "ja": "本番トラフィックを複製して新版に流し、利用者に影響を与えない検証手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145911,7 +146710,8 @@
     "question_text": {
       "en": "In agile, what is the smallest unit of work assigned to a developer?",
       "ja": "アジャイルで開発者にアサインされる最小の作業単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145951,7 +146751,8 @@
     "question_text": {
       "en": "In requirements engineering, what describes a sequence of interactions between user and system?",
       "ja": "要件定義で利用者とシステムのやり取りの流れを記述するものは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145991,7 +146792,8 @@
     "question_text": {
       "en": "Which technology creates an encrypted tunnel over a public network to access a private one?",
       "ja": "公衆網上に暗号化トンネルを張りプライベート網へアクセスする技術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146319,32 +147121,28 @@
         "en": "Eight",
         "ja": "8",
         "ja_typings": [
-          "8",
-          "hachi"
+          "8"
         ]
       },
       {
         "en": "Six",
         "ja": "6",
         "ja_typings": [
-          "6",
-          "roku"
+          "6"
         ]
       },
       {
         "en": "Two",
         "ja": "2",
         "ja_typings": [
-          "2",
-          "ni"
+          "2"
         ]
       },
       {
         "en": "Ten",
         "ja": "10",
         "ja_typings": [
-          "10",
-          "juu"
+          "10"
         ]
       }
     ],
@@ -146355,7 +147153,8 @@
     "question_text": {
       "en": "Which number is \"eight\" in English?",
       "ja": "英語で eight が表す数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147163,32 +147962,28 @@
         "en": "Six",
         "ja": "6",
         "ja_typings": [
-          "6",
-          "roku"
+          "6"
         ]
       },
       {
         "en": "Eight",
         "ja": "8",
         "ja_typings": [
-          "8",
-          "hachi"
+          "8"
         ]
       },
       {
         "en": "Two",
         "ja": "2",
         "ja_typings": [
-          "2",
-          "ni"
+          "2"
         ]
       },
       {
         "en": "Nine",
         "ja": "9",
         "ja_typings": [
-          "9",
-          "kyuu"
+          "9"
         ]
       }
     ],
@@ -147199,7 +147994,8 @@
     "question_text": {
       "en": "Which number is \"six\" in English?",
       "ja": "英語で six が表す数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147447,32 +148243,28 @@
         "en": "Two",
         "ja": "2",
         "ja_typings": [
-          "2",
-          "ni"
+          "2"
         ]
       },
       {
         "en": "Six",
         "ja": "6",
         "ja_typings": [
-          "6",
-          "roku"
+          "6"
         ]
       },
       {
         "en": "Eight",
         "ja": "8",
         "ja_typings": [
-          "8",
-          "hachi"
+          "8"
         ]
       },
       {
         "en": "Three",
         "ja": "3",
         "ja_typings": [
-          "3",
-          "san"
+          "3"
         ]
       }
     ],
@@ -147483,7 +148275,8 @@
     "question_text": {
       "en": "Which number is \"two\" in English?",
       "ja": "英語で two が表す数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -265,6 +265,14 @@ Recommended migration order for existing JA quiz banks:
 
 Validation: no two choices in a question may share a prefix that would make an auto-confirm ambiguous. Enforced by `cargo run --bin lint-questions -- <files>` (CI job `lint-data`) and by the unit tests `shipped_question_data_is_clean_{ja,en}` in `src/io/validator.rs`. The same lint binary also flags `ja_typings redundant-variant` — multiple typings in the same choice that collapse to the same canonical form (e.g. `ninnshou` / `ninshou`, where redundant `nn` before a consonant collapses to `n`). Such duplicates are noise after v0.7.0's canonical_romaji expansion; only register one form per canonical group. Genuine reading variants (`日本` = `nihon` / `nippon`) are preserved because their canonical forms differ (the geminate `pp` distinguishes them).
 
+#### `ja_reviewed` review policy (#135)
+
+`ja_reviewed` marks a question whose Japanese typing data has been verified. Because reviewing thousands of questions by hand is infeasible, verification is automated by reading dimension:
+
+- **kana / ASCII choices** have an unambiguous reading: the canonical IME-strict typing is a function of the label (`romaji::derive_ja_typings`). `cargo run --bin review-ja-typings -- verify <file>` (CI job `lint-data`) fails if any such stored typing is not canonical; `apply` rewrites them to canonical and sets `ja_reviewed = true` on every question whose choices are *all* kana/ASCII. `backfill-ja-typing` shares the same `derive_ja_typings`, so the generator and the verifier cannot drift apart.
+- **A choice whose canonical typing would itself fail the IME-strict form lint** (e.g. a `:` in the label becomes a space, violating the S1 rule) is reported as *needs attention* and left untouched — the auto-reviewer never writes a typing the linter would reject.
+- **kanji-bearing choices** have ambiguous readings (compounds, proper nouns, number readings) that a reading engine like kakasi gets wrong far too often. They keep `ja_reviewed = false` and are verified by an LLM-judge pass (#134), not by `review-ja-typings`.
+
 ### Listening prompt (`data/listening_<lang>.yaml`)
 
 ```yaml

--- a/src/bin/backfill-ja-typing.rs
+++ b/src/bin/backfill-ja-typing.rs
@@ -47,7 +47,9 @@ fn main() -> ExitCode {
             // ASCII / かな のみのラベルは IME-strict の標準形を機械生成できる。
             // 同じかな読みのローマ字 variant は runtime canonical に任せるため、
             // 既存 variant と merge せず標準形で置換する。
-            let Some(generated) = derive_ja_typings(ja) else {
+            // 生成ルールは romaji::derive_ja_typings に一元化（review-ja-typings
+            // が同じ関数で検証するので、生成と検証が乖離しない）。
+            let Some(generated) = romaji::derive_ja_typings(ja) else {
                 continue;
             };
             obj.insert(
@@ -71,14 +73,4 @@ fn main() -> ExitCode {
     }
 
     ExitCode::SUCCESS
-}
-
-fn derive_ja_typings(ja: &str) -> Option<Vec<String>> {
-    match ja {
-        "酸素" => Some(vec!["sanso".to_string()]),
-        "鉄" => Some(vec!["tetsu".to_string()]),
-        _ if ja.is_ascii() => Some(vec![ja.to_ascii_lowercase()]),
-        _ if romaji::contains_han(ja) => None,
-        _ => Some(romaji::hiragana_to_hepburn_variants(ja)),
-    }
 }

--- a/src/bin/review-ja-typings.rs
+++ b/src/bin/review-ja-typings.rs
@@ -232,7 +232,10 @@ fn main() -> ExitCode {
     println!("all-derivable (kana/ASCII): {}", report.all_derivable);
     println!("has-kanji (left for #134) : {}", report.has_kanji);
     println!("non-canonical typings     : {}", report.mismatches.len());
-    println!("needs attention (unsafe)  : {}", report.needs_attention.len());
+    println!(
+        "needs attention (unsafe)  : {}",
+        report.needs_attention.len()
+    );
     for m in report.needs_attention.iter() {
         println!("  ! {m}");
     }

--- a/src/bin/review-ja-typings.rs
+++ b/src/bin/review-ja-typings.rs
@@ -1,0 +1,418 @@
+//! Deterministically review `ja_typings` for kana / ASCII choices and
+//! auto-confirm questions whose every choice is machine-verifiable.
+//!
+//! For any choice whose label has no ambiguous reading — pure ASCII or
+//! kana, plus the hand-curated kanji table — the canonical IME-strict
+//! typing is a *function* of the label (`romaji::derive_ja_typings`). So we
+//! can verify the stored typing without a human and, for questions where
+//! *every* choice is derivable, flip `ja_reviewed` to `true` with high
+//! confidence: the typings provably match the labels' canonical romaji.
+//!
+//! Kanji-bearing labels (compounds, proper nouns, number readings) have no
+//! mechanical reading and are left untouched (`ja_reviewed` unchanged) for
+//! the LLM-judge pass (#134).
+//!
+//! Modes:
+//! - `verify` (CI gate): report any derivable choice whose stored typing is
+//!   not canonical, and exit non-zero. No mutation.
+//! - `apply`: rewrite derivable choices to their canonical typings and set
+//!   `ja_reviewed = true` on every all-derivable question, then write back.
+
+#[path = "../io/romaji.rs"]
+mod romaji;
+
+use serde_json::Value;
+use std::fs;
+use std::process::ExitCode;
+
+/// Result of checking a single choice's stored typings against the
+/// canonical derivation.
+#[derive(Debug, PartialEq)]
+enum ChoiceCheck {
+    /// Label is derivable and the stored typings already equal canonical.
+    Verified,
+    /// Label is derivable but the stored typings differ from canonical.
+    Mismatch { canonical: Vec<String> },
+    /// Label is derivable but the canonical typing itself would fail the
+    /// IME-strict form linter (e.g. a label with a `:` whose canonical
+    /// gains a space). We refuse to write a typing the linter rejects, so
+    /// such a choice is left untouched and surfaced for human attention.
+    Unsafe { canonical: Vec<String> },
+    /// Label is kanji-bearing with no mechanical reading — left for review.
+    NotDerivable,
+}
+
+/// `true` unless a canonical variant contains whitespace that `ja` itself
+/// does not. Mirrors `lint_ja_typings.py`'s S1 rule: a space in the typing
+/// is only legal when the label has one too. The romaji engine turns some
+/// separators (`:`, `(`, `)`, …) into spaces, which would otherwise produce
+/// a typing the form linter rejects — so the auto-reviewer must never emit
+/// or confirm one.
+fn canonical_is_lint_safe(ja: &str, canonical: &[String]) -> bool {
+    let ja_has_ws = ja.chars().any(|c| c.is_whitespace() || c == '　');
+    if ja_has_ws {
+        return true;
+    }
+    !canonical
+        .iter()
+        .any(|t| t.chars().any(|c| c.is_whitespace() || c == '　'))
+}
+
+fn check_choice(ja: &str, stored: &[String]) -> ChoiceCheck {
+    match romaji::derive_ja_typings(ja) {
+        None => ChoiceCheck::NotDerivable,
+        Some(canonical) if !canonical_is_lint_safe(ja, &canonical) => {
+            ChoiceCheck::Unsafe { canonical }
+        }
+        Some(canonical) => {
+            if stored == canonical.as_slice() {
+                ChoiceCheck::Verified
+            } else {
+                ChoiceCheck::Mismatch { canonical }
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct Report {
+    questions: usize,
+    /// Questions where every choice is derivable (auto-confirmable).
+    all_derivable: usize,
+    /// Questions with at least one kanji-bearing choice (left for #134).
+    has_kanji: usize,
+    /// Derivable choices whose stored typings were not canonical.
+    mismatches: Vec<String>,
+    /// Derivable choices whose canonical typing would fail the form linter
+    /// (left untouched, never auto-confirmed).
+    needs_attention: Vec<String>,
+    /// `apply`: choices whose typings were rewritten to canonical.
+    fixed_choices: usize,
+    /// `apply`: questions flipped from ja_reviewed=false to true.
+    confirmed_now: usize,
+}
+
+fn stored_typings(choice: &Value) -> Vec<String> {
+    choice
+        .get("ja_typings")
+        .and_then(Value::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Process one question. In `apply` mode mutates `question` in place
+/// (canonicalises derivable typings, sets `ja_reviewed=true` when every
+/// choice is derivable). Accumulates findings into `report`.
+fn process_question(question: &mut Value, apply: bool, report: &mut Report) {
+    report.questions += 1;
+    let qid = question
+        .get("id")
+        .and_then(Value::as_str)
+        .unwrap_or("?")
+        .to_string();
+
+    let Some(choices) = question.get_mut("choices").and_then(Value::as_array_mut) else {
+        return;
+    };
+
+    let mut all_derivable = true;
+    for (idx, choice) in choices.iter_mut().enumerate() {
+        let Some(ja) = choice.get("ja").and_then(Value::as_str).map(str::to_string) else {
+            all_derivable = false;
+            continue;
+        };
+        let stored = stored_typings(choice);
+        match check_choice(&ja, &stored) {
+            ChoiceCheck::Verified => {}
+            ChoiceCheck::NotDerivable => all_derivable = false,
+            ChoiceCheck::Unsafe { canonical } => {
+                // Canonical itself is not form-linter safe — never rewrite
+                // or confirm; leave the stored typing for a human to fix.
+                all_derivable = false;
+                report.needs_attention.push(format!(
+                    "{qid}#{idx} {ja}: canonical {canonical:?} would fail form lint (stored {stored:?})"
+                ));
+            }
+            ChoiceCheck::Mismatch { canonical } => {
+                report.mismatches.push(format!(
+                    "{qid}#{idx} {ja}: stored {stored:?} != canonical {canonical:?}"
+                ));
+                if apply {
+                    if let Some(obj) = choice.as_object_mut() {
+                        obj.insert(
+                            "ja_typings".to_string(),
+                            Value::Array(canonical.into_iter().map(Value::String).collect()),
+                        );
+                        report.fixed_choices += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    if all_derivable {
+        report.all_derivable += 1;
+        if apply {
+            let was_reviewed = question
+                .get("ja_reviewed")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            if !was_reviewed {
+                report.confirmed_now += 1;
+            }
+            if let Some(obj) = question.as_object_mut() {
+                obj.insert("ja_reviewed".to_string(), Value::Bool(true));
+            }
+        }
+    } else {
+        report.has_kanji += 1;
+    }
+}
+
+fn main() -> ExitCode {
+    let mode = std::env::args().nth(1).unwrap_or_default();
+    let path = std::env::args().nth(2);
+    let apply = match mode.as_str() {
+        "verify" => false,
+        "apply" => true,
+        _ => {
+            eprintln!("usage: review-ja-typings <verify|apply> <path-to-questions_ja.json>");
+            return ExitCode::from(2);
+        }
+    };
+    let Some(path) = path else {
+        eprintln!("usage: review-ja-typings <verify|apply> <path-to-questions_ja.json>");
+        return ExitCode::from(2);
+    };
+
+    let text = match fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(err) => {
+            eprintln!("{path}: read error: {err}");
+            return ExitCode::from(1);
+        }
+    };
+    let mut json: Value = match serde_json::from_str(&text) {
+        Ok(json) => json,
+        Err(err) => {
+            eprintln!("{path}: parse error: {err}");
+            return ExitCode::from(1);
+        }
+    };
+    let Some(questions) = json.as_array_mut() else {
+        eprintln!("{path}: top-level JSON must be an array");
+        return ExitCode::from(1);
+    };
+
+    let mut report = Report::default();
+    for question in questions.iter_mut() {
+        process_question(question, apply, &mut report);
+    }
+
+    if apply {
+        let formatted = match serde_json::to_string_pretty(&json) {
+            Ok(text) => text + "\n",
+            Err(err) => {
+                eprintln!("{path}: serialize error: {err}");
+                return ExitCode::from(1);
+            }
+        };
+        if let Err(err) = fs::write(&path, formatted) {
+            eprintln!("{path}: write error: {err}");
+            return ExitCode::from(1);
+        }
+    }
+
+    println!("questions                 : {}", report.questions);
+    println!("all-derivable (kana/ASCII): {}", report.all_derivable);
+    println!("has-kanji (left for #134) : {}", report.has_kanji);
+    println!("non-canonical typings     : {}", report.mismatches.len());
+    println!("needs attention (unsafe)  : {}", report.needs_attention.len());
+    for m in report.needs_attention.iter() {
+        println!("  ! {m}");
+    }
+    if apply {
+        println!("typings canonicalised     : {}", report.fixed_choices);
+        println!("ja_reviewed confirmed now : {}", report.confirmed_now);
+    } else {
+        for m in report.mismatches.iter().take(20) {
+            println!("  {m}");
+        }
+        if report.mismatches.len() > 20 {
+            println!("  ... and {} more", report.mismatches.len() - 20);
+        }
+    }
+
+    // `verify` fails the build when any derivable choice is non-canonical;
+    // `apply` always succeeds (it just fixed them).
+    if !apply && !report.mismatches.is_empty() {
+        ExitCode::from(1)
+    } else {
+        ExitCode::SUCCESS
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn ascii_label_verified_when_lowercased() {
+        assert_eq!(
+            check_choice("H2O", &["h2o".to_string()]),
+            ChoiceCheck::Verified
+        );
+    }
+
+    #[test]
+    fn ascii_label_mismatch_when_not_lowercase() {
+        assert_eq!(
+            check_choice("H2O", &["H2O".to_string()]),
+            ChoiceCheck::Mismatch {
+                canonical: vec!["h2o".to_string()]
+            }
+        );
+    }
+
+    #[test]
+    fn kana_label_verified_against_canonical() {
+        // ソウル -> souru (the legacy `soru` variant is not canonical).
+        assert_eq!(
+            check_choice("ソウル", &["souru".to_string()]),
+            ChoiceCheck::Verified
+        );
+    }
+
+    #[test]
+    fn kana_label_with_stale_variant_is_mismatch() {
+        match check_choice("ソウル", &["souru".to_string(), "soru".to_string()]) {
+            ChoiceCheck::Mismatch { canonical } => assert_eq!(canonical, vec!["souru".to_string()]),
+            other => panic!("expected mismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn kanji_label_is_not_derivable() {
+        // 陽子 has an ambiguous reading (kakasi guesses the name "Yoko");
+        // it must be left for review, never auto-verified.
+        assert_eq!(
+            check_choice("陽子", &["youshi".to_string()]),
+            ChoiceCheck::NotDerivable
+        );
+    }
+
+    #[test]
+    fn colon_label_is_unsafe_not_mismatch() {
+        // イド:インヴェイデッド: the engine turns `:` into a space, so the
+        // canonical typing would gain whitespace the label lacks and fail
+        // the form linter's S1 rule. The reviewer must flag it Unsafe and
+        // leave the stored typing alone — never rewrite it to a space form.
+        match check_choice("イド:インヴェイデッド", &["idoinveideddo".to_string()]) {
+            ChoiceCheck::Unsafe { canonical } => {
+                assert!(canonical.iter().any(|t| t.contains(' ')));
+            }
+            other => panic!("expected Unsafe, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unsafe_choice_blocks_question_confirmation() {
+        let mut q = json!({
+            "id": "qcolon",
+            "choices": [
+                {"ja": "イド:インヴェイデッド", "ja_typings": ["idoinveideddo"]},
+                {"ja": "ソウル", "ja_typings": ["souru"]}
+            ],
+            "ja_reviewed": false
+        });
+        let mut report = Report::default();
+        process_question(&mut q, true, &mut report);
+
+        assert_eq!(report.needs_attention.len(), 1);
+        assert_eq!(report.all_derivable, 0, "unsafe choice must block confirm");
+        assert_eq!(report.fixed_choices, 0, "unsafe typing left untouched");
+        assert_eq!(q["ja_reviewed"], json!(false));
+        assert_eq!(
+            q["choices"][0]["ja_typings"],
+            json!(["idoinveideddo"]),
+            "stored typing for the unsafe choice is preserved"
+        );
+    }
+
+    #[test]
+    fn canonical_lint_safe_allows_space_when_label_has_space() {
+        // A label that itself contains whitespace may legitimately produce a
+        // spaced typing (e.g. "O(log n)") — that is not unsafe.
+        assert!(canonical_is_lint_safe("a b", &["a b".to_string()]));
+        assert!(!canonical_is_lint_safe("a:b", &["a b".to_string()]));
+    }
+
+    #[test]
+    fn apply_confirms_all_kana_question_and_canonicalises() {
+        let mut q = json!({
+            "id": "qtest",
+            "choices": [
+                {"ja": "ソウル", "ja_typings": ["souru", "soru"]},
+                {"ja": "H2O", "ja_typings": ["h2o"]}
+            ],
+            "ja_reviewed": false
+        });
+        let mut report = Report::default();
+        process_question(&mut q, true, &mut report);
+
+        assert_eq!(report.all_derivable, 1);
+        assert_eq!(report.has_kanji, 0);
+        assert_eq!(report.fixed_choices, 1, "the stale `soru` variant is fixed");
+        assert_eq!(report.confirmed_now, 1);
+        assert_eq!(q["ja_reviewed"], json!(true));
+        assert_eq!(q["choices"][0]["ja_typings"], json!(["souru"]));
+    }
+
+    #[test]
+    fn apply_leaves_kanji_question_unconfirmed() {
+        let mut q = json!({
+            "id": "qkanji",
+            "choices": [
+                {"ja": "陽子", "ja_typings": ["youshi"]},
+                {"ja": "ソウル", "ja_typings": ["souru"]}
+            ],
+            "ja_reviewed": false
+        });
+        let mut report = Report::default();
+        process_question(&mut q, true, &mut report);
+
+        assert_eq!(report.all_derivable, 0);
+        assert_eq!(report.has_kanji, 1);
+        assert_eq!(
+            q["ja_reviewed"],
+            json!(false),
+            "kanji question must stay unreviewed for #134"
+        );
+    }
+
+    #[test]
+    fn verify_mode_does_not_mutate() {
+        let mut q = json!({
+            "id": "qtest",
+            "choices": [{"ja": "ソウル", "ja_typings": ["souru", "soru"]}],
+            "ja_reviewed": false
+        });
+        let mut report = Report::default();
+        process_question(&mut q, false, &mut report);
+
+        assert_eq!(report.mismatches.len(), 1, "mismatch is reported");
+        assert_eq!(report.fixed_choices, 0, "verify never fixes");
+        assert_eq!(q["ja_reviewed"], json!(false), "verify never flips flag");
+        assert_eq!(
+            q["choices"][0]["ja_typings"],
+            json!(["souru", "soru"]),
+            "verify never rewrites typings"
+        );
+    }
+}

--- a/src/bin/review-ja-typings.rs
+++ b/src/bin/review-ja-typings.rs
@@ -48,6 +48,16 @@ enum ChoiceCheck {
 /// separators (`:`, `(`, `)`, …) into spaces, which would otherwise produce
 /// a typing the form linter rejects — so the auto-reviewer must never emit
 /// or confirm one.
+///
+/// Only the S1 (whitespace) rule is checked here, deliberately: the other
+/// form-lint categories are unreachable from `derive_ja_typings` output.
+/// That output only ever contains `[a-z0-9./,-]` plus spaces — the engine
+/// maps `・`→`/`, `、`→`,`, `。`→`.`, treats `（）「」` etc. as separators
+/// (→ space, caught here), drops `+^`, and emits a digit only when the label
+/// already has one (which makes the whole label ASCII, where the linter's
+/// A1 rule does not apply). So S2 (`・　、。「」`) and A1 (`+()[]^`/digits on a
+/// non-ASCII label) cannot fire. If the romaji map ever grows a new symbol,
+/// revisit this guard.
 fn canonical_is_lint_safe(ja: &str, canonical: &[String]) -> bool {
     let ja_has_ws = ja.chars().any(|c| c.is_whitespace() || c == '　');
     if ja_has_ws {
@@ -251,8 +261,15 @@ fn main() -> ExitCode {
         }
     }
 
-    // `verify` fails the build when any derivable choice is non-canonical;
-    // `apply` always succeeds (it just fixed them).
+    // `verify` fails the build only on *mismatches* (a kana/ASCII typing
+    // that is not canonical — a real, fixable regression). `apply` always
+    // succeeds (it just fixed them).
+    //
+    // `needs_attention` (Unsafe) deliberately does NOT fail the build: those
+    // are labels the tool legitimately cannot auto-handle (canonical would
+    // need a space the linter forbids), not regressions. Failing CI would
+    // block an otherwise-valid question from being added. They are printed
+    // for a human / the #134 LLM-judge pass to resolve instead.
     if !apply && !report.mismatches.is_empty() {
         ExitCode::from(1)
     } else {
@@ -322,6 +339,42 @@ mod tests {
             }
             other => panic!("expected Unsafe, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn fullwidth_paren_label_is_unsafe() {
+        // Not just `:` — any separator the engine maps to a space (（）「」 etc.)
+        // must be flagged Unsafe so the separator→space mapping can't sneak a
+        // spaced typing past the form linter.
+        match check_choice("テスト（カッコ）", &["tesutokakko".to_string()]) {
+            ChoiceCheck::Unsafe { canonical } => {
+                assert!(canonical.iter().any(|t| t.contains(' ')), "got {canonical:?}");
+            }
+            other => panic!("expected Unsafe, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mixed_question_canonicalises_kana_choice_but_stays_unconfirmed() {
+        // A question with one kanji choice stays ja_reviewed=false, but its
+        // derivable kana choices are still canonicalised (verify checks every
+        // derivable choice regardless of question-level confirmation).
+        let mut q = json!({
+            "id": "qmixed",
+            "choices": [
+                {"ja": "陽子", "ja_typings": ["youshi"]},
+                {"ja": "ソウル", "ja_typings": ["souru", "soru"]}
+            ],
+            "ja_reviewed": false
+        });
+        let mut report = Report::default();
+        process_question(&mut q, true, &mut report);
+
+        assert_eq!(report.all_derivable, 0, "kanji blocks confirmation");
+        assert_eq!(report.fixed_choices, 1, "kana choice still canonicalised");
+        assert_eq!(report.confirmed_now, 0);
+        assert_eq!(q["ja_reviewed"], json!(false));
+        assert_eq!(q["choices"][1]["ja_typings"], json!(["souru"]));
     }
 
     #[test]

--- a/src/bin/review-ja-typings.rs
+++ b/src/bin/review-ja-typings.rs
@@ -348,7 +348,10 @@ mod tests {
         // spaced typing past the form linter.
         match check_choice("テスト（カッコ）", &["tesutokakko".to_string()]) {
             ChoiceCheck::Unsafe { canonical } => {
-                assert!(canonical.iter().any(|t| t.contains(' ')), "got {canonical:?}");
+                assert!(
+                    canonical.iter().any(|t| t.contains(' ')),
+                    "got {canonical:?}"
+                );
             }
             other => panic!("expected Unsafe, got {other:?}"),
         }

--- a/src/io/romaji.rs
+++ b/src/io/romaji.rs
@@ -35,6 +35,31 @@ pub fn hiragana_to_hepburn_variants(input: &str) -> Vec<String> {
     vec![raw]
 }
 
+/// Derive the canonical IME-strict `ja_typings` for a choice label, or
+/// `None` when the reading can't be generated mechanically.
+///
+/// - ASCII labels → the lowercased label (e.g. `"H2O"` → `["h2o"]`).
+/// - A small hand-curated table for kanji whose single reading is fixed
+///   and common (`酸素`, `鉄`).
+/// - Any other kanji-bearing label → `None`: its reading is ambiguous
+///   (compounds, proper nouns, number readings) and must be reviewed by a
+///   human or an LLM, not guessed by a reading engine.
+/// - Otherwise (pure kana / kana+ASCII) → the canonical Hepburn variants.
+///
+/// Shared by `backfill-ja-typing` (which *writes* these) and
+/// `review-ja-typings` (which *verifies* stored typings against them) so the
+/// generator and the verifier can never drift apart.
+#[allow(dead_code)]
+pub fn derive_ja_typings(ja: &str) -> Option<Vec<String>> {
+    match ja {
+        "酸素" => Some(vec!["sanso".to_string()]),
+        "鉄" => Some(vec!["tetsu".to_string()]),
+        _ if ja.is_ascii() => Some(vec![ja.to_ascii_lowercase()]),
+        _ if contains_han(ja) => None,
+        _ => Some(hiragana_to_hepburn_variants(ja)),
+    }
+}
+
 fn hiragana_to_hepburn_raw(input: &str) -> String {
     let chars: Vec<char> = input.chars().map(normalize_kana).collect();
     let mut out = String::new();


### PR DESCRIPTION
## 関連 Issue
closes #135

## 背景
未レビュー question が 2925件。人手レビューは非現実的なので、**読みが一意に決まる kana/ASCII choice を canonical エンジンで決定的に検証**して自動確定する。漢字 choice は読みが曖昧（kakasi は複合語/固有名詞で約95% 誤読）なので据え置き → #134 の LLM-judge へ。

## 変更
- `romaji::derive_ja_typings` を `romaji.rs` に集約。`backfill-ja-typing` と新 bin が**同一関数で生成/検証**するため乖離不能。
- 新 bin `review-ja-typings`（verify / apply）:
  - **verify**（CI ゲート）: kana/ASCII choice の stored typing が canonical でなければ exit 1。ミューテーションなし
  - **apply**: canonical 化 + 全 choice が kana/ASCII の question を `ja_reviewed=true` に確定
  - canonical 自体が IME-strict 形 lint を破る choice（`イド:インヴェイデッド` の `:` が空白化）は **Unsafe** として据え置き＋needs-attention 報告。**違反 typing を絶対に書かない**不変条件
- `apply` 実行結果: **795 typing を canonical 化 + 1595 question を確定。未レビュー 2925→1330**（残 = 漢字1329 + unsafe 1）
- CI `lint-data` に `verify` を追加（以後 kana/ASCII typing が非 canonical な PR は fail = 再発防止）
- README / docs/spec.md に手順と `ja_reviewed` レビュー方針を明記

## 検証
- データ構造検証: 差分は `ja_typings`(795) / `ja_reviewed`(1595) のみ。id 順・件数・他フィールド不変
- 304 + 60 + 19 tests pass、clippy clean
- lint-questions / lint_ja_typings.py / review-ja-typings verify 全 exit 0